### PR TITLE
fix(app): support inline question prompts

### DIFF
--- a/apps/app/src/app/utils/index.ts
+++ b/apps/app/src/app/utils/index.ts
@@ -810,6 +810,18 @@ function buildToolTitle(state: any, toolName: string): string {
     return "Task";
   }
 
+  if (lower === "question") {
+    const questions = Array.isArray(input.questions) ? input.questions : [];
+    const first = questions[0];
+    if (first && typeof first === "object") {
+      const record = first as Record<string, unknown>;
+      const header = normalizeStepText(record.header);
+      const question = normalizeStepText(record.question);
+      return truncateStepText(header || question || "Asked a question", 56);
+    }
+    return "Asked a question";
+  }
+
   if (lower === "todowrite") {
     return "Update todo list";
   }
@@ -870,6 +882,18 @@ function buildToolDetail(state: any, toolName: string): string | undefined {
     if (description) return truncateStepText(description, 80);
     const agent = formatAgentLabel(pick("subagent_type"));
     if (agent) return `${agent} agent`;
+  }
+
+  if (lower === "question") {
+    const questions = Array.isArray(input.questions) ? input.questions.length : 0;
+    const answers = Array.isArray(state?.output)
+      ? state.output
+      : state?.output && typeof state.output === "object" && Array.isArray(state.output.answers)
+        ? state.output.answers
+        : null;
+    if (answers) return "Answered";
+    if (questions > 1) return `${questions} questions`;
+    return undefined;
   }
 
   if (lower === "todowrite" || lower === "todoread") {

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -21,7 +21,6 @@ import type { ShareWorkspaceModalProps } from "../../workspace/types";
 import { Button } from "@/components/ui/button";
 import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
 import ProviderAuthModal, { type ProviderAuthModalProps } from "../../connections/provider-auth/provider-auth-modal";
-import { QuestionModal } from "../modals/question-modal";
 import { RenameSessionModal } from "../modals/rename-session-modal";
 import { AppSidebar } from "../sidebar/app-sidebar";
 import { SessionSurface, type SessionSurfaceProps } from "../surface/session-surface";
@@ -667,6 +666,9 @@ export function SessionPage(props: SessionPageProps) {
                   activePermission={props.activePermission}
                   permissionReplyBusy={props.permissionReplyBusy}
                   respondPermission={props.respondPermission}
+                  activeQuestion={props.activeQuestion}
+                  questionReplyBusy={props.questionReplyBusy}
+                  respondQuestion={props.respondQuestion}
                   safeStringify={props.safeStringify}
                   onOpenTarget={openTarget}
                   onOpenTargetsChange={handleOpenTargetsChange}
@@ -940,17 +942,6 @@ export function SessionPage(props: SessionPageProps) {
       ) : null}
 
       {props.shareWorkspaceModal ? <ShareWorkspaceModal {...props.shareWorkspaceModal} /> : null}
-
-      <QuestionModal
-        open={Boolean(props.activeQuestion)}
-        questions={props.activeQuestion?.questions ?? []}
-        busy={props.questionReplyBusy ?? false}
-        onReply={(answers) => {
-          if (props.activeQuestion) {
-            props.respondQuestion?.(props.activeQuestion.id, answers);
-          }
-        }}
-      />
 
       {/* Cloud provider notifications are now handled globally by CloudProvidersToast in app-root.tsx */}
     </div>

--- a/apps/app/src/react-app/domains/session/modals/question-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/question-modal.tsx
@@ -3,19 +3,10 @@ import { useEffect, useReducer } from "react";
 import type { QuestionInfo } from "@opencode-ai/sdk/v2/client";
 import { Check, ChevronRight, HelpCircle } from "lucide-react";
 
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { t } from "@/i18n";
 
-export type QuestionModalProps = {
-  open: boolean;
+export type QuestionPanelProps = {
   questions: QuestionInfo[];
   busy: boolean;
   onReply: (answers: string[][]) => void;
@@ -62,6 +53,7 @@ function questionReducer(state: QuestionState, action: QuestionAction): Question
     case "setFocusedOptionIndex":
       return { ...state, focusedOptionIndex: action.value };
     case "moveFocusedOption":
+      if (action.optionsCount <= 0) return state;
       return {
         ...state,
         focusedOptionIndex:
@@ -90,15 +82,15 @@ function questionReducer(state: QuestionState, action: QuestionAction): Question
   }
 }
 
-export function QuestionModal(props: QuestionModalProps) {
+export function QuestionPanel(props: QuestionPanelProps) {
   const [state, dispatch] = useReducer(questionReducer, initialQuestionState);
 
   useEffect(() => {
-    if (!props.open) return;
     dispatch({ type: "reset", questionCount: props.questions.length });
-  }, [props.open, props.questions.length]);
+  }, [props.questions]);
 
   const currentQuestion = props.questions[state.currentIndex];
+  const options = currentQuestion?.options ?? [];
   const isLastQuestion = state.currentIndex === props.questions.length - 1;
   const canProceed = (() => {
     if (!currentQuestion) return false;
@@ -123,7 +115,7 @@ export function QuestionModal(props: QuestionModalProps) {
   };
 
   const toggleOption = (option: string) => {
-    if (!currentQuestion) return;
+    if (!currentQuestion || props.busy) return;
     if (currentQuestion.multiple) {
       dispatch({ type: "toggleMultipleOption", option });
       return;
@@ -143,75 +135,46 @@ export function QuestionModal(props: QuestionModalProps) {
     }
   };
 
-  useEffect(() => {
-    if (!props.open) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (!currentQuestion) return;
-      const optionsCount = currentQuestion.options.length;
-
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        dispatch({ type: "moveFocusedOption", direction: 1, optionsCount });
-      } else if (event.key === "ArrowUp") {
-        event.preventDefault();
-        dispatch({ type: "moveFocusedOption", direction: -1, optionsCount });
-      } else if (event.key === "Enter") {
-        if (event.isComposing || event.keyCode === 229) return;
-        event.preventDefault();
-        if (
-          currentQuestion.custom &&
-          document.activeElement?.tagName === "INPUT"
-        ) {
-          handleNext();
-          return;
-        }
-        const option = currentQuestion.options[state.focusedOptionIndex]?.description;
-        if (option) toggleOption(option);
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.open, currentQuestion, state.focusedOptionIndex]);
-
-  if (!props.open || !currentQuestion) return null;
+  if (!currentQuestion) return null;
 
   return (
-    <Dialog open={props.open}>
-      <DialogContent showCloseButton={false} className="flex max-h-[85vh] min-h-0 w-full max-w-lg flex-col overflow-hidden sm:max-w-lg">
-        <DialogHeader>
-          <div className="mb-2 flex items-center gap-3">
-            <div className="flex size-8 items-center justify-center rounded-full bg-blue-9/20 text-blue-9">
-              <HelpCircle size={18} />
-            </div>
-            <div>
-              <DialogTitle>
+    <div className="overflow-hidden border-b border-dls-border bg-transparent">
+      <div className="border-b border-dls-border px-4 py-3">
+        <div className="flex items-start gap-2.5">
+          <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border border-blue-7/30 bg-blue-3/20 text-blue-11">
+            <HelpCircle size={12} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <div className="text-sm font-medium leading-5 text-gray-12">
                 {currentQuestion.header || t("common.question")}
-              </DialogTitle>
-              <div className="text-xs font-medium text-gray-11">
+              </div>
+              <div className="text-[11px] font-medium leading-4 text-gray-9">
                 {t("question_modal.question_counter", undefined, {
                   current: state.currentIndex + 1,
                   total: props.questions.length,
                 })}
               </div>
             </div>
+            <div className="mt-1 text-sm leading-6 text-gray-11">
+              {currentQuestion.question}
+            </div>
           </div>
-          <DialogDescription>
-            {currentQuestion.question}
-          </DialogDescription>
-        </DialogHeader>
+        </div>
+      </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="max-h-72 space-y-3 overflow-auto px-4 py-3">
+        {options.length > 0 ? (
           <div className="space-y-2">
-            {currentQuestion.options.map((opt, idx) => {
-              const isSelected = state.currentSelection.includes(opt.description);
+            {options.map((opt, idx) => {
+              const isSelected = state.currentSelection.includes(opt.label);
               const isFocused = state.focusedOptionIndex === idx;
               return (
                 <button
-                  key={opt.description}
+                  key={`${opt.label}:${idx}`}
                   type="button"
-                  className={`w-full text-left px-4 py-3 rounded-xl border text-sm transition-all duration-200 flex items-center justify-between group
+                  disabled={props.busy}
+                  className={`flex w-full items-start justify-between gap-3 rounded-xl border px-3 py-2.5 text-left text-sm transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-60
                         ${
                           isSelected
                             ? "bg-blue-9/10 border-blue-9/30 text-gray-12 shadow-sm"
@@ -221,10 +184,15 @@ export function QuestionModal(props: QuestionModalProps) {
                       `}
                   onClick={() => {
                     dispatch({ type: "setFocusedOptionIndex", value: idx });
-                    toggleOption(opt.description);
+                    toggleOption(opt.label);
                   }}
                 >
-                  <span className="font-medium">{opt.description}</span>
+                  <span className="min-w-0">
+                    <span className="block font-medium text-gray-12">{opt.label}</span>
+                    {opt.description && opt.description !== opt.label ? (
+                      <span className="mt-1 block text-xs leading-5 text-gray-11">{opt.description}</span>
+                    ) : null}
+                  </span>
                   {isSelected ? (
                     <div className="size-5 rounded-full bg-blue-9 flex items-center justify-center shadow-sm">
                       <Check size={12} className="text-white" strokeWidth={3} />
@@ -234,9 +202,10 @@ export function QuestionModal(props: QuestionModalProps) {
               );
             })}
           </div>
+        ) : null}
 
           {currentQuestion.custom ? (
-            <div className="mt-4 pt-4 border-t border-dls-border">
+            <div className="border-t border-dls-border pt-3">
               <label className="block text-xs font-semibold text-dls-secondary mb-2 uppercase tracking-wide">
                 {t("question_modal.custom_answer_label")}
               </label>
@@ -251,6 +220,7 @@ export function QuestionModal(props: QuestionModalProps) {
                 }
                 className="w-full px-4 py-3 rounded-xl bg-dls-surface border border-dls-border focus:border-dls-accent focus:ring-4 focus:ring-[rgba(var(--dls-accent-rgb),0.2)] focus:outline-none text-sm text-dls-text placeholder:text-dls-secondary transition-shadow"
                 placeholder={t("question_modal.custom_answer_placeholder")}
+                disabled={props.busy}
                 onKeyDown={(event) => {
                   if (event.key === "Enter") {
                     if (event.nativeEvent.isComposing || event.keyCode === 229)
@@ -262,18 +232,10 @@ export function QuestionModal(props: QuestionModalProps) {
               />
             </div>
           ) : null}
-        </div>
 
-        <DialogFooter className="shrink-0 items-center justify-between">
+        <div className="flex items-center justify-between gap-3">
           <div className="text-xs text-dls-secondary flex items-center gap-2">
-            <span className="px-1.5 py-0.5 rounded border border-dls-border bg-dls-active font-mono">
-              ↑↓
-            </span>
-            <span>{t("common.navigate")}</span>
-            <span className="px-1.5 py-0.5 rounded border border-gray-6 bg-gray-3 font-mono ml-2">
-              ↵
-            </span>
-            <span>{t("common.select")}</span>
+            {props.busy ? "Submitting..." : null}
           </div>
 
           <div className="flex gap-2">
@@ -289,8 +251,8 @@ export function QuestionModal(props: QuestionModalProps) {
               </Button>
             ) : null}
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -21,6 +21,7 @@ import type {
   McpStatusMap,
   ModelRef,
   PendingPermission,
+  PendingQuestion,
   SkillCard,
   TodoItem,
 } from "../../../../app/types";
@@ -43,6 +44,7 @@ import { useLocal } from "../../../kernel/local-provider";
 import { deriveSessionRenderModel } from "../sync/transition-controller";
 import { useSessionScrollController } from "./scroll-controller";
 import { PermissionApprovalPanel } from "../chat/permission-approval-modal";
+import { QuestionPanel } from "../modals/question-modal";
 import { deriveOpenTargets, selectAutoOpenTarget, type OpenTarget } from "../artifacts/open-target";
 import {
   seedSessionState,
@@ -99,6 +101,9 @@ export type SessionSurfaceProps = {
   activePermission?: PendingPermission | null;
   permissionReplyBusy?: boolean;
   respondPermission?: (requestID: string, reply: "once" | "always" | "reject") => void;
+  activeQuestion?: PendingQuestion | null;
+  questionReplyBusy?: boolean;
+  respondQuestion?: (requestID: string, answers: string[][]) => void;
   safeStringify?: (value: unknown) => string;
   onChangeModel?: (model: { providerID: string; modelID: string }) => void;
   onUploadInboxFiles?: ((files: File[], options?: { notify?: boolean }) => void | Promise<unknown>) | null;
@@ -1264,11 +1269,23 @@ export function SessionSurface(props: SessionSurfaceProps) {
         isRemoteWorkspace={props.isRemoteWorkspace}
           isSandboxWorkspace={props.isSandboxWorkspace}
           onUploadInboxFiles={props.onUploadInboxFiles ?? handleUploadInboxFiles}
-          compactTopSpacing={Boolean((props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission)}
+          compactTopSpacing={Boolean(props.activeQuestion || (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission)}
           topAccessory={
-            (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission ? (
+            props.activeQuestion || (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission ? (
               <div>
-                <TodoPanel todos={props.todos ?? []} />
+                {props.activeQuestion ? (
+                  <QuestionPanel
+                    questions={props.activeQuestion.questions}
+                    busy={props.questionReplyBusy ?? false}
+                    onReply={(answers) => {
+                      if (props.activeQuestion) {
+                        props.respondQuestion?.(props.activeQuestion.id, answers);
+                      }
+                    }}
+                  />
+                ) : (
+                  <TodoPanel todos={props.todos ?? []} />
+                )}
                 {props.activePermission ? (
                   <PermissionApprovalPanel
                     permission={props.activePermission}

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -1,10 +1,10 @@
 import type { UIMessage } from "ai";
-import type { Part, PermissionRequest, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
+import type { Part, PermissionRequest, QuestionRequest, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
 import { getReactQueryClient } from "../../../infra/query-client";
 import { createClient } from "../../../../app/lib/opencode";
 import { normalizeEvent } from "../../../../app/utils";
-import type { OpencodeEvent, PendingPermission } from "../../../../app/types";
+import type { OpencodeEvent, PendingPermission, PendingQuestion } from "../../../../app/types";
 import { snapshotToUIMessages } from "./usechat-adapter";
 import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
 import { reconcileTranscriptMessages } from "./transcript-reconcile";
@@ -55,6 +55,8 @@ export const todoKey = (workspaceId: string, sessionId: string) =>
   ["react-session-todos", workspaceId, sessionId] as const;
 export const permissionKey = (workspaceId: string, sessionId: string) =>
   ["react-session-permissions", workspaceId, sessionId] as const;
+export const questionKey = (workspaceId: string, sessionId: string) =>
+  ["react-session-questions", workspaceId, sessionId] as const;
 
 function syncKey(input: SyncOptions) {
   return `${input.workspaceId}:${input.baseUrl}:${input.openworkToken}`;
@@ -144,7 +146,15 @@ function withReceivedAt(permission: PermissionRequest, receivedAt: number): Pend
   return { ...permission, receivedAt };
 }
 
+function questionWithReceivedAt(question: QuestionRequest, receivedAt: number): PendingQuestion {
+  return { ...question, receivedAt };
+}
+
 function sortPermissions(a: PendingPermission, b: PendingPermission) {
+  return a.receivedAt - b.receivedAt || a.id.localeCompare(b.id);
+}
+
+function sortQuestions(a: PendingQuestion, b: PendingQuestion) {
   return a.receivedAt - b.receivedAt || a.id.localeCompare(b.id);
 }
 
@@ -173,6 +183,34 @@ export function seedPermissionState(
           )
         : [];
     return [...seeded, ...liveAfterSnapshot].sort(sortPermissions);
+  });
+}
+
+export function seedQuestionState(
+  workspaceId: string,
+  sessionId: string,
+  questions: QuestionRequest[],
+  options: { snapshotStartedAt?: number } = {},
+) {
+  const queryClient = getReactQueryClient();
+  const now = Date.now();
+  queryClient.setQueryData<PendingQuestion[]>(questionKey(workspaceId, sessionId), (current = []) => {
+    const receivedAtById = new Map(current.map((question) => [question.id, question.receivedAt]));
+    const seeded = questions.flatMap((question) =>
+      question.sessionID === sessionId ? [questionWithReceivedAt(question, receivedAtById.get(question.id) ?? now)] : [],
+    );
+    const seededIds = new Set(seeded.map((question) => question.id));
+    const snapshotStartedAt = options.snapshotStartedAt;
+    const liveAfterSnapshot =
+      typeof snapshotStartedAt === "number"
+        ? current.filter(
+            (question) =>
+              question.sessionID === sessionId &&
+              question.receivedAt > snapshotStartedAt &&
+              !seededIds.has(question.id),
+          )
+        : [];
+    return [...seeded, ...liveAfterSnapshot].sort(sortQuestions);
   });
 }
 
@@ -441,6 +479,32 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     if (!isTrackedSession(entry, props.sessionID)) return;
     queryClient.setQueryData<PendingPermission[]>(permissionKey(workspaceId, props.sessionID), (current = []) =>
       current.filter((permission) => permission.id !== props.requestID),
+    );
+    return;
+  }
+
+  if (event.type === "question.asked") {
+    const question = event.properties as QuestionRequest;
+    if (!question?.id || !question.sessionID) return;
+    if (!isTrackedSession(entry, question.sessionID)) return;
+    const receivedAt = Date.now();
+    queryClient.setQueryData<PendingQuestion[]>(questionKey(workspaceId, question.sessionID), (current = []) => {
+      const existing = current.find((item) => item.id === question.id);
+      const next = questionWithReceivedAt(question, existing?.receivedAt ?? receivedAt);
+      if (existing) {
+        return current.map((item) => (item.id === question.id ? next : item)).sort(sortQuestions);
+      }
+      return [...current, next].sort(sortQuestions);
+    });
+    return;
+  }
+
+  if (event.type === "question.replied" || event.type === "question.rejected") {
+    const props = (event.properties ?? {}) as { sessionID?: string; requestID?: string };
+    if (!props.sessionID || !props.requestID) return;
+    if (!isTrackedSession(entry, props.sessionID)) return;
+    queryClient.setQueryData<PendingQuestion[]>(questionKey(workspaceId, props.sessionID), (current = []) =>
+      current.filter((question) => question.id !== props.requestID),
     );
     return;
   }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -55,6 +55,7 @@ import type {
   ModelOption,
   ModelRef,
   PendingPermission,
+  PendingQuestion,
   SlashCommandOption,
   TodoItem,
   WorkspacePreset,
@@ -84,7 +85,9 @@ import { ReactSessionRuntime } from "../domains/session/sync/runtime-sync";
 import { buildOpenworkEnvSystemContext } from "../domains/session/sync/env-context";
 import {
   permissionKey as reactPermissionKey,
+  questionKey as reactQuestionKey,
   seedPermissionState,
+  seedQuestionState,
   todoKey as reactTodoKey,
 } from "../domains/session/sync/session-sync";
 import { CreateRemoteWorkspaceModal } from "../domains/workspace/create-remote-workspace-modal";
@@ -247,6 +250,7 @@ function focusPromptSoon() {
 }
 
 const emptyPendingPermissions: PendingPermission[] = [];
+const emptyPendingQuestions: PendingQuestion[] = [];
 const emptyTodos: TodoItem[] = [];
 const emptyModelBehaviorOptions: { value: string | null; label: string }[] = [];
 
@@ -582,6 +586,8 @@ export function SessionRoute() {
 
   const [permissionReplyBusy, setPermissionReplyBusy] = useState(false);
   const permissionReplyBusyRef = useRef(false);
+  const [questionReplyBusy, setQuestionReplyBusy] = useState(false);
+  const questionReplyBusyRef = useRef(false);
   // Provider catalog cache. Used to compute the reasoning/thinking variant
   // options for whichever model is currently selected so the composer's
   // behavior pill actually shows its options (bug: was empty before).
@@ -1518,6 +1524,17 @@ export function SessionRoute() {
     permissionQueryKey,
     emptyPendingPermissions,
   );
+  const questionQueryKey = useMemo(
+    () =>
+      selectedWorkspaceId && selectedSessionId
+        ? reactQuestionKey(selectedWorkspaceId, selectedSessionId)
+        : null,
+    [selectedSessionId, selectedWorkspaceId],
+  );
+  const pendingQuestions = useQueryCacheState<PendingQuestion[]>(
+    questionQueryKey,
+    emptyPendingQuestions,
+  );
   const todoQueryKey = useMemo(
     () =>
       selectedWorkspaceId && selectedSessionId
@@ -1540,6 +1557,27 @@ export function SessionRoute() {
       } catch {
         // Keep event-synced permission state if the snapshot read fails.
         // Hiding a pending approval can block the running task.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [opencodeClient, selectedSessionId, selectedWorkspaceId, selectedWorkspaceRoot]);
+
+  useEffect(() => {
+    if (!opencodeClient || !selectedWorkspaceId || !selectedSessionId) return;
+    let cancelled = false;
+    const directory = selectedWorkspaceRoot || undefined;
+    void (async () => {
+      const snapshotStartedAt = Date.now();
+      try {
+        const list = unwrap(await opencodeClient.question.list({ directory }));
+        if (!cancelled) {
+          seedQuestionState(selectedWorkspaceId, selectedSessionId, list, { snapshotStartedAt });
+        }
+      } catch {
+        // Keep event-synced question state if the snapshot read fails.
+        // Hiding a pending question can block the running task.
       }
     })();
     return () => {
@@ -1575,6 +1613,38 @@ export function SessionRoute() {
       } finally {
         permissionReplyBusyRef.current = false;
         setPermissionReplyBusy(false);
+      }
+    },
+    [opencodeClient, selectedSessionId, selectedWorkspaceId, selectedWorkspaceRoot, showToast],
+  );
+  const activeQuestion = pendingQuestions[0] ?? null;
+  const respondQuestion = useCallback(
+    async (requestID: string, answers: string[][]) => {
+      if (!opencodeClient || !selectedWorkspaceId || !selectedSessionId) return;
+      if (questionReplyBusyRef.current) return;
+      questionReplyBusyRef.current = true;
+      setQuestionReplyBusy(true);
+      try {
+        unwrap(
+          await opencodeClient.question.reply({
+            requestID,
+            answers,
+            directory: selectedWorkspaceRoot || undefined,
+          }),
+        );
+        getReactQueryClient().setQueryData<PendingQuestion[]>(
+          reactQuestionKey(selectedWorkspaceId, selectedSessionId),
+          (current = []) => current.filter((question) => question.id !== requestID),
+        );
+      } catch (error) {
+        showToast({
+          title: t("app.error_request_failed"),
+          description: describeRouteError(error),
+          tone: "error",
+        });
+      } finally {
+        questionReplyBusyRef.current = false;
+        setQuestionReplyBusy(false);
       }
     },
     [opencodeClient, selectedSessionId, selectedWorkspaceId, selectedWorkspaceRoot, showToast],
@@ -2787,6 +2857,9 @@ export function SessionRoute() {
       activePermission={activePermission}
       permissionReplyBusy={permissionReplyBusy}
       respondPermission={respondPermission}
+      activeQuestion={activeQuestion}
+      questionReplyBusy={questionReplyBusy}
+      respondQuestion={respondQuestion}
       safeStringify={safeStringify}
       onRenameSession={
         opencodeClient

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { UIMessage } from "ai";
-import type { PermissionRequest } from "@opencode-ai/sdk/v2/client";
+import type { PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2/client";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
@@ -12,7 +12,9 @@ import {
   coalescePendingDeltas,
   ensureWorkspaceSessionSync,
   permissionKey,
+  questionKey,
   seedPermissionState,
+  seedQuestionState,
   seedSessionState,
   trackWorkspaceSessionSync,
   transcriptKey,
@@ -29,6 +31,20 @@ function permission(id: string, sessionID: string): PermissionRequest {
       session: false,
       project: false,
     },
+  };
+}
+
+function question(id: string, sessionID: string): QuestionRequest {
+  return {
+    id,
+    sessionID,
+    questions: [
+      {
+        header: "Choice",
+        question: "Pick one",
+        options: [{ label: "Yes", description: "Proceed" }],
+      },
+    ],
   };
 }
 
@@ -131,6 +147,46 @@ describe("session permission sync", () => {
     seedPermissionState("workspace-a", "session-a", [], { snapshotStartedAt: 200 });
 
     expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-a"))).toEqual([]);
+  });
+});
+
+describe("session question sync", () => {
+  test("seeds only questions for the selected session", () => {
+    seedQuestionState("workspace-a", "session-a", [
+      question("question-a", "session-a"),
+      question("question-b", "session-b"),
+    ]);
+
+    expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-a"))).toMatchObject([
+      { id: "question-a", sessionID: "session-a" },
+    ]);
+  });
+
+  test("adds and removes live question events", () => {
+    const syncInput = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
+    const releaseSession = trackWorkspaceSessionSync(syncInput, "session-a");
+
+    try {
+      __applySessionSyncEventForTest(syncInput, {
+        type: "question.asked",
+        properties: question("question-live", "session-a"),
+      } as any);
+
+      expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-a"))).toMatchObject([
+        { id: "question-live", sessionID: "session-a" },
+      ]);
+
+      __applySessionSyncEventForTest(syncInput, {
+        type: "question.replied",
+        properties: { sessionID: "session-a", requestID: "question-live", answers: [["Yes"]] },
+      } as any);
+
+      expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-a"))).toEqual([]);
+    } finally {
+      releaseSession();
+      cleanup();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Wire OpenCode question requests into session sync, snapshot seeding, and reply handling.
- Replace the blocking question dialog with an inline composer accessory panel that takes priority over tasks and stays visible until answered.
- Submit SDK-compatible option labels and improve question tool summaries in the transcript.

## Tests
- `bun test apps/app/tests/session-sync-permissions.test.ts`
- `pnpm --dir apps/app typecheck`

## Evidence
- No video/screenshot captured; this change was verified with focused sync tests and TypeScript checks in the worktree, but the Electron UI was not run for a recording.