### PR TITLE
refactor(app): register built-in extension runtimes

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -35,6 +35,8 @@ export type McpDirectoryInfo = {
   url?: string;
   type?: "remote" | "local";
   command?: string[];
+  /** OpenWork desktop command resolver for local MCP launch details. */
+  localCommandRef?: string;
   oauth: boolean;
   /** Extension category for UI grouping. Defaults to "mcp". */
   kind?: ExtensionKind;
@@ -63,6 +65,7 @@ function extensionManifestToDirectoryInfo(manifest: OpenWorkExtensionManifest): 
     description: manifest.description,
     type: mcpResource?.command ? "local" : undefined,
     command: mcpResource?.command,
+    localCommandRef: mcpResource?.localCommandRef,
     oauth: false,
     kind: "extension",
     iconSlug: manifest.icon?.simpleIconSlug,
@@ -73,6 +76,10 @@ function extensionManifestToDirectoryInfo(manifest: OpenWorkExtensionManifest): 
     preview: manifest.preview,
     extensionManifest: manifest,
   };
+}
+
+export function getLocalMcpCommandRef(entry: Pick<McpDirectoryInfo, "extensionManifest" | "localCommandRef">): string | undefined {
+  return extensionResource(entry.extensionManifest, "mcp")?.localCommandRef ?? entry.localCommandRef;
 }
 
 export function isBuiltInOpenWorkExtension(entry: Pick<McpDirectoryInfo, "kind" | "extensionManifest">): boolean {
@@ -168,6 +175,7 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     type: "local",
     // Dev builds replace this with the local checkout path before writing config.
     command: ["npx", "-y", "openwork-ui-mcp"],
+    localCommandRef: "openwork.uiMcp",
     oauth: false,
     kind: "ui-control",
     iconSrc: "/openwork-mark.svg",

--- a/apps/app/src/app/extensions.ts
+++ b/apps/app/src/app/extensions.ts
@@ -78,6 +78,13 @@ export type OpenWorkExtensionLifecycle = {
   detection?: string[];
 };
 
+export type OpenWorkExtensionDetail = {
+  setup?: boolean;
+  resources?: boolean;
+  contributions?: boolean;
+  enablement?: boolean;
+};
+
 // ---------------------------------------------------------------------------
 // Enablement — declarative conditions for extension "active" state
 // ---------------------------------------------------------------------------
@@ -122,6 +129,7 @@ export type OpenWorkExtensionManifest = {
   resources: OpenWorkExtensionResource[];
   contributions?: OpenWorkExtensionContribution[];
   lifecycle?: OpenWorkExtensionLifecycle;
+  detail?: OpenWorkExtensionDetail;
   /** Declarative conditions that must ALL be true for the extension to be "active". */
   enablement?: EnablementCondition[];
   defaultEnabled?: boolean;
@@ -322,6 +330,7 @@ export const BUILT_IN_OPENWORK_EXTENSION_MANIFESTS: OpenWorkExtensionManifest[] 
       { type: "composer-prompt", prompt: "Use Google Workspace to ", location: "composer" },
     ],
     lifecycle: { reload: ["config"], detection: ["provider:google-workspace"] },
+    detail: { setup: false, resources: false, contributions: false, enablement: false },
     defaultHidden: true,
   },
   {

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -25,6 +25,7 @@ import type { DenOrgSkillCard, ReloadReason } from "../types";
 import type {
   OpenWorkExtensionContribution,
   OpenWorkExtensionContributionType,
+  OpenWorkExtensionDetail,
   OpenWorkExtensionLifecycle,
   OpenWorkExtensionManifest,
   OpenWorkExtensionResource,
@@ -1173,6 +1174,16 @@ function parseExtensionLifecycle(value: unknown): OpenWorkExtensionLifecycle | u
   };
 }
 
