### PR TITLE
feat(den): handle OAuth provider credentials

### DIFF
--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -73,10 +73,12 @@ const customProviderSchema = z.object({
 const llmProviderWriteSchema = z.object({
   name: z.string().trim().min(1).max(255),
   source: z.enum(["models_dev", "custom"]),
+  credentialKind: z.enum(["api_key", "opencode_oauth"]).optional().default("api_key"),
   providerId: z.string().trim().min(1).max(255).optional(),
   modelIds: z.array(z.string().trim().min(1).max(255)).min(1).optional(),
   customConfigText: z.string().trim().min(1).optional(),
   apiKey: z.string().trim().max(65535).optional(),
+  opencodeAuth: z.string().trim().max(65535).optional(),
   memberIds: z.array(denTypeIdSchema("member")).max(500).optional().default([]),
   teamIds: z.array(denTypeIdSchema("team")).max(500).optional().default([]),
 }).superRefine((value, ctx) => {
@@ -103,6 +105,14 @@ const llmProviderWriteSchema = z.object({
       code: z.ZodIssueCode.custom,
       path: ["customConfigText"],
       message: "Paste a custom provider config.",
+    })
+  }
+
+  if (value.credentialKind === "opencode_oauth" && value.source === "models_dev" && value.providerId?.trim().toLowerCase() !== "openai") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["credentialKind"],
+      message: "OpenCode OAuth credentials can only be used with the OpenAI catalog provider.",
     })
   }
 })
@@ -160,6 +170,33 @@ export function redactLlmProviderCredentials<T extends { apiKey?: unknown; openc
     ...provider,
     apiKey: undefined,
     opencodeAuth: undefined,
+  }
+}
+
+export function canImportLlmProviderCredential(payload: { currentMember: { isOwner: boolean; role: string } }) {
+  return isOrganizationAdmin(payload)
+}
+
+function normalizeOpencodeAuth(value: string | undefined) {
+  const trimmed = value?.trim() ?? ""
+  if (!trimmed) return null
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || (parsed as Record<string, unknown>).type !== "oauth") {
+      throw new Error("invalid auth")
+    }
+    return JSON.stringify(parsed)
+  } catch {
+    throw createFailure(400, "invalid_opencode_auth", "OpenCode OAuth credential must be valid OAuth auth JSON.")
+  }
+}
+
+function buildLlmProviderCredentialPayload(provider: LlmProviderRow) {
+  return {
+    ...redactLlmProviderCredentials(provider),
+    ...getCredentialFlags(provider),
+    apiKey: provider.credentialKind === "api_key" ? provider.apiKey : undefined,
+    opencodeAuth: provider.credentialKind === "opencode_oauth" ? provider.opencodeAuth : undefined,
   }
 }
 
@@ -292,6 +329,10 @@ async function resolveTeamIds(input: {
 }
 
 async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteSchema>) {
+  const credentialKind = input.credentialKind
+  const apiKey = credentialKind === "api_key" ? input.apiKey?.trim() || null : null
+  const opencodeAuth = credentialKind === "opencode_oauth" ? normalizeOpencodeAuth(input.opencodeAuth) : null
+
   if (input.source === "models_dev") {
     const provider = await getModelsDevProvider(input.providerId ?? "")
     if (!provider) {
@@ -308,10 +349,9 @@ async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteS
       return model
     })
 
-    const apiKey = input.apiKey?.trim() || null
-
     return {
       source: input.source,
+      credentialKind,
       providerId: provider.id,
       name: input.name,
       providerConfig: provider.config,
@@ -321,6 +361,7 @@ async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteS
         config: model.config,
       })),
       apiKey,
+      opencodeAuth,
     }
   }
 
@@ -344,6 +385,7 @@ async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteS
 
   return {
     source: input.source,
+    credentialKind,
     providerId: customProvider.data.id,
     name: input.name,
     providerConfig: providerConfig as JsonRecord,
@@ -352,7 +394,8 @@ async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteS
       name: model.name,
       config: model as JsonRecord,
     })),
-    apiKey: input.apiKey?.trim() || null,
+    apiKey,
+    opencodeAuth,
   }
 }
 
@@ -710,6 +753,67 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
     },
   )
 
