### PR TITLE
fix(den): restore routes dropped by sso rebase

### DIFF
--- a/ee/apps/den-api/README.md
+++ b/ee/apps/den-api/README.md
@@ -12,6 +12,18 @@ It carries the full migrated Den API route surface in a foldered Hono structure 
 pnpm --filter @openwork-ee/den-api dev:local
 ```
 
+## Local demo org seed
+
+With a local Den MySQL database running, seed a demo organization:
+
+```bash
+pnpm --filter @openwork-ee/den-api seed:demo-org
+```
+
+This creates `Acme Robotics` with demo users, teams, pending invites, and an imported Anthropic Knowledge Work Plugins marketplace. It is guarded by `OPENWORK_DEV_MODE=1`, defaults to the local Den DB URL, and does not create workers or active external integrations.
+
+Default owner login: `alex@acme.test` / `OpenWorkDemo123!`.
+
 ## Current routes
 
 - `GET /` -> `302 https://openworklabs.com`

--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -9,12 +9,14 @@ import { requestId } from "hono/request-id"
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
 import { z } from "zod"
 import { env } from "./env.js"
+import { registerMcpRoutes } from "./mcp/index.js"
 import type { MemberTeamsContext, OrganizationContextVariables, UserOrganizationsContext } from "./middleware/index.js"
 import { buildOperationId, emptyResponse, htmlResponse, jsonResponse } from "./openapi.js"
 import { registerAdminRoutes } from "./routes/admin/index.js"
 import { registerAuthRoutes } from "./routes/auth/index.js"
 import { registerMeRoutes } from "./routes/me/index.js"
 import { registerOrgRoutes } from "./routes/org/index.js"
+import { registerTelemetryRoutes } from "./routes/telemetry/index.js"
 import { registerVersionRoutes } from "./routes/version/index.js"
 import { registerWebhookRoutes } from "./routes/webhooks/index.js"
 import { registerWorkerRoutes } from "./routes/workers/index.js"
