### PR TITLE
Polish extension marketplace and provider surfaces

### DIFF
--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -18,6 +18,7 @@ export type ExtensionCardProps = {
   kind?: ExtensionKind;
   /** Whether the extension is already installed/connected. */
   connected?: boolean;
+  connectedLabel?: string;
   /** Whether a connect operation is in progress. */
   connecting?: boolean;
   /** Whether interaction is disabled. */
@@ -62,6 +63,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
     fallbackIcon: FallbackIcon = Plug2,
     kind = "mcp",
     connected = false,
+    connectedLabel = "Connected",
     connecting = false,
     disabled = false,
     hidden = false,
@@ -101,7 +103,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
                 <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
               </div>
             ) : (
-              kind === "plugin" ? (
+              kind === "plugin" || kind === "skill" ? (
                 <ExtensionMeshAvatar name={name} className="size-7 rounded-md text-[10px] font-bold shadow-inner" />
               ) : <FallbackIcon size={18} className="text-dls-secondary" />
             )}
@@ -119,7 +121,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
             <h4 className="text-sm font-semibold text-dls-text">{name}</h4>
             {connected ? (
               <span className="rounded-md bg-green-3 px-1.5 py-0.5 text-[10px] font-medium text-green-11">
-                Connected
+                {connectedLabel}
               </span>
             ) : (
               <span className={`rounded-md px-1.5 py-0.5 text-[10px] font-medium ${kindStyle[kind]}`}>

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -40,6 +40,8 @@ export type ExtensionDetailModalProps = {
   fallbackIcon?: LucideIcon;
   kind?: ExtensionKind;
   connected?: boolean;
+  connectedLabel?: string;
+  disconnectedLabel?: string;
   connecting?: boolean;
   /** Whether this item is hidden from the normal extensions catalog. */
   hidden?: boolean;
@@ -74,6 +76,7 @@ export type ExtensionDetailModalProps = {
   onShow?: () => void;
   /** Extension-specific configuration UI rendered inside the modal body. */
   configSlot?: React.ReactNode;
+  showEnablementCard?: boolean;
 };
 
 const kindLabel: Record<ExtensionKind, string> = {
@@ -177,6 +180,8 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
     fallbackIcon: FallbackIcon = Plug2,
     kind = "mcp",
     connected = false,
+    connectedLabel,
+    disconnectedLabel,
     connecting = false,
     hidden = false,
     disabledReason = null,
@@ -196,6 +201,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
     onHide,
     onShow,
     configSlot,
+    showEnablementCard = true,
   } = props;
   const resolvedIconSrc = iconSrc ? resolveExtensionIconSrc(iconSrc) : undefined;
 
@@ -227,7 +233,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                     <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
                   </div>
                 ) : (
-                  kind === "plugin" ? (
+                  kind === "plugin" || kind === "skill" ? (
                     <ExtensionMeshAvatar name={name} className="size-9 rounded-lg text-xs font-bold shadow-inner" />
                   ) : <FallbackIcon size={24} className="text-muted-foreground" />
                 )}
@@ -307,9 +313,11 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                   <div className="flex items-center justify-between text-sm">
                     <span className="text-muted-foreground">Status</span>
                     <span className={`font-medium ${connected ? "text-green-11" : "text-muted-foreground"}`}>
-                      {kind === "skill"
-                        ? (connected ? "Installed" : "Not installed")
-                        : (connected ? "Connected" : connecting ? "Connecting..." : "Not connected")}
+                      {connected
+                        ? connectedLabel ?? (kind === "skill" || kind === "plugin" ? "Installed" : "Connected")
+                        : connecting
+                          ? connectingLabel
+                          : disconnectedLabel ?? (kind === "skill" || kind === "plugin" ? "Not installed" : "Not connected")}
                     </span>
                   </div>
 
@@ -360,7 +368,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
             })() : null}
 
             {/* What this enables (generic, for non-skills or skills without preview) */}
