### PR TITLE
Fix dev browser CDP targeting with prod running

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -157,6 +157,7 @@ declare global {
         initialDeepLinks?: string[];
         platform?: "darwin" | "linux" | "windows";
         version?: string;
+        browserCdpPort?: string;
       };
     };
   }

--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -108,15 +108,11 @@ export function ExtensionCard(props: ExtensionCardProps) {
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <h4 className="text-sm font-semibold text-dls-text">{name}</h4>
-            {connected ? (
-              <span className="rounded-md bg-green-3 px-1.5 py-0.5 text-[10px] font-medium text-green-11">
-                Connected
-              </span>
-            ) : (
+            {!connected ? (
               <span className={`rounded-md px-1.5 py-0.5 text-[10px] font-medium ${kindStyle[kind]}`}>
                 {kindLabel[kind]}
               </span>
-            )}
+            ) : null}
           </div>
           <p className="mt-0.5 line-clamp-2 text-xs text-dls-secondary">{description}</p>
           {!connected && !connecting && actionLabel ? (

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -678,7 +678,16 @@ export function ReactSessionComposer(props: ComposerProps) {
   };
 
   const applyExtensionSelection = (entry: McpDirectoryInfo) => {
-    props.onDraftChange(entry.composerPrompt ?? `Use ${entry.name} to `);
+    if (entry.id === "openwork-browser") {
+      const port = window.__OPENWORK_ELECTRON__?.meta?.browserCdpPort?.trim();
+      props.onDraftChange(
+        port
+          ? `Use the OpenWork Browser extension with browser_url "http://127.0.0.1:${port}". Do not use any other browser_url. `
+          : entry.composerPrompt ?? `Use ${entry.name} to `,
+      );
+    } else {
+      props.onDraftChange(entry.composerPrompt ?? `Use ${entry.name} to `);
+    }
     setToolMenuOpen(false);
   };
 

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -3,7 +3,6 @@ import type * as React from "react";
 import {
   ArrowLeft,
   Bug,
-  ChevronDown,
   CloudCog,
   Cog,
   Container,
@@ -33,12 +32,6 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { t } from "../../../../i18n";
 import type { SettingsTab } from "../../../../app/types";
 import {
@@ -53,7 +46,6 @@ import {
   SettingsPanelToolbarMessage,
   SettingsPanelToolbarStatus,
 } from "./panel";
-import { WorkspaceIcon } from "../../../design-system/workspace-icon";
 
 export function getSettingsTabIcon(tab: SettingsTab) {
   switch (tab) {
@@ -233,31 +225,6 @@ export function SettingsSidebar(props: SettingsSidebarProps) {
               <ArrowLeft size={14} />
               <span>{t("dashboard.back_to_app")}</span>
             </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <SidebarMenuButton type="button">
-                    <WorkspaceIcon seed={props.selectedWorkspaceName} sizeClass="size-4" />
-                    <span className="truncate">{props.selectedWorkspaceName}</span>
-                    <ChevronDown className="ml-auto" />
-                  </SidebarMenuButton>
-                }
-              />
-              <DropdownMenuContent className="w-(--anchor-width)">
-                {props.workspaces.map((workspace) => (
-                  <DropdownMenuItem
-                    key={workspace.id}
-                    onClick={() => props.onSelectWorkspace(workspace.id)}
-                    disabled={workspace.id === props.selectedWorkspaceId}
-                  >
-                    <WorkspaceIcon seed={workspace.name} sizeClass="size-4" />
-                    <span className="truncate">{workspace.name}</span>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -226,15 +226,15 @@ if (process.platform === "darwin" && APP_ICON_IMAGE && !APP_ICON_IMAGE.isEmpty()
 
 // Expose Chrome DevTools Protocol so the opencode-chrome-devtools plugin can
 // drive the built-in browser panel.  Use OPENWORK_ELECTRON_REMOTE_DEBUG_PORT to
-// pin a specific port; otherwise pick a default (9223) that stays out of the
-// way of common dev-tools ports (9222 = Chrome, 9229 = Node inspector).
+// pin a specific port. Prod defaults to 9223; dev defaults to 9823 so both
+// apps can run side by side without the dev browser tools attaching to prod.
 const explicitCdpPort = Number.parseInt(
   process.env.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT?.trim() ?? "",
   10,
 );
 const remoteDebugPort = Number.isFinite(explicitCdpPort) && explicitCdpPort > 0
   ? explicitCdpPort
-  : 9223;
+  : isDevMode ? 9823 : 9223;
 app.commandLine.appendSwitch("remote-debugging-port", String(remoteDebugPort));
 app.commandLine.appendSwitch("remote-debugging-address", "127.0.0.1");
 // Make the port available to the embedded server so it can pass it to OpenCode.

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -133,6 +133,7 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     initialDeepLinks: [],
     platform: normalizePlatform(process.platform),
     version: process.versions.electron,
+    browserCdpPort: process.env.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT || undefined,
   },
 });
 

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -47,6 +47,7 @@ Browser tools (\`browser_navigate\`, \`browser_snapshot\`, \`browser_click\`, \`
 - \`browser_url\`: always use \`"http://127.0.0.1:{{BROWSER_CDP_PORT}}"\`.
 - Use for general browsing tasks. The user sees what you do in real time.
 - Always call \`browser_list\` first to discover available targets, then use the appropriate \`target_id\`.
+- Do not scan common CDP ports or fall back to another port. If this endpoint is unavailable, report that the built-in browser is unavailable.
 
 **Chrome (external browser)**:
 - Use when the user needs their real cookies, sign-ins, or extensions.


### PR DESCRIPTION
## Summary
- Give dev Electron a separate default browser CDP port (9823) while prod stays on 9223.
- Include the active built-in browser CDP port in the OpenWork Browser composer prompt and forbid fallback port scanning in agent guidance.
- Remove the green Connected text pill from extension cards and remove the workspace selector row from the settings sidebar.

## Verification
- Reproduced in Daytona sandbox openwork-test-20260522-212144: prod on 9223, dev launched without override tried 9223 and logged bind() failed / Cannot start http server for devtools; 9223 only listed the prod file:// OpenWork target.
- Ran pnpm --filter @openwork/app typecheck in Daytona: passed.
- Ran pnpm --filter @openwork/desktop build:electron in Daytona: passed.
- Verified fixed prod+dev side-by-side in Daytona: prod target remained file:///workspace/apps/app/dist/index.html#/welcome on 9223; dev target was on 9823.
- Ran the OpenWork Browser composer prompt in dev with browser_url http://127.0.0.1:9823; dev target navigated to https://example.com while prod stayed on the welcome screen.

## Evidence
- Repro screenshot before fix: /var/folders/8j/hhcc8zs100d3fd654fjkk9580000gn/T/browser-screenshot-1779511078562.png
- Fixed dev screenshot after prompt: /var/folders/8j/hhcc8zs100d3fd654fjkk9580000gn/T/browser-screenshot-1779514617693.png
- Fixed prod screenshot after prompt: /var/folders/8j/hhcc8zs100d3fd654fjkk9580000gn/T/browser-screenshot-1779514670639.png