### PR TITLE
feat(den): add provider credential contract base

### DIFF
--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -145,6 +145,24 @@ function isOrganizationAdmin(payload: { currentMember: { isOwner: boolean; role:
   return payload.currentMember.isOwner || memberHasRole(payload.currentMember.role, "admin")
 }
 
+export function getCredentialFlags(provider: Pick<LlmProviderRow, "credentialKind" | "apiKey" | "opencodeAuth">) {
+  const hasApiKey = Boolean(provider.apiKey && provider.apiKey.trim().length > 0)
+  const hasOpencodeAuth = Boolean(provider.opencodeAuth && provider.opencodeAuth.trim().length > 0)
+  return {
+    hasApiKey,
+    hasOpencodeAuth,
+    hasCredential: provider.credentialKind === "opencode_oauth" ? hasOpencodeAuth : hasApiKey,
+  }
+}
+
+export function redactLlmProviderCredentials<T extends { apiKey?: unknown; opencodeAuth?: unknown }>(provider: T): Omit<T, "apiKey" | "opencodeAuth"> & { apiKey: undefined; opencodeAuth: undefined } {
+  return {
+    ...provider,
+    apiKey: undefined,
+    opencodeAuth: undefined,
+  }
+}
+
 function canManageLlmProvider(
   payload: { currentMember: { id: MemberId; isOwner: boolean; role: string } },
   provider: LlmProviderRow,
@@ -464,7 +482,7 @@ async function loadLlmProviders(input: {
 
   return providers.map((provider) => ({
     ...provider,
-    hasApiKey: Boolean(provider.apiKey && provider.apiKey.trim().length > 0),
+    ...getCredentialFlags(provider),
     models: (modelsByProviderId.get(provider.id) ?? [])
       .map((model) => ({
         id: model.modelId,
@@ -607,8 +625,7 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
 
       return c.json({
         llmProviders: providers.map((provider) => ({
-          ...provider,
-          apiKey: undefined,
+          ...redactLlmProviderCredentials(provider),
           canManage: canManageLlmProvider(payload, provider),
         })),
       })
@@ -678,6 +695,8 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
       return c.json({
         llmProvider: {
           ...provider,
+          opencodeAuth: undefined,
+          ...getCredentialFlags(provider),
           models: models
             .map((model) => ({
               id: model.modelId,
@@ -781,10 +800,13 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             organizationId: payload.organization.id,
             createdByOrgMembershipId: payload.currentMember.id,
             source: normalized.source,
+            credentialKind: "api_key",
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
             hasApiKey: Boolean(normalized.apiKey),
+            hasOpencodeAuth: false,
+            hasCredential: Boolean(normalized.apiKey),
             createdAt: now,
             updatedAt: now,
           },
@@ -916,12 +938,15 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
 
         return c.json({
           llmProvider: {
-            ...provider,
+            ...redactLlmProviderCredentials(provider),
             source: normalized.source,
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
+            credentialKind: provider.credentialKind,
             hasApiKey: input.apiKey === undefined ? Boolean(provider.apiKey) : Boolean(normalized.apiKey),
+            hasOpencodeAuth: Boolean(provider.opencodeAuth),
+            hasCredential: input.apiKey === undefined ? getCredentialFlags(provider).hasCredential : Boolean(normalized.apiKey),
             updatedAt,
           },
         })

--- a/ee/packages/den-db/drizzle/0019_llm_provider_opencode_oauth.sql
+++ b/ee/packages/den-db/drizzle/0019_llm_provider_opencode_oauth.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `llm_provider`
+  ADD COLUMN `credential_kind` enum('api_key','opencode_oauth') NOT NULL DEFAULT 'api_key' AFTER `provider_config`,
+  ADD COLUMN `opencode_auth` text AFTER `api_key`;

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1779380000000,
       "tag": "0018_invited_org_members",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "5",
+      "when": 1777486400000,
+      "tag": "0019_llm_provider_opencode_oauth",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/src/schema/sharables/llm-providers.ts
+++ b/ee/packages/den-db/src/schema/sharables/llm-providers.ts
@@ -30,7 +30,11 @@ export const LlmProviderTable = mysqlTable(
     providerConfig: json("provider_config")
       .$type<Record<string, unknown>>()
       .notNull(),
+    credentialKind: mysqlEnum("credential_kind", ["api_key", "opencode_oauth"])
+      .notNull()
+      .default("api_key"),
     apiKey: encryptedTextColumn("api_key"),
+    opencodeAuth: encryptedTextColumn("opencode_auth"),
     createdAt: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { fsp: 3 })
       .notNull()


### PR DESCRIPTION
## Summary

Extracts the smallest provider credential contract/model base from the prior OpenCode OAuth provider work.

This PR adds only the shared storage/response contract needed by follow-up stacked provider credential work:

- `credentialKind` on LLM providers, defaulting to `api_key`.
- encrypted `opencodeAuth` storage for OAuth-backed provider credentials.
- migration `0019_llm_provider_opencode_oauth` and journal entry after upstream `0018_invited_org_members`.
- passive Den API credential redaction/flags so the new field is not leaked by existing provider responses.

## Scope intentionally excluded

- OpenAI device flow routes.
- Den Web OAuth UI.
- desktop/provider import behavior for OAuth-backed providers.
- Den→worker managed provider sync behavior (#1901).
- Docker/runbook/version/seed/static/Entra/dirty-preference/workflow artifact changes.

## Verification

- `pnpm --filter @openwork-ee/den-db build` — PASS.
- From `ee/apps/den-api`: `pnpm exec tsc -p tsconfig.json --noEmit` — PASS.

## Stack

This is PR1 for the provider credential stack. #1901 should be based on this branch so reviewers can inspect worker sync separately from the credential contract base.