### PR TITLE
feat(app): extension manifest foundation

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -1,6 +1,12 @@
 import type { ModelRef, SuggestedPlugin } from "./types";
 import { t } from "../i18n";
 import { readDenBootstrapConfig } from "./lib/den";
+import {
+  BUILT_IN_OPENWORK_EXTENSION_MANIFESTS,
+  extensionContribution,
+  isTrustedBuiltInExtension,
+  type OpenWorkExtensionManifest,
+} from "./extensions";
 
 export const MODEL_PREF_KEY = "openwork.defaultModel";
 export const SESSION_MODEL_PREF_KEY = "openwork.sessionModels";
@@ -39,7 +45,29 @@ export type McpDirectoryInfo = {
   composerPrompt?: string;
   /** Whether OpenWork should show this extension as enabled before user setup. */
   defaultEnabled?: boolean;
+  /** Normalized extension manifest backing this catalog entry. */
+  extensionManifest?: OpenWorkExtensionManifest;
 };
+
+function extensionManifestToDirectoryInfo(manifest: OpenWorkExtensionManifest): McpDirectoryInfo {
+  return {
+    id: manifest.id,
+    name: manifest.name,
+    serverName: manifest.id,
+    description: manifest.description,
+    oauth: false,
+    kind: "extension",
+    iconSlug: manifest.icon?.simpleIconSlug,
+    iconSrc: manifest.icon?.src,
+    composerPrompt: extensionContribution(manifest, "composer-prompt")?.prompt ?? manifest.composer?.prompt,
+    defaultEnabled: manifest.defaultEnabled,
+    extensionManifest: manifest,
+  };
+}
+
+export function isBuiltInOpenWorkExtension(entry: Pick<McpDirectoryInfo, "kind" | "extensionManifest">): boolean {
+  return entry.kind === "extension" && isTrustedBuiltInExtension(entry.extensionManifest);
+}
 
 /** Derive a safe MCP server name from a display name or explicit serverName. */
 export function getMcpServerName(entry: McpDirectoryInfo): string {
@@ -134,37 +162,7 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     kind: "ui-control",
     iconSrc: "/openwork-mark.svg",
   },
-  {
-    id: "openwork-browser",
-    name: "OpenWork Browser",
-    serverName: "openwork-browser",
-    description: "Automate the built-in browser panel that stays visible inside OpenWork.",
-    oauth: false,
-    kind: "extension",
-    iconSrc: "/openwork-mark.svg",
-    composerPrompt: "Use the OpenWork Browser extension to ",
-    defaultEnabled: true,
-  },
-  {
-    id: "openai-image-gen",
-    name: "OpenAI Image Gen",
-    serverName: "openai-image-gen",
-    description: "Generate image artifacts with gpt-image-2.",
-    oauth: false,
-    kind: "extension",
-    iconSrc: "/ext-openai.svg",
-    composerPrompt: "Use the OpenAI Image Gen extension to ",
-  },
-  {
-    id: "ollama",
-    name: "Ollama",
-    serverName: "ollama",
-    description: "Local model provider at http://localhost:11434.",
-    oauth: false,
-    kind: "extension",
-    iconSrc: "/ext-ollama.svg",
-    composerPrompt: "Use the Ollama extension to ",
-  },
+  ...BUILT_IN_OPENWORK_EXTENSION_MANIFESTS.map(extensionManifestToDirectoryInfo),
 ];
 
 export const OPENWORK_EXTENSION_CATALOG = MCP_QUICK_CONNECT.filter((entry) => entry.kind === "extension");

