### PR TITLE
fix(app): save Google Workspace OAuth secret with host auth

### DIFF
--- a/apps/app/src/react-app/domains/settings/extension-registry.tsx
+++ b/apps/app/src/react-app/domains/settings/extension-registry.tsx
@@ -10,6 +10,7 @@ import type { OpenworkServerClient } from "../../../app/lib/openwork-server";
  */
 export type ExtensionConfigContext = {
   openworkServerClient?: OpenworkServerClient | null;
+  hostOpenworkServerClient?: OpenworkServerClient | null;
   extensionConnections?: Record<string, boolean>;
   onExtensionConnectionChange?: (extensionId: string, connected: boolean) => void;
   restartLocalServer?: () => Promise<boolean>;

--- a/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
+++ b/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
@@ -94,13 +94,14 @@ async function waitForGoogleWorkspaceConnection(client: OpenworkServerClient, fl
   throw new Error("Google Workspace OAuth timed out.");
 }
 
-function GoogleWorkspaceConfig({ openworkServerClient, onExtensionConnectionChange, restartLocalServer }: ExtensionConfigContext) {
+function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient, onExtensionConnectionChange, restartLocalServer }: ExtensionConfigContext) {
   const platform = usePlatform();
   const [status, setStatus] = useState<GoogleWorkspaceAuthStatus | null>(null);
   const [busyAction, setBusyAction] = useState<BusyAction | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [clientSecret, setClientSecret] = useState("");
   const serverAvailable = Boolean(openworkServerClient);
+  const hostServerAvailable = Boolean(hostOpenworkServerClient);
   const canConnect = serverAvailable && status?.configured === true && status.vault !== "unavailable";
   const canTest = serverAvailable && status?.connected === true;
 
@@ -153,7 +154,10 @@ function GoogleWorkspaceConfig({ openworkServerClient, onExtensionConnectionChan
   };
 
   const saveGoogleClientSecret = async () => {
-    if (!openworkServerClient) return;
+    if (!hostOpenworkServerClient) {
+      setError("Google OAuth settings can only be saved from the local desktop app.");
+      return;
+    }
     const value = clientSecret.trim();
     if (!value) {
       setError("Enter the client secret from your Google OAuth desktop client.");
@@ -162,8 +166,8 @@ function GoogleWorkspaceConfig({ openworkServerClient, onExtensionConnectionChan
     setBusyAction("save-secret");
     setError(null);
     try {
-      await openworkServerClient.upsertUserEnv([{ key: "OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", value }]);
-      await openworkServerClient.setUserEnvPendingChanges(true);
+      await hostOpenworkServerClient.upsertUserEnv([{ key: "OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", value }]);
+      await hostOpenworkServerClient.setUserEnvPendingChanges(true);
       setClientSecret("");
       if (restartLocalServer) {
         const restarted = await restartLocalServer();
@@ -239,7 +243,7 @@ function GoogleWorkspaceConfig({ openworkServerClient, onExtensionConnectionChan
             </p>
           </CardContent>
           <CardFooter>
-            <Button disabled={busyAction === "save-secret" || !clientSecret.trim()} onClick={() => void saveGoogleClientSecret()}>
+            <Button disabled={busyAction === "save-secret" || !clientSecret.trim() || !hostServerAvailable} onClick={() => void saveGoogleClientSecret()}>
               {busyAction === "save-secret" ? <Loader2 className="size-4 animate-spin" /> : null}
               Save and apply
             </Button>

--- a/apps/app/src/react-app/domains/settings/settings-extension-controller.ts
+++ b/apps/app/src/react-app/domains/settings/settings-extension-controller.ts
@@ -15,6 +15,7 @@ type ProviderLike = {
 
 type SettingsExtensionControllerInput = {
   openworkServerClient: OpenworkServerClient | null;
+  hostOpenworkServerClient: OpenworkServerClient | null;
   enablementContext: EnablementContext;
   mcpServers: McpServerEntry[];
   mcpConnectingName: string | null;
@@ -60,6 +61,7 @@ function hasOpenAiEnv(input: Pick<SettingsExtensionControllerInput, "providers" 
 export function useSettingsExtensionController(input: SettingsExtensionControllerInput) {
   const configContextForEntry = useCallback((entry: McpDirectoryInfo): ExtensionConfigContext => ({
     openworkServerClient: input.openworkServerClient,
+    hostOpenworkServerClient: input.hostOpenworkServerClient,
     restartLocalServer: input.restartLocalServer,
     extensionConnections: {
       "google-workspace": input.googleWorkspaceConnected,

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1701,6 +1701,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   }, [openworkServerStore, refreshRouteState]);
   const extensionController = useSettingsExtensionController({
     openworkServerClient: selectedWorkspaceEndpoint?.client ?? openworkClient,
+    hostOpenworkServerClient: openworkClient,
     enablementContext,
     mcpServers: connectionsSnapshot.mcpServers,
     mcpConnectingName: connectionsSnapshot.mcpConnectingName,


### PR DESCRIPTION
## Summary
- pass a separate local host-auth OpenWork client through extension settings
- use that host client for Google Workspace OAuth secret env writes
- keep selected workspace/server client behavior unchanged for Google Workspace status/connect/test calls

## Testing
- pnpm --filter @openwork/app typecheck

## Evidence
- Could not capture a video in this turn; this is a targeted client-auth routing fix verified by typecheck.