### PR TITLE
Update chat link colors

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/markdown.tsx
+++ b/apps/app/src/react-app/domains/session/surface/markdown.tsx
@@ -67,7 +67,7 @@ const markdownComponents: Components = {
         href={href}
         target="_blank"
         rel="noreferrer noopener"
-        className="text-primary underline underline-offset-2 transition-colors hover:text-primary/80"
+        className="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8"
       >
         {children}
       </a>


### PR DESCRIPTION
## Summary
- Change assistant markdown links in chat to use indigo text colors.
- Keep existing underline styling while setting hover color to `text-indigo-8`.

## Tests
- `pnpm -C apps/app typecheck` passed