### PR TITLE
fix(app): restore remote workspace access

### DIFF
--- a/apps/app/src/react-app/domains/workspace/use-remote-workspace-connection-editor.ts
+++ b/apps/app/src/react-app/domains/workspace/use-remote-workspace-connection-editor.ts
@@ -5,6 +5,7 @@ import {
   workspaceUpdateRemote,
   type WorkspaceInfo,
 } from "../../../app/lib/desktop";
+import { buildOpenworkWorkspaceBaseUrl } from "../../../app/lib/openwork-server";
 import { t } from "../../../i18n";
 import type { RemoteWorkspaceInput } from "./types";
 
@@ -40,16 +41,22 @@ export function useRemoteWorkspaceConnectionEditor<TWorkspace extends WorkspaceI
   );
 
   const initialValues = useMemo(
-    () => ({
-      openworkHostUrl: workspace?.openworkHostUrl ?? workspace?.baseUrl ?? "",
-      openworkToken:
-        workspace?.openworkToken ??
-        workspace?.openworkClientToken ??
-        workspace?.openworkHostToken ??
-        "",
-      directory: workspace?.directory ?? workspace?.path ?? "",
-      displayName: workspace?.displayName ?? workspace?.name ?? "",
-    }),
+    () => {
+      const hostUrl = workspace?.openworkHostUrl ?? workspace?.baseUrl ?? "";
+      const mountedUrl = workspace?.remoteType === "openwork"
+        ? buildOpenworkWorkspaceBaseUrl(hostUrl, workspace.openworkWorkspaceId) ?? hostUrl
+        : hostUrl;
+      return {
+        openworkHostUrl: mountedUrl,
+        openworkToken:
+          workspace?.openworkToken ??
+          workspace?.openworkClientToken ??
+          workspace?.openworkHostToken ??
+          "",
+        directory: workspace?.directory ?? workspace?.path ?? "",
+        displayName: workspace?.displayName ?? workspace?.name ?? "",
+      };
+    },
     [workspace],
   );
 

