### PR TITLE
Prevent browser panel auto-open

### DIFF
--- a/apps/app/scripts/open-target.test.ts
+++ b/apps/app/scripts/open-target.test.ts
@@ -140,14 +140,14 @@ describe("deriveOpenTargets", () => {
     expect(isCollectibleArtifactTarget({ ...target, exists: true })).toBe(true);
   });
 
-  it("prefers localhost browser previews over generated html files", () => {
+  it("auto-opens generated html files instead of localhost browser previews", () => {
     const targets = deriveOpenTargets([
       message("msg_1", "assistant", "Created public/index.html. API: `http://localhost:3000/api/info`. App: `http://localhost:3000`."),
     ]).map((target) => ({ ...target, exists: target.kind === "url" || target.value === "public/index.html" }));
 
     expect(targets.map((target) => target.value)).toContain("http://localhost:3000/api/info");
     expect(targets.map((target) => target.value)).toContain("http://localhost:3000");
-    expect(selectAutoOpenTarget(targets)?.value).toBe("http://localhost:3000");
+    expect(selectAutoOpenTarget(targets)?.value).toBe("public/index.html");
   });
 
   it("normalizes escaped localhost root URL variants into one target", () => {

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -124,30 +124,7 @@ export function isLocalhostBrowserTarget(target: OpenTarget) {
   return target.kind === "url" && /(?:https?|wss?):\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/i.test(target.value);
 }
 
-function browserTargetScore(target: OpenTarget) {
-  if (!isLocalhostBrowserTarget(target)) {
-    return -1;
-  }
-
-  try {
-    const url = new URL(target.value);
-    let score = target.confidence;
-    if (url.protocol === "http:" || url.protocol === "https:") score += 20;
-    if ((url.pathname === "" || url.pathname === "/") && !url.search && !url.hash) score += 40;
-    if (!url.pathname.startsWith("/api/")) score += 10;
-    return score;
-  } catch {
-    return target.confidence;
-  }
-}
-
 export function selectAutoOpenTarget(targets: OpenTarget[]): OpenTarget | null {
-  const browserTargets = targets.filter(isLocalhostBrowserTarget);
-
-  if (browserTargets.length > 0) {
-    return [...browserTargets].sort((left, right) => browserTargetScore(right) - browserTargetScore(left))[0] ?? null;
-  }
-
   return targets.find(shouldAutoOpenTarget) ?? null;
 }
 
@@ -222,7 +199,7 @@ export function deriveOpenTargets(messages: UIMessage[]): OpenTarget[] {
 
 export function shouldAutoOpenTarget(target: OpenTarget): boolean {
   if (target.kind === "url") {
-    return isLocalhostBrowserTarget(target);
+    return false;
   }
 
   return target.exists === true && target.confidence >= 65 && ["markdown", "sheet", "image", "pdf", "html"].includes(target.preview);

--- a/apps/app/src/react-app/shell/ui-state-store.ts
+++ b/apps/app/src/react-app/shell/ui-state-store.ts
@@ -8,9 +8,7 @@ export type SidePanelItem = (typeof SIDE_PANEL_ITEMS)[number];
 export type SidePanelState = Record<string, SidePanelItem | null>;
 
 export type PersistedUiState = {
-  sidebarOpen: boolean;
   sidePanelState?: SidePanelState;
-  applicationMenuVisible?: boolean;
 };
 
 export type UiState = {
@@ -67,26 +65,19 @@ function readPersistedUiState(): UiState {
 
   try {
     const raw = window.localStorage.getItem(PERSISTED_UI_STATE_KEY);
+    const sidebarOpen = readSidebarCookieOpen() ?? initialState.sidebarOpen;
 
     if (!raw) {
-      const sidebarOpen = readSidebarCookieOpen();
-
-      if (sidebarOpen === null) {
-        return initialState;
-      }
-
       return { ...initialState, sidebarOpen };
     }
 
     const parsed: PersistedUiState = JSON.parse(raw);
     const sidePanelState = normalizeSidePanelState(parsed.sidePanelState);
-    const applicationMenuVisible = parsed.applicationMenuVisible ?? initialState.applicationMenuVisible;
 
     return {
       ...initialState,
-      sidebarOpen: parsed.sidebarOpen,
+      sidebarOpen,
       sidePanelState,
-      applicationMenuVisible,
     };
   } catch {
     return initialState;
@@ -102,9 +93,7 @@ export function persistUiState(state: UiState): void {
     window.localStorage.setItem(
       PERSISTED_UI_STATE_KEY,
       JSON.stringify({
-        sidebarOpen: state.sidebarOpen,
         sidePanelState: state.sidePanelState,
-        applicationMenuVisible: state.applicationMenuVisible,
       } satisfies PersistedUiState),
     );
   } catch {

--- a/apps/desktop/electron/browser-native-tools.mjs
+++ b/apps/desktop/electron/browser-native-tools.mjs
@@ -884,7 +884,7 @@ export function createNativeBuiltinServer({
   server.tool(
     "show_browser",
     "Open the built-in browser panel inside the OpenWork app. " +
-    "Called automatically when any browser tool runs, but can also be called explicitly.",
+    "Use this only when the user asks to see the browser panel.",
     {},
     async () => {
       await onToolCall?.("show_browser");

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1003,16 +1003,20 @@ async function ensureBrowserMcpServers() {
       closeTab: async (tabId) => closeBrowserTab(tabId),
       selectTab: async (tabId) => selectBrowserTab(tabId).tabId,
       onBuiltinToolCall: async (toolName) => {
-        // Ensure the browser panel is open so the agent can interact.
-        // preloadDefault: false — the tool will navigate on its own.
         if (!mainWindow) return;
-        if (!browserViewVisible) {
+
+        if (toolName === "show_browser") {
           attachBrowserView(
             { x: 0, y: 0, width: 0, height: 0 },
-            { preloadDefault: false, ensureTab: toolName !== "create_page" },
+            { preloadDefault: false, ensureTab: true },
           );
+          sendToRenderer("openwork:browser:panel-opened");
+          return;
         }
-        sendToRenderer("openwork:browser:panel-opened");
+
+        if (toolName !== "create_page" && !getActiveWebContents()) {
+          createBrowserTab("about:blank", { select: true });
+        }
       },
       onHideBrowser: () => {
         hideBrowserView();

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -41,7 +41,7 @@ OpenWork has a built-in browser and can also control the user's external Chrome.
 Two MCP tool sets are available:
 
 1. **openwork-browser** — Built-in browser panel inside the app.
-   - The panel opens automatically when you call any openwork-browser tool.
+   - The panel stays hidden unless you call `openwork-browser_show_browser`.
    - Use this for general browsing tasks ("go to facebook.com", "search for X").
    - Call \`openwork-browser_hide_browser\` when the browsing task is done.
    - The user can see what you're doing in real time.


### PR DESCRIPTION
## Summary
- Stop built-in browser MCP tool calls from automatically opening the session browser sidebar; only explicit `openwork-browser_show_browser` opens it.
- Stop localhost URL targets from auto-opening the Browser panel while preserving artifact file auto-open behavior.
- Limit `openwork:ui-state:v1` persistence to `sidePanelState` so parent keys like `sidebarOpen` and `applicationMenuVisible` are not read from that payload.

## Testing
- `pnpm --filter @openwork/app test:open-target` passed.
- `pnpm --filter @openwork/app typecheck` passed.
- `pnpm --filter @openwork/desktop check:electron` passed.

## Evidence
- No video/screenshot captured; this change was verified with focused automated checks.