+function parseExtensionDetail(value: unknown): OpenWorkExtensionDetail | undefined {
+  if (!isRecord(value)) return undefined;
+  const detail: OpenWorkExtensionDetail = {};
+  if (typeof value.setup === "boolean") detail.setup = value.setup;
+  if (typeof value.resources === "boolean") detail.resources = value.resources;
+  if (typeof value.contributions === "boolean") detail.contributions = value.contributions;
+  if (typeof value.enablement === "boolean") detail.enablement = value.enablement;
+  return Object.keys(detail).length ? detail : undefined;
+}
+
 function parseExtensionPlatform(value: unknown): OpenWorkExtensionManifest["platform"] | undefined {
   if (!Array.isArray(value)) return undefined;
   const platforms = value.flatMap((item) => {
@@ -1216,6 +1227,7 @@ function parseOpenWorkExtensionManifest(value: unknown): OpenWorkExtensionManife
   if (Array.isArray(value.contributions) && contributions?.length !== value.contributions.length) return null;
   const setup = parseExtensionSetup(value.setup);
   const lifecycle = parseExtensionLifecycle(value.lifecycle);
+  const detail = parseExtensionDetail(value.detail);
   const platform = parseExtensionPlatform(value.platform);
   if (Array.isArray(value.platform) && !platform) return null;
   return {
@@ -1235,6 +1247,7 @@ function parseOpenWorkExtensionManifest(value: unknown): OpenWorkExtensionManife
     resources,
     ...(contributions ? { contributions } : {}),
     ...(lifecycle ? { lifecycle } : {}),
+    ...(detail ? { detail } : {}),
     ...(typeof value.defaultEnabled === "boolean" ? { defaultEnabled: value.defaultEnabled } : {}),
     ...(typeof value.defaultHidden === "boolean" ? { defaultHidden: value.defaultHidden } : {}),
     ...(platform ? { platform } : {}),

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -4,11 +4,11 @@ import { applyEdits, modify, parse, printParseErrorCode } from "jsonc-parser";
 
 import { t } from "../../../i18n";
 import {
+  getLocalMcpCommandRef,
   getMcpServerName,
   MCP_QUICK_CONNECT,
   type McpDirectoryInfo,
 } from "../../../app/constants";
-import { extensionResource } from "../../../app/extensions";
 import { createClient, unwrap } from "../../../app/lib/opencode";
 import { finishPerf, perfNow, recordPerfLog } from "../../../app/lib/perf-log";
 import {
@@ -306,12 +306,8 @@ export function createConnectionsStore(options: {
   };
 
   const resolveLocalMcpCommand = async (entry: McpDirectoryInfo) => {
-    const mcpResource = extensionResource(entry.extensionManifest, "mcp");
-    const commandResolver = mcpResource?.localCommandRef
-      ? DESKTOP_MCP_COMMANDS[mcpResource.localCommandRef]
-      : entry.kind === "ui-control"
-      ? DESKTOP_MCP_COMMANDS["openwork.uiMcp"]
-      : undefined;
+    const localCommandRef = getLocalMcpCommandRef(entry);
+    const commandResolver = localCommandRef ? DESKTOP_MCP_COMMANDS[localCommandRef] : undefined;
     if (commandResolver) {
       const command = await resolveDesktopCommand(commandResolver.command, commandResolver.fallbackOnError);
       return command ?? entry.command;
@@ -320,12 +316,8 @@ export function createConnectionsStore(options: {
   };
 
   const resolveLocalMcpEnvironment = async (entry: McpDirectoryInfo) => {
-    const mcpResource = extensionResource(entry.extensionManifest, "mcp");
-    const environmentCommand = mcpResource?.localCommandRef
-      ? DESKTOP_MCP_ENVIRONMENT_COMMANDS[mcpResource.localCommandRef]
-      : entry.kind === "ui-control"
-      ? DESKTOP_MCP_ENVIRONMENT_COMMANDS["openwork.uiMcp"]
-      : undefined;
+    const localCommandRef = getLocalMcpCommandRef(entry);
+    const environmentCommand = localCommandRef ? DESKTOP_MCP_ENVIRONMENT_COMMANDS[localCommandRef] : undefined;
     if (!environmentCommand) return undefined;
     try {
       const environment = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.(environmentCommand);

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -36,6 +36,21 @@ import type { OpenworkServerStore } from "./openwork-server-store";
 
 type SetStateAction<T> = T | ((current: T) => T);
 
+const DESKTOP_MCP_COMMANDS: Record<string, { command: string; fallbackOnError: boolean }> = {
+  "openwork.computerUseMcp": { command: "getComputerUseMcpCommand", fallbackOnError: false },
+  "openwork.uiMcp": { command: "getOpenworkUiMcpCommand", fallbackOnError: true },
+};
+
+const DESKTOP_MCP_ENVIRONMENT_COMMANDS: Record<string, string> = {
+  "openwork.uiMcp": "getOpenworkUiMcpEnvironment",
+};
+
+function isUiControlBridgeInfo(value: unknown): value is { baseUrl: string; token?: string } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  if (!("baseUrl" in value) || typeof value.baseUrl !== "string") return false;
+  return !("token" in value) || typeof value.token === "string";
+}
+
 export type ConnectionsStoreSnapshot = {
   mcpServers: McpServerEntry[];
   mcpStatus: string | null;
@@ -292,21 +307,28 @@ export function createConnectionsStore(options: {
 
   const resolveLocalMcpCommand = async (entry: McpDirectoryInfo) => {
     const mcpResource = extensionResource(entry.extensionManifest, "mcp");
-    if (mcpResource?.localCommandRef === "openwork.computerUseMcp") {
-      const command = await resolveDesktopCommand("getComputerUseMcpCommand", false);
-      return command ?? entry.command;
-    }
-    if (mcpResource?.localCommandRef === "openwork.uiMcp" || entry.serverName === "openwork-ui") {
-      const command = await resolveDesktopCommand("getOpenworkUiMcpCommand");
+    const commandResolver = mcpResource?.localCommandRef
+      ? DESKTOP_MCP_COMMANDS[mcpResource.localCommandRef]
+      : entry.kind === "ui-control"
+      ? DESKTOP_MCP_COMMANDS["openwork.uiMcp"]
+      : undefined;
+    if (commandResolver) {
+      const command = await resolveDesktopCommand(commandResolver.command, commandResolver.fallbackOnError);
       return command ?? entry.command;
     }
     return entry.command;
   };
 
   const resolveLocalMcpEnvironment = async (entry: McpDirectoryInfo) => {
-    if (entry.serverName !== "openwork-ui") return undefined;
+    const mcpResource = extensionResource(entry.extensionManifest, "mcp");
+    const environmentCommand = mcpResource?.localCommandRef
+      ? DESKTOP_MCP_ENVIRONMENT_COMMANDS[mcpResource.localCommandRef]
+      : entry.kind === "ui-control"
+      ? DESKTOP_MCP_ENVIRONMENT_COMMANDS["openwork.uiMcp"]
+      : undefined;
+    if (!environmentCommand) return undefined;
     try {
-      const environment = await (window as any).__OPENWORK_ELECTRON__?.invokeDesktop?.("getOpenworkUiMcpEnvironment");
+      const environment = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.(environmentCommand);
       if (environment && typeof environment === "object" && !Array.isArray(environment)) {
         return Object.fromEntries(
           Object.entries(environment).filter((entry): entry is [string, string] =>
@@ -315,7 +337,7 @@ export function createConnectionsStore(options: {
         );
       }
     } catch {
-      // Discovery fallback in openwork-ui-mcp still handles normal launches.
+      // Discovery fallback in the MCP package still handles normal launches.
     }
     return undefined;
   };
@@ -521,13 +543,13 @@ export function createConnectionsStore(options: {
     try {
       mutateState((current) => ({ ...current, mcpStatus: null, mcpConnectingName: entry.name }));
 
-      // Resolve dynamic URLs for built-in MCPs
+      // Resolve dynamic URLs for built-in UI-control MCPs.
       let resolvedUrl = entry.url;
       let resolvedHeaders: Record<string, string> | undefined;
-      if (!resolvedUrl && entry.serverName === "openwork-ui") {
+      if (!resolvedUrl && entry.kind === "ui-control") {
         try {
-          const bridgeInfo = await (window as any).__OPENWORK_ELECTRON__?.invokeDesktop?.("getUiControlBridgeInfo");
-          if (bridgeInfo?.baseUrl) {
+          const bridgeInfo = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("getUiControlBridgeInfo");
+          if (isUiControlBridgeInfo(bridgeInfo)) {
             resolvedUrl = `${bridgeInfo.baseUrl}/mcp`;
             if (bridgeInfo.token) {
               resolvedHeaders = { Authorization: `Bearer ${bridgeInfo.token}` };

--- a/apps/app/src/react-app/domains/settings/browser-extension-config.tsx
+++ b/apps/app/src/react-app/domains/settings/browser-extension-config.tsx
@@ -2,12 +2,15 @@
 import { MonitorSmartphone } from "lucide-react";
 
 import { surfaceCardClass } from "../workspace/modal-styles";
-import { registerExtensionConfig } from "./extension-registry";
+import { registerExtensionRuntime } from "./extension-registry";
 
 const openWorkBrowserConfigFactory = () => <OpenWorkBrowserConfig />;
 
-registerExtensionConfig("openwork.browser.settings", openWorkBrowserConfigFactory);
-registerExtensionConfig("openwork-browser", openWorkBrowserConfigFactory);
+registerExtensionRuntime({
+  id: "openwork-browser",
+  settingsPanelRefs: ["openwork.browser.settings"],
+  settingsPanel: openWorkBrowserConfigFactory,
+});
 
 function OpenWorkBrowserConfig() {
   return (

--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -14,7 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { registerExtensionConfig } from "./extension-registry";
+import { registerExtensionRuntime } from "./extension-registry";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,14 +38,18 @@ type ComputerUseConfigProps = {
 // Registration
 // ---------------------------------------------------------------------------
 
-registerExtensionConfig("computer-use", (ctx) => (
-  <ComputerUseConfig
-    connected={ctx.computerUse?.connected ?? false}
-    connecting={ctx.computerUse?.connecting ?? false}
-    onConnect={ctx.computerUse?.onConnect}
-    onRefresh={ctx.computerUse?.onRefresh}
-  />
-));
+registerExtensionRuntime({
+  id: "computer-use",
+  settingsPanel: (ctx) => (
+    <ComputerUseConfig
+      connected={ctx.computerUse?.connected ?? false}
+      connecting={ctx.computerUse?.connecting ?? false}
+      onConnect={ctx.computerUse?.onConnect}
+      onRefresh={ctx.computerUse?.onRefresh}
+    />
+  ),
+  isConnected: (_entry, ctx) => ctx.computerUse?.connected === true,
+});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/apps/app/src/react-app/domains/settings/extension-registry.tsx
+++ b/apps/app/src/react-app/domains/settings/extension-registry.tsx
@@ -53,7 +53,7 @@ export type ExtensionConfigFactory = (ctx: ExtensionConfigContext) => ReactNode;
 
 export type ExtensionRuntimeContext = Pick<
   ExtensionConfigContext,
-  "openworkServerClient" | "extensionConnections" | "onExtensionConnectionChange"
+  "openworkServerClient" | "extensionConnections" | "onExtensionConnectionChange" | "computerUse"
 >;
 
 export type OpenWorkExtensionRuntime = {

--- a/apps/app/src/react-app/domains/settings/ollama-config.tsx
+++ b/apps/app/src/react-app/domains/settings/ollama-config.tsx
@@ -46,7 +46,7 @@ import { formatFileSize } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { OLLAMA_PROVIDER_CONFIG } from "./openai-image-extension";
-import { registerExtensionConfig, type ExtensionConfigContext } from "./extension-registry";
+import { registerExtensionRuntime, type ExtensionConfigContext } from "./extension-registry";
 
 const ollamaConfigFactory = (ctx: ExtensionConfigContext) => (
   <OllamaConfig
@@ -57,8 +57,12 @@ const ollamaConfigFactory = (ctx: ExtensionConfigContext) => (
   />
 );
 
-registerExtensionConfig("openwork.ollama.settings", ollamaConfigFactory);
-registerExtensionConfig("ollama", ollamaConfigFactory);
+registerExtensionRuntime({
+  id: "ollama",
+  settingsPanelRefs: ["openwork.ollama.settings"],
+  settingsPanel: ollamaConfigFactory,
+  isConnected: (_entry, ctx) => ctx.extensionConnections?.ollama === true,
+});
 
 type OllamaModel = {
   name: string;

--- a/apps/app/src/react-app/domains/settings/openai-image-gen-config.tsx
+++ b/apps/app/src/react-app/domains/settings/openai-image-gen-config.tsx
@@ -19,7 +19,7 @@ import {
   FieldLabel,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { registerExtensionConfig, type ExtensionConfigContext } from "./extension-registry";
+import { registerExtensionRuntime, type ExtensionConfigContext } from "./extension-registry";
 
 export type OpenAiImageGenConfigProps = {
   busy: boolean;
@@ -41,8 +41,12 @@ const openAiImageGenConfigFactory = (ctx: ExtensionConfigContext) => (
   />
 );
 
-registerExtensionConfig("openwork.imageGen.settings", openAiImageGenConfigFactory);
-registerExtensionConfig("openai-image-gen", openAiImageGenConfigFactory);
+registerExtensionRuntime({
+  id: "openai-image-gen",
+  settingsPanelRefs: ["openwork.imageGen.settings"],
+  settingsPanel: openAiImageGenConfigFactory,
+  isConnected: (_entry, ctx) => ctx.extensionConnections?.["openai-image-gen"] === true,
+});
 
 const DEFAULT_PROMPT =
   "A friendly robot owl holding a paintbrush, teal neon UI frame, high contrast";

--- a/apps/app/src/react-app/domains/settings/openwork-voice-config.tsx
+++ b/apps/app/src/react-app/domains/settings/openwork-voice-config.tsx
@@ -19,7 +19,7 @@ import {
   FieldLabel,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { registerExtensionConfig, type ExtensionConfigContext } from "./extension-registry";
+import { registerExtensionRuntime, type ExtensionConfigContext } from "./extension-registry";
 
 export type OpenWorkVoiceConfigProps = {
   busy: boolean;
@@ -41,8 +41,11 @@ const openWorkVoiceConfigFactory = (ctx: ExtensionConfigContext) => (
   />
 );
 
-registerExtensionConfig("openwork.voice.settings", openWorkVoiceConfigFactory);
-registerExtensionConfig("openwork-voice", openWorkVoiceConfigFactory);
+registerExtensionRuntime({
+  id: "openwork-voice",
+  settingsPanelRefs: ["openwork.voice.settings"],
+  settingsPanel: openWorkVoiceConfigFactory,
+});
 
 export function OpenWorkVoiceConfig(props: OpenWorkVoiceConfigProps) {
   const [apiKey, setApiKey] = useState("");

--- a/apps/app/src/react-app/domains/settings/pages/extensions-catalog-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-catalog-view.tsx
@@ -22,7 +22,7 @@ import {
   Zap,
 } from "lucide-react";
 
-import { isBuiltInOpenWorkExtension, getMcpServerName, type McpDirectoryInfo } from "../../../../app/constants";
+import { isBuiltInOpenWorkExtension, getLocalMcpCommandRef, getMcpServerName, type McpDirectoryInfo } from "../../../../app/constants";
 import { evaluateEnablement, defaultMcpEnablement } from "../../../../app/enablement";
 import type { EnablementResult } from "../../../../app/extensions";
 import type { CloudImportedPlugin } from "../../../../app/cloud/import-state";
@@ -115,6 +115,11 @@ export type ExtensionsCatalogViewProps = {
 };
 
 const builtInExtensionDisabledReason = "Disabled by organization";
+
+const DESKTOP_MCP_DETAIL_COMMANDS: Record<string, { command?: string; environment?: string }> = {
+  "openwork.computerUseMcp": { command: "getComputerUseMcpCommand" },
+  "openwork.uiMcp": { command: "getOpenworkUiMcpCommand", environment: "getOpenworkUiMcpEnvironment" },
+};
 
 const statusDot = (status: ReactMcpStatus) => {
   switch (status) {
@@ -294,21 +299,26 @@ export function ExtensionsCatalogView(props: ExtensionsCatalogViewProps) {
       try {
         const commandOverrides: Record<string, string[] | undefined> = {};
         const environmentOverrides: Record<string, Record<string, string> | undefined> = {};
-        const command = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("getOpenworkUiMcpCommand");
-        if (Array.isArray(command) && command.every((part) => typeof part === "string")) {
-          commandOverrides["openwork-ui"] = command;
-        }
-        const environment = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("getOpenworkUiMcpEnvironment");
-        if (environment && typeof environment === "object" && !Array.isArray(environment)) {
-          environmentOverrides["openwork-ui"] = Object.fromEntries(
-            Object.entries(environment).filter((entry): entry is [string, string] =>
-              typeof entry[0] === "string" && typeof entry[1] === "string"
-            ),
-          );
-        }
-        const computerUseCommand = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("getComputerUseMcpCommand");
-        if (Array.isArray(computerUseCommand) && computerUseCommand.every((part) => typeof part === "string")) {
-          commandOverrides["computer-use"] = computerUseCommand;
+        for (const entry of quickConnectList) {
+          const localCommandRef = getLocalMcpCommandRef(entry);
+          const detailCommands = localCommandRef ? DESKTOP_MCP_DETAIL_COMMANDS[localCommandRef] : undefined;
+          const identityKey = getMcpIdentityKey(entry);
+          if (detailCommands?.command) {
+            const command = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.(detailCommands.command);
+            if (Array.isArray(command) && command.every((part) => typeof part === "string")) {
+              commandOverrides[identityKey] = command;
+            }
+          }
+          if (detailCommands?.environment) {
+            const environment = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.(detailCommands.environment);
+            if (environment && typeof environment === "object" && !Array.isArray(environment)) {
+              environmentOverrides[identityKey] = Object.fromEntries(
+                Object.entries(environment).filter((entry): entry is [string, string] =>
+                  typeof entry[0] === "string" && typeof entry[1] === "string"
+                ),
+              );
+            }
+          }
         }
         setMcpCommandOverrides(commandOverrides);
         setMcpEnvironmentOverrides(environmentOverrides);
@@ -406,13 +416,12 @@ export function ExtensionsCatalogView(props: ExtensionsCatalogViewProps) {
   };
 
   const launchCommandForEntry = (entry: McpDirectoryInfo) => {
-    if (entry.serverName) return mcpCommandOverrides[entry.serverName] ?? entry.command;
-    return entry.command;
+    const identityKey = getMcpIdentityKey(entry);
+    return mcpCommandOverrides[identityKey] ?? entry.command;
   };
 
   const environmentForEntry = (entry: McpDirectoryInfo) => {
-    if (!entry.serverName) return undefined;
-    return mcpEnvironmentOverrides[entry.serverName];
+    return mcpEnvironmentOverrides[getMcpIdentityKey(entry)];
   };
 
   const supportsOauth = (entry: McpServerEntry) =>

--- a/apps/app/src/react-app/domains/settings/pages/extensions-catalog-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-catalog-view.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useReducer, useRef, useState, type SetStateAction } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import {
   BookOpen,
   CheckCircle2,
@@ -52,11 +52,11 @@ import {
   setOpenWorkExtensionHidden,
 } from "../extension-state";
 import {
-  initialMcpViewLocalState,
-  mcpViewLocalReducer,
+  initialExtensionsViewLocalState,
+  extensionsViewLocalReducer,
   type ConfigScope,
-  type McpViewLocalState,
-} from "./mcp-view-state";
+  type ExtensionsViewLocalState,
+} from "./extensions-view-state";
 
 export type ReactMcpStatus =
   | "connected"
@@ -75,7 +75,7 @@ export type SkillItem = {
 
 const getSkillHiddenId = (skill: SkillItem) => `skill:${skill.name}`;
 
-export type McpViewProps = {
+export type ExtensionsCatalogViewProps = {
   busy: boolean;
   selectedWorkspaceRoot: string;
   isRemoteWorkspace: boolean;
@@ -227,23 +227,22 @@ function isToggleOnlyExtension(entry: McpDirectoryInfo) {
 
 type ExtensionFilter = "all" | "mcp" | "skill" | "plugin";
 
-export function McpView(props: McpViewProps) {
+export function ExtensionsCatalogView(props: ExtensionsCatalogViewProps) {
   const showHeader = props.showHeader !== false;
   const [detailEntry, setDetailEntry] = useState<McpDirectoryInfo | null>(null);
   const [detailSkill, setDetailSkill] = useState<SkillItem | null>(null);
   const [detailSkillContent, setDetailSkillContent] = useState<string | null>(null);
   const [detailPlugin, setDetailPlugin] = useState<CloudImportedPlugin | null>(null);
-  const [openworkUiMcpCommand, setOpenworkUiMcpCommand] = useState<string[] | null>(null);
-  const [openworkUiMcpEnvironment, setOpenworkUiMcpEnvironment] = useState<Record<string, string> | null>(null);
-  const [computerUseMcpCommand, setComputerUseMcpCommand] = useState<string[] | null>(null);
+  const [mcpCommandOverrides, setMcpCommandOverrides] = useState<Record<string, string[] | undefined>>({});
+  const [mcpEnvironmentOverrides, setMcpEnvironmentOverrides] = useState<Record<string, Record<string, string> | undefined>>({});
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<ExtensionFilter>("all");
   const [showHidden, setShowHidden] = useState(false);
   const [, setExtensionStateVersion] = useState(0);
 
   const [localState, dispatchLocal] = useReducer(
-    mcpViewLocalReducer,
-    initialMcpViewLocalState,
+    extensionsViewLocalReducer,
+    initialExtensionsViewLocalState,
   );
   const {
     logoutOpen,
@@ -260,21 +259,21 @@ export function McpView(props: McpViewProps) {
     addMcpModalOpen,
     togglingMcp,
   } = localState;
-  const setLocal = <K extends keyof McpViewLocalState>(
+  const setLocal = <K extends keyof ExtensionsViewLocalState>(
     key: K,
-    value: SetStateAction<McpViewLocalState[K]>,
+    value: ExtensionsViewLocalState[K],
   ) => dispatchLocal({ type: "set", key, value });
-  const setLogoutOpen = (value: SetStateAction<boolean>) => setLocal("logoutOpen", value);
-  const setLogoutTarget = (value: SetStateAction<string | null>) => setLocal("logoutTarget", value);
-  const setLogoutBusy = (value: SetStateAction<boolean>) => setLocal("logoutBusy", value);
-  const setRemoveOpen = (value: SetStateAction<boolean>) => setLocal("removeOpen", value);
-  const setRemoveTarget = (value: SetStateAction<string | null>) => setLocal("removeTarget", value);
-  const setConfigScope = (value: SetStateAction<ConfigScope>) => setLocal("configScope", value);
-  const setConfigError = (value: SetStateAction<string | null>) => setLocal("configError", value);
-  const setRevealBusy = (value: SetStateAction<boolean>) => setLocal("revealBusy", value);
-  const setShowAdvanced = (value: SetStateAction<boolean>) => setLocal("showAdvanced", value);
-  const setAddMcpModalOpen = (value: SetStateAction<boolean>) => setLocal("addMcpModalOpen", value);
-  const setTogglingMcp = (value: SetStateAction<string | null>) => setLocal("togglingMcp", value);
+  const setLogoutOpen = (value: boolean) => setLocal("logoutOpen", value);
+  const setLogoutTarget = (value: string | null) => setLocal("logoutTarget", value);
+  const setLogoutBusy = (value: boolean) => setLocal("logoutBusy", value);
+  const setRemoveOpen = (value: boolean) => setLocal("removeOpen", value);
+  const setRemoveTarget = (value: string | null) => setLocal("removeTarget", value);
+  const setConfigScope = (value: ConfigScope) => setLocal("configScope", value);
+  const setConfigError = (value: string | null) => setLocal("configError", value);
+  const setRevealBusy = (value: boolean) => setLocal("revealBusy", value);
+  const setShowAdvanced = (value: boolean) => setLocal("showAdvanced", value);
+  const setAddMcpModalOpen = (value: boolean) => setLocal("addMcpModalOpen", value);
+  const setTogglingMcp = (value: string | null) => setLocal("togglingMcp", value);
   const configRequestId = useRef(0);
 
   const quickConnectList = props.quickConnect;
@@ -293,26 +292,29 @@ export function McpView(props: McpViewProps) {
     if (!isDesktopRuntime()) return;
     void (async () => {
       try {
+        const commandOverrides: Record<string, string[] | undefined> = {};
+        const environmentOverrides: Record<string, Record<string, string> | undefined> = {};
         const command = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("getOpenworkUiMcpCommand");
         if (Array.isArray(command) && command.every((part) => typeof part === "string")) {
-          setOpenworkUiMcpCommand(command);
+          commandOverrides["openwork-ui"] = command;
         }
         const environment = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("getOpenworkUiMcpEnvironment");
         if (environment && typeof environment === "object" && !Array.isArray(environment)) {
-          setOpenworkUiMcpEnvironment(Object.fromEntries(
+          environmentOverrides["openwork-ui"] = Object.fromEntries(
             Object.entries(environment).filter((entry): entry is [string, string] =>
               typeof entry[0] === "string" && typeof entry[1] === "string"
             ),
-          ));
+          );
         }
         const computerUseCommand = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("getComputerUseMcpCommand");
         if (Array.isArray(computerUseCommand) && computerUseCommand.every((part) => typeof part === "string")) {
-          setComputerUseMcpCommand(computerUseCommand);
+          commandOverrides["computer-use"] = computerUseCommand;
         }
+        setMcpCommandOverrides(commandOverrides);
+        setMcpEnvironmentOverrides(environmentOverrides);
       } catch {
-        setOpenworkUiMcpCommand(null);
-        setOpenworkUiMcpEnvironment(null);
-        setComputerUseMcpCommand(null);
+        setMcpCommandOverrides({});
+        setMcpEnvironmentOverrides({});
       }
     })();
   }, []);
@@ -404,9 +406,13 @@ export function McpView(props: McpViewProps) {
   };
 
   const launchCommandForEntry = (entry: McpDirectoryInfo) => {
-    if (entry.serverName === "openwork-ui") return openworkUiMcpCommand ?? undefined;
-    if (entry.serverName === "computer-use") return computerUseMcpCommand ?? entry.command;
+    if (entry.serverName) return mcpCommandOverrides[entry.serverName] ?? entry.command;
     return entry.command;
+  };
+
+  const environmentForEntry = (entry: McpDirectoryInfo) => {
+    if (!entry.serverName) return undefined;
+    return mcpEnvironmentOverrides[entry.serverName];
   };
 
   const supportsOauth = (entry: McpServerEntry) =>
@@ -484,7 +490,7 @@ export function McpView(props: McpViewProps) {
   return (
     <section className="space-y-8 max-w-3xl w-full animate-in fade-in duration-300">
       {showHeader ? (
-        <McpViewHeader connectedCount={connectedCount} />
+        <ExtensionsCatalogHeader connectedCount={connectedCount} />
       ) : null}
 
       {props.mcpStatus ? (
@@ -668,7 +674,7 @@ export function McpView(props: McpViewProps) {
         revealBusy={revealBusy}
         revealLabel={revealLabel}
         configError={configError}
-        onToggle={() => setShowAdvanced((current) => !current)}
+        onToggle={() => setShowAdvanced(!showAdvanced)}
         onScopeChange={setConfigScope}
         onReveal={revealConfig}
       />
@@ -714,7 +720,7 @@ export function McpView(props: McpViewProps) {
             resourceLabels={shouldShowExtensionDetail(detailEntry, "resources") ? extensionResourceLabels(detailEntry) : []}
             contributionLabels={shouldShowExtensionDetail(detailEntry, "contributions") ? extensionContributionLabels(detailEntry) : []}
             launchCommand={launchCommandForEntry(detailEntry)}
-            environment={detailEntry.serverName === "openwork-ui" ? openworkUiMcpEnvironment ?? undefined : undefined}
+            environment={environmentForEntry(detailEntry)}
             url={typeof detailEntry.url === "string" ? detailEntry.url : undefined}
             oauth={detailEntry.oauth}
             configSlot={disabledReason ? null : extensionConfigSlot}
@@ -790,7 +796,7 @@ export function McpView(props: McpViewProps) {
   );
 }
 
-function McpViewHeader(props: { connectedCount: number }) {
+function ExtensionsCatalogHeader(props: { connectedCount: number }) {
   return (
     <div>
       <h2 className="text-3xl font-semibold text-dls-text">{t("mcp.apps_title")}</h2>
@@ -946,7 +952,7 @@ function McpConfiguredServersSection(props: {
   onRequestLogout: (name: string) => void;
   onRemove: (name: string) => void;
   onToggleEnabled?: (name: string, enabled: boolean) => Promise<void> | void;
-  onToggleBusy: (value: SetStateAction<string | null>) => void;
+  onToggleBusy: (value: string | null) => void;
 }) {
   return (
     <div className="space-y-4">
@@ -1017,7 +1023,7 @@ function McpConfiguredServerRow(props: {
   onRequestLogout: (name: string) => void;
   onRemove: (name: string) => void;
   onToggleEnabled?: (name: string, enabled: boolean) => Promise<void> | void;
-  onToggleBusy: (value: SetStateAction<string | null>) => void;
+  onToggleBusy: (value: string | null) => void;
 }) {
   const Icon = serviceIcon(props.entry.name);
   return (
@@ -1227,4 +1233,4 @@ function McpConfigScopeButton(props: {
   );
 }
 
-export default McpView;
+export default ExtensionsCatalogView;

--- a/apps/app/src/react-app/domains/settings/pages/extensions-view-state.ts
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-view-state.ts
@@ -1,10 +1,8 @@
-import type { SetStateAction } from "react";
-
 import type { OpencodeConfigFile } from "../../../../app/lib/desktop";
 
 export type ConfigScope = "project" | "global";
 
-export type McpViewLocalState = {
+export type ExtensionsViewLocalState = {
   logoutOpen: boolean;
   logoutTarget: string | null;
   logoutBusy: boolean;
@@ -20,13 +18,13 @@ export type McpViewLocalState = {
   togglingMcp: string | null;
 };
 
-type McpViewLocalAction<K extends keyof McpViewLocalState = keyof McpViewLocalState> =
-  | { type: "set"; key: K; value: SetStateAction<any> }
+type ExtensionsViewLocalAction<K extends keyof ExtensionsViewLocalState = keyof ExtensionsViewLocalState> =
+  | { type: "set"; key: K; value: ExtensionsViewLocalState[K] }
   | { type: "configUnavailable" }
   | { type: "configLoaded"; project: OpencodeConfigFile | null; global: OpencodeConfigFile | null }
   | { type: "configLoadError"; error: string };
 
-export const initialMcpViewLocalState: McpViewLocalState = {
+export const initialExtensionsViewLocalState: ExtensionsViewLocalState = {
   logoutOpen: false,
   logoutTarget: null,
   logoutBusy: false,
@@ -42,17 +40,14 @@ export const initialMcpViewLocalState: McpViewLocalState = {
   togglingMcp: null,
 };
 
-export function mcpViewLocalReducer(
-  state: McpViewLocalState,
-  action: McpViewLocalAction,
-): McpViewLocalState {
+export function extensionsViewLocalReducer(
+  state: ExtensionsViewLocalState,
+  action: ExtensionsViewLocalAction,
+): ExtensionsViewLocalState {
   switch (action.type) {
     case "set": {
       const current = state[action.key];
-      const next =
-        typeof action.value === "function"
-          ? (action.value as (value: typeof current) => typeof current)(current)
-          : action.value;
+      const next = action.value;
       if (Object.is(current, next)) return state;
       return { ...state, [action.key]: next };
     }

--- a/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
@@ -35,9 +35,9 @@ export type ExtensionsViewProps = {
   accessHint?: string | null;
   suggestedPlugins: SuggestedPlugin[];
   extensions: PluginsExtensionsStore;
-  mcpConnectedAppsCount: number;
-  /** The MCP view (quick-connect grid + configured servers). Skills are injected into it. */
-  mcpView: ReactNode;
+  connectedExtensionCount: number;
+  /** Runtime extension catalog: MCPs, skills, and marketplace imports in one view. */
+  catalogView: ReactNode;
   /** Organization marketplace content, rendered in the same Extensions pane. */
   cloudMarketplaceView?: ReactNode;
   onRefresh: () => void;
@@ -57,11 +57,11 @@ export function ExtensionsView(props: ExtensionsViewProps) {
     <section className="space-y-6 max-w-3xl w-full animate-in fade-in duration-300">
       <div className="flex items-center justify-between">
         <div className="flex flex-wrap items-center gap-2">
-          {props.mcpConnectedAppsCount > 0 ? (
+          {props.connectedExtensionCount > 0 ? (
             <div className="inline-flex items-center gap-2 rounded-full bg-green-3 px-3 py-1">
               <div className="size-2 rounded-full bg-green-9" />
               <span className="text-xs font-medium text-green-11">
-                {t("extensions.app_count", { count: props.mcpConnectedAppsCount })}
+                {t("extensions.app_count", { count: props.connectedExtensionCount })}
               </span>
             </div>
           ) : null}
@@ -91,7 +91,7 @@ export function ExtensionsView(props: ExtensionsViewProps) {
       {view === "my" ? (
         <>
           {/* Runtime extensions: MCPs + skills + marketplace imports in one view */}
-          {props.mcpView}
+          {props.catalogView}
 
           {/* OpenCode plugins -- advanced, collapsed */}
           {pluginCount > 0 ? (

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -214,6 +214,10 @@ function extensionContributionLabels(entry: McpDirectoryInfo) {
   return entry.extensionManifest?.contributions?.map((contribution) => contribution.label ?? contribution.ref ?? contribution.type) ?? [];
 }
 
+function shouldShowExtensionDetail(entry: McpDirectoryInfo, section: "setup" | "resources" | "contributions" | "enablement") {
+  return entry.extensionManifest?.detail?.[section] !== false;
+}
+
 function isToggleOnlyExtension(entry: McpDirectoryInfo) {
   if (entry.kind !== "extension") return false;
   return entry.extensionManifest?.contributions?.some((contribution) =>
@@ -691,7 +695,6 @@ export function McpView(props: McpViewProps) {
           : detailEntry.kind === "extension" && !isMcpBackedExtension(detailEntry)
           ? props.isExtensionConnected?.(detailEntry) ?? false
           : isQuickConnectConfigured(detailEntry);
-        const isGoogleWorkspace = detailEntry.id === "google-workspace";
         return (
           <ExtensionDetailModal
             open={!!detailEntry}
@@ -707,15 +710,15 @@ export function McpView(props: McpViewProps) {
             hidden={hidden}
             preview={detailEntry.preview}
             disabledReason={disabledReason}
-            setupInstructions={isGoogleWorkspace ? undefined : detailEntry.extensionManifest?.setup?.instructions}
-            resourceLabels={isGoogleWorkspace ? [] : extensionResourceLabels(detailEntry)}
-            contributionLabels={isGoogleWorkspace ? [] : extensionContributionLabels(detailEntry)}
+            setupInstructions={shouldShowExtensionDetail(detailEntry, "setup") ? detailEntry.extensionManifest?.setup?.instructions : undefined}
+            resourceLabels={shouldShowExtensionDetail(detailEntry, "resources") ? extensionResourceLabels(detailEntry) : []}
+            contributionLabels={shouldShowExtensionDetail(detailEntry, "contributions") ? extensionContributionLabels(detailEntry) : []}
             launchCommand={launchCommandForEntry(detailEntry)}
             environment={detailEntry.serverName === "openwork-ui" ? openworkUiMcpEnvironment ?? undefined : undefined}
             url={typeof detailEntry.url === "string" ? detailEntry.url : undefined}
             oauth={detailEntry.oauth}
             configSlot={disabledReason ? null : extensionConfigSlot}
-            showEnablementCard={!isGoogleWorkspace}
+            showEnablementCard={shouldShowExtensionDetail(detailEntry, "enablement")}
             onConnect={disabledReason ? undefined : isToggleOnlyExtension(detailEntry) ? () => {
               setOpenWorkExtensionEnabled(detailEntry, true);
               setDetailEntry(null);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -59,8 +59,8 @@ import { CloudProvidersView } from "../domains/settings/pages/cloud-providers-vi
 import { CloudWorkersView } from "../domains/settings/pages/cloud-workers-view";
 import { DebugView } from "../domains/settings/pages/debug-view";
 import { EnvironmentView } from "../domains/settings/pages/environment-view";
+import { ExtensionsCatalogView } from "../domains/settings/pages/extensions-catalog-view";
 import { ExtensionsView } from "../domains/settings/pages/extensions-view";
-import { McpView } from "../domains/settings/pages/mcp-view";
 import { RecoveryView } from "../domains/settings/pages/recovery-view";
 import { MessagingView } from "../domains/settings/pages/messaging-view";
 import { SkillsView } from "../domains/settings/pages/skills-view";
@@ -1658,7 +1658,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         }]
       : [],
   );
-  const mcpConnectedAppsCount = connectionsSnapshot.mcpServers.length;
+  const connectedExtensionCount = connectionsSnapshot.mcpServers.length;
 
   // Build enablement context from all available runtime state.
   const enablementContext = useMemo<EnablementContext>(() => {
@@ -2080,7 +2080,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             accessHint={pluginsAccessHint}
             suggestedPlugins={SUGGESTED_PLUGINS}
             extensions={extensionsStore}
-            mcpConnectedAppsCount={mcpConnectedAppsCount}
+            connectedExtensionCount={connectedExtensionCount}
             initialSection={route.extensionsSection}
             setSectionRoute={(section) => {
               const path = `extensions/${section}`;
@@ -2091,8 +2091,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               void extensionsStore.refreshPlugins();
               void extensionsStore.refreshCloudOrgMarketplaces({ force: true });
             }}
-            mcpView={
-              <McpView
+            catalogView={
+              <ExtensionsCatalogView
                 busy={busy}
                 selectedWorkspaceRoot={selectedWorkspaceRoot}
                 isRemoteWorkspace={isRemoteWorkspace}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2113,6 +2113,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                   openworkServerClient: selectedWorkspaceEndpoint?.client ?? openworkClient,
                   extensionConnections: {
                     "google-workspace": googleWorkspaceConnected,
+                    "openai-image-gen": imageExtensionInstalled,
+                    ollama: providerConnectedIds.includes("ollama"),
                   },
                   onExtensionConnectionChange: (extensionId, connected) => {
                     if (extensionId === "google-workspace") setGoogleWorkspaceConnected(connected);
@@ -2155,12 +2157,17 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                     openworkServerClient: selectedWorkspaceEndpoint?.client ?? openworkClient,
                     extensionConnections: {
                       "google-workspace": googleWorkspaceConnected,
+                      "openai-image-gen": imageExtensionInstalled,
+                      ollama: providerConnectedIds.includes("ollama"),
+                    },
+                    computerUse: {
+                      connected: connectionsSnapshot.mcpServers.some((server) => server.name === "computer-use"),
+                      connecting: connectionsSnapshot.mcpConnectingName === entry.name,
+                      onConnect: () => connectionsStore.connectMcp(entry),
+                      onRefresh: () => connectionsStore.refreshMcpServers(),
                     },
                   });
                   if (runtimeConnected !== null) return runtimeConnected;
-                  const id = entry.serverName ?? entry.name;
-                  if (id === "openai-image-gen") return imageExtensionInstalled;
-                  if (id === "ollama") return providerConnectedIds.includes("ollama");
                   return false;
                 }}
                 authorizeMcp={(entry) => {


### PR DESCRIPTION
## Summary
- Convert built-in extension settings registrations to the extension runtime registry
- Move Computer Use, OpenAI Image Gen, Ollama, and Google Workspace connected-state/config checks behind runtime entries
- Rename the generic catalog from MCP view/state to extensions catalog/view state
- Drive local MCP command/environment resolution from `localCommandRef` metadata instead of `ui-control` or server-name branches
- Keep actual MCP server/card behavior intact for MCP entries

## Tests
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter openwork-server test src/workspace-init.test.ts`
- `git diff --check`
- Daytona Electron validation on `refactor/builtin-extension-runtimes` at commit `2d7cff7`:
  - Verified real Electron: `Electron/35.7.5`
  - Created local workspace `/workspace/hello`
  - Opened Settings -> Extensions
  - Verified default-visible built-ins render: OpenWork Browser, Computer Use, OpenAI Image Gen, Voice Mode, Ollama
  - Verified Google Workspace is hidden by default, appears after Show hidden, and its detail panel does not expose OAuth scopes, PKCE, vault, Google Cloud, or tool-contract internals
  - Opened built-in detail/config panels
  - Connected OpenWork UI Control MCP, reloaded, and verified catalog shows Connected and Your Apps shows Ready

Recording: https://8090-zth7rbbji9wpolbg.daytonaproxy01.net/recordings/builtin-extension-runtimes-generic-cleanup.mp4