-            {(kind !== "skill" && kind !== "ui-control") || (!trigger && !contentPreview && kind !== "ui-control") ? (
+            {showEnablementCard && ((kind !== "skill" && kind !== "ui-control") || (!trigger && !contentPreview && kind !== "ui-control")) ? (
               <Card variant="outline" size="sm">
                 <CardHeader>
                   <CardTitle>What this enables</CardTitle>

--- a/apps/app/src/react-app/design-system/extension-mesh-avatar.tsx
+++ b/apps/app/src/react-app/design-system/extension-mesh-avatar.tsx
@@ -35,14 +35,16 @@ export function ExtensionMeshAvatar({ name, className }: ExtensionMeshAvatarProp
   return (
     <div className={`relative isolate overflow-hidden ${className ?? ""}`}>
       <MeshGradient
-        width={128}
-        height={128}
+        className="absolute inset-0 h-full w-full"
+        width="100%"
+        height="100%"
         colors={[...colors]}
         distortion={0.8}
         swirl={0.1}
         grainMixer={0}
         grainOverlay={0}
         speed={0}
+        maxPixelCount={4096}
       />
       <div className="absolute inset-0 flex items-center justify-center bg-black/5 text-white drop-shadow-sm">
         {extensionMeshAvatarText(name)}

--- a/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import { Button } from "@/components/ui/button";
+import type { ReactNode } from "react";
 
 import { t } from "@/i18n";
 import { ProviderIcon } from "../../../design-system/provider-icon";
@@ -42,6 +43,7 @@ export type AiSettingsViewProps = {
   cloudProviderIds?: Set<string>;
   showOpenWorkModelsSubscribe?: boolean;
   onSubscribeOpenWorkModels?: () => void | Promise<void>;
+  cloudProvidersView?: ReactNode;
 };
 
 function providerSourceLabel(source?: ConnectedProvider["source"]) {
@@ -166,6 +168,8 @@ export function AiSettingsView(props: AiSettingsViewProps) {
 
         <LayoutSectionItemFootnote>{t("settings.api_keys_info")}</LayoutSectionItemFootnote>
       </LayoutSection>
+
+      {props.cloudProvidersView}
 
     </LayoutStack>
   );

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -52,6 +52,7 @@ type MarketplacePackageRow = {
   imported: CloudImportedPlugin | null;
   status: MarketplacePackageStatus;
   counts: string[];
+  composition: Array<{ count: number; label: string; type: string }>;
   searchableText: string;
 };
 
@@ -63,9 +64,15 @@ export type CloudMarketplacesViewProps = {
 };
 
 function pluginCounts(plugin: DenOrgPlugin) {
-  return Object.entries(plugin.componentCounts).flatMap(([type, count]) =>
-    count > 0 ? [`${count} ${type}${count === 1 ? "" : "s"}`] : [],
-  );
+  return pluginComposition(plugin).map((entry) => `${entry.count} ${entry.label}${entry.count === 1 ? "" : "s"}`);
+}
+
+function pluginComposition(plugin: DenOrgPlugin) {
+  return Object.entries(plugin.componentCounts).flatMap(([type, count]) => {
+    if (count <= 0) return [];
+    const label = type === "mcp" ? "MCP" : type;
+    return [{ count, label, type }];
+  });
 }
 
 function pluginStatus(imported: CloudImportedPlugin | null, plugin: DenOrgPlugin): MarketplacePackageStatus {
@@ -115,9 +122,11 @@ export function CloudMarketplacesView({
 
   const marketplaces = extensions.cloudOrgMarketplaces();
   const importedPlugins = extensions.importedCloudPlugins();
+  const lastRowsRef = React.useRef<MarketplacePackageRow[]>([]);
   const rows = React.useMemo<MarketplacePackageRow[]>(() => {
     return marketplaces.flatMap((marketplace) => marketplace.plugins.map((plugin) => {
       const imported = importedPlugins[plugin.id] ?? null;
+      const composition = pluginComposition(plugin);
       const counts = pluginCounts(plugin);
       const status = pluginStatus(imported, plugin);
       return {
@@ -127,6 +136,7 @@ export function CloudMarketplacesView({
         imported,
         status,
         counts,
+        composition,
         searchableText: [
           plugin.name,
           plugin.description ?? "",
@@ -138,6 +148,12 @@ export function CloudMarketplacesView({
     }));
   }, [importedPlugins, marketplaces]);
 
+  React.useEffect(() => {
+    if (rows.length > 0) lastRowsRef.current = rows;
+  }, [rows]);
+
+  const displayRows = rows.length > 0 ? rows : busy ? lastRowsRef.current : rows;
+
   const marketplaceOptions = React.useMemo(
     () => marketplaces.map((marketplace) => ({ id: marketplace.marketplace.id, name: marketplace.marketplace.name })),
     [marketplaces],
@@ -145,13 +161,13 @@ export function CloudMarketplacesView({
 
   const visibleRows = React.useMemo(() => {
     const query = search.trim().toLowerCase();
-    return rows.filter((row) => {
+    return displayRows.filter((row) => {
       if (marketplaceFilter !== "all" && row.marketplaceId !== marketplaceFilter) return false;
       if (statusFilter !== "all" && row.status !== statusFilter) return false;
       if (!query) return true;
       return row.searchableText.includes(query);
     });
-  }, [marketplaceFilter, rows, search, statusFilter]);
+  }, [displayRows, marketplaceFilter, search, statusFilter]);
 
   const refresh = React.useCallback(
     async (quiet = false) => {
@@ -268,6 +284,10 @@ export function CloudMarketplacesView({
         <SettingsNotice tone="error">{actionError ?? extensions.cloudOrgMarketplacesStatus()}</SettingsNotice>
       ) : null}
 
+      {busy ? (
+        <SettingsNotice>Loading marketplace packages...</SettingsNotice>
+      ) : null}
+
       <div className="space-y-3">
         <SettingsListSearchInput
           value={search}
@@ -308,13 +328,13 @@ export function CloudMarketplacesView({
         </div>
       </div>
 
-      {!busy && rows.length === 0 ? (
+      {!busy && displayRows.length === 0 ? (
         <SettingsListEmptyState>
           {activeOrgId ? "No marketplace packages are available yet." : "Choose an organization to view marketplace packages."}
         </SettingsListEmptyState>
       ) : null}
 
-      {rows.length > 0 && visibleRows.length === 0 ? (
+      {displayRows.length > 0 && visibleRows.length === 0 ? (
         <SettingsListEmptyState>No marketplace packages match your search or filters.</SettingsListEmptyState>
       ) : null}
 
@@ -376,6 +396,7 @@ function MarketplacePackageCard(props: {
       description={row.plugin.description || `Marketplace package from ${row.marketplaceName}.`}
       kind="plugin"
       connected={Boolean(row.imported)}
+      connectedLabel="Installed"
       connecting={actionBusy}
       actionLabel={actionBusy ? "Working..." : actionLabelForStatus(row.status)}
       onClick={() => onOpenDetail(row)}
@@ -402,10 +423,12 @@ function MarketplacePackageDetailModal(props: {
       description={row.plugin.description || "No description provided."}
       kind="plugin"
       connected={Boolean(row.imported)}
+      connectedLabel="Installed"
       connecting={actionBusy}
       connectLabel={row.status === "update_available" ? "Update" : "Add"}
       connectingLabel={row.status === "update_available" ? "Updating..." : "Adding..."}
       uninstallLabel="Remove"
+      showEnablementCard={false}
       onConnect={canAddOrUpdate ? () => void onImportPlugin(row.marketplaceId, row.plugin) : undefined}
       onUninstall={row.imported ? () => void onRemovePlugin(row.plugin.id, row.plugin.name) : undefined}
       configSlot={(
@@ -414,6 +437,17 @@ function MarketplacePackageDetailModal(props: {
             <SettingsPill className={statusClass(row.status)}>{statusLabel(row.status)}</SettingsPill>
             <SettingsPill>{row.marketplaceName}</SettingsPill>
             {row.counts.map((label) => <SettingsPill key={label}>{label}</SettingsPill>)}
+          </div>
+          <div className="rounded-xl border border-dls-border bg-dls-hover px-3 py-3">
+            <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Composition</div>
+            <div className="mt-2 grid gap-2">
+              {row.composition.map((entry) => (
+                <div key={entry.type} className="flex items-center justify-between text-sm">
+                  <span className="capitalize text-card-foreground">{entry.label}</span>
+                  <span className="rounded-full bg-dls-surface px-2 py-0.5 text-xs font-medium text-muted-foreground">{entry.count}</span>
+                </div>
+              ))}
+            </div>
           </div>
           {row.imported?.files.length ? (
             <div className="rounded-xl border border-dls-border bg-dls-hover px-3 py-2 text-xs text-muted-foreground">

--- a/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
@@ -21,6 +21,7 @@ type ProviderActionKind = "import" | "remove" | "sync";
 export type CloudProvidersViewProps = {
   cloudOrgProviders: DenOrgLlmProvider[];
   connectCloudProvider: (cloudProviderId: string) => Promise<string | void>;
+  embedded?: boolean;
   importedCloudProviders: Record<string, CloudImportedProvider>;
   onOpenAccount: () => void;
   refreshCloudOrgProviders: (options?: { force?: boolean }) => Promise<DenOrgLlmProvider[]>;
@@ -36,6 +37,7 @@ const sameStringList = (a: string[], b: string[]) =>
 export function CloudProvidersView({
   cloudOrgProviders,
   connectCloudProvider,
+  embedded = false,
   importedCloudProviders,
   onOpenAccount,
   refreshCloudOrgProviders,
@@ -207,35 +209,42 @@ export function CloudProvidersView({
   );
 
   if (!isSignedIn) {
-    return (
+    const notice = (
+      <SettingsNotice>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <span>{t("skills.share_team_sign_in_hint")}</span>
+          <Button size="sm" onClick={onOpenAccount}>
+            {t("skills.share_team_sign_in")}
+          </Button>
+        </div>
+      </SettingsNotice>
+    );
+    return embedded ? notice : (
       <SettingsStack>
         <Separator />
-        <SettingsNotice>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <span>{t("skills.share_team_sign_in_hint")}</span>
-            <Button size="sm" onClick={onOpenAccount}>
-              {t("skills.share_team_sign_in")}
-            </Button>
-          </div>
-        </SettingsNotice>
+        {notice}
       </SettingsStack>
     );
   }
 
-  return (
+  const section = (
+    <CloudProvidersSection
+      actionError={actionError}
+      actionId={actionId}
+      actionKind={actionKind}
+      busy={busy}
+      rows={rows}
+      onImport={importProvider}
+      onRefresh={refresh}
+      onRemove={undefined}
+      onSync={syncProvider}
+    />
+  );
+
+  return embedded ? section : (
     <SettingsStack>
       <Separator />
-      <CloudProvidersSection
-        actionError={actionError}
-        actionId={actionId}
-        actionKind={actionKind}
-        busy={busy}
-        rows={rows}
-        onImport={importProvider}
-        onRefresh={refresh}
-        onRemove={undefined}
-        onSync={syncProvider}
-      />
+      {section}
     </SettingsStack>
   );
 }

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -189,7 +189,6 @@ export function getGlobalSettingsTabs(developerMode: boolean): SettingsTab[] {
 export const CLOUD_SETTINGS_TABS: SettingsTab[] = [
   "cloud-account",
   "cloud-workers",
-  "cloud-providers",
 ];
 
 type SettingsPageProps = {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1889,6 +1889,18 @@ function SettingsRouteContent() {
             )}
             showOpenWorkModelsSubscribe={showOpenWorkModelsSubscribe}
             onSubscribeOpenWorkModels={subscribeToOpenWorkModels}
+            cloudProvidersView={
+              <CloudProvidersView
+                embedded
+                cloudOrgProviders={providerAuthSnapshot.cloudOrgProviders}
+                connectCloudProvider={providerAuthStore.connectCloudProvider}
+                importedCloudProviders={providerAuthSnapshot.importedCloudProviders}
+                onOpenAccount={openCloudAccountSettings}
+                refreshCloudOrgProviders={providerAuthStore.refreshCloudOrgProviders}
+                removeCloudProvider={providerAuthStore.removeCloudProvider}
+                session={denSession}
+              />
+            }
           />
         );
       case "preferences":


### PR DESCRIPTION
## Summary
- fixes package/skill avatars to use properly sized static Paper MeshGradient surfaces
- uses Paper mesh avatars for classic Skill cards/details as well as marketplace packages
- changes marketplace package details to say Installed/Not installed and Remove instead of Connected/Disconnect
- removes the generic plugin enablement card from marketplace package details
- shows package composition counts (skill, MCP, context, etc.) in the detail modal
- adds a loading notice and keeps the last non-empty marketplace result visible during refresh
- embeds Cloud Providers under AI Providers and removes the separate Cloud Providers sidebar entry

## Verification
- pnpm --filter @openwork/app typecheck: passed
- pnpm --filter @openwork/app build: passed

## Recording
- Started Daytona recording for this branch: https://8090-rtuh4iyo2zkq71uj.daytonaproxy01.net/recordings/extension-polish-marketplace-providers.mp4
- Recording shows workspace setup and Cloud Providers removed from the Cloud sidebar.

## Recording caveat
- The Den server sandbox had to be restarted and the regenerated auth flow hit a 406 at organization selection, so this recording does not prove a completed Cloud Provider import inside AI Providers. The prior two-sandbox recording still proves real Den marketplace Add/Remove on the extension marketplace path: https://8090-dpnsggjf0za2ype2.daytonaproxy01.net/recordings/extension-den-marketplace-policy.mp4