### PR TITLE
fix(den-api): close internal MCP principal impersonation trust boundary

### DIFF
--- a/ee/apps/den-api/src/session.ts
+++ b/ee/apps/den-api/src/session.ts
@@ -1,12 +1,11 @@
 import { and, eq, gt } from "@openwork-ee/den-db/drizzle"
 import { AuthSessionTable, AuthUserTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
-import { createHmac, timingSafeEqual } from "node:crypto"
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto"
 import type { MiddlewareHandler } from "hono"
 import { DEN_API_KEY_HEADER, getApiKeySessionById, type DenApiKeySession } from "./api-keys.js"
 import { auth } from "./auth.js"
 import { db } from "./db.js"
-import { env } from "./env.js"
 
 type AuthSessionLike = Awaited<ReturnType<typeof auth.api.getSession>>
 type AuthSessionValue = NonNullable<AuthSessionLike>
@@ -20,6 +19,13 @@ export type AuthContextVariables = {
 const INTERNAL_MCP_PRINCIPAL_HEADER = "x-den-internal-mcp-principal"
 const INTERNAL_MCP_PRINCIPAL_TTL_MS = 60_000
 
+// Per-process secret used exclusively to sign the internal MCP principal header.
+// It is generated fresh at startup, lives only in memory, and is never derived
+// from betterAuthSecret. This binds the header to in-process callers: even an
+// attacker who learns betterAuthSecret cannot forge a valid principal from an
+// external request, closing the impersonation trust boundary.
+const INTERNAL_MCP_PRINCIPAL_SECRET = new Uint8Array(randomBytes(32))
+
 type InternalMcpPrincipal = {
   userId: string
   organizationId: string
@@ -27,7 +33,7 @@ type InternalMcpPrincipal = {
 }
 
 function signPrincipalPayload(payload: string) {
-  return createHmac("sha256", env.betterAuthSecret).update(payload).digest("base64url")
+  return createHmac("sha256", INTERNAL_MCP_PRINCIPAL_SECRET).update(payload).digest("base64url")
 }
 
 function verifySignature(payload: string, signature: string) {
@@ -47,8 +53,11 @@ export function createInternalMcpPrincipalHeader(input: { userId: string; organi
   return `${payload}.${signPrincipalPayload(payload)}`
 }
 
-async function getSessionFromInternalMcpPrincipal(headers: Headers): Promise<(AuthSessionValue & { activeOrganizationId: string }) | null> {
-  const header = headers.get(INTERNAL_MCP_PRINCIPAL_HEADER)
+// Verifies and parses the internal MCP principal header WITHOUT any DB access.
+// Returns the principal only when the signature (per-process secret) and TTL are
+// valid. Exported for unit testing of the trust boundary. Returns null for any
+// missing, malformed, forged, or expired header.
+export function verifyInternalMcpPrincipalHeader(header: string | null): InternalMcpPrincipal | null {
   if (!header) {
     return null
   }
@@ -66,6 +75,15 @@ async function getSessionFromInternalMcpPrincipal(headers: Headers): Promise<(Au
   }
 
   if (typeof parsed.userId !== "string" || typeof parsed.organizationId !== "string" || typeof parsed.expiresAt !== "number" || parsed.expiresAt < Date.now()) {
+    return null
+  }
+
+  return parsed
+}
+
+async function getSessionFromInternalMcpPrincipal(headers: Headers): Promise<(AuthSessionValue & { activeOrganizationId: string }) | null> {
+  const parsed = verifyInternalMcpPrincipalHeader(headers.get(INTERNAL_MCP_PRINCIPAL_HEADER))
+  if (!parsed) {
     return null
   }
 

--- a/ee/apps/den-api/test/internal-mcp-principal.test.ts
+++ b/ee/apps/den-api/test/internal-mcp-principal.test.ts
@@ -1,0 +1,81 @@
+import { createHmac } from "node:crypto"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let sessionModule: typeof import("../src/session.js")
+const userId = createDenTypeId("user")
+const organizationId = createDenTypeId("organization")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  sessionModule = await import("../src/session.js")
+})
+
+function forgeHeaderWithSecret(secret: string, principal: { userId: string; organizationId: string; expiresAt: number }) {
+  const payload = Buffer.from(JSON.stringify(principal), "utf8").toString("base64url")
+  const signature = createHmac("sha256", secret).update(payload).digest("base64url")
+  return `${payload}.${signature}`
+}
+
+test("legitimately created header round-trips and verifies", () => {
+  const header = sessionModule.createInternalMcpPrincipalHeader({
+    userId,
+    organizationId,
+  })
+
+  const parsed = sessionModule.verifyInternalMcpPrincipalHeader(header)
+  expect(parsed).not.toBeNull()
+  expect(parsed?.userId).toBe(userId)
+  expect(parsed?.organizationId).toBe(organizationId)
+})
+
+test("header forged with BETTER_AUTH_SECRET is REJECTED (trust boundary closed)", () => {
+  // This is the exact pre-fix forgery: signing the principal with betterAuthSecret.
+  // After the fix the internal header is signed with a per-process secret, so an
+  // attacker who knows BETTER_AUTH_SECRET can no longer impersonate anyone.
+  const forged = forgeHeaderWithSecret(process.env.BETTER_AUTH_SECRET as string, {
+    userId,
+    organizationId,
+    expiresAt: Date.now() + 60_000,
+  })
+
+  expect(sessionModule.verifyInternalMcpPrincipalHeader(forged)).toBeNull()
+})
+
+test("header signed with an arbitrary attacker secret is REJECTED", () => {
+  const forged = forgeHeaderWithSecret("attacker-knows-this-not-the-server-secret", {
+    userId,
+    organizationId,
+    expiresAt: Date.now() + 60_000,
+  })
+
+  expect(sessionModule.verifyInternalMcpPrincipalHeader(forged)).toBeNull()
+})
+
+test("expired header is REJECTED even if signature is valid", () => {
+  // Create a legitimately-signed header (correct per-process secret) but at a
+  // moment far enough in the past that its expiresAt has already elapsed. This
+  // isolates the expiry check: the signature passes, only the TTL rejects it.
+  const realNow = Date.now
+  Date.now = () => realNow() - 120_000 // pretend it's 2 minutes ago
+  const header = sessionModule.createInternalMcpPrincipalHeader({ userId, organizationId })
+  Date.now = realNow // restore real time — the header is now expired
+
+  // Confirm signature alone would be valid (header was created by the real signer)
+  // but the function rejects it because expiresAt is in the past.
+  expect(sessionModule.verifyInternalMcpPrincipalHeader(header)).toBeNull()
+})
+
+test("malformed / empty headers are REJECTED", () => {
+  expect(sessionModule.verifyInternalMcpPrincipalHeader(null)).toBeNull()
+  expect(sessionModule.verifyInternalMcpPrincipalHeader("")).toBeNull()
+  expect(sessionModule.verifyInternalMcpPrincipalHeader("garbage")).toBeNull()
+  expect(sessionModule.verifyInternalMcpPrincipalHeader("a.b.c")).toBeNull()
+})


### PR DESCRIPTION
## Summary

Closes a **high-severity cross-tenant impersonation** trust boundary found during a security review of the enterprise API (\`den-api\`).

The internal MCP principal header (\`x-den-internal-mcp-principal\`) was signed with \`betterAuthSecret\` — the same secret that signs session cookies and JWTs. Because \`sessionMiddleware\` checks this header **first** on every request (\`session.ts\`, mounted \`app.use("*", ...)\`) and nothing strips an externally-supplied copy, anyone who learned \`betterAuthSecret\` could forge a principal and **impersonate any user in any organization** — bypassing login, MFA, org membership, and OAuth.

## Fix

Sign the internal principal with a **per-process random secret** (\`randomBytes(32)\`) generated at startup, held only in memory, and independent of \`betterAuthSecret\`. The internal \`app.fetch\` dispatch (\`mcp/invoke.ts\`) signs and verifies in the same process, so legitimate internal calls are unaffected; external forgery is impossible even if \`betterAuthSecret\` leaks.

Also extracted \`verifyInternalMcpPrincipalHeader\` (no DB access) to make the trust boundary unit-testable.

## Tests run

**Local** (\`bun test\`, den-api): \`29 pass / 0 fail\`

**On Daytona** (Den server sandbox \`openwork-sec-pr1\`, real MySQL, branch deployed):
- den-api suite inside sandbox: \`29 pass / 0 fail\` (includes 5 new trust-boundary tests)
- Live API end-to-end against \`https://8788-...daytonaproxy01.net\`:
  - \`GET /health\` → **200**
  - \`GET /v1/me\` no auth → **401**
  - \`GET /v1/me\` with a header **forged using betterAuthSecret** (the exact pre-fix attack) → **401 (rejected)**

Before this fix the forged header returned 200 with full impersonation; it is now rejected end-to-end.

New tests prove forged (betterAuthSecret or arbitrary secret), expired, and malformed headers are all rejected while legitimate headers round-trip.