### PR TITLE
Move Computer Use permission setup to helper app

### DIFF
--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -124,20 +124,6 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
     }
   };
 
-  const relaunchOpenWork = async () => {
-    if (!hasDesktopBridge()) {
-      setError("OpenWork desktop is required to relaunch.");
-      return;
-    }
-
-    setError(null);
-    try {
-      await desktopBridge.relaunchOpenWork();
-    } catch (caught) {
-      setError(errorMessage(caught));
-    }
-  };
-
   const allPermissionsGranted = permissions?.accessibility === true && permissions.screenRecording === true;
 
   return (
@@ -187,9 +173,9 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
               <PermissionStatus label="Accessibility" granted={permissions?.accessibility === true} unknown={!permissions} />
               <PermissionStatus label="Screen Recording" granted={permissions?.screenRecording === true} unknown={!permissions} />
             </div>
-            <Button className="min-h-10 w-full justify-center" onClick={() => void (allPermissionsGranted ? relaunchOpenWork() : openPermissionHelper())}>
+            <Button className="min-h-10 w-full justify-center" onClick={() => void openPermissionHelper()}>
               <Settings2 className="size-4" />
-              {allPermissionsGranted ? "Relaunch OpenWork" : "Grant permissions"}
+              Grant permissions
             </Button>
           </div>
         </SetupRow>

--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -126,6 +126,23 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
     }
   };
 
+  const openPermissionHelper = async () => {
+    if (!hasDesktopBridge()) {
+      setError("OpenWork desktop is required to open the Computer Use app.");
+      return;
+    }
+
+    setError(null);
+    try {
+      const result = await desktopBridge.openComputerUsePermissionSetup();
+      const next = normalizePermissionStatus(result);
+      setPermissions(next);
+      setHint("The Computer Use app is open. Use it to grant Accessibility and Screen Recording, then come back and verify.");
+    } catch (caught) {
+      setError(errorMessage(caught));
+    }
+  };
+
   const allPermissionsGranted = permissions?.accessibility === true && permissions.screenRecording === true;
 
   return (
@@ -167,30 +184,26 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
 
         <SetupRow
           title="2. Grant macOS permissions"
-          description="Computer Use needs Accessibility for semantic UI actions and Screen Recording for snapshots. Open the helper app to grant them."
+          description="Open the separate Computer Use app. macOS grants permissions to that app, not to OpenWork."
           complete={allPermissionsGranted}
         >
-          <div className="flex flex-col gap-2">
-            {permissions && !permissions.accessibility ? (
-              <Alert>
-                <CircleAlert />
-                <AlertDescription>
-                  Accessibility is checked inside the bundled Computer Use helper app, which owns the macOS permission separately from OpenWork.
-                </AlertDescription>
-              </Alert>
-            ) : null}
-            <PermissionRow
-              label="Accessibility"
-              granted={permissions?.accessibility === true}
-              unknown={!permissions}
-              onOpen={() => void openPermissionSettings("accessibility")}
-            />
-            <PermissionRow
-              label="Screen Recording"
-              granted={permissions?.screenRecording === true}
-              unknown={!permissions}
-              onOpen={() => void openPermissionSettings("screenRecording")}
-            />
+          <div className="flex w-full min-w-0 flex-col gap-3">
+            <div className="grid gap-2 sm:grid-cols-2">
+              <PermissionStatus label="Accessibility" granted={permissions?.accessibility === true} unknown={!permissions} />
+              <PermissionStatus label="Screen Recording" granted={permissions?.screenRecording === true} unknown={!permissions} />
+            </div>
+            <Button className="w-full justify-center" onClick={() => void openPermissionHelper()}>
+              <Settings2 className="size-4" />
+              Open Computer Use app
+            </Button>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Button variant="outline" size="sm" onClick={() => void openPermissionSettings("accessibility")}>
+                Request Accessibility
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => void openPermissionSettings("screenRecording")}>
+                Request Screen Recording
+              </Button>
+            </div>
           </div>
         </SetupRow>
       </CardContent>
