### PR TITLE
Fix live session transcript cache expiry

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { UIMessage } from "ai";
 import { useQuery } from "@tanstack/react-query";
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
@@ -29,7 +29,6 @@ import {
   recordInspectorEvent,
 } from "../../../shell/app-inspector";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
-import { getReactQueryClient } from "../../../infra/query-client";
 import { ReactSessionComposer } from "./composer/composer";
 import { DevProfiler } from "../../../shell/dev-profiler";
 import { PaperGrainGradient } from "@openwork/ui/react";
@@ -155,15 +154,12 @@ function controlTextArgument(args: unknown) {
 const waitForControl = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
 
 function useSharedQueryState<T>(queryKey: readonly unknown[], fallback: T) {
-  const queryClient = getReactQueryClient();
-  // useSyncExternalStore requires getSnapshot to return the same reference
-  // while the external store has not changed. Callers must pass stable
-  // fallbacks for empty cache states.
-  return useSyncExternalStore(
-    (callback) => queryClient.getQueryCache().subscribe(callback),
-    () => (queryClient.getQueryData<T>(queryKey) ?? fallback),
-    () => fallback,
-  );
+  const query = useQuery<T, Error, T, readonly unknown[]>({
+    queryKey,
+    queryFn: async () => fallback,
+    enabled: false,
+  });
+  return query.data ?? fallback;
 }
 
 function messageHasVisibleAssistantOutput(message: UIMessage) {

--- a/apps/app/src/react-app/domains/session/sync/runtime-sync.tsx
+++ b/apps/app/src/react-app/domains/session/sync/runtime-sync.tsx
@@ -9,6 +9,7 @@ type ReactSessionRuntimeProps = {
   activeSessionIds?: string[];
   opencodeBaseUrl: string;
   openworkToken: string;
+  onSessionUpdated?: (update: { sessionId: string; info: Record<string, unknown> }) => void;
 };
 
 export function ReactSessionRuntime(props: ReactSessionRuntimeProps) {
@@ -17,6 +18,7 @@ export function ReactSessionRuntime(props: ReactSessionRuntimeProps) {
       workspaceId: props.workspaceId,
       baseUrl: props.opencodeBaseUrl,
       openworkToken: props.openworkToken,
+      onSessionUpdated: props.onSessionUpdated,
     };
     const releaseWorkspace = ensureWorkspaceSessionSync(input);
     const releaseSessions = trackWorkspaceSessionsSync(input, [props.sessionId, ...(props.activeSessionIds ?? [])]);
@@ -24,7 +26,7 @@ export function ReactSessionRuntime(props: ReactSessionRuntimeProps) {
       releaseSessions();
       releaseWorkspace();
     };
-  }, [props.workspaceId, props.sessionId, props.activeSessionIds, props.opencodeBaseUrl, props.openworkToken]);
+  }, [props.workspaceId, props.sessionId, props.activeSessionIds, props.opencodeBaseUrl, props.openworkToken, props.onSessionUpdated]);
 
   return null;
 }

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -13,6 +13,7 @@ type SyncOptions = {
   workspaceId: string;
   baseUrl: string;
   openworkToken: string;
+  onSessionUpdated?: (update: { sessionId: string; info: Record<string, unknown> }) => void;
 };
 
 export type PendingDelta = {
@@ -30,6 +31,7 @@ type SyncEntry = {
   disposeTimer: ReturnType<typeof setTimeout> | null;
   trackedSessionRefs: Map<string, number>;
   retainedSessionTimers: Map<string, ReturnType<typeof setTimeout>>;
+  sessionUpdatedListeners: Set<NonNullable<SyncOptions["onSessionUpdated"]>>;
   pendingDeltas: Map<string, { messageId: string; reasoning: boolean; text: string }>;
   // Coalesce rapid-fire delta events from the SSE stream into one cache
   // commit per animation frame. Without this, a long response produces a
@@ -76,6 +78,22 @@ function shouldRetrySyncSubscribe(error: unknown) {
 
 function isTrackedSession(entry: SyncEntry, sessionId: string) {
   return (entry.trackedSessionRefs.get(sessionId) ?? 0) > 0 || entry.retainedSessionTimers.has(sessionId);
+}
+
+function getSessionUpdatedInfo(event: OpencodeEvent) {
+  if (event.type !== "session.updated") return null;
+  const props = event.properties;
+  if (!props || typeof props !== "object") return null;
+  const record = props as { sessionID?: unknown; info?: unknown };
+  const info = record.info;
+  if (!info || typeof info !== "object") return null;
+  const sessionId = typeof record.sessionID === "string"
+    ? record.sessionID
+    : typeof (info as { id?: unknown }).id === "string"
+      ? (info as { id: string }).id
+      : "";
+  if (!sessionId) return null;
+  return { sessionId, info: info as Record<string, unknown> };
 }
 
 function isLiveStatus(status: SessionStatus | null | undefined) {
@@ -375,6 +393,14 @@ export function coalescePendingDeltas(items: PendingDelta[]) {
 function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent) {
   const queryClient = getReactQueryClient();
   const input = entry.input;
+
+  if (event.type === "session.updated") {
+    const update = getSessionUpdatedInfo(event);
+    if (!update) return;
+    if (!isTrackedSession(entry, update.sessionId)) return;
+    for (const listener of entry.sessionUpdatedListeners) listener(update);
+    return;
+  }
 
   if (event.type === "session.status") {
     const props = (event.properties ?? {}) as { sessionID?: string; status?: SessionStatus };
@@ -692,6 +718,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
       clearTimeout(existing.disposeTimer);
       existing.disposeTimer = null;
     }
+    if (input.onSessionUpdated) existing.sessionUpdatedListeners.add(input.onSessionUpdated);
     existing.refs += 1;
     return () => releaseWorkspaceSessionSync(input);
   }
@@ -703,6 +730,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
     disposeTimer: null,
     trackedSessionRefs: new Map(),
     retainedSessionTimers: new Map(),
+    sessionUpdatedListeners: new Set(input.onSessionUpdated ? [input.onSessionUpdated] : []),
     pendingDeltas: new Map(),
     deltaFlushBuffer: [],
     deltaFlushScheduled: false,
@@ -718,6 +746,7 @@ function releaseWorkspaceSessionSync(input: SyncOptions) {
   const key = syncKey(input);
   const existing = syncs.get(key);
   if (!existing) return;
+  if (input.onSessionUpdated) existing.sessionUpdatedListeners.delete(input.onSessionUpdated);
   existing.refs -= 1;
   if (existing.refs > 0) return;
   if (existing.retainedSessionTimers.size === 0) {
@@ -792,6 +821,7 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
     disposeTimer: null,
     trackedSessionRefs: new Map(),
     retainedSessionTimers: new Map(),
+    sessionUpdatedListeners: new Set(),
     pendingDeltas: new Map(),
     deltaFlushBuffer: [],
     deltaFlushScheduled: false,

--- a/apps/app/src/react-app/infra/query-client.ts
+++ b/apps/app/src/react-app/infra/query-client.ts
@@ -7,6 +7,17 @@ type QueryClientGlobal = typeof globalThis & {
 export function getReactQueryClient(): QueryClient {
   const target = globalThis as QueryClientGlobal;
   if (target.__owReactQueryClient) return target.__owReactQueryClient;
-  target.__owReactQueryClient = new QueryClient();
+  const queryClient = new QueryClient();
+
+  for (const queryKey of [
+    ["react-session-transcript"],
+    ["react-session-status"],
+    ["react-session-todos"],
+    ["react-session-permissions"],
+  ] as const) {
+    queryClient.setQueryDefaults(queryKey, { gcTime: 15_000 });
+  }
+
+  target.__owReactQueryClient = queryClient;
   return target.__owReactQueryClient;
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1057,38 +1057,21 @@ export function SessionRoute() {
     };
   }, [client, endpointForWorkspace, reloadCoordinator, selectedWorkspace, selectedWorkspaceId]);
 
-  useEffect(() => {
-    if (!client || !selectedWorkspaceId || !selectedSessionId) return;
-    const endpoint = endpointForWorkspace(selectedWorkspace);
-    if (!endpoint) return;
-    let cancelled = false;
-
-    const refreshSelectedSessionTitle = async () => {
-      try {
-        const response = await endpoint.client.getSession(endpoint.workspaceId, selectedSessionId);
-        if (cancelled || !response.item) return;
-        setSessionsByWorkspaceId((current) => {
-          const list = current[selectedWorkspaceId] ?? [];
-          const index = list.findIndex((session: any) => session?.id === selectedSessionId);
-          if (index < 0) return current;
-          const nextSession = { ...list[index], ...response.item };
-          if (JSON.stringify(nextSession) === JSON.stringify(list[index])) return current;
-          const nextList = [...list];
-          nextList[index] = nextSession;
-          return { ...current, [selectedWorkspaceId]: nextList };
-        });
-      } catch {
-        // Best-effort title sync; the session surface still owns messages.
-      }
-    };
-
-    void refreshSelectedSessionTitle();
-    const interval = window.setInterval(() => void refreshSelectedSessionTitle(), 3_000);
-    return () => {
-      cancelled = true;
-      window.clearInterval(interval);
-    };
-  }, [client, endpointForWorkspace, selectedSessionId, selectedWorkspace, selectedWorkspaceId]);
+  const handleRuntimeSessionUpdated = useCallback((update: { sessionId: string; info: Record<string, unknown> }) => {
+    if (!selectedWorkspaceId) return;
+    setSessionsByWorkspaceId((current) => {
+      const list = current[selectedWorkspaceId] ?? [];
+      const index = list.findIndex((session: any) => session?.id === update.sessionId);
+      if (index < 0) return current;
+      const nextSession = { ...list[index], ...update.info, id: update.sessionId };
+      if (JSON.stringify(nextSession) === JSON.stringify(list[index])) return current;
+      const nextList = [...list];
+      nextList[index] = nextSession;
+      const next = { ...current, [selectedWorkspaceId]: nextList };
+      sessionsByWorkspaceIdRef.current = next;
+      return next;
+    });
+  }, [selectedWorkspaceId]);
 
   useEffect(() => {
     workspacesRef.current = workspaces;
@@ -2517,6 +2500,7 @@ export function SessionRoute() {
         activeSessionIds={activeSelectedWorkspaceSessionIds}
         opencodeBaseUrl={opencodeBaseUrl}
         openworkToken={selectedWorkspaceServerToken}
+        onSessionUpdated={handleRuntimeSessionUpdated}
       />
     ) : null}
     <SessionPage


### PR DESCRIPTION
## Summary
- keep visible session transcript/status state mounted as React Query observers so live overlay messages are not garbage-collected while the session is open
- replace selected-session title polling with `session.updated` event handling from the existing runtime stream
- set runtime session query GC to 15s to make cache-expiry behavior easy to verify

## Testing
- `pnpm --dir apps/app typecheck` passed

## Notes
- No screen recording captured in this environment. Repro check: open a session, send a message, keep the session visible past the 15s runtime GC window, and verify user/assistant live messages remain visible; also verify session title updates without repeated `GET /workspace/:id/sessions/:sessionId` polling.