### PR TITLE
fix(browser): open new tabs on Google, auto-open pane, fix view centering

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -367,8 +367,18 @@ export function SessionPage(props: SessionPageProps) {
     setCurrentSidePanel(null);
   }, [setCurrentSidePanel]);
   const openBrowserRailPane = useCallback(() => {
+    // Opening the browser pane should land on a usable page, not an empty
+    // panel that forces the user to click "+". If no browser tab exists yet,
+    // create one (defaults to the new-tab URL in the main process).
+    const opening = !panelRailActive;
+    if (opening && isElectronRuntime()) {
+      const hasBrowserTab = sessionPanelState.tabs.some((tab) => tab.type === "browser");
+      if (!hasBrowserTab) {
+        void window.__OPENWORK_ELECTRON__?.browser?.createTab?.();
+      }
+    }
     toggleCurrentSidePanel("panel");
-  }, [toggleCurrentSidePanel]);
+  }, [panelRailActive, sessionPanelState.tabs, toggleCurrentSidePanel]);
   const openArtifactRailPane = useCallback(() => {
     if (!hasArtifactTargets || !props.selectedSessionId) return;
     const activeTab = sessionPanelState.tabs.find((tab) => tab.id === sessionPanelState.activeTabId);

--- a/apps/app/src/react-app/domains/session/panel/utils.ts
+++ b/apps/app/src/react-app/domains/session/panel/utils.ts
@@ -12,12 +12,12 @@ export function getNativeMenuPoint(
   el: HTMLElement | null,
   point?: { clientX: number; clientY: number },
 ) {
-  const zoom = window.__OPENWORK_ZOOM_FACTOR__ ?? 1;
-
+  // Same coordinate space as computeBounds: viewport CSS px already match the
+  // content-area DIP the native overlay uses, so no zoom multiplication.
   if (point) {
     return {
-      x: Math.round(point.clientX * zoom),
-      y: Math.round(point.clientY * zoom),
+      x: Math.round(point.clientX),
+      y: Math.round(point.clientY),
     };
   }
 
@@ -28,20 +28,26 @@ export function getNativeMenuPoint(
   const rect = el.getBoundingClientRect();
 
   return {
-    x: Math.round((rect.left + 8) * zoom),
-    y: Math.round((rect.bottom + 4) * zoom),
+    x: Math.round(rect.left + 8),
+    y: Math.round(rect.bottom + 4),
   };
 }
 
 export function computeBounds(el: HTMLElement) {
+  // WebContentsView.setBounds expects device-independent pixels relative to the
+  // window content area — the same space getBoundingClientRect() reports. The
+  // renderer's zoom is already baked into the measured rect, so it must NOT be
+  // multiplied in again (doing so pushed the native view off-panel at zoom != 1).
+  // Derive width/height from rounded edges to avoid a 1px seam on the far edge.
   const rect = el.getBoundingClientRect();
-  const zoom = window.__OPENWORK_ZOOM_FACTOR__ ?? 1;
+  const x = Math.round(rect.x);
+  const y = Math.round(rect.y);
 
   return {
-    x: Math.round(rect.x * zoom),
-    y: Math.round(rect.y * zoom),
-    width: Math.round(rect.width * zoom),
-    height: Math.round(rect.height * zoom),
+    x,
+    y,
+    width: Math.round(rect.right) - x,
+    height: Math.round(rect.bottom) - y,
   };
 }
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -477,6 +477,9 @@ let browserViewVisible = false;
 let lastBrowserBounds = null;
 let browserTabCounter = 0;
 const BROWSER_DEFAULT_URL = "about:blank";
+// URL a user-initiated new tab (the "+" button / opening the browser panel)
+// lands on. The agent's programmatic path keeps BROWSER_DEFAULT_URL.
+const BROWSER_NEW_TAB_URL = "https://www.google.com";
 const MENU_OVERLAY_HTML = "overlay.html";
 const MENU_OVERLAY_WIDTH = 196;
 const MENU_OVERLAY_HEIGHT = 176;
@@ -2978,7 +2981,8 @@ ipcMain.handle("openwork:browser:bounds", (_event, bounds) => {
 });
 ipcMain.handle("openwork:browser:state", () => browserStatePayload());
 ipcMain.handle("openwork:browser:createTab", (_event, url) => {
-  const tab = createBrowserTab(url ?? "about:blank", { select: true });
+  const target = typeof url === "string" && url.trim() ? url : BROWSER_NEW_TAB_URL;
+  const tab = createBrowserTab(target, { select: true });
   return { tabId: tab.tabId };
 });
 ipcMain.handle("openwork:browser:closeTab", (_event, tabId) => closeBrowserTab(tabId == null ? undefined : String(tabId)));


### PR DESCRIPTION
## Problem

Three issues reported with the embedded browser/artifact panel:

1. **New browser pages opened blank.** A new tab loaded `about:blank` — the user wanted a real site (Google).
2. **Forced to click `+`.** Opening the browser pane (Globe rail button) showed an empty panel; you had to manually click `+` to get a tab.
3. **Browser view not well centered.** The native `WebContentsView` was mis-positioned within its panel.

## Root cause

1/2. New-tab default was hardcoded to `about:blank`, and `openBrowserRailPane` only toggled the panel open without ever creating a tab.

3. `computeBounds` multiplied the measured rect by `window.__OPENWORK_ZOOM_FACTOR__`. But `WebContentsView.setBounds` expects device-independent pixels relative to the window content area — exactly the space `getBoundingClientRect()` already reports (renderer zoom is already baked into the layout it measures). The extra multiply applied zoom twice, pushing the native view down-and-right and oversizing it (a no-op at the default zoom of 1, but broken for font-zoom users). Independent rounding of x/width also left a possible 1px seam.

## Fix

- `apps/desktop/electron/main.mjs`: add `BROWSER_NEW_TAB_URL = "https://www.google.com"` and use it for user-initiated `createTab` (the `+` button / opening the pane). The agent's programmatic path still uses `about:blank` via `BROWSER_DEFAULT_URL`.
- `apps/app/.../chat/session-page.tsx`: `openBrowserRailPane` auto-creates a browser tab when opening the pane and none exists, so the Globe button lands you on Google instead of an empty panel.
- `apps/app/.../panel/utils.ts`: drop the spurious `* zoom` in `computeBounds` (and `getNativeMenuPoint`); derive width/height from rounded edges to avoid a 1px seam. Correct at zoom=1 (identical numbers) and fixed for zoom≠1.

## Testing

`pnpm --filter @openwork/app typecheck` → exit 0.

Verified live in the running Electron app via CDP (after restarting the desktop dev process so the `main.mjs` change took effect):

- Clicked the Globe rail button with no existing tab → browser state became `tabs: [{ url: "https://www.google.com/" }]` with **one** auto-created tab. (Confirms #1 + #2.)
- `computeBounds` returned `{x:656, y:81, width:480, height:739}` — clean integers; the native view sits flush against the panel divider on the left and leaves exactly the 44px (`w-11`) rail gap on the right. (Confirms #3.)

Screenshot of the working panel (tab "Google", URL bar `https://www.google.com/`, nav chrome, content region aligned to the panel):

> Screenshot captured locally during verification at `/tmp/browser-screenshot-1780340865758.png` — reviewer can reproduce by launching the dev app and clicking the Globe rail button.

### Reproduce
1. `pnpm dev`
2. Open a session, click the Globe icon in the right rail.
3. Observe: a tab opens automatically on `https://www.google.com`, and the browser view fills the panel cleanly (no offset).

## Notes
- The `__OPENWORK_ZOOM_FACTOR__` global is still set by `font-zoom.ts` and kept in the type decl; left untouched to keep the diff minimal.