### PR TITLE
fix(den): allow org creation before cloud plan

### DIFF
--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -5,7 +5,6 @@ import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { auth } from "../../auth.js"
-import { requireCloudWorkerAccess } from "../../billing/polar.js"
 import { db } from "../../db.js"
 import { env } from "../../env.js"
 import { jsonValidator, queryValidator, requireUserMiddleware, resolveMemberTeamsMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
@@ -66,16 +65,6 @@ const organizationOwnerSchema = z.object({
   email: z.string().email().nullable(),
   image: z.string().nullable().optional(),
 }).meta({ ref: "OrganizationOwner" })
-
-const paymentRequiredSchema = z.object({
-  error: z.literal("payment_required"),
-  message: z.string(),
-  polar: z.object({
-    checkoutUrl: z.string().nullable(),
-    productId: z.string().nullable().optional(),
-    benefitId: z.string().nullable().optional(),
-  }).passthrough(),
-}).meta({ ref: "PaymentRequiredError" })
 
 const invitationPreviewResponseSchema = z.object({}).passthrough().meta({ ref: "InvitationPreviewResponse" })
 
@@ -151,12 +140,11 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
       tags: ["Organizations"],
       hide: true,
       summary: "Create organization",
-      description: "Creates a new organization for the signed-in user after verifying that their account can provision OpenWork Cloud workspaces.",
+      description: "Creates a new organization for the signed-in user. Billing is enforced only when launching shared cloud workspaces.",
       responses: {
         201: jsonResponse("Organization created successfully.", organizationResponseSchema),
         400: jsonResponse("The organization creation request body was invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to create an organization.", unauthorizedSchema),
-        402: jsonResponse("The caller needs an active cloud plan before creating an organization.", paymentRequiredSchema),
         403: jsonResponse("API keys cannot create organizations.", forbiddenSchema),
       },
     }),
@@ -172,29 +160,6 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
 
     const user = c.get("user")
     const input = c.req.valid("json")
-    const email = getRequiredUserEmail(user)
-
-    if (!email) {
-      return c.json({ error: "user_email_required" }, 400)
-    }
-
-    const access = await requireCloudWorkerAccess({
-      userId: normalizeDenTypeId("user", user.id),
-      email,
-      name: user.name ?? user.email ?? "OpenWork User",
-    })
-
-    if (!access.allowed) {
-      return c.json({
-        error: "payment_required",
-        message: "Creating a workspace requires an active OpenWork Cloud plan.",
-        polar: {
-          checkoutUrl: access.checkoutUrl,
-          productId: env.polar.productId,
-          benefitId: env.polar.benefitId,
-        },
-      }, 402)
-    }
 
     const organizationId = await createOrganizationForUser({
       userId: normalizeDenTypeId("user", user.id),


### PR DESCRIPTION
## Summary
- Remove the active cloud plan check from `POST /v1/org` so new users can create an organization during signup.
- Keep billing enforcement scoped to shared cloud workspace launch, matching the May 8 behavior from `0ece2993`.

## Testing
- `pnpm --filter @openwork-ee/den-api build` passed.