### PR TITLE
Promote OpenWork Models in model pickers

### DIFF
--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, ChevronRight, Settings2, Sparkles } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 import type { ModelOption, ModelRef } from "@/app/types";
 import { ProviderIcon } from "@/react-app/design-system/provider-icon";
@@ -16,7 +17,19 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useWorkspace } from "@/react-app/shell/workspace-provider";
+import { usePlatform } from "@/react-app/kernel/platform";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
+import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
+import {
+  getOpenWorkModelsActionUrl,
+  hasOpenWorkModelsProvider,
+  hideOpenWorkModelsPromo,
+  isOpenWorkModelsPromoHidden,
+  OPENWORK_MODEL_PREVIEWS,
+  OPENWORK_MODELS_PROVIDER_ID,
+  OPENWORK_MODELS_PROVIDER_NAME,
+  openWorkModelsPromoChangedEvent,
+} from "@/react-app/domains/cloud/openwork-models-promo";
 import { getConnectedProviderItems, useProviderListQuery } from "@/react-app/domains/connections/provider-list-query";
 import {
   Command,
@@ -30,7 +43,6 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { isDesktopProviderBlocked } from "@/app/cloud/desktop-app-restrictions";
-import { Settings2 } from "lucide-react";
 import { openModelPickerEvent } from "@/react-app/shell/new-providers-toast";
 import { newProvidersEvent } from "@/app/lib/provider-events";
 
@@ -112,27 +124,67 @@ function useModelOptions(open: boolean) {
   }, [checkDesktopRestriction, data]);
 }
 
