### PR TITLE
fix(den): show real org member count in sidebar switcher

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "OPENWORK_DEV_MODE=1 tsx watch src/server.ts",
-    "dev:local": "sh -lc 'OPENWORK_DEV_MODE=1 PORT=${DEN_API_PORT:-8790} tsx watch src/server.ts'",
+    "dev": "pnpm run build:email && OPENWORK_DEV_MODE=1 tsx watch src/server.ts",
+    "dev:local": "pnpm run build:email && sh -lc 'OPENWORK_DEV_MODE=1 PORT=${DEN_API_PORT:-8790} tsx watch src/server.ts'",
     "build": "node ./scripts/build.mjs",
     "build:email": "pnpm --filter @openwork/email build",
     "build:den-db": "pnpm --filter @openwork-ee/den-db build",

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
+import { and, asc, count, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
 import {
   AuthSessionTable,
   AuthUserTable,
@@ -52,6 +52,7 @@ export type UserOrgSummary = {
   role: string
   orgMemberId: string
   membershipId: string
+  memberCount: number
   createdAt: Date
   updatedAt: Date
 }
@@ -767,6 +768,22 @@ export async function listUserOrgs(userId: UserId) {
     .where(and(eq(MemberTable.userId, userId), isNull(MemberTable.removedAt)))
     .orderBy(asc(MemberTable.createdAt))
 
+  const organizationIds = memberships.map((row) => row.organization.id)
+  const memberCounts = new Map<OrgId, number>()
+  if (organizationIds.length > 0) {
+    const counts = await db
+      .select({
+        organizationId: MemberTable.organizationId,
+        memberCount: count(),
+      })
+      .from(MemberTable)
+      .where(and(inArray(MemberTable.organizationId, organizationIds), isNull(MemberTable.removedAt)))
+      .groupBy(MemberTable.organizationId)
+    for (const row of counts) {
+      memberCounts.set(row.organizationId, row.memberCount)
+    }
+  }
+
   return memberships.map((row) => ({
     id: row.organization.id,
     name: row.organization.name,
@@ -777,6 +794,7 @@ export async function listUserOrgs(userId: UserId) {
     role: row.role,
     orgMemberId: row.membershipId,
     membershipId: row.membershipId,
+    memberCount: memberCounts.get(row.organization.id) ?? 0,
     createdAt: row.organization.createdAt,
     updatedAt: row.organization.updatedAt,
   })) satisfies UserOrgSummary[]

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -7,6 +7,7 @@ export type DenOrgSummary = {
   role: string;
   orgMemberId: string;
   membershipId: string;
+  memberCount: number;
   createdAt: string | null;
   updatedAt: string | null;
   isActive: boolean;
@@ -472,6 +473,7 @@ export function parseOrgListPayload(payload: unknown): {
         role,
         orgMemberId,
         membershipId,
+        memberCount: typeof entry.memberCount === "number" ? entry.memberCount : 0,
         createdAt: asIsoString(entry.createdAt),
         updatedAt: asIsoString(entry.updatedAt),
         isActive: asBoolean(entry.isActive),

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -333,7 +333,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
                   <div className="min-w-0">
                     <span className="block truncate text-[13px] font-medium tracking-[-0.1px]">{org.name}</span>
                     <span className="block truncate text-[12px] text-gray-500">
-                      {org.role === "owner" ? "Creator plan" : "Free plan"} • 1 member
+                      {org.role === "owner" ? "Creator plan" : "Free plan"} • {org.memberCount} {org.memberCount === 1 ? "member" : "members"}
                     </span>
                   </div>
                 </div>

--- a/ee/packages/den-db/src/drizzle.ts
+++ b/ee/packages/den-db/src/drizzle.ts
@@ -1,1 +1,1 @@
-export { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, or, sql } from "drizzle-orm"
+export { and, asc, count, desc, eq, gt, gte, inArray, isNotNull, isNull, or, sql } from "drizzle-orm"


### PR DESCRIPTION
## Summary
- The workspace switcher in the den-web sidebar hardcoded `1 member` for every org, because the org directory payload (`GET /v1/me/orgs`) carried no member count.
- Now thread a real `memberCount` through the stack so the sidebar count matches the **Members tab** count exactly. The count is computed the same way the members tab does it: non-removed `member` rows per org (`removedAt IS NULL`).
- Also build `@openwork/email` before starting `den-api` in dev (`dev` / `dev:local`) so a fresh worktree doesn't crash on the missing `dist` build.

## Changes
- `ee/packages/den-db/src/drizzle.ts` — export `count` from drizzle-orm.
- `ee/apps/den-api/src/orgs.ts` — add `memberCount` to `UserOrgSummary`; in `listUserOrgs`, run a grouped `count()` query over `MemberTable` (filtered `removedAt IS NULL`) and populate per-org. The `/v1/me/orgs` response schema uses `.passthrough()`, so the field flows through automatically.
- `ee/apps/den-web/app/(den)/_lib/den-org.ts` — add `memberCount` to `DenOrgSummary` and parse it in `parseOrgListPayload`.
- `ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx` — render `{memberCount} member(s)` with correct pluralization instead of the hardcoded `1 member`.
- `ee/apps/den-api/package.json` — `dev`/`dev:local` now run `pnpm run build:email &&` first.

## Testing
Commands run:
- `pnpm --filter @openwork-ee/den-db build` — success
- `tsc --noEmit` in `ee/apps/den-api` — exit 0 (clean)
- `tsc --noEmit` in `ee/apps/den-web` — no errors in touched files
- `pnpm dev:web-local` — full local stack started (Docker MySQL, den-api, inference, worker-proxy, den-web); `den-api listening on 8788`
- Seeded demo org "Acme Robotics" (17 members, 3 pending invites), logged in as `alex@acme.test`, opened the sidebar switcher.

Result (verified end-to-end via CDP):
- Sidebar switcher now shows **"Creator plan • 17 members"** (was hardcoded "1 member").
- Members page tab shows **"Members 17"** — exact match.
- Dashboard "OpenWork users" card also shows 17.
- DB query confirmed 17 non-removed `member` rows for that org.

No video captured; verification was done programmatically + screenshot. Repro steps above for reviewers.