### PR TITLE
Add desktop policies

### DIFF
--- a/apps/app/src/app/cloud/desktop-app-restrictions.ts
+++ b/apps/app/src/app/cloud/desktop-app-restrictions.ts
@@ -1,8 +1,8 @@
-import type { DesktopAppRestrictions } from "@openwork/types/den/desktop-app-restrictions";
+import type { DesktopPolicyKey } from "@openwork/types/den/desktop-policies";
 import type { DenDesktopConfig } from "../lib/den";
 import type { ModelRef } from "../types";
 
-export type DesktopAppRestrictionKey = keyof DesktopAppRestrictions;
+export type DesktopAppRestrictionKey = DesktopPolicyKey;
 
 export type DesktopAppRestrictionChecker = (input: {
   restriction: DesktopAppRestrictionKey;
@@ -14,7 +14,7 @@ export function checkDesktopAppRestriction(input: {
   config: DenDesktopConfig | null | undefined;
   restriction: DesktopAppRestrictionKey;
 }) {
-  return input.config?.[input.restriction] === true;
+  return input.config?.[input.restriction] === false;
 }
 
 export function isDesktopProviderBlocked(input: {
@@ -25,7 +25,7 @@ export function isDesktopProviderBlocked(input: {
   if (!providerId) return false;
 
   if (providerId === DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID) {
-    return input.checkRestriction({ restriction: "blockZenModel" });
+    return input.checkRestriction({ restriction: "allowZenModel" });
   }
 
   return false;
@@ -55,7 +55,7 @@ type DesktopAppRestrictionSyncContext = {
 export async function runDesktopAppRestrictionSyncEffects(
   input: DesktopAppRestrictionSyncContext,
 ) {
-  const shouldDisableOpencodeProvider = input.checkRestriction({ restriction: "blockZenModel" });
+  const shouldDisableOpencodeProvider = input.checkRestriction({ restriction: "allowZenModel" });
 
   input.reconcileRestrictedModels?.();
 
@@ -69,7 +69,7 @@ export async function runDesktopAppRestrictionSyncEffects(
       input.onError?.(
         error instanceof Error ? error : new Error(String(error ?? "Desktop restriction effect failed.")),
         {
-          restriction: "blockZenModel",
+          restriction: "allowZenModel",
           action: "ensureProjectProviderDisabledState",
           providerId: DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID,
         },

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -1,7 +1,7 @@
 import {
   normalizeDesktopConfig,
   type DesktopConfig as SharedDesktopConfig,
-} from "@openwork/types/den/desktop-app-restrictions";
+} from "@openwork/types/den/desktop-policies";
 
 // Re-export the shared schema under the local alias so React consumers
 // (e.g. the cloud domain's desktop-config provider) can import it alongside

--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -71,11 +71,11 @@ function useModelOptions(open: boolean) {
   // Apply org-level restrictions (dev #1505) on top of the raw model list
   // so the picker never surfaces blocked options:
   //   - `allowZenModel` hides the built-in OpenCode provider entries when false
-  //   - `allowNonCloudModels` hides providers that OpenCode does not report
+  //   - `allowCustomProviders` hides providers that OpenCode does not report
   //     as connected through the provider list endpoint.
   return React.useMemo(() => {
     const restrictToCloud = checkDesktopRestriction({
-      restriction: "allowNonCloudModels",
+      restriction: "allowCustomProviders",
     });
 
     const options = getConnectedProviderItems(data)

--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -70,12 +70,12 @@ function useModelOptions(open: boolean) {
 
   // Apply org-level restrictions (dev #1505) on top of the raw model list
   // so the picker never surfaces blocked options:
-  //   - `blockZenModel` hides the built-in OpenCode provider entries
-  //   - `disallowNonCloudModels` hides providers that OpenCode does not report
+  //   - `allowZenModel` hides the built-in OpenCode provider entries when false
+  //   - `allowNonCloudModels` hides providers that OpenCode does not report
   //     as connected through the provider list endpoint.
   return React.useMemo(() => {
     const restrictToCloud = checkDesktopRestriction({
-      restriction: "disallowNonCloudModels",
+      restriction: "allowNonCloudModels",
     });
 
     const options = getConnectedProviderItems(data)

--- a/apps/app/src/react-app/design-system/restriction-notice-modal.tsx
+++ b/apps/app/src/react-app/design-system/restriction-notice-modal.tsx
@@ -25,7 +25,7 @@ export type RestrictionNoticeModalProps = {
  *
  * Purposefully framework-free except for the shared Button: this is
  * a thin, declarative surface driven by the cloud domain when an org gates
- * a feature (blockZenModel, disallowNonCloudModels, blockMultipleWorkspaces).
+ * a feature (allowZenModel, allowNonCloudModels, allowMultipleWorkspaces).
  */
 export function RestrictionNoticeModal(props: RestrictionNoticeModalProps) {
   return (

--- a/apps/app/src/react-app/design-system/restriction-notice-modal.tsx
+++ b/apps/app/src/react-app/design-system/restriction-notice-modal.tsx
@@ -25,7 +25,7 @@ export type RestrictionNoticeModalProps = {
  *
  * Purposefully framework-free except for the shared Button: this is
  * a thin, declarative surface driven by the cloud domain when an org gates
- * a feature (allowZenModel, allowNonCloudModels, allowMultipleWorkspaces).
+ * a feature (allowZenModel, allowCustomProviders, allowMultipleWorkspaces).
  */
 export function RestrictionNoticeModal(props: RestrictionNoticeModalProps) {
   return (

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -94,9 +94,9 @@ type DesktopConfigState = {
  * React port of the Solid `DesktopConfigProvider`
  * (`apps/app/src/app/cloud/desktop-config-provider.tsx` on dev).
  *
- * Fetches the org-scoped "desktop app restrictions" config (new
- * `packages/types/den/desktop-app-restrictions.ts` shape) and caches it in
- * localStorage so gates like `blockZenModel` can apply immediately on the
+ * Fetches the org-scoped desktop policy config
+ * (`packages/types/den/desktop-policies.ts` shape) and caches it in
+ * localStorage so gates like `allowZenModel` can apply immediately on the
  * next boot without waiting for the HTTP round-trip. Re-fetches on Den
  * session / settings events and on a one-hour interval.
  */
@@ -233,8 +233,8 @@ export function useDesktopConfig(): DesktopConfigStore {
 }
 
 /**
- * Convenience hook that returns the raw `DesktopAppRestrictions` flags
- * (e.g. `{ blockZenModel: true }`). Callers usually just want the flags,
+ * Convenience hook that returns the raw desktop policy flags
+ * (e.g. `{ allowZenModel: true }`). Callers usually just want the flags,
  * not the loading state — feature gates should read through this.
  */
 export function useOrgRestrictions(): DenDesktopConfig {
@@ -253,7 +253,7 @@ export function useCheckDesktopRestriction(): DesktopAppRestrictionChecker {
 /**
  * Single-restriction hook — returns true/false for a specific key.
  * Use this at feature sites that only care about one flag
- * (e.g. `useDesktopRestriction("blockMultipleWorkspaces")`).
+ * (e.g. `useDesktopRestriction("allowMultipleWorkspaces")`).
  */
 export function useDesktopRestriction(
   restriction: Parameters<DesktopAppRestrictionChecker>[0]["restriction"],

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -10,6 +10,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { desktopPolicyKeys } from "@openwork/types/den/desktop-policies";
 
 import {
   checkDesktopAppRestriction,
@@ -48,6 +49,17 @@ const DesktopConfigContext = createContext<DesktopConfigStore | undefined>(
 const DEFAULT_DESKTOP_CONFIG: DenDesktopConfig = {};
 const DESKTOP_CONFIG_REFRESH_MS = 60 * 60 * 1000;
 const DESKTOP_CONFIG_CACHE_PREFIX = "openwork.den.desktopConfig:";
+const DESKTOP_CONFIG_ITEMS = [
+  ...desktopPolicyKeys,
+  "allowedDesktopVersions",
+] as const satisfies readonly (keyof DenDesktopConfig)[];
+
+type DesktopConfigItem = (typeof DESKTOP_CONFIG_ITEMS)[number];
+type DesktopConfigAction = {
+  item: DesktopConfigItem;
+  nextValue: DenDesktopConfig[DesktopConfigItem];
+  previousValue: DenDesktopConfig[DesktopConfigItem];
+};
 
 function getDesktopConfigCacheKey(): string {
   const settings = readDenSettings();
@@ -81,6 +93,33 @@ function writeCachedDesktopConfig(key: string, config: DenDesktopConfig) {
   }
 }
 
+function desktopConfigItemMatches(
+  previousValue: DenDesktopConfig[DesktopConfigItem],
+  nextValue: DenDesktopConfig[DesktopConfigItem],
+) {
+  if (Array.isArray(previousValue) || Array.isArray(nextValue)) {
+    if (!Array.isArray(previousValue) || !Array.isArray(nextValue)) return false;
+    if (previousValue.length !== nextValue.length) return false;
+    return previousValue.every((value, index) => value === nextValue[index]);
+  }
+
+  return previousValue === nextValue;
+}
+
+function getDesktopConfigActions(input: {
+  currentConfig: DenDesktopConfig;
+  latestConfig: DenDesktopConfig;
+}): DesktopConfigAction[] {
+  return DESKTOP_CONFIG_ITEMS.flatMap((item) => {
+    const previousValue = input.currentConfig[item];
+    const nextValue = input.latestConfig[item];
+
+    if (desktopConfigItemMatches(previousValue, nextValue)) return [];
+
+    return [{ item, previousValue, nextValue }];
+  });
+}
+
 type DesktopConfigProviderProps = {
   children: ReactNode;
 };
@@ -111,20 +150,45 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
   const [settingsVersion, bumpSettingsVersion] = useReducer((value: number) => value + 1, 0);
   // Monotonic run id — same guard-against-stale-resolution pattern as DenAuthProvider.
   const refreshRunRef = useRef(0);
+  // Safe in-memory copy of the last config we actually applied. State drives
+  // rendering, while this ref lets the handler compare without stale closures.
+  const currentDesktopConfigRef = useRef<DenDesktopConfig>(DEFAULT_DESKTOP_CONFIG);
   const isSignedIn = denAuth.isSignedIn;
 
-  const refresh = useCallback(async () => {
+  const applyDesktopConfigActions = useCallback((latestConfig: DenDesktopConfig) => {
+    const normalizedConfig = normalizeDenDesktopConfig(latestConfig);
+    const actions = getDesktopConfigActions({
+      currentConfig: currentDesktopConfigRef.current,
+      latestConfig: normalizedConfig,
+    });
+
+    if (actions.length === 0) return false;
+
+    currentDesktopConfigRef.current = normalizedConfig;
+    setDesktopConfigState((current) => ({
+      ...current,
+      config: normalizedConfig,
+    }));
+    return true;
+  }, []);
+
+  const desktopConfigHandler = useCallback(async () => {
     const currentRun = ++refreshRunRef.current;
     const settings = readDenSettings();
     const token = settings.authToken?.trim() ?? "";
     const cacheKey = getDesktopConfigCacheKey();
 
     if (!isSignedIn || !token || !settings.activeOrgId?.trim()) {
-      setDesktopConfigState({ config: DEFAULT_DESKTOP_CONFIG, loading: false });
+      applyDesktopConfigActions(DEFAULT_DESKTOP_CONFIG);
+      setDesktopConfigState((current) => ({ ...current, loading: false }));
       return;
     }
 
     const cached = readCachedDesktopConfig(cacheKey);
+    if (cached) {
+      applyDesktopConfigActions(cached);
+    }
+
     if (!cached) {
       setDesktopConfigState((current) => ({ ...current, loading: true }));
     }
@@ -139,7 +203,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
       if (currentRun !== refreshRunRef.current) return;
 
       writeCachedDesktopConfig(cacheKey, nextConfig);
-      setDesktopConfigState((current) => ({ ...current, config: nextConfig }));
+      applyDesktopConfigActions(nextConfig);
     } catch (error) {
       if (currentRun !== refreshRunRef.current) return;
 
@@ -155,16 +219,15 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
         );
       }
 
-      setDesktopConfigState((current) => ({
-        ...current,
-        config: cached ?? DEFAULT_DESKTOP_CONFIG,
-      }));
+      applyDesktopConfigActions(cached ?? DEFAULT_DESKTOP_CONFIG);
     } finally {
       if (currentRun === refreshRunRef.current) {
         setDesktopConfigState((current) => ({ ...current, loading: false }));
       }
     }
-  }, [isSignedIn]);
+  }, [applyDesktopConfigActions, isSignedIn]);
+
+  const refresh = desktopConfigHandler;
 
   // Re-run whenever auth flips or Den settings change. Read the cache
   // synchronously so gated UI never flickers through "unrestricted" just
@@ -174,18 +237,17 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     void settingsVersion;
 
     if (!isSignedIn) {
-      setDesktopConfigState({ config: DEFAULT_DESKTOP_CONFIG, loading: false });
+      applyDesktopConfigActions(DEFAULT_DESKTOP_CONFIG);
+      setDesktopConfigState((current) => ({ ...current, loading: false }));
       return;
     }
 
     const cacheKey = getDesktopConfigCacheKey();
     const cached = readCachedDesktopConfig(cacheKey);
-    setDesktopConfigState({
-      config: cached ?? DEFAULT_DESKTOP_CONFIG,
-      loading: !cached,
-    });
-    void refresh();
-  }, [isSignedIn, refresh, settingsVersion]);
+    applyDesktopConfigActions(cached ?? DEFAULT_DESKTOP_CONFIG);
+    setDesktopConfigState((current) => ({ ...current, loading: !cached }));
+    void desktopConfigHandler();
+  }, [applyDesktopConfigActions, desktopConfigHandler, isSignedIn, settingsVersion]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -199,7 +261,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
 
     const interval = window.setInterval(() => {
       if (!isSignedIn) return;
-      void refresh();
+      void desktopConfigHandler();
     }, DESKTOP_CONFIG_REFRESH_MS);
 
     return () => {
@@ -207,7 +269,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
       window.removeEventListener(denSettingsChangedEvent, handleSettingsChanged);
       window.clearInterval(interval);
     };
-  }, [isSignedIn, refresh]);
+  }, [desktopConfigHandler, isSignedIn]);
 
   const value = useMemo<DesktopConfigStore>(() => {
     // Bind the checker to the latest `config` so callers see the most

--- a/apps/app/src/react-app/domains/cloud/restriction-notice-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/restriction-notice-provider.tsx
@@ -40,7 +40,7 @@ type RestrictionNoticeProviderProps = {
  * `useRestrictionNotice()`. Call sites:
  *
  *   const notice = useRestrictionNotice();
- *   if (checkDesktopRestriction({ restriction: "blockMultipleWorkspaces" })) {
+ *   if (checkDesktopRestriction({ restriction: "allowMultipleWorkspaces" })) {
  *     notice.show({ title: "...", message: "..." });
  *     return;
  *   }

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -44,6 +44,10 @@ import {
   type CloudImportedProvider,
 } from "../../../../app/cloud/import-state";
 import { dispatchNewProviders } from "../../../../app/lib/provider-events";
+import {
+  isDesktopProviderBlocked,
+  type DesktopAppRestrictionChecker,
+} from "../../../../app/cloud/desktop-app-restrictions";
 
 type ProviderReturnFocusTarget = "none" | "composer";
 type CloudProviderSyncReason = "sign_in" | "app_launch" | "interval" | "settings_cloud_opened";
@@ -87,6 +91,7 @@ type CreateProviderAuthStoreOptions = {
   providerDefaults: () => Record<string, string>;
   providerConnectedIds: () => string[];
   disabledProviders: () => string[];
+  checkDesktopAppRestriction: DesktopAppRestrictionChecker;
   selectedWorkspaceDisplay: () => WorkspaceDisplay;
   selectedWorkspaceRoot: () => string;
   runtimeWorkspaceId: () => string | null;
@@ -170,6 +175,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     for (const provider of options.providers()) {
       const id = provider.id?.trim();
       if (!id) continue;
+      if (isDesktopProviderBlocked({ providerId: id, checkRestriction: options.checkDesktopAppRestriction })) continue;
       merged.set(id, {
         id,
         name: provider.name?.trim() || id,
@@ -180,6 +186,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     for (const provider of state.cloudOrgProviders) {
       const id = provider.providerId.trim();
       if (!id || merged.has(id)) continue;
+      if (isDesktopProviderBlocked({ providerId: id, checkRestriction: options.checkDesktopAppRestriction })) continue;
       merged.set(id, {
         id,
         name: provider.name.trim() || id,
@@ -496,6 +503,99 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     const next = fallbackUpdate(config);
     await c.config.update({ config: next });
     return true;
+  };
+
+  const normalizeDisabledProviders = (value: unknown) =>
+    Array.isArray(value)
+      ? [
+          ...new Set(
+            value
+              .filter((entry): entry is string => typeof entry === "string")
+              .map((entry) => entry.trim())
+              .filter(Boolean),
+          ),
+        ]
+      : [];
+
+  const formatConfigWithProviderDisabledState = (
+    raw: string,
+    providerId: string,
+    disabled: boolean,
+  ) => {
+    const resolvedProviderId = providerId.trim();
+    let updated = raw.trim()
+      ? raw
+      : '{\n  "$schema": "https://opencode.ai/config.json"\n}\n';
+    const parsed = parse(updated) as Record<string, unknown> | undefined;
+    const currentDisabled = normalizeDisabledProviders(parsed?.disabled_providers);
+    const nextDisabled = disabled
+      ? [...currentDisabled.filter((entry) => entry !== resolvedProviderId), resolvedProviderId]
+      : currentDisabled.filter((entry) => entry !== resolvedProviderId);
+
+    const disabledEdits = modify(
+      updated,
+      ["disabled_providers"],
+      nextDisabled.length ? nextDisabled : undefined,
+      { formattingOptions: { insertSpaces: true, tabSize: 2 } },
+    );
+    updated = applyEdits(updated, disabledEdits);
+    return updated.endsWith("\n") ? updated : `${updated}\n`;
+  };
+
+  const ensureProjectProviderDisabledState = async (
+    providerId: string,
+    disabled: boolean,
+  ) => {
+    const resolvedProviderId = providerId.trim();
+    if (!resolvedProviderId) {
+      throw new Error(t("providers.provider_id_required"));
+    }
+
+    const currentDisabled = normalizeDisabledProviders(options.disabledProviders());
+    const nextDisabled = disabled
+      ? [...currentDisabled.filter((entry) => entry !== resolvedProviderId), resolvedProviderId]
+      : currentDisabled.filter((entry) => entry !== resolvedProviderId);
+
+    if (
+      nextDisabled.length === currentDisabled.length &&
+      nextDisabled.every((entry, index) => entry === currentDisabled[index])
+    ) {
+      return false;
+    }
+
+    const updatedConfig = await updateProjectConfigFile(
+      (raw) => formatConfigWithProviderDisabledState(raw, resolvedProviderId, disabled),
+      (config) => {
+        const nextConfig = { ...config };
+        if (nextDisabled.length) {
+          nextConfig.disabled_providers = nextDisabled;
+        } else {
+          delete nextConfig.disabled_providers;
+        }
+        return nextConfig;
+      },
+    );
+
+    if (!updatedConfig) {
+      throw new Error("Could not update opencode.jsonc for this workspace.");
+    }
+
+    options.setDisabledProviders(nextDisabled);
+    options.markOpencodeConfigReloadRequired();
+    refreshSnapshot();
+    emitChange();
+    return true;
+  };
+
+  const assertProviderAllowedByDesktopPolicy = (providerId: string) => {
+    if (
+      isDesktopProviderBlocked({
+        providerId,
+        checkRestriction: options.checkDesktopAppRestriction,
+      })
+    ) {
+      throw new Error(`${providerId} is blocked by your organization desktop policy.`);
+    }
   };
 
   const escapeRegExp = (value: string) =>
@@ -928,6 +1028,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     for (const provider of availableProviders ?? []) {
       const id = provider.id?.trim();
       if (!id) continue;
+      if (isDesktopProviderBlocked({ providerId: id, checkRestriction: options.checkDesktopAppRestriction })) continue;
       if (!Array.isArray(provider.env) || provider.env.length === 0) continue;
       const existing = merged[id] ?? [];
       if (existing.some((method) => method.type === "api")) continue;
@@ -936,6 +1037,10 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
     const availableProvidersById = new Map((availableProviders ?? []).map((provider) => [provider.id, provider]));
     for (const [id, providerMethods] of Object.entries(merged)) {
+      if (isDesktopProviderBlocked({ providerId: id, checkRestriction: options.checkDesktopAppRestriction })) {
+        delete merged[id];
+        continue;
+      }
       const provider = availableProvidersById.get(id);
       const normalizedId = id.trim().toLowerCase();
       const normalizedName = provider?.name?.trim().toLowerCase() ?? "";
@@ -952,6 +1057,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     for (const provider of cloudProviders) {
       const id = provider.providerId.trim();
       if (!id) continue;
+      if (isDesktopProviderBlocked({ providerId: id, checkRestriction: options.checkDesktopAppRestriction })) continue;
       const existing = merged[id] ?? [];
       if (
         existing.some(
@@ -1007,6 +1113,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       if (!resolved) {
         throw new Error(t("providers.provider_id_required"));
       }
+      assertProviderAllowedByDesktopPolicy(resolved);
 
       const methods = authMethods[resolved];
       if (!methods || !methods.length) {
@@ -1102,6 +1209,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     if (!resolved) {
       throw new Error(t("providers.provider_id_required"));
     }
+    assertProviderAllowedByDesktopPolicy(resolved);
 
     if (!Number.isInteger(methodIndex) || methodIndex < 0) {
       throw new Error(t("providers.oauth_method_required"));
@@ -1176,6 +1284,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     if (!trimmed) {
       throw new Error(t("providers.api_key_required"));
     }
+    assertProviderAllowedByDesktopPolicy(providerId);
 
     try {
       await c.auth.set({ providerID: providerId, auth: { type: "api", key: trimmed } });
@@ -1214,6 +1323,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         token,
       });
       const provider = await den.getOrgLlmProviderConnection(orgId, cloudProviderId);
+      assertProviderAllowedByDesktopPolicy(provider.providerId);
       const existingImported = state.importedCloudProviders[cloudProviderId] ?? null;
       const localProviderId = getCloudManagedProviderId(provider);
       const apiKey = provider.apiKey?.trim() ?? "";
@@ -1510,38 +1620,13 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       return await removeCloudProvider(trackedImport.cloudProviderId);
     }
 
-    const provider = options.providers().find((entry) => entry.id === resolved) as
-      | (ProviderListItem & { source?: string })
-      | undefined;
     // Allow disabling any provider — including built-in/env providers
     // like "opencode" (Zen). The user should be able to hide any provider
     // from the model list by adding it to disabled_providers in opencode.json.
     const canDisableProvider = true;
 
     const disableProvider = async () => {
-      const config = unwrap(await c.config.get());
-      const disabledProviders = Array.isArray(config.disabled_providers)
-        ? config.disabled_providers
-        : [];
-      if (disabledProviders.includes(resolved)) {
-        return false;
-      }
-
-      const next = [...disabledProviders, resolved];
-      options.setDisabledProviders(next);
-      try {
-        const result = await c.config.update({
-          config: { ...config, disabled_providers: next },
-        });
-        assertNoClientError(result);
-        options.markOpencodeConfigReloadRequired();
-      } catch (error) {
-        options.setDisabledProviders(disabledProviders);
-        throw error;
-      }
-      refreshSnapshot();
-      emitChange();
-      return true;
+      return await ensureProjectProviderDisabledState(resolved, true);
     };
 
     try {
@@ -1795,6 +1880,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     connectCloudProvider,
     removeCloudProvider,
     disconnectProvider,
+    ensureProjectProviderDisabledState,
     openProviderAuthModal,
     closeProviderAuthModal,
   };

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1384,8 +1384,22 @@ export function SessionRoute() {
   });
   const selectedModelUnavailable = Boolean(
     local.prefs.defaultModel &&
-      providerListQuery.data &&
-      !isModelAvailableInConnectedProviders(providerListQuery.data, local.prefs.defaultModel),
+      (
+        isDesktopProviderBlocked({
+          providerId: local.prefs.defaultModel.providerID,
+          checkRestriction: checkDesktopRestriction,
+        }) ||
+        (
+          checkDesktopRestriction({ restriction: "disallowNonCloudModels" }) &&
+          !providerConnectedIds.some(
+            (providerId) => providerId.trim() === local.prefs.defaultModel?.providerID.trim(),
+          )
+        ) ||
+        (
+          providerListQuery.data &&
+          !isModelAvailableInConnectedProviders(providerListQuery.data, local.prefs.defaultModel)
+        )
+      ),
   );
   const canCreateTask = Boolean(
     opencodeClient && selectedWorkspaceId && !loading && !selectedWorkspaceError && !selectedModelUnavailable,
@@ -1420,6 +1434,7 @@ export function SessionRoute() {
         providerDefaults: () => sessionProviderAuthStateRef.current.providerDefaults,
         providerConnectedIds: () => sessionProviderAuthStateRef.current.providerConnectedIds,
         disabledProviders: () => sessionProviderAuthStateRef.current.disabledProviderIds,
+        checkDesktopAppRestriction: checkDesktopRestriction,
         selectedWorkspaceDisplay: () =>
           sessionProviderAuthStateRef.current.selectedWorkspace
             ? ({
@@ -1452,7 +1467,7 @@ export function SessionRoute() {
           });
         },
       }),
-    [reloadCoordinator],
+    [checkDesktopRestriction, reloadCoordinator],
   );
 
   useEffect(() => {
@@ -1461,6 +1476,19 @@ export function SessionRoute() {
       sessionProviderAuthStore.dispose();
     };
   }, [sessionProviderAuthStore]);
+
+  useEffect(() => {
+    if (!opencodeClient || !selectedWorkspaceId) return;
+
+    void sessionProviderAuthStore
+      .ensureProjectProviderDisabledState(
+        "opencode",
+        checkDesktopRestriction({ restriction: "blockZenModel" }),
+      )
+      .catch((error) => {
+        console.warn("[desktop-app-restrictions] failed to sync Zen restriction", error);
+      });
+  }, [checkDesktopRestriction, disabledProviderIds, opencodeClient, selectedWorkspaceId, selectedWorkspaceRoot, sessionProviderAuthStore]);
 
   useEffect(() => {
     sessionProviderAuthStore.syncFromOptions();

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1390,7 +1390,7 @@ export function SessionRoute() {
           checkRestriction: checkDesktopRestriction,
         }) ||
         (
-          checkDesktopRestriction({ restriction: "allowNonCloudModels" }) &&
+          checkDesktopRestriction({ restriction: "allowCustomProviders" }) &&
           !providerConnectedIds.some(
             (providerId) => providerId.trim() === local.prefs.defaultModel?.providerID.trim(),
           )
@@ -1747,11 +1747,11 @@ export function SessionRoute() {
   // Apply org-level restrictions (dev #1505) on top of the raw model list
   // so the picker never surfaces blocked options:
   //   - `allowZenModel` hides the built-in OpenCode provider entries when false
-  //   - `allowNonCloudModels` hides providers that OpenCode does not report
+  //   - `allowCustomProviders` hides providers that OpenCode does not report
   //     as connected through the provider list endpoint.
   const allowedModelOptions = useMemo(() => {
     const restrictToCloud = checkDesktopRestriction({
-      restriction: "allowNonCloudModels",
+      restriction: "allowCustomProviders",
     });
     return modelOptions.filter((option) => {
       if (

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1390,7 +1390,7 @@ export function SessionRoute() {
           checkRestriction: checkDesktopRestriction,
         }) ||
         (
-          checkDesktopRestriction({ restriction: "disallowNonCloudModels" }) &&
+          checkDesktopRestriction({ restriction: "allowNonCloudModels" }) &&
           !providerConnectedIds.some(
             (providerId) => providerId.trim() === local.prefs.defaultModel?.providerID.trim(),
           )
@@ -1483,7 +1483,7 @@ export function SessionRoute() {
     void sessionProviderAuthStore
       .ensureProjectProviderDisabledState(
         "opencode",
-        checkDesktopRestriction({ restriction: "blockZenModel" }),
+        checkDesktopRestriction({ restriction: "allowZenModel" }),
       )
       .catch((error) => {
         console.warn("[desktop-app-restrictions] failed to sync Zen restriction", error);
@@ -1746,12 +1746,12 @@ export function SessionRoute() {
 
   // Apply org-level restrictions (dev #1505) on top of the raw model list
   // so the picker never surfaces blocked options:
-  //   - `blockZenModel` hides the built-in OpenCode provider entries
-  //   - `disallowNonCloudModels` hides providers that OpenCode does not report
+  //   - `allowZenModel` hides the built-in OpenCode provider entries when false
+  //   - `allowNonCloudModels` hides providers that OpenCode does not report
   //     as connected through the provider list endpoint.
   const allowedModelOptions = useMemo(() => {
     const restrictToCloud = checkDesktopRestriction({
-      restriction: "disallowNonCloudModels",
+      restriction: "allowNonCloudModels",
     });
     return modelOptions.filter((option) => {
       if (
@@ -1985,13 +1985,13 @@ export function SessionRoute() {
   ]);
 
   const handleOpenCreateWorkspace = useCallback(() => {
-    // Respect the org-level `blockMultipleWorkspaces` restriction (dev
+    // Respect the org-level `allowMultipleWorkspaces` restriction (dev
     // #1505). If the checker returns true, the admin has disabled
     // adding further workspaces; surface a friendly notice instead of
     // opening the modal.
     if (
       workspaces.length > 0 &&
-      checkDesktopRestriction({ restriction: "blockMultipleWorkspaces" })
+      checkDesktopRestriction({ restriction: "allowMultipleWorkspaces" })
     ) {
       restrictionNotice.show({
         title: "Additional workspaces are restricted",

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -750,7 +750,7 @@ function SettingsRouteContent() {
   }, [cloudSession.baseUrl, navigate, platform, providerAuthStore, selectedWorkspaceId]);
 
   const handleOpenProviderAuth = useCallback(() => {
-    if (checkDesktopRestriction({ restriction: "allowNonCloudModels" })) {
+    if (checkDesktopRestriction({ restriction: "allowCustomProviders" })) {
       restrictionNotice.show({
         title: "Adding custom providers is disabled",
         message: "Your organization administrator has disabled adding custom providers.",

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -80,6 +80,7 @@ import {
 } from "../../app/lib/desktop";
 import { isDesktopProviderBlocked } from "../../app/cloud/desktop-app-restrictions";
 import { useCheckDesktopRestriction, useDesktopConfig } from "../domains/cloud/desktop-config-provider";
+import { useRestrictionNotice } from "../domains/cloud/restriction-notice-provider";
 import { useCloudProviderAutoSync } from "../domains/cloud/use-cloud-provider-auto-sync";
 import {
   isDesktopRuntime,
@@ -410,6 +411,7 @@ function SettingsRouteContent() {
   const local = useLocal();
   const platform = usePlatform();
   const checkDesktopRestriction = useCheckDesktopRestriction();
+  const restrictionNotice = useRestrictionNotice();
   const desktopConfig = useDesktopConfig();
   const reloadCoordinator = useReloadCoordinator();
   const route = parseSettingsPath(location.pathname);
@@ -674,6 +676,7 @@ function SettingsRouteContent() {
         providerDefaults: () => routeStateRef.current.providerDefaults,
         providerConnectedIds: () => routeStateRef.current.providerConnectedIds,
         disabledProviders: () => routeStateRef.current.disabledProviders,
+        checkDesktopAppRestriction: checkDesktopRestriction,
         selectedWorkspaceDisplay: () => routeStateRef.current.selectedWorkspaceDisplay,
         selectedWorkspaceRoot: () => routeStateRef.current.selectedWorkspaceRoot,
         runtimeWorkspaceId: () => routeStateRef.current.runtimeWorkspaceId,
@@ -691,7 +694,7 @@ function SettingsRouteContent() {
           });
         },
       }),
-    [openworkServerStore, reloadCoordinator.markReloadRequired],
+    [checkDesktopRestriction, openworkServerStore, reloadCoordinator.markReloadRequired],
   );
   const extensionsStore = useMemo(
     () =>
@@ -745,6 +748,31 @@ function SettingsRouteContent() {
       platform.openLink(getDenInferenceUrl(cloudSession.baseUrl));
     }, 0);
   }, [cloudSession.baseUrl, navigate, platform, providerAuthStore, selectedWorkspaceId]);
+
+  const handleOpenProviderAuth = useCallback(() => {
+    if (checkDesktopRestriction({ restriction: "disallowNonCloudModels" })) {
+      restrictionNotice.show({
+        title: "Adding custom providers is disabled",
+        message: "Your organization administrator has disabled adding custom providers.",
+      });
+      return;
+    }
+
+    void providerAuthStore.openProviderAuthModal();
+  }, [checkDesktopRestriction, providerAuthStore, restrictionNotice]);
+
+  useEffect(() => {
+    if (!activeClient || !selectedWorkspaceId) return;
+
+    void providerAuthStore
+      .ensureProjectProviderDisabledState(
+        "opencode",
+        checkDesktopRestriction({ restriction: "blockZenModel" }),
+      )
+      .catch((error) => {
+        console.warn("[desktop-app-restrictions] failed to sync Zen restriction", error);
+      });
+  }, [activeClient, checkDesktopRestriction, disabledProviders, providerAuthStore, selectedWorkspaceId, selectedWorkspaceRoot]);
 
   const shareWorkspaceState = useShareWorkspaceState({
     workspaces,
@@ -1382,6 +1410,18 @@ function SettingsRouteContent() {
   };
 
   const handleOpenCreateWorkspace = () => {
+    if (
+      workspaces.length > 0 &&
+      checkDesktopRestriction({ restriction: "blockMultipleWorkspaces" })
+    ) {
+      restrictionNotice.show({
+        title: "Additional workspaces are restricted",
+        message:
+          "Your organization administrator has restricted access to adding additional workspaces.",
+      });
+      return;
+    }
+
     setCreateWorkspaceError(null);
     setCreateWorkspaceRemoteError(null);
     setCreateWorkspaceOpen(true);
@@ -1643,7 +1683,7 @@ function SettingsRouteContent() {
             providerConnectError={providerAuthSnapshot.providerAuthError}
             providerDisconnectStatus={configActionStatus}
             providerDisconnectError={null}
-            onOpenProviderAuth={() => providerAuthStore.openProviderAuthModal()}
+            onOpenProviderAuth={handleOpenProviderAuth}
             onDisconnectProvider={async (providerId) => {
               await providerAuthStore.disconnectProvider(providerId);
             }}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -750,7 +750,7 @@ function SettingsRouteContent() {
   }, [cloudSession.baseUrl, navigate, platform, providerAuthStore, selectedWorkspaceId]);
 
   const handleOpenProviderAuth = useCallback(() => {
-    if (checkDesktopRestriction({ restriction: "disallowNonCloudModels" })) {
+    if (checkDesktopRestriction({ restriction: "allowNonCloudModels" })) {
       restrictionNotice.show({
         title: "Adding custom providers is disabled",
         message: "Your organization administrator has disabled adding custom providers.",
@@ -767,7 +767,7 @@ function SettingsRouteContent() {
     void providerAuthStore
       .ensureProjectProviderDisabledState(
         "opencode",
-        checkDesktopRestriction({ restriction: "blockZenModel" }),
+        checkDesktopRestriction({ restriction: "allowZenModel" }),
       )
       .catch((error) => {
         console.warn("[desktop-app-restrictions] failed to sync Zen restriction", error);
@@ -1412,7 +1412,7 @@ function SettingsRouteContent() {
   const handleOpenCreateWorkspace = () => {
     if (
       workspaces.length > 0 &&
-      checkDesktopRestriction({ restriction: "blockMultipleWorkspaces" })
+      checkDesktopRestriction({ restriction: "allowMultipleWorkspaces" })
     ) {
       restrictionNotice.show({
         title: "Additional workspaces are restricted",
@@ -1981,7 +1981,7 @@ function SettingsRouteContent() {
         workerType={providerAuthSnapshot.providerAuthWorkerType}
         // Hide any provider the org blocks at the desktop layer so users
         // can't connect a forbidden one (dev #1505). Same helper covers
-        // opencode-provider gating via the `blockZenModel` restriction.
+        // opencode-provider gating via the `allowZenModel` restriction.
         // We also strip the matching key from `authMethods` because the
         // modal builds its entry list from `Object.keys(authMethods)`,
         // not from `providers`.

--- a/docs/desktop-app-policies.md
+++ b/docs/desktop-app-policies.md
@@ -1,0 +1,128 @@
+# Desktop App Policies
+
+Desktop app policy config is loaded from OpenWork Cloud through `GET /v1/me/desktop-config` and exposed inside the desktop app through `DesktopConfigProvider`.
+
+App code should read policy state through the hooks in `apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx`. Do not read the provider's internal refs directly; those are only used to compare and apply newly loaded config safely.
+
+## Policy Keys
+
+The canonical policy catalog lives in `packages/types/src/den/desktop-policies.ts` as `desktopPolicyDefinitions`. Add or change policy items there first so the API, Den web, and desktop app share the same IDs and copy.
+
+Do not duplicate the list of policy IDs in app docs or feature code unless a feature is intentionally checking a specific policy. Import from the shared package when you need the full catalog.
+
+`allowedDesktopVersions` is part of the desktop config response but is not a boolean policy item in `desktopPolicyDefinitions`.
+
+For boolean policy keys, `false` means the feature is restricted or disabled. `true` or `undefined` means the app should not block the feature locally.
+
+## Preferred Check
+
+Use `useCheckDesktopRestriction()` when gating app behavior.
+
+```tsx
+import { useCheckDesktopRestriction } from "../domains/cloud/desktop-config-provider";
+
+function Example() {
+  const checkDesktopRestriction = useCheckDesktopRestriction();
+  const zenModelsRestricted = checkDesktopRestriction({
+    restriction: "allowZenModel",
+  });
+
+  return zenModelsRestricted ? null : <ZenModelPicker />;
+}
+```
+
+`checkDesktopRestriction()` returns `true` when the feature is restricted.
+
+## Single Policy Hook
+
+Use `useDesktopRestriction()` when a component only needs one policy value.
+
+```tsx
+import { useDesktopRestriction } from "../domains/cloud/desktop-config-provider";
+
+function AddWorkspaceButton() {
+  const multipleWorkspacesRestricted = useDesktopRestriction(
+    "allowMultipleWorkspaces",
+  );
+
+  return (
+    <button disabled={multipleWorkspacesRestricted}>
+      Add workspace
+    </button>
+  );
+}
+```
+
+## Raw Config
+
+Use `useDesktopConfig()` when you need the raw config, loading state, or manual refresh function.
+
+```tsx
+import { useDesktopConfig } from "../domains/cloud/desktop-config-provider";
+
+function DesktopPolicyDebug() {
+  const desktopConfig = useDesktopConfig();
+
+  return (
+    <pre>
+      {JSON.stringify({
+        loading: desktopConfig.loading,
+        config: desktopConfig.config,
+      }, null, 2)}
+    </pre>
+  );
+}
+```
+
+Use `useOrgRestrictions()` only when you need the raw config object without `loading`, `refresh`, or `checkRestriction`.
+
+```tsx
+import { useOrgRestrictions } from "../domains/cloud/desktop-config-provider";
+
+function Example() {
+  const config = useOrgRestrictions();
+  const customProvidersRestricted = config.allowCustomProviders === false;
+
+  return customProvidersRestricted ? <RestrictedNotice /> : <ProviderForm />;
+}
+```
+
+## Helper Functions
+
+For model/provider-specific gates, use the helpers in `apps/app/src/app/cloud/desktop-app-restrictions.ts`.
+
+```tsx
+import { isDesktopModelBlocked } from "../../app/cloud/desktop-app-restrictions";
+import { useCheckDesktopRestriction } from "../domains/cloud/desktop-config-provider";
+
+function ModelOption({ model }: { model: ModelRef }) {
+  const checkDesktopRestriction = useCheckDesktopRestriction();
+  const blocked = isDesktopModelBlocked({
+    model,
+    checkRestriction: checkDesktopRestriction,
+  });
+
+  return <ModelRow model={model} disabled={blocked} />;
+}
+```
+
+## Loading And Refresh
+
+The provider loads cached config first, then fetches the latest config from Cloud. It refreshes on sign-in/session changes, Den settings changes, and a one-hour interval.
+
+Manual refresh is available through `useDesktopConfig().refresh()`:
+
+```tsx
+const desktopConfig = useDesktopConfig();
+
+await desktopConfig.refresh();
+```
+
+## Rule Of Thumb
+
+Use these APIs in this order:
+
+1. `useCheckDesktopRestriction()` for most feature gates.
+2. `useDesktopRestriction(key)` for one-off component checks.
+3. `useDesktopConfig()` when you need loading/refresh/raw config.
+4. `useOrgRestrictions()` only for raw config reads.

--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -8,6 +8,7 @@
     "build": "node ./scripts/build.mjs",
     "build:email": "pnpm --filter @openwork/email build",
     "build:den-db": "pnpm --filter @openwork-ee/den-db build",
+    "backfill:desktop-policies": "pnpm run build:den-db && tsx scripts/backfill-desktop-policies.ts",
     "seed:demo-org": "pnpm run build:den-db && sh -lc 'DEN_WEB_PORT=${DEN_WEB_PORT:-3005}; OPENWORK_DEV_MODE=${OPENWORK_DEV_MODE:-1} DATABASE_URL=${DATABASE_URL:-mysql://root:password@127.0.0.1:3306/openwork_den} DEN_DB_ENCRYPTION_KEY=${DEN_DB_ENCRYPTION_KEY:-local-dev-db-encryption-key-please-change-1234567890} BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-local-dev-secret-not-for-production-use!!} BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:$DEN_WEB_PORT} tsx scripts/seed-demo-org.ts'",
     "start": "node dist/server.js"
   },

--- a/ee/apps/den-api/scripts/backfill-desktop-policies.ts
+++ b/ee/apps/den-api/scripts/backfill-desktop-policies.ts
@@ -1,0 +1,96 @@
+import { and, asc, eq, isNull } from "@openwork-ee/den-db/drizzle"
+import { DesktopPolicyTable, MemberTable, OrganizationTable } from "@openwork-ee/den-db/schema"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { normalizeDesktopAppRestrictions } from "@openwork/types/den/desktop-app-restrictions"
+import type { DesktopPolicyValue } from "@openwork/types/den/desktop-policies"
+import { db } from "../src/db.js"
+
+const DEFAULT_DESKTOP_POLICY_NAME = "Default desktop policy"
+const dryRun = process.argv.includes("--dry-run")
+
+function roleIncludesOwner(roleValue: string) {
+  return roleValue.split(",").map((entry) => entry.trim()).includes("owner")
+}
+
+function legacyRestrictionsToPolicy(value: unknown): Required<DesktopPolicyValue> {
+  const restrictions = normalizeDesktopAppRestrictions(value)
+  return {
+    allowNonCloudModels: restrictions.disallowNonCloudModels !== true,
+    allowZenModel: restrictions.blockZenModel !== true,
+    allowMultipleWorkspaces: restrictions.blockMultipleWorkspaces !== true,
+  }
+}
+
+const organizations = await db
+  .select({
+    id: OrganizationTable.id,
+    desktopAppRestrictions: OrganizationTable.desktopAppRestrictions,
+  })
+  .from(OrganizationTable)
+  .orderBy(asc(OrganizationTable.createdAt))
+
+const existingDefaultPolicies = await db
+  .select({ organizationId: DesktopPolicyTable.organizationId })
+  .from(DesktopPolicyTable)
+  .where(and(eq(DesktopPolicyTable.isDefault, true), isNull(DesktopPolicyTable.deletedAt)))
+
+const organizationsWithDefaultPolicy = new Set(existingDefaultPolicies.map((policy) => policy.organizationId))
+const organizationsToBackfill = organizations.filter((organization) => !organizationsWithDefaultPolicy.has(organization.id))
+
+if (organizationsToBackfill.length === 0) {
+  console.log("No organizations need desktop policy backfill.")
+  process.exit(0)
+}
+
+const members = await db
+  .select({
+    id: MemberTable.id,
+    organizationId: MemberTable.organizationId,
+    role: MemberTable.role,
+    createdAt: MemberTable.createdAt,
+  })
+  .from(MemberTable)
+  .orderBy(asc(MemberTable.createdAt))
+
+const memberByOrganization = new Map<string, typeof members[number]>()
+for (const member of members) {
+  const current = memberByOrganization.get(member.organizationId)
+  if (!current || roleIncludesOwner(member.role)) {
+    memberByOrganization.set(member.organizationId, member)
+  }
+}
+
+const now = new Date()
+const rows = organizationsToBackfill.flatMap((organization) => {
+  const owner = memberByOrganization.get(organization.id)
+  if (!owner || !roleIncludesOwner(owner.role)) {
+    console.warn(`Skipping organization ${organization.id}: owner member not found.`)
+    return []
+  }
+
+  return [{
+    id: createDenTypeId("desktopPolicy"),
+    organizationId: organization.id,
+    policyName: DEFAULT_DESKTOP_POLICY_NAME,
+    isDefault: true,
+    isEnabled: true,
+    policy: legacyRestrictionsToPolicy(organization.desktopAppRestrictions),
+    createdByOrgMemberId: owner.id,
+    createdAt: now,
+    updatedAt: now,
+  }]
+})
+
+if (rows.length === 0) {
+  console.log("No desktop policies were created.")
+  process.exit(0)
+}
+
+if (dryRun) {
+  console.log(`Dry run: would create ${rows.length} default desktop policies.`)
+  process.exit(0)
+}
+
+await db.insert(DesktopPolicyTable).values(rows)
+console.log(`Created ${rows.length} default desktop policies.`)
+process.exit(0)

--- a/ee/apps/den-api/scripts/backfill-desktop-policies.ts
+++ b/ee/apps/den-api/scripts/backfill-desktop-policies.ts
@@ -15,7 +15,7 @@ function roleIncludesOwner(roleValue: string) {
 function legacyRestrictionsToPolicy(value: unknown): Required<DesktopPolicyValue> {
   const restrictions = normalizeDesktopAppRestrictions(value)
   return {
-    allowNonCloudModels: restrictions.disallowNonCloudModels !== true,
+    allowCustomProviders: restrictions.disallowNonCloudModels !== true,
     allowZenModel: restrictions.blockZenModel !== true,
     allowMultipleWorkspaces: restrictions.blockMultipleWorkspaces !== true,
   }

--- a/ee/apps/den-api/scripts/seed-demo-org.ts
+++ b/ee/apps/den-api/scripts/seed-demo-org.ts
@@ -19,6 +19,7 @@ import {
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { auth } from "../src/auth.js"
 import { db } from "../src/db.js"
+import { ensureDefaultDesktopPolicyForOrganization } from "../src/desktop-policies.js"
 import { env } from "../src/env.js"
 import { seedDefaultOrganizationRoles } from "../src/orgs.js"
 
@@ -341,7 +342,11 @@ async function ensureOrganization(ownerUserId: UserId): Promise<OrganizationId> 
       })
       .where(eq(OrganizationTable.id, existing[0].id))
     await seedDefaultOrganizationRoles(existing[0].id)
-    await ensureMember(existing[0].id, ownerUserId, "owner")
+    const ownerMemberId = await ensureMember(existing[0].id, ownerUserId, "owner")
+    await ensureDefaultDesktopPolicyForOrganization({
+      organizationId: existing[0].id,
+      createdByOrgMemberId: ownerMemberId,
+    })
     return existing[0].id
   }
 
@@ -355,7 +360,11 @@ async function ensureOrganization(ownerUserId: UserId): Promise<OrganizationId> 
     slug: DEMO_ORG_SLUG,
   })
   await seedDefaultOrganizationRoles(id)
-  await ensureMember(id, ownerUserId, "owner")
+  const ownerMemberId = await ensureMember(id, ownerUserId, "owner")
+  await ensureDefaultDesktopPolicyForOrganization({
+    organizationId: id,
+    createdByOrgMemberId: ownerMemberId,
+  })
   return id
 }
 

--- a/ee/apps/den-api/src/desktop-policies.ts
+++ b/ee/apps/den-api/src/desktop-policies.ts
@@ -1,0 +1,124 @@
+import { and, asc, eq, inArray, isNull, or } from "@openwork-ee/den-db/drizzle"
+import {
+  DesktopPolicyMemberTable,
+  DesktopPolicyTable,
+  TeamMemberTable,
+  TeamTable,
+} from "@openwork-ee/den-db/schema"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import {
+  allDesktopPolicies,
+  calculateEffectiveDesktopPolicy,
+  desktopPolicyDefaults,
+  normalizeDesktopPolicyValue,
+  type DesktopPolicyValue,
+} from "@openwork/types/den/desktop-policies"
+import { db } from "./db.js"
+
+export type DesktopPolicyId = typeof DesktopPolicyTable.$inferSelect.id
+export type DesktopPolicyRow = typeof DesktopPolicyTable.$inferSelect
+export type DesktopPolicyMemberRow = typeof DesktopPolicyMemberTable.$inferSelect
+export type OrgId = typeof DesktopPolicyTable.$inferSelect.organizationId
+export type OrgMemberId = typeof DesktopPolicyTable.$inferSelect.createdByOrgMemberId
+export type TeamId = typeof TeamTable.$inferSelect.id
+
+export const DEFAULT_DESKTOP_POLICY_NAME = "Default desktop policy"
+
+export async function ensureDefaultDesktopPolicyForOrganization(input: {
+  organizationId: OrgId
+  createdByOrgMemberId: OrgMemberId
+}) {
+  const existing = await db
+    .select({ id: DesktopPolicyTable.id })
+    .from(DesktopPolicyTable)
+    .where(and(
+      eq(DesktopPolicyTable.organizationId, input.organizationId),
+      eq(DesktopPolicyTable.isDefault, true),
+      isNull(DesktopPolicyTable.deletedAt),
+    ))
+    .limit(1)
+
+  if (existing[0]) {
+    return existing[0].id
+  }
+
+  const id = createDenTypeId("desktopPolicy")
+  await db.insert(DesktopPolicyTable).values({
+    id,
+    organizationId: input.organizationId,
+    policyName: DEFAULT_DESKTOP_POLICY_NAME,
+    isDefault: true,
+    isEnabled: true,
+    policy: desktopPolicyDefaults,
+    createdByOrgMemberId: input.createdByOrgMemberId,
+  })
+
+  return id
+}
+
+export async function listTeamIdsForOrgMember(input: {
+  organizationId: OrgId
+  orgMemberId: OrgMemberId
+}) {
+  const rows = await db
+    .select({ id: TeamTable.id })
+    .from(TeamMemberTable)
+    .innerJoin(TeamTable, eq(TeamMemberTable.teamId, TeamTable.id))
+    .where(and(
+      eq(TeamTable.organizationId, input.organizationId),
+      eq(TeamMemberTable.orgMembershipId, input.orgMemberId),
+    ))
+
+  return rows.map((row) => row.id)
+}
+
+export async function calculateDesktopPolicyForOrgMember(input: {
+  organizationId: OrgId
+  orgMemberId: OrgMemberId
+}): Promise<Required<DesktopPolicyValue>> {
+  const orgPolicies = await db
+    .select({
+      id: DesktopPolicyTable.id,
+      isDefault: DesktopPolicyTable.isDefault,
+      isEnabled: DesktopPolicyTable.isEnabled,
+      policy: DesktopPolicyTable.policy,
+    })
+    .from(DesktopPolicyTable)
+    .where(and(
+      eq(DesktopPolicyTable.organizationId, input.organizationId),
+      isNull(DesktopPolicyTable.deletedAt),
+    ))
+    .orderBy(asc(DesktopPolicyTable.createdAt))
+
+  if (orgPolicies.length === 0) {
+    return allDesktopPolicies(true)
+  }
+
+  const defaultPolicy = orgPolicies.find((policy) => policy.isDefault === true && policy.isEnabled === true) ?? null
+  const teamIds = await listTeamIdsForOrgMember(input)
+  const assignedWhere = teamIds.length > 0
+    ? or(
+        eq(DesktopPolicyMemberTable.orgMemberId, input.orgMemberId),
+        inArray(DesktopPolicyMemberTable.teamId, teamIds),
+      )
+    : eq(DesktopPolicyMemberTable.orgMemberId, input.orgMemberId)
+
+  const assignedPolicies = assignedWhere
+    ? await db
+        .select({ policy: DesktopPolicyTable.policy })
+        .from(DesktopPolicyMemberTable)
+        .innerJoin(DesktopPolicyTable, eq(DesktopPolicyMemberTable.desktopPolicyId, DesktopPolicyTable.id))
+        .where(and(
+          eq(DesktopPolicyTable.organizationId, input.organizationId),
+          eq(DesktopPolicyTable.isEnabled, true),
+          isNull(DesktopPolicyTable.deletedAt),
+          assignedWhere,
+        ))
+    : []
+
+  return calculateEffectiveDesktopPolicy({
+    orgPolicyCount: orgPolicies.length,
+    defaultPolicy: defaultPolicy?.policy ?? {},
+    assignedPolicies: assignedPolicies.map((row) => normalizeDesktopPolicyValue(row.policy)),
+  })
+}

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -9,12 +9,12 @@ import {
   TeamMemberTable,
   TeamTable,
 } from "@openwork-ee/den-db/schema"
-import { normalizeDesktopAppRestrictions, type DesktopAppRestrictions } from "@openwork/types/den/desktop-app-restrictions"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "./db.js"
 import { runPostOrganizationMemberChangeHooks } from "./organization-member-hooks.js"
 import { DEFAULT_ORGANIZATION_LIMITS, normalizeOrganizationMetadata, serializeOrganizationMetadata } from "./organization-limits.js"
 import { denDefaultDynamicOrganizationRoles, denOrganizationStaticRoles } from "./organization-access.js"
+import { ensureDefaultDesktopPolicyForOrganization } from "./desktop-policies.js"
 
 type UserId = typeof AuthUserTable.$inferSelect.id
 type SessionId = typeof AuthSessionTable.$inferSelect.id
@@ -63,7 +63,6 @@ export type OrganizationContext = {
     slug: string
     logo: string | null
     allowedEmailDomains: AllowedEmailDomains
-    desktopAppRestrictions: DesktopAppRestrictions
     metadata: string | null
     createdAt: Date
     updatedAt: Date
@@ -536,11 +535,17 @@ async function createOrganizationRecord(input: {
     metadata,
   })
 
+  const ownerMemberId = createDenTypeId("member")
   await db.insert(MemberTable).values({
-    id: createDenTypeId("member"),
+    id: ownerMemberId,
     organizationId,
     userId: input.userId,
     role: "owner",
+  })
+
+  await ensureDefaultDesktopPolicyForOrganization({
+    organizationId,
+    createdByOrgMemberId: ownerMemberId,
   })
 
   await ensureDefaultDynamicRoles(organizationId)
@@ -612,7 +617,6 @@ export async function updateOrganizationSettings(input: {
   organizationId: OrgId
   name?: string
   allowedEmailDomains?: readonly string[] | null
-  desktopAppRestrictions?: DesktopAppRestrictions
   allowedDesktopVersions?: readonly string[] | null
 }) {
   const nextName = typeof input.name === "string" ? input.name.trim() : null
@@ -626,9 +630,6 @@ export async function updateOrganizationSettings(input: {
   }
   if (input.allowedEmailDomains !== undefined) {
     updates.allowedEmailDomains = normalizeAllowedEmailDomains(input.allowedEmailDomains).domains
-  }
-  if (input.desktopAppRestrictions !== undefined) {
-    updates.desktopAppRestrictions = normalizeDesktopAppRestrictions(input.desktopAppRestrictions)
   }
   if (input.allowedDesktopVersions !== undefined) {
     const rows = await db
@@ -695,7 +696,6 @@ export async function listUserOrgs(userId: UserId) {
         slug: OrganizationTable.slug,
         logo: OrganizationTable.logo,
         allowedEmailDomains: OrganizationTable.allowedEmailDomains,
-        desktopAppRestrictions: OrganizationTable.desktopAppRestrictions,
         metadata: OrganizationTable.metadata,
         createdAt: OrganizationTable.createdAt,
         updatedAt: OrganizationTable.updatedAt,
@@ -708,12 +708,11 @@ export async function listUserOrgs(userId: UserId) {
 
   return memberships.map((row) => ({
     id: row.organization.id,
-      name: row.organization.name,
-      slug: row.organization.slug,
-      logo: row.organization.logo,
-      allowedEmailDomains: normalizeStoredAllowedEmailDomains(row.organization.allowedEmailDomains),
-      desktopAppRestrictions: normalizeDesktopAppRestrictions(row.organization.desktopAppRestrictions),
-      metadata: serializeOrganizationMetadata(row.organization.metadata),
+    name: row.organization.name,
+    slug: row.organization.slug,
+    logo: row.organization.logo,
+    allowedEmailDomains: normalizeStoredAllowedEmailDomains(row.organization.allowedEmailDomains),
+    metadata: serializeOrganizationMetadata(row.organization.metadata),
     role: row.role,
     orgMemberId: row.membershipId,
     membershipId: row.membershipId,
@@ -825,16 +824,15 @@ export async function getOrganizationContextForUser(input: {
   const builtInDynamicRoleNames = new Set(Object.keys(denDefaultDynamicOrganizationRoles))
 
   return {
-      organization: {
-        id: organization.id,
-        name: organization.name,
-        slug: organization.slug,
-        logo: organization.logo,
-        allowedEmailDomains: normalizeStoredAllowedEmailDomains(organization.allowedEmailDomains),
-        desktopAppRestrictions: normalizeDesktopAppRestrictions(organization.desktopAppRestrictions),
-        metadata: serializeOrganizationMetadata(organization.metadata),
-        createdAt: organization.createdAt,
-        updatedAt: organization.updatedAt,
+    organization: {
+      id: organization.id,
+      name: organization.name,
+      slug: organization.slug,
+      logo: organization.logo,
+      allowedEmailDomains: normalizeStoredAllowedEmailDomains(organization.allowedEmailDomains),
+      metadata: serializeOrganizationMetadata(organization.metadata),
+      createdAt: organization.createdAt,
+      updatedAt: organization.updatedAt,
     },
     currentMember: {
       id: currentMember.id,

--- a/ee/apps/den-api/src/routes/me/index.ts
+++ b/ee/apps/den-api/src/routes/me/index.ts
@@ -1,6 +1,6 @@
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
-import { desktopConfigSchema } from "@openwork/types/den/desktop-app-restrictions"
+import { desktopConfigSchema } from "@openwork/types/den/desktop-policies"
 import { z } from "zod"
 import { jsonValidator, requireUserMiddleware, resolveOrganizationContextMiddleware, resolveUserOrganizationsMiddleware, type OrganizationContextVariables, type UserOrganizationsContext } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
@@ -8,6 +8,7 @@ import { normalizeOrganizationMetadata } from "../../organization-limits.js"
 import { resolveUserOrganizations, setSessionActiveOrganization } from "../../orgs.js"
 import type { AuthContextVariables } from "../../session.js"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { calculateDesktopPolicyForOrgMember } from "../../desktop-policies.js"
 
 const meResponseSchema = z.object({
   user: z.object({}).passthrough(),
@@ -143,12 +144,17 @@ export function registerMeRoutes<T extends { Variables: AuthContextVariables & P
     }),
     requireUserMiddleware,
     resolveOrganizationContextMiddleware,
-    (c) => {
+    async (c) => {
       const organization = c.get("organizationContext").organization
+      const currentMember = c.get("organizationContext").currentMember
       const metadata = normalizeOrganizationMetadata(organization.metadata).metadata
+      const desktopPolicy = await calculateDesktopPolicyForOrgMember({
+        organizationId: organization.id,
+        orgMemberId: currentMember.id,
+      })
 
       return c.json({
-        ...organization.desktopAppRestrictions,
+        ...desktopPolicy,
         ...(Array.isArray(metadata.allowedDesktopVersions)
           ? { allowedDesktopVersions: metadata.allowedDesktopVersions }
           : {}),

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -1,6 +1,5 @@
 import { eq } from "@openwork-ee/den-db/drizzle"
 import { OrganizationTable } from "@openwork-ee/den-db/schema"
-import { desktopAppRestrictionsSchema } from "@openwork/types/den/desktop-app-restrictions"
 import { normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
@@ -29,9 +28,8 @@ const createOrganizationSchema = z.object({
 const updateOrganizationSchema = z.object({
   name: z.string().trim().min(2).max(120).optional(),
   allowedEmailDomains: z.array(z.string().trim().min(1).max(255)).max(100).nullable().optional(),
-  desktopAppRestrictions: desktopAppRestrictionsSchema.optional(),
   allowedDesktopVersions: z.array(z.string().trim().min(1).max(32)).max(200).nullable().optional(),
-}).refine((value) => value.name !== undefined || value.allowedEmailDomains !== undefined || value.desktopAppRestrictions !== undefined || value.allowedDesktopVersions !== undefined, {
+}).refine((value) => value.name !== undefined || value.allowedEmailDomains !== undefined || value.allowedDesktopVersions !== undefined, {
   message: "Provide at least one organization field to update.",
 })
 
@@ -270,7 +268,7 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
     describeRoute({
       tags: ["Organizations"],
       summary: "Update organization",
-      description: "Updates organization fields that workspace owners are allowed to change, including the display name, allowed invitation email domains, and desktop app restrictions. The slug is immutable to avoid breaking dashboard URLs.",
+      description: "Updates organization fields that workspace owners are allowed to change, including the display name, allowed invitation email domains, and allowed desktop versions. The slug is immutable to avoid breaking dashboard URLs.",
       responses: {
         200: jsonResponse("Organization updated successfully.", organizationResponseSchema),
         400: jsonResponse("The organization update request body was invalid or contained malformed email domains.", invalidEmailDomainSchema),
@@ -307,7 +305,6 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
         organizationId: payload.organization.id,
         name: input.name,
         allowedEmailDomains: normalizedDomains.domains,
-        desktopAppRestrictions: input.desktopAppRestrictions,
         allowedDesktopVersions: input.allowedDesktopVersions,
       })
 

--- a/ee/apps/den-api/src/routes/org/desktop-policies.ts
+++ b/ee/apps/den-api/src/routes/org/desktop-policies.ts
@@ -1,0 +1,402 @@
+import { and, asc, desc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
+import {
+  DesktopPolicyMemberTable,
+  DesktopPolicyTable,
+  MemberTable,
+  TeamTable,
+} from "@openwork-ee/den-db/schema"
+import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import {
+  desktopPolicyDefinitions,
+  desktopPolicyValueSchema,
+  normalizeDefaultDesktopPolicyValue,
+  normalizeDesktopPolicyValue,
+  type DesktopPolicyValue,
+} from "@openwork/types/den/desktop-policies"
+import type { Hono } from "hono"
+import { describeRoute } from "hono-openapi"
+import { z } from "zod"
+import { db } from "../../db.js"
+import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
+import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
+import type { OrgRouteVariables } from "./shared.js"
+import { idParamSchema, memberHasRole } from "./shared.js"
+
+type DesktopPolicyId = typeof DesktopPolicyTable.$inferSelect.id
+type MemberId = typeof MemberTable.$inferSelect.id
+type TeamId = typeof TeamTable.$inferSelect.id
+
+const desktopPolicyParamsSchema = idParamSchema("desktopPolicyId", "desktopPolicy")
+
+const desktopPolicyWriteSchema = z.object({
+  policyName: z.string().trim().min(1).max(255),
+  policy: desktopPolicyValueSchema,
+  isEnabled: z.boolean().optional(),
+  memberIds: z.array(denTypeIdSchema("member")).max(500).optional().default([]),
+  teamIds: z.array(denTypeIdSchema("team")).max(500).optional().default([]),
+})
+
+const desktopPolicyListResponseSchema = z.object({
+  definitions: z.array(z.object({}).passthrough()),
+  desktopPolicies: z.array(z.object({}).passthrough()),
+}).meta({ ref: "DesktopPolicyListResponse" })
+
+const desktopPolicyResponseSchema = z.object({
+  desktopPolicy: z.object({}).passthrough(),
+}).meta({ ref: "DesktopPolicyResponse" })
+
+function isOrganizationAdmin(payload: { currentMember: { isOwner: boolean; role: string } }) {
+  return payload.currentMember.isOwner || memberHasRole(payload.currentMember.role, "admin")
+}
+
+function parseDesktopPolicyId(value: string) {
+  return normalizeDenTypeId("desktopPolicy", value)
+}
+
+function parseMemberId(value: string) {
+  return normalizeDenTypeId("member", value)
+}
+
+function parseTeamId(value: string) {
+  return normalizeDenTypeId("team", value)
+}
+
+async function resolveMemberIds(input: {
+  organizationId: typeof DesktopPolicyTable.$inferSelect.organizationId
+  values: string[]
+}) {
+  const memberIds = [...new Set(input.values)].map(parseMemberId)
+  if (memberIds.length === 0) return [] as MemberId[]
+
+  const rows = await db
+    .select({ id: MemberTable.id })
+    .from(MemberTable)
+    .where(and(eq(MemberTable.organizationId, input.organizationId), inArray(MemberTable.id, memberIds)))
+
+  if (rows.length !== memberIds.length) {
+    throw new Error("member_not_found")
+  }
+
+  return memberIds
+}
+
+async function resolveTeamIds(input: {
+  organizationId: typeof DesktopPolicyTable.$inferSelect.organizationId
+  values: string[]
+}) {
+  const teamIds = [...new Set(input.values)].map(parseTeamId)
+  if (teamIds.length === 0) return [] as TeamId[]
+
+  const rows = await db
+    .select({ id: TeamTable.id })
+    .from(TeamTable)
+    .where(and(eq(TeamTable.organizationId, input.organizationId), inArray(TeamTable.id, teamIds)))
+
+  if (rows.length !== teamIds.length) {
+    throw new Error("team_not_found")
+  }
+
+  return teamIds
+}
+
+async function loadDesktopPolicies(organizationId: typeof DesktopPolicyTable.$inferSelect.organizationId) {
+  const policies = await db
+    .select()
+    .from(DesktopPolicyTable)
+    .where(and(eq(DesktopPolicyTable.organizationId, organizationId), isNull(DesktopPolicyTable.deletedAt)))
+    .orderBy(desc(DesktopPolicyTable.isDefault), asc(DesktopPolicyTable.policyName))
+
+  if (policies.length === 0) return []
+
+  const policyIds = policies.map((policy) => policy.id)
+  const assignments = await db
+    .select({
+      id: DesktopPolicyMemberTable.id,
+      desktopPolicyId: DesktopPolicyMemberTable.desktopPolicyId,
+      orgMemberId: DesktopPolicyMemberTable.orgMemberId,
+      teamId: DesktopPolicyMemberTable.teamId,
+      createdAt: DesktopPolicyMemberTable.createdAt,
+    })
+    .from(DesktopPolicyMemberTable)
+    .where(inArray(DesktopPolicyMemberTable.desktopPolicyId, policyIds))
+
+  return policies.map((policy) => ({
+    id: policy.id,
+    organizationId: policy.organizationId,
+    policyName: policy.policyName,
+    isDefault: policy.isDefault === true,
+    isEnabled: policy.isEnabled === true,
+    policy: policy.isDefault === true
+      ? normalizeDefaultDesktopPolicyValue(policy.policy)
+      : normalizeDesktopPolicyValue(policy.policy),
+    createdByOrgMemberId: policy.createdByOrgMemberId,
+    createdAt: policy.createdAt,
+    updatedAt: policy.updatedAt,
+    deletedAt: policy.deletedAt,
+    assignments: assignments
+      .filter((assignment) => assignment.desktopPolicyId === policy.id)
+      .map((assignment) => ({
+        id: assignment.id,
+        orgMemberId: assignment.orgMemberId,
+        teamId: assignment.teamId,
+        createdAt: assignment.createdAt,
+      })),
+  }))
+}
+
+export function registerOrgDesktopPolicyRoutes<T extends { Variables: OrgRouteVariables }>(app: Hono<T>) {
+  app.get(
+    "/v1/desktop-policies",
+    describeRoute({
+      tags: ["Desktop Policies"],
+      summary: "List desktop policies",
+      responses: {
+        200: jsonResponse("Desktop policies returned successfully.", desktopPolicyListResponseSchema),
+        401: jsonResponse("The caller must be signed in to list desktop policies.", unauthorizedSchema),
+        403: jsonResponse("Only workspace owners and admins can list desktop policies.", forbiddenSchema),
+      },
+    }),
+    requireUserMiddleware,
+    resolveOrganizationContextMiddleware,
+    async (c) => {
+      const payload = c.get("organizationContext")
+      if (!isOrganizationAdmin(payload)) {
+        return c.json({ error: "forbidden", message: "Only workspace owners and admins can manage desktop policies." }, 403)
+      }
+
+      const desktopPolicies = await loadDesktopPolicies(payload.organization.id)
+      return c.json({ definitions: desktopPolicyDefinitions, desktopPolicies })
+    },
+  )
+
+  app.post(
+    "/v1/desktop-policies",
+    describeRoute({
+      tags: ["Desktop Policies"],
+      summary: "Create desktop policy",
+      responses: {
+        201: jsonResponse("Desktop policy created successfully.", desktopPolicyResponseSchema),
+        400: jsonResponse("The desktop policy request was invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to create desktop policies.", unauthorizedSchema),
+        403: jsonResponse("Only workspace owners and admins can create desktop policies.", forbiddenSchema),
+        404: jsonResponse("A referenced member or team was not found.", notFoundSchema),
+      },
+    }),
+    requireUserMiddleware,
+    resolveOrganizationContextMiddleware,
+    jsonValidator(desktopPolicyWriteSchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      if (!isOrganizationAdmin(payload)) {
+        return c.json({ error: "forbidden", message: "Only workspace owners and admins can manage desktop policies." }, 403)
+      }
+
+      const input = c.req.valid("json")
+      try {
+        const memberIds = await resolveMemberIds({ organizationId: payload.organization.id, values: input.memberIds })
+        const teamIds = await resolveTeamIds({ organizationId: payload.organization.id, values: input.teamIds })
+        const desktopPolicyId = createDenTypeId("desktopPolicy")
+        const now = new Date()
+
+        await db.transaction(async (tx) => {
+          await tx.insert(DesktopPolicyTable).values({
+            id: desktopPolicyId,
+            organizationId: payload.organization.id,
+            policyName: input.policyName.trim(),
+            isDefault: null,
+            isEnabled: input.isEnabled ?? true,
+            policy: normalizeDesktopPolicyValue(input.policy),
+            createdByOrgMemberId: payload.currentMember.id,
+            createdAt: now,
+            updatedAt: now,
+          })
+
+          const assignmentRows = [
+            ...memberIds.map((orgMemberId) => ({
+              id: createDenTypeId("desktopPolicyMember"),
+              organizationId: payload.organization.id,
+              desktopPolicyId,
+              orgMemberId,
+              teamId: null,
+              createdAt: now,
+            })),
+            ...teamIds.map((teamId) => ({
+              id: createDenTypeId("desktopPolicyMember"),
+              organizationId: payload.organization.id,
+              desktopPolicyId,
+              orgMemberId: null,
+              teamId,
+              createdAt: now,
+            })),
+          ]
+
+          if (assignmentRows.length > 0) {
+            await tx.insert(DesktopPolicyMemberTable).values(assignmentRows)
+          }
+        })
+
+        const [desktopPolicy] = await loadDesktopPolicies(payload.organization.id)
+          .then((policies) => policies.filter((policy) => policy.id === desktopPolicyId))
+        return c.json({ desktopPolicy }, 201)
+      } catch (error) {
+        if (error instanceof Error && error.message === "member_not_found") return c.json({ error: "member_not_found" }, 404)
+        if (error instanceof Error && error.message === "team_not_found") return c.json({ error: "team_not_found" }, 404)
+        throw error
+      }
+    },
+  )
+
+  app.patch(
+    "/v1/desktop-policies/:desktopPolicyId",
+    describeRoute({
+      tags: ["Desktop Policies"],
+      summary: "Update desktop policy",
+      responses: {
+        200: jsonResponse("Desktop policy updated successfully.", desktopPolicyResponseSchema),
+        400: jsonResponse("The desktop policy request was invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to update desktop policies.", unauthorizedSchema),
+        403: jsonResponse("Only workspace owners and admins can update desktop policies.", forbiddenSchema),
+        404: jsonResponse("The policy or a referenced resource was not found.", notFoundSchema),
+      },
+    }),
+    requireUserMiddleware,
+    paramValidator(desktopPolicyParamsSchema),
+    resolveOrganizationContextMiddleware,
+    jsonValidator(desktopPolicyWriteSchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      if (!isOrganizationAdmin(payload)) {
+        return c.json({ error: "forbidden", message: "Only workspace owners and admins can manage desktop policies." }, 403)
+      }
+
+      let desktopPolicyId: DesktopPolicyId
+      try {
+        desktopPolicyId = parseDesktopPolicyId(c.req.valid("param").desktopPolicyId)
+      } catch {
+        return c.json({ error: "desktop_policy_not_found" }, 404)
+      }
+
+      const rows = await db
+        .select()
+        .from(DesktopPolicyTable)
+        .where(and(
+          eq(DesktopPolicyTable.id, desktopPolicyId),
+          eq(DesktopPolicyTable.organizationId, payload.organization.id),
+          isNull(DesktopPolicyTable.deletedAt),
+        ))
+        .limit(1)
+      const existing = rows[0]
+      if (!existing) return c.json({ error: "desktop_policy_not_found" }, 404)
+
+      const input = c.req.valid("json")
+      if (existing.isDefault === true && input.isEnabled === false) {
+        return c.json({ error: "default_policy_required", message: "The default desktop policy cannot be disabled." }, 400)
+      }
+
+      try {
+        const memberIds = await resolveMemberIds({ organizationId: payload.organization.id, values: input.memberIds })
+        const teamIds = await resolveTeamIds({ organizationId: payload.organization.id, values: input.teamIds })
+        const updatedAt = new Date()
+
+        await db.transaction(async (tx) => {
+          await tx
+            .update(DesktopPolicyTable)
+            .set({
+              policyName: existing.isDefault === true ? existing.policyName : input.policyName.trim(),
+              isEnabled: existing.isDefault === true ? true : input.isEnabled ?? existing.isEnabled,
+              policy: existing.isDefault === true
+                ? normalizeDefaultDesktopPolicyValue(input.policy)
+                : normalizeDesktopPolicyValue(input.policy),
+              updatedAt,
+            })
+            .where(eq(DesktopPolicyTable.id, existing.id))
+
+          if (existing.isDefault !== true) {
+            await tx.delete(DesktopPolicyMemberTable).where(eq(DesktopPolicyMemberTable.desktopPolicyId, existing.id))
+            const assignmentRows = [
+              ...memberIds.map((orgMemberId) => ({
+                id: createDenTypeId("desktopPolicyMember"),
+                organizationId: payload.organization.id,
+                desktopPolicyId: existing.id,
+                orgMemberId,
+                teamId: null,
+                createdAt: updatedAt,
+              })),
+              ...teamIds.map((teamId) => ({
+                id: createDenTypeId("desktopPolicyMember"),
+                organizationId: payload.organization.id,
+                desktopPolicyId: existing.id,
+                orgMemberId: null,
+                teamId,
+                createdAt: updatedAt,
+              })),
+            ]
+            if (assignmentRows.length > 0) {
+              await tx.insert(DesktopPolicyMemberTable).values(assignmentRows)
+            }
+          }
+        })
+
+        const [desktopPolicy] = await loadDesktopPolicies(payload.organization.id)
+          .then((policies) => policies.filter((policy) => policy.id === existing.id))
+        return c.json({ desktopPolicy })
+      } catch (error) {
+        if (error instanceof Error && error.message === "member_not_found") return c.json({ error: "member_not_found" }, 404)
+        if (error instanceof Error && error.message === "team_not_found") return c.json({ error: "team_not_found" }, 404)
+        throw error
+      }
+    },
+  )
+
+  app.delete(
+    "/v1/desktop-policies/:desktopPolicyId",
+    describeRoute({
+      tags: ["Desktop Policies"],
+      summary: "Delete desktop policy",
+      responses: {
+        204: emptyResponse("Desktop policy deleted successfully."),
+        401: jsonResponse("The caller must be signed in to delete desktop policies.", unauthorizedSchema),
+        403: jsonResponse("Only workspace owners and admins can delete desktop policies.", forbiddenSchema),
+        404: jsonResponse("The policy was not found.", notFoundSchema),
+      },
+    }),
+    requireUserMiddleware,
+    paramValidator(desktopPolicyParamsSchema),
+    resolveOrganizationContextMiddleware,
+    async (c) => {
+      const payload = c.get("organizationContext")
+      if (!isOrganizationAdmin(payload)) {
+        return c.json({ error: "forbidden", message: "Only workspace owners and admins can manage desktop policies." }, 403)
+      }
+
+      let desktopPolicyId: DesktopPolicyId
+      try {
+        desktopPolicyId = parseDesktopPolicyId(c.req.valid("param").desktopPolicyId)
+      } catch {
+        return c.json({ error: "desktop_policy_not_found" }, 404)
+      }
+
+      const rows = await db
+        .select()
+        .from(DesktopPolicyTable)
+        .where(and(
+          eq(DesktopPolicyTable.id, desktopPolicyId),
+          eq(DesktopPolicyTable.organizationId, payload.organization.id),
+          isNull(DesktopPolicyTable.deletedAt),
+        ))
+        .limit(1)
+      const existing = rows[0]
+      if (!existing) return c.json({ error: "desktop_policy_not_found" }, 404)
+      if (existing.isDefault === true) {
+        return c.json({ error: "default_policy_required", message: "The default desktop policy cannot be deleted." }, 400)
+      }
+
+      await db
+        .update(DesktopPolicyTable)
+        .set({ deletedAt: new Date(), isEnabled: false })
+        .where(eq(DesktopPolicyTable.id, existing.id))
+
+      return c.body(null, 204)
+    },
+  )
+}

--- a/ee/apps/den-api/src/routes/org/index.ts
+++ b/ee/apps/den-api/src/routes/org/index.ts
@@ -4,6 +4,7 @@ import { registerOrgBillingRoutes } from "./billing.js"
 import { LEGACY_ORG_PROXY_HEADER } from "../../middleware/user-organizations.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { registerOrgCoreRoutes } from "./core.js"
+import { registerOrgDesktopPolicyRoutes } from "./desktop-policies.js"
 import { registerOrgInvitationRoutes } from "./invitations.js"
 import { registerOrgInferenceRoutes } from "./inference.js"
 import { registerOrgLlmProviderRoutes } from "./llm-providers.js"
@@ -43,6 +44,7 @@ export function registerOrgRoutes<T extends { Variables: OrgRouteVariables }>(ap
   registerOrgCoreRoutes(app)
   registerOrgApiKeyRoutes(app)
   registerOrgBillingRoutes(app)
+  registerOrgDesktopPolicyRoutes(app)
   registerOrgInferenceRoutes(app)
   registerOrgInvitationRoutes(app)
   registerOrgLlmProviderRoutes(app)

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -2522,7 +2522,6 @@ async function buildConnectorAutomationContext(input: { connectorInstance: Conne
       organization: {
         allowedEmailDomains: organization.allowedEmailDomains ?? null,
         createdAt: organization.createdAt,
-        desktopAppRestrictions: organization.desktopAppRestrictions,
         id: organization.id,
         logo: organization.logo ?? null,
         metadata: organization.metadata ? JSON.stringify(organization.metadata) : null,

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -1,7 +1,3 @@
-import { normalizeDesktopAppRestrictions, type DesktopAppRestrictions } from "@openwork/types/den/desktop-app-restrictions";
-
-export type DenDesktopAppRestrictions = DesktopAppRestrictions;
-
 export type DenOrgSummary = {
   id: string;
   name: string;
@@ -112,7 +108,6 @@ export type DenOrgContext = {
     slug: string;
     logo: string | null;
     allowedEmailDomains: string[] | null;
-    desktopAppRestrictions: DenDesktopAppRestrictions;
     metadata: string | null;
     createdAt: string | null;
     updatedAt: string | null;
@@ -207,10 +202,6 @@ export function getAllowedDesktopVersionsFromMetadata(metadata: string | null): 
   return [...new Set(values.map((entry) => normalizeDesktopVersionString(entry)).filter((entry): entry is string => Boolean(entry)))];
 }
 
-function asDesktopAppRestrictions(value: unknown): DenDesktopAppRestrictions {
-  return normalizeDesktopAppRestrictions(value);
-}
-
 function parsePermissionRecord(value: unknown): Record<string, string[]> {
   if (!isRecord(value)) {
     return {};
@@ -287,6 +278,18 @@ export function getInferenceRoute(orgSlug?: string | null): string {
 
 export function getLlmProvidersRoute(orgSlug?: string | null): string {
   return getCustomLlmProvidersRoute(orgSlug);
+}
+
+export function getDesktopPoliciesRoute(orgSlug?: string | null): string {
+  return `${getOrgDashboardRoute(orgSlug)}/desktop-policies`;
+}
+
+export function getNewDesktopPolicyRoute(orgSlug?: string | null): string {
+  return `${getDesktopPoliciesRoute(orgSlug)}/new`;
+}
+
+export function getDesktopPolicyRoute(orgSlug: string | null | undefined, desktopPolicyId: string): string {
+  return `${getDesktopPoliciesRoute(orgSlug)}/${encodeURIComponent(desktopPolicyId)}`;
 }
 
 export function getLlmProviderRoute(orgSlug: string | null | undefined, llmProviderId: string): string {
@@ -584,7 +587,6 @@ export function parseOrgContextPayload(payload: unknown): DenOrgContext | null {
       slug: organizationSlug,
       logo: asString(organization.logo),
       allowedEmailDomains: asStringArray(organization.allowedEmailDomains),
-      desktopAppRestrictions: asDesktopAppRestrictions(organization.desktopAppRestrictions),
       metadata: asString(organization.metadata),
       createdAt: asIsoString(organization.createdAt),
       updatedAt: asIsoString(organization.updatedAt),

--- a/ee/apps/den-web/app/(den)/dashboard/desktop-policies/[desktopPolicyId]/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/desktop-policies/[desktopPolicyId]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../o/[orgSlug]/dashboard/desktop-policies/[desktopPolicyId]/page";

--- a/ee/apps/den-web/app/(den)/dashboard/desktop-policies/new/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/desktop-policies/new/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../o/[orgSlug]/dashboard/desktop-policies/new/page";

--- a/ee/apps/den-web/app/(den)/dashboard/desktop-policies/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/desktop-policies/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../o/[orgSlug]/dashboard/desktop-policies/page";

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/desktop-policies-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/desktop-policies-screen.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { Laptop, Plus } from "lucide-react";
+import { DashboardPageTemplate } from "../../../../_components/ui/dashboard-page-template";
+import { DenButton, buttonVariants } from "../../../../_components/ui/button";
+import { getDesktopPolicyRoute, getNewDesktopPolicyRoute } from "../../../../_lib/den-org";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import {
+  deleteDesktopPolicy,
+  useOrgDesktopPolicies,
+  type DenDesktopPolicy,
+} from "./desktop-policy-data";
+
+function formatPolicyTimestamp(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+export function DesktopPoliciesScreen() {
+  const { orgId, orgSlug, orgContext } = useOrgDashboard();
+  const { desktopPolicies, busy, error, reloadPolicies } = useOrgDesktopPolicies(orgId);
+  const [deleting, setDeleting] = useState(false);
+  const [pageError, setPageError] = useState<string | null>(null);
+  const [pageSuccess, setPageSuccess] = useState<string | null>(null);
+
+  const visiblePolicies = useMemo(() => {
+    const list = [...desktopPolicies];
+    list.sort((a, b) => {
+      if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+      if (a.isEnabled !== b.isEnabled) return a.isEnabled ? -1 : 1;
+      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return aTime - bTime;
+    });
+    return list;
+  }, [desktopPolicies]);
+  const canManage = orgContext?.currentMember.isOwner || orgContext?.currentMember.role.split(",").map((role) => role.trim()).includes("admin");
+
+  const softDeletePolicy = async (policy: DenDesktopPolicy) => {
+    if (policy.isDefault || !confirm(`Delete ${policy.policyName}?`)) return;
+    setDeleting(true);
+    setPageError(null);
+    setPageSuccess(null);
+    try {
+      await deleteDesktopPolicy(policy.id);
+      setPageSuccess("Desktop policy deleted.");
+      await reloadPolicies();
+    } catch (error) {
+      setPageError(error instanceof Error ? error.message : "Failed to delete desktop policy.");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <DashboardPageTemplate
+      icon={Laptop}
+      title="Desktop policies"
+      description="Control which desktop capabilities are available to the whole org, specific members, or teams."
+      colors={["#F8FAFC", "#0F172A", "#38BDF8", "#A78BFA"]}
+    >
+      <div className="mb-6 flex flex-wrap items-center justify-end gap-3">
+        {canManage ? (
+          <Link href={getNewDesktopPolicyRoute(orgSlug)} className={buttonVariants({ variant: "primary" })}>
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            New policy
+          </Link>
+        ) : null}
+      </div>
+
+      {pageError ? <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">{pageError}</div> : null}
+      {pageSuccess ? <div className="mb-6 rounded-[24px] border border-emerald-200 bg-emerald-50 px-5 py-4 text-[14px] text-emerald-700">{pageSuccess}</div> : null}
+      {error ? <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">{error}</div> : null}
+
+      {busy ? (
+        <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">Loading desktop policies...</div>
+      ) : visiblePolicies.length === 0 ? (
+        <div className="rounded-[32px] border border-dashed border-gray-200 bg-white px-6 py-12 text-center text-[15px] text-gray-500">No desktop policies.</div>
+      ) : (
+        <section className="overflow-hidden rounded-[28px] border border-gray-200 bg-white">
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-left text-[14px]">
+              <colgroup>
+                <col />
+                <col className="w-[1%]" />
+                <col className="w-[1%]" />
+                <col className="w-[1%]" />
+              </colgroup>
+              <thead className="bg-gray-50 text-[12px] uppercase tracking-[0.08em] text-gray-500">
+                <tr>
+                  <th scope="col" className="whitespace-nowrap px-4 py-3 font-medium">Name</th>
+                  <th scope="col" className="whitespace-nowrap px-4 py-3 font-medium">Enabled</th>
+                  <th scope="col" className="whitespace-nowrap px-4 py-3 font-medium">Created</th>
+                  <th scope="col" className="whitespace-nowrap px-4 py-3 font-medium text-right">
+                    <span className="sr-only">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {visiblePolicies.map((policy) => {
+                  const editHref = getDesktopPolicyRoute(orgSlug, policy.id);
+                  return (
+                    <tr key={policy.id} className="align-middle">
+                      <td className="whitespace-nowrap px-4 py-4">
+                        <div className="flex items-center gap-2">
+                          <span className="text-[14px] font-medium text-gray-950">{policy.policyName}</span>
+                          {policy.isDefault ? (
+                            <span className="inline-flex items-center rounded-full border border-sky-100 bg-sky-50 px-1.5 py-px text-[9px] font-semibold uppercase tracking-[0.1em] leading-none text-sky-700">Default</span>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-4">
+                        <span className={`inline-flex items-center rounded-full px-3 py-1 text-[12px] font-medium ${policy.isEnabled ? "bg-emerald-50 text-emerald-700" : "bg-gray-100 text-gray-500"}`}>
+                          {policy.isEnabled ? "Yes" : "No"}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-4 text-[13px] text-gray-600">
+                        {formatPolicyTimestamp(policy.createdAt)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-4">
+                        <div className="flex justify-end gap-2">
+                          {canManage ? (
+                            <Link href={editHref} className={buttonVariants({ variant: "secondary", size: "sm" })}>
+                              Edit
+                            </Link>
+                          ) : null}
+                          {canManage && !policy.isDefault ? (
+                            <DenButton type="button" variant="destructive" size="sm" onClick={() => void softDeletePolicy(policy)} disabled={deleting}>Delete</DenButton>
+                          ) : null}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </DashboardPageTemplate>
+  );
+}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/desktop-policy-data.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/desktop-policy-data.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { DesktopPolicyDefinition, DesktopPolicyValue } from "@openwork/types/den/desktop-policies";
+import { getErrorMessage, requestJson } from "../../../../_lib/den-flow";
+
+export type DenDesktopPolicyAssignment = {
+  id: string;
+  orgMemberId: string | null;
+  teamId: string | null;
+  createdAt: string | null;
+};
+
+export type DenDesktopPolicy = {
+  id: string;
+  organizationId: string;
+  policyName: string;
+  isDefault: boolean;
+  isEnabled: boolean;
+  policy: DesktopPolicyValue;
+  createdByOrgMemberId: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  assignments: DenDesktopPolicyAssignment[];
+};
+
+export type DesktopPolicyPayload = {
+  policyName: string;
+  policy: DesktopPolicyValue;
+  isEnabled?: boolean;
+  memberIds?: string[];
+  teamIds?: string[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asIsoString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asPolicy(value: unknown): DesktopPolicyValue {
+  if (!isRecord(value)) return {};
+  return {
+    ...(typeof value.allowNonCloudModels === "boolean" ? { allowNonCloudModels: value.allowNonCloudModels } : {}),
+    ...(typeof value.allowZenModel === "boolean" ? { allowZenModel: value.allowZenModel } : {}),
+    ...(typeof value.allowMultipleWorkspaces === "boolean" ? { allowMultipleWorkspaces: value.allowMultipleWorkspaces } : {}),
+  };
+}
+
+function asAssignment(value: unknown): DenDesktopPolicyAssignment | null {
+  if (!isRecord(value)) return null;
+  const id = asString(value.id);
+  if (!id) return null;
+  return {
+    id,
+    orgMemberId: asString(value.orgMemberId),
+    teamId: asString(value.teamId),
+    createdAt: asIsoString(value.createdAt),
+  };
+}
+
+function asDefinition(value: unknown): DesktopPolicyDefinition | null {
+  if (!isRecord(value)) return null;
+  const id = asString(value.id);
+  const name = asString(value.name);
+  const description = asString(value.description);
+  const userNotice = asString(value.userNotice);
+  if (
+    (id !== "allowNonCloudModels" && id !== "allowZenModel" && id !== "allowMultipleWorkspaces") ||
+    !name ||
+    !description ||
+    !userNotice
+  ) {
+    return null;
+  }
+  return {
+    id,
+    name,
+    description,
+    userNotice,
+    defaultValue: value.defaultValue === true,
+  };
+}
+
+function asDesktopPolicy(value: unknown): DenDesktopPolicy | null {
+  if (!isRecord(value)) return null;
+  const id = asString(value.id);
+  const organizationId = asString(value.organizationId);
+  const policyName = asString(value.policyName);
+  const createdByOrgMemberId = asString(value.createdByOrgMemberId);
+  if (!id || !organizationId || !policyName || !createdByOrgMemberId) return null;
+  return {
+    id,
+    organizationId,
+    policyName,
+    isDefault: value.isDefault === true,
+    isEnabled: value.isEnabled === true,
+    policy: asPolicy(value.policy),
+    createdByOrgMemberId,
+    createdAt: asIsoString(value.createdAt),
+    updatedAt: asIsoString(value.updatedAt),
+    assignments: Array.isArray(value.assignments)
+      ? value.assignments.map(asAssignment).filter((entry): entry is DenDesktopPolicyAssignment => entry !== null)
+      : [],
+  };
+}
+
+function parseDesktopPolicyList(payload: unknown) {
+  if (!isRecord(payload)) return { definitions: [], desktopPolicies: [] };
+  return {
+    definitions: Array.isArray(payload.definitions)
+      ? payload.definitions.map(asDefinition).filter((entry): entry is DesktopPolicyDefinition => entry !== null)
+      : [],
+    desktopPolicies: Array.isArray(payload.desktopPolicies)
+      ? payload.desktopPolicies.map(asDesktopPolicy).filter((entry): entry is DenDesktopPolicy => entry !== null)
+      : [],
+  };
+}
+
+export function useOrgDesktopPolicies(orgId: string | null) {
+  const [definitions, setDefinitions] = useState<DesktopPolicyDefinition[]>([]);
+  const [desktopPolicies, setDesktopPolicies] = useState<DenDesktopPolicy[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function reloadPolicies() {
+    if (!orgId) {
+      setDefinitions([]);
+      setDesktopPolicies([]);
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      const { response, payload } = await requestJson("/v1/desktop-policies", { method: "GET" }, 12000);
+      if (!response.ok) {
+        throw new Error(getErrorMessage(payload, `Failed to load desktop policies (${response.status}).`));
+      }
+      const parsed = parseDesktopPolicyList(payload);
+      setDefinitions(parsed.definitions);
+      setDesktopPolicies(parsed.desktopPolicies);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "Failed to load desktop policies.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  useEffect(() => {
+    void reloadPolicies();
+  }, [orgId]);
+
+  return { definitions, desktopPolicies, busy, error, reloadPolicies };
+}
+
+export async function createDesktopPolicy(input: DesktopPolicyPayload) {
+  const { response, payload } = await requestJson("/v1/desktop-policies", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  }, 12000);
+  if (!response.ok) {
+    throw new Error(getErrorMessage(payload, `Failed to create desktop policy (${response.status}).`));
+  }
+}
+
+export async function updateDesktopPolicy(policyId: string, input: DesktopPolicyPayload) {
+  const { response, payload } = await requestJson(`/v1/desktop-policies/${encodeURIComponent(policyId)}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  }, 12000);
+  if (!response.ok) {
+    throw new Error(getErrorMessage(payload, `Failed to update desktop policy (${response.status}).`));
+  }
+}
+
+export async function deleteDesktopPolicy(policyId: string) {
+  const { response, payload } = await requestJson(`/v1/desktop-policies/${encodeURIComponent(policyId)}`, {
+    method: "DELETE",
+  }, 12000);
+  if (!response.ok) {
+    throw new Error(getErrorMessage(payload, `Failed to delete desktop policy (${response.status}).`));
+  }
+}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/desktop-policy-data.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/desktop-policy-data.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { DesktopPolicyDefinition, DesktopPolicyValue } from "@openwork/types/den/desktop-policies";
+import {
+  desktopPolicyKeys,
+  normalizeDesktopPolicyValue,
+  type DesktopPolicyDefinition,
+  type DesktopPolicyValue,
+} from "@openwork/types/den/desktop-policies";
 import { getErrorMessage, requestJson } from "../../../../_lib/den-flow";
 
 export type DenDesktopPolicyAssignment = {
@@ -44,13 +49,12 @@ function asIsoString(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
+function isDesktopPolicyKey(value: string | null): value is DesktopPolicyDefinition["id"] {
+  return value !== null && desktopPolicyKeys.includes(value as DesktopPolicyDefinition["id"]);
+}
+
 function asPolicy(value: unknown): DesktopPolicyValue {
-  if (!isRecord(value)) return {};
-  return {
-    ...(typeof value.allowNonCloudModels === "boolean" ? { allowNonCloudModels: value.allowNonCloudModels } : {}),
-    ...(typeof value.allowZenModel === "boolean" ? { allowZenModel: value.allowZenModel } : {}),
-    ...(typeof value.allowMultipleWorkspaces === "boolean" ? { allowMultipleWorkspaces: value.allowMultipleWorkspaces } : {}),
-  };
+  return normalizeDesktopPolicyValue(value);
 }
 
 function asAssignment(value: unknown): DenDesktopPolicyAssignment | null {
@@ -71,12 +75,7 @@ function asDefinition(value: unknown): DesktopPolicyDefinition | null {
   const name = asString(value.name);
   const description = asString(value.description);
   const userNotice = asString(value.userNotice);
-  if (
-    (id !== "allowNonCloudModels" && id !== "allowZenModel" && id !== "allowMultipleWorkspaces") ||
-    !name ||
-    !description ||
-    !userNotice
-  ) {
+  if (!isDesktopPolicyKey(id) || !name || !description || !userNotice) {
     return null;
   }
   return {

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/desktop-policy-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/desktop-policy-editor-screen.tsx
@@ -4,7 +4,11 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, Laptop } from "lucide-react";
-import type { DesktopPolicyValue } from "@openwork/types/den/desktop-policies";
+import {
+  desktopPolicyDefaults,
+  desktopPolicyKeys,
+  type DesktopPolicyValue,
+} from "@openwork/types/den/desktop-policies";
 import { DashboardPageTemplate } from "../../../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../../../_components/ui/button";
 import { DenInput } from "../../../../_components/ui/input";
@@ -27,23 +31,21 @@ type PolicyDraft = {
 
 const EMPTY_DRAFT: PolicyDraft = {
   policyName: "New desktop policy",
-  policy: {
-    allowNonCloudModels: true,
-    allowZenModel: true,
-    allowMultipleWorkspaces: true,
-  },
+  policy: { ...desktopPolicyDefaults },
   memberIds: [],
   teamIds: [],
 };
 
+function requiredPolicyValue(value: DesktopPolicyValue): Required<DesktopPolicyValue> {
+  return Object.fromEntries(
+    desktopPolicyKeys.map((key) => [key, value[key] === true]),
+  ) as Required<DesktopPolicyValue>;
+}
+
 function draftFromPolicy(policy: DenDesktopPolicy): PolicyDraft {
   return {
     policyName: policy.policyName,
-    policy: {
-      allowNonCloudModels: policy.policy.allowNonCloudModels === true,
-      allowZenModel: policy.policy.allowZenModel === true,
-      allowMultipleWorkspaces: policy.policy.allowMultipleWorkspaces === true,
-    },
+    policy: requiredPolicyValue(policy.policy),
     memberIds: policy.assignments.flatMap((assignment) => (assignment.orgMemberId ? [assignment.orgMemberId] : [])),
     teamIds: policy.assignments.flatMap((assignment) => (assignment.teamId ? [assignment.teamId] : [])),
   };

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/desktop-policy-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/desktop-policy-editor-screen.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, Laptop } from "lucide-react";
+import type { DesktopPolicyValue } from "@openwork/types/den/desktop-policies";
+import { DashboardPageTemplate } from "../../../../_components/ui/dashboard-page-template";
+import { DenButton } from "../../../../_components/ui/button";
+import { DenInput } from "../../../../_components/ui/input";
+import { getDesktopPoliciesRoute, getMembersRoute } from "../../../../_lib/den-org";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import {
+  createDesktopPolicy,
+  updateDesktopPolicy,
+  useOrgDesktopPolicies,
+  type DenDesktopPolicy,
+  type DesktopPolicyPayload,
+} from "./desktop-policy-data";
+
+type PolicyDraft = {
+  policyName: string;
+  policy: Required<DesktopPolicyValue>;
+  memberIds: string[];
+  teamIds: string[];
+};
+
+const EMPTY_DRAFT: PolicyDraft = {
+  policyName: "New desktop policy",
+  policy: {
+    allowNonCloudModels: true,
+    allowZenModel: true,
+    allowMultipleWorkspaces: true,
+  },
+  memberIds: [],
+  teamIds: [],
+};
+
+function draftFromPolicy(policy: DenDesktopPolicy): PolicyDraft {
+  return {
+    policyName: policy.policyName,
+    policy: {
+      allowNonCloudModels: policy.policy.allowNonCloudModels === true,
+      allowZenModel: policy.policy.allowZenModel === true,
+      allowMultipleWorkspaces: policy.policy.allowMultipleWorkspaces === true,
+    },
+    memberIds: policy.assignments.flatMap((assignment) => (assignment.orgMemberId ? [assignment.orgMemberId] : [])),
+    teamIds: policy.assignments.flatMap((assignment) => (assignment.teamId ? [assignment.teamId] : [])),
+  };
+}
+
+function toggleId(ids: string[], id: string) {
+  return ids.includes(id) ? ids.filter((entry) => entry !== id) : [...ids, id];
+}
+
+function policyToAssignmentPayload(policy: DenDesktopPolicy) {
+  return {
+    memberIds: policy.assignments.flatMap((assignment) => (assignment.orgMemberId ? [assignment.orgMemberId] : [])),
+    teamIds: policy.assignments.flatMap((assignment) => (assignment.teamId ? [assignment.teamId] : [])),
+  };
+}
+
+export function DesktopPolicyEditorScreen({ desktopPolicyId }: { desktopPolicyId?: string }) {
+  const router = useRouter();
+  const { orgId, orgSlug, orgContext } = useOrgDashboard();
+  const { definitions, desktopPolicies, busy, error, reloadPolicies } = useOrgDesktopPolicies(orgId);
+
+  const policy = useMemo(() => {
+    if (!desktopPolicyId) return null;
+    return desktopPolicies.find((entry) => entry.id === desktopPolicyId) ?? null;
+  }, [desktopPolicyId, desktopPolicies]);
+
+  const [draft, setDraft] = useState<PolicyDraft>(EMPTY_DRAFT);
+  const [saving, setSaving] = useState(false);
+  const [togglingEnabled, setTogglingEnabled] = useState(false);
+  const [pageError, setPageError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!desktopPolicyId) {
+      setDraft(EMPTY_DRAFT);
+      return;
+    }
+    if (policy) {
+      setDraft(draftFromPolicy(policy));
+    }
+  }, [desktopPolicyId, policy]);
+
+  const canManage = orgContext?.currentMember.isOwner || orgContext?.currentMember.role.split(",").map((role) => role.trim()).includes("admin");
+  const isEditing = Boolean(desktopPolicyId);
+  const isDefault = policy?.isDefault === true;
+  const listRoute = getDesktopPoliciesRoute(orgSlug);
+
+  const initialLoad = busy && (definitions.length === 0 || (isEditing && !policy));
+  const notFound = isEditing && !busy && !policy && desktopPolicies.length > 0;
+
+  const handleSave = async () => {
+    const policyName = draft.policyName.trim();
+    if (!policyName) {
+      setPageError("Policy name is required.");
+      return;
+    }
+    setSaving(true);
+    setPageError(null);
+    try {
+      const payload: DesktopPolicyPayload = {
+        policyName,
+        policy: draft.policy,
+        memberIds: isDefault ? [] : draft.memberIds,
+        teamIds: isDefault ? [] : draft.teamIds,
+      };
+      if (isEditing && desktopPolicyId) {
+        // Preserve the current enabled state when saving form edits; the
+        // dedicated Enable/Disable button is the only way to flip it.
+        payload.isEnabled = policy?.isEnabled ?? true;
+        await updateDesktopPolicy(desktopPolicyId, payload);
+      } else {
+        payload.isEnabled = true;
+        await createDesktopPolicy(payload);
+      }
+      await reloadPolicies();
+      router.push(listRoute);
+    } catch (saveError) {
+      setPageError(saveError instanceof Error ? saveError.message : "Failed to save desktop policy.");
+      setSaving(false);
+    }
+  };
+
+  const handleToggleEnabled = async () => {
+    if (!policy || !desktopPolicyId || isDefault) return;
+    setTogglingEnabled(true);
+    setPageError(null);
+    try {
+      const { memberIds, teamIds } = policyToAssignmentPayload(policy);
+      await updateDesktopPolicy(desktopPolicyId, {
+        policyName: policy.policyName,
+        policy: policy.policy,
+        isEnabled: !policy.isEnabled,
+        memberIds,
+        teamIds,
+      });
+      await reloadPolicies();
+    } catch (toggleError) {
+      setPageError(toggleError instanceof Error ? toggleError.message : "Failed to update desktop policy.");
+    } finally {
+      setTogglingEnabled(false);
+    }
+  };
+
+  return (
+    <DashboardPageTemplate
+      icon={Laptop}
+      title={isEditing ? "Edit desktop policy" : "New desktop policy"}
+      description="Default policy values apply org-wide. Other policies can grant access to specific users or teams."
+      colors={["#F8FAFC", "#0F172A", "#38BDF8", "#A78BFA"]}
+    >
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <Link
+          href={listRoute}
+          className="inline-flex items-center gap-2 text-[13px] font-medium text-gray-500 hover:text-gray-900"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          Back to desktop policies
+        </Link>
+      </div>
+
+      {pageError ? (
+        <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">{pageError}</div>
+      ) : null}
+      {error ? (
+        <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">{error}</div>
+      ) : null}
+
+      {initialLoad ? (
+        <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">Loading desktop policy...</div>
+      ) : notFound ? (
+        <div className="rounded-[32px] border border-dashed border-gray-200 bg-white px-6 py-12 text-center text-[15px] text-gray-500">
+          Desktop policy not found.
+        </div>
+      ) : !canManage ? (
+        <div className="rounded-[32px] border border-dashed border-gray-200 bg-white px-6 py-12 text-center text-[15px] text-gray-500">
+          Only workspace owners and admins can manage desktop policies.
+        </div>
+      ) : (
+        <section className="grid gap-5 rounded-[28px] border border-gray-200 bg-white p-6">
+          <div className="flex flex-wrap items-end gap-3">
+            <label className="grid flex-1 min-w-[240px] gap-2">
+              <span className="text-[13px] font-medium text-gray-700">Policy name</span>
+              <DenInput
+                value={draft.policyName}
+                onChange={(event) => setDraft({ ...draft, policyName: event.target.value })}
+                disabled={saving || togglingEnabled || isDefault}
+              />
+              {isDefault ? (
+                <span className="text-[12px] text-gray-500">The default desktop policy name cannot be changed.</span>
+              ) : null}
+            </label>
+            {isEditing && policy && !isDefault ? (
+              <DenButton
+                type="button"
+                variant={policy.isEnabled ? "destructive" : "secondary"}
+                onClick={() => void handleToggleEnabled()}
+                loading={togglingEnabled}
+                disabled={saving}
+              >
+                {policy.isEnabled ? "Disable" : "Enable"}
+              </DenButton>
+            ) : null}
+          </div>
+
+          <div className="grid gap-3">
+            {definitions.map((definition) => (
+              <label
+                key={definition.id}
+                className="flex items-start justify-between gap-4 rounded-[22px] border border-gray-200 bg-gray-50 px-5 py-4"
+              >
+                <span>
+                  <span className="block text-[14px] font-medium text-gray-950">{definition.name}</span>
+                  <span className="mt-1 block text-[13px] leading-6 text-gray-500">{definition.description}</span>
+                </span>
+                <input
+                  type="checkbox"
+                  className="mt-1 h-5 w-5"
+                  checked={draft.policy[definition.id] === true}
+                  onChange={(event) =>
+                    setDraft({
+                      ...draft,
+                      policy: { ...draft.policy, [definition.id]: event.target.checked },
+                    })
+                  }
+                  disabled={saving || togglingEnabled}
+                />
+              </label>
+            ))}
+          </div>
+
+          {!isDefault ? (
+            <div className="grid items-start gap-5 lg:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <p className="text-[13px] font-medium text-gray-700">Members</p>
+                <div className="flex max-h-64 min-h-[160px] flex-col gap-2 overflow-auto rounded-[22px] border border-gray-200 p-3">
+                  {(orgContext?.members ?? []).length === 0 ? (
+                    <Link
+                      href={getMembersRoute(orgSlug)}
+                      className="flex flex-1 items-center justify-center rounded-xl px-3 py-6 text-center text-[13px] text-gray-500 hover:bg-gray-50 hover:text-gray-900"
+                    >
+                      Invite members to assign them to this policy.
+                    </Link>
+                  ) : (
+                    (orgContext?.members ?? []).map((member) => (
+                      <label
+                        key={member.id}
+                        className="flex items-center gap-3 rounded-xl px-2 py-1.5 text-[13px] text-gray-700 hover:bg-gray-50"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={draft.memberIds.includes(member.id)}
+                          disabled={saving || togglingEnabled}
+                          onChange={() => setDraft({ ...draft, memberIds: toggleId(draft.memberIds, member.id) })}
+                        />
+                        <span>{member.user.name || member.user.email}</span>
+                      </label>
+                    ))
+                  )}
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <p className="text-[13px] font-medium text-gray-700">Teams</p>
+                <div className="flex max-h-64 min-h-[160px] flex-col gap-2 overflow-auto rounded-[22px] border border-gray-200 p-3">
+                  {(orgContext?.teams ?? []).length === 0 ? (
+                    <Link
+                      href={getMembersRoute(orgSlug)}
+                      className="flex flex-1 items-center justify-center rounded-xl px-3 py-6 text-center text-[13px] text-gray-500 hover:bg-gray-50 hover:text-gray-900"
+                    >
+                      Click here to set up your teams.
+                    </Link>
+                  ) : (
+                    (orgContext?.teams ?? []).map((team) => (
+                      <label
+                        key={team.id}
+                        className="flex items-center gap-3 rounded-xl px-2 py-1.5 text-[13px] text-gray-700 hover:bg-gray-50"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={draft.teamIds.includes(team.id)}
+                          disabled={saving || togglingEnabled}
+                          onChange={() => setDraft({ ...draft, teamIds: toggleId(draft.teamIds, team.id) })}
+                        />
+                        <span>{team.name}</span>
+                      </label>
+                    ))
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="flex flex-wrap justify-end gap-3">
+            <Link
+              href={listRoute}
+              className="inline-flex h-10 items-center justify-center rounded-full border border-gray-200 bg-white px-5 text-[13px] font-medium text-gray-700 transition-colors hover:border-gray-300 hover:bg-gray-50 hover:text-gray-900"
+            >
+              Cancel
+            </Link>
+            <DenButton type="button" onClick={() => void handleSave()} loading={saving} disabled={togglingEnabled}>
+              {isEditing ? "Save changes" : "Create policy"}
+            </DenButton>
+          </div>
+        </section>
+      )}
+    </DashboardPageTemplate>
+  );
+}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-dashboard-shell.tsx
@@ -12,6 +12,7 @@ import {
   FileText,
   Home,
   KeyRound,
+  Laptop,
   LogOut,
   MessageSquare,
   Puzzle,
@@ -27,6 +28,7 @@ import {
   getApiKeysRoute,
   getBillingRoute,
   getCustomLlmProvidersRoute,
+  getDesktopPoliciesRoute,
   getOrgAccessFlags,
   getIntegrationsRoute,
   getInferenceRoute,
@@ -114,6 +116,9 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
   if (pathname.startsWith(getCustomLlmProvidersRoute(orgSlug))) {
     return "LLM Providers";
   }
+  if (pathname.startsWith(getDesktopPoliciesRoute(orgSlug))) {
+    return "Desktop Policies";
+  }
   if (pathname.startsWith(getInferenceRoute(orgSlug))) {
     return "OpenWork Models";
   }
@@ -186,6 +191,11 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
       href: activeOrg ? getCustomLlmProvidersRoute(activeOrg.slug) : "#",
       label: "LLM Providers",
       icon: Cpu,
+    },
+    {
+      href: activeOrg ? getDesktopPoliciesRoute(activeOrg.slug) : "#",
+      label: "Desktop Policies",
+      icon: Laptop,
     },
     // NOTE: Skill Hubs soft-disabled — uncomment to re-enable
     // {

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
@@ -157,11 +157,6 @@ export function OrgSettingsScreen() {
   const [allowedDomainsDraft, setAllowedDomainsDraft] = useState("");
   const [domainRestrictionsEnabled, setDomainRestrictionsEnabled] =
     useState(false);
-  const [allowNonCloudModelsEnabled, setAllowNonCloudModelsEnabled] =
-    useState(true);
-  const [allowZenModelEnabled, setAllowZenModelEnabled] = useState(true);
-  const [allowMultipleWorkspacesEnabled, setAllowMultipleWorkspacesEnabled] =
-    useState(true);
   const [domainEditModeEnabled, setDomainEditModeEnabled] = useState(false);
   const [desktopVersionOptions, setDesktopVersionOptions] = useState<string[]>(
     [],
@@ -179,8 +174,6 @@ export function OrgSettingsScreen() {
 
   const currentAllowedDomains =
     orgContext?.organization.allowedEmailDomains ?? null;
-  const currentDesktopAppRestrictions =
-    orgContext?.organization.desktopAppRestrictions ?? {};
   const isOwner = orgContext?.currentMember.isOwner ?? false;
   const draftAllowedDomains = useMemo(
     () => normalizeAllowedEmailDomainsInput(allowedDomainsDraft),
@@ -216,17 +209,6 @@ export function OrgSettingsScreen() {
     );
     setDomainRestrictionsEnabled(
       (orgContext.organization.allowedEmailDomains?.length ?? 0) > 0,
-    );
-    setAllowNonCloudModelsEnabled(
-      orgContext.organization.desktopAppRestrictions.disallowNonCloudModels !==
-        true,
-    );
-    setAllowZenModelEnabled(
-      orgContext.organization.desktopAppRestrictions.blockZenModel !== true,
-    );
-    setAllowMultipleWorkspacesEnabled(
-      orgContext.organization.desktopAppRestrictions.blockMultipleWorkspaces !==
-        true,
     );
     setDomainEditModeEnabled(false);
   }, [orgContext]);
@@ -392,15 +374,6 @@ export function OrgSettingsScreen() {
         allowedEmailDomains: domainRestrictionsEnabled
           ? draftAllowedDomains
           : null,
-        desktopAppRestrictions: {
-          ...(!allowNonCloudModelsEnabled
-            ? { disallowNonCloudModels: true }
-            : {}),
-          ...(!allowZenModelEnabled ? { blockZenModel: true } : {}),
-          ...(!allowMultipleWorkspacesEnabled
-            ? { blockMultipleWorkspaces: true }
-            : {}),
-        },
         ...(desktopVersionOptions.length > 0
           ? {
               allowedDesktopVersions: allDesktopVersionsAllowed
@@ -573,77 +546,6 @@ export function OrgSettingsScreen() {
               </div>
             </div>
           ) : null}
-        </DenCard>
-
-        <DenCard size="spacious" className="grid gap-6">
-          <div className="grid gap-2">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
-              Desktop app
-            </p>
-            <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
-              Desktop restrictions
-            </h2>
-            <p className="text-[14px] text-gray-500">
-              Control which desktop-only options remain available after people
-              sign in to this workspace.
-            </p>
-          </div>
-
-          <div className="grid gap-4">
-            <div className="flex items-start justify-between gap-4 rounded-[24px] border border-gray-200 bg-white px-5 py-4">
-              <div className="grid gap-1 pr-4">
-                <p className="text-[15px] font-medium text-gray-900">
-                  Allow non-cloud deployed models
-                </p>
-                <p className="text-[13px] text-gray-500">
-                  Let signed-in desktop users access models that are not
-                  deployed through OpenWork Cloud.
-                </p>
-              </div>
-              <SettingsToggle
-                label="Allow non-cloud deployed models"
-                checked={allowNonCloudModelsEnabled}
-                disabled={!isOwner}
-                onChange={setAllowNonCloudModelsEnabled}
-              />
-            </div>
-
-            <div className="flex items-start justify-between gap-4 rounded-[24px] border border-gray-200 bg-white px-5 py-4">
-              <div className="grid gap-1 pr-4">
-                <p className="text-[15px] font-medium text-gray-900">
-                  Allow usage of OpenCode Zen model
-                </p>
-                <p className="text-[13px] text-gray-500">
-                  Let signed-in desktop users access the OpenCode Zen model in
-                  the desktop app.
-                </p>
-              </div>
-              <SettingsToggle
-                label="Allow usage of OpenCode Zen model"
-                checked={allowZenModelEnabled}
-                disabled={!isOwner}
-                onChange={setAllowZenModelEnabled}
-              />
-            </div>
-
-            <div className="flex items-start justify-between gap-4 rounded-[24px] border border-gray-200 bg-white px-5 py-4">
-              <div className="grid gap-1 pr-4">
-                <p className="text-[15px] font-medium text-gray-900">
-                  Allow users to configure multiple workspaces
-                </p>
-                <p className="text-[13px] text-gray-500">
-                  Let signed-in desktop users create or manage more than one
-                  workspace on their machine.
-                </p>
-              </div>
-              <SettingsToggle
-                label="Allow users to configure multiple workspaces"
-                checked={allowMultipleWorkspacesEnabled}
-                disabled={!isOwner}
-                onChange={setAllowMultipleWorkspacesEnabled}
-              />
-            </div>
-          </div>
         </DenCard>
 
         <DenCard size="spacious" className="grid gap-6">

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/org-dashboard-provider.tsx
@@ -11,7 +11,6 @@ import { usePathname, useRouter } from "next/navigation";
 import { useDenFlow } from "../../../../_providers/den-flow-provider";
 import { getErrorMessage, getOrgLimitError, requestJson } from "../../../../_lib/den-flow";
 import {
-  type DenDesktopAppRestrictions,
   type DenOrgContext,
   type DenOrgSummary,
   getOrgDashboardRoute,
@@ -31,7 +30,7 @@ type OrgDashboardContextValue = {
   refreshOrgData: () => Promise<void>;
   createOrganization: (name: string) => Promise<void>;
   updateOrganizationName: (name: string) => Promise<void>;
-  updateOrganizationSettings: (input: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions; allowedDesktopVersions?: string[] | null }) => Promise<void>;
+  updateOrganizationSettings: (input: { name?: string; allowedEmailDomains?: string[] | null; allowedDesktopVersions?: string[] | null }) => Promise<void>;
   switchOrganization: (slug: string) => void;
   inviteMember: (input: { email: string; role: string }) => Promise<void>;
   cancelInvitation: (invitationId: string) => Promise<void>;
@@ -247,8 +246,8 @@ export function OrgDashboardProvider({
     await updateOrganizationSettings({ name: trimmed });
   }
 
-  async function updateOrganizationSettings(input: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions; allowedDesktopVersions?: string[] | null }) {
-    const body: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions; allowedDesktopVersions?: string[] | null } = {};
+  async function updateOrganizationSettings(input: { name?: string; allowedEmailDomains?: string[] | null; allowedDesktopVersions?: string[] | null }) {
+    const body: { name?: string; allowedEmailDomains?: string[] | null; allowedDesktopVersions?: string[] | null } = {};
     if (typeof input.name === "string") {
       const trimmed = input.name.trim();
       if (!trimmed) {
@@ -258,9 +257,6 @@ export function OrgDashboardProvider({
     }
     if (input.allowedEmailDomains !== undefined) {
       body.allowedEmailDomains = input.allowedEmailDomains;
-    }
-    if (input.desktopAppRestrictions !== undefined) {
-      body.desktopAppRestrictions = input.desktopAppRestrictions;
     }
     if (input.allowedDesktopVersions !== undefined) {
       body.allowedDesktopVersions = input.allowedDesktopVersions;

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/desktop-policies/[desktopPolicyId]/page.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/desktop-policies/[desktopPolicyId]/page.tsx
@@ -1,0 +1,10 @@
+import { DesktopPolicyEditorScreen } from "../../_components/desktop-policy-editor-screen";
+
+export default async function EditDesktopPolicyPage({
+  params,
+}: {
+  params: Promise<{ desktopPolicyId: string }>;
+}) {
+  const { desktopPolicyId } = await params;
+  return <DesktopPolicyEditorScreen desktopPolicyId={desktopPolicyId} />;
+}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/desktop-policies/new/page.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/desktop-policies/new/page.tsx
@@ -1,0 +1,5 @@
+import { DesktopPolicyEditorScreen } from "../../_components/desktop-policy-editor-screen";
+
+export default function NewDesktopPolicyPage() {
+  return <DesktopPolicyEditorScreen />;
+}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/desktop-policies/page.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/desktop-policies/page.tsx
@@ -1,0 +1,5 @@
+import { DesktopPoliciesScreen } from "../_components/desktop-policies-screen";
+
+export default function DesktopPoliciesPage() {
+  return <DesktopPoliciesScreen />;
+}

--- a/ee/packages/den-db/drizzle/0017_desktop_policies.sql
+++ b/ee/packages/den-db/drizzle/0017_desktop_policies.sql
@@ -1,0 +1,35 @@
+CREATE TABLE `desktop_policy` (
+	`id` varchar(64) NOT NULL,
+	`organization_id` varchar(64) NOT NULL,
+	`policy_name` varchar(255) NOT NULL,
+	`is_default` boolean,
+	`is_enabled` boolean NOT NULL DEFAULT true,
+	`policy` json NOT NULL DEFAULT (json_object()),
+	`created_by_org_member_id` varchar(64) NOT NULL,
+	`created_at` timestamp(3) NOT NULL DEFAULT (now()),
+	`updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+	`deleted_at` timestamp(3),
+	CONSTRAINT `desktop_policy_id` PRIMARY KEY(`id`),
+	CONSTRAINT `desktop_policy_org_default` UNIQUE(`organization_id`,`is_default`)
+);
+--> statement-breakpoint
+CREATE TABLE `desktop_policy_member` (
+	`id` varchar(64) NOT NULL,
+	`organization_id` varchar(64) NOT NULL,
+	`desktop_policy_id` varchar(64) NOT NULL,
+	`org_member_id` varchar(64),
+	`team_id` varchar(64),
+	`created_at` timestamp(3) NOT NULL DEFAULT (now()),
+	CONSTRAINT `desktop_policy_member_id` PRIMARY KEY(`id`),
+	CONSTRAINT `desktop_policy_member_policy_org_member` UNIQUE(`desktop_policy_id`,`org_member_id`),
+	CONSTRAINT `desktop_policy_member_policy_team` UNIQUE(`desktop_policy_id`,`team_id`)
+);
+--> statement-breakpoint
+CREATE INDEX `desktop_policy_organization_id` ON `desktop_policy` (`organization_id`);--> statement-breakpoint
+CREATE INDEX `desktop_policy_created_by_member_id` ON `desktop_policy` (`created_by_org_member_id`);--> statement-breakpoint
+CREATE INDEX `desktop_policy_is_enabled` ON `desktop_policy` (`is_enabled`);--> statement-breakpoint
+CREATE INDEX `desktop_policy_deleted_at` ON `desktop_policy` (`deleted_at`);--> statement-breakpoint
+CREATE INDEX `desktop_policy_member_organization_id` ON `desktop_policy_member` (`organization_id`);--> statement-breakpoint
+CREATE INDEX `desktop_policy_member_policy_id` ON `desktop_policy_member` (`desktop_policy_id`);--> statement-breakpoint
+CREATE INDEX `desktop_policy_member_org_member_id` ON `desktop_policy_member` (`org_member_id`);--> statement-breakpoint
+CREATE INDEX `desktop_policy_member_team_id` ON `desktop_policy_member` (`team_id`);

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1778739941884,
       "tag": "0016_uneven_puppet_master",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "5",
+      "when": 1779129600000,
+      "tag": "0017_desktop_policies",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/package.json
+++ b/ee/packages/den-db/package.json
@@ -21,6 +21,11 @@
       "development": "./src/schema/auth.ts",
       "default": "./dist/schema/auth.js"
     },
+    "./schema/desktop-policies": {
+      "types": "./src/schema/desktop-policies.ts",
+      "development": "./src/schema/desktop-policies.ts",
+      "default": "./dist/schema/desktop-policies.js"
+    },
     "./schema/inference": {
       "types": "./src/schema/inference.ts",
       "development": "./src/schema/inference.ts",

--- a/ee/packages/den-db/src/schema/desktop-policies.ts
+++ b/ee/packages/den-db/src/schema/desktop-policies.ts
@@ -1,0 +1,85 @@
+import { relations, sql } from "drizzle-orm"
+import { boolean, index, json, mysqlTable, timestamp, uniqueIndex, varchar } from "drizzle-orm/mysql-core"
+import type { DesktopPolicyValue } from "@openwork/types/den/desktop-policies"
+import { denTypeIdColumn } from "../columns"
+import { MemberTable, OrganizationTable } from "./org"
+import { TeamTable } from "./teams"
+
+export const DesktopPolicyTable = mysqlTable(
+  "desktop_policy",
+  {
+    id: denTypeIdColumn("desktopPolicy", "id").notNull().primaryKey(),
+    organizationId: denTypeIdColumn("organization", "organization_id").notNull(),
+    policyName: varchar("policy_name", { length: 255 }).notNull(),
+    isDefault: boolean("is_default"),
+    isEnabled: boolean("is_enabled").notNull().default(true),
+    policy: json("policy").$type<DesktopPolicyValue>().notNull().default(sql`(json_object())`),
+    createdByOrgMemberId: denTypeIdColumn("member", "created_by_org_member_id").notNull(),
+    createdAt: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { fsp: 3 })
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)`),
+    deletedAt: timestamp("deleted_at", { fsp: 3 }),
+  },
+  (table) => [
+    index("desktop_policy_organization_id").on(table.organizationId),
+    index("desktop_policy_created_by_member_id").on(table.createdByOrgMemberId),
+    index("desktop_policy_is_enabled").on(table.isEnabled),
+    index("desktop_policy_deleted_at").on(table.deletedAt),
+    uniqueIndex("desktop_policy_org_default").on(table.organizationId, table.isDefault),
+  ],
+)
+
+export const DesktopPolicyMemberTable = mysqlTable(
+  "desktop_policy_member",
+  {
+    id: denTypeIdColumn("desktopPolicyMember", "id").notNull().primaryKey(),
+    organizationId: denTypeIdColumn("organization", "organization_id").notNull(),
+    desktopPolicyId: denTypeIdColumn("desktopPolicy", "desktop_policy_id").notNull(),
+    orgMemberId: denTypeIdColumn("member", "org_member_id"),
+    teamId: denTypeIdColumn("team", "team_id"),
+    createdAt: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("desktop_policy_member_organization_id").on(table.organizationId),
+    index("desktop_policy_member_policy_id").on(table.desktopPolicyId),
+    index("desktop_policy_member_org_member_id").on(table.orgMemberId),
+    index("desktop_policy_member_team_id").on(table.teamId),
+    uniqueIndex("desktop_policy_member_policy_org_member").on(table.desktopPolicyId, table.orgMemberId),
+    uniqueIndex("desktop_policy_member_policy_team").on(table.desktopPolicyId, table.teamId),
+  ],
+)
+
+export const desktopPolicyRelations = relations(DesktopPolicyTable, ({ many, one }) => ({
+  organization: one(OrganizationTable, {
+    fields: [DesktopPolicyTable.organizationId],
+    references: [OrganizationTable.id],
+  }),
+  createdByOrgMember: one(MemberTable, {
+    fields: [DesktopPolicyTable.createdByOrgMemberId],
+    references: [MemberTable.id],
+  }),
+  members: many(DesktopPolicyMemberTable),
+}))
+
+export const desktopPolicyMemberRelations = relations(DesktopPolicyMemberTable, ({ one }) => ({
+  organization: one(OrganizationTable, {
+    fields: [DesktopPolicyMemberTable.organizationId],
+    references: [OrganizationTable.id],
+  }),
+  desktopPolicy: one(DesktopPolicyTable, {
+    fields: [DesktopPolicyMemberTable.desktopPolicyId],
+    references: [DesktopPolicyTable.id],
+  }),
+  orgMember: one(MemberTable, {
+    fields: [DesktopPolicyMemberTable.orgMemberId],
+    references: [MemberTable.id],
+  }),
+  team: one(TeamTable, {
+    fields: [DesktopPolicyMemberTable.teamId],
+    references: [TeamTable.id],
+  }),
+}))
+
+export const desktopPolicy = DesktopPolicyTable
+export const desktopPolicyMember = DesktopPolicyMemberTable

--- a/ee/packages/den-db/src/schema/index.ts
+++ b/ee/packages/den-db/src/schema/index.ts
@@ -1,4 +1,5 @@
 export * from "./auth"
+export * from "./desktop-policies"
 export * from "./inference"
 export * from "./org"
 export * from "./sharables/llm-providers"

--- a/ee/packages/den-db/tsup.config.ts
+++ b/ee/packages/den-db/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     index: "src/index.ts",
     schema: "src/schema.ts",
     "schema/auth": "src/schema/auth.ts",
+    "schema/desktop-policies": "src/schema/desktop-policies.ts",
     "schema/inference": "src/schema/inference.ts",
     "schema/org": "src/schema/org.ts",
     "schema/sharables/skills": "src/schema/sharables/skills.ts",

--- a/ee/packages/utils/src/typeid.ts
+++ b/ee/packages/utils/src/typeid.ts
@@ -50,6 +50,8 @@ export const idTypesMapNameToPrefix = {
   llmProvider: "lpr",
   llmProviderModel: "lpm",
   llmProviderAccess: "lpa",
+  desktopPolicy: "dpo",
+  desktopPolicyMember: "dpm",
   organizationRole: "orl",
   adminAllowlist: "aal",
   worker: "wrk",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -13,6 +13,11 @@
       "development": "./src/den/desktop-app-restrictions.ts",
       "default": "./src/den/desktop-app-restrictions.ts"
     },
+    "./den/desktop-policies": {
+      "types": "./src/den/desktop-policies.ts",
+      "development": "./src/den/desktop-policies.ts",
+      "default": "./src/den/desktop-policies.ts"
+    },
     "./den/inference": {
       "types": "./src/den/inference.ts",
       "development": "./src/den/inference.ts",

--- a/packages/types/src/den/desktop-policies.ts
+++ b/packages/types/src/den/desktop-policies.ts
@@ -1,72 +1,135 @@
-import { z } from "zod"
+import { z } from "zod";
 
-export const desktopPolicyValueSchema = z.object({
-  allowNonCloudModels: z.boolean().optional(),
-  allowZenModel: z.boolean().optional(),
-  allowMultipleWorkspaces: z.boolean().optional(),
-}).meta({ ref: "DenDesktopPolicyValue" })
+type DesktopPolicyDefinitionEntry = {
+  id: string;
+  name: string;
+  description: string;
+  userNotice: string;
+  defaultValue: boolean;
+};
 
-export type DesktopPolicyValue = z.infer<typeof desktopPolicyValueSchema>
-export type DesktopPolicyKey = keyof DesktopPolicyValue
-
-export type DesktopPolicyDefinition = {
-  id: DesktopPolicyKey
-  name: string
-  description: string
-  userNotice: string
-  defaultValue: boolean
-}
-
+// Canonical desktop policy catalog.
+//
+// To add a new desktop policy item:
+// 1. Add a matching entry to `desktopPolicyDefinitions` below.
+// 2. Choose a safe `defaultValue` for orgs with missing/older policy data.
+// 3. Wire desktop app behavior to read the key through the desktop config hooks.
+// 4. If the key affects Den web editing copy, update the `name`, `description`,
+//    and `userNotice` here rather than duplicating that copy elsewhere.
+// 5. Do not manually edit `desktopPolicyValueSchema`; it is generated from the
+//    IDs in this definition list.
+//
+// Policy booleans usually use allow-style names. For every policy item,
+// `false` means the feature is restricted/disabled; `true` or an omitted value
+// means the app should not block the feature locally unless a default/effective
+// policy calculation supplies `false`.
 export const desktopPolicyDefinitions = [
   {
-    id: "allowNonCloudModels",
-    name: "Allow non-cloud models",
-    description: "Allow users to add and use models that are not deployed through OpenWork Cloud.",
-    userNotice: "Your organization administrator has disabled adding custom providers.",
+    id: "allowCustomProviders",
+    name: "Custom providers",
+    description:
+      "Allow users to add and use models that are not deployed through OpenWork Cloud.",
+    userNotice:
+      "Your organization administrator has disabled adding custom providers.",
     defaultValue: true,
   },
   {
     id: "allowZenModel",
-    name: "Allow OpenCode Zen Models",
+    name: "Enable OpenCode Zen Models",
     description: "Allow users to use the built in models provided by OpenCode.",
     userNotice: "Your administrator has disabled access to OpenCode Models.",
     defaultValue: true,
   },
   {
     id: "allowMultipleWorkspaces",
-    name: "Allow multiple workspaces",
-    description: "Allow users to create or configure more than one workspace on their machine.",
-    userNotice: "Your organization administrator has restricted access to adding additional workspaces.",
+    name: "Multiple workspaces",
+    description:
+      "Allow users to create or configure more than one workspace on their machine.",
+    userNotice:
+      "Your organization administrator has restricted access to adding additional workspaces.",
     defaultValue: true,
   },
-] as const satisfies readonly DesktopPolicyDefinition[]
+  {
+    id: "allowControlSettings",
+    name: "Control Settings",
+    description: "Allow users to access and change the desktop app settings.",
+    userNotice:
+      "Your organization administrator has disabled changing desktop app settings.",
+    defaultValue: true,
+  },
+  {
+    id: "allowManageExtensions",
+    name: "Manage Extensions",
+    description: "Allow users to install and manage extensions locally.",
+    userNotice:
+      "Your organization administrator has disabled local extension management.",
+    defaultValue: true,
+  },
+  {
+    id: "showWelcomePage",
+    name: "Welcome Page",
+    description: "Show the Getting Started page to new users.",
+    userNotice:
+      "Your organization administrator has disabled the Getting Started page.",
+    defaultValue: true,
+  },
+] as const satisfies readonly DesktopPolicyDefinitionEntry[];
 
-export const desktopPolicyKeys = desktopPolicyDefinitions.map((definition) => definition.id)
+export type DesktopPolicyKey = (typeof desktopPolicyDefinitions)[number]["id"];
+export type DesktopPolicyDefinition = Omit<DesktopPolicyDefinitionEntry, "id"> & {
+  id: DesktopPolicyKey;
+};
+
+const desktopPolicyValueShape = Object.fromEntries(
+  desktopPolicyDefinitions.map((definition) => [
+    definition.id,
+    z.boolean().optional(),
+  ]),
+) as { [key in DesktopPolicyKey]: z.ZodOptional<z.ZodBoolean> };
+
+export const desktopPolicyValueSchema = z
+  .object(desktopPolicyValueShape)
+  .meta({ ref: "DenDesktopPolicyValue" });
+
+export type DesktopPolicyValue = z.infer<typeof desktopPolicyValueSchema>;
+
+export const desktopPolicyKeys = desktopPolicyDefinitions.map(
+  (definition) => definition.id,
+) as DesktopPolicyKey[];
 
 export const desktopPolicyDefaults = Object.fromEntries(
-  desktopPolicyDefinitions.map((definition) => [definition.id, definition.defaultValue]),
-) as Required<DesktopPolicyValue>
+  desktopPolicyDefinitions.map((definition) => [
+    definition.id,
+    definition.defaultValue,
+  ]),
+) as Required<DesktopPolicyValue>;
 
-export const desktopConfigSchema = desktopPolicyValueSchema.extend({
-  allowedDesktopVersions: z.array(z.string().trim().min(1).max(32)).optional(),
-}).meta({ ref: "DenDesktopConfig" })
+export const desktopConfigSchema = desktopPolicyValueSchema
+  .extend({
+    allowedDesktopVersions: z
+      .array(z.string().trim().min(1).max(32))
+      .optional(),
+  })
+  .meta({ ref: "DenDesktopConfig" });
 
-export type DesktopConfig = z.infer<typeof desktopConfigSchema>
+export type DesktopConfig = z.infer<typeof desktopConfigSchema>;
 
 function normalizeDesktopVersionString(value: unknown) {
   if (typeof value !== "string") {
-    return null
+    return null;
   }
 
-  const normalized = value.trim().replace(/^v/i, "")
-  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(normalized)
+  const normalized = value.trim().replace(/^v/i, "");
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+    normalized,
+  )
     ? normalized
-    : null
+    : null;
 }
 
 function normalizeAllowedDesktopVersions(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
-    return undefined
+    return undefined;
   }
 
   return [
@@ -75,70 +138,83 @@ function normalizeAllowedDesktopVersions(value: unknown): string[] | undefined {
         .map((entry) => normalizeDesktopVersionString(entry))
         .filter((entry): entry is string => Boolean(entry)),
     ),
-  ]
+  ];
 }
 
-export function normalizeDesktopPolicyValue(value: unknown): DesktopPolicyValue {
-  const parsed = desktopPolicyValueSchema.safeParse(value)
+export function normalizeDesktopPolicyValue(
+  value: unknown,
+): DesktopPolicyValue {
+  const parsed = desktopPolicyValueSchema.safeParse(value);
   if (parsed.success) {
     return Object.fromEntries(
-      desktopPolicyKeys.flatMap((key) => typeof parsed.data[key] === "boolean" ? [[key, parsed.data[key]] as const] : []),
-    ) as DesktopPolicyValue
+      desktopPolicyKeys.flatMap((key) =>
+        typeof parsed.data[key] === "boolean"
+          ? [[key, parsed.data[key]] as const]
+          : [],
+      ),
+    ) as DesktopPolicyValue;
   }
 
-  return {}
+  return {};
 }
 
-export function normalizeDefaultDesktopPolicyValue(value: unknown): Required<DesktopPolicyValue> {
-  const normalized = normalizeDesktopPolicyValue(value)
+export function normalizeDefaultDesktopPolicyValue(
+  value: unknown,
+): Required<DesktopPolicyValue> {
+  const normalized = normalizeDesktopPolicyValue(value);
   return Object.fromEntries(
     desktopPolicyDefinitions.map((definition) => [
       definition.id,
       normalized[definition.id] ?? definition.defaultValue,
     ]),
-  ) as Required<DesktopPolicyValue>
+  ) as Required<DesktopPolicyValue>;
 }
 
-export function allDesktopPolicies(value: boolean): Required<DesktopPolicyValue> {
+export function allDesktopPolicies(
+  value: boolean,
+): Required<DesktopPolicyValue> {
   return Object.fromEntries(
     desktopPolicyDefinitions.map((definition) => [definition.id, value]),
-  ) as Required<DesktopPolicyValue>
+  ) as Required<DesktopPolicyValue>;
 }
 
 export function calculateEffectiveDesktopPolicy(input: {
-  orgPolicyCount: number
-  defaultPolicy?: DesktopPolicyValue | null
-  assignedPolicies: DesktopPolicyValue[]
+  orgPolicyCount: number;
+  defaultPolicy?: DesktopPolicyValue | null;
+  assignedPolicies: DesktopPolicyValue[];
 }): Required<DesktopPolicyValue> {
   if (input.orgPolicyCount === 0) {
-    return allDesktopPolicies(true)
+    return allDesktopPolicies(true);
   }
 
-  const calculated = allDesktopPolicies(false)
+  const calculated = allDesktopPolicies(false);
   const policies = [
     normalizeDefaultDesktopPolicyValue(input.defaultPolicy ?? {}),
-    ...input.assignedPolicies.map((policy) => normalizeDesktopPolicyValue(policy)),
-  ]
+    ...input.assignedPolicies.map((policy) =>
+      normalizeDesktopPolicyValue(policy),
+    ),
+  ];
 
   for (const policy of policies) {
     for (const key of desktopPolicyKeys) {
       if (policy[key] === true) {
-        calculated[key] = true
+        calculated[key] = true;
       }
     }
   }
 
-  return calculated
+  return calculated;
 }
 
 export function normalizeDesktopConfig(value: unknown): DesktopConfig {
-  const policy = normalizeDesktopPolicyValue(value)
+  const policy = normalizeDesktopPolicyValue(value);
   const allowedDesktopVersions = normalizeAllowedDesktopVersions(
-    (value as { allowedDesktopVersions?: unknown } | null)?.allowedDesktopVersions,
-  )
+    (value as { allowedDesktopVersions?: unknown } | null)
+      ?.allowedDesktopVersions,
+  );
 
   return {
     ...policy,
     ...(allowedDesktopVersions !== undefined ? { allowedDesktopVersions } : {}),
-  }
+  };
 }

--- a/packages/types/src/den/desktop-policies.ts
+++ b/packages/types/src/den/desktop-policies.ts
@@ -1,0 +1,144 @@
+import { z } from "zod"
+
+export const desktopPolicyValueSchema = z.object({
+  allowNonCloudModels: z.boolean().optional(),
+  allowZenModel: z.boolean().optional(),
+  allowMultipleWorkspaces: z.boolean().optional(),
+}).meta({ ref: "DenDesktopPolicyValue" })
+
+export type DesktopPolicyValue = z.infer<typeof desktopPolicyValueSchema>
+export type DesktopPolicyKey = keyof DesktopPolicyValue
+
+export type DesktopPolicyDefinition = {
+  id: DesktopPolicyKey
+  name: string
+  description: string
+  userNotice: string
+  defaultValue: boolean
+}
+
+export const desktopPolicyDefinitions = [
+  {
+    id: "allowNonCloudModels",
+    name: "Allow non-cloud models",
+    description: "Allow users to add and use models that are not deployed through OpenWork Cloud.",
+    userNotice: "Your organization administrator has disabled adding custom providers.",
+    defaultValue: true,
+  },
+  {
+    id: "allowZenModel",
+    name: "Allow OpenCode Zen Models",
+    description: "Allow users to use the built in models provided by OpenCode.",
+    userNotice: "Your administrator has disabled access to OpenCode Models.",
+    defaultValue: true,
+  },
+  {
+    id: "allowMultipleWorkspaces",
+    name: "Allow multiple workspaces",
+    description: "Allow users to create or configure more than one workspace on their machine.",
+    userNotice: "Your organization administrator has restricted access to adding additional workspaces.",
+    defaultValue: true,
+  },
+] as const satisfies readonly DesktopPolicyDefinition[]
+
+export const desktopPolicyKeys = desktopPolicyDefinitions.map((definition) => definition.id)
+
+export const desktopPolicyDefaults = Object.fromEntries(
+  desktopPolicyDefinitions.map((definition) => [definition.id, definition.defaultValue]),
+) as Required<DesktopPolicyValue>
+
+export const desktopConfigSchema = desktopPolicyValueSchema.extend({
+  allowedDesktopVersions: z.array(z.string().trim().min(1).max(32)).optional(),
+}).meta({ ref: "DenDesktopConfig" })
+
+export type DesktopConfig = z.infer<typeof desktopConfigSchema>
+
+function normalizeDesktopVersionString(value: unknown) {
+  if (typeof value !== "string") {
+    return null
+  }
+
+  const normalized = value.trim().replace(/^v/i, "")
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(normalized)
+    ? normalized
+    : null
+}
+
+function normalizeAllowedDesktopVersions(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  return [
+    ...new Set(
+      value
+        .map((entry) => normalizeDesktopVersionString(entry))
+        .filter((entry): entry is string => Boolean(entry)),
+    ),
+  ]
+}
+
+export function normalizeDesktopPolicyValue(value: unknown): DesktopPolicyValue {
+  const parsed = desktopPolicyValueSchema.safeParse(value)
+  if (parsed.success) {
+    return Object.fromEntries(
+      desktopPolicyKeys.flatMap((key) => typeof parsed.data[key] === "boolean" ? [[key, parsed.data[key]] as const] : []),
+    ) as DesktopPolicyValue
+  }
+
+  return {}
+}
+
+export function normalizeDefaultDesktopPolicyValue(value: unknown): Required<DesktopPolicyValue> {
+  const normalized = normalizeDesktopPolicyValue(value)
+  return Object.fromEntries(
+    desktopPolicyDefinitions.map((definition) => [
+      definition.id,
+      normalized[definition.id] ?? definition.defaultValue,
+    ]),
+  ) as Required<DesktopPolicyValue>
+}
+
+export function allDesktopPolicies(value: boolean): Required<DesktopPolicyValue> {
+  return Object.fromEntries(
+    desktopPolicyDefinitions.map((definition) => [definition.id, value]),
+  ) as Required<DesktopPolicyValue>
+}
+
+export function calculateEffectiveDesktopPolicy(input: {
+  orgPolicyCount: number
+  defaultPolicy?: DesktopPolicyValue | null
+  assignedPolicies: DesktopPolicyValue[]
+}): Required<DesktopPolicyValue> {
+  if (input.orgPolicyCount === 0) {
+    return allDesktopPolicies(true)
+  }
+
+  const calculated = allDesktopPolicies(false)
+  const policies = [
+    normalizeDefaultDesktopPolicyValue(input.defaultPolicy ?? {}),
+    ...input.assignedPolicies.map((policy) => normalizeDesktopPolicyValue(policy)),
+  ]
+
+  for (const policy of policies) {
+    for (const key of desktopPolicyKeys) {
+      if (policy[key] === true) {
+        calculated[key] = true
+      }
+    }
+  }
+
+  return calculated
+}
+
+export function normalizeDesktopConfig(value: unknown): DesktopConfig {
+  const policy = normalizeDesktopPolicyValue(value)
+  const allowedDesktopVersions = normalizeAllowedDesktopVersions(
+    (value as { allowedDesktopVersions?: unknown } | null)?.allowedDesktopVersions,
+  )
+
+  return {
+    ...policy,
+    ...(allowedDesktopVersions !== undefined ? { allowedDesktopVersions } : {}),
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./den/desktop-app-restrictions"
+export * from "./den/desktop-policies"
 export * from "./den/inference"

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     "den/desktop-app-restrictions": "src/den/desktop-app-restrictions.ts",
+    "den/desktop-policies": "src/den/desktop-policies.ts",
     "den/inference": "src/den/inference.ts",
   },
   tsconfig: "./tsconfig.json",


### PR DESCRIPTION
## Summary
- Introduce org desktop policies with default policies, member/team assignments, and effective policy calculation.
- Add Den API CRUD routes, DB schema/migration, demo seed/default creation, and a backfill script from legacy desktop app restrictions.
- Add Den web desktop policy list/create/edit screens and update the desktop app to consume allow-style policy config.
- Derive desktop policy schema/keys from desktopPolicyDefinitions and document app-side policy usage.

## Verification
- pnpm --filter @openwork/types build: passed
- pnpm --filter @openwork-ee/den-db build: passed
- pnpm --filter @openwork-ee/den-api build: passed
- pnpm --filter @openwork-ee/den-api exec tsc --noEmit: passed
- pnpm --filter @openwork-ee/den-api exec tsc --noEmit --moduleResolution Bundler --module ESNext --target ES2022 --jsx react-jsx --strict --skipLibCheck scripts/seed-demo-org.ts scripts/backfill-desktop-policies.ts: passed
- pnpm --filter @openwork/app typecheck: passed
- pnpm --filter @openwork-ee/den-web exec tsc --noEmit: passed
- git diff --check: passed

## Manual Checks
- Verified Den web desktop policy create/delete flow locally via Chrome DevTools with no console errors.
- Verified GET /v1/me/desktop-config returns explicit booleans, respects default policy values, applies enabled member/team policies, ignores disabled/deleted policies, and ORs multiple grants.

## Evidence
No video was captured for this PR. Manual browser/API verification was performed locally; the commands above can be rerun by reviewers.