### PR TITLE
fix(app): limit artifacts to written files

### DIFF
--- a/apps/app/scripts/open-target.test.ts
+++ b/apps/app/scripts/open-target.test.ts
@@ -13,6 +13,21 @@ function message(id: string, role: "user" | "assistant", text: string): UIMessag
   return { id, role, parts: [{ type: "text", text, state: "done" }] };
 }
 
+function toolMessage(id: string, toolName: string, input: Record<string, unknown>, output: unknown) {
+  return {
+    id,
+    role: "assistant",
+    parts: [{
+      type: "dynamic-tool",
+      toolName,
+      toolCallId: `${id}_tool`,
+      state: "output-available",
+      input,
+      output,
+    }],
+  };
+}
+
 describe("open target classification", () => {
   it("routes common artifact formats to deterministic previews", () => {
     expect(classifyOpenTarget("report.md", "file")).toBe("markdown");
@@ -27,6 +42,7 @@ describe("open target classification", () => {
 describe("deriveOpenTargets", () => {
   it("extracts file and localhost URL targets from recent assistant output", () => {
     const targets = deriveOpenTargets([
+      toolMessage("msg_tool", "write", { filePath: "reports/revenue.xlsx" }, { filePath: "reports/revenue.xlsx" }),
       message("msg_1", "assistant", "Created reports/revenue.xlsx and started http://localhost:5173 for preview."),
     ]);
 
@@ -37,6 +53,7 @@ describe("deriveOpenTargets", () => {
 
   it("extracts websocket URLs so local socket/dev-server hints stay visible", () => {
     const targets = deriveOpenTargets([
+      toolMessage("msg_tool", "write", { filePath: "dist/index.html" }, { filePath: "dist/index.html" }),
       message("msg_1", "assistant", "Socket open at ws://localhost:5173/socket and preview at dist/index.html"),
     ]);
 
@@ -46,6 +63,8 @@ describe("deriveOpenTargets", () => {
 
   it("normalizes Workspace/<id>/ prefixes from artifact paths", () => {
     const targets = deriveOpenTargets([
+      toolMessage("msg_tool_1", "write", { filePath: "Workspace/32423/reports/artifact-eval.md" }, { filePath: "Workspace/32423/reports/artifact-eval.md" }),
+      toolMessage("msg_tool_2", "write", { filePath: "Workspace/32423/reports/artifact-eval.csv" }, { filePath: "Workspace/32423/reports/artifact-eval.csv" }),
       message("msg_1", "assistant", "See Workspace/32423/reports/artifact-eval.md and Workspace/32423/reports/artifact-eval.csv"),
     ]);
 
@@ -55,73 +74,75 @@ describe("deriveOpenTargets", () => {
 
   it("prefers explicit dynamic tool metadata over prose guesses", () => {
     const targets = deriveOpenTargets([
-      {
-        id: "msg_tool",
-        role: "assistant",
-        parts: [{
-          type: "dynamic-tool",
-          toolName: "write",
-          toolCallId: "tool_1",
-          state: "output-available",
-          input: { path: "summary.md" },
-          output: { path: "summary.md" },
-        } as any],
-      },
+      toolMessage("msg_tool", "write", { path: "summary.md" }, { path: "summary.md" }),
     ]);
 
     expect(targets[0]).toMatchObject({ value: "summary.md", preview: "markdown", confidence: 95 });
   });
 
+  it("extracts filePath metadata from write tools", () => {
+    const targets = deriveOpenTargets([
+      toolMessage("msg_tool", "write", { filePath: "reports/summary.md" }, { filePath: "reports/summary.md" }),
+    ]);
+
+    expect(targets[0]).toMatchObject({ value: "reports/summary.md", preview: "markdown", confidence: 95 });
+  });
+
+  it("does not extract file artifacts from read tool metadata or output", () => {
+    const targets = deriveOpenTargets([
+      toolMessage(
+        "msg_tool",
+        "read",
+        { filePath: "reports/source.md" },
+        { content: "Reviewed reports/source.md and referenced reports/source.csv" },
+      ),
+      message("msg_2", "assistant", "Reviewed reports/source.md and reports/source.csv."),
+    ]);
+
+    expect(targets.map((target) => target.value)).not.toContain("reports/source.md");
+    expect(targets.map((target) => target.value)).not.toContain("reports/source.csv");
+  });
+
+  it("extracts paths written by apply_patch metadata", () => {
+    const targets = deriveOpenTargets([
+      toolMessage("msg_tool", "apply_patch", {
+        patchText: "*** Begin Patch\n*** Add File: reports/new-report.md\n+hello\n*** Update File: reports/existing-report.csv\n@@\n-old\n+new\n*** End Patch",
+      }, "Success. Updated files."),
+    ]);
+
+    expect(targets.map((target) => target.value)).toContain("reports/new-report.md");
+    expect(targets.map((target) => target.value)).toContain("reports/existing-report.csv");
+  });
+
   it("does not turn package search results into artifacts", () => {
     const targets = deriveOpenTargets([
-      {
-        id: "msg_tool",
-        role: "assistant",
-        parts: [{
-          type: "dynamic-tool",
-          toolName: "glob",
-          toolCallId: "tool_1",
-          state: "output-available",
-          input: { pattern: "**/package.json" },
-          output: {
-            files: [
-              "package.json",
-              "apps/app/package.json",
-              "packages/ui/package.json",
-              "reports/revenue.csv",
-            ],
-          },
-        } as any],
-      },
+      toolMessage("msg_tool", "glob", { pattern: "**/package.json" }, {
+        files: [
+          "package.json",
+          "apps/app/package.json",
+          "packages/ui/package.json",
+          "reports/revenue.csv",
+        ],
+      }),
       message("msg_2", "assistant", "Found package.json, apps/app/package.json, and reports/revenue.csv"),
     ]);
 
     expect(targets.map((target) => target.value)).not.toContain("package.json");
     expect(targets.map((target) => target.value)).not.toContain("apps/app/package.json");
     expect(targets.map((target) => target.value)).not.toContain("packages/ui/package.json");
-    expect(targets.map((target) => target.value)).toContain("reports/revenue.csv");
+    expect(targets.map((target) => target.value)).not.toContain("reports/revenue.csv");
   });
 
   it("does not turn discovery tool markdown listings into artifacts", () => {
     const targets = deriveOpenTargets([
-      {
-        id: "msg_tool",
-        role: "assistant",
-        parts: [{
-          type: "dynamic-tool",
-          toolName: "glob",
-          toolCallId: "tool_1",
-          state: "output-available",
-          input: { pattern: "**/*.md" },
-          output: {
-            files: [
-              "README.md",
-              ".opencode/skills/example/SKILL.md",
-              "reports/created-report.md",
-            ],
-          },
-        } as any],
-      },
+      toolMessage("msg_write", "write", { filePath: "reports/created-report.md" }, { filePath: "reports/created-report.md" }),
+      toolMessage("msg_tool", "glob", { pattern: "**/*.md" }, {
+        files: [
+          "README.md",
+          ".opencode/skills/example/SKILL.md",
+          "reports/created-report.md",
+        ],
+      }),
       message("msg_2", "assistant", "Created reports/created-report.md as the deliverable."),
     ]);
 
@@ -132,6 +153,7 @@ describe("deriveOpenTargets", () => {
 
   it("does not collect server-verified missing file targets", () => {
     const target = deriveOpenTargets([
+      toolMessage("msg_tool", "write", { filePath: "index.html" }, { filePath: "index.html" }),
       message("msg_1", "assistant", "Preview file: index.html"),
     ])[0];
 
@@ -142,6 +164,7 @@ describe("deriveOpenTargets", () => {
 
   it("prefers localhost browser previews over generated html files", () => {
     const targets = deriveOpenTargets([
+      toolMessage("msg_tool", "write", { filePath: "public/index.html" }, { filePath: "public/index.html" }),
       message("msg_1", "assistant", "Created public/index.html. API: `http://localhost:3000/api/info`. App: `http://localhost:3000`."),
     ]).map((target) => ({ ...target, exists: target.kind === "url" || target.value === "public/index.html" }));
 
@@ -161,6 +184,7 @@ describe("deriveOpenTargets", () => {
 
   it("keeps accessible targets from earlier session messages", () => {
     const targets = deriveOpenTargets([
+      toolMessage("msg_tool", "write", { filePath: "reports/earlier.csv" }, { filePath: "reports/earlier.csv" }),
       message("msg_1", "assistant", "Created reports/earlier.csv"),
       ...Array.from({ length: 12 }, (_, index) => message(`msg_noise_${index}`, "assistant", `Status update ${index + 1}`)),
       message("msg_last", "assistant", "Server running at http://localhost:3000"),
@@ -172,6 +196,7 @@ describe("deriveOpenTargets", () => {
 
   it("auto-opens high-confidence deliverables and localhost previews only", () => {
     const targets = deriveOpenTargets([
+      toolMessage("msg_tool", "write", { filePath: "data/customers.csv" }, { filePath: "data/customers.csv" }),
       message("msg_1", "assistant", "Created data/customers.csv and see https://example.com for docs."),
     ]);
     const csv = targets.find((target) => target.value === "data/customers.csv");

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -36,6 +36,25 @@ const FILE_PATTERN = /(?:^|[\s"'`([{])((?:\.{1,2}[/\\]|~[/\\]|[/\\])?[\w.\-]+(?:
 const URL_PATTERN = /https?:\/\/[^\s)\]}>"'`]+/gi;
 const SOCKET_PATTERN = /(?:ws|wss):\/\/[^\s)\]}>"'`]+/gi;
 const ARTIFACT_FILE_PREVIEWS = new Set<OpenTargetPreview>(["markdown", "sheet", "image", "pdf", "html"]);
+const DISCOVERY_TOOL_NAMES = new Set(["glob", "grep", "search", "find"]);
+const WRITE_TOOL_NAMES = new Set([
+  "apply_patch",
+  "edit",
+  "edit_file",
+  "multi_edit",
+  "multiedit",
+  "patch",
+  "str_replace_editor",
+  "write",
+  "write_file",
+]);
+const FILE_METADATA_KEYS = ["path", "file", "filePath", "filepath"];
+const PATCH_FILE_PATTERN = /^\*\*\* (?:Add File|Update File):\s*(.+)$/gmi;
+const PATCH_MOVE_TO_PATTERN = /^\*\*\* Move to:\s*(.+)$/gmi;
+
+type DeriveOpenTargetsOptions = {
+  includeFileMentions?: boolean;
+};
 
 function normalizePath(path: string) {
   return path
@@ -151,7 +170,13 @@ export function selectAutoOpenTarget(targets: OpenTarget[]): OpenTarget | null {
   return targets.find(shouldAutoOpenTarget) ?? null;
 }
 
-function scanText(map: Map<string, OpenTarget>, text: string, confidence: number, reason: string) {
+function scanText(
+  map: Map<string, OpenTarget>,
+  text: string,
+  confidence: number,
+  reason: string,
+  options: { includeFiles: boolean },
+) {
   if (!text) {
     return;
   }
@@ -168,8 +193,9 @@ function scanText(map: Map<string, OpenTarget>, text: string, confidence: number
     if (match[0]) addTarget(map, targetFromUrl(match[0], confidence, reason));
   }
 
-  FILE_PATTERN.lastIndex = 0;
+  if (!options.includeFiles) return;
 
+  FILE_PATTERN.lastIndex = 0;
   for (const match of text.matchAll(FILE_PATTERN)) {
     if (match[1]) addTarget(map, targetFromFile(match[1], confidence, reason));
   }
@@ -179,13 +205,65 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
 }
 
-export function deriveOpenTargets(messages: UIMessage[]): OpenTarget[] {
+function normalizedToolName(toolName: string) {
+  return toolName.trim().toLowerCase().replace(/^functions[._-]/, "");
+}
+
+function isDiscoveryTool(toolName: string) {
+  return DISCOVERY_TOOL_NAMES.has(normalizedToolName(toolName));
+}
+
+function isWriteTool(toolName: string) {
+  return WRITE_TOOL_NAMES.has(normalizedToolName(toolName));
+}
+
+function collectFileMetadataValues(value: unknown) {
+  if (!isObject(value)) return [];
+  const values: string[] = [];
+  for (const key of FILE_METADATA_KEYS) {
+    const file = value[key];
+    if (typeof file === "string") values.push(file);
+  }
+  const files = value.files;
+  if (Array.isArray(files)) {
+    for (const file of files) {
+      if (typeof file === "string") values.push(file);
+    }
+  }
+  return values;
+}
+
+function collectPatchFileValues(value: unknown) {
+  if (!isObject(value)) return [];
+  const patchText = value.patchText ?? value.patch ?? value.diff;
+  if (typeof patchText !== "string") return [];
+  const values: string[] = [];
+  PATCH_FILE_PATTERN.lastIndex = 0;
+  for (const match of patchText.matchAll(PATCH_FILE_PATTERN)) {
+    if (match[1]) values.push(match[1]);
+  }
+  PATCH_MOVE_TO_PATTERN.lastIndex = 0;
+  for (const match of patchText.matchAll(PATCH_MOVE_TO_PATTERN)) {
+    if (match[1]) values.push(match[1]);
+  }
+  return values;
+}
+
+function addFileValues(map: Map<string, OpenTarget>, values: string[], confidence: number, reason: string) {
+  for (const value of values) {
+    addTarget(map, targetFromFile(value, confidence, reason));
+  }
+}
+
+export function deriveOpenTargets(messages: UIMessage[], options: DeriveOpenTargetsOptions = {}): OpenTarget[] {
   const targets = new Map<string, OpenTarget>();
 
   for (const message of messages) {
     for (const part of message.parts) {
       if (part.type === "text" && typeof part.text === "string") {
-        scanText(targets, part.text, message.role === "assistant" ? 65 : 40, "message");
+        scanText(targets, part.text, message.role === "assistant" ? 65 : 40, "message", {
+          includeFiles: options.includeFileMentions === true,
+        });
         continue;
       }
 
@@ -193,25 +271,25 @@ export function deriveOpenTargets(messages: UIMessage[]): OpenTarget[] {
         continue;
       }
 
-      const isDiscoveryTool = ["glob", "grep", "search", "find"].includes(part.toolName.toLowerCase());
-        
-        const values = [part.input, part.output].flatMap((value) => {
-          if (isDiscoveryTool || !isObject(value)) {
-            return [];
-          }
+      const discoveryTool = isDiscoveryTool(part.toolName);
+      const writeTool = isWriteTool(part.toolName);
 
-          return [value.path, value.file, ...(Array.isArray(value.files) ? value.files : [])];
-        });
-
-        for (const value of values) {
-          if (typeof value === "string") {
-            addTarget(targets, targetFromFile(value, 95, "tool metadata"));
-          }
+      if (writeTool) {
+        addFileValues(
+          targets,
+          [part.input, part.output].flatMap(collectFileMetadataValues),
+          95,
+          "write tool metadata",
+        );
+        addFileValues(targets, collectPatchFileValues(part.input), 95, "patch metadata");
+        if (typeof part.output === "string") {
+          scanText(targets, part.output, 90, "write tool output", { includeFiles: true });
         }
+      }
 
-        if (!isDiscoveryTool) {
-          scanText(targets, JSON.stringify(part.output ?? part.input ?? ""), 75, "tool output");
-        }
+      if (!discoveryTool) {
+        scanText(targets, JSON.stringify(part.output ?? part.input ?? ""), 75, "tool output", { includeFiles: false });
+      }
     }
   }
 

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -787,7 +787,7 @@ function messageGroupKey(messageId: string, group: MessageGroup) {
 function inlineOpenTargetsForMessage(message: UIMessage, verifiedTargets: OpenTarget[] | undefined) {
   const verifiedById = new Map((verifiedTargets ?? []).map((target) => [target.id, target] as const));
   const inlineTargets = new Map<string, OpenTarget>();
-  for (const candidate of deriveOpenTargets([message])) {
+  for (const candidate of deriveOpenTargets([message], { includeFileMentions: true })) {
     const verified = verifiedById.get(candidate.id);
     if (candidate.kind === "url" && isLocalhostBrowserTarget(candidate)) {
       inlineTargets.set(candidate.id, verified ?? candidate);


### PR DESCRIPTION
## Summary
- Limit file artifact candidates to write/edit/apply_patch-style tool activity instead of read/search output or prose-only mentions.
- Keep URL detection unchanged and allow inline message mentions to display only when they match globally verified written artifact targets.
- Add coverage for write metadata, read exclusion, apply_patch paths, and discovery/search exclusions.

## Verification
- `pnpm --filter @openwork/app test:open-target` passed.
- `pnpm --filter @openwork/app typecheck` passed.

## E2E Evidence
No video or screenshots captured; this is a logic-only artifact extraction change. Reviewer can reproduce with the commands above.