### PR TITLE
feat(app): add session streaming indicator to sidebar

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1525,6 +1525,8 @@ export default {
   "workspace_list.reveal_file_manager": "Show in Files",
   "workspace_list.reveal_finder": "Reveal in Finder",
   "workspace_list.session_actions": "Session actions",
+  "workspace_list.session_active": "Session active",
+  "workspace_list.session_streaming": "Session streaming",
   "workspace_list.share": "Share...",
   "workspace_list.show_child_sessions": "Show child sessions",
   "workspace_list.show_more": "Show {count} more",

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -78,6 +78,32 @@ import type { SessionListItem, SessionTreeState } from "./utils";
 import { cn } from "@/lib/utils";
 import { WorkspaceIcon } from "../../../design-system/workspace-icon";
 
+function SessionStatusIndicator(props: { isStreaming: boolean; isActive: boolean }) {
+  if (props.isStreaming) {
+    return (
+      <span
+        className="flex size-3.5 shrink-0 items-center justify-center text-amber-500"
+        title={t("workspace_list.session_streaming")}
+        aria-label={t("workspace_list.session_streaming")}
+      >
+        <Loader2 className="size-3.5 animate-spin" />
+      </span>
+    );
+  }
+
+  if (props.isActive) {
+    return (
+      <span
+        className="size-1.5 shrink-0 rounded-full bg-amber-500"
+        title={t("workspace_list.session_active")}
+        aria-label={t("workspace_list.session_active")}
+      />
+    );
+  }
+
+  return null;
+}
+
 type SessionActionsProps = {
   className: string;
   sessionId: string;
@@ -865,6 +891,7 @@ function SessionMenuItem({ session, tree, workspaceId, forcedExpandedSessionIds,
   const hasChildren = (tree.descendantCountBySessionId.get(session.id) ?? 0) > 0;
   const isExpanded = ctx.expandedSessionIds.has(session.id) || forcedExpandedSessionIds.has(session.id);
   const isSessionActive = tree.activeIds.has(session.id);
+  const isSessionStreaming = tree.streamingIds.has(session.id);
 
   const openSession = () => {
     ctx.onOpenSession(workspaceId, session.id);
@@ -896,7 +923,7 @@ function SessionMenuItem({ session, tree, workspaceId, forcedExpandedSessionIds,
                   onPointerEnter={prefetchSession}
                   onFocus={prefetchSession}
                 >
-                  {isSessionActive ? <span className="size-1.5 shrink-0 rounded-full bg-amber-500" /> : null}
+                  <SessionStatusIndicator isStreaming={isSessionStreaming} isActive={isSessionActive} />
                   <span
                     className="min-w-0 flex-1 truncate transition-[padding] duration-75 group-hover/menu-sub-item:pe-12 group-has-data-popup-open/menu-sub-item:pe-12 pe-4"
                     title={displayTitle}
@@ -929,7 +956,7 @@ function SessionMenuItem({ session, tree, workspaceId, forcedExpandedSessionIds,
           onFocus={prefetchSession}
           className={cn("transition-[padding] duration-75 group-hover/menu-sub-item:pe-8 group-has-data-popup-open/menu-sub-item:pe-8", depth > 0 && "ps-13")}
         >
-          {isSessionActive ? <span className="size-1.5 shrink-0 rounded-full bg-amber-500" /> : null}
+          <SessionStatusIndicator isStreaming={isSessionStreaming} isActive={isSessionActive} />
           <span className="truncate" title={displayTitle}>{displayTitle}</span>
         </SidebarMenuSubButton>
       </SessionContextMenu>

--- a/apps/app/src/react-app/domains/session/sidebar/utils.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/utils.ts
@@ -12,7 +12,11 @@ export type SessionTreeState = {
   ancestorIdsBySessionId: Map<string, string[]>;
   descendantCountBySessionId: Map<string, number>;
   activeIds: Set<string>;
+  streamingIds: Set<string>;
 };
+
+export const isStreamingSessionStatus = (status: string | undefined) =>
+  status === "running" || status === "busy" || status === "retry" || status === "streaming";
 
 const normalizeSessionParentID = (session: SessionListItem) => {
   const parentID = session.parentID?.trim();
@@ -35,6 +39,7 @@ export const buildSessionTreeState = (
   const ancestorIdsBySessionId = new Map<string, string[]>();
   const descendantCountBySessionId = new Map<string, number>();
   const activeIds = new Set<string>();
+  const streamingIds = new Set<string>();
   const sessionIds = new Set(sessions.map((session) => session.id));
 
   sessions.forEach((session) => {
@@ -49,17 +54,21 @@ export const buildSessionTreeState = (
     ancestorIdsBySessionId.set(session.id, ancestors);
     const children = childrenByParent.get(session.id) ?? [];
     let descendantCount = 0;
-    let subtreeActive = (sessionStatusById?.[session.id] ?? "idle") !== "idle";
+    const ownStatus = sessionStatusById?.[session.id] ?? "idle";
+    let subtreeActive = ownStatus !== "idle";
+    let subtreeStreaming = isStreamingSessionStatus(ownStatus);
 
     children.forEach((child) => {
       const childState = walk(child, [...ancestors, session.id]);
       descendantCount += 1 + childState.descendantCount;
       subtreeActive = subtreeActive || childState.subtreeActive;
+      subtreeStreaming = subtreeStreaming || childState.subtreeStreaming;
     });
 
     descendantCountBySessionId.set(session.id, descendantCount);
     if (subtreeActive) activeIds.add(session.id);
-    return { descendantCount, subtreeActive };
+    if (subtreeStreaming) streamingIds.add(session.id);
+    return { descendantCount, subtreeActive, subtreeStreaming };
   };
 
   getRootSessions(sessions).forEach((session) => {
@@ -71,6 +80,7 @@ export const buildSessionTreeState = (
     ancestorIdsBySessionId,
     descendantCountBySessionId,
     activeIds,
+    streamingIds,
   };
 };
 

--- a/apps/app/src/react-app/domains/session/sync/runtime-sync.tsx
+++ b/apps/app/src/react-app/domains/session/sync/runtime-sync.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect } from "react";
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
 
 import { ensureWorkspaceSessionSync, trackWorkspaceSessionsSync } from "./session-sync";
 
@@ -10,6 +11,7 @@ type ReactSessionRuntimeProps = {
   opencodeBaseUrl: string;
   openworkToken: string;
   onSessionUpdated?: (update: { sessionId: string; info: Record<string, unknown> }) => void;
+  onSessionStatus?: (update: { sessionId: string; status: SessionStatus }) => void;
 };
 
 export function ReactSessionRuntime(props: ReactSessionRuntimeProps) {
@@ -19,6 +21,7 @@ export function ReactSessionRuntime(props: ReactSessionRuntimeProps) {
       baseUrl: props.opencodeBaseUrl,
       openworkToken: props.openworkToken,
       onSessionUpdated: props.onSessionUpdated,
+      onSessionStatus: props.onSessionStatus,
     };
     const releaseWorkspace = ensureWorkspaceSessionSync(input);
     const releaseSessions = trackWorkspaceSessionsSync(input, [props.sessionId, ...(props.activeSessionIds ?? [])]);
@@ -26,7 +29,7 @@ export function ReactSessionRuntime(props: ReactSessionRuntimeProps) {
       releaseSessions();
       releaseWorkspace();
     };
-  }, [props.workspaceId, props.sessionId, props.activeSessionIds, props.opencodeBaseUrl, props.openworkToken, props.onSessionUpdated]);
+  }, [props.workspaceId, props.sessionId, props.activeSessionIds, props.opencodeBaseUrl, props.openworkToken, props.onSessionUpdated, props.onSessionStatus]);
 
   return null;
 }

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -14,6 +14,7 @@ type SyncOptions = {
   baseUrl: string;
   openworkToken: string;
   onSessionUpdated?: (update: { sessionId: string; info: Record<string, unknown> }) => void;
+  onSessionStatus?: (update: { sessionId: string; status: SessionStatus }) => void;
 };
 
 export type PendingDelta = {
@@ -32,6 +33,7 @@ type SyncEntry = {
   trackedSessionRefs: Map<string, number>;
   retainedSessionTimers: Map<string, ReturnType<typeof setTimeout>>;
   sessionUpdatedListeners: Set<NonNullable<SyncOptions["onSessionUpdated"]>>;
+  sessionStatusListeners: Set<NonNullable<SyncOptions["onSessionStatus"]>>;
   pendingDeltas: Map<string, { messageId: string; reasoning: boolean; text: string }>;
   // Coalesce rapid-fire delta events from the SSE stream into one cache
   // commit per animation frame. Without this, a long response produces a
@@ -443,9 +445,10 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.status") {
     const props = (event.properties ?? {}) as { sessionID?: string; status?: SessionStatus };
     if (!props.sessionID || !props.status) return;
-    if (!isTrackedSession(entry, props.sessionID)) return;
-    queryClient.setQueryData(statusKey(workspaceId, props.sessionID), props.status);
-    if (input && !isLiveStatus(props.status)) releaseRetainedSessionSoon(input, entry, props.sessionID);
+    const tracked = isTrackedSession(entry, props.sessionID);
+    if (tracked) queryClient.setQueryData(statusKey(workspaceId, props.sessionID), props.status);
+    for (const listener of entry.sessionStatusListeners) listener({ sessionId: props.sessionID, status: props.status });
+    if (input && tracked && !isLiveStatus(props.status)) releaseRetainedSessionSoon(input, entry, props.sessionID);
     return;
   }
 
@@ -604,9 +607,10 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.idle") {
     const props = (event.properties ?? {}) as { sessionID?: string };
     if (!props.sessionID) return;
-    if (!isTrackedSession(entry, props.sessionID)) return;
-    queryClient.setQueryData(statusKey(workspaceId, props.sessionID), idleStatus);
-    if (input) releaseRetainedSessionSoon(input, entry, props.sessionID);
+    const tracked = isTrackedSession(entry, props.sessionID);
+    if (tracked) queryClient.setQueryData(statusKey(workspaceId, props.sessionID), idleStatus);
+    for (const listener of entry.sessionStatusListeners) listener({ sessionId: props.sessionID, status: idleStatus });
+    if (input && tracked) releaseRetainedSessionSoon(input, entry, props.sessionID);
   }
 }
 
@@ -783,6 +787,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
       existing.disposeTimer = null;
     }
     if (input.onSessionUpdated) existing.sessionUpdatedListeners.add(input.onSessionUpdated);
+    if (input.onSessionStatus) existing.sessionStatusListeners.add(input.onSessionStatus);
     existing.refs += 1;
     return () => releaseWorkspaceSessionSync(input);
   }
@@ -795,6 +800,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
     trackedSessionRefs: new Map(),
     retainedSessionTimers: new Map(),
     sessionUpdatedListeners: new Set(input.onSessionUpdated ? [input.onSessionUpdated] : []),
+    sessionStatusListeners: new Set(input.onSessionStatus ? [input.onSessionStatus] : []),
     pendingDeltas: new Map(),
     deltaFlushBuffer: [],
     deltaFlushScheduled: false,
@@ -811,6 +817,7 @@ function releaseWorkspaceSessionSync(input: SyncOptions) {
   const existing = syncs.get(key);
   if (!existing) return;
   if (input.onSessionUpdated) existing.sessionUpdatedListeners.delete(input.onSessionUpdated);
+  if (input.onSessionStatus) existing.sessionStatusListeners.delete(input.onSessionStatus);
   existing.refs -= 1;
   if (existing.refs > 0) return;
   if (existing.retainedSessionTimers.size === 0) {
@@ -886,6 +893,7 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
     trackedSessionRefs: new Map(),
     retainedSessionTimers: new Map(),
     sessionUpdatedListeners: new Set(),
+    sessionStatusListeners: new Set(),
     pendingDeltas: new Map(),
     deltaFlushBuffer: [],
     deltaFlushScheduled: false,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -13,6 +13,7 @@ import type {
   AgentPartInput,
   FilePartInput,
   ProviderListResponse,
+  SessionStatus,
   TextPartInput,
 } from "@opencode-ai/sdk/v2/client";
 
@@ -71,6 +72,7 @@ import {
   isDesktopRuntime,
   isSandboxWorkspace,
   normalizeDirectoryPath,
+  normalizeSessionStatus,
   resolveModelDisplayName,
   safeStringify,
 } from "../../app/utils";
@@ -371,11 +373,12 @@ function toSessionGroups(
 // Don't compose `<baseUrl>/workspace/<id>` here.
 
 function isActiveSessionStatus(status: unknown) {
-  return status === "running" || status === "retry" || status === "busy";
+  return status === "running" || status === "retry" || status === "busy" || status === "streaming";
 }
 
 function getSessionStatus(session: any) {
-  return session?.status ?? session?.state ?? session?.runStatus ?? null;
+  const status = session?.status ?? session?.state ?? session?.runStatus ?? null;
+  return typeof status === "string" ? status : normalizeSessionStatus(status);
 }
 
 async function fileToDataUrl(file: File) {
@@ -473,6 +476,7 @@ export function SessionRoute() {
   const [workspaces, setWorkspaces] = useState<RouteWorkspace[]>([]);
   const [workspaceOrderIds, setWorkspaceOrderIds] = useState<string[]>(() => readWorkspaceOrderIds());
   const [sessionsByWorkspaceId, setSessionsByWorkspaceId] = useState<Record<string, any[]>>({});
+  const [runtimeSessionStatusById, setRuntimeSessionStatusById] = useState<Record<string, string>>({});
   const [errorsByWorkspaceId, setErrorsByWorkspaceId] = useState<Record<string, string | null>>({});
   const [workspaceConnectionOverrides, setWorkspaceConnectionOverrides] = useState<Record<string, WorkspaceConnectionState>>({});
   const [routeError, setRouteError] = useState<string | null>(null);
@@ -647,6 +651,19 @@ export function SessionRoute() {
         return id ? [id] : [];
       }),
     [selectedWorkspaceId, sessionsByWorkspaceId],
+  );
+  const listedSessionStatusById = useMemo(() => {
+    const next: Record<string, string> = {};
+    for (const session of Object.values(sessionsByWorkspaceId).flat()) {
+      const id = String(session?.id ?? "").trim();
+      if (!id) continue;
+      next[id] = getSessionStatus(session);
+    }
+    return next;
+  }, [sessionsByWorkspaceId]);
+  const sidebarSessionStatusById = useMemo(
+    () => ({ ...listedSessionStatusById, ...runtimeSessionStatusById }),
+    [listedSessionStatusById, runtimeSessionStatusById],
   );
 
   const backgroundSessionLoadInFlight = useRef<Map<string, number>>(new Map());
@@ -1078,6 +1095,16 @@ export function SessionRoute() {
       return next;
     });
   }, [selectedWorkspaceId]);
+
+  const handleRuntimeSessionStatus = useCallback((update: { sessionId: string; status: SessionStatus }) => {
+    const sessionId = update.sessionId;
+    if (!sessionId) return;
+    const status = normalizeSessionStatus(update.status);
+    setRuntimeSessionStatusById((current) => {
+      if (current[sessionId] === status) return current;
+      return { ...current, [sessionId]: status };
+    });
+  }, []);
 
   useEffect(() => {
     workspacesRef.current = workspaces;
@@ -2572,6 +2599,7 @@ export function SessionRoute() {
         opencodeBaseUrl={opencodeBaseUrl}
         openworkToken={selectedWorkspaceServerToken}
         onSessionUpdated={handleRuntimeSessionUpdated}
+        onSessionStatus={handleRuntimeSessionStatus}
       />
     ) : null}
     <SessionPage
@@ -2713,7 +2741,7 @@ export function SessionRoute() {
         selectedWorkspaceId,
         selectedSessionId,
         developerMode: false,
-        sessionStatusById: {},
+        sessionStatusById: sidebarSessionStatusById,
         connectingWorkspaceId: null,
         workspaceConnectionStateById,
         newTaskDisabled: !canCreateTask,

--- a/evals/README.md
+++ b/evals/README.md
@@ -85,3 +85,6 @@ Chrome DevTools MCP. Every tool takes `browser_url` as the first argument.
 - [`browser-extension-flows.md`](./browser-extension-flows.md) — browser
   extension plugin loading, built-in browser navigation, composer extensions
   menu, extension toggle, and stale MCP migration.
+- [`session-sidebar-status-flows.md`](./session-sidebar-status-flows.md) —
+  off-screen session streaming indicators, stop/idle cleanup, and independent
+  sidebar status across sessions.

--- a/evals/session-sidebar-status-flows.md
+++ b/evals/session-sidebar-status-flows.md
@@ -1,0 +1,106 @@
+# Session sidebar status flows
+
+End-to-end scenarios for sidebar indicators that show session activity while a
+task is running. These flows extend the existing streaming evals by verifying
+the off-screen sidebar state, not just transcript streaming.
+
+## Preflight
+
+1. Start the Electron app through Daytona or locally.
+2. Create or select a local workspace with a working model/provider.
+3. Open the main session route and verify the footer/status bar is ready.
+
+## Flow 1: Off-screen session shows streaming
+
+**Goal:** A user can start a long task, switch away, and still see which session
+is running from the sidebar.
+
+### Steps
+
+1. Create Session A.
+2. Send a long prompt that includes a final marker such as
+   `SIDEBAR_STREAM_A_DONE`.
+3. Immediately create or open Session B.
+4. While Session B is selected, inspect the Session A row in the sidebar.
+5. Return to Session A after the run completes.
+
+### CDP steering
+
+- Use `browser_eval` to click `New task`, focus `[contenteditable=true]`, insert
+  the prompt with `document.execCommand('insertText', false, text)`, and click
+  `Run task`.
+- Use `window.location.hash` or sidebar row clicks to switch sessions.
+- Query the sidebar DOM for the row matching Session A and any accessible
+  streaming/status indicator inside it.
+
+### Verification
+
+- Session A status is running while Session B is selected.
+- Session A transcript eventually contains `SIDEBAR_STREAM_A_DONE`.
+
+### Pass criteria
+
+- Session A shows a visible or accessible streaming indicator while off-screen.
+- Session B does not inherit Session A's running state.
+- The Session A indicator clears after idle without a reload.
+
+## Flow 2: Stop clears the sidebar indicator
+
+**Goal:** Stopping a task clears both the composer status and the sidebar
+activity state.
+
+### Steps
+
+1. Create a new session.
+2. Send a long-running prompt.
+3. Wait until the run button changes to `Stop` and the sidebar row shows
+   streaming.
+4. Click `Stop`.
+5. Poll the status bar and sidebar row.
+
+### CDP steering
+
+- Use visible button text for `Run task` and `Stop`.
+- Poll `document.body.innerText` and sidebar row attributes for active status.
+
+### Verification
+
+- Session status becomes idle/ready through the session status API or renderer
+  query cache.
+- Transcript stops receiving new streamed text after abort.
+
+### Pass criteria
+
+- The status bar returns to ready.
+- The sidebar indicator clears without navigating away or reloading.
+- Streaming does not continue after stop.
+
+## Flow 3: Independent status for two sessions
+
+**Goal:** The sidebar distinguishes a completed session from another session
+that is still running.
+
+### Steps
+
+1. Start Session A with a short prompt containing `SESSION_A_DONE`.
+2. Start Session B with a longer prompt containing `SESSION_B_DONE`.
+3. Switch between both sessions while Session B is still running.
+4. Inspect both sidebar rows.
+5. Wait until Session B completes.
+
+### CDP steering
+
+- Capture each session id from the current URL or renderer route state after
+  creation.
+- Query rows by session title, route target, or captured session id.
+
+### Verification
+
+- Session A transcript contains `SESSION_A_DONE` and has idle status.
+- Session B has running status until its final marker arrives.
+
+### Pass criteria
+
+- Session A has no streaming indicator after completion.
+- Session B still shows streaming while running.
+- Both indicators clear once both sessions are idle.


### PR DESCRIPTION
## Summary
- Adds streaming/activity indicators for sessions in the sidebar.
- Propagates session streaming state through runtime/session sync into `SessionRoute`.
- Updates sidebar session tree logic to mark active sessions and ancestors.
- Adds English copy for the new sidebar activity labels.