### PR TITLE
feat(den): add OpenAI OAuth provider flow

### DIFF
--- a/apps/server/src/managed-provider-sync.e2e.test.ts
+++ b/apps/server/src/managed-provider-sync.e2e.test.ts
@@ -32,7 +32,7 @@ function providerPayload() {
         credentialKind: "api_key",
         providerConfig: { id: "anthropic", name: "Anthropic", env: ["ANTHROPIC_API_KEY"], npm: "@ai-sdk/anthropic" },
         models: [{ id: "claude", name: "Claude", config: { id: "claude", limit: { context: 200000 } } }],
-        apiKey: "sk-server-secret",
+        apiKey: "plain-server-secret",
         revision: "provider-rev-1",
       },
       {
@@ -63,7 +63,7 @@ async function boot(options: { failAuth?: boolean } = {}) {
       const url = new URL(request.url);
       if (url.pathname.startsWith("/auth/")) {
         authCalls.push(await request.json());
-        if (options.failAuth) return Response.json({ error: "bad sk-server-secret" }, { status: 500 });
+        if (options.failAuth) return Response.json({ error: "bad plain-server-secret access-secret refresh-secret" }, { status: 500 });
         return Response.json({ ok: true });
       }
       return Response.json({ ok: true });
@@ -129,16 +129,16 @@ describe("managed provider sync runtime route", () => {
       expect(response.status).toBe(200);
       const body = await response.json();
       expect(body).toEqual({ status: "applied", providerCount: 2, revision: "sync-rev-1" });
-      expect(JSON.stringify(body)).not.toContain("sk-server-secret");
+      expect(JSON.stringify(body)).not.toContain("plain-server-secret");
       expect(JSON.stringify(body)).not.toContain("refresh-secret");
     }
 
     const config = readFileSync(join(workspace, "opencode.jsonc"), "utf8");
     expect(config.match(/llmProvider_den_anthropic/g)?.length).toBe(1);
     expect(config.match(/"openai"/g)?.length).toBeGreaterThanOrEqual(1);
-    expect(config).not.toContain("sk-server-secret");
+    expect(config).not.toContain("plain-server-secret");
     expect(authCalls).toHaveLength(4);
-    expect(JSON.stringify(authCalls[0])).toContain("sk-server-secret");
+    expect(JSON.stringify(authCalls[0])).toContain("plain-server-secret");
     expect(JSON.stringify(authCalls[1])).toContain("refresh-secret");
   });
 
@@ -152,6 +152,9 @@ describe("managed provider sync runtime route", () => {
     expect(response.status).toBe(502);
     const body = await response.json();
     expect(body.status).toBe("failed");
-    expect(JSON.stringify(body)).not.toContain("sk-server-secret");
+    expect(JSON.stringify(body)).not.toContain("plain-server-secret");
+    expect(JSON.stringify(body)).not.toContain("access-secret");
+    expect(JSON.stringify(body)).not.toContain("refresh-secret");
+    expect(body.reason).toBe("Managed provider sync failed");
   });
 });

--- a/apps/server/src/managed-provider-sync.e2e.test.ts
+++ b/apps/server/src/managed-provider-sync.e2e.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+type Served = {
+  port: number;
+  stop: (closeActiveConnections?: boolean) => void | Promise<void>;
+};
+
+const HOST_TOKEN = "owt_provider_sync_host_token";
+const CLIENT_TOKEN = "owt_provider_sync_client_token";
+const stops: Array<() => void | Promise<void>> = [];
+const dirs: string[] = [];
+
+function hostAuth() {
+  return { "x-openwork-host-token": HOST_TOKEN, "content-type": "application/json" };
+}
+
+function providerPayload() {
+  return {
+    revision: "sync-rev-1",
+    providers: [
+      {
+        id: "llmProvider_den_anthropic",
+        providerId: "anthropic",
+        name: "Anthropic",
+        source: "models_dev",
+        credentialKind: "api_key",
+        providerConfig: { id: "anthropic", name: "Anthropic", env: ["ANTHROPIC_API_KEY"], npm: "@ai-sdk/anthropic" },
+        models: [{ id: "claude", name: "Claude", config: { id: "claude", limit: { context: 200000 } } }],
+        apiKey: "sk-server-secret",
+        revision: "provider-rev-1",
+      },
+      {
+        id: "llmProvider_den_openai",
+        providerId: "openai",
+        name: "OpenAI",
+        source: "models_dev",
+        credentialKind: "opencode_oauth",
+        providerConfig: { id: "openai", name: "OpenAI", env: ["OPENAI_API_KEY"], npm: "@ai-sdk/openai" },
+        models: [{ id: "gpt-5", name: "GPT-5", config: { id: "gpt-5" } }],
+        opencodeAuth: JSON.stringify({ type: "oauth", access: "access-secret", refresh: "refresh-secret", expires: 9 }),
+        revision: "provider-rev-2",
+      },
+    ],
+  };
+}
+
+async function boot(options: { failAuth?: boolean } = {}) {
+  const workspace = mkdtempSync(join(tmpdir(), "openwork-managed-provider-workspace-"));
+  const stores = mkdtempSync(join(tmpdir(), "openwork-managed-provider-stores-"));
+  dirs.push(workspace, stores);
+  process.env.OPENWORK_TOKEN_STORE = join(stores, "tokens.json");
+
+  const authCalls: unknown[] = [];
+  const opencode = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname.startsWith("/auth/")) {
+        authCalls.push(await request.json());
+        if (options.failAuth) return Response.json({ error: "bad sk-server-secret" }, { status: 500 });
+        return Response.json({ ok: true });
+      }
+      return Response.json({ ok: true });
+    },
+  });
+  stops.push(() => opencode.stop(true));
+
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: CLIENT_TOKEN,
+    hostToken: HOST_TOKEN,
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: workspace, workspaceType: "local", preset: "starter", baseUrl: `http://127.0.0.1:${opencode.port}` }],
+    authorizedRoots: [workspace],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { base: `http://127.0.0.1:${server.port}`, workspace, authCalls };
+}
+
+beforeEach(() => {
+  delete process.env.OPENWORK_TOKEN_STORE;
+});
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+  delete process.env.OPENWORK_TOKEN_STORE;
+});
+
+describe("managed provider sync runtime route", () => {
+  test("requires host token and rejects client bearer tokens", async () => {
+    const { base } = await boot();
+    const unauthenticated = await fetch(`${base}/managed-providers/sync`, { method: "POST", body: JSON.stringify(providerPayload()) });
+    expect(unauthenticated.status).toBe(401);
+
+    const issued = await fetch(`${base}/tokens`, { method: "POST", headers: hostAuth(), body: JSON.stringify({ scope: "owner" }) });
+    const body = (await issued.json()) as { token: string };
+    const ownerBearer = await fetch(`${base}/managed-providers/sync`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${body.token}`, "content-type": "application/json" },
+      body: JSON.stringify(providerPayload()),
+    });
+    expect(ownerBearer.status).toBe(401);
+  });
+
+  test("applies API key and OAuth providers idempotently without response leakage", async () => {
+    const { base, workspace, authCalls } = await boot();
+    for (let index = 0; index < 2; index += 1) {
+      const response = await fetch(`${base}/managed-providers/sync`, {
+        method: "POST",
+        headers: hostAuth(),
+        body: JSON.stringify(providerPayload()),
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual({ status: "applied", providerCount: 2, revision: "sync-rev-1" });
+      expect(JSON.stringify(body)).not.toContain("sk-server-secret");
+      expect(JSON.stringify(body)).not.toContain("refresh-secret");
+    }
+
+    const config = readFileSync(join(workspace, "opencode.jsonc"), "utf8");
+    expect(config.match(/llmProvider_den_anthropic/g)?.length).toBe(1);
+    expect(config.match(/"openai"/g)?.length).toBeGreaterThanOrEqual(1);
+    expect(config).not.toContain("sk-server-secret");
+    expect(authCalls).toHaveLength(4);
+    expect(JSON.stringify(authCalls[0])).toContain("sk-server-secret");
+    expect(JSON.stringify(authCalls[1])).toContain("refresh-secret");
+  });
+
+  test("sanitizes OpenCode auth apply failures", async () => {
+    const { base } = await boot({ failAuth: true });
+    const response = await fetch(`${base}/managed-providers/sync`, {
+      method: "POST",
+      headers: hostAuth(),
+      body: JSON.stringify(providerPayload()),
+    });
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.status).toBe("failed");
+    expect(JSON.stringify(body)).not.toContain("sk-server-secret");
+  });
+});

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1546,6 +1546,58 @@ function createRoutes(
     return jsonResponse({ ok: true });
   });
 
+  addRoute(routes, "POST", "/managed-providers/sync", "host-token", async (ctx) => {
+    ensureWritable(config);
+    const body = await readJsonBody(ctx.request);
+    const payload = parseManagedProviderSyncPayload(body);
+    const workspace = config.workspaces[0];
+    if (!workspace) {
+      throw new ApiError(409, "workspace_unavailable", "No worker workspace is available for managed provider sync");
+    }
+
+    const configFingerprintBefore = await computeReloadFingerprint(workspace.path, "config");
+    const applied: string[] = [];
+    try {
+      for (const provider of payload.providers) {
+        await applyManagedProviderConfig(workspace.path, provider);
+        await applyManagedProviderAuth(config, workspace, provider);
+        applied.push(provider.id);
+      }
+    } catch (error) {
+      return jsonResponse({
+        status: "failed",
+        providerCount: applied.length,
+        revision: payload.revision,
+        reason: sanitizeManagedProviderApplyError(error),
+      }, 502);
+    }
+
+    await writeOpenworkConfig(workspace.path, {
+      managedProviders: {
+        source: "den",
+        revision: payload.revision,
+        applied,
+        appliedAt: new Date().toISOString(),
+      },
+    }, true);
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "host" },
+      action: "managedProviders.sync",
+      target: "opencode.json",
+      summary: `Synced ${applied.length} managed provider${applied.length === 1 ? "" : "s"}`,
+      timestamp: Date.now(),
+    });
+
+    if (configFingerprintBefore !== await computeReloadFingerprint(workspace.path, "config")) {
+      emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(opencodeConfigPath(workspace.path)));
+    }
+
+    return jsonResponse({ status: "applied", providerCount: applied.length, revision: payload.revision });
+  });
+
   addRoute(routes, "POST", "/workspaces/local", "host", async (ctx) => {
     ensureWritable(config);
     const body = await readJsonBody(ctx.request);
@@ -3534,6 +3586,152 @@ async function persistServerWorkspaceState(config: ServerConfig): Promise<boolea
 
 function normalizeOpencodeScope(value: string | null | undefined): "project" | "global" {
   return value?.trim().toLowerCase() === "global" ? "global" : "project";
+}
+
+type ManagedProviderSyncProvider = {
+  id: string;
+  providerId: string;
+  name: string;
+  source: string;
+  credentialKind: "api_key" | "opencode_oauth";
+  providerConfig: Record<string, unknown>;
+  models: Array<{ id: string; name: string; config: Record<string, unknown> }>;
+  apiKey?: string;
+  opencodeAuth?: string;
+  revision: string;
+};
+
+type ManagedProviderSyncPayload = {
+  providers: ManagedProviderSyncProvider[];
+  revision: string;
+};
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readRequiredString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new ApiError(400, "invalid_payload", `${key} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function readOptionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") {
+    throw new ApiError(400, "invalid_payload", `${key} must be a string`);
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function parseManagedProviderSyncPayload(input: unknown): ManagedProviderSyncPayload {
+  if (!isRecordValue(input) || !Array.isArray(input.providers)) {
+    throw new ApiError(400, "invalid_payload", "providers must be an array");
+  }
+  const revision = readRequiredString(input, "revision");
+  const providers = input.providers.map((entry) => {
+    if (!isRecordValue(entry)) {
+      throw new ApiError(400, "invalid_payload", "Each provider must be an object");
+    }
+    const rawCredentialKind = entry.credentialKind;
+    if (rawCredentialKind !== "api_key" && rawCredentialKind !== "opencode_oauth") {
+      throw new ApiError(400, "invalid_payload", "credentialKind must be api_key or opencode_oauth");
+    }
+    const credentialKind: ManagedProviderSyncProvider["credentialKind"] = rawCredentialKind;
+    const providerConfig = entry.providerConfig;
+    if (!isRecordValue(providerConfig)) {
+      throw new ApiError(400, "invalid_payload", "providerConfig must be an object");
+    }
+    const modelsInput = entry.models;
+    if (!Array.isArray(modelsInput)) {
+      throw new ApiError(400, "invalid_payload", "models must be an array");
+    }
+    const models = modelsInput.map((model) => {
+      if (!isRecordValue(model) || !isRecordValue(model.config)) {
+        throw new ApiError(400, "invalid_payload", "Each model must include config");
+      }
+      return {
+        id: readRequiredString(model, "id"),
+        name: readRequiredString(model, "name"),
+        config: model.config,
+      };
+    });
+    return {
+      id: readRequiredString(entry, "id"),
+      providerId: readRequiredString(entry, "providerId"),
+      name: readRequiredString(entry, "name"),
+      source: readRequiredString(entry, "source"),
+      credentialKind,
+      providerConfig,
+      models,
+      apiKey: readOptionalString(entry, "apiKey"),
+      opencodeAuth: readOptionalString(entry, "opencodeAuth"),
+      revision: readRequiredString(entry, "revision"),
+    };
+  });
+  return { providers, revision };
+}
+
+function getManagedProviderEnv(config: Record<string, unknown>) {
+  return Array.isArray(config.env) ? config.env.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0) : [];
+}
+
+export function getManagedProviderRuntimeId(provider: Pick<ManagedProviderSyncProvider, "id" | "providerId" | "source" | "credentialKind">) {
+  if (provider.source === "openwork") return "openwork";
+  if (provider.credentialKind === "opencode_oauth") return provider.providerId.trim();
+  return provider.id.trim();
+}
+
+export function buildManagedProviderRuntimeConfig(provider: ManagedProviderSyncProvider) {
+  const models = Object.fromEntries(provider.models.map((model) => [model.id, { ...model.config, id: model.id, name: model.name }]));
+  const next: Record<string, unknown> = {
+    id: provider.providerId,
+    name: provider.name,
+    env: getManagedProviderEnv(provider.providerConfig),
+    models,
+  };
+  for (const key of ["npm", "api", "options", "whitelist", "blacklist"] as const) {
+    const value = provider.providerConfig[key];
+    if (value !== undefined) next[key] = value;
+  }
+  return next;
+}
+
+async function applyManagedProviderConfig(workspaceRoot: string, provider: ManagedProviderSyncProvider) {
+  const providerId = getManagedProviderRuntimeId(provider);
+  await updateJsoncPath(opencodeConfigPath(workspaceRoot), ["provider", providerId], buildManagedProviderRuntimeConfig(provider));
+}
+
+function parseManagedOpencodeAuth(provider: ManagedProviderSyncProvider): unknown {
+  if (provider.credentialKind === "api_key") {
+    if (!provider.apiKey) throw new ApiError(400, "missing_provider_credential", "Managed provider is missing an API credential");
+    return { type: "api", key: provider.apiKey };
+  }
+  if (!provider.opencodeAuth) throw new ApiError(400, "missing_provider_credential", "Managed provider is missing an OAuth credential");
+  try {
+    const auth = JSON.parse(provider.opencodeAuth) as unknown;
+    if (!isRecordValue(auth) || auth.type !== "oauth") throw new Error("invalid auth");
+    return auth;
+  } catch {
+    throw new ApiError(400, "invalid_provider_credential", "Managed provider OAuth credential is invalid");
+  }
+}
+
+async function applyManagedProviderAuth(config: ServerConfig, workspace: WorkspaceInfo, provider: ManagedProviderSyncProvider) {
+  const providerId = getManagedProviderRuntimeId(provider);
+  await fetchOpencodeJson(config, workspace, `/auth/${encodeURIComponent(providerId)}`, {
+    method: "POST",
+    body: { providerID: providerId, auth: parseManagedOpencodeAuth(provider) },
+  });
+}
+
+function sanitizeManagedProviderApplyError(error: unknown) {
+  const message = error instanceof ApiError || error instanceof Error ? error.message : "Managed provider sync failed";
+  return message.replace(/sk-[A-Za-z0-9_-]+/g, "[redacted]").slice(0, 300);
 }
 
 function resolveOpencodeConfigFilePath(scope: "project" | "global", workspaceRoot: string): string {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -580,6 +580,46 @@ function withCors(response: Response, request: Request, config: ServerConfig) {
   return new Response(response.body, { status: response.status, headers });
 }
 
+async function fetchOpencodeJson(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  path: string,
+  init: { method?: string; body?: unknown } = {},
+): Promise<unknown> {
+  const connection = resolveWorkspaceOpencodeConnection(config, workspace);
+  const baseUrl = connection.baseUrl?.trim();
+  if (!baseUrl) {
+    throw new ApiError(502, "opencode_unavailable", "OpenCode base URL is not configured");
+  }
+
+  const target = new URL(path, baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
+  const headers = new Headers({ "Content-Type": "application/json" });
+  const directory = resolveOpencodeDirectory(workspace);
+  if (directory) {
+    headers.set("X-OpenCode-Directory", directory);
+    headers.set("X-Opencode-Directory", directory);
+  }
+  if (connection.authHeader) {
+    headers.set("Authorization", connection.authHeader);
+  }
+
+  const response = await fetch(target, {
+    method: init.method ?? "GET",
+    headers,
+    body: init.body === undefined ? undefined : JSON.stringify(init.body),
+  });
+  const text = await response.text();
+  const json = text ? parseOpencodeErrorBody(text) : null;
+  if (!response.ok) {
+    throw new ApiError(502, "opencode_request_failed", "OpenCode request failed", {
+      status: response.status,
+      body: json,
+      path,
+    });
+  }
+  return json;
+}
+
 async function requireClient(request: Request, config: ServerConfig, tokens: TokenService): Promise<Actor> {
   const header = request.headers.get("authorization") ?? "";
   const match = header.match(/^Bearer\s+(.+)$/i);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3770,8 +3770,7 @@ async function applyManagedProviderAuth(config: ServerConfig, workspace: Workspa
 }
 
 function sanitizeManagedProviderApplyError(error: unknown) {
-  const message = error instanceof ApiError || error instanceof Error ? error.message : "Managed provider sync failed";
-  return message.replace(/sk-[A-Za-z0-9_-]+/g, "[redacted]").slice(0, 300);
+  return "Managed provider sync failed";
 }
 
 function resolveOpencodeConfigFilePath(scope: "project" | "global", workspaceRoot: string): string {

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -73,10 +73,12 @@ const customProviderSchema = z.object({
 const llmProviderWriteSchema = z.object({
   name: z.string().trim().min(1).max(255),
   source: z.enum(["models_dev", "custom"]),
+  credentialKind: z.enum(["api_key", "opencode_oauth"]).optional().default("api_key"),
   providerId: z.string().trim().min(1).max(255).optional(),
   modelIds: z.array(z.string().trim().min(1).max(255)).min(1).optional(),
   customConfigText: z.string().trim().min(1).optional(),
   apiKey: z.string().trim().max(65535).optional(),
+  opencodeAuth: z.string().trim().max(65535).optional(),
   memberIds: z.array(denTypeIdSchema("member")).max(500).optional().default([]),
   teamIds: z.array(denTypeIdSchema("team")).max(500).optional().default([]),
 }).superRefine((value, ctx) => {
@@ -103,6 +105,14 @@ const llmProviderWriteSchema = z.object({
       code: z.ZodIssueCode.custom,
       path: ["customConfigText"],
       message: "Paste a custom provider config.",
+    })
+  }
+
+  if (value.credentialKind === "opencode_oauth" && value.source === "models_dev" && value.providerId?.trim().toLowerCase() !== "openai") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["credentialKind"],
+      message: "OpenCode OAuth credentials can only be used with the OpenAI catalog provider.",
     })
   }
 })
@@ -160,6 +170,33 @@ export function redactLlmProviderCredentials<T extends { apiKey?: unknown; openc
     ...provider,
     apiKey: undefined,
     opencodeAuth: undefined,
+  }
+}
+
+export function canImportLlmProviderCredential(payload: { currentMember: { isOwner: boolean; role: string } }) {
+  return isOrganizationAdmin(payload)
+}
+
+function normalizeOpencodeAuth(value: string | undefined) {
+  const trimmed = value?.trim() ?? ""
+  if (!trimmed) return null
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || (parsed as Record<string, unknown>).type !== "oauth") {
+      throw new Error("invalid auth")
+    }
+    return JSON.stringify(parsed)
+  } catch {
+    throw createFailure(400, "invalid_opencode_auth", "OpenCode OAuth credential must be valid OAuth auth JSON.")
+  }
+}
+
+function buildLlmProviderCredentialPayload(provider: LlmProviderRow) {
+  return {
+    ...redactLlmProviderCredentials(provider),
+    ...getCredentialFlags(provider),
+    apiKey: provider.credentialKind === "api_key" ? provider.apiKey : undefined,
+    opencodeAuth: provider.credentialKind === "opencode_oauth" ? provider.opencodeAuth : undefined,
   }
 }
 
@@ -292,6 +329,10 @@ async function resolveTeamIds(input: {
 }
 
 async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteSchema>) {
+  const credentialKind = input.credentialKind
+  const apiKey = credentialKind === "api_key" ? input.apiKey?.trim() || null : null
+  const opencodeAuth = credentialKind === "opencode_oauth" ? normalizeOpencodeAuth(input.opencodeAuth) : null
+
   if (input.source === "models_dev") {
     const provider = await getModelsDevProvider(input.providerId ?? "")
     if (!provider) {
@@ -308,10 +349,9 @@ async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteS
       return model
     })
 
-    const apiKey = input.apiKey?.trim() || null
-
     return {
       source: input.source,
+      credentialKind,
       providerId: provider.id,
       name: input.name,
       providerConfig: provider.config,
@@ -321,6 +361,7 @@ async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteS
         config: model.config,
       })),
       apiKey,
+      opencodeAuth,
     }
   }
 
