### PR TITLE
chore: add stop-daytona-recording.sh + document before/after recording workflow

### DIFF
--- a/.devcontainer/stop-daytona-recording.sh
+++ b/.devcontainer/stop-daytona-recording.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop a running Daytona display recording. Sends SIGINT to ffmpeg so it
+# finalizes the mp4 cleanly.
+#
+# Usage:
+#   # Stop from inside the sandbox:
+#   bash .devcontainer/stop-daytona-recording.sh
+#
+#   # Stop from the host:
+#   daytona exec $SANDBOX -- 'bash .devcontainer/stop-daytona-recording.sh'
+
+WAIT="${1:-5}"
+
+pid="$(pgrep -f 'ffmpeg.*x11grab' 2>/dev/null || true)"
+if [ -z "$pid" ]; then
+  echo "No active recording found."
+  exit 0
+fi
+
+kill -INT "$pid" 2>/dev/null || true
+echo "Sent SIGINT to ffmpeg (pid $pid). Waiting ${WAIT}s for finalization..."
+sleep "$WAIT"
+
+if kill -0 "$pid" 2>/dev/null; then
+  echo "WARNING: ffmpeg still running after ${WAIT}s — sending SIGTERM."
+  kill "$pid" 2>/dev/null || true
+fi
+
+echo "Recording stopped."

--- a/.opencode/skills/daytona-electron-test/SKILL.md
+++ b/.opencode/skills/daytona-electron-test/SKILL.md
@@ -417,6 +417,102 @@ Kill the old Electron process before restarting:
 daytona exec "$SANDBOX" -- "bash -lc 'pkill -f electron || true; pkill -f electron-dev || true'"
 ```
 
+## Recording before/after comparisons
+
+Use this workflow to capture a BEFORE recording on the current branch, switch
+to a feature branch on the same sandbox, and capture an AFTER recording. Both
+recordings are saved to the persistent `openwork-eval-artifacts` volume and
+survive sandbox deletion.
+
+### Step 1: Start the sandbox with BEFORE recording
+
+```bash
+bash .devcontainer/test-on-daytona.sh dev --record-video --recording-name my-feature-before
+```
+
+Save the sandbox name from the output (e.g. `SANDBOX=openwork-test-20260601-165424`).
+
+### Step 2: Drive the BEFORE flow
+
+Use browser tools to navigate the app and demonstrate the current behavior.
+The display is being recorded the entire time.
+
+### Step 3: Stop the BEFORE recording
+
+```bash
+daytona exec "$SANDBOX" -- 'bash .devcontainer/stop-daytona-recording.sh'
+```
+
+### Step 4: Switch to the feature branch
+
+```bash
+daytona exec "$SANDBOX" -- "bash -lc 'cd /workspace && git fetch origin feat/my-branch:feat/my-branch && git checkout feat/my-branch'"
+```
+
+Vite HMR picks up the changes automatically. Wait a few seconds, then reset
+any app state needed (e.g. onboarding flag):
+
+```js
+// In browser_eval:
+const raw = localStorage.getItem("openwork.preferences");
+const prefs = raw ? JSON.parse(raw) : {};
+prefs.hasCompletedOnboarding = false;
+localStorage.setItem("openwork.preferences", JSON.stringify(prefs));
+location.reload();
+```
+
+### Step 5: Start the AFTER recording
+
+```bash
+daytona exec "$SANDBOX" -- "bash -lc 'cd /workspace && DISPLAY=:99 .devcontainer/start-daytona-recording.sh --detach --output /daytona-artifacts/recordings/my-feature-after.mp4'"
+```
+
+### Step 6: Drive the AFTER flow
+
+Use browser tools to demonstrate the new behavior. Same steps as BEFORE
+but the UI should reflect the changes.
+
+### Step 7: Stop the AFTER recording
+
+```bash
+daytona exec "$SANDBOX" -- 'bash .devcontainer/stop-daytona-recording.sh'
+```
+
+### Step 8: Get recording URLs
+
+Both recordings are on the persistent artifacts volume, served via the
+Python HTTP server on port 8090:
+
+```bash
+ARTIFACTS_URL=$(daytona preview-url "$SANDBOX" -p 8090 2>/dev/null | grep -v "^time=")
+echo "BEFORE: ${ARTIFACTS_URL}/recordings/my-feature-before.mp4"
+echo "AFTER:  ${ARTIFACTS_URL}/recordings/my-feature-after.mp4"
+```
+
+Include these URLs in your PR description.
+
+### Key recording commands reference
+
+| Action | Command |
+|--------|---------|
+| Start recording (from test-on-daytona.sh) | `--record-video --recording-name NAME` |
+| Start recording (mid-sandbox) | `daytona exec $SANDBOX -- "bash -lc 'cd /workspace && DISPLAY=:99 .devcontainer/start-daytona-recording.sh --detach --output /daytona-artifacts/recordings/NAME.mp4'"` |
+| Stop recording | `daytona exec $SANDBOX -- 'bash .devcontainer/stop-daytona-recording.sh'` |
+| List recordings | `daytona exec $SANDBOX -- 'ls -lah /daytona-artifacts/recordings/'` |
+| Get download URL | `daytona preview-url $SANDBOX -p 8090` then append `/recordings/NAME.mp4` |
+
+### Notes
+
+- Recordings are stored on the `openwork-eval-artifacts` Daytona volume (5 GB,
+  reusable across sandboxes). They persist after `daytona delete`.
+- The `start-daytona-recording.sh` script records to a temp file first, then
+  copies to the artifacts volume on stop — this avoids NFS write issues.
+- Always use `stop-daytona-recording.sh` (or `pkill -INT -f "ffmpeg.*x11grab"`)
+  to stop. SIGINT lets ffmpeg finalize the mp4 container properly. SIGKILL
+  produces a corrupt file.
+- Default resolution is 1920x1080 at 15fps. Override with `--size 1280x800
+  --fps 10` for smaller files.
+
 ## Teardown
 
 ```bash

