### PR TITLE
Expand marketplace package details

### DIFF
--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -77,6 +77,7 @@ export type ExtensionDetailModalProps = {
   /** Extension-specific configuration UI rendered inside the modal body. */
   configSlot?: React.ReactNode;
   showEnablementCard?: boolean;
+  size?: "default" | "wide";
 };
 
 const kindLabel: Record<ExtensionKind, string> = {
@@ -202,6 +203,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
     onShow,
     configSlot,
     showEnablementCard = true,
+    size = "default",
   } = props;
   const resolvedIconSrc = iconSrc ? resolveExtensionIconSrc(iconSrc) : undefined;
 
@@ -213,7 +215,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
       }}
     >
       <DialogContent
-        className="flex max-h-[90vh] min-h-0 w-full max-w-xl flex-col overflow-hidden sm:max-w-xl"
+        className={`flex max-h-[90vh] min-h-0 w-full flex-col overflow-hidden ${size === "wide" ? "max-w-3xl sm:max-w-3xl" : "max-w-xl sm:max-w-xl"}`}
       >
         <DialogHeader>
           <div className="flex min-w-0 items-start gap-4">

--- a/apps/app/src/react-app/design-system/extension-mesh-avatar.tsx
+++ b/apps/app/src/react-app/design-system/extension-mesh-avatar.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { MeshGradient } from "@paper-design/shaders-react";
+import { StaticMeshGradient } from "@paper-design/shaders-react";
 
 type ExtensionMeshAvatarProps = {
   name: string;
@@ -21,6 +21,15 @@ function paletteForName(name: string) {
   return palettes[hash];
 }
 
+function fallbackBackground(colors: readonly string[]) {
+  return [
+    `radial-gradient(circle at 20% 20%, ${colors[0]}, transparent 38%)`,
+    `radial-gradient(circle at 80% 12%, ${colors[1]}, transparent 42%)`,
+    `radial-gradient(circle at 52% 90%, ${colors[2]}, transparent 46%)`,
+    `linear-gradient(135deg, ${colors[0]}, ${colors[3]})`,
+  ].join(", ");
+}
+
 export function extensionMeshAvatarText(name: string) {
   const words = name.trim().split(/\s+/).filter(Boolean);
   const letters = words.length >= 2
@@ -33,18 +42,25 @@ export function ExtensionMeshAvatar({ name, className }: ExtensionMeshAvatarProp
   const colors = paletteForName(name);
 
   return (
-    <div className={`relative isolate overflow-hidden ${className ?? ""}`}>
-      <MeshGradient
-        className="absolute inset-0 h-full w-full"
-        width="100%"
-        height="100%"
+    <div
+      className={`relative isolate overflow-hidden ${className ?? ""}`}
+      style={{ background: fallbackBackground(colors) }}
+    >
+      <StaticMeshGradient
+        className="absolute -inset-2 h-[calc(100%+1rem)] w-[calc(100%+1rem)]"
+        width={96}
+        height={96}
         colors={[...colors]}
-        distortion={0.8}
-        swirl={0.1}
+        positions={4}
+        waveX={0.36}
+        waveY={0.42}
+        waveXShift={0.18}
+        waveYShift={0.12}
+        mixing={0.72}
         grainMixer={0}
         grainOverlay={0}
         speed={0}
-        maxPixelCount={4096}
+        maxPixelCount={9216}
       />
       <div className="absolute inset-0 flex items-center justify-center bg-black/5 text-white drop-shadow-sm">
         {extensionMeshAvatarText(name)}

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 
 import type { CloudImportedPlugin } from "../../../../app/cloud/import-state";
-import type { DenOrgMarketplaceResolved, DenOrgPlugin } from "../../../../app/lib/den";
+import type { DenOrgMarketplaceResolved, DenOrgPlugin, DenOrgPluginResolved } from "../../../../app/lib/den";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { t } from "@/i18n";
@@ -109,7 +109,7 @@ export function CloudMarketplacesView({
   onOpenAccount,
   session,
 }: CloudMarketplacesViewProps) {
-  const { activeOrganization: activeOrg, authToken, isSignedIn, user } = useCloudSession();
+  const { activeOrganization: activeOrg, authToken, client, isSignedIn, user } = useCloudSession();
   const { showToast } = useStatusToasts();
   const [busy, setBusy] = React.useState(false);
   const [actionId, setActionId] = React.useState<string | null>(null);
@@ -118,6 +118,9 @@ export function CloudMarketplacesView({
   const [statusFilter, setStatusFilter] = React.useState<MarketplaceStatusFilter>("all");
   const [marketplaceFilter, setMarketplaceFilter] = React.useState("all");
   const [detailRow, setDetailRow] = React.useState<MarketplacePackageRow | null>(null);
+  const [resolvedPlugins, setResolvedPlugins] = React.useState<Record<string, DenOrgPluginResolved>>({});
+  const [detailLoadingId, setDetailLoadingId] = React.useState<string | null>(null);
+  const [detailError, setDetailError] = React.useState<string | null>(null);
   const activeOrgId = activeOrg?.id ?? "";
 
   const marketplaces = extensions.cloudOrgMarketplaces();
@@ -210,6 +213,30 @@ export function CloudMarketplacesView({
     if (!user || !activeOrgId) return;
     void refresh(true);
   }, [activeOrgId, refresh, user]);
+
+  React.useEffect(() => {
+    if (!detailRow || !isSignedIn || !activeOrgId) return;
+    if (resolvedPlugins[detailRow.plugin.id]) return;
+
+    let cancelled = false;
+    setDetailLoadingId(detailRow.plugin.id);
+    setDetailError(null);
+    void client.getOrgPluginResolved(activeOrgId, detailRow.plugin)
+      .then((resolved) => {
+        if (cancelled) return;
+        setResolvedPlugins((current) => ({ ...current, [detailRow.plugin.id]: resolved }));
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setDetailError(error instanceof Error ? error.message : "Failed to load package composition.");
+      })
+      .finally(() => {
+        if (!cancelled) setDetailLoadingId(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeOrgId, client, detailRow, isSignedIn, resolvedPlugins]);
 
   const importPlugin = React.useCallback(
     async (marketplaceId: string | null, plugin: DenOrgPlugin) => {
@@ -355,6 +382,9 @@ export function CloudMarketplacesView({
         <MarketplacePackageDetailModal
           actionId={actionId}
           row={detailRow}
+          resolved={resolvedPlugins[detailRow.plugin.id] ?? null}
+          resolving={detailLoadingId === detailRow.plugin.id}
+          resolveError={detailError}
           onClose={() => setDetailRow(null)}
           onImportPlugin={importPlugin}
           onRemovePlugin={removePlugin}
@@ -407,11 +437,14 @@ function MarketplacePackageCard(props: {
 function MarketplacePackageDetailModal(props: {
   actionId: string | null;
   row: MarketplacePackageRow;
+  resolved: DenOrgPluginResolved | null;
+  resolving: boolean;
+  resolveError: string | null;
   onClose: () => void;
   onImportPlugin: (marketplaceId: string | null, plugin: DenOrgPlugin) => void | Promise<void>;
   onRemovePlugin: (pluginId: string, pluginName: string) => void | Promise<void>;
 }) {
-  const { actionId, row, onClose, onImportPlugin, onRemovePlugin } = props;
+  const { actionId, row, resolved, resolving, resolveError, onClose, onImportPlugin, onRemovePlugin } = props;
   const actionBusy = actionId === row.plugin.id;
   const canAddOrUpdate = row.status === "available" || row.status === "update_available";
 
@@ -449,6 +482,41 @@ function MarketplacePackageDetailModal(props: {
               ))}
             </div>
           </div>
+          {resolveError ? (
+            <SettingsNotice tone="error">{resolveError}</SettingsNotice>
+          ) : null}
+          {resolving ? (
+            <SettingsNotice>Loading package contents...</SettingsNotice>
+          ) : null}
+          {resolved ? (
+            <div className="space-y-2">
+              <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Package contents</div>
+              {resolved.memberships.length > 0 ? resolved.memberships.map((membership) => {
+                const object = membership.configObject;
+                const version = object?.latestVersion ?? null;
+                if (!object) return null;
+                const preview = version?.rawSourceText?.trim().slice(0, 600) ?? "";
+                return (
+                  <details key={membership.id} className="rounded-xl border border-dls-border bg-dls-surface px-3 py-2">
+                    <summary className="cursor-pointer text-sm font-medium text-card-foreground">
+                      <span className="uppercase text-[10px] tracking-[0.12em] text-muted-foreground">{object.objectType}</span> {object.title}
+                    </summary>
+                    <div className="mt-2 space-y-2 text-xs text-muted-foreground">
+                      {object.description ? <div>{object.description}</div> : null}
+                      {object.currentRelativePath ? <div className="font-mono">{object.currentRelativePath}</div> : null}
+                      {preview ? (
+                        <pre className="max-h-40 overflow-auto whitespace-pre-wrap rounded-lg bg-dls-hover p-2 font-mono text-[11px] text-card-foreground">
+                          {preview}
+                        </pre>
+                      ) : null}
+                    </div>
+                  </details>
+                );
+              }) : (
+                <SettingsNotice>This package does not expose detailed contents yet.</SettingsNotice>
+              )}
+            </div>
+          ) : null}
           {row.imported?.files.length ? (
             <div className="rounded-xl border border-dls-border bg-dls-hover px-3 py-2 text-xs text-muted-foreground">
               Installed files: {row.imported.files.map((file) => `${file.title} (${file.objectType})`).join(", ")}


### PR DESCRIPTION
## Summary
- makes marketplace package detail modals wider
- fetches resolved package contents on detail open so users can expand underlying skills, MCPs, commands, and contexts before install
- shows expandable package contents with descriptions, paths, and raw source previews when available
- switches extension avatars to Paper StaticMeshGradient with a colorful fallback background to avoid the broken tiny WebGL/glitch rendering

## Verification
- pnpm --filter @openwork/app typecheck: passed
- pnpm --filter @openwork/app build: passed

## Notes
- Built from current dev after the previous marketplace/provider polish PR was merged.