### PR TITLE
chore: remove project opencode config

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://opencode.ai/config.json",
-  "permission": "allow",
-  "plugin": ["opencode-chrome-devtools@1.0.4"]
-}


### PR DESCRIPTION
## Summary

Removes the project-level `.opencode/opencode.json` file only.

The current project config defines a `plugin` array. That is a bad default for a shared project because it can override or mask plugins configured globally by the developer, such as workspace or team tooling plugins.

OpenWork should not force project-level OpenCode plugins by default; developers can opt into project-specific plugins intentionally when needed.

## Verification

- `git diff --name-status upstream/dev...pr/opencode-config-cleanup` reviewed; `.opencode/opencode.json` deletion only.
- Confirmed no `tasks/**`, `docs/scrs/**`, codemaps, or generated app-version files are included.

## Known risks

- The project no longer forces `opencode-chrome-devtools@1.0.4` or blanket `permission: "allow"`.

## Linked issues

- Partially fixes #1161