@@ -65,7 +67,7 @@ if (env.corsOrigins.length > 0) {
       cors({
         origin: env.corsOrigins,
         credentials: true,
-        allowHeaders: ["Content-Type", "Authorization", "X-Api-Key", "X-Request-Id"],
+        allowHeaders: ["Content-Type", "Authorization", "X-Api-Key", "X-Request-Id", "X-OpenWork-Legacy-Org-Id"],
         allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
         exposeHeaders: ["Content-Length", "X-Request-Id"],
         maxAge: 600,
@@ -120,6 +122,8 @@ registerOrgRoutes(app)
 registerVersionRoutes(app)
 registerWebhookRoutes(app)
 registerWorkerRoutes(app)
+registerMcpRoutes(app)
+registerTelemetryRoutes(app)
 
 app.get(
   "/openapi.json",
@@ -168,6 +172,7 @@ app.get(
         { name: "Workers", description: "Worker lifecycle, billing, and runtime routes." },
         { name: "Worker Runtime", description: "Worker runtime inspection and upgrade routes." },
         { name: "Worker Activity", description: "Worker heartbeat and activity reporting routes." },
+        { name: "Telemetry", description: "Telemetry event ingestion and adoption analytics." },
         { name: "Admin", description: "Administrative reporting routes." },
         { name: "Users", description: "Current user and membership routes." },
       ],

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -1,13 +1,135 @@
+import { eq } from "@openwork-ee/den-db/drizzle"
+import { OAuthClientTable } from "@openwork-ee/den-db/schema"
+import { oauthProviderAuthServerMetadata, oauthProviderOpenIdConfigMetadata } from "@better-auth/oauth-provider"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { auth } from "../../auth.js"
+import { db } from "../../db.js"
+import { env } from "../../env.js"
 import { emptyResponse } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 import { registerDesktopAuthRoutes } from "./desktop-handoff.js"
 import { registerScimAuthRoutes } from "./scim.js"
 
+function rewriteAuthRequest(request: Request, path: string) {
+  const url = new URL(request.url)
+  url.pathname = path
+  return new Request(url, request)
+}
+
+async function rewriteMcpClientRegistrationRequest(request: Request, path: string) {
+  const url = new URL(request.url)
+  url.pathname = path
+
+  const headers = new Headers(request.headers)
+  const contentType = headers.get("content-type")?.toLowerCase() ?? ""
+  if (!contentType.includes("application/json")) {
+    return new Request(url, request)
+  }
+
+  const body = await request.json() as Record<string, unknown>
+  const scope = typeof body.scope === "string" ? body.scope : ""
+  const scopes = new Set(scope.split(/\s+/).filter(Boolean))
+  if (scopes.has("mcp:read") || scopes.has("mcp:write")) {
+    scopes.add("mcp:read")
+    scopes.add("mcp:write")
+    body.scope = Array.from(scopes).join(" ")
+  }
+
+  headers.set("content-type", "application/json")
+  headers.delete("content-length")
+
+  return new Request(url, {
+    method: request.method,
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+async function rewriteMetadataOrigin(response: Response, origin: string) {
+  const metadata = await response.json() as Record<string, unknown>
+  const headers = new Headers(response.headers)
+  headers.delete("content-length")
+  headers.set("content-type", "application/json")
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof value === "string") {
+      metadata[key] = value.replace(env.betterAuthUrl, origin)
+    }
+  }
+
+  return new Response(JSON.stringify(metadata), {
+    status: response.status,
+    headers,
+  })
+}
+
+function requestOrigin(request: Request) {
+  return new URL(request.url).origin
+}
+
+function readStoredClientScopes(scopes: string | null) {
+  if (!scopes) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(scopes) as unknown
+    if (Array.isArray(parsed)) return parsed.filter((entry): entry is string => typeof entry === "string")
+  } catch {}
+
+  return scopes.split(/\s+/).filter(Boolean)
+}
+
+async function ensureMcpClientScopes(request: Request) {
+  const url = new URL(request.url)
+  const requestedScopes = new Set((url.searchParams.get("scope") ?? "").split(/\s+/).filter(Boolean))
+  if (!requestedScopes.has("mcp:read") && !requestedScopes.has("mcp:write")) {
+    return
+  }
+
+  const clientId = url.searchParams.get("client_id")
+  if (!clientId) {
+    return
+  }
+
+  const [client] = await db
+    .select({ scopes: OAuthClientTable.scopes })
+    .from(OAuthClientTable)
+    .where(eq(OAuthClientTable.clientId, clientId))
+    .limit(1)
+  if (!client) {
+    return
+  }
+
+  const scopes = new Set(readStoredClientScopes(client.scopes))
+  if (!scopes.has("mcp:read") && !scopes.has("mcp:write")) {
+    return
+  }
+
+  scopes.add("mcp:read")
+  scopes.add("mcp:write")
+  await db
+    .update(OAuthClientTable)
+    .set({ scopes: JSON.stringify(Array.from(scopes)) })
+    .where(eq(OAuthClientTable.clientId, clientId))
+}
+
 export function registerAuthRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
   registerScimAuthRoutes(app)
+  app.get("/api/auth/.well-known/oauth-authorization-server", async (c) => rewriteMetadataOrigin(await oauthProviderAuthServerMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
+  app.get("/api/auth/.well-known/openid-configuration", async (c) => rewriteMetadataOrigin(await oauthProviderOpenIdConfigMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
+  app.get("/.well-known/oauth-authorization-server/api/auth", async (c) => rewriteMetadataOrigin(await oauthProviderAuthServerMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
+  app.get("/.well-known/openid-configuration/api/auth", async (c) => rewriteMetadataOrigin(await oauthProviderOpenIdConfigMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
+  app.get("/.well-known/oauth-authorization-server", async (c) => rewriteMetadataOrigin(await oauthProviderAuthServerMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/oauth-authorization-server")), requestOrigin(c.req.raw)))
+  app.get("/.well-known/openid-configuration", async (c) => rewriteMetadataOrigin(await oauthProviderOpenIdConfigMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/openid-configuration")), requestOrigin(c.req.raw)))
+  app.post("/register", async (c) => auth.handler(await rewriteMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register")))
+  app.post("/api/auth/oauth2/register", async (c) => auth.handler(await rewriteMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register")))
+  app.get("/api/auth/oauth2/authorize", async (c) => {
+    await ensureMcpClientScopes(c.req.raw)
+    return auth.handler(c.req.raw)
+  })
+
   app.on(
     ["GET", "POST", "PUT", "PATCH", "DELETE"],
     "/api/auth/*",

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -103,7 +103,12 @@ async function ensureMcpClientScopes(request: Request) {
   }
 
   const scopes = new Set(readStoredClientScopes(client.scopes))
-  if (!scopes.has("mcp:read") && !scopes.has("mcp:write")) {
+  const hasMcpRead = scopes.has("mcp:read")
+  const hasMcpWrite = scopes.has("mcp:write")
+  if (!hasMcpRead && !hasMcpWrite) {
+    return
+  }
+  if (hasMcpRead && hasMcpWrite) {
     return
   }
 

--- a/ee/apps/den-api/src/routes/org/README.md
+++ b/ee/apps/den-api/src/routes/org/README.md
@@ -19,7 +19,7 @@ This folder owns organization-facing Den API routes.
 - New sessions should get an initial `activeOrganizationId` from Better Auth session creation hooks in `src/auth.ts`.
 - `GET /v1/org` returns the active organization from the current session, including a nested `organization.owner` object plus the current member and team context.
 - `POST /v1/org` creates a new organization and switches the session to it. `PATCH /v1/org` updates the active organization.
-- Active-org scoped resources should prefer top-level routes like `/v1/templates`, `/v1/skills`, `/v1/teams`, `/v1/roles`, `/v1/api-keys`, `/v1/llm-providers`, `/v1/scim`, and plugin-system `/v1/...` routes. They should not require `:orgId` or `:orgSlug` in the path.
+- Active-org scoped resources should prefer top-level routes like `/v1/skills`, `/v1/teams`, `/v1/roles`, `/v1/api-keys`, `/v1/llm-providers`, `/v1/scim`, and plugin-system `/v1/...` routes. They should not require `:orgId` or `:orgSlug` in the path.
 - Routes under `/v1/orgs/**` are reserved for cross-org flows that are not tied to the active workspace yet, such as invitation preview/accept.
 - If a client needs to change workspaces, it should call Better Auth set-active first, then use the active-org scoped `/v1/...` resource routes.
 

--- a/ee/apps/den-api/src/routes/org/shared.ts
+++ b/ee/apps/den-api/src/routes/org/shared.ts
@@ -12,10 +12,6 @@ export type OrgRouteVariables =
   & Partial<OrganizationContextVariables>
   & Partial<MemberTeamsContext>
 
-export const orgIdParamSchema = z.object({
-  orgId: denTypeIdSchema("organization"),
-})
-
 export function idParamSchema<K extends string>(key: K, typeName?: DenTypeIdName) {
   if (!typeName) {
     return z.object({
@@ -65,14 +61,6 @@ const createNanoid = customAlphabet("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg
 
 export function buildInvitationLink(inviteToken: string) {
   return new URL(`/join-org?invite=${encodeURIComponent(inviteToken)}`, getInvitationOrigin()).toString()
-}
-
-export function parseTemplateJson(value: string) {
-  try {
-    return JSON.parse(value)
-  } catch {
-    return null
-  }
 }
 
 export function ensureOwner(c: { get: (key: "organizationContext") => OrgRouteVariables["organizationContext"] }) {

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -318,10 +318,6 @@ export function getMembersRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/members`;
 }
 
-export function getSharedSetupsRoute(orgSlug?: string | null): string {
-  return `${getOrgDashboardRoute(orgSlug)}/shared-setups`;
-}
-
 export function getBackgroundAgentsRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/background-agents`;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -16,7 +16,6 @@ import {
   LogOut,
   MessageSquare,
   Puzzle,
-  Share2,
   Shield,
   SlidersHorizontal,
   Sparkles,
@@ -41,7 +40,6 @@ import {
   getPluginsRoute,
   getSsoRoute,
   getScimRoute,
-  getSharedSetupsRoute,
   getSkillHubsRoute,
 } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
@@ -109,9 +107,6 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
   if (pathname === dashboardRoot) {
     return "Home";
   }
-  if (pathname.startsWith(getSharedSetupsRoute(orgSlug))) {
-    return "Team Templates";
-  }
   if (pathname.startsWith(getMembersRoute(orgSlug))) {
     return "Members";
   }
@@ -125,7 +120,7 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
     return "SSO";
   }
   if (pathname.startsWith(getBackgroundAgentsRoute(orgSlug))) {
-    return "Shared Workspaces";
+    return "Background Tasks";
   }
   if (pathname.startsWith(getCustomLlmProvidersRoute(orgSlug))) {
     return "LLM Providers";

--- a/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
@@ -182,10 +182,6 @@ export function OrgDashboardProvider({
       );
 
       if (!response.ok) {
-        if (response.status === 402) {
-          router.push("/checkout");
-          return;
-        }
         throw new Error(getErrorMessage(payload, `Failed to create organization (${response.status}).`));
       }
 

--- a/ee/packages/utils/src/typeid.ts
+++ b/ee/packages/utils/src/typeid.ts
@@ -67,7 +67,6 @@ export const idTypesMapNameToPrefix = {
   inferenceUsageLedgerEntry: "iule",
   inferenceUsageLedgerBucketCharge: "iulc",
   inferenceModelAlias: "ima",
-  tempTemplateSharing: "tts",
   adminAllowlist: "aal",
   worker: "wrk",
   workerInstance: "wki",


### PR DESCRIPTION
## Summary
- Restores Den MCP, telemetry, OAuth metadata, and MCP OAuth helper routes that were dropped during the SSO/SCIM rebase.
- Restores legacy org CORS compatibility and demo org seed docs while keeping the intended SSO/SCIM additions.
- Removes unrelated template-sharing leftovers and stale org-create checkout behavior that were reintroduced by the bad rebase.

## Verification
- `pnpm --filter @openwork-ee/den-api build` passed.
- `pnpm --filter @openwork-ee/den-web build` passed.
- `bun test ee/apps/den-api/test/org-invitations.test.ts` passed: 5 tests.
- Second-pass subagent checks found no missed bad-rebase cleanup items.

## Notes
No video/screenshot attached because this is a backend/API cleanup PR with build and targeted route test coverage rather than a user-facing flow change.