### PR TITLE
feat(extensions): declarative enablement conditions for extension active state

### DIFF
--- a/apps/app/src/app/enablement.ts
+++ b/apps/app/src/app/enablement.ts
@@ -1,0 +1,80 @@
+import type { EnablementCondition, EnablementResult } from "./extensions";
+import type { McpStatusMap } from "./types";
+
+/**
+ * Runtime context needed to evaluate enablement conditions.
+ * Each field is optional — missing context means the condition is unmet.
+ */
+export type EnablementContext = {
+  /** MCP server runtime statuses keyed by server name. */
+  mcpStatuses?: McpStatusMap;
+  /** Set of MCP server names that are at least configured (in opencode.json). */
+  mcpConfigured?: Set<string>;
+  /** Set of loaded plugin package names or path fragments. */
+  loadedPlugins?: Set<string>;
+  /** Set of connected provider IDs. */
+  connectedProviders?: Set<string>;
+  /** Set of environment variable keys that are configured. */
+  configuredEnvKeys?: Set<string>;
+  /** Permission results from the Computer Use --check binary. */
+  permissions?: { accessibility?: boolean; screenRecording?: boolean };
+  /** Toggle state reader — returns true if the extension toggle is on. */
+  isToggleEnabled?: (ref: string) => boolean;
+};
+
+/**
+ * Evaluate a single enablement condition against runtime context.
+ */
+function evaluateCondition(condition: EnablementCondition, ctx: EnablementContext): boolean {
+  switch (condition.type) {
+    case "mcp-connected": {
+      const status = ctx.mcpStatuses?.[condition.ref];
+      return status?.status === "connected";
+    }
+    case "plugin-loaded":
+      return ctx.loadedPlugins?.has(condition.ref) === true;
+    case "provider-connected":
+      return ctx.connectedProviders?.has(condition.ref) === true;
+    case "env-set":
+      return ctx.configuredEnvKeys?.has(condition.ref) === true;
+    case "permission-granted": {
+      if (!ctx.permissions) return false;
+      if (condition.ref === "accessibility") return ctx.permissions.accessibility === true;
+      if (condition.ref === "screenRecording") return ctx.permissions.screenRecording === true;
+      return false;
+    }
+    case "toggle-enabled":
+      return ctx.isToggleEnabled?.(condition.ref) === true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Evaluate all enablement conditions for an extension.
+ * Returns per-condition results and an overall `active` boolean.
+ */
+export function evaluateEnablement(
+  conditions: EnablementCondition[] | undefined,
+  ctx: EnablementContext,
+): { active: boolean; results: EnablementResult[] } {
+  if (!conditions || conditions.length === 0) {
+    return { active: false, results: [] };
+  }
+  const results = conditions.map((condition) => ({
+    condition,
+    met: evaluateCondition(condition, ctx),
+  }));
+  return {
+    active: results.every((r) => r.met),
+    results,
+  };
+}
+
+/**
+ * For plain MCP entries that don't have an extension manifest,
+ * generate a default single-condition enablement: mcp-connected.
+ */
+export function defaultMcpEnablement(serverName: string): EnablementCondition[] {
+  return [{ type: "mcp-connected", ref: serverName, label: "MCP server connected" }];
+}

--- a/apps/app/src/app/extensions.ts
+++ b/apps/app/src/app/extensions.ts
@@ -78,6 +78,32 @@ export type OpenWorkExtensionLifecycle = {
   detection?: string[];
 };
 
+// ---------------------------------------------------------------------------
+// Enablement — declarative conditions for extension "active" state
+// ---------------------------------------------------------------------------
+
+export type EnablementConditionType =
+  | "mcp-connected"
+  | "plugin-loaded"
+  | "provider-connected"
+  | "env-set"
+  | "permission-granted"
+  | "toggle-enabled";
+
+export type EnablementCondition = {
+  type: EnablementConditionType;
+  /** What to check — MCP server name, plugin id, env key, etc. */
+  ref: string;
+  /** Human-readable label shown in the UI. */
+  label: string;
+};
+
+/** Result of evaluating a single enablement condition at runtime. */
+export type EnablementResult = {
+  condition: EnablementCondition;
+  met: boolean;
+};
+
 export type OpenWorkExtensionManifest = {
   schemaVersion: 1;
   id: string;
@@ -96,6 +122,8 @@ export type OpenWorkExtensionManifest = {
   resources: OpenWorkExtensionResource[];
   contributions?: OpenWorkExtensionContribution[];
   lifecycle?: OpenWorkExtensionLifecycle;
+  /** Declarative conditions that must ALL be true for the extension to be "active". */
+  enablement?: EnablementCondition[];
   defaultEnabled?: boolean;
   platform?: Array<"darwin" | "linux" | "windows" | "web">;
 };
@@ -144,6 +172,10 @@ export const BUILT_IN_OPENWORK_EXTENSION_MANIFESTS: OpenWorkExtensionManifest[] 
       { type: "session-side-panel", ref: "openwork.browser.panel", location: "session-right-pane" },
       { type: "composer-prompt", prompt: "Use the OpenWork Browser extension to ", location: "composer" },
     ],
+    enablement: [
+      { type: "toggle-enabled", ref: "openwork-browser", label: "Enabled" },
+      { type: "plugin-loaded", ref: "opencode-chrome-devtools", label: "Browser plugin loaded" },
+    ],
     lifecycle: { reload: ["plugins", "agents"], detection: ["plugin:opencode-chrome-devtools"] },
     defaultEnabled: true,
   },
@@ -186,6 +218,11 @@ export const BUILT_IN_OPENWORK_EXTENSION_MANIFESTS: OpenWorkExtensionManifest[] 
       { type: "test-action", ref: "openwork.computerUse.healthCheck", label: "Verify Computer Use MCP" },
       { type: "composer-prompt", prompt: "Use Computer Use to ", location: "composer" },
     ],
