### PR TITLE
feat(app): drag-and-drop between groups + session management UI controls

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1538,4 +1538,5 @@ export default {
   "session_management.new_group_prompt": "Name this group (e.g. Done, In progress):",
   "session_management.remove_group": "Remove group",
   "session_management.empty_group": "No sessions",
+  "session_management.ungrouped": "Ungrouped",
 } as const;

--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -3,8 +3,10 @@ import { useMemo } from "react";
 
 import type { createClient } from "../../../../app/lib/opencode";
 import type { OpenworkServerClient, OpenworkWorkspaceInfo } from "../../../../app/lib/openwork-server";
+import { setSessionArchived } from "../../../../app/lib/opencode-session";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
+import { useSessionManagementStore } from "../sidebar/session-management-store";
 
 type SessionLike = {
   id?: string;
@@ -202,4 +204,143 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
     execute: openModelPicker,
   }), [openModelPicker, selectedWorkspaceId]);
   useControlAction(modelPickerControlAction);
+
+  // ---------------------------------------------------------------------------
+  // Session management control actions (pin, archive, groups)
+  // ---------------------------------------------------------------------------
+
+  const store = useSessionManagementStore;
+
+  const pinControlAction = useMemo<OpenworkControlAction>(() => ({
+    id: "session.pin",
+    label: "Pin or unpin a session",
+    description: "Toggle pin on a session. Pinned sessions float to the top of the sidebar.",
+    sideEffect: "mutation",
+    requiresArgs: true,
+    args: [{ name: "sessionId", type: "string", required: true, description: "Session ID to pin/unpin." }],
+    execute: (args) => {
+      const sessionId = stringArg(args, "sessionId");
+      if (!sessionId) return { ok: false, error: "sessionId is required" };
+      store.getState().togglePin(sessionId);
+      const pinned = store.getState().pinnedIds.includes(sessionId);
+      return { ok: true, sessionId, pinned };
+    },
+  }), []);
+  useControlAction(pinControlAction);
+
+  const archiveControlAction = useMemo<OpenworkControlAction>(() => ({
+    id: "session.archive",
+    label: "Archive or unarchive a session",
+    description: "Archive a session (non-destructive, preserves context). Archived sessions move to the Archived section. Pass archived=false to unarchive.",
+    sideEffect: "mutation",
+    requiresArgs: true,
+    args: [
+      { name: "sessionId", type: "string", required: true, description: "Session ID." },
+      { name: "archived", type: "boolean", required: true, description: "true to archive, false to unarchive." },
+    ],
+    disabled: !opencodeClient,
+    execute: async (args) => {
+      const sessionId = stringArg(args, "sessionId");
+      const archived = booleanArg(args, "archived");
+      if (!sessionId) return { ok: false, error: "sessionId is required" };
+      if (!opencodeClient) return { ok: false, error: "OpenCode client is not connected" };
+      const targetWorkspace = findSessionWorkspace(workspaces, sessionsByWorkspaceId, sessionId);
+      await setSessionArchived(opencodeClient, sessionId, archived, targetWorkspace?.path || selectedWorkspaceRoot || undefined);
+      await refreshRouteState();
+      return { ok: true, sessionId, archived };
+    },
+  }), [opencodeClient, refreshRouteState, selectedWorkspaceRoot, sessionsByWorkspaceId, workspaces]);
+  useControlAction(archiveControlAction);
+
+  const groupCreateControlAction = useMemo<OpenworkControlAction>(() => ({
+    id: "session.group.create",
+    label: "Create a session group",
+    description: "Create a new group (folder/separator) in the current workspace sidebar. Sessions can then be moved into it.",
+    sideEffect: "mutation",
+    requiresArgs: true,
+    args: [
+      { name: "label", type: "string", required: true, description: "Group name (e.g. 'Done', 'In progress', 'Backlog')." },
+      { name: "workspaceId", type: "string", required: false, description: "Workspace ID. Defaults to the selected workspace." },
+    ],
+    disabled: !selectedWorkspaceId,
+    execute: (args) => {
+      const label = stringArg(args, "label");
+      const wsId = stringArg(args, "workspaceId") || selectedWorkspaceId;
+      if (!label) return { ok: false, error: "label is required" };
+      if (!wsId) return { ok: false, error: "No workspace selected" };
+      store.getState().createGroup(wsId, label);
+      return { ok: true, workspaceId: wsId, label };
+    },
+  }), [selectedWorkspaceId]);
+  useControlAction(groupCreateControlAction);
+
+  const groupMoveControlAction = useMemo<OpenworkControlAction>(() => ({
+    id: "session.group.move",
+    label: "Move a session to a group",
+    description: "Assign a session to a group (folder). Pass groupId=null or omit to remove from current group. Use session.group.list to see available groups.",
+    sideEffect: "mutation",
+    requiresArgs: true,
+    args: [
+      { name: "sessionId", type: "string", required: true, description: "Session ID." },
+      { name: "groupId", type: "string", required: false, description: "Group ID to move into. Omit or null to ungrouped." },
+      { name: "workspaceId", type: "string", required: false, description: "Workspace ID. Defaults to session's workspace." },
+    ],
+    execute: (args) => {
+      const sessionId = stringArg(args, "sessionId");
+      const groupId = stringArg(args, "groupId") || null;
+      if (!sessionId) return { ok: false, error: "sessionId is required" };
+      const targetWorkspace = findSessionWorkspace(workspaces, sessionsByWorkspaceId, sessionId);
+      const wsId = stringArg(args, "workspaceId") || targetWorkspace?.id || selectedWorkspaceId;
+      if (!wsId) return { ok: false, error: "Could not determine workspace" };
+      store.getState().assignGroup(wsId, sessionId, groupId);
+      return { ok: true, sessionId, groupId, workspaceId: wsId };
+    },
+  }), [selectedWorkspaceId, sessionsByWorkspaceId, workspaces]);
+  useControlAction(groupMoveControlAction);
+
+  const groupRemoveControlAction = useMemo<OpenworkControlAction>(() => ({
+    id: "session.group.remove",
+    label: "Remove a session group",
+    description: "Remove a group from the workspace. Sessions in the group become ungrouped (not deleted).",
+    sideEffect: "mutation",
+    requiresConfirmation: true,
+    requiresArgs: true,
+    args: [
+      { name: "groupId", type: "string", required: true, description: "Group ID to remove." },
+      { name: "workspaceId", type: "string", required: false, description: "Workspace ID. Defaults to selected." },
+      { name: "confirmed", type: "boolean", required: true, description: "Must be true." },
+    ],
+    disabled: !selectedWorkspaceId,
+    execute: (args) => {
+      const groupId = stringArg(args, "groupId");
+      const confirmed = booleanArg(args, "confirmed");
+      const wsId = stringArg(args, "workspaceId") || selectedWorkspaceId;
+      if (!groupId) return { ok: false, error: "groupId is required" };
+      if (!confirmed) return { ok: false, error: "Requires confirmed: true" };
+      if (!wsId) return { ok: false, error: "No workspace selected" };
+      store.getState().removeGroup(wsId, groupId);
+      return { ok: true, groupId, workspaceId: wsId };
+    },
+  }), [selectedWorkspaceId]);
+  useControlAction(groupRemoveControlAction);
+
+  const groupListControlAction = useMemo<OpenworkControlAction>(() => ({
+    id: "session.group.list",
+    label: "List session groups",
+    description: "List all groups in a workspace with their IDs and labels.",
+    sideEffect: "none",
+    args: [{ name: "workspaceId", type: "string", required: false, description: "Workspace ID. Defaults to selected." }],
+    execute: (args) => {
+      const wsId = stringArg(args, "workspaceId") || selectedWorkspaceId;
+      if (!wsId) return { ok: false, error: "No workspace selected" };
+      const state = store.getState().groupsByWorkspace[wsId];
+      return {
+        ok: true,
+        workspaceId: wsId,
+        groups: (state?.groups ?? []).map((g) => ({ id: g.id, label: g.label })),
+        assignments: state?.assignments ?? {},
+      };
+    },
+  }), [selectedWorkspaceId]);
+  useControlAction(groupListControlAction);
 }

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1063,9 +1063,38 @@ function WorkspaceSidebarGroup({
   );
 }
 
