### PR TITLE
fix: simplify plugin paths, deduplicate SETTINGS_TABS, add provider restriction guard

### DIFF
--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -173,24 +173,27 @@ export type EngineRuntime = "direct";
 
 export type OnboardingStep = "welcome" | "local" | "server" | "connecting";
 
-export type SettingsTab =
-  | "general"
-  | "ai"
-  | "preferences"
-  | "permissions"
-  | "shell"
-  | "cloud-account"
-  | "cloud-marketplaces"
-  | "cloud-workers"
-  | "cloud-providers"
-  | "skills"
-  | "extensions"
-  | "environment"
-  | "advanced"
-  | "appearance"
-  | "updates"
-  | "recovery"
-  | "debug";
+export const SETTINGS_TAB_VALUES = [
+  "general",
+  "ai",
+  "preferences",
+  "permissions",
+  "shell",
+  "cloud-account",
+  "cloud-marketplaces",
+  "cloud-workers",
+  "cloud-providers",
+  "skills",
+  "extensions",
+  "environment",
+  "advanced",
+  "appearance",
+  "updates",
+  "recovery",
+  "debug",
+] as const;
+
+export type SettingsTab = (typeof SETTINGS_TAB_VALUES)[number];
 
 export type WorkspacePreset = "starter" | "automation" | "minimal";
 

--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -445,25 +445,9 @@ export function useControlActions(actions: readonly OpenworkControlAction[]) {
   }, [registerAction, ids]);
 }
 
-const SETTINGS_TABS: ReadonlySet<string> = new Set<string>([
-  "general",
-  "ai",
-  "preferences",
-  "permissions",
-  "shell",
-  "cloud-account",
-  "cloud-marketplaces",
-  "cloud-workers",
-  "cloud-providers",
-  "skills",
-  "extensions",
-  "environment",
-  "advanced",
-  "appearance",
-  "updates",
-  "recovery",
-  "debug",
-]);
+import { SETTINGS_TAB_VALUES } from "../../../app/types";
+
+const SETTINGS_TABS: ReadonlySet<string> = new Set<string>(SETTINGS_TAB_VALUES);
 
 export function OpenworkRouteControlActions() {
   const navigate = useNavigate();

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2536,6 +2536,9 @@ export function SessionRoute() {
       { name: "providerId", type: "string" as const, required: false, description: "Provider id to pre-select, e.g. 'anthropic', 'openai', 'google'." },
     ],
     execute: async (rawArgs: unknown) => {
+      if (checkDesktopRestriction({ restriction: "allowCustomProviders" })) {
+        return { ok: false, error: "Custom providers are disabled by your organization." };
+      }
       const providerId = typeof rawArgs === "object" && rawArgs !== null
         ? (rawArgs as Record<string, unknown>).providerId
         : undefined;
@@ -2545,7 +2548,7 @@ export function SessionRoute() {
       );
       return { ok: true, opened: "provider_auth_modal", preferredProviderId: preferred ?? null };
     },
-  }), [sessionProviderAuthStore]);
+  }), [checkDesktopRestriction, sessionProviderAuthStore]);
   useControlAction(addProviderControlAction);
 
   const paletteSessionOptions = useMemo<PaletteSessionOption[]>(() => {

--- a/apps/server/src/openwork-extensions-plugin-path.ts
+++ b/apps/server/src/openwork-extensions-plugin-path.ts
@@ -1,14 +1,11 @@
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export function openworkExtensionsPreviewPluginPath(): string {
+function pluginPath(name: string): string {
   const here = dirname(fileURLToPath(import.meta.url));
   const extension = basename(here) === "dist" ? "js" : "ts";
-  return join(here, "opencode-plugins", `openwork-extensions-preview.${extension}`);
+  return join(here, "opencode-plugins", `${name}.${extension}`);
 }
 
-export function openworkCapabilitiesKnowledgePluginPath(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const extension = basename(here) === "dist" ? "js" : "ts";
-  return join(here, "opencode-plugins", `openwork-capabilities-knowledge.${extension}`);
-}
+export const openworkExtensionsPreviewPluginPath = () => pluginPath("openwork-extensions-preview");
+export const openworkCapabilitiesKnowledgePluginPath = () => pluginPath("openwork-capabilities-knowledge");


### PR DESCRIPTION
Three cleanups from code audit:

1. **plugin-path.ts**: Extract `pluginPath(name)` helper — two identical functions collapsed to one
2. **types.ts + control-provider.tsx**: Export `SETTINGS_TAB_VALUES` array, derive both `SettingsTab` type and `SETTINGS_TABS` set from it. Adding a settings tab now requires one edit instead of two.
3. **session-route.tsx**: Add missing `allowCustomProviders` restriction check to `settings.provider.add` control action (bug fix — org-managed desktops could bypass the restriction via voice/agent).

Typecheck passes (app + server). Net -13 lines.