+  app.get(
+    "/v1/llm-providers/:llmProviderId/import-credential",
+    describeRoute({
+      tags: ["LLM Providers"],
+      summary: "Import LLM provider credential",
+      description: "Returns credential material for an organization-managed LLM provider to privileged callers only.",
+      responses: {
+        200: jsonResponse("Provider credential returned successfully.", llmProviderResponseSchema),
+        400: jsonResponse("The provider path parameters were invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to import an organization LLM provider credential.", unauthorizedSchema),
+        403: jsonResponse("Only members who can manage this provider can import its credential.", forbiddenSchema),
+        404: jsonResponse("The provider could not be found.", notFoundSchema),
+      },
+    }),
+    requireUserMiddleware,
+    paramValidator(orgLlmProviderParamsSchema),
+    resolveOrganizationContextMiddleware,
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const params = c.req.valid("param")
+
+      let llmProviderId: LlmProviderId
+      try {
+        llmProviderId = parseLlmProviderId(params.llmProviderId)
+      } catch {
+        return c.json({ error: "llm_provider_not_found" }, 404)
+      }
+
+      const providerRows = await db
+        .select()
+        .from(LlmProviderTable)
+        .where(and(eq(LlmProviderTable.id, llmProviderId), eq(LlmProviderTable.organizationId, payload.organization.id)))
+        .limit(1)
+
+      const provider = providerRows[0]
+      if (!provider) return c.json({ error: "llm_provider_not_found" }, 404)
+      if (!canImportLlmProviderCredential(payload)) {
+        return c.json({ error: "forbidden", message: "Only organization admins can import provider credentials." }, 403)
+      }
+
+      const models = await db
+        .select()
+        .from(LlmProviderModelTable)
+        .where(eq(LlmProviderModelTable.llmProviderId, llmProviderId))
+
+      return c.json({
+        llmProvider: {
+          ...buildLlmProviderCredentialPayload(provider),
+          models: models
+            .map((model) => ({
+              id: model.modelId,
+              name: model.name,
+              config: model.modelConfig,
+              createdAt: model.createdAt,
+            }))
+            .sort((left, right) => left.name.localeCompare(right.name)),
+        },
+      })
+    },
+  )
+
   app.post(
     "/v1/llm-providers",
     describeRoute({
@@ -751,10 +855,12 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             organizationId: payload.organization.id,
             createdByOrgMembershipId: payload.currentMember.id,
             source: normalized.source,
+            credentialKind: normalized.credentialKind,
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
             apiKey: normalized.apiKey,
+            opencodeAuth: normalized.opencodeAuth,
             createdAt: now,
             updatedAt: now,
           })
@@ -800,13 +906,13 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             organizationId: payload.organization.id,
             createdByOrgMembershipId: payload.currentMember.id,
             source: normalized.source,
-            credentialKind: "api_key",
+            credentialKind: normalized.credentialKind,
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
             hasApiKey: Boolean(normalized.apiKey),
-            hasOpencodeAuth: false,
-            hasCredential: Boolean(normalized.apiKey),
+            hasOpencodeAuth: Boolean(normalized.opencodeAuth),
+            hasCredential: normalized.credentialKind === "opencode_oauth" ? Boolean(normalized.opencodeAuth) : Boolean(normalized.apiKey),
             createdAt: now,
             updatedAt: now,
           },
@@ -890,10 +996,16 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             .update(LlmProviderTable)
             .set({
               source: normalized.source,
+              credentialKind: normalized.credentialKind,
               providerId: normalized.providerId,
               name: normalized.name,
               providerConfig: normalized.providerConfig,
-              apiKey: input.apiKey === undefined ? provider.apiKey : normalized.apiKey,
+              apiKey: normalized.credentialKind === "api_key"
+                ? (input.apiKey === undefined ? provider.apiKey : normalized.apiKey)
+                : null,
+              opencodeAuth: normalized.credentialKind === "opencode_oauth"
+                ? (input.opencodeAuth === undefined ? provider.opencodeAuth : normalized.opencodeAuth)
+                : null,
               updatedAt,
             })
             .where(eq(LlmProviderTable.id, provider.id))
