### PR TITLE
fix(desktop): make macOS auto-update actually apply on quit

### DIFF
--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -1,5 +1,6 @@
-import { readFile, mkdir, writeFile } from "node:fs/promises";
+import { readFile, mkdir, writeFile, rm } from "node:fs/promises";
 import { readFileSync } from "node:fs";
+import { execFile } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -162,6 +163,56 @@ async function applyElectronUpdaterFeed(app, updater) {
   return state;
 }
 
+function runDefaults(args) {
+  return new Promise((resolve) => {
+    execFile("/usr/bin/defaults", args, (error) => {
+      // Best-effort: a failure here just means we fall back to Squirrel's
+      // default move-based install. Never block the update on it.
+      if (error) console.warn("[updater] defaults write failed", error?.message ?? error);
+      resolve(undefined);
+    });
+  });
+}
+
+// Squirrel.Mac's `ShipIt` helper (which swaps the .app on macOS) reads its
+// options from this NSUserDefaults domain.
+const SHIP_IT_DEFAULTS_DOMAIN = "com.differentai.openwork.ShipIt";
+
+// Squirrel.Mac defaults to moving the *entire* app bundle through a temp
+// directory. On repeat installs that move can leave the staged bundle missing,
+// producing:
+//   "Failed to copy bundle … no such file or directory"
+//   "Too many attempts to install, aborting update"
+// and silently relaunching the OLD app (so the in-app version looks updated
+// while the on-disk renderer stays stale). Enabling DirectContentsWrite makes
+// ShipIt write file contents in place instead of moving whole bundles, which
+// avoids the ENOENT abort.
+async function enableSquirrelDirectContentsWrite() {
+  if (process.platform !== "darwin") return;
+  await runDefaults(["write", SHIP_IT_DEFAULTS_DOMAIN, "SquirrelMacEnableDirectContentsWrite", "-bool", "YES"]);
+}
+
+// Path of the ShipIt cache that, when stuck, keeps aborting future installs.
+// Exported for tests.
+export function staleUpdaterStatePaths(app) {
+  if (process.platform !== "darwin") return [];
+  const home = app.getPath("home");
+  return [path.join(home, "Library", "Caches", SHIP_IT_DEFAULTS_DOMAIN)];
+}
+
+// Remove a previously-failed, half-applied update so the next attempt starts
+// from a clean slate. A stuck `ShipIt` state (after "Too many attempts to
+// install, aborting update") can otherwise keep aborting future installs.
+async function cleanStaleUpdaterState(app) {
+  for (const target of staleUpdaterStatePaths(app)) {
+    try {
+      await rm(target, { recursive: true, force: true });
+    } catch (error) {
+      console.warn("[updater] failed to clean stale state", target, error?.message ?? error);
+    }
+  }
+}
+
 // electron-updater wiring. Packaged-only; dev builds skip this so the
 // updater doesn't try to probe a non-existent release channel.
 export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
