### PR TITLE
feat(app): add Voice Mode extension

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -167,6 +167,17 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     composerPrompt: "Use the OpenAI Image Gen extension to ",
   },
   {
+    id: "openwork-voice",
+    name: "Voice Mode",
+    serverName: "openwork-voice",
+    description: "Talk to OpenWork through a Realtime voice panel that drives the same semantic UI controls as OpenWork UI MCP.",
+    oauth: false,
+    kind: "extension",
+    iconSrc: "/openwork-mark.svg",
+    composerPrompt: "Use Voice Mode to ",
+    defaultEnabled: true,
+  },
+  {
     id: "ollama",
     name: "Ollama",
     serverName: "ollama",

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1388,6 +1388,22 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         method: "DELETE",
         timeoutMs: timeouts.config,
       }),
+
+    createVoiceRealtimeSession: (payload?: { model?: string }) =>
+      requestJson<{
+        ok: true;
+        clientSecret: string;
+        expiresAt: number | null;
+        model: string;
+        transcriptionModel: string;
+        tools: string[];
+      }>(baseUrl, "/voice/realtime/session", {
+        token,
+        hostToken,
+        method: "POST",
+        body: payload ?? {},
+        timeoutMs: timeouts.config,
+      }),
   };
 }
 

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -40,7 +40,7 @@ import { StatusBar, type StatusBarProps } from "./status-bar";
 import { OwDotTicker } from "../../../shell/dot-ticker";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import { useShellConfig } from "../../../shell/shell-config";
-import { type SidePanelItem, useUiStateStore } from "../../../shell/ui-state-store";
+import { getSidePanelState, type SidePanelItem, useUiStateStore } from "../../../shell/ui-state-store";
 
 import { isElectronRuntime } from "../../../../app/utils";
 import { BrowserPanel } from "../browser/browser-panel";
@@ -222,9 +222,7 @@ export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
   const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
   const setSidebarOpen = useUiStateStore((state) => state.setSidebarOpen);
