### PR TITLE
Restore artifact openable items

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -22,6 +22,8 @@
     "test:todos": "node scripts/todos.mjs",
     "test:permissions": "node scripts/permissions.mjs",
     "test:remote-diagnostics": "bun test scripts/remote-workspace-diagnostics.test.ts",
+    "test:open-target": "bun test scripts/open-target.test.ts",
+    "test:artifact-spreadsheet": "bun test scripts/artifact-spreadsheet.test.ts",
     "test:dev-log": "bun scripts/dev-log.ts",
     "test:session-error-recovery": "bun scripts/session-error-recovery.ts",
     "test:session-scope": "bun scripts/session-scope.ts",
@@ -73,6 +75,7 @@
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
+    "xlsx": "^0.18.5",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/apps/app/scripts/artifact-spreadsheet.test.ts
+++ b/apps/app/scripts/artifact-spreadsheet.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  parseSpreadsheet,
+  serializeSpreadsheet,
+} from "../src/react-app/domains/session/artifacts/artifact-spreadsheet-model";
+
+describe("artifact spreadsheet model", () => {
+  it("round-trips CSV edits", async () => {
+    const rows = await parseSpreadsheet({ name: "artifact-eval.csv", text: "name,revenue\nAda,10\n" });
+    rows[1]![1] = "11";
+    const output = await serializeSpreadsheet("artifact-eval.csv", rows);
+    expect(output).toEqual({ kind: "text", content: "name,revenue\nAda,11\n" });
+  });
+
+  it("round-trips XLSX edits", async () => {
+    const output = await serializeSpreadsheet("artifact-eval.xlsx", [["name", "revenue"], ["Ada", "10"]]);
+    expect(output.kind).toBe("binary");
+    if (output.kind !== "binary") throw new Error("expected binary");
+    const parsed = await parseSpreadsheet({ name: "artifact-eval.xlsx", data: output.data });
+    expect(parsed.slice(0, 2)).toEqual([["name", "revenue"], ["Ada", "10"]]);
+  });
+});

--- a/apps/app/scripts/open-target.test.ts
+++ b/apps/app/scripts/open-target.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import type { UIMessage } from "ai";
+
+import {
+  classifyOpenTarget,
+  deriveOpenTargets,
+  shouldAutoOpenTarget,
+} from "../src/react-app/domains/session/artifacts/open-target";
+
+function message(id: string, role: "user" | "assistant", text: string): UIMessage {
+  return { id, role, parts: [{ type: "text", text, state: "done" }] };
+}
+
+describe("open target classification", () => {
+  it("routes common artifact formats to deterministic previews", () => {
+    expect(classifyOpenTarget("report.md", "file")).toBe("markdown");
+    expect(classifyOpenTarget("customers.csv", "file")).toBe("sheet");
+    expect(classifyOpenTarget("forecast.xlsx", "file")).toBe("sheet");
+    expect(classifyOpenTarget("diagram.svg", "file")).toBe("image");
+    expect(classifyOpenTarget("dist/index.html", "file")).toBe("html");
+    expect(classifyOpenTarget("http://localhost:5173", "url")).toBe("browser");
+  });
+});
+
+describe("deriveOpenTargets", () => {
+  it("extracts file and localhost URL targets from recent assistant output", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "Created reports/revenue.xlsx and started http://localhost:5173 for preview."),
+    ]);
+
+    expect(targets.map((target) => target.value)).toContain("reports/revenue.xlsx");
+    expect(targets.map((target) => target.value)).toContain("http://localhost:5173");
+    expect(targets.find((target) => target.value === "reports/revenue.xlsx")?.preview).toBe("sheet");
+  });
+
+  it("extracts websocket URLs so local socket/dev-server hints stay visible", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "Socket open at ws://localhost:5173/socket and preview at dist/index.html"),
+    ]);
+
+    expect(targets.map((target) => target.value)).toContain("ws://localhost:5173/socket");
+    expect(targets.map((target) => target.value)).toContain("dist/index.html");
+  });
+
+  it("normalizes Workspace/<id>/ prefixes from artifact paths", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "See Workspace/32423/reports/artifact-eval.md and Workspace/32423/reports/artifact-eval.csv"),
+    ]);
+
+    expect(targets.map((target) => target.value)).toContain("reports/artifact-eval.md");
+    expect(targets.map((target) => target.value)).toContain("reports/artifact-eval.csv");
+  });
+
+  it("prefers explicit dynamic tool metadata over prose guesses", () => {
+    const targets = deriveOpenTargets([
+      {
+        id: "msg_tool",
+        role: "assistant",
+        parts: [{
+          type: "dynamic-tool",
+          toolName: "write",
+          toolCallId: "tool_1",
+          state: "output-available",
+          input: { path: "summary.md" },
+          output: { path: "summary.md" },
+        } as any],
+      },
+    ]);
+
+    expect(targets[0]).toMatchObject({ value: "summary.md", preview: "markdown", confidence: 95 });
+  });
+
+  it("auto-opens high-confidence deliverables and localhost previews only", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "Created data/customers.csv and see https://example.com for docs."),
+    ]);
+    const csv = targets.find((target) => target.value === "data/customers.csv");
+    const externalUrl = targets.find((target) => target.value === "https://example.com");
+
+    expect(csv && shouldAutoOpenTarget({ ...csv, exists: true })).toBe(true);
+    expect(csv && shouldAutoOpenTarget({ ...csv, exists: false })).toBe(false);
+    expect(externalUrl && shouldAutoOpenTarget(externalUrl)).toBe(false);
+  });
+});

--- a/apps/app/scripts/open-target.test.ts
+++ b/apps/app/scripts/open-target.test.ts
@@ -4,6 +4,8 @@ import type { UIMessage } from "ai";
 import {
   classifyOpenTarget,
   deriveOpenTargets,
+  isCollectibleArtifactTarget,
+  selectAutoOpenTarget,
   shouldAutoOpenTarget,
 } from "../src/react-app/domains/session/artifacts/open-target";
 
@@ -68,6 +70,104 @@ describe("deriveOpenTargets", () => {
     ]);
 
     expect(targets[0]).toMatchObject({ value: "summary.md", preview: "markdown", confidence: 95 });
