### PR TITLE
fix(app): resolve spaced file mention round-tripping in editor

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -32,6 +32,7 @@ import {
   type NodeKey,
 } from "lexical";
 import type { InitialConfigType } from "@lexical/react/LexicalComposer.js";
+import { decodeComposerMentionValue, encodeComposerMentionValue } from "./mention-encoding";
 
 type EditorProps = {
   value: string;
@@ -85,7 +86,7 @@ class ComposerMentionNode extends TextNode {
   }
 
   constructor(value = "", kind: "agent" | "file" = "file", key?: NodeKey) {
-    super(`@${value}`, key);
+    super(`@${encodeComposerMentionValue(value)}`, key);
     this.__value = value;
     this.__kind = kind;
   }
@@ -407,7 +408,7 @@ function setPrompt(value: string, mentions: Record<string, "agent" | "file">, pa
       }
     }
     if (segment.startsWith("@")) {
-      const token = segment.slice(1);
+      const token = decodeComposerMentionValue(segment.slice(1));
       const kind = mentions[token];
       if (kind) {
         paragraph.append($createComposerMentionNode(token, kind));

--- a/apps/app/src/react-app/domains/session/surface/composer/mention-encoding.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/mention-encoding.ts
@@ -1,0 +1,15 @@
+/**
+ * Percent-encode a mention value so it can be embedded in the draft as a single `@token` with no spaces.
+ * @param value The raw mention value to encode.
+ */
+export function encodeComposerMentionValue(value: string) {
+  return value.replaceAll("%", "%25").replaceAll(" ", "%20");
+}
+
+/**
+ * Recover the original mention value from its encoded form. Preserves literal `%20` sequences in the original.
+ * @param value The encoded mention value to decode.
+ */
+export function decodeComposerMentionValue(value: string) {
+  return value.replaceAll("%20", " ").replaceAll("%25", "%");
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../../shell/app-inspector";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
 import { ReactSessionComposer } from "./composer/composer";
+import { decodeComposerMentionValue, encodeComposerMentionValue } from "./composer/mention-encoding";
 import { DevProfiler } from "../../../shell/dev-profiler";
 import { PaperGrainGradient } from "@openwork/ui/react";
 import { OwDotTicker } from "../../../shell/dot-ticker";
@@ -690,8 +691,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
   });
 
   const buildDraft = useCallback((text: string, nextAttachments: ComposerAttachment[]): ComposerDraft => {
-    const trimmed = text.trim();
-    const slashMatch = trimmed.match(/^\/([^\s]+)\s*(.*)$/);
     const parts: ComposerPart[] = text.split(/(\[pasted text [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {
       if (!segment) return [] as ComposerDraft["parts"];
       const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
@@ -702,7 +701,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         }
       }
       if (segment.startsWith("@")) {
-        const value = segment.slice(1);
+        const value = decodeComposerMentionValue(segment.slice(1));
         const kind = mentions[value];
         if (kind === "agent") return [{ type: "agent", name: value } satisfies ComposerDraft["parts"][number]];
         if (kind === "file") return [{ type: "file", path: value, label: value } satisfies ComposerDraft["parts"][number]];
@@ -715,13 +714,17 @@ export function SessionSurface(props: SessionSurfaceProps) {
     for (const part of pasteParts) {
       resolved = resolved.replace(`[pasted text ${part.label}]`, part.text);
     }
+    for (const value of Object.keys(mentions)) {
+      resolved = resolved.replaceAll(`@${encodeComposerMentionValue(value)}`, `@${value}`);
+    }
+    const resolvedSlashMatch = resolved.trim().match(/^\/([^\s]+)\s*(.*)$/);
     return {
       mode: "prompt",
       parts,
       attachments: nextAttachments,
       text,
       resolvedText: resolved,
-      command: slashMatch ? { name: slashMatch[1] ?? "", arguments: slashMatch[2] ?? "" } : undefined,
+      command: resolvedSlashMatch ? { name: resolvedSlashMatch[1] ?? "", arguments: resolvedSlashMatch[2] ?? "" } : undefined,
     };
   }, [mentions, pasteParts]);
 
@@ -827,7 +830,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   };
 
   const handleInsertMention = (kind: "agent" | "file", value: string) => {
-    setComposerDraft(props.sessionId, draft.replace(/@([^\s@]*)$/, `@${value} `));
+    setComposerDraft(props.sessionId, draft.replace(/@([^\s@]*)$/, `@${encodeComposerMentionValue(value)} `));
     setComposerMentions(props.sessionId, { ...mentions, [value]: kind });
   };
 

--- a/apps/app/tests/mention-encoding.test.ts
+++ b/apps/app/tests/mention-encoding.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { decodeComposerMentionValue, encodeComposerMentionValue } from "../src/react-app/domains/session/surface/composer/mention-encoding";
+
+describe("mention-encoding", () => {
+  test("round-trips paths with spaces", () => {
+    const value = "docs/foo bar.md";
+    expect(decodeComposerMentionValue(encodeComposerMentionValue(value))).toBe(value);
+    expect(encodeComposerMentionValue(value)).toBe("docs/foo%20bar.md");
+  });
+
+  test("preserves literal percent-encoded sequences in paths", () => {
+    const value = "docs/foo%20bar.md";
+    expect(encodeComposerMentionValue(value)).toBe("docs/foo%2520bar.md");
+    expect(decodeComposerMentionValue("docs/foo%2520bar.md")).toBe(value);
+  });
+
+  test("round-trips percent signs", () => {
+    const value = "docs/100% done.md";
+    expect(decodeComposerMentionValue(encodeComposerMentionValue(value))).toBe(value);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes editor round-tripping for file mentions with spaces in their paths.
- Adds mention encoding/decoding helpers used by composer/session surface.
- Updates editor mention serialization to preserve spaced file paths.
- Adds tests for mention encoding behavior.