@@ -344,6 +385,7 @@ async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteS
 
   return {
     source: input.source,
+    credentialKind,
     providerId: customProvider.data.id,
     name: input.name,
     providerConfig: providerConfig as JsonRecord,
@@ -352,7 +394,8 @@ async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteS
       name: model.name,
       config: model as JsonRecord,
     })),
-    apiKey: input.apiKey?.trim() || null,
+    apiKey,
+    opencodeAuth,
   }
 }
 
@@ -710,6 +753,67 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
     },
   )
 
+  app.get(
+    "/v1/llm-providers/:llmProviderId/import-credential",
+    describeRoute({
+      tags: ["LLM Providers"],
+      summary: "Import LLM provider credential",
+      description: "Returns credential material for an organization-managed LLM provider to privileged callers only.",
+      responses: {
+        200: jsonResponse("Provider credential returned successfully.", llmProviderResponseSchema),
+        400: jsonResponse("The provider path parameters were invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to import an organization LLM provider credential.", unauthorizedSchema),
+        403: jsonResponse("Only members who can manage this provider can import its credential.", forbiddenSchema),
+        404: jsonResponse("The provider could not be found.", notFoundSchema),
+      },
+    }),
+    requireUserMiddleware,
+    paramValidator(orgLlmProviderParamsSchema),
+    resolveOrganizationContextMiddleware,
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const params = c.req.valid("param")
+
+      let llmProviderId: LlmProviderId
+      try {
+        llmProviderId = parseLlmProviderId(params.llmProviderId)
+      } catch {
+        return c.json({ error: "llm_provider_not_found" }, 404)
+      }
+
+      const providerRows = await db
+        .select()
+        .from(LlmProviderTable)
+        .where(and(eq(LlmProviderTable.id, llmProviderId), eq(LlmProviderTable.organizationId, payload.organization.id)))
+        .limit(1)
+
+      const provider = providerRows[0]
+      if (!provider) return c.json({ error: "llm_provider_not_found" }, 404)
+      if (!canImportLlmProviderCredential(payload)) {
+        return c.json({ error: "forbidden", message: "Only organization admins can import provider credentials." }, 403)
+      }
+
+      const models = await db
+        .select()
+        .from(LlmProviderModelTable)
+        .where(eq(LlmProviderModelTable.llmProviderId, llmProviderId))
+
+      return c.json({
+        llmProvider: {
+          ...buildLlmProviderCredentialPayload(provider),
+          models: models
+            .map((model) => ({
+              id: model.modelId,
+              name: model.name,
+              config: model.modelConfig,
+              createdAt: model.createdAt,
+            }))
+            .sort((left, right) => left.name.localeCompare(right.name)),
+        },
+      })
+    },
+  )
+
   app.post(
     "/v1/llm-providers",
     describeRoute({
@@ -751,10 +855,12 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             organizationId: payload.organization.id,
             createdByOrgMembershipId: payload.currentMember.id,
             source: normalized.source,
+            credentialKind: normalized.credentialKind,
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
             apiKey: normalized.apiKey,
+            opencodeAuth: normalized.opencodeAuth,
             createdAt: now,
             updatedAt: now,
           })
@@ -800,13 +906,13 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             organizationId: payload.organization.id,
             createdByOrgMembershipId: payload.currentMember.id,
             source: normalized.source,
-            credentialKind: "api_key",
+            credentialKind: normalized.credentialKind,
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
             hasApiKey: Boolean(normalized.apiKey),
-            hasOpencodeAuth: false,
-            hasCredential: Boolean(normalized.apiKey),
+            hasOpencodeAuth: Boolean(normalized.opencodeAuth),
+            hasCredential: normalized.credentialKind === "opencode_oauth" ? Boolean(normalized.opencodeAuth) : Boolean(normalized.apiKey),
             createdAt: now,
             updatedAt: now,
           },
