### PR TITLE
fix(app): preserve session message ordering

### DIFF
--- a/apps/app/scripts/session-render-state.test.ts
+++ b/apps/app/scripts/session-render-state.test.ts
@@ -9,7 +9,7 @@ import {
 import { reconcileTranscriptMessages } from "../src/react-app/domains/session/sync/transcript-reconcile";
 
 function snapshotWithMessages(
-  messages: Array<{ id: string; role: "user" | "assistant"; text: string }>,
+  messages: Array<{ id: string; role: "user" | "assistant"; text: string; created?: number }>,
   sessionId = "ses_test",
 ): OpenworkSessionSnapshot {
   return {
@@ -26,7 +26,7 @@ function snapshotWithMessages(
         id: message.id,
         role: message.role,
         sessionID: sessionId,
-        time: { created: index + 1 },
+        time: { created: message.created ?? index + 1 },
       },
       parts: [
         {
@@ -43,10 +43,11 @@ function snapshotWithMessages(
   } as unknown as OpenworkSessionSnapshot;
 }
 
-function uiMessage(id: string, role: "user" | "assistant", text: string): UIMessage {
+function uiMessage(id: string, role: "user" | "assistant", text: string, created?: number): UIMessage {
   return {
     id,
     role,
+    ...(typeof created === "number" ? { metadata: { opencode: { created } } } : {}),
     parts: [{ type: "text", text, state: "done" }],
   };
 }
@@ -134,6 +135,32 @@ describe("reconcileTranscriptMessages", () => {
 
     expect(merged[1]?.parts[0]).toMatchObject({ text: "finished answer" });
   });
+
+  it("inserts cached-only message blocks by timestamp instead of appending them", () => {
+    const merged = reconcileTranscriptMessages({
+      currentMessages: [
+        uiMessage("msg_block1", "user", "block 1", 1),
+        uiMessage("msg_block2", "assistant", "block 2", 2),
+        uiMessage("msg_block3", "user", "block 3", 3),
+        uiMessage("msg_block4", "assistant", "block 4", 4),
+        uiMessage("msg_streaming", "assistant", "streaming", 5),
+      ],
+      snapshotMessages: [
+        uiMessage("msg_block1", "user", "block 1", 1),
+        uiMessage("msg_block3", "user", "block 3", 3),
+        uiMessage("msg_block4", "assistant", "block 4", 4),
+      ],
+      reason: "snapshot",
+    });
+
+    expect(merged.map((message) => message.id)).toEqual([
+      "msg_block1",
+      "msg_block2",
+      "msg_block3",
+      "msg_block4",
+      "msg_streaming",
+    ]);
+  });
 });
 
 describe("deriveRenderedSessionMessages", () => {
@@ -150,22 +177,20 @@ describe("deriveRenderedSessionMessages", () => {
     });
   });
 
-  it("keeps live transcript cache when it covers the snapshot", () => {
+  it("keeps longer live text when the cache covers the snapshot", () => {
     const cached: UIMessage[] = [
-      {
-        id: "msg_user",
-        role: "assistant",
-        parts: [{ type: "text", text: "live text", state: "done" }],
-      },
+      uiMessage("msg_user", "user", "snapshot text plus live tail", 1),
     ];
 
-    expect(deriveRenderedSessionMessages({
+    const messages = deriveRenderedSessionMessages({
       transcriptState: cached,
       snapshot: snapshotWithText("snapshot text"),
-    })).toBe(cached);
+    });
+
+    expect(messages[0]?.parts[0]).toMatchObject({ text: "snapshot text plus live tail" });
   });
 
-  it("renders the canonical live cache without merging snapshot history", () => {
+  it("keeps snapshot history visible when the live cache only has the active turn", () => {
     const messages = deriveRenderedSessionMessages({
       transcriptState: [
         {
@@ -186,12 +211,14 @@ describe("deriveRenderedSessionMessages", () => {
     });
 
     expect(messages.map((message) => message.id)).toEqual([
+      "msg_old_user",
+      "msg_old_assistant",
       "msg_current_user",
       "msg_current_assistant",
     ]);
   });
 
-  it("keeps live-only tail messages instead of merging a stale snapshot during render", () => {
+  it("keeps live-only tail messages after the stream flips idle before the snapshot catches up", () => {
     const messages = deriveRenderedSessionMessages({
       transcriptState: [
         uiMessage("msg_current_user", "user", "latest prompt"),
@@ -204,8 +231,35 @@ describe("deriveRenderedSessionMessages", () => {
     });
 
     expect(messages.map((message) => message.id)).toEqual([
+      "msg_old_user",
+      "msg_old_assistant",
       "msg_current_user",
       "msg_current_assistant",
+    ]);
+  });
+
+  it("renders cached-only message blocks by timestamp instead of appending them", () => {
+    const messages = deriveRenderedSessionMessages({
+      transcriptState: [
+        uiMessage("msg_block1", "user", "block 1", 1),
+        uiMessage("msg_block2", "assistant", "block 2", 2),
+        uiMessage("msg_block3", "user", "block 3", 3),
+        uiMessage("msg_block4", "assistant", "block 4", 4),
+        uiMessage("msg_streaming", "assistant", "streaming", 5),
+      ],
+      snapshot: snapshotWithMessages([
+        { id: "msg_block1", role: "user", text: "block 1", created: 1 },
+        { id: "msg_block3", role: "user", text: "block 3", created: 3 },
+        { id: "msg_block4", role: "assistant", text: "block 4", created: 4 },
+      ]),
+    });
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "msg_block1",
+      "msg_block2",
+      "msg_block3",
+      "msg_block4",
+      "msg_streaming",
     ]);
   });
 

--- a/apps/app/src/react-app/domains/session/sync/message-merge.ts
+++ b/apps/app/src/react-app/domains/session/sync/message-merge.ts
@@ -24,10 +24,68 @@ function mergeMessageParts(snapshotMessage: UIMessage, cachedMessage: UIMessage)
 }
 
 function mergeSnapshotMessageWithCached(snapshotMessage: UIMessage, cachedMessage: UIMessage): UIMessage {
+  const metadata = snapshotMessage.metadata ?? cachedMessage.metadata;
+
   return {
     ...snapshotMessage,
+    ...(metadata === undefined ? {} : { metadata }),
     parts: mergeMessageParts(snapshotMessage, cachedMessage),
   };
+}
+
+function messageCreated(message: UIMessage) {
+  const metadata = message.metadata;
+  if (!metadata || typeof metadata !== "object" || !("opencode" in metadata)) return null;
+
+  const opencode = metadata.opencode;
+  if (!opencode || typeof opencode !== "object" || !("created" in opencode)) return null;
+
+  const created = opencode.created;
+  return typeof created === "number" ? created : null;
+}
+
+function insertMessageByChronology(messages: UIMessage[], message: UIMessage, sourceOrder: UIMessage[]) {
+  const created = messageCreated(message);
+  if (created !== null) {
+    const timestampIndex = messages.findIndex((existing) => {
+      const existingCreated = messageCreated(existing);
+      return existingCreated !== null && existingCreated > created;
+    });
+    if (timestampIndex !== -1) {
+      messages.splice(timestampIndex, 0, message);
+      return;
+    }
+  }
+
+  const sourceIndex = sourceOrder.findIndex((item) => item.id === message.id);
+  if (sourceIndex !== -1) {
+    for (let index = sourceIndex + 1; index < sourceOrder.length; index += 1) {
+      const nextIndex = messages.findIndex((item) => item.id === sourceOrder[index]?.id);
+      if (nextIndex !== -1) {
+        messages.splice(nextIndex, 0, message);
+        return;
+      }
+    }
+
+    for (let index = sourceIndex - 1; index >= 0; index -= 1) {
+      const previousIndex = messages.findIndex((item) => item.id === sourceOrder[index]?.id);
+      if (previousIndex !== -1) {
+        messages.splice(previousIndex + 1, 0, message);
+        return;
+      }
+    }
+  }
+
+  messages.push(message);
+}
+
+function sortFullyTimestampedMessages(messages: UIMessage[]) {
+  const withCreated = messages.map((message, index) => ({ message, index, created: messageCreated(message) }));
+  if (withCreated.some((item) => item.created === null)) return messages;
+
+  return withCreated
+    .sort((a, b) => (a.created ?? 0) - (b.created ?? 0) || a.index - b.index)
+    .map((item) => item.message);
 }
 
 export function messageListContainsAll(container: UIMessage[], required: UIMessage[]) {
@@ -53,11 +111,11 @@ export function mergeSnapshotAndLiveMessages(
 
   if (options.appendLiveOnlyMessages) {
     for (const liveMessage of liveMessages) {
-      if (!snapshotIds.has(liveMessage.id)) merged.push(liveMessage);
+      if (!snapshotIds.has(liveMessage.id)) insertMessageByChronology(merged, liveMessage, liveMessages);
     }
   }
 
-  return merged;
+  return sortFullyTimestampedMessages(merged);
 }
 
 export function mergeSnapshotIntoCachedMessages(snapshotMessages: UIMessage[], cachedMessages: UIMessage[]) {
@@ -66,11 +124,8 @@ export function mergeSnapshotIntoCachedMessages(snapshotMessages: UIMessage[], c
 
   const snapshotById = new Map(snapshotMessages.map((message) => [message.id, message]));
   const cachedById = new Map(cachedMessages.map((message) => [message.id, message]));
-  const useCachedOrder = cachedMessages.length > snapshotMessages.length;
-  const primary = useCachedOrder ? cachedMessages : snapshotMessages;
-  const secondary = useCachedOrder ? snapshotMessages : cachedMessages;
   const seen = new Set<string>();
-  const merged = primary.map((message) => {
+  const merged = snapshotMessages.map((message) => {
     seen.add(message.id);
     const snapshotMessage = snapshotById.get(message.id);
     const cachedMessage = cachedById.get(message.id);
@@ -79,11 +134,11 @@ export function mergeSnapshotIntoCachedMessages(snapshotMessages: UIMessage[], c
       : message;
   });
 
-  for (const message of secondary) {
+  for (const message of cachedMessages) {
     if (seen.has(message.id)) continue;
     seen.add(message.id);
-    merged.push(message);
+    insertMessageByChronology(merged, message, cachedMessages);
   }
 
-  return merged;
+  return sortFullyTimestampedMessages(merged);
 }

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -513,13 +513,21 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   }
 
   if (event.type === "message.updated") {
-    const props = (event.properties ?? {}) as { info?: { id?: string; role?: UIMessage["role"] | string; sessionID?: string } };
+    const props = (event.properties ?? {}) as {
+      info?: { id?: string; role?: UIMessage["role"] | string; sessionID?: string; time?: { created?: number } };
+    };
     const info = props.info;
     if (!info?.id || !info.sessionID || (info.role !== "user" && info.role !== "assistant" && info.role !== "system")) {
       return;
     }
     if (!isTrackedSession(entry, info.sessionID)) return;
-    const next = { id: info.id, role: info.role, parts: [] } satisfies UIMessage;
+    const created = info.time?.created;
+    const next = {
+      id: info.id,
+      role: info.role,
+      ...(typeof created === "number" ? { metadata: { opencode: { created } } } : {}),
+      parts: [],
+    } satisfies UIMessage;
     queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, info.sessionID), (current = []) =>
       upsertMessage(current, next),
     );

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -82,47 +82,51 @@ function mapToolPart(part: Part): DynamicToolUIPart {
 }
 
 export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessage[] {
-  return snapshot.messages.map((message) => ({
-    id: message.info.id,
-    role: message.info.role,
-    parts: message.parts.flatMap<UIMessage["parts"][number]>((part) => {
-      if (part.type === "text") {
-        return [{
-          type: "text",
-          text: getTextPartValue(part),
-          state: "done" as const,
-          providerMetadata: { opencode: { partId: part.id } },
-        }];
-      }
-      if (part.type === "reasoning") {
-        return [{
-          type: "reasoning",
-          text: getTextPartValue(part),
-          state: "done" as const,
-          providerMetadata: { opencode: { partId: part.id } },
-        }];
-      }
-      if (part.type === "file") {
-        const record = part as Part & { url?: string; filename?: string; mime?: string };
-        return record.url
-          ? [{
-              type: "file",
-              url: record.url,
-              filename: record.filename,
-              mediaType: record.mime ?? "application/octet-stream",
-              providerMetadata: { opencode: { partId: part.id } },
-            }]
-          : [];
-      }
-      if (part.type === "tool") {
-        return [{ ...mapToolPart(part), providerMetadata: { opencode: { partId: part.id } } }];
-      }
-      if (part.type === "step-start") {
-        return [{ type: "step-start", providerMetadata: { opencode: { partId: part.id } } }];
-      }
-      return [];
-    }),
-  }));
+  return snapshot.messages.map((message) => {
+    const created = message.info.time?.created;
+    return {
+      id: message.info.id,
+      role: message.info.role,
+      ...(typeof created === "number" ? { metadata: { opencode: { created } } } : {}),
+      parts: message.parts.flatMap<UIMessage["parts"][number]>((part) => {
+        if (part.type === "text") {
+          return [{
+            type: "text",
+            text: getTextPartValue(part),
+            state: "done" as const,
+            providerMetadata: { opencode: { partId: part.id } },
+          }];
+        }
+        if (part.type === "reasoning") {
+          return [{
+            type: "reasoning",
+            text: getTextPartValue(part),
+            state: "done" as const,
+            providerMetadata: { opencode: { partId: part.id } },
+          }];
+        }
+        if (part.type === "file") {
+          const record = part as Part & { url?: string; filename?: string; mime?: string };
+          return record.url
+            ? [{
+                type: "file",
+                url: record.url,
+                filename: record.filename,
+                mediaType: record.mime ?? "application/octet-stream",
+                providerMetadata: { opencode: { partId: part.id } },
+              }]
+            : [];
+        }
+        if (part.type === "tool") {
+          return [{ ...mapToolPart(part), providerMetadata: { opencode: { partId: part.id } } }];
+        }
+        if (part.type === "step-start") {
+          return [{ type: "step-start", providerMetadata: { opencode: { partId: part.id } } }];
+        }
+        return [];
+      }),
+    };
+  });
 }
 
 function extractLastUserText(messages: UIMessage[]) {


### PR DESCRIPTION
## Summary
- Preserve OpenCode message creation timestamps when converting snapshots/live events into UI messages.
- Merge snapshot and live transcript caches by timestamp/source order so cache-only middle blocks do not get appended after newer messages.
- Add regressions for missing middle-block ordering during snapshot cache updates.

## Tests
- `pnpm -C apps/app exec bun test scripts/session-render-state.test.ts tests/session-sync-permissions.test.ts` (pass, 25 tests)
- `pnpm -C apps/app typecheck` (pass)
- `git diff --check` (pass)

## Evidence
No video or screenshot captured because this is a deterministic transcript merge/order regression covered by focused unit tests. Reviewers can reproduce with the commands above.