### PR TITLE
fix(server): escape browser guidance command

### DIFF
--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -41,7 +41,7 @@ OpenWork has a built-in browser and can also control the user's external Chrome.
 Two MCP tool sets are available:
 
 1. **openwork-browser** — Built-in browser panel inside the app.
-   - The panel stays hidden unless you call `openwork-browser_show_browser`.
+   - The panel stays hidden unless you call \`openwork-browser_show_browser\`.
    - Use this for general browsing tasks ("go to facebook.com", "search for X").
    - Call \`openwork-browser_hide_browser\` when the browsing task is done.
    - The user can see what you're doing in real time.


### PR DESCRIPTION
## Summary
- Escape the `openwork-browser_show_browser` inline code span inside the workspace guidance template literal.
- Restores the server TypeScript build that failed during the alpha Electron build.

## Tests
- `pnpm --filter openwork-server build`
- `pnpm --filter @openwork/desktop build:electron`