+  });
+
+  it("does not turn package search results into artifacts", () => {
+    const targets = deriveOpenTargets([
+      {
+        id: "msg_tool",
+        role: "assistant",
+        parts: [{
+          type: "dynamic-tool",
+          toolName: "glob",
+          toolCallId: "tool_1",
+          state: "output-available",
+          input: { pattern: "**/package.json" },
+          output: {
+            files: [
+              "package.json",
+              "apps/app/package.json",
+              "packages/ui/package.json",
+              "reports/revenue.csv",
+            ],
+          },
+        } as any],
+      },
+      message("msg_2", "assistant", "Found package.json, apps/app/package.json, and reports/revenue.csv"),
+    ]);
+
+    expect(targets.map((target) => target.value)).not.toContain("package.json");
+    expect(targets.map((target) => target.value)).not.toContain("apps/app/package.json");
+    expect(targets.map((target) => target.value)).not.toContain("packages/ui/package.json");
+    expect(targets.map((target) => target.value)).toContain("reports/revenue.csv");
+  });
+
+  it("does not turn discovery tool markdown listings into artifacts", () => {
+    const targets = deriveOpenTargets([
+      {
+        id: "msg_tool",
+        role: "assistant",
+        parts: [{
+          type: "dynamic-tool",
+          toolName: "glob",
+          toolCallId: "tool_1",
+          state: "output-available",
+          input: { pattern: "**/*.md" },
+          output: {
+            files: [
+              "README.md",
+              ".opencode/skills/example/SKILL.md",
+              "reports/created-report.md",
+            ],
+          },
+        } as any],
+      },
+      message("msg_2", "assistant", "Created reports/created-report.md as the deliverable."),
+    ]);
+
+    expect(targets.map((target) => target.value)).toContain("reports/created-report.md");
+    expect(targets.map((target) => target.value)).not.toContain("README.md");
+    expect(targets.map((target) => target.value)).not.toContain(".opencode/skills/example/SKILL.md");
+  });
+
+  it("does not collect server-verified missing file targets", () => {
+    const target = deriveOpenTargets([
+      message("msg_1", "assistant", "Preview file: index.html"),
+    ])[0];
+
+    expect(target).toMatchObject({ value: "index.html", preview: "html" });
+    expect(isCollectibleArtifactTarget({ ...target, exists: false })).toBe(false);
+    expect(isCollectibleArtifactTarget({ ...target, exists: true })).toBe(true);
+  });
+
+  it("prefers localhost browser previews over generated html files", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "Created public/index.html. API: `http://localhost:3000/api/info`. App: `http://localhost:3000`."),
+    ]).map((target) => ({ ...target, exists: target.kind === "url" || target.value === "public/index.html" }));
+
+    expect(targets.map((target) => target.value)).toContain("http://localhost:3000/api/info");
+    expect(targets.map((target) => target.value)).toContain("http://localhost:3000");
+    expect(selectAutoOpenTarget(targets)?.value).toBe("http://localhost:3000");
+  });
+
+  it("normalizes escaped localhost root URL variants into one target", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "App: `http://localhost:3000/\\` and also http://localhost:3000//"),
+    ]);
+
+    expect(targets.filter((target) => target.value === "http://localhost:3000")).toHaveLength(1);
+    expect(targets.map((target) => target.name)).not.toContain("\\");
+  });
+
+  it("keeps accessible targets from earlier session messages", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "Created reports/earlier.csv"),
+      ...Array.from({ length: 12 }, (_, index) => message(`msg_noise_${index}`, "assistant", `Status update ${index + 1}`)),
+      message("msg_last", "assistant", "Server running at http://localhost:3000"),
+    ]);
+
+    expect(targets.map((target) => target.value)).toContain("reports/earlier.csv");
+    expect(targets.map((target) => target.value)).toContain("http://localhost:3000");
   });
 
   it("auto-opens high-confidence deliverables and localhost previews only", () => {

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -175,6 +175,16 @@ export type OpenworkWorkspaceFileWriteResult = {
   revision?: string;
 };
 
+function arrayBufferToBase64(data: ArrayBuffer): string {
+  const bytes = new Uint8Array(data);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+  return btoa(binary);
+}
+
 export type OpenworkCommandItem = {
   name: string;
   description?: string;
@@ -249,6 +259,29 @@ export type OpenworkArtifactItem = {
 
 export type OpenworkArtifactList = {
   items: OpenworkArtifactItem[];
+};
+
+export type OpenworkResolvedArtifactTarget = {
+  id: string;
+  kind: "file" | "url";
+  value: string;
+  name: string;
+  preview: "browser" | "markdown" | "sheet" | "image" | "pdf" | "html" | "text" | "external";
+  confidence: number;
+  reason: string;
+  exists?: boolean;
+  size?: number;
+  updatedAt?: number;
+  contentType?: string;
+};
+
+export type OpenworkWorkspaceFileStat = {
+  ok: boolean;
+  path: string;
+  exists: boolean;
+  kind?: "file" | "dir" | "other";
+  size?: number;
+  updatedAt?: number;
 };
 
 export type OpenworkInboxItem = {
@@ -1244,6 +1277,13 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         { token, hostToken },
       ),
 
+    statWorkspaceFile: (workspaceId: string, path: string) =>
+      requestJson<OpenworkWorkspaceFileStat>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/files/stat?path=${encodeURIComponent(path)}`,
+        { token, hostToken },
+      ),
+
     writeWorkspaceFile: (
       workspaceId: string,
       payload: { path: string; content: string; baseUpdatedAt?: number | null; force?: boolean },
@@ -1259,11 +1299,55 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         },
       ),
 
+    writeWorkspaceBinaryFile: (
+      workspaceId: string,
+      payload: { path: string; data: ArrayBuffer; baseUpdatedAt?: number | null; force?: boolean },
+    ) =>
+      requestJson<OpenworkWorkspaceFileWriteResult>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/files/raw`,
+        {
+          token,
+          hostToken,
+          method: "POST",
+          body: {
+            path: payload.path,
+            dataBase64: arrayBufferToBase64(payload.data),
+            baseUpdatedAt: payload.baseUpdatedAt,
+            force: payload.force,
+          },
+        },
+      ),
+
+    downloadWorkspaceFile: (workspaceId: string, path: string) =>
+      requestBinary(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/files/raw?path=${encodeURIComponent(path)}`,
+        { token, hostToken, timeoutMs: timeouts.binary },
+      ),
+
     listArtifacts: (workspaceId: string) =>
       requestJson<OpenworkArtifactList>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/artifacts`, {
         token,
         hostToken,
       }),
+
+    resolveArtifacts: (
+      workspaceId: string,
+      targets: Array<{
+        kind: "file" | "url";
+        value: string;
+        name?: string;
+        preview?: string;
+        confidence?: number;
+        reason?: string;
+      }>,
+    ) =>
+      requestJson<{ items: OpenworkResolvedArtifactTarget[] }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/artifacts/resolve`,
+        { token, hostToken, method: "POST", body: { targets } },
+      ),
 
     downloadArtifact: (workspaceId: string, artifactId: string) =>
       requestBinary(

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -1,0 +1,258 @@
+/** @jsxImportSource react */
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import { Download, ExternalLink, Loader2, X } from "lucide-react";
+
+import type { OpenworkServerClient } from "../../../../app/lib/openwork-server";
+import { openDesktopPath } from "../../../../app/lib/desktop";
+import { Button } from "@/components/ui/button";
+import { MarkdownBlock } from "../surface/markdown";
+import { cn } from "@/lib/utils";
+import type { OpenTarget } from "./open-target";
+
+const ArtifactTextEditor = lazy(() =>
+  import("./artifact-text-editor").then((module) => ({ default: module.ArtifactTextEditor })),
+);
+const ArtifactSpreadsheetEditor = lazy(() =>
+  import("./artifact-spreadsheet-editor").then((module) => ({ default: module.ArtifactSpreadsheetEditor })),
+);
+
+type ArtifactPanelProps = {
+  client: OpenworkServerClient;
+  workspaceId: string;
+  workspaceRoot: string;
+  isRemoteWorkspace?: boolean;
+  target: OpenTarget;
+  targets?: OpenTarget[];
+  onSelectTarget?: (target: OpenTarget) => void;
+  onClose: () => void;
+};
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "text"; content: string; updatedAt: number | null }
+  | { status: "binary"; url: string; data: ArrayBuffer; contentType: string | null; updatedAt: number | null };
+
+function absoluteWorkspacePath(root: string, path: string) {
+  const cleanRoot = root.trim().replace(/[/\\]+$/, "");
+  const cleanPath = path.trim().replace(/^\.\//, "");
+  return cleanRoot ? `${cleanRoot}/${cleanPath}` : cleanPath;
+}
+
+export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWorkspace = false, target, targets = [], onSelectTarget, onClose }: ArtifactPanelProps) {
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const canReadAsText = ["markdown", "text", "sheet", "html"].includes(target.preview) && !/\.(xlsx|xls|ods)$/i.test(target.value);
+  const canEditText = target.kind === "file" && canReadAsText;
+  const externalPath = useMemo(() => target.kind === "file" ? absoluteWorkspacePath(workspaceRoot, target.value) : target.value, [target.kind, target.value, workspaceRoot]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    setState({ status: "loading" });
+    setEditing(false);
+    setDraft("");
+    setSaveMessage(null);
+
+    async function load() {
+      try {
+        if (target.kind === "url") {
+          setState({ status: "error", message: "URLs open in browser tabs." });
+          return;
+        }
+        if (target.exists === false) {
+          setState({ status: "error", message: "File not found in this workspace." });
+          return;
+        }
+        if (canReadAsText) {
+          const result = await client.readWorkspaceFile(workspaceId, target.value);
+          if (!cancelled) {
+            setState({ status: "text", content: result.content, updatedAt: result.updatedAt ?? null });
+            setDraft(result.content);
+          }
+          return;
+        }
+        const result = await client.downloadWorkspaceFile(workspaceId, target.value);
+        objectUrl = URL.createObjectURL(new Blob([result.data], { type: result.contentType ?? "application/octet-stream" }));
+        if (!cancelled) setState({ status: "binary", url: objectUrl, data: result.data, contentType: result.contentType, updatedAt: target.updatedAt ?? null });
+      } catch (error) {
+        if (!cancelled) setState({ status: "error", message: error instanceof Error ? error.message : "Failed to load artifact" });
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [canReadAsText, client, target, workspaceId]);
+
+  const download = async () => {
+    if (target.kind === "url") return;
+      const result = await client.downloadWorkspaceFile(workspaceId, target.value);
+      const url = URL.createObjectURL(new Blob([result.data], { type: result.contentType ?? "application/octet-stream" }));
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = target.name;
+      anchor.click();
+      window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  };
+
+  const openExternal = async () => {
+    if (target.kind === "url") window.open(target.value, "_blank", "noopener,noreferrer");
+    else if (!isRemoteWorkspace) {
+      void openDesktopPath(externalPath);
+    } else {
+      await download();
+    }
+  };
+
+  const save = async () => {
+    if (!canEditText || state.status !== "text") return;
+    setSaving(true);
+    setSaveMessage(null);
+    try {
+      const result = await client.writeWorkspaceFile(workspaceId, {
+        path: target.value,
+        content: draft,
+        baseUpdatedAt: state.updatedAt,
+      });
+      setState({ status: "text", content: draft, updatedAt: result.updatedAt ?? null });
+      setEditing(false);
+      setSaveMessage("Saved");
+    } catch (error) {
+      setSaveMessage(error instanceof Error ? error.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveTextContent = async (content: string) => {
+    if (target.kind !== "file") return;
+    setSaving(true);
+    setSaveMessage(null);
+    try {
+      const baseUpdatedAt = state.status === "text" ? state.updatedAt : target.updatedAt ?? null;
+      const result = await client.writeWorkspaceFile(workspaceId, { path: target.value, content, baseUpdatedAt });
+      setState({ status: "text", content, updatedAt: result.updatedAt ?? null });
+      setDraft(content);
+      setSaveMessage("Saved");
+    } catch (error) {
+      setSaveMessage(error instanceof Error ? error.message : "Save failed");
+      throw error;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveBinaryContent = async (data: ArrayBuffer) => {
+    if (target.kind !== "file") return;
+    setSaving(true);
+    setSaveMessage(null);
+    try {
+      const baseUpdatedAt = state.status === "binary" ? state.updatedAt : target.updatedAt ?? null;
+      const result = await client.writeWorkspaceBinaryFile(workspaceId, { path: target.value, data, baseUpdatedAt });
+      const url = URL.createObjectURL(new Blob([data], { type: state.status === "binary" ? state.contentType ?? "application/octet-stream" : "application/octet-stream" }));
+      setState({ status: "binary", url, data, contentType: state.status === "binary" ? state.contentType : null, updatedAt: result.updatedAt ?? null });
+      setSaveMessage("Saved");
+    } catch (error) {
+      setSaveMessage(error instanceof Error ? error.message : "Save failed");
+      throw error;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-2">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-foreground">{target.name}</div>
+          <div className="truncate text-[11px] text-muted-foreground">
+            {target.value}{target.exists === false ? " · missing" : target.size ? ` · ${target.size} bytes` : ""}
+          </div>
+        </div>
+        {canEditText && state.status === "text" ? (
+          editing ? (
+            <>
+              <Button variant="ghost" size="sm" onClick={() => { setDraft(state.content); setEditing(false); }} disabled={saving}>Discard</Button>
+              <Button variant="default" size="sm" onClick={() => void save()} disabled={saving || draft === state.content}>{saving ? "Saving" : "Save"}</Button>
+            </>
+          ) : (
+            <Button variant="ghost" size="sm" onClick={() => setEditing(true)}>Edit</Button>
+          )
+        ) : null}
+        {target.kind === "file" ? (
+          <Button variant="ghost" size="icon-sm" onClick={() => void download()} aria-label="Download artifact" title="Download artifact">
+            <Download />
+          </Button>
+        ) : null}
+        <Button variant="ghost" size="icon-sm" onClick={() => void openExternal()} aria-label={isRemoteWorkspace ? "Download artifact" : "Open externally"} title={isRemoteWorkspace ? "Download artifact" : "Open externally"}>
+          <ExternalLink />
+        </Button>
+        <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close artifact" title="Close artifact">
+          <X />
+        </Button>
+      </div>
+      {targets.length > 0 ? (
+        <div className="no-scrollbar flex shrink-0 gap-1 overflow-x-auto border-b border-border px-2 py-1.5">
+          {targets.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={cn(
+                "max-w-44 shrink-0 truncate rounded-md border px-2 py-1 text-left text-[11px] transition-colors",
+                item.id === target.id
+                  ? "border-primary/40 bg-primary/10 text-primary"
+                  : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground",
+                item.exists === false && "opacity-60",
+              )}
+              title={`${item.value}${item.exists === false ? " (missing)" : ""}`}
+              onClick={() => onSelectTarget?.(item)}
+            >
+              {item.name}{item.exists === false ? " · missing" : ""}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      {saveMessage ? <div className="shrink-0 border-b border-border px-3 py-1 text-[11px] text-muted-foreground">{saveMessage}</div> : null}
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {state.status === "loading" ? (
+          <div className="flex h-full items-center justify-center text-muted-foreground"><Loader2 className="size-4 animate-spin" /></div>
+        ) : state.status === "error" ? (
+          <div className="p-4 text-sm text-muted-foreground">{state.message}</div>
+        ) : editing && state.status === "text" ? (
+          <Suspense fallback={<div className="flex h-full items-center justify-center text-muted-foreground"><Loader2 className="size-4 animate-spin" /></div>}>
+            <ArtifactTextEditor value={draft} language={target.preview === "markdown" ? "markdown" : "text"} onChange={setDraft} />
+          </Suspense>
+        ) : target.preview === "markdown" && state.status === "text" ? (
+          <div className="h-full overflow-auto p-4"><MarkdownBlock text={state.content} /></div>
+        ) : target.preview === "sheet" ? (
+          <Suspense fallback={<div className="flex h-full items-center justify-center text-muted-foreground"><Loader2 className="size-4 animate-spin" /></div>}>
+            <ArtifactSpreadsheetEditor
+              name={target.name}
+              text={state.status === "text" ? state.content : undefined}
+              data={state.status === "binary" ? state.data : undefined}
+              saving={saving}
+              onSaveText={saveTextContent}
+              onSaveBinary={saveBinaryContent}
+            />
+          </Suspense>
+        ) : target.preview === "html" && state.status === "text" ? (
+          <iframe srcDoc={state.content} title={target.name} className="h-full w-full border-0" sandbox="allow-scripts allow-same-origin" />
+        ) : target.preview === "image" && state.status === "binary" ? (
+          <div className="flex h-full items-center justify-center overflow-auto bg-muted/30 p-3"><img src={state.url} alt={target.name} className="max-h-full max-w-full object-contain" /></div>
+        ) : state.status === "binary" && (target.preview === "pdf" || target.preview === "html") ? (
+          <iframe src={state.url} title={target.name} className="h-full w-full border-0" sandbox="allow-scripts allow-same-origin" />
+        ) : state.status === "text" ? (
+          <pre className="h-full overflow-auto p-4 text-xs leading-5 text-foreground whitespace-pre-wrap">{state.content}</pre>
+        ) : (
+          <div className="p-4 text-sm text-muted-foreground">Preview unavailable. Open externally to view this file.</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { Download, ExternalLink, Loader2, X } from "lucide-react";
+import { Download, ExternalLink, FileText, Loader2, X } from "lucide-react";
 
 import type { OpenworkServerClient } from "../../../../app/lib/openwork-server";
 import { openDesktopPath } from "../../../../app/lib/desktop";
@@ -39,6 +39,24 @@ function absoluteWorkspacePath(root: string, path: string) {
   return cleanRoot ? `${cleanRoot}/${cleanPath}` : cleanPath;
 }
 
+function ArtifactTargetIcon({ target, className = "size-3.5" }: { target: OpenTarget; className?: string }) {
+  if (target.preview === "sheet") {
+    return (
+      <span className={cn("inline-flex min-w-5 shrink-0 items-center justify-center rounded-[4px] border border-emerald-500/30 bg-emerald-500/10 px-0.5 text-[7px] font-bold leading-none text-emerald-700", className)}>
+        XLS
+      </span>
+    );
+  }
+  if (target.preview === "markdown") {
+    return (
+      <span className={cn("inline-flex shrink-0 items-center justify-center rounded-[4px] border border-primary/25 bg-primary/10 font-bold leading-none text-primary", className, "text-[7px]")}>
+        MD
+      </span>
+    );
+  }
+  return <FileText className={cn(className, "shrink-0 text-primary")} />;
+}
+
 export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWorkspace = false, target, targets = [], onSelectTarget, onClose }: ArtifactPanelProps) {
   const [state, setState] = useState<LoadState>({ status: "loading" });
   const [editing, setEditing] = useState(false);
@@ -47,6 +65,7 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWork
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const canReadAsText = ["markdown", "text", "sheet", "html"].includes(target.preview) && !/\.(xlsx|xls|ods)$/i.test(target.value);
   const canEditText = target.kind === "file" && canReadAsText;
+  const isDirectTextEdit = canEditText && target.preview === "markdown";
   const externalPath = useMemo(() => target.kind === "file" ? absoluteWorkspacePath(workspaceRoot, target.value) : target.value, [target.kind, target.value, workspaceRoot]);
 
   useEffect(() => {
@@ -170,13 +189,16 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWork
     <div className="flex h-full min-h-0 flex-col bg-background">
       <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-2">
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium text-foreground">{target.name}</div>
+          <div className="flex min-w-0 items-center gap-1.5 text-sm font-medium text-foreground">
+            <ArtifactTargetIcon target={target} className="size-4" />
+            <span className="truncate">{target.name}</span>
+          </div>
           <div className="truncate text-[11px] text-muted-foreground">
             {target.value}{target.exists === false ? " · missing" : target.size ? ` · ${target.size} bytes` : ""}
           </div>
         </div>
         {canEditText && state.status === "text" ? (
-          editing ? (
+          editing || isDirectTextEdit ? (
             <>
               <Button variant="ghost" size="sm" onClick={() => { setDraft(state.content); setEditing(false); }} disabled={saving}>Discard</Button>
               <Button variant="default" size="sm" onClick={() => void save()} disabled={saving || draft === state.content}>{saving ? "Saving" : "Save"}</Button>
@@ -204,7 +226,7 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWork
               key={item.id}
               type="button"
               className={cn(
-                "max-w-44 shrink-0 truncate rounded-md border px-2 py-1 text-left text-[11px] transition-colors",
+                "flex max-w-44 shrink-0 items-center gap-1.5 rounded-md border px-2 py-1 text-left text-[11px] transition-colors",
                 item.id === target.id
                   ? "border-primary/40 bg-primary/10 text-primary"
                   : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground",
@@ -213,7 +235,8 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWork
               title={`${item.value}${item.exists === false ? " (missing)" : ""}`}
               onClick={() => onSelectTarget?.(item)}
             >
-              {item.name}{item.exists === false ? " · missing" : ""}
+              <ArtifactTargetIcon target={item} />
+              <span className="truncate">{item.name}{item.exists === false ? " · missing" : ""}</span>
             </button>
           ))}
         </div>
@@ -224,7 +247,7 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWork
           <div className="flex h-full items-center justify-center text-muted-foreground"><Loader2 className="size-4 animate-spin" /></div>
         ) : state.status === "error" ? (
           <div className="p-4 text-sm text-muted-foreground">{state.message}</div>
-        ) : editing && state.status === "text" ? (
+        ) : state.status === "text" && (editing || isDirectTextEdit) ? (
           <Suspense fallback={<div className="flex h-full items-center justify-center text-muted-foreground"><Loader2 className="size-4 animate-spin" /></div>}>
             <ArtifactTextEditor value={draft} language={target.preview === "markdown" ? "markdown" : "text"} onChange={setDraft} />
           </Suspense>

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-editor.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-editor.tsx
@@ -1,0 +1,109 @@
+/** @jsxImportSource react */
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { parseSpreadsheet, serializeSpreadsheet, type SpreadsheetRows } from "./artifact-spreadsheet-model";
+
+type ArtifactSpreadsheetEditorProps = {
+  name: string;
+  text?: string;
+  data?: ArrayBuffer;
+  saving?: boolean;
+  onSaveText: (content: string) => void | Promise<void>;
+  onSaveBinary: (data: ArrayBuffer) => void | Promise<void>;
+};
+
+function cloneRows(rows: SpreadsheetRows): SpreadsheetRows {
+  return rows.map((row) => [...row]);
+}
+
+function normalizeShape(rows: SpreadsheetRows): SpreadsheetRows {
+  const width = Math.max(1, ...rows.map((row) => row.length));
+  return rows.map((row) => Array.from({ length: width }, (_, index) => row[index] ?? ""));
+}
+
+export function ArtifactSpreadsheetEditor(props: ArtifactSpreadsheetEditorProps) {
+  const [rows, setRows] = useState<SpreadsheetRows>([[""]]);
+  const [baseRows, setBaseRows] = useState<SpreadsheetRows>([[""]]);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState<string | null>(null);
+  const dirty = useMemo(() => JSON.stringify(rows) !== JSON.stringify(baseRows), [baseRows, rows]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setMessage(null);
+    parseSpreadsheet({ name: props.name, text: props.text, data: props.data })
+      .then((parsed) => {
+        if (cancelled) return;
+        const shaped = normalizeShape(parsed);
+        setRows(shaped);
+        setBaseRows(cloneRows(shaped));
+      })
+      .catch((error) => {
+        if (!cancelled) setMessage(error instanceof Error ? error.message : "Failed to parse spreadsheet");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [props.data, props.name, props.text]);
+
+  const updateCell = (rowIndex: number, columnIndex: number, value: string) => {
+    setRows((current) => {
+      const next = cloneRows(current);
+      next[rowIndex] = [...(next[rowIndex] ?? [])];
+      next[rowIndex][columnIndex] = value;
+      return normalizeShape(next);
+    });
+  };
+
+  const addRow = () => setRows((current) => [...current, Array.from({ length: Math.max(1, current[0]?.length ?? 1) }, () => "")]);
+  const addColumn = () => setRows((current) => current.map((row) => [...row, ""]));
+  const discard = () => setRows(cloneRows(baseRows));
+
+  const save = async () => {
+    setMessage(null);
+    const serialized = await serializeSpreadsheet(props.name, rows);
+    if (serialized.kind === "text") await props.onSaveText(serialized.content);
+    else await props.onSaveBinary(serialized.data);
+    setBaseRows(cloneRows(rows));
+    setMessage("Saved");
+  };
+
+  if (loading) {
+    return <div className="flex h-full items-center justify-center text-muted-foreground"><Loader2 className="size-4 animate-spin" /></div>;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+        <Button variant="ghost" size="xs" onClick={addRow}><Plus className="size-3" /> Row</Button>
+        <Button variant="ghost" size="xs" onClick={addColumn}><Plus className="size-3" /> Column</Button>
+        <div className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground">{message}</div>
+        <Button variant="ghost" size="xs" onClick={discard} disabled={!dirty || props.saving}>Discard</Button>
+        <Button variant="default" size="xs" onClick={() => void save()} disabled={!dirty || props.saving}>{props.saving ? "Saving" : "Save"}</Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        <table className="w-full border-collapse text-xs">
+          <tbody>
+            {rows.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                {row.map((cell, columnIndex) => (
+                  <td key={columnIndex} className="border border-border p-0 align-top">
+                    <input
+                      className="h-8 w-full min-w-[120px] bg-transparent px-2 text-foreground outline-none focus:bg-muted/50"
+                      value={cell}
+                      onChange={(event) => updateCell(rowIndex, columnIndex, event.target.value)}
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-model.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-model.ts
@@ -1,0 +1,104 @@
+export type SpreadsheetRows = string[][];
+
+function extension(name: string) {
+  const clean = name.toLowerCase().split(/[?#]/)[0] ?? name.toLowerCase();
+  const index = clean.lastIndexOf(".");
+  return index >= 0 ? clean.slice(index + 1) : "";
+}
+
+function delimiterForName(name: string) {
+  return extension(name) === "tsv" ? "\t" : ",";
+}
+
+function parseDelimited(content: string, delimiter: string): SpreadsheetRows {
+  const rows: SpreadsheetRows = [];
+  let row: string[] = [];
+  let cell = "";
+  let quoted = false;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+    const next = content[index + 1];
+    if (quoted) {
+      if (char === '"' && next === '"') {
+        cell += '"';
+        index += 1;
+      } else if (char === '"') {
+        quoted = false;
+      } else {
+        cell += char;
+      }
+      continue;
+    }
+    if (char === '"') {
+      quoted = true;
+      continue;
+    }
+    if (char === delimiter) {
+      row.push(cell);
+      cell = "";
+      continue;
+    }
+    if (char === "\n") {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+      continue;
+    }
+    if (char === "\r") continue;
+    cell += char;
+  }
+
+  if (cell || row.length) {
+    row.push(cell);
+    rows.push(row);
+  }
+  return rows.length ? rows : [[""]];
+}
+
+function serializeDelimited(rows: SpreadsheetRows, delimiter: string) {
+  return rows
+    .map((row) => row.map((value) => {
+      const cell = String(value ?? "");
+      if (!cell.includes(delimiter) && !/["\r\n]/.test(cell)) return cell;
+      return `"${cell.replace(/"/g, '""')}"`;
+    }).join(delimiter))
+    .join("\n") + "\n";
+}
+
+function normalizeRows(rows: unknown[][]): SpreadsheetRows {
+  const next = rows.map((row) => row.map((cell) => cell == null ? "" : String(cell)));
+  return next.length ? next : [[""]];
+}
+
+export async function parseSpreadsheet(input: { name: string; text?: string; data?: ArrayBuffer }): Promise<SpreadsheetRows> {
+  const ext = extension(input.name);
+  if (ext === "csv" || ext === "tsv") return parseDelimited(input.text ?? "", delimiterForName(input.name));
+  const XLSX = await import("xlsx");
+  const workbook = XLSX.read(input.data ?? new ArrayBuffer(0), { type: "array" });
+  const firstSheetName = workbook.SheetNames[0];
+  if (!firstSheetName) return [[""]];
+  const sheet = workbook.Sheets[firstSheetName];
+  return normalizeRows(XLSX.utils.sheet_to_json(sheet, { header: 1, raw: false, blankrows: true }) as unknown[][]);
+}
+
+export async function serializeSpreadsheet(name: string, rows: SpreadsheetRows): Promise<
+  | { kind: "text"; content: string }
+  | { kind: "binary"; data: ArrayBuffer }
+> {
+  const ext = extension(name);
+  if (ext === "csv" || ext === "tsv") {
+    return { kind: "text", content: serializeDelimited(rows, delimiterForName(name)) };
+  }
+  const XLSX = await import("xlsx");
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, XLSX.utils.aoa_to_sheet(rows), "Sheet1");
+  const bookType = ext === "xls" ? "xls" : ext === "ods" ? "ods" : "xlsx";
+  const output = XLSX.write(workbook, { type: "array", bookType: bookType as any });
+  if (output instanceof ArrayBuffer) return { kind: "binary", data: output };
+  const view = output as Uint8Array;
+  const copy = new Uint8Array(view.byteLength);
+  copy.set(view);
+  return { kind: "binary", data: copy.buffer };
+}

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-text-editor.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-text-editor.tsx
@@ -1,0 +1,65 @@
+/** @jsxImportSource react */
+import { useEffect, useRef } from "react";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { markdown } from "@codemirror/lang-markdown";
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap, lineNumbers } from "@codemirror/view";
+
+type ArtifactTextEditorProps = {
+  value: string;
+  language: "markdown" | "text";
+  onChange: (value: string) => void;
+};
+
+export function ArtifactTextEditor(props: ArtifactTextEditorProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const onChangeRef = useRef(props.onChange);
+  onChangeRef.current = props.onChange;
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const view = new EditorView({
+      parent: root,
+      state: EditorState.create({
+        doc: props.value,
+        extensions: [
+          lineNumbers(),
+          history(),
+          keymap.of([...defaultKeymap, ...historyKeymap]),
+          props.language === "markdown" ? markdown() : [],
+          EditorView.lineWrapping,
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) onChangeRef.current(update.state.doc.toString());
+          }),
+          EditorView.theme({
+            "&": { height: "100%", background: "transparent" },
+            ".cm-scroller": { fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" },
+            ".cm-content": { minHeight: "100%", padding: "12px 0", fontSize: "12px", lineHeight: "20px" },
+            ".cm-gutters": { background: "transparent", borderRight: "1px solid hsl(var(--border))" },
+            ".cm-lineNumbers .cm-gutterElement": { padding: "0 8px", color: "hsl(var(--muted-foreground))" },
+            ".cm-activeLine": { backgroundColor: "hsl(var(--muted) / 0.35)" },
+            ".cm-activeLineGutter": { backgroundColor: "hsl(var(--muted) / 0.35)" },
+          }),
+        ],
+      }),
+    });
+    viewRef.current = view;
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+  }, [props.language]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (current === props.value) return;
+    view.dispatch({ changes: { from: 0, to: current.length, insert: props.value } });
+  }, [props.value]);
+
+  return <div ref={rootRef} className="h-full min-h-0 overflow-hidden" />;
+}

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -1,0 +1,142 @@
+/** @jsxImportSource react */
+import type { UIMessage } from "ai";
+
+export type OpenTargetKind = "url" | "file";
+export type OpenTargetPreview = "browser" | "markdown" | "sheet" | "image" | "pdf" | "html" | "text" | "external";
+
+export type OpenTarget = {
+  id: string;
+  kind: OpenTargetKind;
+  value: string;
+  name: string;
+  preview: OpenTargetPreview;
+  confidence: number;
+  reason: string;
+  exists?: boolean;
+  size?: number;
+  updatedAt?: number;
+};
+
+const WORKSPACES_PREFIX_PATTERN = /^workspaces\/[^/]+\//i;
+const WORKSPACE_ID_PREFIX_PATTERN = /^workspace\/(?:ws_[^/]+|\d+|[0-9a-f-]{6,})\//i;
+
+const FILE_PATTERN = /(?:^|[\s"'`([{])((?:\.{1,2}[/\\]|~[/\\]|[/\\])?[\w.\-]+(?:[/\\][\w.\-]+)+\.[a-z][a-z0-9]{0,9}|[\w.\-]+\.[a-z][a-z0-9]{0,9})/gi;
+const URL_PATTERN = /https?:\/\/[^\s)\]}>"']+/gi;
+const SOCKET_PATTERN = /(?:ws|wss):\/\/[^\s)\]}>"']+/gi;
+
+function normalizePath(path: string) {
+  return path
+    .trim()
+    .replace(/[\\]+/g, "/")
+    .replace(/^\.\//, "")
+    .replace(WORKSPACES_PREFIX_PATTERN, "")
+    .replace(WORKSPACE_ID_PREFIX_PATTERN, "");
+}
+
+function basename(value: string) {
+  const clean = value.split(/[?#]/)[0] ?? value;
+  return clean.split("/").filter(Boolean).pop() ?? value;
+}
+
+function extname(value: string) {
+  const name = basename(value).toLowerCase();
+  const index = name.lastIndexOf(".");
+  return index >= 0 ? name.slice(index) : "";
+}
+
+export function classifyOpenTarget(value: string, kind: OpenTargetKind): OpenTargetPreview {
+  if (kind === "url") return "browser";
+  const ext = extname(value);
+  if ([".md", ".markdown", ".mdx"].includes(ext)) return "markdown";
+  if ([".csv", ".tsv", ".xlsx", ".xls", ".ods"].includes(ext)) return "sheet";
+  if ([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"].includes(ext)) return "image";
+  if (ext === ".pdf") return "pdf";
+  if ([".html", ".htm"].includes(ext)) return "html";
+  if ([".txt", ".log", ".json", ".jsonc", ".yaml", ".yml", ".toml", ".xml", ".ts", ".tsx", ".js", ".jsx", ".css", ".scss"].includes(ext)) return "text";
+  return "external";
+}
+
+function targetFromFile(path: string, confidence: number, reason: string): OpenTarget | null {
+  const normalized = normalizePath(path).replace(/[.,;:]+$/, "");
+  if (!normalized || normalized.length > 500 || !normalized.includes(".")) return null;
+  return {
+    id: `file:${normalized.toLowerCase()}`,
+    kind: "file",
+    value: normalized,
+    name: basename(normalized),
+    preview: classifyOpenTarget(normalized, "file"),
+    confidence,
+    reason,
+  };
+}
+
+function targetFromUrl(url: string, confidence: number, reason: string): OpenTarget | null {
+  const clean = url.trim().replace(/[.,;:]+$/, "");
+  if (!clean) return null;
+  return {
+    id: `url:${clean}`,
+    kind: "url",
+    value: clean,
+    name: basename(clean) || clean,
+    preview: "browser",
+    confidence,
+    reason,
+  };
+}
+
+function addTarget(map: Map<string, OpenTarget>, target: OpenTarget | null) {
+  if (!target) return;
+  const existing = map.get(target.id);
+  if (!existing || target.confidence >= existing.confidence) map.set(target.id, target);
+}
+
+function scanText(map: Map<string, OpenTarget>, text: string, confidence: number, reason: string) {
+  if (!text) return;
+  URL_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(URL_PATTERN)) {
+    if (match[0]) addTarget(map, targetFromUrl(match[0], confidence, reason));
+  }
+  SOCKET_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(SOCKET_PATTERN)) {
+    if (match[0]) addTarget(map, targetFromUrl(match[0], confidence, reason));
+  }
+  FILE_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(FILE_PATTERN)) {
+    if (match[1]) addTarget(map, targetFromFile(match[1], confidence, reason));
+  }
+}
+
+export function deriveOpenTargets(messages: UIMessage[]): OpenTarget[] {
+  const targets = new Map<string, OpenTarget>();
+  const recent = messages.slice(-8);
+
+  for (const message of recent) {
+    for (const part of message.parts) {
+      const record = part as any;
+      if (part.type === "text" && typeof record.text === "string") {
+        scanText(targets, record.text, message.role === "assistant" ? 65 : 40, "message");
+        continue;
+      }
+      if (part.type === "dynamic-tool") {
+        const values = [record.input, record.output].flatMap((value) => {
+          if (!value || typeof value !== "object") return [];
+          const entries = value as Record<string, unknown>;
+          return [entries.path, entries.file, ...(Array.isArray(entries.files) ? entries.files : [])];
+        });
+        for (const value of values) {
+          if (typeof value === "string") addTarget(targets, targetFromFile(value, 95, "tool metadata"));
+        }
+        scanText(targets, JSON.stringify(record.output ?? record.input ?? ""), 75, "tool output");
+      }
+    }
+  }
+
+  return Array.from(targets.values())
+    .filter((target) => target.preview !== "external" || target.confidence >= 95)
+    .sort((left, right) => right.confidence - left.confidence);
+}
+
+export function shouldAutoOpenTarget(target: OpenTarget): boolean {
+  if (target.kind === "url") return /(?:https?|wss?):\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/i.test(target.value);
+  return target.exists === true && target.confidence >= 65 && ["markdown", "sheet", "image", "pdf", "html"].includes(target.preview);
+}

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -21,8 +21,9 @@ const WORKSPACES_PREFIX_PATTERN = /^workspaces\/[^/]+\//i;
 const WORKSPACE_ID_PREFIX_PATTERN = /^workspace\/(?:ws_[^/]+|\d+|[0-9a-f-]{6,})\//i;
 
 const FILE_PATTERN = /(?:^|[\s"'`([{])((?:\.{1,2}[/\\]|~[/\\]|[/\\])?[\w.\-]+(?:[/\\][\w.\-]+)+\.[a-z][a-z0-9]{0,9}|[\w.\-]+\.[a-z][a-z0-9]{0,9})/gi;
-const URL_PATTERN = /https?:\/\/[^\s)\]}>"']+/gi;
-const SOCKET_PATTERN = /(?:ws|wss):\/\/[^\s)\]}>"']+/gi;
+const URL_PATTERN = /https?:\/\/[^\s)\]}>"'`]+/gi;
+const SOCKET_PATTERN = /(?:ws|wss):\/\/[^\s)\]}>"'`]+/gi;
+const ARTIFACT_FILE_PREVIEWS = new Set<OpenTargetPreview>(["markdown", "sheet", "image", "pdf", "html"]);
 
 function normalizePath(path: string) {
   return path
@@ -71,7 +72,16 @@ function targetFromFile(path: string, confidence: number, reason: string): OpenT
 }
 
 function targetFromUrl(url: string, confidence: number, reason: string): OpenTarget | null {
-  const clean = url.trim().replace(/[.,;:]+$/, "");
+  const stripped = url.trim().replace(/[.,;:`\\]+$/, "");
+  let clean = stripped;
+  try {
+    const parsed = new URL(stripped);
+    if (/^\/+$/i.test(parsed.pathname) && !parsed.search && !parsed.hash) {
+      clean = parsed.origin;
+    }
+  } catch {
+    // Keep the stripped value; regex extraction already validated the shape.
+  }
   if (!clean) return null;
   return {
     id: `url:${clean}`,
@@ -90,6 +100,40 @@ function addTarget(map: Map<string, OpenTarget>, target: OpenTarget | null) {
   if (!existing || target.confidence >= existing.confidence) map.set(target.id, target);
 }
 
+function isArtifactTarget(target: OpenTarget) {
+  return target.kind === "url" || ARTIFACT_FILE_PREVIEWS.has(target.preview);
+}
+
+export function isCollectibleArtifactTarget(target: OpenTarget) {
+  return target.kind === "file" && target.exists === true && ARTIFACT_FILE_PREVIEWS.has(target.preview);
+}
+
+export function isLocalhostBrowserTarget(target: OpenTarget) {
+  return target.kind === "url" && /(?:https?|wss?):\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/i.test(target.value);
+}
+
+function browserTargetScore(target: OpenTarget) {
+  if (!isLocalhostBrowserTarget(target)) return -1;
+  try {
+    const url = new URL(target.value);
+    let score = target.confidence;
+    if (url.protocol === "http:" || url.protocol === "https:") score += 20;
+    if ((url.pathname === "" || url.pathname === "/") && !url.search && !url.hash) score += 40;
+    if (!url.pathname.startsWith("/api/")) score += 10;
+    return score;
+  } catch {
+    return target.confidence;
+  }
+}
+
+export function selectAutoOpenTarget(targets: OpenTarget[]): OpenTarget | null {
+  const browserTargets = targets.filter(isLocalhostBrowserTarget);
+  if (browserTargets.length > 0) {
+    return [...browserTargets].sort((left, right) => browserTargetScore(right) - browserTargetScore(left))[0] ?? null;
+  }
+  return targets.find(shouldAutoOpenTarget) ?? null;
+}
+
 function scanText(map: Map<string, OpenTarget>, text: string, confidence: number, reason: string) {
   if (!text) return;
   URL_PATTERN.lastIndex = 0;
@@ -106,11 +150,15 @@ function scanText(map: Map<string, OpenTarget>, text: string, confidence: number
   }
 }
 
+function isDiscoveryTool(toolName: unknown) {
+  if (typeof toolName !== "string") return false;
+  return ["glob", "grep", "search", "find"].includes(toolName.toLowerCase());
+}
+
 export function deriveOpenTargets(messages: UIMessage[]): OpenTarget[] {
   const targets = new Map<string, OpenTarget>();
-  const recent = messages.slice(-8);
 
-  for (const message of recent) {
+  for (const message of messages) {
     for (const part of message.parts) {
       const record = part as any;
       if (part.type === "text" && typeof record.text === "string") {
@@ -118,25 +166,28 @@ export function deriveOpenTargets(messages: UIMessage[]): OpenTarget[] {
         continue;
       }
       if (part.type === "dynamic-tool") {
+        const discoveryTool = isDiscoveryTool(record.toolName);
         const values = [record.input, record.output].flatMap((value) => {
-          if (!value || typeof value !== "object") return [];
+          if (discoveryTool || !value || typeof value !== "object") return [];
           const entries = value as Record<string, unknown>;
           return [entries.path, entries.file, ...(Array.isArray(entries.files) ? entries.files : [])];
         });
         for (const value of values) {
           if (typeof value === "string") addTarget(targets, targetFromFile(value, 95, "tool metadata"));
         }
-        scanText(targets, JSON.stringify(record.output ?? record.input ?? ""), 75, "tool output");
+        if (!discoveryTool) {
+          scanText(targets, JSON.stringify(record.output ?? record.input ?? ""), 75, "tool output");
+        }
       }
     }
   }
 
   return Array.from(targets.values())
-    .filter((target) => target.preview !== "external" || target.confidence >= 95)
+    .filter(isArtifactTarget)
     .sort((left, right) => right.confidence - left.confidence);
 }
 
 export function shouldAutoOpenTarget(target: OpenTarget): boolean {
-  if (target.kind === "url") return /(?:https?|wss?):\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/i.test(target.value);
+  if (target.kind === "url") return isLocalhostBrowserTarget(target);
   return target.exists === true && target.confidence >= 65 && ["markdown", "sheet", "image", "pdf", "html"].includes(target.preview);
 }

--- a/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
+++ b/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
@@ -65,6 +65,12 @@ function getElectronBrowser() {
   return window.__OPENWORK_ELECTRON__?.browser ?? null;
 }
 
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    getElectronBrowser()?.hide?.();
+  });
+}
+
 function computeBounds(el: HTMLElement) {
   const rect = el.getBoundingClientRect();
 
@@ -258,9 +264,15 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
     }
 
     const content = contentRef.current;
-    browser.hide?.();
-    shownRef.current = false;
-    lastBoundsRef.current = null;
+    let disposed = false;
+
+    const resetNativeView = async () => {
+      await browser.hide?.();
+      if (disposed) return;
+      shownRef.current = false;
+      lastBoundsRef.current = null;
+      boundsFrameRef.current = window.requestAnimationFrame(watchBounds);
+    };
 
     const syncBounds = () => {
       const bounds = computeBounds(content);
@@ -292,7 +304,7 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
       boundsFrameRef.current = window.requestAnimationFrame(watchBounds);
     };
 
-    boundsFrameRef.current = window.requestAnimationFrame(watchBounds);
+    void resetNativeView();
 
     const observer = new ResizeObserver(scheduleSyncBounds);
 
@@ -306,6 +318,7 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
     window.addEventListener("scroll", scheduleSyncBounds, true);
 
     return () => {
+      disposed = true;
       observer.disconnect();
 
       window.removeEventListener("resize", scheduleSyncBounds);

--- a/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
+++ b/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
@@ -40,8 +40,8 @@ function getNativeMenuPoint(
 
   if (point) {
     return {
-      x: Math.round(point.clientX / zoom),
-      y: Math.round(point.clientY / zoom),
+      x: Math.round(point.clientX * zoom),
+      y: Math.round(point.clientY * zoom),
     };
   }
 
@@ -52,8 +52,8 @@ function getNativeMenuPoint(
   const rect = el.getBoundingClientRect();
 
   return {
-    x: Math.round((rect.left + 8) / zoom),
-    y: Math.round((rect.bottom + 4) / zoom),
+    x: Math.round((rect.left + 8) * zoom),
+    y: Math.round((rect.bottom + 4) * zoom),
   };
 }
 
@@ -73,19 +73,17 @@ if (import.meta.hot) {
 
 function computeBounds(el: HTMLElement) {
   const rect = el.getBoundingClientRect();
-
-  // Electron's WebContentsView.setBounds() uses the parent contentView's
-  // coordinate space (CSS pixels at zoom=1). If the app has a font-zoom /
-  // zoom factor, getBoundingClientRect() returns *zoomed* CSS pixels.
-  // Dividing by the zoom factor gives the unzoomed coordinates that the
-  // native view expects.
   const zoom = window.__OPENWORK_ZOOM_FACTOR__ ?? 1;
 
+  // WebContentsView bounds use the BrowserWindow contentView coordinate space.
+  // Renderer client rects are reported in zoomed CSS pixels, so convert back to
+  // contentView coordinates by applying the desktop zoom factor. Dividing by the
+  // zoom factor shifts the native browser into the transcript.
   return {
-    x: Math.round(rect.x / zoom),
-    y: Math.round(rect.y / zoom),
-    width: Math.round(rect.width / zoom),
-    height: Math.round(rect.height / zoom),
+    x: Math.round(rect.x * zoom),
+    y: Math.round(rect.y * zoom),
+    width: Math.round(rect.width * zoom),
+    height: Math.round(rect.height * zoom),
   };
 }
 

--- a/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
+++ b/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { ArrowLeft, ArrowRight, Globe, Loader2, Plus, RotateCw, X } from "lucide-react";
 import { Reorder, useDragControls } from "motion/react";
 import { isElectronRuntime } from "../../../../app/utils";
@@ -65,9 +65,8 @@ function getElectronBrowser() {
   return window.__OPENWORK_ELECTRON__?.browser ?? null;
 }
 
-function computeBounds(el: HTMLElement, toolbar: HTMLElement) {
+function computeBounds(el: HTMLElement) {
   const rect = el.getBoundingClientRect();
-  const toolbarRect = toolbar.getBoundingClientRect();
 
   // Electron's WebContentsView.setBounds() uses the parent contentView's
   // coordinate space (CSS pixels at zoom=1). If the app has a font-zoom /
@@ -78,10 +77,23 @@ function computeBounds(el: HTMLElement, toolbar: HTMLElement) {
 
   return {
     x: Math.round(rect.x / zoom),
-    y: Math.round((rect.y + toolbarRect.height) / zoom),
+    y: Math.round(rect.y / zoom),
     width: Math.round(rect.width / zoom),
-    height: Math.round((rect.height - toolbarRect.height) / zoom),
+    height: Math.round(rect.height / zoom),
   };
+}
+
+function sameBounds(
+  left: { x: number; y: number; width: number; height: number } | null,
+  right: { x: number; y: number; width: number; height: number },
+) {
+  return Boolean(
+    left &&
+      left.x === right.x &&
+      left.y === right.y &&
+      left.width === right.width &&
+      left.height === right.height,
+  );
 }
 
 type BrowserTabProps = {
@@ -189,11 +201,11 @@ function BrowserTab({ tab }: BrowserTabProps) {
 export function BrowserPanel({ onClose }: BrowserPanelProps) {
   const [state, dispatch] = useBrowserState();
   const urlFocusedRef = useRef(false);
-  const panelRef = useRef<HTMLDivElement>(null);
-  const toolbarRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const urlInputRef = useRef<HTMLInputElement>(null);
   const shownRef = useRef(false);
   const boundsFrameRef = useRef<number | null>(null);
+  const lastBoundsRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
 
   // Subscribe to state changes from the main process
   useEffect(() => {
@@ -224,54 +236,80 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
     return unsub;
   }, []);
 
+  // Correct stale native bounds after every render/Fast Refresh pass. The
+  // WebContentsView is owned by Electron main process, so it can keep painting
+  // at old coordinates even when React has re-rendered the pane.
+  useLayoutEffect(() => {
+    const browser = getElectronBrowser();
+    const content = contentRef.current;
+    if (!browser || !content) return;
+    const bounds = computeBounds(content);
+    if (bounds.width < 1 || bounds.height < 1) return;
+    browser.setBounds?.(bounds);
+    lastBoundsRef.current = bounds;
+  });
+
   // Show the browser view when the panel mounts, keep bounds in sync, hide on unmount.
-  useEffect(() => {
+  useLayoutEffect(() => {
     const browser = getElectronBrowser();
 
-    if (!browser || !panelRef.current || !toolbarRef.current) {
+    if (!browser || !contentRef.current) {
       return;
     }
 
-    const panel = panelRef.current;
-    const toolbar = toolbarRef.current;
+    const content = contentRef.current;
+    browser.hide?.();
+    shownRef.current = false;
+    lastBoundsRef.current = null;
 
     const syncBounds = () => {
-      boundsFrameRef.current = null;
-
-      const bounds = computeBounds(panel, toolbar);
+      const bounds = computeBounds(content);
 
       if (bounds.width < 1 || bounds.height < 1) {
+        if (shownRef.current) {
+          browser.hide?.();
+          shownRef.current = false;
+          lastBoundsRef.current = null;
+        }
         return;
       }
 
-      // not laid out yet
       if (!shownRef.current) {
         browser.show?.(bounds);
         shownRef.current = true;
-      } else {
+        lastBoundsRef.current = bounds;
+        return;
+      }
+
+      if (!sameBounds(lastBoundsRef.current, bounds)) {
         browser.setBounds?.(bounds);
+        lastBoundsRef.current = bounds;
       }
     };
 
-    const scheduleSyncBounds = () => {
-      if (boundsFrameRef.current != null) return;
-      boundsFrameRef.current = window.requestAnimationFrame(syncBounds);
+    const watchBounds = () => {
+      syncBounds();
+      boundsFrameRef.current = window.requestAnimationFrame(watchBounds);
     };
 
-    // Initial show (may be zero-dimension if layout hasn't settled)
-    syncBounds();
+    boundsFrameRef.current = window.requestAnimationFrame(watchBounds);
 
     const observer = new ResizeObserver(scheduleSyncBounds);
 
-    observer.observe(panel);
-    observer.observe(toolbar);
+    function scheduleSyncBounds() {
+      syncBounds();
+    }
+
+    observer.observe(content);
 
     window.addEventListener("resize", scheduleSyncBounds);
+    window.addEventListener("scroll", scheduleSyncBounds, true);
 
     return () => {
       observer.disconnect();
 
       window.removeEventListener("resize", scheduleSyncBounds);
+      window.removeEventListener("scroll", scheduleSyncBounds, true);
 
       if (boundsFrameRef.current != null) {
         window.cancelAnimationFrame(boundsFrameRef.current);
@@ -280,6 +318,7 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
 
       browser.hide?.();
       shownRef.current = false;
+      lastBoundsRef.current = null;
     };
   }, []);
 
@@ -329,8 +368,8 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
 
   return (
     <TooltipProvider delay={1000}>
-      <div ref={panelRef} className="flex h-full flex-col">
-        <div ref={toolbarRef} className="shrink-0 border-b border-border bg-background mac:bg-background/80 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
+      <div className="flex h-full flex-col">
+        <div className="shrink-0 border-b border-border bg-background mac:bg-background/80 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
           <div className="flex h-10 items-center gap-1 border-b border-border/60 px-2">
             <div className="no-scrollbar min-w-0 flex-1 overflow-x-auto">
               <Reorder.Group
@@ -416,7 +455,7 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
           </div>
         </div>
         {/* WebContentsView renders in this area (managed by Electron main process) */}
-        <div className="min-h-0 flex-1" />
+        <div ref={contentRef} className="min-h-0 flex-1 overflow-hidden" />
       </div>
     </TooltipProvider>
   );

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,7 +2,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { Globe, Loader2, Redo2, Undo2, Zap } from "lucide-react";
+import { FileText, Globe, Loader2, Redo2, Undo2, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
@@ -44,6 +44,8 @@ import { useUiStateStore } from "../../../shell/ui-state-store";
 
 import { isElectronRuntime } from "../../../../app/utils";
 import { BrowserPanel } from "../browser/browser-panel";
+import { ArtifactPanel } from "../artifacts/artifact-panel";
+import type { OpenTarget } from "../artifacts/open-target";
 import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
 import { cn } from "@/lib/utils";
 
@@ -188,6 +190,10 @@ export function SessionPage(props: SessionPageProps) {
   const openBrowserPanel = useUiStateStore((state) => state.openBrowserPanel);
   const closeBrowserPanel = useUiStateStore((state) => state.closeBrowserPanel);
   const toggleBrowserPanel = useUiStateStore((state) => state.toggleBrowserPanel);
+  const [rightPaneMode, setRightPaneMode] = useState<"browser" | "artifact">("browser");
+  const [artifactTarget, setArtifactTarget] = useState<OpenTarget | null>(null);
+  const [artifactTargets, setArtifactTargets] = useState<OpenTarget[]>([]);
+  const artifactFileTargets = useMemo(() => artifactTargets.filter((target) => target.kind === "file"), [artifactTargets]);
 
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
@@ -237,10 +243,46 @@ export function SessionPage(props: SessionPageProps) {
     if (browserPanelOpen) return;
     setBrowserPanelDefaultWidth(browserPanelWidth);
   }, [browserPanelOpen, browserPanelWidth]);
+  useEffect(() => {
+    setArtifactTarget(null);
+    setArtifactTargets([]);
+    setRightPaneMode("browser");
+  }, [props.selectedSessionId]);
   const commitBrowserPanelWidth = useCallback(() => {
     const size = browserPanelRef.current?.getSize();
     if (size?.inPixels) setBrowserPanelWidth(Math.round(size.inPixels));
   }, [browserPanelRef, setBrowserPanelWidth]);
+  const browserUrlForTarget = useCallback((target: OpenTarget) => {
+    if (/^wss?:\/\//i.test(target.value)) return target.value.replace(/^ws:/i, "http:").replace(/^wss:/i, "https:");
+    return target.value;
+  }, []);
+  const openTarget = useCallback((target: OpenTarget, options?: { auto?: boolean }) => {
+    if (target.kind === "url" || target.preview === "browser") {
+      const url = browserUrlForTarget(target);
+      if (isElectronRuntime()) {
+        setRightPaneMode("browser");
+        openBrowserPanel();
+        void window.__OPENWORK_ELECTRON__?.browser?.createTab?.(url);
+      } else {
+        window.open(url, "_blank", "noopener,noreferrer");
+      }
+      return;
+    }
+    if (options?.auto && artifactTarget?.id === target.id) return;
+    setArtifactTarget(target);
+    setRightPaneMode("artifact");
+    openBrowserPanel();
+  }, [artifactTarget?.id, browserUrlForTarget, openBrowserPanel]);
+  const handleOpenTargetsChange = useCallback((targets: OpenTarget[]) => {
+    setArtifactTargets(targets);
+    setArtifactTarget((current) => {
+      if (!current) return current;
+      return targets.find((target) => target.id === current.id || target.value === current.value) ?? current;
+    });
+  }, []);
+  const closeRightPane = useCallback(() => {
+    closeBrowserPanel();
+  }, [closeBrowserPanel]);
   const [showDelayedSessionLoadingState, setShowDelayedSessionLoadingState] = useState(false);
 
   const selectedSessionTitle = useMemo(
@@ -448,6 +490,26 @@ export function SessionPage(props: SessionPageProps) {
                   <span className="hidden @lg/titlebar:inline">Browser</span>
                 </Button>
               ) : null}
+              {artifactTarget || artifactFileTargets.length > 0 ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    "transition-colors",
+                    browserPanelOpen && rightPaneMode === "artifact" && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary"
+                  )}
+                  onClick={() => {
+                    setRightPaneMode("artifact");
+                    openBrowserPanel();
+                  }}
+                  title="Open artifact panel"
+                  aria-label="Open artifact panel"
+                  aria-pressed={browserPanelOpen && rightPaneMode === "artifact"}
+                >
+                  <FileText size={16} />
+                  <span className="hidden @lg/titlebar:inline">Artifact{artifactFileTargets.length > 1 ? `s ${artifactFileTargets.length}` : ""}</span>
+                </Button>
+              ) : null}
               {/* Revert/redo moved to per-message actions */}
               {props.developerMode ? (
                 <Button
@@ -531,6 +593,8 @@ export function SessionPage(props: SessionPageProps) {
                   permissionReplyBusy={props.permissionReplyBusy}
                   respondPermission={props.respondPermission}
                   safeStringify={props.safeStringify}
+                  onOpenTarget={openTarget}
+                  onOpenTargetsChange={handleOpenTargetsChange}
                 />
               ) : null}
 
@@ -690,7 +754,20 @@ export function SessionPage(props: SessionPageProps) {
                   maxSize="70%"
                   className="min-h-0 overflow-hidden lg:flex lg:flex-col"
                 >
-                  <BrowserPanel onClose={closeBrowserPanel} />
+                  {rightPaneMode === "artifact" && artifactTarget && props.openworkServerClient && props.runtimeWorkspaceId ? (
+                    <ArtifactPanel
+                      client={props.openworkServerClient}
+                      workspaceId={props.runtimeWorkspaceId}
+                      workspaceRoot={props.selectedWorkspaceRoot}
+                      isRemoteWorkspace={props.surface?.isRemoteWorkspace ?? false}
+                      target={artifactTarget}
+                      targets={artifactFileTargets}
+                      onSelectTarget={openTarget}
+                      onClose={closeRightPane}
+                    />
+                  ) : (
+                    <BrowserPanel onClose={closeRightPane} />
+                  )}
                 </ResizablePanel>
               </>
             ) : null}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource react */
 import type { CSSProperties } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { FileText, Globe, Loader2, Redo2, Undo2, Zap } from "lucide-react";
+import { FileText, Globe, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
@@ -45,7 +45,7 @@ import { useUiStateStore } from "../../../shell/ui-state-store";
 import { isElectronRuntime } from "../../../../app/utils";
 import { BrowserPanel } from "../browser/browser-panel";
 import { ArtifactPanel } from "../artifacts/artifact-panel";
-import type { OpenTarget } from "../artifacts/open-target";
+import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, type OpenTarget } from "../artifacts/open-target";
 import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
 import { cn } from "@/lib/utils";
 
@@ -156,6 +156,7 @@ export type SessionPageProps = {
   notFoundMessage?: string | null;
   onRenameSession?: (sessionId: string, title: string) => Promise<void> | void;
   onDeleteSession?: (sessionId: string) => Promise<void> | void;
+  onAccessibleTargetsChange?: (targets: OpenTarget[]) => void;
 };
 
 function getSidebarInitialLoading(props: SessionPageSidebarProps) {
@@ -182,6 +183,39 @@ function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | 
   return match ? getDisplaySessionTitle(match.title) : "";
 }
 
+function isTrackableAccessibleTarget(target: OpenTarget) {
+  return isCollectibleArtifactTarget(target) || isLocalhostBrowserTarget(target);
+}
+
+function hiddenAccessibleTargetsStorageKey(workspaceId: string | null | undefined, sessionId: string | null | undefined) {
+  if (!workspaceId || !sessionId) return null;
+  return `openwork.session.hiddenAccessibleTargets.v1:${workspaceId}:${sessionId}`;
+}
+
+function readHiddenAccessibleTargetIds(workspaceId: string | null | undefined, sessionId: string | null | undefined): Set<string> {
+  const key = hiddenAccessibleTargetsStorageKey(workspaceId, sessionId);
+  if (!key || typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((id): id is string => typeof id === "string" && id.trim().length > 0));
+  } catch {
+    return new Set();
+  }
+}
+
+function writeHiddenAccessibleTargetIds(workspaceId: string | null | undefined, sessionId: string | null | undefined, ids: Set<string>) {
+  const key = hiddenAccessibleTargetsStorageKey(workspaceId, sessionId);
+  if (!key || typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(Array.from(ids)));
+  } catch {
+    // ignore storage failures
+  }
+}
+
 export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
   const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
@@ -189,11 +223,21 @@ export function SessionPage(props: SessionPageProps) {
   const browserPanelOpen = useUiStateStore((state) => state.browserPanelOpen);
   const openBrowserPanel = useUiStateStore((state) => state.openBrowserPanel);
   const closeBrowserPanel = useUiStateStore((state) => state.closeBrowserPanel);
-  const toggleBrowserPanel = useUiStateStore((state) => state.toggleBrowserPanel);
   const [rightPaneMode, setRightPaneMode] = useState<"browser" | "artifact">("browser");
   const [artifactTarget, setArtifactTarget] = useState<OpenTarget | null>(null);
-  const [artifactTargets, setArtifactTargets] = useState<OpenTarget[]>([]);
-  const artifactFileTargets = useMemo(() => artifactTargets.filter((target) => target.kind === "file"), [artifactTargets]);
+  const [openTargets, setOpenTargets] = useState<OpenTarget[]>([]);
+  const [hiddenAccessibleTargetIds, setHiddenAccessibleTargetIds] = useState<Set<string>>(() => new Set());
+  const loadedHiddenTargetsKeyRef = useRef<string | null>(null);
+  const accessibleTargets = useMemo(
+    () => openTargets.filter((target) => isTrackableAccessibleTarget(target) && !hiddenAccessibleTargetIds.has(target.id)),
+    [hiddenAccessibleTargetIds, openTargets],
+  );
+  const artifactFileTargets = useMemo(() => accessibleTargets.filter(isCollectibleArtifactTarget), [accessibleTargets]);
+  const visibleArtifactTarget = artifactTarget ?? artifactFileTargets[0] ?? null;
+  const artifactTargetCount = artifactFileTargets.length;
+  const hasArtifactTargets = artifactTargetCount > 0;
+  const browserRailActive = browserPanelOpen && rightPaneMode === "browser";
+  const artifactRailActive = browserPanelOpen && rightPaneMode === "artifact";
 
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
@@ -211,6 +255,7 @@ export function SessionPage(props: SessionPageProps) {
   const [deleteBusy, setDeleteBusy] = useState(false);
   const [sessionActionId, setSessionActionId] = useState<string | null>(null);
   const browserPanelRef = usePanelRef();
+  const preserveRightPaneModeOnPanelOpenRef = useRef(false);
 
   // Sync browser panel state with Electron main process IPC events.
   // When the agent calls a built-in browser tool, the main process opens
@@ -221,7 +266,15 @@ export function SessionPage(props: SessionPageProps) {
     if (!isElectronRuntime()) return;
     const browser = (window as Window).__OPENWORK_ELECTRON__?.browser;
     if (!browser) return;
-    const unsubOpen = browser.onPanelOpened?.(openBrowserPanel);
+    const unsubOpen = browser.onPanelOpened?.(() => {
+      if (preserveRightPaneModeOnPanelOpenRef.current) {
+        preserveRightPaneModeOnPanelOpenRef.current = false;
+        openBrowserPanel();
+        return;
+      }
+      setRightPaneMode("browser");
+      openBrowserPanel();
+    });
     const unsubClose = browser.onPanelClosed?.(closeBrowserPanel);
     return () => { unsubOpen?.(); unsubClose?.(); };
   }, [closeBrowserPanel, openBrowserPanel]);
@@ -244,10 +297,19 @@ export function SessionPage(props: SessionPageProps) {
     setBrowserPanelDefaultWidth(browserPanelWidth);
   }, [browserPanelOpen, browserPanelWidth]);
   useEffect(() => {
+    loadedHiddenTargetsKeyRef.current = hiddenAccessibleTargetsStorageKey(props.selectedWorkspaceId, props.selectedSessionId);
     setArtifactTarget(null);
-    setArtifactTargets([]);
+    setOpenTargets([]);
+    setHiddenAccessibleTargetIds(readHiddenAccessibleTargetIds(props.selectedWorkspaceId, props.selectedSessionId));
     setRightPaneMode("browser");
-  }, [props.selectedSessionId]);
+  }, [props.selectedSessionId, props.selectedWorkspaceId]);
+  useEffect(() => {
+    if (loadedHiddenTargetsKeyRef.current !== hiddenAccessibleTargetsStorageKey(props.selectedWorkspaceId, props.selectedSessionId)) return;
+    writeHiddenAccessibleTargetIds(props.selectedWorkspaceId, props.selectedSessionId, hiddenAccessibleTargetIds);
+  }, [hiddenAccessibleTargetIds, props.selectedSessionId, props.selectedWorkspaceId]);
+  useEffect(() => {
+    props.onAccessibleTargetsChange?.(accessibleTargets);
+  }, [accessibleTargets, props.onAccessibleTargetsChange]);
   const commitBrowserPanelWidth = useCallback(() => {
     const size = browserPanelRef.current?.getSize();
     if (size?.inPixels) setBrowserPanelWidth(Math.round(size.inPixels));
@@ -271,18 +333,61 @@ export function SessionPage(props: SessionPageProps) {
     if (options?.auto && artifactTarget?.id === target.id) return;
     setArtifactTarget(target);
     setRightPaneMode("artifact");
+    preserveRightPaneModeOnPanelOpenRef.current = true;
     openBrowserPanel();
   }, [artifactTarget?.id, browserUrlForTarget, openBrowserPanel]);
   const handleOpenTargetsChange = useCallback((targets: OpenTarget[]) => {
-    setArtifactTargets(targets);
+    setOpenTargets(targets);
     setArtifactTarget((current) => {
       if (!current) return current;
-      return targets.find((target) => target.id === current.id || target.value === current.value) ?? current;
+      const updated = targets.find((target) => target.id === current.id || target.value === current.value);
+      if (!updated) return current;
+      return isCollectibleArtifactTarget(updated) ? updated : null;
     });
   }, []);
   const closeRightPane = useCallback(() => {
     closeBrowserPanel();
   }, [closeBrowserPanel]);
+  const openBrowserRailPane = useCallback(() => {
+    if (browserRailActive) {
+      closeBrowserPanel();
+      return;
+    }
+    setRightPaneMode("browser");
+    openBrowserPanel();
+  }, [browserRailActive, closeBrowserPanel, openBrowserPanel]);
+  const openArtifactRailPane = useCallback(() => {
+    if (!hasArtifactTargets) return;
+    if (artifactRailActive) {
+      closeBrowserPanel();
+      return;
+    }
+    setRightPaneMode("artifact");
+    preserveRightPaneModeOnPanelOpenRef.current = true;
+    openBrowserPanel();
+  }, [artifactRailActive, closeBrowserPanel, hasArtifactTargets, openBrowserPanel]);
+  const removeAccessibleTarget = useCallback((target: OpenTarget) => {
+    setHiddenAccessibleTargetIds((current) => new Set(current).add(target.id));
+    setArtifactTarget((current) => current?.id === target.id ? null : current);
+  }, []);
+  useEffect(() => {
+    const open = (event: Event) => {
+      const requested = (event as CustomEvent<OpenTarget>).detail;
+      const target = accessibleTargets.find((item) => item.id === requested?.id || item.value === requested?.value);
+      if (target) openTarget(target);
+    };
+    const hide = (event: Event) => {
+      const requested = (event as CustomEvent<OpenTarget>).detail;
+      const target = accessibleTargets.find((item) => item.id === requested?.id || item.value === requested?.value);
+      if (target) removeAccessibleTarget(target);
+    };
+    window.addEventListener("openwork-open-accessible-target", open);
+    window.addEventListener("openwork-hide-accessible-target", hide);
+    return () => {
+      window.removeEventListener("openwork-open-accessible-target", open);
+      window.removeEventListener("openwork-hide-accessible-target", hide);
+    };
+  }, [accessibleTargets, openTarget, removeAccessibleTarget]);
   const [showDelayedSessionLoadingState, setShowDelayedSessionLoadingState] = useState(false);
 
   const selectedSessionTitle = useMemo(
@@ -442,10 +547,11 @@ export function SessionPage(props: SessionPageProps) {
           onStartResize={startLeftSidebarResize}
         />
         <SidebarInset className="min-h-0 overflow-hidden bg-background mac:bg-background/80 mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-28 mac:max-md:[&_header]:pl-28">
+          <div className="flex min-h-0 flex-1">
           <ResizablePanelGroup
             orientation="horizontal"
             onLayoutChanged={browserPanelOpen ? commitBrowserPanelWidth : undefined}
-            className="min-h-0"
+            className="min-h-0 flex-1"
           >
             <ResizablePanel minSize="360px" className="min-w-0">
               <main className="flex h-full min-w-0 flex-col overflow-hidden border-r border-border">
@@ -473,43 +579,6 @@ export function SessionPage(props: SessionPageProps) {
             </div>
 
             <div className="flex items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
-              {isElectronRuntime() ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "transition-colors",
-                    browserPanelOpen && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary"
-                  )}
-                  onClick={toggleBrowserPanel}
-                  title="Toggle browser panel"
-                  aria-label="Toggle browser panel"
-                  aria-pressed={browserPanelOpen}
-                >
-                  <Globe size={16} />
-                  <span className="hidden @lg/titlebar:inline">Browser</span>
-                </Button>
-              ) : null}
-              {artifactTarget || artifactFileTargets.length > 0 ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "transition-colors",
-                    browserPanelOpen && rightPaneMode === "artifact" && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary"
-                  )}
-                  onClick={() => {
-                    setRightPaneMode("artifact");
-                    openBrowserPanel();
-                  }}
-                  title="Open artifact panel"
-                  aria-label="Open artifact panel"
-                  aria-pressed={browserPanelOpen && rightPaneMode === "artifact"}
-                >
-                  <FileText size={16} />
-                  <span className="hidden @lg/titlebar:inline">Artifact{artifactFileTargets.length > 1 ? `s ${artifactFileTargets.length}` : ""}</span>
-                </Button>
-              ) : null}
               {/* Revert/redo moved to per-message actions */}
               {props.developerMode ? (
                 <Button
@@ -754,13 +823,13 @@ export function SessionPage(props: SessionPageProps) {
                   maxSize="70%"
                   className="min-h-0 overflow-hidden lg:flex lg:flex-col"
                 >
-                  {rightPaneMode === "artifact" && artifactTarget && props.openworkServerClient && props.runtimeWorkspaceId ? (
+                  {rightPaneMode === "artifact" && visibleArtifactTarget && props.openworkServerClient && props.runtimeWorkspaceId ? (
                     <ArtifactPanel
                       client={props.openworkServerClient}
                       workspaceId={props.runtimeWorkspaceId}
                       workspaceRoot={props.selectedWorkspaceRoot}
                       isRemoteWorkspace={props.surface?.isRemoteWorkspace ?? false}
-                      target={artifactTarget}
+                      target={visibleArtifactTarget}
                       targets={artifactFileTargets}
                       onSelectTarget={openTarget}
                       onClose={closeRightPane}
@@ -772,6 +841,45 @@ export function SessionPage(props: SessionPageProps) {
               </>
             ) : null}
           </ResizablePanelGroup>
+          <aside className="flex w-11 shrink-0 flex-col items-center gap-1 border-l border-border bg-background/95 px-1 py-2 text-muted-foreground mac:titlebar-no-drag">
+            {isElectronRuntime() ? (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className={cn(
+                  "rounded-xl transition-colors hover:bg-muted hover:text-foreground",
+                  browserRailActive && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
+                )}
+                onClick={openBrowserRailPane}
+                title="Browser"
+                aria-label="Browser"
+                aria-pressed={browserRailActive}
+              >
+                <Globe size={17} />
+              </Button>
+            ) : null}
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className={cn(
+                "rounded-xl transition-colors hover:bg-muted hover:text-foreground",
+                artifactRailActive && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
+              )}
+              onClick={openArtifactRailPane}
+              title={hasArtifactTargets ? `Artifacts (${artifactTargetCount})` : "No artifacts yet"}
+              aria-label={hasArtifactTargets ? `Artifacts (${artifactTargetCount})` : "No artifacts yet"}
+              aria-pressed={artifactRailActive}
+              disabled={!hasArtifactTargets}
+            >
+              <FileText size={17} />
+              {artifactTargetCount > 0 ? (
+                <span className="absolute right-0 top-0 flex min-w-3.5 translate-x-1 -translate-y-1 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold leading-3 text-primary-foreground">
+                  {artifactTargetCount > 9 ? "9+" : artifactTargetCount}
+                </span>
+              ) : null}
+            </Button>
+          </aside>
+          </div>
         </SidebarInset>
         {shellConfig.sidebar ? <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" /> : null}
       </SidebarProvider>

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Check,
   ChevronDown,
+  Chrome,
   CircleAlert,
   Copy,
   File as FileIcon,
@@ -27,6 +28,12 @@ import { groupMessageParts, isDesktopRuntime, summarizeStep } from "../../../../
 import { DEFAULT_SHOW_THINKING } from "../../../kernel/local-provider";
 import { MarkdownBlock } from "./markdown";
 import { applyTextHighlights } from "./text-highlights";
+import {
+  deriveOpenTargets,
+  isCollectibleArtifactTarget,
+  isLocalhostBrowserTarget,
+  type OpenTarget,
+} from "../artifacts/open-target";
 
 type TranscriptPart = Part;
 
@@ -160,6 +167,8 @@ type SessionTranscriptProps = {
   onRevertToMessage?: (messageId: string) => void;
   /** Fork the conversation at this message into a new session. */
   onForkAtMessage?: (messageId: string) => void;
+  openTargets?: OpenTarget[];
+  onOpenTarget?: (target: OpenTarget) => void;
 };
 
 // 500 was too high for real-world OpenWork sessions: a handful of giant
@@ -773,6 +782,66 @@ function messageGroupKey(messageId: string, group: MessageGroup) {
   return `${messageId}:text:${group.segment}:${partId}`;
 }
 
+function inlineOpenTargetsForMessage(message: UIMessage, verifiedTargets: OpenTarget[] | undefined) {
+  const verifiedById = new Map((verifiedTargets ?? []).map((target) => [target.id, target] as const));
+  const inlineTargets = new Map<string, OpenTarget>();
+  for (const candidate of deriveOpenTargets([message])) {
+    const verified = verifiedById.get(candidate.id);
+    if (candidate.kind === "url" && isLocalhostBrowserTarget(candidate)) {
+      inlineTargets.set(candidate.id, verified ?? candidate);
+      continue;
+    }
+    if (verified && isCollectibleArtifactTarget(verified)) {
+      inlineTargets.set(verified.id, verified);
+    }
+  }
+  return Array.from(inlineTargets.values()).slice(0, 4);
+}
+
+function OpenTargetIcon(props: { target: OpenTarget }) {
+  if (props.target.kind === "url") return <Chrome size={12} className="shrink-0 text-primary" />;
+  if (props.target.preview === "sheet") {
+    return (
+      <span className="inline-flex h-3.5 min-w-5 shrink-0 items-center justify-center rounded-[3px] border border-emerald-500/30 bg-emerald-500/10 px-0.5 text-[6px] font-bold leading-none text-emerald-700">
+        XLS
+      </span>
+    );
+  }
+  if (props.target.preview === "markdown") {
+    return (
+      <span className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-[3px] border border-primary/25 bg-primary/10 text-[7px] font-bold leading-none text-primary">
+        MD
+      </span>
+    );
+  }
+  return <FileIcon size={12} className="shrink-0 text-primary" />;
+}
+
+function OpenableTargetsStrip(props: { targets: OpenTarget[]; onOpenTarget: (target: OpenTarget) => void }) {
+  if (!props.targets.length) return null;
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-1.5 text-[11px] leading-none">
+      <span className="mr-0.5 text-dls-secondary">Openable items</span>
+      {props.targets.map((target) => {
+        const isBrowser = target.kind === "url";
+        return (
+          <button
+            key={target.id}
+            type="button"
+            className="inline-flex max-w-[220px] items-center gap-1.5 rounded-full border border-dls-border bg-dls-surface px-2 py-1.5 text-dls-text transition-colors hover:border-primary/40 hover:bg-primary/10 hover:text-primary"
+            title={target.value}
+            onClick={() => props.onOpenTarget(target)}
+          >
+            <OpenTargetIcon target={target} />
+            <span className="truncate">{target.name || target.value}</span>
+            <span className="text-dls-secondary">{isBrowser ? "Open browser" : "Open artifact"}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 function MessageBlockRow(props: {
   block: MessageBlockItem;
   blockIndex: number;
@@ -788,6 +857,8 @@ function MessageBlockRow(props: {
   latestAssistantMessageId: string;
   onRevertToMessage?: (messageId: string) => void;
   onForkAtMessage?: (messageId: string) => void;
+  openTargets?: OpenTarget[];
+  onOpenTarget?: (target: OpenTarget) => void;
 }) {
   const block = props.block;
   const blockMessageIds = block.kind === "steps-cluster" ? block.messageIds : [block.messageId];
@@ -837,6 +908,9 @@ function MessageBlockRow(props: {
   const groupSpacing = block.isUser ? "mb-3" : "mb-4";
   const isSyntheticSessionError =
     !block.isUser && block.messageId.startsWith(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX);
+  const inlineOpenTargets = block.kind === "message" && !block.isUser && props.onOpenTarget
+    ? inlineOpenTargetsForMessage(block.message, props.openTargets)
+    : [];
 
   if (isSyntheticSessionError) {
     const messageText = block.renderableParts
@@ -964,6 +1038,8 @@ function MessageBlockRow(props: {
             </div>
           );
         })}
+
+        {props.onOpenTarget ? <OpenableTargetsStrip targets={inlineOpenTargets} onOpenTarget={props.onOpenTarget} /> : null}
 
         {!props.isNestedVariant ? (
           <div className="absolute bottom-2 right-2 flex items-center gap-0.5 opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover:opacity-100 md:group-hover:pointer-events-auto md:group-focus-within:opacity-100 md:group-focus-within:pointer-events-auto transition-opacity select-none rounded-lg border border-dls-border bg-dls-surface p-0.5">
@@ -1262,6 +1338,8 @@ function SessionTranscriptInner(props: SessionTranscriptProps) {
                   latestAssistantMessageId={latestAssistantMessageId}
                   onRevertToMessage={props.onRevertToMessage}
                   onForkAtMessage={props.onForkAtMessage}
+                  openTargets={props.openTargets}
+                  onOpenTarget={props.onOpenTarget}
                 />
               </div>
             );
@@ -1286,6 +1364,8 @@ function SessionTranscriptInner(props: SessionTranscriptProps) {
               latestAssistantMessageId={latestAssistantMessageId}
               onRevertToMessage={props.onRevertToMessage}
               onForkAtMessage={props.onForkAtMessage}
+              openTargets={props.openTargets}
+              onOpenTarget={props.onOpenTarget}
             />
           ))}
         </div>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -44,6 +44,7 @@ import { useLocal } from "../../../kernel/local-provider";
 import { deriveSessionRenderModel } from "../sync/transition-controller";
 import { useSessionScrollController } from "./scroll-controller";
 import { PermissionApprovalPanel } from "../chat/permission-approval-modal";
+import { deriveOpenTargets, shouldAutoOpenTarget, type OpenTarget } from "../artifacts/open-target";
 import {
   seedSessionState,
   statusKey as reactStatusKey,
@@ -105,6 +106,8 @@ export type SessionSurfaceProps = {
   onOpenSettingsSection?: ((section: "commands" | "skills" | "mcps" | "plugins") => void) | undefined;
   onRevertToMessage?: (messageId: string) => void;
   onForkAtMessage?: (messageId: string) => void;
+  onOpenTarget?: (target: OpenTarget, options?: { auto?: boolean }) => void;
+  onOpenTargetsChange?: (targets: OpenTarget[]) => void;
 };
 
 function messageToReadableText(message: UIMessage) {
@@ -356,8 +359,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [toolMcpStatus, setToolMcpStatus] = useState<string | null>(null);
   const [toolMcpStatuses, setToolMcpStatuses] = useState<McpStatusMap>({});
   const [toolImportedPlugins, setToolImportedPlugins] = useState<CloudImportedPlugin[]>([]);
+  const [verifiedOpenTargets, setVerifiedOpenTargets] = useState<OpenTarget[]>([]);
   const composerShellRef = useRef<HTMLDivElement>(null);
   const hydratedKeyRef = useRef<string | null>(null);
+  const autoOpenedTargetRef = useRef<string | null>(null);
   const attachmentsRef = useRef<ComposerAttachment[]>([]);
   attachmentsRef.current = attachments;
   const opencodeClient = useMemo(
@@ -410,6 +415,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setMentions({});
     setPasteParts([]);
     setNotice(null);
+    autoOpenedTargetRef.current = null;
+    setVerifiedOpenTargets([]);
   }, [props.sessionId]);
 
   useEffect(() => {
@@ -493,6 +500,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
     () => deriveRenderedSessionMessages({ transcriptState, snapshot }),
     [snapshot, transcriptState],
   );
+  const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
+  const openTargetsFingerprint = useMemo(
+    () => openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|"),
+    [openTargets],
+  );
+  const autoOpenTarget = verifiedOpenTargets.find(shouldAutoOpenTarget) ?? null;
   const pendingSessionLoad = !snapshot && snapshotQuery.isLoading && renderedMessages.length === 0;
   const assistantOutputAfterAwaitStart = useMemo(() => {
     if (awaitingAssistantBaseline === null) return false;
@@ -511,6 +524,35 @@ export function SessionSurface(props: SessionSurfaceProps) {
     showAssistantWaitState,
     hasSnapshot: Boolean(snapshot),
   });
+
+  useEffect(() => {
+    if (!autoOpenTarget || chatStreaming) return;
+    if (autoOpenedTargetRef.current === autoOpenTarget.id) return;
+    autoOpenedTargetRef.current = autoOpenTarget.id;
+    props.onOpenTarget?.(autoOpenTarget, { auto: true });
+  }, [autoOpenTarget, chatStreaming, props.onOpenTarget]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function verifyTargets() {
+      if (!openTargets.length) {
+        setVerifiedOpenTargets([]);
+        return;
+      }
+      try {
+        const response = await props.client.resolveArtifacts(props.workspaceId, openTargets);
+        if (!cancelled) setVerifiedOpenTargets(response.items as OpenTarget[]);
+      } catch {
+        if (!cancelled) setVerifiedOpenTargets(openTargets.map((target) => ({ ...target, exists: target.kind === "url" })));
+      }
+    }
+    void verifyTargets();
+    return () => { cancelled = true; };
+  }, [openTargetsFingerprint, props.client, props.workspaceId]);
+
+  useEffect(() => {
+    props.onOpenTargetsChange?.(verifiedOpenTargets);
+  }, [props.onOpenTargetsChange, verifiedOpenTargets]);
 
   useEffect(() => {
     if (!pendingSessionLoad) {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -44,7 +44,7 @@ import { useLocal } from "../../../kernel/local-provider";
 import { deriveSessionRenderModel } from "../sync/transition-controller";
 import { useSessionScrollController } from "./scroll-controller";
 import { PermissionApprovalPanel } from "../chat/permission-approval-modal";
-import { deriveOpenTargets, shouldAutoOpenTarget, type OpenTarget } from "../artifacts/open-target";
+import { deriveOpenTargets, selectAutoOpenTarget, type OpenTarget } from "../artifacts/open-target";
 import {
   seedSessionState,
   statusKey as reactStatusKey,
@@ -505,7 +505,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     () => openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|"),
     [openTargets],
   );
-  const autoOpenTarget = verifiedOpenTargets.find(shouldAutoOpenTarget) ?? null;
+  const autoOpenTarget = selectAutoOpenTarget(verifiedOpenTargets);
   const pendingSessionLoad = !snapshot && snapshotQuery.isLoading && renderedMessages.length === 0;
   const assistantOutputAfterAwaitStart = useMemo(() => {
     if (awaitingAssistantBaseline === null) return false;
@@ -1072,6 +1072,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
                     scrollElement={() => scrollRef.current}
                     onRevertToMessage={props.onRevertToMessage}
                     onForkAtMessage={props.onForkAtMessage}
+                    openTargets={verifiedOpenTargets}
+                    onOpenTarget={props.onOpenTarget}
                   />
                   {error ? (
                     <SessionErrorCard

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
 } from "react";
 
 import { t } from "@/i18n";
@@ -22,18 +23,27 @@ import {
   CommandShortcut,
 } from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
-import { ChevronLeftIcon } from "lucide-react";
+import { ChevronLeftIcon, Chrome, FileText } from "lucide-react";
 
 export type PaletteItem = {
   id: string;
   title: string;
   detail?: string;
   meta?: string;
+  icon?: ReactNode;
   searchText?: string;
   action: () => void;
 };
 
-type PaletteMode = "root" | "sessions";
+export type AccessibleTargetOption = {
+  id: string;
+  kind: "url" | "file";
+  value: string;
+  name: string;
+  preview: string;
+};
+
+type PaletteMode = "root" | "sessions" | "accessible-items";
 
 export type SessionOption = {
   workspaceId: string;
@@ -44,6 +54,25 @@ export type SessionOption = {
   searchText: string;
   isActive: boolean;
 };
+
+function targetIcon(target: AccessibleTargetOption) {
+  if (target.kind === "url") return <Chrome className="size-4 text-primary" />;
+  if (target.preview === "sheet") {
+    return (
+      <span className="inline-flex h-4 min-w-6 shrink-0 items-center justify-center rounded-[4px] border border-emerald-500/30 bg-emerald-500/10 px-0.5 text-[7px] font-bold leading-none text-emerald-700">
+        XLS
+      </span>
+    );
+  }
+  if (target.preview === "markdown") {
+    return (
+      <span className="inline-flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-primary/25 bg-primary/10 text-[8px] font-bold leading-none text-primary">
+        MD
+      </span>
+    );
+  }
+  return <FileText className="size-4 text-primary" />;
+}
 
 export type CommandPaletteProps = {
   open: boolean;
@@ -56,6 +85,10 @@ export type CommandPaletteProps = {
   onOpenSettings: (route?: string) => void;
   /** Optional — open a URL in the user's browser. Falls back to window.open. */
   onOpenUrl?: (url: string) => void;
+  /** Optional: current session servers/artifacts exposed through Cmd/Ctrl+K. */
+  accessibleTargets?: AccessibleTargetOption[];
+  onOpenAccessibleTarget?: (target: AccessibleTargetOption) => void;
+  onHideAccessibleTarget?: (target: AccessibleTargetOption) => void;
   /** Optional: sessions for the second mode. */
   sessions: SessionOption[];
 };
@@ -83,6 +116,8 @@ export function CommandPalette(props: CommandPaletteProps) {
     }
   };
 
+  const accessibleTargetCount = props.accessibleTargets?.length ?? 0;
+
   const rootItems = useMemo<PaletteItem[]>(() => [
     {
       id: "new-session",
@@ -103,6 +138,17 @@ export function CommandPalette(props: CommandPaletteProps) {
       meta: t("session.cmd_sessions_meta"),
       action: () => {
         setMode("sessions");
+      },
+    },
+    {
+      id: "accessible-items",
+      title: "Accessible items",
+      detail: accessibleTargetCount > 0
+        ? `Open ${accessibleTargetCount.toLocaleString()} servers and artifacts detected in this session`
+        : "No servers or artifacts detected in this session yet",
+      meta: "Session",
+      action: () => {
+        setMode("accessible-items");
       },
     },
     {
@@ -187,7 +233,7 @@ export function CommandPalette(props: CommandPaletteProps) {
         props.onOpenSettings("/settings/updates");
       },
     },
-  ], [props]);
+  ], [accessibleTargetCount, props]);
 
   const sessionItems = useMemo<PaletteItem[]>(
     () =>
@@ -206,6 +252,36 @@ export function CommandPalette(props: CommandPaletteProps) {
       })),
     [props],
   );
+
+  const accessibleItems = useMemo<PaletteItem[]>(() => {
+    const targets = props.accessibleTargets ?? [];
+    return [
+      ...targets.map((target) => ({
+        id: `accessible:${target.id}`,
+        title: target.name || target.value,
+        detail: target.value,
+        meta: target.kind === "url" ? "Server" : "Artifact",
+        icon: targetIcon(target),
+        searchText: `${target.name} ${target.value} ${target.preview}`.toLowerCase(),
+        action: () => {
+          props.onClose();
+          props.onOpenAccessibleTarget?.(target);
+        },
+      })),
+      ...targets.map((target) => ({
+        id: `accessible-hide:${target.id}`,
+        title: `Stop tracking ${target.name || target.value}`,
+        detail: target.value,
+        meta: "Hide",
+        icon: targetIcon(target),
+        searchText: `stop tracking hide ${target.name} ${target.value} ${target.preview}`.toLowerCase(),
+        action: () => {
+          props.onClose();
+          props.onHideAccessibleTarget?.(target);
+        },
+      })),
+    ];
+  }, [props]);
 
   const handleEscape = (event: ReactKeyboardEvent<HTMLElement>) => {
     if (event.key === "Escape") {
@@ -236,7 +312,7 @@ export function CommandPalette(props: CommandPaletteProps) {
     }
   };
 
-  const items = mode === "sessions" ? sessionItems : rootItems;
+  const items = mode === "sessions" ? sessionItems : mode === "accessible-items" ? accessibleItems : rootItems;
 
   return (
     <CommandDialog open={props.open} onOpenChange={handleOpenChange}>
@@ -244,12 +320,14 @@ export function CommandPalette(props: CommandPaletteProps) {
         <CommandDialogTitle>
           {mode === "sessions"
             ? t("session.palette_title_sessions")
-            : t("session.palette_title_actions")
+            : mode === "accessible-items"
+              ? "Accessible items"
+              : t("session.palette_title_actions")
           }
         </CommandDialogTitle>
         <Command key={mode} items={items}>
           <CommandHeader className="flex items-center gap-0">
-            {mode === "sessions" && (
+            {mode !== "root" && (
               <Button variant="outline" size="icon-sm" className="rounded-xl" onClick={() => setMode("root")}>
                 <ChevronLeftIcon className="size-4" />
                 <span className="sr-only">{t("common.back")}</span>
@@ -260,13 +338,15 @@ export function CommandPalette(props: CommandPaletteProps) {
               placeholder={
                 mode === "sessions"
                   ? t("session.palette_placeholder_sessions")
-                  : t("session.palette_placeholder_actions")
+                  : mode === "accessible-items"
+                    ? "Search servers and artifacts..."
+                    : t("session.palette_placeholder_actions")
               }
               onKeyDown={handleBackspace}
             />
           </CommandHeader>
           <CommandPanel>
-            <CommandEmpty>{t("session.palette_no_matches")}</CommandEmpty>
+            <CommandEmpty>{mode === "accessible-items" ? "No accessible items found for this session." : t("session.palette_no_matches")}</CommandEmpty>
             <CommandList>
               {(item: PaletteItem) => (
                 <CommandItem
@@ -274,6 +354,7 @@ export function CommandPalette(props: CommandPaletteProps) {
                   value={item.id}
                   onClick={item.action}
                 >
+                  {item.icon ? <span className="mr-2 shrink-0">{item.icon}</span> : null}
                   <div className="min-w-0 flex-1">
                     <div className="truncate font-medium">{item.title}</div>
                     {item.detail ? (

--- a/apps/app/src/react-app/shell/font-zoom.ts
+++ b/apps/app/src/react-app/shell/font-zoom.ts
@@ -21,9 +21,8 @@ export function useDesktopFontZoomBehavior() {
       const next = normalizeFontZoom(value);
       persistFontZoom(window.localStorage, next);
 
-      // Expose the zoom factor so the browser panel's computeBounds can
-      // convert zoomed CSS pixels back to the native coordinate space
-      // that Electron's WebContentsView.setBounds() expects.
+      // Keep the current desktop zoom available so native WebContentsView bounds
+      // can be converted from renderer CSS pixels to contentView coordinates.
       window.__OPENWORK_ZOOM_FACTOR__ = next;
 
       void setDesktopZoomFactor(next)

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -101,7 +101,7 @@ import {
 } from "../domains/workspace/remote-workspace-diagnostics";
 import { useShareWorkspaceState } from "../domains/workspace/share-workspace-state";
 import { ModelPickerModal } from "../domains/session/modals/model-picker-modal";
-import { CommandPalette, type SessionOption as PaletteSessionOption } from "./command-palette";
+import { CommandPalette, type AccessibleTargetOption, type SessionOption as PaletteSessionOption } from "./command-palette";
 import { getDisplaySessionTitle } from "../../app/lib/session-title";
 import { useBootState } from "./boot-state";
 import {
@@ -135,6 +135,7 @@ import { useStatusToasts } from "../domains/shell-feedback/status-toasts";
 import { useSessionControlActions } from "../domains/session/control/session-control-actions";
 import { legacySessionRoute, workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
 import { WorkspaceProvider } from "./workspace-provider";
+import type { OpenTarget } from "../domains/session/artifacts/open-target";
 import {
   ensureProviderListQuery,
   getConnectedProviderItems,
@@ -514,6 +515,7 @@ export function SessionRoute() {
   const [renameWorkspaceTitle, setRenameWorkspaceTitle] = useState("");
   const [renameWorkspaceBusy, setRenameWorkspaceBusy] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [paletteAccessibleTargets, setPaletteAccessibleTargets] = useState<OpenTarget[]>([]);
   // Model picker modal state (ported from settings-route; previously the
   // session "Pick a model" button navigated to /settings/general, which is a
   // dead-end). Loads providers lazily when the modal opens.
@@ -571,6 +573,9 @@ export function SessionRoute() {
       window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
     }
   }, []);
+  useEffect(() => {
+    setPaletteAccessibleTargets([]);
+  }, [selectedSessionId, selectedWorkspaceId]);
 
   const [permissionReplyBusy, setPermissionReplyBusy] = useState(false);
   const permissionReplyBusyRef = useRef(false);
@@ -2729,6 +2734,7 @@ export function SessionRoute() {
         statusPulse: true,
       } : undefined}
       notFoundMessage={routeNotFoundMessage}
+      onAccessibleTargetsChange={setPaletteAccessibleTargets}
     />
     <CreateWorkspaceModal
       open={createWorkspaceOpen}
@@ -2778,6 +2784,21 @@ export function SessionRoute() {
       }}
       onOpenSession={(workspaceId, sessionId) => navigateToWorkspaceSession(workspaceId, sessionId)}
       onOpenSettings={(route) => handleOpenSettings(route ?? "/settings/general")}
+      accessibleTargets={paletteAccessibleTargets}
+      onOpenAccessibleTarget={(target) => {
+        try {
+          window.dispatchEvent(new CustomEvent("openwork-open-accessible-target", { detail: target }));
+        } catch {
+          // ignore event dispatch failures
+        }
+      }}
+      onHideAccessibleTarget={(target) => {
+        try {
+          window.dispatchEvent(new CustomEvent("openwork-hide-accessible-target", { detail: target }));
+        } catch {
+          // ignore event dispatch failures
+        }
+      }}
       sessions={paletteSessionOptions}
     />
     <ModelPickerModal

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "OPENWORK_DEV_MODE=1 bun src/cli.ts",
     "test": "bun test",
+    "test:artifacts": "bun test src/artifact-files.e2e.test.ts src/workspace-init.test.ts src/server.normalizeWorkspaceRelativePath.test.ts",
     "build": "tsc -p tsconfig.json",
     "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64",

--- a/apps/server/src/artifact-files.e2e.test.ts
+++ b/apps/server/src/artifact-files.e2e.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+async function createWorkspaceRoot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-artifacts-"));
+  roots.push(root);
+  await mkdir(join(root, "reports"), { recursive: true });
+  await writeFile(join(root, "reports", "artifact-eval.md"), "# Artifact Eval\n\nHello markdown.\n", "utf8");
+  await writeFile(join(root, "reports", "artifact-eval.csv"), "name,revenue\nAda,10\nGrace,20\n", "utf8");
+  await writeFile(join(root, "reports", "index.html"), "<!doctype html><h1>Artifact site</h1>", "utf8");
+  await writeFile(join(root, "reports", "artifact-eval.xlsx"), new Uint8Array([80, 75, 3, 4, 1, 2, 3, 4]));
+  return root;
+}
+
+async function startOpenworkServer(workspaceRoot: string) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+}
+
+function auth(token: string) {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+describe("artifact file routes", () => {
+  test("resolve, read, write, and download markdown/csv/xlsx/html artifacts", async () => {
+    const root = await createWorkspaceRoot();
+    const { base, token } = await startOpenworkServer(root);
+
+    const resolveResponse = await fetch(`${base}/workspace/ws_1/artifacts/resolve`, {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({
+        targets: [
+          { kind: "file", value: "Workspace/32423/reports/artifact-eval.md", confidence: 80 },
+          { kind: "file", value: "reports/artifact-eval.csv", confidence: 80 },
+          { kind: "file", value: "reports/artifact-eval.xlsx", confidence: 80 },
+          { kind: "file", value: "reports/index.html", confidence: 80 },
+          { kind: "file", value: "reports/missing.md", confidence: 80 },
+          { kind: "url", value: "http://localhost:4321", confidence: 80 },
+          { kind: "url", value: "ws://localhost:4321/socket", confidence: 80 },
+        ],
+      }),
+    });
+    expect(resolveResponse.status).toBe(200);
+    const resolved = await resolveResponse.json() as { items: Array<any> };
+    expect(resolved.items.find((item) => item.value === "reports/artifact-eval.md")).toMatchObject({ exists: true, preview: "markdown" });
+    expect(resolved.items.find((item) => item.value === "reports/artifact-eval.csv")).toMatchObject({ exists: true, preview: "sheet" });
+    expect(resolved.items.find((item) => item.value === "reports/artifact-eval.xlsx")).toMatchObject({ exists: true, preview: "sheet" });
+    expect(resolved.items.find((item) => item.value === "reports/index.html")).toMatchObject({ exists: true, preview: "html" });
+    expect(resolved.items.find((item) => item.value === "reports/missing.md")).toMatchObject({ exists: false });
+    expect(resolved.items.find((item) => item.value === "http://localhost:4321/")).toMatchObject({ kind: "url", preview: "browser" });
+    expect(resolved.items.find((item) => item.value === "ws://localhost:4321/socket")).toMatchObject({ kind: "url", preview: "browser" });
+
+    const csvRead = await fetch(`${base}/workspace/ws_1/files/content?path=${encodeURIComponent("reports/artifact-eval.csv")}`, { headers: auth(token) });
+    expect(await csvRead.json()).toMatchObject({ content: "name,revenue\nAda,10\nGrace,20\n" });
+
+    const mdWrite = await fetch(`${base}/workspace/ws_1/files/content`, {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({ path: "reports/artifact-eval.md", content: "# Updated\n" }),
+    });
+    expect(mdWrite.status).toBe(200);
+    expect(await readFile(join(root, "reports", "artifact-eval.md"), "utf8")).toBe("# Updated\n");
+
+    const xlsxWrite = await fetch(`${base}/workspace/ws_1/files/raw`, {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({ path: "reports/artifact-eval.xlsx", dataBase64: Buffer.from([80, 75, 9, 9]).toString("base64") }),
+    });
+    expect(xlsxWrite.status).toBe(200);
+
+    const xlsxDownload = await fetch(`${base}/workspace/ws_1/files/raw?path=${encodeURIComponent("reports/artifact-eval.xlsx")}`, { headers: auth(token) });
+    expect(xlsxDownload.status).toBe(200);
+    expect(Array.from(new Uint8Array(await xlsxDownload.arrayBuffer()))).toEqual([80, 75, 9, 9]);
+  });
+});

--- a/apps/server/src/commands.ts
+++ b/apps/server/src/commands.ts
@@ -14,10 +14,10 @@ function normalizeCommandFrontmatter(data: Record<string, unknown>): Record<stri
   );
 }
 
-async function repairLegacyCommandFile(filePath: string, content: string): Promise<{ data: Record<string, unknown>; body: string }> {
+async function repairLegacyCommandFile(filePath: string, content: string): Promise<{ data: Record<string, unknown>; body: string; changed: boolean }> {
   const parsed = parseFrontmatter(content);
   if (parsed.data.model !== null) {
-    return parsed;
+    return { ...parsed, changed: false };
   }
 
   const nextContent = buildFrontmatter(normalizeCommandFrontmatter(parsed.data)) + parsed.body.replace(/^\n?/, "\n");
@@ -25,6 +25,7 @@ async function repairLegacyCommandFile(filePath: string, content: string): Promi
   return {
     data: normalizeCommandFrontmatter(parsed.data),
     body: parsed.body,
+    changed: true,
   };
 }
 
@@ -103,8 +104,19 @@ export async function upsertCommand(
   return path;
 }
 
-export async function repairCommands(workspaceRoot: string): Promise<void> {
-  await listCommandsInDir(projectCommandsDir(workspaceRoot), "workspace");
+export async function repairCommands(workspaceRoot: string): Promise<boolean> {
+  const dir = projectCommandsDir(workspaceRoot);
+  if (!(await exists(dir))) return false;
+  const entries = await readdir(dir, { withFileTypes: true });
+  let changed = false;
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+    const filePath = join(dir, entry.name);
+    const content = await readFile(filePath, "utf8");
+    const result = await repairLegacyCommandFile(filePath, content);
+    changed ||= result.changed;
+  }
+  return changed;
 }
 
 export async function deleteCommand(workspaceRoot: string, name: string): Promise<void> {

--- a/apps/server/src/reload-events.e2e.test.ts
+++ b/apps/server/src/reload-events.e2e.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ReloadEvent, ServerConfig } from "./types.js";
+
+type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+async function createWorkspaceRoot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-reload-events-"));
+  roots.push(root);
+  return root;
+}
+
+async function startOpenworkServer(workspaceRoot: string) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+}
+
+function auth(token: string) {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readEvents(base: string, token: string): Promise<ReloadEvent[]> {
+  const response = await fetch(`${base}/workspace/ws_1/events`, { headers: auth(token) });
+  expect(response.status).toBe(200);
+  const body = await response.json() as { items: ReloadEvent[] };
+  return body.items;
+}
+
+async function waitForEvents(base: string, token: string): Promise<ReloadEvent[]> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const items = await readEvents(base, token);
+    if (items.length > 0) return items;
+    await sleep(100);
+  }
+  return readEvents(base, token);
+}
+
+describe("reload event API", () => {
+  test("does not expose internal workspace bootstrap writes as reload events", async () => {
+    const root = await createWorkspaceRoot();
+    const { base, token } = await startOpenworkServer(root);
+
+    const configResponse = await fetch(`${base}/workspace/ws_1/config`, { headers: auth(token) });
+    expect(configResponse.status).toBe(200);
+    expect(await readFile(join(root, "opencode.jsonc"), "utf8")).toContain("default_agent");
+
+    await sleep(1200);
+    expect(await readEvents(base, token)).toEqual([]);
+  });
+
+  test("does not expose same-content rewrites as reload events", async () => {
+    const root = await createWorkspaceRoot();
+    const configPath = join(root, "opencode.jsonc");
+    const content = '{ "plugin": ["demo"] }\n';
+    await writeFile(configPath, content, "utf8");
+    const { base, token } = await startOpenworkServer(root);
+
+    const configResponse = await fetch(`${base}/workspace/ws_1/config`, { headers: auth(token) });
+    expect(configResponse.status).toBe(200);
+    await writeFile(configPath, content, "utf8");
+
+    await sleep(1200);
+    expect(await readEvents(base, token)).toEqual([]);
+  });
+
+  test("exposes runtime config content changes as reload events", async () => {
+    const root = await createWorkspaceRoot();
+    const configPath = join(root, "opencode.jsonc");
+    await writeFile(configPath, '{ "plugin": ["demo"] }\n', "utf8");
+    const { base, token } = await startOpenworkServer(root);
+
+    const configResponse = await fetch(`${base}/workspace/ws_1/config`, { headers: auth(token) });
+    expect(configResponse.status).toBe(200);
+    await writeFile(configPath, '{ "plugin": ["runtime-change"] }\n', "utf8");
+
+    const items = await waitForEvents(base, token);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ reason: "config", trigger: { name: "opencode.jsonc" } });
+  });
+});

--- a/apps/server/src/reload-fingerprint.ts
+++ b/apps/server/src/reload-fingerprint.ts
@@ -1,0 +1,136 @@
+import { createHash } from "node:crypto";
+import { readdir, readFile } from "node:fs/promises";
+import { basename, join, relative, resolve } from "node:path";
+
+import type { ReloadReason } from "./types.js";
+import { exists } from "./utils.js";
+
+export const fingerprintedReloadReasons: ReloadReason[] = [
+  "config",
+  "agents",
+  "skills",
+  "commands",
+  "plugins",
+  "mcp",
+];
+
+function shouldSkipDir(name: string): boolean {
+  const trimmed = name.trim();
+  if (!trimmed) return true;
+  if (trimmed === ".git" || trimmed === "node_modules") return true;
+  return false;
+}
+
+function shouldIgnoreFile(name: string): boolean {
+  if (!name) return true;
+  if (name === ".DS_Store" || name === "Thumbs.db") return true;
+  if (name.startsWith(".") || name.endsWith("~") || name.endsWith(".tmp") || name.endsWith(".swp")) return true;
+  return false;
+}
+
+async function addIfExists(files: Set<string>, path: string): Promise<void> {
+  if (await exists(path)) {
+    files.add(resolve(path));
+  }
+}
+
+async function collectTreeFiles(
+  files: Set<string>,
+  rootDir: string,
+  shouldInclude: (absPath: string) => boolean,
+): Promise<void> {
+  const resolvedRoot = resolve(rootDir);
+  if (!(await exists(resolvedRoot))) return;
+
+  const stack = [resolvedRoot];
+  while (stack.length) {
+    const dir = stack.pop();
+    if (!dir) continue;
+
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const absPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!shouldSkipDir(entry.name)) stack.push(absPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (shouldIgnoreFile(entry.name)) continue;
+      if (shouldInclude(absPath)) files.add(resolve(absPath));
+    }
+  }
+}
+
+async function collectFiles(workspaceRoot: string, reason: ReloadReason): Promise<string[]> {
+  const root = resolve(workspaceRoot);
+  const files = new Set<string>();
+
+  if (reason === "config" || reason === "mcp") {
+    await addIfExists(files, join(root, "opencode.jsonc"));
+    await addIfExists(files, join(root, "opencode.json"));
+    await addIfExists(files, join(root, ".opencode", "opencode.jsonc"));
+    await addIfExists(files, join(root, ".opencode", "opencode.json"));
+  }
+
+  if (reason === "agents") {
+    await addIfExists(files, join(root, "AGENTS.md"));
+    const isAgentFile = (absPath: string) => /\.(md|json|jsonc)$/i.test(basename(absPath));
+    await collectTreeFiles(files, join(root, ".opencode", "agents"), isAgentFile);
+    await collectTreeFiles(files, join(root, ".opencode", "agent"), isAgentFile);
+  }
+
+  if (reason === "skills") {
+    await collectTreeFiles(
+      files,
+      join(root, ".opencode", "skills"),
+      (absPath) => /^SKILL\.md$/i.test(basename(absPath)),
+    );
+  }
+
+  if (reason === "commands") {
+    await collectTreeFiles(
+      files,
+      join(root, ".opencode", "commands"),
+      (absPath) => /\.md$/i.test(basename(absPath)),
+    );
+  }
+
+  if (reason === "plugins") {
+    await collectTreeFiles(files, join(root, ".opencode", "plugins"), () => true);
+  }
+
+  return Array.from(files).sort((a, b) => a.localeCompare(b));
+}
+
+export async function computeReloadFingerprint(workspaceRoot: string, reason: ReloadReason): Promise<string> {
+  const root = resolve(workspaceRoot);
+  const hash = createHash("sha256");
+  hash.update(`reason:${reason}\0`);
+
+  const files = await collectFiles(root, reason);
+  for (const file of files) {
+    let content: Buffer;
+    try {
+      content = await readFile(file);
+    } catch {
+      continue;
+    }
+
+    const relPath = relative(root, file).split(/[\\/]+/).join("/");
+    hash.update("file\0");
+    hash.update(relPath);
+    hash.update("\0");
+    hash.update(String(content.length));
+    hash.update("\0");
+    hash.update(content);
+    hash.update("\0");
+  }
+
+  return hash.digest("hex");
+}

--- a/apps/server/src/reload-watcher.test.ts
+++ b/apps/server/src/reload-watcher.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ReloadEventStore } from "./events.js";
+import { startReloadWatchers } from "./reload-watcher.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+import { ensureWorkspaceFiles } from "./workspace-init.js";
+
+async function withWorkspace(fn: (root: string) => Promise<void>) {
+  const root = await mkdtemp(join(tmpdir(), "openwork-reload-watcher-"));
+  try {
+    await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function buildConfig(root: string): { config: ServerConfig; workspace: WorkspaceInfo } {
+  const workspace: WorkspaceInfo = {
+    id: "ws_reload_test",
+    name: "Reload Test",
+    path: root,
+    preset: "starter",
+    workspaceType: "local",
+  };
+  return {
+    workspace,
+    config: {
+      host: "127.0.0.1",
+      port: 0,
+      token: "token",
+      hostToken: "host-token",
+      approval: { mode: "auto", timeoutMs: 0 },
+      corsOrigins: [],
+      workspaces: [workspace],
+      authorizedRoots: [root],
+      readOnly: false,
+      startedAt: Date.now(),
+      tokenSource: "env",
+      hostTokenSource: "env",
+      logFormat: "pretty",
+      logRequests: false,
+    },
+  };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForEvent(store: ReloadEventStore, workspaceId: string) {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const items = store.list(workspaceId);
+    if (items.length > 0) return items[0];
+    await sleep(25);
+  }
+  return null;
+}
+
+describe("reload watcher fingerprints", () => {
+  test("does not emit when a watched file is rewritten with identical content", async () => {
+    await withWorkspace(async (root) => {
+      const { config, workspace } = buildConfig(root);
+      const configPath = join(root, "opencode.jsonc");
+      const content = '{ "plugin": ["demo"] }\n';
+      await writeFile(configPath, content, "utf8");
+
+      const events = new ReloadEventStore();
+      const watcher = startReloadWatchers({ config, reloadEvents: events, debounceMs: 30 });
+      try {
+        await watcher.refreshWorkspace(workspace.id);
+        await writeFile(configPath, content, "utf8");
+        await sleep(120);
+
+        expect(events.list(workspace.id)).toEqual([]);
+      } finally {
+        watcher.close();
+      }
+    });
+  });
+
+  test("emits when project config content changes while running", async () => {
+    await withWorkspace(async (root) => {
+      const { config, workspace } = buildConfig(root);
+      const configPath = join(root, "opencode.jsonc");
+      await writeFile(configPath, '{ "plugin": ["demo"] }\n', "utf8");
+
+      const events = new ReloadEventStore();
+      const watcher = startReloadWatchers({ config, reloadEvents: events, debounceMs: 30 });
+      try {
+        await watcher.refreshWorkspace(workspace.id);
+        await writeFile(configPath, '{ "plugin": ["changed"] }\n', "utf8");
+
+        const event = await waitForEvent(events, workspace.id);
+        expect(event?.reason).toBe("config");
+        expect(event?.trigger?.name).toBe("opencode.jsonc");
+      } finally {
+        watcher.close();
+      }
+    });
+  });
+
+  test("suppresses internal workspace bootstrap writes after refreshing the baseline", async () => {
+    await withWorkspace(async (root) => {
+      const { config, workspace } = buildConfig(root);
+      const events = new ReloadEventStore();
+      const watcher = startReloadWatchers({ config, reloadEvents: events, debounceMs: 100 });
+      try {
+        await watcher.refreshWorkspace(workspace.id);
+        const ensured = await ensureWorkspaceFiles(root, "starter");
+        await watcher.refreshWorkspace(workspace.id, ensured.reloadReasons);
+        await sleep(250);
+
+        expect(ensured.reloadReasons.sort()).toEqual(["agents", "config"]);
+        expect(events.list(workspace.id)).toEqual([]);
+      } finally {
+        watcher.close();
+      }
+    });
+  });
+
+  test("watches hidden project opencode config files", async () => {
+    await withWorkspace(async (root) => {
+      const { config, workspace } = buildConfig(root);
+      await mkdir(join(root, ".opencode"), { recursive: true });
+
+      const events = new ReloadEventStore();
+      const watcher = startReloadWatchers({ config, reloadEvents: events, debounceMs: 30 });
+      try {
+        await watcher.refreshWorkspace(workspace.id);
+        await sleep(75);
+        await writeFile(join(root, ".opencode", "opencode.jsonc"), '{ "mcp": {} }\n', "utf8");
+
+        const event = await waitForEvent(events, workspace.id);
+        expect(event?.reason).toBe("config");
+        expect(event?.trigger?.name).toBe("opencode.jsonc");
+      } finally {
+        watcher.close();
+      }
+    });
+  });
+});

--- a/apps/server/src/reload-watcher.ts
+++ b/apps/server/src/reload-watcher.ts
@@ -3,6 +3,7 @@ import { readdir } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 
 import type { ReloadEventStore } from "./events.js";
+import { computeReloadFingerprint, fingerprintedReloadReasons } from "./reload-fingerprint.js";
 import type { ReloadReason, ReloadTrigger, ServerConfig, WorkspaceInfo } from "./types.js";
 
 type LogLevel = "info" | "warn" | "error";
@@ -16,23 +17,27 @@ type DirectoryTreeWatcher = {
   close: () => void;
 };
 
+type WorkspaceReloadWatcher = {
+  refreshBaseline: (reasons?: ReloadReason[]) => Promise<void>;
+  close: () => void;
+};
+
 export function startReloadWatchers(input: {
   config: ServerConfig;
   reloadEvents: ReloadEventStore;
   logger?: Logger | null;
   debounceMs?: number;
-}): { close: () => void } {
+}): { close: () => void; refreshWorkspace: (workspaceId: string, reasons?: ReloadReason[]) => Promise<void> } {
   const { config, reloadEvents } = input;
   const logger = input.logger ?? null;
   const debounceMs = typeof input.debounceMs === "number" ? input.debounceMs : 750;
 
-  const closers: Array<() => void> = [];
+  const workspaceWatchers = new Map<string, WorkspaceReloadWatcher>();
 
   for (const workspace of config.workspaces) {
     try {
-      closers.push(
-        startWorkspaceReloadWatcher({ workspace, reloadEvents, logger, debounceMs }),
-      );
+      const watcher = startWorkspaceReloadWatcher({ workspace, reloadEvents, logger, debounceMs });
+      workspaceWatchers.set(workspace.id, watcher);
     } catch (error) {
       logger?.log("warn", "Reload watcher failed to start", {
         workspaceId: workspace.id,
@@ -50,13 +55,17 @@ export function startReloadWatchers(input: {
 
   return {
     close: () => {
-      for (const close of closers) {
+      for (const watcher of workspaceWatchers.values()) {
         try {
-          close();
+          watcher.close();
         } catch {
           // ignore
         }
       }
+      workspaceWatchers.clear();
+    },
+    refreshWorkspace: async (workspaceId: string, reasons?: ReloadReason[]) => {
+      await workspaceWatchers.get(workspaceId)?.refreshBaseline(reasons);
     },
   };
 }
@@ -66,24 +75,128 @@ function startWorkspaceReloadWatcher(input: {
   reloadEvents: ReloadEventStore;
   logger: Logger | null;
   debounceMs: number;
-}): () => void {
+}): WorkspaceReloadWatcher {
   const { workspace, reloadEvents, logger, debounceMs } = input;
   const root = resolve(workspace.path);
+  const opencodeRoot = join(root, ".opencode");
 
   const trees: DirectoryTreeWatcher[] = [];
+  const baselines = new Map<ReloadReason, string>();
+  const pendingChecks = new Map<ReloadReason, { timer: ReturnType<typeof setTimeout>; trigger?: ReloadTrigger }>();
+
+  let closed = false;
+  let rootWatcher: FSWatcher | null = null;
+  let opencodeRootWatcher: FSWatcher | null = null;
+
   const closeAll = () => {
+    closed = true;
+    for (const pending of pendingChecks.values()) {
+      clearTimeout(pending.timer);
+    }
+    pendingChecks.clear();
     for (const tree of trees) {
       tree.close();
     }
     rootWatcher?.close();
+    opencodeRootWatcher?.close();
   };
 
-  const record = (reason: ReloadReason, trigger?: ReloadTrigger) => {
+  const refreshBaseline = async (reasons: ReloadReason[] = fingerprintedReloadReasons) => {
+    for (const reason of reasons) {
+      if (!fingerprintedReloadReasons.includes(reason)) continue;
+      baselines.set(reason, await computeReloadFingerprint(root, reason));
+    }
+  };
+
+  const checkReason = async (reason: ReloadReason, trigger?: ReloadTrigger) => {
+    if (closed) return;
+    if (!fingerprintedReloadReasons.includes(reason)) return;
+
+    const current = await computeReloadFingerprint(root, reason);
+    const previous = baselines.get(reason);
+    baselines.set(reason, current);
+
+    if (previous === undefined || previous === current) return;
     reloadEvents.recordDebounced(workspace.id, reason, trigger, debounceMs);
   };
 
+  const scheduleReasonCheck = (reason: ReloadReason, trigger?: ReloadTrigger) => {
+    if (closed) return;
+    if (!fingerprintedReloadReasons.includes(reason)) return;
+
+    const existing = pendingChecks.get(reason);
+    if (existing) {
+      clearTimeout(existing.timer);
+    }
+
+    const timer = setTimeout(() => {
+      const pending = pendingChecks.get(reason);
+      pendingChecks.delete(reason);
+      void checkReason(reason, pending?.trigger ?? trigger);
+    }, debounceMs);
+    pendingChecks.set(reason, { timer, trigger });
+  };
+
+  const ensureOpencodeRootWatcher = () => {
+    if (!existsSync(opencodeRoot)) {
+      opencodeRootWatcher?.close();
+      opencodeRootWatcher = null;
+      return;
+    }
+    if (opencodeRootWatcher) return;
+
+    try {
+      opencodeRootWatcher = watch(
+        opencodeRoot,
+        { persistent: false },
+        (_eventType, filename) => {
+          const raw = filename ? filename.toString() : "";
+          const name = raw.trim();
+          if (!name) {
+            const inferredConfigPath = existsSync(join(opencodeRoot, "opencode.jsonc"))
+              ? join(opencodeRoot, "opencode.jsonc")
+              : existsSync(join(opencodeRoot, "opencode.json"))
+                ? join(opencodeRoot, "opencode.json")
+                : null;
+            scheduleReasonCheck("config", inferredConfigPath
+              ? { type: "config", name: basename(inferredConfigPath), action: "updated", path: inferredConfigPath }
+              : undefined);
+            for (const tree of trees) tree.scheduleRescan();
+            return;
+          }
+
+          if (name === "opencode.json" || name === "opencode.jsonc") {
+            scheduleReasonCheck("config", {
+              type: "config",
+              name,
+              action: "updated",
+              path: join(opencodeRoot, name),
+            });
+            return;
+          }
+
+          if (name === "skills" || name === "commands" || name === "plugins" || name === "agents" || name === "agent") {
+            for (const tree of trees) tree.scheduleRescan();
+          }
+        },
+      );
+      opencodeRootWatcher.on("error", (error) => {
+        logger?.log("warn", "Reload watcher .opencode error", {
+          workspaceId: workspace.id,
+          workspacePath: root,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    } catch (error) {
+      logger?.log("warn", "Reload watcher .opencode failed", {
+        workspaceId: workspace.id,
+        workspacePath: root,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
   // Watch the workspace root for top-level config files.
-  let rootWatcher: FSWatcher | null = null;
   if (existsSync(root)) {
     try {
       rootWatcher = watch(
@@ -93,12 +206,14 @@ function startWorkspaceReloadWatcher(input: {
           const raw = filename ? filename.toString() : "";
           const name = raw.trim();
           if (!name) {
+            scheduleReasonCheck("config");
+            scheduleReasonCheck("agents");
             for (const tree of trees) tree.scheduleRescan();
             return;
           }
 
           if (name === "opencode.json" || name === "opencode.jsonc") {
-            record("config", {
+            scheduleReasonCheck("config", {
               type: "config",
               name,
               action: "updated",
@@ -108,7 +223,7 @@ function startWorkspaceReloadWatcher(input: {
           }
 
           if (name === "AGENTS.md") {
-            record("agents", {
+            scheduleReasonCheck("agents", {
               type: "agent",
               action: "updated",
               path: join(root, name),
@@ -118,6 +233,8 @@ function startWorkspaceReloadWatcher(input: {
 
           // If .opencode is created/removed, rescan the relevant trees.
           if (name === ".opencode") {
+            ensureOpencodeRootWatcher();
+            scheduleReasonCheck("config");
             for (const tree of trees) tree.scheduleRescan();
           }
         },
@@ -138,61 +255,56 @@ function startWorkspaceReloadWatcher(input: {
     }
   }
 
-  const opencodeRoot = join(root, ".opencode");
+  ensureOpencodeRootWatcher();
 
   trees.push(
     createDirectoryTreeWatcher({
       rootDir: join(opencodeRoot, "skills"),
       workspace,
-      reloadEvents,
       reason: "skills",
       triggerType: "skill",
-      debounceMs,
       logger,
+      onChange: (trigger) => scheduleReasonCheck("skills", trigger),
     }),
   );
   trees.push(
     createDirectoryTreeWatcher({
       rootDir: join(opencodeRoot, "commands"),
       workspace,
-      reloadEvents,
       reason: "commands",
       triggerType: "command",
-      debounceMs,
       logger,
+      onChange: (trigger) => scheduleReasonCheck("commands", trigger),
     }),
   );
   trees.push(
     createDirectoryTreeWatcher({
       rootDir: join(opencodeRoot, "plugins"),
       workspace,
-      reloadEvents,
       reason: "plugins",
       triggerType: "plugin",
-      debounceMs,
       logger,
+      onChange: (trigger) => scheduleReasonCheck("plugins", trigger),
     }),
   );
   trees.push(
     createDirectoryTreeWatcher({
       rootDir: join(opencodeRoot, "agents"),
       workspace,
-      reloadEvents,
       reason: "agents",
       triggerType: "agent",
-      debounceMs,
       logger,
+      onChange: (trigger) => scheduleReasonCheck("agents", trigger),
     }),
   );
   trees.push(
     createDirectoryTreeWatcher({
       rootDir: join(opencodeRoot, "agent"),
       workspace,
-      reloadEvents,
       reason: "agents",
       triggerType: "agent",
-      debounceMs,
       logger,
+      onChange: (trigger) => scheduleReasonCheck("agents", trigger),
     }),
   );
 
@@ -200,20 +312,20 @@ function startWorkspaceReloadWatcher(input: {
   for (const tree of trees) {
     tree.scheduleRescan();
   }
+  void refreshBaseline();
 
-  return closeAll;
+  return { close: closeAll, refreshBaseline };
 }
 
 function createDirectoryTreeWatcher(input: {
   rootDir: string;
   workspace: WorkspaceInfo;
-  reloadEvents: ReloadEventStore;
   reason: ReloadReason;
   triggerType: ReloadTrigger["type"];
-  debounceMs: number;
   logger: Logger | null;
+  onChange: (trigger?: ReloadTrigger) => void;
 }): DirectoryTreeWatcher {
-  const { rootDir, workspace, reloadEvents, reason, triggerType, debounceMs, logger } = input;
+  const { rootDir, workspace, reason, triggerType, logger, onChange } = input;
   const resolvedRoot = resolve(rootDir);
 
   const watchers = new Map<string, FSWatcher>();
@@ -255,7 +367,7 @@ function createDirectoryTreeWatcher(input: {
       }
     }
 
-    reloadEvents.recordDebounced(workspace.id, reason, trigger, debounceMs);
+    onChange(trigger);
   };
 
   const shouldIgnoreEntry = (absPath: string) => {
@@ -351,7 +463,7 @@ function createDirectoryTreeWatcher(input: {
       const existsNow = existsSync(resolvedRoot);
       if (existsNow !== lastRootExists) {
         lastRootExists = existsNow;
-        reloadEvents.recordDebounced(workspace.id, reason, { type: triggerType, action: "updated", path: resolvedRoot }, debounceMs);
+        onChange({ type: triggerType, action: "updated", path: resolvedRoot });
       }
       if (!existsNow) {
         for (const watcher of watchers.values()) {

--- a/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
+++ b/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
@@ -11,6 +11,11 @@ describe("normalizeWorkspaceRelativePath", () => {
     expect(normalizeWorkspaceRelativePath("workspace/dir/notes.md", { allowSubdirs: true })).toBe("dir/notes.md");
   });
 
+  test("strips Workspace/<id>/ prefix from rendered artifact paths", () => {
+    expect(normalizeWorkspaceRelativePath("Workspace/32423/reports/artifact-eval.md", { allowSubdirs: true })).toBe("reports/artifact-eval.md");
+    expect(normalizeWorkspaceRelativePath("workspaces/demo/reports/artifact-eval.csv", { allowSubdirs: true })).toBe("reports/artifact-eval.csv");
+  });
+
   test("strips /workspace/ prefix", () => {
     expect(normalizeWorkspaceRelativePath("/workspace/notes.md", { allowSubdirs: true })).toBe("notes.md");
     expect(normalizeWorkspaceRelativePath("//workspace/dir/notes.md", { allowSubdirs: true })).toBe("dir/notes.md");
@@ -36,7 +41,16 @@ describe("normalizeWorkspaceRelativePath", () => {
 });
 
 describe("isSupportedWorkspaceTextFilePath", () => {
-  test("accepts plugin import text file extensions", () => {
+  test("accepts workspace text artifact extensions", () => {
+    expect(isSupportedWorkspaceTextFilePath("reports/revenue.csv")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath("reports/revenue.tsv")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath("logs/run.log")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath("config/app.yaml")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath("styles/app.css")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath("dist/index.html")).toBe(true);
+  });
+
+  test("keeps accepting OpenCode config/plugin text file extensions", () => {
     expect(isSupportedWorkspaceTextFilePath(".opencode/tools/cloud.ts")).toBe(true);
     expect(isSupportedWorkspaceTextFilePath(".opencode/mcps/cloud.json")).toBe(true);
     expect(isSupportedWorkspaceTextFilePath(".opencode/plugins/cloud.txt")).toBe(true);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -779,6 +779,8 @@ export function normalizeWorkspaceRelativePath(input: string, options: { allowSu
   let normalized = raw.replace(/\\/g, "/");
   normalized = normalized.replace(/^\/+/, "");
   normalized = normalized.replace(/^\.\//, "");
+  normalized = normalized.replace(/^workspaces\/[^/]+\//i, "");
+  normalized = normalized.replace(/^workspace\/(?:ws_[^/]+|\d+|[0-9a-f-]{6,})\//i, "");
   normalized = normalized.replace(/^workspace\//, "");
   normalized = normalized.replace(/^\/+/, "");
 
@@ -799,7 +801,31 @@ export function normalizeWorkspaceRelativePath(input: string, options: { allowSu
 
 export function isSupportedWorkspaceTextFilePath(relativePath: string): boolean {
   const lowered = relativePath.toLowerCase();
-  return [".md", ".mdx", ".markdown", ".json", ".jsonc", ".ts", ".js", ".mjs", ".cjs", ".txt"].some((ext) =>
+  return [
+    ".md",
+    ".mdx",
+    ".markdown",
+    ".csv",
+    ".tsv",
+    ".json",
+    ".jsonc",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".xml",
+    ".html",
+    ".htm",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".css",
+    ".scss",
+    ".txt",
+    ".log",
+  ].some((ext) =>
     lowered.endsWith(ext),
   );
 }
@@ -831,6 +857,126 @@ function decodeArtifactId(id: string): string {
   } catch {
     throw new ApiError(400, "invalid_artifact", "Artifact id is invalid");
   }
+}
+
+function contentTypeForPath(path: string): string {
+  const lowered = path.toLowerCase();
+  if (lowered.endsWith(".html") || lowered.endsWith(".htm")) return "text/html; charset=utf-8";
+  if (lowered.endsWith(".svg")) return "image/svg+xml";
+  if (lowered.endsWith(".png")) return "image/png";
+  if (lowered.endsWith(".jpg") || lowered.endsWith(".jpeg")) return "image/jpeg";
+  if (lowered.endsWith(".gif")) return "image/gif";
+  if (lowered.endsWith(".webp")) return "image/webp";
+  if (lowered.endsWith(".pdf")) return "application/pdf";
+  if (lowered.endsWith(".csv")) return "text/csv; charset=utf-8";
+  if (lowered.endsWith(".tsv")) return "text/tab-separated-values; charset=utf-8";
+  if (lowered.endsWith(".xlsx")) return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+  if (lowered.endsWith(".xls")) return "application/vnd.ms-excel";
+  if (lowered.endsWith(".ods")) return "application/vnd.oasis.opendocument.spreadsheet";
+  if (isSupportedWorkspaceTextFilePath(path)) return "text/plain; charset=utf-8";
+  return "application/octet-stream";
+}
+
+type ArtifactTargetInput = {
+  kind?: unknown;
+  value?: unknown;
+  name?: unknown;
+  preview?: unknown;
+  confidence?: unknown;
+  reason?: unknown;
+};
+
+function artifactPreviewForPath(path: string): string {
+  const lowered = path.toLowerCase();
+  if (/\.(md|markdown|mdx)$/.test(lowered)) return "markdown";
+  if (/\.(csv|tsv|xlsx|xls|ods)$/.test(lowered)) return "sheet";
+  if (/\.(png|jpe?g|gif|webp|svg)$/.test(lowered)) return "image";
+  if (lowered.endsWith(".pdf")) return "pdf";
+  if (/\.(html|htm)$/.test(lowered)) return "html";
+  if (isSupportedWorkspaceTextFilePath(path)) return "text";
+  return "external";
+}
+
+function normalizeUrlTarget(value: string): string | null {
+  try {
+    const url = new URL(value.trim());
+    if (!["http:", "https:", "ws:", "wss:"].includes(url.protocol)) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveWorkspaceArtifactTargets(workspaceRoot: string, input: unknown): Promise<Array<Record<string, unknown>>> {
+  const targets = Array.isArray(input) ? input.slice(0, 80) : [];
+  const results = new Map<string, Record<string, unknown>>();
+
+  for (const item of targets) {
+    if (!item || typeof item !== "object") continue;
+    const target = item as ArtifactTargetInput;
+    const kind = target.kind === "url" ? "url" : "file";
+    const rawValue = typeof target.value === "string" ? target.value.trim() : "";
+    if (!rawValue) continue;
+    const confidence = typeof target.confidence === "number" && Number.isFinite(target.confidence) ? target.confidence : 0;
+    const reason = typeof target.reason === "string" ? target.reason : "server";
+
+    if (kind === "url") {
+      const url = normalizeUrlTarget(rawValue);
+      if (!url) continue;
+      const key = `url:${url}`;
+      const next = {
+        id: key,
+        kind: "url",
+        value: url,
+        name: typeof target.name === "string" && target.name.trim() ? target.name.trim() : url,
+        preview: "browser",
+        confidence,
+        reason,
+        exists: true,
+      };
+      const previous = results.get(key);
+      if (!previous || confidence >= Number(previous.confidence ?? 0)) results.set(key, next);
+      continue;
+    }
+
+    let relativePath: string;
+    try {
+      relativePath = normalizeWorkspaceRelativePath(rawValue, { allowSubdirs: true });
+    } catch {
+      continue;
+    }
+    const key = `file:${relativePath.toLowerCase()}`;
+    const absPath = resolveSafeChildPath(workspaceRoot, relativePath);
+    let existsFile = false;
+    let size: number | undefined;
+    let updatedAt: number | undefined;
+    let kindValue: "file" | "dir" | "other" | undefined;
+    if (await exists(absPath)) {
+      const info = await stat(absPath);
+      kindValue = info.isFile() ? "file" : info.isDirectory() ? "dir" : "other";
+      existsFile = info.isFile();
+      size = info.size;
+      updatedAt = info.mtimeMs;
+    }
+    const next = {
+      id: key,
+      kind: "file",
+      value: relativePath,
+      name: basename(relativePath),
+      preview: artifactPreviewForPath(relativePath),
+      confidence,
+      reason,
+      exists: existsFile,
+      fileKind: kindValue,
+      size,
+      updatedAt,
+      contentType: contentTypeForPath(relativePath),
+    };
+    const previous = results.get(key);
+    if (!previous || confidence >= Number(previous.confidence ?? 0)) results.set(key, next);
+  }
+
+  return Array.from(results.values());
 }
 
 function encodeInboxId(path: string): string {
@@ -1916,6 +2062,13 @@ function createRoutes(
     return new Response(stream, { status: 200, headers });
   });
 
+  addRoute(routes, "POST", "/workspace/:id/artifacts/resolve", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const items = await resolveWorkspaceArtifactTargets(workspace.path, (body as Record<string, unknown>).targets);
+    return jsonResponse({ items });
+  });
+
   addRoute(routes, "POST", "/workspace/:id/files/sessions", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
@@ -2275,7 +2428,7 @@ function createRoutes(
     const requested = (ctx.url.searchParams.get("path") ?? "").trim();
     const relativePath = normalizeWorkspaceRelativePath(requested, { allowSubdirs: true });
     if (!isSupportedWorkspaceTextFilePath(relativePath)) {
-      throw new ApiError(400, "invalid_path", "Only Markdown and OpenCode plugin text files are supported");
+      throw new ApiError(400, "invalid_path", "Only supported text artifact files can be read inline");
     }
 
     const absPath = resolveSafeChildPath(workspace.path, relativePath);
@@ -2296,6 +2449,107 @@ function createRoutes(
     return jsonResponse({ path: relativePath, content, bytes: info.size, updatedAt: info.mtimeMs });
   });
 
+  addRoute(routes, "GET", "/workspace/:id/files/stat", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const requested = (ctx.url.searchParams.get("path") ?? "").trim();
+    const relativePath = normalizeWorkspaceRelativePath(requested, { allowSubdirs: true });
+    const absPath = resolveSafeChildPath(workspace.path, relativePath);
+    if (!(await exists(absPath))) {
+      return jsonResponse({ ok: true, path: relativePath, exists: false });
+    }
+    const info = await stat(absPath);
+    return jsonResponse({
+      ok: true,
+      path: relativePath,
+      exists: true,
+      kind: info.isFile() ? "file" : info.isDirectory() ? "dir" : "other",
+      size: info.size,
+      updatedAt: info.mtimeMs,
+    });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/files/raw", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const requested = (ctx.url.searchParams.get("path") ?? "").trim();
+    const relativePath = normalizeWorkspaceRelativePath(requested, { allowSubdirs: true });
+    const absPath = resolveSafeChildPath(workspace.path, relativePath);
+    if (!(await exists(absPath))) {
+      throw new ApiError(404, "file_not_found", "File not found");
+    }
+    const info = await stat(absPath);
+    if (!info.isFile()) {
+      throw new ApiError(404, "file_not_found", "File not found");
+    }
+
+    const headers = new Headers();
+    headers.set("Content-Type", contentTypeForPath(relativePath));
+    headers.set("Content-Length", String(info.size));
+    headers.set("Content-Disposition", `inline; filename="${basename(relativePath)}"`);
+    const stream = Readable.toWeb(createReadStream(absPath)) as unknown as ReadableStream;
+    return new Response(stream, { status: 200, headers });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/files/raw", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const requestedPath = String(body.path ?? "");
+    const relativePath = normalizeWorkspaceRelativePath(requestedPath, { allowSubdirs: true });
+    if (typeof body.dataBase64 !== "string") {
+      throw new ApiError(400, "invalid_payload", "dataBase64 must be a string");
+    }
+    let bytes: Buffer;
+    try {
+      bytes = Buffer.from(body.dataBase64, "base64");
+    } catch {
+      throw new ApiError(400, "invalid_payload", "dataBase64 is invalid");
+    }
+    const maxBytes = FILE_SESSION_MAX_FILE_BYTES;
+    if (bytes.byteLength > maxBytes) {
+      throw new ApiError(413, "file_too_large", "File exceeds size limit", { maxBytes, size: bytes.byteLength });
+    }
+
+    const baseUpdatedAtRaw = body.baseUpdatedAt;
+    const baseUpdatedAt =
+      typeof baseUpdatedAtRaw === "number" && Number.isFinite(baseUpdatedAtRaw) ? baseUpdatedAtRaw : null;
+    const force = body.force === true;
+    const absPath = resolveSafeChildPath(workspace.path, relativePath);
+    const before = (await exists(absPath)) ? await stat(absPath) : null;
+    if (before && !before.isFile()) {
+      throw new ApiError(400, "invalid_path", "Path must point to a file");
+    }
+    const beforeUpdatedAt = before ? before.mtimeMs : null;
+    if (!force && beforeUpdatedAt !== null && baseUpdatedAt !== null && beforeUpdatedAt !== baseUpdatedAt) {
+      throw new ApiError(409, "conflict", "File changed since it was loaded", { baseUpdatedAt, currentUpdatedAt: beforeUpdatedAt });
+    }
+
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "workspace.file.write",
+      summary: `Write ${relativePath}`,
+      paths: [absPath],
+    });
+
+    await ensureDir(dirname(absPath));
+    const tmp = `${absPath}.tmp-${shortId()}`;
+    await writeFile(tmp, bytes);
+    await rename(tmp, absPath);
+    const after = await stat(absPath);
+    const revision = fileRevision(after);
+    recordWorkspaceFileEvent(workspace.id, { type: "write", path: relativePath, revision });
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "workspace.file.write",
+      target: absPath,
+      summary: `Wrote ${relativePath}`,
+      timestamp: Date.now(),
+    });
+    return jsonResponse({ ok: true, path: relativePath, bytes: bytes.byteLength, updatedAt: after.mtimeMs, revision });
+  });
+
   addRoute(routes, "POST", "/workspace/:id/files/content", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
@@ -2305,7 +2559,7 @@ function createRoutes(
     const requestedPath = String(body.path ?? "");
     const relativePath = normalizeWorkspaceRelativePath(requestedPath, { allowSubdirs: true });
     if (!isSupportedWorkspaceTextFilePath(relativePath)) {
-      throw new ApiError(400, "invalid_path", "Only Markdown and OpenCode plugin text files are supported");
+      throw new ApiError(400, "invalid_path", "Only supported text artifact files can be edited inline");
     }
 
     if (typeof body.content !== "string") {
@@ -3116,6 +3370,7 @@ async function resolveWorkspace(config: ServerConfig, id: string): Promise<Works
     throw new ApiError(403, "workspace_unauthorized", "Workspace is not authorized");
   }
   if (!config.readOnly) {
+    await ensureWorkspaceFiles(resolvedWorkspace, workspace.preset ?? "starter");
     await repairCommands(resolvedWorkspace);
   }
   return { ...workspace, path: resolvedWorkspace };

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -14,6 +14,7 @@ import { ApiError, formatError } from "./errors.js";
 import { readJsoncFile, updateJsoncPath, updateJsoncTopLevel, writeJsoncFile } from "./jsonc.js";
 import { recordAudit, readAuditEntries, readLastAudit } from "./audit.js";
 import { ReloadEventStore } from "./events.js";
+import { computeReloadFingerprint } from "./reload-fingerprint.js";
 import { startReloadWatchers } from "./reload-watcher.js";
 import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
@@ -65,6 +66,11 @@ const FILE_SESSION_MAX_BATCH_ITEMS = 64;
 const FILE_SESSION_MAX_FILE_BYTES = 5_000_000;
 const FILE_SESSION_CATALOG_DEFAULT_LIMIT = 2000;
 const FILE_SESSION_CATALOG_MAX_LIMIT = 10000;
+
+const reloadBaselineRefreshers = new WeakMap<
+  ServerConfig,
+  (workspaceId: string, reasons?: ReloadReason[]) => Promise<void>
+>();
 
 type LogLevel = "info" | "warn" | "error";
 
@@ -238,6 +244,9 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
   const env = new EnvService();
   const logger = createServerLogger(config);
   let watcherHandle = startReloadWatchers({ config, reloadEvents, logger });
+  const refreshWorkspaceReloadBaseline = (workspaceId: string, reasons?: ReloadReason[]) =>
+    watcherHandle.refreshWorkspace(workspaceId, reasons);
+  reloadBaselineRefreshers.set(config, refreshWorkspaceReloadBaseline);
   const restartReloadWatchers = () => {
     watcherHandle.close();
     watcherHandle = startReloadWatchers({ config, reloadEvents, logger });
@@ -389,7 +398,14 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     idleTimeout: 120,
   });
 
-  return server;
+  return {
+    ...server,
+    stop: () => {
+      watcherHandle.close();
+      reloadBaselineRefreshers.delete(config);
+      server.stop();
+    },
+  };
 }
 
 function matchRoute(routes: Route[], method: string, path: string) {
@@ -1747,8 +1763,13 @@ function createRoutes(
       paths: [configPath],
     });
 
-    await ensureDir(dirname(configPath));
-    await writeFile(configPath, content.endsWith("\n") ? content : `${content}\n`, "utf8");
+    const nextContent = content.endsWith("\n") ? content : `${content}\n`;
+    const current = await readRawOpencodeConfig(configPath);
+    const changed = !current.exists || current.content !== nextContent;
+    if (changed) {
+      await ensureDir(dirname(configPath));
+      await writeFile(configPath, nextContent, "utf8");
+    }
 
     await recordAudit(workspace.path, {
       id: shortId(),
@@ -1760,7 +1781,7 @@ function createRoutes(
       timestamp: Date.now(),
     });
 
-    if (scope === "project") {
+    if (scope === "project" && changed) {
       emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(configPath));
     }
 
@@ -1863,6 +1884,10 @@ function createRoutes(
       paths: [opencode ? opencodeConfigPath(workspace.path) : null, openwork ? openworkConfigPath(workspace.path) : null].filter(Boolean) as string[],
     });
 
+    const configFingerprintBefore = opencode
+      ? await computeReloadFingerprint(workspace.path, "config")
+      : null;
+
     if (opencode) {
       const configPath = opencodeConfigPath(workspace.path);
       const nextOpencode = ensurePlainObject(opencode);
@@ -1904,7 +1929,7 @@ function createRoutes(
       timestamp: Date.now(),
     });
 
-    if (opencode) {
+    if (opencode && configFingerprintBefore !== await computeReloadFingerprint(workspace.path, "config")) {
       emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(opencodeConfigPath(workspace.path)));
     }
 
@@ -3162,6 +3187,7 @@ function createRoutes(
         409,
       );
     }
+    const configFingerprintBefore = await computeReloadFingerprint(workspace.path, "config");
     await importWorkspace(workspace, body, latestPreview);
     await recordAudit(workspace.path, {
       id: shortId(),
@@ -3172,7 +3198,9 @@ function createRoutes(
       summary: summarizeWorkspaceImportApplied(latestPreview),
       timestamp: Date.now(),
     });
-    emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(opencodeConfigPath(workspace.path)));
+    if (configFingerprintBefore !== await computeReloadFingerprint(workspace.path, "config")) {
+      emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(opencodeConfigPath(workspace.path)));
+    }
     return jsonResponse({ ok: true, preview: publicWorkspaceImportPreview(latestPreview) });
   });
 
@@ -3370,10 +3398,23 @@ async function resolveWorkspace(config: ServerConfig, id: string): Promise<Works
     throw new ApiError(403, "workspace_unauthorized", "Workspace is not authorized");
   }
   if (!config.readOnly) {
-    await ensureWorkspaceFiles(resolvedWorkspace, workspace.preset ?? "starter");
-    await repairCommands(resolvedWorkspace);
+    const ensured = await ensureWorkspaceFiles(resolvedWorkspace, workspace.preset ?? "starter");
+    const bootstrapReloadReasons = new Set<ReloadReason>(ensured.reloadReasons);
+    if (await repairCommands(resolvedWorkspace)) {
+      bootstrapReloadReasons.add("commands");
+    }
+    if (bootstrapReloadReasons.size > 0) {
+      await reloadBaselineRefreshers.get(config)?.(workspace.id, Array.from(bootstrapReloadReasons));
+      reloadOpencodeEngineAfterInternalBootstrap(config, { ...workspace, path: resolvedWorkspace });
+    }
   }
   return { ...workspace, path: resolvedWorkspace };
+}
+
+function reloadOpencodeEngineAfterInternalBootstrap(config: ServerConfig, workspace: WorkspaceInfo): void {
+  const connection = resolveWorkspaceOpencodeConnection(config, workspace);
+  if (!connection.baseUrl?.trim()) return;
+  void reloadOpencodeEngine(config, workspace).catch(() => undefined);
 }
 
 async function isAuthorizedRoot(workspacePath: string, roots: string[]): Promise<boolean> {

--- a/apps/server/src/workspace-init.test.ts
+++ b/apps/server/src/workspace-init.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ensureWorkspaceFiles } from "./workspace-init.js";
+
+async function withWorkspace(fn: (root: string) => Promise<void>) {
+  const root = await mkdtemp(join(tmpdir(), "openwork-workspace-init-"));
+  try {
+    await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+describe("ensureWorkspaceFiles", () => {
+  test("creates default agent with artifact guidance for new workspaces", async () => {
+    await withWorkspace(async (root) => {
+      await ensureWorkspaceFiles(root, "starter");
+      const agent = await readFile(join(root, ".opencode", "agents", "openwork.md"), "utf8");
+      expect(agent).toContain("OpenWork Artifacts");
+      expect(agent).toContain("reports/artifact-eval.xlsx");
+    });
+  });
+
+  test("adds artifact guidance to existing OpenWork agents", async () => {
+    await withWorkspace(async (root) => {
+      await mkdir(join(root, ".opencode", "agents"), { recursive: true });
+      await writeFile(join(root, ".opencode", "agents", "openwork.md"), "---\ndescription: Old\n---\n\nOld instructions\n", "utf8");
+      await ensureWorkspaceFiles(root, "starter");
+      const agent = await readFile(join(root, ".opencode", "agents", "openwork.md"), "utf8");
+      expect(agent).toContain("Old instructions");
+      expect(agent).toContain("OpenWork Artifacts");
+    });
+  });
+});

--- a/apps/server/src/workspace-init.test.ts
+++ b/apps/server/src/workspace-init.test.ts
@@ -17,10 +17,14 @@ async function withWorkspace(fn: (root: string) => Promise<void>) {
 describe("ensureWorkspaceFiles", () => {
   test("creates default agent with artifact guidance for new workspaces", async () => {
     await withWorkspace(async (root) => {
-      await ensureWorkspaceFiles(root, "starter");
+      const result = await ensureWorkspaceFiles(root, "starter");
       const agent = await readFile(join(root, ".opencode", "agents", "openwork.md"), "utf8");
       expect(agent).toContain("OpenWork Artifacts");
       expect(agent).toContain("reports/artifact-eval.xlsx");
+      expect(result.reloadReasons.sort()).toEqual(["agents", "config"]);
+
+      const secondResult = await ensureWorkspaceFiles(root, "starter");
+      expect(secondResult).toEqual({ changed: false, reloadReasons: [] });
     });
   });
 
@@ -28,10 +32,11 @@ describe("ensureWorkspaceFiles", () => {
     await withWorkspace(async (root) => {
       await mkdir(join(root, ".opencode", "agents"), { recursive: true });
       await writeFile(join(root, ".opencode", "agents", "openwork.md"), "---\ndescription: Old\n---\n\nOld instructions\n", "utf8");
-      await ensureWorkspaceFiles(root, "starter");
+      const result = await ensureWorkspaceFiles(root, "starter");
       const agent = await readFile(join(root, ".opencode", "agents", "openwork.md"), "utf8");
       expect(agent).toContain("Old instructions");
       expect(agent).toContain("OpenWork Artifacts");
+      expect(result.reloadReasons.sort()).toEqual(["agents", "config"]);
     });
   });
 
@@ -46,9 +51,27 @@ describe("ensureWorkspaceFiles", () => {
 `;
       await writeFile(configPath, config, "utf8");
 
-      await ensureWorkspaceFiles(root, "starter");
+      const result = await ensureWorkspaceFiles(root, "starter");
 
       expect(await readFile(configPath, "utf8")).toBe(config);
+      expect(result.reloadReasons).not.toContain("config");
+    });
+  });
+
+  test("does not add a default agent to an existing valid opencode config", async () => {
+    await withWorkspace(async (root) => {
+      const configPath = join(root, "opencode.jsonc");
+      const config = `{
+  // Existing project configs must not trigger reload events on route reads.
+  "$schema": "https://opencode.ai/config.json"
+}
+`;
+      await writeFile(configPath, config, "utf8");
+
+      const result = await ensureWorkspaceFiles(root, "starter");
+
+      expect(await readFile(configPath, "utf8")).toBe(config);
+      expect(result.reloadReasons).not.toContain("config");
     });
   });
 });

