### PR TITLE
Harden Computer Use runtime state

### DIFF
--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/AccessibilityService.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/AccessibilityService.swift
@@ -16,12 +16,16 @@ final class AccessibilityService: @unchecked Sendable {
     ]
 
     func resolveTarget(appName: String?) throws -> WindowTarget {
+        try resolveTarget(appName: appName, windowTitle: nil)
+    }
+
+    func resolveTarget(appName: String?, windowTitle: String?) throws -> WindowTarget {
         guard AXIsProcessTrusted() else { throw ComputerUseError.accessibilityDenied }
 
         let app = try resolveApp(appName: appName)
         let pid = app.processIdentifier
         let axApp = AXUIElementCreateApplication(pid)
-        let axWindow = firstAXWindow(axApp: axApp)
+        let axWindow = firstAXWindow(axApp: axApp, title: windowTitle)
         let title = axWindow.flatMap { axString($0, kAXTitleAttribute) }
         let info = firstCGWindowInfo(pid: pid, title: title)
         let bounds = axWindow.flatMap(axFrame) ?? info?.bounds
@@ -42,10 +46,12 @@ final class AccessibilityService: @unchecked Sendable {
     }
 
     func snapshot(target: WindowTarget, strictMode: Bool, backgroundActivated: Bool) async throws -> AppSnapshot {
-        let records = target.axWindow.map(semanticRecords(window:)) ?? []
+        let records = records(target: target)
         let (data, meta) = try await captureScreenshot(target: target)
 
         return AppSnapshot(
+            id: "",
+            observation: 0,
             appName: target.appName,
             pid: target.pid,
             windowNumber: target.windowNumber,
@@ -55,8 +61,15 @@ final class AccessibilityService: @unchecked Sendable {
             screenshotMeta: meta,
             records: records,
             strictMode: strictMode,
-            backgroundActivated: backgroundActivated
+            backgroundActivated: backgroundActivated,
+            recentActions: [],
+            addedLabels: [],
+            removedLabels: []
         )
+    }
+
+    func records(target: WindowTarget) -> [AXElementRecord] {
+        target.axWindow.map(semanticRecords(window:)) ?? []
     }
 
     func press(record: AXElementRecord) -> Bool {
@@ -99,16 +112,20 @@ final class AccessibilityService: @unchecked Sendable {
         throw ComputerUseError.appNotFound(rawName)
     }
 
-    private func firstAXWindow(axApp: AXUIElement) -> AXUIElement? {
+    private func firstAXWindow(axApp: AXUIElement, title preferredTitle: String?) -> AXUIElement? {
         var windowValue: CFTypeRef?
         guard AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowValue) == .success,
               let windows = windowValue as? [AXUIElement] else {
             return nil
         }
-        return windows.first { window in
+        let usable = windows.filter { window in
             guard let frame = axFrame(window) else { return false }
             return frame.width > 20 && frame.height > 20
         }
+        if let preferredTitle, let match = usable.first(where: { axString($0, kAXTitleAttribute) == preferredTitle }) {
+            return match
+        }
+        return usable.first
     }
 
     private func semanticRecords(window: AXUIElement) -> [AXElementRecord] {

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/ComputerUseRuntime.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/ComputerUseRuntime.swift
@@ -12,6 +12,10 @@ actor ComputerUseRuntime {
     private var activationPreviousPID: pid_t?
     private var activationTargetPID: pid_t?
     private var frontmostMonitor: FrontmostApplicationMonitor?
+    private var snapshotSequence = 0
+    private var previousLabelsByWindow: [String: Set<String>] = [:]
+    private var recentActions: [String] = []
+    private var staleSnapshotReason: String?
 
     func setStrictMode(_ enabled: Bool) -> ActionMetadata {
         strictMode = enabled
@@ -48,21 +52,28 @@ actor ComputerUseRuntime {
             strictMode: effectiveStrict,
             backgroundActivated: backgroundActivated
         )
-        lastSnapshot = snapshot
-        return snapshot
+        let annotatedSnapshot = annotate(snapshot: snapshot)
+        staleSnapshotReason = nil
+        lastSnapshot = annotatedSnapshot
+        return annotatedSnapshot
     }
 
-    func click(ref: String?, index: Int?, imageX: Double?, imageY: Double?, clickCount: Int, strict requestedStrict: Bool?) async throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func click(snapshotID: String?, ref: String?, index: Int?, imageX: Double?, imageY: Double?, clickCount: Int, strict requestedStrict: Bool?) async throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
         let effectiveStrict = requestedStrict ?? snapshot.strictMode
+        try validateSnapshotForAction(snapshot: snapshot, strict: effectiveStrict)
 
         if let record = findRecord(ref: ref, index: index, in: snapshot) {
-            AgentCursorOverlay.shared.show(at: record.semantic.frame.center)
-            if record.semantic.capabilities.canPress, accessibility.press(record: record) {
-                return ActionMetadata(ok: true, path: .accessibility, strictMode: effectiveStrict, backgroundSafe: true, fallbackUsed: false, message: "Pressed \(record.semantic.ref) via AXPress.")
-            }
-            if record.semantic.capabilities.canFocus, accessibility.focus(record: record) {
-                return ActionMetadata(ok: true, path: .accessibility, strictMode: effectiveStrict, backgroundSafe: true, fallbackUsed: false, message: "Focused \(record.semantic.ref) via AX.")
+            let fresh = freshRecord(matching: record, in: snapshot)
+            if let fresh {
+                AgentCursorOverlay.shared.show(at: fresh.semantic.frame.center)
+                if fresh.semantic.capabilities.canPress, accessibility.press(record: fresh) {
+                    return recordAction(ActionMetadata(ok: true, path: .accessibility, strictMode: effectiveStrict, backgroundSafe: true, fallbackUsed: false, message: "Pressed \(fresh.semantic.ref) via AXPress."))
+                }
+                if fresh.semantic.capabilities.canFocus, accessibility.focus(record: fresh) {
+                    return recordAction(ActionMetadata(ok: true, path: .accessibility, strictMode: effectiveStrict, backgroundSafe: true, fallbackUsed: false, message: "Focused \(fresh.semantic.ref) via AX."))
+                }
+                return try await clickPoint(fresh.semantic.frame.center, clickCount: clickCount, strict: effectiveStrict, fallbackUsed: true)
             }
             return try await clickPoint(record.semantic.frame.center, clickCount: clickCount, strict: effectiveStrict, fallbackUsed: true)
         }
@@ -75,33 +86,36 @@ actor ComputerUseRuntime {
         throw ComputerUseError.invalidElement(ref ?? index.map(String.init) ?? "<missing>")
     }
 
-    func typeText(_ text: String, strict requestedStrict: Bool?) throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func typeText(snapshotID: String?, text: String, strict requestedStrict: Bool?) throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
         let effectiveStrict = requestedStrict ?? snapshot.strictMode
+        try validateSnapshotForAction(snapshot: snapshot, strict: effectiveStrict)
         if effectiveStrict {
             try BackgroundInputDispatcher.typeText(pid: snapshot.pid, text: text)
-            return ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Typed text with postToPid.")
+            return recordAction(ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Typed text with postToPid."))
         }
 
         try foregroundInput.typeText(text)
-        return ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Typed text with foreground HID fallback.")
+        return recordAction(ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Typed text with foreground HID fallback."))
     }
 
-    func pressKey(_ combo: String, strict requestedStrict: Bool?) throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func pressKey(snapshotID: String?, combo: String, strict requestedStrict: Bool?) throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
         let effectiveStrict = requestedStrict ?? snapshot.strictMode
+        try validateSnapshotForAction(snapshot: snapshot, strict: effectiveStrict)
         if effectiveStrict {
             try BackgroundInputDispatcher.pressKey(pid: snapshot.pid, combo: combo)
-            return ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Pressed key with postToPid.")
+            return recordAction(ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Pressed key with postToPid."))
         }
 
         try foregroundInput.pressKey(combo)
-        return ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Pressed key with foreground HID fallback.")
+        return recordAction(ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Pressed key with foreground HID fallback."))
     }
 
-    func scroll(direction: String?, pages: Double, imageX: Double?, imageY: Double?, strict requestedStrict: Bool?) throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func scroll(snapshotID: String?, direction: String?, pages: Double, imageX: Double?, imageY: Double?, strict requestedStrict: Bool?) throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
         let effectiveStrict = requestedStrict ?? snapshot.strictMode
+        try validateSnapshotForAction(snapshot: snapshot, strict: effectiveStrict)
         let amount = max(1, Int32(pages * 5))
         let deltas = scrollDeltas(direction: direction, amount: amount)
         let point: CGPoint = {
@@ -117,31 +131,39 @@ actor ComputerUseRuntime {
                 throw ComputerUseError.strictModeViolation("background scroll requires a CG window number")
             }
             try BackgroundInputDispatcher.scroll(pid: snapshot.pid, windowNumber: windowNumber, point: point, deltaX: deltas.x, deltaY: deltas.y)
-            return ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Scrolled with postToPid.")
+            return recordAction(ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: false, message: "Scrolled with postToPid."))
         }
 
         try foregroundInput.scroll(point: point, deltaX: deltas.x, deltaY: deltas.y)
-        return ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Scrolled with foreground HID fallback.")
+        return recordAction(ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Scrolled with foreground HID fallback."))
     }
 
-    func setValue(ref: String?, index: Int?, value: String) throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func setValue(snapshotID: String?, ref: String?, index: Int?, value: String) throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
+        try validateSnapshotForAction(snapshot: snapshot, strict: snapshot.strictMode)
         guard let record = findRecord(ref: ref, index: index, in: snapshot) else {
             throw ComputerUseError.invalidElement(ref ?? index.map(String.init) ?? "<missing>")
         }
-        AgentCursorOverlay.shared.show(at: record.semantic.frame.center)
-        let ok = accessibility.setValue(record: record, value: value)
-        return ActionMetadata(ok: ok, path: .accessibility, strictMode: snapshot.strictMode, backgroundSafe: true, fallbackUsed: false, message: ok ? "Set \(record.semantic.ref) via AXValue." : "Element value is not settable.")
+        guard let fresh = freshRecord(matching: record, in: snapshot) else {
+            throw ComputerUseError.staleSnapshot("The target element changed. Take a new snapshot before setting its value.")
+        }
+        AgentCursorOverlay.shared.show(at: fresh.semantic.frame.center)
+        let ok = accessibility.setValue(record: fresh, value: value)
+        return recordAction(ActionMetadata(ok: ok, path: .accessibility, strictMode: snapshot.strictMode, backgroundSafe: true, fallbackUsed: false, message: ok ? "Set \(fresh.semantic.ref) via AXValue." : "Element value is not settable."))
     }
 
-    func performAction(ref: String?, index: Int?, action: String) throws -> ActionMetadata {
-        let snapshot = try requireSnapshot()
+    func performAction(snapshotID: String?, ref: String?, index: Int?, action: String) throws -> ActionMetadata {
+        let snapshot = try requireSnapshot(snapshotID: snapshotID)
+        try validateSnapshotForAction(snapshot: snapshot, strict: snapshot.strictMode)
         guard let record = findRecord(ref: ref, index: index, in: snapshot) else {
             throw ComputerUseError.invalidElement(ref ?? index.map(String.init) ?? "<missing>")
         }
-        AgentCursorOverlay.shared.show(at: record.semantic.frame.center)
-        let ok = accessibility.performAction(record: record, action: action)
-        return ActionMetadata(ok: ok, path: .accessibility, strictMode: snapshot.strictMode, backgroundSafe: true, fallbackUsed: false, message: ok ? "Performed \(action) on \(record.semantic.ref)." : "AX action \(action) failed.")
+        guard let fresh = freshRecord(matching: record, in: snapshot) else {
+            throw ComputerUseError.staleSnapshot("The target element changed. Take a new snapshot before performing another action.")
+        }
+        AgentCursorOverlay.shared.show(at: fresh.semantic.frame.center)
+        let ok = accessibility.performAction(record: fresh, action: action)
+        return recordAction(ActionMetadata(ok: ok, path: .accessibility, strictMode: snapshot.strictMode, backgroundSafe: true, fallbackUsed: false, message: ok ? "Performed \(action) on \(fresh.semantic.ref)." : "AX action \(action) failed."))
     }
 
     func wait(milliseconds: Int) async -> ActionMetadata {
@@ -152,17 +174,18 @@ actor ComputerUseRuntime {
 
     private func clickPoint(_ point: CGPoint, clickCount: Int, strict: Bool, fallbackUsed: Bool) async throws -> ActionMetadata {
         let snapshot = try requireSnapshot()
+        try validateSnapshotForAction(snapshot: snapshot, strict: strict)
         AgentCursorOverlay.shared.show(at: point)
         if strict {
             guard let windowNumber = snapshot.windowNumber else {
                 throw ComputerUseError.strictModeViolation("background click requires a CG window number")
             }
             try await BackgroundInputDispatcher.click(pid: snapshot.pid, windowNumber: windowNumber, point: point, doubleClick: clickCount >= 2)
-            return ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: fallbackUsed, message: "Clicked with postToPid at \(Int(point.x)),\(Int(point.y)).")
+            return recordAction(ActionMetadata(ok: true, path: .backgroundCGEvent, strictMode: true, backgroundSafe: true, fallbackUsed: fallbackUsed, message: "Clicked with postToPid at \(Int(point.x)),\(Int(point.y))."))
         }
 
         try await foregroundInput.click(point: point, doubleClick: clickCount >= 2)
-        return ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Clicked with foreground HID fallback at \(Int(point.x)),\(Int(point.y)).")
+        return recordAction(ActionMetadata(ok: true, path: .foregroundCGEvent, strictMode: false, backgroundSafe: false, fallbackUsed: true, message: "Clicked with foreground HID fallback at \(Int(point.x)),\(Int(point.y))."))
     }
 
     private func ensureBackgroundActivation(target: WindowTarget) async throws -> Bool {
@@ -203,7 +226,13 @@ actor ComputerUseRuntime {
 
     private func frontmostApplicationChanged(pid: pid_t?) {
         guard let pid, activationSession != nil else { return }
-        if pid == activationPreviousPID { return }
+        if pid == activationPreviousPID {
+            staleSnapshotReason = "The user returned focus to the previous app. Take a new snapshot before sending more input."
+        } else if pid == activationTargetPID {
+            staleSnapshotReason = "The target app became frontmost. Take a new snapshot before continuing."
+        } else {
+            staleSnapshotReason = "The user changed app focus. Take a new snapshot before sending more input."
+        }
         resetBackgroundActivation()
     }
 
@@ -216,9 +245,79 @@ actor ComputerUseRuntime {
         activationTargetPID = nil
     }
 
-    private func requireSnapshot() throws -> AppSnapshot {
+    private func requireSnapshot(snapshotID: String? = nil) throws -> AppSnapshot {
         guard let lastSnapshot else { throw ComputerUseError.noSnapshot }
+        if let snapshotID, snapshotID != lastSnapshot.id {
+            throw ComputerUseError.staleSnapshot("Snapshot \(snapshotID) is no longer current. Take a new snapshot before retrying.")
+        }
         return lastSnapshot
+    }
+
+    private func validateSnapshotForAction(snapshot: AppSnapshot, strict: Bool) throws {
+        if let staleSnapshotReason {
+            throw ComputerUseError.staleSnapshot(staleSnapshotReason)
+        }
+        guard strict else { return }
+        if NSWorkspace.shared.frontmostApplication?.processIdentifier == snapshot.pid { return }
+        guard activationSession != nil, activationTargetPID == snapshot.pid else {
+            throw ComputerUseError.staleSnapshot("The target app is no longer safely activated. Take a new snapshot before retrying.")
+        }
+    }
+
+    private func annotate(snapshot: AppSnapshot) -> AppSnapshot {
+        snapshotSequence += 1
+        let key = windowKey(snapshot: snapshot)
+        let labels = Set(snapshot.records.map { stableLabel(for: $0.semantic) }.filter { !$0.isEmpty })
+        let previous = previousLabelsByWindow[key] ?? []
+        previousLabelsByWindow[key] = labels
+
+        let added = labels.subtracting(previous).sorted()
+        let removed = previous.subtracting(labels).sorted()
+        return snapshot.withSessionMetadata(
+            id: UUID().uuidString.lowercased(),
+            observation: snapshotSequence,
+            recentActions: Array(recentActions.suffix(8)),
+            addedLabels: Array(added.prefix(16)),
+            removedLabels: Array(removed.prefix(16))
+        )
+    }
+
+    private func recordAction(_ metadata: ActionMetadata) -> ActionMetadata {
+        recentActions.append(metadata.message)
+        if recentActions.count > 12 {
+            recentActions.removeFirst(recentActions.count - 12)
+        }
+        return metadata
+    }
+
+    private func freshRecord(matching record: AXElementRecord, in snapshot: AppSnapshot) -> AXElementRecord? {
+        guard let target = try? accessibility.resolveTarget(appName: snapshot.appName, windowTitle: snapshot.windowTitle) else {
+            return nil
+        }
+        let records = accessibility.records(target: target)
+        if let index = records.firstIndex(where: { $0.semantic.id == record.semantic.id }), stableMatch(records[index].semantic, record.semantic) {
+            return records[index]
+        }
+        return records.first { stableMatch($0.semantic, record.semantic) }
+    }
+
+    private func stableMatch(_ candidate: SemanticAXElement, _ target: SemanticAXElement) -> Bool {
+        candidate.role == target.role && stableLabel(for: candidate) == stableLabel(for: target)
+    }
+
+    private func stableLabel(for element: SemanticAXElement) -> String {
+        let value = element.value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let label = element.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        let display = value.isEmpty ? label : "\(label) \(value)"
+        return "\(element.role):\(display)"
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .lowercased()
+    }
+
+    private func windowKey(snapshot: AppSnapshot) -> String {
+        "\(snapshot.pid):\(snapshot.windowNumber ?? -1)"
     }
 
     private func findRecord(ref: String?, index: Int?, in snapshot: AppSnapshot) -> AXElementRecord? {

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/MCPServer.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/MCPServer.swift
@@ -6,6 +6,7 @@ import ScreenCaptureKit
 actor MCPServer {
     private let runtime = ComputerUseRuntime()
     private let input = InputService()
+    private var cuaSnapshotFrontmostPID: pid_t?
 
     func run() async {
         log("Computer Use server starting")
@@ -60,6 +61,7 @@ actor MCPServer {
                 description: "Click a semantic ref like {e1}, an index, or screenshot x/y. AX is tried first; strict mode only falls back to background postToPid.",
                 properties: [
                     "ref": ["type": "string", "description": "Semantic ref from snapshot, e.g. {e1}."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "index": ["type": "number", "description": "Element id or zero-based compatibility index."],
                     "x": ["type": "number", "description": "Screenshot x coordinate."],
                     "y": ["type": "number", "description": "Screenshot y coordinate."],
@@ -72,6 +74,7 @@ actor MCPServer {
                 description: "Type text into the target process. In strict mode this uses CGEvent.postToPid and does not move the real cursor.",
                 properties: [
                     "text": ["type": "string", "description": "Text to type."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "strict": ["type": "boolean", "description": "Override strict mode for this action."],
                 ]
             ),
@@ -80,6 +83,7 @@ actor MCPServer {
                 description: "Press a key combo such as command+k, return, tab, or escape.",
                 properties: [
                     "combo": ["type": "string", "description": "Key combo."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "strict": ["type": "boolean", "description": "Override strict mode for this action."],
                 ]
             ),
@@ -88,6 +92,7 @@ actor MCPServer {
                 description: "Scroll the target window without foregrounding it in strict mode.",
                 properties: [
                     "direction": ["type": "string", "description": "up, down, left, or right."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "pages": ["type": "number", "description": "Approximate page count. Default 1."],
                     "x": ["type": "number", "description": "Optional screenshot x coordinate."],
                     "y": ["type": "number", "description": "Optional screenshot y coordinate."],
@@ -99,6 +104,7 @@ actor MCPServer {
                 description: "Set a semantic AX element value directly. This stays background-safe.",
                 properties: [
                     "ref": ["type": "string", "description": "Semantic ref from snapshot."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "index": ["type": "number", "description": "Element id or zero-based compatibility index."],
                     "value": ["type": "string", "description": "Value to set."],
                 ]
@@ -108,6 +114,7 @@ actor MCPServer {
                 description: "Perform a named AX action such as AXPress, AXShowMenu, AXIncrement, or AXDecrement.",
                 properties: [
                     "ref": ["type": "string", "description": "Semantic ref from snapshot."],
+                    "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "index": ["type": "number", "description": "Element id or zero-based compatibility index."],
                     "action": ["type": "string", "description": "AX action name. Default AXPress."],
                 ]
@@ -154,6 +161,7 @@ actor MCPServer {
                 return try await snapshotResult(args: args)
             case "click":
                 let metadata = try await runtime.click(
+                    snapshotID: snapshotIDArg(args),
                     ref: args["ref"] as? String,
                     index: intArg(args, "index"),
                     imageX: doubleArg(args, "x"),
@@ -163,13 +171,14 @@ actor MCPServer {
                 )
                 return jsonResult(metadata.dictionary)
             case "type_text":
-                let metadata = try await runtime.typeText(args["text"] as? String ?? "", strict: boolArg(args, "strict"))
+                let metadata = try await runtime.typeText(snapshotID: snapshotIDArg(args), text: args["text"] as? String ?? "", strict: boolArg(args, "strict"))
                 return jsonResult(metadata.dictionary)
             case "press_key":
-                let metadata = try await runtime.pressKey(args["combo"] as? String ?? "", strict: boolArg(args, "strict"))
+                let metadata = try await runtime.pressKey(snapshotID: snapshotIDArg(args), combo: args["combo"] as? String ?? "", strict: boolArg(args, "strict"))
                 return jsonResult(metadata.dictionary)
             case "scroll":
                 let metadata = try await runtime.scroll(
+                    snapshotID: snapshotIDArg(args),
                     direction: args["direction"] as? String,
                     pages: doubleArg(args, "pages") ?? 1,
                     imageX: doubleArg(args, "x"),
@@ -178,10 +187,10 @@ actor MCPServer {
                 )
                 return jsonResult(metadata.dictionary)
             case "set_value":
-                let metadata = try await runtime.setValue(ref: args["ref"] as? String, index: intArg(args, "index"), value: args["value"] as? String ?? "")
+                let metadata = try await runtime.setValue(snapshotID: snapshotIDArg(args), ref: args["ref"] as? String, index: intArg(args, "index"), value: args["value"] as? String ?? "")
                 return jsonResult(metadata.dictionary)
             case "perform_action":
-                let metadata = try await runtime.performAction(ref: args["ref"] as? String, index: intArg(args, "index"), action: args["action"] as? String ?? kAXPressAction)
+                let metadata = try await runtime.performAction(snapshotID: snapshotIDArg(args), ref: args["ref"] as? String, index: intArg(args, "index"), action: args["action"] as? String ?? kAXPressAction)
                 return jsonResult(metadata.dictionary)
             case "wait":
                 let metadata = await runtime.wait(milliseconds: intArg(args, "milliseconds") ?? 1000)
@@ -211,21 +220,31 @@ actor MCPServer {
             case "cua_screenshot":
                 return try await cuaScreenshotResult()
             case "cua_click":
+                try validateCuaSnapshotFresh()
+                AgentCursorOverlay.shared.show(at: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 try await input.click(point: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 return jsonResult(["ok": true])
             case "cua_double_click":
+                try validateCuaSnapshotFresh()
+                AgentCursorOverlay.shared.show(at: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 try await input.click(point: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0), doubleClick: true)
                 return jsonResult(["ok": true])
             case "cua_move":
+                try validateCuaSnapshotFresh()
+                AgentCursorOverlay.shared.show(at: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 try input.moveMouse(point: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 return jsonResult(["ok": true])
             case "cua_type":
+                try validateCuaSnapshotFresh()
                 try input.typeText(args["text"] as? String ?? "")
                 return jsonResult(["ok": true])
             case "cua_keypress":
+                try validateCuaSnapshotFresh()
                 try input.pressKey(cuaKeysToCombo(args["keys"] as? [String] ?? []))
                 return jsonResult(["ok": true])
             case "cua_scroll":
+                try validateCuaSnapshotFresh()
+                AgentCursorOverlay.shared.show(at: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0))
                 try input.scroll(
                     point: CGPoint(x: intArg(args, "x") ?? 0, y: intArg(args, "y") ?? 0),
                     deltaX: Int32(intArg(args, "scroll_x") ?? 0),
@@ -233,7 +252,12 @@ actor MCPServer {
                 )
                 return jsonResult(["ok": true])
             case "cua_drag":
-                try await input.drag(path: parsePointPath(args["path"]))
+                try validateCuaSnapshotFresh()
+                let path = parsePointPath(args["path"])
+                if let first = path.first {
+                    AgentCursorOverlay.shared.show(at: first)
+                }
+                try await input.drag(path: path)
                 return jsonResult(["ok": true])
             case "cua_wait":
                 try await Task.sleep(nanoseconds: 1_000_000_000)
@@ -274,6 +298,9 @@ actor MCPServer {
         var result: [String: Any] = [
             "ok": true,
             "semanticAXVersion": 1,
+            "snapshotId": snapshot.id,
+            "snapshot_id": snapshot.id,
+            "observation": snapshot.observation,
             "app": snapshot.appName,
             "pid": Int(snapshot.pid),
             "windowTitle": snapshot.windowTitle ?? "",
@@ -286,6 +313,12 @@ actor MCPServer {
             "elements": elements,
             "hint": "Use refs like {e1}. Prefer AX-capable refs; strict mode rejects foreground fallback and reports path metadata after every action.",
         ]
+        if !snapshot.recentActions.isEmpty {
+            result["recentActions"] = snapshot.recentActions
+        }
+        if !snapshot.addedLabels.isEmpty || !snapshot.removedLabels.isEmpty {
+            result["stateDelta"] = ["added": snapshot.addedLabels, "removed": snapshot.removedLabels]
+        }
         if let windowNumber = snapshot.windowNumber {
             result["windowNumber"] = windowNumber
         }
@@ -347,6 +380,7 @@ actor MCPServer {
 
     private func cuaScreenshotResult() async throws -> [[String: Any]] {
         guard let screen = NSScreen.main else { throw ComputerUseError.screenshotFailed }
+        cuaSnapshotFrontmostPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
         let cgImage = await screenCaptureKitDisplayImage() ?? CGWindowListCreateImage(CGRect.null, .optionOnScreenOnly, kCGNullWindowID, [.bestResolution])
         guard let cgImage else {
             throw ComputerUseError.screenshotFailed
@@ -467,6 +501,16 @@ actor MCPServer {
         }
     }
 
+    private func validateCuaSnapshotFresh() throws {
+        guard let snapshotPID = cuaSnapshotFrontmostPID else {
+            throw ComputerUseError.staleSnapshot("CUA action requires a screenshot first.")
+        }
+        let currentPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
+        guard currentPID == snapshotPID else {
+            throw ComputerUseError.staleSnapshot("The user changed focus since the last CUA screenshot. Capture a new screenshot before acting.")
+        }
+    }
+
     private func valueAsDouble(_ value: Any) -> Double? {
         if let value = value as? Double { return value }
         if let value = value as? Int { return Double(value) }
@@ -511,6 +555,12 @@ actor MCPServer {
     private func errorPayload(_ error: Error) -> [String: Any] {
         let message = error.localizedDescription
         var payload: [String: Any] = ["ok": false, "error": message]
+        if case ComputerUseError.staleSnapshot = error {
+            payload["staleSnapshot"] = true
+            payload["retryable"] = false
+            payload["requiredNextAction"] = "snapshot"
+            payload["hint"] = "Take a fresh snapshot before retrying. Do not repeat the same action against stale UI state."
+        }
         if message.localizedCaseInsensitiveContains("accessibility") {
             payload["permissionNeeded"] = "accessibility"
         }
@@ -545,5 +595,9 @@ actor MCPServer {
             if value == "false" { return false }
         }
         return nil
+    }
+
+    private func snapshotIDArg(_ args: [String: Any]) -> String? {
+        args["snapshot_id"] as? String ?? args["snapshotId"] as? String
     }
 }

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/Types.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/Types.swift
@@ -135,6 +135,8 @@ struct WindowTarget: @unchecked Sendable {
 }
 
 struct AppSnapshot: @unchecked Sendable {
+    let id: String
+    let observation: Int
     let appName: String
     let pid: pid_t
     let windowNumber: Int?
@@ -145,9 +147,32 @@ struct AppSnapshot: @unchecked Sendable {
     let records: [AXElementRecord]
     let strictMode: Bool
     let backgroundActivated: Bool
+    let recentActions: [String]
+    let addedLabels: [String]
+    let removedLabels: [String]
 
     var elements: [SemanticAXElement] {
         records.map(\.semantic)
+    }
+
+    func withSessionMetadata(id: String, observation: Int, recentActions: [String], addedLabels: [String], removedLabels: [String]) -> AppSnapshot {
+        AppSnapshot(
+            id: id,
+            observation: observation,
+            appName: appName,
+            pid: pid,
+            windowNumber: windowNumber,
+            windowTitle: windowTitle,
+            screenshotData: screenshotData,
+            screenshotMimeType: screenshotMimeType,
+            screenshotMeta: screenshotMeta,
+            records: records,
+            strictMode: strictMode,
+            backgroundActivated: backgroundActivated,
+            recentActions: recentActions,
+            addedLabels: addedLabels,
+            removedLabels: removedLabels
+        )
     }
 }
 
@@ -185,6 +210,7 @@ enum ComputerUseError: LocalizedError {
     case noFrontmostApplication
     case noWindow(String)
     case noSnapshot
+    case staleSnapshot(String)
     case invalidElement(String)
     case strictModeViolation(String)
     case eventSourceFailed
@@ -205,6 +231,8 @@ enum ComputerUseError: LocalizedError {
             return "No usable window found for \(app)."
         case .noSnapshot:
             return "No snapshot is available. Call snapshot first."
+        case .staleSnapshot(let reason):
+            return "The last snapshot is stale. \(reason)"
         case .invalidElement(let ref):
             return "Element \(ref) was not found in the last semantic snapshot."
         case .strictModeViolation(let reason):

--- a/packages/handsfree/src/cua-runner.mjs
+++ b/packages/handsfree/src/cua-runner.mjs
@@ -59,7 +59,12 @@ export async function runCuaLoop({
       if (signal?.aborted) return { ok: true, messages, turns: turn + 1, aborted: true };
       if (action.type === "screenshot") continue;
       onProgress?.({ kind: "action", ...summarizeAction(action) });
-      await executeCuaAction(callTool, action);
+      const actionResult = await executeCuaAction(callTool, action);
+      const actionPayload = parseToolText(actionResult);
+      if (actionPayload?.ok === false) {
+        if (actionPayload.requiredNextAction === "snapshot") break;
+        throw new Error(actionPayload.error || `Computer action failed: ${action.type}`);
+      }
       await delay(150);
     }
 


### PR DESCRIPTION
## Summary
- add snapshot ids, observation counters, recent actions, and state deltas to Computer Use snapshots
- guard semantic actions against stale snapshots/focus changes and refresh AX elements before acting
- tear down background activation when focus changes instead of continuing to suppress focus events
- make CUA compatibility actions fail safely when the user changes focus after a screenshot
- show the agent cursor overlay consistently for CUA mouse actions

## Verification
- `swift build --package-path packages/handsfree/native/HandsFree -c release --product HandsFreeComputerUse`
- `pnpm --filter @openwork/handsfree check:js`

## Notes
- This PR targets `computer-use-permission-helper-app` so it can layer on top of the helper-app permission flow.
- No video captured in this pass.