### PR TITLE
chore: ignore OpenWork local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ vendor/opencode/
 
 # OpenWork workspace-local artifacts
 .opencode/openwork/
+.opencode/agents/openwork.md
+.opencode/openwork.json
 .vercel
 .env*.local
 .claude/*

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ vendor/opencode/
 .opencode/openwork/
 .opencode/agents/openwork.md
 .opencode/openwork.json
+opencode.jsonc
 .vercel
 .env*.local
 .claude/*


### PR DESCRIPTION
## Summary
- Ignore generated OpenWork/OpenCode local artifact files under `.opencode`.
- Keeps workspace-specific agent/config files out of git status.

## Tests
- Not run; `.gitignore`-only change.