### PR TITLE
fix(app): keep hidden tasks running

### DIFF
--- a/apps/app/src/app/lib/opencode.ts
+++ b/apps/app/src/app/lib/opencode.ts
@@ -64,7 +64,7 @@ export type OpencodeAuth = {
 const DEFAULT_OPENCODE_REQUEST_TIMEOUT_MS = 10_000;
 const OAUTH_OPENCODE_REQUEST_TIMEOUT_MS = 5 * 60_000;
 const MCP_AUTH_OPENCODE_REQUEST_TIMEOUT_MS = 90_000;
-const SESSION_COMMAND_URL_RE = /\/session\/[^/?#]+\/command(?:[?#]|$)/;
+const SESSION_LONG_RUNNING_URL_RE = /\/session\/[^/?#]+\/(?:command|prompt_async|summarize)(?:[?#]|$)/;
 
 function getRequestUrl(input: RequestInfo | URL): string {
   if (typeof input === "string") return input;
@@ -75,7 +75,7 @@ function getRequestUrl(input: RequestInfo | URL): string {
 
 function resolveRequestTimeoutMs(input: RequestInfo | URL, fallbackMs: number): number {
   const url = getRequestUrl(input);
-  if (SESSION_COMMAND_URL_RE.test(url)) {
+  if (SESSION_LONG_RUNNING_URL_RE.test(url)) {
     return 0;
   }
   if (/\/provider\/oauth\//.test(url) || /\/mcp\/auth\/callback\b/.test(url)) {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -657,6 +657,7 @@ async function ensureMenuOverlayView() {
     webPreferences: {
       // Electron only runs ESM preload scripts reliably with sandbox disabled.
       // Keep the bridge isolated and node-free for the React overlay document.
+      backgroundThrottling: false,
       sandbox: false,
       contextIsolation: true,
       nodeIntegration: false,
@@ -779,6 +780,7 @@ function createBrowserTab(url = "about:blank", { select = true } = {}) {
   const tabId = createBrowserTabId();
   const view = new WebContentsView({
     webPreferences: {
+      backgroundThrottling: false,
       sandbox: true,
       contextIsolation: true,
       nodeIntegration: false,
@@ -2758,6 +2760,9 @@ async function createMainWindow() {
     ...windowAppearanceOptions,
     ...(APP_ICON_IMAGE && !APP_ICON_IMAGE.isEmpty() ? { icon: APP_ICON_IMAGE } : {}),
     webPreferences: {
+      // The renderer owns session dispatch + event streams; keep it running
+      // while hidden/minimized so background tasks are not interrupted.
+      backgroundThrottling: false,
       preload: preloadPath,
       contextIsolation: true,
       nodeIntegration: false,


### PR DESCRIPTION
## Summary
- keep Electron renderers unthrottled while hidden/minimized so session streams keep running
- exempt long-running OpenCode session endpoints from the desktop fetch timeout, including prompt_async and summarize/compact

## Verification
- Passed: `node --check apps/desktop/electron/main.mjs`
- Passed: Daytona Electron minimized-window test in `openwork-test-20260519-171755`: created a workspace, started a 12s shell task, minimized OpenWork, restored it, and confirmed `hidden-task.txt` was created with a 200 session response.
- Attempted: `pnpm --filter @openwork/desktop typecheck:electron` failed on existing unrelated Electron MCP/menu typing errors.
- Attempted: `pnpm --filter @openwork/app typecheck` failed on existing unrelated `browser-panel.tsx` prop typing.

## Daytona Evidence
- CDP: https://9825-jx151btinpuo7th6.daytonaproxy01.net
- noVNC: https://6080-uuqla8vrnrfsri0e.daytonaproxy01.net
