### PR TITLE
Create org members when inviting users

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -33,6 +33,7 @@
     "dotenv": "^16.4.5",
     "hono": "^4.7.2",
     "hono-openapi": "^1.3.0",
+    "nanoid": "^5.1.11",
     "openapi-types": "^12.1.3",
     "stripe": "^22.1.1",
     "zod": "^4.3.6"

--- a/ee/apps/den-api/src/active-organization.ts
+++ b/ee/apps/den-api/src/active-organization.ts
@@ -1,4 +1,4 @@
-import { asc, eq } from "@openwork-ee/den-db/drizzle"
+import { and, asc, eq, isNull } from "@openwork-ee/den-db/drizzle"
 import { MemberTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "./db.js"
@@ -11,7 +11,7 @@ export async function getInitialActiveOrganizationIdForUser(userId: string) {
       organizationId: MemberTable.organizationId,
     })
     .from(MemberTable)
-    .where(eq(MemberTable.userId, normalizedUserId))
+    .where(and(eq(MemberTable.userId, normalizedUserId), isNull(MemberTable.removedAt)))
     .orderBy(asc(MemberTable.createdAt))
     .limit(1)
 

--- a/ee/apps/den-api/src/api-keys.ts
+++ b/ee/apps/den-api/src/api-keys.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray } from "@openwork-ee/den-db/drizzle"
+import { and, asc, desc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
 import { AuthApiKeyTable, AuthUserTable, MemberTable } from "@openwork-ee/den-db/schema"
 import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "./db.js"
@@ -136,19 +136,20 @@ export async function listOrganizationApiKeys(organizationId: OrganizationId): P
     })
     .from(MemberTable)
     .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
-    .where(eq(MemberTable.organizationId, organizationId))
+    .where(and(eq(MemberTable.organizationId, organizationId), isNull(MemberTable.removedAt)))
     .orderBy(asc(MemberTable.createdAt))
 
   if (members.length === 0) {
     return []
   }
 
-  const memberByUserId = new Map(members.map((member) => [member.userId, member]))
+  const joinedMembers = members.filter((member): member is typeof member & { userId: UserId } => Boolean(member.userId))
+  const memberByUserId = new Map(joinedMembers.map((member) => [member.userId, member]))
 
   const apiKeys = await db
     .select()
     .from(AuthApiKeyTable)
