### PR TITLE
Improve Google Workspace setup and multi-account support

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -297,10 +297,13 @@ export type OpenworkArtifactList = {
 };
 
 export type GoogleWorkspaceAccount = {
+  accountId: string | null;
   email: string | null;
   name: string | null;
   picture: string | null;
   sub: string | null;
+  scopes?: string[];
+  connectedAt?: string | null;
 };
 
 export type GoogleWorkspaceAuthStatus = {
@@ -309,6 +312,8 @@ export type GoogleWorkspaceAuthStatus = {
   vault: "encrypted" | "plaintext-dev" | "unavailable";
   connected: boolean;
   account: GoogleWorkspaceAccount | null;
+  accounts: GoogleWorkspaceAccount[];
+  activeAccountId: string | null;
   scopes: string[];
   connectedAt: string | null;
   error: string | null;
@@ -961,7 +966,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     googleWorkspaceStatus: () => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/status", { token, hostToken, timeoutMs: timeouts.status }),
     googleWorkspaceConnectStart: () => requestJson<GoogleWorkspaceConnectStart>(baseUrl, "/experimental/google-workspace/connect/start", { token, hostToken, method: "POST", timeoutMs: timeouts.status }),
     googleWorkspaceConnectStatus: (flowId: string) => requestJson<GoogleWorkspaceConnectStatus>(baseUrl, `/experimental/google-workspace/connect/status/${encodeURIComponent(flowId)}`, { token, hostToken, timeoutMs: timeouts.status }),
-    googleWorkspaceDisconnect: () => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/disconnect", { token, hostToken, method: "POST", timeoutMs: timeouts.status }),
+    googleWorkspaceDisconnect: (accountId?: string | null) => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/disconnect", { token, hostToken, method: "POST", body: accountId ? { accountId } : {}, timeoutMs: timeouts.status }),
     googleWorkspaceTestConnection: () => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/test", { token, hostToken, method: "POST", timeoutMs: 60_000 }),
     googleWorkspaceRunScopeSmokeTest: () => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/smoke-test", { token, hostToken, method: "POST", timeoutMs: 120_000 }),
     callExtensionAction: (payload: OpenworkExtensionActionCall) =>

--- a/apps/app/src/react-app/domains/settings/extension-registry.tsx
+++ b/apps/app/src/react-app/domains/settings/extension-registry.tsx
@@ -12,6 +12,7 @@ export type ExtensionConfigContext = {
   openworkServerClient?: OpenworkServerClient | null;
   extensionConnections?: Record<string, boolean>;
   onExtensionConnectionChange?: (extensionId: string, connected: boolean) => void;
+  restartLocalServer?: () => Promise<boolean>;
   computerUse?: {
     connected: boolean;
     connecting: boolean;

--- a/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
+++ b/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
@@ -12,12 +12,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import type { GoogleWorkspaceAuthStatus, OpenworkServerClient } from "../../../app/lib/openwork-server";
 import { usePlatform } from "../../kernel/platform";
 import type { ExtensionConfigContext } from "./extension-registry";
 import { registerExtensionRuntime } from "./extension-registry";
 
-type BusyAction = "status" | "connect" | "disconnect" | "test" | "smoke-test";
+type BusyAction = "status" | "connect" | "disconnect" | "test" | "smoke-test" | "save-secret";
 type GoogleWorkspaceCommand = () => Promise<unknown>;
 const DESKTOP_ACTION_TIMEOUT_MS = 6 * 60 * 1000;
 const CONNECT_POLL_INTERVAL_MS = 1_000;
@@ -34,11 +35,19 @@ function normalizeStringList(value: unknown): string[] {
 function normalizeGoogleWorkspaceAccount(value: unknown): GoogleWorkspaceAuthStatus["account"] {
   if (!isRecord(value)) return null;
   return {
+    accountId: typeof value.accountId === "string" ? value.accountId : null,
     email: typeof value.email === "string" ? value.email : null,
     name: typeof value.name === "string" ? value.name : null,
     picture: typeof value.picture === "string" ? value.picture : null,
     sub: typeof value.sub === "string" ? value.sub : null,
+    scopes: normalizeStringList(value.scopes),
+    connectedAt: typeof value.connectedAt === "string" ? value.connectedAt : null,
   };
+}
+
+function normalizeGoogleWorkspaceAccounts(value: unknown): GoogleWorkspaceAuthStatus["accounts"] {
+  if (!Array.isArray(value)) return [];
+  return value.map(normalizeGoogleWorkspaceAccount).filter((item): item is NonNullable<GoogleWorkspaceAuthStatus["account"]> => item !== null);
 }
 
 function normalizeGoogleWorkspaceSmokeTest(value: unknown): GoogleWorkspaceAuthStatus["smokeTest"] {
@@ -59,6 +68,8 @@ function normalizeGoogleWorkspaceAuthStatus(value: unknown): GoogleWorkspaceAuth
     vault,
     connected: record.connected === true,
     account: normalizeGoogleWorkspaceAccount(record.account),
+    accounts: normalizeGoogleWorkspaceAccounts(record.accounts),
+    activeAccountId: typeof record.activeAccountId === "string" ? record.activeAccountId : null,
     scopes: normalizeStringList(record.scopes),
     connectedAt: typeof record.connectedAt === "string" ? record.connectedAt : null,
     error: typeof record.error === "string" ? record.error : null,
@@ -83,11 +94,12 @@ async function waitForGoogleWorkspaceConnection(client: OpenworkServerClient, fl
   throw new Error("Google Workspace OAuth timed out.");
 }
 
-function GoogleWorkspaceConfig({ openworkServerClient, onExtensionConnectionChange }: ExtensionConfigContext) {
+function GoogleWorkspaceConfig({ openworkServerClient, onExtensionConnectionChange, restartLocalServer }: ExtensionConfigContext) {
   const platform = usePlatform();
   const [status, setStatus] = useState<GoogleWorkspaceAuthStatus | null>(null);
   const [busyAction, setBusyAction] = useState<BusyAction | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [clientSecret, setClientSecret] = useState("");
   const serverAvailable = Boolean(openworkServerClient);
   const canConnect = serverAvailable && status?.configured === true && status.vault !== "unavailable";
   const canTest = serverAvailable && status?.connected === true;
@@ -140,6 +152,35 @@ function GoogleWorkspaceConfig({ openworkServerClient, onExtensionConnectionChan
     return waitForGoogleWorkspaceConnection(openworkServerClient, flow.flowId, flow.expiresAt);
   };
 
+  const saveGoogleClientSecret = async () => {
+    if (!openworkServerClient) return;
+    const value = clientSecret.trim();
+    if (!value) {
+      setError("Enter the client secret from your Google OAuth desktop client.");
+      return;
+    }
+    setBusyAction("save-secret");
+    setError(null);
+    try {
+      await openworkServerClient.upsertUserEnv([{ key: "OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", value }]);
+      await openworkServerClient.setUserEnvPendingChanges(true);
+      setClientSecret("");
+      if (restartLocalServer) {
+        const restarted = await restartLocalServer();
+        if (!restarted) setError("Saved Google OAuth settings. Restart OpenWork to apply them.");
+      } else {
+        setError("Saved Google OAuth settings. Restart OpenWork to apply them.");
+      }
+      await loadStatus({ clearError: false });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save Google OAuth settings.");
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  const connectedAccounts = status?.accounts.length ? status.accounts : status?.account ? [status.account] : [];
+
   return (
     <div className="space-y-4">
       {!serverAvailable ? (
@@ -155,7 +196,7 @@ function GoogleWorkspaceConfig({ openworkServerClient, onExtensionConnectionChan
           <CheckCircle2 />
           <AlertTitle>Connected to Google Workspace</AlertTitle>
           <AlertDescription>
-            {status.account?.email ? `Signed in as ${status.account.email}.` : "Your Google account is connected."}
+            {connectedAccounts.length === 1 && connectedAccounts[0]?.email ? `Signed in as ${connectedAccounts[0].email}.` : `${connectedAccounts.length} Google accounts connected.`}
             {status.testStatus ? ` ${status.testStatus}` : ""}
           </AlertDescription>
         </Alert>
@@ -173,8 +214,37 @@ function GoogleWorkspaceConfig({ openworkServerClient, onExtensionConnectionChan
         <Alert variant="warning">
           <XCircle />
           <AlertTitle>Google OAuth client not configured</AlertTitle>
-          <AlertDescription>Google Workspace is not configured in this build.</AlertDescription>
+          <AlertDescription>Add your Google OAuth desktop client secret to connect Google Workspace.</AlertDescription>
         </Alert>
+      ) : null}
+
+      {status && !status.configured ? (
+        <Card variant="outline" size="sm">
+          <CardHeader>
+            <CardTitle>Set up Google OAuth</CardTitle>
+            <CardDescription>
+              Use a Google Cloud OAuth desktop client. OpenWork already includes the desktop client ID; paste the matching client secret here.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Input
+              type="password"
+              value={clientSecret}
+              onChange={(event) => setClientSecret(event.target.value)}
+              placeholder="Google OAuth desktop client secret"
+              autoComplete="off"
+            />
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              The secret is saved locally in OpenWork environment settings and applied after the local server restarts.
+            </p>
+          </CardContent>
+          <CardFooter>
+            <Button disabled={busyAction === "save-secret" || !clientSecret.trim()} onClick={() => void saveGoogleClientSecret()}>
+              {busyAction === "save-secret" ? <Loader2 className="size-4 animate-spin" /> : null}
+              Save and apply
+            </Button>
+          </CardFooter>
+        </Card>
       ) : null}
 
       {status?.vault === "unavailable" ? (
@@ -228,19 +298,33 @@ function GoogleWorkspaceConfig({ openworkServerClient, onExtensionConnectionChan
       </Card>
 
       <Card variant="outline" size="sm">
+        {connectedAccounts.length > 0 ? (
+          <CardContent className="space-y-2 pt-6">
+            {connectedAccounts.map((account) => (
+              <div key={account.accountId ?? account.email ?? account.sub ?? "google-account"} className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-border bg-card p-3">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium text-card-foreground">{account.email ?? account.name ?? "Google account"}</div>
+                  <div className="text-xs text-muted-foreground">{account.accountId === status?.activeAccountId ? "Default for extension actions" : "Connected"}</div>
+                </div>
+                <Button variant="destructive" size="sm" disabled={Boolean(busyAction)} onClick={() => void runDesktopAction("disconnect", () => openworkServerClient?.googleWorkspaceDisconnect(account.accountId) ?? Promise.resolve(null))}>
+                  Disconnect
+                </Button>
+              </div>
+            ))}
+          </CardContent>
+        ) : null}
         <CardFooter className="flex-wrap gap-2 justify-between">
           <div className="flex flex-wrap gap-2">
-            {status?.connected ? (
+            <Button disabled={Boolean(busyAction) || !canConnect} onClick={() => void runDesktopAction("connect", connectGoogleWorkspace)}>
+              {busyAction === "connect" ? <Loader2 className="size-4 animate-spin" /> : null}
+              {status?.connected ? "Add another Google account" : "Connect with Google"}
+            </Button>
+            {connectedAccounts.length > 1 ? (
               <Button variant="destructive" disabled={Boolean(busyAction)} onClick={() => void runDesktopAction("disconnect", () => openworkServerClient?.googleWorkspaceDisconnect() ?? Promise.resolve(null))}>
                 {busyAction === "disconnect" ? <Loader2 className="size-4 animate-spin" /> : null}
-                Disconnect
+                Disconnect all
               </Button>
-            ) : (
-              <Button disabled={Boolean(busyAction) || !canConnect} onClick={() => void runDesktopAction("connect", connectGoogleWorkspace)}>
-                {busyAction === "connect" ? <Loader2 className="size-4 animate-spin" /> : null}
-                Connect with Google
-              </Button>
-            )}
+            ) : null}
             <Button variant="outline" disabled={Boolean(busyAction) || !canTest} onClick={() => void runDesktopAction("test", () => openworkServerClient?.googleWorkspaceTestConnection() ?? Promise.resolve(null))}>
               {busyAction === "test" ? <Loader2 className="size-4 animate-spin" /> : null}
               Test connection

--- a/apps/app/src/react-app/domains/settings/settings-extension-controller.ts
+++ b/apps/app/src/react-app/domains/settings/settings-extension-controller.ts
@@ -21,6 +21,7 @@ type SettingsExtensionControllerInput = {
   onComputerUsePermissionsChange: (permissions: { accessibility: boolean; screenRecording: boolean }) => void;
   googleWorkspaceConnected: boolean;
   setGoogleWorkspaceConnected: (connected: boolean) => void;
+  restartLocalServer?: () => Promise<boolean>;
   connectMcp: (entry: McpDirectoryInfo) => void | Promise<void>;
   refreshMcpServers: () => void | Promise<void>;
   providers: ProviderLike[];
@@ -59,6 +60,7 @@ function hasOpenAiEnv(input: Pick<SettingsExtensionControllerInput, "providers" 
 export function useSettingsExtensionController(input: SettingsExtensionControllerInput) {
   const configContextForEntry = useCallback((entry: McpDirectoryInfo): ExtensionConfigContext => ({
     openworkServerClient: input.openworkServerClient,
+    restartLocalServer: input.restartLocalServer,
     extensionConnections: {
       "google-workspace": input.googleWorkspaceConnected,
     },

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1685,6 +1685,20 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     () => connectionsStore.quickConnect.filter(isBuiltInOpenWorkExtension),
     [connectionsStore.quickConnect],
   );
+  const restartExtensionLocalServer = useCallback(async () => {
+    if (!isDesktopRuntime()) return false;
+    try {
+      await openworkServerRestart({
+        remoteAccessEnabled:
+          readOpenworkServerSettings().remoteAccessEnabled === true,
+      });
+      await openworkServerStore.reconnectOpenworkServer();
+      await refreshRouteState();
+      return true;
+    } catch {
+      return false;
+    }
+  }, [openworkServerStore, refreshRouteState]);
   const extensionController = useSettingsExtensionController({
     openworkServerClient: selectedWorkspaceEndpoint?.client ?? openworkClient,
     enablementContext,
@@ -1693,6 +1707,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     onComputerUsePermissionsChange: setComputerUsePermissions,
     googleWorkspaceConnected,
     setGoogleWorkspaceConnected,
+    restartLocalServer: restartExtensionLocalServer,
     connectMcp: (entry) => connectionsStore.connectMcp(entry),
     refreshMcpServers: () => connectionsStore.refreshMcpServers(),
     providers,

--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import type { ServerConfig } from "../types.js";
+import { googleWorkspaceDisconnect, googleWorkspaceStatus } from "./google-workspace.js";
+
+function createTestConfig(): ServerConfig {
+  const tempDir = join(
+    tmpdir(),
+    `openwork-google-workspace-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  return {
+    host: "127.0.0.1",
+    port: 8787,
+    token: "test-client-token",
+    hostToken: "test-host-token",
+    configPath: join(tempDir, "server.json"),
+    approval: { mode: "auto", timeoutMs: 30000 },
+    corsOrigins: ["*"],
+    workspaces: [],
+    authorizedRoots: [],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+function plaintextVaultPath(config: ServerConfig) {
+  return join(dirname(config.configPath ?? ""), "extensions", "google-workspace", "oauth.dev-plaintext.json");
+}
+
+async function writePlaintextVault(config: ServerConfig, value: Record<string, unknown>) {
+  const target = plaintextVaultPath(config);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function accountRecord(email: string, sub: string) {
+  return {
+    account: { email, name: email, sub, picture: null },
+    scopes: ["openid"],
+    token: { accessToken: `access-${sub}`, refreshToken: `refresh-${sub}`, expiresAt: Date.now() + 3600 * 1000 },
+    connectedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+const previousEnv = {
+  devMode: process.env.OPENWORK_DEV_MODE,
+  plaintextVault: process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT,
+  clientSecret: process.env.OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET,
+  brokerUrl: process.env.OPENWORK_GOOGLE_WORKSPACE_TOKEN_BROKER_URL,
+};
+const previousFetch = globalThis.fetch;
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (typeof value === "string") process.env[key] = value;
+  else delete process.env[key];
+}
+
+afterEach(() => {
+  restoreEnv("OPENWORK_DEV_MODE", previousEnv.devMode);
+  restoreEnv("OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT", previousEnv.plaintextVault);
+  restoreEnv("OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", previousEnv.clientSecret);
+  restoreEnv("OPENWORK_GOOGLE_WORKSPACE_TOKEN_BROKER_URL", previousEnv.brokerUrl);
+  globalThis.fetch = previousFetch;
+});
+
+describe("Google Workspace extension", () => {
+  test("reports only the user-configurable OAuth secret as missing", async () => {
+    process.env.OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_TOKEN_BROKER_URL = "";
+    const status = await googleWorkspaceStatus(createTestConfig());
+    expect(status.configured).toBe(false);
+    expect(status.missing).toEqual(["OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET"]);
+  });
+
+  test("reads multi-account vaults and exposes active account", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-two",
+      accounts: [accountRecord("one@example.com", "sub-one"), accountRecord("two@example.com", "sub-two")],
+    });
+
+    const status = await googleWorkspaceStatus(config);
+    expect(status.connected).toBe(true);
+    expect(status.account?.email).toBe("two@example.com");
+    expect(status.accounts.map((account) => account.email)).toEqual(["one@example.com", "two@example.com"]);
+    expect(status.activeAccountId).toBe("sub-two");
+  });
+
+  test("disconnect can remove one connected account", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    globalThis.fetch = Object.assign(
+      async () => new Response("{}", { status: 200 }),
+      { preconnect: previousFetch.preconnect },
+    );
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one"), accountRecord("two@example.com", "sub-two")],
+    });
+
+    const status = await googleWorkspaceDisconnect(config, "sub-one");
+    expect(status.connected).toBe(true);
+    expect(status.accounts.map((account) => account.email)).toEqual(["two@example.com"]);
+    expect(status.activeAccountId).toBe("sub-two");
+  });
+});

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -131,7 +131,7 @@ function googleWorkspaceCredentials() {
   const tokenBrokerUrl = process.env[GOOGLE_WORKSPACE_TOKEN_BROKER_URL_ENV]?.trim() || process.env.GOOGLE_WORKSPACE_TOKEN_BROKER_URL?.trim() || "";
   const missing: string[] = [];
   if (!clientId) missing.push(GOOGLE_WORKSPACE_CLIENT_ID_ENV);
-  if (!clientSecret && !tokenBrokerUrl) missing.push(`${GOOGLE_WORKSPACE_CLIENT_SECRET_ENV} or ${GOOGLE_WORKSPACE_TOKEN_BROKER_URL_ENV}`);
+  if (!clientSecret && !tokenBrokerUrl) missing.push(GOOGLE_WORKSPACE_CLIENT_SECRET_ENV);
   return { clientId, clientSecret, tokenBrokerUrl, missing };
 }
 
@@ -245,6 +245,7 @@ async function removeGoogleWorkspaceVault(config: ServerConfig): Promise<void> {
 function googleWorkspaceSafeAccount(account: unknown) {
   if (!isRecord(account)) return null;
   return {
+    accountId: googleWorkspaceAccountId({ account }),
     email: typeof account.email === "string" ? account.email : null,
     name: typeof account.name === "string" ? account.name : null,
     picture: typeof account.picture === "string" ? account.picture : null,
@@ -252,17 +253,71 @@ function googleWorkspaceSafeAccount(account: unknown) {
   };
 }
 
+function googleWorkspaceAccountId(record: unknown): string | null {
+  if (!isRecord(record)) return null;
+  const account = isRecord(record.account) ? record.account : null;
+  const sub = typeof account?.sub === "string" && account.sub.trim() ? account.sub.trim() : null;
+  const email = typeof account?.email === "string" && account.email.trim() ? account.email.trim().toLowerCase() : null;
+  return sub ?? email;
+}
+
+function googleWorkspaceAccountRecords(record: Record<string, unknown> | null): Record<string, unknown>[] {
+  if (!record) return [];
+  if (Array.isArray(record.accounts)) return record.accounts.filter(isRecord);
+  return isRecord(record.token) ? [record] : [];
+}
+
+function googleWorkspacePrimaryRecord(record: Record<string, unknown> | null): Record<string, unknown> | null {
+  const accounts = googleWorkspaceAccountRecords(record);
+  if (accounts.length === 0) return null;
+  const activeAccountId = typeof record?.activeAccountId === "string" ? record.activeAccountId : "";
+  return accounts.find((account) => googleWorkspaceAccountId(account) === activeAccountId) ?? accounts[0] ?? null;
+}
+
+function googleWorkspacePublicAccounts(record: Record<string, unknown> | null) {
+  return googleWorkspaceAccountRecords(record).map((entry) => ({
+    ...googleWorkspaceSafeAccount(entry.account),
+    accountId: googleWorkspaceAccountId(entry),
+    scopes: Array.isArray(entry.scopes) ? entry.scopes.filter((item): item is string => typeof item === "string") : [],
+    connectedAt: typeof entry.connectedAt === "string" ? entry.connectedAt : null,
+  })).filter((entry) => entry.accountId !== null);
+}
+
+async function writeGoogleWorkspaceAccountsVault(config: ServerConfig, accounts: Record<string, unknown>[], activeAccountId: string | null): Promise<void> {
+  if (accounts.length === 0) {
+    await removeGoogleWorkspaceVault(config);
+    return;
+  }
+  await writeGoogleWorkspaceVault(config, {
+    version: 2,
+    accounts,
+    activeAccountId,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+async function upsertGoogleWorkspaceAccount(config: ServerConfig, accountRecord: Record<string, unknown>): Promise<void> {
+  const accountId = googleWorkspaceAccountId(accountRecord);
+  if (!accountId) throw new Error("Google account identifier is unavailable.");
+  const current = await readGoogleWorkspaceVault(config);
+  const accounts = googleWorkspaceAccountRecords(current);
+  const nextAccounts = [accountRecord, ...accounts.filter((entry) => googleWorkspaceAccountId(entry) !== accountId)];
+  await writeGoogleWorkspaceAccountsVault(config, nextAccounts, accountId);
+}
+
 function googleWorkspaceStatusPayload(record: Record<string, unknown> | null = null, extra: Record<string, unknown> = {}) {
   const credentials = googleWorkspaceCredentials();
-  const token = isRecord(record?.token) ? record.token : null;
+  const primary = googleWorkspacePrimaryRecord(record);
   return {
     configured: credentials.missing.length === 0,
     missing: credentials.missing,
     vault: googleWorkspaceVaultMode(),
-    connected: Boolean(token?.refreshToken || token?.accessToken),
-    account: googleWorkspaceSafeAccount(record?.account),
-    scopes: Array.isArray(record?.scopes) ? record.scopes.filter((item): item is string => typeof item === "string") : [],
-    connectedAt: typeof record?.connectedAt === "string" ? record.connectedAt : null,
+    connected: googleWorkspaceAccountRecords(record).length > 0,
+    account: googleWorkspaceSafeAccount(primary?.account),
+    accounts: googleWorkspacePublicAccounts(record),
+    activeAccountId: googleWorkspaceAccountId(primary),
+    scopes: Array.isArray(primary?.scopes) ? primary.scopes.filter((item): item is string => typeof item === "string") : [],
+    connectedAt: typeof primary?.connectedAt === "string" ? primary.connectedAt : null,
     error: null,
     testStatus: null,
     smokeTest: null,
@@ -337,7 +392,7 @@ async function exchangeGoogleWorkspaceCode(input: { code: string; redirectUri: s
   });
 }
 
-async function refreshGoogleWorkspaceVault(config: ServerConfig, record: Record<string, unknown>) {
+async function refreshGoogleWorkspaceVault(record: Record<string, unknown>) {
   const token = isRecord(record.token) ? record.token : null;
   const expiresAt = Number(token?.expiresAt ?? 0);
   const accessToken = typeof token?.accessToken === "string" ? token.accessToken : "";
@@ -364,14 +419,19 @@ async function refreshGoogleWorkspaceVault(config: ServerConfig, record: Record<
     },
     updatedAt: new Date().toISOString(),
   };
-  await writeGoogleWorkspaceVault(config, next);
   return next;
 }
 
 async function googleWorkspaceAccessToken(config: ServerConfig): Promise<{ record: Record<string, unknown>; accessToken: string }> {
-  const record = await readGoogleWorkspaceVault(config);
+  const vault = await readGoogleWorkspaceVault(config);
+  const record = googleWorkspacePrimaryRecord(vault);
   if (!record) throw new ApiError(400, "google_workspace_not_connected", "Connect Google Workspace in OpenWork Settings to use this tool.");
-  const refreshed = await refreshGoogleWorkspaceVault(config, record);
+  const refreshed = await refreshGoogleWorkspaceVault(record);
+  const refreshedAccountId = googleWorkspaceAccountId(refreshed);
+  if (refreshedAccountId) {
+    const nextAccounts = googleWorkspaceAccountRecords(vault).map((entry) => googleWorkspaceAccountId(entry) === refreshedAccountId ? refreshed : entry);
+    await writeGoogleWorkspaceAccountsVault(config, nextAccounts, refreshedAccountId);
+  }
   const token = isRecord(refreshed.token) ? refreshed.token : null;
   const accessToken = typeof token?.accessToken === "string" ? token.accessToken : "";
   if (!accessToken) throw new Error("Google Workspace access token is unavailable. Reconnect Google Workspace.");
@@ -534,12 +594,17 @@ export async function googleWorkspaceRunScopeSmokeTest(config: ServerConfig) {
   });
 }
 
-export async function googleWorkspaceDisconnect(config: ServerConfig) {
-  const record = await readGoogleWorkspaceVault(config);
-  const token = isRecord(record?.token) ? record.token : null;
-  const revokeToken = typeof token?.refreshToken === "string" ? token.refreshToken : typeof token?.accessToken === "string" ? token.accessToken : "";
+export async function googleWorkspaceDisconnect(config: ServerConfig, accountId: string | null = null) {
+  const vault = await readGoogleWorkspaceVault(config);
+  const accounts = googleWorkspaceAccountRecords(vault);
+  const selectedAccounts = accountId
+    ? accounts.filter((entry) => googleWorkspaceAccountId(entry) === accountId)
+    : accounts;
   let revokeError: Error | null = null;
-  if (revokeToken) {
+  for (const record of selectedAccounts) {
+    const token = isRecord(record.token) ? record.token : null;
+    const revokeToken = typeof token?.refreshToken === "string" ? token.refreshToken : typeof token?.accessToken === "string" ? token.accessToken : "";
+    if (!revokeToken) continue;
     try {
       await fetchGoogleJson("https://oauth2.googleapis.com/revoke", {
         method: "POST",
@@ -550,8 +615,13 @@ export async function googleWorkspaceDisconnect(config: ServerConfig) {
       revokeError = error instanceof Error ? error : new Error(String(error));
     }
   }
-  await removeGoogleWorkspaceVault(config);
-  return googleWorkspaceStatusPayload(null, revokeError ? { error: `Local Google Workspace tokens were removed, but Google token revocation failed: ${revokeError.message}` } : { testStatus: "Google Workspace access revoked and local tokens removed." });
+  const remainingAccounts = accountId
+    ? accounts.filter((entry) => googleWorkspaceAccountId(entry) !== accountId)
+    : [];
+  const activeAccountId = remainingAccounts.length > 0 ? googleWorkspaceAccountId(remainingAccounts[0]) : null;
+  await writeGoogleWorkspaceAccountsVault(config, remainingAccounts, activeAccountId);
+  const nextVault = await readGoogleWorkspaceVault(config);
+  return googleWorkspaceStatusPayload(nextVault, revokeError ? { error: `Local Google Workspace tokens were removed, but Google token revocation failed: ${revokeError.message}` } : { testStatus: "Google Workspace access revoked and local tokens removed." });
 }
 
 function escapeHtml(value: string): string {
@@ -637,7 +707,7 @@ export function createGoogleWorkspaceConnectFlowManager(config: ServerConfig) {
               connectedAt: new Date().toISOString(),
               updatedAt: new Date().toISOString(),
             };
-            await writeGoogleWorkspaceVault(config, record);
+            await upsertGoogleWorkspaceAccount(config, record);
             flow.status = "connected";
             flow.account = account;
           } catch (exchangeError) {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1940,7 +1940,9 @@ function createRoutes(
 
   addRoute(routes, "POST", "/experimental/google-workspace/disconnect", "client", async (ctx) => {
     if (ctx.actor?.scope === "viewer") throw new ApiError(403, "forbidden", "Viewer tokens cannot disconnect Google Workspace");
-    return jsonResponse(await googleWorkspaceDisconnect(config));
+    const body = await readOptionalJsonBody(ctx.request);
+    const accountId = typeof body.accountId === "string" && body.accountId.trim() ? body.accountId.trim() : null;
+    return jsonResponse(await googleWorkspaceDisconnect(config, accountId));
   });
 
   addRoute(routes, "POST", "/experimental/google-workspace/test", "client", async () => {

--- a/docs/google-workspace-oauth-verification.md
+++ b/docs/google-workspace-oauth-verification.md
@@ -45,47 +45,13 @@ OpenWork uses this scope to create Gmail drafts for the user to review in Gmail.
 
 OpenWork uses Google Workspace data only to provide user-requested features, such as reading calendar context, reading explicitly selected Drive files, and creating Gmail drafts. OpenWork does not sell Google user data, use Google user data for advertising, or use Google user data to train generalized AI models. Desktop OAuth tokens are stored locally using encrypted OS storage when available.
 
-## Deployment Modes
-
-### Local-first desktop OAuth
+## Deployment Mode
 
 The default desktop flow uses a Google Desktop OAuth client with PKCE and a loopback redirect. The desktop app exchanges authorization codes directly with Google and stores user tokens locally in encrypted OS storage.
 
 For installed desktop apps, Google may provide both a `client_id` and `client_secret`. In this context, the `client_secret` is client metadata, not a confidential backend secret, because any value shipped in a desktop binary can be extracted. It is acceptable for official OpenWork desktop builds to include the OpenWork-owned Google Desktop OAuth client metadata, while user access tokens and refresh tokens must remain protected and must never be committed.
 
 For local development, pass `OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET` from the Google Cloud desktop client metadata instead of committing it to source. This keeps source checkouts and forks from accidentally reusing the official OpenWork OAuth client metadata unless they opt in explicitly.
-
-### Enterprise token broker
-
-Enterprise deployments can use a hardened token broker by setting `OPENWORK_GOOGLE_WORKSPACE_TOKEN_BROKER_URL`. When this is set, OpenWork Desktop still owns the browser OAuth flow and PKCE verifier, but sends token exchange and refresh requests to the configured broker endpoint instead of calling Google's token endpoint directly.
-
-This lets an enterprise or self-hosted OpenWork deployment keep Google OAuth client metadata on its own server, enforce organization policy, add audit logging, rotate credentials centrally, and avoid distributing Google OAuth client metadata in desktop builds. The broker is also the right place to add domain allowlists, admin approvals, or additional revocation policy for managed environments.
-
-The broker receives JSON `POST` requests shaped like:
-
-```json
-{
-  "provider": "google-workspace",
-  "grantType": "authorization_code",
-  "clientId": "<google-desktop-client-id>",
-  "code": "<authorization-code>",
-  "codeVerifier": "<pkce-verifier>",
-  "redirectUri": "http://127.0.0.1:<port>/"
-}
-```
-
-For refresh:
-
-```json
-{
-  "provider": "google-workspace",
-  "grantType": "refresh_token",
-  "clientId": "<google-desktop-client-id>",
-  "refreshToken": "<refresh-token>"
-}
-```
-
-The broker should return Google's token response shape, including `access_token`, `expires_in`, optional `refresh_token`, and optional `scope`.
 
 ## Demo Video Script
 


### PR DESCRIPTION
## Summary
- Let users configure Google Workspace locally by saving OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET from the extension settings panel when the app is not configured.
- Keep token broker details out of user-facing copy and docs.
- Add multi-account Google Workspace vault support: new connects add/update accounts, status returns all accounts, tools use the active/latest account, and the UI can disconnect one account or all accounts.
- Preserve legacy single-account vault compatibility.

## Testing
- pnpm --filter openwork-server test src/extensions/google-workspace.test.ts
- pnpm --filter openwork-server typecheck
- pnpm --filter @openwork/app typecheck

## Notes
- Real Google OAuth was not exercised because this environment does not have a live Google OAuth client secret/test account flow available.
- Multi-account behavior is covered with plaintext dev-vault tests.