@@ -220,32 +233,29 @@ function SetupRow(props: { title: string; description: string; complete: boolean
   return (
     <div className="rounded-xl border border-border bg-card p-3">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="flex min-w-0 gap-3">
+        <div className="flex min-w-0 flex-1 gap-3">
           <StatusIcon complete={props.complete} />
           <div className="min-w-0">
             <div className="text-sm font-medium text-card-foreground">{props.title}</div>
             <div className="mt-1 text-xs leading-relaxed text-muted-foreground">{props.description}</div>
           </div>
         </div>
-        <div className="shrink-0">{props.children}</div>
+        <div className="w-full min-w-0 sm:w-[min(24rem,45%)]">{props.children}</div>
       </div>
     </div>
   );
 }
 
-function PermissionRow(props: { label: string; granted: boolean; unknown: boolean; onOpen: () => void }) {
+function PermissionStatus(props: { label: string; granted: boolean; unknown: boolean }) {
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-border bg-muted/40 p-2 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex min-w-0 items-center justify-between gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2">
       <div className="flex items-center gap-2 text-sm">
         <StatusIcon complete={props.granted} muted={props.unknown} />
         <span>{props.label}</span>
-        <span className={props.granted ? "text-green-11" : "text-muted-foreground"}>
-          {props.unknown ? "Unknown" : props.granted ? "Granted" : "Needed"}
-        </span>
       </div>
-      <Button variant="outline" size="sm" onClick={props.onOpen}>
-        Setup permission
-      </Button>
+      <span className={`shrink-0 text-xs font-medium ${props.granted ? "text-green-11" : "text-amber-11"}`}>
+        {props.unknown ? "Check" : props.granted ? "Granted" : "Needed"}
+      </span>
     </div>
   );
 }

--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -78,24 +78,20 @@ function errorMessage(error: unknown) {
 export function ComputerUseConfig(props: ComputerUseConfigProps) {
   const [permissions, setPermissions] = useState<ComputerUsePermissionStatus | null>(null);
   const [checking, setChecking] = useState(false);
+  // launching: true while we are waiting for the helper app to start
+  const [launching, setLaunching] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [hint, setHint] = useState<string | null>(null);
 
   const refreshPermissions = useCallback(async () => {
     if (!hasDesktopBridge()) {
       setError("Computer Use setup is only available in the OpenWork desktop app on macOS.");
       return;
     }
-
     setChecking(true);
     setError(null);
     try {
       const result = await desktopBridge.checkComputerUsePermissions();
-      const next = normalizePermissionStatus(result);
-      setPermissions(next);
-      if (next.error) {
-        setError(next.error);
-      }
+      setPermissions(normalizePermissionStatus(result));
     } catch (caught) {
       setError(errorMessage(caught));
     } finally {
@@ -109,22 +105,27 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
 
   const openPermissionHelper = async () => {
     if (!hasDesktopBridge()) {
-      setError("OpenWork desktop is required to open the Computer Use app.");
+      setError("OpenWork desktop is required to launch the Computer Use helper.");
       return;
     }
-
     setError(null);
+    setLaunching(true);
     try {
+      // This IPC call launches the helper app and polls until it responds.
+      // It throws if the helper binary cannot be found or does not start.
       const result = await desktopBridge.openComputerUsePermissionSetup();
       const next = normalizePermissionStatus(result);
       setPermissions(next);
-      setHint("OpenWork Computer Use is open. Grant both permissions there, then come back and verify.");
     } catch (caught) {
       setError(errorMessage(caught));
+    } finally {
+      setLaunching(false);
     }
   };
 
-  const allPermissionsGranted = permissions?.accessibility === true && permissions.screenRecording === true;
+  const allGranted = permissions?.accessibility === true && permissions.screenRecording === true;
+  const helperRunning = permissions?.appRunning === true;
+  const initialChecking = permissions === null && checking;
 
   return (
     <Card variant="outline" size="sm">
@@ -132,66 +133,109 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
         <CardTitle>Computer Use setup</CardTitle>
         <CardDescription>Connect the local MCP server and grant the macOS permissions it needs to control apps.</CardDescription>
         <CardAction>
-          <Button variant="ghost" size="icon-sm" onClick={() => void refreshPermissions()} disabled={checking}>
+          <Button variant="ghost" size="icon-sm" onClick={() => void refreshPermissions()} disabled={checking || launching}>
             <RefreshCw className={checking ? "animate-spin" : ""} />
           </Button>
         </CardAction>
       </CardHeader>
+
       <CardContent className="space-y-4">
         {error ? (
           <Alert variant="destructive">
             <CircleAlert />
-            <AlertDescription>{error}</AlertDescription>
+            <AlertDescription className="break-words">{error}</AlertDescription>
           </Alert>
         ) : null}
 
-        {hint ? (
-          <Alert>
-            <Settings2 />
-            <AlertDescription>{hint}</AlertDescription>
-          </Alert>
-        ) : null}
-
+        {/* Step 1 */}
         <SetupRow
           title="1. Connect Computer Use MCP"
           description="Adds the local Computer Use server to this workspace so Composer can use the computer-control tools."
           complete={props.connected}
         >
-          <Button className="min-h-10 w-full whitespace-normal text-center lg:w-auto" onClick={() => void props.onConnect?.()} disabled={!props.onConnect || props.connected || props.connecting}>
+          <Button
+            className="min-h-10 w-full whitespace-normal text-center lg:w-auto"
+            onClick={() => void props.onConnect?.()}
+            disabled={!props.onConnect || props.connected || props.connecting}
+          >
             {props.connecting ? <Loader2 className="size-4 shrink-0 animate-spin" /> : null}
-            <span className="min-w-0 break-words">{props.connected ? "Configured" : props.connecting ? "Connecting..." : "Connect MCP"}</span>
+            <span className="min-w-0 break-words">
+              {props.connected ? "Configured" : props.connecting ? "Connecting…" : "Connect MCP"}
+            </span>
           </Button>
         </SetupRow>
 
+        {/* Step 2 */}
         <SetupRow
           title="2. Grant macOS permissions"
-          description="Open the separate OpenWork Computer Use app. macOS grants permissions to that app, not to OpenWork."
-          complete={allPermissionsGranted}
+          description="Opens the OpenWork Computer Use helper app. macOS grants Accessibility and Screen Recording to that app."
+          complete={allGranted}
         >
           <div className="flex w-full min-w-0 flex-col gap-3">
             <div className="grid gap-2 xl:grid-cols-2">
-              <PermissionStatus label="Accessibility" granted={permissions?.accessibility === true} unknown={!permissions} />
-              <PermissionStatus label="Screen Recording" granted={permissions?.screenRecording === true} unknown={!permissions} />
+              <PermissionPill
+                label="Accessibility"
+                granted={permissions?.accessibility === true}
+                unknown={initialChecking || (!helperRunning && !launching)}
+              />
+              <PermissionPill
+                label="Screen Recording"
+                granted={permissions?.screenRecording === true}
+                unknown={initialChecking || (!helperRunning && !launching)}
+              />
             </div>
-            <Button className="min-h-10 w-full justify-center whitespace-normal text-center" onClick={() => void openPermissionHelper()}>
-              <Settings2 className="size-4 shrink-0" />
-              <span className="min-w-0 break-words">Grant permissions</span>
+
+            <Button
+              className="min-h-10 w-full justify-center whitespace-normal text-center"
+              onClick={() => void openPermissionHelper()}
+              disabled={launching || checking}
+            >
+              {launching ? (
+                <>
+                  <Loader2 className="size-4 shrink-0 animate-spin" />
+                  <span className="min-w-0 break-words">Opening helper…</span>
+                </>
+              ) : (
+                <>
+                  <Settings2 className="size-4 shrink-0" />
+                  <span className="min-w-0 break-words">
+                    {allGranted ? "Reopen helper" : "Grant permissions"}
+                  </span>
+                </>
+              )}
             </Button>
+
+            {!helperRunning && !launching && permissions !== null && !error ? (
+              <p className="text-center text-xs text-muted-foreground">
+                Helper app is not running — click above to open it.
+              </p>
+            ) : null}
           </div>
         </SetupRow>
       </CardContent>
+
       <CardFooter className="border-t border-border">
         <div className="flex w-full flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-          <div className="text-xs text-muted-foreground">
-            {allPermissionsGranted ? "Permissions verified. Try a Composer prompt that asks Computer Use to open an app and type." : "After granting permissions, return here and verify again."}
-          </div>
+          <p className="text-xs text-muted-foreground">
+            {allGranted
+              ? "Permissions verified. Try a Composer prompt that asks Computer Use to open an app and type."
+              : "After granting permissions, return here and verify."}
+          </p>
           <div className="flex w-full flex-col gap-2 xl:w-auto xl:flex-row">
             {props.onRefresh ? (
-              <Button className="min-h-10 w-full whitespace-normal text-center xl:w-auto" variant="outline" onClick={() => void props.onRefresh?.()}>
+              <Button
+                className="min-h-10 w-full whitespace-normal text-center xl:w-auto"
+                variant="outline"
+                onClick={() => void props.onRefresh?.()}
+              >
                 <span className="min-w-0 break-words">Refresh MCP</span>
               </Button>
             ) : null}
-            <Button className="min-h-10 w-full whitespace-normal text-center xl:w-auto" onClick={() => void refreshPermissions()} disabled={checking}>
+            <Button
+              className="min-h-10 w-full whitespace-normal text-center xl:w-auto"
+              onClick={() => void refreshPermissions()}
+              disabled={checking || launching}
+            >
               {checking ? <Loader2 className="size-4 shrink-0 animate-spin" /> : null}
               <span className="min-w-0 break-words">Verify permissions</span>
             </Button>
@@ -219,15 +263,16 @@ function SetupRow(props: { title: string; description: string; complete: boolean
   );
 }
 
-function PermissionStatus(props: { label: string; granted: boolean; unknown: boolean }) {
+function PermissionPill(props: { label: string; granted: boolean; unknown: boolean }) {
+  const { label, granted, unknown } = props;
   return (
     <div className="flex min-w-0 items-center justify-between gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2">
       <div className="flex items-center gap-2 text-sm">
-        <StatusIcon complete={props.granted} muted={props.unknown} />
-        <span className="truncate">{props.label}</span>
+        <StatusIcon complete={granted} muted={unknown} />
+        <span className="truncate">{label}</span>
       </div>
-      <span className={`shrink-0 text-xs font-medium ${props.granted ? "text-green-11" : "text-amber-11"}`}>
-        {props.unknown ? "Check" : props.granted ? "Granted" : "Needed"}
+      <span className={`shrink-0 text-xs font-medium ${granted ? "text-green-11" : unknown ? "text-muted-foreground" : "text-amber-11"}`}>
+        {unknown ? "Unknown" : granted ? "Granted" : "Needed"}
       </span>
     </div>
   );

--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useState, type ReactNode } from "react";
-import { CheckCircle2, CircleAlert, Loader2, RefreshCw, Settings2 } from "lucide-react";
+import { CheckCircle2, CircleAlert, Loader2, RefreshCw } from "lucide-react";
 
 import { desktopBridge } from "../../../app/lib/desktop";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -9,17 +9,22 @@ import {
   Card,
   CardAction,
   CardContent,
-  CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
+  CardDescription,
 } from "@/components/ui/card";
 import { registerExtensionConfig } from "./extension-registry";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 type ComputerUsePermissionStatus = {
   ok: boolean;
   accessibility: boolean;
   screenRecording: boolean;
+  appRunning: boolean;
   error?: string;
 };
 
@@ -30,6 +35,10 @@ type ComputerUseConfigProps = {
   onRefresh?: () => void | Promise<void>;
 };
 
+// ---------------------------------------------------------------------------
+// Extension registration
+// ---------------------------------------------------------------------------
+
 registerExtensionConfig("computer-use", (ctx) => (
   <ComputerUseConfig
     connected={ctx.computerUse?.connected ?? false}
@@ -39,35 +48,24 @@ registerExtensionConfig("computer-use", (ctx) => (
   />
 ));
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 function hasDesktopBridge() {
   return typeof window !== "undefined" && Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop);
 }
 
 function normalizePermissionStatus(value: unknown): ComputerUsePermissionStatus {
   if (typeof value !== "object" || value === null) {
-    return {
-      ok: false,
-      accessibility: false,
-      screenRecording: false,
-      error: "Computer Use returned an unreadable permission response.",
-    };
+    return { ok: false, accessibility: false, screenRecording: false, appRunning: false };
   }
-
-  if (!("accessibility" in value) || !("screenRecording" in value)) {
-    return {
-      ok: false,
-      accessibility: false,
-      screenRecording: false,
-      error: "Computer Use did not return both required macOS permission checks.",
-    };
-  }
-
-  const error = "error" in value && typeof value.error === "string" ? value.error : undefined;
   return {
     ok: "ok" in value && value.ok === true,
-    accessibility: value.accessibility === true,
-    screenRecording: value.screenRecording === true,
-    error,
+    accessibility: "accessibility" in value && value.accessibility === true,
+    screenRecording: "screenRecording" in value && value.screenRecording === true,
+    appRunning: "appRunning" in value && value.appRunning === true,
+    error: "error" in value && typeof value.error === "string" ? value.error : undefined,
   };
 }
 
@@ -75,27 +73,27 @@ function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
 
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
 export function ComputerUseConfig(props: ComputerUseConfigProps) {
   const [permissions, setPermissions] = useState<ComputerUsePermissionStatus | null>(null);
   const [checking, setChecking] = useState(false);
+  const [launching, setLaunching] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [hint, setHint] = useState<string | null>(null);
 
+  // Quick silent check (no launch) — run on mount to see if helper is already running.
   const refreshPermissions = useCallback(async () => {
     if (!hasDesktopBridge()) {
       setError("Computer Use setup is only available in the OpenWork desktop app on macOS.");
       return;
     }
-
     setChecking(true);
     setError(null);
     try {
       const result = await desktopBridge.checkComputerUsePermissions();
-      const next = normalizePermissionStatus(result);
-      setPermissions(next);
-      if (next.error) {
-        setError(next.error);
-      }
+      setPermissions(normalizePermissionStatus(result));
     } catch (caught) {
       setError(errorMessage(caught));
     } finally {
@@ -107,36 +105,49 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
     void refreshPermissions();
   }, [refreshPermissions]);
 
+  // Launch the helper app, wait until it responds, then update status.
   const openPermissionHelper = async () => {
     if (!hasDesktopBridge()) {
-      setError("OpenWork desktop is required to open the Computer Use app.");
+      setError("OpenWork desktop is required to open the Computer Use helper.");
       return;
     }
-
     setError(null);
+    setLaunching(true);
     try {
       const result = await desktopBridge.openComputerUsePermissionSetup();
-      const next = normalizePermissionStatus(result);
-      setPermissions(next);
-      setHint("OpenWork Computer Use is open. Grant both permissions there, then come back and verify.");
+      setPermissions(normalizePermissionStatus(result));
     } catch (caught) {
       setError(errorMessage(caught));
+    } finally {
+      setLaunching(false);
     }
   };
 
-  const allPermissionsGranted = permissions?.accessibility === true && permissions.screenRecording === true;
+  const allGranted = permissions?.accessibility === true && permissions.screenRecording === true;
+  // Helper is running but we can see its real state.
+  const appRunning = permissions?.appRunning === true;
+  // Still waiting for initial check.
+  const initialChecking = permissions === null && checking;
 
   return (
     <Card variant="outline" size="sm">
       <CardHeader>
         <CardTitle>Computer Use setup</CardTitle>
-        <CardDescription>Connect the local MCP server and grant the macOS permissions it needs to control apps.</CardDescription>
+        <CardDescription>
+          Connect the local MCP server and grant the macOS permissions it needs to control apps.
+        </CardDescription>
         <CardAction>
-          <Button variant="ghost" size="icon-sm" onClick={() => void refreshPermissions()} disabled={checking}>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => void refreshPermissions()}
+            disabled={checking || launching}
+          >
             <RefreshCw className={checking ? "animate-spin" : ""} />
           </Button>
         </CardAction>
       </CardHeader>
+
       <CardContent className="space-y-4">
         {error ? (
           <Alert variant="destructive">
@@ -145,53 +156,97 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
           </Alert>
         ) : null}
 
-        {hint ? (
-          <Alert>
-            <Settings2 />
-            <AlertDescription>{hint}</AlertDescription>
-          </Alert>
-        ) : null}
-
+        {/* Step 1 — MCP */}
         <SetupRow
           title="1. Connect Computer Use MCP"
           description="Adds the local Computer Use server to this workspace so Composer can use the computer-control tools."
           complete={props.connected}
         >
-          <Button className="min-h-10 w-full whitespace-normal text-center lg:w-auto" onClick={() => void props.onConnect?.()} disabled={!props.onConnect || props.connected || props.connecting}>
+          <Button
+            className="min-h-10 w-full whitespace-normal text-center lg:w-auto"
+            onClick={() => void props.onConnect?.()}
+            disabled={!props.onConnect || props.connected || props.connecting}
+          >
             {props.connecting ? <Loader2 className="size-4 shrink-0 animate-spin" /> : null}
-            <span className="min-w-0 break-words">{props.connected ? "Configured" : props.connecting ? "Connecting..." : "Connect MCP"}</span>
+            <span className="min-w-0 break-words">
+              {props.connected ? "Configured" : props.connecting ? "Connecting..." : "Connect MCP"}
+            </span>
           </Button>
         </SetupRow>
 
+        {/* Step 2 — Permissions */}
         <SetupRow
           title="2. Grant macOS permissions"
           description="Open the separate OpenWork Computer Use app. macOS grants permissions to that app, not to OpenWork."
-          complete={allPermissionsGranted}
+          complete={allGranted}
         >
           <div className="flex w-full min-w-0 flex-col gap-3">
+            {/* Permission status badges */}
             <div className="grid gap-2 xl:grid-cols-2">
-              <PermissionStatus label="Accessibility" granted={permissions?.accessibility === true} unknown={!permissions} />
-              <PermissionStatus label="Screen Recording" granted={permissions?.screenRecording === true} unknown={!permissions} />
+              <PermissionPill
+                label="Accessibility"
+                granted={permissions?.accessibility === true}
+                loading={initialChecking}
+                appRunning={appRunning}
+              />
+              <PermissionPill
+                label="Screen Recording"
+                granted={permissions?.screenRecording === true}
+                loading={initialChecking}
+                appRunning={appRunning}
+              />
             </div>
-            <Button className="min-h-10 w-full justify-center whitespace-normal text-center" onClick={() => void openPermissionHelper()}>
-              <Settings2 className="size-4 shrink-0" />
-              <span className="min-w-0 break-words">Grant permissions</span>
+
+            {/* Grant / launch button */}
+            <Button
+              className="min-h-10 w-full justify-center whitespace-normal text-center"
+              onClick={() => void openPermissionHelper()}
+              disabled={launching || checking}
+            >
+              {launching ? (
+                <>
+                  <Loader2 className="size-4 shrink-0 animate-spin" />
+                  <span className="min-w-0 break-words">Opening helper app…</span>
+                </>
+              ) : (
+                <span className="min-w-0 break-words">
+                  {allGranted ? "Reopen helper app" : "Grant permissions"}
+                </span>
+              )}
             </Button>
+
+            {/* Offline hint — shown only when app is confirmed not running */}
+            {!appRunning && !launching && permissions !== null ? (
+              <p className="text-center text-xs text-muted-foreground">
+                Helper app is not running — click above to open it.
+              </p>
+            ) : null}
           </div>
         </SetupRow>
       </CardContent>
+
       <CardFooter className="border-t border-border">
         <div className="flex w-full flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-          <div className="text-xs text-muted-foreground">
-            {allPermissionsGranted ? "Permissions verified. Try a Composer prompt that asks Computer Use to open an app and type." : "After granting permissions, return here and verify again."}
-          </div>
+          <p className="text-xs text-muted-foreground">
+            {allGranted
+              ? "Permissions verified. Try a Composer prompt that asks Computer Use to open an app and type."
+              : "After granting permissions, return here and verify."}
+          </p>
           <div className="flex w-full flex-col gap-2 xl:w-auto xl:flex-row">
             {props.onRefresh ? (
-              <Button className="min-h-10 w-full whitespace-normal text-center xl:w-auto" variant="outline" onClick={() => void props.onRefresh?.()}>
+              <Button
+                className="min-h-10 w-full whitespace-normal text-center xl:w-auto"
+                variant="outline"
+                onClick={() => void props.onRefresh?.()}
+              >
                 <span className="min-w-0 break-words">Refresh MCP</span>
               </Button>
             ) : null}
-            <Button className="min-h-10 w-full whitespace-normal text-center xl:w-auto" onClick={() => void refreshPermissions()} disabled={checking}>
+            <Button
+              className="min-h-10 w-full whitespace-normal text-center xl:w-auto"
+              onClick={() => void refreshPermissions()}
+              disabled={checking || launching}
+            >
               {checking ? <Loader2 className="size-4 shrink-0 animate-spin" /> : null}
               <span className="min-w-0 break-words">Verify permissions</span>
             </Button>
@@ -201,6 +256,10 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
     </Card>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
 
 function SetupRow(props: { title: string; description: string; complete: boolean; children: ReactNode }) {
   return (
@@ -219,16 +278,42 @@ function SetupRow(props: { title: string; description: string; complete: boolean
   );
 }
 
-function PermissionStatus(props: { label: string; granted: boolean; unknown: boolean }) {
+function PermissionPill(props: {
+  label: string;
+  granted: boolean;
+  loading: boolean;
+  appRunning: boolean;
+}) {
+  const { label, granted, loading, appRunning } = props;
+
+  let statusText: string;
+  let statusClass: string;
+
+  if (loading) {
+    statusText = "Checking";
+    statusClass = "text-muted-foreground";
+  } else if (!appRunning) {
+    statusText = "Unknown";
+    statusClass = "text-muted-foreground";
+  } else if (granted) {
+    statusText = "Granted";
+    statusClass = "text-green-11";
+  } else {
+    statusText = "Needed";
+    statusClass = "text-amber-11";
+  }
+
   return (
     <div className="flex min-w-0 items-center justify-between gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2">
       <div className="flex items-center gap-2 text-sm">
-        <StatusIcon complete={props.granted} muted={props.unknown} />
-        <span className="truncate">{props.label}</span>
+        {loading ? (
+          <Loader2 className="mt-0.5 size-4 shrink-0 animate-spin text-muted-foreground" />
+        ) : (
+          <StatusIcon complete={granted} muted={!appRunning} />
+        )}
+        <span className="truncate">{label}</span>
       </div>
-      <span className={`shrink-0 text-xs font-medium ${props.granted ? "text-green-11" : "text-amber-11"}`}>
-        {props.unknown ? "Check" : props.granted ? "Granted" : "Needed"}
-      </span>
+      <span className={`shrink-0 text-xs font-medium ${statusClass}`}>{statusText}</span>
     </div>
   );
 }
@@ -237,5 +322,9 @@ function StatusIcon(props: { complete: boolean; muted?: boolean }) {
   if (props.complete) {
     return <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-green-11" />;
   }
-  return <CircleAlert className={`mt-0.5 size-4 shrink-0 ${props.muted ? "text-muted-foreground" : "text-amber-11"}`} />;
+  return (
+    <CircleAlert
+      className={`mt-0.5 size-4 shrink-0 ${props.muted ? "text-muted-foreground" : "text-amber-11"}`}
+    />
+  );
 }

--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -16,8 +16,6 @@ import {
 } from "@/components/ui/card";
 import { registerExtensionConfig } from "./extension-registry";
 
-type PermissionTarget = "accessibility" | "screenRecording";
-
 type ComputerUsePermissionStatus = {
   ok: boolean;
   accessibility: boolean;
@@ -109,23 +107,6 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
     void refreshPermissions();
   }, [refreshPermissions]);
 
-  const openPermissionSettings = async (target: PermissionTarget) => {
-    if (!hasDesktopBridge()) {
-      setError("OpenWork desktop is required to open macOS Privacy settings.");
-      return;
-    }
-
-    setError(null);
-    try {
-      const result = await desktopBridge.openComputerUsePermissionSettings(target);
-      const next = normalizePermissionStatus(result);
-      setPermissions(next);
-      setHint("The Computer Use helper app is open. Grant the requested permission there, then click Verify permissions.");
-    } catch (caught) {
-      setError(errorMessage(caught));
-    }
-  };
-
   const openPermissionHelper = async () => {
     if (!hasDesktopBridge()) {
       setError("OpenWork desktop is required to open the Computer Use app.");
@@ -137,7 +118,21 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
       const result = await desktopBridge.openComputerUsePermissionSetup();
       const next = normalizePermissionStatus(result);
       setPermissions(next);
-      setHint("The Computer Use app is open. Use it to grant Accessibility and Screen Recording, then come back and verify.");
+      setHint("OpenWork Computer Use is open. Grant both permissions there, then come back and verify.");
+    } catch (caught) {
+      setError(errorMessage(caught));
+    }
+  };
+
+  const relaunchOpenWork = async () => {
+    if (!hasDesktopBridge()) {
+      setError("OpenWork desktop is required to relaunch.");
+      return;
+    }
+
+    setError(null);
+    try {
+      await desktopBridge.relaunchOpenWork();
     } catch (caught) {
       setError(errorMessage(caught));
     }
@@ -176,7 +171,7 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
           description="Adds the local Computer Use server to this workspace so Composer can use the computer-control tools."
           complete={props.connected}
         >
-          <Button onClick={() => void props.onConnect?.()} disabled={!props.onConnect || props.connected || props.connecting}>
+          <Button className="w-full sm:w-auto" onClick={() => void props.onConnect?.()} disabled={!props.onConnect || props.connected || props.connecting}>
             {props.connecting ? <Loader2 className="size-4 animate-spin" /> : null}
             {props.connected ? "MCP configured" : props.connecting ? "Connecting..." : "Connect MCP"}
           </Button>
@@ -184,7 +179,7 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
 
         <SetupRow
           title="2. Grant macOS permissions"
-          description="Open the separate Computer Use app. macOS grants permissions to that app, not to OpenWork."
+          description="Open the separate OpenWork Computer Use app. macOS grants permissions to that app, not to OpenWork."
           complete={allPermissionsGranted}
         >
           <div className="flex w-full min-w-0 flex-col gap-3">
@@ -192,33 +187,25 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
               <PermissionStatus label="Accessibility" granted={permissions?.accessibility === true} unknown={!permissions} />
               <PermissionStatus label="Screen Recording" granted={permissions?.screenRecording === true} unknown={!permissions} />
             </div>
-            <Button className="w-full justify-center" onClick={() => void openPermissionHelper()}>
+            <Button className="min-h-10 w-full justify-center" onClick={() => void (allPermissionsGranted ? relaunchOpenWork() : openPermissionHelper())}>
               <Settings2 className="size-4" />
-              Open Computer Use app
+              {allPermissionsGranted ? "Relaunch OpenWork" : "Grant permissions"}
             </Button>
-            <div className="grid gap-2 sm:grid-cols-2">
-              <Button variant="outline" size="sm" onClick={() => void openPermissionSettings("accessibility")}>
-                Request Accessibility
-              </Button>
-              <Button variant="outline" size="sm" onClick={() => void openPermissionSettings("screenRecording")}>
-                Request Screen Recording
-              </Button>
-            </div>
           </div>
         </SetupRow>
       </CardContent>
       <CardFooter className="border-t border-border">
-        <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="text-xs text-muted-foreground">
             {allPermissionsGranted ? "Permissions verified. Try a Composer prompt that asks Computer Use to open an app and type." : "After granting permissions, return here and verify again."}
           </div>
-          <div className="flex gap-2">
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
             {props.onRefresh ? (
-              <Button variant="outline" onClick={() => void props.onRefresh?.()}>
+              <Button className="w-full sm:w-auto" variant="outline" onClick={() => void props.onRefresh?.()}>
                 Refresh MCP
               </Button>
             ) : null}
-            <Button onClick={() => void refreshPermissions()} disabled={checking}>
+            <Button className="w-full sm:w-auto" onClick={() => void refreshPermissions()} disabled={checking}>
               {checking ? <Loader2 className="size-4 animate-spin" /> : null}
               Verify permissions
             </Button>
@@ -240,7 +227,7 @@ function SetupRow(props: { title: string; description: string; complete: boolean
             <div className="mt-1 text-xs leading-relaxed text-muted-foreground">{props.description}</div>
           </div>
         </div>
-        <div className="w-full min-w-0 sm:w-[min(24rem,45%)]">{props.children}</div>
+        <div className="w-full min-w-0 sm:w-[min(22rem,44%)]">{props.children}</div>
       </div>
     </div>
   );
@@ -251,7 +238,7 @@ function PermissionStatus(props: { label: string; granted: boolean; unknown: boo
     <div className="flex min-w-0 items-center justify-between gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2">
       <div className="flex items-center gap-2 text-sm">
         <StatusIcon complete={props.granted} muted={props.unknown} />
-        <span>{props.label}</span>
+        <span className="truncate">{props.label}</span>
       </div>
       <span className={`shrink-0 text-xs font-medium ${props.granted ? "text-green-11" : "text-amber-11"}`}>
         {props.unknown ? "Check" : props.granted ? "Granted" : "Needed"}

--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { CheckCircle2, CircleAlert, Loader2, RefreshCw, Settings2 } from "lucide-react";
 
 import { desktopBridge } from "../../../app/lib/desktop";
@@ -16,7 +16,11 @@ import {
 } from "@/components/ui/card";
 import { registerExtensionConfig } from "./extension-registry";
 
-type ComputerUsePermissionStatus = {
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type PermissionResult = {
   ok: boolean;
   accessibility: boolean;
   screenRecording: boolean;
@@ -30,6 +34,10 @@ type ComputerUseConfigProps = {
   onRefresh?: () => void | Promise<void>;
 };
 
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
 registerExtensionConfig("computer-use", (ctx) => (
   <ComputerUseConfig
     connected={ctx.computerUse?.connected ?? false}
@@ -39,148 +47,94 @@ registerExtensionConfig("computer-use", (ctx) => (
   />
 ));
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 function hasDesktopBridge() {
   return typeof window !== "undefined" && Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop);
 }
 
-function normalizePermissionStatus(value: unknown): ComputerUsePermissionStatus {
+function normalize(value: unknown): PermissionResult {
   if (typeof value !== "object" || value === null) {
-    return {
-      ok: false,
-      accessibility: false,
-      screenRecording: false,
-      error: "Computer Use returned an unreadable permission response.",
-    };
+    return { ok: false, accessibility: false, screenRecording: false, error: "Unreadable response." };
   }
-
-  if (!("accessibility" in value) || !("screenRecording" in value)) {
-    return {
-      ok: false,
-      accessibility: false,
-      screenRecording: false,
-      error: "Computer Use did not return both required macOS permission checks.",
-    };
-  }
-
-  const error = "error" in value && typeof value.error === "string" ? value.error : undefined;
   return {
     ok: "ok" in value && value.ok === true,
-    accessibility: value.accessibility === true,
-    screenRecording: value.screenRecording === true,
-    error,
+    accessibility: "accessibility" in value && value.accessibility === true,
+    screenRecording: "screenRecording" in value && value.screenRecording === true,
+    error: "error" in value && typeof value.error === "string" ? value.error : undefined,
   };
 }
 
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
+function errMsg(e: unknown) {
+  return e instanceof Error ? e.message : String(e);
 }
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 export function ComputerUseConfig(props: ComputerUseConfigProps) {
-  const [permissions, setPermissions] = useState<ComputerUsePermissionStatus | null>(null);
-  const [checking, setChecking] = useState(false);
-  const [launching, setLaunching] = useState(false);
-  // watchingForGrant: true while we are polling after the helper is open
-  const [watchingForGrant, setWatchingForGrant] = useState(false);
+  const [result, setResult] = useState<PermissionResult | null>(null);
+  const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const watchIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const watchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Stop the background polling loop.
-  const stopWatching = useCallback(() => {
-    if (watchIntervalRef.current !== null) {
-      clearInterval(watchIntervalRef.current);
-      watchIntervalRef.current = null;
-    }
-    if (watchTimeoutRef.current !== null) {
-      clearTimeout(watchTimeoutRef.current);
-      watchTimeoutRef.current = null;
-    }
-    setWatchingForGrant(false);
-  }, []);
-
-  // Start polling every 2 s until both permissions are granted or 3 min pass.
-  const startWatching = useCallback(() => {
-    stopWatching();
-    setWatchingForGrant(true);
-
-    const poll = async () => {
-      if (!hasDesktopBridge()) return;
-      try {
-        const result = await desktopBridge.checkComputerUsePermissions();
-        const next = normalizePermissionStatus(result);
-        setPermissions(next);
-        if (next.accessibility && next.screenRecording) {
-          stopWatching();
-        }
-      } catch {
-        // silent — keep polling
-      }
-    };
-
-    watchIntervalRef.current = setInterval(() => void poll(), 2_000);
-    // Auto-cancel after 3 minutes so we don't poll forever.
-    watchTimeoutRef.current = setTimeout(stopWatching, 3 * 60 * 1_000);
-  }, [stopWatching]);
-
-  // Clean up on unmount.
-  useEffect(() => () => stopWatching(), [stopWatching]);
-
-  const refreshPermissions = useCallback(async () => {
+  // Spawn --check → fresh TCC read. Works whether or not the GUI is open.
+  const verify = useCallback(async () => {
     if (!hasDesktopBridge()) {
-      setError("Computer Use setup is only available in the OpenWork desktop app on macOS.");
+      setError("Computer Use setup requires the OpenWork desktop app on macOS.");
       return;
     }
-    setChecking(true);
+    setBusy(true);
     setError(null);
     try {
-      const result = await desktopBridge.checkComputerUsePermissions();
-      setPermissions(normalizePermissionStatus(result));
-    } catch (caught) {
-      setError(errorMessage(caught));
+      const raw = await desktopBridge.checkComputerUsePermissions();
+      const next = normalize(raw);
+      setResult(next);
+      if (next.error) setError(next.error);
+    } catch (e) {
+      setError(errMsg(e));
     } finally {
-      setChecking(false);
+      setBusy(false);
     }
   }, []);
 
-  useEffect(() => {
-    void refreshPermissions();
-  }, [refreshPermissions]);
+  // Check on mount.
+  useEffect(() => { void verify(); }, [verify]);
 
-  const openPermissionHelper = async () => {
+  // Open the setup GUI then immediately re-verify.
+  const grant = async () => {
     if (!hasDesktopBridge()) {
-      setError("OpenWork desktop is required to launch the Computer Use helper.");
+      setError("OpenWork desktop is required.");
       return;
     }
+    setBusy(true);
     setError(null);
-    setLaunching(true);
-    stopWatching();
     try {
-      const result = await desktopBridge.openComputerUsePermissionSetup();
-      const next = normalizePermissionStatus(result);
-      setPermissions(next);
-      // Helper is confirmed running — start polling so we pick up grants immediately.
-      if (!next.accessibility || !next.screenRecording) {
-        startWatching();
-      }
-    } catch (caught) {
-      setError(errorMessage(caught));
+      const raw = await desktopBridge.openComputerUsePermissionSetup();
+      const next = normalize(raw);
+      setResult(next);
+      if (next.error) setError(next.error);
+    } catch (e) {
+      setError(errMsg(e));
     } finally {
-      setLaunching(false);
+      setBusy(false);
     }
   };
 
-  const allGranted = permissions?.accessibility === true && permissions.screenRecording === true;
-  const helperRunning = permissions?.appRunning === true;
-  const initialChecking = permissions === null && checking;
+  const allGranted = result?.accessibility === true && result.screenRecording === true;
 
   return (
     <Card variant="outline" size="sm">
       <CardHeader>
         <CardTitle>Computer Use setup</CardTitle>
-        <CardDescription>Connect the local MCP server and grant the macOS permissions it needs to control apps.</CardDescription>
+        <CardDescription>
+          Connect the local MCP server and grant the macOS permissions it needs to control apps.
+        </CardDescription>
         <CardAction>
-          <Button variant="ghost" size="icon-sm" onClick={() => void refreshPermissions()} disabled={checking || launching || watchingForGrant}>
-            <RefreshCw className={checking ? "animate-spin" : ""} />
+          <Button variant="ghost" size="icon-sm" onClick={() => void verify()} disabled={busy}>
+            <RefreshCw className={busy ? "animate-spin" : ""} />
           </Button>
         </CardAction>
       </CardHeader>
@@ -193,7 +147,7 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
           </Alert>
         ) : null}
 
-        {/* Step 1 */}
+        {/* Step 1 — MCP */}
         <SetupRow
           title="1. Connect Computer Use MCP"
           description="Adds the local Computer Use server to this workspace so Composer can use the computer-control tools."
@@ -211,60 +165,32 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
           </Button>
         </SetupRow>
 
-        {/* Step 2 */}
+        {/* Step 2 — Permissions */}
         <SetupRow
           title="2. Grant macOS permissions"
-          description="Opens the OpenWork Computer Use helper app. macOS grants Accessibility and Screen Recording to that app."
+          description="Opens the OpenWork Computer Use helper. Grant both permissions there, then click Verify below."
           complete={allGranted}
         >
           <div className="flex w-full min-w-0 flex-col gap-3">
             <div className="grid gap-2 xl:grid-cols-2">
-              <PermissionPill
-                label="Accessibility"
-                granted={permissions?.accessibility === true}
-                unknown={initialChecking || (!helperRunning && !launching && !watchingForGrant)}
-                watching={watchingForGrant && permissions?.accessibility !== true}
-              />
-              <PermissionPill
-                label="Screen Recording"
-                granted={permissions?.screenRecording === true}
-                unknown={initialChecking || (!helperRunning && !launching && !watchingForGrant)}
-                watching={watchingForGrant && permissions?.screenRecording !== true}
-              />
+              <Pill label="Accessibility" granted={result?.accessibility === true} checked={result !== null} />
+              <Pill label="Screen Recording" granted={result?.screenRecording === true} checked={result !== null} />
             </div>
-
-            {watchingForGrant && !allGranted ? (
-              <p className="flex items-center justify-center gap-1.5 text-center text-xs text-muted-foreground">
-                <Loader2 className="size-3 animate-spin" />
-                Waiting for permissions to be granted in the helper app…
-              </p>
-            ) : null}
 
             <Button
               className="min-h-10 w-full justify-center whitespace-normal text-center"
-              onClick={() => void openPermissionHelper()}
-              disabled={launching || checking}
+              onClick={() => void grant()}
+              disabled={busy}
             >
-              {launching ? (
-                <>
-                  <Loader2 className="size-4 shrink-0 animate-spin" />
-                  <span className="min-w-0 break-words">Opening helper…</span>
-                </>
+              {busy ? (
+                <Loader2 className="size-4 shrink-0 animate-spin" />
               ) : (
-                <>
-                  <Settings2 className="size-4 shrink-0" />
-                  <span className="min-w-0 break-words">
-                    {allGranted ? "Reopen helper" : watchingForGrant ? "Reopen helper" : "Grant permissions"}
-                  </span>
-                </>
+                <Settings2 className="size-4 shrink-0" />
               )}
+              <span className="min-w-0 break-words">
+                {busy ? "Opening…" : allGranted ? "Reopen helper" : "Grant permissions"}
+              </span>
             </Button>
-
-            {!helperRunning && !launching && !watchingForGrant && permissions !== null && !error ? (
-              <p className="text-center text-xs text-muted-foreground">
-                Helper app is not running — click above to open it.
-              </p>
-            ) : null}
           </div>
         </SetupRow>
       </CardContent>
@@ -273,8 +199,8 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
         <div className="flex w-full flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
           <p className="text-xs text-muted-foreground">
             {allGranted
-              ? "Permissions verified. Try a Composer prompt that asks Computer Use to open an app and type."
-              : "After granting permissions, return here and verify."}
+              ? "Permissions verified. Try a Composer prompt that uses Computer Use."
+              : "After granting permissions in the helper, click Verify."}
           </p>
           <div className="flex w-full flex-col gap-2 xl:w-auto xl:flex-row">
             {props.onRefresh ? (
@@ -283,16 +209,16 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
                 variant="outline"
                 onClick={() => void props.onRefresh?.()}
               >
-                <span className="min-w-0 break-words">Refresh MCP</span>
+                Refresh MCP
               </Button>
             ) : null}
             <Button
               className="min-h-10 w-full whitespace-normal text-center xl:w-auto"
-              onClick={() => { stopWatching(); void refreshPermissions(); }}
-              disabled={checking || launching}
+              onClick={() => void verify()}
+              disabled={busy}
             >
-              {checking ? <Loader2 className="size-4 shrink-0 animate-spin" /> : null}
-              <span className="min-w-0 break-words">Verify permissions</span>
+              {busy ? <Loader2 className="size-4 shrink-0 animate-spin" /> : null}
+              Verify permissions
             </Button>
           </div>
         </div>
@@ -300,6 +226,10 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
     </Card>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
 
 function SetupRow(props: { title: string; description: string; complete: boolean; children: ReactNode }) {
   return (
@@ -318,20 +248,20 @@ function SetupRow(props: { title: string; description: string; complete: boolean
   );
 }
 
-function PermissionPill(props: { label: string; granted: boolean; unknown: boolean; watching?: boolean }) {
-  const { label, granted, unknown, watching } = props;
+function Pill(props: { label: string; granted: boolean; checked: boolean }) {
+  const { label, granted, checked } = props;
   return (
     <div className="flex min-w-0 items-center justify-between gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2">
       <div className="flex items-center gap-2 text-sm">
-        {watching ? (
-          <Loader2 className="mt-0.5 size-4 shrink-0 animate-spin text-muted-foreground" />
-        ) : (
-          <StatusIcon complete={granted} muted={unknown} />
-        )}
+        <StatusIcon complete={granted} muted={!checked} />
         <span className="truncate">{label}</span>
       </div>
-      <span className={`shrink-0 text-xs font-medium ${granted ? "text-green-11" : watching || unknown ? "text-muted-foreground" : "text-amber-11"}`}>
-        {watching ? "Waiting…" : unknown ? "Unknown" : granted ? "Granted" : "Needed"}
+      <span
+        className={`shrink-0 text-xs font-medium ${
+          !checked ? "text-muted-foreground" : granted ? "text-green-11" : "text-amber-11"
+        }`}
+      >
+        {!checked ? "…" : granted ? "Granted" : "Needed"}
       </span>
     </div>
   );
@@ -341,5 +271,9 @@ function StatusIcon(props: { complete: boolean; muted?: boolean }) {
   if (props.complete) {
     return <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-green-11" />;
   }
-  return <CircleAlert className={`mt-0.5 size-4 shrink-0 ${props.muted ? "text-muted-foreground" : "text-amber-11"}`} />;
+  return (
+    <CircleAlert
+      className={`mt-0.5 size-4 shrink-0 ${props.muted ? "text-muted-foreground" : "text-amber-11"}`}
+    />
+  );
 }

--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { CheckCircle2, CircleAlert, Loader2, RefreshCw, Settings2 } from "lucide-react";
 
 import { desktopBridge } from "../../../app/lib/desktop";
@@ -78,9 +78,52 @@ function errorMessage(error: unknown) {
 export function ComputerUseConfig(props: ComputerUseConfigProps) {
   const [permissions, setPermissions] = useState<ComputerUsePermissionStatus | null>(null);
   const [checking, setChecking] = useState(false);
-  // launching: true while we are waiting for the helper app to start
   const [launching, setLaunching] = useState(false);
+  // watchingForGrant: true while we are polling after the helper is open
+  const [watchingForGrant, setWatchingForGrant] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const watchIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const watchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Stop the background polling loop.
+  const stopWatching = useCallback(() => {
+    if (watchIntervalRef.current !== null) {
+      clearInterval(watchIntervalRef.current);
+      watchIntervalRef.current = null;
+    }
+    if (watchTimeoutRef.current !== null) {
+      clearTimeout(watchTimeoutRef.current);
+      watchTimeoutRef.current = null;
+    }
+    setWatchingForGrant(false);
+  }, []);
+
+  // Start polling every 2 s until both permissions are granted or 3 min pass.
+  const startWatching = useCallback(() => {
+    stopWatching();
+    setWatchingForGrant(true);
+
+    const poll = async () => {
+      if (!hasDesktopBridge()) return;
+      try {
+        const result = await desktopBridge.checkComputerUsePermissions();
+        const next = normalizePermissionStatus(result);
+        setPermissions(next);
+        if (next.accessibility && next.screenRecording) {
+          stopWatching();
+        }
+      } catch {
+        // silent — keep polling
+      }
+    };
+
+    watchIntervalRef.current = setInterval(() => void poll(), 2_000);
+    // Auto-cancel after 3 minutes so we don't poll forever.
+    watchTimeoutRef.current = setTimeout(stopWatching, 3 * 60 * 1_000);
+  }, [stopWatching]);
+
+  // Clean up on unmount.
+  useEffect(() => () => stopWatching(), [stopWatching]);
 
   const refreshPermissions = useCallback(async () => {
     if (!hasDesktopBridge()) {
@@ -110,12 +153,15 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
     }
     setError(null);
     setLaunching(true);
+    stopWatching();
     try {
-      // This IPC call launches the helper app and polls until it responds.
-      // It throws if the helper binary cannot be found or does not start.
       const result = await desktopBridge.openComputerUsePermissionSetup();
       const next = normalizePermissionStatus(result);
       setPermissions(next);
+      // Helper is confirmed running — start polling so we pick up grants immediately.
+      if (!next.accessibility || !next.screenRecording) {
+        startWatching();
+      }
     } catch (caught) {
       setError(errorMessage(caught));
     } finally {
@@ -133,7 +179,7 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
         <CardTitle>Computer Use setup</CardTitle>
         <CardDescription>Connect the local MCP server and grant the macOS permissions it needs to control apps.</CardDescription>
         <CardAction>
-          <Button variant="ghost" size="icon-sm" onClick={() => void refreshPermissions()} disabled={checking || launching}>
+          <Button variant="ghost" size="icon-sm" onClick={() => void refreshPermissions()} disabled={checking || launching || watchingForGrant}>
             <RefreshCw className={checking ? "animate-spin" : ""} />
           </Button>
         </CardAction>
@@ -176,14 +222,23 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
               <PermissionPill
                 label="Accessibility"
                 granted={permissions?.accessibility === true}
-                unknown={initialChecking || (!helperRunning && !launching)}
+                unknown={initialChecking || (!helperRunning && !launching && !watchingForGrant)}
+                watching={watchingForGrant && permissions?.accessibility !== true}
               />
               <PermissionPill
                 label="Screen Recording"
                 granted={permissions?.screenRecording === true}
-                unknown={initialChecking || (!helperRunning && !launching)}
+                unknown={initialChecking || (!helperRunning && !launching && !watchingForGrant)}
+                watching={watchingForGrant && permissions?.screenRecording !== true}
               />
             </div>
+
+            {watchingForGrant && !allGranted ? (
+              <p className="flex items-center justify-center gap-1.5 text-center text-xs text-muted-foreground">
+                <Loader2 className="size-3 animate-spin" />
+                Waiting for permissions to be granted in the helper app…
+              </p>
+            ) : null}
 
             <Button
               className="min-h-10 w-full justify-center whitespace-normal text-center"
@@ -199,13 +254,13 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
                 <>
                   <Settings2 className="size-4 shrink-0" />
                   <span className="min-w-0 break-words">
-                    {allGranted ? "Reopen helper" : "Grant permissions"}
+                    {allGranted ? "Reopen helper" : watchingForGrant ? "Reopen helper" : "Grant permissions"}
                   </span>
                 </>
               )}
             </Button>
 
-            {!helperRunning && !launching && permissions !== null && !error ? (
+            {!helperRunning && !launching && !watchingForGrant && permissions !== null && !error ? (
               <p className="text-center text-xs text-muted-foreground">
                 Helper app is not running — click above to open it.
               </p>
@@ -233,7 +288,7 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
             ) : null}
             <Button
               className="min-h-10 w-full whitespace-normal text-center xl:w-auto"
-              onClick={() => void refreshPermissions()}
+              onClick={() => { stopWatching(); void refreshPermissions(); }}
               disabled={checking || launching}
             >
               {checking ? <Loader2 className="size-4 shrink-0 animate-spin" /> : null}
@@ -263,16 +318,20 @@ function SetupRow(props: { title: string; description: string; complete: boolean
   );
 }
 
-function PermissionPill(props: { label: string; granted: boolean; unknown: boolean }) {
-  const { label, granted, unknown } = props;
+function PermissionPill(props: { label: string; granted: boolean; unknown: boolean; watching?: boolean }) {
+  const { label, granted, unknown, watching } = props;
   return (
     <div className="flex min-w-0 items-center justify-between gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2">
       <div className="flex items-center gap-2 text-sm">
-        <StatusIcon complete={granted} muted={unknown} />
+        {watching ? (
+          <Loader2 className="mt-0.5 size-4 shrink-0 animate-spin text-muted-foreground" />
+        ) : (
+          <StatusIcon complete={granted} muted={unknown} />
+        )}
         <span className="truncate">{label}</span>
       </div>
-      <span className={`shrink-0 text-xs font-medium ${granted ? "text-green-11" : unknown ? "text-muted-foreground" : "text-amber-11"}`}>
-        {unknown ? "Unknown" : granted ? "Granted" : "Needed"}
+      <span className={`shrink-0 text-xs font-medium ${granted ? "text-green-11" : watching || unknown ? "text-muted-foreground" : "text-amber-11"}`}>
+        {watching ? "Waiting…" : unknown ? "Unknown" : granted ? "Granted" : "Needed"}
       </span>
     </div>
   );

--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -157,9 +157,9 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
           description="Adds the local Computer Use server to this workspace so Composer can use the computer-control tools."
           complete={props.connected}
         >
-          <Button className="w-full sm:w-auto" onClick={() => void props.onConnect?.()} disabled={!props.onConnect || props.connected || props.connecting}>
-            {props.connecting ? <Loader2 className="size-4 animate-spin" /> : null}
-            {props.connected ? "MCP configured" : props.connecting ? "Connecting..." : "Connect MCP"}
+          <Button className="min-h-10 w-full whitespace-normal text-center lg:w-auto" onClick={() => void props.onConnect?.()} disabled={!props.onConnect || props.connected || props.connecting}>
+            {props.connecting ? <Loader2 className="size-4 shrink-0 animate-spin" /> : null}
+            <span className="min-w-0 break-words">{props.connected ? "Configured" : props.connecting ? "Connecting..." : "Connect MCP"}</span>
           </Button>
         </SetupRow>
 
@@ -169,31 +169,31 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
           complete={allPermissionsGranted}
         >
           <div className="flex w-full min-w-0 flex-col gap-3">
-            <div className="grid gap-2 sm:grid-cols-2">
+            <div className="grid gap-2 xl:grid-cols-2">
               <PermissionStatus label="Accessibility" granted={permissions?.accessibility === true} unknown={!permissions} />
               <PermissionStatus label="Screen Recording" granted={permissions?.screenRecording === true} unknown={!permissions} />
             </div>
-            <Button className="min-h-10 w-full justify-center" onClick={() => void openPermissionHelper()}>
-              <Settings2 className="size-4" />
-              Grant permissions
+            <Button className="min-h-10 w-full justify-center whitespace-normal text-center" onClick={() => void openPermissionHelper()}>
+              <Settings2 className="size-4 shrink-0" />
+              <span className="min-w-0 break-words">Grant permissions</span>
             </Button>
           </div>
         </SetupRow>
       </CardContent>
       <CardFooter className="border-t border-border">
-        <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex w-full flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
           <div className="text-xs text-muted-foreground">
             {allPermissionsGranted ? "Permissions verified. Try a Composer prompt that asks Computer Use to open an app and type." : "After granting permissions, return here and verify again."}
           </div>
-          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+          <div className="flex w-full flex-col gap-2 xl:w-auto xl:flex-row">
             {props.onRefresh ? (
-              <Button className="w-full sm:w-auto" variant="outline" onClick={() => void props.onRefresh?.()}>
-                Refresh MCP
+              <Button className="min-h-10 w-full whitespace-normal text-center xl:w-auto" variant="outline" onClick={() => void props.onRefresh?.()}>
+                <span className="min-w-0 break-words">Refresh MCP</span>
               </Button>
             ) : null}
-            <Button className="w-full sm:w-auto" onClick={() => void refreshPermissions()} disabled={checking}>
-              {checking ? <Loader2 className="size-4 animate-spin" /> : null}
-              Verify permissions
+            <Button className="min-h-10 w-full whitespace-normal text-center xl:w-auto" onClick={() => void refreshPermissions()} disabled={checking}>
+              {checking ? <Loader2 className="size-4 shrink-0 animate-spin" /> : null}
+              <span className="min-w-0 break-words">Verify permissions</span>
             </Button>
           </div>
         </div>
@@ -205,7 +205,7 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
 function SetupRow(props: { title: string; description: string; complete: boolean; children: ReactNode }) {
   return (
     <div className="rounded-xl border border-border bg-card p-3">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
         <div className="flex min-w-0 flex-1 gap-3">
           <StatusIcon complete={props.complete} />
           <div className="min-w-0">
@@ -213,7 +213,7 @@ function SetupRow(props: { title: string; description: string; complete: boolean
             <div className="mt-1 text-xs leading-relaxed text-muted-foreground">{props.description}</div>
           </div>
         </div>
-        <div className="w-full min-w-0 sm:w-[min(22rem,44%)]">{props.children}</div>
+        <div className="w-full min-w-0 xl:w-[min(22rem,44%)]">{props.children}</div>
       </div>
     </div>
   );

--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -117,8 +117,10 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
 
     setError(null);
     try {
-      await desktopBridge.openComputerUsePermissionSettings(target);
-      setHint("Enable Computer Use in macOS Privacy settings. If it is already enabled, toggle it off and on, restart OpenWork, then click Verify permissions.");
+      const result = await desktopBridge.openComputerUsePermissionSettings(target);
+      const next = normalizePermissionStatus(result);
+      setPermissions(next);
+      setHint("The Computer Use helper app is open. Grant the requested permission there, then click Verify permissions.");
     } catch (caught) {
       setError(errorMessage(caught));
     }
@@ -165,7 +167,7 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
 
         <SetupRow
           title="2. Grant macOS permissions"
-          description="Computer Use needs Accessibility for semantic UI actions and Screen Recording for snapshots."
+          description="Computer Use needs Accessibility for semantic UI actions and Screen Recording for snapshots. Open the helper app to grant them."
           complete={allPermissionsGranted}
         >
           <div className="flex flex-col gap-2">
@@ -242,7 +244,7 @@ function PermissionRow(props: { label: string; granted: boolean; unknown: boolea
         </span>
       </div>
       <Button variant="outline" size="sm" onClick={props.onOpen}>
-        Open settings
+        Setup permission
       </Button>
     </div>
   );

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2408,11 +2408,6 @@ async function handleDesktopInvoke(event, command, ...args) {
     case "openComputerUsePermissionSetup": {
       return computerUsePermissionAppRequest("/status");
     }
-    case "relaunchOpenWork": {
-      app.relaunch();
-      app.exit(0);
-      return { ok: true };
-    }
     case "openComputerUsePermissionSettings": {
       const target = String(args[0] ?? "accessibility");
       const route = target === "screenRecording" ? "/request/screen-recording" : "/request/accessibility";

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2405,6 +2405,9 @@ async function handleDesktopInvoke(event, command, ...args) {
     case "checkComputerUsePermissions": {
       return checkComputerUsePermissions();
     }
+    case "openComputerUsePermissionSetup": {
+      return computerUsePermissionAppRequest("/status");
+    }
     case "openComputerUsePermissionSettings": {
       const target = String(args[0] ?? "accessibility");
       const route = target === "screenRecording" ? "/request/screen-recording" : "/request/accessibility";

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -83,31 +83,75 @@ function getComputerUseMcpCommand() {
 }
 
 async function checkComputerUsePermissions() {
-  // Single fast probe — no launch. Returns appRunning:false if helper is not up.
+  // Single fast probe with no launch. Returns appRunning:false if helper is offline.
   return computerUsePermissionFetch("/status", { timeoutMs: 700 });
 }
 
 async function launchAndQueryComputerUsePermissions(route, method = "GET") {
+  // --- Resolve the binary to launch ---
   const appPath = computerUseHelperAppPath();
-  if (!appPath) throw new Error("OpenWork Computer Use is missing from this OpenWork build.");
+  const execPath = appPath
+    ? path.join(appPath, "Contents", "MacOS", COMPUTER_USE_HELPER_EXECUTABLE)
+    : computerUseHelperDevBinaryPath();
 
-  // Bring to front (or start) the helper app.
-  await shell.openPath(appPath);
-
-  // Wait for AppKit to start and bind the HTTP server (Swift apps need ~0.5-1.5s).
-  await new Promise((resolve) => setTimeout(resolve, 900));
-
-  // Poll until the server responds — up to ~6 seconds total.
-  let lastError;
-  for (let i = 0; i < 20; i += 1) {
-    try {
-      return await computerUsePermissionFetch(route, { method, timeoutMs: 1_200 });
-    } catch (err) {
-      lastError = err;
-      await new Promise((resolve) => setTimeout(resolve, 300));
-    }
+  if (!execPath) {
+    const msg =
+      "OpenWork Computer Use helper app is not found. " +
+      "Run `pnpm dev` once so the Swift helper app is built, then try again.";
+    console.error("[ComputerUse]", msg);
+    throw new Error(msg);
   }
-  throw lastError ?? new Error("OpenWork Computer Use did not respond after launch.");
+
+  console.log("[ComputerUse] launching helper:", execPath);
+
+  // --- Launch ---
+  // Use spawn directly on the binary rather than shell.openPath so we get real
+  // error feedback. The binary with no arguments runs the permission-setup GUI.
+  const child = spawn(execPath, [], {
+    detached: true,
+    stdio: "ignore",
+    env: process.env,
+  });
+  child.unref();
+
+  child.on("error", (err) => {
+    console.error("[ComputerUse] helper launch error:", err.message);
+  });
+
+  // --- Wait for the HTTP server to bind (Swift AppKit startup ~0.5-1.5 s) ---
+  await new Promise((resolve) => setTimeout(resolve, 1_000));
+
+  // --- Poll until responsive, up to ~6 seconds ---
+  let lastResult = { ok: false, accessibility: false, screenRecording: false, appRunning: false };
+  for (let i = 0; i < 20; i += 1) {
+    const result = await computerUsePermissionFetch(route, { method, timeoutMs: 1_200 });
+    if (result.appRunning) {
+      console.log("[ComputerUse] helper responded on attempt", i + 1);
+      return result;
+    }
+    lastResult = result;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  }
+
+  console.error("[ComputerUse] helper did not respond after 20 attempts");
+  throw new Error(
+    "OpenWork Computer Use opened but did not respond. " +
+    "Try running `pnpm dev` to rebuild the helper, then try again."
+  );
+}
+
+function computerUseHelperDevBinaryPath() {
+  if (app.isPackaged) return null;
+  // Locations where the Swift binary might exist after a local build.
+  const swiftPkg = path.resolve(__dirname, "../../..", "packages/handsfree/native/HandsFree");
+  const candidates = [
+    path.join(swiftPkg, ".build", "release", "HandsFreeComputerUse"),
+    path.join(swiftPkg, ".build", "arm64-apple-macosx", "release", "HandsFreeComputerUse"),
+    path.join(swiftPkg, ".build", "debug", "HandsFreeComputerUse"),
+    path.join(swiftPkg, ".build", "arm64-apple-macosx", "debug", "HandsFreeComputerUse"),
+    process.env.OPENWORK_COMPUTER_USE_BINARY?.trim(),
+  ].filter(Boolean);
+  return candidates.find((c) => existsSync(c)) ?? null;
 }
 
 async function computerUsePermissionFetch(route, options = {}) {
@@ -133,7 +177,7 @@ async function computerUsePermissionFetch(route, options = {}) {
   }
 }
 
-// Legacy — kept for openComputerUsePermissionSettings backward compat.
+// Legacy path used by openComputerUsePermissionSettings.
 async function computerUsePermissionAppRequest(route, options = {}) {
   if (options.launch !== false) {
     await shell.openPath(computerUseHelperAppPath() ?? "");

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -43,7 +43,7 @@ const RELEASE_DOWNLOAD_BASE_URL = "https://github.com/different-ai/openwork/rele
 const RELEASE_PAGE_URL = "https://github.com/different-ai/openwork/releases/latest";
 const DOCS_PAGE_URL = "https://openworklabs.com/docs";
 const BROWSER_PLUGIN = "opencode-chrome-devtools";
-const COMPUTER_USE_HELPER_APP_NAME = "Computer Use.app";
+const COMPUTER_USE_HELPER_APP_NAME = "OpenWork Computer Use.app";
 const COMPUTER_USE_HELPER_EXECUTABLE = "ComputerUse";
 
 function computerUseHelperExecutablePath() {
@@ -73,7 +73,7 @@ function getComputerUseMcpCommand() {
   if (helperExecutable) return [helperExecutable, "mcp"];
 
   if (app.isPackaged) {
-    throw new Error("Computer Use helper app is missing from this OpenWork build.");
+    throw new Error("OpenWork Computer Use is missing from this OpenWork build.");
   }
 
   if (process.env.OPENWORK_DEV_MODE === "1") {
@@ -119,12 +119,12 @@ async function computerUsePermissionAppRequest(route, options = {}) {
   if (options.launch === false) {
     return { ok: false, accessibility: false, screenRecording: false, error: undefined };
   }
-  throw lastError ?? new Error("Computer Use permission app did not respond.");
+    throw lastError ?? new Error("OpenWork Computer Use did not respond.");
 }
 
 async function ensureComputerUsePermissionApp() {
   const appPath = computerUseHelperAppPath();
-  if (!appPath) throw new Error("Computer Use helper app is missing from this OpenWork build.");
+  if (!appPath) throw new Error("OpenWork Computer Use is missing from this OpenWork build.");
   await shell.openPath(appPath);
 }
 
@@ -2407,6 +2407,11 @@ async function handleDesktopInvoke(event, command, ...args) {
     }
     case "openComputerUsePermissionSetup": {
       return computerUsePermissionAppRequest("/status");
+    }
+    case "relaunchOpenWork": {
+      app.relaunch();
+      app.exit(0);
+      return { ok: true };
     }
     case "openComputerUsePermissionSettings": {
       const target = String(args[0] ?? "accessibility");

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -83,52 +83,72 @@ function getComputerUseMcpCommand() {
 }
 
 async function checkComputerUsePermissions() {
-  return computerUsePermissionAppRequest("/status", { launch: false });
+  // Single fast probe — no launch. Returns appRunning:false if helper is not up.
+  return computerUsePermissionFetch("/status", { timeoutMs: 700 });
 }
 
+async function launchAndQueryComputerUsePermissions(route, method = "GET") {
+  const appPath = computerUseHelperAppPath();
+  if (!appPath) throw new Error("OpenWork Computer Use is missing from this OpenWork build.");
+
+  // Bring to front (or start) the helper app.
+  await shell.openPath(appPath);
+
+  // Wait for AppKit to start and bind the HTTP server (Swift apps need ~0.5-1.5s).
+  await new Promise((resolve) => setTimeout(resolve, 900));
+
+  // Poll until the server responds — up to ~6 seconds total.
+  let lastError;
+  for (let i = 0; i < 20; i += 1) {
+    try {
+      return await computerUsePermissionFetch(route, { method, timeoutMs: 1_200 });
+    } catch (err) {
+      lastError = err;
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    }
+  }
+  throw lastError ?? new Error("OpenWork Computer Use did not respond after launch.");
+}
+
+async function computerUsePermissionFetch(route, options = {}) {
+  const controller = new AbortController();
+  const tid = setTimeout(() => controller.abort(), options.timeoutMs ?? 1_000);
+  try {
+    const response = await fetch(`http://127.0.0.1:49731${route}`, {
+      method: options.method ?? "GET",
+      signal: controller.signal,
+    });
+    const parsed = await response.json();
+    return {
+      ok: parsed?.ok === true,
+      accessibility: parsed?.accessibility === true,
+      screenRecording: parsed?.screenRecording === true,
+      appRunning: true,
+      error: typeof parsed?.error === "string" ? parsed.error : undefined,
+    };
+  } catch {
+    return { ok: false, accessibility: false, screenRecording: false, appRunning: false };
+  } finally {
+    clearTimeout(tid);
+  }
+}
+
+// Legacy — kept for openComputerUsePermissionSettings backward compat.
 async function computerUsePermissionAppRequest(route, options = {}) {
   if (options.launch !== false) {
-    await ensureComputerUsePermissionApp();
+    await shell.openPath(computerUseHelperAppPath() ?? "");
   }
-
   let lastError;
   const attempts = options.launch === false ? 1 : 12;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 1_000);
     try {
-      const response = await fetch(`http://127.0.0.1:49731${route}`, {
-        method: options.method ?? "GET",
-        signal: controller.signal,
-      });
-      const parsed = await response.json();
-      return {
-        ok: parsed?.ok === true,
-        accessibility: parsed?.accessibility === true,
-        screenRecording: parsed?.screenRecording === true,
-        error: typeof parsed?.error === "string" ? parsed.error : undefined,
-      };
-    } catch (error) {
-      lastError = error;
+      return await computerUsePermissionFetch(route, { method: options.method ?? "GET", timeoutMs: 1_000 });
+    } catch (err) {
+      lastError = err;
       await new Promise((resolve) => setTimeout(resolve, 250));
-    } finally {
-      clearTimeout(timeout);
     }
   }
-
-  if (options.launch === false) {
-    return { ok: false, accessibility: false, screenRecording: false, error: undefined };
-  }
-  if (options.allowUnavailable === true) {
-    return { ok: false, accessibility: false, screenRecording: false, error: undefined };
-  }
-  throw lastError ?? new Error("OpenWork Computer Use did not respond.");
-}
-
-async function ensureComputerUsePermissionApp() {
-  const appPath = computerUseHelperAppPath();
-  if (!appPath) throw new Error("OpenWork Computer Use is missing from this OpenWork build.");
-  await shell.openPath(appPath);
+  return { ok: false, accessibility: false, screenRecording: false, appRunning: false };
 }
 
 // Production Electron shares the same on-disk state folder as the Tauri shell
@@ -2409,12 +2429,13 @@ async function handleDesktopInvoke(event, command, ...args) {
       return checkComputerUsePermissions();
     }
     case "openComputerUsePermissionSetup": {
-      return computerUsePermissionAppRequest("/status", { allowUnavailable: true });
+      // Launch the helper app, wait for it to start, then return live status.
+      return launchAndQueryComputerUsePermissions("/status");
     }
     case "openComputerUsePermissionSettings": {
       const target = String(args[0] ?? "accessibility");
       const route = target === "screenRecording" ? "/request/screen-recording" : "/request/accessibility";
-      return computerUsePermissionAppRequest(route, { method: "POST" });
+      return launchAndQueryComputerUsePermissions(route, "POST");
     }
     case "getOpenworkUiMcpEnvironment": {
       return {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -47,15 +47,22 @@ const COMPUTER_USE_HELPER_APP_NAME = "Computer Use.app";
 const COMPUTER_USE_HELPER_EXECUTABLE = "ComputerUse";
 
 function computerUseHelperExecutablePath() {
+  const appPath = computerUseHelperAppPath();
   const explicitBinary = process.env.OPENWORK_COMPUTER_USE_BINARY?.trim();
-  const explicitApp = process.env.OPENWORK_COMPUTER_USE_APP?.trim();
   const candidates = [
     explicitBinary,
-    explicitApp ? path.join(explicitApp, "Contents", "MacOS", COMPUTER_USE_HELPER_EXECUTABLE) : null,
-    process.resourcesPath
-      ? path.join(process.resourcesPath, "helpers", COMPUTER_USE_HELPER_APP_NAME, "Contents", "MacOS", COMPUTER_USE_HELPER_EXECUTABLE)
-      : null,
-    path.resolve(__dirname, "..", "resources", "helpers", COMPUTER_USE_HELPER_APP_NAME, "Contents", "MacOS", COMPUTER_USE_HELPER_EXECUTABLE),
+    appPath ? path.join(appPath, "Contents", "MacOS", COMPUTER_USE_HELPER_EXECUTABLE) : null,
+  ].filter(Boolean);
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function computerUseHelperAppPath() {
+  const explicitApp = process.env.OPENWORK_COMPUTER_USE_APP?.trim();
+  const candidates = [
+    explicitApp,
+    process.resourcesPath ? path.join(process.resourcesPath, "helpers", COMPUTER_USE_HELPER_APP_NAME) : null,
+    path.resolve(__dirname, "..", "resources", "helpers", COMPUTER_USE_HELPER_APP_NAME),
   ].filter(Boolean);
 
   return candidates.find((candidate) => existsSync(candidate)) ?? null;
@@ -75,111 +82,50 @@ function getComputerUseMcpCommand() {
   return ["npx", "-y", "@openwork/handsfree", "mcp"];
 }
 
-function callComputerUseMcpTool(name, args = {}) {
-  const [command, ...commandArgs] = getComputerUseMcpCommand();
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, commandArgs, {
-      stdio: ["pipe", "pipe", "pipe"],
-      env: process.env,
-    });
-    let stdoutBuffer = "";
-    let stderr = "";
-    let settled = false;
-
-    const cleanup = () => {
-      clearTimeout(timeout);
-      child.kill();
-    };
-
-    const fail = (error) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      reject(error);
-    };
-
-    const finish = (response) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve(response);
-    };
-
-    const timeout = setTimeout(() => {
-      fail(new Error(`Computer Use MCP ${name} timed out.${stderr.trim() ? ` ${stderr.trim()}` : ""}`));
-    }, 45_000);
-
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => {
-      stdoutBuffer += chunk;
-      for (;;) {
-        const newlineIndex = stdoutBuffer.indexOf("\n");
-        if (newlineIndex === -1) break;
-        const line = stdoutBuffer.slice(0, newlineIndex).trim();
-        stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
-        if (!line) continue;
-        try {
-          const response = JSON.parse(line);
-          if (response.id === 2) {
-            finish(response);
-            return;
-          }
-        } catch {
-          // Package managers can write progress lines; ignore non-JSON stdout.
-        }
-      }
-    });
-
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk;
-    });
-
-    child.on("error", fail);
-    child.on("exit", (code) => {
-      if (!settled && code !== 0) {
-        fail(new Error(stderr.trim() || `Computer Use MCP exited with status ${code ?? "unknown"}.`));
-      }
-    });
-
-    child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} })}\n`);
-    child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`);
-    child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name, arguments: args } })}\n`);
-  });
-}
-
-function computerUseToolText(response) {
-  const content = response?.result?.content;
-  if (!Array.isArray(content)) return "";
-  const textPart = content.find((part) => part?.type === "text" && typeof part.text === "string");
-  return textPart?.text ?? "";
-}
-
 async function checkComputerUsePermissions() {
-  const response = await callComputerUseMcpTool("check_permissions");
-  const text = computerUseToolText(response);
-  try {
-    const parsed = JSON.parse(text);
-    return {
-      ok: parsed?.ok === true,
-      accessibility: parsed?.accessibility === true,
-      screenRecording: parsed?.screenRecording === true,
-    };
-  } catch {
-    return {
-      ok: false,
-      accessibility: false,
-      screenRecording: false,
-      error: text || "Computer Use permission check returned an unreadable response.",
-    };
-  }
+  return computerUsePermissionAppRequest("/status", { launch: false });
 }
 
-function computerUsePermissionSettingsUrl(target) {
-  if (target === "screenRecording") {
-    return "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture";
+async function computerUsePermissionAppRequest(route, options = {}) {
+  if (options.launch !== false) {
+    await ensureComputerUsePermissionApp();
   }
-  return "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
+
+  let lastError;
+  const attempts = options.launch === false ? 1 : 12;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 1_000);
+    try {
+      const response = await fetch(`http://127.0.0.1:49731${route}`, {
+        method: options.method ?? "GET",
+        signal: controller.signal,
+      });
+      const parsed = await response.json();
+      return {
+        ok: parsed?.ok === true,
+        accessibility: parsed?.accessibility === true,
+        screenRecording: parsed?.screenRecording === true,
+        error: typeof parsed?.error === "string" ? parsed.error : undefined,
+      };
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  if (options.launch === false) {
+    return { ok: false, accessibility: false, screenRecording: false, error: undefined };
+  }
+  throw lastError ?? new Error("Computer Use permission app did not respond.");
+}
+
+async function ensureComputerUsePermissionApp() {
+  const appPath = computerUseHelperAppPath();
+  if (!appPath) throw new Error("Computer Use helper app is missing from this OpenWork build.");
+  await shell.openPath(appPath);
 }
 
 // Production Electron shares the same on-disk state folder as the Tauri shell
@@ -2461,8 +2407,8 @@ async function handleDesktopInvoke(event, command, ...args) {
     }
     case "openComputerUsePermissionSettings": {
       const target = String(args[0] ?? "accessibility");
-      await shell.openExternal(computerUsePermissionSettingsUrl(target));
-      return { ok: true };
+      const route = target === "screenRecording" ? "/request/screen-recording" : "/request/accessibility";
+      return computerUsePermissionAppRequest(route, { method: "POST" });
     }
     case "getOpenworkUiMcpEnvironment": {
       return {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -83,52 +83,54 @@ function getComputerUseMcpCommand() {
 }
 
 async function checkComputerUsePermissions() {
-  return computerUsePermissionAppRequest("/status", { launch: false });
+  // Quick single attempt with no launch — returns appRunning:false if not reachable.
+  return computerUsePermissionFetch("/status", { method: "GET", timeoutMs: 800 });
 }
 
 async function computerUsePermissionAppRequest(route, options = {}) {
-  if (options.launch !== false) {
-    await ensureComputerUsePermissionApp();
-  }
-
-  let lastError;
-  const attempts = options.launch === false ? 1 : 12;
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 1_000);
-    try {
-      const response = await fetch(`http://127.0.0.1:49731${route}`, {
-        method: options.method ?? "GET",
-        signal: controller.signal,
-      });
-      const parsed = await response.json();
-      return {
-        ok: parsed?.ok === true,
-        accessibility: parsed?.accessibility === true,
-        screenRecording: parsed?.screenRecording === true,
-        error: typeof parsed?.error === "string" ? parsed.error : undefined,
-      };
-    } catch (error) {
-      lastError = error;
-      await new Promise((resolve) => setTimeout(resolve, 250));
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-
-  if (options.launch === false) {
-    return { ok: false, accessibility: false, screenRecording: false, error: undefined };
-  }
-  if (options.allowUnavailable === true) {
-    return { ok: false, accessibility: false, screenRecording: false, error: undefined };
-  }
-  throw lastError ?? new Error("OpenWork Computer Use did not respond.");
-}
-
-async function ensureComputerUsePermissionApp() {
   const appPath = computerUseHelperAppPath();
   if (!appPath) throw new Error("OpenWork Computer Use is missing from this OpenWork build.");
+
+  // Launch (or bring to front) the helper app.
   await shell.openPath(appPath);
+
+  // Give the Swift app time to start before the first poll.
+  await new Promise((resolve) => setTimeout(resolve, 800));
+
+  // Poll until the HTTP server responds (up to ~6 seconds total).
+  let lastError;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      return await computerUsePermissionFetch(route, { method: options.method ?? "GET", timeoutMs: 1_200 });
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    }
+  }
+  throw lastError ?? new Error("OpenWork Computer Use did not respond after launch.");
+}
+
+async function computerUsePermissionFetch(route, options = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 1_000);
+  try {
+    const response = await fetch(`http://127.0.0.1:49731${route}`, {
+      method: options.method ?? "GET",
+      signal: controller.signal,
+    });
+    const parsed = await response.json();
+    return {
+      ok: parsed?.ok === true,
+      accessibility: parsed?.accessibility === true,
+      screenRecording: parsed?.screenRecording === true,
+      appRunning: true,
+      error: typeof parsed?.error === "string" ? parsed.error : undefined,
+    };
+  } catch {
+    return { ok: false, accessibility: false, screenRecording: false, appRunning: false };
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 // Production Electron shares the same on-disk state folder as the Tauri shell
@@ -2409,7 +2411,8 @@ async function handleDesktopInvoke(event, command, ...args) {
       return checkComputerUsePermissions();
     }
     case "openComputerUsePermissionSetup": {
-      return computerUsePermissionAppRequest("/status", { allowUnavailable: true });
+      // Launch the app and wait until it responds.
+      return computerUsePermissionAppRequest("/status");
     }
     case "openComputerUsePermissionSettings": {
       const target = String(args[0] ?? "accessibility");

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -82,117 +82,86 @@ function getComputerUseMcpCommand() {
   return ["npx", "-y", "@openwork/handsfree", "mcp"];
 }
 
-async function checkComputerUsePermissions() {
-  // Single fast probe with no launch. Returns appRunning:false if helper is offline.
-  return computerUsePermissionFetch("/status", { timeoutMs: 700 });
-}
+// ---------------------------------------------------------------------------
+// Permission checks — spawn the binary with --check, read stdout, done.
+// Fresh process = fresh TCC read = always accurate. No HTTP server needed.
+// ---------------------------------------------------------------------------
 
-async function launchAndQueryComputerUsePermissions(route, method = "GET") {
-  // --- Resolve the binary to launch ---
+function resolveComputerUseExecutable() {
+  // 1. Explicit env override.
+  const explicit = process.env.OPENWORK_COMPUTER_USE_BINARY?.trim();
+  if (explicit && existsSync(explicit)) return explicit;
+
+  // 2. .app bundle (packaged builds + pnpm dev).
   const appPath = computerUseHelperAppPath();
-  const execPath = appPath
-    ? path.join(appPath, "Contents", "MacOS", COMPUTER_USE_HELPER_EXECUTABLE)
-    : computerUseHelperDevBinaryPath();
-
-  if (!execPath) {
-    const msg =
-      "OpenWork Computer Use helper app is not found. " +
-      "Run `pnpm dev` once so the Swift helper app is built, then try again.";
-    console.error("[ComputerUse]", msg);
-    throw new Error(msg);
+  if (appPath) {
+    const bin = path.join(appPath, "Contents", "MacOS", COMPUTER_USE_HELPER_EXECUTABLE);
+    if (existsSync(bin)) return bin;
   }
 
-  console.log("[ComputerUse] launching helper:", execPath);
-
-  // --- Launch ---
-  // Use spawn directly on the binary rather than shell.openPath so we get real
-  // error feedback. The binary with no arguments runs the permission-setup GUI.
-  const child = spawn(execPath, [], {
-    detached: true,
-    stdio: "ignore",
-    env: process.env,
-  });
-  child.unref();
-
-  child.on("error", (err) => {
-    console.error("[ComputerUse] helper launch error:", err.message);
-  });
-
-  // --- Wait for the HTTP server to bind (Swift AppKit startup ~0.5-1.5 s) ---
-  await new Promise((resolve) => setTimeout(resolve, 1_000));
-
-  // --- Poll until responsive, up to ~6 seconds ---
-  let lastResult = { ok: false, accessibility: false, screenRecording: false, appRunning: false };
-  for (let i = 0; i < 20; i += 1) {
-    const result = await computerUsePermissionFetch(route, { method, timeoutMs: 1_200 });
-    if (result.appRunning) {
-      console.log("[ComputerUse] helper responded on attempt", i + 1);
-      return result;
+  // 3. Dev fallback — raw Swift build output.
+  if (!app.isPackaged) {
+    const swiftPkg = path.resolve(__dirname, "../../..", "packages/handsfree/native/HandsFree");
+    const devCandidates = [
+      path.join(swiftPkg, ".build", "release", "HandsFreeComputerUse"),
+      path.join(swiftPkg, ".build", "arm64-apple-macosx", "release", "HandsFreeComputerUse"),
+      path.join(swiftPkg, ".build", "debug", "HandsFreeComputerUse"),
+      path.join(swiftPkg, ".build", "arm64-apple-macosx", "debug", "HandsFreeComputerUse"),
+    ];
+    for (const c of devCandidates) {
+      if (existsSync(c)) return c;
     }
-    lastResult = result;
-    await new Promise((resolve) => setTimeout(resolve, 300));
   }
 
-  console.error("[ComputerUse] helper did not respond after 20 attempts");
-  throw new Error(
-    "OpenWork Computer Use opened but did not respond. " +
-    "Try running `pnpm dev` to rebuild the helper, then try again."
-  );
+  return null;
 }
 
-function computerUseHelperDevBinaryPath() {
-  if (app.isPackaged) return null;
-  // Locations where the Swift binary might exist after a local build.
-  const swiftPkg = path.resolve(__dirname, "../../..", "packages/handsfree/native/HandsFree");
-  const candidates = [
-    path.join(swiftPkg, ".build", "release", "HandsFreeComputerUse"),
-    path.join(swiftPkg, ".build", "arm64-apple-macosx", "release", "HandsFreeComputerUse"),
-    path.join(swiftPkg, ".build", "debug", "HandsFreeComputerUse"),
-    path.join(swiftPkg, ".build", "arm64-apple-macosx", "debug", "HandsFreeComputerUse"),
-    process.env.OPENWORK_COMPUTER_USE_BINARY?.trim(),
-  ].filter(Boolean);
-  return candidates.find((c) => existsSync(c)) ?? null;
+async function checkComputerUsePermissions() {
+  // Spawn binary --check → read JSON from stdout → exit. Always fresh.
+  const bin = resolveComputerUseExecutable();
+  if (!bin) {
+    return { ok: false, accessibility: false, screenRecording: false, error: "Helper binary not found. Run pnpm dev to build it." };
+  }
+  return spawnCheckPermissions(bin);
 }
 
-async function computerUsePermissionFetch(route, options = {}) {
-  const controller = new AbortController();
-  const tid = setTimeout(() => controller.abort(), options.timeoutMs ?? 1_000);
-  try {
-    const response = await fetch(`http://127.0.0.1:49731${route}`, {
-      method: options.method ?? "GET",
-      signal: controller.signal,
+function spawnCheckPermissions(bin) {
+  return new Promise((resolve) => {
+    let stdout = "";
+    const child = spawn(bin, ["--check"], { stdio: ["ignore", "pipe", "ignore"], timeout: 5_000 });
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.on("error", () => resolve({ ok: false, accessibility: false, screenRecording: false, error: "Failed to run permission check." }));
+    child.on("close", () => {
+      try {
+        const parsed = JSON.parse(stdout.trim());
+        resolve({
+          ok: parsed?.ok === true,
+          accessibility: parsed?.accessibility === true,
+          screenRecording: parsed?.screenRecording === true,
+        });
+      } catch {
+        resolve({ ok: false, accessibility: false, screenRecording: false, error: "Permission check returned invalid output." });
+      }
     });
-    const parsed = await response.json();
-    return {
-      ok: parsed?.ok === true,
-      accessibility: parsed?.accessibility === true,
-      screenRecording: parsed?.screenRecording === true,
-      appRunning: true,
-      error: typeof parsed?.error === "string" ? parsed.error : undefined,
-    };
-  } catch {
-    return { ok: false, accessibility: false, screenRecording: false, appRunning: false };
-  } finally {
-    clearTimeout(tid);
-  }
+  });
 }
 
-// Legacy path used by openComputerUsePermissionSettings.
-async function computerUsePermissionAppRequest(route, options = {}) {
-  if (options.launch !== false) {
-    await shell.openPath(computerUseHelperAppPath() ?? "");
+async function openComputerUseSetupApp() {
+  // Open the GUI. Use the .app bundle if available so macOS shows it as
+  // a real app with its own dock icon and permission identity.
+  const appPath = computerUseHelperAppPath();
+  if (appPath) {
+    const result = await shell.openPath(appPath);
+    if (result) console.error("[ComputerUse] shell.openPath error:", result);
+    return;
   }
-  let lastError;
-  const attempts = options.launch === false ? 1 : 12;
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    try {
-      return await computerUsePermissionFetch(route, { method: options.method ?? "GET", timeoutMs: 1_000 });
-    } catch (err) {
-      lastError = err;
-      await new Promise((resolve) => setTimeout(resolve, 250));
-    }
-  }
-  return { ok: false, accessibility: false, screenRecording: false, appRunning: false };
+
+  // Fallback: spawn the raw binary (opens the same GUI).
+  const bin = resolveComputerUseExecutable();
+  if (!bin) throw new Error("Helper binary not found. Run pnpm dev to build it.");
+  const child = spawn(bin, [], { detached: true, stdio: "ignore" });
+  child.unref();
 }
 
 // Production Electron shares the same on-disk state folder as the Tauri shell
@@ -2470,16 +2439,19 @@ async function handleDesktopInvoke(event, command, ...args) {
       return getComputerUseMcpCommand();
     }
     case "checkComputerUsePermissions": {
+      // Spawn --check → fresh TCC read → always accurate.
       return checkComputerUsePermissions();
     }
     case "openComputerUsePermissionSetup": {
-      // Launch the helper app, wait for it to start, then return live status.
-      return launchAndQueryComputerUsePermissions("/status");
+      // Open the GUI app. Returns immediately — React shows "verify" CTA.
+      await openComputerUseSetupApp();
+      // Return a fresh check so the UI shows the current state.
+      return checkComputerUsePermissions();
     }
     case "openComputerUsePermissionSettings": {
-      const target = String(args[0] ?? "accessibility");
-      const route = target === "screenRecording" ? "/request/screen-recording" : "/request/accessibility";
-      return launchAndQueryComputerUsePermissions(route, "POST");
+      // Legacy: open the setup app (same as above).
+      await openComputerUseSetupApp();
+      return checkComputerUsePermissions();
     }
     case "getOpenworkUiMcpEnvironment": {
       return {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -119,7 +119,10 @@ async function computerUsePermissionAppRequest(route, options = {}) {
   if (options.launch === false) {
     return { ok: false, accessibility: false, screenRecording: false, error: undefined };
   }
-    throw lastError ?? new Error("OpenWork Computer Use did not respond.");
+  if (options.allowUnavailable === true) {
+    return { ok: false, accessibility: false, screenRecording: false, error: undefined };
+  }
+  throw lastError ?? new Error("OpenWork Computer Use did not respond.");
 }
 
 async function ensureComputerUsePermissionApp() {
@@ -2406,7 +2409,7 @@ async function handleDesktopInvoke(event, command, ...args) {
       return checkComputerUsePermissions();
     }
     case "openComputerUsePermissionSetup": {
-      return computerUsePermissionAppRequest("/status");
+      return computerUsePermissionAppRequest("/status", { allowUnavailable: true });
     }
     case "openComputerUsePermissionSettings": {
       const target = String(args[0] ?? "accessibility");

--- a/apps/desktop/scripts/prepare-computer-use-helper.mjs
+++ b/apps/desktop/scripts/prepare-computer-use-helper.mjs
@@ -82,8 +82,6 @@ function infoPlist() {
   <string>1</string>
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>
-  <key>LSUIElement</key>
-  <true/>
 </dict>
 </plist>
 `;

--- a/apps/desktop/scripts/prepare-computer-use-helper.mjs
+++ b/apps/desktop/scripts/prepare-computer-use-helper.mjs
@@ -7,9 +7,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(__dirname, "..");
 const repoRoot = resolve(desktopRoot, "../..");
 const packagePath = resolve(repoRoot, "packages", "handsfree", "native", "HandsFree");
+const iconPath = resolve(desktopRoot, "resources", "icons", "icon.icns");
 const productName = "HandsFreeComputerUse";
 const helperExecutableName = "ComputerUse";
-const helperAppName = "Computer Use.app";
+const helperAppName = "OpenWork Computer Use.app";
 const bundleIdentifier = "com.differentai.openwork.computer-use";
 
 const readArg = (name) => {
@@ -65,15 +66,17 @@ function infoPlist() {
   <key>CFBundleDevelopmentRegion</key>
   <string>en</string>
   <key>CFBundleDisplayName</key>
-  <string>Computer Use</string>
+  <string>OpenWork Computer Use</string>
   <key>CFBundleExecutable</key>
   <string>${helperExecutableName}</string>
   <key>CFBundleIdentifier</key>
   <string>${bundleIdentifier}</string>
+  <key>CFBundleIconFile</key>
+  <string>AppIcon</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>
-  <string>Computer Use</string>
+  <string>OpenWork Computer Use</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
@@ -111,6 +114,9 @@ mkdirSync(join(appPath, "Contents", "Resources"), { recursive: true });
 writeFileSync(join(appPath, "Contents", "Info.plist"), infoPlist(), "utf8");
 writeFileSync(join(appPath, "Contents", "PkgInfo"), "APPL????", "utf8");
 copyFileSync(builtExecutable, join(appPath, "Contents", "MacOS", helperExecutableName));
+if (existsSync(iconPath)) {
+  copyFileSync(iconPath, join(appPath, "Contents", "Resources", "AppIcon.icns"));
+}
 chmodSync(join(appPath, "Contents", "MacOS", helperExecutableName), 0o755);
 signHelperApp();
 

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/AccessibilityService.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/AccessibilityService.swift
@@ -16,12 +16,16 @@ final class AccessibilityService: @unchecked Sendable {
     ]
 
     func resolveTarget(appName: String?) throws -> WindowTarget {
+        try resolveTarget(appName: appName, windowTitle: nil)
+    }
+
+    func resolveTarget(appName: String?, windowTitle: String?) throws -> WindowTarget {
         guard AXIsProcessTrusted() else { throw ComputerUseError.accessibilityDenied }
 
         let app = try resolveApp(appName: appName)
         let pid = app.processIdentifier
         let axApp = AXUIElementCreateApplication(pid)
-        let axWindow = firstAXWindow(axApp: axApp)
+        let axWindow = firstAXWindow(axApp: axApp, title: windowTitle)
         let title = axWindow.flatMap { axString($0, kAXTitleAttribute) }
         let info = firstCGWindowInfo(pid: pid, title: title)
         let bounds = axWindow.flatMap(axFrame) ?? info?.bounds
@@ -42,10 +46,12 @@ final class AccessibilityService: @unchecked Sendable {
     }
 
     func snapshot(target: WindowTarget, strictMode: Bool, backgroundActivated: Bool) async throws -> AppSnapshot {
-        let records = target.axWindow.map(semanticRecords(window:)) ?? []
+        let records = records(target: target)
         let (data, meta) = try await captureScreenshot(target: target)
 
         return AppSnapshot(
+            id: "",
+            observation: 0,
             appName: target.appName,
             pid: target.pid,
             windowNumber: target.windowNumber,
@@ -55,8 +61,15 @@ final class AccessibilityService: @unchecked Sendable {
             screenshotMeta: meta,
             records: records,
             strictMode: strictMode,
-            backgroundActivated: backgroundActivated
+            backgroundActivated: backgroundActivated,
+            recentActions: [],
+            addedLabels: [],
+            removedLabels: []
         )
+    }
+
+    func records(target: WindowTarget) -> [AXElementRecord] {
+        target.axWindow.map(semanticRecords(window:)) ?? []
     }
 
     func press(record: AXElementRecord) -> Bool {
@@ -99,16 +112,20 @@ final class AccessibilityService: @unchecked Sendable {
         throw ComputerUseError.appNotFound(rawName)
     }
 
-    private func firstAXWindow(axApp: AXUIElement) -> AXUIElement? {
+    private func firstAXWindow(axApp: AXUIElement, title preferredTitle: String?) -> AXUIElement? {
         var windowValue: CFTypeRef?
         guard AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowValue) == .success,
               let windows = windowValue as? [AXUIElement] else {
             return nil
         }
-        return windows.first { window in
+        let usable = windows.filter { window in
             guard let frame = axFrame(window) else { return false }
             return frame.width > 20 && frame.height > 20
         }
+        if let preferredTitle, let match = usable.first(where: { axString($0, kAXTitleAttribute) == preferredTitle }) {
+            return match
+        }
+        return usable.first
     }
 
     private func semanticRecords(window: AXUIElement) -> [AXElementRecord] {

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/ComputerUseRuntime.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/ComputerUseRuntime.swift
@@ -12,6 +12,10 @@ actor ComputerUseRuntime {
     private var activationPreviousPID: pid_t?
     private var activationTargetPID: pid_t?
     private var frontmostMonitor: FrontmostApplicationMonitor?
+    private var snapshotSequence = 0
+    private var previousLabelsByWindow: [String: Set<String>] = [:]
+    private var recentActions: [String] = []
+    private var staleSnapshotReason: String?
 
     func setStrictMode(_ enabled: Bool) -> ActionMetadata {
         strictMode = enabled
@@ -48,21 +52,28 @@ actor ComputerUseRuntime {
             strictMode: effectiveStrict,
             backgroundActivated: backgroundActivated
         )
-        lastSnapshot = snapshot
-        return snapshot
+        let annotatedSnapshot = annotate(snapshot: snapshot)
+        staleSnapshotReason = nil
+        lastSnapshot = annotatedSnapshot
+        return annotatedSnapshot
     }
 
-    func click(ref: String?, index: Int?, imageX: Double?, imageY: Double?, clickCount: Int, strict requestedStrict: Bool?) async throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func click(snapshotID: String?, ref: String?, index: Int?, imageX: Double?, imageY: Double?, clickCount: Int, strict requestedStrict: Bool?) async throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
         let effectiveStrict = requestedStrict ?? snapshot.strictMode
+        try validateSnapshotForAction(snapshot: snapshot, strict: effectiveStrict)
 
         if let record = findRecord(ref: ref, index: index, in: snapshot) {
-            AgentCursorOverlay.shared.show(at: record.semantic.frame.center)
-            if record.semantic.capabilities.canPress, accessibility.press(record: record) {
-                return ActionMetadata(ok: true, path: .accessibility, strictMode: effectiveStrict, backgroundSafe: true, fallbackUsed: false, message: "Pressed \(record.semantic.ref) via AXPress.")
-            }
-            if record.semantic.capabilities.canFocus, accessibility.focus(record: record) {
-                return ActionMetadata(ok: true, path: .accessibility, strictMode: effectiveStrict, backgroundSafe: true, fallbackUsed: false, message: "Focused \(record.semantic.ref) via AX.")
+            let fresh = freshRecord(matching: record, in: snapshot)
+            if let fresh {
+                AgentCursorOverlay.shared.show(at: fresh.semantic.frame.center)
+                if fresh.semantic.capabilities.canPress, accessibility.press(record: fresh) {
+                    return recordAction(ActionMetadata(ok: true, path: .accessibility, strictMode: effectiveStrict, backgroundSafe: true, fallbackUsed: false, message: "Pressed \(fresh.semantic.ref) via AXPress."))
+                }
+                if fresh.semantic.capabilities.canFocus, accessibility.focus(record: fresh) {
+                    return recordAction(ActionMetadata(ok: true, path: .accessibility, strictMode: effectiveStrict, backgroundSafe: true, fallbackUsed: false, message: "Focused \(fresh.semantic.ref) via AX."))
+                }
+                return try await clickPoint(fresh.semantic.frame.center, clickCount: clickCount, strict: effectiveStrict, fallbackUsed: true)
             }
             return try await clickPoint(record.semantic.frame.center, clickCount: clickCount, strict: effectiveStrict, fallbackUsed: true)
         }
@@ -75,33 +86,36 @@ actor ComputerUseRuntime {
         throw ComputerUseError.invalidElement(ref ?? index.map(String.init) ?? "<missing>")
     }
 
-    func typeText(_ text: String, strict requestedStrict: Bool?) throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func typeText(snapshotID: String?, text: String, strict requestedStrict: Bool?) throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
         let effectiveStrict = requestedStrict ?? snapshot.strictMode
+        try validateSnapshotForAction(snapshot: snapshot, strict: effectiveStrict)
         if effectiveStrict {
             try BackgroundInputDispatcher.typeText(pid: snapshot.pid, text: text)
-            return ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Typed text with postToPid.")
+            return recordAction(ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Typed text with postToPid."))
         }
 
         try foregroundInput.typeText(text)
-        return ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Typed text with foreground HID fallback.")
+        return recordAction(ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Typed text with foreground HID fallback."))
     }
 
-    func pressKey(_ combo: String, strict requestedStrict: Bool?) throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func pressKey(snapshotID: String?, combo: String, strict requestedStrict: Bool?) throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
         let effectiveStrict = requestedStrict ?? snapshot.strictMode
+        try validateSnapshotForAction(snapshot: snapshot, strict: effectiveStrict)
         if effectiveStrict {
             try BackgroundInputDispatcher.pressKey(pid: snapshot.pid, combo: combo)
-            return ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Pressed key with postToPid.")
+            return recordAction(ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Pressed key with postToPid."))
         }
 
         try foregroundInput.pressKey(combo)
-        return ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Pressed key with foreground HID fallback.")
+        return recordAction(ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Pressed key with foreground HID fallback."))
     }
 
-    func scroll(direction: String?, pages: Double, imageX: Double?, imageY: Double?, strict requestedStrict: Bool?) throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func scroll(snapshotID: String?, direction: String?, pages: Double, imageX: Double?, imageY: Double?, strict requestedStrict: Bool?) throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
         let effectiveStrict = requestedStrict ?? snapshot.strictMode
+        try validateSnapshotForAction(snapshot: snapshot, strict: effectiveStrict)
         let amount = max(1, Int32(pages * 5))
         let deltas = scrollDeltas(direction: direction, amount: amount)
         let point: CGPoint = {
@@ -117,31 +131,39 @@ actor ComputerUseRuntime {
                 throw ComputerUseError.strictModeViolation("background scroll requires a CG window number")
             }
             try BackgroundInputDispatcher.scroll(pid: snapshot.pid, windowNumber: windowNumber, point: point, deltaX: deltas.x, deltaY: deltas.y)
-            return ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Scrolled with postToPid.")
+            return recordAction(ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Scrolled with postToPid."))
         }
 
         try foregroundInput.scroll(point: point, deltaX: deltas.x, deltaY: deltas.y)
-        return ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Scrolled with foreground HID fallback.")
+        return recordAction(ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Scrolled with foreground HID fallback."))
     }
 
-    func setValue(ref: String?, index: Int?, value: String) throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func setValue(snapshotID: String?, ref: String?, index: Int?, value: String) throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
+        try validateSnapshotForAction(snapshot: snapshot, strict: snapshot.strictMode)
         guard let record = findRecord(ref: ref, index: index, in: snapshot) else {
             throw ComputerUseError.invalidElement(ref ?? index.map(String.init) ?? "<missing>")
         }
-        AgentCursorOverlay.shared.show(at: record.semantic.frame.center)
-        let ok = accessibility.setValue(record: record, value: value)
-        return ActionMetadata(ok: ok, path: .accessibility, strictMode: snapshot.strictMode, backgroundSafe: true, fallbackUsed: false, message: ok ? "Set \(record.semantic.ref) via AXValue." : "Element value is not settable.")
+        guard let fresh = freshRecord(matching: record, in: snapshot) else {
+            throw ComputerUseError.staleSnapshot("The target element changed. Take a new snapshot before setting its value.")
+        }
+        AgentCursorOverlay.shared.show(at: fresh.semantic.frame.center)
+        let ok = accessibility.setValue(record: fresh, value: value)
+        return recordAction(ActionMetadata(ok: ok, path: .accessibility, strictMode: snapshot.strictMode, backgroundSafe: true, fallbackUsed: false, message: ok ? "Set \(fresh.semantic.ref) via AXValue." : "Element value is not settable."))
     }
 
-    func performAction(ref: String?, index: Int?, action: String) throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func performAction(snapshotID: String?, ref: String?, index: Int?, action: String) throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
+        try validateSnapshotForAction(snapshot: snapshot, strict: snapshot.strictMode)
         guard let record = findRecord(ref: ref, index: index, in: snapshot) else {
             throw ComputerUseError.invalidElement(ref ?? index.map(String.init) ?? "<missing>")
         }
-        AgentCursorOverlay.shared.show(at: record.semantic.frame.center)
-        let ok = accessibility.performAction(record: record, action: action)
-        return ActionMetadata(ok: ok, path: .accessibility, strictMode: snapshot.strictMode, backgroundSafe: true, fallbackUsed: false, message: ok ? "Performed \(action) on \(record.semantic.ref)." : "AX action \(action) failed.")
+        guard let fresh = freshRecord(matching: record, in: snapshot) else {
+            throw ComputerUseError.staleSnapshot("The target element changed. Take a new snapshot before performing another action.")
+        }
+        AgentCursorOverlay.shared.show(at: fresh.semantic.frame.center)
+        let ok = accessibility.performAction(record: fresh, action: action)
+        return recordAction(ActionMetadata(ok: ok, path: .accessibility, strictMode: snapshot.strictMode, backgroundSafe: true, fallbackUsed: false, message: ok ? "Performed \(action) on \(fresh.semantic.ref)." : "AX action \(action) failed."))
     }
 
     func wait(milliseconds: Int) async -> ActionMetadata {
@@ -152,17 +174,18 @@ actor ComputerUseRuntime {
 
     private func clickPoint(_ point: CGPoint, clickCount: Int, strict: Bool, fallbackUsed: Bool) async throws -> ActionMetadata {
         let snapshot = try requireSnapshot()
+        try validateSnapshotForAction(snapshot: snapshot, strict: strict)
         AgentCursorOverlay.shared.show(at: point)
         if strict {
             guard let windowNumber = snapshot.windowNumber else {
                 throw ComputerUseError.strictModeViolation("background click requires a CG window number")
             }
             try await BackgroundInputDispatcher.click(pid: snapshot.pid, windowNumber: windowNumber, point: point, doubleClick: clickCount >= 2)
-            return ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: fallbackUsed, message: "Clicked with postToPid at \(Int(point.x)),\(Int(point.y)).")
+            return recordAction(ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: fallbackUsed, message: "Clicked with postToPid at \(Int(point.x)),\(Int(point.y))."))
         }
 
         try await foregroundInput.click(point: point, doubleClick: clickCount >= 2)
-        return ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Clicked with foreground HID fallback at \(Int(point.x)),\(Int(point.y)).")
+        return recordAction(ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Clicked with foreground HID fallback at \(Int(point.x)),\(Int(point.y))."))
     }
 
     private func ensureBackgroundActivation(target: WindowTarget) async throws -> Bool {
@@ -203,7 +226,13 @@ actor ComputerUseRuntime {
 
     private func frontmostApplicationChanged(pid: pid_t?) {
         guard let pid, activationSession != nil else { return }
-        if pid == activationPreviousPID { return }
+        if pid == activationPreviousPID {
+            staleSnapshotReason = "The user returned focus to the previous app. Take a new snapshot before sending more input."
+        } else if pid == activationTargetPID {
+            staleSnapshotReason = "The target app became frontmost. Take a new snapshot before continuing."
+        } else {
+            staleSnapshotReason = "The user changed app focus. Take a new snapshot before sending more input."
+        }
         resetBackgroundActivation()
     }
 
@@ -216,9 +245,79 @@ actor ComputerUseRuntime {
         activationTargetPID = nil
     }
 
-    private func requireSnapshot() throws -> AppSnapshot {
+    private func requireSnapshot(snapshotID: String? = nil) throws -> AppSnapshot {
         guard let lastSnapshot else { throw ComputerUseError.noSnapshot }
+        if let snapshotID, snapshotID != lastSnapshot.id {
+            throw ComputerUseError.staleSnapshot("Snapshot \(snapshotID) is no longer current. Take a new snapshot before retrying.")
+        }
         return lastSnapshot
+    }
+
+    private func validateSnapshotForAction(snapshot: AppSnapshot, strict: Bool) throws {
+        if let staleSnapshotReason {
+            throw ComputerUseError.staleSnapshot(staleSnapshotReason)
+        }
+        guard strict else { return }
+        if NSWorkspace.shared.frontmostApplication?.processIdentifier == snapshot.pid { return }
+        guard activationSession != nil, activationTargetPID == snapshot.pid else {
+            throw ComputerUseError.staleSnapshot("The target app is no longer safely activated. Take a new snapshot before retrying.")
+        }
+    }
+
+    private func annotate(snapshot: AppSnapshot) -> AppSnapshot {
+        snapshotSequence += 1
+        let key = windowKey(snapshot: snapshot)
+        let labels = Set(snapshot.records.map { stableLabel(for: $0.semantic) }.filter { !$0.isEmpty })
+        let previous = previousLabelsByWindow[key] ?? []
+        previousLabelsByWindow[key] = labels
+
+        let added = labels.subtracting(previous).sorted()
+        let removed = previous.subtracting(labels).sorted()
+        return snapshot.withSessionMetadata(
+            id: UUID().uuidString.lowercased(),
+            observation: snapshotSequence,
+            recentActions: Array(recentActions.suffix(8)),
+            addedLabels: Array(added.prefix(16)),
+            removedLabels: Array(removed.prefix(16))
+        )
+    }
+
+    private func recordAction(_ metadata: ActionMetadata) -> ActionMetadata {
+        recentActions.append(metadata.message)
+        if recentActions.count > 12 {
+            recentActions.removeFirst(recentActions.count - 12)
+        }
+        return metadata
+    }
+
+    private func freshRecord(matching record: AXElementRecord, in snapshot: AppSnapshot) -> AXElementRecord? {
+        guard let target = try? accessibility.resolveTarget(appName: snapshot.appName, windowTitle: snapshot.windowTitle) else {
+            return nil
+        }
+        let records = accessibility.records(target: target)
+        if let index = records.firstIndex(where: { $0.semantic.id == record.semantic.id }), stableMatch(records[index].semantic, record.semantic) {
+            return records[index]
+        }
+        return records.first { stableMatch($0.semantic, record.semantic) }
+    }
+
+    private func stableMatch(_ candidate: SemanticAXElement, _ target: SemanticAXElement) -> Bool {
+        candidate.role == target.role && stableLabel(for: candidate) == stableLabel(for: target)
+    }
+
+    private func stableLabel(for element: SemanticAXElement) -> String {
+        let value = element.value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let label = element.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        let display = value.isEmpty ? label : "\(label) \(value)"
+        return "\(element.role):\(display)"
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .lowercased()
+    }
+
+    private func windowKey(snapshot: AppSnapshot) -> String {
+        "\(snapshot.pid):\(snapshot.windowNumber ?? -1)"
     }
 
     private func findRecord(ref: String?, index: Int?, in snapshot: AppSnapshot) -> AXElementRecord? {

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/MCPServer.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/MCPServer.swift
@@ -6,6 +6,7 @@ import ScreenCaptureKit
 actor MCPServer {
     private let runtime = ComputerUseRuntime()
     private let input = InputService()
+    private var cuaSnapshotFrontmostPID: pid_t?
 
     func run() async {
         log("Computer Use server starting")
@@ -60,6 +61,7 @@ actor MCPServer {
                 description: "Click a semantic ref like {e1}, an index, or screenshot x/y. AX is tried first; strict mode only falls back to background postToPid.",
                 properties: [
                     "ref": ["type": "string", "description": "Semantic ref from snapshot, e.g. {e1}."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "index": ["type": "number", "description": "Element id or zero-based compatibility index."],
                     "x": ["type": "number", "description": "Screenshot x coordinate."],
                     "y": ["type": "number", "description": "Screenshot y coordinate."],
@@ -72,6 +74,7 @@ actor MCPServer {
                 description: "Type text into the target process. In strict mode this uses CGEvent.postToPid and does not move the real cursor.",
                 properties: [
                     "text": ["type": "string", "description": "Text to type."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "strict": ["type": "boolean", "description": "Override strict mode for this action."],
                 ]
             ),
@@ -80,6 +83,7 @@ actor MCPServer {
                 description: "Press a key combo such as command+k, return, tab, or escape.",
                 properties: [
                     "combo": ["type": "string", "description": "Key combo."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "strict": ["type": "boolean", "description": "Override strict mode for this action."],
                 ]
             ),
@@ -88,6 +92,7 @@ actor MCPServer {
                 description: "Scroll the target window without foregrounding it in strict mode.",
                 properties: [
                     "direction": ["type": "string", "description": "up, down, left, or right."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "pages": ["type": "number", "description": "Approximate page count. Default 1."],
                     "x": ["type": "number", "description": "Optional screenshot x coordinate."],
                     "y": ["type": "number", "description": "Optional screenshot y coordinate."],
@@ -99,6 +104,7 @@ actor MCPServer {
                 description: "Set a semantic AX element value directly. This stays background-safe.",
                 properties: [
                     "ref": ["type": "string", "description": "Semantic ref from snapshot."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "index": ["type": "number", "description": "Element id or zero-based compatibility index."],
                     "value": ["type": "string", "description": "Value to set."],
                 ]
@@ -108,6 +114,7 @@ actor MCPServer {
                 description: "Perform a named AX action such as AXPress, AXShowMenu, AXIncrement, or AXDecrement.",
                 properties: [
                     "ref": ["type": "string", "description": "Semantic ref from snapshot."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "index": ["type": "number", "description": "Element id or zero-based compatibility index."],
                     "action": ["type": "string", "description": "AX action name. Default AXPress."],
                 ]
@@ -154,6 +161,7 @@ actor MCPServer {
                 return try await snapshotResult(args: args)
             case "click":
                 let metadata = try await runtime.click(
+                    snapshotID: snapshotIDArg(args),
                     ref: args["ref"] as? String,
                     index: intArg(args, "index"),
                     imageX: doubleArg(args, "x"),
@@ -163,13 +171,14 @@ actor MCPServer {
                 )
                 return jsonResult(metadata.dictionary)
             case "type_text":
-                let metadata = try await runtime.typeText(args["text"] as? String ?? "", strict: boolArg(args, "strict"))
+                let metadata = try await runtime.typeText(snapshotID: snapshotIDArg(args), text: args["text"] as? String ?? "", strict: boolArg(args, "strict"))
                 return jsonResult(metadata.dictionary)
             case "press_key":
-                let metadata = try await runtime.pressKey(args["combo"] as? String ?? "", strict: boolArg(args, "strict"))
+                let metadata = try await runtime.pressKey(snapshotID: snapshotIDArg(args), combo: args["combo"] as? String ?? "", strict: boolArg(args, "strict"))
                 return jsonResult(metadata.dictionary)
             case "scroll":
                 let metadata = try await runtime.scroll(
+                    snapshotID: snapshotIDArg(args),
                     direction: args["direction"] as? String,
                     pages: doubleArg(args, "pages") ?? 1,
                     imageX: doubleArg(args, "x"),
@@ -178,10 +187,10 @@ actor MCPServer {
                 )
                 return jsonResult(metadata.dictionary)
             case "set_value":
-                let metadata = try await runtime.setValue(ref: args["ref"] as? String, index: intArg(args, "index"), value: args["value"] as? String ?? "")
+                let metadata = try await runtime.setValue(snapshotID: snapshotIDArg(args), ref: args["ref"] as? String, index: intArg(args, "index"), value: args["value"] as? String ?? "")
                 return jsonResult(metadata.dictionary)
             case "perform_action":
-                let metadata = try await runtime.performAction(ref: args["ref"] as? String, index: intArg(args, "index"), action: args["action"] as? String ?? kAXPressAction)
+                let metadata = try await runtime.performAction(snapshotID: snapshotIDArg(args), ref: args["ref"] as? String, index: intArg(args, "index"), action: args["action"] as? String ?? kAXPressAction)
                 return jsonResult(metadata.dictionary)
             case "wait":
                 let metadata = await runtime.wait(milliseconds: intArg(args, "milliseconds") ?? 1000)
@@ -211,21 +220,31 @@ actor MCPServer {
             case "cua_screenshot":
                 return try await cuaScreenshotResult()
             case "cua_click":
+                try validateCuaSnapshotFresh()
+                AgentCursorOverlay.shared.show(at: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 try await input.click(point: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 return jsonResult(["ok": true])
             case "cua_double_click":
+                try validateCuaSnapshotFresh()
+                AgentCursorOverlay.shared.show(at: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 try await input.click(point: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0), doubleClick: true)
                 return jsonResult(["ok": true])
             case "cua_move":
+                try validateCuaSnapshotFresh()
+                AgentCursorOverlay.shared.show(at: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 try input.moveMouse(point: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 return jsonResult(["ok": true])
             case "cua_type":
+                try validateCuaSnapshotFresh()
                 try input.typeText(args["text"] as? String ?? "")
                 return jsonResult(["ok": true])
             case "cua_keypress":
+                try validateCuaSnapshotFresh()
                 try input.pressKey(cuaKeysToCombo(args["keys"] as? [String] ?? []))
                 return jsonResult(["ok": true])
             case "cua_scroll":
+                try validateCuaSnapshotFresh()
+                AgentCursorOverlay.shared.show(at: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 try input.scroll(
                     point: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0),
                     deltaX: Int32(intArg(args, "scroll_x") ?? 0),
@@ -233,7 +252,12 @@ actor MCPServer {
                 )
                 return jsonResult(["ok": true])
             case "cua_drag":
-                try await input.drag(path: parsePointPath(args["path"]))
+                try validateCuaSnapshotFresh()
+                let path = parsePointPath(args["path"])
+                if let first = path.first {
+                    AgentCursorOverlay.shared.show(at: first)
+                }
+                try await input.drag(path: path)
                 return jsonResult(["ok": true])
             case "cua_wait":
                 try await Task.sleep(nanoseconds: 1_000_000_000)
@@ -274,6 +298,9 @@ actor MCPServer {
         var result: [String: Any] = [
             "ok": true,
             "semanticAXVersion": 1,
+            "snapshotId": snapshot.id,
+            "snapshot_id": snapshot.id,
+            "observation": snapshot.observation,
             "app": snapshot.appName,
             "pid": Int(snapshot.pid),
             "windowTitle": snapshot.windowTitle ?? "",
@@ -286,6 +313,12 @@ actor MCPServer {
             "elements": elements,
             "hint": "Use refs like {e1}. Prefer AX-capable refs; strict mode rejects foreground fallback and reports path metadata after every action.",
         ]
+        if !snapshot.recentActions.isEmpty {
+            result["recentActions"] = snapshot.recentActions
+        }
+        if !snapshot.addedLabels.isEmpty || !snapshot.removedLabels.isEmpty {
+            result["stateDelta"] = ["added": snapshot.addedLabels, "removed": snapshot.removedLabels]
+        }
         if let windowNumber = snapshot.windowNumber {
             result["windowNumber"] = windowNumber
         }
@@ -347,6 +380,7 @@ actor MCPServer {
 
     private func cuaScreenshotResult() async throws -> [[String: Any]] {
         guard let screen = NSScreen.main else { throw ComputerUseError.screenshotFailed }
+        cuaSnapshotFrontmostPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
         let cgImage = await screenCaptureKitDisplayImage() ?? CGWindowListCreateImage(CGRect.null, .optionOnScreenOnly, kCGNullWindowID, [.bestResolution])
         guard let cgImage else {
             throw ComputerUseError.screenshotFailed
@@ -467,6 +501,16 @@ actor MCPServer {
         }
     }
 
+    private func validateCuaSnapshotFresh() throws {
+        guard let snapshotPID = cuaSnapshotFrontmostPID else {
+            throw ComputerUseError.staleSnapshot("CUA action requires a screenshot first.")
+        }
+        let currentPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
+        guard currentPID == snapshotPID else {
+            throw ComputerUseError.staleSnapshot("The user changed focus since the last CUA screenshot. Capture a new screenshot before acting.")
+        }
+    }
+
     private func valueAsDouble(_ value: Any) -> Double? {
         if let value = value as? Double { return value }
         if let value = value as? Int { return Double(value) }
@@ -511,6 +555,12 @@ actor MCPServer {
     private func errorPayload(_ error: Error) -> [String: Any] {
         let message = error.localizedDescription
         var payload: [String: Any] = ["ok": false, "error": message]
+        if case ComputerUseError.staleSnapshot = error {
+            payload["staleSnapshot"] = true
+            payload["retryable"] = false
+            payload["requiredNextAction"] = "snapshot"
+            payload["hint"] = "Take a fresh snapshot before retrying. Do not repeat the same action against stale UI state."
+        }
         if message.localizedCaseInsensitiveContains("accessibility") {
             payload["permissionNeeded"] = "accessibility"
         }
@@ -545,5 +595,9 @@ actor MCPServer {
             if value == "false" { return false }
         }
         return nil
+    }
+
+    private func snapshotIDArg(_ args: [String: Any]) -> String? {
+        args["snapshot_id"] as? String ?? args["snapshotId"] as? String
     }
 }

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/MCPServer.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/MCPServer.swift
@@ -293,10 +293,7 @@ actor MCPServer {
     }
 
     private func checkPermissions() -> [String: Any] {
-        let accessibilityOptions = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
-        let accessibility = AXIsProcessTrustedWithOptions(accessibilityOptions)
-        let screenRecording = CGPreflightScreenCaptureAccess()
-        return ["ok": true, "accessibility": accessibility, "screenRecording": screenRecording]
+        ComputerUsePermissions.status().dictionary
     }
 
     private func handleActivateApp(args: [String: Any]) -> [String: Any] {

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
@@ -26,22 +26,15 @@ struct ComputerUsePermissionStatus {
 }
 
 enum ComputerUsePermissions {
+    /// Non-prompting check — safe to call on a timer / from HTTP polling.
     static func status() -> ComputerUsePermissionStatus {
-        // AXIsProcessTrusted() checks the live TCC state every call — reliable.
-        let accessibility = AXIsProcessTrusted()
-
-        // CGPreflightScreenCaptureAccess() can return a stale cached "false" in
-        // the same process even after the user enables the toggle in System Settings.
-        // CGRequestScreenCaptureAccess() forces a live TCC re-read and returns the
-        // real current state without showing a dialog if already decided.
-        let screenRecording = CGRequestScreenCaptureAccess()
-
-        return ComputerUsePermissionStatus(
-            accessibility: accessibility,
-            screenRecording: screenRecording
+        ComputerUsePermissionStatus(
+            accessibility: AXIsProcessTrusted(),
+            screenRecording: CGPreflightScreenCaptureAccess()
         )
     }
 
+    /// Prompting request — only call when the user explicitly clicks "Grant".
     static func request(_ target: ComputerUsePermissionTarget) {
         switch target {
         case .accessibility:

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
@@ -3,7 +3,9 @@ import ApplicationServices
 import Foundation
 import Network
 
-private let permissionServerPort: UInt16 = 49731
+// MARK: - Permission model
+
+private let kPermissionServerPort: UInt16 = 49731
 
 enum ComputerUsePermissionTarget: String {
     case accessibility
@@ -13,15 +15,9 @@ enum ComputerUsePermissionTarget: String {
 struct ComputerUsePermissionStatus {
     let accessibility: Bool
     let screenRecording: Bool
-
     var ok: Bool { accessibility && screenRecording }
-
     var dictionary: [String: Any] {
-        [
-            "ok": ok,
-            "accessibility": accessibility,
-            "screenRecording": screenRecording,
-        ]
+        ["ok": ok, "accessibility": accessibility, "screenRecording": screenRecording]
     }
 }
 
@@ -36,256 +32,600 @@ enum ComputerUsePermissions {
     static func request(_ target: ComputerUsePermissionTarget) {
         switch target {
         case .accessibility:
-            let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
-            _ = AXIsProcessTrustedWithOptions(options)
+            let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+            _ = AXIsProcessTrustedWithOptions(opts)
         case .screenRecording:
             _ = CGRequestScreenCaptureAccess()
         }
     }
 }
 
+// MARK: - App delegate
+
 @MainActor
 final class PermissionSetupAppDelegate: NSObject, NSApplicationDelegate {
-    private var windowController: PermissionSetupWindowController?
+    private var windowController: NSWindowController?
     private var server: PermissionSetupHTTPServer?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         do {
-            let server = try PermissionSetupHTTPServer()
-            server.start()
-            self.server = server
+            let s = try PermissionSetupHTTPServer()
+            s.start()
+            server = s
         } catch {
-            fputs("[ComputerUse] Failed to start permission server: \(error.localizedDescription)\n", stderr)
+            fputs("[ComputerUse] HTTP server failed: \(error.localizedDescription)\n", stderr)
         }
-
-        let windowController = PermissionSetupWindowController()
-        self.windowController = windowController
-        windowController.showWindow(nil)
+        let window = PermissionSetupWindow()
+        let vc = PermissionSetupViewController()
+        window.contentViewController = vc
+        let wc = NSWindowController(window: window)
+        windowController = wc
+        wc.showWindow(nil)
         NSApplication.shared.activate(ignoringOtherApps: true)
     }
 
-    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        true
-    }
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
 }
 
-@MainActor
-final class PermissionSetupWindowController: NSWindowController {
-    private let accessibilityStatus = NSTextField(labelWithString: "")
-    private let screenRecordingStatus = NSTextField(labelWithString: "")
-    private let footerLabel = NSTextField(wrappingLabelWithString: "")
-    private var timer: Timer?
+// MARK: - Window
 
+private final class PermissionSetupWindow: NSWindow {
     init() {
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 620, height: 620),
-            styleMask: [.titled, .closable, .miniaturizable],
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 460, height: 600),
+            styleMask: [.titled, .closable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
-        window.title = "OpenWork Computer Use"
-        window.minSize = NSSize(width: 420, height: 560)
-        window.center()
-        super.init(window: window)
-        window.contentView = makeContentView()
+        title = "OpenWork Computer Use"
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+        isMovableByWindowBackground = true
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = true
+        center()
+    }
+}
+
+// MARK: - View controller
+
+@MainActor
+final class PermissionSetupViewController: NSViewController {
+    private var axBadge = StatusBadge()
+    private var srBadge = StatusBadge()
+    private var axGrantButton: NSButton?
+    private var srGrantButton: NSButton?
+    private var timer: Timer?
+
+    init() { super.init(nibName: nil, bundle: nil) }
+    required init?(coder: NSCoder) { nil }
+    deinit { timer?.invalidate() }
+
+    override func loadView() {
+        // Liquid glass: NSVisualEffectView blending with content behind the window
+        let blur = NSVisualEffectView()
+        blur.material = .underWindowBackground
+        blur.blendingMode = .behindWindow
+        blur.state = .active
+        blur.wantsLayer = true
+        blur.layer?.cornerRadius = 12
+        blur.layer?.masksToBounds = true
+        view = blur
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        buildLayout()
         refresh()
         timer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.refresh() }
         }
     }
 
-    required init?(coder: NSCoder) {
-        nil
-    }
+    private func buildLayout() {
+        let iconView = NSImageView()
+        iconView.image = NSApplication.shared.applicationIconImage
+        iconView.imageScaling = .scaleProportionallyUpOrDown
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.widthAnchor.constraint(equalToConstant: 52).isActive = true
+        iconView.heightAnchor.constraint(equalToConstant: 52).isActive = true
 
-    deinit {
-        timer?.invalidate()
-    }
+        let titleField = textField("Computer Use Setup", size: 20, weight: .semibold)
+        titleField.alignment = .center
 
-    private func makeContentView() -> NSView {
-        let root = NSView()
-        root.wantsLayer = true
-        root.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
-
-        let icon = DraggableAppIconView(frame: NSRect(x: 0, y: 0, width: 84, height: 84))
-        icon.image = NSApplication.shared.applicationIconImage
-        icon.imageScaling = .scaleProportionallyUpOrDown
-        icon.translatesAutoresizingMaskIntoConstraints = false
-        icon.widthAnchor.constraint(equalToConstant: 84).isActive = true
-        icon.heightAnchor.constraint(equalToConstant: 84).isActive = true
-
-        let iconHint = NSTextField(labelWithString: "Drag this icon into Screen Recording if macOS does not list the app.")
-        iconHint.font = .systemFont(ofSize: 12)
-        iconHint.textColor = .secondaryLabelColor
-        iconHint.alignment = .center
-        iconHint.lineBreakMode = .byWordWrapping
-        iconHint.maximumNumberOfLines = 2
-
-        let title = NSTextField(labelWithString: "OpenWork Computer Use")
-        title.font = .systemFont(ofSize: 26, weight: .semibold)
-        title.alignment = .center
-        title.lineBreakMode = .byTruncatingTail
-
-        let subtitle = NSTextField(wrappingLabelWithString: "Grant Accessibility and Screen Recording to this app. After both are granted, relaunch OpenWork so macOS applies the new permissions cleanly.")
-        subtitle.font = .systemFont(ofSize: 14)
-        subtitle.textColor = .secondaryLabelColor
-        subtitle.alignment = .center
-
-        let accessibilityRow = permissionRow(
-            title: "Accessibility",
-            body: "Allows semantic UI actions, focusing controls, and keyboard input.",
-            statusLabel: accessibilityStatus,
-            action: #selector(requestAccessibility)
+        let subtitleField = wrappingField(
+            "Grant two permissions so agents can see and control apps in the background.",
+            size: 13
         )
-        let screenRecordingRow = permissionRow(
-            title: "Screen Recording",
-            body: "Allows snapshots so agents can understand what is on screen. If macOS opens Privacy & Security, enable OpenWork Computer Use. If it is not listed, drag the app icon above into Screen Recording.",
-            statusLabel: screenRecordingStatus,
-            action: #selector(requestScreenRecording)
-        )
+        subtitleField.textColor = .secondaryLabelColor
+        subtitleField.alignment = .center
 
-        footerLabel.font = .systemFont(ofSize: 13)
-        footerLabel.textColor = .secondaryLabelColor
-        footerLabel.alignment = .center
+        let header = vstack([iconView, titleField, subtitleField], spacing: 8, alignment: NSLayoutConstraint.Attribute.centerX)
 
-        let doneButton = NSButton(title: "Done", target: self, action: #selector(done))
-        doneButton.bezelStyle = .rounded
-        doneButton.controlSize = .large
+        let axCard = makeAccessibilityCard()
+        let srCard = makeScreenRecordingCard()
 
-        let stack = NSStackView(views: [icon, iconHint, title, subtitle, accessibilityRow, screenRecordingRow, footerLabel, doneButton])
-        stack.orientation = .vertical
-        stack.spacing = 16
-        stack.alignment = .centerX
-        stack.translatesAutoresizingMaskIntoConstraints = false
+        let doneBtn = NSButton(title: "Done — Return to OpenWork", target: self, action: #selector(done))
+        doneBtn.bezelStyle = .rounded
+        doneBtn.controlSize = .large
+        doneBtn.keyEquivalent = "\r"
 
-        accessibilityRow.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
-        screenRecordingRow.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
-        iconHint.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
-        subtitle.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
-        footerLabel.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        let root = vstack([header, axCard, srCard, doneBtn], spacing: 14, alignment: NSLayoutConstraint.Attribute.leading)
+        root.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(root)
 
-        root.addSubview(stack)
         NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 24),
-            stack.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -24),
-            stack.topAnchor.constraint(greaterThanOrEqualTo: root.topAnchor, constant: 24),
-            stack.bottomAnchor.constraint(lessThanOrEqualTo: root.bottomAnchor, constant: -24),
-            stack.centerYAnchor.constraint(equalTo: root.centerYAnchor),
+            root.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            root.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            root.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor, constant: 52),
+            root.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor, constant: -20),
+            root.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 10),
+            axCard.widthAnchor.constraint(equalTo: root.widthAnchor),
+            srCard.widthAnchor.constraint(equalTo: root.widthAnchor),
+            doneBtn.widthAnchor.constraint(equalTo: root.widthAnchor),
         ])
-        return root
     }
 
-    private func permissionRow(title: String, body: String, statusLabel: NSTextField, action: Selector) -> NSView {
-        let titleLabel = NSTextField(labelWithString: title)
-        titleLabel.font = .systemFont(ofSize: 16, weight: .medium)
-        titleLabel.lineBreakMode = .byTruncatingTail
+    // MARK: Accessibility card
 
-        let bodyLabel = NSTextField(wrappingLabelWithString: body)
-        bodyLabel.font = .systemFont(ofSize: 13)
-        bodyLabel.textColor = .secondaryLabelColor
+    private func makeAccessibilityCard() -> NSView {
+        let step = StepCircle(number: "1")
+        let title = textField("Accessibility", size: 15, weight: .semibold)
+        let body = wrappingField(
+            "Allows agents to interact with UI controls, click buttons, and type text entirely in the background.",
+            size: 13
+        )
+        body.textColor = .secondaryLabelColor
 
-        statusLabel.font = .systemFont(ofSize: 13, weight: .medium)
-        statusLabel.lineBreakMode = .byTruncatingTail
+        let btn = NSButton(title: "Grant Accessibility", target: self, action: #selector(grantAccessibility))
+        btn.bezelStyle = .rounded
+        btn.controlSize = .regular
+        axGrantButton = btn
 
-        let button = NSButton(title: "Grant Permission", target: self, action: action)
-        button.bezelStyle = .rounded
-        button.controlSize = .large
-        button.lineBreakMode = .byTruncatingTail
-        button.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        let top = hstack([step, title, springy(), axBadge], spacing: 8)
+        let inner = vstack([top, body, btn], spacing: 10, alignment: NSLayoutConstraint.Attribute.leading)
+        btn.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
 
-        let textStack = NSStackView(views: [titleLabel, bodyLabel, statusLabel])
-        textStack.orientation = .vertical
-        textStack.spacing = 4
-        textStack.alignment = .leading
-
-        let row = NSStackView(views: [textStack, button])
-        row.orientation = .vertical
-        row.spacing = 12
-        row.alignment = .leading
-        row.distribution = .fill
-        textStack.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        button.widthAnchor.constraint(equalTo: row.widthAnchor).isActive = true
-
-        let container = NSBox()
-        container.boxType = .custom
-        container.cornerRadius = 14
-        container.borderWidth = 1
-        container.borderColor = .separatorColor
-        container.contentViewMargins = NSSize(width: 18, height: 14)
-        container.contentView = row
-        container.translatesAutoresizingMaskIntoConstraints = false
-        container.heightAnchor.constraint(greaterThanOrEqualToConstant: 150).isActive = true
-        return container
+        return glassCard(inner)
     }
+
+    // MARK: Screen Recording card
+
+    private func makeScreenRecordingCard() -> NSView {
+        let step = StepCircle(number: "2")
+        let title = textField("Screen Recording", size: 15, weight: .semibold)
+        let body = wrappingField(
+            "Lets agents see what is on screen. If macOS does not prompt automatically, drag the app icon below into the Screen Recording list.",
+            size: 13
+        )
+        body.textColor = .secondaryLabelColor
+
+        let dragFlow = makeDragFlowView()
+
+        let reqBtn = NSButton(title: "Request Screen Recording", target: self, action: #selector(requestScreenRecording))
+        reqBtn.bezelStyle = .rounded
+        reqBtn.controlSize = .regular
+        srGrantButton = reqBtn
+
+        let openBtn = NSButton(title: "Open Privacy & Security", target: self, action: #selector(openPrivacySecurity))
+        openBtn.bezelStyle = .rounded
+        openBtn.controlSize = .small
+
+        let top = hstack([step, title, springy(), srBadge], spacing: 8)
+        let inner = vstack([top, body, dragFlow, reqBtn, openBtn], spacing: 10, alignment: NSLayoutConstraint.Attribute.leading)
+        reqBtn.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+        openBtn.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+        dragFlow.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        return glassCard(inner)
+    }
+
+    // MARK: Drag flow visualization
+
+    private func makeDragFlowView() -> NSView {
+        // Large draggable app icon
+        let iconView = DraggableAppIconView(frame: .zero)
+        iconView.image = NSApplication.shared.applicationIconImage
+        iconView.imageScaling = .scaleProportionallyUpOrDown
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.widthAnchor.constraint(equalToConstant: 56).isActive = true
+        iconView.heightAnchor.constraint(equalToConstant: 56).isActive = true
+
+        let dragHint = textField("Drag me", size: 10)
+        dragHint.textColor = .tertiaryLabelColor
+        dragHint.alignment = .center
+
+        let iconCol = vstack([iconView, dragHint], spacing: 5, alignment: NSLayoutConstraint.Attribute.centerX)
+
+        let arrow = textField("→", size: 20)
+        arrow.textColor = .tertiaryLabelColor
+
+        let dropZone = PrivacyDropZoneView()
+        dropZone.translatesAutoresizingMaskIntoConstraints = false
+        dropZone.widthAnchor.constraint(equalToConstant: 116).isActive = true
+        dropZone.heightAnchor.constraint(equalToConstant: 60).isActive = true
+
+        let row = hstack([iconCol, arrow, dropZone], spacing: 14)
+        row.alignment = NSLayoutConstraint.Attribute.centerY
+        row.distribution = NSStackView.Distribution.fill
+
+        let hint = wrappingField(
+            "Drag this icon into the Screen Recording list in Privacy & Security, then enable it.",
+            size: 11
+        )
+        hint.textColor = .secondaryLabelColor
+        hint.alignment = .center
+
+        let content = vstack([row, hint], spacing: 8, alignment: NSLayoutConstraint.Attribute.centerX)
+        content.translatesAutoresizingMaskIntoConstraints = false
+
+        let wrapper = InnerTintView()
+        wrapper.translatesAutoresizingMaskIntoConstraints = false
+        wrapper.addSubview(content)
+        NSLayoutConstraint.activate([
+            content.topAnchor.constraint(equalTo: wrapper.topAnchor, constant: 12),
+            content.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor, constant: -12),
+            content.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor, constant: 12),
+            content.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor, constant: -12),
+        ])
+        return wrapper
+    }
+
+    // MARK: Refresh
 
     private func refresh() {
         let status = ComputerUsePermissions.status()
-        update(label: accessibilityStatus, granted: status.accessibility)
-        update(label: screenRecordingStatus, granted: status.screenRecording)
-        footerLabel.stringValue = status.ok
-            ? "All permissions are granted. Click Done, then relaunch OpenWork from the setup screen."
-            : "Grant both permissions here. macOS may ask you to quit and reopen apps after Screen Recording changes."
+        axBadge.update(granted: status.accessibility)
+        srBadge.update(granted: status.screenRecording)
+        axGrantButton?.isEnabled = !status.accessibility
+        srGrantButton?.isEnabled = !status.screenRecording
     }
 
-    private func update(label: NSTextField, granted: Bool) {
-        label.stringValue = granted ? "Granted" : "Needed"
-        label.textColor = granted ? .systemGreen : .systemOrange
-    }
+    // MARK: Actions
 
-    @objc private func requestAccessibility() {
+    @objc private func grantAccessibility() {
         ComputerUsePermissions.request(.accessibility)
-        refresh()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in self?.refresh() }
     }
 
     @objc private func requestScreenRecording() {
         ComputerUsePermissions.request(.screenRecording)
-        refresh()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in self?.refresh() }
+    }
+
+    @objc private func openPrivacySecurity() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") else { return }
+        NSWorkspace.shared.open(url)
     }
 
     @objc private func done() {
         NSApplication.shared.terminate(nil)
     }
-}
 
-final class DraggableAppIconView: NSImageView, NSDraggingSource {
-    override func mouseDown(with event: NSEvent) {
-        let appURL = Bundle.main.bundleURL
-        guard let image else { return }
-        let pasteboardItem = NSPasteboardItem()
-        pasteboardItem.setString(appURL.absoluteString, forType: .fileURL)
+    // MARK: Builder helpers
 
-        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
-        draggingItem.setDraggingFrame(bounds, contents: image)
-        beginDraggingSession(with: [draggingItem], event: event, source: self)
+    private func glassCard(_ content: NSView) -> GlassCardView {
+        let card = GlassCardView()
+        card.addContent(content)
+        return card
     }
 
-    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+    private func textField(_ text: String, size: CGFloat, weight: NSFont.Weight = .regular) -> NSTextField {
+        let f = NSTextField(labelWithString: text)
+        f.font = .systemFont(ofSize: size, weight: weight)
+        return f
+    }
+
+    private func wrappingField(_ text: String, size: CGFloat) -> NSTextField {
+        let f = NSTextField(wrappingLabelWithString: text)
+        f.font = .systemFont(ofSize: size)
+        return f
+    }
+
+    private func vstack(_ views: [NSView], spacing: CGFloat, alignment: NSLayoutConstraint.Attribute = NSLayoutConstraint.Attribute.leading) -> NSStackView {
+        let sv = NSStackView(views: views)
+        sv.orientation = .vertical
+        sv.spacing = spacing
+        sv.alignment = alignment
+        return sv
+    }
+
+    private func hstack(_ views: [NSView], spacing: CGFloat) -> NSStackView {
+        let sv = NSStackView(views: views)
+        sv.orientation = .horizontal
+        sv.spacing = spacing
+        sv.alignment = NSLayoutConstraint.Attribute.centerY
+        return sv
+    }
+
+    private func springy() -> NSView {
+        let v = NSView()
+        v.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        v.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return v
+    }
+}
+
+// MARK: - Glass card
+
+/// NSView container with an NSVisualEffectView inside for the glass effect.
+/// Uses updateLayer() so the border color responds to appearance changes.
+final class GlassCardView: NSView {
+    private let blur: NSVisualEffectView
+
+    override init(frame: NSRect) {
+        blur = NSVisualEffectView()
+        blur.material = .contentBackground
+        blur.blendingMode = .withinWindow
+        blur.state = .active
+        blur.wantsLayer = true
+        blur.layer?.cornerRadius = 13
+        blur.layer?.masksToBounds = true
+        blur.translatesAutoresizingMaskIntoConstraints = false
+
+        super.init(frame: frame)
+        wantsLayer = true
+        layer?.cornerRadius = 14
+
+        addSubview(blur)
+        NSLayoutConstraint.activate([
+            blur.topAnchor.constraint(equalTo: topAnchor),
+            blur.bottomAnchor.constraint(equalTo: bottomAnchor),
+            blur.leadingAnchor.constraint(equalTo: leadingAnchor),
+            blur.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override var wantsUpdateLayer: Bool { true }
+    override func updateLayer() {
+        layer?.borderWidth = 0.5
+        layer?.borderColor = NSColor.separatorColor.cgColor
+    }
+
+    func addContent(_ content: NSView) {
+        content.translatesAutoresizingMaskIntoConstraints = false
+        blur.addSubview(content)
+        NSLayoutConstraint.activate([
+            content.topAnchor.constraint(equalTo: blur.topAnchor, constant: 16),
+            content.bottomAnchor.constraint(equalTo: blur.bottomAnchor, constant: -16),
+            content.leadingAnchor.constraint(equalTo: blur.leadingAnchor, constant: 16),
+            content.trailingAnchor.constraint(equalTo: blur.trailingAnchor, constant: -16),
+        ])
+    }
+}
+
+// MARK: - Status badge
+
+/// Pill badge showing Granted/Needed with adaptive color.
+@MainActor
+final class StatusBadge: NSView {
+    private let dot = NSView()
+    private let label = NSTextField(labelWithString: "")
+    private var isGranted = false
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        wantsLayer = true
+        layer?.cornerRadius = 10
+
+        dot.wantsLayer = true
+        dot.layer?.cornerRadius = 4
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        dot.widthAnchor.constraint(equalToConstant: 8).isActive = true
+        dot.heightAnchor.constraint(equalToConstant: 8).isActive = true
+
+        label.font = .systemFont(ofSize: 12, weight: .medium)
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let row = NSStackView(views: [dot, label])
+        row.orientation = .horizontal
+        row.spacing = 5
+        row.alignment = .centerY
+        row.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(row)
+
+        NSLayoutConstraint.activate([
+            row.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+            row.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
+            row.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            row.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+        ])
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    func update(granted: Bool) {
+        isGranted = granted
+        applyColors()
+        label.stringValue = granted ? "Granted" : "Needed"
+        label.textColor = granted ? .systemGreen : .systemOrange
+    }
+
+    private func applyColors() {
+        layer?.backgroundColor = isGranted
+            ? NSColor.systemGreen.withAlphaComponent(0.15).cgColor
+            : NSColor.systemOrange.withAlphaComponent(0.12).cgColor
+        dot.layer?.backgroundColor = isGranted
+            ? NSColor.systemGreen.cgColor
+            : NSColor.systemOrange.cgColor
+    }
+
+    override var wantsUpdateLayer: Bool { true }
+    override func updateLayer() { applyColors() }
+}
+
+// MARK: - Step circle
+
+private final class StepCircle: NSView {
+    init(number: String) {
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.controlAccentColor.cgColor
+        layer?.cornerRadius = 11
+        translatesAutoresizingMaskIntoConstraints = false
+        widthAnchor.constraint(equalToConstant: 22).isActive = true
+        heightAnchor.constraint(equalToConstant: 22).isActive = true
+
+        let label = NSTextField(labelWithString: number)
+        label.font = .systemFont(ofSize: 12, weight: .semibold)
+        label.textColor = .white
+        label.alignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override var wantsUpdateLayer: Bool { true }
+    override func updateLayer() {
+        layer?.backgroundColor = NSColor.controlAccentColor.cgColor
+    }
+}
+
+// MARK: - Inner tint (drag flow background)
+
+/// Subtle tinted background for the drag-flow visualization.
+/// Adapts to light/dark appearance via updateLayer().
+private final class InnerTintView: NSView {
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        wantsLayer = true
+        layer?.cornerRadius = 10
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override var wantsUpdateLayer: Bool { true }
+    override func updateLayer() {
+        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        layer?.backgroundColor = isDark
+            ? NSColor.white.withAlphaComponent(0.05).cgColor
+            : NSColor.black.withAlphaComponent(0.04).cgColor
+    }
+}
+
+// MARK: - Privacy drop zone
+
+/// Dashed rounded rect showing where the user should drop the app icon.
+final class PrivacyDropZoneView: NSView {
+    private let label: NSTextField
+
+    override init(frame: NSRect) {
+        label = NSTextField(labelWithString: "Screen Recording\nlist")
+        super.init(frame: frame)
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = .tertiaryLabelColor
+        label.alignment = .center
+        label.maximumNumberOfLines = 2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 4),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -4),
+        ])
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        NSGraphicsContext.saveGraphicsState()
+        let path = NSBezierPath(roundedRect: bounds.insetBy(dx: 1, dy: 1), xRadius: 8, yRadius: 8)
+        path.lineWidth = 1.5
+        path.setLineDash([6.0, 4.0], count: 2, phase: 0)
+        NSColor.tertiaryLabelColor.setStroke()
+        path.stroke()
+        NSGraphicsContext.restoreGraphicsState()
+    }
+}
+
+// MARK: - Draggable app icon
+
+/// NSImageView that initiates a drag session carrying the app bundle URL,
+/// so it can be dropped into System Settings > Privacy & Security > Screen Recording.
+final class DraggableAppIconView: NSImageView, NSDraggingSource {
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        wantsLayer = true
+        layer?.cornerRadius = 12
+        layer?.masksToBounds = true
+        addTrackingArea(NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        ))
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override func mouseEntered(with event: NSEvent) {
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.12
+            animator().alphaValue = 0.75
+        }
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.12
+            animator().alphaValue = 1.0
+        }
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard let image else { return }
+        let appURL = Bundle.main.bundleURL
+        let item = NSPasteboardItem()
+        item.setString(appURL.absoluteString, forType: .fileURL)
+        let dragItem = NSDraggingItem(pasteboardWriter: item)
+        dragItem.setDraggingFrame(bounds, contents: image)
+        beginDraggingSession(with: [dragItem], event: event, source: self)
+    }
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation {
         .copy
     }
 }
+
+// MARK: - HTTP Server
 
 final class PermissionSetupHTTPServer {
     private let listener: NWListener
 
     init() throws {
-        guard let port = NWEndpoint.Port(rawValue: permissionServerPort) else {
-            throw NSError(domain: "ComputerUse", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid permission server port."])
+        guard let port = NWEndpoint.Port(rawValue: kPermissionServerPort) else {
+            throw NSError(domain: "ComputerUse", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Invalid permission server port.",
+            ])
         }
         listener = try NWListener(using: .tcp, on: port)
     }
 
     func start() {
-        listener.newConnectionHandler = { connection in
+        listener.newConnectionHandler = { [weak self] connection in
             connection.start(queue: .main)
-            self.handle(connection: connection)
+            self?.handle(connection: connection)
         }
         listener.start(queue: .main)
     }
 
     private func handle(connection: NWConnection) {
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { data, _, _, _ in
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { [weak self] data, _, _, _ in
             let request = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
-            let response = self.response(for: request)
+            let response = self?.response(for: request) ?? ""
             connection.send(content: response.data(using: .utf8), completion: .contentProcessed { _ in
                 connection.cancel()
             })
@@ -315,6 +655,13 @@ final class PermissionSetupHTTPServer {
     private func jsonResponse(_ body: [String: Any], status: String = "200 OK") -> String {
         let data = try? JSONSerialization.data(withJSONObject: body)
         let text = data.flatMap { String(data: $0, encoding: .utf8) } ?? "{\"ok\":false}"
-        return "HTTP/1.1 \(status)\r\nContent-Type: application/json\r\nContent-Length: \(text.utf8.count)\r\nConnection: close\r\n\r\n\(text)"
+        return [
+            "HTTP/1.1 \(status)",
+            "Content-Type: application/json",
+            "Content-Length: \(text.utf8.count)",
+            "Connection: close",
+            "",
+            text,
+        ].joined(separator: "\r\n")
     }
 }

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
@@ -1,0 +1,258 @@
+import AppKit
+import ApplicationServices
+import Foundation
+import Network
+
+private let permissionServerPort: UInt16 = 49731
+
+enum ComputerUsePermissionTarget: String {
+    case accessibility
+    case screenRecording = "screen-recording"
+}
+
+struct ComputerUsePermissionStatus {
+    let accessibility: Bool
+    let screenRecording: Bool
+
+    var ok: Bool { accessibility && screenRecording }
+
+    var dictionary: [String: Any] {
+        [
+            "ok": ok,
+            "accessibility": accessibility,
+            "screenRecording": screenRecording,
+        ]
+    }
+}
+
+enum ComputerUsePermissions {
+    static func status() -> ComputerUsePermissionStatus {
+        ComputerUsePermissionStatus(
+            accessibility: AXIsProcessTrusted(),
+            screenRecording: CGPreflightScreenCaptureAccess()
+        )
+    }
+
+    static func request(_ target: ComputerUsePermissionTarget) {
+        switch target {
+        case .accessibility:
+            let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+            _ = AXIsProcessTrustedWithOptions(options)
+        case .screenRecording:
+            _ = CGRequestScreenCaptureAccess()
+        }
+    }
+}
+
+@MainActor
+final class PermissionSetupAppDelegate: NSObject, NSApplicationDelegate {
+    private var windowController: PermissionSetupWindowController?
+    private var server: PermissionSetupHTTPServer?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        do {
+            let server = try PermissionSetupHTTPServer()
+            server.start()
+            self.server = server
+        } catch {
+            fputs("[ComputerUse] Failed to start permission server: \(error.localizedDescription)\n", stderr)
+        }
+
+        let windowController = PermissionSetupWindowController()
+        self.windowController = windowController
+        windowController.showWindow(nil)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        true
+    }
+}
+
+@MainActor
+final class PermissionSetupWindowController: NSWindowController {
+    private let accessibilityStatus = NSTextField(labelWithString: "")
+    private let screenRecordingStatus = NSTextField(labelWithString: "")
+    private var timer: Timer?
+
+    init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 400),
+            styleMask: [.titled, .closable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Computer Use Setup"
+        window.center()
+        super.init(window: window)
+        window.contentView = makeContentView()
+        refresh()
+        timer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.refresh() }
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    private func makeContentView() -> NSView {
+        let root = NSView()
+        root.wantsLayer = true
+        root.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+
+        let title = NSTextField(labelWithString: "Enable Computer Use")
+        title.font = .systemFont(ofSize: 26, weight: .semibold)
+        title.alignment = .center
+
+        let subtitle = NSTextField(wrappingLabelWithString: "OpenWork uses this helper app to request and verify macOS permissions. Grant both permissions, then return to OpenWork.")
+        subtitle.font = .systemFont(ofSize: 14)
+        subtitle.textColor = .secondaryLabelColor
+        subtitle.alignment = .center
+
+        let accessibilityRow = permissionRow(
+            title: "Accessibility",
+            body: "Allows semantic UI actions, focusing controls, and keyboard input.",
+            statusLabel: accessibilityStatus,
+            action: #selector(requestAccessibility)
+        )
+        let screenRecordingRow = permissionRow(
+            title: "Screen Recording",
+            body: "Allows snapshots so agents can understand what is on screen.",
+            statusLabel: screenRecordingStatus,
+            action: #selector(requestScreenRecording)
+        )
+
+        let stack = NSStackView(views: [title, subtitle, accessibilityRow, screenRecordingRow])
+        stack.orientation = .vertical
+        stack.spacing = 18
+        stack.alignment = .leading
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        root.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 32),
+            stack.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -32),
+            stack.centerYAnchor.constraint(equalTo: root.centerYAnchor),
+        ])
+        return root
+    }
+
+    private func permissionRow(title: String, body: String, statusLabel: NSTextField, action: Selector) -> NSView {
+        let titleLabel = NSTextField(labelWithString: title)
+        titleLabel.font = .systemFont(ofSize: 16, weight: .medium)
+
+        let bodyLabel = NSTextField(wrappingLabelWithString: body)
+        bodyLabel.font = .systemFont(ofSize: 13)
+        bodyLabel.textColor = .secondaryLabelColor
+
+        statusLabel.font = .systemFont(ofSize: 13, weight: .medium)
+
+        let button = NSButton(title: "Grant Permission", target: self, action: action)
+        button.bezelStyle = .rounded
+
+        let textStack = NSStackView(views: [titleLabel, bodyLabel, statusLabel])
+        textStack.orientation = .vertical
+        textStack.spacing = 4
+        textStack.alignment = .leading
+
+        let row = NSStackView(views: [textStack, button])
+        row.orientation = .horizontal
+        row.spacing = 16
+        row.alignment = .centerY
+        row.distribution = .fill
+        textStack.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        button.setContentHuggingPriority(.required, for: .horizontal)
+
+        let container = NSBox()
+        container.boxType = .custom
+        container.cornerRadius = 14
+        container.borderWidth = 1
+        container.borderColor = .separatorColor
+        container.contentViewMargins = NSSize(width: 18, height: 14)
+        container.contentView = row
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.heightAnchor.constraint(greaterThanOrEqualToConstant: 108).isActive = true
+        return container
+    }
+
+    private func refresh() {
+        let status = ComputerUsePermissions.status()
+        update(label: accessibilityStatus, granted: status.accessibility)
+        update(label: screenRecordingStatus, granted: status.screenRecording)
+    }
+
+    private func update(label: NSTextField, granted: Bool) {
+        label.stringValue = granted ? "Granted" : "Needed"
+        label.textColor = granted ? .systemGreen : .systemOrange
+    }
+
+    @objc private func requestAccessibility() {
+        ComputerUsePermissions.request(.accessibility)
+        refresh()
+    }
+
+    @objc private func requestScreenRecording() {
+        ComputerUsePermissions.request(.screenRecording)
+        refresh()
+    }
+}
+
+final class PermissionSetupHTTPServer {
+    private let listener: NWListener
+
+    init() throws {
+        guard let port = NWEndpoint.Port(rawValue: permissionServerPort) else {
+            throw NSError(domain: "ComputerUse", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid permission server port."])
+        }
+        listener = try NWListener(using: .tcp, on: port)
+    }
+
+    func start() {
+        listener.newConnectionHandler = { connection in
+            connection.start(queue: .main)
+            self.handle(connection: connection)
+        }
+        listener.start(queue: .main)
+    }
+
+    private func handle(connection: NWConnection) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { data, _, _, _ in
+            let request = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+            let response = self.response(for: request)
+            connection.send(content: response.data(using: .utf8), completion: .contentProcessed { _ in
+                connection.cancel()
+            })
+        }
+    }
+
+    private func response(for request: String) -> String {
+        let firstLine = request.components(separatedBy: "\r\n").first ?? ""
+        let parts = firstLine.split(separator: " ")
+        let method = parts.first.map(String.init) ?? "GET"
+        let path = parts.dropFirst().first.map(String.init) ?? "/"
+
+        if method == "POST", path == "/request/accessibility" {
+            ComputerUsePermissions.request(.accessibility)
+            return jsonResponse(ComputerUsePermissions.status().dictionary)
+        }
+        if method == "POST", path == "/request/screen-recording" {
+            ComputerUsePermissions.request(.screenRecording)
+            return jsonResponse(ComputerUsePermissions.status().dictionary)
+        }
+        if path == "/status" || path == "/" {
+            return jsonResponse(ComputerUsePermissions.status().dictionary)
+        }
+        return jsonResponse(["ok": false, "error": "Not found"], status: "404 Not Found")
+    }
+
+    private func jsonResponse(_ body: [String: Any], status: String = "200 OK") -> String {
+        let data = try? JSONSerialization.data(withJSONObject: body)
+        let text = data.flatMap { String(data: $0, encoding: .utf8) } ?? "{\"ok\":false}"
+        return "HTTP/1.1 \(status)\r\nContent-Type: application/json\r\nContent-Length: \(text.utf8.count)\r\nConnection: close\r\n\r\n\(text)"
+    }
+}

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
@@ -73,16 +73,17 @@ final class PermissionSetupAppDelegate: NSObject, NSApplicationDelegate {
 final class PermissionSetupWindowController: NSWindowController {
     private let accessibilityStatus = NSTextField(labelWithString: "")
     private let screenRecordingStatus = NSTextField(labelWithString: "")
+    private let footerLabel = NSTextField(wrappingLabelWithString: "")
     private var timer: Timer?
 
     init() {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 520, height: 400),
+            contentRect: NSRect(x: 0, y: 0, width: 580, height: 540),
             styleMask: [.titled, .closable, .miniaturizable],
             backing: .buffered,
             defer: false
         )
-        window.title = "Computer Use Setup"
+        window.title = "OpenWork Computer Use"
         window.center()
         super.init(window: window)
         window.contentView = makeContentView()
@@ -105,11 +106,23 @@ final class PermissionSetupWindowController: NSWindowController {
         root.wantsLayer = true
         root.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
 
-        let title = NSTextField(labelWithString: "Enable Computer Use")
+        let icon = DraggableAppIconView(frame: NSRect(x: 0, y: 0, width: 84, height: 84))
+        icon.image = NSApplication.shared.applicationIconImage
+        icon.imageScaling = .scaleProportionallyUpOrDown
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.widthAnchor.constraint(equalToConstant: 84).isActive = true
+        icon.heightAnchor.constraint(equalToConstant: 84).isActive = true
+
+        let iconHint = NSTextField(labelWithString: "Drag this icon into Screen Recording if macOS does not list the app.")
+        iconHint.font = .systemFont(ofSize: 12)
+        iconHint.textColor = .secondaryLabelColor
+        iconHint.alignment = .center
+
+        let title = NSTextField(labelWithString: "OpenWork Computer Use")
         title.font = .systemFont(ofSize: 26, weight: .semibold)
         title.alignment = .center
 
-        let subtitle = NSTextField(wrappingLabelWithString: "OpenWork uses this helper app to request and verify macOS permissions. Grant both permissions, then return to OpenWork.")
+        let subtitle = NSTextField(wrappingLabelWithString: "Grant Accessibility and Screen Recording to this app. After both are granted, relaunch OpenWork so macOS applies the new permissions cleanly.")
         subtitle.font = .systemFont(ofSize: 14)
         subtitle.textColor = .secondaryLabelColor
         subtitle.alignment = .center
@@ -122,16 +135,28 @@ final class PermissionSetupWindowController: NSWindowController {
         )
         let screenRecordingRow = permissionRow(
             title: "Screen Recording",
-            body: "Allows snapshots so agents can understand what is on screen.",
+            body: "Allows snapshots so agents can understand what is on screen. If macOS opens Privacy & Security, enable OpenWork Computer Use. If it is not listed, drag the app icon above into Screen Recording.",
             statusLabel: screenRecordingStatus,
             action: #selector(requestScreenRecording)
         )
 
-        let stack = NSStackView(views: [title, subtitle, accessibilityRow, screenRecordingRow])
+        footerLabel.font = .systemFont(ofSize: 13)
+        footerLabel.textColor = .secondaryLabelColor
+        footerLabel.alignment = .center
+
+        let doneButton = NSButton(title: "Done", target: self, action: #selector(done))
+        doneButton.bezelStyle = .rounded
+        doneButton.controlSize = .large
+
+        let stack = NSStackView(views: [icon, iconHint, title, subtitle, accessibilityRow, screenRecordingRow, footerLabel, doneButton])
         stack.orientation = .vertical
-        stack.spacing = 18
-        stack.alignment = .leading
+        stack.spacing = 16
+        stack.alignment = .centerX
         stack.translatesAutoresizingMaskIntoConstraints = false
+
+        accessibilityRow.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        screenRecordingRow.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        footerLabel.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
 
         root.addSubview(stack)
         NSLayoutConstraint.activate([
@@ -176,7 +201,7 @@ final class PermissionSetupWindowController: NSWindowController {
         container.contentViewMargins = NSSize(width: 18, height: 14)
         container.contentView = row
         container.translatesAutoresizingMaskIntoConstraints = false
-        container.heightAnchor.constraint(greaterThanOrEqualToConstant: 108).isActive = true
+        container.heightAnchor.constraint(greaterThanOrEqualToConstant: 124).isActive = true
         return container
     }
 
@@ -184,6 +209,9 @@ final class PermissionSetupWindowController: NSWindowController {
         let status = ComputerUsePermissions.status()
         update(label: accessibilityStatus, granted: status.accessibility)
         update(label: screenRecordingStatus, granted: status.screenRecording)
+        footerLabel.stringValue = status.ok
+            ? "All permissions are granted. Click Done, then relaunch OpenWork from the setup screen."
+            : "Grant both permissions here. macOS may ask you to quit and reopen apps after Screen Recording changes."
     }
 
     private func update(label: NSTextField, granted: Bool) {
@@ -199,6 +227,27 @@ final class PermissionSetupWindowController: NSWindowController {
     @objc private func requestScreenRecording() {
         ComputerUsePermissions.request(.screenRecording)
         refresh()
+    }
+
+    @objc private func done() {
+        NSApplication.shared.terminate(nil)
+    }
+}
+
+final class DraggableAppIconView: NSImageView, NSDraggingSource {
+    override func mouseDown(with event: NSEvent) {
+        let appURL = Bundle.main.bundleURL
+        guard let image else { return }
+        let pasteboardItem = NSPasteboardItem()
+        pasteboardItem.setString(appURL.absoluteString, forType: .fileURL)
+
+        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
+        draggingItem.setDraggingFrame(bounds, contents: image)
+        beginDraggingSession(with: [draggingItem], event: event, source: self)
+    }
+
+    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+        .copy
     }
 }
 

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
@@ -78,12 +78,13 @@ final class PermissionSetupWindowController: NSWindowController {
 
     init() {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 580, height: 540),
+            contentRect: NSRect(x: 0, y: 0, width: 620, height: 620),
             styleMask: [.titled, .closable, .miniaturizable],
             backing: .buffered,
             defer: false
         )
         window.title = "OpenWork Computer Use"
+        window.minSize = NSSize(width: 420, height: 560)
         window.center()
         super.init(window: window)
         window.contentView = makeContentView()
@@ -117,10 +118,13 @@ final class PermissionSetupWindowController: NSWindowController {
         iconHint.font = .systemFont(ofSize: 12)
         iconHint.textColor = .secondaryLabelColor
         iconHint.alignment = .center
+        iconHint.lineBreakMode = .byWordWrapping
+        iconHint.maximumNumberOfLines = 2
 
         let title = NSTextField(labelWithString: "OpenWork Computer Use")
         title.font = .systemFont(ofSize: 26, weight: .semibold)
         title.alignment = .center
+        title.lineBreakMode = .byTruncatingTail
 
         let subtitle = NSTextField(wrappingLabelWithString: "Grant Accessibility and Screen Recording to this app. After both are granted, relaunch OpenWork so macOS applies the new permissions cleanly.")
         subtitle.font = .systemFont(ofSize: 14)
@@ -156,12 +160,16 @@ final class PermissionSetupWindowController: NSWindowController {
 
         accessibilityRow.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
         screenRecordingRow.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        iconHint.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        subtitle.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
         footerLabel.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
 
         root.addSubview(stack)
         NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 32),
-            stack.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -32),
+            stack.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -24),
+            stack.topAnchor.constraint(greaterThanOrEqualTo: root.topAnchor, constant: 24),
+            stack.bottomAnchor.constraint(lessThanOrEqualTo: root.bottomAnchor, constant: -24),
             stack.centerYAnchor.constraint(equalTo: root.centerYAnchor),
         ])
         return root
@@ -170,15 +178,20 @@ final class PermissionSetupWindowController: NSWindowController {
     private func permissionRow(title: String, body: String, statusLabel: NSTextField, action: Selector) -> NSView {
         let titleLabel = NSTextField(labelWithString: title)
         titleLabel.font = .systemFont(ofSize: 16, weight: .medium)
+        titleLabel.lineBreakMode = .byTruncatingTail
 
         let bodyLabel = NSTextField(wrappingLabelWithString: body)
         bodyLabel.font = .systemFont(ofSize: 13)
         bodyLabel.textColor = .secondaryLabelColor
 
         statusLabel.font = .systemFont(ofSize: 13, weight: .medium)
+        statusLabel.lineBreakMode = .byTruncatingTail
 
         let button = NSButton(title: "Grant Permission", target: self, action: action)
         button.bezelStyle = .rounded
+        button.controlSize = .large
+        button.lineBreakMode = .byTruncatingTail
+        button.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         let textStack = NSStackView(views: [titleLabel, bodyLabel, statusLabel])
         textStack.orientation = .vertical
@@ -186,12 +199,12 @@ final class PermissionSetupWindowController: NSWindowController {
         textStack.alignment = .leading
 
         let row = NSStackView(views: [textStack, button])
-        row.orientation = .horizontal
-        row.spacing = 16
-        row.alignment = .centerY
+        row.orientation = .vertical
+        row.spacing = 12
+        row.alignment = .leading
         row.distribution = .fill
         textStack.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        button.setContentHuggingPriority(.required, for: .horizontal)
+        button.widthAnchor.constraint(equalTo: row.widthAnchor).isActive = true
 
         let container = NSBox()
         container.boxType = .custom
@@ -201,7 +214,7 @@ final class PermissionSetupWindowController: NSWindowController {
         container.contentViewMargins = NSSize(width: 18, height: 14)
         container.contentView = row
         container.translatesAutoresizingMaskIntoConstraints = false
-        container.heightAnchor.constraint(greaterThanOrEqualToConstant: 124).isActive = true
+        container.heightAnchor.constraint(greaterThanOrEqualToConstant: 150).isActive = true
         return container
     }
 

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/PermissionSetupApp.swift
@@ -27,9 +27,18 @@ struct ComputerUsePermissionStatus {
 
 enum ComputerUsePermissions {
     static func status() -> ComputerUsePermissionStatus {
-        ComputerUsePermissionStatus(
-            accessibility: AXIsProcessTrusted(),
-            screenRecording: CGPreflightScreenCaptureAccess()
+        // AXIsProcessTrusted() checks the live TCC state every call — reliable.
+        let accessibility = AXIsProcessTrusted()
+
+        // CGPreflightScreenCaptureAccess() can return a stale cached "false" in
+        // the same process even after the user enables the toggle in System Settings.
+        // CGRequestScreenCaptureAccess() forces a live TCC re-read and returns the
+        // real current state without showing a dialog if already decided.
+        let screenRecording = CGRequestScreenCaptureAccess()
+
+        return ComputerUsePermissionStatus(
+            accessibility: accessibility,
+            screenRecording: screenRecording
         )
     }
 

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/Types.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/Types.swift
@@ -135,6 +135,8 @@ struct WindowTarget: @unchecked Sendable {
 }
 
 struct AppSnapshot: @unchecked Sendable {
+    let id: String
+    let observation: Int
     let appName: String
     let pid: pid_t
     let windowNumber: Int?
@@ -145,9 +147,32 @@ struct AppSnapshot: @unchecked Sendable {
     let records: [AXElementRecord]
     let strictMode: Bool
     let backgroundActivated: Bool
+    let recentActions: [String]
+    let addedLabels: [String]
+    let removedLabels: [String]
 
     var elements: [SemanticAXElement] {
         records.map(\.semantic)
+    }
+
+    func withSessionMetadata(id: String, observation: Int, recentActions: [String], addedLabels: [String], removedLabels: [String]) -> AppSnapshot {
+        AppSnapshot(
+            id: id,
+            observation: observation,
+            appName: appName,
+            pid: pid,
+            windowNumber: windowNumber,
+            windowTitle: windowTitle,
+            screenshotData: screenshotData,
+            screenshotMimeType: screenshotMimeType,
+            screenshotMeta: screenshotMeta,
+            records: records,
+            strictMode: strictMode,
+            backgroundActivated: backgroundActivated,
+            recentActions: recentActions,
+            addedLabels: addedLabels,
+            removedLabels: removedLabels
+        )
     }
 }
 
@@ -185,6 +210,7 @@ enum ComputerUseError: LocalizedError {
     case noFrontmostApplication
     case noWindow(String)
     case noSnapshot
+    case staleSnapshot(String)
     case invalidElement(String)
     case strictModeViolation(String)
     case eventSourceFailed
@@ -205,6 +231,8 @@ enum ComputerUseError: LocalizedError {
             return "No usable window found for \(app)."
         case .noSnapshot:
             return "No snapshot is available. Call snapshot first."
+        case .staleSnapshot(let reason):
+            return "The last snapshot is stale. \(reason)"
         case .invalidElement(let ref):
             return "Element \(ref) was not found in the last semantic snapshot."
         case .strictModeViolation(let reason):

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/main.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/main.swift
@@ -17,8 +17,7 @@ if args.count >= 2 && args[1] == "mcp" {
         await runMCPServerWithOverlay()
     }
 } else {
-    fputs("Usage: Computer Use mcp\n", stderr)
-    exit(1)
+    await runPermissionSetupApp()
 }
 
 @MainActor
@@ -31,5 +30,13 @@ func runMCPServerWithOverlay() async {
             NSApplication.shared.terminate(nil)
         }
     }
+    NSApplication.shared.run()
+}
+
+@MainActor
+func runPermissionSetupApp() async {
+    NSApplication.shared.setActivationPolicy(.regular)
+    let appDelegate = PermissionSetupAppDelegate()
+    NSApplication.shared.delegate = appDelegate
     NSApplication.shared.run()
 }

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/main.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/main.swift
@@ -1,7 +1,9 @@
 /// Computer Use: semantic AX and background-safe macOS computer use.
 ///
-/// The runtime is MCP-independent. This binary exposes it over a small stdio
-/// adapter because existing agent clients already speak MCP.
+/// Three modes:
+///   mcp       — run the MCP server over stdio
+///   --check   — print permission status as JSON to stdout and exit
+///   (default) — open the permission setup GUI
 
 import AppKit
 import Foundation
@@ -9,14 +11,23 @@ import Foundation
 setbuf(stdout, nil)
 
 let args = CommandLine.arguments
-if args.count >= 2 && args[1] == "mcp" {
+let subcommand = args.count >= 2 ? args[1] : ""
+
+switch subcommand {
+case "mcp":
     if ProcessInfo.processInfo.environment["OPENWORK_COMPUTER_USE_CURSOR_OVERLAY"] == "0" {
         let server = MCPServer()
         await server.run()
     } else {
         await runMCPServerWithOverlay()
     }
-} else {
+case "--check":
+    // Fresh process → fresh TCC read → always accurate.
+    let status = ComputerUsePermissions.status()
+    let json = "{\"ok\":\(status.ok),\"accessibility\":\(status.accessibility),\"screenRecording\":\(status.screenRecording)}"
+    print(json)
+    exit(0)
+default:
     await runPermissionSetupApp()
 }
 

--- a/packages/handsfree/src/cua-runner.mjs
+++ b/packages/handsfree/src/cua-runner.mjs
@@ -59,7 +59,12 @@ export async function runCuaLoop({
       if (signal?.aborted) return { ok: true, messages, turns: turn + 1, aborted: true };
       if (action.type === "screenshot") continue;
       onProgress?.({ kind: "action", ...summarizeAction(action) });
-      await executeCuaAction(callTool, action);
+      const actionResult = await executeCuaAction(callTool, action);
+      const actionPayload = parseToolText(actionResult);
+      if (actionPayload?.ok === false) {
+        if (actionPayload.requiredNextAction === "snapshot") break;
+        throw new Error(actionPayload.error || `Computer action failed: ${action.type}`);
+      }
       await delay(150);
     }
 


### PR DESCRIPTION
## Summary
- add a standalone Computer Use helper app setup mode for macOS permissions
- expose helper-owned permission status/request endpoints on localhost
- update Electron setup to launch/query the helper instead of probing permissions through MCP

## Verification
- `node --check apps/desktop/electron/main.mjs`
- `node --check apps/desktop/scripts/prepare-computer-use-helper.mjs`
- `swift build --package-path packages/handsfree/native/HandsFree -c release --product HandsFreeComputerUse`
- `pnpm --filter @openwork/app typecheck`

## Notes
- I also smoke-tested a packaged helper app locally against `GET /status` and got a permission status JSON response.
- No video/screenshot captured in this pass.