-    .where(inArray(AuthApiKeyTable.referenceId, members.map((member) => member.userId)))
+    .where(inArray(AuthApiKeyTable.referenceId, joinedMembers.map((member) => member.userId)))
     .orderBy(desc(AuthApiKeyTable.createdAt))
 
   return apiKeys

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -186,7 +186,7 @@ export const auth = betterAuth({
       },
       "/sign-up/email": {
         window: 3600,
-        max: 3,
+        max: env.devMode ? 100 : 5,
       },
       "/email-otp/send-verification-otp": {
         window: 3600,

--- a/ee/apps/den-api/src/inference.ts
+++ b/ee/apps/den-api/src/inference.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "node:crypto"
-import { and, eq, inArray, sql } from "@openwork-ee/den-db/drizzle"
+import { and, eq, inArray, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import {
   InferenceKeyTable,
   InferenceOrgLimitPolicyTable,
@@ -71,12 +71,12 @@ async function activeMemberCount(organizationId: OrgId) {
   const [row] = await db
     .select({ count: sql<number>`count(*)` })
     .from(MemberTable)
-    .where(eq(MemberTable.organizationId, organizationId))
+    .where(and(eq(MemberTable.organizationId, organizationId), isNull(MemberTable.removedAt)))
   return Math.max(0, Number(row?.count ?? 0))
 }
 
 async function listOrgMembers(organizationId: OrgId) {
-  return db.select({ id: MemberTable.id }).from(MemberTable).where(eq(MemberTable.organizationId, organizationId))
+  return db.select({ id: MemberTable.id }).from(MemberTable).where(and(eq(MemberTable.organizationId, organizationId), isNull(MemberTable.removedAt)))
 }
 
 function addWindow(start: Date, windowType: InferenceWindowType) {

--- a/ee/apps/den-api/src/organization-limits.ts
+++ b/ee/apps/den-api/src/organization-limits.ts
@@ -1,5 +1,5 @@
-import { and, eq, gt, sql } from "@openwork-ee/den-db/drizzle"
-import { InvitationTable, MemberTable, OrganizationTable, WorkerTable } from "@openwork-ee/den-db/schema"
+import { and, eq, isNull, sql } from "@openwork-ee/den-db/drizzle"
+import { MemberTable, OrganizationTable, WorkerTable } from "@openwork-ee/den-db/schema"
 import { db } from "./db.js"
 
 export const DEFAULT_ORGANIZATION_LIMITS = {
@@ -155,16 +155,7 @@ async function countOrganizationMembers(organizationId: OrganizationId) {
   const rows = await db
     .select({ count: sql<number>`count(*)` })
     .from(MemberTable)
-    .where(eq(MemberTable.organizationId, organizationId))
-
-  return Number(rows[0]?.count ?? 0)
-}
-
-async function countPendingOrganizationInvitations(organizationId: OrganizationId) {
-  const rows = await db
-    .select({ count: sql<number>`count(*)` })
-    .from(InvitationTable)
-    .where(and(eq(InvitationTable.organizationId, organizationId), eq(InvitationTable.status, "pending"), gt(InvitationTable.expiresAt, new Date())))
+    .where(and(eq(MemberTable.organizationId, organizationId), isNull(MemberTable.removedAt)))
 
   return Number(rows[0]?.count ?? 0)
 }
@@ -182,7 +173,7 @@ export async function getOrganizationLimitStatus(organizationId: OrganizationId,
   const metadata = await getOrInitializeOrganizationMetadata(organizationId)
   const currentCount =
     limitType === "members"
-      ? (await countOrganizationMembers(organizationId)) + (await countPendingOrganizationInvitations(organizationId))
+      ? await countOrganizationMembers(organizationId)
       : await countOrganizationWorkers(organizationId)
 
   const limit = metadata.limits[limitType]

--- a/ee/apps/den-api/src/organization-member-hooks.ts
+++ b/ee/apps/den-api/src/organization-member-hooks.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "@openwork-ee/den-db/drizzle"
+import { and, eq, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import { MemberTable, OrganizationTable } from "@openwork-ee/den-db/schema"
 import { db } from "./db.js"
 import { syncInferenceAfterMemberChange } from "./inference.js"
@@ -27,7 +27,7 @@ async function countOrganizationMembers(organizationId: OrgId) {
   const [row] = await db
     .select({ count: sql<number>`count(*)` })
     .from(MemberTable)
-    .where(eq(MemberTable.organizationId, organizationId))
+    .where(and(eq(MemberTable.organizationId, organizationId), isNull(MemberTable.removedAt)))
   return Math.max(0, Number(row?.count ?? 0))
 }
 

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray } from "@openwork-ee/den-db/drizzle"
+import { and, asc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
 import {
   AuthSessionTable,
   AuthUserTable,
@@ -72,16 +72,19 @@ export type OrganizationContext = {
     userId: UserId
     role: string
     createdAt: Date
+    joinedAt: Date | null
     isOwner: boolean
   }
   members: Array<{
     id: MemberId
-    userId: UserId
+    userId: UserId | null
+    inviteId: InvitationRow["id"] | null
     role: string
     createdAt: Date
+    joinedAt: Date | null
     isOwner: boolean
     user: {
-      id: UserId
+      id: UserId | MemberId
       email: string
       name: string
       image: string | null
@@ -94,6 +97,7 @@ export type OrganizationContext = {
     status: string
     expiresAt: Date
     createdAt: Date
+    inviteToken: string | null
   }>
   roles: Array<{
     id: string
@@ -210,6 +214,20 @@ function getEmailDomain(email: string) {
   return normalized.slice(atIndex + 1)
 }
 
+function getEmailLocalPart(email: string) {
+  const atIndex = email.indexOf("@")
+  return atIndex > 0 ? email.slice(0, atIndex) : email
+}
+
+function getEmailDomainName(email: string) {
+  const domain = getEmailDomain(email)
+  return domain?.split(".")[0] ?? "invited"
+}
+
+function getInvitedMemberName(email: string) {
+  return `${getEmailLocalPart(email)} ${getEmailDomainName(email)}`.trim()
+}
+
 export function isEmailAllowedForOrganization(allowedEmailDomains: readonly string[] | null | undefined, email: string) {
   if (!allowedEmailDomains || allowedEmailDomains.length === 0) {
     return true
@@ -279,7 +297,7 @@ async function listMembershipRows(userId: UserId) {
   return db
     .select()
     .from(MemberTable)
-    .where(eq(MemberTable.userId, userId))
+    .where(and(eq(MemberTable.userId, userId), isNull(MemberTable.removedAt)))
     .orderBy(asc(MemberTable.createdAt))
 }
 
@@ -292,6 +310,16 @@ function getInvitationStatus(invitation: Pick<InvitationRow, "status" | "expires
 }
 
 async function getInvitationById(invitationIdRaw: string) {
+  const tokenRows = await db
+    .select()
+    .from(InvitationTable)
+    .where(eq(InvitationTable.inviteToken, invitationIdRaw))
+    .limit(1)
+
+  if (tokenRows[0]) {
+    return tokenRows[0]
+  }
+
   let invitationId
   try {
     invitationId = normalizeDenTypeId("invitation", invitationIdRaw)
@@ -354,7 +382,7 @@ async function insertMemberIfMissing(input: {
   const existing = await db
     .select()
     .from(MemberTable)
-    .where(and(eq(MemberTable.organizationId, input.organizationId), eq(MemberTable.userId, input.userId)))
+    .where(and(eq(MemberTable.organizationId, input.organizationId), eq(MemberTable.userId, input.userId), isNull(MemberTable.removedAt)))
     .limit(1)
 
   if (existing.length > 0) {
@@ -366,12 +394,13 @@ async function insertMemberIfMissing(input: {
     organizationId: input.organizationId,
     userId: input.userId,
     role: input.role,
+    joinedAt: new Date(),
   })
 
   const created = await db
     .select()
     .from(MemberTable)
-    .where(and(eq(MemberTable.organizationId, input.organizationId), eq(MemberTable.userId, input.userId)))
+    .where(and(eq(MemberTable.organizationId, input.organizationId), eq(MemberTable.userId, input.userId), isNull(MemberTable.removedAt)))
     .limit(1)
 
   if (!created[0]) {
@@ -384,12 +413,39 @@ async function insertMemberIfMissing(input: {
 async function acceptInvitation(invitation: InvitationRow, userId: UserId) {
   const availableRoles = await listAssignableRoles(invitation.organizationId)
   const role = normalizeAssignableRole(invitation.role, availableRoles)
+  const joinedAt = new Date()
 
-  const member = await insertMemberIfMissing({
-    organizationId: invitation.organizationId,
-    userId,
-    role,
-  })
+  const existingMemberRows = await db
+    .select()
+    .from(MemberTable)
+    .where(and(eq(MemberTable.organizationId, invitation.organizationId), eq(MemberTable.userId, userId), isNull(MemberTable.removedAt)))
+    .limit(1)
+
+  const invitedMemberRows = await db
+    .select()
+    .from(MemberTable)
+    .where(and(eq(MemberTable.inviteId, invitation.id), eq(MemberTable.organizationId, invitation.organizationId), isNull(MemberTable.removedAt)))
+    .limit(1)
+
+  const invitedMember = invitedMemberRows[0] ?? null
+  const existingMember = existingMemberRows[0] ?? null
+  let member = existingMember
+
+  if (!member && invitedMember) {
+    await db
+      .update(MemberTable)
+      .set({ userId, role, joinedAt })
+      .where(eq(MemberTable.id, invitedMember.id))
+    member = { ...invitedMember, userId, role, joinedAt }
+  }
+
+  if (!member) {
+    member = await insertMemberIfMissing({
+      organizationId: invitation.organizationId,
+      userId,
+      role,
+    })
+  }
 
   if (invitation.teamId) {
     const teams = await db
@@ -466,10 +522,8 @@ export async function acceptInvitationForUser(input: {
 }
 
 export async function getInvitationPreview(invitationIdRaw: string): Promise<InvitationPreview | null> {
-  let invitationId
-  try {
-    invitationId = normalizeDenTypeId("invitation", invitationIdRaw)
-  } catch {
+  const invitation = await getInvitationById(invitationIdRaw)
+  if (!invitation) {
     return null
   }
 
@@ -492,7 +546,7 @@ export async function getInvitationPreview(invitationIdRaw: string): Promise<Inv
     })
     .from(InvitationTable)
     .innerJoin(OrganizationTable, eq(InvitationTable.organizationId, OrganizationTable.id))
-    .where(eq(InvitationTable.id, invitationId))
+    .where(eq(InvitationTable.id, invitation.id))
     .limit(1)
 
   const row = rows[0]
@@ -703,7 +757,7 @@ export async function listUserOrgs(userId: UserId) {
     })
     .from(MemberTable)
     .innerJoin(OrganizationTable, eq(MemberTable.organizationId, OrganizationTable.id))
-    .where(eq(MemberTable.userId, userId))
+    .where(and(eq(MemberTable.userId, userId), isNull(MemberTable.removedAt)))
     .orderBy(asc(MemberTable.createdAt))
 
   return memberships.map((row) => ({
@@ -772,11 +826,15 @@ export async function getOrganizationContextForUser(input: {
   const currentMemberRows = await db
     .select()
     .from(MemberTable)
-    .where(and(eq(MemberTable.organizationId, organization.id), eq(MemberTable.userId, input.userId)))
+    .where(and(eq(MemberTable.organizationId, organization.id), eq(MemberTable.userId, input.userId), isNull(MemberTable.removedAt)))
     .limit(1)
 
   const currentMember = currentMemberRows[0]
   if (!currentMember) {
+    return null
+  }
+
+  if (!currentMember.userId) {
     return null
   }
 
@@ -786,18 +844,24 @@ export async function getOrganizationContextForUser(input: {
     .select({
       id: MemberTable.id,
       userId: MemberTable.userId,
+      inviteId: MemberTable.inviteId,
       role: MemberTable.role,
       createdAt: MemberTable.createdAt,
+      joinedAt: MemberTable.joinedAt,
       user: {
         id: AuthUserTable.id,
         email: AuthUserTable.email,
         name: AuthUserTable.name,
         image: AuthUserTable.image,
       },
+      invitation: {
+        email: InvitationTable.email,
+      },
     })
     .from(MemberTable)
-    .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
-    .where(eq(MemberTable.organizationId, organization.id))
+    .leftJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
+    .leftJoin(InvitationTable, eq(MemberTable.inviteId, InvitationTable.id))
+    .where(and(eq(MemberTable.organizationId, organization.id), isNull(MemberTable.removedAt)))
     .orderBy(asc(MemberTable.createdAt))
 
   const invitations = await db
@@ -808,6 +872,7 @@ export async function getOrganizationContextForUser(input: {
       status: InvitationTable.status,
       expiresAt: InvitationTable.expiresAt,
       createdAt: InvitationTable.createdAt,
+      inviteToken: InvitationTable.inviteToken,
     })
     .from(InvitationTable)
     .where(eq(InvitationTable.organizationId, organization.id))
@@ -839,12 +904,28 @@ export async function getOrganizationContextForUser(input: {
       userId: currentMember.userId,
       role: currentMember.role,
       createdAt: currentMember.createdAt,
+      joinedAt: currentMember.joinedAt,
       isOwner: roleIncludesOwner(currentMember.role),
     },
-    members: members.map((member) => ({
-      ...member,
-      isOwner: roleIncludesOwner(member.role),
-    })),
+    members: members.map((member) => {
+      const email = member.user?.email ?? member.invitation?.email ?? "invited@example.com"
+      const name = member.user?.name ?? getInvitedMemberName(email)
+      return {
+        id: member.id,
+        userId: member.userId,
+        inviteId: member.inviteId,
+        role: member.role,
+        createdAt: member.createdAt,
+        joinedAt: member.joinedAt,
+        isOwner: roleIncludesOwner(member.role),
+        user: {
+          id: member.user?.id ?? member.id,
+          email,
+          name,
+          image: member.user?.image ?? null,
+        },
+      }
+    }),
     invitations,
     roles: [
       {
@@ -928,11 +1009,12 @@ export async function listTeamsForMember(input: {
 export async function removeOrganizationMember(input: {
   organizationId: OrgId
   memberId: MemberRow["id"]
+  removedByOrgMemberId?: MemberRow["id"]
 }) {
   const memberRows = await db
     .select()
     .from(MemberTable)
-    .where(and(eq(MemberTable.id, input.memberId), eq(MemberTable.organizationId, input.organizationId)))
+    .where(and(eq(MemberTable.id, input.memberId), eq(MemberTable.organizationId, input.organizationId), isNull(MemberTable.removedAt)))
     .limit(1)
 
   const member = memberRows[0] ?? null
@@ -952,7 +1034,10 @@ export async function removeOrganizationMember(input: {
         .where(and(eq(TeamMemberTable.teamId, team.id), eq(TeamMemberTable.orgMembershipId, member.id)))
     }
 
-    await tx.delete(MemberTable).where(eq(MemberTable.id, member.id))
+    await tx
+      .update(MemberTable)
+      .set({ removedAt: new Date(), removedByOrgMember: input.removedByOrgMemberId ?? null })
+      .where(eq(MemberTable.id, member.id))
   })
 
   await runPostOrganizationMemberChangeHooks({ organizationId: input.organizationId, memberId: member.id, change: "removed" })

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -34,11 +34,11 @@ const updateOrganizationSchema = z.object({
 })
 
 const invitationPreviewQuerySchema = z.object({
-  id: denTypeIdSchema("invitation"),
+  id: z.string().trim().min(1).max(255),
 })
 
 const acceptInvitationSchema = z.object({
-  id: denTypeIdSchema("invitation"),
+  id: z.string().trim().min(1).max(255),
 })
 
 const organizationResponseSchema = z.object({

--- a/ee/apps/den-api/src/routes/org/desktop-policies.ts
+++ b/ee/apps/den-api/src/routes/org/desktop-policies.ts
@@ -71,7 +71,7 @@ async function resolveMemberIds(input: {
   const rows = await db
     .select({ id: MemberTable.id })
     .from(MemberTable)
-    .where(and(eq(MemberTable.organizationId, input.organizationId), inArray(MemberTable.id, memberIds)))
+    .where(and(eq(MemberTable.organizationId, input.organizationId), inArray(MemberTable.id, memberIds), isNull(MemberTable.removedAt)))
 
   if (rows.length !== memberIds.length) {
     throw new Error("member_not_found")

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -1,6 +1,6 @@
-import { and, eq, gt } from "@openwork-ee/den-db/drizzle"
+import { and, eq, gt, isNull } from "@openwork-ee/den-db/drizzle"
 import { AuthUserTable, InvitationTable, MemberTable } from "@openwork-ee/den-db/schema"
-import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
@@ -8,10 +8,11 @@ import { db } from "../../db.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
 import { getOrganizationLimitStatus } from "../../organization-limits.js"
-import { isEmailAllowedForOrganization, listAssignableRoles } from "../../orgs.js"
+import { runPostOrganizationMemberChangeHooks } from "../../organization-member-hooks.js"
+import { isEmailAllowedForOrganization, listAssignableRoles, removeOrganizationMember } from "../../orgs.js"
 import { DenEmailSendError, sendEmail } from "../../utils/email/send-email.js"
 import type { OrgRouteVariables } from "./shared.js"
-import { buildInvitationLink, createInvitationId, ensureInviteManager, idParamSchema, normalizeRoleName } from "./shared.js"
+import { buildInvitationLink, createInvitationId, createInvitationToken, ensureInviteManager, idParamSchema, normalizeRoleName } from "./shared.js"
 
 const inviteMemberSchema = z.object({
   email: z.string().email(),
@@ -23,6 +24,7 @@ const invitationResponseSchema = z.object({
   email: z.string().email(),
   role: z.string(),
   expiresAt: z.string().datetime(),
+  inviteToken: z.string(),
 }).meta({ ref: "InvitationResponse" })
 
 const invitationEmailFailedSchema = z.object({
@@ -98,7 +100,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       .select({ id: MemberTable.id })
       .from(MemberTable)
       .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
-      .where(and(eq(MemberTable.organizationId, payload.organization.id), eq(AuthUserTable.email, email)))
+      .where(and(eq(MemberTable.organizationId, payload.organization.id), eq(AuthUserTable.email, email), isNull(MemberTable.removedAt)))
       .limit(1)
 
     if (existingMembers[0]) {
@@ -136,12 +138,39 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
 
     const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7)
     const invitationId = existingInvitation[0]?.id ?? createInvitationId()
+    const inviteToken = createInvitationToken()
+    let createdOrgMemberId: typeof MemberTable.$inferSelect.id | null = null
 
     if (existingInvitation[0]) {
       await db
         .update(InvitationTable)
-        .set({ role, inviterId: normalizeDenTypeId("user", user.id), expiresAt })
+        .set({ role, inviterId: normalizeDenTypeId("user", user.id), orgMemberId: payload.currentMember.id, inviteToken, expiresAt })
         .where(eq(InvitationTable.id, existingInvitation[0].id))
+
+      const invitedMemberRows = await db
+        .select({ id: MemberTable.id })
+        .from(MemberTable)
+        .where(and(eq(MemberTable.inviteId, existingInvitation[0].id), eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.removedAt)))
+        .limit(1)
+
+      if (invitedMemberRows[0]) {
+        await db
+          .update(MemberTable)
+          .set({ role, invitedByOrgMember: payload.currentMember.id })
+          .where(eq(MemberTable.id, invitedMemberRows[0].id))
+      } else {
+        const memberId = createDenTypeId("member")
+        await db.insert(MemberTable).values({
+          id: memberId,
+          organizationId: payload.organization.id,
+          userId: null,
+          inviteId: existingInvitation[0].id,
+          invitedByOrgMember: payload.currentMember.id,
+          role,
+          joinedAt: null,
+        })
+        createdOrgMemberId = memberId
+      }
     } else {
       await db.insert(InvitationTable).values({
         id: invitationId,
@@ -150,8 +179,26 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         role,
         status: "pending",
         inviterId: normalizeDenTypeId("user", user.id),
+        orgMemberId: payload.currentMember.id,
+        inviteToken,
         expiresAt,
       })
+
+      const memberId = createDenTypeId("member")
+      await db.insert(MemberTable).values({
+        id: memberId,
+        organizationId: payload.organization.id,
+        userId: null,
+        inviteId: invitationId,
+        invitedByOrgMember: payload.currentMember.id,
+        role,
+        joinedAt: null,
+      })
+      createdOrgMemberId = memberId
+    }
+
+    if (createdOrgMemberId) {
+      await runPostOrganizationMemberChangeHooks({ organizationId: payload.organization.id, memberId: createdOrgMemberId, change: "added" })
     }
 
     try {
@@ -159,7 +206,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         to: email,
         template: "organizationInvite",
         props: {
-          inviteLink: buildInvitationLink(invitationId),
+          inviteLink: buildInvitationLink(inviteToken),
           invitedByName: user.name ?? user.email ?? "OpenWork",
           invitedByEmail: user.email ?? "",
           organizationName: payload.organization.name,
@@ -192,7 +239,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       throw error
     }
 
-    return c.json({ invitationId, email, role, expiresAt }, existingInvitation[0] ? 200 : 201)
+    return c.json({ invitationId, email, role, expiresAt, inviteToken }, existingInvitation[0] ? 200 : 201)
     },
   )
 
@@ -238,7 +285,22 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       return c.json({ error: "invitation_not_found" }, 404)
     }
 
+    const invitedMemberRows = await db
+      .select({ id: MemberTable.id })
+      .from(MemberTable)
+      .where(and(eq(MemberTable.inviteId, invitationId), eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.joinedAt), isNull(MemberTable.removedAt)))
+      .limit(1)
+
     await db.update(InvitationTable).set({ status: "canceled" }).where(eq(InvitationTable.id, invitationId))
+
+    if (invitedMemberRows[0]) {
+      await removeOrganizationMember({
+        organizationId: payload.organization.id,
+        memberId: invitedMemberRows[0].id,
+        removedByOrgMemberId: payload.currentMember.id,
+      })
+    }
+
     return c.json({ success: true })
     },
   )

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -1,6 +1,7 @@
-import { and, desc, eq, inArray, isNotNull, or } from "@openwork-ee/den-db/drizzle"
+import { and, desc, eq, inArray, isNotNull, isNull, or } from "@openwork-ee/den-db/drizzle"
 import {
   AuthUserTable,
+  InvitationTable,
   LlmProviderAccessTable,
   LlmProviderModelTable,
   LlmProviderTable,
@@ -37,6 +38,11 @@ type RouteFailure = {
   status: number
   error: string
   message?: string
+}
+
+function getInvitedMemberName(email: string) {
+  const [localPart, domain = "invited"] = email.split("@")
+  return `${localPart} ${domain.split(".")[0] ?? "invited"}`.trim()
 }
 
 const providerCatalogParamsSchema = z.object({
@@ -229,7 +235,7 @@ async function resolveMemberIds(input: {
   const rows = await db
     .select({ id: MemberTable.id })
     .from(MemberTable)
-    .where(and(eq(MemberTable.organizationId, input.organizationId), inArray(MemberTable.id, memberIds)))
+    .where(and(eq(MemberTable.organizationId, input.organizationId), inArray(MemberTable.id, memberIds), isNull(MemberTable.removedAt)))
 
   if (rows.length !== memberIds.length) {
     throw createFailure(404, "member_not_found")
@@ -395,11 +401,15 @@ async function loadLlmProviders(input: {
         email: AuthUserTable.email,
         image: AuthUserTable.image,
       },
+      invitation: {
+        email: InvitationTable.email,
+      },
     })
     .from(LlmProviderAccessTable)
     .innerJoin(MemberTable, eq(LlmProviderAccessTable.orgMembershipId, MemberTable.id))
-    .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
-    .where(and(inArray(LlmProviderAccessTable.llmProviderId, providerIds), isNotNull(LlmProviderAccessTable.orgMembershipId)))
+    .leftJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
+    .leftJoin(InvitationTable, eq(MemberTable.inviteId, InvitationTable.id))
+    .where(and(inArray(LlmProviderAccessTable.llmProviderId, providerIds), isNotNull(LlmProviderAccessTable.orgMembershipId), isNull(MemberTable.removedAt)))
 
   const teamAccessRows = await db
     .select({
@@ -464,13 +474,21 @@ async function loadLlmProviders(input: {
       }))
       .sort((left, right) => left.name.localeCompare(right.name)),
     access: {
-      members: (memberAccessByProviderId.get(provider.id) ?? []).map((row) => ({
-        id: row.access.id,
-        orgMembershipId: row.member.id,
-        role: row.member.role,
-        user: row.user,
-        createdAt: row.access.createdAt,
-      })),
+      members: (memberAccessByProviderId.get(provider.id) ?? []).map((row) => {
+        const email = row.user?.email ?? row.invitation?.email ?? "invited@example.com"
+        return {
+          id: row.access.id,
+          orgMembershipId: row.member.id,
+          role: row.member.role,
+          user: {
+            id: row.user?.id ?? row.member.id,
+            name: row.user?.name ?? getInvitedMemberName(email),
+            email,
+            image: row.user?.image ?? null,
+          },
+          createdAt: row.access.createdAt,
+        }
+      }),
       teams: (teamAccessByProviderId.get(provider.id) ?? []).map((row) => ({
         id: row.access.id,
         teamId: row.team.id,

--- a/ee/apps/den-api/src/routes/org/members.ts
+++ b/ee/apps/den-api/src/routes/org/members.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "@openwork-ee/den-db/drizzle"
+import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
 import { MemberTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
@@ -57,7 +57,7 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
     const memberRows = await db
       .select()
       .from(MemberTable)
-      .where(and(eq(MemberTable.id, memberId), eq(MemberTable.organizationId, payload.organization.id)))
+      .where(and(eq(MemberTable.id, memberId), eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.removedAt)))
       .limit(1)
 
     const member = memberRows[0]
@@ -115,7 +115,7 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
     const memberRows = await db
       .select()
       .from(MemberTable)
-      .where(and(eq(MemberTable.id, memberId), eq(MemberTable.organizationId, payload.organization.id)))
+      .where(and(eq(MemberTable.id, memberId), eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.removedAt)))
       .limit(1)
 
     const member = memberRows[0]
@@ -130,6 +130,7 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
     await removeOrganizationMember({
       organizationId: payload.organization.id,
       memberId: member.id,
+      removedByOrgMemberId: payload.currentMember.id,
     })
     return c.body(null, 204)
     },

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -2500,11 +2500,16 @@ async function buildConnectorAutomationContext(input: { connectorInstance: Conne
     .where(and(
       eq(MemberTable.organizationId, input.connectorInstance.organizationId),
       eq(MemberTable.id, input.connectorInstance.createdByOrgMembershipId),
+      isNull(MemberTable.removedAt),
     ))
     .limit(1)
   const member = memberRows[0] as MemberRow | undefined
   if (!member) {
     throw new PluginArchRouteFailure(404, "member_not_found", "Connector creator member not found.")
+  }
+
+  if (!member.userId) {
+    throw new PluginArchRouteFailure(404, "member_not_joined", "Connector creator member has not joined the organization.")
   }
 
   return {
@@ -2514,6 +2519,7 @@ async function buildConnectorAutomationContext(input: { connectorInstance: Conne
         createdAt: member.createdAt,
         id: member.id,
         isOwner: roleIncludesOwner(member.role),
+        joinedAt: member.joinedAt,
         role: member.role,
         userId: member.userId,
       },

--- a/ee/apps/den-api/src/routes/org/roles.ts
+++ b/ee/apps/den-api/src/routes/org/roles.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "@openwork-ee/den-db/drizzle"
+import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
 import { InvitationTable, MemberTable, OrganizationRoleTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
@@ -152,7 +152,7 @@ export function registerOrgRoleRoutes<T extends { Variables: OrgRouteVariables }
       const members = await db
         .select()
         .from(MemberTable)
-        .where(eq(MemberTable.organizationId, payload.organization.id))
+        .where(and(eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.removedAt)))
 
       for (const member of members) {
         if (!splitRoles(member.role).includes(roleRow.role)) {
@@ -232,7 +232,7 @@ export function registerOrgRoleRoutes<T extends { Variables: OrgRouteVariables }
     const membersUsingRole = await db
       .select({ role: MemberTable.role })
       .from(MemberTable)
-      .where(eq(MemberTable.organizationId, payload.organization.id))
+      .where(and(eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.removedAt)))
 
     if (membersUsingRole.some((member) => splitRoles(member.role).includes(roleRow.role))) {
       return c.json({ error: "role_in_use", message: "Update members using this role before deleting it." }, 400)

--- a/ee/apps/den-api/src/routes/org/shared.ts
+++ b/ee/apps/den-api/src/routes/org/shared.ts
@@ -1,4 +1,5 @@
 import { createDenTypeId, type DenTypeIdName } from "@openwork-ee/utils/typeid"
+import { customAlphabet } from "nanoid"
 import { z } from "zod"
 import type { MemberTeamsContext, OrganizationContextVariables, UserOrganizationsContext } from "../../middleware/index.js"
 import { env } from "../../env.js"
@@ -56,8 +57,10 @@ export function getInvitationOrigin() {
   return env.betterAuthTrustedOrigins.find((origin) => origin !== "*") ?? env.betterAuthUrl
 }
 
-export function buildInvitationLink(invitationId: string) {
-  return new URL(`/join-org?invite=${encodeURIComponent(invitationId)}`, getInvitationOrigin()).toString()
+const createNanoid = customAlphabet("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", 21)
+
+export function buildInvitationLink(inviteToken: string) {
+  return new URL(`/join-org?invite=${encodeURIComponent(inviteToken)}`, getInvitationOrigin()).toString()
 }
 
 export function ensureOwner(c: { get: (key: "organizationContext") => OrgRouteVariables["organizationContext"] }) {
@@ -149,6 +152,10 @@ export function ensureApiKeyManager(c: { get: (key: "organizationContext") => Or
 
 export function createInvitationId() {
   return createDenTypeId("invitation")
+}
+
+export function createInvitationToken() {
+  return createNanoid()
 }
 
 export function createRoleId() {

--- a/ee/apps/den-api/src/routes/org/skills.ts
+++ b/ee/apps/den-api/src/routes/org/skills.ts
@@ -1,6 +1,7 @@
-import { and, desc, eq, inArray, isNotNull, or } from "@openwork-ee/den-db/drizzle"
+import { and, desc, eq, inArray, isNotNull, isNull, or } from "@openwork-ee/den-db/drizzle"
 import {
   AuthUserTable,
+  InvitationTable,
   MemberTable,
   SkillHubMemberTable,
   SkillHubSkillTable,
@@ -100,6 +101,11 @@ const addSkillHubAccessSchema = z.object({
 type SkillId = typeof SkillTable.$inferSelect.id
 type SkillHubId = typeof SkillHubTable.$inferSelect.id
 type SkillHubMemberId = typeof SkillHubMemberTable.$inferSelect.id
+
+function getInvitedMemberName(email: string) {
+  const [localPart, domain = "invited"] = email.split("@")
+  return `${localPart} ${domain.split(".")[0] ?? "invited"}`.trim()
+}
 type TeamId = typeof TeamTable.$inferSelect.id
 type MemberId = typeof MemberTable.$inferSelect.id
 type SkillRow = typeof SkillTable.$inferSelect
@@ -603,11 +609,15 @@ export function registerOrgSkillRoutes<T extends { Variables: OrgRouteVariables 
             email: AuthUserTable.email,
             image: AuthUserTable.image,
           },
+          invitation: {
+            email: InvitationTable.email,
+          },
         })
         .from(SkillHubMemberTable)
         .innerJoin(MemberTable, eq(SkillHubMemberTable.orgMembershipId, MemberTable.id))
-        .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
-        .where(and(inArray(SkillHubMemberTable.skillHubId, skillHubIds), isNotNull(SkillHubMemberTable.orgMembershipId)))
+        .leftJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
+        .leftJoin(InvitationTable, eq(MemberTable.inviteId, InvitationTable.id))
+        .where(and(inArray(SkillHubMemberTable.skillHubId, skillHubIds), isNotNull(SkillHubMemberTable.orgMembershipId), isNull(MemberTable.removedAt)))
 
       const teamAccessRows = await db
         .select({
@@ -673,13 +683,21 @@ export function registerOrgSkillRoutes<T extends { Variables: OrgRouteVariables 
           accessibleVia: accessibleViaByHubId.get(skillHub.id) ?? { orgMembershipIds: [], teamIds: [] },
           skills: skillsByHubId.get(skillHub.id) ?? [],
           access: {
-            members: (memberAccessByHubId.get(skillHub.id) ?? []).map((row) => ({
-              id: row.access.id,
-              orgMembershipId: row.member.id,
-              role: row.member.role,
-              user: row.user,
-              createdAt: row.access.createdAt,
-            })),
+            members: (memberAccessByHubId.get(skillHub.id) ?? []).map((row) => {
+              const email = row.user?.email ?? row.invitation?.email ?? "invited@example.com"
+              return {
+                id: row.access.id,
+                orgMembershipId: row.member.id,
+                role: row.member.role,
+                user: {
+                  id: row.user?.id ?? row.member.id,
+                  name: row.user?.name ?? getInvitedMemberName(email),
+                  email,
+                  image: row.user?.image ?? null,
+                },
+                createdAt: row.access.createdAt,
+              }
+            }),
             teams: (teamAccessByHubId.get(skillHub.id) ?? []).map((row) => ({
               id: row.access.id,
               teamId: row.team.id,
@@ -1020,7 +1038,7 @@ export function registerOrgSkillRoutes<T extends { Variables: OrgRouteVariables 
         const memberRows = await db
           .select({ id: MemberTable.id })
           .from(MemberTable)
-          .where(and(eq(MemberTable.id, orgMembershipId), eq(MemberTable.organizationId, payload.organization.id)))
+          .where(and(eq(MemberTable.id, orgMembershipId), eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.removedAt)))
           .limit(1)
 
         if (!memberRows[0]) {

--- a/ee/apps/den-api/src/routes/org/teams.ts
+++ b/ee/apps/den-api/src/routes/org/teams.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "@openwork-ee/den-db/drizzle"
+import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
 import {
   MemberTable,
   SkillHubMemberTable,
@@ -76,7 +76,7 @@ async function ensureMembersBelongToOrganization(input: {
   const rows = await db
     .select({ id: MemberTable.id })
     .from(MemberTable)
-    .where(eq(MemberTable.organizationId, input.organizationId))
+    .where(and(eq(MemberTable.organizationId, input.organizationId), isNull(MemberTable.removedAt)))
 
   const memberIds = new Set(rows.map((row) => row.id))
   return input.memberIds.every((memberId) => memberIds.has(memberId))

--- a/ee/apps/den-api/src/routes/telemetry/index.ts
+++ b/ee/apps/den-api/src/routes/telemetry/index.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, sql } from "@openwork-ee/den-db/drizzle"
+import { and, eq, gte, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import { TelemetryEventTable, MemberTable, InvitationTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
@@ -108,7 +108,7 @@ export function registerTelemetryRoutes<T extends { Variables: TelemetryRouteVar
         db
           .select({ count: sql<number>`count(*)` })
           .from(MemberTable)
-          .where(eq(MemberTable.organizationId, orgId)),
+          .where(and(eq(MemberTable.organizationId, orgId), isNull(MemberTable.removedAt))),
         db
           .select({ count: sql<number>`count(*)` })
           .from(InvitationTable)

--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -1,5 +1,5 @@
 import Stripe from "stripe"
-import { and, eq, sql } from "@openwork-ee/den-db/drizzle"
+import { and, eq, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import {
   MemberTable,
   OrgSubscriptionStatus,
@@ -82,7 +82,7 @@ async function activeMemberCount(organizationId: OrgId) {
   const [row] = await db
     .select({ count: sql<number>`count(*)` })
     .from(MemberTable)
-    .where(eq(MemberTable.organizationId, organizationId))
+    .where(and(eq(MemberTable.organizationId, organizationId), isNull(MemberTable.removedAt)))
   return Math.max(0, Number(row?.count ?? 0))
 }
 

--- a/ee/apps/den-api/test/org-invitations.test.ts
+++ b/ee/apps/den-api/test/org-invitations.test.ts
@@ -56,7 +56,7 @@ test("legacy org-scoped proxy also reaches non-invitation org resources", async 
 
 test("current org endpoints are not swallowed by the legacy proxy", async () => {
   const app = createOrgApp()
-  const response = await app.request("http://den.local/v1/orgs/invitations/preview?id=bad", {
+  const response = await app.request("http://den.local/v1/orgs/invitations/preview?id=", {
     method: "GET",
   })
 

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -14,9 +14,11 @@ export type DenOrgSummary = {
 
 export type DenOrgMember = {
   id: string;
-  userId: string;
+  userId: string | null;
+  inviteId: string | null;
   role: string;
   createdAt: string | null;
+  joinedAt: string | null;
   isOwner: boolean;
   user: {
     id: string;
@@ -33,6 +35,7 @@ export type DenOrgInvitation = {
   status: string;
   expiresAt: string | null;
   createdAt: string | null;
+  inviteToken: string | null;
 };
 
 export type DenOrgTeam = {
@@ -459,15 +462,17 @@ export function parseOrgContextPayload(payload: unknown): DenOrgContext | null {
           const userEmail = asString(user.email);
           const userName = asString(user.name);
           const userIdentity = asString(user.id);
-          if (!id || !userId || !role || !userEmail || !userName || !userIdentity) {
+          if (!id || !role || !userEmail || !userName || !userIdentity) {
             return null;
           }
 
           return {
             id,
             userId,
+            inviteId: asString(entry.inviteId),
             role,
             createdAt: asIsoString(entry.createdAt),
+            joinedAt: asIsoString(entry.joinedAt),
             isOwner: asBoolean(entry.isOwner),
             user: {
               id: userIdentity,
@@ -502,6 +507,7 @@ export function parseOrgContextPayload(payload: unknown): DenOrgContext | null {
             status,
             expiresAt: asIsoString(entry.expiresAt),
             createdAt: asIsoString(entry.createdAt),
+            inviteToken: asString(entry.inviteToken),
           } satisfies DenOrgInvitation;
         })
         .filter((entry): entry is DenOrgInvitation => entry !== null)

--- a/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
@@ -4,10 +4,12 @@ import { type ElementType, useEffect, useMemo, useState } from "react";
 import {
   CheckCircle2,
   Circle,
+  Link,
   Lock,
-  Mail,
+  MoreHorizontal,
   Pencil,
   Plus,
+  Send,
   Settings,
   Shield,
   Trash2,
@@ -17,6 +19,7 @@ import {
 import {
   DEN_ROLE_PERMISSION_OPTIONS,
   formatRoleLabel,
+  getJoinOrgRoute,
   getOrgAccessFlags,
   getMembersRoute,
   splitRoleString,
@@ -31,8 +34,9 @@ import { DenButton } from "../../_components/ui/button";
 import { DenCard } from "../../_components/ui/card";
 import { DenInput } from "../../_components/ui/input";
 import { DenSelect } from "../../_components/ui/select";
+import { OrgMemberIdentity } from "./org-member-identity";
 
-type MembersTab = "members" | "teams" | "roles" | "invitations";
+type MembersTab = "members" | "teams" | "roles";
 
 function clonePermissionRecord(value: Record<string, string[]>) {
   return Object.fromEntries(
@@ -139,6 +143,7 @@ export function ManageMembersScreen() {
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState("member");
   const [editingMemberId, setEditingMemberId] = useState<string | null>(null);
+  const [openMemberMenuId, setOpenMemberMenuId] = useState<string | null>(null);
   const [memberRoleDraft, setMemberRoleDraft] = useState("member");
   const [showTeamForm, setShowTeamForm] = useState(false);
   const [editingTeamId, setEditingTeamId] = useState<string | null>(null);
@@ -166,19 +171,10 @@ export function ManageMembersScreen() {
     [orgContext?.currentMember.isOwner, orgContext?.currentMember.role],
   );
 
-  const pendingInvitations = useMemo(
-    () =>
-      (orgContext?.invitations ?? []).filter(
-        (invitation) => invitation.status === "pending",
-      ),
-    [orgContext?.invitations],
-  );
-
   const tabCounts: Record<MembersTab, number> = {
     members: orgContext?.members.length ?? 0,
     teams: orgContext?.teams.length ?? 0,
     roles: orgContext?.roles.length ?? 0,
-    invitations: pendingInvitations.length,
   };
 
   const teamMemberNames = useMemo(() => {
@@ -197,6 +193,11 @@ export function ManageMembersScreen() {
       ]),
     );
   }, [orgContext?.members, orgContext?.teams]);
+
+  const invitationsById = useMemo(
+    () => new Map((orgContext?.invitations ?? []).map((invitation) => [invitation.id, invitation])),
+    [orgContext?.invitations],
+  );
 
   const feedbackHref = useMemo(
     () =>
@@ -441,16 +442,7 @@ export function ManageMembersScreen() {
                       ) : (
                         <Circle className="mt-0.5 h-6 w-6 shrink-0 text-gray-300" />
                       )}
-                      <div>
-                        <p className="text-[15px] font-medium tracking-[-0.03em]">
-                          {member.user.name}
-                        </p>
-                        <p
-                          className={`mt-1 text-[13px] ${selected ? "text-white/70" : "text-gray-400"}`}
-                        >
-                          {member.user.email}
-                        </p>
-                      </div>
+                      <OrgMemberIdentity member={member} inverted={selected} />
                     </button>
                   );
                 })}
@@ -599,15 +591,6 @@ export function ManageMembersScreen() {
         },
       };
     }
-    if (activeTab === "invitations" && access.canInviteMembers) {
-      return {
-        label: "Invite member",
-        onClick: () => {
-          resetMemberEditor();
-          setShowInviteForm((current) => !current);
-        },
-      };
-    }
     return null;
   })();
 
@@ -645,7 +628,6 @@ export function ManageMembersScreen() {
           { value: "members", label: "Members", icon: User, count: tabCounts.members },
           { value: "teams", label: "Teams", icon: Users, count: tabCounts.teams },
           { value: "roles", label: "Roles", icon: Shield, count: tabCounts.roles },
-          { value: "invitations", label: "Invitations", icon: Mail, count: tabCounts.invitations },
         ]}
       />
 
@@ -653,7 +635,6 @@ export function ManageMembersScreen() {
       {activeTab === "members" ? editMemberForm : null}
       {activeTab === "teams" ? teamForm : null}
       {activeTab === "roles" ? roleForm : null}
-      {activeTab === "invitations" ? inviteForm : null}
 
       {activeTab === "members" ? (
         <div>
@@ -670,7 +651,7 @@ export function ManageMembersScreen() {
             ) : null}
           </div>
 
-          <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
+          <div className="overflow-visible rounded-2xl border border-gray-100 bg-white">
             <div className="grid grid-cols-[minmax(0,1fr)_180px_140px_160px] gap-4 border-b border-gray-100 px-6 py-3 text-[11px] font-medium uppercase tracking-wide text-gray-400">
               <span>Member</span>
               <span>Role</span>
@@ -678,86 +659,147 @@ export function ManageMembersScreen() {
               <span />
             </div>
 
-            {orgContext.members.map((member) => (
-              <div
-                key={member.id}
-                className="grid grid-cols-[minmax(0,1fr)_180px_140px_160px] items-center gap-4 border-b border-gray-100 px-6 py-3.5 transition hover:bg-gray-50/60 last:border-b-0"
-              >
-                <div className="flex min-w-0 items-center gap-3">
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#0f172a] text-[11px] font-semibold uppercase text-white">
-                    {member.user.name
-                      .split(" ")
-                      .map((part) => part[0])
-                      .join("")
-                      .slice(0, 2)}
-                  </div>
-                  <div className="min-w-0">
-                    <p className="truncate text-[13px] font-medium text-gray-900">
-                      {member.user.name}
-                    </p>
-                    <p className="truncate text-[12px] text-gray-400">
-                      {member.user.email}
-                    </p>
+            {orgContext.members.map((member) => {
+              const isInvited = !member.joinedAt;
+              const inviteId = member.inviteId;
+              const inviteToken = inviteId ? invitationsById.get(inviteId)?.inviteToken : null;
+              const canOpenActions = member.isOwner
+                ? false
+                : isInvited
+                  ? access.canInviteMembers || access.canCancelInvitations
+                  : access.canManageMembers;
+
+              return (
+                <div
+                  key={member.id}
+                  className="grid grid-cols-[minmax(0,1fr)_180px_140px_160px] items-center gap-4 border-b border-gray-100 px-6 py-3.5 transition hover:bg-gray-50/60 last:border-b-0"
+                >
+                  <OrgMemberIdentity member={member} />
+                  <span className="text-[13px] text-gray-500">
+                    {splitRoleString(member.role).map(formatRoleLabel).join(", ")}
+                  </span>
+                  <span className="text-[13px] text-gray-400">
+                    {member.joinedAt
+                      ? new Date(member.joinedAt).toLocaleDateString()
+                      : "Pending"}
+                  </span>
+                  <div className="relative flex items-center justify-end gap-2">
+                    {member.isOwner ? (
+                      <span className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-[12px] text-gray-400">
+                        <Lock className="h-3 w-3" />
+                        Locked
+                      </span>
+                    ) : canOpenActions ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => setOpenMemberMenuId((current) => current === member.id ? null : member.id)}
+                          className="rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700"
+                          aria-label={`Open actions for ${member.user.name}`}
+                        >
+                          <MoreHorizontal className="h-4 w-4" />
+                        </button>
+                        {openMemberMenuId === member.id ? (
+                          <div className="absolute right-0 top-9 z-10 w-44 overflow-hidden rounded-2xl border border-gray-100 bg-white p-1.5 text-[13px] shadow-xl shadow-gray-900/10">
+                            {isInvited && inviteToken ? (
+                              <button
+                                type="button"
+                                onClick={async () => {
+                                  const inviteUrl = new URL(getJoinOrgRoute(inviteToken), window.location.origin).toString();
+                                  await navigator.clipboard.writeText(inviteUrl);
+                                  setOpenMemberMenuId(null);
+                                }}
+                                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50"
+                              >
+                                <Link className="h-3.5 w-3.5" />
+                                Copy invite link
+                              </button>
+                            ) : null}
+                            {isInvited && access.canInviteMembers ? (
+                              <button
+                                type="button"
+                                onClick={async () => {
+                                  setPageError(null);
+                                  try {
+                                    await inviteMember({ email: member.user.email, role: member.role });
+                                    setOpenMemberMenuId(null);
+                                  } catch (error) {
+                                    setPageError(error instanceof Error ? error.message : "Could not resend invitation.");
+                                  }
+                                }}
+                                disabled={mutationBusy === "invite-member"}
+                                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                <Send className="h-3.5 w-3.5" />
+                                Resend invite
+                              </button>
+                            ) : null}
+                            {isInvited && access.canCancelInvitations && inviteId ? (
+                              <button
+                                type="button"
+                                onClick={async () => {
+                                  setPageError(null);
+                                  try {
+                                    await cancelInvitation(inviteId);
+                                    setOpenMemberMenuId(null);
+                                  } catch (error) {
+                                    setPageError(error instanceof Error ? error.message : "Could not cancel invitation.");
+                                  }
+                                }}
+                                disabled={mutationBusy === "cancel-invitation"}
+                                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                                Cancel invite
+                              </button>
+                            ) : null}
+                            {!isInvited && access.canManageMembers ? (
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setEditingMemberId(member.id);
+                                  setMemberRoleDraft(member.role);
+                                  setShowInviteForm(false);
+                                  setOpenMemberMenuId(null);
+                                }}
+                                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50"
+                              >
+                                <Settings className="h-3.5 w-3.5" />
+                                Edit role
+                              </button>
+                            ) : null}
+                            {!isInvited && access.canManageMembers ? (
+                              <button
+                                type="button"
+                                onClick={async () => {
+                                  setPageError(null);
+                                  try {
+                                    await removeMember(member.id);
+                                    if (editingMemberId === member.id) {
+                                      resetMemberEditor();
+                                    }
+                                    setOpenMemberMenuId(null);
+                                  } catch (error) {
+                                    setPageError(error instanceof Error ? error.message : "Could not remove member.");
+                                  }
+                                }}
+                                disabled={mutationBusy === "remove-member"}
+                                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                                Remove member
+                              </button>
+                            ) : null}
+                          </div>
+                        ) : null}
+                      </>
+                    ) : (
+                      <span className="text-[13px] text-gray-400">Read only</span>
+                    )}
                   </div>
                 </div>
-                <span className="text-[13px] text-gray-500">
-                  {splitRoleString(member.role).map(formatRoleLabel).join(", ")}
-                </span>
-                <span className="text-[13px] text-gray-400">
-                  {member.createdAt
-                    ? new Date(member.createdAt).toLocaleDateString()
-                    : "-"}
-                </span>
-                <div className="flex items-center justify-end gap-2">
-                  {member.isOwner ? (
-                    <span className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-[12px] text-gray-400">
-                      <Lock className="h-3 w-3" />
-                      Locked
-                    </span>
-                  ) : access.canManageMembers ? (
-                    <>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setEditingMemberId(member.id);
-                          setMemberRoleDraft(member.role);
-                          setShowInviteForm(false);
-                        }}
-                        className="rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700"
-                        aria-label={`Edit ${member.user.name}`}
-                      >
-                        <Settings className="h-4 w-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={async () => {
-                          setPageError(null);
-                          try {
-                            await removeMember(member.id);
-                            if (editingMemberId === member.id) {
-                              resetMemberEditor();
-                            }
-                          } catch (error) {
-                            setPageError(
-                              error instanceof Error
-                                ? error.message
-                                : "Could not remove member.",
-                            );
-                          }
-                        }}
-                        disabled={mutationBusy === "remove-member"}
-                        className="rounded-full p-2 text-gray-400 transition hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-60"
-                        aria-label={`Remove ${member.user.name}`}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </>
-                  ) : (
-                    <span className="text-[13px] text-gray-400">Read only</span>
-                  )}
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       ) : null}
@@ -773,7 +815,7 @@ export function ManageMembersScreen() {
             ) : null}
           </div>
 
-          <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
+          <div className="overflow-x-auto overflow-y-visible rounded-2xl border border-gray-100 bg-white">
             <div className="grid grid-cols-[minmax(0,1fr)_160px_200px] gap-4 border-b border-gray-100 px-6 py-3 text-[11px] font-medium uppercase tracking-wide text-gray-400">
               <span>Team</span>
               <span>Members</span>
@@ -868,7 +910,7 @@ export function ManageMembersScreen() {
             ) : null}
           </div>
 
-          <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
+          <div className="overflow-x-auto overflow-y-visible rounded-2xl border border-gray-100 bg-white">
             <div className="grid grid-cols-[minmax(0,1fr)_120px_200px] gap-4 border-b border-gray-100 px-6 py-3 text-[11px] font-medium uppercase tracking-wide text-gray-400">
               <span>Role</span>
               <span>Type</span>
@@ -935,82 +977,6 @@ export function ManageMembersScreen() {
                 </div>
               </div>
             ))}
-          </div>
-        </div>
-      ) : null}
-
-      {activeTab === "invitations" ? (
-        <div>
-          <div className="mb-6 flex items-center justify-between gap-4">
-            <p className="text-[15px] text-gray-400">
-              Admins and owners can revoke pending invites before they are accepted.
-            </p>
-            {toolbarAction ? (
-              <DenButton icon={Plus} onClick={toolbarAction.onClick}>
-                {toolbarAction.label}
-              </DenButton>
-            ) : null}
-          </div>
-
-          <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
-            <div className="grid grid-cols-[minmax(0,1fr)_140px_140px_120px] gap-4 border-b border-gray-100 px-6 py-3 text-[11px] font-medium uppercase tracking-wide text-gray-400">
-              <span>Email</span>
-              <span>Role</span>
-              <span>Expires</span>
-              <span />
-            </div>
-
-            {pendingInvitations.length === 0 ? (
-              <div className="px-6 py-8 text-center text-[13px] text-gray-400">
-                You have no pending workspace invites.
-              </div>
-            ) : (
-              pendingInvitations.map((invitation) => (
-                <div
-                  key={invitation.id}
-                  className="grid grid-cols-[minmax(0,1fr)_140px_140px_120px] items-center gap-4 border-b border-gray-100 px-6 py-3.5 transition hover:bg-gray-50/60 last:border-b-0"
-                >
-                  <span className="truncate text-[13px] text-gray-900">
-                    {invitation.email}
-                  </span>
-                  <span className="text-[13px] text-gray-500">
-                    {formatRoleLabel(invitation.role)}
-                  </span>
-                  <span className="text-[13px] text-gray-400">
-                    {invitation.expiresAt
-                      ? new Date(invitation.expiresAt).toLocaleDateString()
-                      : "-"}
-                  </span>
-                  <div className="flex justify-end">
-                    {access.canCancelInvitations ? (
-                      <ActionButton
-                        disabled={mutationBusy === "cancel-invitation"}
-                        onClick={async () => {
-                          setPageError(null);
-                          try {
-                            await cancelInvitation(invitation.id);
-                          } catch (error) {
-                            setPageError(
-                              error instanceof Error
-                                ? error.message
-                                : "Could not cancel invitation.",
-                            );
-                          }
-                        }}
-                      >
-                        {mutationBusy === "cancel-invitation"
-                          ? "Cancelling..."
-                          : "Cancel"}
-                      </ActionButton>
-                    ) : (
-                      <span className="text-[13px] text-gray-400">
-                        Read only
-                      </span>
-                    )}
-                  </div>
-                </div>
-              ))
-            )}
           </div>
         </div>
       ) : null}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-member-identity.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-member-identity.tsx
@@ -1,0 +1,48 @@
+import { splitRoleString, type DenOrgMember } from "../../_lib/den-org";
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2);
+}
+
+export function OrgMemberIdentity({
+  member,
+  inverted = false,
+}: {
+  member: DenOrgMember;
+  inverted?: boolean;
+}) {
+  const isAdmin = splitRoleString(member.role).includes("admin");
+  const isInvited = !member.joinedAt;
+
+  return (
+    <div className="flex min-w-0 items-center gap-3">
+      <div className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold uppercase ${inverted ? "bg-white/15 text-white" : "bg-[#0f172a] text-white"}`}>
+        {getInitials(member.user.name)}
+      </div>
+      <div className="min-w-0">
+        <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+          <p className={`truncate text-[13px] font-medium ${inverted ? "text-white" : "text-gray-900"}`}>
+            {member.user.name}
+          </p>
+          {isAdmin ? (
+            <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] ${inverted ? "bg-white/15 text-white/80" : "bg-indigo-50 text-indigo-600"}`}>
+              Admin
+            </span>
+          ) : null}
+          {isInvited ? (
+            <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] ${inverted ? "bg-white/15 text-white/80" : "bg-amber-50 text-amber-700"}`}>
+              Invited
+            </span>
+          ) : null}
+        </div>
+        <p className={`truncate text-[12px] ${inverted ? "text-white/70" : "text-gray-400"}`}>
+          {member.user.email}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ee/packages/den-db/drizzle/0018_invited_org_members.sql
+++ b/ee/packages/den-db/drizzle/0018_invited_org_members.sql
@@ -1,0 +1,29 @@
+ALTER TABLE `member` MODIFY COLUMN `user_id` varchar(64);
+--> statement-breakpoint
+ALTER TABLE `member` ADD `invite_id` varchar(64);
+--> statement-breakpoint
+ALTER TABLE `member` ADD `invited_by_org_member` varchar(64);
+--> statement-breakpoint
+ALTER TABLE `member` ADD `joined_at` timestamp(3) NULL DEFAULT (now());
+--> statement-breakpoint
+UPDATE `member` SET `joined_at` = `created_at` WHERE `joined_at` IS NULL;
+--> statement-breakpoint
+ALTER TABLE `member` ADD `removed_at` timestamp(3);
+--> statement-breakpoint
+ALTER TABLE `member` ADD `removed_by_org_member` varchar(64);
+--> statement-breakpoint
+ALTER TABLE `invitation` ADD `org_member_id` varchar(64);
+--> statement-breakpoint
+ALTER TABLE `invitation` ADD `invite_token` varchar(64);
+--> statement-breakpoint
+CREATE INDEX `member_invite_id` ON `member` (`invite_id`);
+--> statement-breakpoint
+CREATE INDEX `member_invited_by_org_member` ON `member` (`invited_by_org_member`);
+--> statement-breakpoint
+CREATE INDEX `member_removed_at` ON `member` (`removed_at`);
+--> statement-breakpoint
+CREATE INDEX `member_removed_by_org_member` ON `member` (`removed_by_org_member`);
+--> statement-breakpoint
+CREATE INDEX `invitation_org_member_id` ON `invitation` (`org_member_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `invitation_invite_token` ON `invitation` (`invite_token`);

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1779129600000,
       "tag": "0017_desktop_policies",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "5",
+      "when": 1779380000000,
+      "tag": "0018_invited_org_members",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/src/schema/org.ts
+++ b/ee/packages/den-db/src/schema/org.ts
@@ -42,13 +42,22 @@ export const MemberTable = mysqlTable(
   {
     id: denTypeIdColumn("member", "id").notNull().primaryKey(),
     organizationId: denTypeIdColumn("organization", "organization_id").notNull(),
-    userId: denTypeIdColumn("user", "user_id").notNull(),
+    userId: denTypeIdColumn("user", "user_id"),
+    inviteId: denTypeIdColumn("invitation", "invite_id"),
+    invitedByOrgMember: denTypeIdColumn("member", "invited_by_org_member"),
     role: varchar("role", { length: 255 }).notNull().default("member"),
+    joinedAt: timestamp("joined_at", { fsp: 3 }).defaultNow(),
+    removedAt: timestamp("removed_at", { fsp: 3 }),
+    removedByOrgMember: denTypeIdColumn("member", "removed_by_org_member"),
     createdAt: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),
   },
   (table) => [
     index("member_organization_id").on(table.organizationId),
     index("member_user_id").on(table.userId),
+    index("member_invite_id").on(table.inviteId),
+    index("member_invited_by_org_member").on(table.invitedByOrgMember),
+    index("member_removed_at").on(table.removedAt),
+    index("member_removed_by_org_member").on(table.removedByOrgMember),
     uniqueIndex("member_organization_user").on(table.organizationId, table.userId),
   ],
 )
@@ -63,6 +72,8 @@ export const InvitationTable = mysqlTable(
     status: varchar("status", { length: 32 }).notNull().default("pending"),
     teamId: denTypeIdColumn("team", "team_id"),
     inviterId: denTypeIdColumn("user", "inviter_id").notNull(),
+    orgMemberId: denTypeIdColumn("member", "org_member_id"),
+    inviteToken: varchar("invite_token", { length: 64 }),
     expiresAt: timestamp("expires_at", { fsp: 3 }).notNull(),
     createdAt: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),
   },
@@ -71,6 +82,8 @@ export const InvitationTable = mysqlTable(
     index("invitation_email").on(table.email),
     index("invitation_status").on(table.status),
     index("invitation_team_id").on(table.teamId),
+    index("invitation_org_member_id").on(table.orgMemberId),
+    uniqueIndex("invitation_invite_token").on(table.inviteToken),
   ],
 )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,9 @@ importers:
       hono-openapi:
         specifier: ^1.3.0
         version: 1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.8))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(hono@4.12.8)(openapi-types@12.1.3)
+      nanoid:
+        specifier: ^5.1.11
+        version: 5.1.11
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
@@ -7289,6 +7292,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   nanostores@1.2.0:
@@ -16413,6 +16421,8 @@ snapshots:
       lru.min: 1.1.4
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.11: {}
 
   nanostores@1.2.0: {}
 


### PR DESCRIPTION
## Summary
- Create an organization member row when an invitation is sent, using a short nanoid invite token for email/join links.
- Link accepted invites back to the existing invited member and soft-remove members/invites instead of deleting active records.
- Merge pending invitations into the members UI with invited/admin badges and invite actions in the member overflow menu.

## Testing
- `pnpm --filter @openwork-ee/den-api build` passed.
- `pnpm --filter @openwork-ee/den-web build` passed.
- `bun test ee/apps/den-api/test/org-invitations.test.ts` passed.
- Manually verified local invite creation, token-based email link preview/accept, resend, copy invite link, pending member badge/actions, accepted member transition, and cancel invite flow in `pnpm dev:web-local`.

## Review Evidence
- No screen recording or screenshots were captured in this run. The manual verification steps above can be reproduced with `pnpm dev:web-local`.

## Notes
- `db:push` prompted interactively for the new unique invite-token index during local verification, so the local schema was applied manually for testing.