-  const activeSidePanel = useUiStateStore((state) => (
-    props.selectedSessionId ? state.sidePanelState[props.selectedSessionId] ?? null : null
-  ));
+  const activeSidePanel = useUiStateStore((state) => getSidePanelState(state, props.selectedSessionId));
   const setSidePanelState = useUiStateStore((state) => state.setSidePanelState);
   const toggleSidePanelState = useUiStateStore((state) => state.toggleSidePanelState);
   const [artifactTarget, setArtifactTarget] = useState<OpenTarget | null>(null);

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,9 +2,10 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { FileText, Globe, Settings2, Zap } from "lucide-react";
+import { FileText, Globe, Mic2, Settings2, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
+import { OPENWORK_EXTENSION_CATALOG } from "../../../../app/constants";
 import { type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
@@ -45,7 +46,10 @@ import { isElectronRuntime } from "../../../../app/utils";
 import { BrowserPanel } from "../browser/browser-panel";
 import { ArtifactPanel } from "../artifacts/artifact-panel";
 import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, type OpenTarget } from "../artifacts/open-target";
+import { VoicePanel } from "../voice/voice-panel";
 import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
+import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
+import { getExtensionId, isOpenWorkExtensionEnabled, OPENWORK_EXTENSION_STATE_CHANGED } from "../../settings/extension-state";
 import { cn } from "@/lib/utils";
 
 const STARTUP_SKELETON_ROWS = [
@@ -123,6 +127,7 @@ export type SessionPageProps = {
   clientConnected: boolean;
   openworkServerStatus: OpenworkServerStatus;
   openworkServerClient: OpenworkServerClient | null;
+  hostOpenworkServerClient?: OpenworkServerClient | null;
   openworkServerToken?: string | null;
   developerMode: boolean;
   headerStatus: string;
@@ -225,6 +230,7 @@ export function SessionPage(props: SessionPageProps) {
   const [artifactTarget, setArtifactTarget] = useState<OpenTarget | null>(null);
   const [openTargets, setOpenTargets] = useState<OpenTarget[]>([]);
   const [hiddenAccessibleTargetIds, setHiddenAccessibleTargetIds] = useState<Set<string>>(() => new Set());
+  const [, setExtensionStateVersion] = useState(0);
   const loadedHiddenTargetsKeyRef = useRef<string | null>(null);
   const accessibleTargets = useMemo(
     () => openTargets.filter((target) => isTrackableAccessibleTarget(target) && !hiddenAccessibleTargetIds.has(target.id)),
@@ -238,6 +244,12 @@ export function SessionPage(props: SessionPageProps) {
   const browserRailActive = activeSidePanel === "browser";
   const artifactRailActive = activeSidePanel === "artifacts";
   const extensionsRailActive = activeSidePanel === "extensions";
+  const voiceRailActive = activeSidePanel === "voice";
+  const voiceExtension = useMemo(
+    () => OPENWORK_EXTENSION_CATALOG.find((entry) => getExtensionId(entry) === "openwork-voice") ?? null,
+    [],
+  );
+  const voiceExtensionEnabled = voiceExtension ? isOpenWorkExtensionEnabled(voiceExtension) : false;
 
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
@@ -364,6 +376,9 @@ export function SessionPage(props: SessionPageProps) {
   const openExtensionsRailPane = useCallback(() => {
     toggleCurrentSidePanel("extensions");
   }, [toggleCurrentSidePanel]);
+  const openVoiceRailPane = useCallback(() => {
+    toggleCurrentSidePanel("voice");
+  }, [toggleCurrentSidePanel]);
   const removeAccessibleTarget = useCallback((target: OpenTarget) => {
     setHiddenAccessibleTargetIds((current) => new Set(current).add(target.id));
     setArtifactTarget((current) => current?.id === target.id ? null : current);
@@ -393,7 +408,49 @@ export function SessionPage(props: SessionPageProps) {
     window.addEventListener("openwork-close-right-pane", handler);
     return () => window.removeEventListener("openwork-close-right-pane", handler);
   }, [setCurrentSidePanel]);
+  useEffect(() => {
+    const refresh = () => setExtensionStateVersion((value) => value + 1);
+    window.addEventListener(OPENWORK_EXTENSION_STATE_CHANGED, refresh);
+    window.addEventListener("storage", refresh);
+    return () => {
+      window.removeEventListener(OPENWORK_EXTENSION_STATE_CHANGED, refresh);
+      window.removeEventListener("storage", refresh);
+    };
+  }, []);
+  useEffect(() => {
+    if (activeSidePanel === "voice" && !voiceExtensionEnabled) {
+      setCurrentSidePanel(null);
+    }
+  }, [activeSidePanel, setCurrentSidePanel, voiceExtensionEnabled]);
   const [showDelayedSessionLoadingState, setShowDelayedSessionLoadingState] = useState(false);
+
+  const openVoicePanelControlAction = useMemo<OpenworkControlAction | null>(() => (
+    voiceExtensionEnabled && props.selectedSessionId ? {
+      id: "voice.panel.open",
+      label: "Open Voice Mode",
+      description: "Open the Voice Mode right-side panel for the active session.",
+      sideEffect: "none",
+      execute: () => {
+        setCurrentSidePanel("voice");
+        return { open: true };
+      },
+    } : null
+  ), [props.selectedSessionId, setCurrentSidePanel, voiceExtensionEnabled]);
+  useControlAction(openVoicePanelControlAction);
+
+  const closeVoicePanelControlAction = useMemo<OpenworkControlAction | null>(() => (
+    voiceExtensionEnabled && activeSidePanel === "voice" ? {
+      id: "voice.panel.close",
+      label: "Close Voice Mode",
+      description: "Close the Voice Mode right-side panel.",
+      sideEffect: "none",
+      execute: () => {
+        setCurrentSidePanel(null);
+        return { open: false };
+      },
+    } : null
+  ), [activeSidePanel, setCurrentSidePanel, voiceExtensionEnabled]);
+  useControlAction(closeVoicePanelControlAction);
 
   const selectedSessionTitle = useMemo(
     () => sessionTitleForId(props.sidebar.workspaceSessionGroups, props.selectedSessionId),
@@ -441,6 +498,12 @@ export function SessionPage(props: SessionPageProps) {
     selectedWorkspaceGroupError ||
     "";
   const showSelectedWorkspaceError = Boolean(selectedWorkspaceErrorMessage);
+  const rightPanelDefaultSize = activeSidePanel === "extensions"
+    ? `${Math.max(browserPanelDefaultWidth, 480)}px`
+    : activeSidePanel === "voice"
+      ? `${Math.max(browserPanelDefaultWidth, 380)}px`
+      : `${browserPanelDefaultWidth}px`;
+  const rightPanelMinSize = activeSidePanel === "extensions" ? "420px" : activeSidePanel === "voice" ? "360px" : "320px";
 
   const reactSessionBaseUrl = props.opencodeBaseUrl?.trim() ?? "";
   const reactSessionToken =
@@ -822,8 +885,8 @@ export function SessionPage(props: SessionPageProps) {
                 <ResizableHandle withHandle className="hidden lg:flex" />
                 <ResizablePanel
                   panelRef={browserPanelRef}
-                  defaultSize={`${activeSidePanel === "extensions" ? Math.max(browserPanelDefaultWidth, 480) : browserPanelDefaultWidth}px`}
-                  minSize={activeSidePanel === "extensions" ? "420px" : "320px"}
+                  defaultSize={rightPanelDefaultSize}
+                  minSize={rightPanelMinSize}
                   maxSize="70%"
                   className="min-h-0 overflow-hidden lg:flex lg:flex-col"
                 >
@@ -831,6 +894,12 @@ export function SessionPage(props: SessionPageProps) {
                     <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-background">
                       {props.settingsSlot}
                     </div>
+                  ) : activeSidePanel === "voice" ? (
+                    <VoicePanel
+                      client={props.hostOpenworkServerClient ?? props.openworkServerClient}
+                      sessionId={props.selectedSessionId}
+                      onClose={closeRightPane}
+                    />
                   ) : activeSidePanel === "artifacts" && visibleArtifactTarget && props.openworkServerClient && props.runtimeWorkspaceId ? (
                     <ArtifactPanel
                       client={props.openworkServerClient}
@@ -864,6 +933,23 @@ export function SessionPage(props: SessionPageProps) {
                 aria-pressed={browserRailActive}
               >
                 <Globe size={17} />
+              </Button>
+            ) : null}
+            {voiceExtensionEnabled ? (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className={cn(
+                  "rounded-xl transition-colors hover:bg-muted hover:text-foreground",
+                  voiceRailActive && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
+                )}
+                onClick={openVoiceRailPane}
+                title={props.selectedSessionId ? "Voice Mode" : "Open a session to use Voice Mode"}
+                aria-label={props.selectedSessionId ? "Voice Mode" : "Open a session to use Voice Mode"}
+                aria-pressed={voiceRailActive}
+                disabled={!props.selectedSessionId}
+              >
+                <Mic2 size={17} />
               </Button>
             ) : null}
             <Button

--- a/apps/app/src/react-app/domains/session/settings/extensions-pane-slot.tsx
+++ b/apps/app/src/react-app/domains/session/settings/extensions-pane-slot.tsx
@@ -25,6 +25,7 @@ import type { ProviderListItem } from "../../../../app/types";
 import "../../settings/openai-image-gen-config";
 import "../../settings/ollama-config";
 import "../../settings/browser-extension-config";
+import "../../settings/openwork-voice-config";
 
 export type ExtensionsPaneSlotProps = {
   openworkClient: OpenworkServerClient | null;
@@ -49,6 +50,10 @@ export function ExtensionsPaneSlot(props: ExtensionsPaneSlotProps) {
   const [lpBusy, setLpBusy] = useState(false);
   const [lpStatus, setLpStatus] = useState<string | null>(null);
   const [lpError, setLpError] = useState<string | null>(null);
+  const [voiceBusy, setVoiceBusy] = useState(false);
+  const [voiceStatus, setVoiceStatus] = useState<string | null>(null);
+  const [voiceError, setVoiceError] = useState<string | null>(null);
+  const [userEnvKeys, setUserEnvKeys] = useState<string[]>([]);
   const [, setExtensionStateVersion] = useState(0);
 
   useEffect(() => {
@@ -71,6 +76,16 @@ export function ExtensionsPaneSlot(props: ExtensionsPaneSlotProps) {
       .catch(() => { if (!cancelled) setImageInstalled(false); });
     return () => { cancelled = true; };
   }, [props.workspaceClient, props.workspaceId]);
+
+  useEffect(() => {
+    const client = props.openworkClient;
+    if (!client) { setUserEnvKeys([]); return; }
+    let cancelled = false;
+    void client.listUserEnvKeys()
+      .then((response) => { if (!cancelled) setUserEnvKeys(response.keys); })
+      .catch(() => { if (!cancelled) setUserEnvKeys([]); });
+    return () => { cancelled = true; };
+  }, [props.openworkClient]);
 
   const installImage = useCallback(async (apiKey: string) => {
     const client = props.workspaceClient;
@@ -120,6 +135,28 @@ export function ExtensionsPaneSlot(props: ExtensionsPaneSlotProps) {
     } catch (e) { setLpError(e instanceof Error ? e.message : String(e)); } finally { setLpBusy(false); }
   }, [props]);
 
+  const saveVoiceApiKey = useCallback(async (apiKey: string) => {
+    const client = props.openworkClient;
+    const value = apiKey.trim();
+    if (!client || !value) { setVoiceError("API key required."); return; }
+    setVoiceBusy(true); setVoiceStatus(null); setVoiceError(null);
+    try {
+      await client.upsertUserEnv([{ key: "OPENAI_API_KEY", value }]);
+      setUserEnvKeys((current) => Array.from(new Set([...current, "OPENAI_API_KEY"])));
+      setVoiceStatus("Saved OPENAI_API_KEY for Voice Mode and other OpenAI extensions.");
+    } catch (e) { setVoiceError(e instanceof Error ? e.message : String(e)); } finally { setVoiceBusy(false); }
+  }, [props.openworkClient]);
+
+  const testVoiceSession = useCallback(async () => {
+    const client = props.openworkClient;
+    if (!client) { setVoiceError("OpenWork host connection required."); return; }
+    setVoiceBusy(true); setVoiceStatus(null); setVoiceError(null);
+    try {
+      const session = await client.createVoiceRealtimeSession();
+      setVoiceStatus(`Realtime ready with ${session.model} (${session.tools.length} OpenWork tools).`);
+    } catch (e) { setVoiceError(e instanceof Error ? e.message : String(e)); } finally { setVoiceBusy(false); }
+  }, [props.openworkClient]);
+
   const configCtx: ExtensionConfigContext = {
     imageExtension: {
       busy: imageBusy || genBusy,
@@ -128,6 +165,18 @@ export function ExtensionsPaneSlot(props: ExtensionsPaneSlotProps) {
       envKeyDetected: props.providers.some((p) => p.id === "openai" && p.source === "env") || props.providerConnectedIds.includes("openai"),
       onInstall: installImage,
       onTestGenerate: testGen,
+    },
+    voiceExtension: {
+      busy: voiceBusy,
+      status: voiceStatus,
+      error: voiceError,
+      envKeyDetected:
+        userEnvKeys.includes("OPENAI_REALTIME_API_KEY") ||
+        userEnvKeys.includes("OPENAI_API_KEY") ||
+        props.providers.some((p) => p.id === "openai" && p.source === "env") ||
+        props.providerConnectedIds.includes("openai"),
+      onSaveApiKey: saveVoiceApiKey,
+      onTestSession: testVoiceSession,
     },
     localProvider: { busy: lpBusy, status: lpStatus, error: lpError, onInstall: installLocal },
   };

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -873,6 +873,24 @@ export function SessionSurface(props: SessionSurfaceProps) {
     await waitForControl(40);
   }, [props.sessionId, setComposerDraft]);
 
+  useEffect(() => {
+    const handleVoiceTranscript = (event: Event) => {
+      if (!(event instanceof CustomEvent)) return;
+      const detail: unknown = event.detail;
+      if (!detail || typeof detail !== "object" || Array.isArray(detail) || !("text" in detail) || typeof detail.text !== "string") return;
+      const text = detail.text;
+      void typeComposerText(text);
+      props.onDraftChange(buildDraft(text, attachments));
+      recordInspectorEvent("voice.transcript.applied", {
+        workspaceId: props.workspaceId,
+        sessionId: props.sessionId,
+        length: text.length,
+      });
+    };
+    window.addEventListener("openwork:voice-transcript", handleVoiceTranscript);
+    return () => window.removeEventListener("openwork:voice-transcript", handleVoiceTranscript);
+  }, [attachments, buildDraft, props.onDraftChange, props.sessionId, props.workspaceId, typeComposerText]);
+
   const composerSetTextControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "composer.set_text",
     label: "Type into the composer",

--- a/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
+++ b/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { ChevronDown, ChevronRight, Loader2, Mic2, MicOff, Radio, SendHorizontal, Sparkles, Square, X } from "lucide-react";
 import { PaperGrainGradient } from "@openwork/ui/react";
 
@@ -24,6 +24,15 @@ type VoiceTimelineEntry = {
   at: number;
 };
 
+type VoiceRuntimeSnapshot = {
+  status: VoiceStatus;
+  statusText: string;
+  micMuted: boolean;
+  entries: VoiceTimelineEntry[];
+  latestUserTranscript: string;
+  assistantPreview: string;
+};
+
 type VoicePanelProps = {
   client: OpenworkServerClient | null;
   sessionId: string | null;
@@ -42,6 +51,49 @@ const TOOL_LABELS: Record<string, string> = {
   openwork_list_actions: "Listing controls",
   openwork_execute_action: "Running UI action",
 };
+
+const initialVoiceRuntimeSnapshot: VoiceRuntimeSnapshot = {
+  status: "idle",
+  statusText: "Ready for voice control.",
+  micMuted: false,
+  entries: [],
+  latestUserTranscript: "",
+  assistantPreview: "",
+};
+
+const voiceRealtime = {
+  peer: null as RTCPeerConnection | null,
+  channel: null as RTCDataChannel | null,
+  stream: null as MediaStream | null,
+  remoteAudio: null as HTMLAudioElement | null,
+  assistantBuffer: "",
+  responseInProgress: false,
+  pendingResponse: false,
+  micMuted: false,
+};
+
+let voiceRuntimeSnapshot: VoiceRuntimeSnapshot = initialVoiceRuntimeSnapshot;
+const voiceRuntimeListeners = new Set<() => void>();
+
+function getVoiceRuntimeSnapshot() {
+  return voiceRuntimeSnapshot;
+}
+
+function subscribeVoiceRuntime(listener: () => void) {
+  voiceRuntimeListeners.add(listener);
+  return () => {
+    voiceRuntimeListeners.delete(listener);
+  };
+}
+
+function setVoiceRuntimeSnapshot(update: (current: VoiceRuntimeSnapshot) => VoiceRuntimeSnapshot) {
+  voiceRuntimeSnapshot = update(voiceRuntimeSnapshot);
+  voiceRuntimeListeners.forEach((listener) => listener());
+}
+
+function useVoiceRuntimeSnapshot() {
+  return useSyncExternalStore(subscribeVoiceRuntime, getVoiceRuntimeSnapshot, getVoiceRuntimeSnapshot);
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -229,71 +281,60 @@ function VoiceTimelineRow(props: {
 
 export function VoicePanel(props: VoicePanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
-  const peerRef = useRef<RTCPeerConnection | null>(null);
-  const channelRef = useRef<RTCDataChannel | null>(null);
-  const streamRef = useRef<MediaStream | null>(null);
-  const remoteAudioRef = useRef<HTMLAudioElement | null>(null);
   const timelineEndRef = useRef<HTMLDivElement>(null);
-  const assistantBufferRef = useRef("");
-  const responseInProgressRef = useRef(false);
-  const pendingResponseRef = useRef(false);
-  const micMutedRef = useRef(false);
-  const [status, setStatus] = useState<VoiceStatus>("idle");
-  const [statusText, setStatusText] = useState("Ready for voice control.");
-  const [micMuted, setMicMuted] = useState(false);
-  const [entries, setEntries] = useState<VoiceTimelineEntry[]>([]);
   const [textCommand, setTextCommand] = useState("");
-  const [latestUserTranscript, setLatestUserTranscript] = useState("");
-  const [assistantPreview, setAssistantPreview] = useState("");
   const [expandedEntries, setExpandedEntries] = useState<Set<string>>(() => new Set());
+  const { status, statusText, micMuted, entries, latestUserTranscript, assistantPreview } = useVoiceRuntimeSnapshot();
   const connected = status === "listening" || status === "speaking" || status === "muted";
-
-  useEffect(() => {
-    micMutedRef.current = micMuted;
-  }, [micMuted]);
 
   const addEntry = useCallback((role: VoiceTimelineEntry["role"], text: string, options: { toolName?: string; error?: boolean } = {}) => {
     const trimmed = text.trim();
     if ((role === "user" || role === "assistant") && !trimmed) return;
-    setEntries((current) => [
+    setVoiceRuntimeSnapshot((current) => ({
       ...current,
-      {
-        id: `voice-${Date.now()}-${current.length}`,
-        role,
-        text: trimmed || options.toolName || "Tool call",
-        toolName: options.toolName,
-        error: options.error,
-        at: Date.now(),
-      },
-    ].slice(-120));
+      entries: [
+        ...current.entries,
+        {
+          id: `voice-${Date.now()}-${current.entries.length}`,
+          role,
+          text: trimmed || options.toolName || "Tool call",
+          toolName: options.toolName,
+          error: options.error,
+          at: Date.now(),
+        },
+      ].slice(-120),
+    }));
   }, []);
 
   const setRuntimeStatus = useCallback((nextStatus: VoiceStatus, text?: string) => {
-    setStatus(nextStatus);
-    setStatusText(text ?? (
-      nextStatus === "connecting" ? "Connecting to OpenAI Realtime..." :
-        nextStatus === "listening" ? "Listening. Ask OpenWork to act." :
-          nextStatus === "speaking" ? "OpenWork is speaking..." :
-            nextStatus === "muted" ? "Connected, microphone muted." :
-              nextStatus === "error" ? "Voice Mode needs attention." :
-                "Ready for voice control."
-    ));
+    setVoiceRuntimeSnapshot((current) => ({
+      ...current,
+      status: nextStatus,
+      statusText: text ?? (
+        nextStatus === "connecting" ? "Connecting to OpenAI Realtime..." :
+          nextStatus === "listening" ? "Listening. Ask OpenWork to act." :
+            nextStatus === "speaking" ? "OpenWork is speaking..." :
+              nextStatus === "muted" ? "Connected, microphone muted." :
+                nextStatus === "error" ? "Voice Mode needs attention." :
+                  "Ready for voice control."
+      ),
+    }));
   }, []);
 
   const disconnectRealtime = useCallback((silent = false) => {
-    try { streamRef.current?.getTracks().forEach((track) => track.stop()); } catch {}
-    streamRef.current = null;
-    try { channelRef.current?.close(); } catch {}
-    channelRef.current = null;
-    try { peerRef.current?.close(); } catch {}
-    peerRef.current = null;
-    try { remoteAudioRef.current?.remove(); } catch {}
-    remoteAudioRef.current = null;
-    assistantBufferRef.current = "";
-    responseInProgressRef.current = false;
-    pendingResponseRef.current = false;
-    setMicMuted(false);
-    setAssistantPreview("");
+    try { voiceRealtime.stream?.getTracks().forEach((track) => track.stop()); } catch {}
+    voiceRealtime.stream = null;
+    try { voiceRealtime.channel?.close(); } catch {}
+    voiceRealtime.channel = null;
+    try { voiceRealtime.peer?.close(); } catch {}
+    voiceRealtime.peer = null;
+    try { voiceRealtime.remoteAudio?.remove(); } catch {}
+    voiceRealtime.remoteAudio = null;
+    voiceRealtime.assistantBuffer = "";
+    voiceRealtime.responseInProgress = false;
+    voiceRealtime.pendingResponse = false;
+    voiceRealtime.micMuted = false;
+    setVoiceRuntimeSnapshot((current) => ({ ...current, micMuted: false, assistantPreview: "" }));
     setRuntimeStatus("idle");
     if (!silent) addEntry("system", "Voice session stopped.");
     recordInspectorEvent("voice.disconnected", { sessionId: props.sessionId });
@@ -313,11 +354,11 @@ export function VoicePanel(props: VoicePanelProps) {
   }, []);
 
   const requestRealtimeResponse = useCallback((channel: RTCDataChannel, deferIfBusy = true) => {
-    if (responseInProgressRef.current) {
-      if (deferIfBusy) pendingResponseRef.current = true;
+    if (voiceRealtime.responseInProgress) {
+      if (deferIfBusy) voiceRealtime.pendingResponse = true;
       return false;
     }
-    responseInProgressRef.current = true;
+    voiceRealtime.responseInProgress = true;
     channel.send(JSON.stringify({ type: "response.create", response: { output_modalities: ["audio"] } }));
     return true;
   }, []);
@@ -336,14 +377,14 @@ export function VoicePanel(props: VoicePanelProps) {
       return;
     }
     if (type === "response.created") {
-      responseInProgressRef.current = true;
-      pendingResponseRef.current = false;
+      voiceRealtime.responseInProgress = true;
+      voiceRealtime.pendingResponse = false;
       return;
     }
     if (type === "conversation.item.input_audio_transcription.completed") {
       const transcript = readString(event, "transcript").trim();
       if (transcript && isMeaningfulTranscript(transcript)) {
-        setLatestUserTranscript(transcript);
+        setVoiceRuntimeSnapshot((current) => ({ ...current, latestUserTranscript: transcript }));
         addEntry("user", transcript);
         recordInspectorEvent("voice.transcript", { sessionId: props.sessionId, transcript });
       }
@@ -351,8 +392,8 @@ export function VoicePanel(props: VoicePanelProps) {
     }
     if (type === "response.output_text.delta" || type === "response.output_audio_transcript.delta" || type === "response.audio_transcript.delta") {
       const delta = readString(event, "delta");
-      assistantBufferRef.current += delta;
-      setAssistantPreview(assistantBufferRef.current.trim());
+      voiceRealtime.assistantBuffer += delta;
+      setVoiceRuntimeSnapshot((current) => ({ ...current, assistantPreview: voiceRealtime.assistantBuffer.trim() }));
       setRuntimeStatus("speaking");
       return;
     }
@@ -366,7 +407,7 @@ export function VoicePanel(props: VoicePanelProps) {
         const error = typeof output.error === "string" ? output.error : "Tool failed.";
         addEntry("tool", error, { toolName, error: true });
       }
-      const channel = channelRef.current;
+      const channel = voiceRealtime.channel;
       if (!callId || !channel || channel.readyState !== "open") return;
       channel.send(JSON.stringify({
         type: "conversation.item.create",
@@ -376,22 +417,22 @@ export function VoicePanel(props: VoicePanelProps) {
       return;
     }
     if (type === "response.done") {
-      const text = assistantBufferRef.current.trim();
+      const text = voiceRealtime.assistantBuffer.trim();
       if (text) addEntry("assistant", text);
-      assistantBufferRef.current = "";
-      setAssistantPreview("");
-      responseInProgressRef.current = false;
-      const channel = channelRef.current;
-      if (pendingResponseRef.current && channel?.readyState === "open") {
-        pendingResponseRef.current = false;
+      voiceRealtime.assistantBuffer = "";
+      setVoiceRuntimeSnapshot((current) => ({ ...current, assistantPreview: "" }));
+      voiceRealtime.responseInProgress = false;
+      const channel = voiceRealtime.channel;
+      if (voiceRealtime.pendingResponse && channel?.readyState === "open") {
+        voiceRealtime.pendingResponse = false;
         requestRealtimeResponse(channel, false);
       } else {
-        setRuntimeStatus(micMutedRef.current ? "muted" : "listening");
+        setRuntimeStatus(voiceRealtime.micMuted ? "muted" : "listening");
       }
       return;
     }
     if (type === "error") {
-      responseInProgressRef.current = false;
+      voiceRealtime.responseInProgress = false;
       const error = readRecord(event, "error");
       const message = typeof error.message === "string" ? error.message : "Realtime returned an error.";
       addEntry("system", message, { error: true });
@@ -409,13 +450,13 @@ export function VoicePanel(props: VoicePanelProps) {
     const realtimeSession = await client.createVoiceRealtimeSession();
 
     const peer = new RTCPeerConnection();
-    peerRef.current = peer;
+    voiceRealtime.peer = peer;
     if (audioInput) {
       setRuntimeStatus("connecting", "Requesting microphone...");
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
       });
-      streamRef.current = stream;
+      voiceRealtime.stream = stream;
       for (const track of stream.getAudioTracks()) {
         peer.addTrack(track, stream);
       }
@@ -427,16 +468,16 @@ export function VoicePanel(props: VoicePanelProps) {
     audio.autoplay = true;
     audio.style.display = "none";
     document.body.appendChild(audio);
-    remoteAudioRef.current = audio;
+    voiceRealtime.remoteAudio = audio;
     peer.ontrack = (event) => {
       audio.srcObject = event.streams[0] ?? null;
     };
 
     const channel = peer.createDataChannel("oai-events");
-    channelRef.current = channel;
+    voiceRealtime.channel = channel;
     channel.addEventListener("message", (event) => void handleRealtimeMessage(String(event.data)));
     channel.addEventListener("close", () => {
-      if (channelRef.current === channel) setRuntimeStatus("idle");
+      if (voiceRealtime.channel === channel) setRuntimeStatus("idle");
     });
 
     const offer = await peer.createOffer();
@@ -479,10 +520,10 @@ export function VoicePanel(props: VoicePanelProps) {
   }, [disconnectRealtime]);
 
   const toggleMic = useCallback(() => {
-    const nextMuted = !micMutedRef.current;
-    micMutedRef.current = nextMuted;
-    setMicMuted(nextMuted);
-    streamRef.current?.getAudioTracks().forEach((track) => {
+    const nextMuted = !voiceRealtime.micMuted;
+    voiceRealtime.micMuted = nextMuted;
+    setVoiceRuntimeSnapshot((current) => ({ ...current, micMuted: nextMuted }));
+    voiceRealtime.stream?.getAudioTracks().forEach((track) => {
       track.enabled = !nextMuted;
     });
     setRuntimeStatus(nextMuted ? "muted" : "listening");
@@ -492,7 +533,7 @@ export function VoicePanel(props: VoicePanelProps) {
   const sendTextCommand = useCallback(async (text: string) => {
     const value = text.trim();
     if (!value) return { ok: false, error: "Text command required." };
-    if (!channelRef.current || channelRef.current.readyState !== "open") {
+    if (!voiceRealtime.channel || voiceRealtime.channel.readyState !== "open") {
       try {
         await connectRealtime(false);
       } catch (error) {
@@ -502,7 +543,7 @@ export function VoicePanel(props: VoicePanelProps) {
         return { ok: false, error: message };
       }
     }
-    const channel = channelRef.current;
+    const channel = voiceRealtime.channel;
     if (!channel || channel.readyState !== "open") return { ok: false, error: "Realtime channel is not open." };
     addEntry("user", value);
     channel.send(JSON.stringify({
@@ -516,11 +557,11 @@ export function VoicePanel(props: VoicePanelProps) {
   const injectAudio = useCallback(async (args: unknown) => {
     const audio = voiceAudioArgument(args);
     if (!audio) return { ok: false, error: "pcm16Base64 audio is required." };
-    if (!channelRef.current || channelRef.current.readyState !== "open") {
+    if (!voiceRealtime.channel || voiceRealtime.channel.readyState !== "open") {
       const started = await startVoice();
       if (isRecord(started) && started.ok === false) return started;
     }
-    const channel = channelRef.current;
+    const channel = voiceRealtime.channel;
     if (!channel || channel.readyState !== "open") return { ok: false, error: "Realtime channel is not open." };
     addEntry("system", "Injected deterministic audio into the Realtime input buffer.");
     channel.send(JSON.stringify({ type: "input_audio_buffer.append", audio }));
@@ -531,7 +572,7 @@ export function VoicePanel(props: VoicePanelProps) {
 
   const injectTranscript = useCallback(async (args: unknown) => {
     const text = voiceTextArgument(args);
-    setLatestUserTranscript(text);
+    setVoiceRuntimeSnapshot((current) => ({ ...current, latestUserTranscript: text }));
     addEntry("user", text);
     window.dispatchEvent(new CustomEvent("openwork:voice-transcript", { detail: { text } }));
     recordInspectorEvent("voice.inject_transcript", { sessionId: props.sessionId, text });
@@ -558,8 +599,6 @@ export function VoicePanel(props: VoicePanelProps) {
     }));
     return dispose;
   }, [assistantPreview, connected, entries, latestUserTranscript, micMuted, props.sessionId, status, statusText, textCommand.length]);
-
-  useEffect(() => () => disconnectRealtime(true), [disconnectRealtime]);
 
   const startAction = useMemo<OpenworkControlAction>(() => ({
     id: "voice.start",

--- a/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
+++ b/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
@@ -7,8 +7,8 @@ import { desktopFetch } from "../../../../app/lib/desktop";
 import type { OpenworkServerClient } from "../../../../app/lib/openwork-server";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupTextarea } from "@/components/ui/input-group";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { publishInspectorSlice, recordInspectorEvent } from "../../../shell/app-inspector";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
@@ -749,26 +749,37 @@ export function VoicePanel(props: VoicePanelProps) {
                 Typed voice command
               </CardTitle>
             </CardHeader>
-            <CardContent className="flex flex-col gap-2">
-              <Textarea
-                value={textCommand}
-                onChange={(event) => setTextCommand(event.currentTarget.value)}
-                placeholder={DEFAULT_TEXT_COMMAND}
-                rows={3}
-              />
-              <Button
-                variant="outline"
-                className="self-end"
-                onClick={() => {
-                  const text = textCommand;
-                  setTextCommand("");
-                  void sendTextCommand(text);
-                }}
-                disabled={!textCommand.trim() || status === "connecting"}
-              >
-                <SendHorizontal data-icon="inline-start" />
-                Send to voice model
-              </Button>
+            <CardContent>
+              <InputGroup>
+                <InputGroupTextarea
+                  value={textCommand}
+                  onChange={(event) => setTextCommand(event.currentTarget.value)}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" || event.shiftKey) return;
+                    event.preventDefault();
+                    const text = textCommand;
+                    setTextCommand("");
+                    void sendTextCommand(text);
+                  }}
+                  placeholder={DEFAULT_TEXT_COMMAND}
+                  rows={3}
+                />
+                <InputGroupAddon align="block-end" className="justify-between border-t border-border">
+                  <span className="text-xs text-muted-foreground">Enter to send, Shift+Enter for newline</span>
+                  <InputGroupButton
+                    variant="outline"
+                    onClick={() => {
+                      const text = textCommand;
+                      setTextCommand("");
+                      void sendTextCommand(text);
+                    }}
+                    disabled={!textCommand.trim() || status === "connecting"}
+                  >
+                    <SendHorizontal data-icon="inline-start" />
+                    Send
+                  </InputGroupButton>
+                </InputGroupAddon>
+              </InputGroup>
             </CardContent>
           </Card>
 

--- a/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
+++ b/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
@@ -1,0 +1,795 @@
+/** @jsxImportSource react */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, ChevronRight, Loader2, Mic2, MicOff, Radio, SendHorizontal, Sparkles, Square, X } from "lucide-react";
+import { PaperGrainGradient } from "@openwork/ui/react";
+
+import { desktopFetch } from "../../../../app/lib/desktop";
+import type { OpenworkServerClient } from "../../../../app/lib/openwork-server";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { publishInspectorSlice, recordInspectorEvent } from "../../../shell/app-inspector";
+import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
+
+type VoiceStatus = "idle" | "connecting" | "listening" | "muted" | "speaking" | "error";
+
+type VoiceTimelineEntry = {
+  id: string;
+  role: "user" | "assistant" | "tool" | "system";
+  text: string;
+  toolName?: string;
+  error?: boolean;
+  at: number;
+};
+
+type VoicePanelProps = {
+  client: OpenworkServerClient | null;
+  sessionId: string | null;
+  onClose: () => void;
+};
+
+const DEFAULT_TEXT_COMMAND = "Summarize the current OpenWork session and put the next step in the composer.";
+const VOICE_SUGGESTIONS = [
+  "Read the latest message in this session",
+  "Put a concise next step in the composer",
+  "Open extension settings",
+  "Send the current composer prompt",
+];
+const TOOL_LABELS: Record<string, string> = {
+  openwork_snapshot: "Checking OpenWork",
+  openwork_list_actions: "Listing controls",
+  openwork_execute_action: "Running UI action",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown, key: string) {
+  if (!isRecord(value)) return "";
+  const field = value[key];
+  return typeof field === "string" ? field : "";
+}
+
+function readRecord(value: unknown, key: string): Record<string, unknown> {
+  if (!isRecord(value)) return {};
+  const field = value[key];
+  return isRecord(field) ? field : {};
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function safeJson(value: unknown) {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return JSON.stringify({ ok: false, error: "Could not serialize tool result" });
+  }
+}
+
+function humanToolLabel(toolName?: string) {
+  if (!toolName) return "OpenWork action";
+  return TOOL_LABELS[toolName] ?? toolName.replace(/_/g, " ");
+}
+
+function relativeTime(at: number) {
+  const seconds = Math.max(0, Math.round((Date.now() - at) / 1000));
+  if (seconds < 5) return "now";
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  return `${minutes}m`;
+}
+
+function isMeaningfulTranscript(value: string) {
+  return /[\p{Letter}\p{Number}]/u.test(value);
+}
+
+function voiceTextArgument(args: unknown) {
+  if (typeof args === "string") return args.trim();
+  if (isRecord(args) && typeof args.text === "string") return args.text.trim();
+  return DEFAULT_TEXT_COMMAND;
+}
+
+function voiceAudioArgument(args: unknown) {
+  if (!isRecord(args)) return "";
+  return typeof args.pcm16Base64 === "string" ? args.pcm16Base64.trim() : "";
+}
+
+function waitForDataChannelOpen(channel: RTCDataChannel) {
+  if (channel.readyState === "open") return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      window.clearTimeout(timeout);
+      channel.removeEventListener("open", handleOpen);
+      channel.removeEventListener("close", handleClose);
+      channel.removeEventListener("error", handleError);
+    };
+    const timeout = window.setTimeout(() => {
+      cleanup();
+      reject(new Error("Realtime data channel did not open in time."));
+    }, 10_000);
+    const handleOpen = () => { cleanup(); resolve(); };
+    const handleClose = () => { cleanup(); reject(new Error("Realtime data channel closed before opening.")); };
+    const handleError = () => { cleanup(); reject(new Error("Realtime data channel failed.")); };
+    channel.addEventListener("open", handleOpen);
+    channel.addEventListener("close", handleClose);
+    channel.addEventListener("error", handleError);
+  });
+}
+
+async function executeOpenWorkTool(name: string, args: Record<string, unknown>) {
+  const control = window.__openworkControl;
+  if (!control) return { ok: false, error: "OpenWork control surface is not available." };
+
+  if (name === "openwork_snapshot") return { ok: true, snapshot: control.snapshot() };
+  if (name === "openwork_list_actions") return { ok: true, actions: control.listActions() };
+  if (name === "openwork_execute_action") {
+    const actionId = typeof args.actionId === "string" ? args.actionId.trim() : "";
+    if (!actionId) return { ok: false, error: "Missing actionId." };
+    const actionArgs = isRecord(args.args) ? args.args : {};
+    return control.execute(actionId, actionArgs);
+  }
+
+  return { ok: false, error: `Unknown OpenWork voice tool: ${name}` };
+}
+
+function VoiceOrb(props: { status: VoiceStatus; muted: boolean }) {
+  const active = props.status === "listening" || props.status === "speaking";
+  const colors = props.status === "speaking"
+    ? ["#fb7185", "#fbbf24", "#818cf8", "#111827"]
+    : props.muted
+      ? ["#94a3b8", "#475569", "#cbd5e1", "#0f172a"]
+      : ["#8ddde7", "#4f8b7b", "#bfdfa4", "#102b24"];
+
+  return (
+    <div className="relative mx-auto flex size-34 items-center justify-center rounded-full border border-border bg-card shadow-[0_24px_80px_rgba(0,0,0,0.24)]">
+      <div className="absolute inset-2 overflow-hidden rounded-full">
+        <PaperGrainGradient
+          speed={props.status === "speaking" ? 18 : active ? 12 : 4}
+          softness={0.16}
+          intensity={1}
+          noise={0.06}
+          shape="sphere"
+          colors={colors}
+          colorBack="#ffffff00"
+          style={{ width: "100%", height: "100%", borderRadius: "9999px" }}
+        />
+      </div>
+      <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_32%_20%,rgba(255,255,255,0.55),transparent_26%)]" />
+      <div className={cn(
+        "absolute -bottom-2 rounded-full border border-border bg-background px-3 py-1 text-[11px] font-medium text-muted-foreground shadow-sm",
+        active && "text-foreground",
+      )}>
+        {props.status === "speaking" ? "Speaking" : props.muted ? "Muted" : active ? "Listening" : "Ready"}
+      </div>
+    </div>
+  );
+}
+
+function VoiceTimelineRow(props: {
+  entry: VoiceTimelineEntry;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const { entry } = props;
+  const isAction = entry.role === "tool" || entry.role === "system";
+  const canExpand = isAction && entry.text.length > 72;
+  const copy = canExpand && !props.expanded ? `${entry.text.slice(0, 72)}...` : entry.text;
+
+  if (entry.role === "user") {
+    return (
+      <article className="ml-8 rounded-2xl border border-primary/20 bg-primary/10 px-3 py-2 text-sm leading-relaxed text-foreground">
+        {entry.text}
+      </article>
+    );
+  }
+
+  if (entry.role === "assistant") {
+    return (
+      <article className="mr-8 rounded-2xl border border-border bg-card px-3 py-2 text-sm leading-relaxed text-card-foreground shadow-sm">
+        {entry.error ? <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-destructive">Error</div> : null}
+        <div className="whitespace-pre-wrap break-words">{entry.text}</div>
+      </article>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "group flex w-full items-start gap-2 rounded-xl border bg-muted/40 px-2.5 py-2 text-left text-xs text-muted-foreground transition-colors hover:bg-muted",
+        entry.error && "border-destructive/35 bg-destructive/10 text-destructive hover:bg-destructive/15",
+      )}
+      onClick={canExpand ? props.onToggle : undefined}
+    >
+      {canExpand ? (
+        props.expanded ? <ChevronDown className="mt-0.5 shrink-0" /> : <ChevronRight className="mt-0.5 shrink-0" />
+      ) : (
+        <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-current opacity-60" />
+      )}
+      <span className="min-w-0 flex-1">
+        <span className="font-medium text-foreground/80">
+          {entry.toolName ? humanToolLabel(entry.toolName) : entry.error ? "Voice error" : "Voice note"}
+        </span>
+        <span className="ml-2 text-[10px] opacity-70">{relativeTime(entry.at)}</span>
+        {copy ? <span className="mt-1 block whitespace-pre-wrap break-words">{copy}</span> : null}
+      </span>
+    </button>
+  );
+}
+
+export function VoicePanel(props: VoicePanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const peerRef = useRef<RTCPeerConnection | null>(null);
+  const channelRef = useRef<RTCDataChannel | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const remoteAudioRef = useRef<HTMLAudioElement | null>(null);
+  const timelineEndRef = useRef<HTMLDivElement>(null);
+  const assistantBufferRef = useRef("");
+  const responseInProgressRef = useRef(false);
+  const pendingResponseRef = useRef(false);
+  const micMutedRef = useRef(false);
+  const [status, setStatus] = useState<VoiceStatus>("idle");
+  const [statusText, setStatusText] = useState("Ready for voice control.");
+  const [micMuted, setMicMuted] = useState(false);
+  const [entries, setEntries] = useState<VoiceTimelineEntry[]>([]);
+  const [textCommand, setTextCommand] = useState("");
+  const [latestUserTranscript, setLatestUserTranscript] = useState("");
+  const [assistantPreview, setAssistantPreview] = useState("");
+  const [expandedEntries, setExpandedEntries] = useState<Set<string>>(() => new Set());
+  const connected = status === "listening" || status === "speaking" || status === "muted";
+
+  useEffect(() => {
+    micMutedRef.current = micMuted;
+  }, [micMuted]);
+
+  const addEntry = useCallback((role: VoiceTimelineEntry["role"], text: string, options: { toolName?: string; error?: boolean } = {}) => {
+    const trimmed = text.trim();
+    if ((role === "user" || role === "assistant") && !trimmed) return;
+    setEntries((current) => [
+      ...current,
+      {
+        id: `voice-${Date.now()}-${current.length}`,
+        role,
+        text: trimmed || options.toolName || "Tool call",
+        toolName: options.toolName,
+        error: options.error,
+        at: Date.now(),
+      },
+    ].slice(-120));
+  }, []);
+
+  const setRuntimeStatus = useCallback((nextStatus: VoiceStatus, text?: string) => {
+    setStatus(nextStatus);
+    setStatusText(text ?? (
+      nextStatus === "connecting" ? "Connecting to OpenAI Realtime..." :
+        nextStatus === "listening" ? "Listening. Ask OpenWork to act." :
+          nextStatus === "speaking" ? "OpenWork is speaking..." :
+            nextStatus === "muted" ? "Connected, microphone muted." :
+              nextStatus === "error" ? "Voice Mode needs attention." :
+                "Ready for voice control."
+    ));
+  }, []);
+
+  const disconnectRealtime = useCallback((silent = false) => {
+    try { streamRef.current?.getTracks().forEach((track) => track.stop()); } catch {}
+    streamRef.current = null;
+    try { channelRef.current?.close(); } catch {}
+    channelRef.current = null;
+    try { peerRef.current?.close(); } catch {}
+    peerRef.current = null;
+    try { remoteAudioRef.current?.remove(); } catch {}
+    remoteAudioRef.current = null;
+    assistantBufferRef.current = "";
+    responseInProgressRef.current = false;
+    pendingResponseRef.current = false;
+    setMicMuted(false);
+    setAssistantPreview("");
+    setRuntimeStatus("idle");
+    if (!silent) addEntry("system", "Voice session stopped.");
+    recordInspectorEvent("voice.disconnected", { sessionId: props.sessionId });
+  }, [addEntry, props.sessionId, setRuntimeStatus]);
+
+  useEffect(() => {
+    timelineEndRef.current?.scrollIntoView({ block: "end", behavior: "smooth" });
+  }, [entries.length, assistantPreview]);
+
+  const toggleEntryExpanded = useCallback((id: string) => {
+    setExpandedEntries((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const requestRealtimeResponse = useCallback((channel: RTCDataChannel, deferIfBusy = true) => {
+    if (responseInProgressRef.current) {
+      if (deferIfBusy) pendingResponseRef.current = true;
+      return false;
+    }
+    responseInProgressRef.current = true;
+    channel.send(JSON.stringify({ type: "response.create", response: { output_modalities: ["audio"] } }));
+    return true;
+  }, []);
+
+  const handleRealtimeMessage = useCallback(async (raw: string) => {
+    let event: unknown = null;
+    try {
+      event = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    const type = readString(event, "type");
+
+    if (type === "input_audio_buffer.speech_started") {
+      setRuntimeStatus("listening", "Hearing you...");
+      return;
+    }
+    if (type === "response.created") {
+      responseInProgressRef.current = true;
+      pendingResponseRef.current = false;
+      return;
+    }
+    if (type === "conversation.item.input_audio_transcription.completed") {
+      const transcript = readString(event, "transcript").trim();
+      if (transcript && isMeaningfulTranscript(transcript)) {
+        setLatestUserTranscript(transcript);
+        addEntry("user", transcript);
+        recordInspectorEvent("voice.transcript", { sessionId: props.sessionId, transcript });
+      }
+      return;
+    }
+    if (type === "response.output_text.delta" || type === "response.output_audio_transcript.delta" || type === "response.audio_transcript.delta") {
+      const delta = readString(event, "delta");
+      assistantBufferRef.current += delta;
+      setAssistantPreview(assistantBufferRef.current.trim());
+      setRuntimeStatus("speaking");
+      return;
+    }
+    if (type === "response.function_call_arguments.done") {
+      const toolName = readString(event, "name") || "tool";
+      const callId = readString(event, "call_id");
+      const args = parseJsonRecord(readString(event, "arguments"));
+      addEntry("tool", toolName, { toolName });
+      const output = await executeOpenWorkTool(toolName, args);
+      if (isRecord(output) && output.ok === false) {
+        const error = typeof output.error === "string" ? output.error : "Tool failed.";
+        addEntry("tool", error, { toolName, error: true });
+      }
+      const channel = channelRef.current;
+      if (!callId || !channel || channel.readyState !== "open") return;
+      channel.send(JSON.stringify({
+        type: "conversation.item.create",
+        item: { type: "function_call_output", call_id: callId, output: safeJson(output) },
+      }));
+      requestRealtimeResponse(channel);
+      return;
+    }
+    if (type === "response.done") {
+      const text = assistantBufferRef.current.trim();
+      if (text) addEntry("assistant", text);
+      assistantBufferRef.current = "";
+      setAssistantPreview("");
+      responseInProgressRef.current = false;
+      const channel = channelRef.current;
+      if (pendingResponseRef.current && channel?.readyState === "open") {
+        pendingResponseRef.current = false;
+        requestRealtimeResponse(channel, false);
+      } else {
+        setRuntimeStatus(micMutedRef.current ? "muted" : "listening");
+      }
+      return;
+    }
+    if (type === "error") {
+      responseInProgressRef.current = false;
+      const error = readRecord(event, "error");
+      const message = typeof error.message === "string" ? error.message : "Realtime returned an error.";
+      addEntry("system", message, { error: true });
+      setRuntimeStatus("error", message);
+    }
+  }, [addEntry, props.sessionId, requestRealtimeResponse, setRuntimeStatus]);
+
+  const connectRealtime = useCallback(async (audioInput = true) => {
+    const client = props.client;
+    if (!client) throw new Error("OpenWork host connection is not ready.");
+    if (audioInput && !navigator.mediaDevices?.getUserMedia) throw new Error("Microphone capture is unavailable in this runtime.");
+
+    disconnectRealtime(true);
+    setRuntimeStatus("connecting", "Minting Realtime session...");
+    const realtimeSession = await client.createVoiceRealtimeSession();
+
+    const peer = new RTCPeerConnection();
+    peerRef.current = peer;
+    if (audioInput) {
+      setRuntimeStatus("connecting", "Requesting microphone...");
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+      });
+      streamRef.current = stream;
+      for (const track of stream.getAudioTracks()) {
+        peer.addTrack(track, stream);
+      }
+    } else {
+      peer.addTransceiver("audio", { direction: "recvonly" });
+    }
+
+    const audio = document.createElement("audio");
+    audio.autoplay = true;
+    audio.style.display = "none";
+    document.body.appendChild(audio);
+    remoteAudioRef.current = audio;
+    peer.ontrack = (event) => {
+      audio.srcObject = event.streams[0] ?? null;
+    };
+
+    const channel = peer.createDataChannel("oai-events");
+    channelRef.current = channel;
+    channel.addEventListener("message", (event) => void handleRealtimeMessage(String(event.data)));
+    channel.addEventListener("close", () => {
+      if (channelRef.current === channel) setRuntimeStatus("idle");
+    });
+
+    const offer = await peer.createOffer();
+    await peer.setLocalDescription(offer);
+    if (!offer.sdp) throw new Error("Realtime offer did not include SDP.");
+
+    setRuntimeStatus("connecting", "Opening voice channel...");
+    const sdpResponse = await desktopFetch("https://api.openai.com/v1/realtime/calls", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${realtimeSession.clientSecret}`, "Content-Type": "application/sdp" },
+      body: offer.sdp,
+    });
+    if (!sdpResponse.ok) {
+      const detail = await sdpResponse.text().catch(() => "");
+      throw new Error(`OpenAI Realtime SDP failed: ${sdpResponse.status} ${detail}`.trim());
+    }
+    await peer.setRemoteDescription({ type: "answer", sdp: await sdpResponse.text() });
+    await waitForDataChannelOpen(channel);
+    setRuntimeStatus("listening", audioInput ? undefined : "Connected. Send a typed voice command.");
+    addEntry("system", `Realtime connected with ${realtimeSession.model} and ${realtimeSession.tools.length} OpenWork tools.`);
+    recordInspectorEvent("voice.connected", { sessionId: props.sessionId, model: realtimeSession.model });
+  }, [addEntry, disconnectRealtime, handleRealtimeMessage, props.client, props.sessionId, setRuntimeStatus]);
+
+  const startVoice = useCallback(async () => {
+    try {
+      await connectRealtime(true);
+      return true;
+    } catch (error) {
+      disconnectRealtime(true);
+      const message = error instanceof Error ? error.message : String(error);
+      setRuntimeStatus("error", message);
+      addEntry("system", message, { error: true });
+      return { ok: false, error: message };
+    }
+  }, [addEntry, connectRealtime, disconnectRealtime, setRuntimeStatus]);
+
+  const stopVoice = useCallback(() => {
+    disconnectRealtime();
+    return true;
+  }, [disconnectRealtime]);
+
+  const toggleMic = useCallback(() => {
+    const nextMuted = !micMutedRef.current;
+    micMutedRef.current = nextMuted;
+    setMicMuted(nextMuted);
+    streamRef.current?.getAudioTracks().forEach((track) => {
+      track.enabled = !nextMuted;
+    });
+    setRuntimeStatus(nextMuted ? "muted" : "listening");
+    return { muted: nextMuted };
+  }, [setRuntimeStatus]);
+
+  const sendTextCommand = useCallback(async (text: string) => {
+    const value = text.trim();
+    if (!value) return { ok: false, error: "Text command required." };
+    if (!channelRef.current || channelRef.current.readyState !== "open") {
+      try {
+        await connectRealtime(false);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setRuntimeStatus("error", message);
+        addEntry("system", message, { error: true });
+        return { ok: false, error: message };
+      }
+    }
+    const channel = channelRef.current;
+    if (!channel || channel.readyState !== "open") return { ok: false, error: "Realtime channel is not open." };
+    addEntry("user", value);
+    channel.send(JSON.stringify({
+      type: "conversation.item.create",
+      item: { type: "message", role: "user", content: [{ type: "input_text", text: value }] },
+    }));
+    requestRealtimeResponse(channel);
+    return { ok: true, text: value };
+  }, [addEntry, connectRealtime, requestRealtimeResponse, setRuntimeStatus]);
+
+  const injectAudio = useCallback(async (args: unknown) => {
+    const audio = voiceAudioArgument(args);
+    if (!audio) return { ok: false, error: "pcm16Base64 audio is required." };
+    if (!channelRef.current || channelRef.current.readyState !== "open") {
+      const started = await startVoice();
+      if (isRecord(started) && started.ok === false) return started;
+    }
+    const channel = channelRef.current;
+    if (!channel || channel.readyState !== "open") return { ok: false, error: "Realtime channel is not open." };
+    addEntry("system", "Injected deterministic audio into the Realtime input buffer.");
+    channel.send(JSON.stringify({ type: "input_audio_buffer.append", audio }));
+    channel.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
+    requestRealtimeResponse(channel);
+    return { ok: true, bytesBase64: audio.length };
+  }, [addEntry, requestRealtimeResponse, startVoice]);
+
+  const injectTranscript = useCallback(async (args: unknown) => {
+    const text = voiceTextArgument(args);
+    setLatestUserTranscript(text);
+    addEntry("user", text);
+    window.dispatchEvent(new CustomEvent("openwork:voice-transcript", { detail: { text } }));
+    recordInspectorEvent("voice.inject_transcript", { sessionId: props.sessionId, text });
+    return { ok: true, transcript: text };
+  }, [addEntry, props.sessionId]);
+
+  useEffect(() => {
+    const dispose = publishInspectorSlice("voice", () => ({
+      sessionId: props.sessionId,
+      status,
+      statusText,
+      connected,
+      micMuted,
+      latestUserTranscript,
+      assistantPreview,
+      textCommandLength: textCommand.length,
+      timeline: entries.slice(-12).map((entry) => ({
+        role: entry.role,
+        text: entry.text,
+        toolName: entry.toolName,
+        error: entry.error === true,
+        at: entry.at,
+      })),
+    }));
+    return dispose;
+  }, [assistantPreview, connected, entries, latestUserTranscript, micMuted, props.sessionId, status, statusText, textCommand.length]);
+
+  useEffect(() => () => disconnectRealtime(true), [disconnectRealtime]);
+
+  const startAction = useMemo<OpenworkControlAction>(() => ({
+    id: "voice.start",
+    label: "Start Voice Mode",
+    description: "Connect the Voice Mode panel to OpenAI Realtime and start listening.",
+    sideEffect: "external",
+    disabled: !props.client || connected || status === "connecting",
+    targetRef: panelRef,
+    execute: startVoice,
+  }), [connected, props.client, startVoice, status]);
+  useControlAction(startAction);
+
+  const stopAction = useMemo<OpenworkControlAction>(() => ({
+    id: "voice.stop",
+    label: "Stop Voice Mode",
+    description: "Disconnect the active Voice Mode Realtime session.",
+    sideEffect: "external",
+    disabled: !connected,
+    targetRef: panelRef,
+    execute: stopVoice,
+  }), [connected, stopVoice]);
+  useControlAction(stopAction);
+
+  const muteAction = useMemo<OpenworkControlAction>(() => ({
+    id: "voice.toggle_mute",
+    label: micMuted ? "Unmute Voice Mode" : "Mute Voice Mode",
+    description: "Toggle the microphone track without closing the Realtime session.",
+    sideEffect: "none",
+    disabled: !connected,
+    targetRef: panelRef,
+    execute: toggleMic,
+  }), [connected, micMuted, toggleMic]);
+  useControlAction(muteAction);
+
+  const injectTranscriptAction = useMemo<OpenworkControlAction>(() => ({
+    id: "voice.inject_transcript",
+    label: "Inject a voice transcript",
+    description: "Deterministic eval hook: add a transcript to Voice Mode and place it in the composer.",
+    sideEffect: "mutation",
+    requiresArgs: true,
+    args: [{ name: "text", type: "string", required: true, description: "Transcript text to inject." }],
+    previewArgs: { text: DEFAULT_TEXT_COMMAND },
+    targetRef: panelRef,
+    execute: injectTranscript,
+  }), [injectTranscript]);
+  useControlAction(injectTranscriptAction);
+
+  const sendTextAction = useMemo<OpenworkControlAction>(() => ({
+    id: "voice.send_text",
+    label: "Send text through Voice Mode",
+    description: "Send a deterministic text command through the active OpenAI Realtime voice session.",
+    sideEffect: "external",
+    requiresArgs: true,
+    args: [{ name: "text", type: "string", required: true, description: "Text command to send through the Realtime model." }],
+    previewArgs: { text: DEFAULT_TEXT_COMMAND },
+    targetRef: panelRef,
+    execute: (args) => sendTextCommand(voiceTextArgument(args)),
+  }), [sendTextCommand]);
+  useControlAction(sendTextAction);
+
+  const injectAudioAction = useMemo<OpenworkControlAction>(() => ({
+    id: "voice.inject_audio",
+    label: "Inject voice audio",
+    description: "Deterministic eval hook: send PCM16 audio through the active OpenAI Realtime input buffer.",
+    sideEffect: "external",
+    requiresArgs: true,
+    args: [{ name: "pcm16Base64", type: "string", required: true, description: "Base64 encoded PCM16 mono audio." }],
+    targetRef: panelRef,
+    execute: injectAudio,
+  }), [injectAudio]);
+  useControlAction(injectAudioAction);
+
+  const statusAction = useMemo<OpenworkControlAction>(() => ({
+    id: "voice.status",
+    label: "Read Voice Mode status",
+    description: "Return the Voice Mode runtime state for tests and agents.",
+    sideEffect: "none",
+    execute: () => ({ status, statusText, connected, micMuted, latestUserTranscript, assistantPreview }),
+  }), [assistantPreview, connected, latestUserTranscript, micMuted, status, statusText]);
+  useControlAction(statusAction);
+
+  return (
+    <div ref={panelRef} className="flex h-full min-h-0 flex-col bg-background">
+      <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <span
+              className={cn(
+                "size-2 rounded-full bg-muted-foreground",
+                status === "connecting" && "animate-pulse bg-amber-9",
+                (status === "listening" || status === "speaking") && "bg-green-9",
+                status === "error" && "bg-destructive",
+              )}
+            />
+            <Radio className="text-primary" />
+            Voice Mode
+          </div>
+          <div className="truncate text-xs text-muted-foreground">Realtime voice over OpenWork UI MCP controls</div>
+        </div>
+        <Button variant="ghost" size="icon-sm" onClick={props.onClose} aria-label="Close Voice Mode">
+          <X />
+        </Button>
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="flex flex-col gap-5 px-4 py-5">
+          <VoiceOrb status={status} muted={micMuted} />
+
+          <div className="text-center">
+            <div className="text-sm font-medium text-foreground">{statusText}</div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              Say things like "type a follow-up", "send it", or "read the latest session message".
+            </div>
+          </div>
+
+          {entries.length === 0 && !assistantPreview ? (
+            <div className="flex flex-wrap justify-center gap-1.5">
+              {VOICE_SUGGESTIONS.map((suggestion) => (
+                <Button
+                  key={suggestion}
+                  variant="outline"
+                  size="xs"
+                  className="rounded-full"
+                  onClick={() => setTextCommand(suggestion)}
+                >
+                  {suggestion}
+                </Button>
+              ))}
+            </div>
+          ) : null}
+
+          <div className="grid grid-cols-2 gap-2">
+            <Button onClick={() => void startVoice()} disabled={!props.client || connected || status === "connecting"}>
+              {status === "connecting" ? <Loader2 data-icon="inline-start" className="animate-spin" /> : <Mic2 data-icon="inline-start" />}
+              Start voice
+            </Button>
+            <Button variant="outline" onClick={stopVoice} disabled={!connected}>
+              <Square data-icon="inline-start" />
+              Stop
+            </Button>
+            <Button variant="outline" onClick={toggleMic} disabled={!connected} className="col-span-2">
+              {micMuted ? <Mic2 data-icon="inline-start" /> : <MicOff data-icon="inline-start" />}
+              {micMuted ? "Unmute microphone" : "Mute microphone"}
+            </Button>
+          </div>
+
+          {!props.client ? (
+            <Card variant="outline" size="sm">
+              <CardHeader>
+                <CardTitle>Host connection required</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">
+                Voice Mode needs the local OpenWork server so it can mint short-lived Realtime client secrets without exposing your API key to the renderer.
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {assistantPreview ? (
+            <Card variant="outline" size="sm" className="overflow-hidden">
+              <CardContent className="relative p-0">
+                <div className="absolute inset-x-0 top-0 h-1 overflow-hidden">
+                  <PaperGrainGradient
+                    speed={16}
+                    softness={0.14}
+                    intensity={1}
+                    noise={0.05}
+                    shape="wave"
+                    colors={["#818cf8", "#fb7185", "#fbbf24", "#34d399"]}
+                    colorBack="#ffffff00"
+                    style={{ width: "100%", height: "100%" }}
+                  />
+                </div>
+                <div className="flex flex-col gap-2 px-3 pb-3 pt-4">
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Rendering response</div>
+                  <div className="whitespace-pre-wrap break-words text-sm leading-relaxed text-card-foreground" aria-live="polite">
+                    {assistantPreview}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          <Card variant="outline" size="sm">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-sm">
+                <Sparkles className="text-primary" />
+                Typed voice command
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-2">
+              <Textarea
+                value={textCommand}
+                onChange={(event) => setTextCommand(event.currentTarget.value)}
+                placeholder={DEFAULT_TEXT_COMMAND}
+                rows={3}
+              />
+              <Button
+                variant="outline"
+                className="self-end"
+                onClick={() => {
+                  const text = textCommand;
+                  setTextCommand("");
+                  void sendTextCommand(text);
+                }}
+                disabled={!textCommand.trim() || status === "connecting"}
+              >
+                <SendHorizontal data-icon="inline-start" />
+                Send to voice model
+              </Button>
+            </CardContent>
+          </Card>
+
+          <div className="flex flex-col gap-2">
+            <div className="text-xs font-medium uppercase tracking-[0.15em] text-muted-foreground">Timeline</div>
+            {entries.length ? entries.map((entry) => (
+              <VoiceTimelineRow
+                key={entry.id}
+                entry={entry}
+                expanded={expandedEntries.has(entry.id)}
+                onToggle={() => toggleEntryExpanded(entry.id)}
+              />
+            )) : (
+              <div className="rounded-2xl border border-dashed border-border px-4 py-5 text-center text-sm text-muted-foreground">
+                Start voice or inject a transcript from UI MCP to see the voice timeline.
+              </div>
+            )}
+            <div ref={timelineEndRef} />
+          </div>
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/settings/extension-registry.tsx
+++ b/apps/app/src/react-app/domains/settings/extension-registry.tsx
@@ -15,6 +15,14 @@ export type ExtensionConfigContext = {
     onInstall: (apiKey: string) => void | Promise<void>;
     onTestGenerate: (input: { apiKey: string; prompt: string }) => void | Promise<void>;
   };
+  voiceExtension: {
+    busy: boolean;
+    status: string | null;
+    error: string | null;
+    envKeyDetected: boolean;
+    onSaveApiKey: (apiKey: string) => void | Promise<void>;
+    onTestSession: () => void | Promise<void>;
+  };
   localProvider: {
     busy: boolean;
     status: string | null;

--- a/apps/app/src/react-app/domains/settings/openwork-voice-config.tsx
+++ b/apps/app/src/react-app/domains/settings/openwork-voice-config.tsx
@@ -1,0 +1,107 @@
+/** @jsxImportSource react */
+import { useState } from "react";
+import { CheckCircle2, Loader2, Mic2, XCircle } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { registerExtensionConfig } from "./extension-registry";
+
+export type OpenWorkVoiceConfigProps = {
+  busy: boolean;
+  status: string | null;
+  error: string | null;
+  envKeyDetected: boolean;
+  onSaveApiKey: (apiKey: string) => void | Promise<void>;
+  onTestSession: () => void | Promise<void>;
+};
+
+registerExtensionConfig("openwork-voice", (ctx) => (
+  <OpenWorkVoiceConfig
+    busy={ctx.voiceExtension.busy}
+    status={ctx.voiceExtension.status}
+    error={ctx.voiceExtension.error}
+    envKeyDetected={ctx.voiceExtension.envKeyDetected}
+    onSaveApiKey={ctx.voiceExtension.onSaveApiKey}
+    onTestSession={ctx.voiceExtension.onTestSession}
+  />
+));
+
+export function OpenWorkVoiceConfig(props: OpenWorkVoiceConfigProps) {
+  const [apiKey, setApiKey] = useState("");
+  const canSave = Boolean(apiKey.trim());
+
+  return (
+    <Card variant="outline" size="sm">
+      <CardHeader>
+        <CardTitle>Realtime voice</CardTitle>
+        <CardDescription>
+          Voice Mode uses OpenAI Realtime and the same OpenWork UI control surface exposed through OpenWork UI MCP.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {props.envKeyDetected ? (
+          <Alert>
+            <Mic2 />
+            <AlertTitle>OpenAI key detected</AlertTitle>
+            <AlertDescription>
+              Voice Mode will use OPENAI_REALTIME_API_KEY when present, otherwise OPENAI_API_KEY from OpenWork environment variables.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <FieldGroup className="gap-4">
+          <Field>
+            <FieldLabel htmlFor="openwork-voice-api-key">OpenAI API key</FieldLabel>
+            <Input
+              id="openwork-voice-api-key"
+              type="password"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.currentTarget.value)}
+              placeholder="sk-..."
+            />
+            <FieldDescription>
+              Saved as OPENAI_API_KEY in OpenWork's local env store. The renderer only receives short-lived Realtime client secrets.
+            </FieldDescription>
+          </Field>
+        </FieldGroup>
+
+        {props.status ? (
+          <Alert>
+            <CheckCircle2 />
+            <AlertDescription>{props.status}</AlertDescription>
+          </Alert>
+        ) : null}
+        {props.error ? (
+          <Alert variant="destructive">
+            <XCircle />
+            <AlertDescription>{props.error}</AlertDescription>
+          </Alert>
+        ) : null}
+      </CardContent>
+      <CardFooter className="flex-wrap gap-2 border-t border-border justify-between">
+        <Button onClick={() => void props.onSaveApiKey(apiKey)} disabled={props.busy || !canSave}>
+          {props.busy ? <Loader2 data-icon="inline-start" className="animate-spin" /> : null}
+          Save key
+        </Button>
+        <Button variant="outline" onClick={() => void props.onTestSession()} disabled={props.busy || !props.envKeyDetected}>
+          Test Realtime
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2591,6 +2591,7 @@ export function SessionRoute() {
       clientConnected={canCreateTask}
       openworkServerStatus={client ? "connected" : "disconnected"}
       openworkServerClient={selectedWorkspaceEndpoint?.client ?? client}
+      hostOpenworkServerClient={client}
       openworkServerToken={selectedWorkspaceServerToken}
       developerMode={typeof window !== "undefined" && window.localStorage.getItem("openwork.developerMode") === "1"}
       headerStatus={canCreateTask ? t("status.connected") : t("session.loading_detail")}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -40,6 +40,7 @@ import { AiSettingsView } from "../domains/settings/pages/ai-view";
 import "../domains/settings/openai-image-gen-config";
 import "../domains/settings/ollama-config";
 import "../domains/settings/browser-extension-config";
+import "../domains/settings/openwork-voice-config";
 import { getExtensionConfigSlot, type ExtensionConfigContext } from "../domains/settings/extension-registry";
 import { PreferencesView } from "../domains/settings/pages/preferences-view";
 import { ShellCustomizationView } from "../domains/settings/pages/shell-view";
@@ -505,6 +506,10 @@ function SettingsRouteContent() {
   const [imageGenerationBusy, setImageGenerationBusy] = useState(false);
   const [imageGenerationStatus, setImageGenerationStatus] = useState<string | null>(null);
   const [imageGenerationError, setImageGenerationError] = useState<string | null>(null);
+  const [voiceBusy, setVoiceBusy] = useState(false);
+  const [voiceStatus, setVoiceStatus] = useState<string | null>(null);
+  const [voiceError, setVoiceError] = useState<string | null>(null);
+  const [userEnvKeys, setUserEnvKeys] = useState<string[]>([]);
   const emptyWorkspaceDisplay = useMemo<WorkspaceDisplay>(
     () => ({
       id: "",
@@ -894,6 +899,18 @@ function SettingsRouteContent() {
     };
   }, [openworkClient, runtimeWorkspaceId, selectedWorkspaceEndpoint]);
 
+  useEffect(() => {
+    if (!openworkClient) {
+      setUserEnvKeys([]);
+      return;
+    }
+    let cancelled = false;
+    void openworkClient.listUserEnvKeys()
+      .then((response) => { if (!cancelled) setUserEnvKeys(response.keys); })
+      .catch(() => { if (!cancelled) setUserEnvKeys([]); });
+    return () => { cancelled = true; };
+  }, [openworkClient]);
+
   const installOpenAiImageExtension = useCallback(async (apiKey: string) => {
     const workspaceClient = selectedWorkspaceEndpoint?.client ?? openworkClient;
     const workspaceId = runtimeWorkspaceId?.trim() ?? "";
@@ -937,6 +954,7 @@ function SettingsRouteContent() {
       // upsertUserEnv requires the host token; use openworkClient which carries it.
       if (openworkClient) {
         await openworkClient.upsertUserEnv([{ key: "OPENAI_API_KEY", value: resolvedApiKey }]);
+        setUserEnvKeys((current) => Array.from(new Set([...current, "OPENAI_API_KEY"])));
       }
       reloadCoordinator.markReloadRequired("plugins", { type: "plugin", name: "openwork-image-generation", action: "added" });
       setImageExtensionInstalled(true);
@@ -981,6 +999,44 @@ function SettingsRouteContent() {
       setImageGenerationBusy(false);
     }
   }, [openworkClient, runtimeWorkspaceId, selectedWorkspaceEndpoint]);
+
+  const saveVoiceApiKey = useCallback(async (apiKey: string) => {
+    const resolvedApiKey = apiKey.trim();
+    if (!openworkClient || !resolvedApiKey) {
+      setVoiceError("OpenAI API key is required.");
+      return;
+    }
+    setVoiceBusy(true);
+    setVoiceStatus(null);
+    setVoiceError(null);
+    try {
+      await openworkClient.upsertUserEnv([{ key: "OPENAI_API_KEY", value: resolvedApiKey }]);
+      setUserEnvKeys((current) => Array.from(new Set([...current, "OPENAI_API_KEY"])));
+      setVoiceStatus("Saved OPENAI_API_KEY for Voice Mode.");
+    } catch (error) {
+      setVoiceError(describeRouteError(error));
+    } finally {
+      setVoiceBusy(false);
+    }
+  }, [openworkClient]);
+
+  const testVoiceSession = useCallback(async () => {
+    if (!openworkClient) {
+      setVoiceError("OpenWork server is not connected.");
+      return;
+    }
+    setVoiceBusy(true);
+    setVoiceStatus(null);
+    setVoiceError(null);
+    try {
+      const session = await openworkClient.createVoiceRealtimeSession();
+      setVoiceStatus(`Realtime ready with ${session.model} (${session.tools.length} OpenWork tools).`);
+    } catch (error) {
+      setVoiceError(describeRouteError(error));
+    } finally {
+      setVoiceBusy(false);
+    }
+  }, [openworkClient]);
 
   const installLocalProvider = useCallback(async (input: LocalProviderInstallInput) => {
     const client = selectedWorkspaceEndpoint?.client ?? openworkClient;
@@ -1967,6 +2023,18 @@ function SettingsRouteContent() {
                     envKeyDetected: providers.some((p) => p.id === "openai" && p.source === "env") || providerConnectedIds.includes("openai"),
                     onInstall: installOpenAiImageExtension,
                     onTestGenerate: generateOpenAiTestImage,
+                  },
+                  voiceExtension: {
+                    busy: voiceBusy,
+                    status: voiceStatus,
+                    error: voiceError,
+                    envKeyDetected:
+                      userEnvKeys.includes("OPENAI_REALTIME_API_KEY") ||
+                      userEnvKeys.includes("OPENAI_API_KEY") ||
+                      providers.some((p) => p.id === "openai" && p.source === "env") ||
+                      providerConnectedIds.includes("openai"),
+                    onSaveApiKey: saveVoiceApiKey,
+                    onTestSession: testVoiceSession,
                   },
                   localProvider: {
                     busy: localProviderBusy,

--- a/apps/app/src/react-app/shell/ui-state-store.ts
+++ b/apps/app/src/react-app/shell/ui-state-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 export const PERSISTED_UI_STATE_KEY = "openwork:ui-state:v1";
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
+export const GLOBAL_SIDE_PANEL_STATE_KEY = "__openwork_global__";
 
 export const SIDE_PANEL_ITEMS = ["browser", "artifacts", "extensions", "voice"] as const;
 export type SidePanelItem = (typeof SIDE_PANEL_ITEMS)[number];
@@ -117,6 +118,10 @@ export function toggleSidebar(state: UiState): UiState {
 }
 
 export function getSidePanelState(state: UiState, sessionId: string | null | undefined): SidePanelItem | null {
+  if (state.sidePanelState[GLOBAL_SIDE_PANEL_STATE_KEY] === "voice") {
+    return "voice";
+  }
+
   if (!sessionId) {
     return null;
   }
@@ -129,14 +134,36 @@ export function setSidePanelState(
   sessionId: string | null | undefined,
   panel: SidePanelItem | null,
 ): UiState {
-  if (!sessionId || getSidePanelState(state, sessionId) === panel) {
+  if (getSidePanelState(state, sessionId) === panel) {
     return state;
+  }
+
+  if (panel === "voice") {
+    return {
+      ...state,
+      sidePanelState: {
+        ...state.sidePanelState,
+        [GLOBAL_SIDE_PANEL_STATE_KEY]: "voice",
+      },
+    };
+  }
+
+  if (!sessionId) {
+    if (state.sidePanelState[GLOBAL_SIDE_PANEL_STATE_KEY] !== "voice") return state;
+    return {
+      ...state,
+      sidePanelState: {
+        ...state.sidePanelState,
+        [GLOBAL_SIDE_PANEL_STATE_KEY]: null,
+      },
+    };
   }
 
   return {
     ...state,
     sidePanelState: {
       ...state.sidePanelState,
+      [GLOBAL_SIDE_PANEL_STATE_KEY]: null,
       [sessionId]: panel,
     },
   };

--- a/apps/app/src/react-app/shell/ui-state-store.ts
+++ b/apps/app/src/react-app/shell/ui-state-store.ts
@@ -3,7 +3,7 @@ import { create } from "zustand";
 export const PERSISTED_UI_STATE_KEY = "openwork:ui-state:v1";
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 
-export const SIDE_PANEL_ITEMS = ["browser", "artifacts", "extensions"] as const;
+export const SIDE_PANEL_ITEMS = ["browser", "artifacts", "extensions", "voice"] as const;
 export type SidePanelItem = (typeof SIDE_PANEL_ITEMS)[number];
 export type SidePanelState = Record<string, SidePanelItem | null>;
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2652,6 +2652,18 @@ async function runOpenworkControlCommand(command, args = {}) {
       return { ok: true, actions: control.listActions() };
     })()`);
   }
+  if (command === "inspect") {
+    return evaluateOpenworkControl(`(async () => {
+      const inspector = window.__openwork;
+      const input = JSON.parse(${argsJsonLiteral});
+      if (!inspector) return { ok: false, error: "OpenWork inspector surface is not available yet." };
+      const slice = typeof input.slice === "string" ? input.slice.trim() : "";
+      if (slice) {
+        return { ok: true, slice, value: inspector.slice(slice), events: inspector.events?.(20) ?? [] };
+      }
+      return { ok: true, slices: inspector.listSlices(), snapshot: inspector.snapshot(), events: inspector.events?.(20) ?? [] };
+    })()`);
+  }
   if (command === "execute") {
     return evaluateOpenworkControl(`(async () => {
       const control = window.__openworkControl;
@@ -2686,6 +2698,10 @@ async function startUiControlServer() {
       }
       if (request.method === "GET" && url.pathname === "/actions") {
         sendJsonResponse(response, 200, await runOpenworkControlCommand("actions"));
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/inspect") {
+        sendJsonResponse(response, 200, await runOpenworkControlCommand("inspect", { slice: url.searchParams.get("slice") ?? "" }));
         return;
       }
       if (request.method === "POST" && url.pathname === "/execute") {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -109,19 +109,19 @@ function readStringField(value: unknown, key: string): string {
 }
 
 async function resolveOpenAiRealtimeApiKey(env: EnvService): Promise<string> {
+  const records = await env.list();
+  const storedKey =
+    records.find((entry) => entry.key === "OPENAI_REALTIME_API_KEY")?.value.trim() ||
+    records.find((entry) => entry.key === "OPENAI_API_KEY")?.value.trim() ||
+    "";
+  if (storedKey) return storedKey;
+
   const processKey =
     process.env.OPENWORK_OPENAI_REALTIME_API_KEY?.trim() ||
     process.env.OPENAI_REALTIME_API_KEY?.trim() ||
     process.env.OPENAI_API_KEY?.trim() ||
     "";
-  if (processKey) return processKey;
-
-  const records = await env.list();
-  return (
-    records.find((entry) => entry.key === "OPENAI_REALTIME_API_KEY")?.value.trim() ||
-    records.find((entry) => entry.key === "OPENAI_API_KEY")?.value.trim() ||
-    ""
-  );
+  return processKey;
 }
 
 function openworkVoiceRealtimeInstructions() {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -66,6 +66,170 @@ const FILE_SESSION_MAX_BATCH_ITEMS = 64;
 const FILE_SESSION_MAX_FILE_BYTES = 5_000_000;
 const FILE_SESSION_CATALOG_DEFAULT_LIMIT = 2000;
 const FILE_SESSION_CATALOG_MAX_LIMIT = 10000;
+const OPENWORK_VOICE_REALTIME_MODEL = "gpt-realtime-2";
+const OPENWORK_VOICE_TRANSCRIPTION_MODEL = "gpt-4o-transcribe";
+
+const OPENWORK_VOICE_REALTIME_TOOLS = [
+  {
+    type: "function",
+    name: "openwork_snapshot",
+    description: "Read the current OpenWork UI control snapshot: route, status, narration, and visible action metadata.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    type: "function",
+    name: "openwork_list_actions",
+    description: "List semantic OpenWork UI actions. Call this before openwork_execute_action when you do not know the exact action id.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    type: "function",
+    name: "openwork_execute_action",
+    description: "Execute a semantic OpenWork UI action by id. Prefer this over screen coordinates or DOM guessing.",
+    parameters: {
+      type: "object",
+      properties: {
+        actionId: { type: "string", description: "The action id from openwork_list_actions, such as composer.set_text or composer.send." },
+        args: { type: "object", description: "Optional JSON arguments for the action.", additionalProperties: true },
+      },
+      required: ["actionId"],
+      additionalProperties: false,
+    },
+  },
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readStringField(value: unknown, key: string): string {
+  if (!isRecord(value)) return "";
+  const field = value[key];
+  return typeof field === "string" ? field.trim() : "";
+}
+
+async function resolveOpenAiRealtimeApiKey(env: EnvService): Promise<string> {
+  const processKey =
+    process.env.OPENWORK_OPENAI_REALTIME_API_KEY?.trim() ||
+    process.env.OPENAI_REALTIME_API_KEY?.trim() ||
+    process.env.OPENAI_API_KEY?.trim() ||
+    "";
+  if (processKey) return processKey;
+
+  const records = await env.list();
+  return (
+    records.find((entry) => entry.key === "OPENAI_REALTIME_API_KEY")?.value.trim() ||
+    records.find((entry) => entry.key === "OPENAI_API_KEY")?.value.trim() ||
+    ""
+  );
+}
+
+function openworkVoiceRealtimeInstructions() {
+  return `# Role and Objective
+
+You are OpenWork Voice Mode, a voice-first control layer inside OpenWork.
+Help the user control OpenWork by using the semantic OpenWork UI tools.
+
+# Tool Policy
+
+- Prefer openwork_snapshot, openwork_list_actions, and openwork_execute_action over visual guessing.
+- If the user asks to write or draft something, use composer.set_text.
+- If the user asks to send or run the current prompt, use composer.send.
+- For navigation, settings, session, transcript, and composer work, inspect the action list first if the action id is unknown.
+- Do not claim an action completed until the tool succeeds.
+- Ask for confirmation before destructive actions such as deleting a session.
+
+# Voice Style
+
+- Be concise, calm, and direct.
+- If audio is unclear, ask the user to repeat it instead of guessing.
+- Ignore background speech that is not addressed to OpenWork.
+- Summarize tool results briefly and offer the next useful step.`;
+}
+
+function readOpenAiClientSecret(payload: unknown): { clientSecret: string; expiresAt: number | null } {
+  if (!isRecord(payload)) return { clientSecret: "", expiresAt: null };
+  const clientSecret = payload.client_secret;
+  if (typeof clientSecret === "string") return { clientSecret, expiresAt: null };
+  if (isRecord(clientSecret)) {
+    const value = typeof clientSecret.value === "string" ? clientSecret.value : "";
+    const expiresAt = typeof clientSecret.expires_at === "number" ? clientSecret.expires_at : null;
+    return { clientSecret: value, expiresAt };
+  }
+  const value = typeof payload.value === "string" ? payload.value : "";
+  return { clientSecret: value, expiresAt: null };
+}
+
+async function createOpenAiRealtimeVoiceSession(env: EnvService, input: unknown) {
+  const apiKey = await resolveOpenAiRealtimeApiKey(env);
+  if (!apiKey) {
+    throw new ApiError(
+      400,
+      "openai_api_key_missing",
+      "OpenAI API key missing. Save OPENAI_API_KEY in OpenWork Environment Variables or configure the Voice Mode extension.",
+    );
+  }
+
+  const model = readStringField(input, "model") || OPENWORK_VOICE_REALTIME_MODEL;
+  const response = await fetch("https://api.openai.com/v1/realtime/client_secrets", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      session: {
+        type: "realtime",
+        model,
+        output_modalities: ["audio"],
+        audio: {
+          input: {
+            transcription: { model: OPENWORK_VOICE_TRANSCRIPTION_MODEL, language: "en" },
+            turn_detection: {
+              type: "server_vad",
+              threshold: 0.58,
+              silence_duration_ms: 320,
+              prefix_padding_ms: 300,
+              create_response: true,
+              interrupt_response: true,
+            },
+          },
+        },
+        instructions: openworkVoiceRealtimeInstructions(),
+        tool_choice: "auto",
+        tools: OPENWORK_VOICE_REALTIME_TOOLS,
+      },
+    }),
+  });
+
+  const text = await response.text();
+  let payload: unknown = null;
+  try {
+    payload = text ? JSON.parse(text) : null;
+  } catch {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    const errorPayload = isRecord(payload) && isRecord(payload.error) ? payload.error : null;
+    const message = typeof errorPayload?.message === "string" ? errorPayload.message : response.statusText;
+    throw new ApiError(response.status, "openai_realtime_failed", message || "Failed to create OpenAI Realtime session");
+  }
+
+  const { clientSecret, expiresAt } = readOpenAiClientSecret(payload);
+  if (!clientSecret) {
+    throw new ApiError(502, "openai_realtime_invalid_response", "OpenAI did not return a usable Realtime client secret");
+  }
+
+  return {
+    ok: true,
+    clientSecret,
+    expiresAt,
+    model,
+    transcriptionModel: OPENWORK_VOICE_TRANSCRIPTION_MODEL,
+    tools: OPENWORK_VOICE_REALTIME_TOOLS.map((tool) => tool.name),
+  };
+}
 
 const reloadBaselineRefreshers = new WeakMap<
   ServerConfig,
@@ -1581,6 +1745,11 @@ function createRoutes(
       throw new ApiError(404, "env_not_found", "Environment variable not found");
     }
     return jsonResponse({ ok: true });
+  });
+
+  addRoute(routes, "POST", "/voice/realtime/session", "host-token", async (ctx) => {
+    const body = await readJsonBody(ctx.request);
+    return jsonResponse(await createOpenAiRealtimeVoiceSession(env, body));
   });
 
   addRoute(routes, "POST", "/workspaces/local", "host", async (ctx) => {

--- a/docs/mcp-ui-control-profile.md
+++ b/docs/mcp-ui-control-profile.md
@@ -32,6 +32,7 @@ That's it. HandsFree can now list your sessions, read transcripts, type into the
 - `ui_snapshot` — see the current route, status, and available actions.
 - `ui_list_actions` — get every action the app currently exposes (session controls, composer, navigation, etc.).
 - `ui_execute_action` — run an action by ID, e.g. `session.create_task`, `composer.set_text`, `composer.send`.
+- `ui_inspect` / `ui_assert` / `ui_wait_for` — read and assert structured app state for evals such as Voice Mode.
 - `ui_status` — check if OpenWork is running and the bridge is reachable.
 
 ## Install
@@ -85,7 +86,7 @@ Both use the same MCP config shape. Add to your `claude_desktop_config.json` or 
 }
 ```
 
-Restart the app. The four tools (`ui_status`, `ui_snapshot`, `ui_list_actions`, `ui_execute_action`) will appear in the tool list.
+Restart the app. The UI tools (`ui_status`, `ui_snapshot`, `ui_list_actions`, `ui_execute_action`, `ui_inspect`, `ui_assert`, `ui_wait_for`) will appear in the tool list.
 
 ## Add to your own MCP client
 
@@ -189,6 +190,24 @@ Example — send the composer prompt:
 { "actionId": "composer.send" }
 ```
 
+### `ui_inspect`
+
+Read OpenWork's structured runtime inspector. This is the preferred eval surface when you need assertions without DOM scraping.
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `slice` | string (optional) | Inspector slice such as `composer` or `voice` |
+
+### `ui_assert` and `ui_wait_for`
+
+Assert a dot path inside the inspector, immediately or with polling.
+
+Example — wait for Voice Mode to open:
+
+```json
+{ "slice": "voice", "path": "status", "equals": "idle", "timeoutMs": 5000 }
+```
+
 ## Available actions
 
 The exact list depends on the current OpenWork route and state. Common actions include:
@@ -213,6 +232,11 @@ The exact list depends on the current OpenWork route and state. Common actions i
 | `session.model_picker.open` | Open the model picker |
 | `status.docs.open` | Open documentation |
 | `status.settings.open` | Open settings from the status bar |
+| `voice.panel.open` | Open the Voice Mode right-side panel |
+| `voice.start` | Start OpenAI Realtime voice control |
+| `voice.inject_transcript` | Deterministically inject a transcript into Voice Mode and the composer |
+| `voice.send_text` | Send a deterministic text command through the active Realtime session |
+| `voice.inject_audio` | Send PCM16 audio through the active Realtime input buffer for audio evals |
 
 ## Requirements
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -85,3 +85,5 @@ Chrome DevTools MCP. Every tool takes `browser_url` as the first argument.
 - [`browser-extension-flows.md`](./browser-extension-flows.md) — browser
   extension plugin loading, built-in browser navigation, composer extensions
   menu, extension toggle, and stale MCP migration.
+- [`voice-mode-flows.md`](./voice-mode-flows.md) — Voice Mode extension,
+  deterministic UI MCP assertions, and optional OpenAI Realtime microphone eval.

--- a/evals/voice-mode-flows.md
+++ b/evals/voice-mode-flows.md
@@ -1,0 +1,113 @@
+# Voice Mode flows
+
+End-to-end scenarios for the Voice Mode extension, right-side panel, OpenWork UI MCP controls, and optional OpenAI Realtime audio path.
+
+## Preflight
+
+1. Start Electron with CDP:
+   ```bash
+   OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9823 pnpm dev
+   ```
+2. List targets:
+   ```
+   browser_list({ browser_url: "http://127.0.0.1:9823" })
+   ```
+3. Enable control mode:
+   ```js
+   window.__openworkControl.setEnabled(true)
+   ```
+
+## Flow 1 — Extension opens the Voice panel
+
+Steps:
+1. Open or create a session.
+2. Execute `voice.panel.open` through `window.__openworkControl.execute`.
+3. Read `window.__openwork.slice("voice")`.
+
+Pass criteria:
+- The right rail shows a Voice Mode button when the Voice Mode extension is enabled.
+- The Voice panel opens on the right side.
+- The `voice` inspector slice exists with `status: "idle"`.
+- `ui_assert` can assert `slice: "voice", path: "status", equals: "idle"`.
+
+## Flow 2 — Deterministic transcript injection
+
+Steps:
+1. Open Voice Mode with `voice.panel.open`.
+2. Execute:
+   ```js
+   window.__openworkControl.execute("voice.inject_transcript", {
+     text: "Summarize this repo and put the next step in the composer."
+   })
+   ```
+3. Wait with UI MCP:
+   ```json
+   { "slice": "voice", "path": "latestUserTranscript", "contains": "Summarize this repo" }
+   ```
+4. Assert the composer slice contains the same draft.
+
+Pass criteria:
+- Voice timeline shows the injected user transcript.
+- `window.__openwork.slice("composer").draft` contains the injected text.
+- No OpenAI credentials or microphone are required for this flow.
+
+## Flow 3 — Optional OpenAI Realtime voice path
+
+Start Electron with fake media for repeatable microphone input:
+
+```bash
+OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9823 \
+ELECTRON_EXTRA_LAUNCH_ARGS="--use-fake-device-for-media-stream --use-fake-ui-for-media-stream --use-file-for-fake-audio-capture=/absolute/path/sample.wav" \
+pnpm dev
+```
+
+Ensure `OPENAI_API_KEY` or `OPENAI_REALTIME_API_KEY` is saved in OpenWork Environment Variables, or set `OPENWORK_OPENAI_REALTIME_API_KEY` in the launching shell.
+
+Steps:
+1. Open Voice Mode.
+2. Execute `voice.start`.
+3. Use `ui_wait_for` with `slice: "voice", path: "connected", equals: true`.
+4. Let the fake audio run, then wait for `latestUserTranscript` to become non-empty.
+5. Execute `voice.stop`.
+
+Pass criteria:
+- Voice status reaches `listening` or `speaking`.
+- The transcript appears in the Voice timeline.
+- Tool calls route through OpenWork actions (`openwork_snapshot`, `openwork_list_actions`, `openwork_execute_action`), not screen coordinates.
+- `voice.stop` returns the panel to `idle`.
+
+## Flow 4 — Realtime data-channel tool call
+
+Use this when microphone capture is unavailable but an OpenAI key is present. It still exercises the real Realtime WebRTC/data-channel path and OpenWork tool invocation.
+
+Steps:
+1. Open Voice Mode.
+2. Execute `voice.start` and wait for `slice: "voice", path: "connected", equals: true`.
+3. Execute `voice.send_text` with:
+   ```json
+   { "text": "Use the OpenWork UI action composer.set_text to put exactly REAL VOICE EVAL PASSED in the composer. Do it now." }
+   ```
+4. Wait for `slice: "composer", path: "draft", equals: "REAL VOICE EVAL PASSED"`.
+
+Pass criteria:
+- Voice timeline shows a user command, an `openwork_execute_action` tool row, and an assistant response.
+- Composer draft equals `REAL VOICE EVAL PASSED`.
+
+## Flow 5 — Deterministic audio-buffer transcription
+
+Use this when Chromium fake microphone flags are silent in Electron. Convert a short speech fixture to raw PCM16 mono and inject it through the Realtime input buffer:
+
+```bash
+say -o /tmp/hello-world.aiff "hello world"
+ffmpeg -y -i /tmp/hello-world.aiff -ac 1 -ar 24000 -f s16le -c:a pcm_s16le /tmp/hello-world.pcm
+```
+
+Steps:
+1. Open Voice Mode.
+2. Execute `voice.start` and wait for `connected: true`.
+3. Base64-encode `/tmp/hello-world.pcm` and execute `voice.inject_audio` with `{ "pcm16Base64": "..." }`.
+4. Wait for a new `voice.timeline` user entry containing `hello`.
+
+Pass criteria:
+- The audio buffer produces a Realtime transcription such as `Hello world.`.
+- Punctuation-only transcription fragments do not overwrite the last meaningful transcript.

--- a/evals/voice-mode-flows.md
+++ b/evals/voice-mode-flows.md
@@ -111,3 +111,24 @@ Steps:
 Pass criteria:
 - The audio buffer produces a Realtime transcription such as `Hello world.`.
 - Punctuation-only transcription fragments do not overwrite the last meaningful transcript.
+
+## Flow 6 — Voice survives session creation
+
+This catches regressions where Voice Mode is treated like a session-owned artifact panel and gets unmounted when the route changes.
+
+Steps:
+1. Open an existing session.
+2. Execute `voice.panel.open`.
+3. Execute `voice.send_text` with:
+   ```json
+   { "text": "Use the OpenWork UI action session.create_task to create a new session. After the new session opens, use composer.set_text to put exactly VOICE SESSION SURVIVED in the composer." }
+   ```
+4. Wait for the `route.selectedSessionId` value to change.
+5. Wait for `slice: "voice", path: "connected", equals: true`.
+6. Wait for `slice: "composer", path: "draft", equals: "VOICE SESSION SURVIVED"`.
+
+Pass criteria:
+- The right-side Voice Mode panel remains open after the new session route loads.
+- The Realtime session remains connected.
+- The model can execute a second UI action in the new session.
+- Composer draft in the new session equals `VOICE SESSION SURVIVED`.

--- a/packages/openwork-ui-mcp/index.mjs
+++ b/packages/openwork-ui-mcp/index.mjs
@@ -152,6 +152,54 @@ function formatExecutionResult(actionId, result) {
   return `Executed ${actionId}.`;
 }
 
+function getPathValue(source, path) {
+  if (!path) return source;
+  const parts = String(path).split(".").map((part) => part.trim()).filter(Boolean);
+  let current = source;
+  for (const part of parts) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = current[part];
+  }
+  return current;
+}
+
+function valuesEqual(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function inspectPayload(result) {
+  if (Object.prototype.hasOwnProperty.call(result, "value")) return result.value;
+  if (Object.prototype.hasOwnProperty.call(result, "snapshot")) return result.snapshot;
+  return result;
+}
+
+function evaluateInspectorAssertion(source, assertion) {
+  const actual = getPathValue(source, assertion.path || "");
+  if (assertion.exists === true && actual === undefined) {
+    return { ok: false, actual, message: `${assertion.path || "value"} does not exist` };
+  }
+  if (assertion.exists === false && actual !== undefined) {
+    return { ok: false, actual, message: `${assertion.path || "value"} exists` };
+  }
+  if (Object.prototype.hasOwnProperty.call(assertion, "equals") && !valuesEqual(actual, assertion.equals)) {
+    return { ok: false, actual, message: `${assertion.path || "value"} did not equal ${JSON.stringify(assertion.equals)}` };
+  }
+  if (typeof assertion.contains === "string") {
+    const haystack = typeof actual === "string" ? actual : JSON.stringify(actual);
+    if (!haystack.includes(assertion.contains)) {
+      return { ok: false, actual, message: `${assertion.path || "value"} did not contain ${JSON.stringify(assertion.contains)}` };
+    }
+  }
+  return { ok: true, actual, message: "Assertion passed" };
+}
+
+async function inspectBridge(slice) {
+  const suffix = slice ? `?slice=${encodeURIComponent(slice)}` : "";
+  const result = await bridgeRequest(`/inspect${suffix}`);
+  if (!result.ok && result.error) return result;
+  return { ok: true, raw: result, value: inspectPayload(result) };
+}
+
 // ── MCP Server ──
 
 const server = new McpServer({
@@ -221,6 +269,81 @@ server.tool(
       return { content: [{ type: "text", text: `Error executing ${actionId}: ${result.error}` }], isError: true };
     }
     return { content: [{ type: "text", text: formatExecutionResult(actionId, result) }] };
+  }
+);
+
+// ── ui.inspect ──
+server.tool(
+  "ui_inspect",
+  "Read OpenWork's structured runtime inspector. Use this for deterministic evals and assertions, including slices like 'composer' or 'voice'.",
+  {
+    slice: z.string().optional().describe("Optional inspector slice name, e.g. 'composer' or 'voice'. Omit to return the full inspector snapshot."),
+  },
+  async ({ slice }) => {
+    const result = await inspectBridge(slice?.trim() || "");
+    if (!result.ok && result.error) {
+      return { content: [{ type: "text", text: `Error: ${result.error}` }], isError: true };
+    }
+    return { content: [{ type: "text", text: JSON.stringify(result.value, null, 2) }] };
+  }
+);
+
+// ── ui.assert ──
+server.tool(
+  "ui_assert",
+  "Assert against OpenWork's structured runtime inspector without DOM scraping. Supports dot paths, equality, contains, and existence checks.",
+  {
+    slice: z.string().optional().describe("Optional inspector slice name, e.g. 'voice'."),
+    path: z.string().optional().describe("Dot path inside the inspected payload, e.g. 'status' when slice='voice' or 'voice.status' for the full snapshot."),
+    equals: z.unknown().optional().describe("Expected JSON value."),
+    contains: z.string().optional().describe("Expected substring in the actual string or JSON-rendered value."),
+    exists: z.boolean().optional().describe("Whether the value must exist."),
+  },
+  async (assertion) => {
+    const result = await inspectBridge(assertion.slice?.trim() || "");
+    if (!result.ok && result.error) {
+      return { content: [{ type: "text", text: `Error: ${result.error}` }], isError: true };
+    }
+    const evaluated = evaluateInspectorAssertion(result.value, assertion);
+    const text = `${evaluated.message}\nActual: ${JSON.stringify(evaluated.actual, null, 2)}`;
+    return { content: [{ type: "text", text }], isError: !evaluated.ok };
+  }
+);
+
+// ── ui.wait_for ──
+server.tool(
+  "ui_wait_for",
+  "Wait until an OpenWork inspector assertion passes. Use this in CDP/Electron evals instead of arbitrary sleeps.",
+  {
+    slice: z.string().optional().describe("Optional inspector slice name, e.g. 'voice'."),
+    path: z.string().optional().describe("Dot path inside the inspected payload."),
+    equals: z.unknown().optional().describe("Expected JSON value."),
+    contains: z.string().optional().describe("Expected substring in the actual string or JSON-rendered value."),
+    exists: z.boolean().optional().describe("Whether the value must exist."),
+    timeoutMs: z.number().optional().describe("Maximum wait time in milliseconds. Defaults to 5000."),
+    intervalMs: z.number().optional().describe("Polling interval in milliseconds. Defaults to 150."),
+  },
+  async (assertion) => {
+    const timeoutMs = Math.min(Math.max(assertion.timeoutMs ?? 5000, 100), 60000);
+    const intervalMs = Math.min(Math.max(assertion.intervalMs ?? 150, 50), 2000);
+    const started = Date.now();
+    let last = null;
+    while (Date.now() - started <= timeoutMs) {
+      const result = await inspectBridge(assertion.slice?.trim() || "");
+      if (!result.ok && result.error) {
+        last = { ok: false, actual: null, message: result.error };
+      } else {
+        last = evaluateInspectorAssertion(result.value, assertion);
+        if (last.ok) {
+          return { content: [{ type: "text", text: `Condition met after ${Date.now() - started}ms.\nActual: ${JSON.stringify(last.actual, null, 2)}` }] };
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    return {
+      content: [{ type: "text", text: `Timed out after ${timeoutMs}ms: ${last?.message || "condition not met"}\nActual: ${JSON.stringify(last?.actual, null, 2)}` }],
+      isError: true,
+    };
   }
 );
 


### PR DESCRIPTION
## Summary
- Add a Voice Mode OpenWork extension with a right-side Realtime voice panel.
- Add host-side OpenAI Realtime client-secret minting using the existing env store.
- Prefer user-saved env-store Realtime keys over stale process env keys.
- Keep Voice Mode panel and runtime state open across session changes so the voice timeline survives navigation/new sessions.
- Extend OpenWork UI MCP with inspect/assert/wait tools for deterministic evals.
- Add Voice Mode eval docs covering transcript injection, Realtime text tool calls, audio-buffer transcription, and session-transition continuity.

## Verification
- pnpm --filter @openwork/app typecheck
- pnpm --filter openwork-server typecheck
- pnpm --filter openwork-ui-mcp check
- git diff --check
- Isolated Electron/CDP eval on local feature worktree: connected OpenWork UI Control, verified opencode.jsonc MCP config, reloaded MCP, verified UI MCP can navigate/open Voice Mode.
- Real OpenAI Realtime eval with local OPENAI_API_KEY env: verified Realtime connection, model called openwork_execute_action, composer changed to REPEAT CHAT EVAL PASSED.
- Direct OpenAI Realtime client-secret verification with temporary key: returned 200 and a client secret.
- Realtime audio-buffer eval: injected PCM16 hello-world audio and verified Realtime transcription produced Hello world.
- Exact session-transition CDP eval: opened Voice Mode, injected FIRST VOICE MESSAGE MUST REMAIN, created a new session, verified the first voice message still remained visible in the Voice timeline, then injected SECOND SESSION MESSAGE into the new session composer.

## Notes
- Did not include API keys or eval temp artifacts in the commit.
- Chromium fake microphone flags were silent locally, so deterministic audio eval uses Realtime input_audio_buffer injection.