### PR TITLE
fix(app): use Den API URL for cloud sessions

### DIFF
--- a/apps/app/src/react-app/domains/settings/cloud/cloud-session-provider.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/cloud-session-provider.tsx
@@ -9,6 +9,7 @@ import {
   type DenOrgSummary,
   type DenUser,
 } from "../../../../app/lib/den";
+import { denSettingsChangedEvent } from "../../../../app/lib/den-session-events";
 
 type CloudActiveOrganization = Pick<DenOrgSummary, "id" | "name" | "slug">;
 
@@ -40,6 +41,7 @@ export function CloudSessionProvider({ children }: CloudSessionProviderProps) {
   const initial = React.useMemo(() => readDenSettings(), []);
 
   const [baseUrl, setBaseUrl] = React.useState(() => initial.baseUrl || DEFAULT_DEN_BASE_URL);
+  const [apiBaseUrl, setApiBaseUrl] = React.useState(() => initial.apiBaseUrl || "");
   const [authToken, setAuthToken] = React.useState(initial.authToken?.trim() || "");
   const [isSignedIn, setIsSignedIn] = React.useState(false);
   const [user, setUser] = React.useState<DenUser | null>(null);
@@ -58,9 +60,20 @@ export function CloudSessionProvider({ children }: CloudSessionProviderProps) {
   const activeOrgName = activeOrganization?.name ?? "";
   const hasActiveOrg = Boolean(activeOrganization);
 
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleSettingsChanged = () => {
+      setApiBaseUrl(readDenSettings().apiBaseUrl || "");
+    };
+
+    window.addEventListener(denSettingsChangedEvent, handleSettingsChanged);
+    return () => window.removeEventListener(denSettingsChangedEvent, handleSettingsChanged);
+  }, []);
+
   const client = React.useMemo(
-    () => createDenClient({ baseUrl, token: authToken }),
-    [authToken, baseUrl],
+    () => createDenClient({ baseUrl, apiBaseUrl, token: authToken }),
+    [apiBaseUrl, authToken, baseUrl],
   );
 
   const value = React.useMemo<CloudSessionContextValue>(


### PR DESCRIPTION
## Summary
- pass the persisted Den `apiBaseUrl` into the shared Cloud session client
- keep the Cloud session client in sync when Den settings change
- fixes split Den Web/API deployments where `/v1/me` must go to the API host instead of the web host

## Verification
- `pnpm --filter @openwork/app exec bun test tests/den-extension-projection.test.ts`
- `pnpm --filter @openwork/app typecheck`
- Daytona Electron manual check: after checking out this fix, configured separate Den Web and API preview URLs; Settings -> Cloud -> Account showed `Connected` for `pr1923+1779571770862@example.com` and `PR 1923 Test Org`.

## Evidence
- Related Desktop Cloud marketplace flow recording from PR #1923 validation: https://8090-gvgu5lgbscbzsa4e.daytonaproxy01.net/recordings/pr-1923-desktop-cloud-plugin-import.mp4
- No separate recording was captured for this one-line follow-up; the Daytona Electron manual check above verifies the split-host bug this PR fixes.

## Notes
- Targeting `extension-manifest-voice-v2` because #1923 is already merged there; this keeps the PR to one follow-up commit and avoids reintroducing the merged #1923 commits.