### PR TITLE
fix(app): persist session scroll positions

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -1301,7 +1301,7 @@ function SessionTranscriptInner(props: SessionTranscriptProps) {
   const shouldUseContentVisibility = !shouldVirtualize && messageBlocks.length > 24;
 
   return (
-    <div className={cn(isNestedVariant ? "pb-0" : "pb-10")} style={{ contain: "layout paint style" }}>
+    <div className="pb-0" style={{ contain: "layout paint style" }}>
       {shouldVirtualize ? (
         // Always render the virtualized container once we've decided to
         // virtualize — even if virtualRows is empty on the very first tick
@@ -1327,7 +1327,7 @@ function SessionTranscriptInner(props: SessionTranscriptProps) {
                     virtualizer.measureElement(element);
                   }
                 }}
-                className="absolute left-0 top-0 w-full pb-4"
+                className="absolute left-0 top-0 w-full"
                 style={{
                   transform: `translateY(${virtualRow.start}px)`,
                 }}

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -946,7 +946,7 @@ function MessageBlockRow(props: {
 
   return (
     <div
-      className={cn("flex group justify-start relative pb-4", block.isUser && "justify-end", !props.isNestedVariant && "pb-12")}
+      className={cn("flex group justify-start relative pb-4", block.isUser && "justify-end", !props.isNestedVariant && "pb-8")}
       data-message-role={block.isUser ? "user" : "assistant"}
       data-message-id={block.messageId}
       style={{ contain: "layout style paint", ...perfStyle }}
@@ -1046,7 +1046,12 @@ function MessageBlockRow(props: {
         {props.onOpenTarget ? <OpenableTargetsStrip targets={inlineOpenTargets} onOpenTarget={props.onOpenTarget} /> : null}
 
         {!props.isNestedVariant ? (
-          <div className="absolute bottom-2 right-2 flex items-center gap-0.5 opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover:opacity-100 md:group-hover:pointer-events-auto md:group-focus-within:opacity-100 md:group-focus-within:pointer-events-auto transition-opacity select-none">
+          <div
+            className={cn(
+              "absolute bottom-2 flex items-center gap-0.5 opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover:opacity-100 md:group-hover:pointer-events-auto md:group-focus-within:opacity-100 md:group-focus-within:pointer-events-auto transition-opacity select-none",
+              block.isUser ? "right-0" : "left-0",
+            )}
+          >
             {props.onRevertToMessage ? (
               <Button
                 variant="ghost"

--- a/apps/app/src/react-app/domains/session/surface/scroll-controller.ts
+++ b/apps/app/src/react-app/domains/session/surface/scroll-controller.ts
@@ -1,14 +1,14 @@
-import { useCallback, useEffect, useReducer, useRef, type RefObject, type UIEventHandler } from "react";
+import { useCallback, useEffect, useRef, type RefObject, type UIEventHandler } from "react";
 
-import { initialSessionScrollState, sessionScrollReducer } from "./scroll-controller-state";
+import { getSessionScrollState, useSessionScrollStore } from "./scroll-store";
 
-const FOLLOW_LATEST_BOTTOM_GAP_PX = 96;
+const EXACT_BOTTOM_GAP_PX = 1;
 // Widened from 250ms so a single wheel or trackpad flick isn't missed between
 // two rapid programmatic scroll-to-bottom frames during streaming.
 const SCROLL_GESTURE_WINDOW_MS = 600;
 // Threshold (px) that counts as a meaningful "scroll upward" gesture. Anything
 // smaller is treated as anchoring jitter and ignored so we don't trip out of
-// follow-latest for pixel-level content growth.
+// sticky bottom mode for pixel-level content growth.
 const MANUAL_BROWSE_UPWARD_THRESHOLD_PX = 16;
 
 type SessionScrollControllerOptions = {
@@ -18,13 +18,64 @@ type SessionScrollControllerOptions = {
   contentRef: RefObject<HTMLDivElement | null>;
 };
 
+function scrollBottomGap(container: HTMLElement) {
+  return container.scrollHeight - (container.scrollTop + container.clientHeight);
+}
+
+function isExactlyAtBottom(container: HTMLElement) {
+  return scrollBottomGap(container) <= EXACT_BOTTOM_GAP_PX;
+}
+
+function messageIdForElement(element: HTMLElement) {
+  const id = element.getAttribute("data-message-id")?.trim();
+  return id && id.length > 0 ? id : null;
+}
+
+function latestMessageElement(container: HTMLElement) {
+  const messageEls = container.querySelectorAll("[data-message-id]");
+  for (let index = messageEls.length - 1; index >= 0; index -= 1) {
+    const element = messageEls.item(index);
+    if (element instanceof HTMLElement) return element;
+  }
+  return null;
+}
+
+function messageElementById(container: HTMLElement, messageId: string) {
+  const messageEls = container.querySelectorAll("[data-message-id]");
+  for (const element of messageEls) {
+    if (!(element instanceof HTMLElement)) continue;
+    if (messageIdForElement(element) === messageId) return element;
+  }
+  return null;
+}
+
+function latestMessageTopClippedId(container: HTMLElement) {
+  const latestMessage = latestMessageElement(container);
+  if (!latestMessage) return null;
+
+  const messageId = messageIdForElement(latestMessage);
+  if (!messageId) return null;
+
+  const containerRect = container.getBoundingClientRect();
+  const latestRect = latestMessage.getBoundingClientRect();
+  const lastMessageDoesNotFit = latestRect.height > containerRect.height + 1;
+  const startVisible = latestRect.top >= containerRect.top - 1 && latestRect.top <= containerRect.bottom + 1;
+
+  return lastMessageDoesNotFit && !startVisible ? messageId : null;
+}
+
 export function useSessionScrollController(
   options: SessionScrollControllerOptions,
 ) {
-  const [{ mode, topClippedMessageId }, dispatchScroll] = useReducer(
-    sessionScrollReducer,
-    initialSessionScrollState,
+  const selectedSessionId = options.selectedSessionId;
+  const selectScrollState = useCallback(
+    (state: ReturnType<typeof useSessionScrollStore.getState>) => getSessionScrollState(state.sessions, selectedSessionId),
+    [selectedSessionId],
   );
+  const scrollState = useSessionScrollStore(selectScrollState);
+  const setStickyBottom = useSessionScrollStore((state) => state.setStickyBottom);
+  const setManualScroll = useSessionScrollStore((state) => state.setManualScroll);
+  const setTopClippedMessageId = useSessionScrollStore((state) => state.setTopClippedMessageId);
 
   const lastKnownScrollTopRef = useRef(0);
   const programmaticScrollRef = useRef(false);
@@ -34,7 +85,8 @@ export function useSessionScrollController(
   const lastGestureAtRef = useRef(0);
   const previousSessionIdRef = useRef<string | null>(null);
 
-  const isAtBottom = mode === "follow-latest";
+  const isAtBottom = scrollState.mode === "stickyBottom";
+  const topClippedMessageId = scrollState.topClippedMessageId;
 
   const hasScrollGesture = useCallback(
     () => Date.now() - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS,
@@ -85,45 +137,17 @@ export function useSessionScrollController(
 
   const refreshTopClippedMessage = useCallback(() => {
     const container = options.containerRef.current;
-    if (!container) {
-      dispatchScroll({ type: "topClippedMessage", id: null });
-      return;
-    }
-
-    const containerRect = container.getBoundingClientRect();
-    const messageEls = container.querySelectorAll("[data-message-id]");
-    const latestMessageEl = messageEls[messageEls.length - 1] as HTMLElement | undefined;
-    const latestMessageId = latestMessageEl?.getAttribute("data-message-id")?.trim() ?? "";
-    let nextId: string | null = null;
-
-    for (const node of messageEls) {
-      const el = node as HTMLElement;
-      const rect = el.getBoundingClientRect();
-      if (rect.bottom <= containerRect.top + 1) continue;
-      if (rect.top >= containerRect.bottom - 1) break;
-
-      if (rect.top < containerRect.top - 1) {
-        const id = el.getAttribute("data-message-id")?.trim() ?? "";
-        if (id) {
-          const isLatestMessage = id === latestMessageId;
-          const fillsViewportTail = rect.bottom >= containerRect.bottom - 1;
-          if (isLatestMessage || fillsViewportTail) {
-            nextId = id;
-          }
-        }
-      }
-      break;
-    }
-
-    dispatchScroll({ type: "topClippedMessage", id: nextId });
-  }, [options.containerRef]);
+    const nextId = container ? latestMessageTopClippedId(container) : null;
+    setTopClippedMessageId(selectedSessionId, nextId);
+    return nextId;
+  }, [options.containerRef, selectedSessionId, setTopClippedMessageId]);
 
   const scrollToBottom = useCallback(
     (behavior: ScrollBehavior = "auto") => {
       const container = options.containerRef.current;
       if (!container) return;
 
-      dispatchScroll({ type: "followLatest" });
+      setStickyBottom(selectedSessionId, null);
       programmaticScrollRef.current = true;
 
       if (behavior === "smooth") {
@@ -133,6 +157,7 @@ export function useSessionScrollController(
       }
 
       container.scrollTop = container.scrollHeight;
+      lastKnownScrollTopRef.current = container.scrollTop;
       window.requestAnimationFrame(() => {
         const next = options.containerRef.current;
         if (!next) {
@@ -140,10 +165,25 @@ export function useSessionScrollController(
           return;
         }
         next.scrollTop = next.scrollHeight;
+        lastKnownScrollTopRef.current = next.scrollTop;
+        refreshTopClippedMessage();
         releaseProgrammaticScrollSoon();
       });
     },
-    [options.containerRef, releaseProgrammaticScrollSoon],
+    [options.containerRef, refreshTopClippedMessage, releaseProgrammaticScrollSoon, selectedSessionId, setStickyBottom],
+  );
+
+  const saveScrollPosition = useCallback(
+    (container: HTMLDivElement) => {
+      const nextTopClippedMessageId = latestMessageTopClippedId(container);
+      if (isExactlyAtBottom(container)) {
+        setStickyBottom(selectedSessionId, nextTopClippedMessageId);
+      } else {
+        setManualScroll(selectedSessionId, container.scrollTop, nextTopClippedMessageId);
+      }
+      return nextTopClippedMessageId;
+    },
+    [selectedSessionId, setManualScroll, setStickyBottom],
   );
 
   const handleScroll = useCallback<UIEventHandler<HTMLDivElement>>(
@@ -163,9 +203,8 @@ export function useSessionScrollController(
       if (programmaticScrollRef.current && (userGestured || scrolledUp)) {
         programmaticScrollRef.current = false;
         clearProgrammaticScrollReset();
-        dispatchScroll({ type: "mode", mode: "manual-browse" });
+        saveScrollPosition(container);
         lastKnownScrollTopRef.current = currentTop;
-        refreshTopClippedMessage();
         return;
       }
 
@@ -175,25 +214,20 @@ export function useSessionScrollController(
         return;
       }
 
-      // Even without a fresh gesture, a strong upward delta means the user
-      // dragged a scrollbar or triggered a keyboard paging shortcut. Treat it
-      // as a manual browse request.
       if (!userGestured && !scrolledUp) {
+        if (isExactlyAtBottom(container)) {
+          setStickyBottom(selectedSessionId, latestMessageTopClippedId(container));
+        } else {
+          refreshTopClippedMessage();
+        }
         lastKnownScrollTopRef.current = currentTop;
-        refreshTopClippedMessage();
         return;
       }
 
-      const bottomGap = container.scrollHeight - (currentTop + container.clientHeight);
-      if (bottomGap <= FOLLOW_LATEST_BOTTOM_GAP_PX) {
-        dispatchScroll({ type: "mode", mode: "follow-latest" });
-      } else if (scrolledUp) {
-        dispatchScroll({ type: "mode", mode: "manual-browse" });
-      }
+      saveScrollPosition(container);
       lastKnownScrollTopRef.current = currentTop;
-      refreshTopClippedMessage();
     },
-    [clearProgrammaticScrollReset, hasScrollGesture, refreshTopClippedMessage],
+    [clearProgrammaticScrollReset, hasScrollGesture, refreshTopClippedMessage, saveScrollPosition, selectedSessionId, setStickyBottom],
   );
 
   const jumpToLatest = useCallback(
@@ -209,16 +243,13 @@ export function useSessionScrollController(
       const container = options.containerRef.current;
       if (!messageId || !container) return;
 
-      const escapedId = messageId.replace(/"/g, '\\"');
-      const target = container.querySelector(
-        `[data-message-id="${escapedId}"]`,
-      ) as HTMLElement | null;
+      const target = messageElementById(container, messageId);
       if (!target) return;
 
-      dispatchScroll({ type: "mode", mode: "manual-browse" });
+      setManualScroll(selectedSessionId, container.scrollTop, topClippedMessageId);
       target.scrollIntoView({ behavior, block: "start" });
     },
-    [options.containerRef, topClippedMessageId],
+    [options.containerRef, selectedSessionId, setManualScroll, topClippedMessageId],
   );
 
   useEffect(() => {
@@ -239,7 +270,7 @@ export function useSessionScrollController(
       const grew = nextHeight > previousContentHeight + 1;
       observedContentHeightRef.current = nextHeight;
 
-      // Only re-anchor to the bottom when we're already in follow-latest mode
+      // Only re-anchor to the bottom when we're already in sticky bottom mode
       // AND the user isn't actively scrolling. If they've touched the wheel,
       // touchpad, or scrollbar in the last SCROLL_GESTURE_WINDOW_MS, treat
       // that as intent to break out of autoscroll and leave their position
@@ -257,37 +288,38 @@ export function useSessionScrollController(
   }, [hasScrollGesture, isAtBottom, options.contentRef, refreshTopClippedMessage, scrollToBottom]);
 
   useEffect(() => {
-    if (options.selectedSessionId === previousSessionIdRef.current) return;
-    previousSessionIdRef.current = options.selectedSessionId;
-    if (!options.selectedSessionId) return;
+    if (selectedSessionId === previousSessionIdRef.current) return;
+    previousSessionIdRef.current = selectedSessionId;
+    if (!selectedSessionId) return;
 
-    dispatchScroll({ type: "followLatest" });
     observedContentHeightRef.current = 0;
+    lastKnownScrollTopRef.current = 0;
     queueMicrotask(() => {
       const container = options.containerRef.current;
       if (!container) return;
 
-      const messageEls = container.querySelectorAll("[data-message-id]");
-      const latest = messageEls[messageEls.length - 1] as HTMLElement | undefined;
-      if (!latest) {
-        scrollToBottom("auto");
-        return;
-      }
-
-      const latestHeight = latest.getBoundingClientRect().height;
-      const containerHeight = container.getBoundingClientRect().height;
-      if (latestHeight > containerHeight) {
-        dispatchScroll({ type: "mode", mode: "manual-browse" });
-        dispatchScroll({ type: "topClippedMessage", id: null });
+      const savedState = getSessionScrollState(useSessionScrollStore.getState().sessions, selectedSessionId);
+      if (savedState.mode === "manual") {
         programmaticScrollRef.current = true;
-        latest.scrollIntoView({ block: "start" });
-        releaseProgrammaticScrollSoon();
+        container.scrollTop = Math.min(savedState.scrollTop, Math.max(0, container.scrollHeight - container.clientHeight));
+        lastKnownScrollTopRef.current = container.scrollTop;
+        window.requestAnimationFrame(() => {
+          const next = options.containerRef.current;
+          if (!next) {
+            programmaticScrollRef.current = false;
+            return;
+          }
+          next.scrollTop = Math.min(savedState.scrollTop, Math.max(0, next.scrollHeight - next.clientHeight));
+          lastKnownScrollTopRef.current = next.scrollTop;
+          saveScrollPosition(next);
+          releaseProgrammaticScrollSoon();
+        });
         return;
       }
 
       scrollToBottom("auto");
     });
-  }, [options.containerRef, options.selectedSessionId, releaseProgrammaticScrollSoon, scrollToBottom]);
+  }, [options.containerRef, releaseProgrammaticScrollSoon, saveScrollPosition, scrollToBottom, selectedSessionId]);
 
   useEffect(() => {
     void options.renderedMessages;

--- a/apps/app/src/react-app/domains/session/surface/scroll-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/scroll-store.ts
@@ -1,0 +1,172 @@
+import { create } from "zustand";
+
+export const SESSION_SCROLL_STORAGE_KEY = "openwork:session-scroll:v1";
+
+export type StickyBottomSessionScrollState = {
+  mode: "stickyBottom";
+  topClippedMessageId: string | null;
+};
+
+export type ManualSessionScrollState = {
+  mode: "manual";
+  scrollTop: number;
+  topClippedMessageId: string | null;
+};
+
+export type SessionScrollState = StickyBottomSessionScrollState | ManualSessionScrollState;
+
+export type SessionScrollStateById = Record<string, SessionScrollState>;
+
+export const INITIAL_SESSION_SCROLL_STATE: StickyBottomSessionScrollState = {
+  mode: "stickyBottom",
+  topClippedMessageId: null,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeTopClippedMessageId(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function normalizeSessionScrollState(value: unknown): SessionScrollState | null {
+  if (!isRecord(value)) return null;
+
+  const topClippedMessageId = normalizeTopClippedMessageId(value.topClippedMessageId);
+  if (value.mode === "stickyBottom") {
+    return { mode: "stickyBottom", topClippedMessageId };
+  }
+
+  if (value.mode !== "manual" || typeof value.scrollTop !== "number" || !Number.isFinite(value.scrollTop)) {
+    return null;
+  }
+
+  return {
+    mode: "manual",
+    scrollTop: Math.max(0, Math.round(value.scrollTop)),
+    topClippedMessageId,
+  };
+}
+
+function readPersistedSessionScrollState(): SessionScrollStateById {
+  if (globalThis.window === undefined) return {};
+
+  try {
+    const raw = window.localStorage.getItem(SESSION_SCROLL_STORAGE_KEY);
+    if (!raw) return {};
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return {};
+
+    const sessions: SessionScrollStateById = {};
+    for (const [sessionId, value] of Object.entries(parsed)) {
+      const state = normalizeSessionScrollState(value);
+      if (state) sessions[sessionId] = state;
+    }
+    return sessions;
+  } catch {
+    return {};
+  }
+}
+
+function persistSessionScrollState(sessions: SessionScrollStateById): void {
+  if (globalThis.window === undefined) return;
+
+  try {
+    window.localStorage.setItem(SESSION_SCROLL_STORAGE_KEY, JSON.stringify(sessions));
+  } catch {
+    return;
+  }
+}
+
+export function getSessionScrollState(
+  sessions: SessionScrollStateById,
+  sessionId: string | null | undefined,
+): SessionScrollState {
+  if (!sessionId) return INITIAL_SESSION_SCROLL_STATE;
+  return sessions[sessionId] ?? INITIAL_SESSION_SCROLL_STATE;
+}
+
+function setSessionStickyBottom(
+  sessions: SessionScrollStateById,
+  sessionId: string | null | undefined,
+  topClippedMessageId: string | null,
+): SessionScrollStateById {
+  if (!sessionId) return sessions;
+
+  const current = getSessionScrollState(sessions, sessionId);
+  if (current.mode === "stickyBottom" && current.topClippedMessageId === topClippedMessageId) {
+    return sessions;
+  }
+
+  return {
+    ...sessions,
+    [sessionId]: { mode: "stickyBottom", topClippedMessageId },
+  };
+}
+
+function setSessionManualScroll(
+  sessions: SessionScrollStateById,
+  sessionId: string | null | undefined,
+  scrollTop: number,
+  topClippedMessageId: string | null,
+): SessionScrollStateById {
+  if (!sessionId) return sessions;
+
+  const nextScrollTop = Math.max(0, Math.round(scrollTop));
+  const current = getSessionScrollState(sessions, sessionId);
+  if (
+    current.mode === "manual" &&
+    current.scrollTop === nextScrollTop &&
+    current.topClippedMessageId === topClippedMessageId
+  ) {
+    return sessions;
+  }
+
+  return {
+    ...sessions,
+    [sessionId]: { mode: "manual", scrollTop: nextScrollTop, topClippedMessageId },
+  };
+}
+
+function setSessionTopClippedMessageId(
+  sessions: SessionScrollStateById,
+  sessionId: string | null | undefined,
+  topClippedMessageId: string | null,
+): SessionScrollStateById {
+  if (!sessionId) return sessions;
+
+  const current = getSessionScrollState(sessions, sessionId);
+  if (current.topClippedMessageId === topClippedMessageId) return sessions;
+
+  return {
+    ...sessions,
+    [sessionId]: { ...current, topClippedMessageId },
+  };
+}
+
+type SessionScrollStore = {
+  sessions: SessionScrollStateById;
+  setStickyBottom: (sessionId: string | null | undefined, topClippedMessageId: string | null) => void;
+  setManualScroll: (sessionId: string | null | undefined, scrollTop: number, topClippedMessageId: string | null) => void;
+  setTopClippedMessageId: (sessionId: string | null | undefined, topClippedMessageId: string | null) => void;
+};
+
+export const useSessionScrollStore = create<SessionScrollStore>((set) => ({
+  sessions: readPersistedSessionScrollState(),
+  setStickyBottom: (sessionId, topClippedMessageId) => set((state) => {
+    const sessions = setSessionStickyBottom(state.sessions, sessionId, topClippedMessageId);
+    return sessions === state.sessions ? state : { sessions };
+  }),
+  setManualScroll: (sessionId, scrollTop, topClippedMessageId) => set((state) => {
+    const sessions = setSessionManualScroll(state.sessions, sessionId, scrollTop, topClippedMessageId);
+    return sessions === state.sessions ? state : { sessions };
+  }),
+  setTopClippedMessageId: (sessionId, topClippedMessageId) => set((state) => {
+    const sessions = setSessionTopClippedMessageId(state.sessions, sessionId, topClippedMessageId);
+    return sessions === state.sessions ? state : { sessions };
+  }),
+}));
+
+useSessionScrollStore.subscribe((state) => persistSessionScrollState(state.sessions));

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1204,10 +1204,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
             )}
           </div>
         </div>
-        {!sessionScroll.isAtBottom || sessionScroll.topClippedMessageId ? (
+        {!sessionScroll.isAtBottom || (!chatStreaming && sessionScroll.topClippedMessageId) ? (
           <div className="pointer-events-none absolute bottom-2 left-1/2 z-30 flex -translate-x-1/2 justify-center">
             <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-dls-border bg-dls-surface/95 p-1 shadow-[var(--dls-card-shadow)] backdrop-blur-md">
-              {sessionScroll.topClippedMessageId ? (
+              {!chatStreaming && sessionScroll.topClippedMessageId ? (
                 <button
                   type="button"
                   className="rounded-full px-3 py-1.5 text-xs text-dls-text transition-colors hover:bg-dls-hover"

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -238,7 +238,7 @@ function AssistantWaitingCard({ label = t("session.assistant_thinking"), collaps
   );
 
   if (collapseLayout) {
-    return <div className="h-px overflow-visible">{content}</div>;
+    return <div>{content}</div>;
   }
 
   return (


### PR DESCRIPTION
## Summary
- Persist session transcript scroll state per session, including sticky-bottom/manual scroll and Jump to start state.
- Show Jump to latest based on exact bottom position, hide Jump to start while streaming, and only show it when the latest message start is clipped.
- Pin message action controls to the assistant/user side and adjust spacing around hover actions/status tags.

## Tests
- `pnpm --dir apps/app typecheck` passed.

## Evidence
- No video captured; changes were verified with typecheck only.