### PR TITLE
feat(inference): add MiniMax M3 model alias

### DIFF
--- a/ee/apps/inference/src/models/openwork-dev.json
+++ b/ee/apps/inference/src/models/openwork-dev.json
@@ -61,6 +61,26 @@
         "limit": { "context": 1048576, "output": 393216 },
         "cost": { "input": 0.14, "output": 0.28, "cache_read": 0.028 }
       },
+      "minimax/minimax-m3": {
+        "id": "minimax/minimax-m3",
+        "name": "MiniMax M3",
+        "family": "minimax",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-05-29",
+        "last_updated": "2026-05-29",
+        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "open_weights": true,
+        "limit": { "context": 512000, "output": 131072 },
+        "cost": {
+          "input": 0.3,
+          "output": 1.2,
+          "cache_read": 0.06,
+          "cache_write": 0.375
+        }
+      },
       "minimax/minimax-m2.7": {
         "id": "minimax/minimax-m2.7",
         "name": "MiniMax M2.7",

--- a/ee/apps/inference/src/models/openwork-prod.json
+++ b/ee/apps/inference/src/models/openwork-prod.json
@@ -61,6 +61,26 @@
         "limit": { "context": 1048576, "output": 393216 },
         "cost": { "input": 0.14, "output": 0.28, "cache_read": 0.028 }
       },
+      "minimax/minimax-m3": {
+        "id": "minimax/minimax-m3",
+        "name": "MiniMax M3",
+        "family": "minimax",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-05-29",
+        "last_updated": "2026-05-29",
+        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "open_weights": true,
+        "limit": { "context": 512000, "output": 131072 },
+        "cost": {
+          "input": 0.3,
+          "output": 1.2,
+          "cache_read": 0.06,
+          "cache_write": 0.375
+        }
+      },
       "minimax/minimax-m2.7": {
         "id": "minimax/minimax-m2.7",
         "name": "MiniMax M2.7",

--- a/packages/types/src/den/inference.ts
+++ b/packages/types/src/den/inference.ts
@@ -72,6 +72,12 @@ export const INFERENCE_MODEL_ALIASES = {
     enabled: true,
     usageFactor: 1,
   },
+  "minimax/minimax-m3": {
+    upstreamModel: "minimax/minimax-m3",
+    displayName: "OpenWork: MiniMax M3",
+    enabled: true,
+    usageFactor: 1,
+  },
   "minimax/minimax-m2.7": {
     upstreamModel: "minimax/minimax-m2.7",
     displayName: "OpenWork: MiniMax M2.7",


### PR DESCRIPTION
## Summary

- Add `minimax/minimax-m3` to `INFERENCE_MODEL_ALIASES` so the OpenWork inference proxy exposes the new MiniMax M3 flagship model alongside the existing M2.7 entry.
- Mirror the alias in `openwork-dev.json` / `openwork-prod.json` with M3's spec (512K context, 128K max output, image input).

## Why

MiniMax M3 is the latest MiniMax flagship model and is a natural next addition to the openwork-hosted catalog now that M2.7 was wired up in #1821. This is the smallest possible patch — no provider/runtime changes, no behavior changes, no defaults moved.

## Scope

- `packages/types/src/den/inference.ts`
- `ee/apps/inference/src/models/openwork-dev.json`
- `ee/apps/inference/src/models/openwork-prod.json`

## Out of scope

- `base.json` — left untouched (regenerated upstream from models.dev).
- Default model selection — unchanged.

## Testing

### Ran

- `node ee/apps/inference/scripts/build-models.mjs`

### Result

- pass: `models-site/models/api.json` regenerates cleanly and includes both `minimax/minimax-m3` and `minimax/minimax-m2.7` under the openwork provider.

## Manual verification

1. `node ee/apps/inference/scripts/build-models.mjs` succeeds.
2. The generated `api.json` lists `minimax/minimax-m3` under the openwork provider's models map.
3. `INFERENCE_MODEL_ALIASES` exports both aliases as enabled.

## Risk

- Low. Pure config addition; no removals; no behavior change for existing M2.7 traffic.

## Rollback

- Revert this PR; the alias map returns to the pre-change state.