-function groupByProvider(modelOptions: ModelOption[]) {
-  const groups = new Map<string, ModelOption[]>();
+type ModelSelectModelItem = {
+  kind: "model";
+  id: string;
+  option: ModelOption;
+};
+
+type ModelSelectOpenWorkItem = {
+  kind: "openwork";
+  id: string;
+  title: string;
+  subtitle: string;
+};
+
+type ModelSelectItem = ModelSelectModelItem | ModelSelectOpenWorkItem;
+
+type ModelSelectGroup = {
+  value: string;
+  items: ModelSelectItem[];
+  promo: boolean;
+};
+
+function groupByProvider(modelOptions: ModelOption[]): ModelSelectGroup[] {
+  const groups = new Map<string, ModelSelectModelItem[]>();
 
   for (const option of modelOptions) {
     const providerLabel = option.description ?? getProviderDisplayName(option.providerID);
+    const item: ModelSelectModelItem = {
+      kind: "model",
+      id: `${option.providerID}:${option.modelID}`,
+      option,
+    };
     const existing = groups.get(providerLabel);
 
     if (existing) {
-      existing.push(option);
+      existing.push(item);
       continue;
     }
 
-    groups.set(providerLabel, [option]);
+    groups.set(providerLabel, [item]);
   }
 
   return [...groups.entries()]
     .map(([providerLabel, options]) => ({
       value: providerLabel,
-      items: [...options].sort((a, b) => a.title.localeCompare(b.title)),
+      items: [...options].sort((a, b) => a.option.title.localeCompare(b.option.title)),
+      promo: false,
     }))
     .sort((a, b) => a.value.localeCompare(b.value));
+}
+
+function openWorkModelsGroup(): ModelSelectGroup {
+  return {
+    value: OPENWORK_MODELS_PROVIDER_NAME,
+    promo: true,
+    items: OPENWORK_MODEL_PREVIEWS.map((model) => ({
+      kind: "openwork",
+      id: model.id,
+      title: model.title,
+      subtitle: model.subtitle,
+    })),
+  };
 }
 
 function isSameModel(a: ModelRef, b: ModelRef) {
@@ -155,8 +207,18 @@ export function ModelSelect({
   disabled = false,
 }: ModelSelectProps) {
   const [search, setSearch] = React.useState("");
+  const [promoHidden, setPromoHidden] = React.useState(isOpenWorkModelsPromoHidden);
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const modelOptions = useModelOptions(open);
+  const denAuth = useDenAuth();
+  const navigate = useNavigate();
+  const platform = usePlatform();
+
+  React.useEffect(() => {
+    const handlePromoChanged = () => setPromoHidden(isOpenWorkModelsPromoHidden());
+    window.addEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+    return () => window.removeEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+  }, []);
 
   const focusSearchInput = React.useCallback(() => {
     window.requestAnimationFrame(() => {
@@ -186,16 +248,39 @@ export function ModelSelect({
     }),
   );
 
-  const groups = React.useMemo(
-    () => groupByProvider(modelOptions ?? []),
-    [modelOptions],
+  const showOpenWorkModelsPromo = React.useMemo(
+    () => !promoHidden && !hasOpenWorkModelsProvider(modelOptions.map((option) => option.providerID)),
+    [modelOptions, promoHidden],
   );
+
+  const groups = React.useMemo(() => {
+    const providerGroups = groupByProvider(modelOptions);
+    return showOpenWorkModelsPromo
+      ? [openWorkModelsGroup(), ...providerGroups]
+      : providerGroups;
+  }, [modelOptions, showOpenWorkModelsPromo]);
 
   const handleSelect = (option: ModelOption) => {
     onChange({ providerID: option.providerID, modelID: option.modelID });
     setSearch("");
     onOpenChange(false);
   };
+
+  const handleOpenWorkModels = React.useCallback(() => {
+    onOpenChange(false);
+    setSearch("");
+    if (!denAuth.isSignedIn) {
+      navigate("/settings/cloud-account");
+    }
+    window.setTimeout(() => {
+      platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn));
+    }, 0);
+  }, [denAuth.isSignedIn, navigate, onOpenChange, platform]);
+
+  const handleHideOpenWorkModels = React.useCallback(() => {
+    hideOpenWorkModelsPromo();
+    setPromoHidden(true);
+  }, []);
 
   return (
     <Popover
@@ -243,56 +328,103 @@ export function ModelSelect({
           </CommandHeader>
           <CommandEmpty>No models found.</CommandEmpty>
           <CommandList>
-            {(group) => (
+            {(group: ModelSelectGroup) => (
               <CommandGroup
                 key={group.value}
                 items={group.items}
               >
-                <CommandGroupLabel>{group.value}</CommandGroupLabel>
+                <CommandGroupLabel className={group.promo ? "flex items-center gap-1.5 text-foreground" : undefined}>
+                  {group.promo ? <Sparkles className="size-3 text-blue-11" /> : null}
+                  {group.value}
+                </CommandGroupLabel>
                 <CommandCollection>
-                  {(option: ModelOption) => (
-                    <CommandItem
-                      className="gap-2"
-                      key={`${option.providerID}:${option.modelID}`}
-                      value={`${option.providerID}:${option.modelID}`}
-                      onClick={() => handleSelect(option)}
-                      data-checked={isSameModel(value, option)}
-                    >
-                      <ProviderIcon
-                        providerId={option.providerID}
-                        providerName={option.description}
-                        className="size-3.5 opacity-70"
-                        size={14}
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate text-foreground">
-                          {option.title}
+                  {(item: ModelSelectItem) => {
+                    if (item.kind === "openwork") {
+                      return (
+                        <CommandItem
+                          className="gap-2 border border-blue-6/50 bg-blue-2/40 data-highlighted:bg-blue-3"
+                          key={item.id}
+                          value={`${OPENWORK_MODELS_PROVIDER_NAME} ${item.title} ${item.id} sign in subscribe`}
+                          onClick={handleOpenWorkModels}
+                        >
+                          <ProviderIcon
+                            providerId={OPENWORK_MODELS_PROVIDER_ID}
+                            providerName={OPENWORK_MODELS_PROVIDER_NAME}
+                            className="size-3.5 text-blue-11"
+                            size={14}
+                          />
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-foreground">
+                              {item.title}
+                            </span>
+                            <span className="block truncate text-xs text-muted-foreground">
+                              {item.subtitle} - {denAuth.isSignedIn ? "Subscribe to add this model" : "Sign in to unlock"}
+                            </span>
+                          </span>
+                          <span className="shrink-0 rounded-full border border-blue-6 bg-blue-3 px-1.5 py-0.5 text-[10px] font-medium text-blue-11">
+                            {denAuth.isSignedIn ? "Subscribe" : "Sign in"}
+                          </span>
+                          <ChevronRight className="size-3.5 text-blue-11" />
+                        </CommandItem>
+                      );
+                    }
+
+                    const option = item.option;
+                    return (
+                      <CommandItem
+                        className="gap-2"
+                        key={item.id}
+                        value={`${option.providerID}:${option.modelID} ${option.title} ${option.description ?? ""}`}
+                        onClick={() => handleSelect(option)}
+                        data-checked={isSameModel(value, option)}
+                      >
+                        <ProviderIcon
+                          providerId={option.providerID}
+                          providerName={option.description}
+                          className="size-3.5 opacity-70"
+                          size={14}
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-foreground">
+                            {option.title}
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {option.description ??
+                              getProviderDisplayName(option.providerID)}
+                          </span>
                         </span>
-                        <span className="block truncate text-xs text-muted-foreground">
-                          {option.description ??
-                            getProviderDisplayName(option.providerID)}
-                        </span>
-                      </span>
-                    </CommandItem>
-                  )}
+                      </CommandItem>
+                    );
+                  }}
                 </CommandCollection>
               </CommandGroup>
             )}
           </CommandList>
           {/* Link to full model picker */}
           <div className="border-t border-border px-2 py-1.5">
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-              onClick={() => {
-                onOpenChange(false);
-                setSearch("");
-                window.dispatchEvent(new CustomEvent(openModelPickerEvent));
-              }}
-            >
-              <Settings2 className="size-3.5" />
-              All models
-            </button>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                className="flex flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                onClick={() => {
+                  onOpenChange(false);
+                  setSearch("");
+                  window.dispatchEvent(new CustomEvent(openModelPickerEvent));
+                }}
+              >
+                <Settings2 className="size-3.5" />
+                All models
+              </button>
+              {showOpenWorkModelsPromo ? (
+                <button
+                  type="button"
+                  className="shrink-0 rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                  onClick={handleHideOpenWorkModels}
+                >
+                  Hide
+                </button>
+              ) : null}
+            </div>
           </div>
         </Command>
       </PopoverContent>

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
@@ -1,0 +1,77 @@
+import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
+
+import {
+  buildDenAuthUrl,
+  getDenInferenceUrl,
+  readDenBootstrapConfig,
+  readDenSettings,
+} from "../../../app/lib/den";
+
+export const OPENWORK_MODELS_PROVIDER_ID = "openwork";
+export const OPENWORK_MODELS_PROVIDER_NAME = "OpenWork Models";
+export const OPENWORK_MODELS_PROMO_HIDDEN_KEY = "openwork.openworkModelsPromo.hidden";
+export const OPENWORK_MODELS_PROMO_LAST_SHOWN_KEY = "openwork.openworkModelsPromo.lastShownAt";
+export const openWorkModelsPromoChangedEvent = "openwork-openwork-models-promo-changed";
+export const OPENWORK_MODELS_PROMO_SHOW_DELAY_MS = 4_000;
+export const OPENWORK_MODELS_PROMO_VISIBLE_MS = 14_000;
+export const OPENWORK_MODELS_PROMO_REPEAT_MS = 6 * 60 * 60 * 1000;
+
+export type OpenWorkModelPreview = {
+  id: string;
+  title: string;
+  subtitle: string;
+};
+
+export const OPENWORK_MODEL_PREVIEWS: OpenWorkModelPreview[] = Object.entries(
+  INFERENCE_MODEL_ALIASES,
+)
+  .filter(([, model]) => model.enabled)
+  .map(([id, model]) => ({
+    id,
+    title: model.displayName.replace(/^OpenWork:\s*/, ""),
+    subtitle: "OpenWork hosted",
+  }));
+
+export function hasOpenWorkModelsProvider(providerIds: readonly string[]) {
+  return providerIds.some((id) => id.trim().toLowerCase() === OPENWORK_MODELS_PROVIDER_ID);
+}
+
+export function getOpenWorkModelsActionUrl(isSignedIn: boolean) {
+  const settings = readDenSettings();
+  const baseUrl = settings.baseUrl || readDenBootstrapConfig().baseUrl;
+  return isSignedIn ? getDenInferenceUrl(baseUrl) : buildDenAuthUrl(baseUrl, "sign-in");
+}
+
+export function isOpenWorkModelsPromoHidden() {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(OPENWORK_MODELS_PROMO_HIDDEN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function hideOpenWorkModelsPromo() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(OPENWORK_MODELS_PROMO_HIDDEN_KEY, "1");
+    window.dispatchEvent(new Event(openWorkModelsPromoChangedEvent));
+  } catch {}
+}
+
+export function shouldShowOpenWorkModelsPromo(now = Date.now()) {
+  if (typeof window === "undefined" || isOpenWorkModelsPromoHidden()) return false;
+  try {
+    const lastShown = Number(window.localStorage.getItem(OPENWORK_MODELS_PROMO_LAST_SHOWN_KEY) ?? "0");
+    return !Number.isFinite(lastShown) || now - lastShown >= OPENWORK_MODELS_PROMO_REPEAT_MS;
+  } catch {
+    return true;
+  }
+}
+
+export function markOpenWorkModelsPromoShown(now = Date.now()) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(OPENWORK_MODELS_PROMO_LAST_SHOWN_KEY, String(now));
+  } catch {}
+}

--- a/apps/app/src/react-app/domains/session/chat/status-bar.tsx
+++ b/apps/app/src/react-app/domains/session/chat/status-bar.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
-import { useEffect, useMemo, useRef, useState } from "react";
-import { BookOpen, Cloud, MessageCircleMore, Settings } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowRight, BookOpen, Cloud, MessageCircleMore, Settings, Sparkles, X } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -12,6 +13,17 @@ import { useDenAuth } from "../../cloud/den-auth-provider";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
 import { useShellConfig } from "../../../shell/shell-config";
 import type { OpenworkServerStatus } from "../../../../app/lib/openwork-server";
+import {
+  getOpenWorkModelsActionUrl,
+  hasOpenWorkModelsProvider,
+  hideOpenWorkModelsPromo,
+  isOpenWorkModelsPromoHidden,
+  markOpenWorkModelsPromoShown,
+  OPENWORK_MODELS_PROMO_SHOW_DELAY_MS,
+  OPENWORK_MODELS_PROMO_VISIBLE_MS,
+  openWorkModelsPromoChangedEvent,
+  shouldShowOpenWorkModelsPromo,
+} from "../../cloud/openwork-models-promo";
 
 const DOCS_URL = "https://openworklabs.com/docs";
 const STATUS_BAR_BOOT_STARTED_AT = Date.now();
@@ -137,10 +149,16 @@ export type StatusBarProps = {
 export function StatusBar(props: StatusBarProps) {
   const platform = usePlatform();
   const denAuth = useDenAuth();
+  const navigate = useNavigate();
   const { config: shellConfig } = useShellConfig();
   const docsButtonRef = useRef<HTMLButtonElement>(null);
   const feedbackButtonRef = useRef<HTMLButtonElement>(null);
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
+  const [openWorkModelsHintVisible, setOpenWorkModelsHintVisible] = useState(false);
+  const hasOpenWorkModels = useMemo(
+    () => hasOpenWorkModelsProvider(props.providerConnectedIds),
+    [props.providerConnectedIds],
+  );
   const [initializing, setInitializing] = useState(
     () => Date.now() - STATUS_BAR_BOOT_STARTED_AT < STATUS_BAR_INITIALIZING_MS,
   );
@@ -154,6 +172,66 @@ export function StatusBar(props: StatusBarProps) {
     const timeout = window.setTimeout(() => setInitializing(false), remaining);
     return () => window.clearTimeout(timeout);
   }, [initializing]);
+
+  useEffect(() => {
+    const handlePromoChanged = () => {
+      if (isOpenWorkModelsPromoHidden()) {
+        setOpenWorkModelsHintVisible(false);
+      }
+    };
+    window.addEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+    return () => window.removeEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+  }, []);
+
+  useEffect(() => {
+    if (!shellConfig.cloudSignin || hasOpenWorkModels) {
+      setOpenWorkModelsHintVisible(false);
+      return;
+    }
+    if (denAuth.status === "checking") return;
+
+    let showTimeout: number | null = null;
+    const maybeShow = () => {
+      if (showTimeout !== null || !shouldShowOpenWorkModelsPromo()) return;
+      showTimeout = window.setTimeout(() => {
+        showTimeout = null;
+        if (!shouldShowOpenWorkModelsPromo()) return;
+        markOpenWorkModelsPromoShown();
+        setOpenWorkModelsHintVisible(true);
+      }, OPENWORK_MODELS_PROMO_SHOW_DELAY_MS);
+    };
+
+    maybeShow();
+    const interval = window.setInterval(maybeShow, 60_000);
+    return () => {
+      if (showTimeout !== null) {
+        window.clearTimeout(showTimeout);
+      }
+      window.clearInterval(interval);
+    };
+  }, [denAuth.status, hasOpenWorkModels, shellConfig.cloudSignin]);
+
+  useEffect(() => {
+    if (!openWorkModelsHintVisible) return;
+    const timeout = window.setTimeout(
+      () => setOpenWorkModelsHintVisible(false),
+      OPENWORK_MODELS_PROMO_VISIBLE_MS,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [openWorkModelsHintVisible]);
+
+  const openOpenWorkModels = useCallback(() => {
+    setOpenWorkModelsHintVisible(false);
+    if (!denAuth.isSignedIn) {
+      navigate("/settings/cloud-account");
+    }
+    platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn));
+  }, [denAuth.isSignedIn, navigate, platform]);
+
+  const hideOpenWorkModels = useCallback(() => {
+    setOpenWorkModelsHintVisible(false);
+    hideOpenWorkModelsPromo();
+  }, []);
 
   const docsControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "status.docs.open",
@@ -199,6 +277,30 @@ export function StatusBar(props: StatusBarProps) {
         />
 
         <div className="flex items-center gap-1">
+          {openWorkModelsHintVisible ? (
+            <div className="mr-1 flex h-6 items-center overflow-hidden rounded-full border border-blue-6/60 bg-blue-2/70 shadow-[0_0_18px_rgba(var(--dls-accent-rgb),0.16)] animate-in fade-in slide-in-from-bottom-1 zoom-in-95 duration-300">
+              <button
+                type="button"
+                className="flex min-w-0 items-center gap-1.5 px-2.5 text-xs font-medium text-blue-12 transition-colors hover:bg-blue-3/70"
+                onClick={openOpenWorkModels}
+              >
+                <Sparkles className="size-3.5 text-blue-11" />
+                <span className="whitespace-nowrap">OpenWork Models</span>
+                <span className="hidden whitespace-nowrap font-normal text-blue-11/75 lg:inline">
+                  hosted frontier models
+                </span>
+                <ArrowRight className="size-3.5 text-blue-11" />
+              </button>
+              <button
+                type="button"
+                className="flex size-6 shrink-0 items-center justify-center border-l border-blue-6/60 text-blue-11 transition-colors hover:bg-blue-3/70"
+                onClick={hideOpenWorkModels}
+                aria-label="Hide OpenWork Models hint"
+              >
+                <X className="size-3" />
+              </button>
+            </div>
+          ) : null}
           {shellConfig.cloudSignin && !denAuth.isSignedIn && denAuth.status !== "checking" ? (
             <Tooltip>
               <TooltipTrigger

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -6,7 +6,8 @@ import {
   useRef,
   useState,
 } from "react";
-import { Check, ChevronDown, ChevronRight, Search, Star } from "lucide-react";
+import { ArrowRight, Check, ChevronDown, ChevronRight, Search, Sparkles, Star, X } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 import {
   Dialog,
@@ -22,6 +23,17 @@ import { modelEquals, resolveProviderDisplayName } from "../../../../app/utils";
 import type { ModelOption, ModelRef } from "../../../../app/types";
 import { isRecommendedModel } from "../../../../app/defaults";
 import { ProviderIcon } from "../../../design-system/provider-icon";
+import { useDenAuth } from "../../cloud/den-auth-provider";
+import { usePlatform } from "../../../kernel/platform";
+import {
+  getOpenWorkModelsActionUrl,
+  hasOpenWorkModelsProvider,
+  hideOpenWorkModelsPromo,
+  isOpenWorkModelsPromoHidden,
+  OPENWORK_MODELS_PROVIDER_ID,
+  OPENWORK_MODELS_PROVIDER_NAME,
+  openWorkModelsPromoChangedEvent,
+} from "../../cloud/openwork-models-promo";
 
 export type ModelPickerModalProps = {
   open: boolean;
@@ -52,6 +64,10 @@ type ProviderGroup = {
 export function ModelPickerModal(props: ModelPickerModalProps) {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
+  const [promoHidden, setPromoHidden] = useState(isOpenWorkModelsPromoHidden);
+  const denAuth = useDenAuth();
+  const navigate = useNavigate();
+  const platform = usePlatform();
 
   const disabledSet = useMemo(
     () => new Set(props.disabledProviders ?? []),
@@ -64,6 +80,12 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
       props.setQuery("");
     }
   }, [props.open]);
+
+  useEffect(() => {
+    const handlePromoChanged = () => setPromoHidden(isOpenWorkModelsPromoHidden());
+    window.addEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+    return () => window.removeEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+  }, []);
 
   // Focus search
   useEffect(() => {
@@ -147,6 +169,26 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
     });
   }, []);
 
+  const showOpenWorkModelsPromo = useMemo(
+    () => !promoHidden && !hasOpenWorkModelsProvider(props.options.map((option) => option.providerID)),
+    [promoHidden, props.options],
+  );
+
+  const openOpenWorkModels = useCallback(() => {
+    props.onClose();
+    if (!denAuth.isSignedIn) {
+      navigate("/settings/cloud-account");
+    }
+    window.setTimeout(() => {
+      platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn));
+    }, 0);
+  }, [denAuth.isSignedIn, navigate, platform, props.onClose]);
+
+  const hideOpenWorkModels = useCallback(() => {
+    hideOpenWorkModelsPromo();
+    setPromoHidden(true);
+  }, []);
+
   const handleSelect = useCallback(
     (opt: ModelOption) => props.onSelect({ providerID: opt.providerID, modelID: opt.modelID }),
     [props.onSelect],
@@ -190,6 +232,39 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
               onChange={(e) => props.setQuery(e.target.value)}
             />
           </div>
+
+          {showOpenWorkModelsPromo ? (
+            <div className="mb-3 flex shrink-0 items-center overflow-hidden rounded-2xl border border-blue-6/60 bg-blue-2/60 shadow-[0_12px_30px_-20px_rgba(var(--dls-accent-rgb),0.45)]">
+              <button
+                type="button"
+                className="flex min-w-0 flex-1 items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-blue-3/70"
+                onClick={openOpenWorkModels}
+              >
+                <ProviderIcon providerId={OPENWORK_MODELS_PROVIDER_ID} providerName={OPENWORK_MODELS_PROVIDER_NAME} size={18} className="shrink-0 text-blue-11" />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5 text-[13px] font-medium text-dls-text">
+                    <Sparkles className="size-3.5 text-blue-11" />
+                    <span>{OPENWORK_MODELS_PROVIDER_NAME}</span>
+                  </div>
+                  <div className="truncate text-[11px] text-dls-secondary">
+                    {denAuth.isSignedIn ? "Subscribe to use hosted frontier models in this workspace." : "Sign in to unlock hosted frontier models for your team."}
+                  </div>
+                </div>
+                <span className="flex shrink-0 items-center gap-1 rounded-full border border-blue-6 bg-blue-3 px-2 py-0.5 text-[11px] font-medium text-blue-11">
+                  {denAuth.isSignedIn ? "Subscribe" : "Sign in"}
+                  <ArrowRight className="size-3" />
+                </span>
+              </button>
+              <button
+                type="button"
+                className="flex size-9 shrink-0 items-center justify-center border-l border-blue-6/60 text-blue-11 transition-colors hover:bg-blue-3/70"
+                onClick={hideOpenWorkModels}
+                aria-label="Hide OpenWork Models"
+              >
+                <X className="size-3.5" />
+              </button>
+            </div>
+          ) : null}
 
           {/* Content */}
           <div className="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1 -mr-1">
@@ -362,5 +437,3 @@ function DefaultModelRow({
     </button>
   );
 }
-
-


### PR DESCRIPTION
## Summary

- Add shared OpenWork Models promo state, preview models, and sign-in/subscription URL handling.
- Add dismissible OpenWork Models rows to the compact composer model picker.
- Add a dismissible OpenWork Models banner to the full model picker plus a periodic status-bar hint.

## Tests

- `pnpm typecheck` passed.
- Manual CDP smoke test on `http://127.0.0.1:5179`: cleared promo storage, verified the status-bar hint appears after the delay, opened the full model picker CTA, and confirmed it routes to Cloud Account sign-in.

## Recording

- Captured local MP4: `/var/folders/8j/hhcc8zs100d3fd654fjkk9580000gn/T/opencode/openwork-models-promo-flow-final.mp4`
- The GitHub CLI does not support attaching PR video files directly; this file is ready to upload through the GitHub web UI.