--- a/apps/app/src/app/extensions.ts
+++ b/apps/app/src/app/extensions.ts
@@ -1,0 +1,192 @@
+import type { ReloadReason } from "./types";
+
+export type OpenWorkExtensionSourceFormat =
+  | "openwork-builtin"
+  | "openwork-extension-manifest"
+  | "claude-plugin"
+  | "opencode-plugin"
+  | "mcp-directory"
+  | "manual";
+
+export type OpenWorkExtensionSource = {
+  format: OpenWorkExtensionSourceFormat;
+  trusted: boolean;
+  origin?: "builtin" | "den" | "workspace" | "local";
+  reference?: string;
+};
+
+export type OpenWorkExtensionResourceType =
+  | "skill"
+  | "agent"
+  | "command"
+  | "tool"
+  | "mcp"
+  | "opencode-plugin"
+  | "provider"
+  | "hook"
+  | "context"
+  | "secret"
+  | "file"
+  | "local-service"
+  | "native-binary";
+
+export type OpenWorkExtensionResource = {
+  type: OpenWorkExtensionResourceType;
+  id: string;
+  label?: string;
+  description?: string;
+  path?: string;
+  command?: string[];
+  envKey?: string;
+  packageName?: string;
+  providerId?: string;
+  mcpServerName?: string;
+  required?: boolean;
+};
+
+export type OpenWorkExtensionContributionType =
+  | "settings-panel"
+  | "setup-instructions"
+  | "composer-prompt"
+  | "session-side-panel"
+  | "session-rail-item"
+  | "control-actions"
+  | "server-route"
+  | "native-capability"
+  | "test-action";
+
+export type OpenWorkExtensionContribution = {
+  type: OpenWorkExtensionContributionType;
+  ref?: string;
+  label?: string;
+  description?: string;
+  prompt?: string;
+  location?: "settings-detail" | "composer" | "session-right-pane" | "session-rail" | "server" | "native";
+};
+
+export type OpenWorkExtensionSetup = {
+  instructions?: string;
+  primaryCta?: string;
+  secondaryCta?: string;
+  requiredEnv?: string[];
+  testActionRef?: string;
+};
+
+export type OpenWorkExtensionLifecycle = {
+  reload?: ReloadReason[];
+  detection?: string[];
+};
+
+export type OpenWorkExtensionManifest = {
+  schemaVersion: 1;
+  id: string;
+  name: string;
+  description: string;
+  source: OpenWorkExtensionSource;
+  icon?: {
+    src?: string;
+    simpleIconSlug?: string;
+  };
+  composer?: {
+    prompt: string;
+  };
+  setup?: OpenWorkExtensionSetup;
+  resources: OpenWorkExtensionResource[];
+  contributions?: OpenWorkExtensionContribution[];
+  lifecycle?: OpenWorkExtensionLifecycle;
+  defaultEnabled?: boolean;
+  platform?: Array<"darwin" | "linux" | "windows" | "web">;
+};
+
+export function extensionContribution(
+  manifest: OpenWorkExtensionManifest | undefined,
+  type: OpenWorkExtensionContributionType,
+): OpenWorkExtensionContribution | undefined {
+  return manifest?.contributions?.find((contribution) => contribution.type === type);
+}
+
+export function isTrustedBuiltInExtension(manifest: OpenWorkExtensionManifest | undefined): boolean {
+  return manifest?.source.origin === "builtin" && manifest.source.trusted;
+}
+
+export const BUILT_IN_OPENWORK_EXTENSION_MANIFESTS: OpenWorkExtensionManifest[] = [
+  {
+    schemaVersion: 1,
+    id: "openwork-browser",
+    name: "OpenWork Browser",
+    description: "Automate the built-in browser panel that stays visible inside OpenWork.",
+    source: { format: "openwork-builtin", origin: "builtin", trusted: true },
+    icon: { src: "/openwork-mark.svg" },
+    composer: { prompt: "Use the OpenWork Browser extension to " },
+    setup: {
+      instructions: "OpenWork Browser is ready by default in desktop workspaces.",
+      primaryCta: "Enable browser automation",
+    },
+    resources: [
+      {
+        type: "opencode-plugin",
+        id: "opencode-chrome-devtools",
+        packageName: "opencode-chrome-devtools",
+        required: true,
+      },
+    ],
+    contributions: [
+      { type: "settings-panel", ref: "openwork.browser.settings", location: "settings-detail" },
+      { type: "session-side-panel", ref: "openwork.browser.panel", location: "session-right-pane" },
+      { type: "composer-prompt", prompt: "Use the OpenWork Browser extension to ", location: "composer" },
+    ],
+    lifecycle: { reload: ["plugins", "agents"], detection: ["plugin:opencode-chrome-devtools"] },
+    defaultEnabled: true,
+  },
+  {
+    schemaVersion: 1,
+    id: "openai-image-gen",
+    name: "OpenAI Image Gen",
+    description: "Generate image artifacts with gpt-image-2.",
+    source: { format: "openwork-builtin", origin: "builtin", trusted: true },
+    icon: { src: "/ext-openai.svg" },
+    composer: { prompt: "Use the OpenAI Image Gen extension to " },
+    setup: {
+      instructions: "Add an OpenAI API key, then OpenWork installs an OpenCode plugin that exposes image_generate.",
+      primaryCta: "Enable image generation",
+      secondaryCta: "Generate test image",
+      requiredEnv: ["OPENAI_API_KEY"],
+      testActionRef: "openwork.imageGen.testGenerate",
+    },
+    resources: [
+      { type: "opencode-plugin", id: "openwork-image-generation", path: ".opencode/plugins/openwork-image-generation.ts", required: true },
+      { type: "secret", id: "openai-api-key", envKey: "OPENAI_API_KEY", required: true },
+      { type: "file", id: "openai-image-config", path: ".opencode/openwork-extensions/openai-image-generation.json", required: true },
+    ],
+    contributions: [
+      { type: "settings-panel", ref: "openwork.imageGen.settings", location: "settings-detail" },
+      { type: "test-action", ref: "openwork.imageGen.testGenerate", label: "Generate test image" },
+      { type: "composer-prompt", prompt: "Use the OpenAI Image Gen extension to ", location: "composer" },
+    ],
+    lifecycle: { reload: ["plugins"], detection: ["plugin:openwork-image-generation"] },
+  },
+  {
+    schemaVersion: 1,
+    id: "ollama",
+    name: "Ollama",
+    description: "Local model provider at http://localhost:11434.",
+    source: { format: "openwork-builtin", origin: "builtin", trusted: true },
+    icon: { src: "/ext-ollama.svg" },
+    composer: { prompt: "Use the Ollama extension to " },
+    setup: {
+      instructions: "Run Ollama locally, choose or pull a model, then add it as an OpenCode provider.",
+      primaryCta: "Add Ollama model",
+      secondaryCta: "Pull model",
+    },
+    resources: [
+      { type: "local-service", id: "ollama-api", label: "Ollama API", description: "http://localhost:11434", required: true },
+      { type: "provider", id: "ollama", providerId: "ollama", packageName: "@ai-sdk/openai-compatible", required: true },
+    ],
+    contributions: [
+      { type: "settings-panel", ref: "openwork.ollama.settings", location: "settings-detail" },
+      { type: "test-action", ref: "openwork.ollama.listModels", label: "Check local models" },
+      { type: "composer-prompt", prompt: "Use the Ollama extension to ", location: "composer" },
+    ],
+    lifecycle: { reload: ["config"], detection: ["provider:ollama"] },
+  },
+];

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -22,6 +22,7 @@ import {
 } from "./desktop";
 import { isDesktopRuntime } from "../utils";
 import type { DenOrgSkillCard } from "../types";
