### PR TITLE
fix(app): preserve workspace sessions when path normalization mismatches

### DIFF
--- a/apps/app/src/app/lib/session-scope.ts
+++ b/apps/app/src/app/lib/session-scope.ts
@@ -99,3 +99,50 @@ export function shouldRedirectMissingSessionAfterScopedLoad(input: {
 
   return scopedRootsMatch(input.loadedScopeRoot, workspaceRoot);
 }
+
+export type SessionLike = { directory?: string | null };
+
+export type SessionScopeFilterMismatch = {
+  workspaceRoot: string;
+  sampleSessionDirectory: string;
+  totalServerSessions: number;
+};
+
+/**
+ * Filter a server-returned session list down to those whose `directory` matches
+ * the active workspace root.
+ *
+ * **Fails open.** If the strict path comparison would drop every session even
+ * though the server returned a non-empty list, the unfiltered list is returned
+ * and `onMismatch` is invoked. The openwork server already routes the request
+ * to the workspace's own OpenCode instance, so an empty filtered result almost
+ * always means the two paths differ in form (resolved vs unresolved symlinks,
+ * NFC vs NFD unicode, case, trailing separators) rather than the sessions
+ * legitimately belonging to a different workspace. Hiding the user's sessions
+ * in that situation is worse than rendering them.
+ *
+ * See: GitHub issue #1140.
+ */
+export function filterSessionsToWorkspace<S extends SessionLike>(
+  sessions: ReadonlyArray<S>,
+  workspaceRoot: string | null | undefined,
+  options?: { onMismatch?: (info: SessionScopeFilterMismatch) => void },
+): S[] {
+  const root = normalizeDirectoryPath(workspaceRoot ?? "");
+  if (!root) return sessions.slice();
+
+  const filtered = sessions.filter(
+    (session) => normalizeDirectoryPath(session?.directory ?? "") === root,
+  );
+
+  if (filtered.length === 0 && sessions.length > 0) {
+    options?.onMismatch?.({
+      workspaceRoot: root,
+      sampleSessionDirectory: normalizeDirectoryPath(sessions[0]?.directory ?? ""),
+      totalServerSessions: sessions.length,
+    });
+    return sessions.slice();
+  }
+
+  return filtered;
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -65,6 +65,7 @@ import type {
   WorkspaceSessionGroup,
 } from "../../app/types";
 import { buildFeedbackUrl } from "../../app/lib/feedback";
+import { filterSessionsToWorkspace } from "../../app/lib/session-scope";
 import {
   getWorkspaceTaskLoadErrorDisplay,
   isDesktopRuntime,
@@ -690,12 +691,14 @@ export function SessionRoute() {
         backgroundSessionLoadInFlight.current.set(workspace.id, requestStartedAt);
         try {
           const response = await endpoint.client.listSessions(endpoint.workspaceId, { limit: 200 });
-          const workspaceRoot = normalizeDirectoryPath(workspace.path ?? "");
-          const items = workspaceRoot
-            ? (response.items ?? []).filter((session: any) =>
-                normalizeDirectoryPath(session?.directory ?? "") === workspaceRoot,
-              )
-            : (response.items ?? []);
+          const items = filterSessionsToWorkspace(response.items ?? [], workspace.path, {
+            onMismatch: (info) => {
+              console.warn(
+                "[openwork] sidebar session list did not match workspace path; falling back to server-scoped list",
+                { workspaceId: workspace.id, ...info },
+              );
+            },
+          });
           setSessionsByWorkspaceId((current) => {
             const nextItems = mergeFetchedSessionsWithPending(workspace.id, items, current[workspace.id] ?? []);
             const next = { ...current, [workspace.id]: nextItems };

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -86,6 +86,7 @@ import {
 import { isDesktopProviderBlocked } from "../../app/cloud/desktop-app-restrictions";
 import { useCheckDesktopRestriction, useDesktopConfig } from "../domains/cloud/desktop-config-provider";
 import { useCloudProviderAutoSync } from "../domains/cloud/use-cloud-provider-auto-sync";
+import { filterSessionsToWorkspace } from "../../app/lib/session-scope";
 import {
   isDesktopRuntime,
   isElectronRuntime,
@@ -955,12 +956,14 @@ function SettingsRouteContent() {
           }
           try {
             const response = await client.listSessions(workspace.id, { limit: 200 });
-            const workspaceRoot = normalizeDirectoryPath(workspace.path ?? "");
-            const items = workspaceRoot
-              ? (response.items ?? []).filter((session: any) =>
-                  normalizeDirectoryPath(session?.directory ?? "") === workspaceRoot,
-                )
-              : (response.items ?? []);
+            const items = filterSessionsToWorkspace(response.items ?? [], workspace.path, {
+              onMismatch: (info) => {
+                console.warn(
+                  "[openwork] settings session list did not match workspace path; falling back to server-scoped list",
+                  { workspaceId: workspace.id, ...info },
+                );
+              },
+            });
             return {
               workspaceId: workspace.id,
               sessions: items,

--- a/apps/app/tests/session-scope-filter.test.ts
+++ b/apps/app/tests/session-scope-filter.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  filterSessionsToWorkspace,
+  type SessionScopeFilterMismatch,
+} from "../src/app/lib/session-scope";
+
+type Session = { id: string; directory?: string | null };
+
+const session = (id: string, directory?: string | null): Session => ({ id, directory });
+
+describe("filterSessionsToWorkspace", () => {
+  test("returns server list unchanged when workspace root is empty", () => {
+    const all = [session("a", "/Users/x/work"), session("b", "/Users/x/other")];
+    expect(filterSessionsToWorkspace(all, "")).toEqual(all);
+    expect(filterSessionsToWorkspace(all, null)).toEqual(all);
+    expect(filterSessionsToWorkspace(all, undefined)).toEqual(all);
+  });
+
+  test("returns empty when the server returned no sessions", () => {
+    const calls: SessionScopeFilterMismatch[] = [];
+    const result = filterSessionsToWorkspace([], "/Users/x/work", {
+      onMismatch: (info) => calls.push(info),
+    });
+    expect(result).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  test("keeps sessions whose directory matches workspace root", () => {
+    const all = [
+      session("a", "/Users/x/work"),
+      session("b", "/Users/x/work/"),
+      session("c", "/Users/x/other"),
+    ];
+    const result = filterSessionsToWorkspace(all, "/Users/x/work");
+    expect(result.map((s) => s.id)).toEqual(["a", "b"]);
+  });
+
+  test("fails open when strict comparison drops every session", () => {
+    // Mimics #1140: server returned sessions but client-side path comparison
+    // would hide all of them (e.g., resolved vs unresolved symlinks). The
+    // server already routed the request to this workspace's OpenCode
+    // instance, so trust the server's scope rather than hiding user data.
+    const calls: SessionScopeFilterMismatch[] = [];
+    const all = [
+      session("a", "/private/var/folders/abc/Workspace"),
+      session("b", "/private/var/folders/abc/Workspace"),
+    ];
+    const result = filterSessionsToWorkspace(all, "/Users/me/Workspace", {
+      onMismatch: (info) => calls.push(info),
+    });
+    expect(result).toEqual(all);
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.totalServerSessions).toBe(2);
+  });
+
+  test("does not fire onMismatch when filter retains anything", () => {
+    const calls: SessionScopeFilterMismatch[] = [];
+    const all = [
+      session("a", "/Users/x/work"),
+      session("b", "/Users/x/other"),
+    ];
+    const result = filterSessionsToWorkspace(all, "/Users/x/work", {
+      onMismatch: (info) => calls.push(info),
+    });
+    expect(result.map((s) => s.id)).toEqual(["a"]);
+    expect(calls).toEqual([]);
+  });
+
+  test("treats missing session.directory as empty (filtered out, unless fail-open triggers)", () => {
+    const all = [session("a"), session("b", null), session("c", "/Users/x/work")];
+    const result = filterSessionsToWorkspace(all, "/Users/x/work");
+    expect(result.map((s) => s.id)).toEqual(["c"]);
+  });
+
+  test("returns a fresh array (does not leak the server array reference)", () => {
+    const all = [session("a", "/Users/x/work")];
+    const result = filterSessionsToWorkspace(all, "/Users/x/work");
+    expect(result).not.toBe(all);
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts the sidebar/settings session-list filter into a shared `filterSessionsToWorkspace` helper.
- Makes the filter **fail open**: if the strict path comparison would empty a non-empty server response, the server's list is returned unchanged and a `console.warn` is emitted for diagnosis.
- Replaces the inline filter at both call sites (`session-route.tsx`, `settings-route.tsx`).

## Why
The openwork server already proxies session listing to the workspace's own OpenCode instance (`apps/server/src/server.ts:3010`), so the response is already scoped to that workspace. The client-side filter is defensive double-filtering. When `workspace.path` and `session.directory` differ in form — resolved vs unresolved symlinks, NFC vs NFD unicode on macOS, trailing separators, case, or path-format changes across app versions — the strict-equality comparison drops every session even though the data is intact. The user experience is "all my workspace sessions disappeared," matching the three variants in #1140.

The filter was introduced in `fa3c9c4d` ("fix session loading") as a port of the legacy `context/workspace.ts::listWorkspaceSessions` filter. Failing open preserves its defensive intent against a hypothetical cross-workspace response while no longer hiding the user's data when the comparison drifts.

## Issue
- Closes #1140

## Scope
- `apps/app/src/app/lib/session-scope.ts` — new `filterSessionsToWorkspace` helper
- `apps/app/src/react-app/shell/session-route.tsx` — sidebar session load
- `apps/app/src/react-app/shell/settings-route.tsx` — settings session load
- `apps/app/tests/session-scope-filter.test.ts` — 7 bun tests

## Out of scope
- Investigating *why* paths drift (symlink resolution differences, version-to-version format changes); the fail-open warning gives us telemetry to chase that next.
- Server-side session listing in `apps/server` — already correct.

## Testing
### Ran
- \`bun test apps/app/tests/session-scope-filter.test.ts\` — 7 pass / 0 fail
- \`pnpm typecheck\` — exit 0
- \`pnpm test:e2e\` — exit 0 (\`test:local-file-path → e2e → session-switch → fs-engine → browser-entry\`)
- \`node scripts/i18n-audit.mjs --ci\` — pass

### Result
- pass

## CI status
- pass:
- code-related failures:
- external/env/auth blockers:

## Manual verification
1. \`pnpm install\`
2. \`bun test apps/app/tests/session-scope-filter.test.ts\`
3. \`pnpm typecheck\`
4. \`pnpm test:e2e\`
5. Open a workspace that previously had sessions; confirm the session list renders. If a path mismatch occurs, check the renderer console for \`[openwork] sidebar session list did not match workspace path …\` — the sessions still appear and the warning helps trace the underlying path drift.

## Evidence
- No UI-flow change for the happy path (paths already match). Video/screenshot not applicable; the user-visible effect is "session list is no longer empty when the previously-buggy mismatch occurs," which requires reproducing the path drift to capture.
- Local test output:
  \`\`\`
  bun test v1.3.14
  apps/app/tests/session-scope-filter.test.ts:
   7 pass, 0 fail, 13 expect() calls
  \`\`\`

## Risk
- Low. Happy path is unchanged (filter still strips truly out-of-scope sessions). The fail-open branch only fires when the strict filter would otherwise yield an empty list from a non-empty server response — same situation that currently shows the user an empty workspace.

## Rollback
- Revert this commit. No data migration, no persisted schema change. The filter reverts to strict equality.