### PR TITLE
fix(app): resolve extension icon asset paths

### DIFF
--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -2,6 +2,7 @@
 import { CheckCircle2, Loader2, Plug2 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { ExtensionKind } from "../../app/constants";
+import { getExtensionIconSrc } from "./extension-icon-src";
 
 export type ExtensionCardProps = {
   name: string;
@@ -61,6 +62,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
     actionLabel,
     onClick,
   } = props;
+  const resolvedIconSrc = getExtensionIconSrc(iconSrc, iconSlug);
 
   return (
     <button
@@ -83,13 +85,9 @@ export function ExtensionCard(props: ExtensionCardProps) {
           >
             {connecting ? (
               <Loader2 size={18} className="animate-spin text-dls-secondary" />
-            ) : iconSrc ? (
+            ) : resolvedIconSrc ? (
               <div className="flex size-6 items-center justify-center rounded-md bg-white">
-                <img src={iconSrc} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
-              </div>
-            ) : iconSlug ? (
-              <div className="flex size-6 items-center justify-center rounded-md bg-white">
-                <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
+                <img src={resolvedIconSrc} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
               </div>
             ) : (
               <FallbackIcon size={18} className="text-dls-secondary" />

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -17,6 +17,7 @@ import {
   modalBodyClass,
   surfaceCardClass,
 } from "../domains/workspace/modal-styles";
+import { getExtensionIconSrc } from "./extension-icon-src";
 
 export type ExtensionDetailModalProps = {
   open: boolean;
@@ -167,6 +168,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
     onUninstall,
     configSlot,
   } = props;
+  const resolvedIconSrc = getExtensionIconSrc(iconSrc, iconSlug);
 
   return (
     <Dialog
@@ -187,13 +189,9 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                   connected ? "border-green-6 bg-green-2" : "border-dls-border bg-dls-hover"
                 }`}
               >
-                {iconSrc ? (
+                {resolvedIconSrc ? (
                   <div className="flex size-8 items-center justify-center rounded-md bg-white">
-                    <img src={iconSrc} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
-                  </div>
-                ) : iconSlug ? (
-                  <div className="flex size-8 items-center justify-center rounded-md bg-white">
-                    <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
+                    <img src={resolvedIconSrc} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
                   </div>
                 ) : (
                   <FallbackIcon size={24} className="text-dls-secondary" />

--- a/apps/app/src/react-app/design-system/extension-icon-src.ts
+++ b/apps/app/src/react-app/design-system/extension-icon-src.ts
@@ -1,0 +1,11 @@
+export function getExtensionIconSrc(iconSrc?: string, iconSlug?: string) {
+  if (iconSrc) {
+    if (iconSrc.startsWith("/") && !iconSrc.startsWith("//")) {
+      return `${import.meta.env.BASE_URL}${iconSrc.slice(1)}`;
+    }
+
+    return iconSrc;
+  }
+
+  return iconSlug ? `https://cdn.simpleicons.org/${iconSlug}` : undefined;
+}


### PR DESCRIPTION
## Summary
- resolve extension icon URLs through Vite's base URL before rendering
- keep CDN Simple Icons fallback behavior in one shared helper
- fixes Electron packaged prod builds where root-relative public assets resolve to file system root

## Validation
- pnpm install (needed because the isolated worktree had no node_modules)
- pnpm --filter @openwork/app typecheck
- OPENWORK_ELECTRON_BUILD=1 pnpm --filter @openwork/app build
- confirmed built Electron bundle contains resolver output that maps root-relative icons to ./ paths and dist includes ext-*.svg public assets

## Evidence
- No screenshot/video captured; validated via production Electron asset build output and compiled bundle inspection.