### PR TITLE
Fix model picker: show all models and sort alphabetically

### DIFF
--- a/apps/app/src/app/defaults/index.ts
+++ b/apps/app/src/app/defaults/index.ts
@@ -11,8 +11,6 @@
  */
 
 export {
-  DEFAULT_VISIBLE_MODELS,
   RECOMMENDED_MODEL_PATTERNS,
-  isDefaultVisibleModel,
   isRecommendedModel,
 } from "./models";

--- a/apps/app/src/app/defaults/models.ts
+++ b/apps/app/src/app/defaults/models.ts
@@ -1,37 +1,11 @@
 /**
- * Default model visibility and recommendation constants.
+ * Default model recommendation constants.
  *
- * These are hardcoded client-side defaults that can be overridden by the
- * user via the "Available models" tab in the model picker (persisted to
- * localStorage). There is no server-side API for these — if one is added
+ * These are hardcoded client-side defaults. If a server-side API is added
  * later, these should be replaced by the server response.
  *
- * To add or remove models from the defaults, edit this file.
+ * To add or remove recommended models, edit this file.
  */
-
-/**
- * Models visible by default for providers with large model catalogs.
- * Everything else from these providers is hidden on first run.
- *
- * Key: provider ID (lowercase).
- * Value: array of model ID substrings — a model is visible if its ID
- * contains any of these patterns.
- *
- * Providers not listed here show ALL their models by default.
- */
-export const DEFAULT_VISIBLE_MODELS: Record<string, string[]> = {
-  openai: [
-    "gpt-5.5",
-    "gpt-5.4",
-    "o3",
-    "o4-mini",
-    "gpt-4o",
-  ],
-  anthropic: [
-    "claude-opus-4-6",
-    "claude-sonnet-4-7",
-  ],
-};
 
 /**
  * Models considered "recommended" and shown with a star icon at the top
@@ -44,18 +18,6 @@ export const RECOMMENDED_MODEL_PATTERNS: string[] = [
   "gpt-5.5",
   "kimi-k2.6",
 ];
-
-/**
- * Check if a model should be visible by default for its provider.
- * Returns true if the provider has no curated list (show everything)
- * or if the model ID matches one of the curated patterns.
- */
-export function isDefaultVisibleModel(providerId: string, modelId: string): boolean {
-  const patterns = DEFAULT_VISIBLE_MODELS[providerId.toLowerCase()];
-  if (!patterns) return true;
-  const lower = modelId.toLowerCase();
-  return patterns.some((p) => lower.includes(p));
-}
 
 /**
  * Check if a model is in the recommended list.

--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -30,7 +30,6 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { isDesktopProviderBlocked } from "@/app/cloud/desktop-app-restrictions";
-import { readHiddenModels } from "@/react-app/domains/session/modals/model-picker-modal";
 import { Settings2 } from "lucide-react";
 import { openModelPickerEvent } from "@/react-app/shell/new-providers-toast";
 import { newProvidersEvent } from "@/app/lib/provider-events";
@@ -128,10 +127,12 @@ function groupByProvider(modelOptions: ModelOption[]) {
     groups.set(providerLabel, [option]);
   }
 
-  return [...groups.entries()].map(([providerLabel, options]) => ({
-    value: providerLabel,
-    items: options,
-  }));
+  return [...groups.entries()]
+    .map(([providerLabel, options]) => ({
+      value: providerLabel,
+      items: [...options].sort((a, b) => a.title.localeCompare(b.title)),
+    }))
+    .sort((a, b) => a.value.localeCompare(b.value));
 }
 
 function isSameModel(a: ModelRef, b: ModelRef) {
@@ -185,20 +186,9 @@ export function ModelSelect({
     }),
   );
 
-  // Filter out models the user has hidden via the "Available models" tab.
-  // Re-read localStorage when the popover opens so changes from the
-  // model picker modal are picked up immediately.
-  const visibleOptions = React.useMemo(() => {
-    const hidden = readHiddenModels();
-    if (hidden.size === 0) return modelOptions ?? [];
-    return (modelOptions ?? []).filter(
-      (opt) => !hidden.has(`${opt.providerID}/${opt.modelID}`),
-    );
-  }, [modelOptions, open]);
-
   const groups = React.useMemo(
-    () => groupByProvider(visibleOptions),
-    [visibleOptions],
+    () => groupByProvider(modelOptions ?? []),
+    [modelOptions],
   );
 
   const handleSelect = (option: ModelOption) => {

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -20,56 +20,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { modelEquals, resolveProviderDisplayName } from "../../../../app/utils";
 import type { ModelOption, ModelRef } from "../../../../app/types";
-import { isDefaultVisibleModel, isRecommendedModel } from "../../../../app/defaults";
+import { isRecommendedModel } from "../../../../app/defaults";
 import { ProviderIcon } from "../../../design-system/provider-icon";
-import { t } from "../../../../i18n";
-
-const HIDDEN_MODELS_KEY = "openwork.hiddenModels";
-const HIDDEN_MODELS_SEEDED_KEY = "openwork.hiddenModelsSeeded";
-
-/**
- * Seed the hidden models set on first run. For providers with curated
- * default-visible lists (OpenAI, Anthropic), hide everything except
- * the top picks defined in app/defaults/models.ts.
- */
-function seedHiddenModels(options: ModelOption[]): Set<string> {
-  const hidden = new Set<string>();
-  for (const opt of options) {
-    if (!isDefaultVisibleModel(opt.providerID, opt.modelID)) {
-      hidden.add(`${opt.providerID}/${opt.modelID}`);
-    }
-  }
-  return hidden;
-}
-
-export function readHiddenModels(): Set<string> {
-  try {
-    const raw = window.localStorage.getItem(HIDDEN_MODELS_KEY);
-    return new Set(raw ? JSON.parse(raw) : []);
-  } catch {
-    return new Set();
-  }
-}
-
-function writeHiddenModels(hidden: Set<string>): void {
-  try {
-    window.localStorage.setItem(HIDDEN_MODELS_KEY, JSON.stringify([...hidden]));
-  } catch {}
-}
-
-function hasSeededHiddenModels(): boolean {
-  try {
-    return window.localStorage.getItem(HIDDEN_MODELS_SEEDED_KEY) === "1";
-  } catch {
-    return false;
-  }
-}
-
-function markSeededHiddenModels(): void {
-  try {
-    window.localStorage.setItem(HIDDEN_MODELS_SEEDED_KEY, "1");
-  } catch {}
-}
 
 export type ModelPickerModalProps = {
   open: boolean;
@@ -100,27 +52,18 @@ type ProviderGroup = {
 export function ModelPickerModal(props: ModelPickerModalProps) {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
-  const [hiddenModels, setHiddenModels] = useState<Set<string>>(() => readHiddenModels());
 
   const disabledSet = useMemo(
     () => new Set(props.disabledProviders ?? []),
     [props.disabledProviders],
   );
 
-  // Reset on open + seed defaults on first run
+  // Reset on open
   useEffect(() => {
     if (props.open) {
       props.setQuery("");
-      if (!hasSeededHiddenModels() && props.options.length > 0) {
-        const seeded = seedHiddenModels(props.options);
-        writeHiddenModels(seeded);
-        markSeededHiddenModels();
-        setHiddenModels(seeded);
-      } else {
-        setHiddenModels(readHiddenModels());
-      }
     }
-  }, [props.open, props.options]);
+  }, [props.open]);
 
   // Focus search
   useEffect(() => {
@@ -169,7 +112,12 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
         group.hasCurrent = true;
       }
     }
-    return [...map.values()].sort((a, b) => {
+    const groups = [...map.values()];
+    for (const group of groups) {
+      group.recommended.sort((a, b) => a.title.localeCompare(b.title));
+      group.other.sort((a, b) => a.title.localeCompare(b.title));
+    }
+    return groups.sort((a, b) => {
       if (a.isDisabled !== b.isDisabled) return a.isDisabled ? 1 : -1;
       if (a.isNew !== b.isNew) return a.isNew ? -1 : 1;
       if (a.hasCurrent !== b.hasCurrent) return a.hasCurrent ? -1 : 1;
@@ -198,33 +146,6 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
       return next;
     });
   }, []);
-
-  const toggleModelVisible = useCallback((providerID: string, modelID: string) => {
-    const key = `${providerID}/${modelID}`;
-    setHiddenModels((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key); else next.add(key);
-      writeHiddenModels(next);
-      return next;
-    });
-  }, []);
-
-  const batchToggleProvider = useCallback((providerID: string, showAll: boolean) => {
-    setHiddenModels((prev) => {
-      const next = new Set(prev);
-      const models = filteredOptions.filter((o) => o.providerID === providerID);
-      for (const m of models) {
-        const key = `${m.providerID}/${m.modelID}`;
-        if (showAll) {
-          next.delete(key);
-        } else {
-          next.add(key);
-        }
-      }
-      writeHiddenModels(next);
-      return next;
-    });
-  }, [filteredOptions]);
 
   const handleSelect = useCallback(
     (opt: ModelOption) => props.onSelect({ providerID: opt.providerID, modelID: opt.modelID }),


### PR DESCRIPTION
## Summary

- The hidden-models feature was partially removed: the full picker modal no longer renders the toggle UI, but the composer popover still respected the orphaned `openwork.hiddenModels` localStorage set seeded on first run, hiding most models with no way to unhide them.
- Remove the dead `hiddenModels` state, seeding, helpers, and localStorage usage from the modal, along with the now-unused `DEFAULT_VISIBLE_MODELS` / `isDefaultVisibleModel` defaults.
- Sort models alphabetically by title within each provider group (both in the composer popover and the full picker), and sort provider groups by name in the popover.

## Files

- `apps/app/src/components/model-select.tsx` — drop `readHiddenModels` filter; sort provider groups and models alphabetically.
- `apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx` — remove dead hidden-models code; sort recommended/other lists alphabetically.
- `apps/app/src/app/defaults/models.ts` + `index.ts` — remove orphaned default-visible-models constant and helper.

## Verification

- `pnpm --filter @openwork/app exec tsc --noEmit` passes clean.
- No remaining references to `hiddenModels`, `readHiddenModels`, `DEFAULT_VISIBLE_MODELS`, `isDefaultVisibleModel`, or the `openwork.hiddenModels` localStorage key.

I did not capture a screen recording for this change — it's a small UI bug fix with clear behavior (more models show, alphabetized). Reviewer repro: open a session, click the model name in the composer to open the model popover, confirm all connected models appear sorted alphabetically; click "All models" and confirm the full picker also lists models alphabetically within each provider.