### PR TITLE
feat(server): add UI control tools to in-process plugin

### DIFF
--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir, platform } from "node:os";
 import { z } from "zod";
 
 type OpenCodeContext = {
@@ -25,8 +28,78 @@ const callArgsSchema = z.object({
   args: z.record(z.string(), z.unknown()).optional().describe("JSON arguments for the action."),
 });
 
+const uiExecuteArgsSchema = z.object({
+  actionId: z.string().describe("The action id from openwork_ui_list_actions, e.g. 'settings.panel.open' or 'composer.set_text'."),
+  args: z.record(z.string(), z.unknown()).optional().describe("JSON arguments for the action, if required."),
+});
+
 const OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION =
   "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
+
+const OPENWORK_UI_CONTROL_INSTRUCTION =
+  "You can control the OpenWork desktop UI. Use openwork_ui_list_actions to discover available actions (navigate settings, open panels, compose messages, manage sessions), then openwork_ui_execute_action to perform them. Common actions: settings.panel.open (with panel arg like 'ai', 'extensions', 'permissions'), composer.set_text, composer.send, session.create_task, help.capabilities.";
+
+// ── UI control bridge discovery ──
+
+type UiBridge = { baseUrl: string; token: string };
+let cachedBridge: UiBridge | null = null;
+let cachedBridgeAt = 0;
+const BRIDGE_CACHE_MS = 2_000;
+const BRIDGE_TIMEOUT_MS = 5_000;
+
+function userAppDataDir(): string {
+  if (platform() === "darwin") return join(homedir(), "Library", "Application Support");
+  if (platform() === "win32") return process.env.APPDATA || join(homedir(), "AppData", "Roaming");
+  return process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+}
+
+function uiControlDiscoveryPaths(): string[] {
+  return [
+    process.env.OPENWORK_UI_CONTROL_DISCOVERY?.trim(),
+    join(userAppDataDir(), "com.differentai.openwork", "openwork-ui-control.json"),
+    join(userAppDataDir(), "com.differentai.openwork.dev", "openwork-ui-control.json"),
+  ].filter((p): p is string => Boolean(p));
+}
+
+async function discoverUiBridge(): Promise<UiBridge | null> {
+  if (cachedBridge && Date.now() - cachedBridgeAt < BRIDGE_CACHE_MS) return cachedBridge;
+  for (const candidate of uiControlDiscoveryPaths()) {
+    try {
+      const raw = await readFile(candidate, "utf8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      if (typeof parsed.baseUrl === "string" && typeof parsed.token === "string") {
+        cachedBridge = { baseUrl: parsed.baseUrl, token: parsed.token };
+        cachedBridgeAt = Date.now();
+        return cachedBridge;
+      }
+    } catch {
+      // Try next
+    }
+  }
+  return null;
+}
+
+async function uiBridgeRequest(path: string, options: { method?: string; body?: unknown } = {}): Promise<unknown> {
+  const bridge = await discoverUiBridge();
+  if (!bridge) return { ok: false, error: "OpenWork UI bridge not available. The desktop app may not be running." };
+  try {
+    const response = await fetch(`${bridge.baseUrl}${path}`, {
+      method: options.method || "GET",
+      signal: AbortSignal.timeout(BRIDGE_TIMEOUT_MS),
+      headers: {
+        Authorization: `Bearer ${bridge.token}`,
+        ...(options.body ? { "Content-Type": "application/json" } : {}),
+      },
+      ...(options.body ? { body: JSON.stringify(options.body) } : {}),
+    });
+    const text = await response.text();
+    try { return JSON.parse(text); } catch { return { ok: false, error: text || `HTTP ${response.status}` }; }
+  } catch (error) {
+    cachedBridge = null;
+    cachedBridgeAt = 0;
+    return { ok: false, error: `UI bridge unreachable: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
 
 function serverUrl(): string {
   return String(process.env.OPENWORK_SERVER_URL || "").replace(/\/$/, "");
@@ -103,6 +176,7 @@ function contextPayload(context: OpenCodeContext) {
 export const OpenWorkExtensionsPreview = async () => ({
   "experimental.chat.system.transform": async (_input: unknown, output: { system: string[] }) => {
     output.system.push(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
+    output.system.push(OPENWORK_UI_CONTROL_INSTRUCTION);
   },
   tool: {
     openwork_extension_list_actions: {
@@ -132,6 +206,34 @@ export const OpenWorkExtensionsPreview = async () => ({
           context: contextPayload(context),
         });
         return JSON.stringify(payload, null, 2);
+      },
+    },
+    openwork_ui_snapshot: {
+      description: "Get a snapshot of the current OpenWork UI state: active route, narration, visible actions, and status. Use this to understand what the user sees before taking action.",
+      args: {},
+      async execute() {
+        const result = await uiBridgeRequest("/snapshot");
+        return JSON.stringify(result, null, 2);
+      },
+    },
+    openwork_ui_list_actions: {
+      description: `List all UI control actions currently available in OpenWork. Each action has an id you can pass to openwork_ui_execute_action. ${OPENWORK_UI_CONTROL_INSTRUCTION}`,
+      args: {},
+      async execute() {
+        const result = await uiBridgeRequest("/actions");
+        return JSON.stringify(result, null, 2);
+      },
+    },
+    openwork_ui_execute_action: {
+      description: `Execute an OpenWork UI action by its id. Use openwork_ui_list_actions first to see available actions. ${OPENWORK_UI_CONTROL_INSTRUCTION}`,
+      args: uiExecuteArgsSchema.shape,
+      async execute(rawArgs: unknown) {
+        const { actionId, args } = uiExecuteArgsSchema.parse(rawArgs);
+        const result = await uiBridgeRequest("/execute", {
+          method: "POST",
+          body: { actionId, args: args ?? {} },
+        });
+        return JSON.stringify(result, null, 2);
       },
     },
   },


### PR DESCRIPTION
Adds openwork_ui_snapshot, openwork_ui_list_actions, openwork_ui_execute_action to the openwork-extensions-preview plugin. No npx, no subprocess — runs in-process. Discovers the Electron bridge via the discovery file. Typecheck passes.