### PR TITLE
fix(app): restyle archived section to match group separator style

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1539,4 +1539,5 @@ export default {
   "session_management.remove_group": "Remove group",
   "session_management.empty_group": "No sessions",
   "session_management.ungrouped": "Ungrouped",
+  "session_management.archived_label": "Archived",
 } as const;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1374,21 +1374,21 @@ function ArchivedSessionsSection({
   const pinned = usePinnedSessionIds();
   return (
     <Collapsible open={expanded} onOpenChange={onToggle} className="group/archived">
-      <SidebarMenuSubItem>
-        <CollapsibleTrigger
-          render={
-            <SidebarMenuSubButton className="relative text-muted-foreground text-xs">
-              <Archive className="size-3.5 shrink-0" />
-              <span className="min-w-0 flex-1 truncate">
-                {t("session_management.archived_count", { count: sessions.length })}
-              </span>
-              <span className="flex items-center justify-center size-6 absolute right-2 top-1/2 -translate-y-1/2">
-                <ChevronRight className="size-4 text-muted-foreground transition-transform duration-200 group-data-open/archived:rotate-90" />
-              </span>
-            </SidebarMenuSubButton>
-          }
-        />
-      </SidebarMenuSubItem>
+      <CollapsibleTrigger
+        render={
+          <button
+            type="button"
+            className="group/separator flex w-full cursor-pointer items-center gap-1.5 px-2 pb-1 pt-2.5 rounded transition-colors hover:bg-sidebar-accent/50"
+          >
+            <Archive className="size-3 shrink-0 text-muted-foreground" />
+            <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              {t("session_management.archived_label")}
+            </span>
+            <span className="text-[10px] tabular-nums text-muted-foreground/70">{sessions.length}</span>
+            <ChevronRight className="ml-auto size-3.5 text-muted-foreground transition-transform duration-200 group-data-open/archived:rotate-90" />
+          </button>
+        }
+      />
       <CollapsibleContent>
         {sessions.map((session) => (
           <SessionMenuItem


### PR DESCRIPTION
The archived section looked like a button row instead of a group header. Now matches the DONE/IN PROGRESS separator style:

- Uppercase label + archive icon + count badge + chevron
- Same padding/font/weight as group separators
- Hover state for the collapsible trigger
- Only visible when archived count > 0 (unchanged)

```
pnpm --filter @openwork/app run typecheck  # exit 0
```