### PR TITLE
Fix packaged extension icon paths

### DIFF
--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -2,6 +2,7 @@
 import { CheckCircle2, Loader2, Plug2 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { ExtensionKind } from "../../app/constants";
+import { resolveExtensionIconSrc } from "./extension-icon-src";
 
 export type ExtensionCardProps = {
   name: string;
@@ -61,6 +62,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
     actionLabel,
     onClick,
   } = props;
+  const resolvedIconSrc = iconSrc ? resolveExtensionIconSrc(iconSrc) : undefined;
 
   return (
     <button
@@ -83,9 +85,9 @@ export function ExtensionCard(props: ExtensionCardProps) {
           >
             {connecting ? (
               <Loader2 size={18} className="animate-spin text-dls-secondary" />
-            ) : iconSrc ? (
+            ) : resolvedIconSrc ? (
               <div className="flex size-6 items-center justify-center rounded-md bg-white">
-                <img src={iconSrc} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
+                <img src={resolvedIconSrc} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
               </div>
             ) : iconSlug ? (
               <div className="flex size-6 items-center justify-center rounded-md bg-white">

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -17,6 +17,7 @@ import {
   modalBodyClass,
   surfaceCardClass,
 } from "../domains/workspace/modal-styles";
+import { resolveExtensionIconSrc } from "./extension-icon-src";
 
 export type ExtensionDetailModalProps = {
   open: boolean;
@@ -167,6 +168,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
     onUninstall,
     configSlot,
   } = props;
+  const resolvedIconSrc = iconSrc ? resolveExtensionIconSrc(iconSrc) : undefined;
 
   return (
     <Dialog
@@ -187,9 +189,9 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                   connected ? "border-green-6 bg-green-2" : "border-dls-border bg-dls-hover"
                 }`}
               >
-                {iconSrc ? (
+                {resolvedIconSrc ? (
                   <div className="flex size-8 items-center justify-center rounded-md bg-white">
-                    <img src={iconSrc} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
+                    <img src={resolvedIconSrc} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
                   </div>
                 ) : iconSlug ? (
                   <div className="flex size-8 items-center justify-center rounded-md bg-white">

--- a/apps/app/src/react-app/design-system/extension-icon-src.ts
+++ b/apps/app/src/react-app/design-system/extension-icon-src.ts
@@ -1,0 +1,8 @@
+export function resolveExtensionIconSrc(iconSrc: string): string {
+  if (!iconSrc.startsWith("/")) {
+    return iconSrc;
+  }
+
+  const base = import.meta.env.BASE_URL || "/";
+  return `${base.replace(/\/?$/, "/")}${iconSrc.replace(/^\/+/, "")}`;
+}


### PR DESCRIPTION
## Summary
- Resolve local extension icon asset paths against Vite's base URL so packaged Electron builds load bundled SVGs correctly.
- Apply the same resolver to extension cards and detail modals used by the sidebar pane and settings extensions view.

## Testing
- `pnpm -C apps/app typecheck` passed.
- `OPENWORK_ELECTRON_BUILD=1 pnpm -C apps/app build` passed.

## Evidence
- No video or screenshots captured; verification was done with typecheck and an Electron-base production build.