### PR TITLE
Add Daytona Den server sandbox

### DIFF
--- a/.devcontainer/Dockerfile.daytona-server
+++ b/.devcontainer/Dockerfile.daytona-server
@@ -1,0 +1,36 @@
+# Daytona image for the OpenWork Den server stack.
+#
+# This intentionally does not run Docker inside Daytona. The sandbox runs the
+# same services as packaging/docker/docker-compose.den-dev.yml directly:
+# MySQL, Den API, Den Web, and the worker proxy.
+FROM daytonaio/sandbox:0.6.0
+
+USER root
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    default-mysql-client \
+    default-mysql-server \
+    git \
+    procps \
+    sudo \
+  && /usr/local/share/nvm/current/bin/npm install -g pnpm@10.27.0 bun \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /root/.cache /root/.npm /tmp/*
+
+WORKDIR /workspace
+
+RUN git clone --depth 1 --branch dev https://github.com/different-ai/openwork.git . \
+  && mkdir -p /workspace/.openwork-daytona \
+  && sha256sum /workspace/pnpm-lock.yaml | cut -d ' ' -f 1 > /workspace/.openwork-daytona/pnpm-lock.sha256 \
+  && git gc --prune=now \
+  && rm -rf /home/daytona/.cache /home/daytona/.npm /home/daytona/.local/share/pnpm/store \
+    /workspace/node_modules
+
+RUN chown -R daytona:daytona /workspace \
+  && printf 'daytona ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/daytona-openwork \
+  && chmod 0440 /etc/sudoers.d/daytona-openwork
+
+USER daytona

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -40,6 +40,27 @@ Do not use the generic `daytona create https://github.com/different-ai/openwork`
 flow for Electron/noVNC tests. The default resource size is too small and the
 generic image path does not guarantee the desktop stack we need.
 
+## Quick start with Daytona server
+
+```bash
+bash .devcontainer/create-daytona-openwork-server-snapshot.sh  # one-time / refresh when deps change
+bash .devcontainer/test-server-on-daytona.sh [branch-or-commit]
+```
+
+The server helper creates a separate public Daytona sandbox for the Den stack:
+MySQL, Den API, Den Web, and the worker proxy. It prints public preview URLs and
+the exact Electron command to point a desktop sandbox at that server:
+
+```bash
+bash .devcontainer/test-on-daytona.sh [branch-or-commit] \
+  --den-base-url https://3005-...daytonaproxy... \
+  --den-api-base-url https://8788-...daytonaproxy...
+```
+
+This keeps the architecture simple: the server sandbox owns cloud auth, orgs,
+policies, workers, and persistence; the Electron sandbox stays a real desktop
+client and talks to the server through public Daytona preview URLs.
+
 ## How it works
 
 1. `.devcontainer/Dockerfile.daytona-vnc` starts from `daytonaio/sandbox:0.6.0`,
@@ -80,6 +101,10 @@ Your Browser
     │
     └── :8788 Den API (Hono) ──▶ MySQL :3306
 ```
+
+With a separate server sandbox, the Electron box uses Daytona preview URLs for
+Den Web/API instead of `localhost`, while the server sandbox still keeps its
+internal service graph local.
 
 ## Automation
 

--- a/.devcontainer/create-daytona-openwork-server-snapshot.sh
+++ b/.devcontainer/create-daytona-openwork-server-snapshot.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build/refresh the reusable Daytona snapshot used by Den server sandboxes.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SNAPSHOT_NAME="${DAYTONA_SERVER_SNAPSHOT:-openwork-server}"
+REGION="${DAYTONA_TARGET:-us}"
+
+snapshot_id() {
+  daytona snapshot list -f json | node -e 'const name = process.argv[1]; let input = ""; process.stdin.on("data", (chunk) => input += chunk); process.stdin.on("end", () => { const snapshot = JSON.parse(input).find((item) => item.name === name); if (snapshot) process.stdout.write(snapshot.id || snapshot.name); });' "$1"
+}
+
+existing_snapshot_id="$(snapshot_id "$SNAPSHOT_NAME")"
+if [ -n "$existing_snapshot_id" ]; then
+  echo "==> Deleting existing snapshot: $SNAPSHOT_NAME"
+  daytona snapshot delete "$existing_snapshot_id" >/dev/null <<< "y"
+  for _ in $(seq 1 60); do
+    if [ -z "$(snapshot_id "$SNAPSHOT_NAME")" ]; then
+      break
+    fi
+    sleep 5
+  done
+fi
+
+echo "==> Creating Daytona server snapshot: $SNAPSHOT_NAME"
+daytona snapshot create "$SNAPSHOT_NAME" \
+  --dockerfile "$ROOT_DIR/.devcontainer/Dockerfile.daytona-server" \
+  --cpu 4 \
+  --memory 8 \
+  --disk 10 \
+  --region "$REGION"
+
+echo "Snapshot ready: $SNAPSHOT_NAME"

--- a/.devcontainer/start-daytona-server.sh
+++ b/.devcontainer/start-daytona-server.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start the Den server stack inside a Daytona sandbox.
+# Services: MySQL, Den API, Den Web, and worker proxy.
+
+if [ -n "${OPENWORK_WORKSPACE_DIR:-}" ]; then
+  REPO_DIR="$OPENWORK_WORKSPACE_DIR"
+elif [ -f /workspace/package.json ]; then
+  REPO_DIR="/workspace"
+else
+  REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+cd "$REPO_DIR"
+
+DEN_API_PORT="${DEN_API_PORT:-8788}"
+DEN_WEB_PORT="${DEN_WEB_PORT:-3005}"
+DEN_WORKER_PROXY_PORT="${DEN_WORKER_PROXY_PORT:-8789}"
+PNPM_STORE="${PNPM_STORE:-$REPO_DIR/.openwork-daytona/pnpm-store}"
+
+DEN_API_PUBLIC_URL="${DEN_API_PUBLIC_URL:-http://localhost:$DEN_API_PORT}"
+DEN_WEB_PUBLIC_URL="${DEN_WEB_PUBLIC_URL:-http://localhost:$DEN_WEB_PORT}"
+DEN_WORKER_PROXY_PUBLIC_URL="${DEN_WORKER_PROXY_PUBLIC_URL:-http://localhost:$DEN_WORKER_PROXY_PORT}"
+
+export OPENWORK_DEV_MODE="${OPENWORK_DEV_MODE:-1}"
+export DATABASE_URL="${DATABASE_URL:-mysql://root:password@127.0.0.1:3306/openwork_den}"
+export DEN_DB_ENCRYPTION_KEY="${DEN_DB_ENCRYPTION_KEY:-daytona-den-db-encryption-key-please-change-1234567890}"
+export BETTER_AUTH_SECRET="${BETTER_AUTH_SECRET:-daytona-den-auth-secret-please-change-1234567890}"
+export BETTER_AUTH_URL="${BETTER_AUTH_URL:-$DEN_WEB_PUBLIC_URL}"
+export DEN_BETTER_AUTH_URL="$BETTER_AUTH_URL"
+export DEN_MCP_RESOURCE_URL="${DEN_MCP_RESOURCE_URL:-$DEN_API_PUBLIC_URL/mcp}"
+export DEN_API_BASE="${DEN_API_BASE:-http://127.0.0.1:$DEN_API_PORT}"
+export DEN_AUTH_ORIGIN="${DEN_AUTH_ORIGIN:-$DEN_WEB_PUBLIC_URL}"
+export DEN_AUTH_FALLBACK_BASE="${DEN_AUTH_FALLBACK_BASE:-http://127.0.0.1:$DEN_API_PORT}"
+export NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL="${NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL:-$DEN_WEB_PUBLIC_URL}"
+export DEN_PROVISIONER_MODE="${DEN_PROVISIONER_MODE:-stub}"
+export DEN_WORKER_URL_TEMPLATE="${DEN_WORKER_URL_TEMPLATE:-https://workers.local/{workerId}}"
+export DAYTONA_WORKER_PROXY_BASE_URL="${DAYTONA_WORKER_PROXY_BASE_URL:-$DEN_WORKER_PROXY_PUBLIC_URL}"
+export DEN_DAYTONA_WORKER_PROXY_BASE_URL="$DAYTONA_WORKER_PROXY_BASE_URL"
+
+DEFAULT_ORIGINS="http://localhost:$DEN_WEB_PORT,http://127.0.0.1:$DEN_WEB_PORT,http://localhost:$DEN_API_PORT,http://127.0.0.1:$DEN_API_PORT,http://localhost:$DEN_WORKER_PROXY_PORT,http://127.0.0.1:$DEN_WORKER_PROXY_PORT,$DEN_WEB_PUBLIC_URL,$DEN_API_PUBLIC_URL,$DEN_WORKER_PROXY_PUBLIC_URL"
+export CORS_ORIGINS="${CORS_ORIGINS:-$DEFAULT_ORIGINS}"
+export DEN_BETTER_AUTH_TRUSTED_ORIGINS="${DEN_BETTER_AUTH_TRUSTED_ORIGINS:-$CORS_ORIGINS}"
+
+run_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    echo "ERROR: root privileges are required to start MySQL." >&2
+    exit 1
+  fi
+}
+
+MYSQL_ROOT_CMD=(run_root mysql -uroot)
+
+wait_for_http() {
+  local url="$1"
+  local label="$2"
+  local max_wait="${3:-180}"
+  local elapsed=0
+
+  while [ "$elapsed" -lt "$max_wait" ]; do
+    if curl -sf "$url" >/dev/null 2>&1; then
+      echo "==> $label ready after ${elapsed}s"
+      return 0
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+
+  echo "ERROR: $label did not become ready at $url" >&2
+  return 1
+}
+
+echo "==> Starting MySQL..."
+run_root service mysql start >/tmp/openwork-mysql-service.log 2>&1 || run_root service mariadb start >/tmp/openwork-mysql-service.log 2>&1
+
+for _ in $(seq 1 60); do
+  if mysql -uroot -ppassword -e "SELECT 1" >/dev/null 2>&1; then
+    MYSQL_ROOT_CMD=(mysql -uroot -ppassword)
+    break
+  fi
+  if run_root mysql -uroot -e "SELECT 1" >/dev/null 2>&1; then
+    MYSQL_ROOT_CMD=(run_root mysql -uroot)
+    break
+  fi
+  sleep 2
+done
+
+"${MYSQL_ROOT_CMD[@]}" <<'SQL'
+CREATE DATABASE IF NOT EXISTS openwork_den;
+ALTER USER 'root'@'localhost' IDENTIFIED BY 'password';
+CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED BY 'password';
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
+FLUSH PRIVILEGES;
+SQL
+
+echo "==> Installing dependencies if needed..."
+mkdir -p "$PNPM_STORE" .openwork-daytona
+baseline=.openwork-daytona/pnpm-lock.sha256
+current="$(sha256sum pnpm-lock.yaml | cut -d " " -f 1)"
+if [ ! -d node_modules ] || [ ! -f "$baseline" ] || [ "$(cat "$baseline")" != "$current" ]; then
+  CI=1 pnpm install --store-dir "$PNPM_STORE" --frozen-lockfile || CI=1 pnpm install --store-dir "$PNPM_STORE"
+  printf "%s" "$current" > "$baseline"
+else
+  echo "==> Skipping pnpm install (node_modules present and lockfile unchanged)."
+fi
+
+echo "==> Pushing Den DB schema..."
+pnpm --filter @openwork-ee/den-db db:push > /tmp/den-db-push.log 2>&1
+
+echo "==> Starting Den API on :$DEN_API_PORT..."
+pkill -f "ee/apps/den-api/src/server.ts" >/dev/null 2>&1 || true
+nohup env \
+  PORT="$DEN_API_PORT" \
+  DATABASE_URL="$DATABASE_URL" \
+  DEN_DB_ENCRYPTION_KEY="$DEN_DB_ENCRYPTION_KEY" \
+  BETTER_AUTH_SECRET="$BETTER_AUTH_SECRET" \
+  BETTER_AUTH_URL="$BETTER_AUTH_URL" \
+  DEN_MCP_RESOURCE_URL="$DEN_MCP_RESOURCE_URL" \
+  DEN_BETTER_AUTH_TRUSTED_ORIGINS="$DEN_BETTER_AUTH_TRUSTED_ORIGINS" \
+  CORS_ORIGINS="$CORS_ORIGINS" \
+  PROVISIONER_MODE="$DEN_PROVISIONER_MODE" \
+  WORKER_URL_TEMPLATE="$DEN_WORKER_URL_TEMPLATE" \
+  DAYTONA_WORKER_PROXY_BASE_URL="$DAYTONA_WORKER_PROXY_BASE_URL" \
+  OPENWORK_DEV_MODE="$OPENWORK_DEV_MODE" \
+  NODE_OPTIONS="--conditions=development" \
+  pnpm --filter @openwork-ee/den-api exec tsx watch src/server.ts > /tmp/den-api.log 2>&1 &
+
+wait_for_http "http://127.0.0.1:$DEN_API_PORT/health" "Den API" 180
+
+echo "==> Starting worker proxy on :$DEN_WORKER_PROXY_PORT..."
+pkill -f "ee/apps/den-worker-proxy/src/server.ts" >/dev/null 2>&1 || true
+nohup env \
+  PORT="$DEN_WORKER_PROXY_PORT" \
+  DATABASE_URL="$DATABASE_URL" \
+  OPENWORK_DEV_MODE="$OPENWORK_DEV_MODE" \
+  DAYTONA_API_URL="${DAYTONA_API_URL:-}" \
+  DAYTONA_API_KEY="${DAYTONA_API_KEY:-}" \
+  DAYTONA_TARGET="${DAYTONA_TARGET:-}" \
+  DAYTONA_OPENWORK_PORT="${DAYTONA_OPENWORK_PORT:-8787}" \
+  DAYTONA_SIGNED_PREVIEW_EXPIRES_SECONDS="${DAYTONA_SIGNED_PREVIEW_EXPIRES_SECONDS:-86400}" \
+  pnpm --filter @openwork-ee/den-worker-proxy exec tsx watch src/server.ts > /tmp/den-worker-proxy.log 2>&1 &
+
+wait_for_http_status() {
+  local url="$1"
+  local label="$2"
+  local max_wait="${3:-120}"
+  local elapsed=0
+  local status=""
+
+  while [ "$elapsed" -lt "$max_wait" ]; do
+    status="$(curl -s -o /dev/null -w '%{http_code}' "$url" 2>/dev/null || true)"
+    if [ "$status" != "000" ]; then
+      echo "==> $label ready after ${elapsed}s (HTTP $status)"
+      return 0
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+
+  echo "ERROR: $label did not respond at $url" >&2
+  return 1
+}
+
+wait_for_http_status "http://127.0.0.1:$DEN_WORKER_PROXY_PORT/unknown" "worker proxy" 120
+
+echo "==> Starting Den Web on :$DEN_WEB_PORT..."
+pkill -f "next dev --hostname 0.0.0.0 --port $DEN_WEB_PORT" >/dev/null 2>&1 || true
+nohup env \
+  DEN_WEB_PORT="$DEN_WEB_PORT" \
+  DEN_API_BASE="$DEN_API_BASE" \
+  DEN_AUTH_ORIGIN="$DEN_AUTH_ORIGIN" \
+  DEN_AUTH_FALLBACK_BASE="$DEN_AUTH_FALLBACK_BASE" \
+  NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL="$NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL" \
+  NEXT_PUBLIC_POSTHOG_KEY= \
+  NEXT_PUBLIC_POSTHOG_API_KEY= \
+  OPENWORK_DEV_MODE="$OPENWORK_DEV_MODE" \
+  pnpm --filter @openwork-ee/den-web exec next dev --hostname 0.0.0.0 --port "$DEN_WEB_PORT" > /tmp/den-web.log 2>&1 &
+
+wait_for_http "http://127.0.0.1:$DEN_WEB_PORT/api/den/health" "Den Web" 180
+
+cat > .openwork-daytona/server-env <<EOF
+DEN_API_URL=$DEN_API_PUBLIC_URL
+DEN_WEB_URL=$DEN_WEB_PUBLIC_URL
+DEN_WORKER_PROXY_URL=$DEN_WORKER_PROXY_PUBLIC_URL
+BETTER_AUTH_URL=$BETTER_AUTH_URL
+DEN_MCP_RESOURCE_URL=$DEN_MCP_RESOURCE_URL
+DEN_PROVISIONER_MODE=$DEN_PROVISIONER_MODE
+EOF
+
+echo ""
+echo "============================================"
+echo "  OpenWork Daytona server stack ready"
+echo ""
+echo "  Den Web:       $DEN_WEB_PUBLIC_URL"
+echo "  Den API:       $DEN_API_PUBLIC_URL"
+echo "  Worker Proxy:  $DEN_WORKER_PROXY_PUBLIC_URL"
+echo ""
+echo "  Logs:"
+echo "    /tmp/den-api.log"
+echo "    /tmp/den-web.log"
+echo "    /tmp/den-worker-proxy.log"
+echo "    /tmp/den-db-push.log"
+echo "============================================"

--- a/.devcontainer/test-on-daytona.sh
+++ b/.devcontainer/test-on-daytona.sh
@@ -14,6 +14,9 @@ set -euo pipefail
 
 REF=""
 FORCE_INSTALL=0
+DEN_BASE_URL=""
+DEN_API_BASE_URL=""
+DEN_REQUIRE_SIGNIN=0
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -23,6 +26,17 @@ while [ "$#" -gt 0 ]; do
     --snapshot)
       shift
       DAYTONA_EVAL_SNAPSHOT="${1:?missing snapshot name}"
+      ;;
+    --den-base-url)
+      shift
+      DEN_BASE_URL="${1:?missing Den base URL}"
+      ;;
+    --den-api-base-url)
+      shift
+      DEN_API_BASE_URL="${1:?missing Den API base URL}"
+      ;;
+    --require-signin)
+      DEN_REQUIRE_SIGNIN=1
       ;;
     --help|-h)
       sed -n '1,12p' "$0"
@@ -137,7 +151,7 @@ daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; REF=\"$R
 
 echo ""
 echo "==> Starting OpenWork sandbox dev stack..."
-daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; export DAYTONA_SECRETS_ENV=\"$DAYTONA_SECRETS_ENV\" DAYTONA_ELECTRON_EXTRA_LAUNCH_ARGS=\"$DAYTONA_ELECTRON_EXTRA_LAUNCH_ARGS\" OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=$CDP_PORT OPENWORK_WORKSPACE_DIR=/workspace; pnpm dev:sandbox'"
+daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; DEN_BASE_URL=\"$DEN_BASE_URL\"; DEN_API_BASE_URL=\"$DEN_API_BASE_URL\"; DEN_REQUIRE_SIGNIN=\"$DEN_REQUIRE_SIGNIN\"; if [ -n \"\$DEN_BASE_URL\" ] || [ -n \"\$DEN_API_BASE_URL\" ] || [ \"\$DEN_REQUIRE_SIGNIN\" = 1 ]; then mkdir -p /workspace/.openwork-daytona; DEN_BASE_URL=\"\$DEN_BASE_URL\" DEN_API_BASE_URL=\"\$DEN_API_BASE_URL\" DEN_REQUIRE_SIGNIN=\"\$DEN_REQUIRE_SIGNIN\" node -e '\''const fs = require(\"node:fs\"); const baseUrl = process.env.DEN_BASE_URL || \"https://app.openworklabs.com\"; const apiBaseUrl = process.env.DEN_API_BASE_URL || null; const requireSignin = process.env.DEN_REQUIRE_SIGNIN === \"1\"; fs.writeFileSync(\"/workspace/.openwork-daytona/desktop-bootstrap.json\", JSON.stringify({ baseUrl, apiBaseUrl, requireSignin }, null, 2) + \"\\n\");'\''; fi; export DAYTONA_SECRETS_ENV=\"$DAYTONA_SECRETS_ENV\" DAYTONA_ELECTRON_EXTRA_LAUNCH_ARGS=\"$DAYTONA_ELECTRON_EXTRA_LAUNCH_ARGS\" OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=$CDP_PORT OPENWORK_WORKSPACE_DIR=/workspace; if [ -f /workspace/.openwork-daytona/desktop-bootstrap.json ]; then export OPENWORK_DESKTOP_BOOTSTRAP_PATH=/workspace/.openwork-daytona/desktop-bootstrap.json; fi; pnpm dev:sandbox'"
 
 echo ""
 echo "==> Waiting for Electron CDP on port $CDP_PORT (up to ${MAX_WAIT}s)..."
@@ -170,6 +184,9 @@ else
 fi
 
 echo "==> Secrets env: ${DAYTONA_SECRETS_ENV} (sourced if present)"
+if [ -n "$DEN_BASE_URL" ]; then
+  echo "==> Den base URL: $DEN_BASE_URL"
+fi
 
 CDP_URL=$(daytona preview-url "$SANDBOX" -p "$CDP_PORT" 2>/dev/null | grep -v "^time=")
 NOVNC_URL=$(daytona preview-url "$SANDBOX" -p "$NOVNC_PORT" 2>/dev/null | grep -v "^time=")

--- a/.devcontainer/test-server-on-daytona.sh
+++ b/.devcontainer/test-server-on-daytona.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-server-on-daytona.sh — one-command Daytona Den server sandbox.
+#
+# Usage:
+#   bash .devcontainer/test-server-on-daytona.sh [branch-or-commit]
+#   bash .devcontainer/test-server-on-daytona.sh [branch-or-commit] --force-install
+#
+# Creates a Daytona sandbox, starts MySQL + Den API + Den Web + worker proxy,
+# waits for health checks, and prints public preview URLs.
+
+REF=""
+FORCE_INSTALL=0
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SANDBOX="openwork-server-$(date +%Y%m%d-%H%M%S)"
+DAYTONA_SERVER_SNAPSHOT="${DAYTONA_SERVER_SNAPSHOT:-openwork-server}"
+DAYTONA_TARGET="${DAYTONA_TARGET:-us}"
+DEN_API_PORT="${DEN_API_PORT:-8788}"
+DEN_WEB_PORT="${DEN_WEB_PORT:-3005}"
+DEN_WORKER_PROXY_PORT="${DEN_WORKER_PROXY_PORT:-8789}"
+MAX_WAIT="${DAYTONA_SERVER_MAX_WAIT:-240}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --force-install)
+      FORCE_INSTALL=1
+      ;;
+    --snapshot)
+      shift
+      DAYTONA_SERVER_SNAPSHOT="${1:?missing snapshot name}"
+      ;;
+    --name)
+      shift
+      SANDBOX="${1:?missing sandbox name}"
+      ;;
+    --help|-h)
+      sed -n '1,13p' "$0"
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      if [ -n "$REF" ]; then
+        echo "Unexpected extra argument: $1" >&2
+        exit 1
+      fi
+      REF="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$REF" ]; then
+  REF="$(git branch --show-current 2>/dev/null || true)"
+  REF="${REF:-$(git rev-parse HEAD)}"
+fi
+
+snapshot_id() {
+  daytona snapshot list -f json | node -e 'const name = process.argv[1]; let input = ""; process.stdin.on("data", (chunk) => input += chunk); process.stdin.on("end", () => { const snapshot = JSON.parse(input).find((item) => item.name === name); if (snapshot) process.stdout.write(snapshot.id || snapshot.name); });' "$1"
+}
+
+SNAPSHOT_ID="$(snapshot_id "$DAYTONA_SERVER_SNAPSHOT")"
+CREATE_ARGS=(--name "$SANDBOX" --auto-stop 60 --public --target "$DAYTONA_TARGET")
+if [ -n "$SNAPSHOT_ID" ]; then
+  echo "==> Using Daytona server snapshot: $DAYTONA_SERVER_SNAPSHOT"
+  CREATE_ARGS+=(--snapshot "$SNAPSHOT_ID")
+else
+  echo "==> Daytona server snapshot '$DAYTONA_SERVER_SNAPSHOT' not found; building from Dockerfile."
+  CREATE_ARGS+=(--dockerfile "$ROOT_DIR/.devcontainer/Dockerfile.daytona-server" --cpu 4 --memory 8 --disk 10)
+fi
+
+echo "==> Creating server sandbox: $SANDBOX"
+echo "    Ref: $REF"
+daytona create "${CREATE_ARGS[@]}"
+
+echo "==> Waiting for sandbox exec readiness..."
+exec_ready=0
+for _ in $(seq 1 60); do
+  if daytona exec "$SANDBOX" -- "bash -lc 'true'" >/dev/null 2>&1; then
+    exec_ready=1
+    break
+  fi
+  sleep 5
+done
+if [ "$exec_ready" -ne 1 ]; then
+  echo "ERROR: sandbox did not become exec-ready" >&2
+  exit 1
+fi
+
+DEN_WEB_URL="$(daytona preview-url "$SANDBOX" -p "$DEN_WEB_PORT" 2>/dev/null | grep -v "^time=")"
+DEN_API_URL="$(daytona preview-url "$SANDBOX" -p "$DEN_API_PORT" 2>/dev/null | grep -v "^time=")"
+DEN_WORKER_PROXY_URL="$(daytona preview-url "$SANDBOX" -p "$DEN_WORKER_PROXY_PORT" 2>/dev/null | grep -v "^time=")"
+
+echo "==> Checking out $REF..."
+daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; REF=\"$REF\"; FORCE_INSTALL=\"$FORCE_INSTALL\"; if git fetch origin \"\$REF\"; then git checkout --detach FETCH_HEAD; else git fetch origin dev --depth 50 || true; git checkout \"\$REF\"; fi; git rev-parse --short HEAD; if [ \"\$FORCE_INSTALL\" = 1 ]; then rm -f .openwork-daytona/pnpm-lock.sha256; fi'"
+
+echo "==> Uploading server start script..."
+START_SCRIPT_B64="$(base64 < "$ROOT_DIR/.devcontainer/start-daytona-server.sh" | tr -d '\n')"
+daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; mkdir -p .devcontainer; printf %s $START_SCRIPT_B64 | base64 -d > .devcontainer/start-daytona-server.sh; chmod +x .devcontainer/start-daytona-server.sh'"
+
+echo "==> Starting OpenWork Den server stack..."
+daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; cd /workspace; DEN_WEB_PUBLIC_URL=\"$DEN_WEB_URL\" DEN_API_PUBLIC_URL=\"$DEN_API_URL\" DEN_WORKER_PROXY_PUBLIC_URL=\"$DEN_WORKER_PROXY_URL\" DEN_WEB_PORT=$DEN_WEB_PORT DEN_API_PORT=$DEN_API_PORT DEN_WORKER_PROXY_PORT=$DEN_WORKER_PROXY_PORT bash .devcontainer/start-daytona-server.sh'"
+
+echo "==> Waiting for public Den Web health (up to ${MAX_WAIT}s)..."
+elapsed=0
+while [ "$elapsed" -lt "$MAX_WAIT" ]; do
+  if curl -sf "$DEN_WEB_URL/api/den/health" >/dev/null 2>&1; then
+    echo "    Den Web ready after ${elapsed}s."
+    break
+  fi
+  sleep 5
+  elapsed=$((elapsed + 5))
+  printf "    %ds...\r" "$elapsed"
+done
+
+if [ "$elapsed" -ge "$MAX_WAIT" ]; then
+  echo ""
+  echo "WARNING: Den Web did not become ready within ${MAX_WAIT}s." >&2
+  echo "Check logs:" >&2
+  echo "  daytona exec $SANDBOX -- 'tail -120 /tmp/den-api.log'" >&2
+  echo "  daytona exec $SANDBOX -- 'tail -120 /tmp/den-web.log'" >&2
+  echo "  daytona exec $SANDBOX -- 'tail -120 /tmp/den-worker-proxy.log'" >&2
+  exit 1
+fi
+
+echo ""
+echo "============================================"
+echo "  Server sandbox ready: $SANDBOX"
+echo ""
+echo "  Den Web:       $DEN_WEB_URL"
+echo "  Den API:       $DEN_API_URL"
+echo "  Worker Proxy:  $DEN_WORKER_PROXY_URL"
+echo ""
+echo "  Start Electron against this server:"
+echo "    bash .devcontainer/test-on-daytona.sh $REF --den-base-url $DEN_WEB_URL --den-api-base-url $DEN_API_URL"
+echo ""
+echo "  Cleanup:"
+echo "    daytona delete $SANDBOX"
+echo "============================================"

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -119,7 +119,11 @@ export function useDenSession({
   }, [authError, isSignedIn, sessionBusy]);
 
   const syncCurrentDenSettings = React.useCallback(() => {
-    const resolved = resolveDenBaseUrls(baseUrl);
+    const currentSettings = readDenSettings();
+    const resolved = resolveDenBaseUrls({
+      baseUrl,
+      apiBaseUrl: currentSettings.apiBaseUrl,
+    });
     writeDenSettings({
       baseUrl: resolved.baseUrl,
       apiBaseUrl: resolved.apiBaseUrl,

--- a/evals/cloud-auth-flows.md
+++ b/evals/cloud-auth-flows.md
@@ -1,0 +1,169 @@
+# Cloud auth flows
+
+End-to-end user flows for signing the desktop app into OpenWork Cloud through a
+Daytona-hosted Den server. These flows should run against a real Electron app
+through CDP, not a web-only build.
+
+## Preflight
+
+1. Start the Den server sandbox:
+   ```bash
+   bash .devcontainer/test-server-on-daytona.sh [branch-or-commit]
+   ```
+
+2. Start the Electron sandbox against the printed Den URLs:
+   ```bash
+   bash .devcontainer/test-on-daytona.sh [branch-or-commit] \
+     --den-base-url DEN_WEB_URL \
+     --den-api-base-url DEN_API_URL
+   ```
+
+3. Connect to the printed Electron CDP URL with `browser_list` and verify the
+   target is the real desktop app:
+   ```js
+   navigator.userAgent
+   ```
+   Expected: contains `Electron/`.
+
+4. In all flows, use the desktop Settings route unless explicitly stated:
+   ```js
+   window.location.hash = '#/settings/cloud-account'
+   ```
+
+## Flow 1: Cloud sign-in happy path
+
+**Goal:** A signed-out desktop user signs into a Daytona Den server and sees the
+connected cloud account in Electron.
+
+### Setup
+
+Create a Den Web account through the UI or through Den API. If using API setup,
+read the dev OTP from `/tmp/den-api.log` in the server sandbox and complete email
+verification before starting desktop handoff.
+
+### Steps
+
+1. Open Settings -> Cloud -> Account.
+2. Verify the page shows `Signed out`, `Sign in`, `Create account`, and `Paste sign-in code`.
+3. From Den Web, start a desktop handoff or create one through Den API:
+   ```bash
+   curl -H "authorization: Bearer $TOKEN" \
+     -H 'content-type: application/json' \
+     --data '{"desktopScheme":"openwork"}' \
+     "$DEN_API_URL/v1/auth/desktop-handoff"
+   ```
+4. Paste the full `openwork://den-auth?...&denBaseUrl=...` link into `Paste sign-in code`.
+5. Click `Finish sign-in`.
+
+### Expected outcome
+
+- Cloud Account shows `Connected`.
+- The signed-in email is visible.
+- The active organization appears if one exists.
+- `localStorage.openwork.den.authToken` is present.
+- Den API logs include `POST /v1/auth/desktop-handoff/exchange 200` and `GET /v1/me/orgs 200`.
+
+## Flow 2: Raw code fallback
+
+**Goal:** Verify whether pasting only the one-time grant works in the current
+deployment topology.
+
+### Steps
+
+1. Start from a signed-out desktop session.
+2. Create a fresh desktop handoff grant.
+3. Paste only the `grant` value, not the full deep link.
+4. Click `Finish sign-in`.
+
+### Expected outcome
+
+- In same-origin Den Web/API deployments, sign-in should succeed.
+- In split Den Web/API deployments, this may fail with a clear user-visible error.
+- No partial auth state is persisted when the exchange fails.
+
+### Regression caught
+
+This catches desktop manual-auth flows that derive the exchange URL from the
+wrong base in split Den Web/API deployments.
+
+## Flow 3: Expired or consumed handoff grant
+
+**Goal:** A bad handoff grant fails safely.
+
+### Steps
+
+1. Complete Flow 1 with a grant so it is consumed.
+2. Sign out from Cloud Account.
+3. Reopen `Paste sign-in code`.
+4. Paste the same full deep link again.
+5. Click `Finish sign-in`.
+
+### Expected outcome
+
+- The UI shows a useful failure message.
+- `localStorage.openwork.den.authToken` remains empty.
+- The Cloud Account page stays signed out.
+- Den API returns `404 grant_not_found` for the exchange.
+
+## Flow 4: Cloud sign-out cleanup
+
+**Goal:** Signing out removes cloud auth state without breaking local state.
+
+### Steps
+
+1. Start signed in from Flow 1.
+2. Open Settings -> Cloud -> Account.
+3. Click `Sign out`.
+4. Navigate to Cloud Providers and AI Providers.
+
+### Expected outcome
+
+- Cloud Account shows `Signed out`.
+- Cloud Providers requires sign-in or shows no org providers.
+- Cloud-managed provider IDs (`lpr_*`) are not shown as connected local providers.
+- Local providers such as manually configured OpenAI remain available if they existed before sign-out.
+
+## Flow 5: Workspace-less cloud state
+
+**Goal:** A user can sign in before creating a local workspace, but workspace
+sync actions wait until a workspace exists.
+
+### Steps
+
+1. Start from the Welcome page with no selected workspace.
+2. Navigate directly to `#/settings/cloud-account`.
+3. Complete Flow 1.
+4. Navigate to Cloud Providers and Marketplace.
+5. Create a local workspace.
+6. Reopen Cloud Providers and Marketplace.
+
+### Expected outcome
+
+- Account sign-in succeeds before a workspace exists.
+- Provider/plugin import actions are disabled, hidden, or fail with a clear workspace-required message before workspace creation.
+- After workspace creation, provider/plugin import actions become available.
+
+## Flow 6: Org switch sync
+
+**Goal:** A user in two organizations switches active orgs and the desktop cloud
+tabs reflect the selected org.
+
+### Setup
+
+Create two orgs for the same account. Add at least one provider or marketplace
+to each org with distinct names.
+
+### Steps
+
+1. Sign into Cloud Account.
+2. Select Org A.
+3. Open Cloud Providers and record the visible provider names.
+4. Return to Cloud Account and select Org B.
+5. Open Cloud Providers and Marketplace.
+
+### Expected outcome
+
+- Cloud Account shows the newly selected org.
+- Cloud Providers no longer shows Org A-only providers.
+- Marketplace no longer shows Org A-only marketplaces.
+- Den API logs show provider/marketplace requests for the active org context.

--- a/evals/cloud-marketplace-sync-flows.md
+++ b/evals/cloud-marketplace-sync-flows.md
@@ -1,0 +1,115 @@
+# Cloud marketplace sync flows
+
+End-to-end user flows for organization marketplace and plugin sync from Den to
+the desktop workspace.
+
+## Preflight
+
+1. Start Daytona Den server and Electron sandboxes.
+2. Sign the desktop app into Cloud Account.
+3. Create a local workspace.
+4. Use a Den org where the signed-in user can create plugins and marketplaces.
+
+## Flow 1: Marketplace import with files
+
+**Goal:** A plugin with config objects is published to a marketplace, imported
+from desktop, and materializes files/config in the workspace.
+
+### Setup
+
+Through Den API:
+
+1. Create a plugin with a recognizable name.
+2. Create at least one config object, such as a skill or command, with raw source text.
+3. Attach the config object to the plugin.
+4. Create a marketplace.
+5. Attach the plugin to the marketplace.
+
+### Steps
+
+1. Open Settings -> Cloud -> Marketplace.
+2. Click `Refresh`.
+3. Select the marketplace if needed.
+4. Verify the plugin appears under `Available`.
+5. Click `Import`.
+6. Click reload if prompted.
+7. Inspect the workspace config files through the app or filesystem.
+
+### Expected outcome
+
+- The marketplace and plugin are visible in desktop.
+- Import succeeds with a non-zero file count.
+- The expected skill/command/config file appears in the workspace.
+- Reload applies the imported config without losing workspace state.
+
+## Flow 2: Marketplace update sync
+
+**Goal:** Updating a plugin's config object in Den marks the desktop import as
+out of sync and re-import updates local files.
+
+### Steps
+
+1. Import a non-empty plugin using Flow 1.
+2. Create a new config object version in Den with changed source text.
+3. Open Settings -> Cloud -> Marketplace.
+4. Click `Refresh`.
+5. Verify the plugin row shows an update or out-of-sync state.
+6. Re-import the plugin.
+7. Inspect the local file contents.
+
+### Expected outcome
+
+- Desktop detects the updated plugin.
+- Re-import updates the local file contents.
+- The imported plugin state records the new version metadata.
+
+## Flow 3: Marketplace plugin removal
+
+**Goal:** Removing a plugin from a marketplace is reflected in desktop.
+
+### Steps
+
+1. Import a marketplace plugin.
+2. Remove that plugin from the marketplace through Den API.
+3. Open Marketplace settings and click `Refresh`.
+
+### Expected outcome
+
+- The plugin no longer appears as available in that marketplace.
+- Previously imported local files are not silently deleted without user action.
+- The UI clearly distinguishes local imported state from current marketplace availability.
+
+## Flow 4: Metadata-only plugin import
+
+**Goal:** A plugin with zero files imports without crashing and reports a clear
+zero-file result.
+
+### Steps
+
+1. Create a plugin without config objects.
+2. Attach it to a marketplace.
+3. Open Marketplace settings and import it.
+
+### Expected outcome
+
+- Import succeeds or returns a clear no-files message.
+- UI does not show a false non-zero file count.
+- No unexpected workspace files are created.
+
+## Flow 5: Marketplace refresh timing
+
+**Goal:** Measure how fast a newly published marketplace/plugin appears in the
+desktop Marketplace tab.
+
+### Steps
+
+1. Open Marketplace settings.
+2. Create a marketplace and plugin through Den API.
+3. Attach the plugin to the marketplace.
+4. Click `Refresh`.
+5. Poll CDP until both names are visible.
+
+### Expected outcome
+
+- Manual refresh should reveal the marketplace and plugin within a few seconds.
+- Record the duration in the eval report.

--- a/evals/cloud-org-membership-flows.md
+++ b/evals/cloud-org-membership-flows.md
@@ -1,0 +1,100 @@
+# Cloud org membership flows
+
+End-to-end user flows for organization membership, invitations, roles, and org
+switching from the user's desktop perspective.
+
+## Preflight
+
+1. Start Daytona Den server and Electron sandboxes.
+2. Sign in as an org owner in the desktop app.
+3. Create or select an org dedicated to the eval.
+
+## Flow 1: Invite teammate and accept
+
+**Goal:** An owner invites a teammate, the teammate accepts, and the owner can see
+the updated org membership through desktop-connected cloud state.
+
+### Steps
+
+1. As owner, create an invitation through Den Web or Den API.
+2. Create/sign in as the invited user.
+3. Accept the invite.
+4. In the owner desktop app, refresh Cloud Account or fetch `/v1/org` from the Electron renderer.
+
+### Expected outcome
+
+- The invitation returns an invite token/id.
+- The invited user becomes a member of the org.
+- Owner-side cloud state shows the additional member.
+- Den API logs show invitation creation and acceptance requests.
+
+## Flow 2: Role update propagates
+
+**Goal:** Changing a member role server-side is visible to desktop-connected org
+state.
+
+### Steps
+
+1. Complete Flow 1.
+2. As owner, update the invited member role through Den API.
+3. In Electron, fetch or refresh org context.
+
+### Expected outcome
+
+- The member role changes in `/v1/org`.
+- If the member is signed in on another desktop instance, Cloud Account reflects the changed role after refresh.
+
+## Flow 3: Remove member
+
+**Goal:** Removing a member from the org revokes their cloud access.
+
+### Steps
+
+1. Sign in as a member in a second Electron profile or sandbox.
+2. As owner, remove that member through Den API.
+3. In the member desktop app, refresh Cloud Account, Cloud Providers, and Marketplace.
+
+### Expected outcome
+
+- Member no longer has active org context.
+- Cloud Providers and Marketplace stop returning org resources for that org.
+- The UI shows a clear signed-in-but-no-org or access removed state.
+
+## Flow 4: Org switch sync
+
+**Goal:** A user in multiple orgs sees resources update after switching active
+org.
+
+### Setup
+
+Create two orgs. Add a uniquely named provider and marketplace to each.
+
+### Steps
+
+1. Sign in as a user belonging to both orgs.
+2. Select Org A in Cloud Account.
+3. Verify Org A provider/marketplace names appear.
+4. Select Org B.
+5. Verify Org B provider/marketplace names appear and Org A-only names disappear.
+
+### Expected outcome
+
+- Active org selection persists in local storage.
+- Cloud provider and marketplace requests use the active org context.
+- Workspace-imported cloud resources are reconciled for the selected org.
+
+## Flow 5: Invitation domain restriction
+
+**Goal:** Organization email-domain restrictions are enforced and visible to the
+user.
+
+### Steps
+
+1. Set `allowedEmailDomains` for an org.
+2. Try inviting an address outside the allowed domains.
+3. Try accepting an invite with an account outside the allowed domains.
+
+### Expected outcome
+
+- Invite creation or acceptance fails with a clear domain restriction message.
+- No member row is created for the rejected account.

--- a/evals/cloud-provider-sync-flows.md
+++ b/evals/cloud-provider-sync-flows.md
@@ -1,0 +1,145 @@
+# Cloud provider sync flows
+
+End-to-end user flows for organization-managed LLM providers syncing from Den to
+the desktop app and workspace config.
+
+## Preflight
+
+1. Start a Daytona Den server sandbox and a Daytona Electron sandbox pointed at it.
+2. Sign the desktop app into Cloud Account.
+3. Create or select a local workspace through the desktop UI.
+4. Ensure the workspace has a writable `opencode.jsonc`.
+
+## Flow 1: Provider add-to-use
+
+**Goal:** A provider created in Den appears in the desktop app, imports into the
+workspace, and becomes selectable as a model provider.
+
+### Setup
+
+Create an org LLM provider through Den API:
+
+```bash
+curl -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' \
+  --data '{
+    "name":"Eval Provider",
+    "source":"custom",
+    "customConfigText":"{\"id\":\"eval_provider\",\"name\":\"Eval Provider\",\"npm\":\"@ai-sdk/openai-compatible\",\"env\":[\"EVAL_API_KEY\"],\"doc\":\"https://example.com\",\"api\":\"https://api.example.com/v1\",\"models\":[{\"id\":\"eval-model\",\"name\":\"Eval Model\"}]}",
+    "apiKey":"sk-eval"
+  }' \
+  "$DEN_API_URL/v1/llm-providers"
+```
+
+### Steps
+
+1. Open Settings -> Cloud -> Cloud Providers.
+2. Click `Refresh`.
+3. Verify the provider appears under `Available`.
+4. Click `Import`.
+5. Click the reload banner if shown.
+6. Open the model selector in the session composer.
+
+### Expected outcome
+
+- The provider appears with `Credential ready`.
+- `opencode.jsonc` contains an `lpr_*` provider block.
+- The model selector shows the imported provider/model.
+- No provider key is written to the visible provider config.
+
+## Flow 2: Provider update sync
+
+**Goal:** A provider changed in Den is detected by desktop and can be refreshed.
+
+### Steps
+
+1. Import a provider using Flow 1.
+2. Update the provider in Den by changing the name and model list.
+3. Open Settings -> Cloud -> Cloud Providers.
+4. Click `Refresh`.
+5. Verify the provider row marks itself out of sync or updates its metadata.
+6. Import or re-import the provider.
+7. Inspect `opencode.jsonc`.
+
+### Expected outcome
+
+- The changed provider metadata is visible in the desktop UI.
+- `opencode.jsonc` reflects the new model list after sync.
+- Removed models are not left as stale selectable models.
+
+## Flow 3: Provider delete sync
+
+**Goal:** A provider deleted from Den is removed from the desktop cloud-imported
+state.
+
+### Steps
+
+1. Import a provider using Flow 1.
+2. Delete the provider in Den API.
+3. Open Settings -> Cloud -> Cloud Providers.
+4. Click `Refresh` or wait for cloud sync.
+5. Inspect `opencode.jsonc`.
+
+### Expected outcome
+
+- The provider disappears from Cloud Providers.
+- The local `lpr_*` provider block is removed or disabled.
+- The model selector no longer shows the deleted cloud provider.
+- Local non-cloud providers remain untouched.
+
+## Flow 4: Refresh timing
+
+**Goal:** Measure how quickly server-side provider changes are visible in the
+desktop UI.
+
+### Steps
+
+1. Open Cloud Providers.
+2. Create a provider through Den API and record `createdAt` or local timestamp.
+3. Immediately click `Refresh` in the desktop UI.
+4. Poll `document.body.innerText` over CDP until the provider name appears.
+
+### Expected outcome
+
+- Manual refresh should reveal the provider within a few seconds.
+- Record the measured duration in the eval report.
+- Automatic interval sync is expected to be slower; current interval is 5 minutes.
+
+## Flow 5: Reload required banner
+
+**Goal:** Importing a provider tells the user to reload the workspace and reload
+applies the config.
+
+### Steps
+
+1. Import a cloud provider into an active workspace.
+2. Verify the UI shows `Reload required` or equivalent messaging.
+3. Click `Reload now`.
+4. Open the model selector.
+
+### Expected outcome
+
+- Reload banner appears after config changes.
+- Reload completes without losing the selected workspace.
+- Imported cloud model is selectable after reload.
+
+## Flow 6: Permission boundary
+
+**Goal:** A member without provider-management permissions cannot create or edit
+org providers, but can consume providers granted to them.
+
+### Setup
+
+Invite a member account to the org. Grant that member access to one provider.
+
+### Steps
+
+1. Sign in as the member.
+2. Open Cloud Providers.
+3. Verify the granted provider is visible and importable.
+4. Attempt to create or edit a provider through Den Web or API.
+
+### Expected outcome
+
+- Granted provider is consumable by the member.
+- Provider create/edit returns forbidden or hides the control for non-admin users.

--- a/evals/cloud-worker-flows.md
+++ b/evals/cloud-worker-flows.md
@@ -1,0 +1,102 @@
+# Cloud worker flows
+
+End-to-end user flows for launching and connecting remote OpenWork workers from
+the desktop app.
+
+## Preflight
+
+1. Start the Daytona Den server sandbox with worker proxy enabled.
+2. If testing real Daytona worker provisioning, configure `DEN_PROVISIONER_MODE=daytona` and Daytona credentials on the server sandbox.
+3. Start an Electron sandbox against the Den server.
+4. Sign into Cloud Account and select an org.
+
+## Flow 1: Launch remote worker
+
+**Goal:** A user launches a cloud worker from desktop and sees it appear in Cloud
+Workers.
+
+### Steps
+
+1. Open Settings -> Cloud -> Cloud Workers.
+2. Click the create/launch worker action.
+3. Enter a worker name.
+4. Submit the form.
+5. Poll the Cloud Workers page until the worker appears.
+
+### Expected outcome
+
+- The worker row appears with a provisioning or ready status.
+- Den API records a worker for the active org.
+- If `DEN_PROVISIONER_MODE=stub`, the UI clearly shows stub URL behavior.
+- If `DEN_PROVISIONER_MODE=daytona`, the worker gets a real Daytona preview URL.
+
+## Flow 2: Connect remote workspace
+
+**Goal:** A launched cloud worker can be connected as a remote workspace in the
+desktop app.
+
+### Steps
+
+1. Complete Flow 1 and wait for a ready worker.
+2. Click the connect/open action on the worker row.
+3. Follow the desktop remote workspace flow.
+4. Verify the sidebar shows the remote workspace.
+
+### Expected outcome
+
+- A remote workspace is added to the desktop workspace list.
+- The workspace status reaches ready.
+- The app does not require local folder authorization for the remote workspace.
+
+## Flow 3: Run a task on remote worker
+
+**Goal:** A user can run a simple task against the remote worker after connecting
+it.
+
+### Steps
+
+1. Open the connected remote workspace.
+2. Create a new task.
+3. Send a simple prompt such as `List the workspace root files.`
+4. Wait for the assistant response.
+
+### Expected outcome
+
+- The task starts and streams normally.
+- Tool calls and file results come from the remote worker workspace.
+- No local workspace path is leaked into the remote task.
+
+## Flow 4: Worker token refresh
+
+**Goal:** A connected worker continues working after the desktop refreshes worker
+metadata or tokens.
+
+### Steps
+
+1. Connect a remote workspace.
+2. Restart the Electron app or reload the workspace.
+3. Open Cloud Workers and refresh.
+4. Return to the remote workspace and run a task.
+
+### Expected outcome
+
+- Worker metadata reloads successfully.
+- The remote workspace remains connected or reconnects cleanly.
+- Task execution still works.
+
+## Flow 5: Worker failure recovery
+
+**Goal:** The UI handles a worker that is stopped or unreachable.
+
+### Steps
+
+1. Connect a worker.
+2. Stop or delete the underlying worker sandbox.
+3. Return to the remote workspace.
+4. Open Cloud Workers and refresh.
+
+### Expected outcome
+
+- The UI shows a clear unreachable/stopped state.
+- The app does not spin forever in ready state.
+- Recovery controls, if present, are actionable.

--- a/evals/daytona-flows.md
+++ b/evals/daytona-flows.md
@@ -426,6 +426,47 @@ browser from opening the OAuth URL.
 
 ---
 
+## Flow 6: Desktop cloud login against Daytona server
+
+**Goal:** Prove a real Electron Daytona sandbox can sign in against a separate
+Daytona-hosted Den server stack.
+
+### Steps
+
+1. Start the server sandbox:
+   ```bash
+   bash .devcontainer/test-server-on-daytona.sh [branch-or-commit]
+   ```
+
+2. Copy the printed `Den Web` and `Den API` URLs, then start Electron against
+   the server:
+   ```bash
+   bash .devcontainer/test-on-daytona.sh [branch-or-commit] \
+     --den-base-url DEN_WEB_URL \
+     --den-api-base-url DEN_API_URL
+   ```
+
+3. In Electron, open Settings, then `Cloud Account`.
+
+4. Verify developer mode shows the Daytona Den Web URL as the configured base
+   URL, and the signed-out panel is visible.
+
+5. Create or sign in to a Den Web account, then use the desktop handoff code or
+   full `openwork://den-auth?...` link in `Paste sign-in code`.
+
+6. Verify Electron shows the cloud account as connected and can load orgs from
+   the Daytona Den API.
+
+### Expected outcome
+
+- Electron bootstrap config points at the Daytona server sandbox, not production.
+- Manual desktop handoff exchange succeeds.
+- Settings show the signed-in user and at least one organization or the org
+  selection prompt.
+- Den API logs show `/v1/auth/desktop-handoff/exchange` and `/v1/me/orgs`.
+
+---
+
 ## Teardown
 
 ```bash

--- a/evals/daytona-server-failure-recovery-flows.md
+++ b/evals/daytona-server-failure-recovery-flows.md
@@ -1,0 +1,112 @@
+# Daytona server failure recovery flows
+
+End-to-end failure and recovery flows for a real Electron app connected to a
+separate Daytona Den server sandbox.
+
+## Preflight
+
+1. Start a Daytona server sandbox with `.devcontainer/test-server-on-daytona.sh`.
+2. Start a Daytona Electron sandbox against that server.
+3. Sign into Cloud Account and create a local workspace.
+
+## Flow 1: Den API outage and recovery
+
+**Goal:** The desktop UI surfaces a recoverable error when Den API is down and
+recovers when it returns.
+
+### Steps
+
+1. Open Settings -> Cloud -> Cloud Providers.
+2. In the server sandbox, stop Den API:
+   ```bash
+   daytona exec SERVER_SANDBOX -- "bash -lc 'pkill -f ee/apps/den-api/src/server.ts || true'"
+   ```
+3. Click `Refresh` in Cloud Providers.
+4. Restart the server stack:
+   ```bash
+   daytona exec SERVER_SANDBOX -- "bash -lc 'cd /workspace && bash .devcontainer/start-daytona-server.sh'"
+   ```
+5. Click `Refresh` again.
+
+### Expected outcome
+
+- During outage, Cloud Providers shows a clear network/server error.
+- The app does not clear local cloud auth state.
+- After restart, refresh succeeds and providers return.
+
+## Flow 2: Den Web outage during sign-in
+
+**Goal:** Browser sign-in failures do not leave partial desktop auth state.
+
+### Steps
+
+1. Start signed out in desktop.
+2. Stop Den Web in the server sandbox.
+3. Click `Sign in` from Cloud Account.
+4. Restart Den Web.
+5. Complete sign-in with a full handoff deep link.
+
+### Expected outcome
+
+- Initial browser sign-in fails visibly or opens an unreachable page.
+- Desktop remains signed out.
+- Sign-in succeeds after Den Web restarts.
+
+## Flow 3: Worker proxy outage
+
+**Goal:** Cloud worker UI handles worker proxy failure without affecting account
+or provider sync.
+
+### Steps
+
+1. Open Settings -> Cloud -> Cloud Workers.
+2. Stop worker proxy in the server sandbox.
+3. Refresh Cloud Workers.
+4. Open Cloud Providers and refresh.
+5. Restart worker proxy.
+6. Refresh Cloud Workers again.
+
+### Expected outcome
+
+- Cloud Workers shows a worker/proxy-specific error.
+- Cloud Account and Cloud Providers continue to work.
+- Worker state recovers after proxy restart.
+
+## Flow 4: MySQL restart
+
+**Goal:** Restarting MySQL causes temporary cloud errors and the stack recovers
+without Electron restart.
+
+### Steps
+
+1. Stop MySQL in the server sandbox.
+2. Refresh Cloud Account, Cloud Providers, and Marketplace.
+3. Start MySQL again.
+4. Restart Den API if needed.
+5. Refresh the same desktop tabs.
+
+### Expected outcome
+
+- Each cloud tab shows a recoverable error during DB outage.
+- No infinite loading state persists after recovery.
+- Existing desktop auth token remains present.
+
+## Flow 5: Server sandbox restart
+
+**Goal:** A stopped and restarted server sandbox can serve the already-running
+Electron client again.
+
+### Steps
+
+1. Sign in and import a provider.
+2. Stop the server sandbox.
+3. Verify cloud refresh fails in Electron.
+4. Start the server sandbox again.
+5. Restart `.devcontainer/start-daytona-server.sh` if needed.
+6. Refresh Cloud Account and Cloud Providers.
+
+### Expected outcome
+
+- The desktop app does not need to be restarted.
+- Cloud tabs recover after the server stack is healthy.
+- Previously imported workspace config remains intact.

--- a/evals/daytona-server-sync-report.md
+++ b/evals/daytona-server-sync-report.md
@@ -1,0 +1,87 @@
+# Daytona Server Sync Eval Report
+
+Date: 2026-05-21
+PR: https://github.com/different-ai/openwork/pull/1887
+
+## Topology
+
+- Server sandbox: `openwork-server-20260521-195504`
+- Electron sandbox: `openwork-test-20260521-200726`
+- Den Web: `https://3005-8a1fmav0r1lc67wb.daytonaproxy01.net`
+- Den API: `https://8788-fsjfdaoh0xoklgyn.daytonaproxy01.net`
+- Worker proxy: `https://8789-lex0iaxjjidavjfz.daytonaproxy01.net`
+- Electron CDP: `https://9825-acrhqyxitcliiodm.daytonaproxy01.net`
+
+The server sandbox ran MySQL, Den API, Den Web, and worker proxy. The Electron sandbox ran the real desktop app and talked to the server sandbox over Daytona preview URLs.
+
+## Baseline Checks
+
+- Den Web health: `GET /api/den/health` returned `{"ok":true,"service":"den-api"}`.
+- Den API health: `GET /health` returned `{"ok":true,"service":"den-api"}`.
+- Worker proxy: `GET /unknown` returned HTTP `404`, proving the proxy process was reachable.
+- Electron CDP connected and `navigator.userAgent` contained `Electron/35.7.5`.
+
+## Desktop Login
+
+Result: pass.
+
+- Created and verified a Den user on the Daytona server.
+- Created a desktop handoff grant from Den API.
+- Pasted the full `openwork://den-auth?...` link into the desktop Cloud Account manual sign-in flow.
+- Electron showed `OpenWork Cloud Connected` and `Signed in as daytona-proof-1779419514@example.com`.
+- Den API logs showed:
+  - `POST /v1/auth/desktop-handoff/exchange 200`
+  - `GET /v1/me/orgs 200`
+
+Finding: raw one-time grant paste is fragile in split Den Web/Den API deployments because the manual flow only receives the grant and derives the exchange base from the configured Den Web base URL. Pasting the full deep link works because it carries the explicit `denBaseUrl`.
+
+## User Pre-Population
+
+Result: pass.
+
+- Created organization `Daytona Sync Eval`.
+- Invited and accepted two users:
+  - `daytona-sync-user-1-1779420561@example.com`
+  - `daytona-sync-user-2-1779420561@example.com`
+- Verified from the Electron renderer using Den API fetch that the active org had `memberCount: 3` and included the owner plus both invited users.
+
+Observation: the desktop Cloud Account page shows the active organization but does not expose a member list, so member sync verification was API-backed from the Electron runtime rather than a visible member-management UI.
+
+## LLM Provider Sync
+
+Result: pass.
+
+- Created custom org LLM providers through Den API.
+- Cloud Providers settings displayed the providers as available/imported.
+- Direct provider list from Electron renderer took about `69ms`.
+- A newly created provider appeared in the Cloud Providers UI after pressing Refresh in about `252ms`.
+- After a local workspace was created, cloud-provider sync wrote providers into `/workspace/sync-eval/opencode.jsonc`.
+- A provider created after workspace sync was imported into `opencode.jsonc` when opening the workspace Cloud Providers settings.
+
+Observation: automatic interval sync is configured for `5 * 60 * 1000` ms. Immediate sync happens on sign-in, Den settings changes, workspace availability, and opening cloud-provider settings.
+
+## Marketplace And Plugin Sync
+
+Result: pass.
+
+- Created plugin `Sync Eval Plugin 1779420801` through Den API.
+- Created marketplace `Sync Eval Marketplace 1779420801` through Den API.
+- Attached the plugin to the marketplace through Den API; attach returned HTTP `201`.
+- Desktop Marketplace settings showed the marketplace and plugin immediately after navigation.
+- Clicking Import succeeded and showed `Imported Sync Eval Plugin 1779420801 with 0 files. Reload workspace to apply config changes.`
+
+Observation: the API allows adding a plugin to a marketplace, and the desktop marketplace UI can see and import it. This test used a metadata-only plugin with zero config files, so follow-up coverage should add a config object to prove non-empty file import.
+
+## Issues Found
+
+- Fixed in this PR: desktop cloud settings sync overwrote a custom Den API URL with the Den Web URL. This broke split Daytona Den Web/Den API topologies.
+- Not fixed in this PR: raw manual sign-in grant paste does not reliably target the Den API in split Den Web/Den API deployments. Use the full `openwork://den-auth?...&denBaseUrl=...` handoff link for now.
+- Follow-up recommended: add a non-empty plugin/config-object eval so marketplace import proves actual file materialization, not just plugin visibility and zero-file import.
+
+## Commands And Checks
+
+- `bash -n .devcontainer/test-on-daytona.sh`
+- `bash -n .devcontainer/test-server-on-daytona.sh`
+- `bash -n .devcontainer/start-daytona-server.sh`
+- `bash -n .devcontainer/create-daytona-openwork-server-snapshot.sh`
+- `pnpm --filter @openwork/app typecheck`


### PR DESCRIPTION
## Summary
- add a Daytona Den server sandbox path for MySQL, Den API, Den Web, and worker proxy
- let the Electron Daytona helper boot against Daytona Den Web/API preview URLs
- preserve custom Den API base URLs during desktop cloud settings sync
- document the desktop-to-server Daytona login flow
- add expanded sync eval report at evals/daytona-server-sync-report.md
- add user-perspective cloud E2E eval specs for auth, provider sync, marketplace sync, workers, org membership, and failure recovery

## Verification
- bash -n .devcontainer/test-on-daytona.sh
- bash -n .devcontainer/test-server-on-daytona.sh
- bash -n .devcontainer/start-daytona-server.sh
- bash -n .devcontainer/create-daytona-openwork-server-snapshot.sh
- pnpm --filter @openwork/app typecheck
- Daytona server sandbox health checks passed for Den Web, Den API, and worker proxy
- Daytona Electron sandbox signed in via desktop handoff against the Daytona server sandbox
- Pre-populated org users and verified member sync from Electron renderer
- Created Den API LLM providers and verified Cloud Providers UI plus opencode.jsonc sync
- Created Den API marketplace/plugin link and verified Marketplace UI plus import action

## Added eval specs
- evals/cloud-auth-flows.md
- evals/cloud-provider-sync-flows.md
- evals/cloud-marketplace-sync-flows.md
- evals/cloud-worker-flows.md
- evals/cloud-org-membership-flows.md
- evals/daytona-server-failure-recovery-flows.md

## Known follow-ups
- Raw one-time grant paste is fragile in split Den Web/Den API deployments; full openwork://den-auth deep link works.
- Marketplace import was verified with a metadata-only plugin; follow-up should add non-empty config-object import coverage.