+import type { OpenWorkExtensionManifest, OpenWorkExtensionSourceFormat } from "../extensions";
 
 const STORAGE_BASE_URL = "openwork.den.baseUrl";
 const STORAGE_API_BASE_URL = "openwork.den.apiBaseUrl";
@@ -153,6 +154,14 @@ export type DenPluginMembership = {
   configObject?: DenPluginConfigObject;
 };
 
+export type DenOrgExtensionProjection = {
+  id: string;
+  name: string;
+  description: string | null;
+  sourceFormat: OpenWorkExtensionSourceFormat;
+  manifest: OpenWorkExtensionManifest | null;
+};
+
 export type DenOrgPlugin = {
   id: string;
   name: string;
@@ -161,6 +170,8 @@ export type DenOrgPlugin = {
   memberCount: number;
   updatedAt: string | null;
   componentCounts: Record<string, number>;
+  /** Preferred Den surface: plugins are normalized into OpenWork extensions. */
+  extension?: DenOrgExtensionProjection | null;
 };
 
 export type DenOrgMarketplace = {
@@ -180,6 +191,8 @@ export type DenOrgMarketplaceResolved = {
 export type DenOrgPluginResolved = {
   plugin: DenOrgPlugin;
   memberships: DenPluginMembership[];
+  /** Future Den extension manifest; absent while Claude plugin imports are resource-only. */
+  extension?: DenOrgExtensionProjection | null;
 };
 
 export type DenBillingPrice = {

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -49,6 +49,12 @@ export type ExtensionDetailModalProps = {
   disabledReason?: string | null;
   /** Remote URL if applicable. */
   url?: string;
+  /** Declarative setup instructions from an extension manifest. */
+  setupInstructions?: string;
+  /** Declarative install resource labels from an extension manifest. */
+  resourceLabels?: string[];
+  /** Declarative UI/runtime contribution labels from an extension manifest. */
+  contributionLabels?: string[];
   /** Whether OAuth is required. */
   oauth?: boolean;
   /** Exact local command this extension will launch, when known. */
@@ -187,6 +193,9 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
     hidden = false,
     disabledReason = null,
     url,
+    setupInstructions,
+    resourceLabels = [],
+    contributionLabels = [],
     oauth,
     launchCommand,
     environment,
@@ -261,6 +270,51 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
             <div className="text-sm leading-relaxed text-card-foreground">
               {description}
             </div>
+
+            {setupInstructions ? (
+              <Card variant="outline" size="sm">
+                <CardHeader>
+                  <CardTitle>Setup</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-sm leading-relaxed text-muted-foreground">
+                    {setupInstructions}
+                  </div>
+                </CardContent>
+              </Card>
+            ) : null}
+
+            {resourceLabels.length > 0 || contributionLabels.length > 0 ? (
+              <Card variant="outline" size="sm">
+                <CardHeader>
+                  <CardTitle>Extension manifest</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-3 text-sm">
+                    {resourceLabels.length > 0 ? (
+                      <div>
+                        <div className="mb-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Resources</div>
+                        <div className="flex flex-wrap gap-1.5">
+                          {resourceLabels.map((label) => (
+                            <span key={label} className="rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground">{label}</span>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
+                    {contributionLabels.length > 0 ? (
+                      <div>
+                        <div className="mb-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Contributions</div>
+                        <div className="flex flex-wrap gap-1.5">
+                          {contributionLabels.map((label) => (
+                            <span key={label} className="rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground">{label}</span>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                </CardContent>
+              </Card>
+            ) : null}
 
             {/* Details */}
             <Card variant="outline" size="sm">

--- a/apps/app/src/react-app/domains/settings/browser-extension-config.tsx
+++ b/apps/app/src/react-app/domains/settings/browser-extension-config.tsx
@@ -4,7 +4,10 @@ import { MonitorSmartphone } from "lucide-react";
 import { surfaceCardClass } from "../workspace/modal-styles";
 import { registerExtensionConfig } from "./extension-registry";
 
-registerExtensionConfig("openwork-browser", () => <OpenWorkBrowserConfig />);
+const openWorkBrowserConfigFactory = () => <OpenWorkBrowserConfig />;
+
+registerExtensionConfig("openwork.browser.settings", openWorkBrowserConfigFactory);
+registerExtensionConfig("openwork-browser", openWorkBrowserConfigFactory);
 
 function OpenWorkBrowserConfig() {
   return (

--- a/apps/app/src/react-app/domains/settings/extension-registry.tsx
+++ b/apps/app/src/react-app/domains/settings/extension-registry.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import type { ReactNode } from "react";
 import type { McpDirectoryInfo } from "../../../app/constants";
+import { extensionContribution } from "../../../app/extensions";
 
 /**
  * Context bag that the settings route passes to extension config factories.
@@ -38,11 +39,15 @@ export function registerExtensionConfig(id: string, factory: ExtensionConfigFact
   registry.set(id, factory);
 }
 
+function configRegistryId(entry: McpDirectoryInfo) {
+  return extensionContribution(entry.extensionManifest, "settings-panel")?.ref ?? entry.serverName ?? entry.name;
+}
+
 export function getExtensionConfigSlot(
   entry: McpDirectoryInfo,
   ctx: ExtensionConfigContext,
 ): ReactNode | null {
-  const id = entry.serverName ?? entry.name;
+  const id = configRegistryId(entry);
   const factory = registry.get(id);
   return factory ? factory(ctx) : null;
 }

--- a/apps/app/src/react-app/domains/settings/ollama-config.tsx
+++ b/apps/app/src/react-app/domains/settings/ollama-config.tsx
@@ -46,16 +46,19 @@ import { formatFileSize } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { OLLAMA_PROVIDER_CONFIG } from "./openai-image-extension";
-import { registerExtensionConfig } from "./extension-registry";
+import { registerExtensionConfig, type ExtensionConfigContext } from "./extension-registry";
 
-registerExtensionConfig("ollama", (ctx) => (
+const ollamaConfigFactory = (ctx: ExtensionConfigContext) => (
   <OllamaConfig
     busy={ctx.localProvider.busy}
     status={ctx.localProvider.status}
     error={ctx.localProvider.error}
     onInstall={ctx.localProvider.onInstall}
   />
-));
+);
+
+registerExtensionConfig("openwork.ollama.settings", ollamaConfigFactory);
+registerExtensionConfig("ollama", ollamaConfigFactory);
 
 type OllamaModel = {
   name: string;

--- a/apps/app/src/react-app/domains/settings/openai-image-gen-config.tsx
+++ b/apps/app/src/react-app/domains/settings/openai-image-gen-config.tsx
@@ -19,7 +19,7 @@ import {
   FieldLabel,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { registerExtensionConfig } from "./extension-registry";
+import { registerExtensionConfig, type ExtensionConfigContext } from "./extension-registry";
 
 export type OpenAiImageGenConfigProps = {
   busy: boolean;
@@ -30,7 +30,7 @@ export type OpenAiImageGenConfigProps = {
   onTestGenerate: (input: { apiKey: string; prompt: string }) => void | Promise<void>;
 };
 
-registerExtensionConfig("openai-image-gen", (ctx) => (
+const openAiImageGenConfigFactory = (ctx: ExtensionConfigContext) => (
   <OpenAiImageGenConfig
     busy={ctx.imageExtension.busy}
     status={ctx.imageExtension.status}
@@ -39,7 +39,10 @@ registerExtensionConfig("openai-image-gen", (ctx) => (
     onInstall={ctx.imageExtension.onInstall}
     onTestGenerate={ctx.imageExtension.onTestGenerate}
   />
-));
+);
+
+registerExtensionConfig("openwork.imageGen.settings", openAiImageGenConfigFactory);
+registerExtensionConfig("openai-image-gen", openAiImageGenConfigFactory);
 
 const DEFAULT_PROMPT =
   "A friendly robot owl holding a paintbrush, teal neon UI frame, high contrast";

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -186,14 +186,14 @@ export function CloudMarketplacesView({
           const count = extensions.cloudOrgMarketplaces().reduce((total, marketplace) => total + marketplace.plugins.length, 0);
           showToast({
             title: count > 0
-              ? `Loaded ${count} marketplace package${count === 1 ? "" : "s"} for ${activeOrg?.name ?? t("den.active_org_title")}.`
-              : `No marketplace packages are available for ${activeOrg?.name ?? t("den.active_org_title")}.`,
+              ? `Loaded ${count} marketplace extension${count === 1 ? "" : "s"} for ${activeOrg?.name ?? t("den.active_org_title")}.`
+              : `No marketplace extensions are available for ${activeOrg?.name ?? t("den.active_org_title")}.`,
             tone: "info",
           });
         }
       } catch (error) {
         if (!quiet) {
-          setActionError(error instanceof Error ? error.message : "Failed to load marketplace packages.");
+          setActionError(error instanceof Error ? error.message : "Failed to load marketplace extensions.");
         }
       } finally {
         setBusy(false);
@@ -228,7 +228,7 @@ export function CloudMarketplacesView({
       })
       .catch((error) => {
         if (cancelled) return;
-        setDetailError(error instanceof Error ? error.message : "Failed to load package composition.");
+        setDetailError(error instanceof Error ? error.message : "Failed to load extension composition.");
       })
       .finally(() => {
         if (!cancelled) setDetailLoadingId(null);
@@ -281,7 +281,7 @@ export function CloudMarketplacesView({
   const content = !isSignedIn ? (
     <SettingsNotice>
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <span>Sign in to OpenWork Cloud to browse organization marketplace packages.</span>
+        <span>Sign in to OpenWork Cloud to browse organization marketplace extensions.</span>
         <Button size="sm" onClick={onOpenAccount}>
           {t("skills.share_team_sign_in")}
         </Button>
@@ -291,9 +291,9 @@ export function CloudMarketplacesView({
     <SettingsSection>
       <SettingsSectionHeader>
         <SettingsSectionHeaderContent>
-          <SettingsSectionHeaderTitle>Marketplace</SettingsSectionHeaderTitle>
+          <SettingsSectionHeaderTitle>Extension Marketplace</SettingsSectionHeaderTitle>
           <SettingsSectionHeaderDescription>
-            Add packages from OpenWork Cloud. Each package installs runtime extensions such as skills, MCPs, commands, or tools.
+            Add extensions from OpenWork Cloud. Claude-compatible plugins are normalized into OpenWork extensions with installable resources such as skills, MCPs, commands, or tools.
           </SettingsSectionHeaderDescription>
         </SettingsSectionHeaderContent>
         <SettingsSectionHeaderActions>
@@ -312,14 +312,14 @@ export function CloudMarketplacesView({
       ) : null}
 
       {busy ? (
-        <SettingsNotice>Loading marketplace packages...</SettingsNotice>
+        <SettingsNotice>Loading marketplace extensions...</SettingsNotice>
       ) : null}
 
       <div className="space-y-3">
         <SettingsListSearchInput
           value={search}
           onChange={(event) => setSearch(event.currentTarget.value)}
-          placeholder="Search marketplace packages..."
+          placeholder="Search marketplace extensions..."
         />
         <div className="flex flex-wrap items-center gap-2">
           {(["all", "available", "installed", "update_available"] as const).map((filter) => (
@@ -357,12 +357,12 @@ export function CloudMarketplacesView({
 
       {!busy && displayRows.length === 0 ? (
         <SettingsListEmptyState>
-          {activeOrgId ? "No marketplace packages are available yet." : "Choose an organization to view marketplace packages."}
+          {activeOrgId ? "No marketplace extensions are available yet." : "Choose an organization to view marketplace extensions."}
         </SettingsListEmptyState>
       ) : null}
 
       {displayRows.length > 0 && visibleRows.length === 0 ? (
-        <SettingsListEmptyState>No marketplace packages match your search or filters.</SettingsListEmptyState>
+        <SettingsListEmptyState>No marketplace extensions match your search or filters.</SettingsListEmptyState>
       ) : null}
 
       {visibleRows.length > 0 ? (
@@ -423,8 +423,8 @@ function MarketplacePackageCard(props: {
   return (
     <ExtensionCard
       name={row.plugin.name}
-      description={row.plugin.description || `Marketplace package from ${row.marketplaceName}.`}
-      kind="plugin"
+      description={row.plugin.description || `Marketplace extension from ${row.marketplaceName}.`}
+      kind="extension"
       connected={Boolean(row.imported)}
       connectedLabel="Installed"
       connecting={actionBusy}
@@ -454,7 +454,7 @@ function MarketplacePackageDetailModal(props: {
       onClose={onClose}
       name={row.plugin.name}
       description={row.plugin.description || "No description provided."}
-      kind="plugin"
+      kind="extension"
       connected={Boolean(row.imported)}
       connectedLabel="Installed"
       connecting={actionBusy}
@@ -486,11 +486,11 @@ function MarketplacePackageDetailModal(props: {
             <SettingsNotice tone="error">{resolveError}</SettingsNotice>
           ) : null}
           {resolving ? (
-            <SettingsNotice>Loading package contents...</SettingsNotice>
+            <SettingsNotice>Loading extension contents...</SettingsNotice>
           ) : null}
           {resolved ? (
             <div className="space-y-2">
-              <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Package contents</div>
+              <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Extension contents</div>
               {resolved.memberships.length > 0 ? resolved.memberships.map((membership) => {
                 const object = membership.configObject;
                 const version = object?.latestVersion ?? null;
@@ -513,7 +513,7 @@ function MarketplacePackageDetailModal(props: {
                   </details>
                 );
               }) : (
-                <SettingsNotice>This package does not expose detailed contents yet.</SettingsNotice>
+                <SettingsNotice>This extension does not expose detailed contents yet.</SettingsNotice>
               )}
             </div>
           ) : null}

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -22,7 +22,7 @@ import {
   Zap,
 } from "lucide-react";
 
-import { type McpDirectoryInfo } from "../../../../app/constants";
+import { isBuiltInOpenWorkExtension, type McpDirectoryInfo } from "../../../../app/constants";
 import type { CloudImportedPlugin } from "../../../../app/cloud/import-state";
 import { ExtensionCard } from "../../../design-system/extension-card";
 import { ExtensionDetailModal } from "../../../design-system/extension-detail-modal";
@@ -111,10 +111,6 @@ export type McpViewProps = {
 };
 
 const builtInExtensionDisabledReason = "Disabled by organization";
-
-function isBuiltInExtension(entry: McpDirectoryInfo) {
-  return entry.kind === "extension";
-}
 
 const statusDot = (status: ReactMcpStatus) => {
   switch (status) {
@@ -205,6 +201,14 @@ const serviceIconBg = (name: string) => {
   if (lower.includes("openwork")) return "bg-gray-3 border-gray-6";
   return "bg-dls-hover border-dls-border";
 };
+
+function extensionResourceLabels(entry: McpDirectoryInfo) {
+  return entry.extensionManifest?.resources.map((resource) => resource.label ?? resource.id) ?? [];
+}
+
+function extensionContributionLabels(entry: McpDirectoryInfo) {
+  return entry.extensionManifest?.contributions?.map((contribution) => contribution.label ?? contribution.ref ?? contribution.type) ?? [];
+}
 
 type ExtensionFilter = "all" | "mcp" | "skill" | "plugin";
 
@@ -376,7 +380,7 @@ export function McpView(props: McpViewProps) {
     (props.installedSkills ?? []).filter((skill) => isOpenWorkExtensionHidden(getSkillHiddenId(skill))).length +
     (props.installedPlugins ?? []).filter((plugin) => isOpenWorkExtensionHidden(`plugin:${plugin.pluginId}`)).length;
   const policyHiddenBuiltInCount = props.builtInExtensionsDisabled
-    ? quickConnectList.filter((entry) => isBuiltInExtension(entry) && !isOpenWorkExtensionHidden(entry)).length
+    ? quickConnectList.filter((entry) => isBuiltInOpenWorkExtension(entry) && !isOpenWorkExtensionHidden(entry)).length
     : 0;
   const hiddenOrPolicyCount = hiddenCount + policyHiddenBuiltInCount;
 
@@ -487,7 +491,7 @@ export function McpView(props: McpViewProps) {
       <McpQuickConnectSection
         entries={
           quickConnectList.filter((entry) => {
-            if (!showHidden && (isOpenWorkExtensionHidden(entry) || (props.builtInExtensionsDisabled && isBuiltInExtension(entry)))) return false;
+            if (!showHidden && (isOpenWorkExtensionHidden(entry) || (props.builtInExtensionsDisabled && isBuiltInOpenWorkExtension(entry)))) return false;
             if (filter === "skill") return false;
             if (filter === "mcp" && (entry.kind ?? "mcp") !== "mcp" && entry.kind !== "ui-control") return false;
             if (!search.trim()) return true;
@@ -522,12 +526,12 @@ export function McpView(props: McpViewProps) {
         isSkillHidden={(skill) => isOpenWorkExtensionHidden(getSkillHiddenId(skill))}
         isPluginHidden={(plugin) => isOpenWorkExtensionHidden(`plugin:${plugin.pluginId}`)}
         disabledReasonForEntry={(entry) =>
-          props.builtInExtensionsDisabled && isBuiltInExtension(entry)
+          props.builtInExtensionsDisabled && isBuiltInOpenWorkExtension(entry)
             ? builtInExtensionDisabledReason
             : null
         }
         isConfigured={(entry) =>
-          props.builtInExtensionsDisabled && isBuiltInExtension(entry)
+          props.builtInExtensionsDisabled && isBuiltInOpenWorkExtension(entry)
             ? false
             : entry.kind === "extension"
             ? (entry.defaultEnabled ? isOpenWorkExtensionEnabled(entry) : props.isExtensionConnected?.(entry) ?? false)
@@ -633,7 +637,7 @@ export function McpView(props: McpViewProps) {
         const extensionConfigSlot = props.configSlotForEntry?.(detailEntry) ?? null;
         const hasConfigSlot = extensionConfigSlot !== null;
         const hidden = isOpenWorkExtensionHidden(detailEntry);
-        const disabledReason = props.builtInExtensionsDisabled && isBuiltInExtension(detailEntry)
+        const disabledReason = props.builtInExtensionsDisabled && isBuiltInOpenWorkExtension(detailEntry)
           ? builtInExtensionDisabledReason
           : null;
         const isConnected = disabledReason
@@ -655,6 +659,9 @@ export function McpView(props: McpViewProps) {
             connecting={props.mcpConnectingName === detailEntry.name}
             hidden={hidden}
             disabledReason={disabledReason}
+            setupInstructions={detailEntry.extensionManifest?.setup?.instructions}
+            resourceLabels={extensionResourceLabels(detailEntry)}
+            contributionLabels={extensionContributionLabels(detailEntry)}
             launchCommand={detailEntry.serverName === "openwork-ui" ? openworkUiMcpCommand ?? undefined : undefined}
             environment={detailEntry.serverName === "openwork-ui" ? openworkUiMcpEnvironment ?? undefined : undefined}
             url={typeof detailEntry.url === "string" ? detailEntry.url : undefined}
@@ -714,8 +721,8 @@ export function McpView(props: McpViewProps) {
             open={!!detailPlugin}
             onClose={() => setDetailPlugin(null)}
             name={detailPlugin.name}
-            description={detailPlugin.description ?? "Marketplace package installed in this workspace."}
-            kind="plugin"
+            description={detailPlugin.description ?? "Marketplace extension installed in this workspace."}
+            kind="extension"
             connected={true}
             hidden={hidden}
             onUninstall={props.removeCloudPlugin ? () => {
@@ -844,8 +851,8 @@ function McpQuickConnectSection(props: {
             <ExtensionCard
               key={`plugin:${plugin.pluginId}`}
               name={plugin.name}
-              description={plugin.description ?? `Marketplace package with ${fileCount} installed file${fileCount === 1 ? "" : "s"}.`}
-              kind="plugin"
+              description={plugin.description ?? `Marketplace extension with ${fileCount} installed file${fileCount === 1 ? "" : "s"}.`}
+              kind="extension"
               connected={true}
               hidden={hidden}
               actionLabel="View details"

--- a/docs/extensions-manifest-foundation.md
+++ b/docs/extensions-manifest-foundation.md
@@ -1,0 +1,34 @@
+# Extension Manifest Foundation
+
+OpenWork should expose `extension` as the user-facing abstraction. Claude/Anthropic plugins are an initial source format that Den adapts into OpenWork extensions, not a separate product concept.
+
+## Shape
+
+An extension is a manifest-backed installed capability:
+
+- `source`: where it came from, such as built-in, Den Claude plugin import, OpenWork manifest, MCP directory, or manual local install.
+- `resources`: installable primitives, such as skills, MCP servers, OpenCode plugins, providers, secrets, native binaries, hooks, commands, or context files.
+- `setup`: custom instructions, required env vars, primary CTA text, and optional test action refs.
+- `contributions`: allowlisted UI/runtime refs, such as settings panels, composer prompts, session side panels, rail items, server routes, control actions, native capabilities, and tests.
+- `lifecycle`: reload/detection hints for OpenCode config, plugins, skills, MCP, agents, or commands.
+
+## PR Stack
+
+1. Foundation PR: typed manifest model, manifest-backed built-in catalog, generic setup/resource/contribution display, Den copy shifted to extensions.
+2. Handsfree PR: add a trusted built-in extension manifest with native-binary, local MCP, macOS permission, health-check, and setup/test contributions.
+3. Voice Mode PR: add a trusted built-in extension manifest with settings, side panel, rail item, server route, Realtime secret, control-action, and test contributions.
+4. Den follow-up: expose extension projections from existing plugin rows while initially supporting Claude-compatible plugin repos as the only external source adapter.
+
+## Electron CDP Flows
+
+Always launch these from the Electron sandbox, not a standalone browser:
+
+- Extensions catalog opens and shows built-ins from manifests.
+- Built-in policy disables only trusted built-in extensions, not Den marketplace extensions.
+- Marketplace imports appear as installed extensions with resource composition.
+- Image Gen setup accepts `OPENAI_API_KEY`, writes plugin/config files, and can run the test action.
+- Ollama setup detects local availability, lists/pulls models, patches provider config, and reloads.
+- Handsfree setup shows macOS permission/health status, resolves the Electron-local MCP command, installs MCP config, and verifies a tool call.
+- Voice setup saves/uses an OpenAI key, mints a Realtime client secret through the local server, opens the right-side panel, and executes a semantic OpenWork UI action.
+
+Den/local endpoint testing should point Electron at the target Den base URL through the existing Cloud account settings or the desktop bootstrap env/config path. OpenAI-key flows should use the OpenWork env store, preferring short-lived renderer credentials for Realtime.


### PR DESCRIPTION
## What

Add a typed `OpenWorkExtensionManifest` model and convert built-in extensions (Browser, OpenAI Image Gen, Ollama) from hard-coded catalog entries to manifest-backed entries. This is the foundation PR for the extension abstraction stack.

## Why

Extensions should be a superset that can be a skill, an OpenCode plugin, an MCP, a provider, or a full UI/runtime integration like Voice Mode or HandsFree Computer Use. Today they are hard-coded entries in `MCP_QUICK_CONNECT` with special-cased install/setup logic. This PR introduces the manifest contract so future PRs can add Handsfree, Voice Mode, and Den-imported Claude plugins as extensions without more special-casing.

## Shape

`Extension = manifest + resources + contributions + setup + lifecycle + source`

- **Source**: where it came from (builtin, Den Claude plugin, OpenWork manifest, MCP directory, manual)
- **Resources**: installable primitives (skill, MCP, OpenCode plugin, provider, secret, native binary, etc.)
- **Setup**: custom instructions, required env vars, primary CTA text, test action refs
- **Contributions**: allowlisted UI/runtime refs (settings panel, composer prompt, session side panel, rail item, server route, control actions, native capabilities, tests)
- **Lifecycle**: reload/detection hints for OpenCode config

## Changes

- New `apps/app/src/app/extensions.ts` with manifest types and built-in manifests for Browser, Image Gen, Ollama
- `constants.ts` generates the catalog from manifests via `extensionManifestToDirectoryInfo`
- Extension detail modal shows declarative setup instructions, resource labels, and contribution labels from the manifest
- Settings config registry resolves contribution refs alongside legacy IDs
- Den marketplace UI copy shifted from "packages" to "extensions"
- Den client types gain `DenOrgExtensionProjection` for future API support
- `isBuiltInOpenWorkExtension` uses manifest `source.origin + trusted` flag
- `docs/extensions-manifest-foundation.md` documents the PR stack and CDP flows

## PR Stack

1. **This PR**: typed manifest model, manifest-backed built-in catalog, generic manifest display, Den copy
2. **Handsfree PR** (next): trusted built-in extension manifest with native-binary, local MCP, macOS permissions
3. **Voice Mode PR** (next): trusted built-in extension manifest with settings, side panel, rail item, server route, Realtime secret, control actions
4. **Den follow-up**: expose extension projections from existing plugin rows, Claude-compatible plugins as first source adapter

## Testing

- `pnpm --filter @openwork/app typecheck` passed locally and on Daytona
- Daytona Electron CDP (`Electron/35.7.5`): created workspace, opened Extensions, opened OpenAI Image Gen detail modal, verified manifest setup/resources/contributions display, verified marketplace "extensions" copy
- Daytona sandbox deleted after verification
