### PR TITLE
fix(browser): restore zoom scaling for native view bounds

### DIFF
--- a/apps/app/src/react-app/domains/session/panel/utils.ts
+++ b/apps/app/src/react-app/domains/session/panel/utils.ts
@@ -8,16 +8,27 @@ export function getElectronBrowser() {
   return window.__OPENWORK_ELECTRON__?.browser ?? null;
 }
 
+// The renderer uses Electron's webContents.setZoomFactor, which scales the page
+// so getBoundingClientRect() / innerWidth report CSS pixels DIVIDED by the zoom
+// factor (e.g. at zoom 1.5 a 1180 DIP window measures ~786). WebContentsView
+// bounds, however, are in window device-independent pixels. So renderer rects
+// must be multiplied back by the zoom factor to land in the native coordinate
+// space. At zoom = 1 this is the identity.
+function getZoomFactor() {
+  const zoom = window.__OPENWORK_ZOOM_FACTOR__;
+  return typeof zoom === "number" && zoom > 0 ? zoom : 1;
+}
+
 export function getNativeMenuPoint(
   el: HTMLElement | null,
   point?: { clientX: number; clientY: number },
 ) {
-  // Same coordinate space as computeBounds: viewport CSS px already match the
-  // content-area DIP the native overlay uses, so no zoom multiplication.
+  const zoom = getZoomFactor();
+
   if (point) {
     return {
-      x: Math.round(point.clientX),
-      y: Math.round(point.clientY),
+      x: Math.round(point.clientX * zoom),
+      y: Math.round(point.clientY * zoom),
     };
   }
 
@@ -28,26 +39,24 @@ export function getNativeMenuPoint(
   const rect = el.getBoundingClientRect();
 
   return {
-    x: Math.round(rect.left + 8),
-    y: Math.round(rect.bottom + 4),
+    x: Math.round((rect.left + 8) * zoom),
+    y: Math.round((rect.bottom + 4) * zoom),
   };
 }
 
 export function computeBounds(el: HTMLElement) {
-  // WebContentsView.setBounds expects device-independent pixels relative to the
-  // window content area — the same space getBoundingClientRect() reports. The
-  // renderer's zoom is already baked into the measured rect, so it must NOT be
-  // multiplied in again (doing so pushed the native view off-panel at zoom != 1).
-  // Derive width/height from rounded edges to avoid a 1px seam on the far edge.
+  // Scale each edge to native DIP, then derive width/height from the rounded
+  // edges so the far edge has no sub-pixel seam at any zoom level.
   const rect = el.getBoundingClientRect();
-  const x = Math.round(rect.x);
-  const y = Math.round(rect.y);
+  const zoom = getZoomFactor();
+  const x = Math.round(rect.x * zoom);
+  const y = Math.round(rect.y * zoom);
 
   return {
     x,
     y,
-    width: Math.round(rect.right) - x,
-    height: Math.round(rect.bottom) - y,
+    width: Math.round(rect.right * zoom) - x,
+    height: Math.round(rect.bottom * zoom) - y,
   };
 }
 


### PR DESCRIPTION
## Problem

After #2020, the embedded browser view is misaligned within its panel **whenever the app zoom is not 100%**. At zoom 1.0 it's pixel-perfect; at any other zoom the native view no longer lines up with the panel chrome.

## Root cause

#2020 removed the `* zoom` multiply from `computeBounds`, on the assumption that `getBoundingClientRect()` already reports coordinates in the native view's coordinate space. **That assumption is wrong.**

Zoom is applied via Electron's `webContents.setZoomFactor` (see `__setZoomFactor` in `main.mjs`). Under `setZoomFactor(f)`, the page is scaled so `getBoundingClientRect()` / `innerWidth` report **CSS pixels divided by the zoom factor**. `WebContentsView.setBounds`, however, takes **window device-independent pixels** — a content area whose size does **not** change with page zoom.

Verified live via a temporary debug IPC (`getContentBounds` / view `getBounds`):

| | zoom 1.0 | zoom 1.5 |
|---|---|---|
| `innerWidth` | 1180 | 786 (= 1180 / 1.5) |
| window `contentBounds.width` | 1180 | 1180 (unchanged) |

So renderer rects must be multiplied **back** by the zoom factor (786 × 1.5 = 1180) to map into native DIP. Removing the multiply under-scaled the view at zoom ≠ 1.

## Fix

Restore the zoom multiplication in `computeBounds` and `getNativeMenuPoint` (extracted into a small `getZoomFactor()` helper), while keeping the rounded-edge `width`/`height` derivation from #2020 that avoids a 1px seam. At zoom = 1 the output is identical to current `dev`.

## Testing

`pnpm --filter @openwork/app typecheck` → exit 0.

Verified live via CDP at **zoom 1.0 and 1.5** by comparing the panel chrome rect (×zoom) to the actual native `WebContentsView` bounds:

- **zoom 1.0:** view `{x:705, y:81, w:431, h:739}` — matches placeholder exactly.
- **zoom 1.5:** view `{x:745, y:122, w:369, h:698}` — `leftAligned: true`, `rightAligned: true`, chrome-bottom→view-top `gap: 0`. Right edge (1114) leaves exactly the 66 DIP (44 CSS × 1.5) rail.
- Bounds **auto-resync** on a live zoom change (ResizeObserver fires, no manual nudge needed): `autoSynced: true`.

### Reproduce
1. `pnpm dev`, open a session.
2. Zoom the app (Cmd +) to e.g. 150%.
3. Click the Globe rail button → browser opens on Google and the web view fills the panel flush with the chrome (no offset/gap).

## Notes
- Follow-up to #2020 (which fixed the default URL + auto-open but regressed the zoom math).