### PR TITLE
chore(dx): prevent typecheck from purging node_modules on stale lockfile

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -12,7 +12,6 @@
     "prebuild:web": "pnpm --dir ../../packages/ui build",
     "build:web": "vite build",
     "preview": "vite preview",
-    "pretypecheck": "pnpm --dir ../../packages/ui build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test:health": "node scripts/health.mjs",
     "test:mention-send": "node scripts/mention-send.mjs",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,13 @@ minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - "@opencode-ai/sdk"
 
+# Do not auto-verify node_modules against the lockfile before running scripts.
+# A stale/out-of-date lockfile (e.g. an in-progress, uncommitted workspace
+# package not yet reflected in pnpm-lock.yaml) must NEVER cause a read-only
+# command like `pnpm run typecheck` to trigger an implicit `pnpm install`,
+# which can destructively purge the root node_modules directory.
+verifyDepsBeforeRun: false
+
 packages:
   - "apps/*"
   - "packages/*"


### PR DESCRIPTION
## Problem

Running a read-only check like `pnpm --filter @openwork/app typecheck` could **destructively purge the entire root `node_modules` directory**.

Observed errors:
```
[ERR_PNPM_OUTDATED_LOCKFILE] ... lockfile is not up to date with .../packages/homepod-runtime/package.json
[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
```

A typecheck should never be able to wipe `node_modules`.

## Root cause

1. `pnpm-workspace.yaml` globs include `packages/*`, which picks up **in-progress/uncommitted** workspace package dirs (e.g. an untracked `packages/homepod-runtime/` that is not reflected in the committed `pnpm-lock.yaml`).
2. With pnpm 11.4.0, `pnpm run <script>` performs a **deps-status check** before running. When it finds the lockfile stale, it kicks off an implicit `pnpm install`.
3. That implicit install attempts to reconcile and (in non-TTY/CI contexts) tries to **remove the modules directory** — turning a harmless `typecheck` into a destructive operation.

Additionally, the app's `pretypecheck` script ran a full `tsup` build of `@openwork/ui` before every typecheck. That build is unnecessary for `tsc --noEmit`: `@openwork/ui` `exports` map `types`/`default` directly to `./src/react/index.ts` (source), so TypeScript resolves types from source, not `dist`.

## Fix

Smallest, safest defensive change:

- **`pnpm-workspace.yaml`**: add `verifyDepsBeforeRun: false`. This is the supported pnpm 11.4.0 setting (the rc/runtime key `verifyDepsBeforeRun`, accepting `false | warn | error | prompt | install`). With `false`, pnpm skips the deps-status check before `pnpm run`, so a read-only command can **never** trigger an implicit install/purge.
  - Note: this setting is read by pnpm 11.4.0 from `pnpm-workspace.yaml` (via `getOptionsFromPnpmSettings`) / the `pnpm_config_verify_deps_before_run` env var. A root `.npmrc` entry was tested and **not** honored for this key in 11.4.0, so the fix lives in `pnpm-workspace.yaml`.
- **`apps/app/package.json`**: remove the `pretypecheck` step (`pnpm --dir ../../packages/ui build`). Typecheck no longer builds `@openwork/ui` because its types resolve from source.

This does not silence anything destructive: it disables an auto-install that should never run for read-only scripts. `pnpm install` still verifies and updates the lockfile when run explicitly.

### Follow-up (out of scope here)

The trigger in our environment was an **uncommitted** `packages/homepod-runtime/` WIP package (untracked; not in the committed lockfile) being matched by the `packages/*` glob. The correct long-term fix is to either commit `homepod-runtime` with an updated `pnpm-lock.yaml`, or keep WIP package dirs out of the install graph until committed. That belongs to the owning task and is intentionally **not** touched here. The `verifyDepsBeforeRun: false` change is the defensive guard so a stale lockfile can never silently wipe `node_modules` during a non-install command.

## Verification

All commands run inside a dedicated worktree (`chore/dx-typecheck-no-purge` off `dev`) after one `pnpm install`.

To reproduce the original footgun, a temporary stale workspace package (`packages/_dx_stale_probe` with a dep not in the lockfile) was added so the lockfile was guaranteed stale — mirroring the `homepod-runtime` situation.

**Before the fix** (with stale lockfile): `pnpm run typecheck` triggered the deps check and tried to install:
```
$ CI=true pnpm --filter @openwork/app run typecheck
Scope: all 20 workspace projects
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with .../packages/_dx_stale_probe/package.json
...
    at runDepsStatusCheck (.../pnpm.mjs:213652:7)
```

**After the fix** (with the same stale lockfile still present), run twice — stable, non-destructive, no `ERR_PNPM_OUTDATED_LOCKFILE`:
```
=== RUN 1 ===
$ tsc -p tsconfig.json --noEmit
NODE_MODULES UNCHANGED (inode 415819702)

=== RUN 2 ===
$ tsc -p tsconfig.json --noEmit
EXIT CODE: 0
NODE_MODULES UNCHANGED (inode 415819702)
no ERR_PNPM_OUTDATED_LOCKFILE above = success
```

**Final clean run** (temporary probe removed, lockfile matches committed state):
```
$ CI=true pnpm --filter @openwork/app run typecheck
$ tsc -p tsconfig.json --noEmit
EXIT: 0
```

Exact verification commands:
```bash
# one-time, expected in a fresh worktree
pnpm install

# the real test (run twice; stable + non-destructive)
CI=true pnpm --filter @openwork/app run typecheck
CI=true pnpm --filter @openwork/app run typecheck
```

## Constraints honored
- pnpm only; no npm/yarn.
- No `any`/casts; no unrelated code changed.
- Minimal diff (2 files, +7/-1).
- Did not touch the main checkout's working tree or any running dev instance.
