### PR TITLE
Add desktop policy to disable built-in extensions

### DIFF
--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -24,6 +24,8 @@ export type ExtensionCardProps = {
   disabled?: boolean;
   /** Whether this item is hidden from the normal catalog view. */
   hidden?: boolean;
+  /** Reason this item is visible but unavailable. */
+  disabledReason?: string | null;
   /** Action label shown at bottom. */
   actionLabel?: string;
   /** Click handler. */
@@ -63,6 +65,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
     connecting = false,
     disabled = false,
     hidden = false,
+    disabledReason = null,
     actionLabel,
     onClick,
   } = props;
@@ -128,9 +131,19 @@ export function ExtensionCard(props: ExtensionCardProps) {
                 Hidden
               </span>
             ) : null}
+            {disabledReason ? (
+              <span className="rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
+                Disabled
+              </span>
+            ) : null}
           </div>
           <p className="mt-0.5 line-clamp-2 text-xs text-dls-secondary">{description}</p>
-          {!connecting && actionLabel ? (
+          {disabledReason ? (
+            <div className="mt-2 text-[11px] font-medium text-amber-11">
+              {disabledReason}
+            </div>
+          ) : null}
+          {!disabledReason && !connecting && actionLabel ? (
             <div className="mt-2 text-[11px] font-medium text-dls-text transition-colors group-hover:opacity-80">
               {actionLabel}
             </div>

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -43,6 +43,8 @@ export type ExtensionDetailModalProps = {
   connecting?: boolean;
   /** Whether this item is hidden from the normal extensions catalog. */
   hidden?: boolean;
+  /** Reason this item is visible but unavailable. */
+  disabledReason?: string | null;
   /** Remote URL if applicable. */
   url?: string;
   /** Whether OAuth is required. */
@@ -177,6 +179,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
     connected = false,
     connecting = false,
     hidden = false,
+    disabledReason = null,
     url,
     oauth,
     launchCommand,
@@ -314,6 +317,13 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                     <span className="text-muted-foreground">Visibility</span>
                     <span className="font-medium text-card-foreground">{hidden ? "Hidden" : "Shown"}</span>
                   </div>
+
+                  {disabledReason ? (
+                    <div className="flex items-center justify-between gap-4 text-sm">
+                      <span className="text-muted-foreground">Availability</span>
+                      <span className="text-right font-medium text-amber-11">{disabledReason}</span>
+                    </div>
+                  ) : null}
                 </div>
               </CardContent>
             </Card>

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -8,6 +8,7 @@ import type { CloudImportedPlugin, CloudImportedPluginFile } from "../../../../.
 import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "../../../../../app/types";
 import { t } from "../../../../../i18n";
 import { isOpenWorkExtensionEnabled, isOpenWorkExtensionHidden, OPENWORK_EXTENSION_STATE_CHANGED } from "../../../settings/extension-state";
+import { useDesktopRestriction } from "../../../cloud/desktop-config-provider";
 import { ModelBehaviorSelect } from "../../../../../components/model-behavior-select";
 import { ModelSelect } from "../../../../../components/model-select";
 import { LexicalPromptEditor } from "./editor";
@@ -259,6 +260,7 @@ function pluginSlashCommandName(file: CloudImportedPluginFile) {
 }
 
 export function ReactSessionComposer(props: ComposerProps) {
+  const builtInExtensionsDisabled = useDesktopRestriction("allowBuiltInExtensions");
   let fileInput: HTMLInputElement | undefined;
   const [agents, setAgents] = useState<Agent[]>([]);
   const [agentMenuOpen, setAgentMenuOpen] = useState(false);
@@ -635,6 +637,7 @@ export function ReactSessionComposer(props: ComposerProps) {
     ? pluginSections.find((entry) => entry.section === toolMenuSection)?.plugin ?? null
     : null;
   const composerExtensions = OPENWORK_EXTENSION_CATALOG.filter((entry) =>
+    !builtInExtensionsDisabled &&
     !isOpenWorkExtensionHidden(entry) && (!entry.defaultEnabled || isOpenWorkExtensionEnabled(entry))
   );
   const canSend = props.draft.trim().length > 0 || props.attachments.length > 0;

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -106,7 +106,15 @@ export type McpViewProps = {
   configSlotForEntry?: (entry: McpDirectoryInfo) => React.ReactNode | null;
   /** Check if an extension-kind entry is connected/active. */
   isExtensionConnected?: (entry: McpDirectoryInfo) => boolean;
+  /** Organization policy restriction for OpenWork-provided built-in extensions. */
+  builtInExtensionsDisabled?: boolean;
 };
+
+const builtInExtensionDisabledReason = "Disabled by organization";
+
+function isBuiltInExtension(entry: McpDirectoryInfo) {
+  return entry.kind === "extension";
+}
 
 const statusDot = (status: ReactMcpStatus) => {
   switch (status) {
@@ -367,6 +375,10 @@ export function McpView(props: McpViewProps) {
   const hiddenCount = quickConnectList.filter((entry) => isOpenWorkExtensionHidden(entry)).length +
     (props.installedSkills ?? []).filter((skill) => isOpenWorkExtensionHidden(getSkillHiddenId(skill))).length +
     (props.installedPlugins ?? []).filter((plugin) => isOpenWorkExtensionHidden(`plugin:${plugin.pluginId}`)).length;
+  const policyHiddenBuiltInCount = props.builtInExtensionsDisabled
+    ? quickConnectList.filter((entry) => isBuiltInExtension(entry) && !isOpenWorkExtensionHidden(entry)).length
+    : 0;
+  const hiddenOrPolicyCount = hiddenCount + policyHiddenBuiltInCount;
 
   const requestLogout = (name: string) => {
     if (!name.trim()) return;
@@ -432,6 +444,12 @@ export function McpView(props: McpViewProps) {
         </div>
       ) : null}
 
+      {props.builtInExtensionsDisabled ? (
+        <div className="rounded-xl border border-amber-6 bg-amber-2 px-4 py-3 text-xs text-amber-11">
+          Built-in OpenWork extensions are disabled by your organization. Use Show hidden to review blocked built-ins.
+        </div>
+      ) : null}
+
       <McpCustomAppCard onOpen={() => setAddMcpModalOpen(true)} />
 
       {/* Search + filter */}
@@ -461,7 +479,7 @@ export function McpView(props: McpViewProps) {
             size="xs"
             onClick={() => setShowHidden((current) => !current)}
           >
-            {showHidden ? "Showing hidden" : hiddenCount > 0 ? `Show hidden (${hiddenCount})` : "Show hidden"}
+            {showHidden ? "Showing hidden" : hiddenOrPolicyCount > 0 ? `Show hidden (${hiddenOrPolicyCount})` : "Show hidden"}
           </Button>
         </div>
       </div>
@@ -469,7 +487,7 @@ export function McpView(props: McpViewProps) {
       <McpQuickConnectSection
         entries={
           quickConnectList.filter((entry) => {
-            if (!showHidden && isOpenWorkExtensionHidden(entry)) return false;
+            if (!showHidden && (isOpenWorkExtensionHidden(entry) || (props.builtInExtensionsDisabled && isBuiltInExtension(entry)))) return false;
             if (filter === "skill") return false;
             if (filter === "mcp" && (entry.kind ?? "mcp") !== "mcp" && entry.kind !== "ui-control") return false;
             if (!search.trim()) return true;
@@ -503,8 +521,15 @@ export function McpView(props: McpViewProps) {
         isEntryHidden={(entry) => isOpenWorkExtensionHidden(entry)}
         isSkillHidden={(skill) => isOpenWorkExtensionHidden(getSkillHiddenId(skill))}
         isPluginHidden={(plugin) => isOpenWorkExtensionHidden(`plugin:${plugin.pluginId}`)}
+        disabledReasonForEntry={(entry) =>
+          props.builtInExtensionsDisabled && isBuiltInExtension(entry)
+            ? builtInExtensionDisabledReason
+            : null
+        }
         isConfigured={(entry) =>
-          entry.kind === "extension"
+          props.builtInExtensionsDisabled && isBuiltInExtension(entry)
+            ? false
+            : entry.kind === "extension"
             ? (entry.defaultEnabled ? isOpenWorkExtensionEnabled(entry) : props.isExtensionConnected?.(entry) ?? false)
             : isQuickConnectConfigured(entry)
         }
@@ -608,7 +633,12 @@ export function McpView(props: McpViewProps) {
         const extensionConfigSlot = props.configSlotForEntry?.(detailEntry) ?? null;
         const hasConfigSlot = extensionConfigSlot !== null;
         const hidden = isOpenWorkExtensionHidden(detailEntry);
-        const isConnected = detailEntry.kind === "extension"
+        const disabledReason = props.builtInExtensionsDisabled && isBuiltInExtension(detailEntry)
+          ? builtInExtensionDisabledReason
+          : null;
+        const isConnected = disabledReason
+          ? false
+          : detailEntry.kind === "extension"
           ? (detailEntry.defaultEnabled ? isOpenWorkExtensionEnabled(detailEntry) : props.isExtensionConnected?.(detailEntry) ?? false)
           : isQuickConnectConfigured(detailEntry);
         return (
@@ -624,19 +654,20 @@ export function McpView(props: McpViewProps) {
             connected={isConnected}
             connecting={props.mcpConnectingName === detailEntry.name}
             hidden={hidden}
+            disabledReason={disabledReason}
             launchCommand={detailEntry.serverName === "openwork-ui" ? openworkUiMcpCommand ?? undefined : undefined}
             environment={detailEntry.serverName === "openwork-ui" ? openworkUiMcpEnvironment ?? undefined : undefined}
             url={typeof detailEntry.url === "string" ? detailEntry.url : undefined}
             oauth={detailEntry.oauth}
-            configSlot={extensionConfigSlot}
-            onConnect={detailEntry.defaultEnabled ? () => {
+            configSlot={disabledReason ? null : extensionConfigSlot}
+            onConnect={disabledReason ? undefined : detailEntry.defaultEnabled ? () => {
               setOpenWorkExtensionEnabled(detailEntry, true);
               setDetailEntry(null);
             } : hasConfigSlot ? undefined : () => {
               props.connectMcp(detailEntry);
               setDetailEntry(null);
             }}
-            onUninstall={detailEntry.defaultEnabled && isConnected ? () => {
+            onUninstall={disabledReason ? undefined : detailEntry.defaultEnabled && isConnected ? () => {
               setOpenWorkExtensionEnabled(detailEntry, false);
             } : isQuickConnectConfigured(detailEntry) ? () => {
               const slug = getMcpIdentityKey(detailEntry);
@@ -743,6 +774,7 @@ function McpQuickConnectSection(props: {
   isEntryHidden: (entry: McpDirectoryInfo) => boolean;
   isSkillHidden: (skill: SkillItem) => boolean;
   isPluginHidden: (plugin: CloudImportedPlugin) => boolean;
+  disabledReasonForEntry: (entry: McpDirectoryInfo) => string | null;
   isConfigured: (entry: McpDirectoryInfo) => boolean;
   statusForEntry: (entry: McpDirectoryInfo) => { status: ReactMcpStatus } | undefined;
   onConnect: (entry: McpDirectoryInfo) => void;
@@ -766,6 +798,7 @@ function McpQuickConnectSection(props: {
           const connecting = props.connectingName === entry.name;
           const FallbackIcon = serviceIcon(entry.name);
           const hidden = props.isEntryHidden(entry);
+          const disabledReason = props.disabledReasonForEntry(entry);
 
           return (
             <ExtensionCard
@@ -779,6 +812,7 @@ function McpQuickConnectSection(props: {
               connected={configured}
               connecting={connecting}
               hidden={hidden}
+              disabledReason={disabledReason}
               disabled={props.busy}
               actionLabel={configured ? "View details" : t("mcp.tap_to_connect")}
               onClick={() => props.onDetail(entry)}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1957,6 +1957,7 @@ function SettingsRouteContent() {
                 selectedMcp={connectionsSnapshot.selectedMcp}
                 setSelectedMcp={(name) => connectionsStore.setSelectedMcp(name)}
                 quickConnect={connectionsStore.quickConnect}
+                builtInExtensionsDisabled={checkDesktopRestriction({ restriction: "allowBuiltInExtensions" })}
                 connectMcp={(entry) => {
                   void connectionsStore.connectMcp(entry);
                 }}

--- a/evals/README.md
+++ b/evals/README.md
@@ -87,6 +87,9 @@ takes `browser_url` as the first argument.
   menu, extension toggle, and stale MCP migration.
 - [`extensions-marketplace-flows.md`](./extensions-marketplace-flows.md) —
   extension runtime and marketplace install/remove/search/filter flows.
+- [`desktop-policy-extension-flows.md`](./desktop-policy-extension-flows.md) —
+  admin-to-member extension policy flows for disabling and restoring built-in
+  extensions.
 - [`workspace-layout-state-flows.md`](./workspace-layout-state-flows.md) —
   persisted sidebar/browser layout, legacy layout migration, and workspace-safe
   layout state.

--- a/evals/desktop-policy-extension-flows.md
+++ b/evals/desktop-policy-extension-flows.md
@@ -1,0 +1,63 @@
+# Desktop policy extension flows
+
+End-to-end scenarios for organization-managed extension policy. These flows are
+the PR 2 baseline for Daytona/CDP automation and recordings.
+
+## Flow 1: Disable built-in extensions for a member
+
+**Goal:** An admin disables built-in OpenWork extensions and the assigned member
+desktop stops showing or offering those extensions in normal UI.
+
+### Admin setup
+
+1. Sign in to Den as an org owner or admin.
+2. Open Dashboard -> Desktop policies.
+3. Create or edit a policy.
+4. Turn off `Built-in Extensions`.
+5. Assign the policy to the target member or a team containing that member.
+6. Save the policy.
+
+### Desktop steps
+
+1. Sign in to the desktop app as the assigned member.
+2. Open Settings -> Extensions -> My Extensions.
+3. Confirm built-in extension cards such as `OpenWork Browser`, `Chrome`,
+   `OpenAI Image Gen`, and `Ollama` are absent from the normal catalog.
+4. Click `Show hidden`.
+5. Confirm the same built-in extensions appear with `Disabled by organization`.
+6. Open the composer tool menu -> Extensions.
+
+### Expected outcome
+
+- The member desktop receives the policy without an app restart.
+- Normal My Extensions does not show built-in extension cards.
+- `Show hidden` reveals blocked built-ins with `Disabled by organization`.
+- Built-in extension detail modals do not expose connect/install actions.
+- Composer Extensions has no built-in extension shortcuts.
+- Marketplace packages, custom MCPs, skills, providers, and workers are not
+  disabled by this policy.
+
+## Flow 2: Re-enable built-in extensions for a member
+
+**Goal:** Reverting the policy restores built-in extensions dynamically.
+
+### Admin setup
+
+1. As org owner or admin, edit the same desktop policy.
+2. Turn on `Built-in Extensions`.
+3. Save the policy.
+
+### Desktop steps
+
+1. Keep the assigned member desktop app open.
+2. Refresh the desktop policy context by switching orgs, refreshing Cloud
+   Account, or waiting for policy refresh.
+3. Open Settings -> Extensions -> My Extensions.
+4. Open the composer tool menu -> Extensions.
+
+### Expected outcome
+
+- Built-in extension cards return to the normal runtime extension list.
+- Composer Extensions shows enabled built-in shortcuts again.
+- Existing local hidden/disabled preferences are preserved independently of the
+  org policy toggle.

--- a/packages/types/src/den/desktop-policies.ts
+++ b/packages/types/src/den/desktop-policies.ts
@@ -66,6 +66,15 @@ export const desktopPolicyDefinitions = [
     defaultValue: true,
   },
   {
+    id: "allowBuiltInExtensions",
+    name: "Built-in Extensions",
+    description:
+      "Allow users to see and use OpenWork's built-in extensions, including browser, image, and local-provider extensions.",
+    userNotice:
+      "Your organization administrator has disabled built-in OpenWork extensions.",
+    defaultValue: true,
+  },
+  {
     id: "showWelcomePage",
     name: "Welcome Page",
     description: "Show the Getting Started page to new users.",


### PR DESCRIPTION
## Summary
- adds `allowBuiltInExtensions` to desktop policy definitions
- hides built-in OpenWork extension rows from normal My Extensions when disabled by policy
- lets Show hidden reveal policy-disabled built-ins with `Disabled by organization`
- suppresses connect/install CTAs for policy-disabled built-ins
- filters built-in extension shortcuts out of the composer when policy-disabled
- adds desktop-policy extension eval flows

## Verification
- pnpm --filter @openwork/app typecheck: passed
- pnpm --filter @openwork/app build: passed

## Base
- Rebuilt directly on `dev` after PR #1909 merged.

## Daytona evidence
- The two-sandbox recording from before the rebase was run from this branch plus PR #1909 code and covers the real Den-backed marketplace add/remove path: https://8090-dpnsggjf0za2ype2.daytonaproxy01.net/recordings/extension-den-marketplace-policy.mp4

## Remaining eval gap
- The admin-created desktop policy assignment flow is documented in `evals/desktop-policy-extension-flows.md` but I have not yet completed the full admin policy assignment recording in Den Web.