### PR TITLE
fix(desktop): include zod in packaged app

### DIFF
--- a/apps/app/src/react-app/shell/loading-overlay.tsx
+++ b/apps/app/src/react-app/shell/loading-overlay.tsx
@@ -2,6 +2,8 @@
 import { useBootState, useBootOverlayVisible } from "./boot-state";
 import { OwDotTicker } from "./dot-ticker";
 
+const RELEASES_URL = "https://github.com/different-ai/openwork/releases";
+
 /**
  * Quiet, opaque boot overlay. Solid surface fill so nothing bleeds through.
  * A minimal typographic beat plus a small dot ticker. Fades once both the
@@ -30,7 +32,20 @@ export function LoadingOverlay() {
           {message || "Preparing workspace"}
         </div>
         {error ? (
-          <div className="text-[12px] leading-5 text-red-11">{error}</div>
+          <div className="flex flex-col gap-2 text-[12px] leading-5 text-red-11">
+            <div>{error}</div>
+            <div className="text-dls-secondary">
+              Download the latest version manually here:{" "}
+              <a
+                href={RELEASES_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="text-dls-primary underline decoration-dls-primary/40 underline-offset-4"
+              >
+                {RELEASES_URL}
+              </a>
+            </div>
+          </div>
         ) : null}
       </div>
     </div>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,7 +28,8 @@
     "electron-updater": "^6.3.9",
     "jsonc-parser": "^3.2.1",
     "minimatch": "^10.0.1",
-    "yaml": "^2.6.1"
+    "yaml": "^2.6.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "electron": "^35.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       yaml:
         specifier: ^2.6.1
         version: 2.8.2
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       electron:
         specifier: ^35.0.0


### PR DESCRIPTION
## Summary
- add zod back to the Electron desktop runtime dependencies so packaged server imports resolve from app.asar
- add a manual GitHub releases link to the boot error overlay

## Root cause
- first bad commit: c9f8dd86 feat(app): surface browser tools as extensions (#1861)
- that commit removed zod from apps/desktop/package.json, but apps/server/dist/session-read-model.js still imports zod at runtime inside the packaged Electron app

## Tests
- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/desktop typecheck:electron
- pnpm --filter @openwork/desktop check:electron
- node --check apps/desktop/electron/main.mjs
- git diff --check

## E2E evidence
- No video or screenshot captured. I did not build/install a packaged .app locally; verification was focused on dependency packaging metadata and type/syntax checks.