### PR TITLE
Move desktop config state to server

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -175,6 +175,18 @@ export type OpenworkWorkspaceFileWriteResult = {
   revision?: string;
 };
 
+export type OpenworkAuthorizedFoldersResponse = {
+  folders: string[];
+  hiddenCount: number;
+  workspaceRoot: string;
+};
+
+export type OpenworkAuthorizedFoldersUpdateResponse = {
+  folders: string[];
+  hiddenCount: number;
+  updatedAt: number;
+};
+
 function arrayBufferToBase64(data: ArrayBuffer): string {
   const bytes = new Uint8Array(data);
   let binary = "";
@@ -338,6 +350,13 @@ export type OpenworkInboxUploadResult = {
   ok: boolean;
   path: string;
   bytes: number;
+};
+
+export type OpenworkUserEnvItem = {
+  key: string;
+  updatedAt: number;
+  hasValue: boolean;
+  value?: string;
 };
 
 export type OpenworkActor = {
@@ -916,6 +935,26 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         body: payload,
         timeoutMs: timeouts.activateWorkspace,
       }),
+    createRemoteWorkspace: (payload: {
+      baseUrl: string;
+      openworkHostUrl?: string | null;
+      openworkToken?: string | null;
+      openworkWorkspaceId?: string | null;
+      openworkWorkspaceName?: string | null;
+      displayName?: string | null;
+      directory?: string | null;
+      remoteType?: "openwork" | "opencode";
+      sandboxBackend?: string | null;
+      sandboxRunId?: string | null;
+      sandboxContainerName?: string | null;
+    }) =>
+      requestJson<WorkspaceList>(baseUrl, "/workspaces/remote", {
+        token,
+        hostToken,
+        method: "POST",
+        body: payload,
+        timeoutMs: timeouts.activateWorkspace,
+      }),
     updateWorkspaceDisplayName: (workspaceId: string, displayName: string | null) =>
       requestJson<WorkspaceList>(baseUrl, `/workspaces/${encodeURIComponent(workspaceId)}/display-name`, {
         token,
@@ -924,12 +963,14 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         body: { displayName },
         timeoutMs: timeouts.activateWorkspace,
       }),
