### PR TITLE
Expose session errors in chat with copy button

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -471,15 +471,16 @@ async function revealFileInFinder(path: string) {
   }
 }
 
-function CopyButton(props: { getText: () => string }) {
+function CopyButton(props: { getText: () => string; label?: string }) {
   const [copied, setCopied] = useState(false);
+  const label = props.label ?? "Copy message";
 
   return (
     <Button
       variant="ghost"
       size="icon-sm"
-      title="Copy message"
-      aria-label="Copy message"
+      title={label}
+      aria-label={label}
       onClick={async () => {
         await navigator.clipboard.writeText(props.getText());
         setCopied(true);
@@ -958,9 +959,11 @@ function MessageBlockRow(props: {
     : [];
 
   if (isSyntheticSessionError) {
-    const messageText = block.renderableParts
+    const fullErrorText = block.renderableParts
       .map((part) => partToText(part))
-      .join(" ")
+      .join("\n")
+      .trim();
+    const messageText = fullErrorText
       .replace(/\s*\n+\s*/g, " ")
       .replace(/\s{2,}/g, " ")
       .trim();
@@ -974,11 +977,14 @@ function MessageBlockRow(props: {
       >
         <div className={cn("w-full relative", !props.isNestedVariant && "max-w-[650px]", searchOutlineClass)}>
           <div
-            className="inline-flex max-w-full items-start gap-2 rounded-[18px] border border-red-7/20 bg-red-1/35 px-3 py-2 text-sm leading-5 text-red-12 shadow-sm"
+            className="inline-flex max-w-full items-start gap-2 rounded-[18px] border border-red-7/20 bg-red-1/35 py-2 pl-3 pr-2 text-sm leading-5 text-red-12 shadow-sm"
             role="alert"
           >
             <CircleAlert size={14} className="mt-0.5 shrink-0" />
-            <div className="min-w-0 wrap-break-word">{messageText}</div>
+            <div className="min-w-0 wrap-break-word pt-px">{messageText}</div>
+            <div className="shrink-0 opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 transition-opacity">
+              <CopyButton getText={() => fullErrorText} label="Copy error" />
+            </div>
           </div>
         </div>
       </div>

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -4,8 +4,8 @@ import type { Part, PermissionRequest, QuestionRequest, SessionStatus, Todo } fr
 import { getReactQueryClient } from "../../../infra/query-client";
 import { createClient } from "@/app/lib/opencode";
 import { normalizeEvent, safeStringify } from "@/app/utils";
-import type { OpencodeEvent, PendingPermission, PendingQuestion } from "@/app/types";
-import { snapshotToUIMessages } from "./usechat-adapter";
+import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX, type OpencodeEvent, type PendingPermission, type PendingQuestion } from "@/app/types";
+import { createSessionErrorUIMessage, describeOpencodeSessionError, snapshotToUIMessages } from "./usechat-adapter";
 import type { OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
 import { reconcileTranscriptMessages } from "./transcript-reconcile";
 import { useSessionActivityStore } from "../status/session-activity-store";
@@ -128,6 +128,25 @@ function sessionIdFromProperties(properties: unknown) {
   if (!properties || typeof properties !== "object") return "";
   const sessionID = (properties as { sessionID?: unknown }).sessionID;
   return typeof sessionID === "string" ? sessionID : "";
+}
+
+function sessionErrorFromProperties(properties: unknown) {
+  if (!properties || typeof properties !== "object") return undefined;
+  return (properties as { error?: unknown }).error;
+}
+
+function latestAssistantMessageId(messages: UIMessage[]) {
+  // The snapshot keys each error to its errored assistant message id, so the
+  // live event must resolve to that same id to dedupe on reload. Skipping
+  // synthetic error messages ensures a follow-up error keys off the real
+  // assistant turn rather than overwriting the previous error message.
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message || message.role !== "assistant") continue;
+    if (message.id.startsWith(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX)) continue;
+    return message.id;
+  }
+  return null;
 }
 
 function partHasVisibleAssistantOutput(part: Part) {
@@ -578,7 +597,24 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
 
   if (event.type === "session.error") {
     const sessionId = sessionIdFromProperties(event.properties);
-    if (sessionId) useSessionActivityStore.getState().setError(workspaceId, sessionId);
+    if (sessionId) {
+      useSessionActivityStore.getState().setError(workspaceId, sessionId);
+      if (isTrackedSession(entry, sessionId)) {
+        const errorText = describeOpencodeSessionError(sessionErrorFromProperties(event.properties));
+        queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, sessionId), (current = []) => {
+          // Key the error to the latest assistant turn so it lands beside the
+          // turn that failed and a later turn's error becomes its own message
+          // instead of overwriting this one. Falls back to the session id when
+          // no assistant turn exists yet (e.g. error before any output).
+          const turnKey = latestAssistantMessageId(current) ?? sessionId;
+          // Note: turnKey matches the snapshot's per-turn key (the errored
+          // assistant message id) so a reload reconciles instead of
+          // duplicating; the sessionId fallback only applies when the run
+          // errored before any assistant message existed.
+          return upsertMessage(current, createSessionErrorUIMessage(turnKey, errorText));
+        });
+      }
+    }
     return;
   }
 

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -5,7 +5,7 @@ import type { Part } from "@opencode-ai/sdk/v2/client";
 import { abortSessionSafe } from "../../../../app/lib/opencode-session";
 import type { OpenworkSessionMessage, OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
 import { normalizeEvent, safeStringify } from "../../../../app/utils";
-import type { OpencodeEvent } from "../../../../app/types";
+import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX, type OpencodeEvent } from "../../../../app/types";
 import { createClient } from "../../../../app/lib/opencode";
 
 type TransportOptions = {
@@ -47,6 +47,86 @@ type TextPart = Extract<Part, { type: "text" | "reasoning" }>;
 type FilePart = Extract<Part, { type: "file" }>;
 
 const STRUCTURED_OUTPUT_TOOL = "StructuredOutput";
+
+function recordValue(value: unknown, key: string) {
+  if (!value || typeof value !== "object") return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function firstStringValue(records: unknown[], keys: string[]) {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = recordValue(record, key);
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+  }
+  return null;
+}
+
+function firstNumberValue(records: unknown[], keys: string[]) {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = recordValue(record, key);
+      if (typeof value === "number" && Number.isFinite(value)) return value;
+    }
+  }
+  return null;
+}
+
+export function describeOpencodeSessionError(error: unknown, fallback = "Session failed") {
+  if (error instanceof Error) return error.message || fallback;
+  if (typeof error === "string") return error.trim() || fallback;
+  if (!error || typeof error !== "object") return fallback;
+
+  const data = recordValue(error, "data");
+  const cause = recordValue(error, "cause");
+  const causeData = recordValue(cause, "data");
+  const records = [error, data, cause, causeData].filter(Boolean);
+  const message = firstStringValue(records, ["message", "detail", "reason", "error"]);
+  const status = firstNumberValue(records, ["statusCode", "status"]);
+  const provider = firstStringValue(records, ["providerID", "providerId", "provider"]);
+  const code = firstStringValue(records, ["code", "errorCode"]);
+  const responseBody = firstStringValue(records, ["responseBody", "body", "response"]);
+
+  const lines = [message ?? fallback];
+  if (status && !lines[0]?.includes(String(status))) lines.push(`Status: ${status}`);
+  if (provider && !lines[0]?.includes(provider)) lines.push(`Provider: ${provider}`);
+  if (code) lines.push(`Code: ${code}`);
+  if (responseBody && responseBody !== message) lines.push(`Response: ${responseBody}`);
+  if (lines.some((line) => line !== fallback)) return lines.join("\n");
+
+  const serialized = safeStringify(error);
+  return serialized && serialized !== "{}" ? serialized : fallback;
+}
+
+function sessionErrorMessageId(turnKey: string) {
+  return `${SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX}${turnKey}`;
+}
+
+/**
+ * Build the synthetic chat message that surfaces a session error.
+ *
+ * The error is keyed to the *turn* that failed (`turnKey`), not the session.
+ * Both the live `session.error` event and the snapshot reload derive the same
+ * `turnKey` from the errored assistant message id, so they reconcile to one
+ * message instead of duplicating — while a brand new error on a later turn
+ * still produces its own message instead of overwriting the previous one.
+ */
+export function createSessionErrorUIMessage(turnKey: string, text: string, options?: { created?: number }): UIMessage {
+  const id = sessionErrorMessageId(turnKey);
+  const created = options?.created;
+  return {
+    id,
+    role: "assistant",
+    ...(typeof created === "number" ? { metadata: { opencode: { created } } } : {}),
+    parts: [{
+      type: "text",
+      text,
+      state: "done",
+      providerMetadata: { opencode: { partId: `${id}:text` } },
+    }],
+  };
+}
 
 function fileProviderMetadata(part: FilePart) {
   if (part.source) {
@@ -161,9 +241,9 @@ function mapToolPart(part: ToolPart): DynamicToolUIPart {
 }
 
 export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessage[] {
-  return snapshot.messages.map((message) => {
+  return snapshot.messages.flatMap((message) => {
     const created = message.info.time?.created;
-    return {
+    const uiMessage = {
       id: message.info.id,
       role: message.info.role,
       ...(typeof created === "number" ? { metadata: { opencode: { created } } } : {}),
@@ -222,6 +302,18 @@ export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessa
         return [];
       }),
     };
+
+    // Surface a failed turn as its own synthetic error message keyed by the
+    // errored assistant message id. The live `session.error` event keys its
+    // message off the latest assistant turn the same way, so the two
+    // reconcile to one message instead of duplicating — while a later turn's
+    // error still gets its own message. An empty assistant carcass for the
+    // errored turn is dropped so the error reads as that turn's outcome.
+    const error = message.info.role === "assistant" && "error" in message.info ? message.info.error : undefined;
+    if (!error) return [uiMessage];
+
+    const errorMessage = createSessionErrorUIMessage(message.info.id, describeOpencodeSessionError(error), { created });
+    return uiMessage.parts.length > 0 ? [uiMessage, errorMessage] : [errorMessage];
   });
 }
 
@@ -435,13 +527,7 @@ function handleEventChunk(
   if (event.type === "session.error") {
     const record = (event.properties ?? {}) as Record<string, unknown>;
     if (record.sessionID !== sessionId) return;
-    const errorObj = record.error;
-    const errorText =
-      typeof errorObj === "object" && errorObj && "message" in (errorObj as Record<string, unknown>)
-        ? String((errorObj as Record<string, unknown>).message ?? "")
-        : typeof record.error === "string"
-          ? record.error
-          : "Session failed";
+    const errorText = describeOpencodeSessionError(record.error);
     finalizeOpenParts(controller, state);
     controller.enqueue({ type: "error", errorText: errorText || "Session failed" });
     controller.enqueue({ type: "finish", finishReason: "error" });


### PR DESCRIPTION
## Summary
- Surface OpenCode session errors in the chat transcript instead of only showing a generic "Error" status. Extracts the real error detail (`data.message` plus status/provider/code/response) for both live `session.error` events and session snapshots.
- Key the synthetic error message per failed turn so a follow-up error renders its own message, while the live and snapshot paths reconcile to a single message (fixes the duplicate that appeared when reopening a session).
- Add a copy button to the error box that copies the full (multi-line) error text; it reveals on hover/focus like the other chat message actions.

## Why
Previously the desktop app collapsed OpenCode errors to the literal word "Error" and lost the underlying message. OpenCode does return structured errors (`session.error` event `properties.error`, and assistant `info.error`), so this wires that detail through to the chat view.

## Changes
- `usechat-adapter.ts`: `describeOpencodeSessionError` extractor; `createSessionErrorUIMessage` keyed per turn; snapshot mapping emits per-turn error messages and drops empty errored-assistant bubbles; live event-chunk path reuses the extractor.
- `session-sync.ts`: live `session.error` appends a transcript error message keyed off the latest assistant turn (matching the snapshot key for dedupe).
- `message-list.tsx`: `CopyButton` gains an optional `label`; error box renders a "Copy error" button copying full text.

## Testing
- `pnpm --dir apps/app typecheck` — passing.

Note: I have not run a live end-to-end / video capture of the multi-error + copy flow. Reproduce by triggering a provider error in a session, sending another prompt that errors again (second error should appear as its own message), switching away and back (no duplicate), and using the copy button on the error box.