### PR TITLE
Add optional Daytona recording artifacts

### DIFF
--- a/.devcontainer/Dockerfile.daytona-vnc
+++ b/.devcontainer/Dockerfile.daytona-vnc
@@ -7,6 +7,10 @@ FROM daytonaio/sandbox:0.6.0
 
 USER root
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN /usr/local/share/nvm/current/bin/npm install -g pnpm@10.27.0 bun
 
 WORKDIR /workspace

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -36,6 +36,19 @@ bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken
 Future Daytona test sandboxes mount `openwork-eval-secrets:/daytona-secrets`
 and source `/daytona-secrets/openai.env` automatically before Electron starts.
 
+For downloadable eval artifacts or optional video recording, use:
+
+```bash
+bash .devcontainer/test-on-daytona.sh [branch-or-commit] --artifacts-volume
+bash .devcontainer/test-on-daytona.sh [branch-or-commit] --record-video
+```
+
+The artifacts flow mounts `openwork-eval-artifacts:/daytona-artifacts`, starts a
+static download server on port 8090, and prints a Daytona preview URL. Recording
+writes mp4 files to `/daytona-artifacts/recordings` and prints the direct video
+URL. Stop recording with the printed `pkill -INT -f "ffmpeg.*x11grab"` command so
+ffmpeg finalizes the file cleanly.
+
 Do not use the generic `daytona create https://github.com/different-ai/openwork`
 flow for Electron/noVNC tests. The default resource size is too small and the
 generic image path does not guarantee the desktop stack we need.
@@ -77,6 +90,8 @@ client and talks to the server through public Daytona preview URLs.
 6. `/opt/openwork-daytona/start-daytona-electron.sh` sources optional secrets,
    applies Daytona-safe Chromium flags, and starts Electron on display `:99`.
 7. **CDP on port 9825** enables Chrome MCP and browser-tool automation.
+8. Optional artifact capture mounts `/daytona-artifacts`, serves it on port 8090,
+   and records display `:99` with ffmpeg when `--record-video` is passed.
 
 ## Testing the customization system
 

--- a/.devcontainer/start-daytona-recording.sh
+++ b/.devcontainer/start-daytona-recording.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Record the Daytona Electron display to an mp4 artifact. Stop with SIGINT so
+# ffmpeg finalizes the file cleanly.
+
+OUTPUT="/daytona-artifacts/recordings/daytona-recording.mp4"
+SIZE="1920x1080"
+FPS="15"
+LOG_PATH="/tmp/daytona-recording.log"
+DETACH=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --detach)
+      DETACH=1
+      ;;
+    --output)
+      shift
+      OUTPUT="${1:?missing output path}"
+      ;;
+    --size)
+      shift
+      SIZE="${1:?missing recording size}"
+      ;;
+    --fps)
+      shift
+      FPS="${1:?missing recording fps}"
+      ;;
+    --log)
+      shift
+      LOG_PATH="${1:?missing log path}"
+      ;;
+    --help|-h)
+      printf '%s\n' \
+        "Usage: start-daytona-recording.sh [--detach] [--output PATH] [--size WxH] [--fps N]" \
+        "" \
+        "Records DISPLAY, defaulting to :99, and writes an mp4 file."
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      echo "Unexpected argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "ERROR: ffmpeg is required for Daytona display recording." >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+FFMPEG_ARGS=(
+  -y
+  -f x11grab
+  -video_size "$SIZE"
+  -framerate "$FPS"
+  -i "${DISPLAY:-:99}"
+  -codec:v libx264
+  -preset veryfast
+  -pix_fmt yuv420p
+  "$OUTPUT"
+)
+
+if [ "$DETACH" -eq 1 ]; then
+  nohup ffmpeg "${FFMPEG_ARGS[@]}" >"$LOG_PATH" 2>&1 &
+  echo "Recording started: $OUTPUT"
+  echo "Recording log: $LOG_PATH"
+  exit 0
+fi
+
+exec ffmpeg "${FFMPEG_ARGS[@]}"

--- a/.devcontainer/start-daytona-recording.sh
+++ b/.devcontainer/start-daytona-recording.sh
@@ -55,7 +55,21 @@ if ! command -v ffmpeg >/dev/null 2>&1; then
   exit 1
 fi
 
