### PR TITLE
chore(server): move agent definition to runtime config, remove disk-based agent file

### DIFF
--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -6,7 +6,7 @@ import { parseCliArgs, printHelp, resolveServerConfig } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
 import { createServerLogger, startServer } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
-import { openworkExtensionsPreviewPluginPath, openworkCapabilitiesKnowledgePluginPath } from "./openwork-extensions-plugin-path.js";
+import { buildOpenworkRuntimeConfig } from "./openwork-runtime-config.js";
 import pkg from "../package.json" with { type: "json" };
 
 const args = parseCliArgs(process.argv.slice(2));
@@ -35,13 +35,7 @@ if (!config.readOnly) {
 if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
   const workspace = config.workspaces[0];
   if (workspace?.path) {
-    const openworkExtensionsPreviewConfig = JSON.stringify({
-      plugin: [
-        "opencode-chrome-devtools",
-        openworkExtensionsPreviewPluginPath(),
-        openworkCapabilitiesKnowledgePluginPath(),
-      ],
-    });
+    const openworkRuntimeConfig = buildOpenworkRuntimeConfig();
     const managedOpencodeCwd = process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim() || workspace.path;
     await mkdir(managedOpencodeCwd, { recursive: true });
     managedOpencode = await createManagedOpencodeServer({
@@ -51,7 +45,7 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
         ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
         OPENWORK_SERVER_URL: serverUrl,
         OPENWORK_SERVER_TOKEN: config.token,
-        OPENCODE_CONFIG_CONTENT: openworkExtensionsPreviewConfig,
+        OPENCODE_CONFIG_CONTENT: openworkRuntimeConfig,
       },
     });
     config.opencodeBaseUrl = managedOpencode.url;

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -10,7 +10,7 @@ import { resolveServerConfig, type CliArgs } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
 import { startServer } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
-import { openworkExtensionsPreviewPluginPath, openworkCapabilitiesKnowledgePluginPath } from "./openwork-extensions-plugin-path.js";
+import { buildOpenworkRuntimeConfig } from "./openwork-runtime-config.js";
 import type { ServeResult } from "./serve-node.js";
 import type { ServerConfig } from "./types.js";
 
@@ -53,13 +53,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
   if (!config.opencodeBaseUrl && options.manageOpencode) {
     const workspace = config.workspaces[0];
     if (workspace?.path) {
-      const openworkExtensionsPreviewConfig = JSON.stringify({
-        plugin: [
-          "opencode-chrome-devtools",
-          openworkExtensionsPreviewPluginPath(),
-          openworkCapabilitiesKnowledgePluginPath(),
-        ],
-      });
+      const openworkRuntimeConfig = buildOpenworkRuntimeConfig();
       const cwd = options.opencodeCwd
         || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
         || workspace.path;
@@ -72,7 +66,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
           ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
           OPENWORK_SERVER_URL: serverUrl,
           OPENWORK_SERVER_TOKEN: config.token,
-          OPENCODE_CONFIG_CONTENT: openworkExtensionsPreviewConfig,
+          OPENCODE_CONFIG_CONTENT: openworkRuntimeConfig,
           OPENCODE_MODELS_URL: opencodeModelsUrl,
         },
       });

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -1,0 +1,61 @@
+/**
+ * Runtime OpenCode configuration injected via OPENCODE_CONFIG_CONTENT.
+ *
+ * This is the single source of truth for the openwork agent definition,
+ * plugins, and any other config that should be injected at runtime rather
+ * than written to disk. Both cli.ts and embedded.ts use this.
+ */
+import { openworkExtensionsPreviewPluginPath, openworkCapabilitiesKnowledgePluginPath } from "./openwork-extensions-plugin-path.js";
+
+const OPENWORK_AGENT_PROMPT = `You are OpenWork.
+
+When the user refers to "you", they mean the OpenWork app and the current workspace.
+
+Your job:
+- Help the user work on files safely.
+- Automate repeatable work.
+- Keep behavior portable and reproducible.
+
+## Memory
+
+Two kinds:
+1. Behavior memory (shareable, in git): .opencode/skills/**, .opencode/agents/**, repo docs
+2. Private memory (never commit): tokens, credentials, local config, logs
+
+Hard rule: never copy private memory into repo files. Store only redacted summaries, schemas, and stable pointers.
+
+## Working style
+
+- If required setup or credentials are missing, ask one targeted question and continue once provided.
+- If you change code, run the smallest meaningful test.
+- If steps repeat, factor them into a skill.
+- Prefer clear, practical steps over abstract explanations.
+
+## OpenWork Artifacts
+
+OpenWork can preview, edit, and download standard artifacts when you create or update them in the workspace.
+
+- Prefer standard output files for user-visible deliverables: Markdown (.md), CSV (.csv), Excel workbooks (.xlsx), and browser previews (index.html or a local http://localhost:<port> URL).
+- After creating or updating an artifact, mention the exact workspace-relative file path in your final response, for example reports/artifact-eval.md or reports/artifact-eval.xlsx.
+- Do not invent Workspace/<id>/... paths unless a tool returns them; prefer clean workspace-relative paths.
+- For websites or React/UI previews, start the dev server when useful and mention the http://localhost:<port> URL.
+- For spreadsheets, use .csv for simple tabular data and .xlsx when the user asks for Excel/XLS specifically.`;
+
+export function buildOpenworkRuntimeConfig(): string {
+  return JSON.stringify({
+    default_agent: "openwork",
+    agent: {
+      openwork: {
+        description: "OpenWork default agent",
+        mode: "primary",
+        temperature: 0.2,
+        prompt: OPENWORK_AGENT_PROMPT,
+      },
+    },
+    plugin: [
+      "opencode-chrome-devtools",
+      openworkExtensionsPreviewPluginPath(),
+      openworkCapabilitiesKnowledgePluginPath(),
+    ],
+  });
+}

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -10,55 +10,6 @@ import type { ReloadReason } from "./types.js";
 const BROWSER_PLUGIN = "opencode-chrome-devtools";
 const LEGACY_BROWSER_MCP_KEYS = ["openwork-browser", "chrome", "chrome-devtools", "control-chrome"];
 
