### PR TITLE
Add experimental Google Workspace Gmail read

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -315,13 +315,18 @@ export type GoogleWorkspaceAuthStatus = {
   accounts: GoogleWorkspaceAccount[];
   activeAccountId: string | null;
   scopes: string[];
+  experimentalScopes: string[];
+  experimentalScopesGranted: boolean;
   connectedAt: string | null;
   error: string | null;
   testStatus: string | null;
   smokeTest: {
+    calendarEventId?: string | null;
+    calendarEventDeleted?: boolean;
     driveFileId: string | null;
     driveFileName: string | null;
     gmailDraftId: string | null;
+    gmailReadResultSizeEstimate?: number | null;
   } | null;
 };
 
@@ -351,6 +356,12 @@ export type OpenworkExtensionActionResult = {
   extensionId: string;
   action: string;
   result: unknown;
+  attachments?: Array<{
+    type: "file";
+    mime: string;
+    url: string;
+    filename?: string;
+  }>;
   context?: Record<string, unknown>;
 };
 

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -5,6 +5,7 @@ import {
   AlertTriangle,
   Check,
   Copy,
+  Download,
   FileIcon,
   Split,
   Undo2,
@@ -144,36 +145,56 @@ interface FileMessageProps {
   tone: "assistant" | "user"
 }
 
+function downloadFilePart(part: FileUIPart, title: string) {
+  if (!part.url) return
+  const anchor = document.createElement("a")
+  anchor.href = part.url
+  anchor.download = part.filename || title || "download"
+  anchor.rel = "noopener noreferrer"
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+}
+
 function FileMessage({ part, tone }: FileMessageProps) {
   const title = getFileTitle(part)
   const badge = getMediaBadge(part)
   const isImage = part.mediaType.startsWith("image/") && part.url
+  const downloadable = Boolean(part.url)
 
   if (isImage) {
     return (
-      <Image
-        src={part.url}
-        alt={title}
-        loading="lazy"
-        decoding="async"
-        className="size-full object-cover"
-      />
+      <button
+        type="button"
+        className="size-full overflow-hidden text-left"
+        onClick={() => downloadFilePart(part, title)}
+        aria-label={`Download ${title}`}
+      >
+        <Image
+          src={part.url}
+          alt={title}
+          loading="lazy"
+          decoding="async"
+          className="size-full object-cover"
+        />
+      </button>
     )
   }
 
   return (
-    <DescriptiveButton className="px-2 py-1 items-center gap-2">
+    <DescriptiveButton className="px-2 py-1 items-center gap-2" onClick={downloadable ? () => downloadFilePart(part, title) : undefined} aria-label={downloadable ? `Download ${title}` : title}>
       <DescriptiveButtonIcon>
         <FileIcon className="size-6 shrink-0" />
       </DescriptiveButtonIcon>
       <DescriptiveButtonContent className="gap-0">
         <DescriptiveButtonTitle>{title}</DescriptiveButtonTitle>
-        {badge ? (
+        {badge || downloadable ? (
           <DescriptiveButtonDescription className="text-xs">
-            {badge}
+            {[badge, downloadable ? "Download" : null].filter(Boolean).join(" · ")}
           </DescriptiveButtonDescription>
         ) : null}
       </DescriptiveButtonContent>
+      {downloadable ? <Download className="size-4 shrink-0 text-muted-foreground" /> : null}
     </DescriptiveButton>
   )
 }

--- a/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
+++ b/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect, useState } from "react";
-import { CalendarDays, CheckCircle2, FileText, Loader2, MailPlus, ShieldCheck, XCircle } from "lucide-react";
+import { CalendarDays, CalendarPlus, CheckCircle2, FileText, Loader2, Mail, MailPlus, ShieldCheck, XCircle } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -22,6 +22,10 @@ type BusyAction = "status" | "connect" | "disconnect" | "test" | "smoke-test" | 
 type GoogleWorkspaceCommand = () => Promise<unknown>;
 const DESKTOP_ACTION_TIMEOUT_MS = 6 * 60 * 1000;
 const CONNECT_POLL_INTERVAL_MS = 1_000;
+const EXPERIMENTAL_GOOGLE_WORKSPACE_SCOPES = [
+  "https://www.googleapis.com/auth/gmail.readonly",
+  "https://www.googleapis.com/auth/calendar.events",
+];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -53,15 +57,21 @@ function normalizeGoogleWorkspaceAccounts(value: unknown): GoogleWorkspaceAuthSt
 function normalizeGoogleWorkspaceSmokeTest(value: unknown): GoogleWorkspaceAuthStatus["smokeTest"] {
   if (!isRecord(value)) return null;
   return {
+    calendarEventId: typeof value.calendarEventId === "string" ? value.calendarEventId : null,
+    calendarEventDeleted: value.calendarEventDeleted === true,
     driveFileId: typeof value.driveFileId === "string" ? value.driveFileId : null,
     driveFileName: typeof value.driveFileName === "string" ? value.driveFileName : null,
     gmailDraftId: typeof value.gmailDraftId === "string" ? value.gmailDraftId : null,
+    gmailReadResultSizeEstimate: typeof value.gmailReadResultSizeEstimate === "number" ? value.gmailReadResultSizeEstimate : null,
   };
 }
 
 function normalizeGoogleWorkspaceAuthStatus(value: unknown): GoogleWorkspaceAuthStatus {
   const record = isRecord(value) ? value : {};
   const vault = record.vault === "encrypted" || record.vault === "plaintext-dev" ? record.vault : "unavailable";
+  const scopes = normalizeStringList(record.scopes);
+  const experimentalScopes = normalizeStringList(record.experimentalScopes);
+  const resolvedExperimentalScopes = experimentalScopes.length ? experimentalScopes : EXPERIMENTAL_GOOGLE_WORKSPACE_SCOPES;
   return {
     configured: record.configured === true,
     missing: normalizeStringList(record.missing),
@@ -70,7 +80,9 @@ function normalizeGoogleWorkspaceAuthStatus(value: unknown): GoogleWorkspaceAuth
     account: normalizeGoogleWorkspaceAccount(record.account),
     accounts: normalizeGoogleWorkspaceAccounts(record.accounts),
     activeAccountId: typeof record.activeAccountId === "string" ? record.activeAccountId : null,
-    scopes: normalizeStringList(record.scopes),
+    scopes,
+    experimentalScopes: resolvedExperimentalScopes,
+    experimentalScopesGranted: record.experimentalScopesGranted === true || resolvedExperimentalScopes.every((scope) => scopes.includes(scope)),
     connectedAt: typeof record.connectedAt === "string" ? record.connectedAt : null,
     error: typeof record.error === "string" ? record.error : null,
     testStatus: typeof record.testStatus === "string" ? record.testStatus : null,
@@ -99,6 +111,7 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
   const [status, setStatus] = useState<GoogleWorkspaceAuthStatus | null>(null);
   const [busyAction, setBusyAction] = useState<BusyAction | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const serverAvailable = Boolean(openworkServerClient);
   const hostServerAvailable = Boolean(hostOpenworkServerClient);
@@ -158,16 +171,21 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
       setError("Google OAuth settings can only be saved from the local desktop app.");
       return;
     }
-    const value = clientSecret.trim();
-    if (!value) {
+    const secretValue = clientSecret.trim();
+    const clientIdValue = clientId.trim();
+    if (!secretValue) {
       setError("Enter the client secret from your Google OAuth desktop client.");
       return;
     }
     setBusyAction("save-secret");
     setError(null);
     try {
-      await hostOpenworkServerClient.upsertUserEnv([{ key: "GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", value }]);
+      await hostOpenworkServerClient.upsertUserEnv([
+        ...(clientIdValue ? [{ key: "OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_ID", value: clientIdValue }] : []),
+        { key: "GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", value: secretValue },
+      ]);
       await hostOpenworkServerClient.setUserEnvPendingChanges(true);
+      setClientId("");
       setClientSecret("");
       if (restartLocalServer) {
         const restarted = await restartLocalServer();
@@ -184,6 +202,9 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
   };
 
   const connectedAccounts = status?.accounts.length ? status.accounts : status?.account ? [status.account] : [];
+  const experimentalScopesGranted = status?.experimentalScopesGranted === true;
+  const needsExperimentalReconnect = status?.connected === true && !experimentalScopesGranted;
+  const connectLabel = needsExperimentalReconnect ? "Reconnect with Google" : status?.connected ? "Add another Google account" : "Connect with Google";
 
   return (
     <div className="space-y-4">
@@ -218,7 +239,17 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
         <Alert variant="warning">
           <XCircle />
           <AlertTitle>Google OAuth client not configured</AlertTitle>
-          <AlertDescription>Add your Google OAuth desktop client secret to connect Google Workspace.</AlertDescription>
+          <AlertDescription>Add your Google OAuth desktop client credentials to connect Google Workspace.</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {needsExperimentalReconnect ? (
+        <Alert variant="warning">
+          <ShieldCheck />
+          <AlertTitle>Reconnect for experimental scopes</AlertTitle>
+          <AlertDescription>
+            Gmail read and Calendar write are experimental, only work with your own Google OAuth credentials for now, and may be removed. Reconnect this account to request the new scopes.
+          </AlertDescription>
         </Alert>
       ) : null}
 
@@ -227,10 +258,16 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
           <CardHeader>
             <CardTitle>Set up Google OAuth</CardTitle>
             <CardDescription>
-              Use a Google Cloud OAuth desktop client. OpenWork already includes the desktop client ID; paste the matching client secret here.
+              Use your own Google Cloud OAuth desktop client for experimental Gmail read and Calendar write. These scopes may be removed.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
+            <Input
+              value={clientId}
+              onChange={(event) => setClientId(event.target.value)}
+              placeholder="Google OAuth desktop client ID"
+              autoComplete="off"
+            />
             <Input
               type="password"
               value={clientSecret}
@@ -239,7 +276,7 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
               autoComplete="off"
             />
             <p className="text-xs leading-relaxed text-muted-foreground">
-              The secret is saved locally in OpenWork environment settings and applied after the local server restarts.
+              The client ID and secret are saved locally in OpenWork environment settings and applied after the local server restarts.
             </p>
           </CardContent>
           <CardFooter>
@@ -271,7 +308,7 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
         <Alert>
           <CheckCircle2 />
           <AlertTitle>Scope smoke test complete</AlertTitle>
-          <AlertDescription>Calendar, Drive, and Gmail draft access were verified.</AlertDescription>
+          <AlertDescription>Calendar read/write, Drive, Gmail read, and Gmail draft access were verified.</AlertDescription>
         </Alert>
       ) : null}
 
@@ -279,10 +316,10 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
         <CardHeader>
           <CardTitle>What OpenWork can do</CardTitle>
           <CardDescription>
-            Connect Google Workspace so OpenWork can help with meeting prep, selected files, and draft emails.
+            Connect Google Workspace so OpenWork can help with meeting prep, selected files, draft emails, and experimental email/calendar actions.
           </CardDescription>
         </CardHeader>
-        <CardContent className="grid gap-3 sm:grid-cols-3">
+        <CardContent className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
           <div className="rounded-2xl border border-border bg-card p-3">
             <CalendarDays className="mb-2 size-4 text-blue-11" />
             <div className="text-sm font-medium text-card-foreground">Calendar read</div>
@@ -292,6 +329,16 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
             <MailPlus className="mb-2 size-4 text-red-11" />
             <div className="text-sm font-medium text-card-foreground">Gmail drafts</div>
             <div className="mt-1 text-xs leading-relaxed text-muted-foreground">Create draft emails only. No send tool in Phase 1.</div>
+          </div>
+          <div className="rounded-2xl border border-amber-6 bg-amber-2/40 p-3">
+            <Mail className="mb-2 size-4 text-amber-11" />
+            <div className="text-sm font-medium text-card-foreground">Gmail read experimental</div>
+            <div className="mt-1 text-xs leading-relaxed text-muted-foreground">Read recent email and expose attachments as chat downloads. Own OAuth credentials required for now; may be removed.</div>
+          </div>
+          <div className="rounded-2xl border border-amber-6 bg-amber-2/40 p-3">
+            <CalendarPlus className="mb-2 size-4 text-amber-11" />
+            <div className="text-sm font-medium text-card-foreground">Calendar write experimental</div>
+            <div className="mt-1 text-xs leading-relaxed text-muted-foreground">Create calendar events when you ask. Own OAuth credentials required for now; may be removed.</div>
           </div>
           <div className="rounded-2xl border border-border bg-card p-3">
             <FileText className="mb-2 size-4 text-green-11" />
@@ -321,7 +368,7 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
           <div className="flex flex-wrap gap-2">
             <Button disabled={Boolean(busyAction) || !canConnect} onClick={() => void runDesktopAction("connect", connectGoogleWorkspace)}>
               {busyAction === "connect" ? <Loader2 className="size-4 animate-spin" /> : null}
-              {status?.connected ? "Add another Google account" : "Connect with Google"}
+              {connectLabel}
             </Button>
             {connectedAccounts.length > 1 ? (
               <Button variant="destructive" disabled={Boolean(busyAction)} onClick={() => void runDesktopAction("disconnect", () => openworkServerClient?.googleWorkspaceDisconnect() ?? Promise.resolve(null))}>

--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import type { ServerConfig } from "../types.js";
-import { googleWorkspaceDisconnect, googleWorkspaceStatus } from "./google-workspace.js";
+import {
+  callGoogleWorkspaceExtensionAction,
+  GOOGLE_WORKSPACE_EXTENSION_ACTIONS,
+  googleWorkspaceDisconnect,
+  googleWorkspaceStatus,
+} from "./google-workspace.js";
 
 function createTestConfig(): ServerConfig {
   const tempDir = join(
@@ -43,7 +48,11 @@ async function writePlaintextVault(config: ServerConfig, value: Record<string, u
 function accountRecord(email: string, sub: string) {
   return {
     account: { email, name: email, sub, picture: null },
-    scopes: ["openid"],
+    scopes: [
+      "openid",
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/calendar.events",
+    ],
     token: { accessToken: `access-${sub}`, refreshToken: `refresh-${sub}`, expiresAt: Date.now() + 3600 * 1000 },
     connectedAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
@@ -74,6 +83,13 @@ afterEach(() => {
 });
 
 describe("Google Workspace extension", () => {
+  test("registers experimental Gmail read and Calendar write actions", () => {
+    expect(GOOGLE_WORKSPACE_EXTENSION_ACTIONS.map((entry) => entry.action)).toContain("gmail_get_latest_message");
+    expect(GOOGLE_WORKSPACE_EXTENSION_ACTIONS.map((entry) => entry.action)).toContain("gmail_read_message");
+    expect(GOOGLE_WORKSPACE_EXTENSION_ACTIONS.map((entry) => entry.action)).toContain("gmail_download_attachment");
+    expect(GOOGLE_WORKSPACE_EXTENSION_ACTIONS.map((entry) => entry.action)).toContain("calendar_create_event");
+  });
+
   test("reports only the user-configurable OAuth secret as missing", async () => {
     process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "";
     process.env.OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "";
@@ -99,6 +115,70 @@ describe("Google Workspace extension", () => {
     expect(status.account?.email).toBe("two@example.com");
     expect(status.accounts.map((account) => account.email)).toEqual(["one@example.com", "two@example.com"]);
     expect(status.activeAccountId).toBe("sub-two");
+    expect(status.experimentalScopesGranted).toBe(true);
+  });
+
+  test("reads latest Gmail message and exposes attachments", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one")],
+    });
+    globalThis.fetch = Object.assign(
+      async (input: unknown) => {
+        const url = input instanceof URL ? input.toString() : input instanceof Request ? input.url : String(input);
+        if (url.startsWith("https://gmail.googleapis.com/gmail/v1/users/me/messages?") && url.includes("maxResults=1")) {
+          return new Response(JSON.stringify({ messages: [{ id: "msg-one" }], resultSizeEstimate: 1 }), { status: 200 });
+        }
+        if (url === "https://gmail.googleapis.com/gmail/v1/users/me/messages/msg-one?format=full") {
+          return new Response(JSON.stringify({
+            id: "msg-one",
+            threadId: "thread-one",
+            snippet: "Latest email snippet",
+            labelIds: ["INBOX"],
+            payload: {
+              mimeType: "multipart/mixed",
+              headers: [
+                { name: "Subject", value: "Latest email" },
+                { name: "From", value: "sender@example.com" },
+                { name: "To", value: "one@example.com" },
+              ],
+              parts: [
+                { mimeType: "text/plain", body: { data: "SGVsbG8gZnJvbSBHbWFpbA" } },
+                { partId: "1", filename: "notes.txt", mimeType: "text/plain", body: { attachmentId: "att-one", size: 11 } },
+              ],
+            },
+          }), { status: 200 });
+        }
+        if (url === "https://gmail.googleapis.com/gmail/v1/users/me/messages/msg-one/attachments/att-one") {
+          return new Response(JSON.stringify({ data: "YXR0YWNobWVudA", size: 10 }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ error: { message: `Unexpected URL: ${url}` } }), { status: 404 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    const response = await callGoogleWorkspaceExtensionAction(config, "gmail_get_latest_message", {}, {});
+    expect(response?.result).toMatchObject({
+      query: "in:inbox",
+      message: {
+        id: "msg-one",
+        subject: "Latest email",
+        body: "Hello from Gmail",
+      },
+    });
+    expect(response && "attachments" in response ? response.attachments : []).toEqual([
+      {
+        type: "file",
+        mime: "text/plain",
+        url: "data:text/plain;base64,YXR0YWNobWVudA==",
+        filename: "notes.txt",
+      },
+    ]);
   });
 
   test("disconnect can remove one connected account", async () => {

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -17,6 +17,10 @@ const GOOGLE_WORKSPACE_TOKEN_BROKER_URL_ENV = "OPENWORK_GOOGLE_WORKSPACE_TOKEN_B
 const GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT_ENV = "OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT";
 const GOOGLE_WORKSPACE_AUTH_TIMEOUT_MS = 5 * 60 * 1000;
 const GOOGLE_WORKSPACE_API_TIMEOUT_MS = 30_000;
+const GOOGLE_WORKSPACE_EXPERIMENTAL_SCOPES = [
+  "https://www.googleapis.com/auth/gmail.readonly",
+  "https://www.googleapis.com/auth/calendar.events",
+];
 const GOOGLE_WORKSPACE_SCOPES = [
   "openid",
   "https://www.googleapis.com/auth/userinfo.email",
@@ -24,7 +28,14 @@ const GOOGLE_WORKSPACE_SCOPES = [
   "https://www.googleapis.com/auth/calendar.readonly",
   "https://www.googleapis.com/auth/gmail.compose",
   "https://www.googleapis.com/auth/drive.file",
+  ...GOOGLE_WORKSPACE_EXPERIMENTAL_SCOPES,
 ];
+const GMAIL_DEFAULT_BODY_CHARS = 20_000;
+const GMAIL_MAX_BODY_CHARS = 100_000;
+const GMAIL_DEFAULT_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+const GMAIL_MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+const GMAIL_DEFAULT_ATTACHMENT_COUNT = 5;
+const GMAIL_MAX_ATTACHMENT_COUNT = 10;
 
 export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
   {
@@ -52,6 +63,27 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
   },
   {
     extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
+    action: "calendar_create_event",
+    title: "Create calendar event",
+    description: "Experimentally create a Google Calendar event. Requires your own Google OAuth credentials for now and may be removed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "Event title." },
+        start: { type: "string", description: "Event start as an ISO datetime." },
+        end: { type: "string", description: "Event end as an ISO datetime." },
+        timeZone: { type: "string", description: "Optional IANA time zone, such as America/Los_Angeles." },
+        description: { type: "string", description: "Optional event description." },
+        location: { type: "string", description: "Optional event location." },
+        attendees: { type: "array", items: { type: "string" }, description: "Optional attendee email addresses." },
+        sendUpdates: { type: "string", description: "Calendar notification behavior: all, externalOnly, or none." },
+      },
+      required: ["summary", "start", "end"],
+      additionalProperties: false,
+    },
+  },
+  {
+    extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
     action: "gmail_create_draft",
     title: "Create Gmail draft",
     description: "Create a Gmail draft for the connected account. This does not send email.",
@@ -65,6 +97,61 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
         body: { type: "string", description: "Plain text draft body." },
       },
       required: ["to", "subject", "body"],
+      additionalProperties: false,
+    },
+  },
+  {
+    extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
+    action: "gmail_get_latest_message",
+    title: "Get latest Gmail message",
+    description: "Experimentally read the latest Gmail message, defaulting to the inbox. Requires your own Google OAuth credentials for now and may be removed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Optional Gmail search query. Defaults to in:inbox." },
+        includeBody: { type: "boolean", description: "Include the message body. Defaults to true." },
+        maxBodyChars: { type: "number", description: "Maximum body characters to return." },
+        includeAttachments: { type: "boolean", description: "Download attachments into chat file cards when possible." },
+        maxAttachmentBytes: { type: "number", description: "Maximum bytes per downloaded attachment." },
+        maxAttachments: { type: "number", description: "Maximum number of attachments to download." },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
+    action: "gmail_read_message",
+    title: "Read Gmail message",
+    description: "Experimentally read a Gmail message by id and optionally expose attachments as chat downloads. Requires your own Google OAuth credentials for now and may be removed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        messageId: { type: "string", description: "Gmail message id." },
+        includeBody: { type: "boolean", description: "Include the message body. Defaults to true." },
+        maxBodyChars: { type: "number", description: "Maximum body characters to return." },
+        includeAttachments: { type: "boolean", description: "Download attachments into chat file cards when possible." },
+        maxAttachmentBytes: { type: "number", description: "Maximum bytes per downloaded attachment." },
+        maxAttachments: { type: "number", description: "Maximum number of attachments to download." },
+      },
+      required: ["messageId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
+    action: "gmail_download_attachment",
+    title: "Download Gmail attachment",
+    description: "Experimentally download a Gmail attachment and show it as a downloadable chat file. Requires your own Google OAuth credentials for now and may be removed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        messageId: { type: "string", description: "Gmail message id." },
+        attachmentId: { type: "string", description: "Gmail attachment id from gmail_read_message or gmail_get_latest_message." },
+        filename: { type: "string", description: "Suggested download filename." },
+        mimeType: { type: "string", description: "Attachment MIME type." },
+        maxAttachmentBytes: { type: "number", description: "Maximum bytes to download." },
+      },
+      required: ["messageId", "attachmentId"],
       additionalProperties: false,
     },
   },
@@ -112,6 +199,28 @@ type GoogleWorkspaceFlow = {
   server: Server;
 };
 
+type GoogleWorkspaceToolAttachment = {
+  type: "file";
+  mime: string;
+  url: string;
+  filename?: string;
+};
+
+type GmailCollectedAttachment = {
+  messageId: string;
+  partId: string | null;
+  attachmentId: string | null;
+  filename: string;
+  mimeType: string;
+  size: number | null;
+  data: string | null;
+};
+
+type GmailParsedMessage = {
+  message: Record<string, unknown>;
+  attachments: GmailCollectedAttachment[];
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -120,6 +229,35 @@ function readStringField(value: unknown, key: string): string {
   if (!isRecord(value)) return "";
   const field = value[key];
   return typeof field === "string" ? field.trim() : "";
+}
+
+function readRecordField(value: unknown, key: string): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  const field = value[key];
+  return isRecord(field) ? field : null;
+}
+
+function readRecordArrayField(value: unknown, key: string): Record<string, unknown>[] {
+  if (!isRecord(value)) return [];
+  const field = value[key];
+  return Array.isArray(field) ? field.filter(isRecord) : [];
+}
+
+function readOptionalNumberField(value: unknown, key: string): number | null {
+  if (!isRecord(value)) return null;
+  const field = value[key];
+  if (typeof field === "number" && Number.isFinite(field)) return field;
+  if (typeof field === "string" && field.trim()) {
+    const parsed = Number(field);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function clampNumber(value: unknown, fallback: number, min: number, max: number): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : fallback;
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(Math.max(Math.floor(parsed), min), max);
 }
 
 function configDir(config: ServerConfig): string {
@@ -166,6 +304,20 @@ function base64Url(buffer: Buffer): string {
 
 function base64UrlString(value: string): string {
   return Buffer.from(value, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function base64UrlToBuffer(value: string): Buffer {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = (4 - (normalized.length % 4)) % 4;
+  return Buffer.from(`${normalized}${"=".repeat(padding)}`, "base64");
+}
+
+function dataUrlFromBuffer(buffer: Buffer, mimeType: string): string {
+  return `data:${mimeType || "application/octet-stream"};base64,${buffer.toString("base64")}`;
+}
+
+function decodeGmailText(data: string): string {
+  return base64UrlToBuffer(data).toString("utf8");
 }
 
 function createGoogleWorkspacePkce() {
@@ -309,6 +461,7 @@ async function upsertGoogleWorkspaceAccount(config: ServerConfig, accountRecord:
 function googleWorkspaceStatusPayload(record: Record<string, unknown> | null = null, extra: Record<string, unknown> = {}) {
   const credentials = googleWorkspaceCredentials();
   const primary = googleWorkspacePrimaryRecord(record);
+  const scopes = Array.isArray(primary?.scopes) ? primary.scopes.filter((item): item is string => typeof item === "string") : [];
   return {
     configured: credentials.missing.length === 0,
     missing: credentials.missing,
@@ -317,7 +470,9 @@ function googleWorkspaceStatusPayload(record: Record<string, unknown> | null = n
     account: googleWorkspaceSafeAccount(primary?.account),
     accounts: googleWorkspacePublicAccounts(record),
     activeAccountId: googleWorkspaceAccountId(primary),
-    scopes: Array.isArray(primary?.scopes) ? primary.scopes.filter((item): item is string => typeof item === "string") : [],
+    scopes,
+    experimentalScopes: GOOGLE_WORKSPACE_EXPERIMENTAL_SCOPES,
+    experimentalScopesGranted: GOOGLE_WORKSPACE_EXPERIMENTAL_SCOPES.every((scope) => scopes.includes(scope)),
     connectedAt: typeof primary?.connectedAt === "string" ? primary.connectedAt : null,
     error: null,
     testStatus: null,
@@ -485,6 +640,40 @@ async function googleWorkspaceListEvents(config: ServerConfig, args: Record<stri
   return fetchGoogleJson(url.toString(), { headers: { Authorization: `Bearer ${accessToken}` } });
 }
 
+async function googleWorkspaceCreateEvent(config: ServerConfig, args: Record<string, unknown>) {
+  const summary = readStringField(args, "summary");
+  const start = readStringField(args, "start");
+  const end = readStringField(args, "end");
+  if (!summary || !start || !end) throw new ApiError(400, "invalid_payload", "summary, start, and end are required");
+
+  const timeZone = readStringField(args, "timeZone");
+  const sendUpdates = readStringField(args, "sendUpdates") || "none";
+  if (!["all", "externalOnly", "none"].includes(sendUpdates)) {
+    throw new ApiError(400, "invalid_payload", "sendUpdates must be all, externalOnly, or none");
+  }
+
+  const event: Record<string, unknown> = {
+    summary,
+    start: timeZone ? { dateTime: start, timeZone } : { dateTime: start },
+    end: timeZone ? { dateTime: end, timeZone } : { dateTime: end },
+  };
+  const description = readStringField(args, "description");
+  const location = readStringField(args, "location");
+  const attendees = stringArrayField(args.attendees).map((email) => ({ email }));
+  if (description) event.description = description;
+  if (location) event.location = location;
+  if (attendees.length) event.attendees = attendees;
+
+  const { accessToken } = await googleWorkspaceAccessToken(config);
+  const url = new URL("https://www.googleapis.com/calendar/v3/calendars/primary/events");
+  url.searchParams.set("sendUpdates", sendUpdates);
+  return fetchGoogleJson(url.toString(), {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify(event),
+  });
+}
+
 async function googleWorkspaceCreateDraft(config: ServerConfig, args: Record<string, unknown>) {
   const to = stringArrayField(args.to);
   const cc = stringArrayField(args.cc);
@@ -498,6 +687,222 @@ async function googleWorkspaceCreateDraft(config: ServerConfig, args: Record<str
     headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
     body: JSON.stringify({ message: { raw: base64UrlString(gmailRawMessage({ to, cc, bcc, subject, body })) } }),
   });
+}
+
+function gmailHeaderValue(headers: Record<string, unknown>[], name: string): string {
+  const target = name.toLowerCase();
+  for (const header of headers) {
+    if (readStringField(header, "name").toLowerCase() === target) return readStringField(header, "value");
+  }
+  return "";
+}
+
+function gmailHtmlToText(value: string): string {
+  return value
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<br\s*\/?\s*>/gi, "\n")
+    .replace(/<\/p>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n\s+/g, "\n")
+    .trim();
+}
+
+function gmailPayloadParts(payload: Record<string, unknown>): Record<string, unknown>[] {
+  const children = readRecordArrayField(payload, "parts");
+  return [payload, ...children.flatMap(gmailPayloadParts)];
+}
+
+function gmailBodyText(payload: Record<string, unknown>): string {
+  let html = "";
+  for (const part of gmailPayloadParts(payload)) {
+    const body = readRecordField(part, "body");
+    const data = readStringField(body, "data");
+    if (!data) continue;
+    const mimeType = readStringField(part, "mimeType");
+    if (mimeType === "text/plain") return decodeGmailText(data);
+    if (mimeType === "text/html" && !html) html = decodeGmailText(data);
+  }
+  return html ? gmailHtmlToText(html) : "";
+}
+
+function gmailAttachments(messageId: string, payload: Record<string, unknown>): GmailCollectedAttachment[] {
+  return gmailPayloadParts(payload).flatMap((part): GmailCollectedAttachment[] => {
+    const filename = readStringField(part, "filename");
+    const body = readRecordField(part, "body");
+    if (!filename || !body) return [];
+    const attachmentId = readStringField(body, "attachmentId") || null;
+    const data = readStringField(body, "data") || null;
+    if (!attachmentId && !data) return [];
+    return [{
+      messageId,
+      partId: readStringField(part, "partId") || null,
+      attachmentId,
+      filename,
+      mimeType: readStringField(part, "mimeType") || "application/octet-stream",
+      size: readOptionalNumberField(body, "size"),
+      data,
+    }];
+  });
+}
+
+async function fetchGmailMessage(accessToken: string, messageId: string): Promise<GmailParsedMessage> {
+  const message = await fetchGoogleJson(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${encodeURIComponent(messageId)}?format=full`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!isRecord(message)) throw new Error("Gmail message response was invalid.");
+  const payload = readRecordField(message, "payload");
+  return { message, attachments: payload ? gmailAttachments(messageId, payload) : [] };
+}
+
+function gmailMessageResult(parsed: GmailParsedMessage, includeBody: boolean, maxBodyChars: number) {
+  const message = parsed.message;
+  const payload = readRecordField(message, "payload");
+  const headers = payload ? readRecordArrayField(payload, "headers") : [];
+  const body = includeBody && payload ? gmailBodyText(payload) : "";
+  const labelIds = Array.isArray(message.labelIds) ? message.labelIds.filter((item): item is string => typeof item === "string") : [];
+  return {
+    id: readStringField(message, "id"),
+    threadId: readStringField(message, "threadId"),
+    labelIds,
+    snippet: readStringField(message, "snippet"),
+    internalDate: readStringField(message, "internalDate"),
+    subject: gmailHeaderValue(headers, "subject"),
+    from: gmailHeaderValue(headers, "from"),
+    to: gmailHeaderValue(headers, "to"),
+    cc: gmailHeaderValue(headers, "cc"),
+    date: gmailHeaderValue(headers, "date"),
+    body: includeBody ? body.slice(0, maxBodyChars) : null,
+    bodyTruncated: includeBody ? body.length > maxBodyChars : false,
+    attachments: parsed.attachments.map((attachment) => ({
+      messageId: attachment.messageId,
+      partId: attachment.partId,
+      attachmentId: attachment.attachmentId,
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      size: attachment.size,
+      downloadable: Boolean(attachment.attachmentId || attachment.data),
+    })),
+  };
+}
+
+async function fetchGmailAttachmentData(accessToken: string, messageId: string, attachmentId: string): Promise<string> {
+  const attachment = await fetchGoogleJson(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!isRecord(attachment) || typeof attachment.data !== "string") throw new Error("Gmail attachment response did not include data.");
+  return attachment.data;
+}
+
+async function downloadGmailAttachments(accessToken: string, attachments: GmailCollectedAttachment[], maxBytes: number, maxCount: number) {
+  const toolAttachments: GoogleWorkspaceToolAttachment[] = [];
+  const details: Record<string, unknown>[] = [];
+  for (const attachment of attachments.slice(0, maxCount)) {
+    const detail = {
+      messageId: attachment.messageId,
+      attachmentId: attachment.attachmentId,
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      size: attachment.size,
+    };
+    if (attachment.size !== null && attachment.size > maxBytes) {
+      details.push({ ...detail, downloaded: false, skippedReason: `Attachment is larger than ${maxBytes} bytes.` });
+      continue;
+    }
+    const data = attachment.data ?? (attachment.attachmentId ? await fetchGmailAttachmentData(accessToken, attachment.messageId, attachment.attachmentId) : "");
+    if (!data) {
+      details.push({ ...detail, downloaded: false, skippedReason: "Attachment data is unavailable." });
+      continue;
+    }
+    const buffer = base64UrlToBuffer(data);
+    if (buffer.byteLength > maxBytes) {
+      details.push({ ...detail, downloaded: false, skippedReason: `Attachment is larger than ${maxBytes} bytes.` });
+      continue;
+    }
+    toolAttachments.push({
+      type: "file",
+      mime: attachment.mimeType,
+      url: dataUrlFromBuffer(buffer, attachment.mimeType),
+      filename: attachment.filename,
+    });
+    details.push({ ...detail, size: buffer.byteLength, downloaded: true });
+  }
+  return { toolAttachments, details };
+}
+
+async function googleWorkspaceReadGmailMessage(config: ServerConfig, args: Record<string, unknown>) {
+  const messageId = readStringField(args, "messageId");
+  if (!messageId) throw new ApiError(400, "invalid_payload", "messageId is required");
+  const includeBody = args.includeBody !== false;
+  const includeAttachments = args.includeAttachments !== false;
+  const maxBodyChars = clampNumber(args.maxBodyChars, GMAIL_DEFAULT_BODY_CHARS, 0, GMAIL_MAX_BODY_CHARS);
+  const maxAttachmentBytes = clampNumber(args.maxAttachmentBytes, GMAIL_DEFAULT_ATTACHMENT_BYTES, 1, GMAIL_MAX_ATTACHMENT_BYTES);
+  const maxAttachments = clampNumber(args.maxAttachments, GMAIL_DEFAULT_ATTACHMENT_COUNT, 0, GMAIL_MAX_ATTACHMENT_COUNT);
+  const { accessToken } = await googleWorkspaceAccessToken(config);
+  const parsed = await fetchGmailMessage(accessToken, messageId);
+  const downloaded = includeAttachments
+    ? await downloadGmailAttachments(accessToken, parsed.attachments, maxAttachmentBytes, maxAttachments)
+    : { toolAttachments: [], details: [] };
+  return {
+    result: {
+      message: gmailMessageResult(parsed, includeBody, maxBodyChars),
+      downloadedAttachments: downloaded.details,
+    },
+    attachments: downloaded.toolAttachments,
+  };
+}
+
+async function googleWorkspaceGetLatestGmailMessage(config: ServerConfig, args: Record<string, unknown>) {
+  const query = readStringField(args, "query") || "in:inbox";
+  const { accessToken } = await googleWorkspaceAccessToken(config);
+  const url = new URL("https://gmail.googleapis.com/gmail/v1/users/me/messages");
+  url.searchParams.set("maxResults", "1");
+  url.searchParams.set("q", query);
+  const listed = await fetchGoogleJson(url.toString(), { headers: { Authorization: `Bearer ${accessToken}` } });
+  const messages = readRecordArrayField(listed, "messages");
+  const first = messages[0];
+  if (!first) {
+    return {
+      result: {
+        query,
+        resultSizeEstimate: readOptionalNumberField(listed, "resultSizeEstimate"),
+        message: null,
+        downloadedAttachments: [],
+      },
+      attachments: [],
+    };
+  }
+  const messageId = readStringField(first, "id");
+  if (!messageId) throw new Error("Gmail latest message response did not include a message id.");
+  const readResult = await googleWorkspaceReadGmailMessage(config, { ...args, messageId });
+  return { result: { query, ...readResult.result }, attachments: readResult.attachments };
+}
+
+async function googleWorkspaceDownloadGmailAttachment(config: ServerConfig, args: Record<string, unknown>) {
+  const messageId = readStringField(args, "messageId");
+  const attachmentId = readStringField(args, "attachmentId");
+  if (!messageId || !attachmentId) throw new ApiError(400, "invalid_payload", "messageId and attachmentId are required");
+  const filename = readStringField(args, "filename") || "gmail-attachment";
+  const mimeType = readStringField(args, "mimeType") || "application/octet-stream";
+  const maxAttachmentBytes = clampNumber(args.maxAttachmentBytes, GMAIL_DEFAULT_ATTACHMENT_BYTES, 1, GMAIL_MAX_ATTACHMENT_BYTES);
+  const { accessToken } = await googleWorkspaceAccessToken(config);
+  const data = await fetchGmailAttachmentData(accessToken, messageId, attachmentId);
+  const buffer = base64UrlToBuffer(data);
+  if (buffer.byteLength > maxAttachmentBytes) {
+    throw new ApiError(400, "attachment_too_large", `Attachment is larger than ${maxAttachmentBytes} bytes.`);
+  }
+  const attachment: GoogleWorkspaceToolAttachment = { type: "file", mime: mimeType, url: dataUrlFromBuffer(buffer, mimeType), filename };
+  return {
+    result: { messageId, attachmentId, filename, mimeType, size: buffer.byteLength, downloaded: true },
+    attachments: [attachment],
+  };
 }
 
 async function googleWorkspaceSearchFiles(config: ServerConfig, args: Record<string, unknown>) {
@@ -530,20 +935,30 @@ async function googleWorkspaceReadFile(config: ServerConfig, args: Record<string
   return { metadata, content };
 }
 
+function googleWorkspaceActionResponse(action: string, result: unknown, context: Record<string, unknown>, attachments: GoogleWorkspaceToolAttachment[] = []) {
+  const response = { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result, context };
+  return attachments.length ? { ...response, attachments } : response;
+}
+
 export async function callGoogleWorkspaceExtensionAction(config: ServerConfig, action: string, args: Record<string, unknown>, context: Record<string, unknown>) {
-  if (action === "status") {
-    return {
-      ok: true,
-      extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
-      action,
-      result: await googleWorkspaceStatus(config),
-      context,
-    };
+  if (action === "status") return googleWorkspaceActionResponse(action, await googleWorkspaceStatus(config), context);
+  if (action === "calendar_list_events") return googleWorkspaceActionResponse(action, await googleWorkspaceListEvents(config, args), context);
+  if (action === "calendar_create_event") return googleWorkspaceActionResponse(action, await googleWorkspaceCreateEvent(config, args), context);
+  if (action === "gmail_create_draft") return googleWorkspaceActionResponse(action, await googleWorkspaceCreateDraft(config, args), context);
+  if (action === "gmail_get_latest_message") {
+    const result = await googleWorkspaceGetLatestGmailMessage(config, args);
+    return googleWorkspaceActionResponse(action, result.result, context, result.attachments);
   }
-  if (action === "calendar_list_events") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceListEvents(config, args), context };
-  if (action === "gmail_create_draft") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateDraft(config, args), context };
-  if (action === "drive_search_files") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceSearchFiles(config, args), context };
-  if (action === "drive_read_file") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceReadFile(config, args), context };
+  if (action === "gmail_read_message") {
+    const result = await googleWorkspaceReadGmailMessage(config, args);
+    return googleWorkspaceActionResponse(action, result.result, context, result.attachments);
+  }
+  if (action === "gmail_download_attachment") {
+    const result = await googleWorkspaceDownloadGmailAttachment(config, args);
+    return googleWorkspaceActionResponse(action, result.result, context, result.attachments);
+  }
+  if (action === "drive_search_files") return googleWorkspaceActionResponse(action, await googleWorkspaceSearchFiles(config, args), context);
+  if (action === "drive_read_file") return googleWorkspaceActionResponse(action, await googleWorkspaceReadFile(config, args), context);
   return null;
 }
 
@@ -570,6 +985,26 @@ export async function googleWorkspaceRunScopeSmokeTest(config: ServerConfig) {
   if (!email) throw new Error("Google account email is unavailable.");
   await fetchGoogleJson("https://www.googleapis.com/calendar/v3/users/me/calendarList?maxResults=1", { headers: { Authorization: `Bearer ${accessToken}` } });
   const createdAt = new Date().toISOString();
+  const eventStart = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+  const eventEnd = new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString();
+  const calendarEvent = await fetchGoogleJson("https://www.googleapis.com/calendar/v3/calendars/primary/events?sendUpdates=none", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      summary: "OpenWork Google Workspace smoke test event",
+      description: `Created by OpenWork to verify Calendar write access at ${createdAt}. This event is deleted by the diagnostic.`,
+      start: { dateTime: eventStart },
+      end: { dateTime: eventEnd },
+    }),
+  });
+  const calendarEventId = isRecord(calendarEvent) && typeof calendarEvent.id === "string" ? calendarEvent.id : null;
+  if (calendarEventId) {
+    await fetchGoogleJson(`https://www.googleapis.com/calendar/v3/calendars/primary/events/${encodeURIComponent(calendarEventId)}?sendUpdates=none`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+  }
+  const gmailRead = await fetchGoogleJson("https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=1", { headers: { Authorization: `Bearer ${accessToken}` } });
   const driveBoundary = `openwork_${randomBytes(8).toString("hex")}`;
   const driveFile = await fetchGoogleJson("https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,webViewLink", {
     method: "POST",
@@ -586,11 +1021,14 @@ export async function googleWorkspaceRunScopeSmokeTest(config: ServerConfig) {
     body: JSON.stringify({ message: { raw: base64UrlString(gmailRawMessage({ to: [email], subject: "OpenWork Google Workspace smoke test draft", body: `This draft was created by OpenWork to verify Gmail draft access at ${createdAt}.\nOpenWork does not send this email automatically.` })) } }),
   });
   return googleWorkspaceStatusPayload(record, {
-    testStatus: "Calendar read, Drive file create/read, and Gmail draft creation verified.",
+    testStatus: "Calendar read/write, Gmail read/draft, and Drive file create/read verified.",
     smokeTest: {
+      calendarEventId,
+      calendarEventDeleted: Boolean(calendarEventId),
       driveFileId: isRecord(driveFile) && typeof driveFile.id === "string" ? driveFile.id : null,
       driveFileName: isRecord(driveFile) && typeof driveFile.name === "string" ? driveFile.name : null,
       gmailDraftId: isRecord(draft) && typeof draft.id === "string" ? draft.id : null,
+      gmailReadResultSizeEstimate: readOptionalNumberField(gmailRead, "resultSizeEstimate"),
     },
   });
 }

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -18,6 +18,19 @@ type ExtensionActionPayload = {
   context: ReturnType<typeof contextPayload>;
 };
 
+type ToolAttachment = {
+  type: "file";
+  mime: string;
+  url: string;
+  filename?: string;
+};
+
+type ToolResultWithAttachments = {
+  output: string;
+  metadata: Record<string, unknown>;
+  attachments: ToolAttachment[];
+};
+
 const listActionsArgsSchema = z.object({
   extensionId: z.string().optional().describe("Optional extension id to filter by, such as google-workspace."),
 });
@@ -147,6 +160,32 @@ function getStringProperty(value: unknown, key: string): string | null {
   return typeof property === "string" ? property : null;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isToolAttachment(value: unknown): value is ToolAttachment {
+  if (!isRecord(value)) return false;
+  return value.type === "file"
+    && typeof value.mime === "string"
+    && typeof value.url === "string"
+    && (value.filename === undefined || typeof value.filename === "string");
+}
+
+function toolAttachments(payload: unknown): ToolAttachment[] {
+  if (!isRecord(payload) || !Array.isArray(payload.attachments)) return [];
+  return payload.attachments.filter(isToolAttachment);
+}
+
+function payloadWithoutToolAttachments(payload: unknown): unknown {
+  if (!isRecord(payload)) return payload;
+  const copy: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(payload)) {
+    if (key !== "attachments") copy[key] = value;
+  }
+  return copy;
+}
+
 function addContext(payload: unknown, context: OpenCodeContext): object {
   if (typeof payload === "object" && payload !== null && !Array.isArray(payload)) {
     return Object.assign({}, payload, { context: contextPayload(context) });
@@ -156,6 +195,17 @@ function addContext(payload: unknown, context: OpenCodeContext): object {
 
 function errorMessage(payload: unknown, fallback: string): string {
   return getStringProperty(payload, "message") ?? getStringProperty(payload, "code") ?? fallback;
+}
+
+function extensionCallToolResult(payload: unknown, context: OpenCodeContext): string | ToolResultWithAttachments {
+  const attachments = toolAttachments(payload);
+  const output = JSON.stringify(addContext(payloadWithoutToolAttachments(payload), context), null, 2);
+  if (attachments.length === 0) return output;
+  return {
+    output,
+    metadata: { attachmentCount: attachments.length },
+    attachments,
+  };
 }
 
 async function postJson(path: string, body: ExtensionActionPayload): Promise<unknown> {
@@ -217,7 +267,7 @@ export const OpenWorkExtensionsPreview = async () => ({
           args: args.args ?? {},
           context: contextPayload(context),
         });
-        return JSON.stringify(payload, null, 2);
+        return extensionCallToolResult(payload, context);
       },
     },
     openwork_ui_snapshot: {

--- a/docs/google-workspace-oauth-verification.md
+++ b/docs/google-workspace-oauth-verification.md
@@ -23,6 +23,15 @@ https://www.googleapis.com/auth/drive.file
 https://www.googleapis.com/auth/gmail.compose
 ```
 
+## Experimental Scopes
+
+These scopes are experimental, currently intended only for users running OpenWork with their own Google Cloud OAuth desktop client credentials, and may be removed.
+
+```text
+https://www.googleapis.com/auth/gmail.readonly
+https://www.googleapis.com/auth/calendar.events
+```
+
 ## Scope Justifications
 
 ### `openid`, `userinfo.email`, `userinfo.profile`
@@ -41,9 +50,17 @@ OpenWork uses this scope to access only the specific Google Drive files that the
 
 OpenWork uses this scope to create Gmail drafts for the user to review in Gmail. Phase 1 does not expose an automatic send-email tool. Draft creation is used for workflows like drafting a meeting follow-up after the user asks for it. Users remain in control and send messages themselves from Gmail.
 
+### Experimental `gmail.readonly`
+
+OpenWork uses this scope only when the user explicitly asks to read email, such as "get me my last email." The extension can read Gmail message metadata, body text, and attachment metadata, and can expose requested attachments as downloadable chat file cards. This scope is experimental, requires the user to run their own Google OAuth credentials for now, and may be removed.
+
+### Experimental `calendar.events`
+
+OpenWork uses this scope only when the user explicitly asks to create or modify calendar events. This scope is experimental, requires the user to run their own Google OAuth credentials for now, and may be removed.
+
 ## Data Use Statement
 
-OpenWork uses Google Workspace data only to provide user-requested features, such as reading calendar context, reading explicitly selected Drive files, and creating Gmail drafts. OpenWork does not sell Google user data, use Google user data for advertising, or use Google user data to train generalized AI models. Desktop OAuth tokens are stored locally using encrypted OS storage when available.
+OpenWork uses Google Workspace data only to provide user-requested features, such as reading calendar context, reading explicitly selected Drive files, creating Gmail drafts, experimentally reading user-requested Gmail messages, and experimentally creating calendar events. OpenWork does not sell Google user data, use Google user data for advertising, or use Google user data to train generalized AI models. Desktop OAuth tokens are stored locally using encrypted OS storage when available.
 
 ## Deployment Mode
 
@@ -78,14 +95,16 @@ Google's verification video should show the OAuth consent flow and each requeste
 
 6. Approve access with a test account.
 
-7. Return to OpenWork and show the connected account email.
+7. Return to OpenWork and show the connected account email. Point out the experimental Gmail read and Calendar write cards and their note that they require the user's own OAuth credentials for now and may be removed.
 
 8. Click `Test connection` and show profile + Calendar read access verified.
 
-9. Click `Run scope smoke test` and show the success state, including the created Drive file and Gmail draft IDs. This verifies all requested Phase 1 scopes:
-   - Calendar read through the Calendar API.
-   - Drive selected/app-created file access by creating and reading `OpenWork Google Workspace smoke test.txt`.
-   - Gmail compose access by creating `OpenWork Google Workspace smoke test draft` in Gmail drafts.
+9. Click `Run scope smoke test` and show the success state, including the created Drive file, temporary Calendar event, Gmail read check, and Gmail draft IDs. This verifies all requested Phase 1 and experimental scopes:
+    - Calendar read through the Calendar API.
+    - Calendar write by creating and deleting `OpenWork Google Workspace smoke test event`.
+    - Drive selected/app-created file access by creating and reading `OpenWork Google Workspace smoke test.txt`.
+    - Gmail read by listing the latest Gmail message metadata.
+    - Gmail compose access by creating `OpenWork Google Workspace smoke test draft` in Gmail drafts.
 
 10. Open Google Drive and show the created smoke-test file.
 
@@ -113,5 +132,6 @@ bash /opt/openwork-daytona/start-daytona-electron.sh --detach
 
 ## Current Verification Blockers
 
-- `gmail.compose` is a restricted Gmail scope. Google may require restricted-scope verification and possibly additional security review.
+- `gmail.compose` and experimental `gmail.readonly` are restricted Gmail scopes. Google may require restricted-scope verification and possibly additional security review.
+- Experimental Gmail read and Calendar write currently require user-provided Google OAuth credentials and may be removed.
 - The privacy policy source includes Google Workspace data-use language, but it must be deployed publicly before submitting verification.


### PR DESCRIPTION
## Summary
- Add experimental Google Workspace scopes for Gmail read and Calendar event write.
- Add Gmail latest/read/download actions that can return Gmail attachments as downloadable chat file parts.
- Update Google Workspace settings copy to warn that experimental Gmail read and Calendar write require your own OAuth credentials for now and may be removed.
- Make chat file cards downloadable and update Google Workspace OAuth docs.

## Verification
- PASS: `pnpm --filter openwork-server test src/extensions/google-workspace.test.ts`
- PASS: `pnpm --filter openwork-server typecheck`
- PASS: `pnpm --filter @openwork/app typecheck`
- FAIL (baseline/unrelated): `pnpm --filter openwork-server test` fails with existing workspace bootstrap/import/reload expectations, Bun `better-sqlite3` unsupported loading, and serve-node stream error.

## Daytona E2E
- Started Electron sandbox from `feature/google-workspace-experimental-scopes` and confirmed real Electron UA.
- Created a local workspace in the app.
- Opened Settings -> Extensions -> Google Workspace and verified the experimental Gmail read / Calendar write cards, own-OAuth warning, and client ID field.
- Verified the running server action registry includes `calendar_create_event`, `gmail_get_latest_message`, `gmail_read_message`, and `gmail_download_attachment`.
- PASS in Daytona: `pnpm --filter openwork-server test src/extensions/google-workspace.test.ts`.
- Live Google OAuth/Gmail API flow was not run because no Google OAuth credentials were available in the sandbox.

Recording: https://8090-fugzd4hvnd9ibvvm.daytonaproxy01.net/recordings/google-workspace-experimental-scopes.mp4