### PR TITLE
fix(desktop): probe for free CDP port to avoid collisions

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import { execFile, execFileSync } from "node:child_process";
 import { createServer } from "node:http";
+import net from "node:net";
 import { existsSync } from "node:fs";
 import {
   cp,
@@ -226,18 +227,38 @@ if (process.platform === "darwin" && APP_ICON_IMAGE && !APP_ICON_IMAGE.isEmpty()
 
 // Expose Chrome DevTools Protocol so the opencode-chrome-devtools plugin can
 // drive the built-in browser panel.  Use OPENWORK_ELECTRON_REMOTE_DEBUG_PORT to
-// pin a specific port; otherwise pick a default (9223) that stays out of the
-// way of common dev-tools ports (9222 = Chrome, 9229 = Node inspector).
+// pin a specific port; otherwise probe for a free one starting at 9223.
+// Must resolve before app.commandLine.appendSwitch (before `ready`).
+function probePort(port) {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.once("error", () => resolve(false));
+    srv.listen({ port, host: "127.0.0.1" }, () => {
+      srv.close(() => resolve(true));
+    });
+  });
+}
+
+async function findFreeCdpPort(candidates) {
+  for (const port of candidates) {
+    if (await probePort(port)) return port;
+  }
+  return 0;
+}
+
 const explicitCdpPort = Number.parseInt(
   process.env.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT?.trim() ?? "",
   10,
 );
 const remoteDebugPort = Number.isFinite(explicitCdpPort) && explicitCdpPort > 0
   ? explicitCdpPort
-  : 9223;
-app.commandLine.appendSwitch("remote-debugging-port", String(remoteDebugPort));
-app.commandLine.appendSwitch("remote-debugging-address", "127.0.0.1");
-// Make the port available to the embedded server so it can pass it to OpenCode.
+  : await findFreeCdpPort([9223, 9224, 9225, 9226, 9227]);
+if (remoteDebugPort > 0) {
+  app.commandLine.appendSwitch("remote-debugging-port", String(remoteDebugPort));
+  app.commandLine.appendSwitch("remote-debugging-address", "127.0.0.1");
+}
+// Make the resolved port available to the embedded server so it flows into
+// agent instructions via ensureOpenworkAgent → resolveAgentTemplate.
 process.env.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT = String(remoteDebugPort);
 
 // Apply extra Chromium flags from ELECTRON_EXTRA_LAUNCH_ARGS.


### PR DESCRIPTION
## Problem

When multiple OpenWork instances run simultaneously (prod + dev), they both try to bind CDP port 9223. The second instance's browser tools end up targeting the wrong app — e.g. navigating the prod browser panel when the user is working in dev.

## Fix

Electron now probes ports 9223–9227 at startup using `net.createServer()` and picks the first free one. The resolved port flows into agent instructions via `resolveAgentTemplate()` so the `opencode-chrome-devtools` plugin always connects to the correct instance.

`OPENWORK_ELECTRON_REMOTE_DEBUG_PORT` still works as an explicit override.

## Testing

1. Blocked port 9223 with a dummy TCP server
2. Started Electron dev instance
3. Confirmed it picked port **9224** (`DevTools listening on ws://127.0.0.1:9224/...`)
4. Verified agent file has `browser_url: "http://127.0.0.1:9224"`
5. Sent browser task → `browser_list` + `browser_navigate` worked on port 9224
6. Browser panel navigated to example.com successfully

## Changes

- `apps/desktop/electron/main.mjs`: `probePort()` + `findFreeCdpPort()` with top-level await
- 1 file, +27/-6 lines