### PR TITLE
feat(app): fall back to text part for non-multimodal attachments

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -61,6 +61,51 @@ const fileToDataUrl = (file: File) =>
     reader.readAsDataURL(file);
   });
 
+const fileToText = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error(`Failed to read attachment: ${file.name}`));
+    reader.onload = () => {
+      resolve(typeof reader.result === "string" ? reader.result : "");
+    };
+    reader.readAsText(file);
+  });
+
+// MIME types that downstream providers accept as multimodal bytes in the prompt.
+// Anthropic accepts image/* + application/pdf in messages; OpenAI accepts image/* + application/pdf.
+// Anything else is rejected or silently dropped, so we route those through a text fallback instead.
+const TEXT_MIME_ALLOWLIST = new Set([
+  "application/csv",
+  "application/json",
+  "application/javascript",
+  "application/sql",
+  "application/typescript",
+  "application/xml",
+  "application/x-sh",
+  "application/x-yaml",
+  "application/yaml",
+]);
+const MAX_TEXT_INLINE_BYTES = 256 * 1024;
+
+type AttachmentDelivery = "multimodal" | "text-inline" | "text-too-large" | "binary-unsupported";
+
+function classifyAttachment(attachment: ComposerAttachment): AttachmentDelivery {
+  const mime = attachment.mimeType?.trim().toLowerCase() ?? "";
+  if (attachment.kind === "image" || mime.startsWith("image/")) return "multimodal";
+  if (mime === "application/pdf") return "multimodal";
+  if (mime.startsWith("text/") || TEXT_MIME_ALLOWLIST.has(mime)) {
+    return attachment.size <= MAX_TEXT_INLINE_BYTES ? "text-inline" : "text-too-large";
+  }
+  return "binary-unsupported";
+}
+
+function formatAttachmentSize(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 export function createSessionActionsStore(options: {
   client: () => Client | null;
   baseUrl: () => string;
@@ -146,12 +191,36 @@ export function createSessionActionsStore(options: {
 
   type PartInput = TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput;
 
-  const attachmentToFilePart = async (attachment: ComposerAttachment): Promise<FilePartInput> => ({
-    type: "file",
-    url: await fileToDataUrl(attachment.file),
-    filename: attachment.name,
-    mime: attachment.mimeType,
-  });
+  const attachmentToPart = async (attachment: ComposerAttachment): Promise<PartInput> => {
+    const delivery = classifyAttachment(attachment);
+    if (delivery === "multimodal") {
+      return {
+        type: "file",
+        url: await fileToDataUrl(attachment.file),
+        filename: attachment.name,
+        mime: attachment.mimeType,
+      } satisfies FilePartInput;
+    }
+    if (delivery === "text-inline") {
+      const content = await fileToText(attachment.file);
+      const header = `[attached file: ${attachment.name}]`;
+      const footer = `[end of ${attachment.name}]`;
+      return {
+        type: "text",
+        text: `${header}\n${content}\n${footer}`,
+      } satisfies TextPartInput;
+    }
+    if (delivery === "text-too-large") {
+      return {
+        type: "text",
+        text: `[attached text file: ${attachment.name} (${formatAttachmentSize(attachment.size)}) is too large to inline. Save it to the workspace and use Read/Bash to access it.]`,
+      } satisfies TextPartInput;
+    }
+    return {
+      type: "text",
+      text: `[attached binary file: ${attachment.name} (${attachment.mimeType || "unknown type"}, ${formatAttachmentSize(attachment.size)}) is not multimodal-supported by the current provider. Save it to the workspace and use Read/Bash to access it.]`,
+    } satisfies TextPartInput;
+  };
 
   const buildPromptParts = async (draft: ComposerDraft): Promise<PartInput[]> => {
     const parts: PartInput[] = [];
@@ -190,7 +259,7 @@ export function createSessionActionsStore(options: {
       }
     }
 
-    parts.push(...(await Promise.all(draft.attachments.map(attachmentToFilePart))));
+    parts.push(...(await Promise.all(draft.attachments.map(attachmentToPart))));
     return parts;
   };
 
@@ -225,7 +294,13 @@ export function createSessionActionsStore(options: {
       } as FilePartInput);
     }
 
-    parts.push(...(await Promise.all(draft.attachments.map(attachmentToFilePart))));
+    // Slash commands strictly accept file parts only, so we drop the text-fallback
+    // attachments here. The agent will still get the file metadata via the prompt
+    // surface when the user runs the same attachment through a regular send.
+    const attachmentParts = await Promise.all(draft.attachments.map(attachmentToPart));
+    for (const part of attachmentParts) {
+      if (part.type === "file") parts.push(part);
+    }
     return parts;
   };
 


### PR DESCRIPTION
Refs #1777

## Summary
- Branch composer attachments by MIME instead of unconditionally encoding every file as a base64 `type: "file"` data URL. Images and PDFs keep the existing multimodal path. Text-like files (`text/*` plus a small allowlist of `application/{json,xml,yaml,csv,javascript,typescript,sql,x-sh,x-yaml}`) are emitted as `type: "text"` parts with the content inlined between `[attached file: name]` / `[end of name]` markers so the agent can reason about them without provider-side rejection.
- Cap inline text at 256 KB and emit a clear "too large to inline, save it to the workspace" notice above that size so very large CSVs do not balloon the prompt.
- For binary attachments outside the multimodal set (xlsx, zip, etc.), emit a placeholder text part naming the file and asking the agent to read it from the workspace via Read/Bash, instead of silently sending a payload the provider will drop.
- Slash commands still accept file parts only (SDK constraint), so the new text-fallback parts are filtered out of `buildCommandFileParts` rather than passed through as an invalid shape.

## Verification
- `pnpm --filter @openwork/app typecheck` reports the same pre-existing `origin/dev` errors as before (missing `@heroicons/react/24/solid`, `xlsx`, `marked-emoji`, `marked-shiki`, `emojilib`, `@shikijs/transformers`, `shiki` type decls); no new errors land in `actions-store.ts`.
- `node scripts/i18n-audit.mjs --ci` passes — no i18n surface changed.

## Notes
- The reporter on #1777 raised the broader design question of writing attachments to a real workspace path so MCP/Bash can reach them via tools. That is the right long-term shape but needs the Electron bridge plumbing and per-platform tempdir lifecycle. This PR is the narrower fix that unblocks "agent reasons about a CSV/JSON/code attachment" today without provider-side drops, and leaves the path-on-disk story for a follow-up that pairs with the desktop write surface.
- The MIME allowlist is intentionally small; happy to grow it once we see common attachment types in user reports.