### PR TITLE
fix: pass UI control discovery path to managed OpenCode via env

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2843,6 +2843,8 @@ async function startUiControlServer() {
     `${JSON.stringify({ version: 1, app: APP_NAME, identifier: APP_IDENTIFIER, platform: process.platform, baseUrl: `http://127.0.0.1:${port}`, token: uiControlToken }, null, 2)}\n`,
     "utf8",
   );
+  // Make the discovery path available to child processes (server → managed OpenCode → plugin).
+  process.env.OPENWORK_UI_CONTROL_DISCOVERY = uiControlDiscoveryPath;
 }
 
 async function stopUiControlServer() {

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -43,6 +43,7 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
       cwd: managedOpencodeCwd,
       env: {
         ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
+        ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
         OPENWORK_SERVER_URL: serverUrl,
         OPENWORK_SERVER_TOKEN: config.token,
         OPENCODE_CONFIG_CONTENT: openworkRuntimeConfig,

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -64,6 +64,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
         cwd,
         env: {
           ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
+          ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
           OPENWORK_SERVER_URL: serverUrl,
           OPENWORK_SERVER_TOKEN: config.token,
           OPENCODE_CONFIG_CONTENT: openworkRuntimeConfig,


### PR DESCRIPTION
The openwork_ui_* tools returned 'UI bridge not available' because the plugin couldn't find the discovery file. In dev mode, HOME is overridden so homedir() looked in the wrong place.

Fix: set `OPENWORK_UI_CONTROL_DISCOVERY` on `process.env` when the Electron UI control server starts, then forward it through cli.ts/embedded.ts to the managed OpenCode child process. The plugin already checks this env var first (before falling back to homedir-based paths).

+4 lines across 3 files.