### PR TITLE
feat(settings): show env var indicator on AI providers and disable disconnect

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
@@ -129,6 +129,11 @@ export function AiSettingsView(props: AiSettingsViewProps) {
                           Cloud
                         </span>
                       ) : null}
+                      {provider.source === "env" ? (
+                        <span className="shrink-0 rounded-full border border-amber-6 bg-amber-2 px-2 py-0.5 text-[10px] font-medium text-amber-11">
+                          {providerSourceLabel("env")}
+                        </span>
+                      ) : null}
                     </div>
                     <div className="truncate font-mono text-xs text-muted-foreground">{provider.id}</div>
                   </div>

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1646,6 +1646,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       ? [{
           id: provider.id,
           name: provider.name ?? provider.id,
+          source: provider.source,
         }]
       : [],
   );
@@ -2083,7 +2084,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             onDisconnectProvider={async (providerId) => {
               await providerAuthStore.disconnectProvider(providerId);
             }}
-            canDisconnectProvider={() => true}
+            canDisconnectProvider={(source) => source !== "env"}
             cloudProviderIds={new Set(
               Object.values(providerAuthSnapshot.importedCloudProviders ?? {}).map((p) => p.providerId)
             )}


### PR DESCRIPTION
## Summary

Wire up the provider `source` field from the opencode SDK to the AI settings view. Providers configured via environment variables now:

- Display an **Environment** badge (amber) next to the provider name
- Show **Managed by env** instead of **Disconnect** on the action button
- Have the disconnect button disabled since env-var providers cannot be removed from the UI

## What changed

`settings-route.tsx`:
- Pass `source: provider.source` when building `connectedProviders`
- Change `canDisconnectProvider` from `() => true` to `(source) => source !== "env"`

`ai-view.tsx`:
- Render an amber "Environment" badge when `provider.source === "env"` (uses existing `providerSourceLabel` helper and `settings.provider_source_env` i18n key)

## Context

The `ai-view.tsx` component already had full infrastructure for this (the `ConnectedProvider.source` type, `providerSourceLabel()` helper, `canDisconnectProvider` callback, and i18n keys) but `settings-route.tsx` was not passing the `source` field and was hardcoding `canDisconnectProvider` to always return `true`.

## Testing

- `tsc --noEmit` passes clean
- Reviewer can reproduce by setting e.g. `OPENAI_API_KEY` env var and opening Settings > AI to see the badge and disabled disconnect button