### PR TITLE
fix(den): restore org subscription TypeID prefix

### DIFF
--- a/ee/packages/utils/src/typeid.ts
+++ b/ee/packages/utils/src/typeid.ts
@@ -49,7 +49,7 @@ export const idTypesMapNameToPrefix = {
   desktopPolicy: "dpo",
   desktopPolicyMember: "dpm",
   organizationRole: "orl",
-  orgSubscription: "osb",
+  orgSubscription: "osub",
   scimProvider: "scp",
   ssoConnection: "ssc",
   ssoProvider: "ssp",


### PR DESCRIPTION
## Summary
- Restore `orgSubscription` TypeID prefix from `osb` back to the persisted `osub` prefix used by existing `org_subscriptions` rows.
- Fixes `/v1/inference` failures when Drizzle maps existing subscription IDs from the database.

## Testing
- `pnpm --filter @openwork-ee/utils build` passed.