+    enablement: [
+      { type: "mcp-connected", ref: "computer-use", label: "MCP server connected" },
+      { type: "permission-granted", ref: "accessibility", label: "Accessibility permission" },
+      { type: "permission-granted", ref: "screenRecording", label: "Screen Recording permission" },
+    ],
     lifecycle: { reload: ["mcp"], detection: ["mcp:computer-use"] },
     platform: ["darwin"],
   },
@@ -213,6 +250,10 @@ export const BUILT_IN_OPENWORK_EXTENSION_MANIFESTS: OpenWorkExtensionManifest[] 
       { type: "settings-panel", ref: "openwork.imageGen.settings", location: "settings-detail" },
       { type: "test-action", ref: "openwork.imageGen.testGenerate", label: "Generate test image" },
       { type: "composer-prompt", prompt: "Use the OpenAI Image Gen extension to ", location: "composer" },
+    ],
+    enablement: [
+      { type: "plugin-loaded", ref: "openwork-image-generation", label: "Image plugin installed" },
+      { type: "env-set", ref: "OPENAI_API_KEY", label: "OpenAI API key" },
     ],
     lifecycle: { reload: ["plugins"], detection: ["plugin:openwork-image-generation"] },
   },
@@ -246,6 +287,10 @@ export const BUILT_IN_OPENWORK_EXTENSION_MANIFESTS: OpenWorkExtensionManifest[] 
       { type: "test-action", ref: "openwork.voice.testRealtime", label: "Test Realtime" },
       { type: "composer-prompt", prompt: "Use Voice Mode to ", location: "composer" },
     ],
+    enablement: [
+      { type: "toggle-enabled", ref: "openwork-voice", label: "Enabled" },
+      { type: "env-set", ref: "OPENAI_API_KEY", label: "OpenAI API key" },
+    ],
     lifecycle: { reload: ["config"], detection: ["env:OPENAI_REALTIME_API_KEY", "env:OPENAI_API_KEY"] },
   },
   {
@@ -269,6 +314,9 @@ export const BUILT_IN_OPENWORK_EXTENSION_MANIFESTS: OpenWorkExtensionManifest[] 
       { type: "settings-panel", ref: "openwork.ollama.settings", location: "settings-detail" },
       { type: "test-action", ref: "openwork.ollama.listModels", label: "Check local models" },
       { type: "composer-prompt", prompt: "Use the Ollama extension to ", location: "composer" },
+    ],
+    enablement: [
+      { type: "provider-connected", ref: "ollama", label: "Ollama provider" },
     ],
     lifecycle: { reload: ["config"], detection: ["provider:ollama"] },
   },

--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -1,7 +1,8 @@
 /** @jsxImportSource react */
