### PR TITLE
feat(den): expose extension projections for plugins

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -21,8 +21,18 @@ import {
   type DesktopBootstrapConfig as ShellDesktopBootstrapConfig,
 } from "./desktop";
 import { isDesktopRuntime } from "../utils";
-import type { DenOrgSkillCard } from "../types";
-import type { OpenWorkExtensionManifest, OpenWorkExtensionSourceFormat } from "../extensions";
+import type { DenOrgSkillCard, ReloadReason } from "../types";
+import type {
+  OpenWorkExtensionContribution,
+  OpenWorkExtensionContributionType,
+  OpenWorkExtensionLifecycle,
+  OpenWorkExtensionManifest,
+  OpenWorkExtensionResource,
+  OpenWorkExtensionResourceType,
+  OpenWorkExtensionSetup,
+  OpenWorkExtensionSource,
+  OpenWorkExtensionSourceFormat,
+} from "../extensions";
 
 const STORAGE_BASE_URL = "openwork.den.baseUrl";
 const STORAGE_API_BASE_URL = "openwork.den.apiBaseUrl";
@@ -989,6 +999,247 @@ function parseExtensionSourceFormat(value: unknown): OpenWorkExtensionSourceForm
   }
 }
 
+function parseExtensionSourceOrigin(value: unknown): OpenWorkExtensionSource["origin"] | undefined {
+  switch (value) {
+    case "builtin":
+    case "den":
+    case "workspace":
+    case "local":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function parseExtensionSource(value: unknown): OpenWorkExtensionSource | null {
+  if (!isRecord(value) || typeof value.trusted !== "boolean") return null;
+  const format = parseExtensionSourceFormat(value.format);
+  if (!format) return null;
+  const origin = parseExtensionSourceOrigin(value.origin);
+  return {
+    format,
+    trusted: value.trusted,
+    ...(origin ? { origin } : {}),
+    ...(typeof value.reference === "string" ? { reference: value.reference } : {}),
+  };
+}
+
+function parseStringList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) return undefined;
+  return value;
+}
+
+function parseExtensionResourceType(value: unknown): OpenWorkExtensionResourceType | null {
+  switch (value) {
+    case "skill":
+    case "agent":
+    case "command":
+    case "tool":
+    case "mcp":
+    case "opencode-plugin":
+    case "provider":
+    case "hook":
+    case "context":
+    case "secret":
+    case "file":
+    case "local-service":
+    case "native-binary":
+      return value;
+    default:
+      return null;
+  }
+}
+
+function parseExtensionLocalCommandRef(value: unknown): OpenWorkExtensionResource["localCommandRef"] | undefined {
+  switch (value) {
+    case "openwork.handsfreeMcp":
+    case "openwork.uiMcp":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function parseExtensionResource(value: unknown): OpenWorkExtensionResource | null {
+  if (!isRecord(value) || typeof value.id !== "string") return null;
+  const type = parseExtensionResourceType(value.type);
+  if (!type) return null;
+  const command = parseStringList(value.command);
+  const localCommandRef = parseExtensionLocalCommandRef(value.localCommandRef);
+  return {
+    type,
+    id: value.id,
+    ...(typeof value.label === "string" ? { label: value.label } : {}),
+    ...(typeof value.description === "string" ? { description: value.description } : {}),
+    ...(typeof value.path === "string" ? { path: value.path } : {}),
+    ...(command ? { command } : {}),
+    ...(typeof value.envKey === "string" ? { envKey: value.envKey } : {}),
+    ...(typeof value.packageName === "string" ? { packageName: value.packageName } : {}),
+    ...(typeof value.providerId === "string" ? { providerId: value.providerId } : {}),
+    ...(typeof value.mcpServerName === "string" ? { mcpServerName: value.mcpServerName } : {}),
+    ...(localCommandRef ? { localCommandRef } : {}),
+    ...(typeof value.required === "boolean" ? { required: value.required } : {}),
+  };
+}
+
+function parseExtensionContributionType(value: unknown): OpenWorkExtensionContributionType | null {
+  switch (value) {
+    case "settings-panel":
+    case "setup-instructions":
+    case "composer-prompt":
+    case "session-side-panel":
+    case "session-rail-item":
+    case "control-actions":
+    case "server-route":
+    case "native-capability":
+    case "test-action":
+      return value;
+    default:
+      return null;
+  }
+}
+
+function parseExtensionContributionLocation(value: unknown): OpenWorkExtensionContribution["location"] | undefined {
+  switch (value) {
+    case "settings-detail":
+    case "composer":
+    case "session-right-pane":
+    case "session-rail":
+    case "server":
+    case "native":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function parseExtensionContribution(value: unknown): OpenWorkExtensionContribution | null {
+  if (!isRecord(value)) return null;
+  const type = parseExtensionContributionType(value.type);
+  if (!type) return null;
+  const location = parseExtensionContributionLocation(value.location);
+  return {
+    type,
+    ...(typeof value.ref === "string" ? { ref: value.ref } : {}),
+    ...(typeof value.label === "string" ? { label: value.label } : {}),
+    ...(typeof value.description === "string" ? { description: value.description } : {}),
+    ...(typeof value.prompt === "string" ? { prompt: value.prompt } : {}),
+    ...(location ? { location } : {}),
+  };
+}
+
+function parseExtensionSetup(value: unknown): OpenWorkExtensionSetup | undefined {
+  if (!isRecord(value)) return undefined;
+  const requiredEnv = parseStringList(value.requiredEnv);
+  return {
+    ...(typeof value.instructions === "string" ? { instructions: value.instructions } : {}),
+    ...(typeof value.primaryCta === "string" ? { primaryCta: value.primaryCta } : {}),
+    ...(typeof value.secondaryCta === "string" ? { secondaryCta: value.secondaryCta } : {}),
+    ...(requiredEnv ? { requiredEnv } : {}),
+    ...(typeof value.testActionRef === "string" ? { testActionRef: value.testActionRef } : {}),
+  };
+}
+
+function parseReloadReason(value: unknown): ReloadReason | null {
+  switch (value) {
+    case "plugins":
+    case "skills":
+    case "mcp":
+    case "config":
+    case "agents":
+    case "commands":
+      return value;
+    default:
+      return null;
+  }
+}
+
+function parseReloadReasons(value: unknown): ReloadReason[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const reasons = value.flatMap((item) => {
+    const reason = parseReloadReason(item);
+    return reason ? [reason] : [];
+  });
+  return reasons.length === value.length ? reasons : undefined;
+}
+
+function parseExtensionLifecycle(value: unknown): OpenWorkExtensionLifecycle | undefined {
+  if (!isRecord(value)) return undefined;
+  const reload = parseReloadReasons(value.reload);
+  const detection = parseStringList(value.detection);
+  return {
+    ...(reload ? { reload } : {}),
+    ...(detection ? { detection } : {}),
+  };
+}
+
+function parseExtensionPlatform(value: unknown): OpenWorkExtensionManifest["platform"] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const platforms = value.flatMap((item) => {
+    switch (item) {
+      case "darwin":
+      case "linux":
+      case "windows":
+      case "web":
+        return [item];
+      default:
+        return [];
+    }
+  });
+  return platforms.length === value.length ? platforms : undefined;
+}
+
+function parseOpenWorkExtensionManifest(value: unknown): OpenWorkExtensionManifest | null {
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !== 1 ||
+    typeof value.id !== "string" ||
+    typeof value.name !== "string" ||
+    typeof value.description !== "string" ||
+    !Array.isArray(value.resources)
+  ) {
+    return null;
+  }
+  const source = parseExtensionSource(value.source);
+  if (!source) return null;
+  const resources = value.resources.flatMap((entry) => {
+    const resource = parseExtensionResource(entry);
+    return resource ? [resource] : [];
+  });
+  if (resources.length !== value.resources.length) return null;
+  const contributions = Array.isArray(value.contributions)
+    ? value.contributions.flatMap((entry) => {
+        const contribution = parseExtensionContribution(entry);
+        return contribution ? [contribution] : [];
+      })
+    : undefined;
+  if (Array.isArray(value.contributions) && contributions?.length !== value.contributions.length) return null;
+  const setup = parseExtensionSetup(value.setup);
+  const lifecycle = parseExtensionLifecycle(value.lifecycle);
+  const platform = parseExtensionPlatform(value.platform);
+  if (Array.isArray(value.platform) && !platform) return null;
+  return {
+    schemaVersion: 1,
+    id: value.id,
+    name: value.name,
+    description: value.description,
+    source,
+    ...(isRecord(value.icon)
+      ? { icon: {
+          ...(typeof value.icon.src === "string" ? { src: value.icon.src } : {}),
+          ...(typeof value.icon.simpleIconSlug === "string" ? { simpleIconSlug: value.icon.simpleIconSlug } : {}),
+        } }
+      : {}),
+    ...(isRecord(value.composer) && typeof value.composer.prompt === "string" ? { composer: { prompt: value.composer.prompt } } : {}),
+    ...(setup ? { setup } : {}),
+    resources,
+    ...(contributions ? { contributions } : {}),
+    ...(lifecycle ? { lifecycle } : {}),
+    ...(typeof value.defaultEnabled === "boolean" ? { defaultEnabled: value.defaultEnabled } : {}),
+    ...(platform ? { platform } : {}),
+  };
+}
+
 function parseDenExtensionProjection(value: unknown): DenOrgExtensionProjection | null {
   if (!isRecord(value) || typeof value.id !== "string" || typeof value.name !== "string") return null;
   const sourceFormat = parseExtensionSourceFormat(value.sourceFormat);
@@ -998,7 +1249,7 @@ function parseDenExtensionProjection(value: unknown): DenOrgExtensionProjection 
     name: value.name,
     description: typeof value.description === "string" ? value.description : null,
     sourceFormat,
-    manifest: null,
+    manifest: parseOpenWorkExtensionManifest(value.manifest),
   };
 }
 

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -975,6 +975,33 @@ function parsePluginConfigObject(value: unknown): DenPluginConfigObject | null {
   };
 }
 
