### PR TITLE
fix(app): resolve text attachments broken

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -50,7 +50,7 @@ type SessionActionsSnapshot = {
 
 const FLUSH_PROMPT_EVENT = "openwork:flushPromptDraft";
 
-const fileToDataUrl = (file: File) =>
+const fileToDataUrl = (file: File, mimeType: string) =>
   new Promise<string>((resolve, reject) => {
     const reader = new FileReader();
     reader.onerror = () => reject(new Error(`Failed to read attachment: ${file.name}`));
@@ -58,8 +58,16 @@ const fileToDataUrl = (file: File) =>
       const result = typeof reader.result === "string" ? reader.result : "";
       resolve(result);
     };
-    reader.readAsDataURL(file);
+    reader.readAsDataURL(new Blob([file], { type: mimeType }));
   });
+
+function attachmentMime(attachment: ComposerAttachment) {
+  if (attachment.kind === "image") return attachment.mimeType;
+  if (attachment.mimeType === "application/pdf") return attachment.mimeType;
+  if (attachment.mimeType === "application/json") return "text/plain";
+  if (attachment.mimeType.startsWith("text/")) return "text/plain";
+  return attachment.mimeType;
+}
 
 export function createSessionActionsStore(options: {
   client: () => Client | null;
@@ -146,12 +154,15 @@ export function createSessionActionsStore(options: {
 
   type PartInput = TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput;
 
-  const attachmentToFilePart = async (attachment: ComposerAttachment): Promise<FilePartInput> => ({
-    type: "file",
-    url: await fileToDataUrl(attachment.file),
-    filename: attachment.name,
-    mime: attachment.mimeType,
-  });
+  const attachmentToFilePart = async (attachment: ComposerAttachment): Promise<FilePartInput> => {
+    const mime = attachmentMime(attachment);
+    return {
+      type: "file",
+      url: await fileToDataUrl(attachment.file, mime),
+      filename: attachment.name,
+      mime,
+    };
+  };
 
   const buildPromptParts = async (draft: ComposerDraft): Promise<PartInput[]> => {
     const parts: PartInput[] = [];

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -410,13 +410,21 @@ function getSessionStatus(session: any) {
   return typeof status === "string" ? status : normalizeSessionStatus(status);
 }
 
-async function fileToDataUrl(file: File) {
+async function fileToDataUrl(file: File, mimeType: string) {
   return await new Promise<string>((resolve, reject) => {
     const reader = new FileReader();
     reader.onerror = () => reject(new Error(`Failed to read attachment: ${file.name}`));
     reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : "");
-    reader.readAsDataURL(file);
+    reader.readAsDataURL(new Blob([file], { type: mimeType }));
   });
+}
+
+function attachmentMime(attachment: ComposerAttachment) {
+  if (attachment.kind === "image") return attachment.mimeType;
+  if (attachment.mimeType === "application/pdf") return attachment.mimeType;
+  if (attachment.mimeType === "application/json") return "text/plain";
+  if (attachment.mimeType.startsWith("text/")) return "text/plain";
+  return attachment.mimeType;
 }
 
 async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
@@ -465,12 +473,15 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
 
   parts.push(
     ...(await Promise.all(
-      draft.attachments.map(async (attachment) => ({
-        type: "file" as const,
-        url: await fileToDataUrl(attachment.file),
-        filename: attachment.name,
-        mime: attachment.mimeType,
-      })),
+      draft.attachments.map(async (attachment) => {
+        const mime = attachmentMime(attachment);
+        return {
+          type: "file" as const,
+          url: await fileToDataUrl(attachment.file, mime),
+          filename: attachment.name,
+          mime,
+        };
+      }),
     )),
   );
 


### PR DESCRIPTION
## Summary
- Fixes uploaded text-like attachments failing in OpenCode by normalizing `text/*` and `application/json` files to `text/plain`.
- Keeps images, PDFs, archives, and other binary files on their original MIME types.
- Updates both attachment send paths so the file part `mime` and generated data URL MIME prefix match.
- Covers CSV specifically, plus other browser-labeled text files like TSV, Markdown, logs, and JSON.