@@ -190,6 +241,15 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
       if (autoUpdaterInstance) {
         autoUpdaterInstance.autoDownload = false;
         autoUpdaterInstance.autoInstallOnAppQuit = true;
+        // Differential (blockmap) downloads reconstruct the update zip from the
+        // installed app + a diff. On macOS that reconstructed bundle is what
+        // feeds Squirrel's fragile move-based install, and is a common trigger
+        // for the "Failed to copy bundle … no such file" abort. Download the
+        // full zip instead — alpha builds are swapped wholesale anyway.
+        autoUpdaterInstance.disableDifferentialDownload = true;
+        // Make Squirrel.Mac write contents in place rather than moving whole
+        // bundles (see enableSquirrelDirectContentsWrite for why).
+        await enableSquirrelDirectContentsWrite();
         autoUpdaterInstance.on("error", (err) => {
           console.warn("[updater] error", err);
         });
@@ -273,6 +333,9 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
       if (!checkedUpdateVersion) {
         return { ok: false, reason: "No update available." };
       }
+      // Clear any stuck ShipIt state from a prior aborted install so this
+      // download applies cleanly on quit.
+      await cleanStaleUpdaterState(app);
       await updater.downloadUpdate();
       return { ok: true };
     } catch (error) {
@@ -284,6 +347,9 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     const updater = await ensureAutoUpdater();
     if (!updater) return { ok: false, reason: "unavailable" };
     try {
+      // Re-assert the in-place-write default right before the swap; the ShipIt
+      // defaults domain may have been wiped when stale state was cleaned.
+      await enableSquirrelDirectContentsWrite();
       updater.quitAndInstall(false, true);
       return { ok: true };
     } catch (error) {

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -1,0 +1,18 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { staleUpdaterStatePaths } from "./updater.mjs";
+
+const fakeApp = { getPath: (key) => (key === "home" ? "/Users/test" : `/Users/test/${key}`) };
+
+describe("staleUpdaterStatePaths", () => {
+  it("targets the ShipIt cache on macOS", { skip: process.platform !== "darwin" }, () => {
+    assert.deepEqual(staleUpdaterStatePaths(fakeApp), [
+      "/Users/test/Library/Caches/com.differentai.openwork.ShipIt",
+    ]);
+  });
+
+  it("is a no-op off macOS", { skip: process.platform === "darwin" }, () => {
+    assert.deepEqual(staleUpdaterStatePaths(fakeApp), []);
+  });
+});


### PR DESCRIPTION
## Problem

macOS alpha auto-updates download successfully but **never apply**. The app keeps running the old version after quit+relaunch, while the in-app "latest available" shows the new version — making it look updated when it isn't.

### Root cause (from the ShipIt log)

`~/Library/Caches/com.differentai.openwork.ShipIt/ShipIt_stderr.log` on an affected machine:

```
Moving bundles directly as SquirrelMacEnableDirectContentsWrite is disabled for app: com.differentai.openwork.ShipIt
...
Installation error: SQRLInstallerErrorDomain Code=-1 "Failed to copy bundle
file:///.../update.8eefvvp/OpenWork.app/ to directory .../OpenWork.app"
  NSCocoaErrorDomain Code=260 "... no such file."
  NSPOSIXErrorDomain Code=2 "No such file or directory"
Resuming installation attempt 2 ... attempt 3 ...
Too many attempts to install, aborting update
... Successfully launched application at file:///Applications/OpenWork.app/   ← the OLD app
```

Squirrel.Mac (ShipIt) moves the **entire** app bundle through a temp directory. On repeat installs that move leaves the staged `update.<id>/OpenWork.app` missing, so the copy step hits ENOENT, retries 3×, aborts, and relaunches the stale app.

Verified independently that this was *not* a code/build problem: the published alpha.986 renderer bundle contained the new code; the staged update zip in the updater cache was byte-perfect (sha512 matched). The failure is purely the apply step.

## Fix

In `apps/desktop/electron/updater.mjs`:
1. **Enable `SquirrelMacEnableDirectContentsWrite`** (written to the `com.differentai.openwork.ShipIt` defaults domain) so ShipIt writes file contents in place instead of moving whole bundles — removes the ENOENT trigger.
2. **Disable differential downloads** (`disableDifferentialDownload = true`); the reconstructed differential bundle is what feeds the fragile move path. Alpha builds are swapped wholesale anyway.
3. **Clean stuck ShipIt cache state** before a fresh download so a previously aborted install ("Too many attempts…") can't keep poisoning future installs. Re-assert the default right before `quitAndInstall`.

## Testing

From `apps/desktop`:
- `pnpm run check:electron` — passes (bridge covers 50 methods)
- `pnpm run typecheck:electron` — passes
- `node --test electron/*.test.mjs` — 14 pass, 1 skipped (off-macOS case); includes a new `updater.test.mjs` covering `staleUpdaterStatePaths`.

### Manual verification needed
The real fix can only be fully verified through an actual alpha→alpha auto-update cycle on macOS (download in-app, quit, relaunch, confirm new renderer). I could not run a full signed update cycle locally. Reviewer repro:
1. Install a prior alpha, then trigger in-app update to a newer alpha.
2. Quit (Cmd-Q) and relaunch.
3. Confirm the on-disk bundle changed: `defaults read /Applications/OpenWork.app/Contents/Info.plist CFBundleShortVersionString` matches the new version, and `~/Library/Caches/com.differentai.openwork.ShipIt/ShipIt_stderr.log` shows no "aborting update".

For users already stuck, deleting `~/Library/Caches/com.differentai.openwork.ShipIt` lets the next update apply (this PR does that automatically before download).