### PR TITLE
Stop logging health checks

### DIFF
--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -40,7 +40,16 @@ const openApiDocumentSchema = z.object({
 
 const app = new Hono<{ Variables: AppVariables }>()
 
-app.use("*", logger())
+const requestLogger = logger()
+
+app.use("*", async (c, next) => {
+  if (c.req.path === "/health") {
+    await next()
+    return
+  }
+
+  return requestLogger(c, next)
+})
 app.use("*", requestId({
   headerName: "",
   generator: () => createDenTypeId("request"),

--- a/ee/apps/inference/src/app.ts
+++ b/ee/apps/inference/src/app.ts
@@ -17,13 +17,22 @@ const shouldServeLocalModelCatalog = !isVercelRuntime && (process.env.NODE_ENV !
 
 const app = new Hono();
 
-app.use("*", logger((message, ...rest) => {
+const requestLogger = logger((message, ...rest) => {
   if (/-->\s+\S+\s+\S+\s+[45]\d\d\b/.test(message)) {
     console.error(message, ...rest);
     return;
   }
   console.log(message, ...rest);
-}));
+});
+
+app.use("*", async (c, next) => {
+  if (c.req.path === "/health") {
+    await next();
+    return;
+  }
+
+  return requestLogger(c, next);
+});
 
 if (env.corsOrigins.length > 0) {
   app.use(


### PR DESCRIPTION
## Summary
- Skip Hono request logging for `/health` in den-api.
- Skip Hono request logging for `/health` in inference while preserving existing error logging behavior.

## Tests
- `pnpm --filter @openwork-ee/inference build` passed
- `pnpm --filter @openwork-ee/den-api build` passed