@@ -890,10 +996,16 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             .update(LlmProviderTable)
             .set({
               source: normalized.source,
+              credentialKind: normalized.credentialKind,
               providerId: normalized.providerId,
               name: normalized.name,
               providerConfig: normalized.providerConfig,
-              apiKey: input.apiKey === undefined ? provider.apiKey : normalized.apiKey,
+              apiKey: normalized.credentialKind === "api_key"
+                ? (input.apiKey === undefined ? provider.apiKey : normalized.apiKey)
+                : null,
+              opencodeAuth: normalized.credentialKind === "opencode_oauth"
+                ? (input.opencodeAuth === undefined ? provider.opencodeAuth : normalized.opencodeAuth)
+                : null,
               updatedAt,
             })
             .where(eq(LlmProviderTable.id, provider.id))
@@ -943,10 +1055,16 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
-            credentialKind: provider.credentialKind,
-            hasApiKey: input.apiKey === undefined ? Boolean(provider.apiKey) : Boolean(normalized.apiKey),
-            hasOpencodeAuth: Boolean(provider.opencodeAuth),
-            hasCredential: input.apiKey === undefined ? getCredentialFlags(provider).hasCredential : Boolean(normalized.apiKey),
+            credentialKind: normalized.credentialKind,
+            hasApiKey: normalized.credentialKind === "api_key"
+              ? (input.apiKey === undefined ? Boolean(provider.apiKey) : Boolean(normalized.apiKey))
+              : false,
+            hasOpencodeAuth: normalized.credentialKind === "opencode_oauth"
+              ? (input.opencodeAuth === undefined ? Boolean(provider.opencodeAuth) : Boolean(normalized.opencodeAuth))
+              : false,
+            hasCredential: normalized.credentialKind === "opencode_oauth"
+              ? (input.opencodeAuth === undefined ? Boolean(provider.opencodeAuth) : Boolean(normalized.opencodeAuth))
+              : (input.apiKey === undefined ? Boolean(provider.apiKey) : Boolean(normalized.apiKey)),
             updatedAt,
           },
         })

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -1,7 +1,6 @@
-import { and, desc, eq, inArray, isNotNull, isNull, or } from "@openwork-ee/den-db/drizzle"
+import { and, desc, eq, inArray, isNotNull, or } from "@openwork-ee/den-db/drizzle"
 import {
   AuthUserTable,
-  InvitationTable,
   LlmProviderAccessTable,
   LlmProviderModelTable,
   LlmProviderTable,
@@ -33,16 +32,15 @@ type LlmProviderAccessId = typeof LlmProviderAccessTable.$inferSelect.id
 type MemberId = typeof MemberTable.$inferSelect.id
 type TeamId = typeof TeamTable.$inferSelect.id
 type LlmProviderRow = typeof LlmProviderTable.$inferSelect
+const OPENAI_AUTH_ISSUER = "https://auth.openai.com"
+const OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+const OPENAI_DEVICE_REDIRECT_URI = `${OPENAI_AUTH_ISSUER}/deviceauth/callback`
+const OPENAI_DEVICE_POLLING_SAFETY_MARGIN_MS = 3000
 
 type RouteFailure = {
   status: number
   error: string
   message?: string
-}
-
-function getInvitedMemberName(email: string) {
-  const [localPart, domain = "invited"] = email.split("@")
-  return `${localPart} ${domain.split(".")[0] ?? "invited"}`.trim()
 }
 
 const providerCatalogParamsSchema = z.object({
@@ -108,12 +106,14 @@ const llmProviderWriteSchema = z.object({
     })
   }
 
-  if (value.credentialKind === "opencode_oauth" && value.source === "models_dev" && value.providerId?.trim().toLowerCase() !== "openai") {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ["credentialKind"],
-      message: "OpenCode OAuth credentials can only be used with the OpenAI catalog provider.",
-    })
+  if (value.credentialKind === "opencode_oauth") {
+    if (value.source === "models_dev" && !isOpencodeOauthProviderAllowed(value.providerId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["credentialKind"],
+        message: "OpenCode OAuth credentials can only be used with the OpenAI catalog provider.",
+      })
+    }
   }
 })
 
@@ -143,6 +143,24 @@ const conflictSchema = z.object({
   message: z.string().optional(),
 }).meta({ ref: "ConflictError" })
 
+const openAiOauthStartResponseSchema = z.object({
+  verificationUrl: z.string(),
+  userCode: z.string(),
+  deviceAuthId: z.string(),
+  intervalMs: z.number(),
+}).meta({ ref: "OpenAiOauthStartResponse" })
+
+const openAiOauthCompleteSchema = z.object({
+  deviceAuthId: z.string().trim().min(1),
+  userCode: z.string().trim().min(1),
+})
+
+const openAiOauthCompleteResponseSchema = z.object({
+  opencodeAuth: z.string(),
+  accountId: z.string().nullable(),
+  expires: z.number(),
+}).meta({ ref: "OpenAiOauthCompleteResponse" })
+
 function createFailure(status: number, error: string, message?: string): RouteFailure {
   return { status, error, message }
 }
@@ -151,53 +169,128 @@ function isRouteFailure(value: unknown): value is RouteFailure {
   return typeof value === "object" && value !== null && "status" in value && "error" in value
 }
 
+function parseJwtClaims(token: string): Record<string, unknown> | null {
+  const parts = token.split(".")
+  if (parts.length !== 3 || !parts[1]) return null
+  try {
+    return JSON.parse(Buffer.from(parts[1], "base64url").toString()) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+function extractOpenAiAccountId(tokens: { id_token?: string; access_token?: string }) {
+  const claims = tokens.id_token ? parseJwtClaims(tokens.id_token) : tokens.access_token ? parseJwtClaims(tokens.access_token) : null
+  if (!claims) return null
+  const apiAuth = claims["https://api.openai.com/auth"]
+  if (typeof claims.chatgpt_account_id === "string") return claims.chatgpt_account_id
+  if (apiAuth && typeof apiAuth === "object" && !Array.isArray(apiAuth) && typeof (apiAuth as Record<string, unknown>).chatgpt_account_id === "string") {
+    return (apiAuth as Record<string, string>).chatgpt_account_id
+  }
+  const organizations = claims.organizations
+  if (Array.isArray(organizations)) {
+    const first = organizations.find((entry): entry is Record<string, unknown> => typeof entry === "object" && entry !== null && !Array.isArray(entry))
+    if (typeof first?.id === "string") return first.id
+  }
+  return null
+}
+
+export async function startOpenAiDeviceAuth() {
+  const response = await fetch(`${OPENAI_AUTH_ISSUER}/api/accounts/deviceauth/usercode`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": "opencode/den",
+    },
+    body: JSON.stringify({ client_id: OPENAI_CODEX_CLIENT_ID }),
+  })
+  if (!response.ok) {
+    throw createFailure(502, "openai_oauth_start_failed", `OpenAI device authorization failed with ${response.status}.`)
+  }
+  const data = await response.json() as { device_auth_id?: unknown; user_code?: unknown; interval?: unknown }
+  if (typeof data.device_auth_id !== "string" || typeof data.user_code !== "string") {
+    throw createFailure(502, "openai_oauth_start_failed", "OpenAI device authorization response was incomplete.")
+  }
+  const interval = Math.max(Number.parseInt(String(data.interval ?? "5"), 10) || 5, 1) * 1000
+  return {
+    verificationUrl: `${OPENAI_AUTH_ISSUER}/codex/device`,
+    userCode: data.user_code,
+    deviceAuthId: data.device_auth_id,
+    intervalMs: interval + OPENAI_DEVICE_POLLING_SAFETY_MARGIN_MS,
+  }
+}
+
+export async function completeOpenAiDeviceAuth(input: { deviceAuthId: string; userCode: string }) {
+  const deviceResponse = await fetch(`${OPENAI_AUTH_ISSUER}/api/accounts/deviceauth/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": "opencode/den",
+    },
+    body: JSON.stringify({
+      device_auth_id: input.deviceAuthId,
+      user_code: input.userCode,
+    }),
+  })
+
+  if (deviceResponse.status === 403 || deviceResponse.status === 404) {
+    throw createFailure(409, "openai_oauth_pending", "OpenAI authorization is not complete yet.")
+  }
+  if (!deviceResponse.ok) {
+    throw createFailure(502, "openai_oauth_complete_failed", `OpenAI device authorization failed with ${deviceResponse.status}.`)
+  }
+  const deviceData = await deviceResponse.json() as { authorization_code?: unknown; code_verifier?: unknown }
+  if (typeof deviceData.authorization_code !== "string" || typeof deviceData.code_verifier !== "string") {
+    throw createFailure(502, "openai_oauth_complete_failed", "OpenAI device token response was incomplete.")
+  }
+
+  const tokenResponse = await fetch(`${OPENAI_AUTH_ISSUER}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code: deviceData.authorization_code,
+      redirect_uri: OPENAI_DEVICE_REDIRECT_URI,
+      client_id: OPENAI_CODEX_CLIENT_ID,
+      code_verifier: deviceData.code_verifier,
+    }).toString(),
+  })
+  if (!tokenResponse.ok) {
+    throw createFailure(502, "openai_oauth_complete_failed", `OpenAI token exchange failed with ${tokenResponse.status}.`)
+  }
+  const tokens = await tokenResponse.json() as { id_token?: string; access_token?: string; refresh_token?: string; expires_in?: number }
+  if (!tokens.access_token || !tokens.refresh_token) {
+    throw createFailure(502, "openai_oauth_complete_failed", "OpenAI token response did not include OAuth tokens.")
+  }
+  const expires = Date.now() + (tokens.expires_in ?? 3600) * 1000
+  const accountId = extractOpenAiAccountId(tokens)
+  return {
+    opencodeAuth: JSON.stringify({
+      type: "oauth",
+      refresh: tokens.refresh_token,
+      access: tokens.access_token,
+      expires,
+      ...(accountId ? { accountId } : {}),
+    }),
+    accountId,
+    expires,
+  }
+}
+
 function isOrganizationAdmin(payload: { currentMember: { isOwner: boolean; role: string } }) {
   return payload.currentMember.isOwner || memberHasRole(payload.currentMember.role, "admin")
 }
 