-    activateWorkspace: (workspaceId: string) =>
-      requestJson<{ activeId: string; workspace: OpenworkWorkspaceInfo }>(
+    activateWorkspace: (workspaceId: string, options?: { persist?: boolean }) => {
+      const query = options?.persist ? "?persist=true" : "";
+      return requestJson<{ activeId: string; workspace: OpenworkWorkspaceInfo; persisted: boolean }>(
         baseUrl,
-        `/workspaces/${encodeURIComponent(workspaceId)}/activate`,
+        `/workspaces/${encodeURIComponent(workspaceId)}/activate${query}`,
         { token, hostToken, method: "POST", timeoutMs: timeouts.activateWorkspace },
-      ),
+      );
+    },
     deleteWorkspace: (workspaceId: string) =>
       requestJson<{ ok: boolean; deleted: boolean; persisted: boolean; activeId: string | null; items: OpenworkWorkspaceInfo[]; workspaces?: WorkspaceInfo[] }>(
         baseUrl,
@@ -1035,6 +1076,24 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         baseUrl,
         `/workspace/${workspaceId}/config`,
         { token, hostToken, timeoutMs: timeouts.config },
+      ),
+    listAuthorizedFolders: (workspaceId: string) =>
+      requestJson<OpenworkAuthorizedFoldersResponse>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/authorized-folders`,
+        { token, hostToken, timeoutMs: timeouts.config },
+      ),
+    setAuthorizedFolders: (workspaceId: string, folders: string[]) =>
+      requestJson<OpenworkAuthorizedFoldersUpdateResponse>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/authorized-folders`,
+        {
+          token,
+          hostToken,
+          method: "PUT",
+          body: { folders },
+          timeoutMs: timeouts.config,
+        },
       ),
     patchConfig: (workspaceId: string, payload: { opencode?: Record<string, unknown>; openwork?: Record<string, unknown> }) =>
       requestJson<{ updatedAt?: number | null }>(baseUrl, `/workspace/${workspaceId}/config`, {
@@ -1384,10 +1443,37 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         { token, hostToken, timeoutMs: timeouts.config },
       ),
 
-    listUserEnv: () =>
-      requestJson<{ items: Array<{ key: string; value: string; updatedAt: number }> }>(
+    getUserEnvStatus: (runtimeKey?: string | null) => {
+      const params = new URLSearchParams();
+      if (runtimeKey?.trim()) params.set("runtimeKey", runtimeKey.trim());
+      const query = params.size ? `?${params.toString()}` : "";
+      return requestJson<{ runtimeKey: string; pendingChanges: boolean }>(
         baseUrl,
-        "/env",
+        `/env/status${query}`,
+        { token, hostToken, timeoutMs: timeouts.config },
+      );
+    },
+
+    setUserEnvPendingChanges: (pendingChanges: boolean, runtimeKey?: string | null) =>
+      requestJson<{ runtimeKey: string; pendingChanges: boolean }>(baseUrl, "/env/status", {
+        token,
+        hostToken,
+        method: "PUT",
+        body: { pendingChanges, runtimeKey: runtimeKey?.trim() || undefined },
+        timeoutMs: timeouts.config,
+      }),
+
+    listUserEnv: () =>
+      requestJson<{ items: OpenworkUserEnvItem[] }>(
+        baseUrl,
+        "/env?includeValues=false",
+        { token, hostToken, timeoutMs: timeouts.config },
+      ),
+
+    getUserEnv: (key: string) =>
+      requestJson<{ item: OpenworkUserEnvItem & { value: string } }>(
+        baseUrl,
+        `/env/${encodeURIComponent(key)}`,
         { token, hostToken, timeoutMs: timeouts.config },
       ),
 

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -95,6 +95,7 @@ type CreateProviderAuthStoreOptions = {
   selectedWorkspaceDisplay: () => WorkspaceDisplay;
   selectedWorkspaceRoot: () => string;
   runtimeWorkspaceId: () => string | null;
+  ensureRuntimeWorkspaceId?: () => Promise<string | null | undefined>;
   openworkServer: OpenworkServerStore;
   setProviders: (value: ProviderListItem[]) => void;
   setProviderDefaults: (value: Record<string, string>) => void;
@@ -195,6 +196,27 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
 
     return Array.from(merged.values()).toSorted(compareProviders);
+  };
+
+  const resolveOpenworkConfigTarget = async (mode: "read" | "write") => {
+    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkClient = openworkSnapshot.openworkServerClient;
+    let openworkWorkspaceId = options.runtimeWorkspaceId()?.trim() || null;
+    if (!openworkWorkspaceId && openworkSnapshot.openworkServerStatus === "connected" && openworkClient) {
+      openworkWorkspaceId = (await options.ensureRuntimeWorkspaceId?.())?.trim() || null;
+    }
+    const hasOpenworkTarget =
+      openworkSnapshot.openworkServerStatus === "connected" &&
+      Boolean(openworkClient && openworkWorkspaceId);
+    const canUseOpenworkServer =
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.config?.[mode] !== false;
+    return {
+      openworkClient,
+      openworkWorkspaceId,
+      hasOpenworkTarget,
+      canUseOpenworkServer,
+    };
   };
 
   const refreshSnapshot = () => {
@@ -322,19 +344,16 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     const root = options.selectedWorkspaceRoot().trim();
     const isLocalWorkspace =
       options.selectedWorkspaceDisplay().workspaceType === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = openworkSnapshot.openworkServerCapabilities;
-    const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkCapabilities?.config?.read;
+    const { openworkClient, openworkWorkspaceId, hasOpenworkTarget, canUseOpenworkServer } =
+      await resolveOpenworkConfigTarget("read");
 
-    if (canUseOpenworkServer) {
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       const config = await openworkClient.getConfig(openworkWorkspaceId);
       return config.openwork ?? {};
+    }
+
+    if (hasOpenworkTarget) {
+      return {};
     }
 
     if (isLocalWorkspace && isDesktopRuntime() && root) {
@@ -352,19 +371,16 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     const root = options.selectedWorkspaceRoot().trim();
     const isLocalWorkspace =
       options.selectedWorkspaceDisplay().workspaceType === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = openworkSnapshot.openworkServerCapabilities;
-    const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkCapabilities?.config?.write;
+    const { openworkClient, openworkWorkspaceId, hasOpenworkTarget, canUseOpenworkServer } =
+      await resolveOpenworkConfigTarget("write");
 
-    if (canUseOpenworkServer) {
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       await openworkClient.patchConfig(openworkWorkspaceId, { openwork: config });
       return true;
+    }
+
+    if (hasOpenworkTarget) {
+      return false;
     }
 
     if (isLocalWorkspace && isDesktopRuntime() && root) {
@@ -418,19 +434,15 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     const root = options.selectedWorkspaceRoot().trim();
     const isLocalWorkspace =
       options.selectedWorkspaceDisplay().workspaceType === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = openworkSnapshot.openworkServerCapabilities;
-    const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkCapabilities?.config?.read &&
-      typeof openworkClient.readOpencodeConfigFile === "function";
+    const { openworkClient, openworkWorkspaceId, hasOpenworkTarget, canUseOpenworkServer } =
+      await resolveOpenworkConfigTarget("read");
 
-    if (canUseOpenworkServer) {
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       return await openworkClient.readOpencodeConfigFile(openworkWorkspaceId, "project");
+    }
+
+    if (hasOpenworkTarget) {
+      throw new Error("OpenWork server config API is unavailable for this workspace.");
     }
 
     if (isLocalWorkspace && isDesktopRuntime() && root) {
@@ -444,18 +456,10 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     const root = options.selectedWorkspaceRoot().trim();
     const isLocalWorkspace =
       options.selectedWorkspaceDisplay().workspaceType === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = openworkSnapshot.openworkServerCapabilities;
-    const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkCapabilities?.config?.write &&
-      typeof openworkClient.writeOpencodeConfigFile === "function";
+    const { openworkClient, openworkWorkspaceId, hasOpenworkTarget, canUseOpenworkServer } =
+      await resolveOpenworkConfigTarget("write");
 
-    if (canUseOpenworkServer) {
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       const result = await openworkClient.writeOpencodeConfigFile(
         openworkWorkspaceId,
         "project",
@@ -465,6 +469,10 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         throw new Error(result.stderr || result.stdout || "Failed to write opencode.jsonc");
       }
       return true;
+    }
+
+    if (hasOpenworkTarget) {
+      throw new Error("OpenWork server config API is unavailable for this workspace.");
     }
 
     if (isLocalWorkspace && isDesktopRuntime() && root) {

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -128,6 +128,54 @@ export function createConnectionsStore(options: {
 
   const getOpenworkSnapshot = () => options.openworkServer.getSnapshot();
 
+  const resolveOpenworkWorkspaceId = async () => {
+    const current = options.runtimeWorkspaceId()?.trim();
+    if (current) return current;
+    const openworkSnapshot = getOpenworkSnapshot();
+    if (openworkSnapshot.openworkServerStatus !== "connected" || !openworkSnapshot.openworkServerClient) {
+      return null;
+    }
+    const ensured = (await options.ensureRuntimeWorkspaceId?.())?.trim();
+    if (ensured) return ensured;
+    return options.workspaceType() === "local" ? options.selectedWorkspaceId().trim() || null : null;
+  };
+
+  const resolveConfigOpenworkTarget = async (mode: "read" | "write") => {
+    const openworkSnapshot = getOpenworkSnapshot();
+    const openworkClient = openworkSnapshot.openworkServerClient;
+    const openworkWorkspaceId = await resolveOpenworkWorkspaceId();
+    const hasOpenworkTarget =
+      openworkSnapshot.openworkServerStatus === "connected" &&
+      Boolean(openworkClient && openworkWorkspaceId);
+    const canUseOpenworkServer =
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.config?.[mode] !== false;
+    return {
+      openworkClient,
+      openworkWorkspaceId,
+      hasOpenworkTarget,
+      canUseOpenworkServer,
+    };
+  };
+
+  const resolveMcpOpenworkTarget = async (mode: "read" | "write") => {
+    const openworkSnapshot = getOpenworkSnapshot();
+    const openworkClient = openworkSnapshot.openworkServerClient;
+    const openworkWorkspaceId = await resolveOpenworkWorkspaceId();
+    const hasOpenworkTarget =
+      openworkSnapshot.openworkServerStatus === "connected" &&
+      Boolean(openworkClient && openworkWorkspaceId);
+    const canUseOpenworkServer =
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.mcp?.[mode] !== false;
+    return {
+      openworkClient,
+      openworkWorkspaceId,
+      hasOpenworkTarget,
+      canUseOpenworkServer,
+    };
+  };
+
   const filterConfiguredStatuses = (status: McpStatusMap, entries: McpServerEntry[]) => {
     const configured = new Set(entries.map((entry) => entry.name));
     return Object.fromEntries(
@@ -137,20 +185,18 @@ export function createConnectionsStore(options: {
 
   const readMcpConfigFile = async (scope: "project" | "global"): Promise<OpencodeConfigFile | null> => {
     const projectDir = options.projectDir().trim();
-    const openworkSnapshot = getOpenworkSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.config?.read;
+    const { openworkClient, openworkWorkspaceId, hasOpenworkTarget, canUseOpenworkServer } =
+      await resolveConfigOpenworkTarget("read");
 
     if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       return openworkClient.readOpencodeConfigFile(openworkWorkspaceId, scope);
     }
 
-    if (!isDesktopRuntime()) {
+    if (hasOpenworkTarget) {
+      return null;
+    }
+
+    if (options.workspaceType() !== "local" || !isDesktopRuntime()) {
       return null;
     }
 
@@ -171,7 +217,7 @@ export function createConnectionsStore(options: {
     }
 
     const mountedBaseUrl =
-      buildOpenworkWorkspaceBaseUrl(openworkBaseUrl, options.runtimeWorkspaceId()) ?? openworkBaseUrl;
+      buildOpenworkWorkspaceBaseUrl(openworkBaseUrl, await resolveOpenworkWorkspaceId()) ?? openworkBaseUrl;
     activeClient = createClient(`${mountedBaseUrl.replace(/\/+$/, "")}/opencode`, undefined, {
       token,
       mode: "openwork",
@@ -181,25 +227,7 @@ export function createConnectionsStore(options: {
   };
 
   const resolveWritableOpenworkTarget = async () => {
-    const openworkSnapshot = getOpenworkSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    let openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = openworkSnapshot.openworkServerCapabilities;
-    if (!openworkWorkspaceId && openworkClient && openworkSnapshot.openworkServerStatus === "connected") {
-      openworkWorkspaceId = (await options.ensureRuntimeWorkspaceId?.()) ?? null;
-    }
-
-    const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkCapabilities?.mcp?.write;
-
-    return {
-      openworkClient,
-      openworkWorkspaceId,
-      canUseOpenworkServer: Boolean(canUseOpenworkServer),
-    };
+    return resolveMcpOpenworkTarget("write");
   };
 
   const resolveProjectDir = async (activeClient: Client | null, currentProjectDir: string) => {
@@ -223,26 +251,23 @@ export function createConnectionsStore(options: {
 
   const listMcpFromOpenworkServer = async (projectDir: string) => {
     const openworkSnapshot = getOpenworkSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId =
-      options.runtimeWorkspaceId()?.trim() ||
-      options.selectedWorkspaceId().trim() ||
-      ((await options.ensureRuntimeWorkspaceId?.()) ?? "")?.trim();
-    const canTryOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      Boolean(openworkClient) &&
-      Boolean(openworkWorkspaceId) &&
-      openworkSnapshot.openworkServerCapabilities?.mcp?.read !== false;
+    const { openworkClient, openworkWorkspaceId, hasOpenworkTarget, canUseOpenworkServer } =
+      await resolveMcpOpenworkTarget("read");
+    const canTryOpenworkServer = canUseOpenworkServer;
 
     recordPerfLog(options.developerMode(), "mcp.refresh", "server-path-check", {
       workspaceType: options.workspaceType(),
       projectDir: projectDir || null,
       openworkStatus: openworkSnapshot.openworkServerStatus,
       hasOpenworkClient: Boolean(openworkClient),
-      openworkWorkspaceId: openworkWorkspaceId || null,
+      openworkWorkspaceId: openworkWorkspaceId ?? null,
       canReadMcp: openworkSnapshot.openworkServerCapabilities?.mcp?.read ?? null,
       canTryOpenworkServer,
     });
+
+    if (hasOpenworkTarget && !canTryOpenworkServer) {
+      throw new Error("OpenWork server cannot read MCP config for this workspace.");
+    }
 
     if (!canTryOpenworkServer || !openworkClient || !openworkWorkspaceId) return null;
 
@@ -343,7 +368,8 @@ export function createConnectionsStore(options: {
       recordPerfLog(options.developerMode(), "mcp.refresh", "server-path-error", {
         message: error instanceof Error ? error.message : String(error),
       });
-      if (isRemoteWorkspace) {
+      const serverTarget = await resolveMcpOpenworkTarget("read").catch(() => null);
+      if (isRemoteWorkspace || serverTarget?.hasOpenworkTarget) {
         mutateState((current) => ({
           ...current,
           mcpServers: [],
@@ -470,13 +496,21 @@ export function createConnectionsStore(options: {
       projectDir: projectDir || null,
     });
 
-    const { openworkClient, openworkWorkspaceId, canUseOpenworkServer } =
+    const { openworkClient, openworkWorkspaceId, hasOpenworkTarget, canUseOpenworkServer } =
       await resolveWritableOpenworkTarget();
 
     if (isRemoteWorkspace && !canUseOpenworkServer) {
       setStateField("mcpStatus", "OpenWork server unavailable. MCP config is read-only.");
       finishPerf(options.developerMode(), "mcp.connect", "blocked", startedAt, {
         reason: "openwork-server-unavailable",
+      });
+      return;
+    }
+
+    if (hasOpenworkTarget && !canUseOpenworkServer) {
+      setStateField("mcpStatus", "OpenWork server MCP config is read-only.");
+      finishPerf(options.developerMode(), "mcp.connect", "blocked", startedAt, {
+        reason: "openwork-server-read-only",
       });
       return;
     }
@@ -489,7 +523,7 @@ export function createConnectionsStore(options: {
       return;
     }
 
-    if (!isRemoteWorkspace && !projectDir) {
+    if (!isRemoteWorkspace && !projectDir && !canUseOpenworkServer) {
       setStateField("mcpStatus", t("mcp.pick_workspace_first"));
       finishPerf(options.developerMode(), "mcp.connect", "blocked", startedAt, {
         reason: "missing-workspace",
@@ -497,8 +531,8 @@ export function createConnectionsStore(options: {
       return;
     }
 
-    const activeClient = await ensureActiveClient();
-    if (!activeClient) {
+    const activeClient = canUseOpenworkServer ? options.client() ?? await ensureActiveClient().catch(() => null) : await ensureActiveClient();
+    if (!activeClient && !canUseOpenworkServer) {
       setStateField("mcpStatus", t("mcp.connect_server_first"));
       finishPerf(options.developerMode(), "mcp.connect", "blocked", startedAt, {
         reason: "no-active-client",
@@ -506,8 +540,8 @@ export function createConnectionsStore(options: {
       return;
     }
 
-    const resolvedProjectDir = await resolveProjectDir(activeClient, projectDir);
-    if (!resolvedProjectDir) {
+    const resolvedProjectDir = activeClient ? await resolveProjectDir(activeClient, projectDir) : projectDir;
+    if (!resolvedProjectDir && !canUseOpenworkServer) {
       setStateField("mcpStatus", t("mcp.pick_workspace_first"));
       finishPerf(options.developerMode(), "mcp.connect", "blocked", startedAt, {
         reason: "missing-workspace-after-discovery",
@@ -573,6 +607,9 @@ export function createConnectionsStore(options: {
           config: mcpEntryConfig,
         });
       } else {
+        if (!activeClient || !resolvedProjectDir) {
+          throw new Error(t("mcp.connect_server_first"));
+        }
         const configFile = await readOpencodeConfig("project", resolvedProjectDir) as OpencodeConfigFile;
 
         const raw = configFile.exists && configFile.content?.trim()
@@ -618,6 +655,9 @@ export function createConnectionsStore(options: {
         // `workspace_not_found` after the config write already succeeded.
         setStateField("mcpStatuses", filterConfiguredStatuses(snapshot.mcpStatuses, snapshot.mcpServers));
       } else {
+        if (!activeClient || !resolvedProjectDir) {
+          throw new Error(t("mcp.connect_server_first"));
+        }
         const mcpAddConfig =
           entryType === "remote"
             ? {
@@ -710,11 +750,16 @@ export function createConnectionsStore(options: {
       (!isDesktopRuntime() && openworkSnapshot.openworkServerStatus === "connected");
     const projectDir = options.projectDir().trim();
 
-    const { openworkClient, openworkWorkspaceId, canUseOpenworkServer } =
+    const { openworkClient, openworkWorkspaceId, hasOpenworkTarget, canUseOpenworkServer } =
       await resolveWritableOpenworkTarget();
 
     if (isRemoteWorkspace && !canUseOpenworkServer) {
       setStateField("mcpStatus", "OpenWork server unavailable. MCP auth is read-only.");
+      return;
+    }
+
+    if (hasOpenworkTarget && !canUseOpenworkServer) {
+      setStateField("mcpStatus", "OpenWork server MCP auth is read-only.");
       return;
     }
 
@@ -723,14 +768,14 @@ export function createConnectionsStore(options: {
       return;
     }
 
-    const activeClient = await ensureActiveClient();
-    if (!activeClient) {
+    const activeClient = canUseOpenworkServer ? options.client() : await ensureActiveClient();
+    if (!activeClient && !canUseOpenworkServer) {
       setStateField("mcpStatus", t("mcp.connect_server_first"));
       return;
     }
 
-    const resolvedProjectDir = await resolveProjectDir(activeClient, projectDir);
-    if (!resolvedProjectDir) {
+    const resolvedProjectDir = activeClient ? await resolveProjectDir(activeClient, projectDir) : projectDir;
+    if (!resolvedProjectDir && !canUseOpenworkServer) {
       setStateField("mcpStatus", t("mcp.pick_workspace_first"));
       return;
     }
@@ -742,6 +787,9 @@ export function createConnectionsStore(options: {
       if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
         await openworkClient.logoutMcpAuth(openworkWorkspaceId, safeName);
       } else {
+        if (!activeClient || !resolvedProjectDir) {
+          throw new Error(t("mcp.connect_server_first"));
+        }
         try {
           await activeClient.mcp.disconnect({ directory: resolvedProjectDir, name: safeName });
         } catch {
@@ -751,8 +799,10 @@ export function createConnectionsStore(options: {
       }
 
       try {
-        const status = unwrap(await activeClient.mcp.status({ directory: resolvedProjectDir }));
-        setStateField("mcpStatuses", status as McpStatusMap);
+        if (activeClient && resolvedProjectDir) {
+          const status = unwrap(await activeClient.mcp.status({ directory: resolvedProjectDir }));
+          setStateField("mcpStatuses", status as McpStatusMap);
+        }
       } catch {
         // ignore
       }
@@ -771,18 +821,16 @@ export function createConnectionsStore(options: {
     try {
       setStateField("mcpStatus", null);
 
-      const openworkSnapshot = getOpenworkSnapshot();
-      const openworkClient = openworkSnapshot.openworkServerClient;
-      const openworkWorkspaceId = options.runtimeWorkspaceId();
-      const canUseOpenworkServer =
-        openworkSnapshot.openworkServerStatus === "connected" &&
-        openworkClient &&
-        openworkWorkspaceId &&
-        openworkSnapshot.openworkServerCapabilities?.mcp?.write;
+      const { openworkClient, openworkWorkspaceId, hasOpenworkTarget, canUseOpenworkServer } =
+        await resolveWritableOpenworkTarget();
 
       if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
         await openworkClient.removeMcp(openworkWorkspaceId, name);
       } else {
+        if (hasOpenworkTarget) {
+          setStateField("mcpStatus", "OpenWork server MCP config is read-only.");
+          return;
+        }
         const projectDir = options.projectDir().trim();
         if (!projectDir) {
           setStateField("mcpStatus", t("mcp.pick_workspace_first"));
@@ -849,14 +897,8 @@ export function createConnectionsStore(options: {
   // from the existing reload-required popup; no extra banner here.
   async function setMcpEnabled(name: string, enabled: boolean) {
     try {
-      const openworkSnapshot = getOpenworkSnapshot();
-      const openworkClient = openworkSnapshot.openworkServerClient;
-      const openworkWorkspaceId = options.runtimeWorkspaceId();
-      const canUseOpenworkServer =
-        openworkSnapshot.openworkServerStatus === "connected" &&
-        openworkClient &&
-        openworkWorkspaceId &&
-        openworkSnapshot.openworkServerCapabilities?.mcp?.write;
+      const { openworkClient, openworkWorkspaceId, canUseOpenworkServer } =
+        await resolveWritableOpenworkTarget();
 
       if (!canUseOpenworkServer || !openworkClient || !openworkWorkspaceId) {
         setStateField("mcpStatus", t("mcp.toggle_requires_server"));
@@ -897,7 +939,11 @@ export function createConnectionsStore(options: {
     lastWorkspaceContextKey = workspaceContextKey;
     lastProjectDir = projectDir;
 
-    if (!started || disposed || !isDesktopRuntime() || !changed) {
+    if (!started || disposed || !changed) {
+      return;
+    }
+
+    if (!isDesktopRuntime() && getOpenworkSnapshot().openworkServerStatus !== "connected") {
       return;
     }
 

--- a/apps/app/src/react-app/domains/settings/pages/environment-variable-provider.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/environment-variable-provider.tsx
@@ -107,10 +107,10 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
   
   const { mutate: applyAsync, isPending: isApplying, reset: resetApply, error: applyError } = useMutation({
     mutationFn: async () => onApplyChanges?.(),
-    onSuccess: async (result) => {
+    onSuccess: (result) => {
       clearOpenworkEnvSystemContextCache();
-      await client?.setUserEnvPendingChanges(false, runtimeKey).catch(() => undefined);
       queryClient.setQueryData(["settings", "environment", "pending-changes", runtimeKey], false);
+      client?.setUserEnvPendingChanges(false, runtimeKey).catch(() => undefined);
       showToast({
         title: result?.statusMessage ?? t("settings.environment.apply_success"),
         tone: "success",
@@ -124,12 +124,11 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
     },
   });
 
-  const markChangesPending = useCallback(async () => {
+  const markChangesPending = useCallback(() => {
     clearOpenworkEnvSystemContextCache();
-    await client?.setUserEnvPendingChanges(true, runtimeKey).catch(() => undefined);
-
     queryClient.setQueryData(["settings", "environment", "pending-changes", runtimeKey], true);
     resetApply();
+    client?.setUserEnvPendingChanges(true, runtimeKey).catch(() => undefined);
 
     showToast({ title: t("settings.environment.restart_required"), tone: "info" });
   }, [client, resetApply, queryClient, runtimeKey, showToast]);
@@ -158,7 +157,7 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
       return client.upsertUserEnv([{ key, value: nextEditor.value }]);
     },
     onSuccess: async () => {
-      await markChangesPending();
+      markChangesPending();
 
       await queryClient.invalidateQueries({
         queryKey: environmentUserEnvQueryKey(runtimeKey),
@@ -177,7 +176,7 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
       return key;
     },
     onSuccess: async () => {
-      await markChangesPending();
+      markChangesPending();
 
       await queryClient.invalidateQueries({
         queryKey: environmentUserEnvQueryKey(runtimeKey),

--- a/apps/app/src/react-app/domains/settings/pages/environment-variable-provider.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/environment-variable-provider.tsx
@@ -2,10 +2,6 @@ import { createContext, use, useCallback, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient, type UseMutateFunction } from "@tanstack/react-query";
 
 import type { OpenworkServerClient } from "@/app/lib/openwork-server";
-import {
-  readOpenworkEnvPendingChanges,
-  writeOpenworkEnvPendingChanges,
-} from "@/app/lib/openwork-env-runtime";
 import { t } from "@/i18n";
 import { useStatusToasts } from "../../shell-feedback/status-toasts";
 import { clearOpenworkEnvSystemContextCache } from "../../session/sync/env-context";
@@ -42,9 +38,13 @@ type UseEnvironmentVariableListOptions = {
   runtimeKey?: string | null;
 };
 
+export function environmentUserEnvQueryKey(runtimeKey?: string | null) {
+  return ["settings", "environment", "user-env", runtimeKey];
+}
+
 export function useEnvironmentVariableList(options: UseEnvironmentVariableListOptions) {
   return useQuery({
-    queryKey: ["settings", "environment", "user-env", options.runtimeKey],
+    queryKey: environmentUserEnvQueryKey(options.runtimeKey),
     queryFn: async () => {
       if (!options.client || options.isRemoteWorkspace) {
         return { items: [] };
@@ -97,16 +97,19 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
 
   const { data } = useQuery({
     queryKey: ["settings", "environment", "pending-changes", runtimeKey],
-    queryFn: () => readOpenworkEnvPendingChanges(runtimeKey),
-    staleTime: Infinity,
+    queryFn: async () => {
+      if (!client) return false;
+      return (await client.getUserEnvStatus(runtimeKey)).pendingChanges;
+    },
+    staleTime: 10_000,
     refetchOnWindowFocus: false,
   });
   
   const { mutate: applyAsync, isPending: isApplying, reset: resetApply, error: applyError } = useMutation({
     mutationFn: async () => onApplyChanges?.(),
-    onSuccess: (result) => {
+    onSuccess: async (result) => {
       clearOpenworkEnvSystemContextCache();
-      writeOpenworkEnvPendingChanges(false);
+      await client?.setUserEnvPendingChanges(false, runtimeKey).catch(() => undefined);
       queryClient.setQueryData(["settings", "environment", "pending-changes", runtimeKey], false);
       showToast({
         title: result?.statusMessage ?? t("settings.environment.apply_success"),
@@ -121,15 +124,15 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
     },
   });
 
-  const markChangesPending = useCallback(() => {
+  const markChangesPending = useCallback(async () => {
     clearOpenworkEnvSystemContextCache();
-    writeOpenworkEnvPendingChanges(true, runtimeKey);
+    await client?.setUserEnvPendingChanges(true, runtimeKey).catch(() => undefined);
 
     queryClient.setQueryData(["settings", "environment", "pending-changes", runtimeKey], true);
     resetApply();
 
     showToast({ title: t("settings.environment.restart_required"), tone: "info" });
-  }, [resetApply, queryClient, runtimeKey, showToast]);
+  }, [client, resetApply, queryClient, runtimeKey, showToast]);
 
   const { mutate: modifyAsync, isPending: isModifying, reset: resetModify, error: modifyError } = useMutation({
     mutationFn: async (nextEditor: EnvironmentEditorDraft) => {
@@ -144,12 +147,9 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
       }
 
       const key = nextEditor.key.trim();
-      const existingItems = queryClient.getQueryData<{ items: EnvironmentVariableItem[] }>([
-        "settings",
-        "environment",
-        "user-env",
-        runtimeKey,
-      ])?.items;
+      const existingItems = queryClient.getQueryData<{ items: EnvironmentVariableItem[] }>(
+        environmentUserEnvQueryKey(runtimeKey),
+      )?.items;
 
       if (nextEditor.mode === "add" && existingItems?.some((item) => item.key === key)) {
         throw new Error(t("settings.environment.validation_duplicate"));
@@ -158,10 +158,10 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
       return client.upsertUserEnv([{ key, value: nextEditor.value }]);
     },
     onSuccess: async () => {
-      markChangesPending();
+      await markChangesPending();
 
       await queryClient.invalidateQueries({
-        queryKey: ["settings", "environment", "user-env", runtimeKey],
+        queryKey: environmentUserEnvQueryKey(runtimeKey),
       });
     },
   }); 
@@ -177,10 +177,10 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
       return key;
     },
     onSuccess: async () => {
-      markChangesPending();
+      await markChangesPending();
 
       await queryClient.invalidateQueries({
-        queryKey: ["settings", "environment", "user-env", runtimeKey],
+        queryKey: environmentUserEnvQueryKey(runtimeKey),
       });
     },
     onError: (error) => {

--- a/apps/app/src/react-app/domains/settings/pages/environment-variable-table.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/environment-variable-table.tsx
@@ -27,7 +27,8 @@ import { Spinner } from "../settings-section";
 
 export type EnvironmentVariableItem = {
   key: string;
-  value: string;
+  value?: string;
+  hasValue: boolean;
   updatedAt: number;
 };
 
@@ -78,6 +79,7 @@ export function EnvironmentVariableTableBody({ children }: EnvironmentVariableTa
 
 export type EnvironmentVariableTableRevealButtonProps = {
   isRevealed: boolean;
+  disabled?: boolean;
   onToggleReveal: () => void;
 };
 
@@ -92,6 +94,7 @@ export function EnvironmentVariableTableRevealButton(props: EnvironmentVariableT
             variant="ghost"
             size="icon-sm"
             pressed={props.isRevealed}
+            disabled={props.disabled}
             onPressedChange={() => props.onToggleReveal()}
             aria-label={label}
           >
@@ -161,6 +164,7 @@ export type EnvironmentVariableTableItemProps = {
   isRevealed: boolean;
   canEdit: boolean;
   deleting: boolean;
+  revealing: boolean;
   onEdit: (item: EnvironmentVariableItem) => void;
   onToggleReveal: (key: string) => void;
   onDelete: (item: EnvironmentVariableItem) => void;
@@ -196,6 +200,7 @@ export function EnvironmentVariableTableItem(props: EnvironmentVariableTableItem
           <div className="flex h-lh shrink-0 items-center justify-center">
             <EnvironmentVariableTableRevealButton
               isRevealed={props.isRevealed}
+              disabled={props.revealing}
               onToggleReveal={() => props.onToggleReveal(props.item.key)}
             />
           </div>
@@ -203,7 +208,7 @@ export function EnvironmentVariableTableItem(props: EnvironmentVariableTableItem
             <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
               {props.item.value || t("settings.environment.empty_value")}
             </code>
-          ) : props.item.value ? (
+          ) : props.item.hasValue ? (
             <span className="font-mono text-xs text-muted-foreground">{MASKED_VALUE_DISPLAY}</span>
           ) : (
             <span className="text-xs text-muted-foreground">{t("settings.environment.empty_value")}</span>

--- a/apps/app/src/react-app/domains/settings/pages/environment-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/environment-view.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect, useId, useState, type SetStateAction } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Plus, RefreshCw } from "lucide-react";
 
 import {
@@ -25,6 +26,7 @@ import type { OpenworkServerClient } from "@/app/lib/openwork-server";
 import { t } from "@/i18n";
 import {
   EnvironmentVariableProvider,
+  environmentUserEnvQueryKey,
   type ApplyEnvironmentChangesResult,
   type EnvironmentEditorDraft,
   useEnvironmentVariableApplyChanges,
@@ -125,11 +127,53 @@ type EnvironmentSettingsPanelProps = {
 
 function EnvironmentSettingsPanel(props: EnvironmentSettingsPanelProps) {
   const isPendingChanges = useIsEnvironmentVariableChangesPending();
+  const queryClient = useQueryClient();
+  const { showToast } = useStatusToasts();
   const { data, error, isLoading } = useEnvironmentVariableList({
     client: props.client,
     isRemoteWorkspace: props.isRemoteWorkspace,
     runtimeKey: props.runtimeKey,
   });
+
+  const readEnvironmentValue = async (item: EnvItem) => {
+    if (typeof item.value === "string") return item.value;
+    if (!item.hasValue) {
+      queryClient.setQueryData<{ items: EnvItem[] }>(
+        environmentUserEnvQueryKey(props.runtimeKey),
+        (current) => {
+          if (!current) return current;
+          return {
+            items: current.items.map((entry) =>
+              entry.key === item.key ? { ...entry, value: "" } : entry,
+            ),
+          };
+        },
+      );
+      return "";
+    }
+    if (!props.client) throw new Error(t("app.unknown_error"));
+
+    const response = await props.client.getUserEnv(item.key);
+    queryClient.setQueryData<{ items: EnvItem[] }>(
+      environmentUserEnvQueryKey(props.runtimeKey),
+      (current) => {
+        if (!current) return current;
+        return {
+          items: current.items.map((entry) =>
+            entry.key === item.key
+              ? {
+                  ...entry,
+                  value: response.item.value,
+                  hasValue: response.item.hasValue,
+                  updatedAt: response.item.updatedAt,
+                }
+              : entry,
+          ),
+        };
+      },
+    );
+    return response.item.value;
+  };
 
   const openAdd = () => {
     if (!props.canEdit) {
@@ -142,7 +186,14 @@ function EnvironmentSettingsPanel(props: EnvironmentSettingsPanelProps) {
     if (!props.canEdit) {
       return;
     }
-    props.onEditorChange({ mode: "edit", key: item.key, value: item.value });
+    void readEnvironmentValue(item)
+      .then((value) => props.onEditorChange({ mode: "edit", key: item.key, value }))
+      .catch((readError) => {
+        showToast({
+          title: readError instanceof Error ? readError.message : t("app.unknown_error"),
+          tone: "error",
+        });
+      });
   };
 
   return (
@@ -185,6 +236,7 @@ function EnvironmentSettingsPanel(props: EnvironmentSettingsPanelProps) {
           canEdit={props.canEdit}
           onAdd={openAdd}
           onEdit={openEdit}
+          onRevealValue={readEnvironmentValue}
         />
       ) : null}
 
@@ -271,12 +323,36 @@ type EnvironmentItemsTableProps = {
   canEdit: boolean;
   onAdd: () => void;
   onEdit: (item: EnvItem) => void;
+  onRevealValue: (item: EnvItem) => Promise<string>;
 };
 
 function EnvironmentItemsTable(props: EnvironmentItemsTableProps) {
   const [revealed, setRevealed] = useState<Record<string, boolean>>({});
+  const [revealing, setRevealing] = useState<Record<string, boolean>>({});
   const [deleteCandidate, setDeleteCandidate] = useState<EnvItem | null>(null);
   const { isRemoving } = useEnvironmentVariableRemove();
+  const { showToast } = useStatusToasts();
+
+  const toggleReveal = async (key: string) => {
+    const item = props.items.find((entry) => entry.key === key);
+    if (revealed[key] && typeof item?.value === "string") {
+      setRevealed((current) => ({ ...current, [key]: false }));
+      return;
+    }
+    if (!item) return;
+    setRevealing((current) => ({ ...current, [key]: true }));
+    try {
+      await props.onRevealValue(item);
+      setRevealed((current) => ({ ...current, [key]: true }));
+    } catch (readError) {
+      showToast({
+        title: readError instanceof Error ? readError.message : t("app.unknown_error"),
+        tone: "error",
+      });
+    } finally {
+      setRevealing((current) => ({ ...current, [key]: false }));
+    }
+  };
 
   if (props.loading && props.items.length === 0) {
     return <EnvironmentVariableTableLoading />;
@@ -293,11 +369,12 @@ function EnvironmentItemsTable(props: EnvironmentItemsTableProps) {
             <EnvironmentVariableTableItem
               key={item.key}
               item={item}
-              isRevealed={Boolean(revealed[item.key])}
+              isRevealed={Boolean(revealed[item.key]) && typeof item.value === "string"}
               canEdit={props.canEdit}
               deleting={isRemoving && deleteCandidate?.key === item.key}
+              revealing={Boolean(revealing[item.key])}
               onEdit={props.onEdit}
-              onToggleReveal={(key) => setRevealed((current) => ({ ...current, [key]: !current[key] }))}
+              onToggleReveal={(key) => void toggleReveal(key)}
               onDelete={setDeleteCandidate}
             />
           ))}
@@ -481,4 +558,3 @@ export function EnvironmentApplyModal(props: EnvironmentApplyModalProps) {
     />
   );
 }
-

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -318,8 +318,9 @@ export function McpView(props: McpViewProps) {
     const nextId = configRequestId.current + 1;
     configRequestId.current = nextId;
     const readConfig = props.readConfigFile;
+    const canReadDesktopConfig = !props.isRemoteWorkspace && isDesktopRuntime();
 
-    if (!readConfig && !isDesktopRuntime()) {
+    if (!readConfig && !canReadDesktopConfig) {
       dispatchLocal({ type: "configUnavailable" });
       return;
     }
@@ -331,9 +332,15 @@ export function McpView(props: McpViewProps) {
           root
             ? readConfig
               ? readConfig("project")
-              : readOpencodeConfig("project", root)
+              : canReadDesktopConfig
+              ? readOpencodeConfig("project", root)
+              : Promise.resolve(null)
             : Promise.resolve(null),
-          readConfig ? readConfig("global") : readOpencodeConfig("global", root),
+          readConfig
+            ? readConfig("global")
+            : canReadDesktopConfig
+            ? readOpencodeConfig("global", root)
+            : Promise.resolve(null),
         ]);
         if (nextId !== configRequestId.current) return;
         dispatchLocal({
@@ -349,7 +356,7 @@ export function McpView(props: McpViewProps) {
         });
       }
     })();
-  }, [props.readConfigFile, props.selectedWorkspaceRoot]);
+  }, [props.isRemoteWorkspace, props.readConfigFile, props.selectedWorkspaceRoot]);
 
   const activeConfig = configScope === "project" ? projectConfig : globalConfig;
 
@@ -359,6 +366,7 @@ export function McpView(props: McpViewProps) {
 
   const canRevealConfig =
     isDesktopRuntime() &&
+    !props.isRemoteWorkspace &&
     !revealBusy &&
     !(configScope === "project" && !props.selectedWorkspaceRoot.trim()) &&
     Boolean(activeConfig?.exists);
@@ -458,7 +466,9 @@ export function McpView(props: McpViewProps) {
     try {
       const resolved = props.readConfigFile
         ? await props.readConfigFile(configScope)
-        : await readOpencodeConfig(configScope, root);
+        : !props.isRemoteWorkspace
+        ? await readOpencodeConfig(configScope, root)
+        : null;
       const configFile = resolved as OpencodeConfigFile | null;
       if (!configFile) {
         throw new Error(t("mcp.config_load_failed"));

--- a/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel-state.ts
+++ b/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel-state.ts
@@ -12,8 +12,12 @@ export type AuthorizedFoldersState = {
   error: string | null;
 };
 
+type AuthorizedFoldersSetAction = {
+  [K in keyof AuthorizedFoldersState]: { type: "set"; key: K; value: SetStateAction<AuthorizedFoldersState[K]> };
+}[keyof AuthorizedFoldersState];
+
 type AuthorizedFoldersAction =
-  | { type: "set"; key: keyof AuthorizedFoldersState; value: SetStateAction<any> }
+  | AuthorizedFoldersSetAction
   | { type: "reset" }
   | { type: "loadStart" }
   | { type: "loadSuccess"; folders: string[]; status: string | null }
@@ -56,52 +60,11 @@ export function authorizedFoldersReducer(
   }
 }
 
-export const ensureRecord = (value: unknown): Record<string, unknown> => {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-  return value as Record<string, unknown>;
-};
-
 export const normalizeAuthorizedFolderPath = (input: string | null | undefined) => {
   const trimmed = (input ?? "").trim();
   if (!trimmed) return "";
   const withoutWildcard = trimmed.replace(/[\\/]\*+$/, "");
   return normalizeDirectoryQueryPath(withoutWildcard);
-};
-
-const authorizedFolderToExternalDirectoryKey = (folder: string) => {
-  const normalized = normalizeAuthorizedFolderPath(folder);
-  if (!normalized) return "";
-  return normalized === "/" ? "/*" : `${normalized}/*`;
-};
-
-const externalDirectoryKeyToAuthorizedFolder = (key: string, value: unknown) => {
-  if (value !== "allow") return null;
-  const trimmed = key.trim();
-  if (!trimmed) return null;
-  if (trimmed === "/*") return "/";
-  if (!trimmed.endsWith("/*")) return null;
-  return normalizeAuthorizedFolderPath(trimmed.slice(0, -2));
-};
-
-export const readAuthorizedFoldersFromConfig = (opencodeConfig: Record<string, unknown>) => {
-  const permission = ensureRecord(opencodeConfig.permission);
-  const externalDirectory = ensureRecord(permission.external_directory);
-  const folders: string[] = [];
-  const hiddenEntries: Record<string, unknown> = {};
-  const seen = new Set<string>();
-
-  for (const [key, value] of Object.entries(externalDirectory)) {
-    const folder = externalDirectoryKeyToAuthorizedFolder(key, value);
-    if (!folder) {
-      hiddenEntries[key] = value;
-      continue;
-    }
-    if (seen.has(folder)) continue;
-    seen.add(folder);
-    folders.push(folder);
-  }
-
-  return { folders, hiddenEntries };
 };
 
 export const buildAuthorizedFoldersStatus = (preservedCount: number, action?: string) => {
@@ -113,17 +76,4 @@ export const buildAuthorizedFoldersStatus = (preservedCount: number, action?: st
       : null;
   if (action && preservedLabel) return `${action} ${preservedLabel}`;
   return action ?? preservedLabel;
-};
-
-export const mergeAuthorizedFoldersIntoExternalDirectory = (
-  folders: string[],
-  hiddenEntries: Record<string, unknown>,
-): Record<string, unknown> | undefined => {
-  const next: Record<string, unknown> = { ...hiddenEntries };
-  for (const folder of folders) {
-    const key = authorizedFolderToExternalDirectoryKey(folder);
-    if (!key) continue;
-    next[key] = "allow";
-  }
-  return Object.keys(next).length ? next : undefined;
 };

--- a/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
+++ b/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useMemo, useReducer, type SetStateAction } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState, type SetStateAction } from "react";
 import { Folder, Info, Plus, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -26,12 +26,8 @@ import {
 import {
   authorizedFoldersReducer,
   buildAuthorizedFoldersStatus,
-  ensureRecord,
   initialAuthorizedFoldersState,
-  mergeAuthorizedFoldersIntoExternalDirectory,
   normalizeAuthorizedFolderPath,
-  readAuthorizedFoldersFromConfig,
-  type AuthorizedFoldersState,
 } from "./authorized-folders-panel-state";
 import {
   SettingsNotice,
@@ -119,6 +115,7 @@ function AuthorizedFolderItem(props: AuthorizedFolderItemProps) {
 }
 
 export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
+  const [serverWorkspaceRoot, setServerWorkspaceRoot] = useState("");
   const [folderState, dispatchFolderState] = useReducer(
     authorizedFoldersReducer,
     initialAuthorizedFoldersState,
@@ -130,14 +127,10 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
     status: authorizedFoldersStatus,
     error: authorizedFoldersError,
   } = folderState;
-  const setFolderState = <K extends keyof AuthorizedFoldersState>(
-    key: K,
-    value: SetStateAction<AuthorizedFoldersState[K]>,
-  ) => dispatchFolderState({ type: "set", key, value });
-  const setAuthorizedFolders = (value: SetStateAction<string[]>) => setFolderState("folders", value);
-  const setAuthorizedFoldersSaving = (value: SetStateAction<boolean>) => setFolderState("saving", value);
-  const setAuthorizedFoldersStatus = (value: SetStateAction<string | null>) => setFolderState("status", value);
-  const setAuthorizedFoldersError = (value: SetStateAction<string | null>) => setFolderState("error", value);
+  const setAuthorizedFolders = (value: SetStateAction<string[]>) => dispatchFolderState({ type: "set", key: "folders", value });
+  const setAuthorizedFoldersSaving = (value: SetStateAction<boolean>) => dispatchFolderState({ type: "set", key: "saving", value });
+  const setAuthorizedFoldersStatus = (value: SetStateAction<string | null>) => dispatchFolderState({ type: "set", key: "status", value });
+  const setAuthorizedFoldersError = (value: SetStateAction<string | null>) => dispatchFolderState({ type: "set", key: "error", value });
 
   const openworkServerReady = props.openworkServerStatus === "connected";
   const openworkServerWorkspaceReady = Boolean(props.runtimeWorkspaceId);
@@ -160,10 +153,10 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
 
   const canPickAuthorizedFolder =
     isDesktopRuntime() && canWriteConfig && props.activeWorkspaceType === "local";
-  const workspaceRootFolder = props.selectedWorkspaceRoot.trim();
+  const workspaceRootFolder = serverWorkspaceRoot || props.selectedWorkspaceRoot.trim();
   const visibleAuthorizedFolders = useMemo(() => {
     const root = workspaceRootFolder;
-    return root ? [root, ...authorizedFolders] : authorizedFolders;
+    return root ? [root, ...authorizedFolders.filter((folder) => folder !== root)] : authorizedFolders;
   }, [authorizedFolders, workspaceRootFolder]);
 
   useEffect(() => {
@@ -171,6 +164,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
     const openworkWorkspaceId = props.runtimeWorkspaceId;
 
     if (!openworkClient || !openworkWorkspaceId || !canReadConfig) {
+      setServerWorkspaceRoot("");
       dispatchFolderState({ type: "reset" });
       return;
     }
@@ -180,13 +174,13 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
 
     void (async () => {
       try {
-        const config = await openworkClient.getConfig(openworkWorkspaceId);
+        const response = await openworkClient.listAuthorizedFolders(openworkWorkspaceId);
         if (cancelled) return;
-        const next = readAuthorizedFoldersFromConfig(ensureRecord(config.opencode));
+        setServerWorkspaceRoot(response.workspaceRoot.trim());
         dispatchFolderState({
           type: "loadSuccess",
-          folders: next.folders,
-          status: buildAuthorizedFoldersStatus(Object.keys(next.hiddenEntries).length),
+          folders: response.folders,
+          status: buildAuthorizedFoldersStatus(response.hiddenCount),
         });
       } catch (error) {
         if (cancelled) return;
@@ -215,26 +209,11 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
     setAuthorizedFoldersStatus(t("context_panel.saving_folders"));
 
     try {
-      const currentConfig = await openworkClient.getConfig(openworkWorkspaceId);
-      const currentAuthorizedFolders = readAuthorizedFoldersFromConfig(
-        ensureRecord(currentConfig.opencode),
-      );
-      const nextExternalDirectory = mergeAuthorizedFoldersIntoExternalDirectory(
-        nextFolders,
-        currentAuthorizedFolders.hiddenEntries,
-      );
-
-      await openworkClient.patchConfig(openworkWorkspaceId, {
-        opencode: {
-          permission: {
-            external_directory: nextExternalDirectory,
-          },
-        },
-      });
-      setAuthorizedFolders(nextFolders);
+      const response = await openworkClient.setAuthorizedFolders(openworkWorkspaceId, nextFolders);
+      setAuthorizedFolders(response.folders);
       setAuthorizedFoldersStatus(
         buildAuthorizedFoldersStatus(
-          Object.keys(currentAuthorizedFolders.hiddenEntries).length,
+          response.hiddenCount,
           t("context_panel.folders_updated"),
         ),
       );
@@ -248,7 +227,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
     } finally {
       setAuthorizedFoldersSaving(false);
     }
-  }, [canWriteConfig, props]);
+  }, [canWriteConfig, props.onConfigUpdated, props.openworkServerClient, props.runtimeWorkspaceId]);
 
   const removeAuthorizedFolder = useCallback(async (folder: string) => {
     const nextFolders = authorizedFolders.filter((entry) => entry !== folder);

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -272,6 +272,7 @@ export function createExtensionsStore(options: {
     openworkServerCapabilities: OpenworkServerCapabilities | null;
   };
   runtimeWorkspaceId: () => string | null;
+  ensureRuntimeWorkspaceId?: () => Promise<string | null | undefined>;
   setBusy: (value: boolean) => void;
   setBusyLabel: (value: string | null) => void;
   setBusyStartedAt: (value: number | null) => void;
@@ -368,6 +369,24 @@ export function createExtensionsStore(options: {
     };
   };
 
+  const resolveWorkspaceServerTarget = async () => {
+    const openworkSnapshot = getOpenworkServerSnapshot();
+    const openworkClient = openworkSnapshot.openworkServerClient;
+    let openworkWorkspaceId = options.runtimeWorkspaceId()?.trim() || null;
+    if (!openworkWorkspaceId && openworkSnapshot.openworkServerStatus === "connected" && openworkClient) {
+      openworkWorkspaceId = (await options.ensureRuntimeWorkspaceId?.())?.trim() || null;
+    }
+    const hasOpenworkTarget =
+      openworkSnapshot.openworkServerStatus === "connected" &&
+      Boolean(openworkClient && openworkWorkspaceId);
+    return {
+      openworkSnapshot,
+      openworkClient,
+      openworkWorkspaceId,
+      hasOpenworkTarget,
+    };
+  };
+
   const refreshSnapshot = () => {
     const workspaceContextKey = getWorkspaceContextKey();
     const orgId = readDenSettings().activeOrgId?.trim() ?? "";
@@ -453,18 +472,19 @@ export function createExtensionsStore(options: {
   const readWorkspaceOpenworkConfigRecord = async (): Promise<Record<string, unknown>> => {
     const root = options.selectedWorkspaceRoot().trim();
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.config?.read;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.config?.read !== false;
 
-    if (canUseOpenworkServer) {
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       const config = await openworkClient.getConfig(openworkWorkspaceId);
       return config.openwork ?? {};
+    }
+
+    if (hasOpenworkTarget) {
+      return {};
     }
 
     if (isLocalWorkspace && isDesktopRuntime() && root) {
@@ -477,18 +497,19 @@ export function createExtensionsStore(options: {
   const writeWorkspaceOpenworkConfigRecord = async (config: Record<string, unknown>) => {
     const root = options.selectedWorkspaceRoot().trim();
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.config?.write;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.config?.write !== false;
 
-    if (canUseOpenworkServer) {
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       await openworkClient.patchConfig(openworkWorkspaceId, { openwork: config });
       return true;
+    }
+
+    if (hasOpenworkTarget) {
+      return false;
     }
 
     if (isLocalWorkspace && isDesktopRuntime() && root) {
@@ -605,22 +626,23 @@ export function createExtensionsStore(options: {
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
     const root = options.selectedWorkspaceRoot().trim();
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.skills?.write;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.skills?.write !== false;
 
-    if (canUseOpenworkServer) {
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       await openworkClient.upsertSkill(openworkWorkspaceId, {
         name,
         content,
         description,
       });
       return;
+    }
+
+    if (hasOpenworkTarget) {
+      throw new Error("OpenWork server cannot write skills for this workspace.");
     }
 
     if (isRemoteWorkspace) {
@@ -679,18 +701,19 @@ export function createExtensionsStore(options: {
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
     const root = options.selectedWorkspaceRoot().trim();
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.skills?.write;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.skills?.write !== false;
 
-    if (canUseOpenworkServer) {
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       await openworkClient.deleteSkill(openworkWorkspaceId, name);
       return;
+    }
+
+    if (hasOpenworkTarget) {
+      throw new Error("OpenWork server cannot remove skills for this workspace.");
     }
 
     if (isRemoteWorkspace) {
@@ -949,13 +972,13 @@ export function createExtensionsStore(options: {
   };
 
   const writePluginWorkspaceFile = async (path: string, content: string) => {
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     if (
-      openworkSnapshot.openworkServerStatus === "connected" &&
+      hasOpenworkTarget &&
       openworkClient &&
       openworkWorkspaceId &&
+      openworkSnapshot.openworkServerCapabilities?.config?.write !== false &&
       typeof openworkClient.writeWorkspaceFile === "function"
     ) {
       await openworkClient.writeWorkspaceFile(openworkWorkspaceId, { path, content, force: true });
@@ -1605,14 +1628,11 @@ export function createExtensionsStore(options: {
     if (!repo) return { ok: false, message: "Select a hub repo before installing skills." };
 
     const isRemoteWorkspace = options.workspaceType() === "remote";
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.hub?.skills?.install;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.hub?.skills?.install !== false;
 
     if (!canUseOpenworkServer) {
       if (isRemoteWorkspace) return { ok: false, message: "OpenWork server unavailable. Connect to install skills." };
@@ -1625,6 +1645,7 @@ export function createExtensionsStore(options: {
 
     try {
       const repoOverride: OpenworkHubRepo = { owner: repo.owner, repo: repo.repo, ref: repo.ref };
+      if (!openworkClient || !openworkWorkspaceId) return { ok: false, message: "Hub install requires OpenWork server." };
       const result = await openworkClient.installHubSkill(openworkWorkspaceId, trimmed, { repo: repoOverride });
       await Promise.all([refreshSkills({ force: true }), refreshHubSkills({ force: true })]);
       if (!result?.ok) return { ok: false, message: "Install failed." };
@@ -1733,18 +1754,14 @@ export function createExtensionsStore(options: {
 
   async function refreshSkills(optionsOverride?: { force?: boolean }) {
     const root = options.selectedWorkspaceRoot().trim();
-    const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.skills?.read;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.skills?.read !== false;
 
-    if (!root) {
+    if (!root && !hasOpenworkTarget) {
       mutateState((current) => ({
         ...current,
         skills: [],
@@ -1753,8 +1770,9 @@ export function createExtensionsStore(options: {
       return;
     }
 
-    if (canUseOpenworkServer) {
-      if (root !== skillsRoot) skillsLoaded = false;
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
+      const skillCacheKey = root || openworkWorkspaceId;
+      if (skillCacheKey !== skillsRoot) skillsLoaded = false;
       if (!optionsOverride?.force && skillsLoaded) return;
       if (refreshSkillsInFlight) return;
 
@@ -1779,7 +1797,7 @@ export function createExtensionsStore(options: {
           skillsContextKey: getWorkspaceContextKey(),
         }));
         skillsLoaded = true;
-        skillsRoot = root;
+        skillsRoot = skillCacheKey;
       } catch (error) {
         if (refreshSkillsAborted) return;
         mutateState((current) => ({
@@ -1790,6 +1808,15 @@ export function createExtensionsStore(options: {
       } finally {
         refreshSkillsInFlight = false;
       }
+      return;
+    }
+
+    if (hasOpenworkTarget) {
+      mutateState((current) => ({
+        ...current,
+        skills: [],
+        skillsStatus: "OpenWork server cannot read skills for this workspace.",
+      }));
       return;
     }
 
@@ -1893,14 +1920,11 @@ export function createExtensionsStore(options: {
   async function refreshPlugins(scopeOverride?: PluginScope) {
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.plugins?.read;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.plugins?.read !== false;
 
     if (refreshPluginsInFlight) return;
     refreshPluginsInFlight = true;
@@ -1921,7 +1945,7 @@ export function createExtensionsStore(options: {
       return;
     }
 
-    if (scope === "project" && canUseOpenworkServer) {
+    if (scope === "project" && canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       mutateState((current) => ({
         ...current,
         pluginConfig: null,
@@ -1955,6 +1979,18 @@ export function createExtensionsStore(options: {
       } finally {
         refreshPluginsInFlight = false;
       }
+      return;
+    }
+
+    if (scope === "project" && hasOpenworkTarget) {
+      mutateState((current) => ({
+        ...current,
+        pluginStatus: "OpenWork server cannot read plugins for this workspace.",
+        pluginList: [],
+        sidebarPluginStatus: "OpenWork server cannot read plugins for this workspace.",
+        sidebarPluginList: [],
+      }));
+      refreshPluginsInFlight = false;
       return;
     }
 
@@ -2062,16 +2098,12 @@ export function createExtensionsStore(options: {
     const isManualInput = pluginNameOverride == null;
     const triggerName = stripPluginVersion(pluginName);
 
-    const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.plugins?.write;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.plugins?.write !== false;
 
     if (!pluginName) {
       if (isManualInput) setStateField("pluginStatus", t("skills.enter_plugin_name"));
@@ -2083,7 +2115,7 @@ export function createExtensionsStore(options: {
       return;
     }
 
-    if (snapshot.pluginScope === "project" && canUseOpenworkServer) {
+    if (snapshot.pluginScope === "project" && canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       try {
         setStateField("pluginStatus", null);
         await openworkClient.addPlugin(openworkWorkspaceId, pluginName);
@@ -2096,12 +2128,17 @@ export function createExtensionsStore(options: {
       return;
     }
 
+    if (snapshot.pluginScope === "project" && hasOpenworkTarget) {
+      setStateField("pluginStatus", "OpenWork server cannot write plugins for this workspace.");
+      return;
+    }
+
     if (!isDesktopRuntime()) {
       setStateField("pluginStatus", t("skills.plugin_management_host_only"));
       return;
     }
 
-    if (!isLocalWorkspace && !canUseOpenworkServer) {
+    if (!isLocalWorkspace) {
       setStateField("pluginStatus", "OpenWork server unavailable. Connect to manage plugins.");
       return;
     }
@@ -2158,21 +2195,18 @@ export function createExtensionsStore(options: {
     }
 
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.plugins?.write;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.plugins?.write !== false;
 
     if (snapshot.pluginScope !== "project" && !isLocalWorkspace) {
       setStateField("pluginStatus", "Global plugins are only available for local workers.");
       return;
     }
 
-    if (snapshot.pluginScope === "project" && canUseOpenworkServer) {
+    if (snapshot.pluginScope === "project" && canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       try {
         setStateField("pluginStatus", null);
         await openworkClient.removePlugin(openworkWorkspaceId, name);
@@ -2184,12 +2218,17 @@ export function createExtensionsStore(options: {
       return;
     }
 
+    if (snapshot.pluginScope === "project" && hasOpenworkTarget) {
+      setStateField("pluginStatus", "OpenWork server cannot write plugins for this workspace.");
+      return;
+    }
+
     if (!isDesktopRuntime()) {
       setStateField("pluginStatus", t("skills.plugin_management_host_only"));
       return;
     }
 
-    if (!isLocalWorkspace && !canUseOpenworkServer) {
+    if (!isLocalWorkspace) {
       setStateField("pluginStatus", "OpenWork server unavailable. Connect to manage plugins.");
       return;
     }
@@ -2271,16 +2310,13 @@ export function createExtensionsStore(options: {
   async function installSkillCreator(): Promise<{ ok: boolean; message: string }> {
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.skills?.write;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.skills?.write !== false;
 
-    if (canUseOpenworkServer) {
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       options.setBusy(true);
       options.setError(null);
       setStateField("skillsStatus", t("skills.installing_skill_creator"));
@@ -2300,6 +2336,12 @@ export function createExtensionsStore(options: {
       } finally {
         options.setBusy(false);
       }
+    }
+
+    if (hasOpenworkTarget) {
+      const message = "OpenWork server cannot write skills for this workspace.";
+      setStateField("skillsStatus", message);
+      return { ok: false, message };
     }
 
     if (isRemoteWorkspace) {
@@ -2394,11 +2436,6 @@ export function createExtensionsStore(options: {
   }
 
   async function uninstallSkill(name: string) {
-    const root = options.selectedWorkspaceRoot().trim();
-    if (!root) {
-      setStateField("skillsStatus", t("skills.pick_workspace_first"));
-      return;
-    }
     const trimmed = name.trim();
     if (!trimmed) return;
 
@@ -2423,23 +2460,15 @@ export function createExtensionsStore(options: {
     const trimmed = name.trim();
     if (!trimmed) return null;
     const root = options.selectedWorkspaceRoot().trim();
-    if (!root) {
-      setStateField("skillsStatus", t("skills.pick_workspace_first"));
-      return null;
-    }
-
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.skills?.read;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.skills?.read !== false;
 
-    if (canUseOpenworkServer) {
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       try {
         setStateField("skillsStatus", null);
         const result = await openworkClient.getSkill(openworkWorkspaceId, trimmed, { includeGlobal: isLocalWorkspace });
@@ -2448,6 +2477,16 @@ export function createExtensionsStore(options: {
         setStateField("skillsStatus", error instanceof Error ? error.message : t("skills.failed_to_load"));
         return null;
       }
+    }
+
+    if (hasOpenworkTarget) {
+      setStateField("skillsStatus", "OpenWork server cannot read skills for this workspace.");
+      return null;
+    }
+
+    if (!root) {
+      setStateField("skillsStatus", t("skills.pick_workspace_first"));
+      return null;
     }
 
     if (isRemoteWorkspace) {
@@ -2477,23 +2516,15 @@ export function createExtensionsStore(options: {
     const trimmed = input.name.trim();
     if (!trimmed) return;
     const root = options.selectedWorkspaceRoot().trim();
-    if (!root) {
-      setStateField("skillsStatus", t("skills.pick_workspace_first"));
-      return;
-    }
-
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = getOpenworkServerSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
-    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
     const canUseOpenworkServer =
-      openworkSnapshot.openworkServerStatus === "connected" &&
-      openworkClient &&
-      openworkWorkspaceId &&
-      openworkSnapshot.openworkServerCapabilities?.skills?.write;
+      hasOpenworkTarget &&
+      openworkSnapshot.openworkServerCapabilities?.skills?.write !== false;
 
-    if (canUseOpenworkServer) {
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       options.setBusy(true);
       options.setError(null);
       setStateField("skillsStatus", null);
@@ -2512,6 +2543,16 @@ export function createExtensionsStore(options: {
       } finally {
         options.setBusy(false);
       }
+      return;
+    }
+
+    if (hasOpenworkTarget) {
+      setStateField("skillsStatus", "OpenWork server cannot write skills for this workspace.");
+      return;
+    }
+
+    if (!root) {
+      setStateField("skillsStatus", t("skills.pick_workspace_first"));
       return;
     }
 

--- a/apps/app/src/react-app/shell/desktop-runtime-boot.ts
+++ b/apps/app/src/react-app/shell/desktop-runtime-boot.ts
@@ -95,10 +95,43 @@ export function useDesktopRuntimeBoot() {
         hydrateOpenworkServerSettingsFromEnv();
         const preferredRemoteAccess = readOpenworkServerSettings().remoteAccessEnabled === true;
 
+        const publishOpenworkServerInfo = (serverInfo: BootOpenworkServerInfo | null | undefined) => {
+          if (!serverInfo?.baseUrl) return;
+          writeOpenworkServerSettings({
+            urlOverride: serverInfo.baseUrl,
+            token:
+              serverInfo.ownerToken?.trim() ||
+              serverInfo.clientToken?.trim() ||
+              undefined,
+            hostToken: serverInfo.hostToken?.trim() || undefined,
+            portOverride: serverInfo.port ?? undefined,
+            remoteAccessEnabled: serverInfo.remoteAccessEnabled === true,
+          });
+          try {
+            window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
+          } catch {
+            /* ignore */
+          }
+        };
+
+        const startServerWithoutDesktopWorkspace = async () => {
+          setPhase("starting-engine", "Starting OpenWork server");
+          const serverInfo = await openworkServerRestart({ remoteAccessEnabled: preferredRemoteAccess }).catch((error) => {
+            console.warn("[desktop-boot] openworkServerRestart failed:", error);
+            return null;
+          });
+          if (!isOpenworkServerInfoLike(serverInfo) || !isOpenworkServerReady(serverInfo)) {
+            setError("OpenWork server did not finish starting. Please restart OpenWork.");
+            return;
+          }
+          publishOpenworkServerInfo(serverInfo);
+          markReady();
+        };
+
         setPhase("bootstrapping-workspaces");
         const list = await workspaceBootstrap().catch(() => null) as WorkspaceList | null;
         if (!list) {
-          markReady();
+          await startServerWithoutDesktopWorkspace();
           return;
         }
 
@@ -107,13 +140,13 @@ export function useDesktopRuntimeBoot() {
           ? list.workspaces.find((w) => w.id === selectedId)
           : undefined;
         if (!workspace || workspace.workspaceType === "remote") {
-          markReady();
+          await startServerWithoutDesktopWorkspace();
           return;
         }
 
         const workspaceRoot = workspace.path?.trim();
         if (!workspaceRoot) {
-          markReady();
+          await startServerWithoutDesktopWorkspace();
           return;
         }
 
@@ -151,23 +184,7 @@ export function useDesktopRuntimeBoot() {
             });
             if (isOpenworkServerInfoLike(restarted)) serverInfo = restarted;
           }
-          if (serverInfo?.baseUrl) {
-            writeOpenworkServerSettings({
-              urlOverride: serverInfo.baseUrl,
-              token:
-                serverInfo.ownerToken?.trim() ||
-                serverInfo.clientToken?.trim() ||
-                undefined,
-              hostToken: serverInfo.hostToken?.trim() || undefined,
-              portOverride: serverInfo.port ?? undefined,
-              remoteAccessEnabled: serverInfo.remoteAccessEnabled === true,
-            });
-            try {
-              window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
-            } catch {
-              /* ignore */
-            }
-          }
+          publishOpenworkServerInfo(serverInfo);
           markReady();
           return;
         }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -37,13 +37,9 @@ import {
   pickDirectory,
   resolveWorkspaceListSelectedId,
   workspaceBootstrap,
-  workspaceCreate,
-  workspaceCreateRemote,
-  workspaceExportConfig,
   workspaceForget,
   workspaceSetRuntimeActive,
   workspaceSetSelected,
-  workspaceUpdateDisplayName,
   type EngineInfo,
   type OpenworkServerInfo,
   type WorkspaceInfo,
@@ -210,6 +206,24 @@ function workspaceLabel(workspace: OpenworkWorkspaceInfo) {
     workspace.path?.trim() ||
     t("session.workspace_fallback")
   );
+}
+
+function workspaceExportFilename(workspace: OpenworkWorkspaceInfo) {
+  const slug = workspaceLabel(workspace).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return `${slug || "workspace"}-openwork-export.json`;
+}
+
+function downloadWorkspaceJson(filename: string, payload: unknown) {
+  if (typeof document === "undefined") return;
+  const blob = new Blob([`${JSON.stringify(payload, null, 2)}\n`], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
 }
 
 const emptyWorkspaceDisplay: WorkspaceDisplay = {
@@ -2192,12 +2206,6 @@ export function SessionRoute() {
       // desktop-provided workspaceBootstrap results). Either call failing on
       // its own should NOT block the other — the user's intent was "rename
       // this workspace" and a soft failure in one store is recoverable.
-      if (isDesktopRuntime()) {
-        await workspaceUpdateDisplayName({
-          workspaceId: renameWorkspaceId,
-          displayName: trimmed,
-        }).catch(() => undefined);
-      }
       if (client) {
         await client
           .updateWorkspaceDisplayName(renameWorkspaceId, trimmed)
@@ -2236,22 +2244,17 @@ export function SessionRoute() {
 
   const handleExportWorkspaceConfig = useCallback(
     async (workspaceId: string) => {
-      if (!isDesktopRuntime()) return;
       const workspace = workspaces.find((item) => item.id === workspaceId) ?? null;
       if (!workspace) return;
-      const outputPath = await pickDirectory({
-        title: `Choose where to export ${workspaceLabel(workspace)}`,
-      });
-      const targetPath = Array.isArray(outputPath) ? outputPath[0] : outputPath;
-      if (!targetPath) return;
-      await workspaceExportConfig({ workspaceId, outputPath: targetPath });
-      try {
-        await revealDesktopItemInDir(targetPath);
-      } catch {
-        // ignore reveal failures
+      const endpoint = endpointForWorkspace(workspace);
+      if (endpoint) {
+        const payload = await endpoint.client.exportWorkspace(endpoint.workspaceId);
+        downloadWorkspaceJson(workspaceExportFilename(workspace), payload);
+        return;
       }
+      throw new Error("OpenWork server is unavailable. Reconnect the server before exporting workspace config.");
     },
-    [workspaces],
+    [endpointForWorkspace, workspaces],
   );
 
   const handleForgetWorkspace = useCallback(
@@ -2264,11 +2267,11 @@ export function SessionRoute() {
       }
       // Remove from both stores so the next refresh can't resurrect the row
       // from whichever list wins the merge.
-      if (isDesktopRuntime()) {
-        await workspaceForget(workspaceId).catch(() => undefined);
-      }
       if (client) {
         await client.deleteWorkspace(workspaceId).catch(() => undefined);
+      }
+      if (isDesktopRuntime()) {
+        await workspaceForget(workspaceId).catch(() => undefined);
       }
       if (selectedWorkspaceId === workspaceId) {
         setLegacySelectedWorkspaceId("");
@@ -2548,11 +2551,20 @@ export function SessionRoute() {
     setCreateWorkspaceError(null);
     try {
       const workspaceName = folderNameFromPath(folder);
-      const list = await workspaceCreate({
-        folderPath: folder,
-        name: workspaceName,
-        preset,
-      }) as WorkspaceList;
+      let list: WorkspaceList | null = null;
+      let createdOnServer = false;
+      if (client) {
+        list = await client
+          .createLocalWorkspace({ folderPath: folder, name: workspaceName, preset })
+          .then((serverList) => {
+            createdOnServer = true;
+            return serverList;
+          })
+          .catch(() => null);
+      }
+      if (!list) {
+        throw new Error("OpenWork server is unavailable. Start or reconnect the server before creating a workspace.");
+      }
       const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
       let targetWorkspaceId = createdId;
       let targetWorkspace = list.workspaces.find((workspace: WorkspaceInfo) => workspace.id === createdId) ?? null;
@@ -2560,27 +2572,13 @@ export function SessionRoute() {
         await workspaceSetSelected(createdId).catch(() => undefined);
         await workspaceSetRuntimeActive(createdId).catch(() => undefined);
       }
-      // Register the workspace with the running openwork-server so
-      // listWorkspaces() reflects it immediately. Without this the UI only
-      // picks up the new workspace after an app restart (because the server
-      // is launched with a fixed --workspace list at boot and the bridge
-      // write only updates desktop-side state).
-      if (client) {
-        const serverList = await client
-          .createLocalWorkspace({ folderPath: folder, name: workspaceName, preset })
-          .catch(() => null);
-        targetWorkspaceId = serverList
-          ? resolveWorkspaceListSelectedId(serverList) || serverList.workspaces[serverList.workspaces.length - 1]?.id || targetWorkspaceId
-          : targetWorkspaceId;
-        targetWorkspace = serverList?.workspaces.find((workspace) => workspace.id === targetWorkspaceId) ?? targetWorkspace;
-      }
       setCreateWorkspaceOpen(false);
       // Mark onboarding complete so the /welcome redirect never fires again.
       local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true }));
       await refreshRouteState();
       if (targetWorkspaceId) {
         const workspacePath = targetWorkspace?.path?.trim() || folder;
-        const session = baseUrl && token
+        const session = createdOnServer && baseUrl && token
           ? unwrap(await createClient(
               `${(buildOpenworkWorkspaceBaseUrl(baseUrl, targetWorkspaceId) ?? baseUrl).replace(/\/+$/, "")}/opencode`,
               workspacePath || undefined,
@@ -2609,7 +2607,7 @@ export function SessionRoute() {
     } finally {
       setCreateWorkspaceBusy(false);
     }
-  }, [client, local, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession]);
+  }, [baseUrl, client, local, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession, token]);
 
   const handleCreateRemoteWorkspace = useCallback(async (input: {
     openworkHostUrl?: string | null;
@@ -2622,14 +2620,22 @@ export function SessionRoute() {
     setCreateWorkspaceRemoteBusy(true);
     setCreateWorkspaceRemoteError(null);
     try {
-      const list = await workspaceCreateRemote({
+      const remoteType: "openwork" = "openwork";
+      const payload = {
         baseUrl: baseUrlValue,
         openworkHostUrl: baseUrlValue,
         openworkToken: input.openworkToken?.trim() || null,
         displayName: input.displayName?.trim() || null,
         directory: input.directory?.trim() || null,
-        remoteType: "openwork",
-      }) as WorkspaceList;
+        remoteType,
+      };
+      let list: WorkspaceList | null = null;
+      if (client) {
+        list = await client.createRemoteWorkspace(payload).catch(() => null);
+      }
+      if (!list) {
+        throw new Error("OpenWork server is unavailable. Start or reconnect the server before connecting a remote workspace.");
+      }
       const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
       if (createdId) {
         await workspaceSetSelected(createdId).catch(() => undefined);
@@ -2646,7 +2652,7 @@ export function SessionRoute() {
     } finally {
       setCreateWorkspaceRemoteBusy(false);
     }
-  }, [local, refreshRouteState]);
+  }, [client, local, refreshRouteState]);
 
   return (
     <WorkspaceProvider
@@ -2770,11 +2776,11 @@ export function SessionRoute() {
           // Without this, the permissions from opencode.jsonc are never
           // applied on the workspace the user is already on at launch. See
           // issue #870.
-          if (workspaceId && client) {
+          if (workspaceId) {
             const workspace = workspaces.find((item) => item.id === workspaceId) ?? null;
             const endpoint = endpointForWorkspace(workspace);
             if (endpoint) {
-              void endpoint.client.activateWorkspace(endpoint.workspaceId).catch(() => undefined);
+              void endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true }).catch(() => undefined);
             }
           }
           // If we remember what the user last opened here and that session

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2201,23 +2201,27 @@ export function SessionRoute() {
     if (!trimmed) return;
     setRenameWorkspaceBusy(true);
     try {
-      // Rename on both ends so the sidebar reflects the change regardless of
-      // which list wins the next refresh (server-provided routeWorkspaces or
-      // desktop-provided workspaceBootstrap results). Either call failing on
-      // its own should NOT block the other — the user's intent was "rename
-      // this workspace" and a soft failure in one store is recoverable.
-      if (client) {
-        await client
-          .updateWorkspaceDisplayName(renameWorkspaceId, trimmed)
-          .catch(() => undefined);
+      if (!client) {
+        showToast({
+          title: "OpenWork server is unavailable. Reconnect the server before renaming workspaces.",
+          tone: "error",
+        });
+        return;
       }
+      await client.updateWorkspaceDisplayName(renameWorkspaceId, trimmed);
       setRenameWorkspaceId(null);
       setRenameWorkspaceTitle("");
       await refreshRouteState();
+    } catch (error) {
+      showToast({
+        title: "Workspace rename failed",
+        description: describeRouteError(error),
+        tone: "error",
+      });
     } finally {
       setRenameWorkspaceBusy(false);
     }
-  }, [client, refreshRouteState, renameWorkspaceId, renameWorkspaceTitle]);
+  }, [client, refreshRouteState, renameWorkspaceId, renameWorkspaceTitle, showToast]);
 
   const handleRevealWorkspace = useCallback(async (workspaceId: string) => {
     const workspace = workspaces.find((item) => item.id === workspaceId);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -83,13 +83,9 @@ import {
   pickDirectory,
   resolveWorkspaceListSelectedId,
   workspaceBootstrap,
-  workspaceCreate,
-  workspaceCreateRemote,
-  workspaceExportConfig,
   workspaceForget,
   workspaceSetRuntimeActive,
   workspaceSetSelected,
-  workspaceUpdateDisplayName,
   type WorkspaceInfo,
   type WorkspaceList,
   revealDesktopItemInDir,
@@ -313,6 +309,24 @@ function workspaceLabel(workspace: OpenworkWorkspaceInfo) {
     workspace.path?.trim() ||
     t("session.workspace_fallback")
   );
+}
+
+function workspaceExportFilename(workspace: OpenworkWorkspaceInfo) {
+  const slug = workspaceLabel(workspace).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return `${slug || "workspace"}-openwork-export.json`;
+}
+
+function downloadWorkspaceJson(filename: string, payload: unknown) {
+  if (typeof document === "undefined") return;
+  const blob = new Blob([`${JSON.stringify(payload, null, 2)}\n`], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
 }
 
 function toSessionGroups(
@@ -721,6 +735,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         workspaceType: () => routeStateRef.current.selectedWorkspaceType,
         openworkServer: openworkServerStore,
         runtimeWorkspaceId: () => routeStateRef.current.runtimeWorkspaceId,
+        ensureRuntimeWorkspaceId: async () =>
+          routeStateRef.current.runtimeWorkspaceId?.trim() ||
+          routeStateRef.current.selectedWorkspaceId.trim() ||
+          null,
         developerMode: () => routeStateRef.current.developerMode,
         markReloadRequired: reloadCoordinator.markReloadRequired,
       }),
@@ -741,6 +759,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         selectedWorkspaceDisplay: () => routeStateRef.current.selectedWorkspaceDisplay,
         selectedWorkspaceRoot: () => routeStateRef.current.selectedWorkspaceRoot,
         runtimeWorkspaceId: () => routeStateRef.current.runtimeWorkspaceId,
+        ensureRuntimeWorkspaceId: async () =>
+          routeStateRef.current.runtimeWorkspaceId?.trim() ||
+          routeStateRef.current.selectedWorkspaceId.trim() ||
+          null,
         openworkServer: openworkServerStore,
         setProviders,
         setProviderDefaults,
@@ -772,6 +794,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           openworkServerCapabilities: routeStateRef.current.openworkServerCapabilities,
         }),
         runtimeWorkspaceId: () => routeStateRef.current.runtimeWorkspaceId,
+        ensureRuntimeWorkspaceId: async () =>
+          routeStateRef.current.runtimeWorkspaceId?.trim() ||
+          routeStateRef.current.selectedWorkspaceId.trim() ||
+          null,
         setBusy,
         setBusyLabel,
         setBusyStartedAt: () => {},
@@ -1760,12 +1786,17 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const handleSelectSettingsWorkspace = useCallback((workspaceId: string) => {
     setLegacySelectedWorkspaceId(workspaceId);
     writeActiveWorkspaceId(workspaceId);
+    const workspace = workspaces.find((item) => item.id === workspaceId) ?? null;
+    const endpoint = resolveWorkspaceEndpoint(workspace, { baseUrl, token });
+    if (endpoint) {
+      void endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true }).catch(() => undefined);
+    }
     if (isDesktopRuntime()) {
       void workspaceSetSelected(workspaceId).catch(() => undefined);
       void workspaceSetRuntimeActive(workspaceId).catch(() => undefined);
     }
     navigate(workspaceSettingsRoute(workspaceId, settingsPathForRoute(route)), { state: location.state });
-  }, [location, navigate, route]);
+  }, [baseUrl, location, navigate, route, token, workspaces]);
 
   const handleOpenRenameWorkspace = useCallback((workspaceId: string) => {
     const workspace = workspaces.find((item) => item.id === workspaceId);
@@ -1780,12 +1811,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     if (!trimmed) return;
     setRenameWorkspaceBusy(true);
     try {
-      if (isDesktopRuntime()) {
-        await workspaceUpdateDisplayName({
-          workspaceId: renameWorkspaceId,
-          displayName: trimmed,
-        }).catch(() => undefined);
-      }
       if (openworkClient) {
         await openworkClient
           .updateWorkspaceDisplayName(renameWorkspaceId, trimmed)
@@ -1807,33 +1832,32 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   }, [workspaces]);
 
   const handleExportWorkspaceConfig = useCallback(async (workspaceId: string) => {
-    if (!isDesktopRuntime()) return;
     const workspace = workspaces.find((item) => item.id === workspaceId) ?? null;
     if (!workspace) return;
-    const outputPath = await pickDirectory({
-      title: `Choose where to export ${workspaceLabel(workspace)}`,
-    });
-    const targetPath = Array.isArray(outputPath) ? outputPath[0] : outputPath;
-    if (!targetPath) return;
-    setExportWorkspaceBusy(true);
-    try {
-      await workspaceExportConfig({ workspaceId, outputPath: targetPath });
-      await revealDesktopItemInDir(targetPath).catch(() => undefined);
-    } finally {
-      setExportWorkspaceBusy(false);
+    const endpoint = resolveWorkspaceEndpoint(workspace, { baseUrl, token });
+    if (endpoint) {
+      setExportWorkspaceBusy(true);
+      try {
+        const payload = await endpoint.client.exportWorkspace(endpoint.workspaceId);
+        downloadWorkspaceJson(workspaceExportFilename(workspace), payload);
+      } finally {
+        setExportWorkspaceBusy(false);
+      }
+      return;
     }
-  }, [workspaces]);
+    throw new Error("OpenWork server is unavailable. Reconnect the server before exporting workspace config.");
+  }, [baseUrl, token, workspaces]);
 
   const handleForgetWorkspace = useCallback(async (workspaceId: string) => {
     if (typeof window !== "undefined") {
       const message = t("workspace_list.remove_confirm") || "Remove this workspace from the sidebar?";
       if (!window.confirm(message)) return;
     }
-    if (isDesktopRuntime()) {
-      await workspaceForget(workspaceId).catch(() => undefined);
-    }
     if (openworkClient) {
       await openworkClient.deleteWorkspace(workspaceId).catch(() => undefined);
+    }
+    if (isDesktopRuntime()) {
+      await workspaceForget(workspaceId).catch(() => undefined);
     }
     if (selectedWorkspaceId === workspaceId) {
       const nextWorkspace = workspaces.find((workspace) => workspace.id !== workspaceId);
@@ -1852,25 +1876,19 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     setCreateWorkspaceError(null);
     try {
       const workspaceName = folderNameFromPath(folder);
-      const list = await workspaceCreate({
-        folderPath: folder,
-        name: workspaceName,
-        preset,
-      }) as WorkspaceList;
+      let list: WorkspaceList | null = null;
+      if (openworkClient) {
+        list = await openworkClient
+          .createLocalWorkspace({ folderPath: folder, name: workspaceName, preset })
+          .catch(() => null);
+      }
+      if (!list) {
+        throw new Error("OpenWork server is unavailable. Start or reconnect the server before creating a workspace.");
+      }
       const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
       if (createdId) {
         await workspaceSetSelected(createdId).catch(() => undefined);
         await workspaceSetRuntimeActive(createdId).catch(() => undefined);
-      }
-      // Register the workspace with the running openwork-server so
-      // listWorkspaces() reflects it immediately. Without this the UI only
-      // picks up the new workspace after an app restart (because the server
-      // is launched with a fixed --workspace list at boot and the bridge
-      // write only updates desktop-side state).
-      if (openworkClient) {
-        await openworkClient
-          .createLocalWorkspace({ folderPath: folder, name: workspaceName, preset })
-          .catch(() => undefined);
       }
       setCreateWorkspaceOpen(false);
       await refreshRouteState();
@@ -1892,14 +1910,22 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     setCreateWorkspaceRemoteBusy(true);
     setCreateWorkspaceRemoteError(null);
     try {
-      const list = await workspaceCreateRemote({
+      const remoteType: "openwork" = "openwork";
+      const payload = {
         baseUrl: baseUrlValue,
         openworkHostUrl: baseUrlValue,
         openworkToken: input.openworkToken?.trim() || null,
         displayName: input.displayName?.trim() || null,
         directory: input.directory?.trim() || null,
-        remoteType: "openwork",
-      }) as WorkspaceList;
+        remoteType,
+      };
+      let list: WorkspaceList | null = null;
+      if (openworkClient) {
+        list = await openworkClient.createRemoteWorkspace(payload).catch(() => null);
+      }
+      if (!list) {
+        throw new Error("OpenWork server is unavailable. Start or reconnect the server before connecting a remote workspace.");
+      }
       const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
       if (createdId) {
         await workspaceSetSelected(createdId).catch(() => undefined);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -109,6 +109,7 @@ import { RenameWorkspaceModal } from "../domains/workspace/rename-workspace-moda
 import { ShareWorkspaceModal } from "../domains/workspace/share-workspace-modal";
 import { useShareWorkspaceState } from "../domains/workspace/share-workspace-state";
 import { useRemoteWorkspaceConnectionEditor } from "../domains/workspace/use-remote-workspace-connection-editor";
+import { useStatusToasts } from "../domains/shell-feedback/status-toasts";
 import {
   diagnoseRemoteWorkspaceTaskLoadFailure,
   getRemoteWorkspaceConnectionKey,
@@ -527,6 +528,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [renameWorkspaceId, setRenameWorkspaceId] = useState<string | null>(null);
   const [renameWorkspaceTitle, setRenameWorkspaceTitle] = useState("");
   const [renameWorkspaceBusy, setRenameWorkspaceBusy] = useState(false);
+  const { showToast } = useStatusToasts();
   const [exportWorkspaceBusy, setExportWorkspaceBusy] = useState(false);
   const [autoCompactContext, setAutoCompactContext] = useState(true);
   const [autoCompactContextBusy, setAutoCompactContextBusy] = useState(false);
@@ -1811,18 +1813,27 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     if (!trimmed) return;
     setRenameWorkspaceBusy(true);
     try {
-      if (openworkClient) {
-        await openworkClient
-          .updateWorkspaceDisplayName(renameWorkspaceId, trimmed)
-          .catch(() => undefined);
+      if (!openworkClient) {
+        showToast({
+          title: "OpenWork server is unavailable. Reconnect the server before renaming workspaces.",
+          tone: "error",
+        });
+        return;
       }
+      await openworkClient.updateWorkspaceDisplayName(renameWorkspaceId, trimmed);
       setRenameWorkspaceId(null);
       setRenameWorkspaceTitle("");
       await refreshRouteState();
+    } catch (error) {
+      showToast({
+        title: "Workspace rename failed",
+        description: describeRouteError(error),
+        tone: "error",
+      });
     } finally {
       setRenameWorkspaceBusy(false);
     }
-  }, [openworkClient, refreshRouteState, renameWorkspaceId, renameWorkspaceTitle]);
+  }, [openworkClient, refreshRouteState, renameWorkspaceId, renameWorkspaceTitle, showToast]);
 
   const handleRevealWorkspace = useCallback(async (workspaceId: string) => {
     const workspace = workspaces.find((item) => item.id === workspaceId);

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -6,8 +6,6 @@ import { t } from "../../i18n";
 import {
   pickDirectory,
   resolveWorkspaceListSelectedId,
-  workspaceCreate,
-  workspaceCreateRemote,
   workspaceSetRuntimeActive,
   workspaceSetSelected,
   type WorkspaceInfo,
@@ -112,56 +110,56 @@ export function WelcomeRoute() {
       dispatch({ type: "create:start" });
       try {
         const workspaceName = folderNameFromPath(folder);
-      const list = await workspaceCreate({
-        folderPath: folder,
-        name: workspaceName,
-        preset: "starter",
-      }) as WorkspaceList;
-      const createdId =
-        resolveWorkspaceListSelectedId(list) ||
-        list.workspaces[list.workspaces.length - 1]?.id ||
-        "";
-      let targetWorkspaceId = createdId;
-      let targetWorkspace = list.workspaces.find((workspace: WorkspaceInfo) => workspace.id === createdId) ?? null;
+        let list: WorkspaceList | null = null;
+        let serverBaseUrl = "";
+        let serverToken = "";
+        try {
+          const { normalizedBaseUrl, resolvedToken, resolvedHostToken } =
+            await resolveOpenworkConnection();
+          if (normalizedBaseUrl && (resolvedToken || resolvedHostToken)) {
+            const openworkClient = createOpenworkServerClient({
+              baseUrl: normalizedBaseUrl,
+              token: resolvedToken || undefined,
+              hostToken: resolvedHostToken || undefined,
+            });
+            list = await openworkClient.createLocalWorkspace({
+              folderPath: folder,
+              name: workspaceName,
+              preset: "starter",
+            });
+            serverBaseUrl = normalizedBaseUrl;
+            serverToken = resolvedToken;
+          }
+        } catch {
+          list = null;
+        }
+        if (!list) {
+          throw new Error("OpenWork server is unavailable. Start or reconnect the server before creating a workspace.");
+        }
+        const createdId =
+          resolveWorkspaceListSelectedId(list) ||
+          list.workspaces[list.workspaces.length - 1]?.id ||
+          "";
+        let targetWorkspaceId = createdId;
+        let targetWorkspace = list.workspaces.find((workspace: WorkspaceInfo) => workspace.id === createdId) ?? null;
         let targetSessionId: string | null = null;
         if (createdId) {
           await workspaceSetSelected(createdId).catch(() => undefined);
           await workspaceSetRuntimeActive(createdId).catch(() => undefined);
           writeActiveWorkspaceId(createdId);
         }
-        // Register with the running openwork-server if available.
-        try {
-          const { normalizedBaseUrl, resolvedToken, resolvedHostToken } =
-            await resolveOpenworkConnection();
-          if (normalizedBaseUrl && resolvedToken) {
-            const openworkClient = createOpenworkServerClient({
-              baseUrl: normalizedBaseUrl,
-              token: resolvedToken,
-              hostToken: resolvedHostToken || undefined,
-            });
-            const serverList = await openworkClient
-              .createLocalWorkspace({
-                folderPath: folder,
-                name: workspaceName,
-                preset: "starter",
-              })
-              .catch(() => null);
-            targetWorkspaceId = serverList
-              ? resolveWorkspaceListSelectedId(serverList) || serverList.workspaces[serverList.workspaces.length - 1]?.id || targetWorkspaceId
-              : targetWorkspaceId;
-            targetWorkspace = serverList?.workspaces.find((workspace) => workspace.id === targetWorkspaceId) ?? targetWorkspace;
-            if (targetWorkspaceId) {
-              const workspacePath = targetWorkspace?.path?.trim() || folder;
-              const session = unwrap(await createClient(
-                `${(buildOpenworkWorkspaceBaseUrl(normalizedBaseUrl, targetWorkspaceId) ?? normalizedBaseUrl).replace(/\/+$/, "")}/opencode`,
-                workspacePath || undefined,
-                { token: resolvedToken, mode: "openwork" },
-              ).session.create({ directory: workspacePath || undefined }));
-              targetSessionId = session.id;
-            }
+        if (targetWorkspaceId && serverBaseUrl && serverToken) {
+          try {
+            const workspacePath = targetWorkspace?.path?.trim() || folder;
+            const session = unwrap(await createClient(
+              `${(buildOpenworkWorkspaceBaseUrl(serverBaseUrl, targetWorkspaceId) ?? serverBaseUrl).replace(/\/+$/, "")}/opencode`,
+              workspacePath || undefined,
+              { token: serverToken, mode: "openwork" },
+            ).session.create({ directory: workspacePath || undefined }));
+            targetSessionId = session.id;
+          } catch {
+            // Best-effort first task creation.
           }
-        } catch {
-          // Best-effort server registration.
         }
         if (targetWorkspaceId) {
           writeActiveWorkspaceId(targetWorkspaceId);
@@ -194,18 +192,36 @@ export function WelcomeRoute() {
       if (!baseUrlValue) return false;
       dispatch({ type: "remote:start" });
       try {
-      const list = await workspaceCreateRemote({
-        baseUrl: baseUrlValue,
-        openworkHostUrl: baseUrlValue,
-        openworkToken: input.openworkToken?.trim() || null,
-        displayName: input.displayName?.trim() || null,
-        directory: input.directory?.trim() || null,
-        remoteType: "openwork",
-      }) as WorkspaceList;
-      const createdId =
-        resolveWorkspaceListSelectedId(list) ||
-        list.workspaces[list.workspaces.length - 1]?.id ||
-        "";
+        const remoteType: "openwork" = "openwork";
+        const payload = {
+          baseUrl: baseUrlValue,
+          openworkHostUrl: baseUrlValue,
+          openworkToken: input.openworkToken?.trim() || null,
+          displayName: input.displayName?.trim() || null,
+          directory: input.directory?.trim() || null,
+          remoteType,
+        };
+        let list: WorkspaceList | null = null;
+        try {
+          const { normalizedBaseUrl, resolvedToken, resolvedHostToken } =
+            await resolveOpenworkConnection();
+          if (normalizedBaseUrl && (resolvedToken || resolvedHostToken)) {
+            list = await createOpenworkServerClient({
+              baseUrl: normalizedBaseUrl,
+              token: resolvedToken || undefined,
+              hostToken: resolvedHostToken || undefined,
+            }).createRemoteWorkspace(payload);
+          }
+        } catch {
+          list = null;
+        }
+        if (!list) {
+          throw new Error("OpenWork server is unavailable. Start or reconnect the server before connecting a remote workspace.");
+        }
+        const createdId =
+          resolveWorkspaceListSelectedId(list) ||
+          list.workspaces[list.workspaces.length - 1]?.id ||
+          "";
         if (createdId) {
           await workspaceSetSelected(createdId).catch(() => undefined);
           await workspaceSetRuntimeActive(createdId).catch(() => undefined);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1702,12 +1702,50 @@ const runtimeManager = createRuntimeManager({
 });
 
 let runtimeDisposedForQuit = false;
+let runtimeDisposeInProgress = false;
 let runtimeBootstrapPromise = null;
 
+function showShutdownScreen() {
+  const win = mainWindow;
+  if (!win || win.isDestroyed()) return;
+  try {
+    win.show();
+    win.webContents.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(`<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html, body { height: 100%; margin: 0; background: #0b0b0f; color: #f4f4f5; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      body { display: grid; place-items: center; }
+      main { display: grid; gap: 10px; justify-items: center; }
+      .spinner { width: 22px; height: 22px; border: 2px solid rgba(244,244,245,.25); border-top-color: #f4f4f5; border-radius: 50%; animation: spin .9s linear infinite; }
+      .title { font-size: 15px; font-weight: 600; }
+      .body { font-size: 13px; color: #a1a1aa; }
+      @keyframes spin { to { transform: rotate(360deg); } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="spinner" aria-hidden="true"></div>
+      <div class="title">Stopping OpenWork services</div>
+      <div class="body">Closing local workers and background services...</div>
+    </main>
+  </body>
+</html>`)}`);
+  } catch {
+    // Ignore renderer teardown races during quit.
+  }
+}
+
 async function disposeRuntimeBeforeQuit() {
-  if (runtimeDisposedForQuit) return;
-  runtimeDisposedForQuit = true;
-  await runtimeManager.dispose().catch(() => undefined);
+  if (runtimeDisposedForQuit || runtimeDisposeInProgress) return;
+  runtimeDisposeInProgress = true;
+  try {
+    await runtimeManager.dispose().catch(() => undefined);
+    runtimeDisposedForQuit = true;
+  } finally {
+    runtimeDisposeInProgress = false;
+  }
 }
 
 function assertOpenworkServerReady(info) {
@@ -2977,6 +3015,8 @@ if (!app.requestSingleInstanceLock()) {
   app.on("before-quit", (event) => {
     if (runtimeDisposedForQuit) return;
     event.preventDefault();
+    if (runtimeDisposeInProgress) return;
+    showShutdownScreen();
     void Promise.all([disposeRuntimeBeforeQuit(), stopUiControlServer()]).finally(() => app.quit());
   });
 

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -47,6 +47,23 @@ export function prioritizeWorkspacePaths(preferredPath, workspacePaths = []) {
   return paths;
 }
 
+export function resolveOpenworkServerConfigPath(env = process.env) {
+  const override = String(env.OPENWORK_SERVER_CONFIG ?? "").trim();
+  if (override) return path.resolve(override);
+  if (process.platform === "win32") {
+    const appData = String(env.APPDATA ?? "").trim();
+    const root = appData || path.join(os.homedir(), "AppData", "Roaming");
+    return path.join(root, "openwork", "server.json");
+  }
+  const xdgConfigHome = String(env.XDG_CONFIG_HOME ?? "").trim();
+  const root = xdgConfigHome || path.join(os.homedir(), ".config");
+  return path.join(root, "openwork", "server.json");
+}
+
+export function seedWorkspacePathsForEmbeddedServer(workspacePaths, serverConfigExists) {
+  return serverConfigExists ? [] : workspacePaths;
+}
+
 function nowMs() {
   return Date.now();
 }
@@ -1002,11 +1019,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     }
     await stopChild(openworkServerState);
 
-    const workspacePaths = options.workspacePaths.filter((value) => value.trim().length > 0);
-    const activeWorkspace = workspacePaths[0] ?? "";
     const host = options.remoteAccessEnabled ? "0.0.0.0" : "127.0.0.1";
-    const port = await resolveOpenworkPort(host, activeWorkspace);
-    const tokens = await loadOrCreateWorkspaceTokens(activeWorkspace);
 
     const managedOpencode = options.manageOpencode ? resolveOpencodeBinary(options.opencodeBinPath) : null;
     openworkServerState.managedOpencodeBinPath = managedOpencode?.path ?? null;
@@ -1019,6 +1032,19 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     // Inject user env vars so the server and managed OpenCode inherit them.
     const serverEnv = await buildChildEnv({});
     Object.assign(process.env, serverEnv);
+
+    // Once the embedded server has a persisted registry, it is the source of
+    // truth. Do not pass Electron's legacy workspace list as CLI workspaces or
+    // the server config loader will ignore server.json and lose server-created
+    // workspaces after restart.
+    const serverConfigPath = resolveOpenworkServerConfigPath(process.env);
+    const workspacePaths = seedWorkspacePathsForEmbeddedServer(
+      options.workspacePaths.filter((value) => value.trim().length > 0),
+      existsSync(serverConfigPath),
+    );
+    const activeWorkspace = workspacePaths[0] ?? "";
+    const port = await resolveOpenworkPort(host, activeWorkspace);
+    const tokens = await loadOrCreateWorkspaceTokens(activeWorkspace);
 
     // One call: resolve config, spawn managed OpenCode, start HTTP server.
     // Dev must prefer apps/server/dist; build output also stages a packaged
@@ -1041,6 +1067,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       port,
       corsOrigins: ["*"],
       approvalMode: "auto",
+      configPath: serverConfigPath,
       workspaces: workspacePaths,
       token: tokens.clientToken,
       hostToken: tokens.hostToken,
@@ -1357,7 +1384,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   async function openworkServerRestart(options = {}) {
     const workspacePaths = prioritizeWorkspacePaths(engineState.projectDir, await listLocalWorkspacePaths());
     const shouldManageOpencode = Boolean(
-      openworkServerState.managedOpencodeBinPath || engineState.opencodeBinPath,
+      openworkServerState.managedOpencodeBinPath || engineState.opencodeBinPath || !engineState.baseUrl,
     );
     return startOpenworkServer({
       workspacePaths,

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -1266,7 +1266,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   async function stopAllRuntimeChildren() {
     // Stop the in-process server (and its managed OpenCode child) if running.
     if (inProcessServer) {
-      try { inProcessServer.stop(); } catch { /* ignore */ }
+      try { await inProcessServer.stop(); } catch { /* ignore */ }
       inProcessServer = null;
     }
     await stopChild(openworkServerState);

--- a/apps/desktop/electron/runtime.test.mjs
+++ b/apps/desktop/electron/runtime.test.mjs
@@ -1,7 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { prioritizeWorkspacePaths } from "./runtime.mjs";
+import {
+  prioritizeWorkspacePaths,
+  resolveOpenworkServerConfigPath,
+  seedWorkspacePathsForEmbeddedServer,
+} from "./runtime.mjs";
 
 describe("prioritizeWorkspacePaths", () => {
   it("keeps the active runtime workspace first", () => {
@@ -15,6 +19,39 @@ describe("prioritizeWorkspacePaths", () => {
     assert.deepEqual(
       prioritizeWorkspacePaths("/workspace/current/../current", ["/workspace/current"]),
       ["/workspace/current/../current"],
+    );
+  });
+});
+
+describe("seedWorkspacePathsForEmbeddedServer", () => {
+  it("uses persisted server config instead of Electron workspace state once config exists", () => {
+    assert.deepEqual(
+      seedWorkspacePathsForEmbeddedServer(["/workspace/legacy"], true),
+      [],
+    );
+  });
+
+  it("seeds from Electron workspace state before server config exists", () => {
+    assert.deepEqual(
+      seedWorkspacePathsForEmbeddedServer(["/workspace/first"], false),
+      ["/workspace/first"],
+    );
+  });
+});
+
+describe("resolveOpenworkServerConfigPath", () => {
+  it("respects explicit server config path", () => {
+    assert.equal(
+      resolveOpenworkServerConfigPath({ OPENWORK_SERVER_CONFIG: "/tmp/openwork/server.json" }),
+      "/tmp/openwork/server.json",
+    );
+  });
+
+  it("uses XDG config home on Unix", () => {
+    if (process.platform === "win32") return;
+    assert.equal(
+      resolveOpenworkServerConfigPath({ XDG_CONFIG_HOME: "/tmp/xdg" }),
+      "/tmp/xdg/openwork/server.json",
     );
   });
 });

--- a/apps/server/src/authorized-folders.e2e.test.ts
+++ b/apps/server/src/authorized-folders.e2e.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+type Served = {
+  port: number;
+  stop: (closeActiveConnections?: boolean) => void | Promise<void>;
+};
+
+const CLIENT_TOKEN = "owt_authorized_folders_client";
+const HOST_TOKEN = "owt_authorized_folders_host";
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+const priorDataDir = process.env.OPENWORK_DATA_DIR;
+const priorTokenStore = process.env.OPENWORK_TOKEN_STORE;
+
+type AuthorizedFoldersBody = {
+  folders: string[];
+  hiddenCount: number;
+  workspaceRoot?: string;
+  updatedAt?: number;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function clientAuth(token = CLIENT_TOKEN) {
+  return { authorization: `Bearer ${token}`, "content-type": "application/json" };
+}
+
+function hostAuth() {
+  return { "x-openwork-host-token": HOST_TOKEN, "content-type": "application/json" };
+}
+
+async function createTempRoot(prefix: string) {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function createWorkspaceRoot() {
+  return createTempRoot("openwork-authorized-folders-");
+}
+
+async function startOpenworkServer(workspaceRoot: string, options?: { readOnly?: boolean }) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: CLIENT_TOKEN,
+    hostToken: HOST_TOKEN,
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspaceRoot],
+    readOnly: options?.readOnly === true,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { base: `http://127.0.0.1:${server.port}` };
+}
+
+function readExternalDirectory(raw: string): Record<string, unknown> {
+  const config = asRecord(JSON.parse(raw));
+  const permission = asRecord(config.permission);
+  return asRecord(permission.external_directory);
+}
+
+beforeEach(async () => {
+  const envRoot = await createTempRoot("openwork-authorized-folders-env-");
+  process.env.OPENWORK_DATA_DIR = join(envRoot, "data");
+  process.env.OPENWORK_TOKEN_STORE = join(envRoot, "tokens.json");
+});
+
+afterEach(async () => {
+  while (stops.length) {
+    await stops.pop()?.();
+  }
+  while (roots.length) {
+    await rm(roots.pop()!, { recursive: true, force: true });
+  }
+  if (priorDataDir === undefined) {
+    delete process.env.OPENWORK_DATA_DIR;
+  } else {
+    process.env.OPENWORK_DATA_DIR = priorDataDir;
+  }
+  if (priorTokenStore === undefined) {
+    delete process.env.OPENWORK_TOKEN_STORE;
+  } else {
+    process.env.OPENWORK_TOKEN_STORE = priorTokenStore;
+  }
+});
+
+describe("authorized folders routes", () => {
+  test("lists visible folders and counts preserved hidden entries", async () => {
+    const root = resolve(await createWorkspaceRoot());
+    await writeFile(join(root, "opencode.jsonc"), JSON.stringify({
+      permission: {
+        external_directory: {
+          [`${root}/*`]: "allow",
+          "/shared/*": "allow",
+          "/hidden": "allow",
+          "/denied/*": "deny",
+        },
+      },
+    }, null, 2) + "\n", "utf8");
+    const { base } = await startOpenworkServer(root);
+
+    const response = await fetch(`${base}/workspace/ws_1/authorized-folders`, { headers: clientAuth() });
+    expect(response.status).toBe(200);
+    const body = await response.json() as AuthorizedFoldersBody;
+
+    expect(body).toMatchObject({
+      folders: ["/shared"],
+      hiddenCount: 2,
+      workspaceRoot: root,
+    });
+  });
+
+  test("dedupes, filters workspace root, and preserves hidden entries on write", async () => {
+    const root = resolve(await createWorkspaceRoot());
+    const configPath = join(root, "opencode.jsonc");
+    await writeFile(configPath, JSON.stringify({
+      permission: {
+        external_directory: {
+          [`${root}/*`]: "allow",
+          "/existing/*": "allow",
+          "/hidden": "allow",
+          "/denied/*": "deny",
+        },
+      },
+    }, null, 2) + "\n", "utf8");
+    const { base } = await startOpenworkServer(root);
+
+    const response = await fetch(`${base}/workspace/ws_1/authorized-folders`, {
+      method: "PUT",
+      headers: clientAuth(),
+      body: JSON.stringify({ folders: ["/shared", "/shared/", root, `${root}/*`, "/existing/*"] }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json() as AuthorizedFoldersBody;
+    expect(body.folders).toEqual(["/shared", "/existing"]);
+    expect(body.hiddenCount).toBe(2);
+    expect(typeof body.updatedAt).toBe("number");
+
+    const externalDirectory = readExternalDirectory(await readFile(configPath, "utf8"));
+    expect(externalDirectory["/hidden"]).toBe("allow");
+    expect(externalDirectory["/denied/*"]).toBe("deny");
+    expect(externalDirectory["/shared/*"]).toBe("allow");
+    expect(externalDirectory["/existing/*"]).toBe("allow");
+    expect(externalDirectory[`${root}/*`]).toBeUndefined();
+    expect(Object.keys(externalDirectory).sort()).toEqual([
+      "/denied/*",
+      "/existing/*",
+      "/hidden",
+      "/shared/*",
+    ]);
+  });
+
+  test("requires client auth, collaborator scope, and writable server", async () => {
+    const root = await createWorkspaceRoot();
+    const { base } = await startOpenworkServer(root);
+
+    const unauthenticated = await fetch(`${base}/workspace/ws_1/authorized-folders`);
+    expect(unauthenticated.status).toBe(401);
+
+    const issued = await fetch(`${base}/tokens`, {
+      method: "POST",
+      headers: hostAuth(),
+      body: JSON.stringify({ scope: "viewer", label: "viewer" }),
+    });
+    expect(issued.status).toBe(201);
+    const issuedBody = asRecord(await issued.json());
+    const viewerToken = typeof issuedBody.token === "string" ? issuedBody.token : "";
+    expect(viewerToken).not.toBe("");
+
+    const viewerWrite = await fetch(`${base}/workspace/ws_1/authorized-folders`, {
+      method: "PUT",
+      headers: clientAuth(viewerToken),
+      body: JSON.stringify({ folders: ["/shared"] }),
+    });
+    expect(viewerWrite.status).toBe(403);
+
+    const readOnlyRoot = await createWorkspaceRoot();
+    const readOnly = await startOpenworkServer(readOnlyRoot, { readOnly: true });
+    const readOnlyWrite = await fetch(`${readOnly.base}/workspace/ws_1/authorized-folders`, {
+      method: "PUT",
+      headers: clientAuth(),
+      body: JSON.stringify({ folders: ["/shared"] }),
+    });
+    expect(readOnlyWrite.status).toBe(403);
+  });
+});

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -101,9 +101,9 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
     port: server.port,
     url: `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${server.port}`,
     config,
-    stop() {
+    async stop() {
       managedOpencode?.close();
-      server.stop();
+      await server.stop();
     },
   };
 }

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -80,10 +80,17 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
       config.opencodeUsername = managedOpencode.username;
       config.opencodePassword = managedOpencode.password;
       for (const entry of config.workspaces) {
-        entry.baseUrl ??= managedOpencode.url;
-        entry.opencodeUsername ??= managedOpencode.username;
-        entry.opencodePassword ??= managedOpencode.password;
-        entry.directory ??= entry.path;
+        if (entry.workspaceType === "remote") {
+          entry.baseUrl ??= managedOpencode.url;
+          entry.opencodeUsername ??= managedOpencode.username;
+          entry.opencodePassword ??= managedOpencode.password;
+          entry.directory ??= entry.path;
+          continue;
+        }
+        entry.baseUrl = managedOpencode.url;
+        entry.opencodeUsername = managedOpencode.username;
+        entry.opencodePassword = managedOpencode.password;
+        entry.directory = entry.path;
       }
     }
   }

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -31,7 +31,7 @@ export type EmbeddedServerHandle = {
   /** The resolved server config (with OpenCode URLs populated). */
   config: ServerConfig;
   /** Stop the HTTP server and managed OpenCode (if any). */
-  stop: () => void;
+  stop: () => Promise<void>;
 };
 
 export async function startEmbeddedServer(options: EmbeddedServerOptions): Promise<EmbeddedServerHandle> {

--- a/apps/server/src/env-routes.e2e.test.ts
+++ b/apps/server/src/env-routes.e2e.test.ts
@@ -138,6 +138,72 @@ describe("env routes", () => {
     expect(body.items[0]).toMatchObject({ key: "ANTHROPIC_API_KEY", value: "sk-ant-abc" });
   });
 
+  test("GET /env can return metadata without raw values", async () => {
+    const { base } = await boot();
+    await fetch(`${base}/env`, {
+      method: "PUT",
+      headers: hostAuth(),
+      body: JSON.stringify({ entries: [{ key: "WITH_VALUE", value: "secret" }, { key: "EMPTY_VALUE", value: "" }] }),
+    });
+
+    const list = await fetch(`${base}/env?includeValues=false`, { headers: hostAuth() });
+    expect(list.status).toBe(200);
+    const body = (await list.json()) as { items: Array<{ key: string; hasValue: boolean; value?: string }> };
+    expect(body.items).toHaveLength(2);
+    expect(body.items[0]).toMatchObject({ key: "EMPTY_VALUE", hasValue: false });
+    expect(body.items[1]).toMatchObject({ key: "WITH_VALUE", hasValue: true });
+    expect(Object.prototype.hasOwnProperty.call(body.items[0], "value")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(body.items[1], "value")).toBe(false);
+  });
+
+  test("GET /env/:key reveals one raw value", async () => {
+    const { base } = await boot();
+    await fetch(`${base}/env`, {
+      method: "PUT",
+      headers: hostAuth(),
+      body: JSON.stringify({ key: "ANTHROPIC_API_KEY", value: "sk-ant-abc" }),
+    });
+
+    const reveal = await fetch(`${base}/env/ANTHROPIC_API_KEY`, { headers: hostAuth() });
+    expect(reveal.status).toBe(200);
+    expect(await reveal.json()).toMatchObject({
+      item: { key: "ANTHROPIC_API_KEY", value: "sk-ant-abc" },
+    });
+
+    const missing = await fetch(`${base}/env/MISSING`, { headers: hostAuth() });
+    expect(missing.status).toBe(404);
+  });
+
+  test("GET and PUT /env/status track pending changes per runtime", async () => {
+    const { base } = await boot();
+
+    const initial = await fetch(`${base}/env/status?runtimeKey=runtime-a`, { headers: hostAuth() });
+    expect(initial.status).toBe(200);
+    expect(await initial.json()).toEqual({ runtimeKey: "runtime-a", pendingChanges: false });
+
+    const setPending = await fetch(`${base}/env/status`, {
+      method: "PUT",
+      headers: hostAuth(),
+      body: JSON.stringify({ runtimeKey: "runtime-a", pendingChanges: true }),
+    });
+    expect(setPending.status).toBe(200);
+    expect(await setPending.json()).toEqual({ runtimeKey: "runtime-a", pendingChanges: true });
+
+    const otherRuntime = await fetch(`${base}/env/status?runtimeKey=runtime-b`, { headers: hostAuth() });
+    expect(await otherRuntime.json()).toEqual({ runtimeKey: "runtime-b", pendingChanges: false });
+
+    const updated = await fetch(`${base}/env/status?runtimeKey=runtime-a`, { headers: hostAuth() });
+    expect(await updated.json()).toEqual({ runtimeKey: "runtime-a", pendingChanges: true });
+
+    const cleared = await fetch(`${base}/env/status`, {
+      method: "PUT",
+      headers: hostAuth(),
+      body: JSON.stringify({ runtimeKey: "runtime-a", pendingChanges: false }),
+    });
+    expect(cleared.status).toBe(200);
+    expect(await cleared.json()).toEqual({ runtimeKey: "runtime-a", pendingChanges: false });
+  });
+
   test("GET /env/keys returns names without values", async () => {
     const { base } = await boot();
     await fetch(`${base}/env`, {

--- a/apps/server/src/serve-node.test.ts
+++ b/apps/server/src/serve-node.test.ts
@@ -88,4 +88,36 @@ describe("serve", () => {
     expect(second.port).toBe(port);
     await second.stop();
   });
+
+  test("does not log expected connection aborts as unhandled errors", async () => {
+    const errors: unknown[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args);
+    };
+
+    const server = await serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => {
+        if (new URL(request.url).pathname === "/health") {
+          return Response.json({ ok: true });
+        }
+        throw new TypeError("terminated", { cause: { code: "UND_ERR_SOCKET" } });
+      },
+    });
+
+    try {
+      await fetch(`http://127.0.0.1:${server.port}/abort`).catch(() => undefined);
+      await delay(25);
+      expect(errors).toEqual([]);
+
+      const health = await fetch(`http://127.0.0.1:${server.port}/health`);
+      expect(health.status).toBe(200);
+      expect(await health.json()).toEqual({ ok: true });
+    } finally {
+      console.error = originalError;
+      await server.stop();
+    }
+  });
 });

--- a/apps/server/src/serve-node.ts
+++ b/apps/server/src/serve-node.ts
@@ -30,6 +30,19 @@ function isWriteAfterEndError(error: unknown): boolean {
   return code === "ERR_STREAM_WRITE_AFTER_END" || error.message.includes("write after end");
 }
 
+function isExpectedConnectionAbort(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  const causeCode = (error as { cause?: { code?: string } }).cause?.code;
+  return (
+    code === "ECONNRESET" ||
+    code === "UND_ERR_SOCKET" ||
+    causeCode === "UND_ERR_SOCKET" ||
+    error.name === "AbortError" ||
+    error.message === "terminated"
+  );
+}
+
 function endResponse(nodeRes: ServerResponse, chunk?: string): void {
   if (!isResponseWritable(nodeRes)) return;
   nodeRes.end(chunk);
@@ -159,6 +172,12 @@ export function serve(options: ServeOptions): Promise<ServeResult> {
       const webRes = await fetchHandler(webReq);
       await writeWebResponse(webRes, nodeRes);
     } catch (error) {
+      if (isExpectedConnectionAbort(error)) {
+        if (isResponseWritable(nodeRes) && !nodeRes.headersSent) {
+          nodeRes.destroy();
+        }
+        return;
+      }
       console.error("[serve-node] Unhandled error:", error);
       if (!isResponseWritable(nodeRes)) return;
       if (!nodeRes.headersSent) {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4199,6 +4199,7 @@ async function readServerConfigFile(configPath: string): Promise<OpenworkServerC
 }
 
 function serializeWorkspaceConfigEntry(workspace: WorkspaceInfo): Record<string, unknown> {
+  const isLocalWorkspace = workspace.workspaceType !== "remote";
   return {
     id: workspace.id,
     path: workspace.path,
@@ -4206,8 +4207,8 @@ function serializeWorkspaceConfigEntry(workspace: WorkspaceInfo): Record<string,
     preset: workspace.preset,
     workspaceType: workspace.workspaceType,
     ...(workspace.remoteType ? { remoteType: workspace.remoteType } : {}),
-    ...(workspace.baseUrl ? { baseUrl: workspace.baseUrl } : {}),
-    ...(workspace.directory ? { directory: workspace.directory } : {}),
+    ...(!isLocalWorkspace && workspace.baseUrl ? { baseUrl: workspace.baseUrl } : {}),
+    ...(!isLocalWorkspace && workspace.directory ? { directory: workspace.directory } : {}),
     ...(workspace.displayName ? { displayName: workspace.displayName } : {}),
     ...(workspace.openworkHostUrl ? { openworkHostUrl: workspace.openworkHostUrl } : {}),
     ...(workspace.openworkToken ? { openworkToken: workspace.openworkToken } : {}),
@@ -4216,8 +4217,8 @@ function serializeWorkspaceConfigEntry(workspace: WorkspaceInfo): Record<string,
     ...(workspace.sandboxBackend ? { sandboxBackend: workspace.sandboxBackend } : {}),
     ...(workspace.sandboxRunId ? { sandboxRunId: workspace.sandboxRunId } : {}),
     ...(workspace.sandboxContainerName ? { sandboxContainerName: workspace.sandboxContainerName } : {}),
-    ...(workspace.opencodeUsername ? { opencodeUsername: workspace.opencodeUsername } : {}),
-    ...(workspace.opencodePassword ? { opencodePassword: workspace.opencodePassword } : {}),
+    ...(!isLocalWorkspace && workspace.opencodeUsername ? { opencodeUsername: workspace.opencodeUsername } : {}),
+    ...(!isLocalWorkspace && workspace.opencodePassword ? { opencodePassword: workspace.opencodePassword } : {}),
   };
 }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -19,7 +19,7 @@ import { computeReloadFingerprint } from "./reload-fingerprint.js";
 import { startReloadWatchers } from "./reload-watcher.js";
 import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
-import { workspaceIdForPath } from "./workspaces.js";
+import { workspaceIdForPath, workspaceIdForRemote } from "./workspaces.js";
 import { ensureWorkspaceFiles, readRawOpencodeConfig } from "./workspace-init.js";
 import { sanitizeCommandName, validateMcpName } from "./validators.js";
 import { TokenService } from "./tokens.js";
@@ -114,6 +114,130 @@ function readStringField(value: unknown, key: string): string {
   if (!isRecord(value)) return "";
   const field = value[key];
   return typeof field === "string" ? field.trim() : "";
+}
+
+function normalizeRemoteDirectory(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function parseOpenworkWorkspaceIdFromUrl(input: string | null | undefined): string | null {
+  const raw = input?.trim() ?? "";
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    const segments = url.pathname.split("/").filter(Boolean);
+    const workspaceIndex = segments.indexOf("workspace");
+    const legacyIndex = segments.indexOf("w");
+    const mountIndex = workspaceIndex >= 0 ? workspaceIndex : legacyIndex;
+    return mountIndex >= 0 && segments[mountIndex + 1]
+      ? decodeURIComponent(segments[mountIndex + 1])
+      : null;
+  } catch {
+    const match = raw.match(/\/(?:workspace|w)\/([^/?#]+)/);
+    if (!match?.[1]) return null;
+    try {
+      return decodeURIComponent(match[1]);
+    } catch {
+      return match[1];
+    }
+  }
+}
+
+function stripOpenworkWorkspaceMount(input: string | null | undefined): string | null {
+  const raw = input?.trim() ?? "";
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    const segments = url.pathname.split("/").filter(Boolean);
+    const workspaceIndex = segments.indexOf("workspace");
+    const legacyIndex = segments.indexOf("w");
+    const mountIndex = workspaceIndex >= 0 ? workspaceIndex : legacyIndex;
+    if (mountIndex >= 0 && segments[mountIndex + 1]) {
+      const prefix = segments.slice(0, mountIndex).join("/");
+      url.pathname = prefix ? `/${prefix}` : "/";
+    }
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return raw.replace(/\/(?:workspace|w)\/[^/?#]+.*$/, "").replace(/\/+$/, "") || raw;
+  }
+}
+
+function openworkRemoteWorkspaceId(hostUrl: string, workspaceId: string | null | undefined): string {
+  const remoteWorkspaceId = workspaceId?.trim() || parseOpenworkWorkspaceIdFromUrl(hostUrl);
+  return remoteWorkspaceId ? `rem_${remoteWorkspaceId}` : workspaceIdForRemote(hostUrl, null);
+}
+
+function workspaceDirectoryCandidates(workspace: Record<string, unknown>): string[] {
+  const opencode = isRecord(workspace.opencode) ? workspace.opencode : {};
+  return [workspace.directory, workspace.path, opencode.directory]
+    .map(normalizeRemoteDirectory)
+    .filter(Boolean);
+}
+
+function selectOpenworkWorkspaceForConnection(list: unknown, directory: string | null): Record<string, unknown> | null {
+  if (!isRecord(list)) return null;
+  const rawItems = Array.isArray(list.items)
+    ? list.items
+    : Array.isArray(list.workspaces)
+      ? list.workspaces
+      : [];
+  const items = rawItems.filter(isRecord);
+  if (!items.length) return null;
+
+  const expectedDirectory = normalizeRemoteDirectory(directory);
+  if (expectedDirectory) {
+    return items.find((item) => workspaceDirectoryCandidates(item).includes(expectedDirectory)) ?? null;
+  }
+
+  const activeId = readStringField(list, "activeId");
+  return (activeId ? items.find((item) => readStringField(item, "id") === activeId) : null) ?? items[0] ?? null;
+}
+
+function openworkWorkspaceDisplayName(workspace: Record<string, unknown>): string | null {
+  return readStringField(workspace, "displayName")
+    || readStringField(workspace, "openworkWorkspaceName")
+    || readStringField(workspace, "name")
+    || readStringField(workspace, "id")
+    || null;
+}
+
+async function fetchOpenworkWorkspaceList(hostUrl: string, token: string, hostToken: string): Promise<unknown> {
+  const url = `${hostUrl.replace(/\/+$/, "")}/workspaces`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8_000);
+  const headers = new Headers();
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  if (hostToken) headers.set("X-OpenWork-Host-Token", hostToken);
+
+  try {
+    const response = await fetch(url, { headers, signal: controller.signal });
+    if (!response.ok) {
+      throw new ApiError(
+        502,
+        "openwork_workspace_discovery_failed",
+        `OpenWork workspace discovery failed (${response.status} ${response.statusText || "HTTP error"})`,
+      );
+    }
+    return await response.json();
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+    throw new ApiError(502, "openwork_workspace_discovery_failed", "OpenWork workspace discovery failed", {
+      error: String(error),
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function discoverOpenworkWorkspace(input: {
+  hostUrl: string;
+  token: string;
+  hostToken: string;
+  directory: string | null;
+}): Promise<Record<string, unknown> | null> {
+  const list = await fetchOpenworkWorkspaceList(input.hostUrl, input.token, input.hostToken);
+  return selectOpenworkWorkspaceForConnection(list, input.directory);
 }
 
 async function resolveOpenAiRealtimeApiKey(env: EnvService): Promise<string> {
@@ -1383,6 +1507,144 @@ function buildConfigTrigger(path: string): ReloadTrigger {
   };
 }
 
+export type AuthorizedFoldersResponse = {
+  folders: string[];
+  hiddenCount: number;
+  workspaceRoot: string;
+};
+
+export type AuthorizedFoldersUpdateResponse = {
+  folders: string[];
+  hiddenCount: number;
+  updatedAt: number;
+};
+
+type AuthorizedFoldersConfig = {
+  folders: string[];
+  hiddenEntries: Record<string, unknown>;
+};
+
+function normalizeAuthorizedFolderPath(input: string | null | undefined): string {
+  const trimmed = (input ?? "").trim();
+  if (!trimmed) return "";
+  if (trimmed === "/*") return "/";
+  const withoutWildcard = trimmed.replace(/[\\/]\*+$/, "");
+  const withoutVerbatim = /^\\\\\?\\UNC\\/i.test(withoutWildcard)
+    ? `\\${withoutWildcard.slice(7)}`
+    : /^\\\\\?\\[a-zA-Z]:[\\/]/.test(withoutWildcard)
+      ? withoutWildcard.slice(4)
+      : withoutWildcard;
+  const unified = withoutVerbatim.replace(/\\/g, "/");
+  const withoutTrailing = unified.replace(/\/+$/, "");
+  return withoutTrailing || "/";
+}
+
+function externalDirectoryKeyToAuthorizedFolder(key: string, value: unknown): string | null {
+  if (value !== "allow") return null;
+  const trimmed = key.trim();
+  if (!trimmed) return null;
+  if (trimmed === "/*") return "/";
+  if (!trimmed.endsWith("/*")) return null;
+  return normalizeAuthorizedFolderPath(trimmed.slice(0, -2));
+}
+
+function authorizedFolderToExternalDirectoryKey(folder: string): string {
+  return folder === "/" ? "/*" : `${folder}/*`;
+}
+
+function hasOwnKey(object: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function readAuthorizedFoldersFromOpencodeConfig(
+  opencodeConfig: Record<string, unknown>,
+  workspaceRoot: string,
+): AuthorizedFoldersConfig {
+  const workspaceRootFolder = normalizeAuthorizedFolderPath(workspaceRoot);
+  const permission = ensurePlainObject(opencodeConfig.permission);
+  const externalDirectory = ensurePlainObject(permission.external_directory);
+  const folders: string[] = [];
+  const hiddenEntries: Record<string, unknown> = {};
+  const seen = new Set<string>();
+
+  for (const [key, value] of Object.entries(externalDirectory)) {
+    const folder = externalDirectoryKeyToAuthorizedFolder(key, value);
+    if (!folder) {
+      hiddenEntries[key] = value;
+      continue;
+    }
+    if (folder === workspaceRootFolder || seen.has(folder)) continue;
+    seen.add(folder);
+    folders.push(folder);
+  }
+
+  return { folders, hiddenEntries };
+}
+
+function parseAuthorizedFoldersPayload(input: unknown, workspaceRoot: string): string[] {
+  if (!Array.isArray(input)) {
+    throw new ApiError(400, "invalid_payload", "folders must be an array");
+  }
+
+  const workspaceRootFolder = normalizeAuthorizedFolderPath(workspaceRoot);
+  const folders: string[] = [];
+  const seen = new Set<string>();
+
+  for (const item of input) {
+    if (typeof item !== "string") {
+      throw new ApiError(400, "invalid_payload", "folders must be an array of strings");
+    }
+    const folder = normalizeAuthorizedFolderPath(item);
+    if (!folder || folder === workspaceRootFolder || seen.has(folder)) continue;
+    seen.add(folder);
+    folders.push(folder);
+  }
+
+  return folders;
+}
+
+function mergeAuthorizedFoldersIntoExternalDirectory(
+  folders: string[],
+  hiddenEntries: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const next: Record<string, unknown> = { ...hiddenEntries };
+  for (const folder of folders) {
+    next[authorizedFolderToExternalDirectoryKey(folder)] = "allow";
+  }
+  return Object.keys(next).length ? next : undefined;
+}
+
+async function writeAuthorizedFoldersToOpencodeConfig(
+  configPath: string,
+  existingOpencode: Record<string, unknown>,
+  nextExternalDirectory: Record<string, unknown> | undefined,
+): Promise<void> {
+  const existingPermission = ensurePlainObject(existingOpencode.permission);
+  const hasExternalDirectory = hasOwnKey(existingPermission, "external_directory");
+  if (typeof nextExternalDirectory === "undefined" && !hasExternalDirectory) return;
+
+  const existingPermissionKeys = Object.keys(existingPermission);
+  const removePermissionParent =
+    typeof nextExternalDirectory === "undefined" &&
+    (existingPermissionKeys.length === 0 ||
+      (existingPermissionKeys.length === 1 && hasExternalDirectory));
+
+  if (removePermissionParent) {
+    await updateJsoncPath(configPath, ["permission"], undefined);
+    return;
+  }
+
+  await updateJsoncPath(configPath, ["permission", "external_directory"], nextExternalDirectory);
+}
+
+function buildAuthorizedFoldersResponse(workspace: WorkspaceInfo, config: AuthorizedFoldersConfig): AuthorizedFoldersResponse {
+  return {
+    folders: config.folders,
+    hiddenCount: Object.keys(config.hiddenEntries).length,
+    workspaceRoot: normalizeAuthorizedFolderPath(workspace.path),
+  };
+}
+
 function serializeWorkspace(workspace: ServerConfig["workspaces"][number]) {
   const { opencodeUsername, opencodePassword, ...rest } = workspace;
   const opencodeDirectory = resolveOpencodeDirectory(workspace);
@@ -1411,6 +1673,7 @@ function createRoutes(
   const routes: Route[] = [];
   const fileSessions = new FileSessionStore();
   const googleWorkspaceConnectFlows = createGoogleWorkspaceConnectFlowManager(config);
+  const envPendingChangesByRuntime = new Map<string, boolean>();
 
   const serializeFileSession = (session: {
     id: string;
@@ -1718,18 +1981,68 @@ function createRoutes(
   }
 
   // User-level env vars (see apps/app/pr/environment-variables.md). All routes
-  // require the desktop host token (not owner bearer tokens) because values are
-  // returned raw; the React pane masks them only for display. Reload semantics
-  // are driven from the UI after a write; this surface is user-scoped, not
-  // workspace-scoped, so no audit.
-  addRoute(routes, "GET", "/env", "host-token", async () => {
+  // require the desktop host token (not owner bearer tokens). List callers can
+  // request metadata-only results so renderer settings panes do not receive
+  // every raw secret value up front. Reload semantics are driven from the UI
+  // after a write; this surface is user-scoped, not workspace-scoped, so no audit.
+  addRoute(routes, "GET", "/env", "host-token", async (ctx) => {
+    const includeValues = parseOptionalBoolean(ctx.url.searchParams.get("includeValues"), "includeValues") ?? true;
     const items = await env.list().catch(rethrowEnvStoreReadError);
-    return jsonResponse({ items });
+    return jsonResponse({
+      items: items.map((item) => ({
+        key: item.key,
+        updatedAt: item.updatedAt,
+        hasValue: item.value.length > 0,
+        ...(includeValues ? { value: item.value } : {}),
+      })),
+    });
   });
 
   addRoute(routes, "GET", "/env/keys", "host-token", async () => {
     const items = await env.list().catch(rethrowEnvStoreReadError);
     return jsonResponse({ keys: items.map((item) => item.key) });
+  });
+
+  function envRuntimeKeyFromUrl(url: URL): string {
+    return url.searchParams.get("runtimeKey")?.trim() || "default";
+  }
+
+  addRoute(routes, "GET", "/env/status", "host-token", async (ctx) => {
+    const runtimeKey = envRuntimeKeyFromUrl(ctx.url);
+    return jsonResponse({ runtimeKey, pendingChanges: envPendingChangesByRuntime.get(runtimeKey) === true });
+  });
+
+  addRoute(routes, "PUT", "/env/status", "host-token", async (ctx) => {
+    const body = await readJsonBody(ctx.request);
+    const runtimeKey = typeof body.runtimeKey === "string" && body.runtimeKey.trim()
+      ? body.runtimeKey.trim()
+      : "default";
+    const pendingChanges = body.pendingChanges === true;
+    if (pendingChanges) {
+      envPendingChangesByRuntime.set(runtimeKey, true);
+    } else {
+      envPendingChangesByRuntime.delete(runtimeKey);
+    }
+    return jsonResponse({ runtimeKey, pendingChanges });
+  });
+
+  addRoute(routes, "GET", "/env/:key", "host-token", async (ctx) => {
+    const key = ctx.params.key;
+    if (!isValidEnvKey(key)) {
+      throw new ApiError(400, "invalid_env_key", "Invalid environment variable name");
+    }
+    const item = (await env.list().catch(rethrowEnvStoreReadError)).find((entry) => entry.key === key);
+    if (!item) {
+      throw new ApiError(404, "env_not_found", "Environment variable not found");
+    }
+    return jsonResponse({
+      item: {
+        key: item.key,
+        updatedAt: item.updatedAt,
+        hasValue: item.value.length > 0,
+        value: item.value,
+      },
+    });
   });
 
   addRoute(routes, "PUT", "/env", "host-token", async (ctx) => {
@@ -1840,9 +2153,101 @@ function createRoutes(
     }, 201);
   });
 
+  addRoute(routes, "POST", "/workspaces/remote", "host", async (ctx) => {
+    ensureWritable(config);
+    const body = await readJsonBody(ctx.request);
+    const baseUrl = readStringField(body, "baseUrl");
+    if (!baseUrl) {
+      throw new ApiError(400, "invalid_payload", "baseUrl is required");
+    }
+    if (!/^https?:\/\//i.test(baseUrl)) {
+      throw new ApiError(400, "invalid_payload", "baseUrl must start with http:// or https://");
+    }
+
+    const remoteType = readStringField(body, "remoteType") === "opencode" ? "opencode" : "openwork";
+    const directory = readStringField(body, "directory") || null;
+    const displayName = readStringField(body, "displayName") || null;
+    const rawOpenworkHostUrl = readStringField(body, "openworkHostUrl") || null;
+    const openworkHostUrl = remoteType === "openwork"
+      ? stripOpenworkWorkspaceMount(rawOpenworkHostUrl ?? baseUrl)
+      : rawOpenworkHostUrl;
+    const openworkToken = readStringField(body, "openworkToken");
+    const openworkHostToken = readStringField(body, "openworkHostToken");
+    const sandboxBackend = readStringField(body, "sandboxBackend");
+    const sandboxRunId = readStringField(body, "sandboxRunId");
+    const sandboxContainerName = readStringField(body, "sandboxContainerName");
+    let openworkWorkspaceId = remoteType === "openwork"
+      ? readStringField(body, "openworkWorkspaceId")
+        || parseOpenworkWorkspaceIdFromUrl(rawOpenworkHostUrl)
+        || parseOpenworkWorkspaceIdFromUrl(baseUrl)
+      : "";
+    let openworkWorkspaceName = readStringField(body, "openworkWorkspaceName") || null;
+
+    if (remoteType === "openwork" && !openworkWorkspaceId) {
+      const discovered = await discoverOpenworkWorkspace({
+        hostUrl: openworkHostUrl ?? baseUrl,
+        token: openworkToken,
+        hostToken: openworkHostToken,
+        directory,
+      });
+      openworkWorkspaceId = discovered ? readStringField(discovered, "id") : "";
+      openworkWorkspaceName = discovered ? openworkWorkspaceDisplayName(discovered) : openworkWorkspaceName;
+      if (!openworkWorkspaceId) {
+        throw new ApiError(
+          400,
+          "openwork_workspace_not_found",
+          directory
+            ? `OpenWork server has no workspace matching ${directory}.`
+            : "OpenWork server returned no workspaces.",
+        );
+      }
+    }
+
+    const workspace: WorkspaceInfo = {
+      id: remoteType === "openwork"
+        ? openworkRemoteWorkspaceId(openworkHostUrl ?? baseUrl, openworkWorkspaceId)
+        : workspaceIdForRemote(baseUrl, directory),
+      name: displayName ?? openworkWorkspaceName ?? "Remote workspace",
+      path: directory ?? "",
+      preset: "remote",
+      workspaceType: "remote",
+      remoteType,
+      baseUrl: remoteType === "openwork" ? (openworkHostUrl ?? baseUrl) : baseUrl,
+      ...(directory ? { directory } : {}),
+      ...(displayName ? { displayName } : {}),
+      ...(remoteType === "openwork" && openworkHostUrl ? { openworkHostUrl } : {}),
+      ...(openworkToken ? { openworkToken } : {}),
+      ...(remoteType === "openwork" && openworkWorkspaceId ? { openworkWorkspaceId } : {}),
+      ...(remoteType === "openwork" && openworkWorkspaceName ? { openworkWorkspaceName } : {}),
+      ...(sandboxBackend ? { sandboxBackend } : {}),
+      ...(sandboxRunId ? { sandboxRunId } : {}),
+      ...(sandboxContainerName ? { sandboxContainerName } : {}),
+    };
+
+    config.workspaces = [workspace, ...config.workspaces.filter((entry) => entry.id !== workspace.id)];
+    const persisted = await persistServerWorkspaceState(config);
+    onWorkspacesChanged();
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "host" },
+      action: "workspace.create",
+      target: workspace.path || workspace.baseUrl || "workspace",
+      summary: `Created remote workspace ${workspace.name}`,
+      timestamp: Date.now(),
+    });
+
+    return jsonResponse({
+      activeId: workspace.id,
+      workspaces: config.workspaces.map(serializeWorkspace),
+      persisted,
+    }, 201);
+  });
+
   addRoute(routes, "PATCH", "/workspaces/:id/display-name", "host", async (ctx) => {
     ensureWritable(config);
-    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const workspace = await resolveWorkspaceForRegistry(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const nextDisplayName = typeof body.displayName === "string" && body.displayName.trim()
       ? body.displayName.trim()
@@ -1866,7 +2271,7 @@ function createRoutes(
       workspaceId: workspace.id,
       actor: ctx.actor ?? { type: "host" },
       action: "workspace.rename",
-      target: workspace.path,
+      target: workspace.path || workspace.baseUrl || "workspace",
       summary: `Updated workspace display name${nextDisplayName ? ` to ${nextDisplayName}` : ""}`,
       timestamp: Date.now(),
     });
@@ -1879,11 +2284,17 @@ function createRoutes(
   });
 
   addRoute(routes, "POST", "/workspaces/:id/activate", "host", async (ctx) => {
-    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const workspace = await resolveWorkspaceForRegistry(config, ctx.params.id);
+    const queryPersist = parseOptionalBoolean(ctx.url.searchParams.get("persist"), "persist");
+    const body = queryPersist === undefined ? await readOptionalJsonBody(ctx.request) : {};
+    const persist = queryPersist ?? (body.persist === true);
+    if (persist) ensureWritable(config);
     config.workspaces = [
       workspace,
       ...config.workspaces.filter((entry) => entry.id !== workspace.id),
     ];
+    const persisted = persist ? await persistServerWorkspaceState(config) : false;
+    if (persist) onWorkspacesChanged();
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
@@ -1893,23 +2304,22 @@ function createRoutes(
       summary: "Switched active workspace",
       timestamp: Date.now(),
     });
-    const connection = resolveWorkspaceOpencodeConnection(config, workspace);
-    if (connection.baseUrl?.trim()) {
+    if (workspace.workspaceType === "local" && resolveWorkspaceOpencodeConnection(config, workspace).baseUrl?.trim()) {
       await reloadOpencodeEngine(config, workspace);
     }
-    return jsonResponse({ activeId: workspace.id, workspace: serializeWorkspace(workspace), persisted: false });
+    return jsonResponse({ activeId: workspace.id, workspace: serializeWorkspace(workspace), persisted });
   });
 
   addRoute(routes, "DELETE", "/workspaces/:id", "host", async (ctx) => {
     ensureWritable(config);
 
-    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const workspace = await resolveWorkspaceForRegistry(config, ctx.params.id);
 
     const before = config.workspaces.length;
     config.workspaces = config.workspaces.filter((entry) => entry.id !== workspace.id);
     const deleted = before !== config.workspaces.length;
 
-    if (deleted) {
+    if (deleted && workspace.workspaceType === "local") {
       // Only remove exact matches; authorizedRoots can contain broader entries.
       config.authorizedRoots = config.authorizedRoots.filter((root) => resolve(root) !== resolve(workspace.path));
     }
@@ -1943,6 +2353,65 @@ function createRoutes(
     const openwork = await readOpenworkConfig(workspace.path);
     const lastAudit = await readLastAudit(workspace.path, workspace.id);
     return jsonResponse({ opencode, openwork, updatedAt: lastAudit?.timestamp ?? null });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/authorized-folders", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const opencode = await readOpencodeConfig(workspace.path);
+    const foldersConfig = readAuthorizedFoldersFromOpencodeConfig(opencode, workspace.path);
+    return jsonResponse(buildAuthorizedFoldersResponse(workspace, foldersConfig));
+  });
+
+  addRoute(routes, "PUT", "/workspace/:id/authorized-folders", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const folders = parseAuthorizedFoldersPayload(body.folders, workspace.path);
+    const configPath = opencodeConfigPath(workspace.path);
+
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "config.authorized_folders.write",
+      summary: "Update authorized folders",
+      paths: [configPath],
+    });
+
+    const configFingerprintBefore = await computeReloadFingerprint(workspace.path, "config");
+    const existingOpencode = await readOpencodeConfig(workspace.path);
+    const existingFoldersConfig = readAuthorizedFoldersFromOpencodeConfig(existingOpencode, workspace.path);
+    const nextExternalDirectory = mergeAuthorizedFoldersIntoExternalDirectory(
+      folders,
+      existingFoldersConfig.hiddenEntries,
+    );
+
+    await writeAuthorizedFoldersToOpencodeConfig(configPath, existingOpencode, nextExternalDirectory);
+
+    const updatedAt = Date.now();
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "config.authorized_folders.write",
+      target: configPath,
+      summary: "Updated authorized folders",
+      timestamp: updatedAt,
+    });
+
+    if (configFingerprintBefore !== await computeReloadFingerprint(workspace.path, "config")) {
+      emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(configPath));
+    }
+
+    const updatedFoldersConfig = readAuthorizedFoldersFromOpencodeConfig({
+      permission: { external_directory: nextExternalDirectory ?? {} },
+    }, workspace.path);
+
+    const response: AuthorizedFoldersUpdateResponse = {
+      folders: updatedFoldersConfig.folders,
+      hiddenCount: Object.keys(updatedFoldersConfig.hiddenEntries).length,
+      updatedAt,
+    };
+    return jsonResponse(response);
   });
 
   addRoute(routes, "GET", "/workspace/:id/opencode-config", "client", async (ctx) => {
@@ -3605,6 +4074,21 @@ async function resolveWorkspace(config: ServerConfig, id: string): Promise<Works
   return { ...workspace, path: resolvedWorkspace };
 }
 
+async function resolveWorkspaceForRegistry(config: ServerConfig, id: string): Promise<WorkspaceInfo> {
+  const workspaceId = id.trim();
+  const aliasWorkspaceId = workspaceId.startsWith("rem_") ? workspaceId.slice("rem_".length) : "";
+  const workspace =
+    config.workspaces.find((entry) => entry.id === workspaceId) ??
+    (aliasWorkspaceId ? config.workspaces.find((entry) => entry.id === aliasWorkspaceId) : undefined);
+  if (!workspace) {
+    throw new ApiError(404, "workspace_not_found", "Workspace not found");
+  }
+  if (workspace.workspaceType === "remote") {
+    return { ...workspace, path: workspace.path?.trim() ?? "" };
+  }
+  return resolveWorkspace(config, id);
+}
+
 function reloadOpencodeEngineAfterInternalBootstrap(config: ServerConfig, workspace: WorkspaceInfo): void {
   const connection = resolveWorkspaceOpencodeConnection(config, workspace);
   if (!connection.baseUrl?.trim()) return;
@@ -3647,6 +4131,16 @@ async function readJsonBody(request: Request): Promise<Record<string, unknown>> 
   try {
     const json = await request.json();
     return json as Record<string, unknown>;
+  } catch {
+    throw new ApiError(400, "invalid_json", "Invalid JSON body");
+  }
+}
+
+async function readOptionalJsonBody(request: Request): Promise<Record<string, unknown>> {
+  const text = await request.text();
+  if (!text.trim()) return {};
+  try {
+    return ensurePlainObject(JSON.parse(text));
   } catch {
     throw new ApiError(400, "invalid_json", "Invalid JSON body");
   }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4224,7 +4224,6 @@ function serializeWorkspaceConfigEntry(workspace: WorkspaceInfo): Record<string,
 async function persistServerWorkspaceState(config: ServerConfig): Promise<boolean> {
   const configPath = config.configPath?.trim() ?? "";
   if (!configPath) return false;
-  if (!(await exists(configPath))) return false;
 
   const parsed = await readServerConfigFile(configPath);
   const next: OpenworkServerConfigFile = {

--- a/apps/server/src/workspace-activate.e2e.test.ts
+++ b/apps/server/src/workspace-activate.e2e.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -34,6 +34,39 @@ function hostAuth(token: string) {
   return { "X-OpenWork-Host-Token": token };
 }
 
+function workspaceIdsFromConfig(value: unknown): string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+  if (!("workspaces" in value) || !Array.isArray(value.workspaces)) return [];
+  return value.workspaces.flatMap((workspace) =>
+    workspace && typeof workspace === "object" && !Array.isArray(workspace) && "id" in workspace && typeof workspace.id === "string"
+      ? [workspace.id]
+      : [],
+  );
+}
+
+function workspacesFromConfig(value: unknown): Array<Record<string, unknown>> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+  if (!("workspaces" in value) || !Array.isArray(value.workspaces)) return [];
+  return value.workspaces.filter(
+    (workspace): workspace is Record<string, unknown> =>
+      Boolean(workspace) && typeof workspace === "object" && !Array.isArray(workspace),
+  );
+}
+
+function authorizedRootsFromConfig(value: unknown): string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+  if (!("authorizedRoots" in value) || !Array.isArray(value.authorizedRoots)) return [];
+  return value.authorizedRoots.filter((root): root is string => typeof root === "string");
+}
+
+async function readPersistedWorkspaceIds(configPath: string) {
+  return workspaceIdsFromConfig(JSON.parse(await readFile(configPath, "utf8")));
+}
+
+async function readPersistedConfig(configPath: string): Promise<unknown> {
+  return JSON.parse(await readFile(configPath, "utf8"));
+}
+
 function startMockOpencode() {
   const requests: Array<{ pathname: string; search: string }> = [];
   const server = Bun.serve({
@@ -45,6 +78,32 @@ function startMockOpencode() {
 
       if (url.pathname === "/instance/dispose") {
         return Response.json({ disposed: true });
+      }
+
+      return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
+    },
+  }) as Served;
+  stops.push(() => server.stop(true));
+  return { server, requests };
+}
+
+function startMockRemoteOpenwork() {
+  const requests: Array<{ pathname: string; authorization: string | null }> = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      requests.push({ pathname: url.pathname, authorization: request.headers.get("authorization") });
+
+      if (url.pathname === "/workspaces") {
+        return Response.json({
+          activeId: "ws_remote",
+          items: [
+            { id: "ws_remote", name: "Remote Project", path: "/remote/project" },
+            { id: "ws_other", name: "Other", path: "/remote/other" },
+          ],
+        });
       }
 
       return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
@@ -85,6 +144,33 @@ async function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseU
   return { server, hostToken: config.hostToken };
 }
 
+async function startOpenworkServerWithWorkspaces(input: {
+  configPath: string;
+  workspaces: ServerConfig["workspaces"];
+  authorizedRoots: string[];
+}) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    configPath: input.configPath,
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: input.workspaces,
+    authorizedRoots: input.authorizedRoots,
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { server, hostToken: config.hostToken };
+}
+
 describe("workspace activation", () => {
   test("reloads the bound OpenCode engine on activate", async () => {
     const workspaceRoot = await createWorkspaceRoot();
@@ -111,5 +197,171 @@ describe("workspace activation", () => {
     expect(reloadRequest?.search).toContain(
       `directory=${encodeURIComponent(workspaceRoot)}`,
     );
+  });
+
+  test("persists activation order only when requested", async () => {
+    const firstRoot = await createWorkspaceRoot();
+    const secondRoot = await createWorkspaceRoot();
+    const configPath = join(firstRoot, "server.json");
+    const workspaces: ServerConfig["workspaces"] = [
+      {
+        id: "ws_1",
+        name: "One",
+        path: firstRoot,
+        preset: "starter",
+        workspaceType: "local",
+      },
+      {
+        id: "ws_2",
+        name: "Two",
+        path: secondRoot,
+        preset: "starter",
+        workspaceType: "local",
+      },
+    ];
+    await writeFile(
+      configPath,
+      `${JSON.stringify({ workspaces, authorizedRoots: [firstRoot, secondRoot] }, null, 2)}\n`,
+      "utf8",
+    );
+    const openwork = await startOpenworkServerWithWorkspaces({
+      configPath,
+      workspaces,
+      authorizedRoots: [firstRoot, secondRoot],
+    });
+
+    const base = `http://127.0.0.1:${openwork.server.port}`;
+    const persistedResponse = await fetch(`${base}/workspaces/ws_2/activate?persist=true`, {
+      method: "POST",
+      headers: hostAuth(openwork.hostToken),
+    });
+    expect(persistedResponse.status).toBe(200);
+    const persistedBody = await persistedResponse.json();
+    expect(persistedBody.activeId).toBe("ws_2");
+    expect(persistedBody.persisted).toBe(true);
+    expect(await readPersistedWorkspaceIds(configPath)).toEqual(["ws_2", "ws_1"]);
+
+    const volatileResponse = await fetch(`${base}/workspaces/ws_1/activate`, {
+      method: "POST",
+      headers: hostAuth(openwork.hostToken),
+    });
+    expect(volatileResponse.status).toBe(200);
+    const volatileBody = await volatileResponse.json();
+    expect(volatileBody.activeId).toBe("ws_1");
+    expect(volatileBody.persisted).toBe(false);
+    expect(await readPersistedWorkspaceIds(configPath)).toEqual(["ws_2", "ws_1"]);
+
+    const bodyPersistedResponse = await fetch(`${base}/workspaces/ws_1/activate`, {
+      method: "POST",
+      headers: { ...hostAuth(openwork.hostToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ persist: true }),
+    });
+    expect(bodyPersistedResponse.status).toBe(200);
+    const bodyPersistedBody = await bodyPersistedResponse.json();
+    expect(bodyPersistedBody.activeId).toBe("ws_1");
+    expect(bodyPersistedBody.persisted).toBe(true);
+    expect(await readPersistedWorkspaceIds(configPath)).toEqual(["ws_1", "ws_2"]);
+  });
+});
+
+describe("workspace lifecycle registry", () => {
+  test("creates and persists remote OpenWork workspace records", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const configPath = join(workspaceRoot, "server.json");
+    await writeFile(configPath, `${JSON.stringify({ workspaces: [], authorizedRoots: [] }, null, 2)}\n`, "utf8");
+    const remote = startMockRemoteOpenwork();
+    const openwork = await startOpenworkServerWithWorkspaces({
+      configPath,
+      workspaces: [],
+      authorizedRoots: [],
+    });
+
+    const base = `http://127.0.0.1:${openwork.server.port}`;
+    const response = await fetch(`${base}/workspaces/remote`, {
+      method: "POST",
+      headers: { ...hostAuth(openwork.hostToken), "Content-Type": "application/json" },
+      body: JSON.stringify({
+        baseUrl: `http://127.0.0.1:${remote.server.port}`,
+        openworkHostUrl: `http://127.0.0.1:${remote.server.port}`,
+        openworkToken: "remote_token",
+        directory: "/remote/project",
+        remoteType: "openwork",
+        sandboxRunId: "run_1",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.activeId).toBe("rem_ws_remote");
+    expect(body.workspaces[0].openworkWorkspaceId).toBe("ws_remote");
+    expect(body.workspaces[0].openworkWorkspaceName).toBe("Remote Project");
+    expect(remote.requests[0]).toEqual({ pathname: "/workspaces", authorization: "Bearer remote_token" });
+
+    const persisted = await readPersistedConfig(configPath);
+    const workspaces = workspacesFromConfig(persisted);
+    expect(workspaces[0]?.id).toBe("rem_ws_remote");
+    expect(workspaces[0]?.workspaceType).toBe("remote");
+    expect(workspaces[0]?.remoteType).toBe("openwork");
+    expect(workspaces[0]?.sandboxRunId).toBe("run_1");
+    expect(authorizedRootsFromConfig(persisted)).toEqual([]);
+  });
+
+  test("renames activates and deletes remote records without authorized roots", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const configPath = join(workspaceRoot, "server.json");
+    const workspaces: ServerConfig["workspaces"] = [
+      {
+        id: "rem_ws_one",
+        name: "One",
+        path: "/remote/one",
+        preset: "remote",
+        workspaceType: "remote",
+        remoteType: "openwork",
+        baseUrl: "http://127.0.0.1:9",
+        openworkWorkspaceId: "ws_one",
+      },
+      {
+        id: "rem_ws_two",
+        name: "Two",
+        path: "/remote/two",
+        preset: "remote",
+        workspaceType: "remote",
+        remoteType: "openwork",
+        baseUrl: "http://127.0.0.1:9",
+        openworkWorkspaceId: "ws_two",
+      },
+    ];
+    await writeFile(configPath, `${JSON.stringify({ workspaces, authorizedRoots: [] }, null, 2)}\n`, "utf8");
+    const openwork = await startOpenworkServerWithWorkspaces({
+      configPath,
+      workspaces,
+      authorizedRoots: [],
+    });
+    const base = `http://127.0.0.1:${openwork.server.port}`;
+
+    const renameResponse = await fetch(`${base}/workspaces/rem_ws_one/display-name`, {
+      method: "PATCH",
+      headers: { ...hostAuth(openwork.hostToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ displayName: "Renamed One" }),
+    });
+    expect(renameResponse.status).toBe(200);
+    let persisted = await readPersistedConfig(configPath);
+    expect(workspacesFromConfig(persisted)[0]?.displayName).toBe("Renamed One");
+
+    const activateResponse = await fetch(`${base}/workspaces/rem_ws_two/activate?persist=true`, {
+      method: "POST",
+      headers: hostAuth(openwork.hostToken),
+    });
+    expect(activateResponse.status).toBe(200);
+    expect(await readPersistedWorkspaceIds(configPath)).toEqual(["rem_ws_two", "rem_ws_one"]);
+
+    const deleteResponse = await fetch(`${base}/workspaces/rem_ws_one`, {
+      method: "DELETE",
+      headers: hostAuth(openwork.hostToken),
+    });
+    expect(deleteResponse.status).toBe(200);
+    persisted = await readPersistedConfig(configPath);
+    expect(workspaceIdsFromConfig(persisted)).toEqual(["rem_ws_two"]);
+    expect(authorizedRootsFromConfig(persisted)).toEqual([]);
   });
 });

--- a/apps/server/src/workspace-activate.e2e.test.ts
+++ b/apps/server/src/workspace-activate.e2e.test.ts
@@ -265,6 +265,34 @@ describe("workspace activation", () => {
 });
 
 describe("workspace lifecycle registry", () => {
+  test("creates server config file when adding a local workspace", async () => {
+    const configRoot = await createWorkspaceRoot();
+    const workspaceRoot = await createWorkspaceRoot();
+    const configPath = join(configRoot, "server.json");
+    const openwork = await startOpenworkServerWithWorkspaces({
+      configPath,
+      workspaces: [],
+      authorizedRoots: [],
+    });
+
+    const base = `http://127.0.0.1:${openwork.server.port}`;
+    const response = await fetch(`${base}/workspaces/local`, {
+      method: "POST",
+      headers: { ...hostAuth(openwork.hostToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ folderPath: workspaceRoot, name: "Persisted Local", preset: "starter" }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.persisted).toBe(true);
+
+    const persisted = await readPersistedConfig(configPath);
+    const workspaces = workspacesFromConfig(persisted);
+    expect(workspaces[0]?.path).toBe(workspaceRoot);
+    expect(workspaces[0]?.name).toBe("Persisted Local");
+    expect(authorizedRootsFromConfig(persisted)).toEqual([workspaceRoot]);
+  });
+
   test("creates and persists remote OpenWork workspace records", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const configPath = join(workspaceRoot, "server.json");

--- a/apps/server/src/workspace-activate.e2e.test.ts
+++ b/apps/server/src/workspace-activate.e2e.test.ts
@@ -148,6 +148,9 @@ async function startOpenworkServerWithWorkspaces(input: {
   configPath: string;
   workspaces: ServerConfig["workspaces"];
   authorizedRoots: string[];
+  opencodeBaseUrl?: string;
+  opencodeUsername?: string;
+  opencodePassword?: string;
 }) {
   const config: ServerConfig = {
     host: "127.0.0.1",
@@ -159,6 +162,9 @@ async function startOpenworkServerWithWorkspaces(input: {
     corsOrigins: ["*"],
     workspaces: input.workspaces,
     authorizedRoots: input.authorizedRoots,
+    opencodeBaseUrl: input.opencodeBaseUrl,
+    opencodeUsername: input.opencodeUsername,
+    opencodePassword: input.opencodePassword,
     readOnly: false,
     startedAt: Date.now(),
     tokenSource: "cli",
@@ -291,6 +297,36 @@ describe("workspace lifecycle registry", () => {
     expect(workspaces[0]?.path).toBe(workspaceRoot);
     expect(workspaces[0]?.name).toBe("Persisted Local");
     expect(authorizedRootsFromConfig(persisted)).toEqual([workspaceRoot]);
+  });
+
+  test("does not persist transient local OpenCode runtime fields", async () => {
+    const configRoot = await createWorkspaceRoot();
+    const workspaceRoot = await createWorkspaceRoot();
+    const configPath = join(configRoot, "server.json");
+    const openwork = await startOpenworkServerWithWorkspaces({
+      configPath,
+      workspaces: [],
+      authorizedRoots: [],
+      opencodeBaseUrl: "http://127.0.0.1:49999",
+      opencodeUsername: "runtime-user",
+      opencodePassword: "runtime-pass",
+    });
+
+    const base = `http://127.0.0.1:${openwork.server.port}`;
+    const response = await fetch(`${base}/workspaces/local`, {
+      method: "POST",
+      headers: { ...hostAuth(openwork.hostToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ folderPath: workspaceRoot, name: "Runtime Local", preset: "starter" }),
+    });
+    expect(response.status).toBe(201);
+
+    const persisted = await readPersistedConfig(configPath);
+    const workspace = workspacesFromConfig(persisted)[0];
+    expect(workspace?.path).toBe(workspaceRoot);
+    expect(workspace?.baseUrl).toBeUndefined();
+    expect(workspace?.directory).toBeUndefined();
+    expect(workspace?.opencodeUsername).toBeUndefined();
+    expect(workspace?.opencodePassword).toBeUndefined();
   });
 
   test("creates and persists remote OpenWork workspace records", async () => {


### PR DESCRIPTION
## Summary
- Move desktop-managed workspace lifecycle/config paths onto OpenWork server routes, including remote workspace registry, persistent activation, authorized folders, and workspace export.
- Move environment variable listing/reveal and pending-apply state behind server APIs so the renderer no longer receives all raw secrets or owns restart state.
- Route skills, project plugins, MCP, provider config, and cloud import metadata through server workspace targets when available, keeping desktop only for native/no-server fallback cases.

## Verification
- `pnpm --filter openwork-server exec bun test src/env-routes.e2e.test.ts` passed: 17 tests, 50 assertions.
- `pnpm --filter openwork-server exec bun test src/authorized-folders.e2e.test.ts` passed: 3 tests, 17 assertions.
- `pnpm --filter openwork-server exec bun test src/workspace-activate.e2e.test.ts` passed: 4 tests, 33 assertions.
- `pnpm --filter openwork-server typecheck` passed.
- `pnpm --filter @openwork/app typecheck` passed.
- `pnpm --filter @openwork/app build` passed.
- `git diff --check` passed.

## Manual Smoke
- Started dev desktop with `OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9823 pnpm dev`.
- Verified Environment add/reveal/edit/delete and server pending state using temporary `SERVERIFY_*` variables.
- Verified Permissions and Extensions settings load via server routes (`authorized-folders`, `mcp`, `plugins`, `skills`, `config`, `opencode-config`).

## Notes
- No video captured; smoke evidence is from the dev desktop CDP run and server logs.
- Native folder/file picker and Finder reveal/open remain desktop capabilities.