### PR TITLE
fix(server): resolve artifacts not shown due to lack of absolute path handling

### DIFF
--- a/apps/server/src/artifact-files.e2e.test.ts
+++ b/apps/server/src/artifact-files.e2e.test.ts
@@ -63,6 +63,7 @@ describe("artifact file routes", () => {
       headers: auth(token),
       body: JSON.stringify({
         targets: [
+          { kind: "file", value: join(root, "reports", "artifact-eval.md"), confidence: 95 },
           { kind: "file", value: "Workspace/32423/reports/artifact-eval.md", confidence: 80 },
           { kind: "file", value: "reports/artifact-eval.csv", confidence: 80 },
           { kind: "file", value: "reports/artifact-eval.xlsx", confidence: 80 },
@@ -75,7 +76,7 @@ describe("artifact file routes", () => {
     });
     expect(resolveResponse.status).toBe(200);
     const resolved = await resolveResponse.json() as { items: Array<any> };
-    expect(resolved.items.find((item) => item.value === "reports/artifact-eval.md")).toMatchObject({ exists: true, preview: "markdown" });
+    expect(resolved.items.find((item) => item.value === "reports/artifact-eval.md")).toMatchObject({ exists: true, preview: "markdown", confidence: 95 });
     expect(resolved.items.find((item) => item.value === "reports/artifact-eval.csv")).toMatchObject({ exists: true, preview: "sheet" });
     expect(resolved.items.find((item) => item.value === "reports/artifact-eval.xlsx")).toMatchObject({ exists: true, preview: "sheet" });
     expect(resolved.items.find((item) => item.value === "reports/index.html")).toMatchObject({ exists: true, preview: "html" });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { readFile, writeFile, rm, readdir, rename, stat, appendFile, mkdir } from "node:fs/promises";
 import { homedir, hostname } from "node:os";
-import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor, ReloadReason, ReloadTrigger, TokenScope } from "./types.js";
 import { ApprovalService } from "./approvals.js";
@@ -1064,6 +1064,7 @@ function normalizeUrlTarget(value: string): string | null {
 export async function resolveWorkspaceArtifactTargets(workspaceRoot: string, input: unknown): Promise<Array<Record<string, unknown>>> {
   const targets = Array.isArray(input) ? input.slice(0, 80) : [];
   const results = new Map<string, Record<string, unknown>>();
+  const workspaceResolved = resolve(workspaceRoot);
 
   for (const item of targets) {
     if (!item || typeof item !== "object") continue;
@@ -1095,7 +1096,16 @@ export async function resolveWorkspaceArtifactTargets(workspaceRoot: string, inp
 
     let relativePath: string;
     try {
-      relativePath = normalizeWorkspaceRelativePath(rawValue, { allowSubdirs: true });
+      if (isAbsolute(rawValue)) {
+        const absolutePath = resolve(rawValue);
+        const pathFromWorkspace = relative(workspaceResolved, absolutePath);
+        if (!pathFromWorkspace || pathFromWorkspace === ".." || pathFromWorkspace.startsWith(`..${sep}`) || isAbsolute(pathFromWorkspace)) {
+          continue;
+        }
+        relativePath = normalizeWorkspaceRelativePath(pathFromWorkspace, { allowSubdirs: true });
+      } else {
+        relativePath = normalizeWorkspaceRelativePath(rawValue, { allowSubdirs: true });
+      }
     } catch {
       continue;
     }


### PR DESCRIPTION
## Summary
- Allows artifact target resolution to accept absolute file paths when they are inside the workspace, converting them back to workspace-relative paths.
- Skips absolute paths that point outside the workspace.
- Updates the artifact files E2E test to cover absolute in-workspace paths and preserve the higher confidence score when duplicate targets resolve to the same file.