### PR TITLE
fix(app): resolve grain art avatars in electron builds

### DIFF
--- a/apps/app/src/react-app/design-system/grain-art.ts
+++ b/apps/app/src/react-app/design-system/grain-art.ts
@@ -20,7 +20,7 @@ function categoryPrefix(category: GrainArtCategory) {
 export function grainArtSrc(category: GrainArtCategory, seed: string) {
   const index = (hashSeed(`${category}:${seed}`) % GRAIN_ART_COUNT) + 1;
   const padded = String(index).padStart(3, "0");
-  return `/grain-art/${category}/${categoryPrefix(category)}-${padded}.png`;
+  return `${import.meta.env.BASE_URL}grain-art/${category}/${categoryPrefix(category)}-${padded}.png`;
 }
 
 export function grainArtCategoryForExtensionKind(kind: ExtensionKind): GrainArtCategory {


### PR DESCRIPTION
## Summary
- Resolve static grain art avatar URLs against Vite's build base instead of the filesystem root
- Keeps dev URLs root-relative while Electron packaged builds use relative file URLs

## Root Cause
- The static avatar helper returned /grain-art/...
- Dev runs from http://localhost:5173, so that resolves to http://localhost:5173/grain-art/... and loads
- Production Electron loads the renderer from file://.../dist/index.html, so /grain-art/... resolves to file:///grain-art/... and fails

## Testing
- pnpm --filter @openwork/desktop build: passed
- pnpm --filter @openwork/app typecheck: passed
- CDP inspection before fix: /grain-art/workspaces/workspaces-001.png resolved to file:///grain-art/workspaces/workspaces-001.png and fetch failed
- CDP inspection of dev: same path resolved to http://localhost:5173/grain-art/workspaces/workspaces-001.png and returned 200
- CDP inspection of corrected relative production path: ./grain-art/workspaces/workspaces-001.png resolved under apps/app/dist and returned 200

No screenshot/video captured; this was verified through CDP URL/fetch inspection.