### PR TITLE
fix(desktop): resolve boot race causing "server did not finish starting"

### DIFF
--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -1062,6 +1062,9 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       throw new Error(`Cannot find OpenWork embedded server bundle. Checked: ${candidates.join(", ")}`);
     }
     const { startEmbeddedServer } = await import(pathToFileURL(embeddedPath).href);
+    // startEmbeddedServer falls back to an OS-assigned port if `port` races
+    // into EADDRINUSE (see apps/server/src/serve-node.ts), so the bound port
+    // below is authoritative.
     const handle = await startEmbeddedServer({
       host,
       port,
@@ -1313,6 +1316,27 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     if (!safeProjectDir) {
       throw new Error("projectDir is required");
     }
+
+    // Reuse a healthy server instead of tearing it down. During boot the
+    // main process kicks off bootRuntimeForSelectedWorkspace while renderer
+    // routes independently call ensureDesktopLocalOpenworkConnection. Both go
+    // through this serialized path; without this guard the second call runs
+    // prepareFreshRuntime (killing the freshly bound server) and then rebinds
+    // the sticky preferred port, racing the not-yet-released socket into
+    // EADDRINUSE and leaving the runtime in error -> boot screen.
+    const requestedRemoteAccess = options.openworkRemoteAccess === true;
+    if (
+      openworkServerState.inProcess &&
+      lifecycleState === "healthy" &&
+      normalizeWorkspaceKey(engineState.projectDir) === normalizeWorkspaceKey(safeProjectDir) &&
+      openworkServerState.remoteAccessEnabled === requestedRemoteAccess
+    ) {
+      const existing = snapshotOpenworkServerState(openworkServerState);
+      if (existing.running && existing.baseUrl && (existing.ownerToken || existing.clientToken)) {
+        return snapshotEngineState(engineState);
+      }
+    }
+
     await mkdir(safeProjectDir, { recursive: true });
     await ensureOpencodeConfig(safeProjectDir);
     await prepareFreshRuntime();

--- a/apps/server/src/serve-node.ts
+++ b/apps/server/src/serve-node.ts
@@ -195,7 +195,19 @@ export function serve(options: ServeOptions): Promise<ServeResult> {
   let boundPort = port;
 
   return new Promise<ServeResult>((resolve, reject) => {
-    server.on("error", reject);
+    // The caller probes port availability before calling us, but that
+    // check-then-bind is racy: a just-stopped server may not have released the
+    // socket yet. On EADDRINUSE, retry once with an OS-assigned free port
+    // (port 0) instead of failing the whole startup.
+    let retriedFreePort = false;
+    server.on("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EADDRINUSE" && !retriedFreePort) {
+        retriedFreePort = true;
+        server.listen(0, hostname);
+        return;
+      }
+      reject(error);
+    });
     server.listen(port, hostname, () => {
       const addr = server.address();
       if (addr && typeof addr === "object") {


### PR DESCRIPTION
## Summary

Fixes the intermittent **"OpenWork server did not finish starting. Please restart OpenWork."** error screen seen on `pnpm dev` cold start, where the server is clearly serving requests in the logs and `CMD+R` recovers.

## Root cause

It's a startup race, not a missing timeout. Two paths call `engineStart` during boot:

1. **Main process** (`main.mjs`) kicks off `bootRuntimeForSelectedWorkspace()` on app-ready, binding the embedded server to a *sticky preferred port*.
2. **Renderer route effect** (`session-route.tsx`) fires `ensureDesktopLocalOpenworkConnection` while `client` is still null; its `engineInfo()` probe sees "not running yet" and fires a **second `engineStart`**.

`engineStart` is serialized, so the second call runs after the first but unconditionally tears down the healthy server (`prepareFreshRuntime`) and rebinds the sticky port. The racy check-then-bind hits `EADDRINUSE` (the `Error occurred in handler for 'openwork:desktop'` in the logs), leaving the runtime in `error` → boot screen. `CMD+R` recovers via the fast path because a server is now running.

## Changes

- **`apps/desktop/electron/runtime.mjs`** — `engineStart` reuses an already-healthy server for the same workspace + remote-access setting instead of tearing it down and rebinding the port (eliminates the redundant restart, the root cause).
- **`apps/server/src/serve-node.ts`** — `startServer` falls back to an OS-assigned port on `EADDRINUSE`, so a racy check-then-bind no longer fails startup. Placed here (not in the runtime) so the already-spawned managed OpenCode child isn't duplicated/leaked.

## Testing

- `pnpm --filter openwork-server typecheck` — clean
- `pnpm --filter @openwork/desktop typecheck:electron` — clean
- `pnpm --filter @openwork/desktop check:electron` — bridge covers 50 methods
- `pnpm --filter openwork-server build` — clean
- Verified end-to-end on Daytona: cold start no longer shows the error screen.