### PR TITLE
fix(server): encode non-ASCII OpenCode directory headers

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -606,12 +606,16 @@ function buildOpencodeProxyUrl(baseUrl: string, path: string, search: string) {
   return target.toString();
 }
 
+function buildOpencodeDirectoryHeader(directory: string) {
+  return /[^\x00-\x7F]/.test(directory) ? encodeURIComponent(directory) : directory;
+}
+
 function createOpencodeDirectoryFetch(directory: string): typeof fetch {
   return Object.assign(
     (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
       const request = input instanceof Request ? input : new Request(input, init);
       const headers = new Headers(init?.headers ?? request.headers);
-      headers.set("x-opencode-directory", directory);
+      headers.set("x-opencode-directory", buildOpencodeDirectoryHeader(directory));
       return fetch(new Request(request, { headers }));
     },
     { preconnect: fetch.preconnect },
@@ -673,7 +677,7 @@ async function proxyOpencodeRequest(input: {
 
   const directory = workspace ? resolveOpencodeDirectory(workspace) : null;
   if (directory && !headers.has("x-opencode-directory")) {
-    headers.set("x-opencode-directory", directory);
+    headers.set("x-opencode-directory", buildOpencodeDirectoryHeader(directory));
   }
 
   const auth = workspace ? resolveWorkspaceOpencodeConnection(input.config, workspace).authHeader ?? null : null;

--- a/apps/server/src/session-read-model.e2e.test.ts
+++ b/apps/server/src/session-read-model.e2e.test.ts
@@ -23,11 +23,12 @@ afterEach(async () => {
   }
 });
 
-async function createWorkspaceRoot() {
+async function createWorkspaceRoot(folderName?: string) {
   const root = await mkdtemp(join(tmpdir(), "openwork-session-read-"));
-  await mkdir(join(root, ".opencode"), { recursive: true });
+  const workspaceRoot = folderName ? join(root, folderName) : root;
+  await mkdir(join(workspaceRoot, ".opencode"), { recursive: true });
   roots.push(root);
-  return root;
+  return workspaceRoot;
 }
 
 function auth(token: string) {
@@ -253,6 +254,42 @@ describe("workspace session read APIs", () => {
     expect(body.items[0]?.id).toBe("ses_1");
     expect(body.items[0]?.directory).toBe(workspaceRoot);
     expect(mock.requests.find((request) => request.pathname === "/session")?.directory).toBe(workspaceRoot);
+  });
+
+  test("encodes non-ASCII workspace directory headers for session reads", async () => {
+    const workspaceRoot = await createWorkspaceRoot("项目");
+    const mock = startMockOpencode();
+    const openwork = await startOpenworkServer({
+      workspaceRoot,
+      opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
+    });
+
+    const response = await fetch(`http://127.0.0.1:${openwork.server.port}/workspace/ws_1/sessions`, {
+      headers: auth(openwork.token),
+    });
+
+    expect(response.status).toBe(200);
+    const listRequest = mock.requests.find((request) => request.pathname === "/session");
+    const encodedDirectory = encodeURIComponent(workspaceRoot);
+    expect(listRequest?.directory).toBe(encodedDirectory);
+    expect(listRequest?.search).toContain(`directory=${encodedDirectory}`);
+  });
+
+  test("encodes non-ASCII workspace directory headers for opencode proxy requests", async () => {
+    const workspaceRoot = await createWorkspaceRoot("项目");
+    const mock = startMockOpencode();
+    const openwork = await startOpenworkServer({
+      workspaceRoot,
+      opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
+    });
+
+    const response = await fetch(`http://127.0.0.1:${openwork.server.port}/workspace/ws_1/opencode/session`, {
+      headers: auth(openwork.token),
+    });
+
+    expect(response.status).toBe(200);
+    const proxyRequest = mock.requests.find((request) => request.pathname === "/session");
+    expect(proxyRequest?.directory).toBe(encodeURIComponent(workspaceRoot));
   });
 
   test("returns 404 when the upstream session is missing", async () => {


### PR DESCRIPTION
## Summary
- Encode non-ASCII workspace directory values before setting `x-opencode-directory` from the OpenWork server.
- Cover both server-side OpenCode SDK requests and `/opencode/*` proxy requests with Chinese-character workspace path regression tests.

## Tests
- `bun -e 'const h=new Headers(); h.set("x-opencode-directory", "/tmp/项目"); console.log(h.get("x-opencode-directory"));'` reproduced Bun rejecting raw Chinese header values.
- `pnpm --filter openwork-server test src/session-read-model.e2e.test.ts` passed: 8 pass, 0 fail.
- `pnpm --filter openwork-server typecheck` passed.
- `pnpm --filter openwork-server test` currently fails outside this change in `opencode-db.test.ts` (`better-sqlite3` unsupported in Bun), `workspace-import-preview.test.ts` summary count expectations, and `serve-node.test.ts` stream error logging.

## Evidence
- No video/screenshot captured because this is a server-side header encoding regression; the e2e test exercises the reported Chinese-character path flow through the server.