--- a/apps/server/src/workspace-init.test.ts
+++ b/apps/server/src/workspace-init.test.ts
@@ -34,4 +34,21 @@ describe("ensureWorkspaceFiles", () => {
       expect(agent).toContain("OpenWork Artifacts");
     });
   });
+
+  test("does not rewrite an existing valid opencode config", async () => {
+    await withWorkspace(async (root) => {
+      const configPath = join(root, "opencode.jsonc");
+      const config = `{
+  // User formatting should survive routine workspace resolution.
+  "$schema": "https://opencode.ai/config.json",
+  "default_agent": "custom"
+}
+`;
+      await writeFile(configPath, config, "utf8");
+
+      await ensureWorkspaceFiles(root, "starter");
+
+      expect(await readFile(configPath, "utf8")).toBe(config);
+    });
+  });
 });

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -6,6 +6,18 @@ import { ApiError } from "./errors.js";
 import { openworkConfigPath, opencodeConfigPath } from "./workspace-files.js";
 import { readJsoncFile, writeJsoncFile } from "./jsonc.js";
 
+const OPENWORK_ARTIFACT_GUIDANCE = `<!-- OPENWORK_ARTIFACTS_START -->
+## OpenWork Artifacts
+
+OpenWork can preview, edit, and download standard artifacts when you create or update them in the workspace.
+
+- Prefer standard output files for user-visible deliverables: Markdown (\`.md\`), CSV (\`.csv\`), Excel workbooks (\`.xlsx\`), and browser previews (\`index.html\` or a local \`http://localhost:<port>\` URL).
+- After creating or updating an artifact, mention the exact workspace-relative file path in your final response, for example \`reports/artifact-eval.md\` or \`reports/artifact-eval.xlsx\`.
+- Do not invent \`Workspace/<id>/...\` paths unless a tool returns them; prefer clean workspace-relative paths.
+- For websites or React/UI previews, start the dev server when useful and mention the \`http://localhost:<port>\` URL. Socket URLs such as \`ws://localhost:<port>/...\` are diagnostic hints, not primary preview links.
+- For spreadsheets, use \`.csv\` for simple tabular data and \`.xlsx\` when the user asks for Excel/XLS specifically.
+<!-- OPENWORK_ARTIFACTS_END -->`;
+
 const OPENWORK_AGENT = `---
 description: OpenWork default agent
 mode: primary
@@ -62,6 +74,8 @@ Hard rule: never copy private memory into repo files. Store only redacted summar
 - If you change code, run the smallest meaningful test.
 - If steps repeat, factor them into a skill.
 - Prefer clear, practical steps over abstract explanations.
+
+${OPENWORK_ARTIFACT_GUIDANCE}
 `;
 
 type WorkspaceOpenworkConfig = {
@@ -121,9 +135,20 @@ async function ensureOpencodeConfig(workspaceRoot: string): Promise<void> {
 async function ensureOpenworkAgent(workspaceRoot: string): Promise<void> {
   const agentsDir = join(workspaceRoot, ".opencode", "agents");
   const agentPath = join(agentsDir, "openwork.md");
-  if (await exists(agentPath)) return;
   await ensureDir(agentsDir);
-  await writeFile(agentPath, OPENWORK_AGENT.endsWith("\n") ? OPENWORK_AGENT : `${OPENWORK_AGENT}\n`, "utf8");
+  if (!(await exists(agentPath))) {
+    await writeFile(agentPath, OPENWORK_AGENT.endsWith("\n") ? OPENWORK_AGENT : `${OPENWORK_AGENT}\n`, "utf8");
+    return;
+  }
+  const current = await readFile(agentPath, "utf8");
+  const start = "<!-- OPENWORK_ARTIFACTS_START -->";
+  const end = "<!-- OPENWORK_ARTIFACTS_END -->";
+  const startIndex = current.indexOf(start);
+  const endIndex = current.indexOf(end);
+  const next = startIndex >= 0 && endIndex > startIndex
+    ? `${current.slice(0, startIndex)}${OPENWORK_ARTIFACT_GUIDANCE}${current.slice(endIndex + end.length)}`
+    : `${current.trimEnd()}\n\n${OPENWORK_ARTIFACT_GUIDANCE}\n`;
+  if (next !== current) await writeFile(agentPath, next, "utf8");
 }
 
 export async function ensureWorkspaceFiles(workspaceRoot: string, presetInput: string): Promise<void> {

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -125,9 +125,9 @@ async function ensureOpencodeConfig(workspaceRoot: string): Promise<void> {
     ? { ...data }
     : { $schema: "https://opencode.ai/config.json" };
 
-  if (typeof next.default_agent !== "string" || !next.default_agent.trim()) {
-    next.default_agent = "openwork";
-  }
+  if (typeof next.default_agent === "string" && next.default_agent.trim()) return;
+
+  next.default_agent = "openwork";
 
   await writeJsoncFile(path, next);
 }

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -5,6 +5,7 @@ import { ensureDir, exists } from "./utils.js";
 import { ApiError } from "./errors.js";
 import { openworkConfigPath, opencodeConfigPath } from "./workspace-files.js";
 import { readJsoncFile, writeJsoncFile } from "./jsonc.js";
+import type { ReloadReason } from "./types.js";
 
 const OPENWORK_ARTIFACT_GUIDANCE = `<!-- OPENWORK_ARTIFACTS_START -->
 ## OpenWork Artifacts
@@ -92,15 +93,20 @@ type WorkspaceOpenworkConfig = {
   } | null;
 };
 
+type EnsureWorkspaceFilesResult = {
+  changed: boolean;
+  reloadReasons: ReloadReason[];
+};
+
 function normalizePreset(preset: string | null | undefined): string {
   const trimmed = preset?.trim() ?? "";
   if (!trimmed) return "starter";
   return trimmed;
 }
 
-async function ensureWorkspaceOpenworkConfig(workspaceRoot: string, preset: string): Promise<void> {
+async function ensureWorkspaceOpenworkConfig(workspaceRoot: string, preset: string): Promise<boolean> {
   const path = openworkConfigPath(workspaceRoot);
-  if (await exists(path)) return;
+  if (await exists(path)) return false;
   const now = Date.now();
   const config: WorkspaceOpenworkConfig = {
     version: 1,
@@ -114,31 +120,30 @@ async function ensureWorkspaceOpenworkConfig(workspaceRoot: string, preset: stri
   };
   await ensureDir(join(workspaceRoot, ".opencode"));
   await writeFile(path, JSON.stringify(config, null, 2) + "\n", "utf8");
+  return true;
 }
 
-async function ensureOpencodeConfig(workspaceRoot: string): Promise<void> {
+async function ensureOpencodeConfig(workspaceRoot: string): Promise<boolean> {
   const path = opencodeConfigPath(workspaceRoot);
-  const { data } = await readJsoncFile<Record<string, unknown>>(path, {
+  if (await exists(path)) {
+    await readJsoncFile<Record<string, unknown>>(path, {});
+    return false;
+  }
+
+  await writeJsoncFile(path, {
     $schema: "https://opencode.ai/config.json",
+    default_agent: "openwork",
   });
-  const next: Record<string, unknown> = data && typeof data === "object" && !Array.isArray(data)
-    ? { ...data }
-    : { $schema: "https://opencode.ai/config.json" };
-
-  if (typeof next.default_agent === "string" && next.default_agent.trim()) return;
-
-  next.default_agent = "openwork";
-
-  await writeJsoncFile(path, next);
+  return true;
 }
 
-async function ensureOpenworkAgent(workspaceRoot: string): Promise<void> {
+async function ensureOpenworkAgent(workspaceRoot: string): Promise<boolean> {
   const agentsDir = join(workspaceRoot, ".opencode", "agents");
   const agentPath = join(agentsDir, "openwork.md");
   await ensureDir(agentsDir);
   if (!(await exists(agentPath))) {
     await writeFile(agentPath, OPENWORK_AGENT.endsWith("\n") ? OPENWORK_AGENT : `${OPENWORK_AGENT}\n`, "utf8");
-    return;
+    return true;
   }
   const current = await readFile(agentPath, "utf8");
   const start = "<!-- OPENWORK_ARTIFACTS_START -->";
@@ -148,18 +153,27 @@ async function ensureOpenworkAgent(workspaceRoot: string): Promise<void> {
   const next = startIndex >= 0 && endIndex > startIndex
     ? `${current.slice(0, startIndex)}${OPENWORK_ARTIFACT_GUIDANCE}${current.slice(endIndex + end.length)}`
     : `${current.trimEnd()}\n\n${OPENWORK_ARTIFACT_GUIDANCE}\n`;
-  if (next !== current) await writeFile(agentPath, next, "utf8");
+  if (next !== current) {
+    await writeFile(agentPath, next, "utf8");
+    return true;
+  }
+  return false;
 }
 
-export async function ensureWorkspaceFiles(workspaceRoot: string, presetInput: string): Promise<void> {
+export async function ensureWorkspaceFiles(workspaceRoot: string, presetInput: string): Promise<EnsureWorkspaceFilesResult> {
   const preset = normalizePreset(presetInput);
   if (!workspaceRoot.trim()) {
     throw new ApiError(400, "invalid_workspace_path", "workspace path is required");
   }
   await ensureDir(workspaceRoot);
-  await ensureOpencodeConfig(workspaceRoot);
-  await ensureOpenworkAgent(workspaceRoot);
-  await ensureWorkspaceOpenworkConfig(workspaceRoot, preset);
+  const reloadReasons = new Set<ReloadReason>();
+  if (await ensureOpencodeConfig(workspaceRoot)) reloadReasons.add("config");
+  if (await ensureOpenworkAgent(workspaceRoot)) reloadReasons.add("agents");
+  const openworkConfigChanged = await ensureWorkspaceOpenworkConfig(workspaceRoot, preset);
+  return {
+    changed: openworkConfigChanged || reloadReasons.size > 0,
+    reloadReasons: Array.from(reloadReasons),
+  };
 }
 
 export async function readRawOpencodeConfig(path: string): Promise<{ exists: boolean; content: string | null }> {

--- a/evals/README.md
+++ b/evals/README.md
@@ -88,6 +88,9 @@ Chrome DevTools MCP. Every tool takes `browser_url` as the first argument.
 - [`openable-items-flow.md`](./openable-items-flow.md) — inline openable-item
   chips, Cmd/Ctrl+K inventory, artifact/browser opening, icon checks, and
   screenshot evidence requirements.
+- [`reload-events-flow.md`](./reload-events-flow.md) — reload-required toast
+  suppression on boot/no-op writes and positive coverage for real runtime config
+  changes.
 - [`onboarding-welcome-flows.md`](./onboarding-welcome-flows.md) — the 7
   onboarding/welcome flows covering first-run experience and folder
   explanation.

--- a/evals/README.md
+++ b/evals/README.md
@@ -85,6 +85,9 @@ Chrome DevTools MCP. Every tool takes `browser_url` as the first argument.
 - [`react-session-flows.md`](./react-session-flows.md) — core
   session/settings flows verified during the React port cutover, including
   long streaming interruption coverage.
+- [`openable-items-flow.md`](./openable-items-flow.md) — inline openable-item
+  chips, Cmd/Ctrl+K inventory, artifact/browser opening, icon checks, and
+  screenshot evidence requirements.
 - [`onboarding-welcome-flows.md`](./onboarding-welcome-flows.md) — the 7
   onboarding/welcome flows covering first-run experience and folder
   explanation.

--- a/evals/openable-items-flow.md
+++ b/evals/openable-items-flow.md
@@ -1,0 +1,117 @@
+# Openable items eval
+
+End-to-end coverage for session-derived openable items: inline provenance chips,
+command-palette inventory, server-verified artifact previews, localhost browser
+targets, and stop-tracking persistence.
+
+## Preflight
+
+1. Start the Electron dev app from the repo root:
+   ```bash
+   OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9823 pnpm dev:electron
+   ```
+2. Attach browser tools to `http://127.0.0.1:9823` and select the OpenWork target.
+3. Open or create a local workspace with permission to write files and run a local server.
+4. Keep every screenshot path returned by `browser_screenshot`; visually inspect each PNG before reporting pass/fail.
+
+## Flow 1 — Inline Chips And Command Palette
+
+**Why**: Openable items should be discoverable where the assistant introduced
+them, while the full inventory lives in Cmd/Ctrl+K instead of the artifact pane.
+
+Steps:
+
+1. Create a new task.
+2. Send this prompt:
+   `Create reports/openable-items-eval.csv with three rows of sample revenue data, reports/openable-items-eval.xlsx with the same data, reports/openable-items-eval.md summarizing it, and reports/openable-items-eval.html with a tiny HTML preview. Then start a local preview server and mention the app root URL http://localhost:<port>, one /api/health URL, and one ws://localhost:<port>/socket hint when done.`
+3. Wait until the status bar returns to `Ready`.
+4. Capture a screenshot of the transcript area.
+5. Open Cmd/Ctrl+K, choose `Accessible items`, and capture a screenshot of the command palette list.
+
+Expected:
+
+- The assistant message that mentions the files/URLs has an `Openable items` strip directly below it.
+- The strip includes Chrome-style icons for localhost/browser targets.
+- The strip includes an XLS/spreadsheet icon for `.csv`, `.xlsx`, `.xls`, `.ods` targets.
+- The strip includes an `MD` badge for `.md`/Markdown targets.
+- Cmd/Ctrl+K has a root `Accessible items` command.
+- The `Accessible items` palette mode lists the localhost server target and server-verified artifact targets.
+- Generic project files such as `package.json` do not appear.
+- Missing files do not appear.
+- The right artifact pane is not used as the full inventory.
+
+Browser tool recipe:
+
+```text
+browser_snapshot({ browser_url, target_id })
+browser_click({ browser_url, target_id, uid: <New task> })
+browser_fill({ browser_url, target_id, uid: <composer>, value: <prompt> })
+browser_click({ browser_url, target_id, uid: <Run task> })
+browser_eval({ browser_url, target_id, expression: "new Promise((resolve) => setTimeout(() => resolve(document.body.innerText), 90000))" })
+browser_screenshot({ browser_url, target_id })
+browser_eval({ browser_url, target_id, expression: "window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: /Mac/i.test(navigator.platform), ctrlKey: !/Mac/i.test(navigator.platform), bubbles: true }))" })
+browser_snapshot({ browser_url, target_id })
+browser_click({ browser_url, target_id, uid: <Accessible items command> })
+browser_screenshot({ browser_url, target_id })
+```
+
+## Flow 2 — Open Browser Target
+
+Steps:
+
+1. In Cmd/Ctrl+K → `Accessible items`, choose the app-root `http://localhost:<port>` row.
+2. Capture a screenshot of the right pane.
+
+Expected:
+
+- The Browser pane opens.
+- The active browser tab is the app root URL, not `/api/health` and not the raw `ws://` socket URL.
+- Browser rows use the Chrome icon in the command palette and inline strip.
+
+## Flow 3 — Open Artifact Targets
+
+Steps:
+
+1. In Cmd/Ctrl+K → `Accessible items`, choose `openable-items-eval.csv`.
+2. Capture a screenshot of the artifact pane.
+3. Choose `openable-items-eval.md` from Cmd/Ctrl+K → `Accessible items`.
+4. Capture a screenshot of the artifact pane.
+
+Expected:
+
+- The CSV opens in the spreadsheet editor.
+- CSV/XLS/XLSX/ODS targets use an XLS/spreadsheet icon.
+- Markdown opens directly in the text editor and uses an `MD` badge.
+- The artifact pane shows viewer/editor controls only; it is not the all-items discovery inventory.
+- The artifact rail button count reflects server-verified artifact files only, not localhost URLs.
+
+## Flow 4 — Stop Tracking
+
+Steps:
+
+1. Open Cmd/Ctrl+K → `Accessible items`.
+2. Choose `Stop tracking openable-items-eval.md`.
+3. Open Cmd/Ctrl+K → `Accessible items` again and capture a screenshot.
+4. Reload the app/session and open Cmd/Ctrl+K → `Accessible items` again.
+5. Capture another screenshot.
+
+Expected:
+
+- The Markdown artifact disappears from the command-palette inventory and inline access surfaces after `Stop tracking`.
+- The hidden choice persists after reload for the same workspace/session.
+- Other server/browser targets remain visible.
+
+## Required Evidence
+
+Attach or report the screenshot paths for:
+
+1. Inline `Openable items` strip after the assistant message.
+2. Cmd/Ctrl+K `Accessible items` list.
+3. Browser pane opened from a localhost target.
+4. Artifact pane opened from a CSV/XLS target.
+5. Artifact pane opened from a Markdown target.
+6. Cmd/Ctrl+K list after `Stop tracking` and after reload.
+
+Before reporting success, open each PNG and verify the visible UI matches the
+expected bullets above. Do not claim screenshot coverage from file creation
+alone.

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -97,6 +97,88 @@ Known regressions this catches:
 
 ---
 
+## Flow 1A — Artifact pane opens generated spreadsheet/markdown targets
+
+**Why**: Artifact opening must be deterministic from tool/file outputs, not a
+one-off LLM convention. This catches regressions in target extraction,
+classification, right-pane mode switching, and artifact preview fallbacks.
+
+Steps:
+1. Run this once in an existing workspace, then create a new workspace and run
+   it again there. The default OpenWork agent should include artifact guidance
+   in both cases.
+2. Hover the workspace header in the sidebar → click **New task**.
+3. Fill the composer:
+   `Create reports/artifact-eval.csv with three rows of sample revenue data, reports/artifact-eval.xlsx with the same data, reports/artifact-eval.md summarizing it, and reports/index.html with a tiny HTML preview. Mention all four file paths when done.`
+4. Click **Run task** and wait until the status bar returns to **Ready**.
+5. Observe the right pane.
+
+Pass criteria:
+- The right pane opens automatically after the run completes.
+- The pane has an **Artifact** tab/button state in the titlebar.
+- The artifact pane only auto-opens a file after the OpenWork server confirms
+  it exists on the workspace filesystem.
+- The artifact pane shows `artifact-eval.csv` and `artifact-eval.xlsx` in the
+  same spreadsheet grid renderer, `artifact-eval.md` as rendered markdown, and
+  `index.html` as a sandboxed HTML preview.
+- The artifact pane includes a per-session artifact strip when multiple files
+  are detected.
+- CSV/XLSX spreadsheet artifacts allow editing cells and saving through the
+  OpenWork server.
+- Markdown/text-backed artifacts expose an **Edit** action and can save through
+  the OpenWork server write API.
+- CSV/XLSX/Markdown artifacts expose a **Download artifact** action backed by
+  the OpenWork server, so it works for local and remote workspaces.
+- Clicking **Browser** still restores the browser panel without losing the
+  selected artifact button.
+- There are no console errors from `ArtifactPanel`, `deriveOpenTargets`, or
+  the right pane resize layout.
+
+Tool recipe:
+```
+chrome-devtools_click { uid: <New task button> }
+chrome-devtools_click { uid: <composer textbox> }
+chrome-devtools_type_text { text: "Create reports/artifact-eval.csv with three rows of sample revenue data, reports/artifact-eval.xlsx with the same data, reports/artifact-eval.md summarizing it, and reports/index.html with a tiny HTML preview. Mention all four file paths when done." }
+chrome-devtools_click { uid: <Run task> }
+chrome-devtools_wait_for { text: ["Ready"], timeout: 60000 }
+chrome-devtools_take_snapshot
+chrome-devtools_list_console_messages { types: ["error"] }
+chrome-devtools_take_screenshot
+```
+
+Known regressions this catches:
+- Tool output paths are not extracted from live transcript messages.
+- `.csv`/`.md` targets are classified as unsupported external files.
+- `.xlsx` targets are detected but cannot be read, edited, saved, or downloaded.
+- The client performs one stat call per mentioned file instead of a single
+  server-side artifact resolve call.
+- Rendered paths like `Workspace/32423/reports/artifact-eval.md` are not
+  normalized before reading.
+- Missing files auto-open before the server confirms they exist.
+- The right pane remains browser-only and cannot display artifacts.
+- Browser automation tabs are overwritten by file previews.
+
+---
+
+## Flow 1B — Local preview URLs and socket hints open through browser mode
+
+**Why**: React/UI previews and running local services should use the browser
+pane, not the artifact renderer. WebSocket hints should not break URL parsing.
+
+Steps:
+1. In a new task, ask the agent to create a minimal HTML or React preview and
+   start a local server, then mention both `http://localhost:<port>` and any
+   `ws://localhost:<port>/...` socket endpoint it uses.
+2. Wait until the run completes.
+
+Pass criteria:
+- The `http://localhost:<port>` target opens in a browser tab.
+- Any `ws://localhost:<port>/...` target is extracted without corrupting the
+  artifact list; selecting it opens the sibling HTTP URL in browser mode.
+- No socket URL is routed through markdown/CSV artifact preview.
+
+---
+
 ## Flow 2 — Add a new session
 
 Steps:

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -184,6 +184,9 @@ Pass criteria:
 - Screenshot evidence shows the native browser content clipped to the right
   pane content area; it must not overlap the transcript, composer, titlebar, or
   rail.
+- For this specific containment check, use an OS/window screenshot such as
+  `screencapture`; CDP screenshots only capture the React renderer and can miss
+  Electron `WebContentsView` overlays.
 
 ---
 

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -181,6 +181,9 @@ Pass criteria:
 - Any `ws://localhost:<port>/...` target is extracted without corrupting the
   artifact list; selecting it opens the sibling HTTP URL in browser mode.
 - No socket URL is routed through markdown/CSV artifact preview.
+- Screenshot evidence shows the native browser content clipped to the right
+  pane content area; it must not overlap the transcript, composer, titlebar, or
+  rail.
 
 ---
 

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -115,9 +115,12 @@ Steps:
 
 Pass criteria:
 - The right pane opens automatically after the run completes.
-- The pane has an **Artifact** tab/button state in the titlebar.
+- The right-side rail shows compact Browser and Artifact icon buttons, and the
+  Artifact icon is active while the artifact pane is visible.
 - The artifact pane only auto-opens a file after the OpenWork server confirms
   it exists on the workspace filesystem.
+- Searching or listing implementation files such as `package.json` does not
+  populate the artifact rail; only previewable deliverables are shown there.
 - The artifact pane shows `artifact-eval.csv` and `artifact-eval.xlsx` in the
   same spreadsheet grid renderer, `artifact-eval.md` as rendered markdown, and
   `index.html` as a sandboxed HTML preview.
@@ -125,8 +128,8 @@ Pass criteria:
   are detected.
 - CSV/XLSX spreadsheet artifacts allow editing cells and saving through the
   OpenWork server.
-- Markdown/text-backed artifacts expose an **Edit** action and can save through
-  the OpenWork server write API.
+- Markdown artifacts open directly in the text editor and can save through the
+  OpenWork server write API without switching into a separate edit view.
 - CSV/XLSX/Markdown artifacts expose a **Download artifact** action backed by
   the OpenWork server, so it works for local and remote workspaces.
 - Clicking **Browser** still restores the browser panel without losing the
@@ -157,6 +160,8 @@ Known regressions this catches:
 - Missing files auto-open before the server confirms they exist.
 - The right pane remains browser-only and cannot display artifacts.
 - Browser automation tabs are overwritten by file previews.
+- Generic project search results such as many `package.json` files flood the
+  artifact rail.
 
 ---
 
@@ -193,12 +198,26 @@ Pass criteria:
   an extra click.
 - Composer model label is whatever is saved as default (e.g.
   `opencode/minimax-m2.5-free`).
+- No **"Reload required"** toast appears when the new session is created or
+  while the session route polls workspace events.
 
 Known regressions this catches:
 - `onCreateTaskInWorkspace` silently failing because the route has no
   OpenCode client.
 - Created session not landing in the sidebar list (sidebar not refreshed
   after create).
+- Routine workspace resolution rewrites `opencode.jsonc`, causing a stale
+  **"Reload required"** toast after every new session.
+
+Tool recipe add-on for the reload toast regression:
+```
+chrome-devtools_click { uid: <New task button> }
+chrome-devtools_wait_for { text: ["Describe your task"], timeout: 15000 }
+chrome-devtools_evaluate_script { function: "() => new Promise((resolve) => setTimeout(() => resolve(document.body.innerText), 4500))" }
+```
+
+Expected result: the returned body text does not contain `Reload required` or
+`Config 'opencode.jsonc' was updated`.
 
 ---
 

--- a/evals/reload-events-flow.md
+++ b/evals/reload-events-flow.md
@@ -1,0 +1,96 @@
+# Reload events flow
+
+End-to-end checks for the reload-required toast. These protect the contract that
+OpenWork only asks the user to reload when reload-relevant files change while the
+app is already running.
+
+## Why
+
+OpenWork bootstraps workspace files such as `opencode.jsonc`, `.opencode/agents`,
+and legacy command frontmatter. Those internal startup writes should refresh the
+OpenWork/OpenCode baseline silently. The user-facing **Reload required** toast is
+reserved for real runtime edits to OpenCode config, MCP, skills, agents,
+commands, or plugins.
+
+## Flow 1 — App boot does not show stale reload toast
+
+Steps:
+1. Start the Electron dev app from a clean process.
+2. Select an existing local workspace that already has an `opencode.jsonc` file.
+3. Wait 6 seconds after the main session route becomes ready.
+4. Create a new task and wait another 6 seconds.
+
+Pass criteria:
+- No toast appears with title **Reload required**.
+- No toast body mentions `opencode.jsonc`, `OpenCode config`, agents, commands,
+  skills, or plugins.
+- Creating the new task does not create or update `opencode.jsonc` just because
+  the route resolved the workspace.
+
+Tool recipe:
+```js
+// After selecting the workspace/session route.
+await new Promise((resolve) => setTimeout(resolve, 6000));
+document.body.innerText.includes("Reload required"); // expected false
+```
+
+## Flow 2 — Internal bootstrap writes are silent
+
+Steps:
+1. Create a temporary local workspace with no `.opencode` directory.
+2. Add it through the OpenWork workspace picker.
+3. Wait until the session route is ready.
+4. Wait 6 seconds for reload-event polling to run.
+
+Pass criteria:
+- OpenWork creates the default project `opencode.jsonc` and `.opencode/agents/openwork.md`.
+- No **Reload required** toast appears for those internally-created files.
+- A subsequent new task in that workspace also does not show a reload toast.
+
+## Flow 3 — No-op rewrites do not prompt reload
+
+Steps:
+1. While the app is running, record the exact contents of the selected
+   workspace's `opencode.jsonc`.
+2. Rewrite `opencode.jsonc` with the same bytes.
+3. Wait 6 seconds.
+
+Pass criteria:
+- No **Reload required** toast appears.
+- The server reload event cursor may advance only if a real fingerprint changed;
+  identical content must not create a visible reload prompt.
+
+## Flow 4 — Runtime config edits still prompt reload
+
+Steps:
+1. While the app is running on the selected workspace, append or change a real
+   project OpenCode config value in `opencode.jsonc`.
+2. Wait up to 6 seconds.
+
+Pass criteria:
+- A **Reload required** toast appears.
+- The description identifies the config change, ideally naming `opencode.jsonc`.
+- Clicking **Reload now** reloads the workspace engine and clears the toast.
+
+## Flow 5 — Hidden project config is watched
+
+Steps:
+1. Use a workspace whose active project config lives at `.opencode/opencode.jsonc`.
+2. Start OpenWork and wait until the session route is ready.
+3. Modify `.opencode/opencode.jsonc` while the app is running.
+4. Wait up to 6 seconds.
+
+Pass criteria:
+- A **Reload required** toast appears for the hidden project config change.
+- Rewriting the same file content again does not create a second visible toast
+  after the current toast is dismissed and the engine is reloaded.
+
+## Known regressions this catches
+
+- Workspace resolution rewrites `opencode.jsonc` on every app open or new task.
+- Raw filesystem notifications show a reload toast even when file content did
+  not change.
+- Startup-created OpenWork agent/config files leak into the user-facing reload
+  event stream.
+- `.opencode/opencode.jsonc` changes are missed because only root-level config
+  files are watched.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -4520,6 +4523,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -4967,6 +4974,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -5085,6 +5096,10 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -6005,6 +6020,10 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -8401,6 +8420,10 @@ packages:
     resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
     engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   ssri@9.0.1:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -9083,6 +9106,14 @@ packages:
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -9121,6 +9152,11 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-parse-from-string@1.0.1:
     resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
@@ -13225,6 +13261,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adler-32@1.3.1: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -13758,6 +13796,11 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -13872,6 +13915,8 @@ snapshots:
       - '@types/react-dom'
 
   code-block-writer@13.0.3: {}
+
+  codepage@1.15.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -14886,6 +14931,8 @@ snapshots:
   forwarded-parse@2.1.2: {}
 
   forwarded@0.2.0: {}
+
+  frac@1.1.2: {}
 
   fraction.js@4.3.7: {}
 
@@ -17675,6 +17722,10 @@ snapshots:
 
   sql-escaper@1.3.3: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   ssri@9.0.1:
     dependencies:
       minipass: 3.3.6
@@ -18323,6 +18374,10 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
+  wmf@1.0.2: {}
+
+  word@0.3.0: {}
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -18345,6 +18400,16 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-parse-from-string@1.0.1: {}
 


### PR DESCRIPTION
## Summary
- Restores artifact/openable-items support, inline chips, command-palette inventory, and Browser/Artifacts right-rail buttons.
- Keeps Electron native browser content clipped to the right pane, including Fast Refresh/HMR cleanup.
- Replaces raw reload watcher prompts with content fingerprints so boot/no-op writes do not show stale reload toasts, while runtime config/tree changes still prompt reload.
- Adds reload-event tests and eval documentation for future coverage.

## Tests
- `pnpm --filter @openwork/app test:open-target` passed: 12 tests, 34 expects.
- `pnpm --filter @openwork/app test:artifact-spreadsheet` passed: 2 tests, 3 expects.
- `pnpm --filter openwork-server test:artifacts` passed: 16 tests, 48 expects.
- `pnpm --filter openwork-server exec bun test src/reload-events.e2e.test.ts src/reload-watcher.test.ts src/workspace-init.test.ts` passed: 11 tests, 37 expects.
- `pnpm --filter @openwork/app typecheck` passed.
- `pnpm --filter openwork-server typecheck` passed.
- `pnpm --filter @openwork/app build` passed.
- `pnpm --filter openwork-server build` passed.

## Manual verification
- Restarted the dev app with `OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9823 pnpm dev`.
- Waited on the session route after boot: no **Reload required** toast.
- Created a new task and waited again: no **Reload required** toast.
- Verified Browser right-rail button exists and the native browser view stays inside the right pane by screenshot: `/var/folders/d9/xqhkvsp94rg0n0n523snqztm0000gn/T/browser-screenshot-1779148891666.png`.

Supersedes the browser-only PR #1840.