### PR TITLE
Show built-in extensions in marketplace

### DIFF
--- a/apps/app/src/app/extensions.ts
+++ b/apps/app/src/app/extensions.ts
@@ -158,7 +158,6 @@ export const BUILT_IN_OPENWORK_EXTENSION_MANIFESTS: OpenWorkExtensionManifest[] 
     composer: { prompt: "Use the OpenWork Browser extension to " },
     setup: {
       instructions: "OpenWork Browser is ready by default in desktop workspaces.",
-      primaryCta: "Enable browser automation",
     },
     resources: [
       {
@@ -175,7 +174,6 @@ export const BUILT_IN_OPENWORK_EXTENSION_MANIFESTS: OpenWorkExtensionManifest[] 
     ],
     enablement: [
       { type: "toggle-enabled", ref: "openwork-browser", label: "Enabled" },
-      { type: "plugin-loaded", ref: "opencode-chrome-devtools", label: "Browser plugin loaded" },
     ],
     lifecycle: { reload: ["plugins", "agents"], detection: ["plugin:opencode-chrome-devtools"] },
     defaultEnabled: true,

--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -95,6 +95,7 @@ export type PromptMode = "prompt" | "shell";
 export type ComposerPart =
   | { type: "text"; text: string }
   | { type: "agent"; name: string }
+  | { type: "skill"; name: string }
   | { type: "file"; path: string; label?: string }
   | { type: "paste"; id: string; label: string; text: string; lines: number };
 

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -309,6 +309,28 @@ type UserMessageProps = {
   isStreaming: boolean
 }
 
+const USER_SKILL_TOKEN_RE = /(Load \[skill [^\]]+\] and follow its instructions\.|\[skill [^\]]+\])/
+
+function UserSkillChip(props: { name: string }) {
+  return (
+    <span className="mx-0.5 inline-flex items-center rounded-full border border-violet-6/35 bg-violet-3/20 px-2.5 py-1 text-xs font-medium text-violet-11 align-middle" title={`Skill: ${props.name}`}>
+      {props.name}
+    </span>
+  )
+}
+
+function renderUserTextWithSkillChips(text: string) {
+  if (!USER_SKILL_TOKEN_RE.test(text)) return text
+  let offset = 0
+  return text.split(USER_SKILL_TOKEN_RE).map((segment) => {
+    const key = `${offset}:${segment}`
+    offset += segment.length
+    const skillMatch = segment.match(/^(?:Load )?\[skill ([^\]]+)\](?: and follow its instructions\.)?$/)
+    if (skillMatch?.[1]) return <UserSkillChip key={key} name={skillMatch[1]} />
+    return <React.Fragment key={key}>{segment}</React.Fragment>
+  })
+}
+
 export const UserMessage = React.memo(
   ({ message, isStreaming }: UserMessageProps) => {
     const { onRevertToUserMessage, onForkAtMessage } = useMessageList()
@@ -328,7 +350,7 @@ export const UserMessage = React.memo(
               layoutId={message.id}
               className="bg-muted text-foreground max-w-[85%] rounded-3xl px-5 py-2.5 whitespace-pre-wrap sm:max-w-[75%]"
             >
-              {message.parts.map((part) => (part.type === "text" ? part.text : "")).join("")}
+              {renderUserTextWithSkillChips(message.parts.map((part) => (part.type === "text" ? part.text : "")).join(""))}
             </MessageContent>
           ) : null}
           {!isStreaming && (

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -718,7 +718,17 @@ export function ReactSessionComposer(props: ComposerProps) {
   }, [menuIndex, activeItems.length]);
 
   const applyCommandSelection = (command: SlashCommandOption) => {
+    if (command.source === "skill") {
+      applySkillSelection(command.name);
+      return;
+    }
     props.onDraftChange(`/${command.name} `);
+    setSlashOpen(false);
+    setToolMenuOpen(false);
+  };
+
+  const applySkillSelection = (name: string) => {
+    props.onDraftChange(`Load [skill ${name}] and follow its instructions. `);
     setSlashOpen(false);
     setToolMenuOpen(false);
   };
@@ -726,10 +736,11 @@ export function ReactSessionComposer(props: ComposerProps) {
   const applyPluginFileSelection = (file: CloudImportedPluginFile) => {
     const commandName = pluginSlashCommandName(file);
     if (commandName) {
-      applyCommandSelection({
+      if (file.objectType === "skill") applySkillSelection(commandName);
+      else applyCommandSelection({
         id: `plugin:${file.configObjectId}`,
         name: commandName,
-        source: file.objectType === "skill" ? "skill" : "command",
+        source: "command",
       });
       return;
     }

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -728,7 +728,7 @@ export function ReactSessionComposer(props: ComposerProps) {
   };
 
   const applySkillSelection = (name: string) => {
-    props.onDraftChange(`Load [skill ${name}] and follow its instructions. `);
+    props.onDraftChange(`[skill ${name}] `);
     setSlashOpen(false);
     setToolMenuOpen(false);
   };

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -69,6 +69,15 @@ type SerializedComposerSlashCommandNode = Spread<
   SerializedTextNode
 >;
 
+type SerializedComposerSkillNode = Spread<
+  {
+    skillName: string;
+    type: "composer-skill";
+    version: 1;
+  },
+  SerializedTextNode
+>;
+
 class ComposerMentionNode extends TextNode {
   __value: string;
   __kind: "agent" | "file";
@@ -215,6 +224,74 @@ function $createComposerSlashCommandNode(commandName: string) {
   return $applyNodeReplacement(new ComposerSlashCommandNode(commandName));
 }
 
+class ComposerSkillNode extends TextNode {
+  __skillName: string;
+
+  static override getType() {
+    return "composer-skill";
+  }
+
+  static override clone(node: ComposerSkillNode) {
+    return new ComposerSkillNode(node.__skillName, node.__key);
+  }
+
+  static override importJSON(serializedNode: SerializedComposerSkillNode) {
+    return $createComposerSkillNode(serializedNode.skillName);
+  }
+
+  constructor(skillName = "", key?: NodeKey) {
+    super(`[skill ${skillName}]`, key);
+    this.__skillName = skillName;
+  }
+
+  override exportJSON(): SerializedComposerSkillNode {
+    return {
+      ...super.exportJSON(),
+      skillName: this.__skillName,
+      type: "composer-skill",
+      version: 1,
+    };
+  }
+
+  override createDOM(_config: EditorConfig) {
+    const dom = document.createElement("span");
+    dom.className = "inline-flex items-center rounded-full border border-violet-6/35 bg-violet-3/20 px-2.5 py-1 text-xs font-medium text-violet-11";
+    dom.textContent = this.__skillName;
+    dom.contentEditable = "false";
+    dom.setAttribute("spellcheck", "false");
+    dom.title = `Skill: ${this.__skillName}`;
+    return dom;
+  }
+
+  override updateDOM(prevNode: ComposerSkillNode, dom: HTMLElement) {
+    if (prevNode.__skillName !== this.__skillName) {
+      dom.textContent = this.__skillName;
+      dom.title = `Skill: ${this.__skillName}`;
+    }
+    return false;
+  }
+
+  override canInsertTextBefore(): false {
+    return false;
+  }
+
+  override canInsertTextAfter(): false {
+    return false;
+  }
+
+  override isTextEntity(): true {
+    return true;
+  }
+
+  override isToken(): true {
+    return true;
+  }
+}
+
+function $createComposerSkillNode(skillName: string) {
+  return $applyNodeReplacement(new ComposerSkillNode(skillName));
+}
+
 function pastedTextChipLabel(lines: number) {
   return `Pasted · ${lines} line${lines === 1 ? "" : "s"}`;
 }
@@ -333,7 +410,7 @@ function $createComposerPastedTextNode(label: string, lines: number) {
   return $applyNodeReplacement(new ComposerPastedTextNode(label, lines));
 }
 
-type ComposerInlineTokenNode = ComposerMentionNode | ComposerSlashCommandNode | ComposerPastedTextNode;
+type ComposerInlineTokenNode = ComposerMentionNode | ComposerSlashCommandNode | ComposerSkillNode | ComposerPastedTextNode;
 
 function setSelectionAfterNode(node: ComposerInlineTokenNode) {
   const parent = node.getParent();
@@ -395,7 +472,7 @@ function setPrompt(value: string, mentions: Record<string, "agent" | "file">, pa
     value = slashMatch[2] ?? "";
   }
 
-  const segments = value.split(/(\[pasted text [^\]]+\]|@[^\s@]+)/);
+  const segments = value.split(/(\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
   const pastedTextByLabel = new Map((pastedText ?? []).map((item) => [item.label, item]));
   for (const segment of segments) {
     if (!segment) continue;
@@ -406,6 +483,11 @@ function setPrompt(value: string, mentions: Record<string, "agent" | "file">, pa
         paragraph.append($createComposerPastedTextNode(target.label, target.lines));
         continue;
       }
+    }
+    const skillMatch = segment.match(/^\[skill (.+)\]$/);
+    if (skillMatch?.[1]) {
+      paragraph.append($createComposerSkillNode(skillMatch[1]));
+      continue;
     }
     if (segment.startsWith("@")) {
       const token = decodeComposerMentionValue(segment.slice(1));
@@ -599,7 +681,7 @@ function MentionChipNavigationPlugin() {
         // --- Mention / pasted-text chips: atomic delete (same as before) ---
         if ($isTextNode(anchorNode) && selection.anchor.offset === 0) {
           const previous = anchorNode.getPreviousSibling();
-          if (previous instanceof ComposerMentionNode || previous instanceof ComposerPastedTextNode) {
+          if (previous instanceof ComposerMentionNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode) {
             previous.remove();
             return true;
           }
@@ -607,7 +689,7 @@ function MentionChipNavigationPlugin() {
 
         if ($isElementNode(anchorNode)) {
           const previous = anchorNode.getChildAtIndex(selection.anchor.offset - 1);
-          if (previous instanceof ComposerSlashCommandNode || previous instanceof ComposerMentionNode || previous instanceof ComposerPastedTextNode) {
+          if (previous instanceof ComposerSlashCommandNode || previous instanceof ComposerMentionNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode) {
             previous.remove();
             return true;
           }
@@ -627,7 +709,7 @@ function MentionChipNavigationPlugin() {
 
         if ($isTextNode(anchorNode) && selection.anchor.offset === 0) {
           const previous = anchorNode.getPreviousSibling();
-          if (previous instanceof ComposerMentionNode || previous instanceof ComposerSlashCommandNode || previous instanceof ComposerPastedTextNode) {
+          if (previous instanceof ComposerMentionNode || previous instanceof ComposerSlashCommandNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode) {
             setSelectionBeforeNode(previous);
             return true;
           }
@@ -645,14 +727,14 @@ function MentionChipNavigationPlugin() {
         if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
         const anchorNode = selection.anchor.getNode();
 
-        if (anchorNode instanceof ComposerMentionNode || anchorNode instanceof ComposerSlashCommandNode || anchorNode instanceof ComposerPastedTextNode) {
+        if (anchorNode instanceof ComposerMentionNode || anchorNode instanceof ComposerSlashCommandNode || anchorNode instanceof ComposerSkillNode || anchorNode instanceof ComposerPastedTextNode) {
           setSelectionAfterNode(anchorNode);
           return true;
         }
 
         if ($isElementNode(anchorNode)) {
           const current = anchorNode.getChildAtIndex(selection.anchor.offset);
-          if (current instanceof ComposerMentionNode || current instanceof ComposerSlashCommandNode || current instanceof ComposerPastedTextNode) {
+          if (current instanceof ComposerMentionNode || current instanceof ComposerSlashCommandNode || current instanceof ComposerSkillNode || current instanceof ComposerPastedTextNode) {
             setSelectionAfterNode(current);
             return true;
           }
@@ -692,7 +774,7 @@ export function LexicalPromptEditor(props: EditorProps) {
         throw error;
       },
         editable: !props.disabled,
-        nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerPastedTextNode],
+        nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerSkillNode, ComposerPastedTextNode],
         editorState: () => {
           setPrompt(props.value, props.mentions, props.pastedText);
         },

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -521,7 +521,6 @@ function PastedTextChip(props: { label: string; text: string }) {
 }
 
 const PASTE_TOKEN_RE = /(\[pasted text [^\]]+\])/;
-const SKILL_TOKEN_RE = /(Load \[skill [^\]]+\] and follow its instructions\.|\[skill [^\]]+\])/;
 
 function HighlightedPlainText(props: {
   text: string;
@@ -542,11 +541,8 @@ function HighlightedPlainText(props: {
     });
   }, [props.highlightQuery, props.text]);
 
-  const hasPasteTokens = Boolean(props.pastedTextMap?.size) && PASTE_TOKEN_RE.test(props.text);
-  const hasSkillTokens = SKILL_TOKEN_RE.test(props.text);
-
-  // If no inline tokens present, render as plain text (fast path).
-  if (!hasPasteTokens && !hasSkillTokens) {
+  // If no paste tokens present, render as plain text (fast path).
+  if (!props.pastedTextMap?.size || !PASTE_TOKEN_RE.test(props.text)) {
     return (
       <div ref={rootRef} className={props.className}>
         {props.text}
@@ -554,8 +550,8 @@ function HighlightedPlainText(props: {
     );
   }
 
-  // Split on inline tokens and render chips inline.
-  const segments = props.text.split(/(\[pasted text [^\]]+\]|Load \[skill [^\]]+\] and follow its instructions\.|\[skill [^\]]+\])/);
+  // Split on paste tokens and render chips inline.
+  const segments = props.text.split(PASTE_TOKEN_RE);
   let segmentOffset = 0;
   return (
     <div ref={rootRef} className={props.className}>
@@ -569,21 +565,9 @@ function HighlightedPlainText(props: {
             return <PastedTextChip key={key} label={match[1]} text={pastedBody} />;
           }
         }
-        const skillMatch = segment.match(/^(?:Load )?\[skill ([^\]]+)\](?: and follow its instructions\.)?$/);
-        if (skillMatch?.[1]) {
-          return <SkillChip key={key} name={skillMatch[1]} />;
-        }
         return <span key={key}>{segment}</span>;
       })}
     </div>
-  );
-}
-
-function SkillChip(props: { name: string }) {
-  return (
-    <span className="mx-0.5 inline-flex items-center rounded-full border border-violet-6/35 bg-violet-3/20 px-2.5 py-1 text-xs font-medium text-violet-11 align-middle" title={`Skill: ${props.name}`}>
-      {props.name}
-    </span>
   );
 }
 

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -521,6 +521,7 @@ function PastedTextChip(props: { label: string; text: string }) {
 }
 
 const PASTE_TOKEN_RE = /(\[pasted text [^\]]+\])/;
+const SKILL_TOKEN_RE = /(Load \[skill [^\]]+\] and follow its instructions\.|\[skill [^\]]+\])/;
 
 function HighlightedPlainText(props: {
   text: string;
@@ -541,8 +542,11 @@ function HighlightedPlainText(props: {
     });
   }, [props.highlightQuery, props.text]);
 
-  // If no paste tokens present, render as plain text (fast path).
-  if (!props.pastedTextMap?.size || !PASTE_TOKEN_RE.test(props.text)) {
+  const hasPasteTokens = Boolean(props.pastedTextMap?.size) && PASTE_TOKEN_RE.test(props.text);
+  const hasSkillTokens = SKILL_TOKEN_RE.test(props.text);
+
+  // If no inline tokens present, render as plain text (fast path).
+  if (!hasPasteTokens && !hasSkillTokens) {
     return (
       <div ref={rootRef} className={props.className}>
         {props.text}
@@ -550,8 +554,8 @@ function HighlightedPlainText(props: {
     );
   }
 
-  // Split on paste tokens and render chips inline.
-  const segments = props.text.split(PASTE_TOKEN_RE);
+  // Split on inline tokens and render chips inline.
+  const segments = props.text.split(/(\[pasted text [^\]]+\]|Load \[skill [^\]]+\] and follow its instructions\.|\[skill [^\]]+\])/);
   let segmentOffset = 0;
   return (
     <div ref={rootRef} className={props.className}>
@@ -565,9 +569,21 @@ function HighlightedPlainText(props: {
             return <PastedTextChip key={key} label={match[1]} text={pastedBody} />;
           }
         }
+        const skillMatch = segment.match(/^(?:Load )?\[skill ([^\]]+)\](?: and follow its instructions\.)?$/);
+        if (skillMatch?.[1]) {
+          return <SkillChip key={key} name={skillMatch[1]} />;
+        }
         return <span key={key}>{segment}</span>;
       })}
     </div>
+  );
+}
+
+function SkillChip(props: { name: string }) {
+  return (
+    <span className="mx-0.5 inline-flex items-center rounded-full border border-violet-6/35 bg-violet-3/20 px-2.5 py-1 text-xs font-medium text-violet-11 align-middle" title={`Skill: ${props.name}`}>
+      {props.name}
+    </span>
   );
 }
 

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -753,7 +753,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   });
 
   const buildDraft = useCallback((text: string, nextAttachments: ComposerAttachment[]): ComposerDraft => {
-    const parts: ComposerPart[] = text.split(/(\[pasted text [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {
+    const parts: ComposerPart[] = text.split(/(\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {
       if (!segment) return [] as ComposerDraft["parts"];
       const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
       if (pasteMatch) {
@@ -761,6 +761,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
         if (target) {
           return [{ type: "paste", id: target.id, label: target.label, text: target.text, lines: target.lines }];
         }
+      }
+      const skillMatch = segment.match(/^\[skill (.+)\]$/);
+      if (skillMatch?.[1]) {
+        return [{ type: "skill", name: skillMatch[1] } satisfies ComposerDraft["parts"][number]];
       }
       if (segment.startsWith("@")) {
         const value = decodeComposerMentionValue(segment.slice(1));
@@ -776,6 +780,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     for (const part of pasteParts) {
       resolved = resolved.replace(`[pasted text ${part.label}]`, part.text);
     }
+    resolved = resolved.replace(/\[skill ([^\]]+)\]/g, (_match, name: string) => `the \"${name}\" skill`);
     for (const value of Object.keys(mentions)) {
       resolved = resolved.replaceAll(`@${encodeComposerMentionValue(value)}`, `@${value}`);
     }

--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -32,6 +32,7 @@ type ComputerUseConfigProps = {
   connecting: boolean;
   onConnect?: () => void | Promise<void>;
   onRefresh?: () => void | Promise<void>;
+  onPermissionsChange?: (permissions: { accessibility: boolean; screenRecording: boolean }) => void;
 };
 
 // ---------------------------------------------------------------------------
@@ -44,6 +45,7 @@ registerExtensionConfig("computer-use", (ctx) => (
     connecting={ctx.computerUse?.connecting ?? false}
     onConnect={ctx.computerUse?.onConnect}
     onRefresh={ctx.computerUse?.onRefresh}
+    onPermissionsChange={ctx.computerUse?.onPermissionsChange}
   />
 ));
 
@@ -79,6 +81,7 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
   const [result, setResult] = useState<PermissionResult | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { onPermissionsChange } = props;
 
   // Spawn --check → fresh TCC read. Works whether or not the GUI is open.
   const verify = useCallback(async () => {
@@ -92,13 +95,14 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
       const raw = await desktopBridge.checkComputerUsePermissions();
       const next = normalize(raw);
       setResult(next);
+      onPermissionsChange?.({ accessibility: next.accessibility, screenRecording: next.screenRecording });
       if (next.error) setError(next.error);
     } catch (e) {
       setError(errMsg(e));
     } finally {
       setBusy(false);
     }
-  }, []);
+  }, [onPermissionsChange]);
 
   // Check on mount.
   useEffect(() => { void verify(); }, [verify]);
@@ -115,6 +119,7 @@ export function ComputerUseConfig(props: ComputerUseConfigProps) {
       const raw = await desktopBridge.openComputerUsePermissionSetup();
       const next = normalize(raw);
       setResult(next);
+      onPermissionsChange?.({ accessibility: next.accessibility, screenRecording: next.screenRecording });
       if (next.error) setError(next.error);
     } catch (e) {
       setError(errMsg(e));

--- a/apps/app/src/react-app/domains/settings/extension-items.ts
+++ b/apps/app/src/react-app/domains/settings/extension-items.ts
@@ -1,0 +1,212 @@
+import { getMcpServerName, isBuiltInOpenWorkExtension, type McpDirectoryInfo } from "../../../app/constants";
+import type { CloudImportedPlugin, CloudImportedPluginFile } from "../../../app/cloud/import-state";
+import { evaluateEnablement, type EnablementContext } from "../../../app/enablement";
+import type { EnablementResult } from "../../../app/extensions";
+import type { DenOrgMarketplaceResolved, DenOrgPlugin } from "../../../app/lib/den";
+import type { McpServerEntry } from "../../../app/types";
+
+export type ExtensionItemSource = "builtin" | "marketplace" | "mcp-directory" | "skill";
+export type ExtensionInstallState = "available" | "installed" | "update_available";
+export type ExtensionSetupState = "ready" | "needs_setup" | "partial";
+
+export type ExtensionResourceItem = {
+  id: string;
+  type: string;
+  title: string;
+  path?: string;
+};
+
+export type ExtensionItem = {
+  id: string;
+  source: ExtensionItemSource;
+  name: string;
+  description: string | null;
+  installState: ExtensionInstallState;
+  setupState: ExtensionSetupState;
+  active: boolean;
+  enablement: { active: boolean; results: EnablementResult[] } | null;
+  resources: ExtensionResourceItem[];
+  builtInEntry?: McpDirectoryInfo;
+  marketplaceId?: string | null;
+  marketplaceName?: string;
+  plugin?: DenOrgPlugin;
+  importedPlugin?: CloudImportedPlugin;
+  mcpEntry?: McpDirectoryInfo;
+  skill?: { name: string; description?: string; path: string };
+};
+
+export type ExtensionItemBuildInput = {
+  quickConnect: McpDirectoryInfo[];
+  mcpServers: McpServerEntry[];
+  installedSkills: Array<{ name: string; description?: string; path: string }>;
+  importedCloudPlugins: Record<string, CloudImportedPlugin>;
+  cloudMarketplaces: DenOrgMarketplaceResolved[];
+  enablementContext: EnablementContext;
+  isBuiltInConnected: (entry: McpDirectoryInfo) => boolean;
+};
+
+const MCP_IMPORT_PATH_PREFIX = "opencode.jsonc#mcp.";
+
+function setupStateFromEnablement(enablement: { active: boolean; results: EnablementResult[] } | null): ExtensionSetupState {
+  if (!enablement || enablement.results.length === 0) return "needs_setup";
+  if (enablement.active) return "ready";
+  return enablement.results.some((result) => result.met) ? "partial" : "needs_setup";
+}
+
+function cloudPluginStatus(imported: CloudImportedPlugin | null, plugin: DenOrgPlugin): ExtensionInstallState {
+  if (!imported) return "available";
+  const importedObjectCount = new Set(imported.files.map((file) => file.configObjectId)).size;
+  if (imported.updatedAt !== plugin.updatedAt || importedObjectCount !== plugin.memberCount) return "update_available";
+  return "installed";
+}
+
+function resourceFromImportedFile(file: CloudImportedPluginFile): ExtensionResourceItem {
+  return {
+    id: file.configObjectId,
+    type: file.objectType,
+    title: file.title,
+    path: file.path,
+  };
+}
+
+function childKeysForPlugin(plugin: CloudImportedPlugin) {
+  const mcpServerNames = new Set<string>();
+  const skillPaths = new Set<string>();
+  const skillNames = new Set<string>();
+  for (const file of plugin.files) {
+    if (file.path.startsWith(MCP_IMPORT_PATH_PREFIX)) {
+      mcpServerNames.add(file.path.slice(MCP_IMPORT_PATH_PREFIX.length));
+    }
+    if (file.objectType === "skill") {
+      skillPaths.add(file.path);
+      skillNames.add(file.title);
+    }
+  }
+  return { mcpServerNames, skillPaths, skillNames };
+}
+
+export function buildExtensionItems(input: ExtensionItemBuildInput) {
+  const builtInItems = input.quickConnect.filter(isBuiltInOpenWorkExtension).map((entry): ExtensionItem => {
+    const enablement = entry.extensionManifest?.enablement
+      ? evaluateEnablement(entry.extensionManifest.enablement, input.enablementContext)
+      : null;
+    const active = enablement?.active ?? input.isBuiltInConnected(entry);
+    return {
+      id: `builtin:${entry.id ?? entry.serverName ?? entry.name}`,
+      source: "builtin",
+      name: entry.name,
+      description: entry.description,
+      installState: active ? "installed" : "available",
+      setupState: enablement ? setupStateFromEnablement(enablement) : active ? "ready" : "needs_setup",
+      active,
+      enablement,
+      resources: entry.extensionManifest?.resources.map((resource) => ({
+        id: resource.id,
+        type: resource.type,
+        title: resource.label ?? resource.id,
+        path: resource.path,
+      })) ?? [],
+      builtInEntry: entry,
+    };
+  });
+
+  const cloudPluginItems = input.cloudMarketplaces.flatMap((marketplace) => marketplace.plugins.map((plugin): ExtensionItem => {
+    const imported = input.importedCloudPlugins[plugin.id] ?? null;
+    const manifest = plugin.extension?.manifest ?? undefined;
+    const enablement = manifest?.enablement ? evaluateEnablement(manifest.enablement, input.enablementContext) : null;
+    const installState = cloudPluginStatus(imported, plugin);
+    return {
+      id: `marketplace:${marketplace.marketplace.id}:${plugin.id}`,
+      source: "marketplace",
+      name: plugin.extension?.name ?? plugin.name,
+      description: plugin.extension?.description ?? plugin.description,
+      installState,
+      setupState: enablement ? setupStateFromEnablement(enablement) : installState === "available" ? "needs_setup" : "ready",
+      active: enablement?.active ?? installState !== "available",
+      enablement,
+      resources: imported?.files.map(resourceFromImportedFile) ?? Object.entries(plugin.componentCounts).flatMap(([type, count]) => count > 0 ? [{
+        id: `${plugin.id}:${type}`,
+        type,
+        title: `${count} ${type}${count === 1 ? "" : "s"}`,
+      }] : []),
+      marketplaceId: marketplace.marketplace.id,
+      marketplaceName: marketplace.marketplace.name,
+      plugin,
+      importedPlugin: imported,
+    };
+  }));
+
+  const importedPluginItems = Object.values(input.importedCloudPlugins).flatMap((plugin): ExtensionItem[] => {
+    if (cloudPluginItems.some((item) => item.importedPlugin?.pluginId === plugin.pluginId)) return [];
+    return [{
+      id: `marketplace:installed:${plugin.pluginId}`,
+      source: "marketplace",
+      name: plugin.name,
+      description: plugin.description,
+      installState: "installed",
+      setupState: "ready",
+      active: true,
+      enablement: null,
+      resources: plugin.files.map(resourceFromImportedFile),
+      marketplaceId: plugin.marketplaceId,
+      importedPlugin: plugin,
+    }];
+  });
+
+  const groupedMcpServerNames = new Set<string>();
+  const groupedSkillPaths = new Set<string>();
+  const groupedSkillNames = new Set<string>();
+  for (const plugin of Object.values(input.importedCloudPlugins)) {
+    const keys = childKeysForPlugin(plugin);
+    keys.mcpServerNames.forEach((value) => groupedMcpServerNames.add(value));
+    keys.skillPaths.forEach((value) => groupedSkillPaths.add(value));
+    keys.skillNames.forEach((value) => groupedSkillNames.add(value));
+  }
+
+  const standaloneMcpEntries = input.quickConnect.filter((entry) => {
+    if (isBuiltInOpenWorkExtension(entry)) return false;
+    const serverName = getMcpServerName(entry);
+    if (groupedMcpServerNames.has(serverName)) return false;
+    return input.mcpServers.some((server) => server.name === serverName);
+  });
+
+  const standaloneSkillItems = input.installedSkills.filter((skill) => {
+    if (groupedSkillPaths.has(skill.path)) return false;
+    if (groupedSkillNames.has(skill.name)) return false;
+    return true;
+  }).map((skill): ExtensionItem => ({
+    id: `skill:${skill.name}`,
+    source: "skill",
+    name: skill.name,
+    description: skill.description ?? null,
+    installState: "installed",
+    setupState: "ready",
+    active: true,
+    enablement: null,
+    resources: [{ id: skill.name, type: "skill", title: skill.name, path: skill.path }],
+    skill,
+  }));
+
+  return {
+    items: [...builtInItems, ...cloudPluginItems, ...importedPluginItems, ...standaloneMcpEntries.map((entry): ExtensionItem => ({
+      id: `mcp:${getMcpServerName(entry)}`,
+      source: "mcp-directory",
+      name: entry.name,
+      description: entry.description,
+      installState: "installed",
+      setupState: "ready",
+      active: true,
+      enablement: null,
+      resources: [{ id: getMcpServerName(entry), type: "mcp", title: entry.name }],
+      mcpEntry: entry,
+    })), ...standaloneSkillItems],
+    builtInItems,
+    cloudPluginItems: [...cloudPluginItems, ...importedPluginItems],
+    installedMcpEntries: [
+      ...builtInItems.flatMap((item) => item.active && item.builtInEntry ? [item.builtInEntry] : []),
+      ...standaloneMcpEntries,
+    ],
+    installedSkills: standaloneSkillItems.flatMap((item) => item.skill ? [item.skill] : []),
+    installedCloudPlugins: Object.values(input.importedCloudPlugins),
+  };
+}

--- a/apps/app/src/react-app/domains/settings/extension-items.ts
+++ b/apps/app/src/react-app/domains/settings/extension-items.ts
@@ -47,6 +47,10 @@ export type ExtensionItemBuildInput = {
 
 const MCP_IMPORT_PATH_PREFIX = "opencode.jsonc#mcp.";
 
+export function isToggleControlledExtension(entry: McpDirectoryInfo) {
+  return entry.extensionManifest?.enablement?.some((condition) => condition.type === "toggle-enabled") === true;
+}
+
 function setupStateFromEnablement(enablement: { active: boolean; results: EnablementResult[] } | null): ExtensionSetupState {
   if (!enablement || enablement.results.length === 0) return "needs_setup";
   if (enablement.active) return "ready";
@@ -203,7 +207,7 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
     builtInItems,
     cloudPluginItems: [...cloudPluginItems, ...importedPluginItems],
     installedMcpEntries: [
-      ...builtInItems.flatMap((item) => item.active && item.builtInEntry ? [item.builtInEntry] : []),
+      ...builtInItems.flatMap((item) => item.builtInEntry ? [item.builtInEntry] : []),
       ...standaloneMcpEntries,
     ],
     installedSkills: standaloneSkillItems.flatMap((item) => item.skill ? [item.skill] : []),

--- a/apps/app/src/react-app/domains/settings/extension-registry.tsx
+++ b/apps/app/src/react-app/domains/settings/extension-registry.tsx
@@ -17,6 +17,7 @@ export type ExtensionConfigContext = {
     connecting: boolean;
     onConnect: () => void | Promise<void>;
     onRefresh: () => void | Promise<void>;
+    onPermissionsChange?: (permissions: { accessibility: boolean; screenRecording: boolean }) => void;
   };
   imageExtension: {
     busy: boolean;

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -501,7 +501,7 @@ function MarketplaceCard(props: {
         kind={row.entry.kind ?? "extension"}
         preview={row.entry.preview}
         connected={row.active}
-        connectedLabel="Active"
+        connectedLabel={row.entry.defaultEnabled ? "Ready" : "Active"}
         connecting={actionBusy}
         disabled={props.builtInDisabled}
         disabledReason={props.builtInDisabled ? "Disabled by organization" : null}
@@ -546,7 +546,7 @@ function BuiltInMarketplaceDetailModal(props: {
       iconSrc={entry.iconSrc}
       kind={entry.kind ?? "extension"}
       connected={row.active}
-      connectedLabel="Active"
+      connectedLabel={entry.defaultEnabled ? "Ready" : "Active"}
       disconnectedLabel="Needs setup"
       connecting={connecting}
       preview={entry.preview}

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -10,6 +10,7 @@ import { Separator } from "@/components/ui/separator";
 import { t } from "@/i18n";
 import { ExtensionCard } from "../../../design-system/extension-card";
 import { ExtensionDetailModal } from "../../../design-system/extension-detail-modal";
+import type { ExtensionItem } from "../extension-items";
 import { useStatusToasts } from "../../shell-feedback/status-toasts";
 import { useCloudSession } from "../cloud/cloud-session-provider";
 import type { useDenSession } from "../cloud/use-den-session";
@@ -82,6 +83,7 @@ export type CloudMarketplacesViewProps = {
   builtInConnectingName?: string | null;
   configSlotForBuiltIn?: (entry: McpDirectoryInfo) => React.ReactNode | null;
   isBuiltInConnected?: (entry: McpDirectoryInfo) => boolean;
+  extensionItems?: ExtensionItem[];
 };
 
 function pluginCounts(plugin: DenOrgPlugin) {
@@ -136,6 +138,7 @@ export function CloudMarketplacesView({
   builtInConnectingName = null,
   configSlotForBuiltIn,
   isBuiltInConnected,
+  extensionItems = [],
 }: CloudMarketplacesViewProps) {
   const { activeOrganization: activeOrg, authToken, client, isSignedIn, user } = useCloudSession();
   const { showToast } = useStatusToasts();
@@ -153,13 +156,20 @@ export function CloudMarketplacesView({
 
   const marketplaces = extensions.cloudOrgMarketplaces();
   const importedPlugins = extensions.importedCloudPlugins();
+  const extensionItemsByBuiltInId = React.useMemo(() => new Map(
+    extensionItems.flatMap((item) => item.builtInEntry ? [[item.builtInEntry.id ?? item.builtInEntry.serverName ?? item.builtInEntry.name, item] as const] : []),
+  ), [extensionItems]);
+  const extensionItemsByPluginId = React.useMemo(() => new Map(
+    extensionItems.flatMap((item) => item.plugin ? [[item.plugin.id, item] as const] : []),
+  ), [extensionItems]);
   const lastRowsRef = React.useRef<MarketplaceRow[]>([]);
   const cloudRows = React.useMemo<MarketplacePackageRow[]>(() => {
     return marketplaces.flatMap((marketplace) => marketplace.plugins.map((plugin) => {
       const imported = importedPlugins[plugin.id] ?? null;
       const composition = pluginComposition(plugin);
       const counts = pluginCounts(plugin);
-      const status = pluginStatus(imported, plugin);
+      const item = extensionItemsByPluginId.get(plugin.id);
+      const status = item?.installState ?? pluginStatus(imported, plugin);
       return {
         source: "cloud",
         marketplaceId: marketplace.marketplace.id,
@@ -178,21 +188,22 @@ export function CloudMarketplacesView({
         ].join(" ").toLowerCase(),
       };
     }));
-  }, [importedPlugins, marketplaces]);
+  }, [extensionItemsByPluginId, importedPlugins, marketplaces]);
 
   const builtInRows = React.useMemo<BuiltInMarketplaceRow[]>(() => {
     return builtInEntries.map((entry) => {
+      const item = extensionItemsByBuiltInId.get(entry.id ?? entry.serverName ?? entry.name);
       const enablement = entry.extensionManifest?.enablement && enablementContext
         ? evaluateEnablement(entry.extensionManifest.enablement, enablementContext)
         : null;
-      const active = enablement?.active ?? isBuiltInConnected?.(entry) ?? false;
+      const active = item?.active ?? enablement?.active ?? isBuiltInConnected?.(entry) ?? false;
       return {
         source: "built-in",
         marketplaceId: "openwork-builtins",
         marketplaceName: "OpenWork Built-ins",
         entry,
         active,
-        status: active ? "installed" : "available",
+        status: item?.installState ?? (active ? "installed" : "available"),
         searchableText: [
           entry.name,
           entry.description,
@@ -201,7 +212,7 @@ export function CloudMarketplacesView({
         ].join(" ").toLowerCase(),
       };
     });
-  }, [builtInEntries, enablementContext, isBuiltInConnected]);
+  }, [builtInEntries, enablementContext, extensionItemsByBuiltInId, isBuiltInConnected]);
 
   const rows = React.useMemo<MarketplaceRow[]>(() => [...builtInRows, ...cloudRows], [builtInRows, cloudRows]);
 

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -10,7 +10,7 @@ import { Separator } from "@/components/ui/separator";
 import { t } from "@/i18n";
 import { ExtensionCard } from "../../../design-system/extension-card";
 import { ExtensionDetailModal } from "../../../design-system/extension-detail-modal";
-import type { ExtensionItem } from "../extension-items";
+import { isToggleControlledExtension, type ExtensionItem } from "../extension-items";
 import { useStatusToasts } from "../../shell-feedback/status-toasts";
 import { useCloudSession } from "../cloud/cloud-session-provider";
 import type { useDenSession } from "../cloud/use-den-session";
@@ -84,6 +84,7 @@ export type CloudMarketplacesViewProps = {
   configSlotForBuiltIn?: (entry: McpDirectoryInfo) => React.ReactNode | null;
   isBuiltInConnected?: (entry: McpDirectoryInfo) => boolean;
   extensionItems?: ExtensionItem[];
+  setBuiltInEnabled?: (entry: McpDirectoryInfo, enabled: boolean) => void;
 };
 
 function pluginCounts(plugin: DenOrgPlugin) {
@@ -139,6 +140,7 @@ export function CloudMarketplacesView({
   configSlotForBuiltIn,
   isBuiltInConnected,
   extensionItems = [],
+  setBuiltInEnabled,
 }: CloudMarketplacesViewProps) {
   const { activeOrganization: activeOrg, authToken, client, isSignedIn, user } = useCloudSession();
   const { showToast } = useStatusToasts();
@@ -467,6 +469,7 @@ export function CloudMarketplacesView({
           disabled={builtInExtensionsDisabled}
           connecting={builtInConnectingName === detailRow.entry.name}
           configSlot={configSlotForBuiltIn?.(detailRow.entry) ?? null}
+          onSetEnabled={setBuiltInEnabled}
           onClose={() => setDetailRow(null)}
         />
       ) : null}
@@ -543,10 +546,12 @@ function BuiltInMarketplaceDetailModal(props: {
   disabled: boolean;
   connecting: boolean;
   configSlot: React.ReactNode | null;
+  onSetEnabled?: (entry: McpDirectoryInfo, enabled: boolean) => void;
   onClose: () => void;
 }) {
-  const { row, disabled, connecting, configSlot, onClose } = props;
+  const { row, disabled, connecting, configSlot, onClose, onSetEnabled } = props;
   const entry = row.entry;
+  const toggleControlled = isToggleControlledExtension(entry);
   return (
     <ExtensionDetailModal
       open
@@ -567,6 +572,11 @@ function BuiltInMarketplaceDetailModal(props: {
       contributionLabels={entry.extensionManifest?.contributions?.map((contribution) => contribution.label ?? contribution.ref ?? contribution.type) ?? []}
       configSlot={configSlot}
       showEnablementCard={false}
+      connectLabel="Enable"
+      connectingLabel="Enabling..."
+      uninstallLabel="Disable"
+      onConnect={!disabled && toggleControlled && !row.active && onSetEnabled ? () => onSetEnabled(entry, true) : undefined}
+      onUninstall={!disabled && toggleControlled && row.active && onSetEnabled ? () => onSetEnabled(entry, false) : undefined}
     />
   );
 }

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource react */
 import * as React from "react";
 
+import type { McpDirectoryInfo } from "../../../../app/constants";
 import type { CloudImportedPlugin } from "../../../../app/cloud/import-state";
+import { evaluateEnablement, type EnablementContext } from "../../../../app/enablement";
 import type { DenOrgMarketplaceResolved, DenOrgPlugin, DenOrgPluginResolved } from "../../../../app/lib/den";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -46,6 +48,7 @@ type DenSettingsExtensionsStore = {
 };
 
 type MarketplacePackageRow = {
+  source: "cloud";
   marketplaceId: string;
   marketplaceName: string;
   plugin: DenOrgPlugin;
@@ -56,11 +59,29 @@ type MarketplacePackageRow = {
   searchableText: string;
 };
 
+type BuiltInMarketplaceRow = {
+  source: "built-in";
+  marketplaceId: "openwork-builtins";
+  marketplaceName: string;
+  entry: McpDirectoryInfo;
+  status: MarketplacePackageStatus;
+  active: boolean;
+  searchableText: string;
+};
+
+type MarketplaceRow = MarketplacePackageRow | BuiltInMarketplaceRow;
+
 export type CloudMarketplacesViewProps = {
   extensions: DenSettingsExtensionsStore;
   embedded?: boolean;
   onOpenAccount: () => void;
   session: CloudMarketplacesSession;
+  builtInEntries?: McpDirectoryInfo[];
+  enablementContext?: EnablementContext;
+  builtInExtensionsDisabled?: boolean;
+  builtInConnectingName?: string | null;
+  configSlotForBuiltIn?: (entry: McpDirectoryInfo) => React.ReactNode | null;
+  isBuiltInConnected?: (entry: McpDirectoryInfo) => boolean;
 };
 
 function pluginCounts(plugin: DenOrgPlugin) {
@@ -109,6 +130,12 @@ export function CloudMarketplacesView({
   embedded = false,
   onOpenAccount,
   session,
+  builtInEntries = [],
+  enablementContext,
+  builtInExtensionsDisabled = false,
+  builtInConnectingName = null,
+  configSlotForBuiltIn,
+  isBuiltInConnected,
 }: CloudMarketplacesViewProps) {
   const { activeOrganization: activeOrg, authToken, client, isSignedIn, user } = useCloudSession();
   const { showToast } = useStatusToasts();
@@ -118,7 +145,7 @@ export function CloudMarketplacesView({
   const [search, setSearch] = React.useState("");
   const [statusFilter, setStatusFilter] = React.useState<MarketplaceStatusFilter>("all");
   const [marketplaceFilter, setMarketplaceFilter] = React.useState("all");
-  const [detailRow, setDetailRow] = React.useState<MarketplacePackageRow | null>(null);
+  const [detailRow, setDetailRow] = React.useState<MarketplaceRow | null>(null);
   const [resolvedPlugins, setResolvedPlugins] = React.useState<Record<string, DenOrgPluginResolved>>({});
   const [detailLoadingId, setDetailLoadingId] = React.useState<string | null>(null);
   const [detailError, setDetailError] = React.useState<string | null>(null);
@@ -126,14 +153,15 @@ export function CloudMarketplacesView({
 
   const marketplaces = extensions.cloudOrgMarketplaces();
   const importedPlugins = extensions.importedCloudPlugins();
-  const lastRowsRef = React.useRef<MarketplacePackageRow[]>([]);
-  const rows = React.useMemo<MarketplacePackageRow[]>(() => {
+  const lastRowsRef = React.useRef<MarketplaceRow[]>([]);
+  const cloudRows = React.useMemo<MarketplacePackageRow[]>(() => {
     return marketplaces.flatMap((marketplace) => marketplace.plugins.map((plugin) => {
       const imported = importedPlugins[plugin.id] ?? null;
       const composition = pluginComposition(plugin);
       const counts = pluginCounts(plugin);
       const status = pluginStatus(imported, plugin);
       return {
+        source: "cloud",
         marketplaceId: marketplace.marketplace.id,
         marketplaceName: marketplace.marketplace.name,
         plugin,
@@ -152,6 +180,31 @@ export function CloudMarketplacesView({
     }));
   }, [importedPlugins, marketplaces]);
 
+  const builtInRows = React.useMemo<BuiltInMarketplaceRow[]>(() => {
+    return builtInEntries.map((entry) => {
+      const enablement = entry.extensionManifest?.enablement && enablementContext
+        ? evaluateEnablement(entry.extensionManifest.enablement, enablementContext)
+        : null;
+      const active = enablement?.active ?? isBuiltInConnected?.(entry) ?? false;
+      return {
+        source: "built-in",
+        marketplaceId: "openwork-builtins",
+        marketplaceName: "OpenWork Built-ins",
+        entry,
+        active,
+        status: active ? "installed" : "available",
+        searchableText: [
+          entry.name,
+          entry.description,
+          entry.extensionManifest?.setup?.instructions ?? "",
+          ...(entry.extensionManifest?.resources.map((resource) => `${resource.id} ${resource.label ?? ""}`) ?? []),
+        ].join(" ").toLowerCase(),
+      };
+    });
+  }, [builtInEntries, enablementContext, isBuiltInConnected]);
+
+  const rows = React.useMemo<MarketplaceRow[]>(() => [...builtInRows, ...cloudRows], [builtInRows, cloudRows]);
+
   React.useEffect(() => {
     if (rows.length > 0) lastRowsRef.current = rows;
   }, [rows]);
@@ -159,8 +212,11 @@ export function CloudMarketplacesView({
   const displayRows = rows.length > 0 ? rows : busy ? lastRowsRef.current : rows;
 
   const marketplaceOptions = React.useMemo(
-    () => marketplaces.map((marketplace) => ({ id: marketplace.marketplace.id, name: marketplace.marketplace.name })),
-    [marketplaces],
+    () => [
+      ...(builtInRows.length > 0 ? [{ id: "openwork-builtins", name: "OpenWork Built-ins" }] : []),
+      ...marketplaces.map((marketplace) => ({ id: marketplace.marketplace.id, name: marketplace.marketplace.name })),
+    ],
+    [builtInRows.length, marketplaces],
   );
 
   const visibleRows = React.useMemo(() => {
@@ -216,7 +272,7 @@ export function CloudMarketplacesView({
   }, [activeOrgId, refresh, user]);
 
   React.useEffect(() => {
-    if (!detailRow || !isSignedIn || !activeOrgId) return;
+    if (!detailRow || detailRow.source !== "cloud" || !isSignedIn || !activeOrgId) return;
     if (resolvedPlugins[detailRow.plugin.id]) return;
 
     let cancelled = false;
@@ -279,22 +335,13 @@ export function CloudMarketplacesView({
     [actionId, extensions, showToast],
   );
 
-  const content = !isSignedIn ? (
-    <SettingsNotice>
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <span>Sign in to OpenWork Cloud to browse organization marketplace extensions.</span>
-        <Button size="sm" onClick={onOpenAccount}>
-          {t("skills.share_team_sign_in")}
-        </Button>
-      </div>
-    </SettingsNotice>
-  ) : (
+  const content = (
     <SettingsSection>
       <SettingsSectionHeader>
         <SettingsSectionHeaderContent>
           <SettingsSectionHeaderTitle>Extension Marketplace</SettingsSectionHeaderTitle>
           <SettingsSectionHeaderDescription>
-            Add extensions from OpenWork Cloud. Claude-compatible plugins are normalized into OpenWork extensions with installable resources such as skills, MCPs, commands, or tools.
+            Browse built-in OpenWork extensions and organization marketplace extensions. Claude-compatible plugins are normalized into OpenWork extensions with installable resources such as skills, MCPs, commands, or tools.
           </SettingsSectionHeaderDescription>
         </SettingsSectionHeaderContent>
         <SettingsSectionHeaderActions>
@@ -307,6 +354,17 @@ export function CloudMarketplacesView({
           </RefreshButton>
         </SettingsSectionHeaderActions>
       </SettingsSectionHeader>
+
+      {!isSignedIn ? (
+        <SettingsNotice>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <span>Sign in to OpenWork Cloud to browse organization marketplace extensions. Built-ins are still available.</span>
+            <Button size="sm" onClick={onOpenAccount}>
+              {t("skills.share_team_sign_in")}
+            </Button>
+          </div>
+        </SettingsNotice>
+      ) : null}
 
       {actionError ?? extensions.cloudOrgMarketplacesStatus() ? (
         <SettingsNotice tone="error">{actionError ?? extensions.cloudOrgMarketplacesStatus()}</SettingsNotice>
@@ -369,17 +427,19 @@ export function CloudMarketplacesView({
       {visibleRows.length > 0 ? (
         <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3">
           {visibleRows.map((row) => (
-            <MarketplacePackageCard
-              key={`${row.marketplaceId}:${row.plugin.id}`}
+            <MarketplaceCard
+              key={row.source === "cloud" ? `${row.marketplaceId}:${row.plugin.id}` : `${row.marketplaceId}:${row.entry.id ?? row.entry.name}`}
               actionId={actionId}
               row={row}
               onOpenDetail={setDetailRow}
+              builtInDisabled={builtInExtensionsDisabled}
+              builtInConnectingName={builtInConnectingName}
             />
           ))}
         </div>
       ) : null}
 
-      {detailRow ? (
+      {detailRow?.source === "cloud" ? (
         <MarketplacePackageDetailModal
           actionId={actionId}
           row={detailRow}
@@ -389,6 +449,14 @@ export function CloudMarketplacesView({
           onClose={() => setDetailRow(null)}
           onImportPlugin={importPlugin}
           onRemovePlugin={removePlugin}
+        />
+      ) : detailRow?.source === "built-in" ? (
+        <BuiltInMarketplaceDetailModal
+          row={detailRow}
+          disabled={builtInExtensionsDisabled}
+          connecting={builtInConnectingName === detailRow.entry.name}
+          configSlot={configSlotForBuiltIn?.(detailRow.entry) ?? null}
+          onClose={() => setDetailRow(null)}
         />
       ) : null}
     </SettingsSection>
@@ -413,12 +481,36 @@ function actionLabelForStatus(status: MarketplacePackageStatus) {
   }
 }
 
-function MarketplacePackageCard(props: {
+function MarketplaceCard(props: {
   actionId: string | null;
-  row: MarketplacePackageRow;
-  onOpenDetail: (row: MarketplacePackageRow) => void;
+  row: MarketplaceRow;
+  onOpenDetail: (row: MarketplaceRow) => void;
+  builtInDisabled: boolean;
+  builtInConnectingName: string | null;
 }) {
   const { actionId, row, onOpenDetail } = props;
+
+  if (row.source === "built-in") {
+    const actionBusy = props.builtInConnectingName === row.entry.name;
+    return (
+      <ExtensionCard
+        name={row.entry.name}
+        description={row.entry.description}
+        iconSlug={row.entry.iconSlug}
+        iconSrc={row.entry.iconSrc}
+        kind={row.entry.kind ?? "extension"}
+        preview={row.entry.preview}
+        connected={row.active}
+        connectedLabel="Active"
+        connecting={actionBusy}
+        disabled={props.builtInDisabled}
+        disabledReason={props.builtInDisabled ? "Disabled by organization" : null}
+        actionLabel={row.active ? "Manage" : "View setup"}
+        onClick={() => onOpenDetail(row)}
+      />
+    );
+  }
+
   const actionBusy = actionId === row.plugin.id;
 
   return (
@@ -431,6 +523,39 @@ function MarketplacePackageCard(props: {
       connecting={actionBusy}
       actionLabel={actionBusy ? "Working..." : actionLabelForStatus(row.status)}
       onClick={() => onOpenDetail(row)}
+    />
+  );
+}
+
+function BuiltInMarketplaceDetailModal(props: {
+  row: BuiltInMarketplaceRow;
+  disabled: boolean;
+  connecting: boolean;
+  configSlot: React.ReactNode | null;
+  onClose: () => void;
+}) {
+  const { row, disabled, connecting, configSlot, onClose } = props;
+  const entry = row.entry;
+  return (
+    <ExtensionDetailModal
+      open
+      onClose={onClose}
+      name={entry.name}
+      description={entry.description}
+      iconSlug={entry.iconSlug}
+      iconSrc={entry.iconSrc}
+      kind={entry.kind ?? "extension"}
+      connected={row.active}
+      connectedLabel="Active"
+      disconnectedLabel="Needs setup"
+      connecting={connecting}
+      preview={entry.preview}
+      disabledReason={disabled ? "Disabled by organization" : null}
+      setupInstructions={entry.extensionManifest?.setup?.instructions}
+      resourceLabels={entry.extensionManifest?.resources.map((resource) => resource.label ?? resource.id) ?? []}
+      contributionLabels={entry.extensionManifest?.contributions?.map((contribution) => contribution.label ?? contribution.ref ?? contribution.type) ?? []}
+      configSlot={configSlot}
+      showEnablementCard={false}
     />
   );
 }

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 
 import { isBuiltInOpenWorkExtension, getMcpServerName, type McpDirectoryInfo } from "../../../../app/constants";
-import { evaluateEnablement, defaultMcpEnablement } from "../../../../app/enablement";
+import { evaluateEnablement } from "../../../../app/enablement";
 import type { EnablementResult } from "../../../../app/extensions";
 import type { CloudImportedPlugin } from "../../../../app/cloud/import-state";
 import { ExtensionCard } from "../../../design-system/extension-card";
@@ -396,13 +396,6 @@ export function McpView(props: McpViewProps) {
     const manifest = entry.extensionManifest;
     if (manifest?.enablement && props.enablementContext) {
       return evaluateEnablement(manifest.enablement, props.enablementContext);
-    }
-    // For plain MCP entries, use default mcp-connected enablement.
-    if (entry.kind === "mcp" || entry.kind === "ui-control" || isMcpBackedExtension(entry)) {
-      const serverName = getMcpIdentityKey(entry);
-      if (props.enablementContext) {
-        return evaluateEnablement(defaultMcpEnablement(serverName), props.enablementContext);
-      }
     }
     return null;
   };

--- a/apps/app/src/react-app/domains/settings/settings-extension-controller.ts
+++ b/apps/app/src/react-app/domains/settings/settings-extension-controller.ts
@@ -1,0 +1,107 @@
+/** @jsxImportSource react */
+import { useCallback } from "react";
+
+import type { McpDirectoryInfo } from "../../../app/constants";
+import { evaluateEnablement, type EnablementContext } from "../../../app/enablement";
+import type { OpenworkServerClient } from "../../../app/lib/openwork-server";
+import type { McpServerEntry } from "../../../app/types";
+import { getExtensionConfigSlot, getExtensionConnected, type ExtensionConfigContext } from "./extension-registry";
+import type { LocalProviderInstallInput } from "./openai-image-extension";
+
+type ProviderLike = {
+  id: string;
+  source?: string | null;
+};
+
+type SettingsExtensionControllerInput = {
+  openworkServerClient: OpenworkServerClient | null;
+  enablementContext: EnablementContext;
+  mcpServers: McpServerEntry[];
+  mcpConnectingName: string | null;
+  googleWorkspaceConnected: boolean;
+  setGoogleWorkspaceConnected: (connected: boolean) => void;
+  connectMcp: (entry: McpDirectoryInfo) => void | Promise<void>;
+  refreshMcpServers: () => void | Promise<void>;
+  providers: ProviderLike[];
+  providerConnectedIds: string[];
+  userEnvKeys: string[];
+  imageExtension: {
+    busy: boolean;
+    status: string | null;
+    error: string | null;
+    onInstall: (apiKey: string) => void | Promise<void>;
+    onTestGenerate: (input: { apiKey: string; prompt: string }) => void | Promise<void>;
+  };
+  voiceExtension: {
+    busy: boolean;
+    status: string | null;
+    error: string | null;
+    onSaveApiKey: (apiKey: string) => void | Promise<void>;
+    onTestSession: () => void | Promise<void>;
+  };
+  localProvider: {
+    busy: boolean;
+    status: string | null;
+    error: string | null;
+    onInstall: (input: LocalProviderInstallInput) => void | Promise<void>;
+  };
+};
+
+function hasOpenAiEnv(input: Pick<SettingsExtensionControllerInput, "providers" | "providerConnectedIds" | "userEnvKeys">) {
+  return input.userEnvKeys.includes("OPENAI_REALTIME_API_KEY") ||
+    input.userEnvKeys.includes("OPENAI_API_KEY") ||
+    input.userEnvKeys.includes("OPENWORK_OPENAI_IMAGE_API_KEY") ||
+    input.providers.some((provider) => provider.id === "openai" && provider.source === "env") ||
+    input.providerConnectedIds.includes("openai");
+}
+
+export function useSettingsExtensionController(input: SettingsExtensionControllerInput) {
+  const configContextForEntry = useCallback((entry: McpDirectoryInfo): ExtensionConfigContext => ({
+    openworkServerClient: input.openworkServerClient,
+    extensionConnections: {
+      "google-workspace": input.googleWorkspaceConnected,
+    },
+    onExtensionConnectionChange: (extensionId, connected) => {
+      if (extensionId === "google-workspace") input.setGoogleWorkspaceConnected(connected);
+    },
+    computerUse: {
+      connected: input.mcpServers.some((server) => server.name === "computer-use"),
+      connecting: input.mcpConnectingName === entry.name,
+      onConnect: () => input.connectMcp(entry),
+      onRefresh: input.refreshMcpServers,
+    },
+    imageExtension: {
+      ...input.imageExtension,
+      envKeyDetected: hasOpenAiEnv(input),
+    },
+    voiceExtension: {
+      ...input.voiceExtension,
+      envKeyDetected: hasOpenAiEnv(input),
+    },
+    localProvider: input.localProvider,
+  }), [input]);
+
+  const configSlotForEntry = useCallback(
+    (entry: McpDirectoryInfo) => getExtensionConfigSlot(entry, configContextForEntry(entry)),
+    [configContextForEntry],
+  );
+
+  const isConnected = useCallback((entry: McpDirectoryInfo) => {
+    if (entry.extensionManifest?.enablement) {
+      return evaluateEnablement(entry.extensionManifest.enablement, input.enablementContext).active;
+    }
+    const runtimeConnected = getExtensionConnected(entry, {
+      openworkServerClient: input.openworkServerClient,
+      extensionConnections: {
+        "google-workspace": input.googleWorkspaceConnected,
+      },
+    });
+    return runtimeConnected ?? false;
+  }, [input]);
+
+  return {
+    configContextForEntry,
+    configSlotForEntry,
+    isConnected,
+  };
+}

--- a/apps/app/src/react-app/domains/settings/settings-extension-controller.ts
+++ b/apps/app/src/react-app/domains/settings/settings-extension-controller.ts
@@ -18,6 +18,7 @@ type SettingsExtensionControllerInput = {
   enablementContext: EnablementContext;
   mcpServers: McpServerEntry[];
   mcpConnectingName: string | null;
+  onComputerUsePermissionsChange: (permissions: { accessibility: boolean; screenRecording: boolean }) => void;
   googleWorkspaceConnected: boolean;
   setGoogleWorkspaceConnected: (connected: boolean) => void;
   connectMcp: (entry: McpDirectoryInfo) => void | Promise<void>;
@@ -69,6 +70,7 @@ export function useSettingsExtensionController(input: SettingsExtensionControlle
       connecting: input.mcpConnectingName === entry.name,
       onConnect: () => input.connectMcp(entry),
       onRefresh: input.refreshMcpServers,
+      onPermissionsChange: input.onComputerUsePermissionsChange,
     },
     imageExtension: {
       ...input.imageExtension,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -459,6 +459,10 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
       parts.push({ type: "agent", name: part.name });
       continue;
     }
+    if (part.type === "skill") {
+      parts.push({ type: "text", text: `the \"${part.name}\" skill` });
+      continue;
+    }
     if (part.type === "file") {
       const absolute = toAbsolutePath(part.path);
       if (!absolute) continue;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -460,7 +460,7 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
       continue;
     }
     if (part.type === "skill") {
-      parts.push({ type: "text", text: `the \"${part.name}\" skill` });
+      parts.push({ type: "text", text: `Load [skill ${part.name}] and follow its instructions.` });
       continue;
     }
     if (part.type === "file") {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -46,7 +46,7 @@ import "../domains/settings/openwork-voice-config";
 import "../domains/settings/google-workspace-config";
 import { useSettingsExtensionController } from "../domains/settings/settings-extension-controller";
 import { buildExtensionItems } from "../domains/settings/extension-items";
-import { isOpenWorkExtensionEnabled } from "../domains/settings/extension-state";
+import { isOpenWorkExtensionEnabled, OPENWORK_EXTENSION_STATE_CHANGED, setOpenWorkExtensionEnabled } from "../domains/settings/extension-state";
 import { PreferencesView } from "../domains/settings/pages/preferences-view";
 import { ShellCustomizationView } from "../domains/settings/pages/shell-view";
 import { GeneralSettingsView } from "../domains/settings/pages/general-view";
@@ -530,6 +530,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [imageExtensionStatus, setImageExtensionStatus] = useState<string | null>(null);
   const [imageExtensionError, setImageExtensionError] = useState<string | null>(null);
   const [computerUsePermissions, setComputerUsePermissions] = useState<{ accessibility: boolean; screenRecording: boolean } | null>(null);
+  const [extensionStateVersion, setExtensionStateVersion] = useState(0);
   const [imageGenerationBusy, setImageGenerationBusy] = useState(false);
   const [imageGenerationStatus, setImageGenerationStatus] = useState<string | null>(null);
   const [imageGenerationError, setImageGenerationError] = useState<string | null>(null);
@@ -909,6 +910,16 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   useEffect(() => {
     setActiveClient(opencodeClient);
   }, [opencodeClient]);
+
+  useEffect(() => {
+    const refresh = () => setExtensionStateVersion((value) => value + 1);
+    window.addEventListener(OPENWORK_EXTENSION_STATE_CHANGED, refresh);
+    window.addEventListener("storage", refresh);
+    return () => {
+      window.removeEventListener(OPENWORK_EXTENSION_STATE_CHANGED, refresh);
+      window.removeEventListener("storage", refresh);
+    };
+  }, []);
 
   useEffect(() => {
     if (!isDesktopRuntime() || !isMacPlatform()) return;
@@ -1668,7 +1679,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         return match ? isOpenWorkExtensionEnabled(match) : false;
       },
     };
-  }, [computerUsePermissions, connectionsSnapshot, providerConnectedIds, userEnvKeys]);
+  }, [computerUsePermissions, connectionsSnapshot, extensionStateVersion, providerConnectedIds, userEnvKeys]);
   const builtInExtensionsDisabled = checkDesktopRestriction({ restriction: "allowBuiltInExtensions" });
   const builtInMarketplaceEntries = useMemo(
     () => connectionsStore.quickConnect.filter(isBuiltInOpenWorkExtension),
@@ -2185,6 +2196,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 configSlotForBuiltIn={extensionController.configSlotForEntry}
                 isBuiltInConnected={extensionController.isConnected}
                 extensionItems={extensionItems.items}
+                setBuiltInEnabled={setOpenWorkExtensionEnabled}
               />
             }
           />
@@ -2209,6 +2221,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             configSlotForBuiltIn={extensionController.configSlotForEntry}
             isBuiltInConnected={extensionController.isConnected}
             extensionItems={extensionItems.items}
+            setBuiltInEnabled={setOpenWorkExtensionEnabled}
           />
         );
       case "cloud-workers":

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 
-import { SUGGESTED_PLUGINS } from "../../app/constants";
+import { getMcpServerName, isBuiltInOpenWorkExtension, SUGGESTED_PLUGINS } from "../../app/constants";
 import type { EnablementContext } from "../../app/enablement";
 import { createClient } from "../../app/lib/opencode";
 import {
@@ -44,7 +44,7 @@ import "../domains/settings/computer-use-config";
 import "../domains/settings/browser-extension-config";
 import "../domains/settings/openwork-voice-config";
 import "../domains/settings/google-workspace-config";
-import { getExtensionConfigSlot, getExtensionConnected, type ExtensionConfigContext } from "../domains/settings/extension-registry";
+import { useSettingsExtensionController } from "../domains/settings/settings-extension-controller";
 import { isOpenWorkExtensionEnabled } from "../domains/settings/extension-state";
 import { PreferencesView } from "../domains/settings/pages/preferences-view";
 import { ShellCustomizationView } from "../domains/settings/pages/shell-view";
@@ -515,7 +515,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [localProviderBusy, setLocalProviderBusy] = useState(false);
   const [localProviderStatus, setLocalProviderStatus] = useState<string | null>(null);
   const [localProviderError, setLocalProviderError] = useState<string | null>(null);
-  const [imageExtensionInstalled, setImageExtensionInstalled] = useState(false);
   const [googleWorkspaceConnected, setGoogleWorkspaceConnected] = useState(false);
   const [imageExtensionBusy, setImageExtensionBusy] = useState(false);
   const [imageExtensionStatus, setImageExtensionStatus] = useState<string | null>(null);
@@ -901,15 +900,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   }, [opencodeClient]);
 
   useEffect(() => {
-    setImageExtensionInstalled(
-      userEnvKeys.includes("OPENAI_API_KEY") ||
-      userEnvKeys.includes("OPENWORK_OPENAI_IMAGE_API_KEY") ||
-      providers.some((provider) => provider.id === "openai" && provider.source === "env") ||
-      providerConnectedIds.includes("openai"),
-    );
-  }, [providerConnectedIds, providers, userEnvKeys]);
-
-  useEffect(() => {
     const client = selectedWorkspaceEndpoint?.client ?? openworkClient;
     if (!client) {
       setGoogleWorkspaceConnected(false);
@@ -959,7 +949,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     try {
       await openworkClient.upsertUserEnv([{ key: "OPENAI_API_KEY", value: resolvedApiKey }]);
       setUserEnvKeys((current) => Array.from(new Set([...current, "OPENAI_API_KEY"])));
-      setImageExtensionInstalled(true);
       setImageExtensionStatus("Saved OPENAI_API_KEY. Agents can use OpenWork extension actions for image generation.");
     } catch (error) {
       setImageExtensionError(describeRouteError(error));
@@ -993,7 +982,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       if (openworkClient) {
         await openworkClient.upsertUserEnv([{ key: "OPENAI_API_KEY", value: apiKey }]);
         setUserEnvKeys((current) => Array.from(new Set([...current, "OPENAI_API_KEY"])));
-        setImageExtensionInstalled(true);
       }
       const response = await client.callExtensionAction({
         extensionId: OPENAI_IMAGE_EXTENSION_ID,
@@ -1654,6 +1642,52 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       },
     };
   }, [connectionsSnapshot, providerConnectedIds, userEnvKeys]);
+  const builtInExtensionsDisabled = checkDesktopRestriction({ restriction: "allowBuiltInExtensions" });
+  const builtInMarketplaceEntries = useMemo(
+    () => connectionsStore.quickConnect.filter(isBuiltInOpenWorkExtension),
+    [connectionsStore.quickConnect],
+  );
+  const installedCatalogEntries = useMemo(
+    () => connectionsStore.quickConnect.filter((entry) => {
+      if (isBuiltInOpenWorkExtension(entry)) return false;
+      const serverName = getMcpServerName(entry);
+      return connectionsSnapshot.mcpServers.some((server) => server.name === serverName);
+    }),
+    [connectionsSnapshot.mcpServers, connectionsStore.quickConnect],
+  );
+  const extensionController = useSettingsExtensionController({
+    openworkServerClient: selectedWorkspaceEndpoint?.client ?? openworkClient,
+    enablementContext,
+    mcpServers: connectionsSnapshot.mcpServers,
+    mcpConnectingName: connectionsSnapshot.mcpConnectingName,
+    googleWorkspaceConnected,
+    setGoogleWorkspaceConnected,
+    connectMcp: (entry) => connectionsStore.connectMcp(entry),
+    refreshMcpServers: () => connectionsStore.refreshMcpServers(),
+    providers,
+    providerConnectedIds,
+    userEnvKeys,
+    imageExtension: {
+      busy: imageExtensionBusy || imageGenerationBusy,
+      status: imageExtensionStatus ?? imageGenerationStatus,
+      error: imageExtensionError ?? imageGenerationError,
+      onInstall: installOpenAiImageExtension,
+      onTestGenerate: generateOpenAiTestImage,
+    },
+    voiceExtension: {
+      busy: voiceBusy,
+      status: voiceStatus,
+      error: voiceError,
+      onSaveApiKey: saveVoiceApiKey,
+      onTestSession: testVoiceSession,
+    },
+    localProvider: {
+      busy: localProviderBusy,
+      status: localProviderStatus,
+      error: localProviderError,
+      onInstall: installLocalProvider,
+    },
+  });
   const routeOpenworkStatus = openworkClient ? "connected" : "disconnected";
   const notFoundRouteError = !loading && routeWorkspaceId && !selectedWorkspace
     ? "Workspace was not found. Select a new workspace from the sidebar."
@@ -2076,66 +2110,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 mcpConnectingName={connectionsSnapshot.mcpConnectingName}
                 selectedMcp={connectionsSnapshot.selectedMcp}
                 setSelectedMcp={(name) => connectionsStore.setSelectedMcp(name)}
-                quickConnect={connectionsStore.quickConnect}
+                quickConnect={installedCatalogEntries}
                 enablementContext={enablementContext}
-                builtInExtensionsDisabled={checkDesktopRestriction({ restriction: "allowBuiltInExtensions" })}
+                builtInExtensionsDisabled={builtInExtensionsDisabled}
                 connectMcp={(entry) => {
                   void connectionsStore.connectMcp(entry);
                 }}
-                configSlotForEntry={(entry) => getExtensionConfigSlot(entry, {
-                  openworkServerClient: selectedWorkspaceEndpoint?.client ?? openworkClient,
-                  extensionConnections: {
-                    "google-workspace": googleWorkspaceConnected,
-                  },
-                  onExtensionConnectionChange: (extensionId, connected) => {
-                    if (extensionId === "google-workspace") setGoogleWorkspaceConnected(connected);
-                  },
-                  computerUse: {
-                    connected: connectionsSnapshot.mcpServers.some((server) => server.name === "computer-use"),
-                    connecting: connectionsSnapshot.mcpConnectingName === entry.name,
-                    onConnect: () => connectionsStore.connectMcp(entry),
-                    onRefresh: () => connectionsStore.refreshMcpServers(),
-                  },
-                  imageExtension: {
-                    busy: imageExtensionBusy || imageGenerationBusy,
-                    status: imageExtensionStatus ?? imageGenerationStatus,
-                    error: imageExtensionError ?? imageGenerationError,
-                    envKeyDetected: providers.some((p) => p.id === "openai" && p.source === "env") || providerConnectedIds.includes("openai"),
-                    onInstall: installOpenAiImageExtension,
-                    onTestGenerate: generateOpenAiTestImage,
-                  },
-                  voiceExtension: {
-                    busy: voiceBusy,
-                    status: voiceStatus,
-                    error: voiceError,
-                    envKeyDetected:
-                      userEnvKeys.includes("OPENAI_REALTIME_API_KEY") ||
-                      userEnvKeys.includes("OPENAI_API_KEY") ||
-                      providers.some((p) => p.id === "openai" && p.source === "env") ||
-                      providerConnectedIds.includes("openai"),
-                    onSaveApiKey: saveVoiceApiKey,
-                    onTestSession: testVoiceSession,
-                  },
-                  localProvider: {
-                    busy: localProviderBusy,
-                    status: localProviderStatus,
-                    error: localProviderError,
-                    onInstall: installLocalProvider,
-                  },
-                })}
-                isExtensionConnected={(entry) => {
-                  const runtimeConnected = getExtensionConnected(entry, {
-                    openworkServerClient: selectedWorkspaceEndpoint?.client ?? openworkClient,
-                    extensionConnections: {
-                      "google-workspace": googleWorkspaceConnected,
-                    },
-                  });
-                  if (runtimeConnected !== null) return runtimeConnected;
-                  const id = entry.serverName ?? entry.name;
-                  if (id === "openai-image-gen") return imageExtensionInstalled;
-                  if (id === "ollama") return providerConnectedIds.includes("ollama");
-                  return false;
-                }}
+                configSlotForEntry={extensionController.configSlotForEntry}
+                isExtensionConnected={extensionController.isConnected}
                 authorizeMcp={(entry) => {
                   void connectionsStore.authorizeMcp(entry);
                 }}
@@ -2164,6 +2146,12 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 extensions={extensionsStore}
                 session={denSession}
                 onOpenAccount={openCloudAccountSettings}
+                builtInEntries={builtInMarketplaceEntries}
+                enablementContext={enablementContext}
+                builtInExtensionsDisabled={builtInExtensionsDisabled}
+                builtInConnectingName={connectionsSnapshot.mcpConnectingName}
+                configSlotForBuiltIn={extensionController.configSlotForEntry}
+                isBuiltInConnected={extensionController.isConnected}
               />
             }
           />
@@ -2181,6 +2169,12 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             extensions={extensionsStore}
             session={denSession}
             onOpenAccount={openCloudAccountSettings}
+            builtInEntries={builtInMarketplaceEntries}
+            enablementContext={enablementContext}
+            builtInExtensionsDisabled={builtInExtensionsDisabled}
+            builtInConnectingName={connectionsSnapshot.mcpConnectingName}
+            configSlotForBuiltIn={extensionController.configSlotForEntry}
+            isBuiltInConnected={extensionController.isConnected}
           />
         );
       case "cloud-workers":

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 
-import { getMcpServerName, isBuiltInOpenWorkExtension, SUGGESTED_PLUGINS } from "../../app/constants";
+import { isBuiltInOpenWorkExtension, SUGGESTED_PLUGINS } from "../../app/constants";
 import type { EnablementContext } from "../../app/enablement";
 import { createClient } from "../../app/lib/opencode";
 import {
@@ -45,6 +45,7 @@ import "../domains/settings/browser-extension-config";
 import "../domains/settings/openwork-voice-config";
 import "../domains/settings/google-workspace-config";
 import { useSettingsExtensionController } from "../domains/settings/settings-extension-controller";
+import { buildExtensionItems } from "../domains/settings/extension-items";
 import { isOpenWorkExtensionEnabled } from "../domains/settings/extension-state";
 import { PreferencesView } from "../domains/settings/pages/preferences-view";
 import { ShellCustomizationView } from "../domains/settings/pages/shell-view";
@@ -85,6 +86,7 @@ import {
   workspaceForget,
   workspaceSetRuntimeActive,
   workspaceSetSelected,
+  desktopBridge,
   type WorkspaceInfo,
   type WorkspaceList,
   revealDesktopItemInDir,
@@ -187,6 +189,14 @@ function describeWorkspaceCreateError(error: unknown) {
     return `${message}\n\nOpenWork could not read the workspace config before the filesystem timed out. This often happens when the folder is still syncing from iCloud Drive or another remote folder. Wait for the folder to finish downloading, move the workspace to a local folder, or try again.`;
   }
   return message;
+}
+
+function normalizeComputerUsePermissions(value: unknown) {
+  if (typeof value !== "object" || value === null) return null;
+  return {
+    accessibility: "accessibility" in value && value.accessibility === true,
+    screenRecording: "screenRecording" in value && value.screenRecording === true,
+  };
 }
 
 function mergeRouteWorkspaces(
@@ -899,6 +909,21 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   useEffect(() => {
     setActiveClient(opencodeClient);
   }, [opencodeClient]);
+
+  useEffect(() => {
+    if (!isDesktopRuntime() || !isMacPlatform()) return;
+    let cancelled = false;
+    void desktopBridge.checkComputerUsePermissions()
+      .then((result) => {
+        if (cancelled) return;
+        const permissions = normalizeComputerUsePermissions(result);
+        if (permissions) setComputerUsePermissions(permissions);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     const client = selectedWorkspaceEndpoint?.client ?? openworkClient;
@@ -1683,13 +1708,17 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       onInstall: installLocalProvider,
     },
   });
-  const installedCatalogEntries = useMemo(
-    () => connectionsStore.quickConnect.filter((entry) => {
-      if (isBuiltInOpenWorkExtension(entry)) return extensionController.isConnected(entry);
-      const serverName = getMcpServerName(entry);
-      return connectionsSnapshot.mcpServers.some((server) => server.name === serverName);
+  const extensionItems = useMemo(
+    () => buildExtensionItems({
+      quickConnect: connectionsStore.quickConnect,
+      mcpServers: connectionsSnapshot.mcpServers,
+      installedSkills: extensionsStore.skills(),
+      importedCloudPlugins: extensionsStore.importedCloudPlugins(),
+      cloudMarketplaces: extensionsStore.cloudOrgMarketplaces(),
+      enablementContext,
+      isBuiltInConnected: extensionController.isConnected,
     }),
-    [connectionsSnapshot.mcpServers, connectionsStore.quickConnect, extensionController],
+    [connectionsSnapshot.mcpServers, connectionsStore.quickConnect, enablementContext, extensionController, extensionsStore],
   );
   const routeOpenworkStatus = openworkClient ? "connected" : "disconnected";
   const notFoundRouteError = !loading && routeWorkspaceId && !selectedWorkspace
@@ -2113,7 +2142,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 mcpConnectingName={connectionsSnapshot.mcpConnectingName}
                 selectedMcp={connectionsSnapshot.selectedMcp}
                 setSelectedMcp={(name) => connectionsStore.setSelectedMcp(name)}
-                quickConnect={installedCatalogEntries}
+                quickConnect={extensionItems.installedMcpEntries}
                 enablementContext={enablementContext}
                 builtInExtensionsDisabled={builtInExtensionsDisabled}
                 connectMcp={(entry) => {
@@ -2134,8 +2163,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                     : undefined
                 }
                 readConfigFile={(scope) => connectionsStore.readMcpConfigFile(scope)}
-                installedSkills={extensionsStore.skills()}
-                installedPlugins={Object.values(extensionsStore.importedCloudPlugins())}
+                installedSkills={extensionItems.installedSkills}
+                installedPlugins={extensionItems.installedCloudPlugins}
                 uninstallSkill={(name) => { void extensionsStore.uninstallSkill(name); }}
                 removeCloudPlugin={(pluginId) => { void extensionsStore.removeCloudOrgPlugin(pluginId); }}
                 readSkill={(name) => extensionsStore.readSkill(name)}
@@ -2155,6 +2184,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 builtInConnectingName={connectionsSnapshot.mcpConnectingName}
                 configSlotForBuiltIn={extensionController.configSlotForEntry}
                 isBuiltInConnected={extensionController.isConnected}
+                extensionItems={extensionItems.items}
               />
             }
           />
@@ -2178,6 +2208,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             builtInConnectingName={connectionsSnapshot.mcpConnectingName}
             configSlotForBuiltIn={extensionController.configSlotForEntry}
             isBuiltInConnected={extensionController.isConnected}
+            extensionItems={extensionItems.items}
           />
         );
       case "cloud-workers":

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -519,6 +519,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [imageExtensionBusy, setImageExtensionBusy] = useState(false);
   const [imageExtensionStatus, setImageExtensionStatus] = useState<string | null>(null);
   const [imageExtensionError, setImageExtensionError] = useState<string | null>(null);
+  const [computerUsePermissions, setComputerUsePermissions] = useState<{ accessibility: boolean; screenRecording: boolean } | null>(null);
   const [imageGenerationBusy, setImageGenerationBusy] = useState(false);
   const [imageGenerationStatus, setImageGenerationStatus] = useState<string | null>(null);
   const [imageGenerationError, setImageGenerationError] = useState<string | null>(null);
@@ -1634,6 +1635,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       loadedPlugins,
       connectedProviders,
       configuredEnvKeys,
+      permissions: computerUsePermissions ?? undefined,
       // Toggle state reader for extensions with defaultEnabled / explicit toggle.
       isToggleEnabled: (ref: string) => {
         const catalog = connectionsStore.quickConnect;
@@ -1641,25 +1643,18 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         return match ? isOpenWorkExtensionEnabled(match) : false;
       },
     };
-  }, [connectionsSnapshot, providerConnectedIds, userEnvKeys]);
+  }, [computerUsePermissions, connectionsSnapshot, providerConnectedIds, userEnvKeys]);
   const builtInExtensionsDisabled = checkDesktopRestriction({ restriction: "allowBuiltInExtensions" });
   const builtInMarketplaceEntries = useMemo(
     () => connectionsStore.quickConnect.filter(isBuiltInOpenWorkExtension),
     [connectionsStore.quickConnect],
-  );
-  const installedCatalogEntries = useMemo(
-    () => connectionsStore.quickConnect.filter((entry) => {
-      if (isBuiltInOpenWorkExtension(entry)) return false;
-      const serverName = getMcpServerName(entry);
-      return connectionsSnapshot.mcpServers.some((server) => server.name === serverName);
-    }),
-    [connectionsSnapshot.mcpServers, connectionsStore.quickConnect],
   );
   const extensionController = useSettingsExtensionController({
     openworkServerClient: selectedWorkspaceEndpoint?.client ?? openworkClient,
     enablementContext,
     mcpServers: connectionsSnapshot.mcpServers,
     mcpConnectingName: connectionsSnapshot.mcpConnectingName,
+    onComputerUsePermissionsChange: setComputerUsePermissions,
     googleWorkspaceConnected,
     setGoogleWorkspaceConnected,
     connectMcp: (entry) => connectionsStore.connectMcp(entry),
@@ -1688,6 +1683,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       onInstall: installLocalProvider,
     },
   });
+  const installedCatalogEntries = useMemo(
+    () => connectionsStore.quickConnect.filter((entry) => {
+      if (isBuiltInOpenWorkExtension(entry)) return extensionController.isConnected(entry);
+      const serverName = getMcpServerName(entry);
+      return connectionsSnapshot.mcpServers.some((server) => server.name === serverName);
+    }),
+    [connectionsSnapshot.mcpServers, connectionsStore.quickConnect, extensionController],
+  );
   const routeOpenworkStatus = openworkClient ? "connected" : "disconnected";
   const notFoundRouteError = !loading && routeWorkspaceId && !selectedWorkspace
     ? "Workspace was not found. Select a new workspace from the sidebar."


### PR DESCRIPTION
## Summary
- merge OpenWork built-in extensions into the existing Extension Marketplace grid/filter flow
- add a settings extension controller so route code no longer branches on specific built-in IDs for config/connected state
- keep installed MCP catalog entries out of Marketplace while passing built-ins into both Extensions and standalone marketplace routes

## Tests
- pnpm --filter @openwork/app typecheck

## E2E Evidence
- Not captured in this session; verified with TypeScript typecheck only.