-mkdir -p "$(dirname "$OUTPUT")"
+if [ "$DETACH" -eq 1 ]; then
+  SCRIPT_PATH="${BASH_SOURCE[0]}"
+  nohup bash "$SCRIPT_PATH" --output "$OUTPUT" --size "$SIZE" --fps "$FPS" >"$LOG_PATH" 2>&1 &
+  echo "Recording started: $OUTPUT"
+  echo "Recording log: $LOG_PATH"
+  exit 0
+fi
+
+FINAL_OUTPUT="$OUTPUT"
+RECORD_OUTPUT="$OUTPUT"
+if [[ "$OUTPUT" = /daytona-artifacts/* ]]; then
+  RECORD_OUTPUT="/tmp/daytona-recording-$(basename "$OUTPUT")"
+fi
+
+mkdir -p "$(dirname "$RECORD_OUTPUT")"
 
 FFMPEG_ARGS=(
   -y
@@ -66,14 +80,17 @@ FFMPEG_ARGS=(
   -codec:v libx264
   -preset veryfast
   -pix_fmt yuv420p
-  "$OUTPUT"
+  "$RECORD_OUTPUT"
 )
 
-if [ "$DETACH" -eq 1 ]; then
-  nohup ffmpeg "${FFMPEG_ARGS[@]}" >"$LOG_PATH" 2>&1 &
-  echo "Recording started: $OUTPUT"
-  echo "Recording log: $LOG_PATH"
-  exit 0
+set +e
+ffmpeg "${FFMPEG_ARGS[@]}"
+status="$?"
+set -e
+
+if [ "$RECORD_OUTPUT" != "$FINAL_OUTPUT" ]; then
+  mkdir -p "$(dirname "$FINAL_OUTPUT")"
+  cp "$RECORD_OUTPUT" "$FINAL_OUTPUT"
 fi
 
-exec ffmpeg "${FFMPEG_ARGS[@]}"
+exit "$status"

--- a/.devcontainer/test-on-daytona.sh
+++ b/.devcontainer/test-on-daytona.sh
@@ -6,17 +6,25 @@ set -euo pipefail
 # Usage:
 #   bash .devcontainer/test-on-daytona.sh [branch-or-commit]
 #   bash .devcontainer/test-on-daytona.sh [branch-or-commit] --force-install
+#   bash .devcontainer/test-on-daytona.sh [branch-or-commit] --artifacts-volume
+#   bash .devcontainer/test-on-daytona.sh [branch-or-commit] --record-video
 #   bash .devcontainer/setup-daytona-secrets-volume.sh [.newtoken]
 #
 # Creates a Daytona sandbox from the reusable VNC snapshot, checks out the given
 # ref, installs dependencies with a workspace-local pnpm store when needed,
-# starts `pnpm dev:sandbox`, and prints CDP/noVNC URLs.
+# starts `pnpm dev:sandbox`, and prints CDP/noVNC URLs. Optionally mounts an
+# artifacts volume and records the Electron display.
 
 REF=""
 FORCE_INSTALL=0
 DEN_BASE_URL=""
 DEN_API_BASE_URL=""
 DEN_REQUIRE_SIGNIN=0
+ARTIFACTS_ENABLED=0
+RECORD_VIDEO=0
+RECORDING_NAME=""
+RECORDING_FPS="15"
+RECORDING_SIZE="1920x1080"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -38,8 +46,27 @@ while [ "$#" -gt 0 ]; do
     --require-signin)
       DEN_REQUIRE_SIGNIN=1
       ;;
+    --artifacts-volume)
+      ARTIFACTS_ENABLED=1
+      ;;
+    --record-video)
+      ARTIFACTS_ENABLED=1
+      RECORD_VIDEO=1
+      ;;
+    --recording-name)
+      shift
+      RECORDING_NAME="${1:?missing recording name}"
+      ;;
+    --recording-fps)
+      shift
+      RECORDING_FPS="${1:?missing recording fps}"
+      ;;
+    --recording-size)
+      shift
+      RECORDING_SIZE="${1:?missing recording size}"
+      ;;
     --help|-h)
-      sed -n '1,12p' "$0"
+      sed -n '1,16p' "$0"
       exit 0
       ;;
     --*)
@@ -65,12 +92,31 @@ fi
 SANDBOX="openwork-test-$(date +%Y%m%d-%H%M%S)"
 CDP_PORT=9825
 NOVNC_PORT=6080
+ARTIFACTS_PORT=8090
 MAX_WAIT=90
 DAYTONA_EVAL_SNAPSHOT="${DAYTONA_EVAL_SNAPSHOT:-openwork-eval-vnc}"
 DAYTONA_SECRETS_VOLUME="${DAYTONA_SECRETS_VOLUME:-openwork-eval-secrets}"
 DAYTONA_SECRETS_MOUNT="${DAYTONA_SECRETS_MOUNT:-/daytona-secrets}"
 DAYTONA_SECRETS_ENV="${DAYTONA_SECRETS_ENV:-${DAYTONA_SECRETS_MOUNT}/openai.env}"
+DAYTONA_ARTIFACTS_VOLUME="${DAYTONA_ARTIFACTS_VOLUME:-openwork-eval-artifacts}"
+DAYTONA_ARTIFACTS_MOUNT="${DAYTONA_ARTIFACTS_MOUNT:-/daytona-artifacts}"
 DAYTONA_ELECTRON_EXTRA_LAUNCH_ARGS="${DAYTONA_ELECTRON_EXTRA_LAUNCH_ARGS:---disable-gpu --disable-dev-shm-usage --enable-unsafe-swiftshader}"
+
+if [ -z "$RECORDING_NAME" ]; then
+  RECORDING_NAME="$SANDBOX"
+fi
+if [[ ! "$RECORDING_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "ERROR: recording name may only contain letters, numbers, dots, underscores, and dashes" >&2
+  exit 1
+fi
+if [[ ! "$RECORDING_FPS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: recording fps must be a positive integer" >&2
+  exit 1
+fi
+if [[ ! "$RECORDING_SIZE" =~ ^[0-9]+x[0-9]+$ ]]; then
+  echo "ERROR: recording size must use WxH format, for example 1920x1080" >&2
+  exit 1
+fi
 
 volume_field() {
   local name="$1"
@@ -114,6 +160,18 @@ fi
 wait_for_volume_ready "$DAYTONA_SECRETS_VOLUME"
 DAYTONA_SECRETS_VOLUME_ID="$(volume_field "$DAYTONA_SECRETS_VOLUME" id)"
 
+DAYTONA_ARTIFACTS_VOLUME_ID=""
+if [ "$ARTIFACTS_ENABLED" -eq 1 ]; then
+  echo ""
+  echo "==> Ensuring reusable artifacts volume: $DAYTONA_ARTIFACTS_VOLUME"
+  volume_create_output="$(daytona volume create "$DAYTONA_ARTIFACTS_VOLUME" --size 5 2>&1 || true)"
+  if [ -n "$volume_create_output" ] && ! printf '%s' "$volume_create_output" | grep -qi "already exists"; then
+    printf '%s\n' "$volume_create_output"
+  fi
+  wait_for_volume_ready "$DAYTONA_ARTIFACTS_VOLUME"
+  DAYTONA_ARTIFACTS_VOLUME_ID="$(volume_field "$DAYTONA_ARTIFACTS_VOLUME" id)"
+fi
+
 SNAPSHOT_ID="$(snapshot_id "$DAYTONA_EVAL_SNAPSHOT")"
 if [ -z "$SNAPSHOT_ID" ]; then
   echo "ERROR: Daytona snapshot '$DAYTONA_EVAL_SNAPSHOT' not found." >&2
@@ -122,13 +180,18 @@ if [ -z "$SNAPSHOT_ID" ]; then
 fi
 
 echo "==> Using Daytona snapshot: $DAYTONA_EVAL_SNAPSHOT"
-daytona create \
-  --name "$SANDBOX" \
-  --snapshot "$SNAPSHOT_ID" \
-  --volume "${DAYTONA_SECRETS_VOLUME_ID}:${DAYTONA_SECRETS_MOUNT}" \
-  --auto-stop 60 \
-  --public \
+DAYTONA_CREATE_ARGS=(
+  --name "$SANDBOX"
+  --snapshot "$SNAPSHOT_ID"
+  --volume "${DAYTONA_SECRETS_VOLUME_ID}:${DAYTONA_SECRETS_MOUNT}"
+  --auto-stop 60
+  --public
   --target us
+)
+if [ "$ARTIFACTS_ENABLED" -eq 1 ]; then
+  DAYTONA_CREATE_ARGS+=(--volume "${DAYTONA_ARTIFACTS_VOLUME_ID}:${DAYTONA_ARTIFACTS_MOUNT}")
+fi
+daytona create "${DAYTONA_CREATE_ARGS[@]}"
 
 echo ""
 echo "==> Waiting for sandbox exec readiness..."
@@ -143,6 +206,12 @@ done
 if [ "$exec_ready" -ne 1 ]; then
   echo "ERROR: sandbox did not become exec-ready" >&2
   exit 1
+fi
+
+if [ "$ARTIFACTS_ENABLED" -eq 1 ]; then
+  echo ""
+  echo "==> Starting artifacts download server..."
+  daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; mkdir -p \"$DAYTONA_ARTIFACTS_MOUNT/recordings\"; nohup python3 -m http.server $ARTIFACTS_PORT --directory \"$DAYTONA_ARTIFACTS_MOUNT\" >/tmp/daytona-artifacts.log 2>&1 &'"
 fi
 
 echo ""
@@ -176,6 +245,14 @@ if [ "$elapsed" -ge "$MAX_WAIT" ]; then
   exit 1
 fi
 
+RECORDING_PATH=""
+if [ "$RECORD_VIDEO" -eq 1 ]; then
+  RECORDING_PATH="${DAYTONA_ARTIFACTS_MOUNT}/recordings/${RECORDING_NAME}.mp4"
+  echo ""
+  echo "==> Starting Daytona display recording..."
+  daytona exec "$SANDBOX" -- "bash -lc 'cd /workspace; DISPLAY=:99 .devcontainer/start-daytona-recording.sh --detach --output \"$RECORDING_PATH\" --size \"$RECORDING_SIZE\" --fps \"$RECORDING_FPS\"'"
+fi
+
 echo ""
 if daytona exec "$SANDBOX" -- "bash -lc 'ps aux | grep opencode | grep -v grep'" 2>/dev/null | grep -q opencode; then
   echo "==> opencode sidecar: running"
@@ -190,6 +267,14 @@ fi
 
 CDP_URL=$(daytona preview-url "$SANDBOX" -p "$CDP_PORT" 2>/dev/null | grep -v "^time=")
 NOVNC_URL=$(daytona preview-url "$SANDBOX" -p "$NOVNC_PORT" 2>/dev/null | grep -v "^time=")
+ARTIFACTS_URL=""
+RECORDING_URL=""
+if [ "$ARTIFACTS_ENABLED" -eq 1 ]; then
+  ARTIFACTS_URL=$(daytona preview-url "$SANDBOX" -p "$ARTIFACTS_PORT" 2>/dev/null | grep -v "^time=")
+fi
+if [ "$RECORD_VIDEO" -eq 1 ]; then
+  RECORDING_URL="${ARTIFACTS_URL%/}/recordings/${RECORDING_NAME}.mp4"
+fi
 
 echo ""
 echo "============================================"
@@ -197,6 +282,15 @@ echo "  Sandbox ready: $SANDBOX"
 echo ""
 echo "  Electron CDP:  $CDP_URL"
 echo "  noVNC visual:  $NOVNC_URL"
+if [ "$ARTIFACTS_ENABLED" -eq 1 ]; then
+  echo "  Artifacts:     $ARTIFACTS_URL"
+fi
+if [ "$RECORD_VIDEO" -eq 1 ]; then
+  echo "  Recording:     $RECORDING_URL"
+  echo ""
+  echo "  Stop recording:"
+  echo "    daytona exec $SANDBOX -- 'pkill -INT -f \"ffmpeg.*x11grab\"'"
+fi
 echo ""
 echo "  Connect browser tools:"
 echo "    browser_list({ browser_url: \"$CDP_URL\" })"

--- a/.github/workflows/daytona-eval-image.yml
+++ b/.github/workflows/daytona-eval-image.yml
@@ -8,6 +8,7 @@ on:
       - .devcontainer/Dockerfile.daytona-vnc
       - .devcontainer/start-daytona-vnc.sh
       - .devcontainer/start-daytona-electron.sh
+      - .devcontainer/start-daytona-recording.sh
       - .github/workflows/daytona-eval-image.yml
       - pnpm-lock.yaml
       - package.json

--- a/evals/daytona-flows.md
+++ b/evals/daytona-flows.md
@@ -26,6 +26,28 @@ Create/populate it once with `bash .devcontainer/setup-daytona-secrets-volume.sh
 before Electron starts. The Electron starter also applies Daytona-safe Chromium
 flags via `ELECTRON_EXTRA_LAUNCH_ARGS`.
 
+To persist downloadable artifacts, pass `--artifacts-volume`. The helper mounts
+the reusable `openwork-eval-artifacts` volume at `/daytona-artifacts`, starts a
+static download server, and prints its Daytona preview URL.
+
+To record the Electron display, pass `--record-video`:
+
+```bash
+bash .devcontainer/test-on-daytona.sh [branch-or-commit] --record-video
+```
+
+`--record-video` implies `--artifacts-volume` and writes an mp4 under
+`/daytona-artifacts/recordings`. The helper prints the direct recording URL and
+the stop command:
+
+```bash
+daytona exec <sandbox> -- 'pkill -INT -f "ffmpeg.*x11grab"'
+```
+
+Use `SIGINT` so ffmpeg finalizes the mp4 cleanly before downloading it. Optional
+recording controls are `--recording-name <name>`, `--recording-fps <fps>`, and
+`--recording-size <WxH>`.
+
 ### 2. Get the CDP proxy URL
 
 Use the Electron CDP URL printed by `test-on-daytona.sh`. It looks like


### PR DESCRIPTION
## Summary
- add opt-in Daytona artifacts volume mounting and download server output
- add optional ffmpeg-based Electron display recording helper
- document artifact and recording flows for Daytona evals

## Testing
- `bash -n .devcontainer/test-on-daytona.sh`
- `bash -n .devcontainer/start-daytona-recording.sh`
- `bash .devcontainer/test-on-daytona.sh --help`
- `bash .devcontainer/start-daytona-recording.sh --help`
- `git diff --check`

Did not run a live Daytona recording sandbox from this PR branch in this turn. The PR includes the exact flow to verify with `bash .devcontainer/test-on-daytona.sh <branch> --record-video`.