+function parseExtensionSourceFormat(value: unknown): OpenWorkExtensionSourceFormat | null {
+  switch (value) {
+    case "openwork-builtin":
+    case "openwork-extension-manifest":
+    case "claude-plugin":
+    case "opencode-plugin":
+    case "mcp-directory":
+    case "manual":
+      return value;
+    default:
+      return null;
+  }
+}
+
+function parseDenExtensionProjection(value: unknown): DenOrgExtensionProjection | null {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.name !== "string") return null;
+  const sourceFormat = parseExtensionSourceFormat(value.sourceFormat);
+  if (!sourceFormat) return null;
+  return {
+    id: value.id,
+    name: value.name,
+    description: typeof value.description === "string" ? value.description : null,
+    sourceFormat,
+    manifest: null,
+  };
+}
+
 function parseOrgPlugin(value: unknown): DenOrgPlugin | null {
   if (!isRecord(value) || typeof value.id !== "string" || typeof value.name !== "string") return null;
   const counts = isRecord(value.componentCounts)
@@ -992,6 +1019,7 @@ function parseOrgPlugin(value: unknown): DenOrgPlugin | null {
     memberCount: typeof value.memberCount === "number" && Number.isFinite(value.memberCount) ? value.memberCount : 0,
     updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : null,
     componentCounts: counts,
+    extension: parseDenExtensionProjection(value.extension),
   };
 }
 

