### PR TITLE
Expand pasted text chips

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -76,6 +76,7 @@ type ComposerProps = {
   onPasteText: (text: string) => void;
   onUnsupportedFileLinks: (links: string[]) => void;
   pastedText: PastedTextChip[];
+  onExpandPastedText: (id: string) => void;
   onRevealPastedText: (id: string) => void;
   onRemovePastedText: (id: string) => void;
   isRemoteWorkspace: boolean;
@@ -592,6 +593,12 @@ export function ReactSessionComposer(props: ComposerProps) {
     [props.pastedText],
   );
 
+  const handleExpandPastedText = useCallback((label: string) => {
+    const target = props.pastedText.find((item) => item.label === label);
+    if (!target) return;
+    props.onExpandPastedText(target.id);
+  }, [props.onExpandPastedText, props.pastedText]);
+
   const activeMenu = slashOpen ? "slash" : mentionOpen ? "mention" : null;
   const activeItems = activeMenu === "slash" ? slashFiltered : activeMenu === "mention" ? mentionFiltered : [];
   const toolCommandItems = commands.filter((command) => !command.source || command.source === "command");
@@ -1006,6 +1013,7 @@ export function ReactSessionComposer(props: ComposerProps) {
               placeholder={t("composer.placeholder")}
               onChange={props.onDraftChange}
               onSubmit={props.onSend}
+              onExpandPastedText={handleExpandPastedText}
               onPasteText={props.onPasteText}
               onPaste={(event) => {
                 // Paste policy:

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -41,6 +41,7 @@ type EditorProps = {
   placeholder: string;
   onChange: (value: string) => void;
   onSubmit: () => void | Promise<void>;
+  onExpandPastedText?: (label: string) => void;
   onPaste?: React.ClipboardEventHandler<HTMLDivElement>;
   onPasteText?: (text: string) => void;
   onDrop?: React.DragEventHandler<HTMLDivElement>;
@@ -213,6 +214,50 @@ function $createComposerSlashCommandNode(commandName: string) {
   return $applyNodeReplacement(new ComposerSlashCommandNode(commandName));
 }
 
+function pastedTextChipLabel(lines: number) {
+  return `Pasted · ${lines} line${lines === 1 ? "" : "s"}`;
+}
+
+function createPastedTextChipDom(label: string, lines: number) {
+  const dom = document.createElement("span");
+  dom.className = "inline-flex items-center gap-1 rounded-full border border-amber-6/35 bg-amber-3/15 px-2.5 py-1 text-xs font-medium text-amber-11";
+  dom.contentEditable = "false";
+  dom.setAttribute("spellcheck", "false");
+  dom.title = `Pasted text · ${label}`;
+
+  const text = document.createElement("span");
+  text.textContent = pastedTextChipLabel(lines);
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full text-amber-10 transition-colors hover:bg-amber-4 hover:text-amber-12";
+  button.title = "Expand pasted text";
+  button.setAttribute("aria-label", "Expand pasted text");
+  button.dataset.pastedExpandLabel = label;
+
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 16 16");
+  svg.setAttribute("fill", "currentColor");
+  svg.setAttribute("class", "h-3 w-3");
+  svg.setAttribute("aria-hidden", "true");
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("d", "M5 3h8v8h-1.5V5.56l-7.97 7.97-1.06-1.06 7.97-7.97H5V3Z");
+  svg.append(path);
+  button.append(svg);
+  dom.append(text, button);
+  return dom;
+}
+
+function updatePastedTextChipDom(dom: HTMLElement, label: string, lines: number) {
+  const text = dom.firstElementChild;
+  if (text) text.textContent = pastedTextChipLabel(lines);
+  const button = dom.querySelector("button[data-pasted-expand-label]");
+  if (button instanceof HTMLButtonElement) {
+    button.dataset.pastedExpandLabel = label;
+  }
+  dom.title = `Pasted text · ${label}`;
+}
+
 type SerializedComposerPastedTextNode = Spread<
   {
     pastedLabel: string;
@@ -256,19 +301,12 @@ class ComposerPastedTextNode extends TextNode {
   }
 
   override createDOM(_config: EditorConfig) {
-    const dom = document.createElement("span");
-    dom.className = "inline-flex items-center gap-1 rounded-full border border-amber-6/35 bg-amber-3/15 px-2.5 py-1 text-xs font-medium text-amber-11";
-    dom.textContent = `Pasted · ${this.__pastedLines} line${this.__pastedLines === 1 ? "" : "s"}`;
-    dom.contentEditable = "false";
-    dom.setAttribute("spellcheck", "false");
-    dom.title = `Pasted text · ${this.__pastedLabel}`;
-    return dom;
+    return createPastedTextChipDom(this.__pastedLabel, this.__pastedLines);
   }
 
   override updateDOM(prevNode: ComposerPastedTextNode, dom: HTMLElement) {
     if (prevNode.__pastedLabel !== this.__pastedLabel || prevNode.__pastedLines !== this.__pastedLines) {
-      dom.textContent = `Pasted · ${this.__pastedLines} line${this.__pastedLines === 1 ? "" : "s"}`;
-      dom.title = `Pasted text · ${this.__pastedLabel}`;
+      updatePastedTextChipDom(dom, this.__pastedLabel, this.__pastedLines);
     }
     return false;
   }
@@ -673,6 +711,26 @@ export function LexicalPromptEditor(props: EditorProps) {
     [],
   );
 
+  const handlePastedTextExpandPointer = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const button = target.closest("button[data-pasted-expand-label]");
+    if (!(button instanceof HTMLButtonElement)) return;
+    const label = button.dataset.pastedExpandLabel;
+    if (!label) return;
+    event.preventDefault();
+    event.stopPropagation();
+    props.onExpandPastedText?.(label);
+  }, [props.onExpandPastedText]);
+
+  const handlePastedTextExpandMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    if (!target.closest("button[data-pasted-expand-label]")) return;
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
   return (
     <LexicalComposer initialConfig={initialConfig}>
       {/*
@@ -681,7 +739,7 @@ export function LexicalPromptEditor(props: EditorProps) {
         - max-h caps the composer — long pastes / multi-paragraph drafts scroll
           inside the editor instead of pushing the transcript out of view.
       */}
-      <div className="relative">
+      <div className="relative" onClickCapture={handlePastedTextExpandPointer} onMouseDownCapture={handlePastedTextExpandMouseDown}>
         <PlainTextPlugin
           contentEditable={
             <ContentEditable

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -853,6 +853,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
     });
   };
 
+  const handleExpandPastedText = (id: string) => {
+    const part = pasteParts.find((item) => item.id === id);
+    if (!part) return;
+    setDraft((draftValue) => draftValue.replace(`[pasted text ${part.label}]`, () => part.text));
+    setPasteParts((current) => current.filter((item) => item.id !== id));
+  };
+
   const handleRemovePastedText = (id: string) => {
     setPasteParts((current) => {
       const target = current.find((item) => item.id === id);
@@ -1281,6 +1288,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         onPasteText={handlePasteText}
         onUnsupportedFileLinks={handleUnsupportedFileLinks}
         pastedText={pasteParts}
+        onExpandPastedText={handleExpandPastedText}
         onRevealPastedText={handleRevealPastedText}
         onRemovePastedText={handleRemovePastedText}
         isRemoteWorkspace={props.isRemoteWorkspace}


### PR DESCRIPTION
## Summary
- Add an expand icon to inline pasted-text chips in the composer.
- Replace the collapsed paste placeholder with the original pasted text when expanded.
- Keep paste state in sync after expansion so the chip is removed cleanly.

## Tests
- pnpm --filter @openwork/app typecheck

## Evidence
- Video/screenshot not captured from this CLI workflow.