### PR TITLE
fix(den-db): support socketPath in DATABASE_URL for Cloud SQL connections

### DIFF
--- a/ee/packages/den-db/src/mysql-config.ts
+++ b/ee/packages/den-db/src/mysql-config.ts
@@ -4,6 +4,10 @@ type ParsedMySqlConfig = {
   user: string
   password: string
   database: string
+  // Unix socket path for the MySQL connection (e.g. Cloud SQL's
+  // `/cloudsql/<project>:<region>:<instance>`). When set, `mysql2` ignores
+  // `host`/`port` and connects via the socket.
+  socketPath?: string
   ssl?: {
     rejectUnauthorized: boolean
   }
@@ -29,6 +33,14 @@ function readSslSettings(parsed: URL) {
   return { rejectUnauthorized }
 }
 
+function readSocketPath(parsed: URL): string | undefined {
+  const value =
+    parsed.searchParams.get("socketPath")?.trim() ||
+    parsed.searchParams.get("socket")?.trim() ||
+    ""
+  return value || undefined
+}
+
 export function parseMySqlConnectionConfig(databaseUrl: string): ParsedMySqlConfig {
   const parsed = new URL(databaseUrl)
   const database = parsed.pathname.replace(/^\//, "")
@@ -37,12 +49,15 @@ export function parseMySqlConnectionConfig(databaseUrl: string): ParsedMySqlConf
     throw new Error("DATABASE_URL must include host, username, and database for mysql mode")
   }
 
+  const socketPath = readSocketPath(parsed)
+
   return {
     host: parsed.hostname,
     port: Number(parsed.port || "3306"),
     user: decodeURIComponent(parsed.username),
     password: decodeURIComponent(parsed.password),
     database,
+    ...(socketPath ? { socketPath } : {}),
     ssl: readSslSettings(parsed),
   }
 }

--- a/ee/packages/den-db/test/mysql-config.test.ts
+++ b/ee/packages/den-db/test/mysql-config.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+
+import { parseMySqlConnectionConfig } from "../src/mysql-config.ts"
+
+describe("parseMySqlConnectionConfig", () => {
+  test("parses a basic TCP connection URL", () => {
+    const config = parseMySqlConnectionConfig(
+      "mysql://root:password@127.0.0.1:3306/openwork_den",
+    )
+    expect(config).toEqual({
+      host: "127.0.0.1",
+      port: 3306,
+      user: "root",
+      password: "password",
+      database: "openwork_den",
+    })
+  })
+
+  test("defaults the port to 3306 when missing", () => {
+    const config = parseMySqlConnectionConfig(
+      "mysql://root:password@db.internal/openwork_den",
+    )
+    expect(config.port).toBe(3306)
+  })
+
+  test("decodes percent-encoded username and password", () => {
+    const config = parseMySqlConnectionConfig(
+      "mysql://us%40er:p%40ss%2Fword@host/db",
+    )
+    expect(config.user).toBe("us@er")
+    expect(config.password).toBe("p@ss/word")
+  })
+
+  test("populates socketPath from ?socketPath query parameter (Cloud SQL)", () => {
+    const config = parseMySqlConnectionConfig(
+      "mysql://root:password@localhost/openwork_den?socketPath=/cloudsql/project:region:instance",
+    )
+    expect(config.socketPath).toBe("/cloudsql/project:region:instance")
+    // host/port still present; mysql2 ignores them when socketPath is set.
+    expect(config.host).toBe("localhost")
+    expect(config.port).toBe(3306)
+  })
+
+  test("accepts the ?socket alias", () => {
+    const config = parseMySqlConnectionConfig(
+      "mysql://root:password@localhost/openwork_den?socket=/var/run/mysqld/mysqld.sock",
+    )
+    expect(config.socketPath).toBe("/var/run/mysqld/mysqld.sock")
+  })
+
+  test("prefers ?socketPath over ?socket when both are present", () => {
+    const config = parseMySqlConnectionConfig(
+      "mysql://root:password@localhost/openwork_den?socketPath=/a&socket=/b",
+    )
+    expect(config.socketPath).toBe("/a")
+  })
+
+  test("omits socketPath when neither parameter is present", () => {
+    const config = parseMySqlConnectionConfig(
+      "mysql://root:password@127.0.0.1:3306/openwork_den",
+    )
+    expect(config).not.toHaveProperty("socketPath")
+  })
+
+  test("treats an empty ?socketPath as absent", () => {
+    const config = parseMySqlConnectionConfig(
+      "mysql://root:password@127.0.0.1:3306/openwork_den?socketPath=",
+    )
+    expect(config).not.toHaveProperty("socketPath")
+  })
+
+  test("retains SSL settings alongside socketPath", () => {
+    const config = parseMySqlConnectionConfig(
+      "mysql://root:password@localhost/openwork_den?socketPath=/cloudsql/x&sslmode=require",
+    )
+    expect(config.socketPath).toBe("/cloudsql/x")
+    expect(config.ssl).toEqual({ rejectUnauthorized: true })
+  })
+
+  test("throws when host, username, or database is missing", () => {
+    expect(() => parseMySqlConnectionConfig("mysql://root@/db")).toThrow()
+    expect(() => parseMySqlConnectionConfig("mysql://root@host/")).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- Parse `?socketPath` (and the `?socket` alias) from the MySQL `DATABASE_URL` and pass it through `parseMySqlConnectionConfig`.
- When present, `mysql2` ignores `host`/`port` and connects via the Unix socket — fixing both the den-api runtime and `drizzle-kit db:push`, since `drizzle.config.ts` already routes through the same parser.
- Adds a `mysql-config.test.ts` covering TCP, socketPath, alias, precedence, empty value, SSL coexistence, and validation cases (10 tests).

## Why
On Google Cloud Run with Cloud SQL attached via a Unix socket, the recommended `DATABASE_URL` is `mysql://user:pw@localhost/db?socketPath=/cloudsql/<conn>`. The parser was dropping the `socketPath` query parameter entirely, so `mysql2` fell back to TCP on `127.0.0.1:3306`, which is not available in Cloud Run, and every request 500'd with `ECONNREFUSED`. The fix is single-source: because `drizzle.config.ts` calls the same `parseMySqlConnectionConfig`, fixing the parser fixes migrations too.

## Issue
- Closes #1805

## Scope
- `ee/packages/den-db/src/mysql-config.ts` — type + parser
- `ee/packages/den-db/test/mysql-config.test.ts` — new bun:test coverage

## Out of scope
- TLS/CA handling for socket connections (Cloud SQL sockets do not need it).
- Changes to `client.ts` or `drizzle.config.ts` — neither needs touching since they both spread the parser's return value.

## Testing
### Ran
- `bun test ee/packages/den-db/test/mysql-config.test.ts` — 10 pass / 0 fail
- `pnpm --filter @openwork-ee/den-db build` — ok
- `pnpm test:e2e` — exit 0 (no regression)

### Result
- pass

## CI status
- pass:
- code-related failures:
- external/env/auth blockers: `pnpm typecheck` shows a pre-existing failure on `dev` (`apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-model.ts` cannot find module `xlsx`) introduced by #1836. Unrelated to this change; den-db typechecks clean on its own (`pnpm --filter @openwork-ee/den-db build` succeeds).

## Manual verification
1. `pnpm install`
2. `bun test ee/packages/den-db/test/mysql-config.test.ts`
3. `pnpm --filter @openwork-ee/den-db build`
4. To verify against a real Cloud SQL socket: set `DATABASE_URL=mysql://root:password@localhost/<db>?socketPath=/cloudsql/<project>:<region>:<instance>` and run `pnpm --filter @openwork-ee/den-db db:push`; the migration should succeed instead of failing with `ECONNREFUSED 127.0.0.1:3306`.

## Evidence
- Local test output:
  ```
  bun test v1.3.14
  ee/packages/den-db/test/mysql-config.test.ts:
   10 pass, 0 fail, 15 expect() calls
  ```
- Live Cloud SQL evidence not captured (no Cloud Run sandbox in this dev loop). Patch shape matches the fix proposed in #1805.

## Risk
- Low. New field is optional and additive; absent in the parsed output when the query param is missing, so existing TCP-only `DATABASE_URL` values are unchanged.

## Rollback
- Revert this commit. No schema or migration changes.