### PR TITLE
Allow admins to remove org members

### DIFF
--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -1022,23 +1022,10 @@ export async function removeOrganizationMember(input: {
     return null
   }
 
-  const teams = await db
-    .select({ id: TeamTable.id })
-    .from(TeamTable)
-    .where(eq(TeamTable.organizationId, input.organizationId))
-
-  await db.transaction(async (tx) => {
-    for (const team of teams) {
-      await tx
-        .delete(TeamMemberTable)
-        .where(and(eq(TeamMemberTable.teamId, team.id), eq(TeamMemberTable.orgMembershipId, member.id)))
-    }
-
-    await tx
-      .update(MemberTable)
-      .set({ removedAt: new Date(), removedByOrgMember: input.removedByOrgMemberId ?? null })
-      .where(eq(MemberTable.id, member.id))
-  })
+  await db
+    .update(MemberTable)
+    .set({ removedAt: new Date(), removedByOrgMember: input.removedByOrgMemberId ?? null, userId: null })
+    .where(eq(MemberTable.id, member.id))
 
   await runPostOrganizationMemberChangeHooks({ organizationId: input.organizationId, memberId: member.id, change: "removed" })
 

--- a/ee/apps/den-api/src/routes/org/members.ts
+++ b/ee/apps/den-api/src/routes/org/members.ts
@@ -9,7 +9,7 @@ import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizati
 import { emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
 import { listAssignableRoles, removeOrganizationMember, roleIncludesOwner } from "../../orgs.js"
 import type { OrgRouteVariables } from "./shared.js"
-import { ensureOwner, idParamSchema, normalizeRoleName } from "./shared.js"
+import { ensureMemberRemover, ensureOwner, idParamSchema, normalizeRoleName } from "./shared.js"
 
 const updateMemberRoleSchema = z.object({
   role: z.string().trim().min(1).max(64),
@@ -90,7 +90,7 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
         204: emptyResponse("Member removed successfully."),
         400: jsonResponse("The member removal request was invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to remove organization members.", unauthorizedSchema),
-        403: jsonResponse("Only workspace owners can remove members.", forbiddenSchema),
+        403: jsonResponse("Only workspace owners and admins can remove members.", forbiddenSchema),
         404: jsonResponse("The member or organization could not be found.", notFoundSchema),
       },
     }),
@@ -98,9 +98,9 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
     paramValidator(orgMemberParamsSchema),
     resolveOrganizationContextMiddleware,
     async (c) => {
-    const permission = ensureOwner(c)
+    const permission = ensureMemberRemover(c)
     if (!permission.ok) {
-      return c.json(permission.response, 403)
+      return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
     }
 
     const payload = c.get("organizationContext")

--- a/ee/apps/den-api/src/routes/org/shared.ts
+++ b/ee/apps/den-api/src/routes/org/shared.ts
@@ -102,6 +102,30 @@ export function ensureInviteManager(c: { get: (key: "organizationContext") => Or
   }
 }
 
+export function ensureMemberRemover(c: { get: (key: "organizationContext") => OrgRouteVariables["organizationContext"] }) {
+  const payload = c.get("organizationContext")
+  if (!payload) {
+    return {
+      ok: false as const,
+      response: {
+        error: "organization_not_found",
+      },
+    }
+  }
+
+  if (payload.currentMember.isOwner || memberHasRole(payload.currentMember.role, "admin")) {
+    return { ok: true as const }
+  }
+
+  return {
+    ok: false as const,
+    response: {
+      error: "forbidden",
+      message: "Only workspace owners and admins can remove members.",
+    },
+  }
+}
+
 export function ensureTeamManager(c: { get: (key: "organizationContext") => OrgRouteVariables["organizationContext"] }) {
   const payload = c.get("organizationContext")
   if (!payload) {

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -237,6 +237,7 @@ export function getOrgAccessFlags(roleValue: string, isOwner: boolean) {
     canInviteMembers: isAdmin,
     canCancelInvitations: isAdmin,
     canManageMembers: isOwner,
+    canRemoveMembers: isAdmin,
     canManageRoles: isOwner,
     canManageTeams: isAdmin,
     canManageApiKeys: isAdmin,

--- a/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
@@ -640,8 +640,10 @@ export function ManageMembersScreen() {
         <div>
           <div className="mb-6 flex items-center justify-between gap-4">
             <p className="text-[15px] text-gray-400">
-              {access.canInviteMembers
+              {access.canManageMembers
                 ? "Invite people, update their role, or remove them from the organization."
+                : access.canRemoveMembers
+                  ? "Invite people or remove non-owner members from the organization."
                 : "View who is in the organization and what role they currently hold."}
             </p>
             {toolbarAction ? (
@@ -667,7 +669,7 @@ export function ManageMembersScreen() {
                 ? false
                 : isInvited
                   ? access.canInviteMembers || access.canCancelInvitations
-                  : access.canManageMembers;
+                  : access.canManageMembers || access.canRemoveMembers;
 
               return (
                 <div
@@ -753,7 +755,7 @@ export function ManageMembersScreen() {
                                 Cancel invite
                               </button>
                             ) : null}
-                            {!isInvited && access.canManageMembers ? (
+                            {!isInvited && access.canRemoveMembers ? (
                               <button
                                 type="button"
                                 onClick={() => {


### PR DESCRIPTION
## Summary
- Allow owners and admins to remove non-owner organization members while keeping role editing owner-only.
- Clear `userId` on removed member rows so future re-joins can create fresh active memberships.
- Preserve team membership rows when members are removed, and expose the remove action to admins in Den web.

## Verification
- `pnpm dev:den:mysql` - passed
- `DATABASE_URL=\"mysql://root:password@127.0.0.1:3306/openwork_member_removal_e2e\" DEN_DB_ENCRYPTION_KEY=\"local-dev-db-encryption-key-please-change-1234567890\" pnpm --filter @openwork-ee/den-db db:push` - passed
- `pnpm exec tsx /var/folders/6w/z6896bkn5w7fmyy8f_ryk8h40000gn/T/opencode/delete-org-member-db-e2e.ts` - passed; verified 403 for normal members, 204 for admins, `userId: null`, preserved team membership, and removed-user org access denied
- `pnpm --filter @openwork-ee/den-api build` - passed
- `pnpm --filter @openwork-ee/den-web build` - passed
- `bun test ee/apps/den-api/test/org-invitations.test.ts` - passed

## Evidence
- DB-backed E2E was run against isolated MySQL database `openwork_member_removal_e2e` using the actual Den Hono app routes.
- No screen recording captured; verification is command-based.