--- a/apps/app/src/react-app/shell/desktop-runtime-boot.ts
+++ b/apps/app/src/react-app/shell/desktop-runtime-boot.ts
@@ -5,6 +5,7 @@ import {
   engineInfo,
   engineStart,
   openworkServerInfo,
+  openworkServerRestart,
   resolveWorkspaceListSelectedId,
   runtimeBootstrap,
   workspaceBootstrap,
@@ -30,12 +31,21 @@ import { useBootState } from "./boot-state";
 // keeps running across the transient unmount.
 let BOOT_STARTED = false;
 
-function isOpenworkServerReady(info?: {
+type BootOpenworkServerInfo = {
   running?: boolean | null;
   baseUrl?: string | null;
   ownerToken?: string | null;
   clientToken?: string | null;
-}) {
+  hostToken?: string | null;
+  port?: number | null;
+  remoteAccessEnabled?: boolean;
+};
+
+function isOpenworkServerInfoLike(info: unknown): info is BootOpenworkServerInfo {
+  return typeof info === "object" && info !== null;
+}
+
+function isOpenworkServerReady(info?: BootOpenworkServerInfo) {
   return Boolean(
     info?.running === true &&
       info.baseUrl?.trim() &&
@@ -83,6 +93,7 @@ export function useDesktopRuntimeBoot() {
           }
         }
         hydrateOpenworkServerSettingsFromEnv();
+        const preferredRemoteAccess = readOpenworkServerSettings().remoteAccessEnabled === true;
 
         setPhase("bootstrapping-workspaces");
         const list = await workspaceBootstrap().catch(() => null) as WorkspaceList | null;
@@ -116,15 +127,7 @@ export function useDesktopRuntimeBoot() {
             skipped?: boolean;
             error?: string;
             engine?: { baseUrl?: string | null };
-            openworkServer?: {
-              running?: boolean | null;
-              baseUrl?: string | null;
-              ownerToken?: string | null;
-              clientToken?: string | null;
-              hostToken?: string | null;
-              port?: number | null;
-              remoteAccessEnabled?: boolean;
-            };
+            openworkServer?: BootOpenworkServerInfo;
           };
 
           if (boot.ok === false) {
@@ -140,7 +143,11 @@ export function useDesktopRuntimeBoot() {
           if (boot.engine?.baseUrl) {
             setActive(boot.engine.baseUrl);
           }
-          const serverInfo = boot.openworkServer;
+          let serverInfo = boot.openworkServer;
+          if (preferredRemoteAccess && serverInfo?.remoteAccessEnabled !== true) {
+            const restarted = await openworkServerRestart({ remoteAccessEnabled: true });
+            if (isOpenworkServerInfoLike(restarted)) serverInfo = restarted;
+          }
           if (serverInfo?.baseUrl) {
             writeOpenworkServerSettings({
               urlOverride: serverInfo.baseUrl,

--- a/apps/app/src/react-app/shell/desktop-runtime-boot.ts
+++ b/apps/app/src/react-app/shell/desktop-runtime-boot.ts
@@ -145,7 +145,10 @@ export function useDesktopRuntimeBoot() {
           }
           let serverInfo = boot.openworkServer;
           if (preferredRemoteAccess && serverInfo?.remoteAccessEnabled !== true) {
-            const restarted = await openworkServerRestart({ remoteAccessEnabled: true });
+            const restarted = await openworkServerRestart({ remoteAccessEnabled: true }).catch((error) => {
+              console.warn("[desktop-boot] openworkServerRestart failed:", error);
+              return null;
+            });
             if (isOpenworkServerInfoLike(restarted)) serverInfo = restarted;
           }
           if (serverInfo?.baseUrl) {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -727,7 +727,24 @@ export function SessionRoute() {
 
       const fetchOnce = async (workspace: RouteWorkspace, attempt: number): Promise<void> => {
         const endpoint = endpointForWorkspace(workspace);
-        if (!endpoint) return;
+        if (!endpoint) {
+          if (workspace.workspaceType === "remote") {
+            const message = "Remote worker URL is missing. Edit connection and add a server URL.";
+            setErrorsByWorkspaceId((current) => ({ ...current, [workspace.id]: message }));
+            setWorkspaceConnectionOverrides((current) => ({
+              ...current,
+              [workspace.id]: {
+                status: "error",
+                message,
+                checkedAt: Date.now(),
+              },
+            }));
+            setRetryingWorkspaceIds((current) =>
+              current.includes(workspace.id) ? current.filter((id) => id !== workspace.id) : current,
+            );
+          }
+          return;
+        }
         const startedAt = backgroundSessionLoadInFlight.current.get(workspace.id) ?? 0;
         if (startedAt && Date.now() - startedAt < 5_000) return;
         const requestStartedAt = Date.now();

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2116,9 +2116,12 @@ async function handleDesktopInvoke(event, command, ...args) {
           const directory = typeof nextWorkspace.directory === "string" && nextWorkspace.directory.trim()
             ? nextWorkspace.directory.trim()
             : null;
-          let remoteWorkspaceId = typeof nextWorkspace.openworkWorkspaceId === "string" && nextWorkspace.openworkWorkspaceId.trim()
-            ? nextWorkspace.openworkWorkspaceId.trim()
-            : parseOpenworkWorkspaceIdFromUrl(rawHostUrl) || parseOpenworkWorkspaceIdFromUrl(nextBaseUrl);
+          const parsedWorkspaceId = parseOpenworkWorkspaceIdFromUrl(rawHostUrl) || parseOpenworkWorkspaceIdFromUrl(nextBaseUrl);
+          let remoteWorkspaceId = parsedWorkspaceId || (
+            typeof nextWorkspace.openworkWorkspaceId === "string" && nextWorkspace.openworkWorkspaceId.trim()
+              ? nextWorkspace.openworkWorkspaceId.trim()
+              : null
+          );
           let remoteWorkspaceName = nextWorkspace.openworkWorkspaceName ?? null;
           if (!remoteWorkspaceId) {
             const discovered = await discoverOpenworkWorkspace({

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -445,6 +445,18 @@ function buildOpencodeProxyUrl(baseUrl: string, path: string, search: string) {
   return target.toString();
 }
 
+function createOpencodeDirectoryFetch(directory: string): typeof fetch {
+  return Object.assign(
+    (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      const headers = new Headers(init?.headers ?? request.headers);
+      headers.set("x-opencode-directory", directory);
+      return fetch(new Request(request, { headers }));
+    },
+    { preconnect: fetch.preconnect },
+  );
+}
+
 type OpencodeClientResult<T, E> =
   | { data: T | undefined; error: undefined; response: Response }
   | { data: undefined; error: E; response: Response };
@@ -452,10 +464,12 @@ type OpencodeClientResult<T, E> =
 function createWorkspaceOpencodeClient(config: ServerConfig, workspace: WorkspaceInfo) {
   const connection = resolveWorkspaceOpencodeConnection(config, workspace);
   const directory = resolveOpencodeDirectory(workspace);
+  const directoryFetch = directory ? createOpencodeDirectoryFetch(directory) : undefined;
 
   return createOpencodeClient({
     baseUrl: connection.baseUrl?.trim(),
     ...(directory ? { directory } : {}),
+    ...(directoryFetch ? { fetch: directoryFetch } : {}),
     ...(connection.authHeader ? { headers: { Authorization: connection.authHeader } } : {}),
   });
 }
@@ -3360,7 +3374,11 @@ async function readWorkspaceSessionSnapshot(
 }
 
 async function resolveWorkspace(config: ServerConfig, id: string): Promise<WorkspaceInfo> {
-  const workspace = config.workspaces.find((entry) => entry.id === id);
+  const workspaceId = id.trim();
+  const aliasWorkspaceId = workspaceId.startsWith("rem_") ? workspaceId.slice("rem_".length) : "";
+  const workspace =
+    config.workspaces.find((entry) => entry.id === workspaceId) ??
+    (aliasWorkspaceId ? config.workspaces.find((entry) => entry.id === aliasWorkspaceId) : undefined);
   if (!workspace) {
     throw new ApiError(404, "workspace_not_found", "Workspace not found");
   }

--- a/apps/server/src/session-read-model.e2e.test.ts
+++ b/apps/server/src/session-read-model.e2e.test.ts
@@ -237,6 +237,24 @@ describe("workspace session read APIs", () => {
 
   });
 
+  test("accepts guest-side rem_ workspace aliases for session reads", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const mock = startMockOpencode();
+    const openwork = await startOpenworkServer({
+      workspaceRoot,
+      opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
+    });
+
+    const response = await fetch(`http://127.0.0.1:${openwork.server.port}/workspace/rem_ws_1/sessions`, {
+      headers: auth(openwork.token),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.items[0]?.id).toBe("ses_1");
+    expect(body.items[0]?.directory).toBe(workspaceRoot);
+    expect(mock.requests.find((request) => request.pathname === "/session")?.directory).toBe(workspaceRoot);
+  });
+
   test("returns 404 when the upstream session is missing", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const mock = startMockOpencode();


### PR DESCRIPTION
## Summary
- Preserve Electron remote sharing preference across startup so shared local workspaces do not silently become unshared.
- Show full `/workspace/ws_...` remote URLs in the connection editor and update the stored workspace id when edited URLs include a workspace path.
- Restore OpenCode directory scoping for SDK-backed session reads, accept `rem_` workspace aliases server-side, and surface missing remote endpoints as errors.

## Tests
- `pnpm --filter openwork-server test src/session-read-model.e2e.test.ts` (6 pass)
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/desktop typecheck:electron`

## Evidence
No screen recording captured; this was verified with focused regression tests and typechecks.