### PR TITLE
fix(app): expand pasted text with composer store

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -851,8 +851,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const handleExpandPastedText = (id: string) => {
     const part = pasteParts.find((item) => item.id === id);
     if (!part) return;
-    setDraft((draftValue) => draftValue.replace(`[pasted text ${part.label}]`, () => part.text));
-    setPasteParts((current) => current.filter((item) => item.id !== id));
+    setComposerDraft(props.sessionId, draft.replace(`[pasted text ${part.label}]`, part.text));
+    setComposerPasteParts(props.sessionId, pasteParts.filter((item) => item.id !== id));
   };
 
   const handleRemovePastedText = (id: string) => {


### PR DESCRIPTION
## Summary
- Fix pasted text expansion after composer state moved into the per-session store.
- Replace stale local composer setters with the session-scoped composer store setters.

## Tests
- pnpm --filter @openwork/app typecheck