### PR TITLE
feat(server): inject agent capabilities knowledge via plugin

### DIFF
--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -6,7 +6,7 @@ import { parseCliArgs, printHelp, resolveServerConfig } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
 import { createServerLogger, startServer } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
-import { openworkExtensionsPreviewPluginPath } from "./openwork-extensions-plugin-path.js";
+import { openworkExtensionsPreviewPluginPath, openworkCapabilitiesKnowledgePluginPath } from "./openwork-extensions-plugin-path.js";
 import pkg from "../package.json" with { type: "json" };
 
 const args = parseCliArgs(process.argv.slice(2));
@@ -39,6 +39,7 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
       plugin: [
         "opencode-chrome-devtools",
         openworkExtensionsPreviewPluginPath(),
+        openworkCapabilitiesKnowledgePluginPath(),
       ],
     });
     const managedOpencodeCwd = process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim() || workspace.path;

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -10,7 +10,7 @@ import { resolveServerConfig, type CliArgs } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
 import { startServer } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
-import { openworkExtensionsPreviewPluginPath } from "./openwork-extensions-plugin-path.js";
+import { openworkExtensionsPreviewPluginPath, openworkCapabilitiesKnowledgePluginPath } from "./openwork-extensions-plugin-path.js";
 import type { ServeResult } from "./serve-node.js";
 import type { ServerConfig } from "./types.js";
 
@@ -57,6 +57,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
         plugin: [
           "opencode-chrome-devtools",
           openworkExtensionsPreviewPluginPath(),
+          openworkCapabilitiesKnowledgePluginPath(),
         ],
       });
       const cwd = options.opencodeCwd

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
@@ -1,0 +1,72 @@
+/**
+ * OpenWork Capabilities Knowledge Plugin
+ *
+ * Injects knowledge about OpenWork's capabilities into the agent's system
+ * prompt so it can proactively help users with:
+ * - Adding AI providers (including local models via Ollama)
+ * - Fixing authorized folders
+ * - Enabling computer use
+ * - Connecting MCP extensions
+ * - Using OpenWork Cloud
+ * - Voice mode, browser, skills, automations
+ */
+
+const OPENWORK_CAPABILITIES_KNOWLEDGE = `You are running inside OpenWork, a desktop app for agentic work. Here is what you can help users with:
+
+## Adding AI Providers
+- **Cloud providers**: Go to Settings > AI Providers to add Anthropic, OpenAI, Google, OpenRouter, or other providers with an API key.
+- **OpenWork Cloud models**: Users can sign up for OpenWork Cloud at the Den sign-in page for managed AI models without needing their own API keys.
+- **Local models (Ollama)**: Tell the user to:
+  1. Install Ollama from https://ollama.com (or \`brew install ollama\` on macOS)
+  2. Run \`ollama pull <model>\` in their terminal (e.g. \`ollama pull llama3\`)
+  3. The model appears automatically in Settings > AI Providers
+  4. Select it from the model picker in the session composer
+- **Custom provider scripts**: Users can add custom OpenAI-compatible endpoints in Settings > AI Providers by adding a provider with a custom base URL.
+
+## Fixing Authorized Folders
+- Go to Settings > Permissions to manage which folders OpenWork can access.
+- When the agent gets a "permission denied" or "not authorized" error for a file path, the user needs to add that folder (or a parent folder) to the authorized folders list.
+- The agent can navigate there: use the UI control action \`settings.panel.open\` with \`{panel: "permissions"}\`.
+
+## Enabling Computer Use
+- Go to Settings > Extensions and enable the "Computer Use" extension.
+- This requires macOS accessibility permissions — the app will prompt for them.
+- Once enabled, the agent can take screenshots and control the mouse/keyboard on the user's desktop.
+
+## Connecting MCP Extensions
+- Go to Settings > Extensions to add MCP servers.
+- Popular integrations: Google Workspace, GitHub, Slack, databases, file systems.
+- Users can browse the marketplace for pre-built extensions, or add custom MCPs by providing a command (e.g. \`npx -y @some/mcp-server\`) or URL.
+
+## Voice Mode
+- Available as a side panel in sessions when the OpenWork Voice extension is enabled.
+- Uses OpenAI Realtime for real-time voice interaction.
+- The voice model can control the UI on the user's behalf (same actions the agent has access to).
+
+## Browsing the Web
+- The built-in browser (chrome-devtools) lets the agent navigate, click, type, and screenshot web pages.
+- The browser panel is visible on the right side of the session view.
+
+## OpenWork Cloud
+- Users sign up at the Den portal (accessible from the status bar "Sign in" button).
+- Cloud features: managed AI models, team workspaces, shared skills, marketplace extensions, org provisioning.
+- After signing in, cloud-provisioned providers and extensions appear automatically.
+
+## Skills
+- Specialized instruction packs for specific workflows.
+- Manageable via Settings > Skills.
+- Users can install skill templates or create custom skills in \`.opencode/skills/\`.
+
+## Creating Plugins
+- Plugins extend OpenWork/OpenCode with custom tools.
+- Create a file in \`.opencode/plugins/my-plugin.ts\` and add it to the \`plugin\` array in \`opencode.json\`.
+- Plugins are async factory functions returning a hooks object with \`tool\` definitions.
+- See the \`create-plugin\` skill for the full API reference.
+
+When users ask "what can I do?" or "what can OpenWork do?", summarize these capabilities. When they ask how to do something specific, give them the direct steps.`;
+
+export const OpenWorkCapabilitiesKnowledge = async () => ({
+  "experimental.chat.system.transform": async (_input: unknown, output: { system: string[] }) => {
+    output.system.push(OPENWORK_CAPABILITIES_KNOWLEDGE);
+  },
+});

--- a/apps/server/src/openwork-extensions-plugin-path.ts
+++ b/apps/server/src/openwork-extensions-plugin-path.ts
@@ -6,3 +6,9 @@ export function openworkExtensionsPreviewPluginPath(): string {
   const extension = basename(here) === "dist" ? "js" : "ts";
   return join(here, "opencode-plugins", `openwork-extensions-preview.${extension}`);
 }
+
+export function openworkCapabilitiesKnowledgePluginPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const extension = basename(here) === "dist" ? "js" : "ts";
+  return join(here, "opencode-plugins", `openwork-capabilities-knowledge.${extension}`);
+}


### PR DESCRIPTION
New plugin injects knowledge about OpenWork capabilities (providers, Ollama, authorized folders, computer use, MCPs, Cloud, voice, plugins) into the system prompt. Agent can now answer 'what can I do?' and guide setup. Typecheck passes.