### PR TITLE
Add Den password reset flow

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -216,6 +216,14 @@ export const auth = betterAuth({
     enabled: true,
     autoSignIn: false,
     requireEmailVerification: true,
+    revokeSessionsOnPasswordReset: true,
+    async sendResetPassword({ user, url }) {
+      await sendEmail({
+        to: user.email,
+        template: "passwordReset",
+        props: { resetLink: url },
+      });
+    },
   },
   plugins: [
     jwt(),

--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -2,9 +2,9 @@
 
 import { ArrowRight, CheckCircle2 } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
 import { isSamePathname } from "../_lib/client-route";
-import type { AuthMode } from "../_lib/den-flow";
+import { getErrorMessage, requestJson, type AuthMode } from "../_lib/den-flow";
 import { getMcpOAuthSelectOrganizationRoute } from "../_lib/mcp-oauth-route";
 import { useDenFlow } from "../_providers/den-flow-provider";
 
@@ -97,6 +97,10 @@ export function AuthPanel({
   const pathname = usePathname();
   const prefillRef = useRef<string | null>(null);
   const [copiedDesktopField, setCopiedDesktopField] = useState<"link" | "code" | null>(null);
+  const [passwordResetRequested, setPasswordResetRequested] = useState(false);
+  const [passwordResetBusy, setPasswordResetBusy] = useState(false);
+  const [passwordResetInfo, setPasswordResetInfo] = useState("");
+  const [passwordResetError, setPasswordResetError] = useState<string | null>(null);
   const {
     authMode,
     setAuthMode,
@@ -147,10 +151,20 @@ export function AuthPanel({
     ...verificationContent,
   };
 
+  const passwordResetContent: PanelContent = {
+    title: "Reset your password.",
+    copy: "Enter your email and we'll send you a secure reset link.",
+    submitLabel: "Send reset link",
+  };
+
   const desktopGrant = getDesktopGrant(desktopRedirectUrl);
+  const isPasswordResetRequest = authMode === "sign-in" && passwordResetRequested && !verificationRequired;
+  const formBusy = isPasswordResetRequest ? passwordResetBusy : authBusy || desktopRedirectBusy;
   const activeContent = verificationRequired
     ? resolvedVerificationContent
-    : authMode === "sign-in"
+    : isPasswordResetRequest
+      ? passwordResetContent
+      : authMode === "sign-in"
       ? resolvedSignInContent
       : resolvedSignUpContent;
   const showLockedEmailSummary = Boolean(prefilledEmail && lockEmail && hideEmailField);
@@ -175,6 +189,39 @@ export function AuthPanel({
     window.setTimeout(() => {
       setCopiedDesktopField((current) => (current === field ? null : current));
     }, 1800);
+  };
+
+  const submitPasswordResetRequest = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      setPasswordResetError("Enter your email to receive a reset link.");
+      return;
+    }
+
+    setPasswordResetBusy(true);
+    setPasswordResetInfo("");
+    setPasswordResetError(null);
+    try {
+      const { response, payload } = await requestJson("/api/auth/request-password-reset", {
+        method: "POST",
+        body: JSON.stringify({
+          email: trimmedEmail,
+          redirectTo: new URL("/reset-password", window.location.origin).toString(),
+        }),
+      });
+
+      if (!response.ok) {
+        setPasswordResetError(getErrorMessage(payload, `Could not send reset link (${response.status}).`));
+        return;
+      }
+
+      setPasswordResetInfo(`If an account exists for ${trimmedEmail}, we sent a reset link.`);
+    } catch (error) {
+      setPasswordResetError(error instanceof Error ? error.message : "Could not send reset link.");
+    } finally {
+      setPasswordResetBusy(false);
+    }
   };
 
   /* ------------------------------------------------------------------ */
@@ -271,6 +318,11 @@ export function AuthPanel({
       <form
         className="grid gap-4"
         onSubmit={async (event) => {
+          if (isPasswordResetRequest) {
+            await submitPasswordResetRequest(event);
+            return;
+          }
+
           const next = verificationRequired
             ? await submitVerificationCode(event)
             : await submitAuth(event);
@@ -289,7 +341,7 @@ export function AuthPanel({
           }
         }}
       >
-        {!verificationRequired && !hideSocialAuth ? (
+        {!verificationRequired && !isPasswordResetRequest && !hideSocialAuth ? (
           <>
             <SocialButton
               onClick={() => void beginSocialAuth("github")}
@@ -336,7 +388,7 @@ export function AuthPanel({
           </label>
         ) : null}
 
-        {!verificationRequired ? (
+        {!verificationRequired && !isPasswordResetRequest ? (
           <label className="grid gap-2">
             <span className="den-label">Password</span>
             <input
@@ -348,7 +400,7 @@ export function AuthPanel({
               required
             />
           </label>
-        ) : (
+        ) : isPasswordResetRequest ? null : (
           <label className="grid gap-2">
             <span className="den-label">Verification code</span>
             <input
@@ -366,13 +418,30 @@ export function AuthPanel({
           </label>
         )}
 
+        {authMode === "sign-in" && !verificationRequired && !isPasswordResetRequest && !hideEmailField ? (
+          <div className="-mt-2 flex justify-end">
+            <button
+              type="button"
+              className="text-sm font-medium text-[var(--dls-text-primary)] transition hover:opacity-70"
+              onClick={() => {
+                setAuthMode("sign-in");
+                setPasswordResetRequested(true);
+                setPasswordResetInfo("");
+                setPasswordResetError(null);
+              }}
+            >
+              Forgot password?
+            </button>
+          </div>
+        ) : null}
+
         <button
           type="submit"
           className="den-button-primary w-full"
-          disabled={authBusy || desktopRedirectBusy}
+          disabled={formBusy}
         >
-          {authBusy || desktopRedirectBusy ? "Working..." : activeContent.submitLabel}
-          {!authBusy && !desktopRedirectBusy ? <ArrowRight className="h-4 w-4" /> : null}
+          {formBusy ? "Working..." : activeContent.submitLabel}
+          {!formBusy ? <ArrowRight className="h-4 w-4" /> : null}
         </button>
 
         {verificationRequired ? (
@@ -397,7 +466,23 @@ export function AuthPanel({
         ) : null}
       </form>
 
-      {!verificationRequired ? (
+      {isPasswordResetRequest ? (
+        <div className="flex items-center justify-between gap-3 border-t border-[var(--dls-border)] pt-4 text-sm text-[var(--dls-text-secondary)]">
+          <p className="m-0">Remembered your password?</p>
+          <button
+            type="button"
+            className="font-medium text-[var(--dls-text-primary)] transition hover:opacity-70"
+            onClick={() => {
+              setPasswordResetRequested(false);
+              setPasswordResetInfo("");
+              setPasswordResetError(null);
+              setAuthMode("sign-in");
+            }}
+          >
+            Back to sign in
+          </button>
+        </div>
+      ) : !verificationRequired ? (
         <div className="flex items-center justify-between gap-3 border-t border-[var(--dls-border)] pt-4 text-sm text-[var(--dls-text-secondary)]">
           <p className="m-0">
             {authMode === "sign-in"
@@ -407,7 +492,12 @@ export function AuthPanel({
           <button
             type="button"
             className="font-medium text-[var(--dls-text-primary)] transition hover:opacity-70"
-            onClick={() => setAuthMode(authMode === "sign-in" ? "sign-up" : "sign-in")}
+            onClick={() => {
+              setPasswordResetRequested(false);
+              setPasswordResetInfo("");
+              setPasswordResetError(null);
+              setAuthMode(authMode === "sign-in" ? "sign-up" : "sign-in");
+            }}
           >
             {authMode === "sign-in"
               ? resolvedSignInContent.toggleActionLabel
@@ -416,7 +506,17 @@ export function AuthPanel({
         </div>
       ) : null}
 
-      {showAuthFeedback ? (
+      {isPasswordResetRequest && (passwordResetInfo || passwordResetError) ? (
+        <div
+          className="den-frame-inset grid gap-1 rounded-[1.5rem] px-4 py-3 text-center text-[13px] text-[var(--dls-text-secondary)]"
+          aria-live="polite"
+        >
+          {passwordResetInfo ? <p>{passwordResetInfo}</p> : null}
+          {passwordResetError ? <p className="font-medium text-rose-600">{passwordResetError}</p> : null}
+        </div>
+      ) : null}
+
+      {!isPasswordResetRequest && showAuthFeedback ? (
         <div
           className="den-frame-inset grid gap-1 rounded-[1.5rem] px-4 py-3 text-center text-[13px] text-[var(--dls-text-secondary)]"
           aria-live="polite"

--- a/ee/apps/den-web/app/(den)/_components/reset-password-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/reset-password-screen.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ArrowRight, CheckCircle2 } from "lucide-react";
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useState, type FormEvent } from "react";
 import { getErrorMessage, requestJson } from "../_lib/den-flow";
@@ -88,10 +87,10 @@ export function ResetPasswordScreen() {
               <span className="font-medium">Your password has been reset.</span>
             </div>
             <p className="m-0">Sign in with your new password to continue.</p>
-            <Link href="/?mode=sign-in" className="den-button-primary mt-1 w-full">
+            <a href="/?mode=sign-in" className="den-button-primary mt-1 w-full">
               Back to sign in
               <ArrowRight className="h-4 w-4" />
-            </Link>
+            </a>
           </div>
         ) : (
           <form className="grid gap-4" onSubmit={submitReset}>
@@ -136,9 +135,9 @@ export function ResetPasswordScreen() {
 
         {!success ? (
           <div className="border-t border-[var(--dls-border)] pt-4 text-center text-sm text-[var(--dls-text-secondary)]">
-            <Link href="/?mode=sign-in" className="font-medium text-[var(--dls-text-primary)] transition hover:opacity-70">
+            <a href="/?mode=sign-in" className="font-medium text-[var(--dls-text-primary)] transition hover:opacity-70">
               Back to sign in
-            </Link>
+            </a>
           </div>
         ) : null}
       </div>

--- a/ee/apps/den-web/app/(den)/_components/reset-password-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/reset-password-screen.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { ArrowRight, CheckCircle2 } from "lucide-react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useState, type FormEvent } from "react";
+import { getErrorMessage, requestJson } from "../_lib/den-flow";
+
+function getResetLinkError(error: string | null) {
+  if (!error) {
+    return "This reset link is missing a token. Request a new link from the sign-in page.";
+  }
+
+  if (error === "INVALID_TOKEN") {
+    return "This reset link is invalid or expired. Request a new link from the sign-in page.";
+  }
+
+  return "We could not verify this reset link. Request a new link from the sign-in page.";
+}
+
+export function ResetPasswordScreen() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token")?.trim() ?? "";
+  const callbackError = searchParams.get("error")?.trim() ?? null;
+  const linkError = token ? null : getResetLinkError(callbackError);
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(linkError);
+
+  async function submitReset(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!token) {
+      setError(getResetLinkError(callbackError));
+      return;
+    }
+    if (password.length < 8) {
+      setError("Use at least 8 characters for your new password.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      const { response, payload } = await requestJson("/api/auth/reset-password", {
+        method: "POST",
+        body: JSON.stringify({
+          newPassword: password,
+          token,
+        }),
+      });
+
+      if (!response.ok) {
+        setError(getErrorMessage(payload, `Could not reset password (${response.status}).`));
+        return;
+      }
+
+      setSuccess(true);
+      setPassword("");
+      setConfirmPassword("");
+    } catch (resetError) {
+      setError(resetError instanceof Error ? resetError.message : "Could not reset password.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="den-page flex min-h-[calc(100vh-2.5rem)] w-full items-center justify-center py-6">
+      <div className="den-frame grid w-full max-w-[520px] gap-6 p-6 md:p-8">
+        <div className="grid gap-3">
+          <p className="den-eyebrow">Account</p>
+          <div className="grid gap-2">
+            <h1 className="den-title-lg">Choose a new password.</h1>
+            <p className="den-copy">Use the reset link from your email to secure your OpenWork account.</p>
+          </div>
+        </div>
+
+        {success ? (
+          <div className="den-frame-inset grid gap-3 rounded-[1.5rem] px-4 py-4 text-center text-[13px] text-[var(--dls-text-secondary)]" aria-live="polite">
+            <div className="inline-flex items-center justify-center gap-2 text-emerald-600">
+              <CheckCircle2 className="h-4 w-4" />
+              <span className="font-medium">Your password has been reset.</span>
+            </div>
+            <p className="m-0">Sign in with your new password to continue.</p>
+            <Link href="/?mode=sign-in" className="den-button-primary mt-1 w-full">
+              Back to sign in
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+        ) : (
+          <form className="grid gap-4" onSubmit={submitReset}>
+            <label className="grid gap-2">
+              <span className="den-label">New password</span>
+              <input
+                className="den-input"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete="new-password"
+                disabled={!token || busy}
+                required
+              />
+            </label>
+
+            <label className="grid gap-2">
+              <span className="den-label">Confirm password</span>
+              <input
+                className="den-input"
+                type="password"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                autoComplete="new-password"
+                disabled={!token || busy}
+                required
+              />
+            </label>
+
+            <button type="submit" className="den-button-primary w-full" disabled={!token || busy}>
+              {busy ? "Resetting..." : "Reset password"}
+              {!busy ? <ArrowRight className="h-4 w-4" /> : null}
+            </button>
+          </form>
+        )}
+
+        {error ? (
+          <div className="den-frame-inset rounded-[1.5rem] px-4 py-3 text-center text-[13px] font-medium text-rose-600" aria-live="polite">
+            {error}
+          </div>
+        ) : null}
+
+        {!success ? (
+          <div className="border-t border-[var(--dls-border)] pt-4 text-center text-sm text-[var(--dls-text-secondary)]">
+            <Link href="/?mode=sign-in" className="font-medium text-[var(--dls-text-primary)] transition hover:opacity-70">
+              Back to sign in
+            </Link>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/ee/apps/den-web/app/(den)/reset-password/page.tsx
+++ b/ee/apps/den-web/app/(den)/reset-password/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import { ResetPasswordScreen } from "../_components/reset-password-screen";
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={null}>
+      <ResetPasswordScreen />
+    </Suspense>
+  );
+}

--- a/packages/email/emails/password-reset.tsx
+++ b/packages/email/emails/password-reset.tsx
@@ -1,0 +1,9 @@
+import { PasswordResetEmail, type PasswordResetEmailProps } from "../src/templates/password-reset"
+
+export default function PasswordResetPreview(props: PasswordResetEmailProps) {
+  return <PasswordResetEmail {...props} />
+}
+
+PasswordResetPreview.PreviewProps = {
+  resetLink: "https://app.openworklabs.com/api/auth/reset-password/example-token?callbackURL=https%3A%2F%2Fapp.openworklabs.com%2Freset-password",
+} satisfies PasswordResetEmailProps

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -14,5 +14,6 @@ export {
   type EmailTemplateProps,
   type FeedbackEmailProps,
   type OrganizationInviteEmailProps,
+  type PasswordResetEmailProps,
   type VerificationEmailProps,
 } from "./templates/index.js"

--- a/packages/email/src/templates/index.ts
+++ b/packages/email/src/templates/index.ts
@@ -1,14 +1,17 @@
 import { createElement, type ReactElement } from "react"
 import { FeedbackEmail, type FeedbackEmailProps } from "./feedback.js"
 import { OrganizationInviteEmail, type OrganizationInviteEmailProps } from "./organization-invite.js"
+import { PasswordResetEmail, type PasswordResetEmailProps } from "./password-reset.js"
 import { VerificationEmail, type VerificationEmailProps } from "./verification.js"
 
 export type { FeedbackEmailProps } from "./feedback.js"
 export type { OrganizationInviteEmailProps } from "./organization-invite.js"
+export type { PasswordResetEmailProps } from "./password-reset.js"
 export type { VerificationEmailProps } from "./verification.js"
 
 export type EmailTemplateProps = {
   verification: VerificationEmailProps
+  passwordReset: PasswordResetEmailProps
   organizationInvite: OrganizationInviteEmailProps
   feedback: FeedbackEmailProps
 }
@@ -17,12 +20,14 @@ export type EmailTemplate = keyof EmailTemplateProps
 
 export const emailSubjects: { [Template in EmailTemplate]: (props: EmailTemplateProps[Template]) => string } = {
   verification: ({ verificationCode }) => `Your OpenWork verification code is ${verificationCode}`,
+  passwordReset: () => "Reset your OpenWork password",
   organizationInvite: ({ organizationName }) => `You're invited to join ${organizationName} on OpenWork`,
   feedback: ({ name, source }) => `OpenWork feedback from ${name}${source ? ` (${source})` : ""}`,
 }
 
 export const emailReplyTo: { [Template in EmailTemplate]: (props: EmailTemplateProps[Template]) => string | undefined } = {
   verification: () => undefined,
+  passwordReset: () => undefined,
   organizationInvite: () => undefined,
   feedback: ({ email }) => email,
 }
@@ -34,6 +39,8 @@ export function renderEmailTemplate<Template extends EmailTemplate>(
   switch (template) {
     case "verification":
       return createElement(VerificationEmail, props as EmailTemplateProps["verification"])
+    case "passwordReset":
+      return createElement(PasswordResetEmail, props as EmailTemplateProps["passwordReset"])
     case "organizationInvite":
       return createElement(OrganizationInviteEmail, props as EmailTemplateProps["organizationInvite"])
     case "feedback":

--- a/packages/email/src/templates/password-reset.tsx
+++ b/packages/email/src/templates/password-reset.tsx
@@ -1,0 +1,91 @@
+import { Body, Button, Container, Head, Heading, Hr, Html, Preview, Text } from "@react-email/components"
+
+export type PasswordResetEmailProps = {
+  resetLink: string
+}
+
+export function PasswordResetEmail({ resetLink }: PasswordResetEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Reset your OpenWork password</Preview>
+      <Body style={styles.body}>
+        <Container style={styles.container}>
+          <Text style={styles.eyebrow}>OpenWork account</Text>
+          <Heading style={styles.heading}>Reset your password</Heading>
+          <Text style={styles.text}>Use this secure link to choose a new password for your OpenWork account.</Text>
+          <Button href={resetLink} style={styles.button}>Reset password</Button>
+          <Text style={styles.footer}>This link expires in 1 hour. If you did not request a password reset, you can ignore this email.</Text>
+          <Hr style={styles.hr} />
+          <Text style={styles.footer}>If the button does not work, paste this link into your browser:</Text>
+          <Text style={styles.link}>{resetLink}</Text>
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+const styles = {
+  body: {
+    backgroundColor: "#f6f4ef",
+    color: "#171412",
+    fontFamily: "Arial, sans-serif",
+    margin: 0,
+  },
+  container: {
+    backgroundColor: "#fffdf8",
+    border: "1px solid #e8dfd0",
+    borderRadius: "20px",
+    margin: "40px auto",
+    maxWidth: "560px",
+    padding: "32px",
+  },
+  eyebrow: {
+    color: "#8a5a28",
+    fontSize: "13px",
+    fontWeight: 700,
+    letterSpacing: "0.08em",
+    margin: "0 0 12px",
+    textTransform: "uppercase" as const,
+  },
+  heading: {
+    color: "#171412",
+    fontSize: "28px",
+    lineHeight: "34px",
+    margin: "0 0 16px",
+  },
+  text: {
+    color: "#4d4640",
+    fontSize: "16px",
+    lineHeight: "24px",
+    margin: "0 0 24px",
+  },
+  button: {
+    backgroundColor: "#171412",
+    borderRadius: "999px",
+    color: "#fff8eb",
+    display: "inline-block",
+    fontSize: "15px",
+    fontWeight: 700,
+    marginBottom: "24px",
+    padding: "13px 22px",
+    textDecoration: "none",
+  },
+  hr: {
+    borderColor: "#e8dfd0",
+    margin: "28px 0 18px",
+  },
+  footer: {
+    color: "#756c62",
+    fontSize: "14px",
+    lineHeight: "21px",
+    margin: "0 0 8px",
+  },
+  link: {
+    color: "#5b3a18",
+    fontSize: "13px",
+    lineHeight: "19px",
+    margin: 0,
+    wordBreak: "break-all" as const,
+  },
+}


### PR DESCRIPTION
## Summary
- Adds Better Auth password reset email wiring and a reusable password reset email template.
- Adds the den-web forgot-password request state and a `/reset-password` token reset page.
- Revokes existing sessions after a successful password reset.

## Verification
- `pnpm --filter @openwork/email build` passed.
- `pnpm --filter @openwork-ee/den-api build` passed.
- `pnpm --filter @openwork-ee/den-web build` passed before and after the reset-page link fix.
- `pnpm dev:web-local` end-to-end pass: created local email/password user, verified via dev email code, requested reset from the UI, opened the Better Auth reset link from dev email output, set a new password, and signed in successfully with the new password.
- Stopped dev web/API/proxy/inference ports and the local MySQL container after testing.

## Evidence
- CLI/browser-driven E2E test completed locally. No screen recording captured.