### PR TITLE
fix(app): bound e2e health checks with per-request timeout

### DIFF
--- a/apps/app/scripts/_util.mjs
+++ b/apps/app/scripts/_util.mjs
@@ -59,7 +59,7 @@ export async function spawnOpencodeServe({
 
   const child = spawn("opencode", args, {
     cwd,
-    stdio: ["ignore", "ignore", "pipe"],
+    stdio: ["ignore", "pipe", "pipe"],
     env: {
       ...process.env,
       // Make it explicit we're a non-TUI client.
@@ -69,11 +69,18 @@ export async function spawnOpencodeServe({
 
   const baseUrl = `http://${hostname}:${port}`;
 
-  // If the process dies early, surface stderr.
+  // If the process dies early or never becomes healthy, surface its output so
+  // CI failures are diagnosable instead of showing an empty stderr.
   let stderr = "";
   child.stderr.setEncoding("utf8");
   child.stderr.on("data", (chunk) => {
     stderr += chunk;
+  });
+
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
   });
 
   async function waitForExit(ms) {
@@ -115,16 +122,31 @@ export async function spawnOpencodeServe({
     getStderr() {
       return stderr;
     },
+    getStdout() {
+      return stdout;
+    },
+    getExitInfo() {
+      return { exitCode: child.exitCode, signalCode: child.signalCode };
+    },
   };
 }
 
-export async function waitForHealthy(client, { timeoutMs = 10_000, pollMs = 250 } = {}) {
+export async function waitForHealthy(
+  client,
+  { timeoutMs = 30_000, pollMs = 250, requestTimeoutMs = 5_000 } = {},
+) {
   const start = Date.now();
   let lastError;
 
   while (Date.now() - start < timeoutMs) {
     try {
-      const health = await client.global.health();
+      // Bound each individual request: a single fetch to a port that is not
+      // yet accepting connections can otherwise block for the OS-level connect
+      // timeout (tens of seconds on macOS), blowing past `timeoutMs` because
+      // the loop can only re-check the deadline between awaits.
+      const health = await client.global.health({
+        signal: AbortSignal.timeout(requestTimeoutMs),
+      });
       assert.equal(health.healthy, true);
       assert.ok(typeof health.version === "string");
       return health;

--- a/apps/app/scripts/browser-entry.mjs
+++ b/apps/app/scripts/browser-entry.mjs
@@ -284,6 +284,8 @@ try {
   results.ok = false;
   results.error = message;
   results.stderr = opencode?.getStderr?.() ?? "";
+  results.stdout = opencode?.getStdout?.() ?? "";
+  results.serverExit = opencode?.getExitInfo?.() ?? null;
   console.error(JSON.stringify(results, null, 2));
   process.exitCode = 1;
 } finally {

--- a/apps/app/scripts/e2e.mjs
+++ b/apps/app/scripts/e2e.mjs
@@ -154,6 +154,8 @@ try {
   results.ok = false;
   results.error = message;
   results.stderr = server.getStderr();
+  results.stdout = server.getStdout?.() ?? "";
+  results.serverExit = server.getExitInfo?.() ?? null;
   console.error(JSON.stringify(results, null, 2));
   process.exitCode = 1;
 } finally {

--- a/apps/app/scripts/fs-engine.mjs
+++ b/apps/app/scripts/fs-engine.mjs
@@ -47,7 +47,15 @@ try {
   );
 } catch (e) {
   const message = e instanceof Error ? e.message : String(e);
-  console.error(JSON.stringify({ ok: false, error: message, stderr: server.getStderr() }));
+  console.error(
+    JSON.stringify({
+      ok: false,
+      error: message,
+      stderr: server.getStderr(),
+      stdout: server.getStdout?.() ?? "",
+      serverExit: server.getExitInfo?.() ?? null,
+    }),
+  );
   process.exitCode = 1;
 } finally {
   await server.close();

--- a/apps/app/scripts/session-switch.mjs
+++ b/apps/app/scripts/session-switch.mjs
@@ -144,6 +144,8 @@ try {
   results.ok = false;
   results.error = message;
   results.stderr = server.getStderr();
+  results.stdout = server.getStdout?.() ?? "";
+  results.serverExit = server.getExitInfo?.() ?? null;
   console.error(JSON.stringify(results, null, 2));
   process.exitCode = 1;
 } finally {


### PR DESCRIPTION
## Summary

Fixes the recurring `Timed out waiting for /global/health: fetch failed` failures in the **OpenWork Tests** workflow (macOS-14 runner). Example failing run: https://github.com/different-ai/openwork/actions/runs/26646854880

## Root cause

In `apps/app/scripts/_util.mjs`, `waitForHealthy()` polled the server with **no per-request timeout**:

```js
while (Date.now() - start < timeoutMs) {   // 10s
  const health = await client.global.health();  // no timeout
}
```

The `while` only re-checks the deadline *between* awaits. When `opencode serve` was slow to accept connections on the macOS runner, a single `fetch` to the not-yet-listening port blocked on the OS-level TCP connect timeout (tens of seconds, stacking), blowing far past the 10s budget. That's why failures showed a **~5-minute gap** before erroring rather than ~10s. Linux runners reject/connect faster, so they passed. Empty `stderr` made it undiagnosable because server stdout was discarded.

## Changes

- `_util.mjs`: bound each health request with `AbortSignal.timeout(5s)`; raise overall budget to 30s for slow CI cold starts.
- `_util.mjs`: capture server stdout (`stdio: ["ignore", "pipe", "pipe"]`) and expose `getStdout()` / `getExitInfo()`.
- `e2e.mjs`, `session-switch.mjs`, `fs-engine.mjs`, `browser-entry.mjs`: include `stdout` + `serverExit` in failure output for debuggability.

## Testing

Ran the full chain locally with the pinned opencode `v1.15.12`:

```
pnpm --filter @openwork/app test:e2e
```

Result: all scripts pass (`local-file-path`, `e2e`, `session-switch`, `fs-engine`, `browser-entry`) in ~20s. Could not reproduce the macOS-runner hang locally (the connect behavior differs), but the per-request timeout makes `waitForHealthy` respect its budget regardless of connect latency.