### PR TITLE
fix(den-api): close cross-org IDOR in plugin-system access grants

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -19,6 +19,7 @@ import {
   PluginAccessGrantTable,
   PluginConfigObjectTable,
   PluginTable,
+  TeamTable,
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import type { PluginArchActorContext, PluginArchResourceKind, PluginArchRole } from "./access.js"
@@ -645,6 +646,66 @@ async function getConnectorSyncEventRow(organizationId: OrganizationId, connecto
   return rows[0]?.event ?? null
 }
 
+// Verifies the target resource exists AND belongs to the caller's active
+// organization, returning 404 otherwise. This must run before any role check on
+// access-grant endpoints: resolvePluginArchResourceRole short-circuits to
+// "manager" for org admins without binding the resource to the org, so without
+// this guard an admin in org A could read/add/revoke grants on org B resources
+// by supplying a foreign resourceId.
+async function ensureResourceInOrganization(context: PluginArchActorContext, target: ResourceTarget) {
+  const organizationId = context.organizationContext.organization.id
+  if (target.resourceKind === "config_object") {
+    if (!(await getConfigObjectRow(organizationId, target.resourceId))) {
+      throw new PluginArchRouteFailure(404, "config_object_not_found", "Config object not found.")
+    }
+    return
+  }
+  if (target.resourceKind === "plugin") {
+    if (!(await getPluginRow(organizationId, target.resourceId))) {
+      throw new PluginArchRouteFailure(404, "plugin_not_found", "Plugin not found.")
+    }
+    return
+  }
+  if (target.resourceKind === "marketplace") {
+    if (!(await getMarketplaceRow(organizationId, target.resourceId))) {
+      throw new PluginArchRouteFailure(404, "marketplace_not_found", "Marketplace not found.")
+    }
+    return
+  }
+  if (!(await getConnectorInstanceRow(organizationId, target.resourceId))) {
+    throw new PluginArchRouteFailure(404, "connector_instance_not_found", "Connector instance not found.")
+  }
+}
+
+// Validates that a grant's target member/team belong to the caller's active
+// organization, so a manager cannot grant access to a foreign org's member or
+// team id by smuggling it through the request body.
+async function ensureGrantTargetsInOrganization(context: PluginArchActorContext, value: AccessGrantWrite) {
+  const organizationId = context.organizationContext.organization.id
+
+  if (value.orgMembershipId) {
+    const member = await db
+      .select({ id: MemberTable.id })
+      .from(MemberTable)
+      .where(and(eq(MemberTable.organizationId, organizationId), eq(MemberTable.id, value.orgMembershipId)))
+      .limit(1)
+    if (!member[0]) {
+      throw new PluginArchRouteFailure(404, "member_not_found", "Member not found.")
+    }
+  }
+
+  if (value.teamId) {
+    const team = await db
+      .select({ id: TeamTable.id })
+      .from(TeamTable)
+      .where(and(eq(TeamTable.organizationId, organizationId), eq(TeamTable.id, value.teamId)))
+      .limit(1)
+    if (!team[0]) {
+      throw new PluginArchRouteFailure(404, "team_not_found", "Team not found.")
+    }
+  }
+}
+
 async function ensureVisibleConfigObject(context: PluginArchActorContext, configObjectId: ConfigObjectId) {
   const row = await getConfigObjectRow(context.organizationContext.organization.id, configObjectId)
   if (!row) {
@@ -1243,6 +1304,7 @@ export async function removeConfigObjectFromPlugin(input: { context: PluginArchA
 }
 
 export async function listResourceAccess(input: { context: PluginArchActorContext } & ResourceTarget) {
+  await ensureResourceInOrganization(input.context, input)
   await requirePluginArchResourceRole({ context: input.context, resourceId: input.resourceId, resourceKind: input.resourceKind, role: "manager" })
 
   if (input.resourceKind === "config_object") {
@@ -1262,11 +1324,14 @@ export async function listResourceAccess(input: { context: PluginArchActorContex
 }
 
 export async function createResourceAccessGrant(input: { context: PluginArchActorContext; value: AccessGrantWrite } & ResourceTarget) {
+  await ensureResourceInOrganization(input.context, input)
   await requirePluginArchResourceRole({ context: input.context, resourceId: input.resourceId, resourceKind: input.resourceKind, role: "manager" })
+  await ensureGrantTargetsInOrganization(input.context, input.value)
   return upsertGrant(input)
 }
 
 export async function deleteResourceAccessGrant(input: { context: PluginArchActorContext } & GrantTarget) {
+  await ensureResourceInOrganization(input.context, input)
   await requirePluginArchResourceRole({ context: input.context, resourceId: input.resourceId, resourceKind: input.resourceKind, role: "manager" })
   return removeGrant(input)
 }

--- a/ee/apps/den-api/test/plugin-system-cross-org-idor.test.ts
+++ b/ee/apps/den-api/test/plugin-system-cross-org-idor.test.ts
@@ -1,0 +1,126 @@
+import { beforeAll, expect, mock, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+// Tracks whether any grant mutation/read ran. The IDOR guard must reject a
+// foreign resource BEFORE any of these are reached.
+let insertCalls = 0
+let updateCalls = 0
+
+// A chainable Drizzle-like query stub whose terminal awaited value is [] —
+// i.e. "no row found in this organization". This models a resourceId that
+// belongs to a DIFFERENT org than the caller.
+function emptyQuery() {
+  const chain: any = {
+    from: () => chain,
+    where: () => chain,
+    innerJoin: () => chain,
+    orderBy: () => chain,
+    limit: () => Promise.resolve([]),
+    then: (resolve: (v: unknown[]) => unknown) => resolve([]),
+  }
+  return chain
+}
+
+let storeModule: typeof import("../src/routes/org/plugin-system/store.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+
+  mock.module("../src/db.js", () => ({
+    db: {
+      select: () => emptyQuery(),
+      insert: () => {
+        insertCalls += 1
+        return { values: () => Promise.resolve(undefined) }
+      },
+      update: () => {
+        updateCalls += 1
+        return { set: () => ({ where: () => Promise.resolve(undefined) }) }
+      },
+    },
+  }))
+
+  storeModule = await import("../src/routes/org/plugin-system/store.js")
+})
+
+// An org ADMIN (worst case: resolvePluginArchResourceRole short-circuits to
+// "manager" for admins). Without the org-scope guard this actor could act on a
+// foreign resourceId. The resource lookup returns [] (not in this org).
+function adminContext() {
+  return {
+    memberTeams: [],
+    organizationContext: {
+      organization: { id: "org_caller" },
+      currentMember: {
+        id: "member_admin",
+        isOwner: false,
+        role: "admin",
+        userId: "user_admin",
+      },
+    },
+  } as any
+}
+
+const kinds = ["config_object", "plugin", "marketplace", "connector_instance"] as const
+
+for (const resourceKind of kinds) {
+  test(`createResourceAccessGrant rejects foreign ${resourceKind} with 404 before any write`, async () => {
+    insertCalls = 0
+    updateCalls = 0
+    let status: number | null = null
+    try {
+      await storeModule.createResourceAccessGrant({
+        context: adminContext(),
+        resourceId: "res_foreign" as any,
+        resourceKind,
+        value: { role: "viewer" },
+      } as any)
+      throw new Error("expected rejection")
+    } catch (error: any) {
+      status = error?.status ?? null
+    }
+    expect(status).toBe(404)
+    expect(insertCalls).toBe(0)
+    expect(updateCalls).toBe(0)
+  })
+
+  test(`listResourceAccess rejects foreign ${resourceKind} with 404`, async () => {
+    let status: number | null = null
+    try {
+      await storeModule.listResourceAccess({
+        context: adminContext(),
+        resourceId: "res_foreign" as any,
+        resourceKind,
+      } as any)
+      throw new Error("expected rejection")
+    } catch (error: any) {
+      status = error?.status ?? null
+    }
+    expect(status).toBe(404)
+  })
+
+  test(`deleteResourceAccessGrant rejects foreign ${resourceKind} with 404 before any write`, async () => {
+    insertCalls = 0
+    updateCalls = 0
+    let status: number | null = null
+    try {
+      await storeModule.deleteResourceAccessGrant({
+        context: adminContext(),
+        resourceId: "res_foreign" as any,
+        resourceKind,
+        grantId: "grant_foreign" as any,
+      } as any)
+      throw new Error("expected rejection")
+    } catch (error: any) {
+      status = error?.status ?? null
+    }
+    expect(status).toBe(404)
+    expect(updateCalls).toBe(0)
+  })
+}


### PR DESCRIPTION
## Summary

Closes a **high-severity cross-tenant IDOR** found during a security review of the enterprise API (\`den-api\`).

\`listResourceAccess\`, \`createResourceAccessGrant\`, and \`deleteResourceAccessGrant\` (\`routes/org/plugin-system/store.ts\`) passed the caller-supplied \`resourceId\` straight into the role check **without first scoping it to the caller's organization**. Because \`resolvePluginArchResourceRole\` short-circuits to \`"manager"\` for any org admin/owner, an admin in **org A** could **list, add, or revoke access grants on org B's** config objects, plugins, marketplaces, and connector instances by supplying a foreign \`resourceId\`.

## Fix

- Add \`ensureResourceInOrganization()\` and call it at the top of all three endpoints, so a resource not in the caller's active org **404s before any role check or grant mutation** (mirrors the existing \`ensureVisible*\`/\`ensureEditable*\` helpers).
- Add \`ensureGrantTargetsInOrganization()\` so a grant's \`orgMembershipId\`/\`teamId\` must belong to the active org — prevents a manager from granting access to a foreign org's member/team via the request body.

## Tests run

**Local** (\`bun test\`, den-api): \`36 pass / 0 fail\`
- 12 new tests: create/list/delete × {config_object, plugin, marketplace, connector_instance}, each asserting **404 before any insert/update**.
- **Negative control**: with the guard removed, 8/12 fail (cross-org create/list succeed) — proving the tests catch the bug.

**On Daytona** (Den server sandbox, real MySQL, branch deployed + seeded demo org):
- den-api suite inside sandbox: \`36 pass / 0 fail\`
- Live API end-to-end, signed in as seeded org admin \`alex@acme.test\`:
  - \`GET /v1/plugins/{foreign-plugin}/access\` → **404 plugin_not_found**
  - \`POST /v1/plugins/{foreign-plugin}/access\` → **404 plugin_not_found**
  - Control: \`GET /v1/plugins/{own-plugin}/access\` → **200**

Before this fix the foreign requests returned 200 with manager access; they are now rejected end-to-end.