-import { CheckCircle2, Loader2, Plug2 } from "lucide-react";
+import { AlertCircle, CheckCircle2, Loader2, Plug2 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { ExtensionKind } from "../../app/constants";
+import type { EnablementResult } from "../../app/extensions";
 import { resolveExtensionIconSrc } from "./extension-icon-src";
 import { ExtensionMeshAvatar } from "./extension-mesh-avatar";
 
@@ -19,6 +20,8 @@ export type ExtensionCardProps = {
   /** Whether the extension is already installed/connected. */
   connected?: boolean;
   connectedLabel?: string;
+  /** Per-condition enablement results. When provided, overrides `connected`. */
+  enablement?: EnablementResult[];
   /** Whether a connect operation is in progress. */
   connecting?: boolean;
   /** Whether interaction is disabled. */
@@ -64,8 +67,9 @@ export function ExtensionCard(props: ExtensionCardProps) {
     iconSrc,
     fallbackIcon: FallbackIcon = Plug2,
     kind = "mcp",
-    connected = false,
+    connected: connectedProp = false,
     connectedLabel = "Connected",
+    enablement,
     connecting = false,
     disabled = false,
     hidden = false,
@@ -74,6 +78,11 @@ export function ExtensionCard(props: ExtensionCardProps) {
     actionLabel,
     onClick,
   } = props;
+
+  // When enablement results are provided, derive connected + partial state from them.
+  const allMet = enablement ? enablement.every((r) => r.met) : connectedProp;
+  const someMet = enablement ? enablement.some((r) => r.met) && !allMet : false;
+  const connected = allMet;
   const resolvedIconSrc = iconSrc ? resolveExtensionIconSrc(iconSrc) : undefined;
 
   return (
@@ -84,6 +93,8 @@ export function ExtensionCard(props: ExtensionCardProps) {
       className={`group w-full rounded-xl border p-4 text-left transition-all ${
         connected
           ? "border-green-6 bg-green-2"
+          : someMet
+          ? "border-amber-6 bg-amber-2"
           : "border-dls-border bg-dls-surface hover:bg-dls-hover"
       } ${hidden ? "border-dashed opacity-70" : ""}`}
     >
@@ -92,7 +103,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
         <div className="relative shrink-0">
           <div
             className={`flex size-10 items-center justify-center rounded-lg border ${
-              connected ? "border-green-6 bg-green-2" : "border-dls-border bg-dls-hover"
+              connected ? "border-green-6 bg-green-2" : someMet ? "border-amber-6 bg-amber-2" : "border-dls-border bg-dls-hover"
             }`}
           >
             {connecting ? (
@@ -115,6 +126,10 @@ export function ExtensionCard(props: ExtensionCardProps) {
             <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full border-2 border-dls-surface bg-green-9">
               <CheckCircle2 size={9} className="text-white" strokeWidth={3} />
             </div>
+          ) : someMet ? (
+            <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full border-2 border-dls-surface bg-amber-9">
+              <AlertCircle size={9} className="text-white" strokeWidth={3} />
+            </div>
           ) : null}
         </div>
 
@@ -125,6 +140,10 @@ export function ExtensionCard(props: ExtensionCardProps) {
             {connected ? (
               <span className="shrink-0 rounded-md bg-green-3 px-1.5 py-0.5 text-[10px] font-medium text-green-11">
                 {connectedLabel}
+              </span>
+            ) : someMet ? (
+              <span className="shrink-0 rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
+                Partially set up
               </span>
             ) : (
               <span className={`shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium ${kindStyle[kind]}`}>

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -22,7 +22,9 @@ import {
   Zap,
 } from "lucide-react";
 
-import { isBuiltInOpenWorkExtension, type McpDirectoryInfo } from "../../../../app/constants";
+import { isBuiltInOpenWorkExtension, getMcpServerName, type McpDirectoryInfo } from "../../../../app/constants";
+import { evaluateEnablement, defaultMcpEnablement } from "../../../../app/enablement";
+import type { EnablementResult } from "../../../../app/extensions";
 import type { CloudImportedPlugin } from "../../../../app/cloud/import-state";
 import { ExtensionCard } from "../../../design-system/extension-card";
 import { ExtensionDetailModal } from "../../../design-system/extension-detail-modal";
@@ -106,6 +108,8 @@ export type McpViewProps = {
   configSlotForEntry?: (entry: McpDirectoryInfo) => React.ReactNode | null;
   /** Check if an extension-kind entry is connected/active. */
   isExtensionConnected?: (entry: McpDirectoryInfo) => boolean;
+  /** Enablement context for evaluating extension active state. */
+  enablementContext?: import("../../../../app/enablement").EnablementContext;
   /** Organization policy restriction for OpenWork-provided built-in extensions. */
   builtInExtensionsDisabled?: boolean;
 };
@@ -380,6 +384,21 @@ export function McpView(props: McpViewProps) {
   const isMcpBackedExtension = (entry: McpDirectoryInfo) =>
     entry.kind === "extension" && Boolean(entry.type || entry.command?.length || entry.url);
 
+  const enablementForEntry = (entry: McpDirectoryInfo): { active: boolean; results: EnablementResult[] } | null => {
+    const manifest = entry.extensionManifest;
+    if (manifest?.enablement && props.enablementContext) {
+      return evaluateEnablement(manifest.enablement, props.enablementContext);
+    }
+    // For plain MCP entries, use default mcp-connected enablement.
+    if (entry.kind === "mcp" || entry.kind === "ui-control" || isMcpBackedExtension(entry)) {
+      const serverName = getMcpIdentityKey(entry);
+      if (props.enablementContext) {
+        return evaluateEnablement(defaultMcpEnablement(serverName), props.enablementContext);
+      }
+    }
+    return null;
+  };
+
   const launchCommandForEntry = (entry: McpDirectoryInfo) => {
     if (entry.serverName === "openwork-ui") return openworkUiMcpCommand ?? undefined;
     if (entry.serverName === "computer-use") return computerUseMcpCommand ?? entry.command;
@@ -552,15 +571,16 @@ export function McpView(props: McpViewProps) {
             ? builtInExtensionDisabledReason
             : null
         }
-        isConfigured={(entry) =>
-          props.builtInExtensionsDisabled && isBuiltInOpenWorkExtension(entry)
-            ? false
-            : isToggleOnlyExtension(entry)
-            ? isOpenWorkExtensionEnabled(entry)
-            : entry.kind === "extension" && !isMcpBackedExtension(entry)
-            ? props.isExtensionConnected?.(entry) ?? false
-            : isQuickConnectConfigured(entry)
-        }
+        isConfigured={(entry) => {
+          if (props.builtInExtensionsDisabled && isBuiltInOpenWorkExtension(entry)) return false;
+          const result = enablementForEntry(entry);
+          if (result) return result.active;
+          // Fallback for entries without enablement context.
+          if (isToggleOnlyExtension(entry)) return isOpenWorkExtensionEnabled(entry);
+          if (entry.kind === "extension" && !isMcpBackedExtension(entry)) return props.isExtensionConnected?.(entry) ?? false;
+          return isQuickConnectConfigured(entry);
+        }}
+        enablementForEntry={props.enablementContext ? enablementForEntry : undefined}
         statusForEntry={quickConnectStatus}
         onConnect={props.connectMcp}
         onDetail={setDetailEntry}
@@ -810,6 +830,7 @@ function McpQuickConnectSection(props: {
   isPluginHidden: (plugin: CloudImportedPlugin) => boolean;
   disabledReasonForEntry: (entry: McpDirectoryInfo) => string | null;
   isConfigured: (entry: McpDirectoryInfo) => boolean;
+  enablementForEntry?: (entry: McpDirectoryInfo) => { active: boolean; results: EnablementResult[] } | null;
   statusForEntry: (entry: McpDirectoryInfo) => { status: ReactMcpStatus } | undefined;
   onConnect: (entry: McpDirectoryInfo) => void;
   onDetail: (entry: McpDirectoryInfo) => void;
@@ -829,6 +850,7 @@ function McpQuickConnectSection(props: {
         {/* MCP entries */}
         {props.entries.map((entry) => {
           const configured = props.isConfigured(entry);
+          const enablement = props.enablementForEntry?.(entry);
           const connecting = props.connectingName === entry.name;
           const FallbackIcon = serviceIcon(entry.name);
           const hidden = props.isEntryHidden(entry);
@@ -844,6 +866,7 @@ function McpQuickConnectSection(props: {
               fallbackIcon={FallbackIcon}
               kind={entry.kind ?? "mcp"}
               connected={configured}
+              enablement={enablement?.results}
               connecting={connecting}
               hidden={hidden}
               preview={entry.preview}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { SUGGESTED_PLUGINS } from "../../app/constants";
+import type { EnablementContext } from "../../app/enablement";
 import { createClient } from "../../app/lib/opencode";
 import {
   createOpenworkServerClient,
@@ -43,6 +44,7 @@ import "../domains/settings/computer-use-config";
 import "../domains/settings/browser-extension-config";
 import "../domains/settings/openwork-voice-config";
 import { getExtensionConfigSlot, type ExtensionConfigContext } from "../domains/settings/extension-registry";
+import { isOpenWorkExtensionEnabled } from "../domains/settings/extension-state";
 import { PreferencesView } from "../domains/settings/pages/preferences-view";
 import { ShellCustomizationView } from "../domains/settings/pages/shell-view";
 import { GeneralSettingsView } from "../domains/settings/pages/general-view";
@@ -1634,6 +1636,37 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       : [],
   );
   const mcpConnectedAppsCount = connectionsSnapshot.mcpServers.length;
+
+  // Build enablement context from all available runtime state.
+  const enablementContext = useMemo<EnablementContext>(() => {
+    const mcpConfigured = new Set(connectionsSnapshot.mcpServers.map((s) => s.name));
+    const connectedProviders = new Set(providerConnectedIds);
+    const configuredEnvKeys = new Set(userEnvKeys);
+    const loadedPlugins = new Set<string>();
+    // imageExtensionInstalled is derived from listPlugins — add it to the set.
+    if (imageExtensionInstalled) loadedPlugins.add("openwork-image-generation");
+    // Browser plugin detection: check if any configured plugin matches the chrome-devtools name.
+    // For now, treat it as loaded if the plugin is in the MCP/plugin list — this will
+    // be refined when we add a real plugin-loaded signal from the engine.
+    const browserPluginConfigured = connectionsSnapshot.mcpServers.some(
+      (s) => s.name === "opencode-chrome-devtools" || s.config.command?.some((c: string) => c.includes("chrome-devtools")),
+    );
+    if (browserPluginConfigured) loadedPlugins.add("opencode-chrome-devtools");
+
+    return {
+      mcpStatuses: connectionsSnapshot.mcpStatuses,
+      mcpConfigured,
+      loadedPlugins,
+      connectedProviders,
+      configuredEnvKeys,
+      // Toggle state reader for extensions with defaultEnabled / explicit toggle.
+      isToggleEnabled: (ref: string) => {
+        const catalog = connectionsStore.quickConnect;
+        const match = catalog.find((e: { id?: string; serverName?: string }) => (e.id ?? e.serverName) === ref);
+        return match ? isOpenWorkExtensionEnabled(match) : false;
+      },
+    };
+  }, [connectionsSnapshot, providerConnectedIds, userEnvKeys, imageExtensionInstalled]);
   const routeOpenworkStatus = openworkClient ? "connected" : "disconnected";
   const notFoundRouteError = !loading && routeWorkspaceId && !selectedWorkspace
     ? "Workspace was not found. Select a new workspace from the sidebar."
@@ -2048,6 +2081,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 selectedMcp={connectionsSnapshot.selectedMcp}
                 setSelectedMcp={(name) => connectionsStore.setSelectedMcp(name)}
                 quickConnect={connectionsStore.quickConnect}
+                enablementContext={enablementContext}
                 builtInExtensionsDisabled={checkDesktopRestriction({ restriction: "allowBuiltInExtensions" })}
                 connectMcp={(entry) => {
                   void connectionsStore.connectMcp(entry);


### PR DESCRIPTION
## Summary

Replaces the three hard-coded paths for determining extension 'connected' state with a single declarative system. Each extension manifest now declares an `enablement` array — conditions that must all be true for the extension to show as 'active'.

## Enablement condition types

| Type | What it checks |
|------|---------------|
| `mcp-connected` | MCP server has runtime status `connected` |
| `plugin-loaded` | Plugin is loaded in the engine |
| `provider-connected` | Model provider is reachable |
| `env-set` | Environment variable/secret is configured |
| `permission-granted` | macOS permission (accessibility/screen recording) |
| `toggle-enabled` | User toggle in localStorage |

## Per-extension enablement

| Extension | Conditions |
|-----------|-----------|
| **Browser** | toggle enabled + browser plugin loaded |
| **Computer Use** | MCP connected + accessibility + screen recording |
| **Image Gen** | plugin installed + OPENAI_API_KEY set |
| **Voice** | toggle enabled + OPENAI_API_KEY set |
| **Ollama** | provider connected |
| **Plain MCPs** | default: mcp-connected |

## UI changes

- `ExtensionCard` now accepts `enablement?: EnablementResult[]`
- **Green** card + 'Connected' badge when all conditions met
- **Amber** card + 'Partially set up' badge when some but not all met
- Default card when none met
- Backward compatible: old `isExtensionConnected` callback still works as fallback

## New files

- `apps/app/src/app/enablement.ts` — evaluator + types (~80 lines)

## Verification

- `pnpm --filter @openwork/app typecheck` passes