--- a/apps/app/tests/den-extension-projection.test.ts
+++ b/apps/app/tests/den-extension-projection.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createDenClient } from "../src/app/lib/den";
+
+const originalFetch = globalThis.fetch;
+
+describe("Den extension projections", () => {
+  afterEach(() => {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: originalFetch,
+    });
+  });
+
+  test("keeps extension manifests from marketplace responses", async () => {
+    const calls: string[] = [];
+    const fetchMock: typeof fetch = async (input) => {
+      calls.push(String(input));
+      return new Response(JSON.stringify({
+        item: {
+          marketplace: {
+            id: "marketplace_test",
+            name: "Test Marketplace",
+            description: null,
+            status: "active",
+            pluginCount: 1,
+            updatedAt: "2026-05-23T00:00:00.000Z",
+          },
+          plugins: [{
+            id: "plugin_test",
+            name: "Image Tools",
+            description: "Adds an image command.",
+            status: "active",
+            memberCount: 1,
+            updatedAt: "2026-05-23T00:00:00.000Z",
+            componentCounts: { command: 1 },
+            extension: {
+              id: "plugin_test",
+              name: "Image Tools",
+              description: "Adds an image command.",
+              sourceFormat: "claude-plugin",
+              manifest: {
+                schemaVersion: 1,
+                id: "plugin_test",
+                name: "Image Tools",
+                description: "Adds an image command.",
+                source: {
+                  format: "claude-plugin",
+                  origin: "den",
+                  reference: "plugin_test",
+                  trusted: false,
+                },
+                resources: [{
+                  type: "command",
+                  id: "plugin_test:command",
+                  label: "1 command",
+                  required: true,
+                }],
+                contributions: [{
+                  type: "setup-instructions",
+                  ref: "den.claudePlugin.setup",
+                  label: "Claude-compatible plugin import",
+                  location: "settings-detail",
+                }],
+                setup: {
+                  instructions: "Install from Den.",
+                },
+                lifecycle: {
+                  detection: ["command:plugin_test"],
+                },
+              },
+            },
+          }],
+          source: null,
+        },
+      }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    };
+
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const client = createDenClient({ baseUrl: "http://den.local", token: "token" });
+    const resolved = await client.getOrgMarketplaceResolved("organization_test", "marketplace_test");
+    const plugin = resolved.plugins[0];
+
+    expect(calls).toEqual(["http://den.local/v1/marketplaces/marketplace_test/resolved"]);
+    expect(plugin.extension?.sourceFormat).toBe("claude-plugin");
+    expect(plugin.extension?.manifest?.resources).toEqual([{
+      type: "command",
+      id: "plugin_test:command",
+      label: "1 command",
+      required: true,
+    }]);
+    expect(plugin.extension?.manifest?.setup?.instructions).toBe("Install from Den.");
+    expect(plugin.extension?.manifest?.contributions?.[0]?.ref).toBe("den.claudePlugin.setup");
+  });
+});

