### PR TITLE
Disable reasoning for Claude Opus 4.8

### DIFF
--- a/ee/apps/inference/src/models/base.json
+++ b/ee/apps/inference/src/models/base.json
@@ -26252,7 +26252,7 @@
         "name": "Claude Opus 4.8",
         "family": "claude-opus",
         "attachment": true,
-        "reasoning": true,
+        "reasoning": false,
         "tool_call": true,
         "temperature": false,
         "release_date": "2026-05-28",


### PR DESCRIPTION
## Summary
- Disable the reasoning flag for Claude Opus 4.8 in the inference model metadata.

## Tests
- `pnpm --filter @openwork-ee/inference build` passed.

## Evidence
- No screenshot or video captured because this is a model metadata-only change with no UI flow.