-function SessionGroupSeparator({ label, onRemove }: { label: string; onRemove?: () => void }) {
+const SESSION_DRAG_TYPE = "application/x-openwork-session-id";
+
+function SessionGroupSeparator({ label, groupId, workspaceId, onRemove }: {
+  label: string;
+  groupId: string | null;
+  workspaceId: string;
+  onRemove?: () => void;
+}) {
+  const [dragOver, setDragOver] = React.useState(false);
+  const store = useSessionManagementStore;
+
   return (
-    <div className="group/separator flex items-center gap-1 px-2 pb-1 pt-2.5 first:pt-1">
+    <div
+      className={cn(
+        "group/separator flex items-center gap-1 px-2 pb-1 pt-2.5 first:pt-1 rounded transition-colors",
+        dragOver && "bg-accent/50 ring-1 ring-accent",
+      )}
+      onDragOver={(e) => {
+        if (e.dataTransfer.types.includes(SESSION_DRAG_TYPE)) {
+          e.preventDefault();
+          setDragOver(true);
+        }
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={(e) => {
+        setDragOver(false);
+        const sessionId = e.dataTransfer.getData(SESSION_DRAG_TYPE);
+        if (sessionId) {
+          store.getState().assignGroup(workspaceId, sessionId, groupId);
+        }
+      }}
+    >
       <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
         {label}
       </span>
@@ -1158,6 +1187,8 @@ function GroupedSessionList({ sessionRows, groups, assignments, pinnedIds, tree,
           <React.Fragment key={group.id}>
             <SessionGroupSeparator
               label={group.label}
+              groupId={group.id}
+              workspaceId={workspaceId}
               onRemove={() => store.getState().removeGroup(workspaceId, group.id)}
             />
             {rows.length > 0
@@ -1172,7 +1203,12 @@ function GroupedSessionList({ sessionRows, groups, assignments, pinnedIds, tree,
           </React.Fragment>
         );
       })}
-      {ungroupedRows.length > 0 ? ungroupedRows.map(renderRow) : null}
+      {ungroupedRows.length > 0 ? (
+        <>
+          <SessionGroupSeparator label={t("session_management.ungrouped")} groupId={null} workspaceId={workspaceId} />
+          {ungroupedRows.map(renderRow)}
+        </>
+      ) : null}
     </>
   );
 }
@@ -1228,13 +1264,21 @@ function SessionMenuItem({
     ctx.onPrefetchSession?.(workspaceId, session.id);
   };
 
+  const dragProps = depth === 0 ? {
+    draggable: true,
+    onDragStart: (e: React.DragEvent) => {
+      e.dataTransfer.setData(SESSION_DRAG_TYPE, session.id);
+      e.dataTransfer.effectAllowed = "move";
+    },
+  } : {};
+
   const item = hasChildren ? (
     <Collapsible
       open={isExpanded}
       onOpenChange={() => ctx.toggleSessionExpanded(session.id)}
       className="group/session-collapsible"
     >
-      <SidebarMenuSubItem>
+      <SidebarMenuSubItem {...dragProps}>
         <SessionContextMenu sessionId={session.id} workspaceId={workspaceId} isPinned={isPinned} isArchived={isArchived}>
           <CollapsibleTrigger
             render={
@@ -1270,7 +1314,7 @@ function SessionMenuItem({
       </SidebarMenuSubItem>
     </Collapsible>
   ) : (
-    <SidebarMenuSubItem>
+    <SidebarMenuSubItem {...dragProps}>
       <SessionContextMenu sessionId={session.id} workspaceId={workspaceId} isPinned={isPinned} isArchived={isArchived}>
         <SidebarMenuSubButton
           isActive={isSelected}


### PR DESCRIPTION
## Drag-and-drop between groups

Sessions can now be dragged onto group headers (or the "Ungrouped" zone) to reassign them. Uses native HTML5 DnD — no new dependencies.

- Root sessions (depth 0) get `draggable` + `onDragStart` setting the session ID
- Group separator headers (+ an "Ungrouped" drop zone) handle `onDragOver`/`onDrop`
- Visual highlight (ring + bg accent) on drag-over
- Works in both grouped and ungrouped views

## Session management UI control actions

Seven new control actions, auto-discovered by the opencode plugin and `openwork-ui-mcp`:

| Action ID | Description |
|---|---|
| `session.pin` | Toggle pin on a session |
| `session.archive` | Archive/unarchive a session |
| `session.group.create` | Create a new group in a workspace |
| `session.group.move` | Move a session to a group (or ungrouped) |
| `session.group.remove` | Remove a group (sessions become ungrouped) |
| `session.group.list` | List groups + assignments for a workspace |

This enables natural language workflows like:
- "create a Done folder for this workspace"
- "when you're done, move this task to the Done folder"
- "archive all sessions from yesterday"

No changes needed in `openwork-extensions-preview.ts`, `openwork-ui-mcp`, or `main.mjs` — they are generic and automatically surface whatever actions are registered.

## Tests run

```
pnpm --filter @openwork/app run typecheck   # exit 0
pnpm --filter @openwork/app run build        # exit 0
```

## Diff

+191/-5 across 3 files (i18n, control actions, sidebar).