--- a/.opencode/skills/run-evals/SKILL.md
+++ b/.opencode/skills/run-evals/SKILL.md
@@ -119,6 +119,39 @@ browser_evaluate({ browser_url: URL, expression: "document.body.innerText.substr
 browser_screenshot({ browser_url: URL })
 ```
 
+### Recording eval runs
+
+Always record eval runs so they can be attached to PRs. Use the built-in
+Daytona recording mechanism:
+
+**Start with recording from the beginning:**
+```bash
+bash .devcontainer/test-on-daytona.sh <branch> --record-video --recording-name <eval-name>
+```
+
+**Start a new recording mid-sandbox** (e.g. after switching branches):
+```bash
+daytona exec "$SANDBOX" -- "bash -lc 'cd /workspace && DISPLAY=:99 .devcontainer/start-daytona-recording.sh --detach --output /daytona-artifacts/recordings/<name>.mp4'"
+```
+
+**Stop recording:**
+```bash
+daytona exec "$SANDBOX" -- 'bash .devcontainer/stop-daytona-recording.sh'
+```
+
+**Get the download URL:**
+```bash
+ARTIFACTS_URL=$(daytona preview-url "$SANDBOX" -p 8090 2>/dev/null | grep -v "^time=")
+echo "${ARTIFACTS_URL}/recordings/<name>.mp4"
+```
+
+Recordings are saved to the persistent `openwork-eval-artifacts` volume and
+survive sandbox deletion. Always use `stop-daytona-recording.sh` (not
+`kill -9`) so ffmpeg finalizes the mp4 properly.
+
+For before/after comparison recordings, see the "Recording before/after
+comparisons" section in the `daytona-electron-test` skill.
+
 ### Local fallback
 
 Always include a local fallback in the result. Use it when Daytona is down, quota-limited, or the sandbox cannot expose CDP. At minimum, run the closest local verification commands and report that the Daytona path was unavailable.


### PR DESCRIPTION
## What

Adds the missing pieces for Daytona-based before/after video recording.

### Changes

1. **`.devcontainer/stop-daytona-recording.sh`** — clean stop script that sends SIGINT to ffmpeg (so the mp4 finalizes properly), waits, then SIGTERM as fallback. Usage:
   ```bash
   daytona exec $SANDBOX -- 'bash .devcontainer/stop-daytona-recording.sh'
   ```

2. **`daytona-electron-test` skill** — new "Recording before/after comparisons" section with:
   - Step-by-step: start sandbox with BEFORE recording, stop, switch branch, start AFTER recording, stop, get URLs
   - Commands reference table (start/stop/list/download)
   - Notes on the persistent artifacts volume

3. **`run-evals` skill** — new "Recording eval runs" section explaining how to start/stop/download recordings both from `test-on-daytona.sh` and mid-sandbox.

### Evidence

Verified the full before/after workflow on sandbox `openwork-test-20260601-165424`:
- BEFORE (dev): https://8090-1yidqczytsyuq9gd.daytonaproxy01.net/recordings/onboarding-before.mp4 (1.9MB)
- AFTER (feat/simplify-onboarding): https://8090-1yidqczytsyuq9gd.daytonaproxy01.net/recordings/onboarding-after.mp4 (172KB)

### Files (3 files, +160)
- `.devcontainer/stop-daytona-recording.sh` (new)
- `.opencode/skills/daytona-electron-test/SKILL.md` (+96 lines)
- `.opencode/skills/run-evals/SKILL.md` (+33 lines)