### PR TITLE
fix(app): complete MCP OAuth auth after reload

### DIFF
--- a/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
@@ -69,6 +69,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
   const authCopyTimeoutRef = useRef<number | null>(null);
   const previousOpenRef = useRef(false);
   const previousEntryNameRef = useRef<string | null>(null);
+  const reloadAuthRunRef = useRef(false);
 
   const stopStatusPolling = () => {
     if (statusPollRef.current !== null) {
@@ -376,13 +377,14 @@ export function McpAuthModal(props: McpAuthModalProps) {
   }, [props.open, props.entry, props.client, props.reloadRequired]);
 
   useEffect(() => {
-    if (!props.open || !awaitingReload || props.reloadBlocked || !props.onReloadEngine || !props.entry || reloadStarting) {
+    if (!props.open || !awaitingReload || props.reloadBlocked || !props.onReloadEngine || !props.entry || reloadAuthRunRef.current) {
       return;
     }
 
     let cancelled = false;
 
     void (async () => {
+      reloadAuthRunRef.current = true;
       setReloadStarting(true);
       setError(null);
       setNeedsReload(false);
@@ -417,6 +419,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
         setNeedsReload(true);
         setError(message);
       } finally {
+        reloadAuthRunRef.current = false;
         if (!cancelled) {
           setReloadStarting(false);
         }
@@ -425,8 +428,9 @@ export function McpAuthModal(props: McpAuthModalProps) {
 
     return () => {
       cancelled = true;
+      reloadAuthRunRef.current = false;
     };
-  }, [props.open, awaitingReload, props.reloadBlocked, props.onReloadEngine, props.entry, reloadStarting]);
+  }, [props.open, awaitingReload, props.reloadBlocked, props.onReloadEngine, props.entry]);
 
   const handleRetry = () => {
     void startAuth(true);

--- a/evals/daytona-flows.md
+++ b/evals/daytona-flows.md
@@ -333,6 +333,116 @@ editor. The synthetic paste event is the reliable path.
 
 ---
 
+## Flow 5: Add a custom OAuth MCP app
+
+**Goal:** Prove a newly added OAuth MCP does not get stuck on
+`Applying changes before sign-in`, opens the OAuth authorization URL after the
+worker reload, completes the callback, and appears as `Ready`.
+
+### Source references for controls
+
+| UI control | Preferred selector | Source file |
+|---|---|---|
+| Settings button | `button[aria-label="Settings"]` | `apps/app/src/react-app/domains/session/chat/status-bar.tsx` |
+| Extensions tab | button text `Extensions` | `apps/app/src/react-app/shell/settings-route.tsx` |
+| Add custom MCP | button text `Add Custom App` | `apps/app/src/react-app/domains/settings/pages/mcp-view.tsx` |
+| Server name input | `input[placeholder="github-copilot"]` | `apps/app/src/react-app/domains/connections/modals/add-mcp-modal.tsx` |
+| Server URL input | `input[placeholder="https://api.githubcopilot.com/mcp/"]` | `add-mcp-modal.tsx` |
+| OAuth checkbox | `input[type="checkbox"]` in the modal | `add-mcp-modal.tsx` |
+| Add app submit | button text `Add App` | `add-mcp-modal.tsx` |
+
+### Steps
+
+1. Start the reusable mock OAuth MCP server in the Daytona sandbox:
+   ```bash
+   daytona exec openwork-test 'bash -lc "cd /workspace && nohup env PORT=3978 HOST=127.0.0.1 AUTO_APPROVE=1 node scripts/mock-oauth-mcp-server.mjs > /tmp/mock-mcp.log 2>&1 &"'
+   ```
+
+   Use `AUTO_APPROVE=0` when you specifically want to verify that a real browser
+   page opens and requires a manual approval click.
+
+2. Verify the mock server is healthy:
+   ```bash
+   daytona exec openwork-test 'bash -lc "curl -s http://127.0.0.1:3978/health"'
+   ```
+
+   Expected: `{"ok":true,...}`.
+
+3. Create a workspace using Flow 1, or reuse an existing local workspace.
+
+4. Open Settings, then Extensions:
+   ```js
+   (function(){var el=Array.from(document.querySelectorAll('button,a')).find(function(n){return n.getAttribute('aria-label')==='Settings'}); if(!el)return 'not found'; el.click(); return 'clicked';})()
+   ```
+
+   ```js
+   (function(){var b=Array.from(document.querySelectorAll('button')).find(function(n){return n.textContent.trim()==='Extensions'}); if(!b)return 'not found'; b.click(); return 'clicked';})()
+   ```
+
+5. Click `Add Custom App`.
+
+6. Fill the custom MCP modal and submit:
+   ```js
+   (function() {
+     function setInput(input, value) {
+       Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(input, value);
+       input.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: value }));
+     }
+     var name = document.querySelector('input[placeholder="github-copilot"]');
+     var url = document.querySelector('input[placeholder="https://api.githubcopilot.com/mcp/"]');
+     var checkbox = Array.from(document.querySelectorAll('input[type="checkbox"]')).find(function(el) { return !el.checked; }) || document.querySelector('input[type="checkbox"]');
+     if (!name || !url || !checkbox) return 'missing fields';
+     setInput(name, 'mock-oauth-eval');
+     setInput(url, 'http://127.0.0.1:3978/mcp');
+     if (!checkbox.checked) checkbox.click();
+     var add = Array.from(document.querySelectorAll('button')).find(function(el) { return el.textContent.trim() === 'Add App' && !el.disabled; });
+     if (!add) return 'add disabled';
+     add.click();
+     return 'submitted';
+   })()
+   ```
+
+7. Immediately verify the auth modal appears and shows the reload-prep state:
+   ```js
+   document.body.innerText.includes('Applying changes before sign-in')
+   ```
+
+8. Wait up to 30s, then verify the mock OAuth server saw an authorization
+   request and token exchange:
+   ```bash
+   daytona exec openwork-test 'bash -lc "curl -s http://127.0.0.1:3978/requests"'
+   ```
+
+   Expected request paths include `/authorize`, `/token`, and authenticated
+   `/mcp` calls after `/token`.
+
+9. Verify the app status for `mock-oauth-eval` is `Ready`:
+   ```js
+   (function() {
+     var text = document.body.innerText;
+     var i = text.indexOf('mock-oauth-eval');
+     return i === -1 ? 'missing mock-oauth-eval' : text.slice(i, i + 200);
+   })()
+   ```
+
+   Expected snippet includes `mock-oauth-eval` and `Ready`.
+
+### Expected outcome
+
+- The modal may briefly show `Applying changes before sign-in`, but it must not
+  remain there after the worker reload.
+- The mock server receives `/authorize` and `/token` requests.
+- The configured MCP appears under `Your apps` as `Ready`.
+- No real third-party OAuth provider or credentials are required.
+
+### Regression caught
+
+This catches the auth modal effect self-cancelling when `reloadStarting` changes,
+which leaves the user stuck on `Applying changes before sign-in` and prevents the
+browser from opening the OAuth URL.
+
+---
+
 ## Teardown
 
 ```bash

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+import http from "node:http";
+import { randomUUID } from "node:crypto";
+
+const host = process.env.HOST || "127.0.0.1";
+const port = Number(process.env.PORT || 3978);
+const issuer = process.env.ISSUER || `http://${host}:${port}`;
+const autoApprove = process.env.AUTO_APPROVE !== "0";
+
+const clients = new Map();
+const codes = new Map();
+const tokens = new Set();
+const requests = [];
+
+function json(res, status, body, headers = {}) {
+  res.writeHead(status, {
+    "access-control-allow-origin": "*",
+    "access-control-allow-headers": "authorization, content-type, mcp-protocol-version",
+    "access-control-allow-methods": "GET, POST, OPTIONS",
+    "content-type": "application/json",
+    ...headers,
+  });
+  res.end(JSON.stringify(body));
+}
+
+function text(res, status, body, headers = {}) {
+  res.writeHead(status, {
+    "access-control-allow-origin": "*",
+    "content-type": "text/html; charset=utf-8",
+    ...headers,
+  });
+  res.end(body);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => resolve(raw));
+    req.on("error", reject);
+  });
+}
+
+async function readJson(req) {
+  const raw = await readBody(req);
+  if (!raw.trim()) return {};
+  return JSON.parse(raw);
+}
+
+async function readForm(req) {
+  const raw = await readBody(req);
+  return Object.fromEntries(new URLSearchParams(raw));
+}
+
+function record(req, pathname) {
+  const entry = {
+    id: requests.length + 1,
+    method: req.method,
+    path: pathname,
+    at: new Date().toISOString(),
+  };
+  requests.push(entry);
+  console.log(`[mock-oauth-mcp] ${entry.method} ${entry.path}`);
+}
+
+function protectedResourceMetadata() {
+  return {
+    resource: `${issuer}/mcp`,
+    authorization_servers: [issuer],
+    scopes_supported: ["mcp:read", "mcp:write"],
+    bearer_methods_supported: ["header"],
+  };
+}
+
+function authorizationServerMetadata() {
+  return {
+    issuer,
+    authorization_endpoint: `${issuer}/authorize`,
+    token_endpoint: `${issuer}/token`,
+    registration_endpoint: `${issuer}/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_post", "client_secret_basic"],
+    code_challenge_methods_supported: ["S256", "plain"],
+    scopes_supported: ["mcp:read", "mcp:write"],
+  };
+}
+
+function redirectWithCode(res, params) {
+  const redirectUri = params.get("redirect_uri");
+  if (!redirectUri) {
+    json(res, 400, { error: "invalid_request", error_description: "redirect_uri is required" });
+    return;
+  }
+
+  const code = `mock-code-${randomUUID()}`;
+  codes.set(code, {
+    clientId: params.get("client_id") || "mock-client",
+    codeChallenge: params.get("code_challenge") || null,
+    scope: params.get("scope") || "mcp:read mcp:write",
+  });
+
+  const callback = new URL(redirectUri);
+  callback.searchParams.set("code", code);
+  const state = params.get("state");
+  if (state) callback.searchParams.set("state", state);
+
+  res.writeHead(302, { location: callback.toString() });
+  res.end();
+}
+
+function authorize(req, res, url) {
+  if (autoApprove) {
+    redirectWithCode(res, url.searchParams);
+    return;
+  }
+
+  const approveUrl = new URL(`${issuer}/approve`);
+  for (const [key, value] of url.searchParams) approveUrl.searchParams.set(key, value);
+  text(res, 200, `<!doctype html>
+<html>
+  <head><title>Mock MCP OAuth</title></head>
+  <body style="font-family: system-ui, sans-serif; max-width: 560px; margin: 48px auto;">
+    <h1>Mock MCP OAuth</h1>
+    <p>This fake OAuth provider is for OpenWork MCP end-to-end tests.</p>
+    <form method="post" action="${approveUrl.pathname}${approveUrl.search}">
+      <button style="font: inherit; padding: 10px 14px;">Approve OpenWork</button>
+    </form>
+  </body>
+</html>`);
+}
+
+async function registerClient(req, res) {
+  const body = await readJson(req).catch(() => ({}));
+  const clientId = `mock-client-${randomUUID()}`;
+  const client = {
+    client_id: clientId,
+    client_id_issued_at: Math.floor(Date.now() / 1000),
+    token_endpoint_auth_method: body.token_endpoint_auth_method || "none",
+    redirect_uris: Array.isArray(body.redirect_uris) ? body.redirect_uris : [],
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    scope: "mcp:read mcp:write",
+  };
+  clients.set(clientId, client);
+  json(res, 201, client);
+}
+
+async function issueToken(req, res) {
+  const form = await readForm(req);
+  const grantType = form.grant_type || "authorization_code";
+
+  if (grantType === "authorization_code" && !codes.has(form.code)) {
+    json(res, 400, { error: "invalid_grant" });
+    return;
+  }
+
+  if (form.code) codes.delete(form.code);
+  const accessToken = `mock-access-${randomUUID()}`;
+  tokens.add(accessToken);
+  json(res, 200, {
+    access_token: accessToken,
+    refresh_token: `mock-refresh-${randomUUID()}`,
+    token_type: "Bearer",
+    expires_in: 3600,
+    scope: "mcp:read mcp:write",
+  });
+}
+
+function isAuthorized(req) {
+  const header = req.headers.authorization || "";
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return Boolean(match && tokens.has(match[1]));
+}
+
+function mcpResult(message) {
+  switch (message.method) {
+    case "initialize":
+      return {
+        protocolVersion: "2025-06-18",
+        capabilities: { tools: {} },
+        serverInfo: { name: "mock-oauth-mcp", version: "1.0.0" },
+      };
+    case "tools/list":
+      return {
+        tools: [
+          {
+            name: "mock_echo",
+            title: "Mock Echo",
+            description: "Echoes the provided text from the mock OAuth MCP server.",
+            inputSchema: {
+              type: "object",
+              properties: { text: { type: "string" } },
+              required: ["text"],
+            },
+          },
+        ],
+      };
+    case "tools/call":
+      return {
+        content: [
+          {
+            type: "text",
+            text: String(message.params?.arguments?.text ?? "mock oauth mcp ok"),
+          },
+        ],
+      };
+    default:
+      return {};
+  }
+}
+
+async function handleMcp(req, res) {
+  if (!isAuthorized(req)) {
+    json(res, 401, { error: "missing_mcp_token" }, {
+      "www-authenticate": `Bearer resource_metadata="${issuer}/.well-known/oauth-protected-resource"`,
+    });
+    return;
+  }
+
+  if (req.method === "GET") {
+    json(res, 405, { error: "method_not_allowed" });
+    return;
+  }
+
+  const body = await readJson(req).catch(() => ({}));
+  const messages = Array.isArray(body) ? body : [body];
+  const responses = messages.flatMap((message) => {
+    if (!message || typeof message !== "object" || message.id === undefined) return [];
+    return [{ jsonrpc: "2.0", id: message.id, result: mcpResult(message) }];
+  });
+
+  if (responses.length === 0) {
+    res.writeHead(202, { "access-control-allow-origin": "*" });
+    res.end();
+    return;
+  }
+
+  json(res, 200, Array.isArray(body) ? responses : responses[0]);
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url || "/", issuer);
+    record(req, url.pathname);
+
+    if (req.method === "OPTIONS") {
+      json(res, 204, {});
+      return;
+    }
+
+    if (url.pathname === "/health") {
+      json(res, 200, { ok: true, issuer, autoApprove, requests: requests.length });
+      return;
+    }
+
+    if (url.pathname === "/requests") {
+      json(res, 200, { requests });
+      return;
+    }
+
+    if (
+      url.pathname === "/.well-known/oauth-protected-resource" ||
+      url.pathname === "/.well-known/oauth-protected-resource/mcp" ||
+      url.pathname === "/mcp/.well-known/oauth-protected-resource"
+    ) {
+      json(res, 200, protectedResourceMetadata());
+      return;
+    }
+
+    if (
+      url.pathname === "/.well-known/oauth-authorization-server" ||
+      url.pathname === "/.well-known/oauth-authorization-server/mcp"
+    ) {
+      json(res, 200, authorizationServerMetadata());
+      return;
+    }
+
+    if (url.pathname === "/register" && req.method === "POST") {
+      await registerClient(req, res);
+      return;
+    }
+
+    if (url.pathname === "/authorize" && req.method === "GET") {
+      authorize(req, res, url);
+      return;
+    }
+
+    if (url.pathname === "/approve" && req.method === "POST") {
+      redirectWithCode(res, url.searchParams);
+      return;
+    }
+
+    if (url.pathname === "/token" && req.method === "POST") {
+      await issueToken(req, res);
+      return;
+    }
+
+    if (url.pathname === "/mcp") {
+      await handleMcp(req, res);
+      return;
+    }
+
+    json(res, 404, { error: "not_found" });
+  } catch (error) {
+    json(res, 500, { error: error instanceof Error ? error.message : String(error) });
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(`[mock-oauth-mcp] listening on ${issuer}`);
+  console.log(`[mock-oauth-mcp] MCP URL: ${issuer}/mcp`);
+  console.log(`[mock-oauth-mcp] set AUTO_APPROVE=0 to require an approval click`);
+});


### PR DESCRIPTION
## Summary
- Fix MCP OAuth auth modal getting stuck on `Applying changes before sign-in` by tracking the reload/auth run with a ref instead of a state dependency that cancels itself.
- Add `scripts/mock-oauth-mcp-server.mjs`, a reusable dependency-free OAuth-protected MCP fixture for e2e testing.
- Document the Daytona custom OAuth MCP eval in `evals/daytona-flows.md`.

## Testing
- `node --check scripts/mock-oauth-mcp-server.mjs` ✅
- `pnpm --filter @openwork/app typecheck` ✅
- Daytona Electron e2e on sandbox `openwork-test-20260521-075246` ✅
  - Created workspace `/workspace/mock-mcp-e2e`.
  - Reproduced stuck `Applying changes before sign-in` before the fix.
  - Applied patch and verified mock server received `GET /authorize`.
  - Restarted mock fixture with `AUTO_APPROVE=1` and verified `/authorize`, `/token`, and authenticated `/mcp` calls.
  - Added fresh `mock-oauth-2` MCP and verified it reached `Ready` from the original add flow.

## Evidence
- Screenshot captured locally from the Daytona run: `/var/folders/d9/xqhkvsp94rg0n0n523snqztm0000gn/T/browser-screenshot-1779376725366.png`.