-export function getCredentialFlags(provider: Pick<LlmProviderRow, "credentialKind" | "apiKey" | "opencodeAuth">) {
-  const hasApiKey = Boolean(provider.apiKey && provider.apiKey.trim().length > 0)
-  const hasOpencodeAuth = Boolean(provider.opencodeAuth && provider.opencodeAuth.trim().length > 0)
-  return {
-    hasApiKey,
-    hasOpencodeAuth,
-    hasCredential: provider.credentialKind === "opencode_oauth" ? hasOpencodeAuth : hasApiKey,
-  }
+export function isOpencodeOauthProviderAllowed(providerId: string | undefined | null) {
+  return providerId?.trim().toLowerCase() === "openai"
 }
 
-export function redactLlmProviderCredentials<T extends { apiKey?: unknown; opencodeAuth?: unknown }>(provider: T): Omit<T, "apiKey" | "opencodeAuth"> & { apiKey: undefined; opencodeAuth: undefined } {
-  return {
-    ...provider,
-    apiKey: undefined,
-    opencodeAuth: undefined,
-  }
+export function canUseOpenAiOAuthCredentialFlow(payload: { currentMember: { isOwner: boolean; role: string } }) {
+  return isOrganizationAdmin(payload)
 }
 
 export function canImportLlmProviderCredential(payload: { currentMember: { isOwner: boolean; role: string } }) {
   return isOrganizationAdmin(payload)
-}
-
-function normalizeOpencodeAuth(value: string | undefined) {
-  const trimmed = value?.trim() ?? ""
-  if (!trimmed) return null
-  try {
-    const parsed = JSON.parse(trimmed) as unknown
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || (parsed as Record<string, unknown>).type !== "oauth") {
-      throw new Error("invalid auth")
-    }
-    return JSON.stringify(parsed)
-  } catch {
-    throw createFailure(400, "invalid_opencode_auth", "OpenCode OAuth credential must be valid OAuth auth JSON.")
-  }
-}
-
-function buildLlmProviderCredentialPayload(provider: LlmProviderRow) {
-  return {
-    ...redactLlmProviderCredentials(provider),
-    ...getCredentialFlags(provider),
-    apiKey: provider.credentialKind === "api_key" ? provider.apiKey : undefined,
-    opencodeAuth: provider.credentialKind === "opencode_oauth" ? provider.opencodeAuth : undefined,
-  }
 }
 
 function canManageLlmProvider(
@@ -228,6 +321,66 @@ function parseLlmProviderId(value: string) {
 
 function parseLlmProviderAccessId(value: string) {
   return normalizeDenTypeId("llmProviderAccess", value)
+}
+
+export function getCredentialFlags(provider: Pick<LlmProviderRow, "credentialKind" | "apiKey" | "opencodeAuth">) {
+  const hasApiKey = Boolean(provider.apiKey && provider.apiKey.trim().length > 0)
+  const hasOpencodeAuth = Boolean(provider.opencodeAuth && provider.opencodeAuth.trim().length > 0)
+  return {
+    hasApiKey,
+    hasOpencodeAuth,
+    hasCredential: provider.credentialKind === "opencode_oauth" ? hasOpencodeAuth : hasApiKey,
+  }
+}
+
+export function redactLlmProviderCredentials<T extends { apiKey?: unknown; opencodeAuth?: unknown }>(provider: T): Omit<T, "apiKey" | "opencodeAuth"> & { apiKey: undefined; opencodeAuth: undefined } {
+  return {
+    ...provider,
+    apiKey: undefined,
+    opencodeAuth: undefined,
+  }
+}
+
+function buildLlmProviderCredentialPayload(provider: LlmProviderRow) {
+  return {
+    ...redactLlmProviderCredentials(provider),
+    ...getCredentialFlags(provider),
+    apiKey: provider.credentialKind === "api_key" ? provider.apiKey : undefined,
+    opencodeAuth: provider.credentialKind === "opencode_oauth" ? provider.opencodeAuth : undefined,
+  }
+}
+
+function normalizeOpencodeAuth(value: string | undefined) {
+  const trimmed = value?.trim()
+  if (!trimmed) return null
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("OpenCode OAuth auth must be a JSON object.")
+    }
+    const auth = parsed as Record<string, unknown>
+    if (auth.type !== "oauth") {
+      throw new Error('OpenCode OAuth auth must include "type": "oauth".')
+    }
+    if (typeof auth.access !== "string" || !auth.access.trim()) {
+      throw new Error("OpenCode OAuth auth must include an access token.")
+    }
+    if (typeof auth.refresh !== "string" || !auth.refresh.trim()) {
+      throw new Error("OpenCode OAuth auth must include a refresh token.")
+    }
+    if (typeof auth.expires !== "number" || !Number.isFinite(auth.expires) || auth.expires < 0) {
+      throw new Error("OpenCode OAuth auth must include a non-negative numeric expires value.")
+    }
+  } catch (error) {
+    throw createFailure(
+      400,
+      "invalid_opencode_auth",
+      error instanceof Error ? error.message : "OpenCode OAuth auth must be valid JSON.",
+    )
+  }
+
+  return trimmed
 }
 
 function parseMemberId(value: string) {
@@ -290,7 +443,7 @@ async function resolveMemberIds(input: {
   const rows = await db
     .select({ id: MemberTable.id })
     .from(MemberTable)
-    .where(and(eq(MemberTable.organizationId, input.organizationId), inArray(MemberTable.id, memberIds), isNull(MemberTable.removedAt)))
+    .where(and(eq(MemberTable.organizationId, input.organizationId), inArray(MemberTable.id, memberIds)))
 
   if (rows.length !== memberIds.length) {
     throw createFailure(404, "member_not_found")
@@ -382,6 +535,9 @@ async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteS
   }
 
   const { models, ...providerConfig } = customProvider.data
+  if (credentialKind === "opencode_oauth" && !isOpencodeOauthProviderAllowed(customProvider.data.id)) {
+    throw createFailure(400, "invalid_credential_kind", "OpenCode OAuth credentials can only be used with the OpenAI provider.")
+  }
 
   return {
     source: input.source,
@@ -462,15 +618,11 @@ async function loadLlmProviders(input: {
         email: AuthUserTable.email,
         image: AuthUserTable.image,
       },
-      invitation: {
-        email: InvitationTable.email,
-      },
     })
     .from(LlmProviderAccessTable)
     .innerJoin(MemberTable, eq(LlmProviderAccessTable.orgMembershipId, MemberTable.id))
-    .leftJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
-    .leftJoin(InvitationTable, eq(MemberTable.inviteId, InvitationTable.id))
-    .where(and(inArray(LlmProviderAccessTable.llmProviderId, providerIds), isNotNull(LlmProviderAccessTable.orgMembershipId), isNull(MemberTable.removedAt)))
+    .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
+    .where(and(inArray(LlmProviderAccessTable.llmProviderId, providerIds), isNotNull(LlmProviderAccessTable.orgMembershipId)))
 
   const teamAccessRows = await db
     .select({
@@ -535,21 +687,13 @@ async function loadLlmProviders(input: {
       }))
       .sort((left, right) => left.name.localeCompare(right.name)),
     access: {
-      members: (memberAccessByProviderId.get(provider.id) ?? []).map((row) => {
-        const email = row.user?.email ?? row.invitation?.email ?? "invited@example.com"
-        return {
-          id: row.access.id,
-          orgMembershipId: row.member.id,
-          role: row.member.role,
-          user: {
-            id: row.user?.id ?? row.member.id,
-            name: row.user?.name ?? getInvitedMemberName(email),
-            email,
-            image: row.user?.image ?? null,
-          },
-          createdAt: row.access.createdAt,
-        }
-      }),
+      members: (memberAccessByProviderId.get(provider.id) ?? []).map((row) => ({
+        id: row.access.id,
+        orgMembershipId: row.member.id,
+        role: row.member.role,
+        user: row.user,
+        createdAt: row.access.createdAt,
+      })),
       teams: (teamAccessByProviderId.get(provider.id) ?? []).map((row) => ({
         id: row.access.id,
         teamId: row.team.id,
@@ -563,6 +707,69 @@ async function loadLlmProviders(input: {
 }
 
 export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVariables & Partial<MemberTeamsContext> }>(app: Hono<T>) {
+  app.post(
+    "/v1/llm-providers/openai-oauth/start",
+    describeRoute({
+      tags: ["LLM Providers"],
+      summary: "Start OpenAI OAuth device flow",
+      description: "Starts the same OpenAI/ChatGPT device auth flow used by OpenCode and returns the user code.",
+      responses: {
+        200: jsonResponse("OpenAI OAuth device flow started successfully.", openAiOauthStartResponseSchema),
+        401: jsonResponse("The caller must be signed in to connect OpenAI.", unauthorizedSchema),
+        403: jsonResponse("Only organization admins can connect OpenAI OAuth credentials.", forbiddenSchema),
+        502: jsonResponse("OpenAI OAuth could not be started.", conflictSchema),
+      },
+    }),
+    requireUserMiddleware,
+    resolveOrganizationContextMiddleware,
+    async (c) => {
+      const payload = c.get("organizationContext")
+      if (!canUseOpenAiOAuthCredentialFlow(payload)) {
+        return c.json({ error: "forbidden", message: "Only organization admins can connect OpenAI OAuth credentials." }, 403)
+      }
+
+      try {
+        return c.json(await startOpenAiDeviceAuth())
+      } catch (error) {
+        if (isRouteFailure(error)) return c.json({ error: error.error, message: error.message }, { status: error.status as 409 | 502 })
+        throw error
+      }
+    },
+  )
+
+  app.post(
+    "/v1/llm-providers/openai-oauth/complete",
+    describeRoute({
+      tags: ["LLM Providers"],
+      summary: "Complete OpenAI OAuth device flow",
+      description: "Completes OpenAI device auth and returns an OpenCode-native OAuth auth object serialized as JSON.",
+      responses: {
+        200: jsonResponse("OpenAI OAuth completed successfully.", openAiOauthCompleteResponseSchema),
+        401: jsonResponse("The caller must be signed in to complete OpenAI auth.", unauthorizedSchema),
+        403: jsonResponse("Only organization admins can connect OpenAI OAuth credentials.", forbiddenSchema),
+        409: jsonResponse("OpenAI authorization is still pending.", conflictSchema),
+        502: jsonResponse("OpenAI OAuth could not be completed.", conflictSchema),
+      },
+    }),
+    requireUserMiddleware,
+    resolveOrganizationContextMiddleware,
+    jsonValidator(openAiOauthCompleteSchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      if (!canUseOpenAiOAuthCredentialFlow(payload)) {
+        return c.json({ error: "forbidden", message: "Only organization admins can connect OpenAI OAuth credentials." }, 403)
+      }
+
+      const input = c.req.valid("json")
+      try {
+        return c.json(await completeOpenAiDeviceAuth(input))
+      } catch (error) {
+        if (isRouteFailure(error)) return c.json({ error: error.error, message: error.message }, { status: error.status as 409 | 502 })
+        throw error
+      }
+    },
+  )
+
   app.get(
     "/v1/llm-provider-catalog",
     describeRoute({
@@ -737,8 +944,7 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
 
       return c.json({
         llmProvider: {
-          ...provider,
-          opencodeAuth: undefined,
+          ...redactLlmProviderCredentials(provider),
           ...getCredentialFlags(provider),
           models: models
             .map((model) => ({
@@ -757,11 +963,11 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
     "/v1/llm-providers/:llmProviderId/import-credential",
     describeRoute({
       tags: ["LLM Providers"],
-      summary: "Import LLM provider credential",
-      description: "Returns credential material for an organization-managed LLM provider to privileged callers only.",
+      summary: "Get LLM provider import credential",
+      description: "Returns a stored organization LLM provider credential for explicit import into a managed OpenCode client.",
       responses: {
-        200: jsonResponse("Provider credential returned successfully.", llmProviderResponseSchema),
-        400: jsonResponse("The provider path parameters were invalid.", invalidRequestSchema),
+        200: jsonResponse("Provider import credential returned successfully.", llmProviderResponseSchema),
+        400: jsonResponse("The provider import path parameters were invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to import an organization LLM provider credential.", unauthorizedSchema),
         403: jsonResponse("Only members who can manage this provider can import its credential.", forbiddenSchema),
         404: jsonResponse("The provider could not be found.", notFoundSchema),
@@ -788,7 +994,10 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
         .limit(1)
 
       const provider = providerRows[0]
-      if (!provider) return c.json({ error: "llm_provider_not_found" }, 404)
+      if (!provider) {
+        return c.json({ error: "llm_provider_not_found" }, 404)
+      }
+
       if (!canImportLlmProviderCredential(payload)) {
         return c.json({ error: "forbidden", message: "Only organization admins can import provider credentials." }, 403)
       }

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -145,6 +145,24 @@ function isOrganizationAdmin(payload: { currentMember: { isOwner: boolean; role:
   return payload.currentMember.isOwner || memberHasRole(payload.currentMember.role, "admin")
 }
 
+export function getCredentialFlags(provider: Pick<LlmProviderRow, "credentialKind" | "apiKey" | "opencodeAuth">) {
+  const hasApiKey = Boolean(provider.apiKey && provider.apiKey.trim().length > 0)
+  const hasOpencodeAuth = Boolean(provider.opencodeAuth && provider.opencodeAuth.trim().length > 0)
+  return {
+    hasApiKey,
+    hasOpencodeAuth,
+    hasCredential: provider.credentialKind === "opencode_oauth" ? hasOpencodeAuth : hasApiKey,
+  }
+}
+
+export function redactLlmProviderCredentials<T extends { apiKey?: unknown; opencodeAuth?: unknown }>(provider: T): Omit<T, "apiKey" | "opencodeAuth"> & { apiKey: undefined; opencodeAuth: undefined } {
+  return {
+    ...provider,
+    apiKey: undefined,
+    opencodeAuth: undefined,
+  }
+}
+
 function canManageLlmProvider(
   payload: { currentMember: { id: MemberId; isOwner: boolean; role: string } },
   provider: LlmProviderRow,
@@ -464,7 +482,7 @@ async function loadLlmProviders(input: {
 
   return providers.map((provider) => ({
     ...provider,
-    hasApiKey: Boolean(provider.apiKey && provider.apiKey.trim().length > 0),
+    ...getCredentialFlags(provider),
     models: (modelsByProviderId.get(provider.id) ?? [])
       .map((model) => ({
         id: model.modelId,
@@ -607,8 +625,7 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
 
       return c.json({
         llmProviders: providers.map((provider) => ({
-          ...provider,
-          apiKey: undefined,
+          ...redactLlmProviderCredentials(provider),
           canManage: canManageLlmProvider(payload, provider),
         })),
       })
@@ -678,6 +695,8 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
       return c.json({
         llmProvider: {
           ...provider,
+          opencodeAuth: undefined,
+          ...getCredentialFlags(provider),
           models: models
             .map((model) => ({
               id: model.modelId,
@@ -781,10 +800,13 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             organizationId: payload.organization.id,
             createdByOrgMembershipId: payload.currentMember.id,
             source: normalized.source,
+            credentialKind: "api_key",
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
             hasApiKey: Boolean(normalized.apiKey),
+            hasOpencodeAuth: false,
+            hasCredential: Boolean(normalized.apiKey),
             createdAt: now,
             updatedAt: now,
           },
@@ -916,12 +938,15 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
 
         return c.json({
           llmProvider: {
-            ...provider,
+            ...redactLlmProviderCredentials(provider),
             source: normalized.source,
             providerId: normalized.providerId,
             name: normalized.name,
             providerConfig: normalized.providerConfig,
+            credentialKind: provider.credentialKind,
             hasApiKey: input.apiKey === undefined ? Boolean(provider.apiKey) : Boolean(normalized.apiKey),
+            hasOpencodeAuth: Boolean(provider.opencodeAuth),
+            hasCredential: input.apiKey === undefined ? getCredentialFlags(provider).hasCredential : Boolean(normalized.apiKey),
             updatedAt,
           },
         })

--- a/ee/apps/den-api/src/routes/workers/index.ts
+++ b/ee/apps/den-api/src/routes/workers/index.ts
@@ -3,11 +3,13 @@ import type { WorkerRouteVariables } from "./shared.js"
 import { registerWorkerActivityRoutes } from "./activity.js"
 import { registerWorkerBillingRoutes } from "./billing.js"
 import { registerWorkerCoreRoutes } from "./core.js"
+import { registerManagedProviderSyncRoutes } from "./managed-providers.js"
 import { registerWorkerRuntimeRoutes } from "./runtime.js"
 
 export function registerWorkerRoutes<T extends { Variables: WorkerRouteVariables }>(app: Hono<T>) {
   registerWorkerActivityRoutes(app)
   registerWorkerBillingRoutes(app)
   registerWorkerCoreRoutes(app)
+  registerManagedProviderSyncRoutes(app as unknown as Hono<{ Variables: WorkerRouteVariables }>)
   registerWorkerRuntimeRoutes(app)
 }

--- a/ee/apps/den-api/src/routes/workers/managed-providers.ts
+++ b/ee/apps/den-api/src/routes/workers/managed-providers.ts
@@ -148,6 +148,10 @@ export function registerManagedProviderSyncRoutes(app: Hono<{ Variables: WorkerR
 
       const providers = await listProviders(normalizedOrgId)
       const revision = computeManagedProviderRevision(providers)
+      if (providers.length === 0) {
+        return c.json({ status: "applied", providerCount: 0, revision })
+      }
+
       const runtime = await pushRuntime(worker.id, { providers, revision })
       if (!runtime.ok) {
         return c.json({

--- a/ee/apps/den-api/src/routes/workers/managed-providers.ts
+++ b/ee/apps/den-api/src/routes/workers/managed-providers.ts
@@ -65,10 +65,7 @@ export function computeManagedProviderRevision(providers: Pick<ManagedProviderSy
 }
 
 export function sanitizeManagedProviderSyncFailure(payload: unknown) {
-  if (!payload || typeof payload !== "object") return "Worker provider sync failed."
-  const record = payload as Record<string, unknown>
-  const message = typeof record.message === "string" ? record.message : typeof record.error === "string" ? record.error : "Worker provider sync failed."
-  return message.replace(/sk-[A-Za-z0-9_-]+/g, "[redacted]").slice(0, 300)
+  return "Worker provider sync failed."
 }
 
 export async function listManagedProviderSyncProviders(organizationId: OrganizationId) {

--- a/ee/apps/den-api/src/routes/workers/managed-providers.ts
+++ b/ee/apps/den-api/src/routes/workers/managed-providers.ts
@@ -1,0 +1,167 @@
+import { eq, inArray } from "@openwork-ee/den-db/drizzle"
+import { LlmProviderModelTable, LlmProviderTable } from "@openwork-ee/den-db/schema"
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import type { Hono } from "hono"
+import { describeRoute } from "hono-openapi"
+import { z } from "zod"
+import { db } from "../../db.js"
+import { paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
+import { forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
+import { memberHasRole } from "../org/shared.js"
+import { fetchWorkerRuntimeJson, getWorkerByIdForOrg, parseWorkerIdParam, type WorkerId, type WorkerRouteVariables, workerIdParamSchema } from "./shared.js"
+
+type LlmProviderRow = typeof LlmProviderTable.$inferSelect
+type LlmProviderModelRow = typeof LlmProviderModelTable.$inferSelect
+type OrganizationId = LlmProviderRow["organizationId"]
+
+export type ManagedProviderSyncProvider = {
+  id: string
+  providerId: string
+  name: string
+  source: LlmProviderRow["source"]
+  credentialKind: LlmProviderRow["credentialKind"]
+  providerConfig: Record<string, unknown>
+  models: Array<{ id: string; name: string; config: Record<string, unknown> }>
+  apiKey?: string
+  opencodeAuth?: string
+  revision: string
+}
+
+type ManagedProviderRouteDeps = {
+  middlewares?: never[]
+  getWorker?: (workerId: WorkerId, orgId: OrganizationId) => Promise<{ id: WorkerId } | null>
+  listProviders?: (orgId: OrganizationId) => Promise<ManagedProviderSyncProvider[]>
+  pushRuntime?: (workerId: WorkerId, payload: { providers: ManagedProviderSyncProvider[]; revision: string }) => Promise<{ ok: boolean; status: number; payload: unknown }>
+}
+
+const managedProviderSyncResponseSchema = z.object({
+  status: z.enum(["applied", "failed"]),
+  providerCount: z.number().int().min(0),
+  revision: z.string(),
+  reason: z.string().optional(),
+}).meta({ ref: "ManagedProviderSyncResponse" })
+
+export function canSyncManagedProviders(payload: { currentMember: { isOwner: boolean; role: string } }) {
+  return payload.currentMember.isOwner || memberHasRole(payload.currentMember.role, "admin")
+}
+
+function credentialPresent(provider: Pick<LlmProviderRow, "credentialKind" | "apiKey" | "opencodeAuth">) {
+  return provider.credentialKind === "opencode_oauth"
+    ? Boolean(provider.opencodeAuth?.trim())
+    : Boolean(provider.apiKey?.trim())
+}
+
+function revisionForProvider(provider: Pick<LlmProviderRow, "id" | "updatedAt" | "credentialKind">, models: LlmProviderModelRow[]) {
+  return [
+    provider.id,
+    provider.credentialKind,
+    provider.updatedAt instanceof Date ? provider.updatedAt.toISOString() : String(provider.updatedAt),
+    models.map((model) => `${model.modelId}:${model.name}`).sort().join(","),
+  ].join(":")
+}
+
+export function computeManagedProviderRevision(providers: Pick<ManagedProviderSyncProvider, "id" | "revision">[]) {
+  return providers.map((provider) => `${provider.id}:${provider.revision}`).sort().join("|") || "empty"
+}
+
+export function sanitizeManagedProviderSyncFailure(payload: unknown) {
+  if (!payload || typeof payload !== "object") return "Worker provider sync failed."
+  const record = payload as Record<string, unknown>
+  const message = typeof record.message === "string" ? record.message : typeof record.error === "string" ? record.error : "Worker provider sync failed."
+  return message.replace(/sk-[A-Za-z0-9_-]+/g, "[redacted]").slice(0, 300)
+}
+
+export async function listManagedProviderSyncProviders(organizationId: OrganizationId) {
+  const providers = await db
+    .select()
+    .from(LlmProviderTable)
+    .where(eq(LlmProviderTable.organizationId, organizationId))
+
+  const eligible = providers.filter(credentialPresent)
+  if (!eligible.length) return []
+
+  const models = await db
+    .select()
+    .from(LlmProviderModelTable)
+    .where(inArray(LlmProviderModelTable.llmProviderId, eligible.map((provider) => provider.id)))
+
+  return eligible.map((provider) => {
+    const providerModels = models.filter((model) => model.llmProviderId === provider.id)
+    return {
+      id: provider.id,
+      providerId: provider.providerId,
+      name: provider.name,
+      source: provider.source,
+      credentialKind: provider.credentialKind,
+      providerConfig: provider.providerConfig,
+      models: providerModels.map((model) => ({ id: model.modelId, name: model.name, config: model.modelConfig })),
+      ...(provider.credentialKind === "api_key" && provider.apiKey ? { apiKey: provider.apiKey } : {}),
+      ...(provider.credentialKind === "opencode_oauth" && provider.opencodeAuth ? { opencodeAuth: provider.opencodeAuth } : {}),
+      revision: revisionForProvider(provider, providerModels),
+    }
+  })
+}
+
+export function registerManagedProviderSyncRoutes(app: Hono<{ Variables: WorkerRouteVariables }>, deps: ManagedProviderRouteDeps = {}) {
+  const routeMiddlewares = deps.middlewares ?? [requireUserMiddleware, resolveOrganizationContextMiddleware, paramValidator(workerIdParamSchema)]
+  const getWorker = deps.getWorker ?? getWorkerByIdForOrg
+  const listProviders = deps.listProviders ?? listManagedProviderSyncProviders
+  const pushRuntime = deps.pushRuntime ?? ((workerId, payload) => fetchWorkerRuntimeJson({
+    workerId,
+    path: "/managed-providers/sync",
+    method: "POST",
+    body: payload,
+  }))
+
+  app.post(
+    "/v1/workers/:id/managed-providers/sync",
+    describeRoute({
+      tags: ["Workers", "Managed Providers"],
+      summary: "Sync managed providers to worker runtime",
+      description: "Applies organization-managed provider config/auth to a static worker through the host-token runtime channel.",
+      responses: {
+        200: jsonResponse("Managed providers applied successfully.", managedProviderSyncResponseSchema),
+        400: jsonResponse("The worker path parameters were invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to sync providers.", unauthorizedSchema),
+        403: jsonResponse("Only organization owners and admins can sync providers.", forbiddenSchema),
+        404: jsonResponse("The worker could not be found.", notFoundSchema),
+      },
+    }),
+    ...(routeMiddlewares as never[]),
+    async (c) => {
+      const orgId = c.get("activeOrganizationId")
+      const organizationContext = c.get("organizationContext")
+      const params = c.req.valid("param" as never) as { id: string }
+
+      if (!orgId) return c.json({ error: "worker_not_found" }, 404)
+      if (!organizationContext || !canSyncManagedProviders(organizationContext)) {
+        return c.json({ error: "forbidden", message: "Only organization owners and admins can sync managed providers." }, 403)
+      }
+
+      let workerId: WorkerId
+      try {
+        workerId = parseWorkerIdParam(params.id)
+      } catch {
+        return c.json({ error: "worker_not_found" }, 404)
+      }
+
+      const normalizedOrgId = normalizeDenTypeId("organization", orgId)
+      const worker = await getWorker(workerId, normalizedOrgId)
+      if (!worker) return c.json({ error: "worker_not_found" }, 404)
+
+      const providers = await listProviders(normalizedOrgId)
+      const revision = computeManagedProviderRevision(providers)
+      const runtime = await pushRuntime(worker.id, { providers, revision })
+      if (!runtime.ok) {
+        return c.json({
+          status: "failed",
+          providerCount: providers.length,
+          revision,
+          reason: sanitizeManagedProviderSyncFailure(runtime.payload),
+        }, 502)
+      }
+
+      return c.json({ status: "applied", providerCount: providers.length, revision })
+    },
+  )
+}

--- a/ee/apps/den-api/src/routes/workers/shared.ts
+++ b/ee/apps/den-api/src/routes/workers/shared.ts
@@ -15,7 +15,7 @@ import { z } from "zod"
 import { getCloudWorkerBillingStatus, requireCloudWorkerAccess, setCloudWorkerSubscriptionCancellation } from "../../billing/polar.js"
 import { db } from "../../db.js"
 import { env } from "../../env.js"
-import type { UserOrganizationsContext } from "../../middleware/index.js"
+import type { OrganizationContextVariables, UserOrganizationsContext } from "../../middleware/index.js"
 import { denTypeIdSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 import { deprovisionWorker, provisionWorker } from "../../workers/provisioner.js"
@@ -59,7 +59,7 @@ export const workerIdParamSchema = z.object({
   id: denTypeIdSchema("worker"),
 })
 
-export type WorkerRouteVariables = AuthContextVariables & Partial<UserOrganizationsContext>
+export type WorkerRouteVariables = AuthContextVariables & Partial<UserOrganizationsContext> & Partial<OrganizationContextVariables>
 
 type WorkerRow = typeof WorkerTable.$inferSelect
 type WorkerInstanceRow = typeof WorkerInstanceTable.$inferSelect

--- a/ee/apps/den-api/test/llm-provider-credentials.test.ts
+++ b/ee/apps/den-api/test/llm-provider-credentials.test.ts
@@ -1,0 +1,61 @@
+import { beforeAll, expect, test } from "bun:test"
+import { Hono } from "hono"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+let llmProviderModule: typeof import("../src/routes/org/llm-providers.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  llmProviderModule = await import("../src/routes/org/llm-providers.js")
+})
+
+test("generic provider payload redaction removes API key and OAuth auth material", () => {
+  const redacted = llmProviderModule.redactLlmProviderCredentials({
+    id: "llmProvider_secret_123",
+    apiKey: "plain-secret",
+    opencodeAuth: JSON.stringify({ type: "oauth", access: "access", refresh: "refresh", expires: 1 }),
+  })
+
+  expect(redacted).toEqual({
+    id: "llmProvider_secret_123",
+    apiKey: undefined,
+    opencodeAuth: undefined,
+  })
+})
+
+test("credential flags expose presence only, never credential values", () => {
+  expect(llmProviderModule.getCredentialFlags({
+    credentialKind: "opencode_oauth",
+    apiKey: "plain-secret",
+    opencodeAuth: JSON.stringify({ type: "oauth", access: "access", refresh: "refresh", expires: 1 }),
+  })).toEqual({ hasApiKey: true, hasOpencodeAuth: true, hasCredential: true })
+})
+
+test("credential import permission gate requires organization admin role", () => {
+  const owner = { currentMember: { isOwner: true, role: "member" } }
+  const admin = { currentMember: { isOwner: false, role: "admin" } }
+  const creatorOnly = { currentMember: { isOwner: false, role: "member" } }
+
+  expect(llmProviderModule.canImportLlmProviderCredential(owner)).toBe(true)
+  expect(llmProviderModule.canImportLlmProviderCredential(admin)).toBe(true)
+  expect(llmProviderModule.canImportLlmProviderCredential(creatorOnly)).toBe(false)
+})
+
+test("purpose-specific import endpoint requires authentication", async () => {
+  const app = new Hono()
+  llmProviderModule.registerOrgLlmProviderRoutes(app)
+
+  const response = await app.request("http://den.local/v1/llm-providers/llmProvider_secret_123/import-credential", {
+    method: "GET",
+  })
+
+  expect(response.status).toBe(401)
+  await expect(response.json()).resolves.toEqual({ error: "unauthorized" })
+})

--- a/ee/apps/den-api/test/llm-providers-oauth.test.ts
+++ b/ee/apps/den-api/test/llm-providers-oauth.test.ts
@@ -1,0 +1,198 @@
+import { beforeAll, expect, test } from "bun:test"
+import { readFile } from "node:fs/promises"
+import { Hono } from "hono"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+let llmProviderModule: typeof import("../src/routes/org/llm-providers.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  llmProviderModule = await import("../src/routes/org/llm-providers.js")
+})
+
+function createRouteApp() {
+  const app = new Hono()
+  llmProviderModule.registerOrgLlmProviderRoutes(app)
+  return app
+}
+
+function jwtWithClaims(claims: Record<string, unknown>) {
+  return [
+    Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+    Buffer.from(JSON.stringify(claims)).toString("base64url"),
+    "signature",
+  ].join(".")
+}
+
+test("generic provider payload redaction removes API key and OAuth auth material", () => {
+  const redacted = llmProviderModule.redactLlmProviderCredentials({
+    id: "llmProvider_secret_123",
+    apiKey: "sk-secret",
+    opencodeAuth: JSON.stringify({ type: "oauth", access: "access", refresh: "refresh", expires: 1 }),
+  })
+
+  expect(redacted).toEqual({
+    id: "llmProvider_secret_123",
+    apiKey: undefined,
+    opencodeAuth: undefined,
+  })
+})
+
+test("credential flags expose presence only, never credential values", () => {
+  expect(llmProviderModule.getCredentialFlags({
+    credentialKind: "opencode_oauth",
+    apiKey: "sk-secret",
+    opencodeAuth: JSON.stringify({ type: "oauth", access: "access", refresh: "refresh", expires: 1 }),
+  })).toEqual({ hasApiKey: true, hasOpencodeAuth: true, hasCredential: true })
+})
+
+test("OpenCode OAuth credential type rejects non-OpenAI providers", () => {
+  expect(llmProviderModule.isOpencodeOauthProviderAllowed("openai")).toBe(true)
+  expect(llmProviderModule.isOpencodeOauthProviderAllowed(" OpenAI ")).toBe(true)
+  expect(llmProviderModule.isOpencodeOauthProviderAllowed("anthropic")).toBe(false)
+  expect(llmProviderModule.isOpencodeOauthProviderAllowed(undefined)).toBe(false)
+})
+
+test("OAuth credential and import permission gates require organization admin role", () => {
+  const owner = { currentMember: { isOwner: true, role: "member" } }
+  const admin = { currentMember: { isOwner: false, role: "admin" } }
+  const creatorOnly = { currentMember: { isOwner: false, role: "member" } }
+
+  expect(llmProviderModule.canUseOpenAiOAuthCredentialFlow(owner)).toBe(true)
+  expect(llmProviderModule.canUseOpenAiOAuthCredentialFlow(admin)).toBe(true)
+  expect(llmProviderModule.canUseOpenAiOAuthCredentialFlow(creatorOnly)).toBe(false)
+  expect(llmProviderModule.canImportLlmProviderCredential(owner)).toBe(true)
+  expect(llmProviderModule.canImportLlmProviderCredential(admin)).toBe(true)
+  expect(llmProviderModule.canImportLlmProviderCredential(creatorOnly)).toBe(false)
+})
+
+test("OpenAI OAuth routes require an authenticated caller before returning credential material", async () => {
+  const app = createRouteApp()
+
+  const startResponse = await app.request("http://den.local/v1/llm-providers/openai-oauth/start", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  })
+  expect(startResponse.status).toBe(401)
+  await expect(startResponse.json()).resolves.toEqual({ error: "unauthorized" })
+
+  const completeResponse = await app.request("http://den.local/v1/llm-providers/openai-oauth/complete", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ deviceAuthId: "dev", userCode: "code" }),
+  })
+  expect(completeResponse.status).toBe(401)
+  await expect(completeResponse.json()).resolves.toEqual({ error: "unauthorized" })
+})
+
+test("purpose-specific import endpoint requires authentication", async () => {
+  const app = createRouteApp()
+  const response = await app.request("http://den.local/v1/llm-providers/llmProvider_secret_123/import-credential", {
+    method: "GET",
+  })
+
+  expect(response.status).toBe(401)
+  await expect(response.json()).resolves.toEqual({ error: "unauthorized" })
+})
+
+test("OpenAI OAuth completion reports pending authorization without tokens", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async () => new Response(JSON.stringify({}), { status: 403 })) as typeof fetch
+  try {
+    await expect(llmProviderModule.completeOpenAiDeviceAuth({
+      deviceAuthId: "device-pending",
+      userCode: "CODE",
+    })).rejects.toMatchObject({ error: "openai_oauth_pending", status: 409 })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("OpenAI OAuth start reports upstream failure without credential material", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async () => new Response(JSON.stringify({ error: "upstream" }), { status: 500 })) as typeof fetch
+  try {
+    await expect(llmProviderModule.startOpenAiDeviceAuth()).rejects.toMatchObject({
+      error: "openai_oauth_start_failed",
+      status: 502,
+    })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("OpenAI OAuth completion reports token exchange failure without credential material", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.endsWith("/api/accounts/deviceauth/token")) {
+      return Response.json({ authorization_code: "authorization-code", code_verifier: "verifier" })
+    }
+    if (url.endsWith("/oauth/token")) {
+      return new Response(JSON.stringify({ error: "exchange_failed" }), { status: 500 })
+    }
+    return new Response("not found", { status: 404 })
+  }) as typeof fetch
+
+  try {
+    await expect(llmProviderModule.completeOpenAiDeviceAuth({
+      deviceAuthId: "device-failure",
+      userCode: "CODE",
+    })).rejects.toMatchObject({ error: "openai_oauth_complete_failed", status: 502 })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("OpenAI OAuth completion returns importable OpenCode OAuth auth on success", async () => {
+  const originalFetch = globalThis.fetch
+  const calls: string[] = []
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    calls.push(url)
+    if (url.endsWith("/api/accounts/deviceauth/token")) {
+      return Response.json({ authorization_code: "authorization-code", code_verifier: "verifier" })
+    }
+    if (url.endsWith("/oauth/token")) {
+      return Response.json({
+        access_token: jwtWithClaims({ chatgpt_account_id: "acct_123" }),
+        refresh_token: "refresh-token",
+        expires_in: 60,
+      })
+    }
+    return new Response("not found", { status: 404 })
+  }) as typeof fetch
+
+  try {
+    const completed = await llmProviderModule.completeOpenAiDeviceAuth({
+      deviceAuthId: "device-complete",
+      userCode: "CODE",
+    })
+    const auth = JSON.parse(completed.opencodeAuth) as Record<string, unknown>
+
+    expect(calls).toHaveLength(2)
+    expect(auth.type).toBe("oauth")
+    expect(typeof auth.access).toBe("string")
+    expect(auth.refresh).toBe("refresh-token")
+    expect(auth.accountId).toBe("acct_123")
+    expect(completed.accountId).toBe("acct_123")
+    expect(typeof auth.expires).toBe("number")
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("LLM provider migration journal remains valid JSON", async () => {
+  const journal = await readFile(new URL("../../../packages/den-db/drizzle/meta/_journal.json", import.meta.url), "utf8")
+  const parsed = JSON.parse(journal) as { entries?: Array<{ tag?: string }> }
+
+  expect(parsed.entries?.some((entry) => entry.tag === "0019_llm_provider_opencode_oauth")).toBe(true)
+})

--- a/ee/apps/den-api/test/managed-provider-sync.test.ts
+++ b/ee/apps/den-api/test/managed-provider-sync.test.ts
@@ -23,6 +23,7 @@ beforeAll(async () => {
 function createApp(input: {
   role?: string
   isOwner?: boolean
+  listProviders?: Parameters<typeof managedProviderModule.registerManagedProviderSyncRoutes>[1]["listProviders"]
   pushRuntime?: Parameters<typeof managedProviderModule.registerManagedProviderSyncRoutes>[1]["pushRuntime"]
 }) {
   const app = new Hono()
@@ -52,7 +53,7 @@ function createApp(input: {
       paramValidator(workersSharedModule.workerIdParamSchema),
     ] as never,
     getWorker: async (id, activeOrgId) => id === workerId && activeOrgId === orgId ? { id } : null,
-    listProviders: async () => [provider],
+    listProviders: input.listProviders ?? (async () => [provider]),
     pushRuntime: input.pushRuntime ?? (async () => ({ ok: true, status: 200, payload: { status: "applied" } })),
   })
   return { app, workerId, provider }
@@ -93,6 +94,22 @@ test("managed provider sync sanitizes worker failures", async () => {
   expect(JSON.stringify(body)).not.toContain("access-token-den")
   expect(JSON.stringify(body)).not.toContain("refresh-token-den")
   expect(body.reason).toBe("Worker provider sync failed.")
+})
+
+test("managed provider sync treats an empty provider set as applied without calling worker", async () => {
+  let called = false
+  const { app, workerId } = createApp({
+    listProviders: async () => [],
+    pushRuntime: async () => {
+      called = true
+      return { ok: false, status: 500, payload: { message: "should not be called" } }
+    },
+  })
+
+  const response = await app.request(`http://den.local/v1/workers/${workerId}/managed-providers/sync`, { method: "POST" })
+  expect(response.status).toBe(200)
+  await expect(response.json()).resolves.toEqual({ status: "applied", providerCount: 0, revision: "empty" })
+  expect(called).toBe(false)
 })
 
 test("managed provider sync reports missing worker as not found", async () => {

--- a/ee/apps/den-api/test/managed-provider-sync.test.ts
+++ b/ee/apps/den-api/test/managed-provider-sync.test.ts
@@ -36,7 +36,7 @@ function createApp(input: {
     credentialKind: "api_key" as const,
     providerConfig: { id: "anthropic", name: "Anthropic", env: ["ANTHROPIC_API_KEY"], npm: "@ai-sdk/anthropic" },
     models: [{ id: "claude", name: "Claude", config: { id: "claude" } }],
-    apiKey: "sk-secret-den-test",
+    apiKey: "plain-provider-secret-den-test",
     revision: "rev-1",
   }
   managedProviderModule.registerManagedProviderSyncRoutes(app as never, {
@@ -76,21 +76,23 @@ test("managed provider sync sends credentials only to worker runtime and redacts
   const response = await app.request(`http://den.local/v1/workers/${workerId}/managed-providers/sync`, { method: "POST" })
   expect(response.status).toBe(200)
   const body = await response.json()
-  expect(JSON.stringify(body)).not.toContain("sk-secret")
-  expect(JSON.stringify(calls[0])).toContain("sk-secret-den-test")
+  expect(JSON.stringify(body)).not.toContain("plain-provider-secret")
+  expect(JSON.stringify(calls[0])).toContain("plain-provider-secret-den-test")
   expect(body).toMatchObject({ status: "applied", providerCount: 1 })
 })
 
 test("managed provider sync sanitizes worker failures", async () => {
   const { app, workerId } = createApp({
-    pushRuntime: async () => ({ ok: false, status: 500, payload: { message: "failed with sk-secret-den-test" } }),
+    pushRuntime: async () => ({ ok: false, status: 500, payload: { message: "failed with plain-provider-secret-den-test access-token-den refresh-token-den" } }),
   })
   const response = await app.request(`http://den.local/v1/workers/${workerId}/managed-providers/sync`, { method: "POST" })
   expect(response.status).toBe(502)
   const body = await response.json()
   expect(body.status).toBe("failed")
-  expect(JSON.stringify(body)).not.toContain("sk-secret")
-  expect(body.reason).toContain("[redacted]")
+  expect(JSON.stringify(body)).not.toContain("plain-provider-secret")
+  expect(JSON.stringify(body)).not.toContain("access-token-den")
+  expect(JSON.stringify(body)).not.toContain("refresh-token-den")
+  expect(body.reason).toBe("Worker provider sync failed.")
 })
 
 test("managed provider sync reports missing worker as not found", async () => {
@@ -102,5 +104,5 @@ test("managed provider sync reports missing worker as not found", async () => {
 
 test("managed provider revision is stable and redaction helper removes token-shaped secrets", () => {
   expect(managedProviderModule.computeManagedProviderRevision([{ id: "b", revision: "2" }, { id: "a", revision: "1" }])).toBe("a:1|b:2")
-  expect(managedProviderModule.sanitizeManagedProviderSyncFailure({ message: "bad sk-live-secret" })).toBe("bad [redacted]")
+  expect(managedProviderModule.sanitizeManagedProviderSyncFailure({ message: "bad plain-secret access-token refresh-token" })).toBe("Worker provider sync failed.")
 })

--- a/ee/apps/den-api/test/managed-provider-sync.test.ts
+++ b/ee/apps/den-api/test/managed-provider-sync.test.ts
@@ -1,0 +1,106 @@
+import { beforeAll, expect, test } from "bun:test"
+import { Hono } from "hono"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { paramValidator } from "../src/middleware/validation.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+let managedProviderModule: typeof import("../src/routes/workers/managed-providers.js")
+let workersSharedModule: typeof import("../src/routes/workers/shared.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  managedProviderModule = await import("../src/routes/workers/managed-providers.js")
+  workersSharedModule = await import("../src/routes/workers/shared.js")
+})
+
+function createApp(input: {
+  role?: string
+  isOwner?: boolean
+  pushRuntime?: Parameters<typeof managedProviderModule.registerManagedProviderSyncRoutes>[1]["pushRuntime"]
+}) {
+  const app = new Hono()
+  const orgId = createDenTypeId("organization")
+  const workerId = createDenTypeId("worker")
+  const provider = {
+    id: createDenTypeId("llmProvider"),
+    providerId: "anthropic",
+    name: "Anthropic",
+    source: "models_dev" as const,
+    credentialKind: "api_key" as const,
+    providerConfig: { id: "anthropic", name: "Anthropic", env: ["ANTHROPIC_API_KEY"], npm: "@ai-sdk/anthropic" },
+    models: [{ id: "claude", name: "Claude", config: { id: "claude" } }],
+    apiKey: "sk-secret-den-test",
+    revision: "rev-1",
+  }
+  managedProviderModule.registerManagedProviderSyncRoutes(app as never, {
+    middlewares: [
+      async (c, next) => {
+        c.set("activeOrganizationId", orgId)
+        c.set("organizationContext", {
+          organization: { id: orgId },
+          currentMember: { id: createDenTypeId("member"), userId: createDenTypeId("user"), role: input.role ?? "admin", isOwner: input.isOwner ?? false },
+        })
+        await next()
+      },
+      paramValidator(workersSharedModule.workerIdParamSchema),
+    ] as never,
+    getWorker: async (id, activeOrgId) => id === workerId && activeOrgId === orgId ? { id } : null,
+    listProviders: async () => [provider],
+    pushRuntime: input.pushRuntime ?? (async () => ({ ok: true, status: 200, payload: { status: "applied" } })),
+  })
+  return { app, workerId, provider }
+}
+
+test("managed provider sync rejects non-admin members", async () => {
+  const { app, workerId } = createApp({ role: "member" })
+  const response = await app.request(`http://den.local/v1/workers/${workerId}/managed-providers/sync`, { method: "POST" })
+  expect(response.status).toBe(403)
+})
+
+test("managed provider sync sends credentials only to worker runtime and redacts response", async () => {
+  const calls: unknown[] = []
+  const { app, workerId, provider } = createApp({
+    pushRuntime: async (_workerId, payload) => {
+      calls.push(payload)
+      return { ok: true, status: 200, payload: { status: "applied", apiKey: provider.apiKey } }
+    },
+  })
+
+  const response = await app.request(`http://den.local/v1/workers/${workerId}/managed-providers/sync`, { method: "POST" })
+  expect(response.status).toBe(200)
+  const body = await response.json()
+  expect(JSON.stringify(body)).not.toContain("sk-secret")
+  expect(JSON.stringify(calls[0])).toContain("sk-secret-den-test")
+  expect(body).toMatchObject({ status: "applied", providerCount: 1 })
+})
+
+test("managed provider sync sanitizes worker failures", async () => {
+  const { app, workerId } = createApp({
+    pushRuntime: async () => ({ ok: false, status: 500, payload: { message: "failed with sk-secret-den-test" } }),
+  })
+  const response = await app.request(`http://den.local/v1/workers/${workerId}/managed-providers/sync`, { method: "POST" })
+  expect(response.status).toBe(502)
+  const body = await response.json()
+  expect(body.status).toBe("failed")
+  expect(JSON.stringify(body)).not.toContain("sk-secret")
+  expect(body.reason).toContain("[redacted]")
+})
+
+test("managed provider sync reports missing worker as not found", async () => {
+  const { app } = createApp({ role: "admin" })
+  const missingWorker = createDenTypeId("worker")
+  const response = await app.request(`http://den.local/v1/workers/${missingWorker}/managed-providers/sync`, { method: "POST" })
+  expect(response.status).toBe(404)
+})
+
+test("managed provider revision is stable and redaction helper removes token-shaped secrets", () => {
+  expect(managedProviderModule.computeManagedProviderRevision([{ id: "b", revision: "2" }, { id: "a", revision: "1" }])).toBe("a:1|b:2")
+  expect(managedProviderModule.sanitizeManagedProviderSyncFailure({ message: "bad sk-live-secret" })).toBe("bad [redacted]")
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-data.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { getErrorMessage, requestJson } from "../../_lib/den-flow";
 
 export type DenLlmProviderSource = "models_dev" | "custom" | "openwork";
+export type DenLlmProviderCredentialKind = "api_key" | "opencode_oauth";
 
 export type DenLlmProviderModel = {
   id: string;
@@ -41,7 +42,10 @@ export type DenLlmProvider = {
   providerId: string;
   name: string;
   providerConfig: Record<string, unknown>;
+  credentialKind: DenLlmProviderCredentialKind;
   hasApiKey: boolean;
+  hasOpencodeAuth: boolean;
+  hasCredential: boolean;
   createdAt: string | null;
   updatedAt: string | null;
   canManage: boolean;
@@ -178,6 +182,7 @@ function asLlmProvider(value: unknown): DenLlmProvider | null {
     value.source === "models_dev" || value.source === "custom" || value.source === "openwork"
       ? value.source
       : null;
+  const credentialKind = value.credentialKind === "opencode_oauth" ? "opencode_oauth" : "api_key";
   if (!id || !organizationId || !createdByOrgMembershipId || !providerId || !name || !source) {
     return null;
   }
@@ -190,7 +195,10 @@ function asLlmProvider(value: unknown): DenLlmProvider | null {
     providerId,
     name,
     providerConfig: asJsonRecord(value.providerConfig),
+    credentialKind,
     hasApiKey: value.hasApiKey === true,
+    hasOpencodeAuth: value.hasOpencodeAuth === true,
+    hasCredential: value.hasCredential === true || value.hasApiKey === true || value.hasOpencodeAuth === true,
     createdAt: asIsoString(value.createdAt),
     updatedAt: asIsoString(value.updatedAt),
     canManage: value.canManage === true,

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-detail-screen.tsx
@@ -185,10 +185,10 @@ export function LlmProviderDetailScreen({
                     </div>
 
                     <div
-                        className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-[13px] font-medium ${provider.hasApiKey ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700"}`}
+                        className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-[13px] font-medium ${provider.hasCredential ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700"}`}
                     >
                         <KeyRound className="h-4 w-4" />
-                        {provider.hasApiKey
+                        {provider.hasCredential
                             ? "Credential saved"
                             : "Credential missing"}
                     </div>
@@ -221,10 +221,10 @@ export function LlmProviderDetailScreen({
                     </div>
                     <div className="rounded-[24px] bg-gray-50 p-5">
                         <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
-                            Updated
+                            Credential
                         </p>
                         <p className="mt-3 text-[16px] font-medium text-gray-900">
-                            {formatProviderTimestamp(provider.updatedAt)}
+                            {provider.credentialKind === "opencode_oauth" ? "OpenCode OAuth" : "API key"}
                         </p>
                     </div>
                 </div>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
@@ -34,6 +34,7 @@ import {
     requestLlmProviderCatalogDetail,
     useOrgLlmProviders,
     type DenLlmProvider,
+    type DenLlmProviderCredentialKind,
     type DenModelsDevProviderDetail,
     type DenModelsDevProviderSummary,
 } from "./llm-provider-data";
@@ -88,7 +89,18 @@ export function LlmProviderEditorScreen({
     const [customConfigText, setCustomConfigText] = useState(
         buildCustomProviderTemplate(),
     );
+    const [credentialKind, setCredentialKind] =
+        useState<DenLlmProviderCredentialKind>("api_key");
     const [apiKey, setApiKey] = useState("");
+    const [opencodeAuth, setOpencodeAuth] = useState("");
+    const [openAiOauthBusy, setOpenAiOauthBusy] = useState(false);
+    const [openAiOauthError, setOpenAiOauthError] = useState<string | null>(null);
+    const [openAiOauthSession, setOpenAiOauthSession] = useState<{
+        verificationUrl: string;
+        userCode: string;
+        deviceAuthId: string;
+        intervalMs: number;
+    } | null>(null);
     const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
     const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
     const [saveBusy, setSaveBusy] = useState(false);
@@ -146,7 +158,11 @@ export function LlmProviderEditorScreen({
                     ? buildEditableCustomProviderText(provider)
                     : buildCustomProviderTemplate(),
             );
+            setCredentialKind(provider.credentialKind);
             setApiKey("");
+            setOpencodeAuth("");
+            setOpenAiOauthError(null);
+            setOpenAiOauthSession(null);
             return;
         }
 
@@ -159,8 +175,89 @@ export function LlmProviderEditorScreen({
         );
         setSelectedTeamIds([]);
         setCustomConfigText(buildCustomProviderTemplate());
+        setCredentialKind("api_key");
         setApiKey("");
+        setOpencodeAuth("");
+        setOpenAiOauthError(null);
+        setOpenAiOauthSession(null);
     }, [orgContext?.currentMember.id, provider]);
+
+    useEffect(() => {
+        setOpenAiOauthError(null);
+        setOpenAiOauthSession(null);
+    }, [credentialKind, selectedProviderId, source]);
+
+    async function startOpenAiOauth() {
+        setOpenAiOauthBusy(true);
+        setOpenAiOauthError(null);
+        try {
+            const { response, payload } = await requestJson(
+                "/v1/llm-providers/openai-oauth/start",
+                { method: "POST", body: JSON.stringify({}) },
+                20000,
+            );
+            if (!response.ok) {
+                throw new Error(getErrorMessage(payload, `Failed to start OpenAI OAuth (${response.status}).`));
+            }
+            if (!payload || typeof payload !== "object") {
+                throw new Error("OpenAI OAuth response was empty.");
+            }
+            const data = payload as Record<string, unknown>;
+            if (
+                typeof data.verificationUrl !== "string" ||
+                typeof data.userCode !== "string" ||
+                typeof data.deviceAuthId !== "string" ||
+                typeof data.intervalMs !== "number"
+            ) {
+                throw new Error("OpenAI OAuth response was incomplete.");
+            }
+            setOpenAiOauthSession({
+                verificationUrl: data.verificationUrl,
+                userCode: data.userCode,
+                deviceAuthId: data.deviceAuthId,
+                intervalMs: data.intervalMs,
+            });
+            window.open(data.verificationUrl, "_blank", "noopener,noreferrer");
+        } catch (error) {
+            setOpenAiOauthError(error instanceof Error ? error.message : "Could not start OpenAI OAuth.");
+        } finally {
+            setOpenAiOauthBusy(false);
+        }
+    }
+
+    async function completeOpenAiOauth() {
+        if (!openAiOauthSession) {
+            setOpenAiOauthError("Start OpenAI OAuth first.");
+            return;
+        }
+        setOpenAiOauthBusy(true);
+        setOpenAiOauthError(null);
+        try {
+            const { response, payload } = await requestJson(
+                "/v1/llm-providers/openai-oauth/complete",
+                {
+                    method: "POST",
+                    body: JSON.stringify({
+                        deviceAuthId: openAiOauthSession.deviceAuthId,
+                        userCode: openAiOauthSession.userCode,
+                    }),
+                },
+                20000,
+            );
+            if (!response.ok) {
+                throw new Error(getErrorMessage(payload, response.status === 409 ? "OpenAI authorization is not complete yet." : `Failed to complete OpenAI OAuth (${response.status}).`));
+            }
+            if (!payload || typeof payload !== "object" || typeof (payload as Record<string, unknown>).opencodeAuth !== "string") {
+                throw new Error("OpenAI OAuth completion response was incomplete.");
+            }
+            setOpencodeAuth((payload as { opencodeAuth: string }).opencodeAuth);
+            setOpenAiOauthSession(null);
+        } catch (error) {
+            setOpenAiOauthError(error instanceof Error ? error.message : "Could not complete OpenAI OAuth.");
+        } finally {
+            setOpenAiOauthBusy(false);
+        }
+    }
 
     useEffect(() => {
         if (source !== "models_dev" || !orgId || !selectedProviderId) {
@@ -286,6 +383,11 @@ export function LlmProviderEditorScreen({
             }
         }
 
+        if (credentialKind === "opencode_oauth" && source === "models_dev" && selectedProviderId !== "openai") {
+            setSaveError("OpenCode OAuth credentials are only available for the OpenAI catalog provider.");
+            return;
+        }
+
         if (source === "custom" && !customConfigText.trim()) {
             setSaveError("Paste a custom provider config.");
             return;
@@ -297,6 +399,7 @@ export function LlmProviderEditorScreen({
             const body: Record<string, unknown> = {
                 name: providerName.trim(),
                 source,
+                credentialKind,
                 memberIds: [...new Set(selectedMemberIds)],
                 teamIds: [...new Set(selectedTeamIds)],
             };
@@ -308,8 +411,12 @@ export function LlmProviderEditorScreen({
                 body.customConfigText = customConfigText;
             }
 
-            if (apiKey.trim() || !provider) {
+            if (credentialKind === "api_key" && (apiKey.trim() || !provider || provider.credentialKind !== "api_key")) {
                 body.apiKey = apiKey.trim();
+            }
+
+            if (credentialKind === "opencode_oauth" && (opencodeAuth.trim() || !provider || provider.credentialKind !== "opencode_oauth")) {
+                body.opencodeAuth = opencodeAuth.trim();
             }
 
             const path = provider
@@ -607,28 +714,113 @@ export function LlmProviderEditorScreen({
                             Credential
                         </h2>
                     </div>
-                    {provider?.hasApiKey ? (
+                    {provider?.hasCredential ? (
                         <span className="rounded-full bg-emerald-50 px-4 py-2 text-[13px] font-medium text-emerald-700">
                             Existing credential saved
                         </span>
                     ) : null}
                 </div>
 
-                <label className="grid gap-3">
-                    <span className="text-[14px] font-medium text-gray-700">
-                        API key / credential
-                    </span>
-                    <DenInput
-                        type="password"
-                        value={apiKey}
-                        onChange={(event) => setApiKey(event.target.value)}
-                        placeholder={
-                            provider?.hasApiKey
-                                ? "Leave blank to keep current credential"
-                                : "Paste the provider credential"
-                        }
+                <div className="mb-6 grid gap-3 md:grid-cols-2">
+                    <DenSelectableRow
+                        selected={credentialKind === "api_key"}
+                        title="API key"
+                        description="Store a provider API key and import it into teammates' workspaces."
+                        onClick={() => setCredentialKind("api_key")}
                     />
-                </label>
+                    <DenSelectableRow
+                        selected={credentialKind === "opencode_oauth"}
+                        title="OpenCode OAuth"
+                        description="Store the native OpenCode OAuth auth JSON for the OpenAI provider."
+                        onClick={() => setCredentialKind("opencode_oauth")}
+                    />
+                </div>
+
+                {credentialKind === "api_key" ? (
+                    <label className="grid gap-3">
+                        <span className="text-[14px] font-medium text-gray-700">
+                            API key / credential
+                        </span>
+                        <DenInput
+                            type="password"
+                            value={apiKey}
+                            onChange={(event) => setApiKey(event.target.value)}
+                            placeholder={
+                                provider?.credentialKind === "api_key" && provider.hasApiKey
+                                    ? "Leave blank to keep current credential"
+                                    : "Paste the provider credential"
+                            }
+                        />
+                    </label>
+                ) : (
+                    <div className="grid gap-4">
+                        <div className="rounded-[24px] border border-blue-100 bg-blue-50 p-5">
+                            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                                <div>
+                                    <p className="text-[14px] font-semibold text-blue-950">Connect OpenAI with OpenCode OAuth</p>
+                                    <p className="mt-2 text-[13px] leading-6 text-blue-800">
+                                        This uses the same ChatGPT Pro/Plus device flow as OpenCode, then stores the resulting OAuth auth JSON encrypted in Den.
+                                    </p>
+                                </div>
+                                <DenButton
+                                    variant="secondary"
+                                    loading={openAiOauthBusy && !openAiOauthSession}
+                                    onClick={() => void startOpenAiOauth()}
+                                >
+                                    Connect OpenAI
+                                </DenButton>
+                            </div>
+
+                            {openAiOauthSession ? (
+                                <div className="mt-5 rounded-[18px] bg-white p-4 ring-1 ring-inset ring-blue-100">
+                                    <p className="text-[13px] font-medium text-gray-800">Enter this code on OpenAI:</p>
+                                    <div className="mt-3 inline-flex rounded-xl bg-gray-950 px-4 py-2 font-mono text-[22px] font-semibold tracking-[0.18em] text-white">
+                                        {openAiOauthSession.userCode}
+                                    </div>
+                                    <div className="mt-4 flex flex-wrap gap-3">
+                                        <a
+                                            href={openAiOauthSession.verificationUrl}
+                                            target="_blank"
+                                            rel="noreferrer"
+                                            className="inline-flex items-center justify-center rounded-full bg-white px-4 py-2 text-[13px] font-medium text-gray-700 ring-1 ring-inset ring-gray-200 transition hover:bg-gray-50"
+                                        >
+                                            Open OpenAI page
+                                        </a>
+                                        <DenButton
+                                            loading={openAiOauthBusy}
+                                            onClick={() => void completeOpenAiOauth()}
+                                        >
+                                            I finished authorization
+                                        </DenButton>
+                                    </div>
+                                </div>
+                            ) : null}
+
+                            {openAiOauthError ? (
+                                <p className="mt-4 text-[13px] leading-6 text-red-700">{openAiOauthError}</p>
+                            ) : null}
+                        </div>
+
+                        <label className="grid gap-3">
+                            <span className="text-[14px] font-medium text-gray-700">
+                                OpenCode OAuth JSON
+                            </span>
+                            <DenTextarea
+                                value={opencodeAuth}
+                                onChange={(event) => setOpencodeAuth(event.target.value)}
+                                rows={8}
+                                placeholder={
+                                    provider?.credentialKind === "opencode_oauth" && provider.hasOpencodeAuth
+                                        ? "Leave blank to keep current OpenCode OAuth credential"
+                                        : '{ "type": "oauth", "access": "...", "refresh": "...", "expires": 0 }'
+                                }
+                            />
+                            <p className="text-[13px] leading-6 text-gray-500">
+                                You can connect above or paste the same auth shape OpenCode writes to auth.json for OAuth providers.
+                            </p>
+                        </label>
+                    </div>
+                )}
             </section>
 
             {source === "models_dev" ? (

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-providers-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-providers-screen.tsx
@@ -182,9 +182,9 @@ export function LlmProvidersScreen() {
                 </div>
 
                 <div className="mt-5 flex flex-wrap gap-2">
-                  <span className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-[12px] font-medium ${provider.hasApiKey ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700"}`}>
+                  <span className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-[12px] font-medium ${provider.hasCredential ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700"}`}>
                     <KeyRound className="h-3.5 w-3.5" />
-                    {provider.hasApiKey ? "Credential saved" : "Credential missing"}
+                    {provider.hasCredential ? (provider.credentialKind === "opencode_oauth" ? "OpenCode OAuth" : "Credential saved") : "Credential missing"}
                   </span>
                   {envNames.slice(0, 2).map((envName) => (
                     <span key={envName} className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">

--- a/ee/packages/den-db/drizzle/0019_llm_provider_opencode_oauth.sql
+++ b/ee/packages/den-db/drizzle/0019_llm_provider_opencode_oauth.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `llm_provider`
+  ADD COLUMN `credential_kind` enum('api_key','opencode_oauth') NOT NULL DEFAULT 'api_key' AFTER `provider_config`,
+  ADD COLUMN `opencode_auth` text AFTER `api_key`;

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1779380000000,
       "tag": "0018_invited_org_members",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "5",
+      "when": 1777486400000,
+      "tag": "0019_llm_provider_opencode_oauth",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/src/schema/sharables/llm-providers.ts
+++ b/ee/packages/den-db/src/schema/sharables/llm-providers.ts
@@ -30,7 +30,11 @@ export const LlmProviderTable = mysqlTable(
     providerConfig: json("provider_config")
       .$type<Record<string, unknown>>()
       .notNull(),
+    credentialKind: mysqlEnum("credential_kind", ["api_key", "opencode_oauth"])
+      .notNull()
+      .default("api_key"),
     apiKey: encryptedTextColumn("api_key"),
+    opencodeAuth: encryptedTextColumn("opencode_auth"),
     createdAt: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { fsp: 3 })
       .notNull()


### PR DESCRIPTION
## Scope
- Adds Den API OpenAI/OpenCode OAuth device-flow start and complete routes.
- Adds focused Den API OAuth tests for route auth gates, pending/failed/successful device flow, credential redaction, and migration journal validation.
- Adds Den Web provider UI for selecting OpenCode OAuth credentials, launching OpenAI device authorization, completing the flow, and saving resulting OAuth auth JSON.
- Updates Den Web provider listing/detail copy to distinguish API-key credentials from OpenCode OAuth credentials.

## Dependency chain
- Depends on #1936 only.

## Isolated review diff
- https://github.com/Pagecran/openwork/compare/ghstack/den-api-oauth-credential-handling...ghstack/openai-oauth-device-flow-and-ui

## Tests
Latest ghstack verification passed:
- `pnpm --filter @openwork-ee/den-db build`
- From `ee/apps/den-api`: `pnpm exec tsc -p tsconfig.json --noEmit`
- From `ee/apps/den-api`: `pnpm exec bun test test/managed-provider-sync.test.ts test/llm-provider-credentials.test.ts test/llm-providers-oauth.test.ts` — 21 pass, 0 fail
- From `apps/server`: `pnpm exec bun test src/managed-provider-sync.e2e.test.ts` — 3 pass, 0 fail

## Known baseline note
Earlier app typecheck for this UI-adjacent work failed in unrelated existing/baseline file `src/react-app/design-system/extension-mesh-avatar.tsx` because `@paper-design/shaders-react` types could not be resolved. This PR does not touch that file or dependency.

## Linked issues
- Partially fixes #1855
- Helps fix #1072