### PR TITLE
fix(den-api): invalidate GitHub discovery cache by head sha

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
@@ -486,7 +486,7 @@ export async function getGithubRepositoryTextFile(input: {
   return Buffer.from(response.body.content.replace(/\n/g, ""), "base64").toString("utf8")
 }
 
-export async function getGithubRepositoryTree(input: {
+async function getGithubRepositoryCommit(input: {
   branch: string
   config: GithubConnectorAppConfig
   fetchFn?: GithubFetch
@@ -522,6 +522,36 @@ export async function getGithubRepositoryTree(input: {
     throw new GithubConnectorRequestError("GitHub commit response was missing the head or tree sha.", 502, commitResponse.body)
   }
 
+  return {
+    headSha,
+    repositoryParts,
+    token,
+    treeSha,
+  }
+}
+
+export async function getGithubRepositoryHeadSha(input: {
+  branch: string
+  config: GithubConnectorAppConfig
+  fetchFn?: GithubFetch
+  installationId: number
+  repositoryFullName: string
+  token?: string
+}) {
+  const commit = await getGithubRepositoryCommit(input)
+  return commit.headSha
+}
+
+export async function getGithubRepositoryTree(input: {
+  branch: string
+  config: GithubConnectorAppConfig
+  fetchFn?: GithubFetch
+  installationId: number
+  repositoryFullName: string
+  token?: string
+}) {
+  const commit = await getGithubRepositoryCommit(input)
+
   const treeResponse = await requestGithubJson<{
     truncated?: boolean
     tree?: Array<{
@@ -532,8 +562,10 @@ export async function getGithubRepositoryTree(input: {
     }>
   }>({
     fetchFn: input.fetchFn,
-    headers: authHeaders,
-    path: `/repos/${encodeURIComponent(repositoryParts.owner)}/${encodeURIComponent(repositoryParts.repo)}/git/trees/${encodeURIComponent(treeSha)}?recursive=1`,
+    headers: {
+      Authorization: `Bearer ${commit.token}`,
+    },
+    path: `/repos/${encodeURIComponent(commit.repositoryParts.owner)}/${encodeURIComponent(commit.repositoryParts.repo)}/git/trees/${encodeURIComponent(commit.treeSha)}?recursive=1`,
   })
 
   const treeEntries = Array.isArray(treeResponse.body.tree)
@@ -555,10 +587,10 @@ export async function getGithubRepositoryTree(input: {
     : []
 
   return {
-    headSha,
+    headSha: commit.headSha,
     truncated: Boolean(treeResponse.body.truncated),
     treeEntries,
-    treeSha,
+    treeSha: commit.treeSha,
   } satisfies GithubRepositoryTreeSnapshot
 }
 

--- a/ee/apps/den-api/src/routes/org/plugin-system/github-discovery.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/github-discovery.ts
@@ -69,6 +69,23 @@ export type GithubRepoDiscoveryResult = {
   warnings: string[]
 }
 
+export type GithubDiscoveryCacheIdentity = {
+  branch: string
+  ref: string
+  repositoryFullName: string
+  sourceRevisionRef: string
+}
+
+export function isGithubDiscoveryCacheFresh(input: GithubDiscoveryCacheIdentity & {
+  cached: GithubDiscoveryCacheIdentity | null
+}) {
+  return Boolean(input.cached
+    && input.cached.branch === input.branch
+    && input.cached.ref === input.ref
+    && input.cached.repositoryFullName === input.repositoryFullName
+    && input.cached.sourceRevisionRef === input.sourceRevisionRef)
+}
+
 type MarketplaceEntry = {
   agents?: unknown
   commands?: unknown

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -31,6 +31,7 @@ import {
   getGithubAppSummary,
   getGithubConnectorAppConfig,
   getGithubInstallationAccessToken,
+  getGithubRepositoryHeadSha,
   getGithubRepositoryTextFile,
   getGithubRepositoryTree,
   getGithubInstallationSummary,
@@ -40,6 +41,7 @@ import {
 } from "./github-app.js"
 import {
   buildGithubRepoDiscovery,
+  isGithubDiscoveryCacheFresh,
   type GithubDiscoveredPlugin,
   type GithubDiscoveryClassification,
   type GithubMarketplaceInfo,
@@ -2480,6 +2482,12 @@ async function getGithubDiscoveryContext(input: { connectorInstanceId: Connector
     installationId,
     ref,
     repositoryFullName,
+    sourceRevisionRef: await getGithubRepositoryHeadSha({
+      branch,
+      config: githubConnectorAppConfig(),
+      installationId,
+      repositoryFullName,
+    }),
   }
 }
 
@@ -2727,10 +2735,13 @@ async function resolveGithubConnectorDiscovery(input: { connectorInstanceId: Con
     ? discoveryContext.connectorTarget.targetConfigJson as Record<string, unknown>
     : null
   const cached = readGithubDiscoveryCache(targetConfig)
-  if (cached
-    && cached.branch === discoveryContext.branch
-    && cached.ref === discoveryContext.ref
-    && cached.repositoryFullName === discoveryContext.repositoryFullName) {
+  if (cached && isGithubDiscoveryCacheFresh({
+    cached,
+    branch: discoveryContext.branch,
+    ref: discoveryContext.ref,
+    repositoryFullName: discoveryContext.repositoryFullName,
+    sourceRevisionRef: discoveryContext.sourceRevisionRef,
+  })) {
     return {
       autoImportNewPlugins: discoveryContext.autoImportNewPlugins,
       cache: cached,

--- a/ee/apps/den-api/test/github-connector-app.test.ts
+++ b/ee/apps/den-api/test/github-connector-app.test.ts
@@ -7,6 +7,7 @@ import {
   getGithubAppSummary,
   getGithubConnectorAppConfig,
   getGithubInstallationSummary,
+  getGithubRepositoryHeadSha,
   listGithubInstallationRepositories,
   normalizeGithubPrivateKey,
   validateGithubInstallationTarget,
@@ -84,6 +85,32 @@ describe("github connector app helpers", () => {
     expect(repositories).toEqual([
       { defaultBranch: "main", fullName: "different-ai/openwork", hasPluginManifest: true, id: 42, manifestKind: "marketplace", marketplacePluginCount: 3, private: true },
       { defaultBranch: "dev", fullName: "different-ai/opencode", hasPluginManifest: true, id: 99, manifestKind: "plugin", marketplacePluginCount: null, private: false },
+    ])
+  })
+
+  test("reads the current GitHub branch head sha without fetching the full tree", async () => {
+    const requests: string[] = []
+    const headSha = await getGithubRepositoryHeadSha({
+      branch: "main",
+      config: { appId: "123456", privateKey: privateKeyPem },
+      fetchFn: async (url) => {
+        requests.push(String(url))
+        if (String(url).endsWith("/access_tokens")) {
+          return new Response(JSON.stringify({ token: "installation-token" }), { status: 201 })
+        }
+        if (String(url).endsWith("/repos/different-ai/openwork/commits/main")) {
+          return new Response(JSON.stringify({ sha: "head-sha-1", commit: { tree: { sha: "tree-sha-1" } } }), { status: 200 })
+        }
+        return new Response(JSON.stringify({ message: "not found" }), { status: 404 })
+      },
+      installationId: 777,
+      repositoryFullName: "different-ai/openwork",
+    })
+
+    expect(headSha).toBe("head-sha-1")
+    expect(requests).toEqual([
+      "https://api.github.com/app/installations/777/access_tokens",
+      "https://api.github.com/repos/different-ai/openwork/commits/main",
     ])
   })
 

--- a/ee/apps/den-api/test/github-discovery.test.ts
+++ b/ee/apps/den-api/test/github-discovery.test.ts
@@ -1,11 +1,31 @@
 import { describe, expect, test } from "bun:test"
-import { buildGithubRepoDiscovery, type GithubDiscoveryTreeEntry } from "../src/routes/org/plugin-system/github-discovery.js"
+import { buildGithubRepoDiscovery, isGithubDiscoveryCacheFresh, type GithubDiscoveryTreeEntry } from "../src/routes/org/plugin-system/github-discovery.js"
 
 function blob(path: string): GithubDiscoveryTreeEntry {
   return { id: path, kind: "blob", path, sha: null, size: null }
 }
 
 describe("github discovery", () => {
+  test("treats a changed source revision as a stale discovery cache", () => {
+    const cached = {
+      branch: "main",
+      ref: "refs/heads/main",
+      repositoryFullName: "different-ai/openwork",
+      sourceRevisionRef: "old-head",
+    }
+
+    expect(isGithubDiscoveryCacheFresh({
+      ...cached,
+      cached,
+      sourceRevisionRef: "old-head",
+    })).toBe(true)
+    expect(isGithubDiscoveryCacheFresh({
+      ...cached,
+      cached,
+      sourceRevisionRef: "new-head",
+    })).toBe(false)
+  })
+
   test("classifies marketplace repos and resolves local plugin roots", () => {
     const result = buildGithubRepoDiscovery({
       entries: [


### PR DESCRIPTION
## Summary
- fetch the current GitHub branch head SHA as part of discovery context
- require cached discovery entries to match sourceRevisionRef before reuse
- add focused tests for cache freshness and the head SHA helper

Fixes #1871.

## Tests
- bun test ee/apps/den-api/test/github-discovery.test.ts ee/apps/den-api/test/github-connector-app.test.ts
- pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit --pretty false
- git diff --check