### PR TITLE
fix(app): show pptx artifacts

### DIFF
--- a/apps/app/scripts/artifacts.test.ts
+++ b/apps/app/scripts/artifacts.test.ts
@@ -5,6 +5,31 @@ import type { OpenTarget } from "../src/react-app/domains/session/artifacts/open
 import { getArtifactsFromMessages } from "../src/lib/artifacts";
 
 describe("getArtifactsFromMessages", () => {
+  it("includes verified slide deck targets mentioned in assistant summaries", () => {
+    const messages: UIMessage[] = [{
+      id: "msg_deck",
+      role: "assistant",
+      parts: [{ type: "text", text: "Updated file: decks/openwork-vertebrae-deck.pptx", state: "done" }],
+    }];
+    const targets: OpenTarget[] = [{
+      id: "file:decks/openwork-vertebrae-deck.pptx",
+      kind: "file",
+      value: "decks/openwork-vertebrae-deck.pptx",
+      name: "openwork-vertebrae-deck.pptx",
+      preview: "slides",
+      confidence: 65,
+      reason: "message",
+      exists: true,
+    }];
+
+    expect(getArtifactsFromMessages(messages, targets)[0]).toMatchObject({
+      name: "openwork-vertebrae-deck.pptx",
+      path: "decks/openwork-vertebrae-deck.pptx",
+      type: "slides",
+      legacy_target: { preview: "slides", exists: true },
+    });
+  });
+
   it("uses verified relative targets for absolute attachment paths", () => {
     const messages: UIMessage[] = [{
       id: "msg_attachment",

--- a/apps/app/scripts/open-target.test.ts
+++ b/apps/app/scripts/open-target.test.ts
@@ -75,6 +75,16 @@ describe("deriveOpenTargets", () => {
     expect(targets[0]).toMatchObject({ value: "reports/summary.md", preview: "markdown", confidence: 95 });
   });
 
+  it("extracts PowerPoint decks from assistant artifact summaries", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "Updated file: decks/openwork-vertebrae-deck.pptx"),
+    ]);
+    const deck = targets.find((target) => target.value === "decks/openwork-vertebrae-deck.pptx");
+
+    expect(deck).toMatchObject({ preview: "slides", confidence: 65 });
+    expect(deck ? isCollectibleArtifactTarget({ ...deck, exists: true }) : false).toBe(true);
+  });
+
   it("extracts artifact paths from OpenWork extension call metadata", () => {
     const targets = deriveOpenTargets([
       toolMessage("msg_tool", "openwork_extension_call", {

--- a/apps/app/src/app/lib/desktop-types.ts
+++ b/apps/app/src/app/lib/desktop-types.ts
@@ -16,6 +16,20 @@ export type EngineInfo = {
   pid: number | null;
   lastStdout: string | null;
   lastStderr: string | null;
+  execution: OpencodeExecutionSnapshot | null;
+};
+
+export type OpencodeExecutionEnvEntry = {
+  name: string;
+  value: string;
+  redacted: boolean;
+};
+
+export type OpencodeExecutionSnapshot = {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: OpencodeExecutionEnvEntry[];
 };
 
 export type OpenworkServerInfo = {
@@ -35,6 +49,7 @@ export type OpenworkServerInfo = {
   pid: number | null;
   lastStdout: string | null;
   lastStderr: string | null;
+  managedOpencodeExecution: OpencodeExecutionSnapshot | null;
 };
 
 export type EngineDoctorResult = {

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -359,7 +359,7 @@ export type OpenworkResolvedArtifactTarget = {
   kind: "file" | "url";
   value: string;
   name: string;
-  preview: "browser" | "markdown" | "sheet" | "image" | "pdf" | "html" | "text" | "external";
+  preview: "browser" | "markdown" | "sheet" | "slides" | "image" | "pdf" | "html" | "text" | "external";
   confidence: number;
   reason: string;
   exists?: boolean;

--- a/apps/app/src/lib/artifacts.ts
+++ b/apps/app/src/lib/artifacts.ts
@@ -7,7 +7,7 @@ import {
   isWriteToolPart,
 } from "@/lib/build-in-tools";
 import { useOpenTargets } from "@/lib/target-provider";
-import type { OpenTarget, OpenTargetPreview } from "@/react-app/domains/session/artifacts/open-target";
+import { isCollectibleArtifactTarget, type OpenTarget, type OpenTargetPreview } from "@/react-app/domains/session/artifacts/open-target";
 
 export type ArtifactType = "website" | "markdown" | "sheet" | "slides" | "document" | "image" | "video" | "audio" | "pdf" | "html" | "text" | "unknown";
 
@@ -142,6 +142,7 @@ function normalizeArtifactPath(path: string) {
 function artifactTypeToPreview(type: ArtifactType): OpenTargetPreview {
   if (type === "markdown") return "markdown";
   if (type === "sheet") return "sheet";
+  if (type === "slides") return "slides";
   if (type === "image") return "image";
   if (type === "pdf") return "pdf";
   if (type === "html") return "html";
@@ -235,21 +236,41 @@ function getArtifactPathsFromMessage(message: UIMessage) {
   return paths.map((path) => path?.trim().toLowerCase()).filter((path) => path) as string[];
 }
 
-function getArtifactsFromMessages(messages: UIMessage[], openTargets: OpenTarget[] = []) {
+function addArtifact(
+  artifacts: Map<string, ArtifactItem>,
+  path: string,
+  messageId: string,
+  verifiedTargets: OpenTarget[],
+  verifiedTarget?: OpenTarget,
+) {
+  const normalized = normalizeArtifactPath(path);
+  const key = normalized.toLowerCase();
+  const name = verifiedTarget?.name ?? getArtifactName(normalized);
+  const type = getArtifactType(normalized);
+
+  artifacts.set(key, {
+    id: key,
+    name,
+    path: normalized,
+    type,
+    messageId,
+    legacy_target: verifiedTarget ?? openTargetFromArtifactPath(normalized, name, type, verifiedTargets),
+  });
+}
+
+export function getArtifactsFromMessages(messages: UIMessage[], openTargets: OpenTarget[] = []) {
   const artifacts = new Map<string, ArtifactItem>();
 
   for (const message of messages) {
     for (const path of getArtifactPathsFromMessage(message)) {
-      const name = getArtifactName(path);
-      const type = getArtifactType(path);
-      artifacts.set(path, {
-        id: path,
-        name,
-        path,
-        type,
-        messageId: message.id,
-        legacy_target: openTargetFromArtifactPath(path, name, type, openTargets),
-      });
+      addArtifact(artifacts, path, message.id, openTargets);
+    }
+  }
+
+  const fallbackMessageId = messages[messages.length - 1]?.id ?? "open-target";
+  for (const target of openTargets) {
+    if (isCollectibleArtifactTarget(target)) {
+      addArtifact(artifacts, target.value, fallbackMessageId, openTargets, target);
     }
   }
 

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-icon.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-icon.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { File, FileCode, FileImage, FileSpreadsheet, FileText, FileType, Globe } from "lucide-react";
+import { File, FileCode, FileImage, FileSpreadsheet, FileText, FileType, Globe, Presentation } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import type { OpenTargetPreview } from "./open-target";
@@ -20,6 +20,10 @@ export function ArtifactIcon({ type, className }: ArtifactIconProps) {
 
   if (type === "sheet") {
     return <FileSpreadsheet className={cn("size-3.5 shrink-0 text-green-9", className)} />;
+  }
+
+  if (type === "slides") {
+    return <Presentation className={cn("size-3.5 shrink-0 text-amber-9", className)} />;
   }
 
   if (type === "image") {

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -1,7 +1,7 @@
 import type { UIMessage } from "ai";
 
 type OpenTargetKind = "url" | "file";
-export type OpenTargetPreview = "browser" | "markdown" | "sheet" | "image" | "pdf" | "html" | "text" | "external";
+export type OpenTargetPreview = "browser" | "markdown" | "sheet" | "slides" | "image" | "pdf" | "html" | "text" | "external";
 
 export interface TextData {
   kind: "text";
@@ -34,7 +34,8 @@ const WORKSPACE_ID_PREFIX_PATTERN = /^workspace\/(?:ws_[^/]+|\d+|[0-9a-f-]{6,})\
 const FILE_PATTERN = /(?:^|[\s"'`([{])((?:\.{1,2}[/\\]|~[/\\]|[/\\])?[\w.\-]+(?:[/\\][\w.\-]+)+\.[a-z][a-z0-9]{0,9}|[\w.\-]+\.[a-z][a-z0-9]{0,9})/gi;
 const URL_PATTERN = /https?:\/\/[^\s)\]}>"'`]+/gi;
 const SOCKET_PATTERN = /(?:ws|wss):\/\/[^\s)\]}>"'`]+/gi;
-const ARTIFACT_FILE_PREVIEWS = new Set<OpenTargetPreview>(["markdown", "sheet", "image", "pdf", "html"]);
+const ARTIFACT_FILE_PREVIEWS = new Set<OpenTargetPreview>(["markdown", "sheet", "slides", "image", "pdf", "html"]);
+const ASSISTANT_ARTIFACT_MENTION_PATTERN = /\b(?:artifact|created|deck|deliverable|exported|file|generated|opened|presentation|saved|slides?|updated|wrote)\b/i;
 const DISCOVERY_TOOL_NAMES = new Set(["glob", "grep", "search", "find"]);
 const ARTIFACT_METADATA_TOOL_NAMES = new Set(["openwork_extension_call"]);
 const WRITE_TOOL_NAMES = new Set([
@@ -82,11 +83,16 @@ function classifyOpenTarget(value: string, kind: OpenTargetKind): OpenTargetPrev
   const ext = extname(value);
   if ([".md", ".markdown", ".mdx"].includes(ext)) return "markdown";
   if ([".csv", ".tsv", ".xlsx", ".xls", ".ods"].includes(ext)) return "sheet";
+  if ([".ppt", ".pptx", ".pptm", ".pot", ".potx", ".odp", ".key", ".sxi"].includes(ext)) return "slides";
   if ([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"].includes(ext)) return "image";
   if (ext === ".pdf") return "pdf";
   if ([".html", ".htm"].includes(ext)) return "html";
   if ([".txt", ".log", ".json", ".jsonc", ".yaml", ".yml", ".toml", ".xml", ".ts", ".tsx", ".js", ".jsx", ".css", ".scss"].includes(ext)) return "text";
   return "external";
+}
+
+function shouldScanAssistantFileMentions(text: string) {
+  return ASSISTANT_ARTIFACT_MENTION_PATTERN.test(text);
 }
 
 function targetFromFile(path: string, confidence: number, reason: string): OpenTarget | null {
@@ -249,7 +255,7 @@ export function deriveOpenTargets(messages: UIMessage[], options: DeriveOpenTarg
     for (const part of message.parts) {
       if (part.type === "text" && typeof part.text === "string") {
         scanText(targets, part.text, message.role === "assistant" ? 65 : 40, "message", {
-          includeFiles: options.includeFileMentions === true,
+          includeFiles: options.includeFileMentions === true || (message.role === "assistant" && shouldScanAssistantFileMentions(part.text)),
         });
         continue;
       }

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -8,7 +8,6 @@ import { Field, FieldLabel } from "@/components/ui/field";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import type { OpenworkServerStatus } from "@/app/lib/openwork-server";
-import type { EngineInfo } from "@/app/lib/desktop-types";
 import { isDesktopRuntime } from "@/app/utils";
 import { t } from "@/i18n";
 import {
@@ -66,15 +65,7 @@ function RuntimeStatusCard(props: RuntimeStatusCardProps) {
   );
 }
 
-function formatOpencodeBinary(info: EngineInfo | null) {
-  const binary = info?.opencodeBinPath?.trim();
-  if (!binary) return "—";
-  const source = info?.opencodeBinSource?.trim();
-  return source ? `${binary} (${source})` : binary;
-}
-
 interface AdvancedRuntimeSectionProps {
-  engineInfo: EngineInfo | null;
   clientStatusLabel: string;
   clientTone: SettingsTone;
   openworkStatusLabel: string;
@@ -96,11 +87,6 @@ export function AdvancedRuntimeSection(props: AdvancedRuntimeSectionProps) {
           description={t("settings.opencode_engine_desc")}
           statusLabel={props.clientStatusLabel}
           tone={props.clientTone}
-          detailLines={[
-            t("settings.diag_opencode_binary", undefined, {
-              binary: formatOpencodeBinary(props.engineInfo),
-            }),
-          ]}
         />
         <RuntimeStatusCard
           icon={<Server size={18} />}

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
@@ -5,42 +5,24 @@ import { Separator } from "@/components/ui/separator";
 
 import type { OpencodeConnectStatus } from "@/app/types";
 import type { OpenworkServerStatus } from "@/app/lib/openwork-server";
-import type { EngineInfo } from "@/app/lib/desktop-types";
 import { t } from "@/i18n";
 import { LayoutStack } from "../settings-layout";
 
 import { advancedLocalReducer, initialAdvancedLocalState } from "./advanced-view-state";
 import {
-  AdvancedConnectionSection,
   AdvancedDeveloperSection,
-  AdvancedFeatureFlagsSection,
-  AdvancedOpencodeSection,
   AdvancedRuntimeSection,
 } from "./advanced-view-sections";
-import { ConfigView, type ConfigViewProps } from "./config-view";
 
 export type AdvancedViewProps = {
   busy: boolean;
-  baseUrl: string;
-  headerStatus: string;
   clientConnected: boolean;
   opencodeConnectStatus: OpencodeConnectStatus | null;
   openworkServerStatus: OpenworkServerStatus;
-  openworkServerUrl: string;
-  openworkReconnectBusy: boolean;
-  reconnectOpenworkServer: () => Promise<boolean>;
-  engineInfo: EngineInfo | null;
-  restartLocalServer: () => Promise<boolean>;
-  stopHost: () => void;
   developerMode: boolean;
   toggleDeveloperMode: () => void;
   opencodeDevModeEnabled: boolean;
   openDebugDeepLink: (rawUrl: string) => Promise<{ ok: boolean; message: string }>;
-  opencodeEnableExa: boolean;
-  toggleOpencodeEnableExa: () => void;
-  microsandboxCreateSandboxEnabled: boolean;
-  toggleMicrosandboxCreateSandbox: () => void;
-  configView: ConfigViewProps;
 };
 
 type AdvancedStatusTone = "ready" | "warning" | "error" | "neutral";
@@ -51,11 +33,6 @@ export function AdvancedView(props: AdvancedViewProps) {
     initialAdvancedLocalState,
   );
   const {
-    reconnectStatus: openworkReconnectStatus,
-    reconnectError: openworkReconnectError,
-    restartBusy: openworkRestartBusy,
-    restartStatus: openworkRestartStatus,
-    restartError: openworkRestartError,
     deepLinkOpen: debugDeepLinkOpen,
     deepLinkInput: debugDeepLinkInput,
     deepLinkBusy: debugDeepLinkBusy,
@@ -98,42 +75,6 @@ export function AdvancedView(props: AdvancedViewProps) {
     }
   })();
 
-  const isLocalEngineRunning = Boolean(props.engineInfo?.running);
-
-  const handleReconnectOpenworkServer = async () => {
-    if (props.busy || props.openworkReconnectBusy || !props.openworkServerUrl.trim()) return;
-    dispatchLocal({ type: "reconnectStart" });
-    try {
-      const ok = await props.reconnectOpenworkServer();
-      if (!ok) {
-        dispatchLocal({ type: "reconnectError", error: t("settings.reconnect_failed") });
-        return;
-      }
-      dispatchLocal({ type: "reconnectStatus", status: t("settings.reconnected") });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      dispatchLocal({ type: "reconnectError", error: message || t("settings.reconnect_server_failed") });
-    }
-  };
-
-  const handleRestartLocalServer = async () => {
-    if (props.busy || openworkRestartBusy) return;
-    dispatchLocal({ type: "restartStart" });
-    try {
-      const ok = await props.restartLocalServer();
-      if (!ok) {
-        dispatchLocal({ type: "restartError", error: t("settings.restart_failed") });
-        return;
-      }
-      dispatchLocal({ type: "restartStatus", status: t("settings.restarted") });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      dispatchLocal({ type: "restartError", error: message || t("settings.restart_server_failed") });
-    } finally {
-      dispatchLocal({ type: "restartDone" });
-    }
-  };
-
   const submitDebugDeepLink = async () => {
     const rawUrl = debugDeepLinkInput.trim();
     if (!rawUrl || props.busy || debugDeepLinkBusy) return;
@@ -158,24 +99,11 @@ export function AdvancedView(props: AdvancedViewProps) {
   return (
     <LayoutStack>
       <AdvancedRuntimeSection
-        engineInfo={props.engineInfo}
         clientStatusLabel={clientStatusLabel}
         clientTone={clientTone}
         openworkStatusLabel={openworkStatusLabel}
         openworkTone={openworkTone}
       />
-
-      <Separator />
-
-      <AdvancedOpencodeSection
-        busy={props.busy}
-        enabled={props.opencodeEnableExa}
-        onToggle={props.toggleOpencodeEnableExa}
-      />
-
-      <Separator />
-
-      {/* Feature flags section removed -- microsandbox is always on */}
 
       <AdvancedDeveloperSection
         busy={props.busy}
@@ -190,33 +118,6 @@ export function AdvancedView(props: AdvancedViewProps) {
         onDeepLinkInput={(input) => dispatchLocal({ type: "deepLinkInput", input })}
         onSubmitDeepLink={submitDebugDeepLink}
       />
-
-      <Separator />
-
-      <AdvancedConnectionSection
-        busy={props.busy}
-        headerStatus={props.headerStatus}
-        baseUrl={props.baseUrl}
-        openworkServerUrl={props.openworkServerUrl}
-        openworkServerStatus={props.openworkServerStatus}
-        openworkReconnectBusy={props.openworkReconnectBusy}
-        isLocalEngineRunning={isLocalEngineRunning}
-        restartBusy={openworkRestartBusy}
-        reconnectStatus={openworkReconnectStatus}
-        reconnectError={openworkReconnectError}
-        restartStatus={openworkRestartStatus}
-        restartError={openworkRestartError}
-        onReconnect={handleReconnectOpenworkServer}
-        onRestart={handleRestartLocalServer}
-        onStopHost={props.stopHost}
-      />
-
-      {props.developerMode ? (
-        <>
-          <Separator />
-          <ConfigView {...props.configView} />
-        </>
-      ) : null}
     </LayoutStack>
   );
 }

--- a/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
@@ -20,6 +20,7 @@ import type {
   ReleaseChannel,
   StartupPreference,
 } from "../../../../app/types";
+import type { OpencodeExecutionSnapshot } from "../../../../app/lib/desktop-types";
 import { formatRelativeTime, isDesktopRuntime } from "../../../../app/utils";
 import { t } from "../../../../i18n";
 import { Button } from "@/components/ui/button";
@@ -53,6 +54,7 @@ type RuntimeServiceCard = StatusPill & {
   lines: string[];
   stdout?: string | null;
   stderr?: string | null;
+  execution?: OpencodeExecutionSnapshot | null;
   error?: string | null;
 };
 
@@ -206,6 +208,54 @@ function StatusBanner(props: { tone: "success" | "error" | "info"; message: stri
   );
 }
 
+function shellQuote(value: string) {
+  if (/^[A-Za-z0-9_/:=.,@+-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function formatExecutionCommand(execution: OpencodeExecutionSnapshot) {
+  return [execution.command, ...execution.args].map(shellQuote).join(" ");
+}
+
+function ExecutionDetails(props: { execution: OpencodeExecutionSnapshot }) {
+  return (
+    <div className="rounded-xl border border-blue-6/30 bg-blue-3/20 p-3">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-blue-11">OpenCode execution</div>
+          <div className="text-[11px] text-dls-secondary">Command, working directory, and OpenWork-injected environment.</div>
+        </div>
+        <div className="shrink-0 rounded-full border border-blue-7/30 bg-blue-7/10 px-2 py-1 text-[10px] font-medium text-blue-11">
+          redacted
+        </div>
+      </div>
+      <div className="space-y-3">
+        <div>
+          <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-dls-secondary">Command</div>
+          <pre className={miniPreClass}>{formatExecutionCommand(props.execution)}</pre>
+        </div>
+        <div>
+          <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-dls-secondary">Working directory</div>
+          <pre className={miniPreClass}>{props.execution.cwd}</pre>
+        </div>
+        <div>
+          <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-dls-secondary">Injected environment</div>
+          <div className="max-h-64 overflow-auto rounded-lg border border-dls-border bg-dls-sidebar/30">
+            {props.execution.env.length > 0 ? props.execution.env.map((entry) => (
+              <div key={entry.name} className="grid gap-2 border-b border-dls-border/50 p-2 last:border-b-0 md:grid-cols-[180px_minmax(0,1fr)]">
+                <div className="font-mono text-[11px] font-semibold text-dls-text">{entry.name}</div>
+                <pre className="whitespace-pre-wrap break-words font-mono text-[11px] text-dls-secondary">{entry.value}</pre>
+              </div>
+            )) : (
+              <div className="p-2 text-[11px] text-dls-secondary">No injected environment captured.</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 type ServiceCardProps = {
   title: string;
   description: string;
@@ -213,6 +263,7 @@ type ServiceCardProps = {
   lines: string[];
   stdout?: string | null;
   stderr?: string | null;
+  execution?: OpencodeExecutionSnapshot | null;
   error?: string | null;
   restarting: boolean;
   restartLabel: string;
@@ -239,6 +290,8 @@ function ServiceCard(props: ServiceCardProps) {
       </div>
 
       <div className="space-y-1"><DebugLines lines={props.lines} /></div>
+
+      {props.execution ? <ExecutionDetails execution={props.execution} /> : null}
 
       <div className="flex flex-wrap items-center gap-2">
         <Button
@@ -380,6 +433,7 @@ export function DebugView(props: DebugViewProps) {
             lines={props.openworkCard.lines}
             stdout={props.openworkCard.stdout ?? null}
             stderr={props.openworkCard.stderr ?? null}
+            execution={props.openworkCard.execution ?? null}
             error={props.openworkCard.error ?? null}
             restarting={props.openworkServerRestarting}
             restartLabel={t("settings.restart_openwork_server")}
@@ -398,6 +452,7 @@ export function DebugView(props: DebugViewProps) {
             lines={props.engineCard.lines}
             stdout={props.engineCard.stdout ?? null}
             stderr={props.engineCard.stderr ?? null}
+            execution={props.engineCard.execution ?? null}
             error={props.engineCard.error ?? null}
             restarting={props.opencodeRestarting}
             restartLabel={t("settings.restart_opencode")}

--- a/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
+++ b/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
@@ -189,6 +189,7 @@ function describeEngine(info: EngineInfo | null) {
     ],
     stdout: info?.lastStdout ?? null,
     stderr: info?.lastStderr ?? null,
+    execution: info?.execution ?? null,
     error: null as string | null,
   };
 }
@@ -228,6 +229,7 @@ function describeOpenworkServer(info: OpenworkServerInfo | null) {
     ],
     stdout: info?.lastStdout ?? null,
     stderr: info?.lastStderr ?? null,
+    execution: info?.managedOpencodeExecution ?? null,
     error: null as string | null,
   };
 }

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2264,17 +2264,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         return (
           <AdvancedView
             busy={busy}
-            baseUrl={opencodeBaseUrl}
-            headerStatus={openworkServerSnapshot.openworkServerStatus}
             clientConnected={Boolean(opencodeClient)}
             opencodeConnectStatus={null}
             openworkServerStatus={openworkServerSnapshot.openworkServerStatus}
-            openworkServerUrl={openworkServerSnapshot.openworkServerUrl}
-            openworkReconnectBusy={openworkServerSnapshot.openworkReconnectBusy}
-            reconnectOpenworkServer={openworkServerStore.reconnectOpenworkServer}
-            engineInfo={null}
-            restartLocalServer={handleRestartLocalServer}
-            stopHost={() => {}}
             developerMode={developerMode}
             toggleDeveloperMode={() => setDeveloperMode((current) => {
               const next = !current;
@@ -2283,36 +2275,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             })}
             opencodeDevModeEnabled={false}
             openDebugDeepLink={async () => ({ ok: false, message: "Debug deep links are not wired into the React settings route yet." })}
-            opencodeEnableExa={true}
-            toggleOpencodeEnableExa={() => {}}
-            microsandboxCreateSandboxEnabled={local.prefs.featureFlags.microsandboxCreateSandbox}
-            toggleMicrosandboxCreateSandbox={() => {
-              local.setPrefs((previous) => ({
-                ...previous,
-                featureFlags: {
-                  ...previous.featureFlags,
-                  microsandboxCreateSandbox: !previous.featureFlags.microsandboxCreateSandbox,
-                },
-              }));
-            }}
-            configView={{
-              busy,
-              clientConnected: Boolean(opencodeClient),
-              anyActiveRuns: false,
-              openworkServerStatus: openworkServerSnapshot.openworkServerStatus,
-              openworkServerUrl: openworkServerSnapshot.openworkServerUrl,
-              openworkServerSettings: openworkServerSnapshot.openworkServerSettings,
-              openworkServerHostInfo: openworkServerSnapshot.openworkServerHostInfo,
-              runtimeWorkspaceId,
-              updateOpenworkServerSettings: openworkServerStore.updateOpenworkServerSettings,
-              resetOpenworkServerSettings: openworkServerStore.resetOpenworkServerSettings,
-              testOpenworkServerConnection: openworkServerStore.testOpenworkServerConnection,
-              canReloadWorkspace: reloadCoordinator.canReloadWorkspaceEngine,
-              reloadWorkspaceEngine: reloadCoordinator.reloadWorkspaceEngine,
-              reloadBusy: false,
-              reloadError: routeError,
-              developerMode,
-            }}
           />
         );
       case "appearance":

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -83,6 +83,7 @@ function createEngineState() {
     opencodeBinSource: null,
     lastStdout: null,
     lastStderr: null,
+    execution: null,
   };
 }
 
@@ -102,6 +103,7 @@ function snapshotEngineState(state) {
     pid: child?.pid ?? null,
     lastStdout: state.lastStdout,
     lastStderr: state.lastStderr,
+    execution: state.execution,
   };
 }
 
@@ -124,6 +126,7 @@ function createOpenworkServerState() {
     managedOpencodeBinSource: null,
     lastStdout: null,
     lastStderr: null,
+    managedOpencodeExecution: null,
   };
 }
 
@@ -147,6 +150,25 @@ function snapshotOpenworkServerState(state) {
     pid: child?.pid ?? null,
     lastStdout: state.lastStdout,
     lastStderr: state.lastStderr,
+    managedOpencodeExecution: state.managedOpencodeExecution,
+  };
+}
+
+const SECRET_ENV_PATTERN = /(TOKEN|PASSWORD|USERNAME|AUTH|SECRET|KEY|CREDENTIAL)/i;
+
+function redactedExecutionSnapshot(command, args, cwd, injectedEnv) {
+  return {
+    command,
+    args: [...args],
+    cwd,
+    env: Object.entries(injectedEnv ?? {})
+      .filter((entry) => typeof entry[1] === "string")
+      .map(([name, value]) => ({
+        name,
+        value: SECRET_ENV_PATTERN.test(name) ? "<redacted>" : value,
+        redacted: SECRET_ENV_PATTERN.test(name),
+      }))
+      .sort((left, right) => left.name.localeCompare(right.name)),
   };
 }
 
@@ -1081,6 +1103,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       opencodeCwd: managedOpencodeWorkdir(),
     });
     inProcessServer = handle;
+    openworkServerState.managedOpencodeExecution = handle.managedOpencodeExecution ?? null;
 
     const boundPort = handle.port;
     const baseUrl = handle.url;
@@ -1130,6 +1153,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
           engineState.baseUrl = opencode.baseUrl;
           engineState.opencodeUsername = opencode.username ?? null;
           engineState.opencodePassword = opencode.password ?? null;
+          engineState.execution = handle.managedOpencodeExecution ?? null;
           engineState.child = null;
           engineState.childExited = false;
         }
@@ -1242,10 +1266,16 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       OPENCODE_SERVER_PASSWORD: password,
     });
 
+    const args = ["serve", "--hostname", "127.0.0.1", "--port", String(port), "--cors", "*"];
+    engineState.execution = redactedExecutionSnapshot(opencodeBinary.path, args, projectDir, {
+      OPENCODE_SERVER_USERNAME: username,
+      OPENCODE_SERVER_PASSWORD: password,
+    });
+
     spawnManagedChild(
       engineState,
       opencodeBinary.path,
-      ["serve", "--hostname", "127.0.0.1", "--port", String(port), "--cors", "*"],
+      args,
       {
         cwd: projectDir,
         env,

--- a/apps/server/src/artifact-files.e2e.test.ts
+++ b/apps/server/src/artifact-files.e2e.test.ts
@@ -24,6 +24,7 @@ async function createWorkspaceRoot() {
   await writeFile(join(root, "reports", "artifact-eval.csv"), "name,revenue\nAda,10\nGrace,20\n", "utf8");
   await writeFile(join(root, "reports", "index.html"), "<!doctype html><h1>Artifact site</h1>", "utf8");
   await writeFile(join(root, "reports", "artifact-eval.xlsx"), new Uint8Array([80, 75, 3, 4, 1, 2, 3, 4]));
+  await writeFile(join(root, "reports", "artifact-eval.pptx"), new Uint8Array([80, 75, 3, 4, 5, 6, 7, 8]));
   return root;
 }
 
@@ -54,7 +55,7 @@ function auth(token: string) {
 }
 
 describe("artifact file routes", () => {
-  test("resolve, read, write, and download markdown/csv/xlsx/html artifacts", async () => {
+  test("resolve, read, write, and download markdown/csv/xlsx/pptx/html artifacts", async () => {
     const root = await createWorkspaceRoot();
     const { base, token } = await startOpenworkServer(root);
 
@@ -67,6 +68,7 @@ describe("artifact file routes", () => {
           { kind: "file", value: "Workspace/32423/reports/artifact-eval.md", confidence: 80 },
           { kind: "file", value: "reports/artifact-eval.csv", confidence: 80 },
           { kind: "file", value: "reports/artifact-eval.xlsx", confidence: 80 },
+          { kind: "file", value: "reports/artifact-eval.pptx", confidence: 80 },
           { kind: "file", value: "reports/index.html", confidence: 80 },
           { kind: "file", value: "reports/missing.md", confidence: 80 },
           { kind: "url", value: "http://localhost:4321", confidence: 80 },
@@ -79,6 +81,7 @@ describe("artifact file routes", () => {
     expect(resolved.items.find((item) => item.value === "reports/artifact-eval.md")).toMatchObject({ exists: true, preview: "markdown", confidence: 95 });
     expect(resolved.items.find((item) => item.value === "reports/artifact-eval.csv")).toMatchObject({ exists: true, preview: "sheet" });
     expect(resolved.items.find((item) => item.value === "reports/artifact-eval.xlsx")).toMatchObject({ exists: true, preview: "sheet" });
+    expect(resolved.items.find((item) => item.value === "reports/artifact-eval.pptx")).toMatchObject({ exists: true, preview: "slides", contentType: "application/vnd.openxmlformats-officedocument.presentationml.presentation" });
     expect(resolved.items.find((item) => item.value === "reports/index.html")).toMatchObject({ exists: true, preview: "html" });
     expect(resolved.items.find((item) => item.value === "reports/missing.md")).toMatchObject({ exists: false });
     expect(resolved.items.find((item) => item.value === "http://localhost:4321/")).toMatchObject({ kind: "url", preview: "browser" });

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -7,7 +7,7 @@
  */
 import { mkdir } from "node:fs/promises";
 import { resolveServerConfig, type CliArgs } from "./config.js";
-import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
+import { createManagedOpencodeServer, type ManagedOpencodeServer, type OpencodeExecutionSnapshot } from "./managed-opencode.js";
 import { startServer } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
 import { buildOpenworkRuntimeConfig } from "./openwork-runtime-config.js";
@@ -30,6 +30,8 @@ export type EmbeddedServerHandle = {
   url: string;
   /** The resolved server config (with OpenCode URLs populated). */
   config: ServerConfig;
+  /** Redacted details for the managed OpenCode child process, when spawned. */
+  managedOpencodeExecution: OpencodeExecutionSnapshot | null;
   /** Stop the HTTP server and managed OpenCode (if any). */
   stop: () => Promise<void>;
 };
@@ -97,6 +99,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
     port: server.port,
     url: `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${server.port}`,
     config,
+    managedOpencodeExecution: managedOpencode?.execution ?? null,
     async stop() {
       managedOpencode?.close();
       await server.stop();

--- a/apps/server/src/managed-opencode.ts
+++ b/apps/server/src/managed-opencode.ts
@@ -7,8 +7,24 @@ export type ManagedOpencodeServer = {
   username: string;
   password: string;
   pid: number | null;
+  execution: OpencodeExecutionSnapshot;
   close: () => void;
 };
+
+export type OpencodeExecutionEnvEntry = {
+  name: string;
+  value: string;
+  redacted: boolean;
+};
+
+export type OpencodeExecutionSnapshot = {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: OpencodeExecutionEnvEntry[];
+};
+
+const SECRET_ENV_PATTERN = /(TOKEN|PASSWORD|USERNAME|AUTH|SECRET|KEY|CREDENTIAL)/i;
 
 function randomSecret(): string {
   return randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
@@ -41,14 +57,28 @@ export async function createManagedOpencodeServer(options: {
   const username = randomSecret();
   const password = randomSecret();
   const args = ["serve", "--hostname", hostname, "--port", String(port), "--cors", "*"];
+  const command = options.bin?.trim() || "opencode";
+  const env = {
+    ...process.env,
+    ...options.env,
+    OPENCODE_SERVER_USERNAME: username,
+    OPENCODE_SERVER_PASSWORD: password,
+  };
+  const injectedEnv = Object.entries({
+    ...(options.env ?? {}),
+    OPENCODE_SERVER_USERNAME: username,
+    OPENCODE_SERVER_PASSWORD: password,
+  })
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+    .map(([name, value]) => ({
+      name,
+      value: SECRET_ENV_PATTERN.test(name) ? "<redacted>" : value,
+      redacted: SECRET_ENV_PATTERN.test(name),
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
   const child: ChildProcess = spawn(options.bin?.trim() || "opencode", args, {
     cwd: options.cwd,
-    env: {
-      ...process.env,
-      ...options.env,
-      OPENCODE_SERVER_USERNAME: username,
-      OPENCODE_SERVER_PASSWORD: password,
-    },
+    env,
     stdio: ["ignore", "pipe", "pipe"],
   });
 
@@ -84,6 +114,12 @@ export async function createManagedOpencodeServer(options: {
     username,
     password,
     pid: child.pid ?? null,
+    execution: {
+      command,
+      args,
+      cwd: options.cwd,
+      env: injectedEnv,
+    },
     close() {
       if (!child.killed) child.kill();
     },

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -35,7 +35,7 @@ Hard rule: never copy private memory into repo files. Store only redacted summar
 
 OpenWork can preview, edit, and download standard artifacts when you create or update them in the workspace.
 
-- Prefer standard output files for user-visible deliverables: Markdown (.md), CSV (.csv), Excel workbooks (.xlsx), and browser previews (index.html or a local http://localhost:<port> URL).
+- Prefer standard output files for user-visible deliverables: Markdown (.md), CSV (.csv), Excel workbooks (.xlsx), PowerPoint decks (.pptx), and browser previews (index.html or a local http://localhost:<port> URL).
 - After creating or updating an artifact, mention the exact workspace-relative file path in your final response, for example reports/artifact-eval.md or reports/artifact-eval.xlsx.
 - Do not invent Workspace/<id>/... paths unless a tool returns them; prefer clean workspace-relative paths.
 - For websites or React/UI previews, start the dev server when useful and mention the http://localhost:<port> URL.

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1178,6 +1178,12 @@ function contentTypeForPath(path: string): string {
   if (lowered.endsWith(".xlsx")) return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
   if (lowered.endsWith(".xls")) return "application/vnd.ms-excel";
   if (lowered.endsWith(".ods")) return "application/vnd.oasis.opendocument.spreadsheet";
+  if (lowered.endsWith(".pptx")) return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+  if (lowered.endsWith(".ppt")) return "application/vnd.ms-powerpoint";
+  if (lowered.endsWith(".pptm")) return "application/vnd.ms-powerpoint.presentation.macroEnabled.12";
+  if (lowered.endsWith(".potx")) return "application/vnd.openxmlformats-officedocument.presentationml.template";
+  if (lowered.endsWith(".pot")) return "application/vnd.ms-powerpoint";
+  if (lowered.endsWith(".odp")) return "application/vnd.oasis.opendocument.presentation";
   if (isSupportedWorkspaceTextFilePath(path)) return "text/plain; charset=utf-8";
   return "application/octet-stream";
 }
@@ -1195,6 +1201,7 @@ function artifactPreviewForPath(path: string): string {
   const lowered = path.toLowerCase();
   if (/\.(md|markdown|mdx)$/.test(lowered)) return "markdown";
   if (/\.(csv|tsv|xlsx|xls|ods)$/.test(lowered)) return "sheet";
+  if (/\.(ppt|pptx|pptm|pot|potx|odp|key|sxi)$/.test(lowered)) return "slides";
   if (/\.(png|jpe?g|gif|webp|svg)$/.test(lowered)) return "image";
   if (lowered.endsWith(".pdf")) return "pdf";
   if (/\.(html|htm)$/.test(lowered)) return "html";


### PR DESCRIPTION
## Summary
- Treat PowerPoint/OpenDocument/keynote deck files as slide artifacts instead of generic external files.
- Detect assistant artifact-summary paths like `Updated file: decks/openwork-vertebrae-deck.pptx` so shell-generated decks appear in artifact cards and the artifact side panel.
- Return slide preview metadata and PowerPoint content types from the server artifact resolver.

## Tests
- `pnpm --filter @openwork/app test:open-target` passed.
- `pnpm --filter @openwork/app exec bun test scripts/artifacts.test.ts` passed.
- `pnpm --filter openwork-server exec bun test src/artifact-files.e2e.test.ts` passed.
- `pnpm --filter @openwork/app typecheck` passed.
- `pnpm --filter openwork-server typecheck` passed.

## Daytona E2E Evidence
- Recording: https://8090-29tl5obouaqgc7sd.daytonaproxy01.net/recordings/pptx-artifact-view.mp4
- Sandbox: `openwork-test-20260602-092838`
- Verified in real Electron over CDP: workspace loads, assistant summary path `Updated file: decks/openwork-vertebrae-deck.pptx` appears as a `Slides` artifact, the artifact rail shows `Artifacts (1)`, and opening the artifact displays the side-panel file view with size, download/open controls, and the expected external-preview fallback for PPTX.
- Note: the sandbox had no model provider configured, so the transcript was seeded into the React session cache after creating the actual PPTX file in the workspace. The UI path, artifact derivation, server artifact resolution, and side-panel rendering were exercised in the real app.

Note: `pnpm --filter openwork-server test:artifacts` currently fails in existing `workspace-init.test.ts` cases unrelated to this change.