@@ -943,10 +1055,16 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
-            credentialKind: provider.credentialKind,
-            hasApiKey: input.apiKey === undefined ? Boolean(provider.apiKey) : Boolean(normalized.apiKey),
-            hasOpencodeAuth: Boolean(provider.opencodeAuth),
-            hasCredential: input.apiKey === undefined ? getCredentialFlags(provider).hasCredential : Boolean(normalized.apiKey),
+            credentialKind: normalized.credentialKind,
+            hasApiKey: normalized.credentialKind === "api_key"
+              ? (input.apiKey === undefined ? Boolean(provider.apiKey) : Boolean(normalized.apiKey))
+              : false,
+            hasOpencodeAuth: normalized.credentialKind === "opencode_oauth"
+              ? (input.opencodeAuth === undefined ? Boolean(provider.opencodeAuth) : Boolean(normalized.opencodeAuth))
+              : false,
+            hasCredential: normalized.credentialKind === "opencode_oauth"
+              ? (input.opencodeAuth === undefined ? Boolean(provider.opencodeAuth) : Boolean(normalized.opencodeAuth))
+              : (input.apiKey === undefined ? Boolean(provider.apiKey) : Boolean(normalized.apiKey)),
             updatedAt,
           },
         })

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -145,6 +145,24 @@ function isOrganizationAdmin(payload: { currentMember: { isOwner: boolean; role:
   return payload.currentMember.isOwner || memberHasRole(payload.currentMember.role, "admin")
 }
 
+export function getCredentialFlags(provider: Pick<LlmProviderRow, "credentialKind" | "apiKey" | "opencodeAuth">) {
+  const hasApiKey = Boolean(provider.apiKey && provider.apiKey.trim().length > 0)
+  const hasOpencodeAuth = Boolean(provider.opencodeAuth && provider.opencodeAuth.trim().length > 0)
+  return {
+    hasApiKey,
+    hasOpencodeAuth,
+    hasCredential: provider.credentialKind === "opencode_oauth" ? hasOpencodeAuth : hasApiKey,
+  }
+}
+
+export function redactLlmProviderCredentials<T extends { apiKey?: unknown; opencodeAuth?: unknown }>(provider: T): Omit<T, "apiKey" | "opencodeAuth"> & { apiKey: undefined; opencodeAuth: undefined } {
+  return {
+    ...provider,
+    apiKey: undefined,
+    opencodeAuth: undefined,
+  }
+}
+
 function canManageLlmProvider(
   payload: { currentMember: { id: MemberId; isOwner: boolean; role: string } },
   provider: LlmProviderRow,
@@ -464,7 +482,7 @@ async function loadLlmProviders(input: {
 
   return providers.map((provider) => ({
     ...provider,
-    hasApiKey: Boolean(provider.apiKey && provider.apiKey.trim().length > 0),
+    ...getCredentialFlags(provider),
     models: (modelsByProviderId.get(provider.id) ?? [])
       .map((model) => ({
         id: model.modelId,
@@ -607,8 +625,7 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
 
       return c.json({
         llmProviders: providers.map((provider) => ({
-          ...provider,
-          apiKey: undefined,
+          ...redactLlmProviderCredentials(provider),
           canManage: canManageLlmProvider(payload, provider),
         })),
       })
@@ -678,6 +695,8 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
       return c.json({
         llmProvider: {
           ...provider,
+          opencodeAuth: undefined,
+          ...getCredentialFlags(provider),
           models: models
             .map((model) => ({
               id: model.modelId,
@@ -781,10 +800,13 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             organizationId: payload.organization.id,
             createdByOrgMembershipId: payload.currentMember.id,
             source: normalized.source,
+            credentialKind: "api_key",
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
             hasApiKey: Boolean(normalized.apiKey),
+            hasOpencodeAuth: false,
+            hasCredential: Boolean(normalized.apiKey),
             createdAt: now,
             updatedAt: now,
           },
@@ -916,12 +938,15 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
 
         return c.json({
           llmProvider: {
-            ...provider,
+            ...redactLlmProviderCredentials(provider),
             source: normalized.source,
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
+            credentialKind: provider.credentialKind,
             hasApiKey: input.apiKey === undefined ? Boolean(provider.apiKey) : Boolean(normalized.apiKey),
+            hasOpencodeAuth: Boolean(provider.opencodeAuth),
+            hasCredential: input.apiKey === undefined ? getCredentialFlags(provider).hasCredential : Boolean(normalized.apiKey),
             updatedAt,
           },
         })

--- a/ee/apps/den-api/test/llm-provider-credentials.test.ts
+++ b/ee/apps/den-api/test/llm-provider-credentials.test.ts
@@ -1,0 +1,61 @@
+import { beforeAll, expect, test } from "bun:test"
+import { Hono } from "hono"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+let llmProviderModule: typeof import("../src/routes/org/llm-providers.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  llmProviderModule = await import("../src/routes/org/llm-providers.js")
+})
+
+test("generic provider payload redaction removes API key and OAuth auth material", () => {
+  const redacted = llmProviderModule.redactLlmProviderCredentials({
+    id: "llmProvider_secret_123",
+    apiKey: "plain-secret",
+    opencodeAuth: JSON.stringify({ type: "oauth", access: "access", refresh: "refresh", expires: 1 }),
+  })
+
+  expect(redacted).toEqual({
+    id: "llmProvider_secret_123",
+    apiKey: undefined,
+    opencodeAuth: undefined,
+  })
+})
+
+test("credential flags expose presence only, never credential values", () => {
+  expect(llmProviderModule.getCredentialFlags({
+    credentialKind: "opencode_oauth",
+    apiKey: "plain-secret",
+    opencodeAuth: JSON.stringify({ type: "oauth", access: "access", refresh: "refresh", expires: 1 }),
+  })).toEqual({ hasApiKey: true, hasOpencodeAuth: true, hasCredential: true })
+})
+
+test("credential import permission gate requires organization admin role", () => {
+  const owner = { currentMember: { isOwner: true, role: "member" } }
+  const admin = { currentMember: { isOwner: false, role: "admin" } }
+  const creatorOnly = { currentMember: { isOwner: false, role: "member" } }
+
+  expect(llmProviderModule.canImportLlmProviderCredential(owner)).toBe(true)
+  expect(llmProviderModule.canImportLlmProviderCredential(admin)).toBe(true)
+  expect(llmProviderModule.canImportLlmProviderCredential(creatorOnly)).toBe(false)
+})
+
+test("purpose-specific import endpoint requires authentication", async () => {
+  const app = new Hono()
+  llmProviderModule.registerOrgLlmProviderRoutes(app)
+
+  const response = await app.request("http://den.local/v1/llm-providers/llmProvider_secret_123/import-credential", {
+    method: "GET",
+  })
+
+  expect(response.status).toBe(401)
+  await expect(response.json()).resolves.toEqual({ error: "unauthorized" })
+})

--- a/ee/packages/den-db/drizzle/0019_llm_provider_opencode_oauth.sql
+++ b/ee/packages/den-db/drizzle/0019_llm_provider_opencode_oauth.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `llm_provider`
+  ADD COLUMN `credential_kind` enum('api_key','opencode_oauth') NOT NULL DEFAULT 'api_key' AFTER `provider_config`,
+  ADD COLUMN `opencode_auth` text AFTER `api_key`;

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1779380000000,
       "tag": "0018_invited_org_members",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "5",
+      "when": 1777486400000,
+      "tag": "0019_llm_provider_opencode_oauth",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/src/schema/sharables/llm-providers.ts
+++ b/ee/packages/den-db/src/schema/sharables/llm-providers.ts
@@ -30,7 +30,11 @@ export const LlmProviderTable = mysqlTable(
     providerConfig: json("provider_config")
       .$type<Record<string, unknown>>()
       .notNull(),
+    credentialKind: mysqlEnum("credential_kind", ["api_key", "opencode_oauth"])
+      .notNull()
+      .default("api_key"),
     apiKey: encryptedTextColumn("api_key"),
+    opencodeAuth: encryptedTextColumn("opencode_auth"),
     createdAt: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { fsp: 3 })
       .notNull()


### PR DESCRIPTION
## Summary

Adds Den API handling for API-key versus OpenCode OAuth-backed LLM provider credentials on top of #1920.

Scope:

- Accepts `credentialKind` and `opencodeAuth` in provider create/update payloads.
- Stores exactly one credential shape at a time (`apiKey` for API-key providers, `opencodeAuth` for OAuth-backed providers).
- Includes credential flags/redaction in existing provider responses.
- Adds a privileged provider credential import endpoint for API-key or OAuth credential material.
- Adds focused Den API credential handling tests.

## Stack

- Base PR: #1920 provider credential contract/model base.
- This PR: Den API credential create/update/read/import handling.

GitHub may show `dev` as base because stacked branches live on the fork; review against `Pagecran:stack/provider-credential-contract-base` / #1920.

## Verification

- From `ee/apps/den-api`: `pnpm exec bun test test/llm-provider-credentials.test.ts` — PASS, 4 tests.
- From `ee/apps/den-api`: `pnpm exec tsc -p tsconfig.json --noEmit` — PASS.