### PR TITLE
fix: add missing gap between “Disconnect” and “Close” buttons in ExtensionDetailModal

### DIFF
--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -195,9 +195,8 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
             {/* Icon */}
             <div className="relative shrink-0">
               <div
-                className={`flex size-12 items-center justify-center rounded-xl border ${
-                  connected ? "border-green-6 bg-green-2" : "border-dls-border bg-dls-hover"
-                }`}
+                className={`flex size-12 items-center justify-center rounded-xl border ${connected ? "border-green-6 bg-green-2" : "border-dls-border bg-dls-hover"
+                  }`}
               >
                 {resolvedIconSrc ? (
                   <div className="flex size-8 items-center justify-center rounded-md bg-white">
@@ -345,7 +344,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
         </div>
 
         <DialogFooter className="shrink-0">
-          <div className="flex justify-between">
+          <div className="flex justify-between gap-2">
             <div>
               {connected && onUninstall ? (
                 <Button


### PR DESCRIPTION
## Summary
- Adds a small horizontal gap between the Disconnect and Close buttons in the Extension Detail modal. This resolves the UI overflow where the two buttons were rendered flush together.

## Why
- During testing of the reload‑toast fix (issue #1116) a new visual regression was discovered: the button row in ExtensionDetailModal has no spacing, causing the UI to look cramped and making the “Disconnect” action hard to tap.

## Issue
- Closes #1116 

## Scope
- UI only – no functional changes.
- Adjusts the flex container in extension-detail-modal.tsx to include gap-2.

## Out of scope
- Any changes to the toast component or backend logic.

## Evidence
- video/screenshot link, or `N/A (docs-only)`


<img width="1165" height="790" alt="Screenshot 2026-05-23 at 2 22 44 AM" src="https://github.com/user-attachments/assets/d9ab9ba8-2550-4021-9130-7fdddd0aacf0" />



Previously as mentioned in https://github.com/different-ai/openwork/issues/1116#issuecomment-4522614552
<img width="1169" height="792" alt="Screenshot 2026-05-23 at 2 13 27 AM" src="https://github.com/user-attachments/assets/07d0bdce-90fa-47f7-a4ae-189c519f0cbf" />