### PR TITLE
Fix responsive extension card layout

### DIFF
--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -117,24 +117,24 @@ export function ExtensionCard(props: ExtensionCardProps) {
 
         {/* Content */}
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <h4 className="text-sm font-semibold text-dls-text">{name}</h4>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <h4 className="min-w-0 break-words text-sm font-semibold text-dls-text">{name}</h4>
             {connected ? (
-              <span className="rounded-md bg-green-3 px-1.5 py-0.5 text-[10px] font-medium text-green-11">
+              <span className="shrink-0 rounded-md bg-green-3 px-1.5 py-0.5 text-[10px] font-medium text-green-11">
                 {connectedLabel}
               </span>
             ) : (
-              <span className={`rounded-md px-1.5 py-0.5 text-[10px] font-medium ${kindStyle[kind]}`}>
+              <span className={`shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium ${kindStyle[kind]}`}>
                 {kindLabel[kind]}
               </span>
             )}
             {hidden ? (
-              <span className="rounded-md bg-gray-3 px-1.5 py-0.5 text-[10px] font-medium text-gray-11">
+              <span className="shrink-0 rounded-md bg-gray-3 px-1.5 py-0.5 text-[10px] font-medium text-gray-11">
                 Hidden
               </span>
             ) : null}
             {disabledReason ? (
-              <span className="rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
+              <span className="shrink-0 rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
                 Disabled
               </span>
             ) : null}

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -366,7 +366,7 @@ export function CloudMarketplacesView({
       ) : null}
 
       {visibleRows.length > 0 ? (
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3">
           {visibleRows.map((row) => (
             <MarketplacePackageCard
               key={`${row.marketplaceId}:${row.plugin.id}`}

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -467,7 +467,7 @@ export function McpView(props: McpViewProps) {
             onChange={(e) => setSearch(e.currentTarget.value)}
           />
         </div>
-        <div className="flex items-center gap-1.5">
+        <div className="flex flex-wrap items-center gap-1.5">
           {(["all", "mcp", "skill"] as const).map((f) => (
             <Button
               key={f}
@@ -798,7 +798,7 @@ function McpQuickConnectSection(props: {
         <span className="text-[11px] text-dls-secondary">{t("mcp.one_click_connect")}</span>
       </div>
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3">
         {/* MCP entries */}
         {props.entries.map((entry) => {
           const configured = props.isConfigured(entry);


### PR DESCRIPTION
## Summary
- Make the Extensions card grid respond to available container width instead of the viewport breakpoint.
- Keep the standard two-column extension view when there is enough room.
- Let extension badges wrap safely in cramped cards.

## Why
- The settings pane can be narrow while the window is still above the `sm` viewport breakpoint, which forced cramped two-column cards.

## Issue
- N/A

## Scope
- Extensions quick-connect grid.
- Extensions marketplace grid.
- Shared extension card title/badge wrapping.

## Out of scope
- Extension connection behavior.
- Marketplace data loading.

## Testing
### Ran
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app build`

### Result
- pass: typecheck completed successfully.
- pass: production app build completed successfully.

## CI status
- pass: all PR checks passed, including `i18n-audit`, `openwork-tests (blacksmith-4vcpu-ubuntu-2204)`, `openwork-tests (macos-14)`, and Vercel preview checks.
- code-related failures: none.
- external/env/auth blockers: none.

## Manual verification
1. Opened Settings -> Extensions in the running OpenWork app.
2. Resized the app to 780px wide and confirmed Available apps rendered as a single list with no horizontal overflow.
3. Restored the app to 1180px wide and confirmed Available apps kept the prior two-column card layout.
4. Read both screenshots after capture to confirm the responsive and standard layouts visually.

## Evidence
- Narrow responsive screenshot: `/var/folders/d9/xqhkvsp94rg0n0n523snqztm0000gn/T/browser-screenshot-1779570983001.png`
- Standard view screenshot: `/var/folders/d9/xqhkvsp94rg0n0n523snqztm0000gn/T/browser-screenshot-1779571038226.png`
- Browser computed verification at 780px: grid width 476px, columns `476px`, bodyOverflowX 0.
- Browser computed verification at 1180px: grid width 768px, columns `378px 378px`, bodyOverflowX 0.

## Risk
- Low. This only changes CSS layout thresholds and badge wrapping for extension cards.

## Rollback
- Revert commit `a8d7e7e30`.