--- a/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
@@ -64,6 +64,14 @@ export const connectorMappingKindSchema = z.enum(connectorMappingKindValues)
 export const connectorSyncStatusSchema = z.enum(connectorSyncStatusValues)
 export const connectorSyncEventTypeSchema = z.enum(connectorSyncEventTypeValues)
 export const githubWebhookEventSchema = z.enum(githubWebhookEventValues)
+export const extensionSourceFormatSchema = z.enum([
+  "openwork-builtin",
+  "openwork-extension-manifest",
+  "claude-plugin",
+  "opencode-plugin",
+  "mcp-directory",
+  "manual",
+])
 
 export const pluginArchPaginationQuerySchema = z.object({
   cursor: cursorSchema.optional(),
@@ -436,6 +444,31 @@ export const pluginMembershipSchema = z.object({
   configObject: configObjectSchema.optional(),
 }).meta({ ref: "PluginArchPluginMembership" })
 
+export const extensionManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  id: z.string().trim().min(1).max(255),
+  name: z.string().trim().min(1).max(255),
+  description: z.string().trim().min(1).max(2048),
+  source: z.object({
+    format: extensionSourceFormatSchema,
+    trusted: z.boolean(),
+    origin: z.enum(["builtin", "den", "workspace", "local"]).optional(),
+    reference: z.string().trim().min(1).max(512).optional(),
+  }),
+  resources: z.array(jsonObjectSchema),
+  contributions: z.array(jsonObjectSchema).optional(),
+  setup: jsonObjectSchema.optional(),
+  lifecycle: jsonObjectSchema.optional(),
+}).passthrough().meta({ ref: "OpenWorkExtensionManifest" })
+
+export const pluginExtensionSchema = z.object({
+  id: pluginIdSchema,
+  name: z.string().trim().min(1).max(255),
+  description: nullableStringSchema,
+  sourceFormat: extensionSourceFormatSchema,
+  manifest: extensionManifestSchema.nullable(),
+}).meta({ ref: "PluginArchExtensionProjection" })
+
 export const pluginSchema = z.object({
   id: pluginIdSchema,
   organizationId: denTypeIdSchema("organization"),
@@ -451,6 +484,7 @@ export const pluginSchema = z.object({
     id: marketplaceIdSchema,
     name: z.string().trim().min(1).max(255),
   })).optional(),
+  extension: pluginExtensionSchema.nullable().optional(),
 }).meta({ ref: "PluginArchPlugin" })
 
 export const marketplacePluginSchema = z.object({

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -338,13 +338,75 @@ type PluginMarketplaceSummary = {
   name: string
 }
 
-function serializePlugin(row: PluginRow, memberCount?: number, marketplaces: PluginMarketplaceSummary[] = []) {
+function extensionResourceTypeForConfigObject(objectType: string) {
+  switch (objectType) {
+    case "skill":
+    case "agent":
+    case "command":
+    case "tool":
+    case "mcp":
+    case "hook":
+    case "context":
+      return objectType
+    default:
+      return "file"
+  }
+}
+
+function serializePluginExtension(row: PluginRow, componentCounts: Record<string, number>) {
+  const sourceFormat = "claude-plugin" as const
+  const description = row.description?.trim() || `${row.name} extension`
+  const resources = Object.entries(componentCounts).flatMap(([objectType, count]) => {
+    if (count <= 0) return []
+    const resourceType = extensionResourceTypeForConfigObject(objectType)
+    return [{
+      type: resourceType,
+      id: `${row.id}:${objectType}`,
+      label: `${count} ${objectType}${count === 1 ? "" : "s"}`,
+      required: true,
+    }]
+  })
+  return {
+    description: row.description,
+    id: row.id,
+    manifest: {
+      schemaVersion: 1 as const,
+      id: row.id,
+      name: row.name,
+      description,
+      source: {
+        format: sourceFormat,
+        origin: "den" as const,
+        reference: row.id,
+        trusted: false,
+      },
+      resources,
+      contributions: [{
+        type: "setup-instructions",
+        ref: "den.claudePlugin.setup",
+        label: "Claude-compatible plugin import",
+        location: "settings-detail",
+      }],
+      setup: {
+        instructions: "Imported from a Claude-compatible plugin. OpenWork installs its resources into this workspace as extension components.",
+      },
+      lifecycle: {
+        detection: Object.keys(componentCounts).map((objectType) => `${objectType}:${row.id}`),
+      },
+    },
+    name: row.name,
+    sourceFormat,
+  }
+}
+
+function serializePlugin(row: PluginRow, memberCount?: number, marketplaces: PluginMarketplaceSummary[] = [], componentCounts: Record<string, number> = {}) {
   return {
     createdAt: row.createdAt.toISOString(),
     createdByOrgMembershipId: row.createdByOrgMembershipId,
     deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
     description: row.description,
     id: row.id,
+    extension: serializePluginExtension(row, componentCounts),
     marketplaces,
     memberCount,
     name: row.name,
@@ -1536,10 +1598,13 @@ export async function getMarketplaceResolved(input: { context: PluginArchActorCo
     counts.set(objectType, (counts.get(objectType) ?? 0) + 1)
   }
 
-  const plugins = pluginRows.map((row) => ({
-    ...serializePlugin(row, memberCounts.get(row.id) ?? 0),
-    componentCounts: Object.fromEntries(componentCountsByPlugin.get(row.id) ?? new Map()),
-  }))
+  const plugins = pluginRows.map((row) => {
+    const componentCounts = Object.fromEntries(componentCountsByPlugin.get(row.id) ?? new Map())
+    return {
+      ...serializePlugin(row, memberCounts.get(row.id) ?? 0, [], componentCounts),
+      componentCounts,
+    }
+  })
 
   let source: MarketplaceResolvedSource = null
   if (pluginIds.length > 0) {
@@ -2062,11 +2127,14 @@ export async function getConnectorInstanceConfiguration(input: { connectorInstan
 
   return {
     autoImportNewPlugins: typeof savedAutoImport === "boolean" ? savedAutoImport : true,
-    configuredPlugins: pluginRows.map((row) => ({
-      ...serializePlugin(row, membershipCounts.get(row.id) ?? 0),
-      componentCounts: Object.fromEntries(pluginComponentCounts.get(row.id) ?? new Map()),
-      rootPath: pluginRootPaths.get(row.id) ?? null,
-    })),
+    configuredPlugins: pluginRows.map((row) => {
+      const componentCounts = Object.fromEntries(pluginComponentCounts.get(row.id) ?? new Map())
+      return {
+        ...serializePlugin(row, membershipCounts.get(row.id) ?? 0, [], componentCounts),
+        componentCounts,
+        rootPath: pluginRootPaths.get(row.id) ?? null,
+      }
+    }),
     connectorInstance: serializeConnectorInstance(instance),
     importedConfigObjectCount: configObjectRows.length,
     mappingCount: mappings.length,

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -354,7 +354,7 @@ function extensionResourceTypeForConfigObject(objectType: string) {
 }
 
 function serializePluginExtension(row: PluginRow, componentCounts: Record<string, number>) {
-  const sourceFormat = "claude-plugin" as const
+  const sourceFormat = "claude-plugin"
   const description = row.description?.trim() || `${row.name} extension`
   const resources = Object.entries(componentCounts).flatMap(([objectType, count]) => {
     if (count <= 0) return []
@@ -370,7 +370,7 @@ function serializePluginExtension(row: PluginRow, componentCounts: Record<string
     description: row.description,
     id: row.id,
     manifest: {
-      schemaVersion: 1 as const,
+      schemaVersion: 1,
       id: row.id,
       name: row.name,
       description,


### PR DESCRIPTION
## What

Make Den speak `extension` as the primary client-facing abstraction while keeping Claude-compatible plugins as the first supported source adapter.

## Changes

- Add plugin extension projection schema with `sourceFormat` and `manifest`
- Serialize current plugin rows with `sourceFormat: claude-plugin`
- Emit an OpenWork extension manifest projection for plugin rows
- Include resource summaries from component counts in marketplace and connector configuration responses
- Preserve existing plugin fields for compatibility while adding extension metadata for desktop clients
- Parse extension projections in the desktop Den client type surface

## Stack

Base: `extension-manifest-voice-v2` (#1922)

This is the Den follow-up after:
- Foundation: #1919, merged
- HandsFree: #1921
- Voice Mode: #1922

## Testing

Local:
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork-ee/den-api build`

Daytona final-stack verification:
- Ran Daytona Electron sandbox from this branch
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-server build`
- `pnpm --filter @openwork-ee/den-api build`
- CDP verified real Electron, workspace creation, HandsFree and Voice Mode catalog entries, manifest setup/resources/contributions, Voice settings panel, and Voice rail visibility