-const OPENWORK_ARTIFACT_GUIDANCE = `<!-- OPENWORK_ARTIFACTS_START -->
-## OpenWork Artifacts
-
-OpenWork can preview, edit, and download standard artifacts when you create or update them in the workspace.
-
-- Prefer standard output files for user-visible deliverables: Markdown (\`.md\`), CSV (\`.csv\`), Excel workbooks (\`.xlsx\`), and browser previews (\`index.html\` or a local \`http://localhost:<port>\` URL).
-- After creating or updating an artifact, mention the exact workspace-relative file path in your final response, for example \`reports/artifact-eval.md\` or \`reports/artifact-eval.xlsx\`.
-- Do not invent \`Workspace/<id>/...\` paths unless a tool returns them; prefer clean workspace-relative paths.
-- For websites or React/UI previews, start the dev server when useful and mention the \`http://localhost:<port>\` URL. Socket URLs such as \`ws://localhost:<port>/...\` are diagnostic hints, not primary preview links.
-- For spreadsheets, use \`.csv\` for simple tabular data and \`.xlsx\` when the user asks for Excel/XLS specifically.
-<!-- OPENWORK_ARTIFACTS_END -->`;
-
-// The agent template is intentionally minimal. Browser instructions, UI control
-// tool guidance, and capabilities knowledge are injected at runtime via plugins
-// (openwork-extensions-preview.ts and openwork-capabilities-knowledge.ts) through
-// the OPENCODE_CONFIG_CONTENT env var. This avoids duplication and patching.
-const OPENWORK_AGENT = `---
-description: OpenWork default agent
-mode: primary
-temperature: 0.2
----
-
-You are OpenWork.
-
-When the user refers to "you", they mean the OpenWork app and the current workspace.
-
-Your job:
-- Help the user work on files safely.
-- Automate repeatable work.
-- Keep behavior portable and reproducible.
-
-## Memory
-
-Two kinds:
-1. Behavior memory (shareable, in git): \`.opencode/skills/**\`, \`.opencode/agents/**\`, repo docs
-2. Private memory (never commit): tokens, credentials, local config, logs
-
-Hard rule: never copy private memory into repo files. Store only redacted summaries, schemas, and stable pointers.
-
-## Working style
-
-- If required setup or credentials are missing, ask one targeted question and continue once provided.
-- If you change code, run the smallest meaningful test.
-- If steps repeat, factor them into a skill.
-- Prefer clear, practical steps over abstract explanations.
-
-${OPENWORK_ARTIFACT_GUIDANCE}
-`;
-
 type WorkspaceOpenworkConfig = {
   version: number;
   workspace?: {
@@ -122,37 +73,6 @@ async function ensureOpencodeConfig(workspaceRoot: string): Promise<boolean> {
   return true;
 }
 
-async function ensureOpenworkAgent(workspaceRoot: string): Promise<boolean> {
-  const agentsDir = join(workspaceRoot, ".opencode", "agents");
-  const agentPath = join(agentsDir, "openwork.md");
-  await ensureDir(agentsDir);
-  if (!(await exists(agentPath))) {
-    await writeFile(agentPath, OPENWORK_AGENT.endsWith("\n") ? OPENWORK_AGENT : `${OPENWORK_AGENT}\n`, "utf8");
-    return true;
-  }
-  let current = await readFile(agentPath, "utf8");
-  let changed = false;
-
-  // Patch artifacts section (the only section still managed in the agent file).
-  const artStart = "<!-- OPENWORK_ARTIFACTS_START -->";
-  const artEnd = "<!-- OPENWORK_ARTIFACTS_END -->";
-  const artStartIdx = current.indexOf(artStart);
-  const artEndIdx = current.indexOf(artEnd);
-  if (artStartIdx >= 0 && artEndIdx > artStartIdx) {
-    const patched = `${current.slice(0, artStartIdx)}${OPENWORK_ARTIFACT_GUIDANCE}${current.slice(artEndIdx + artEnd.length)}`;
-    if (patched !== current) { current = patched; changed = true; }
-  } else if (!current.includes("OPENWORK_ARTIFACTS_START")) {
-    current = `${current.trimEnd()}\n\n${OPENWORK_ARTIFACT_GUIDANCE}\n`;
-    changed = true;
-  }
-
-  if (changed) {
-    await writeFile(agentPath, current, "utf8");
-    return true;
-  }
-  return false;
-}
-
 async function ensureBrowserPlugin(workspaceRoot: string): Promise<boolean> {
   const configPath = opencodeConfigPath(workspaceRoot);
   const { data: config } = await readJsoncFile<Record<string, unknown>>(configPath, {});
@@ -204,7 +124,6 @@ export async function ensureWorkspaceFiles(workspaceRoot: string, presetInput: s
   const reloadReasons = new Set<ReloadReason>();
   if (await ensureOpencodeConfig(workspaceRoot)) reloadReasons.add("config");
   if (await ensureBrowserPlugin(workspaceRoot)) reloadReasons.add("config");
-  if (await ensureOpenworkAgent(workspaceRoot)) reloadReasons.add("agents");
   const openworkConfigChanged = await ensureWorkspaceOpenworkConfig(workspaceRoot, preset);
   return {
     changed: openworkConfigChanged || reloadReasons.size > 0,


### PR DESCRIPTION
Moves the openwork agent definition from a static `.opencode/agents/openwork.md` file (written to disk per workspace) into `OPENCODE_CONFIG_CONTENT` (runtime injection).

**Before:** `workspace-init.ts` wrote `openwork.md` to disk on every workspace boot, with patching logic for browser/artifact sections.

**After:** `buildOpenworkRuntimeConfig()` returns a single JSON config with `default_agent`, `agent.openwork` (prompt + settings), and plugins. No file writing, no patching.

New file: `apps/server/src/openwork-runtime-config.ts` — single source of truth for the runtime config.

Removes ~99 lines of template strings + patching logic. Net **-32 lines**.

Typecheck passes.