### PR TITLE
fix(electron): load OpenCode plugins from resources

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -12,10 +12,15 @@ directories:
 files:
   - electron/**/*
   - server/**/*
+  - "!server/dist/opencode-plugins/**"
   - package.json
 extraResources:
   - from: ../app/dist
     to: app-dist
+  - from: server/dist/opencode-plugins
+    to: opencode-plugins
+    filter:
+      - "*.js"
 asar: true
 npmRebuild: false
 afterPack: scripts/electron-after-pack.cjs

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "dev": "OPENWORK_DEV_MODE=1 bun src/cli.ts",
     "test": "bun test",
     "test:artifacts": "bun test src/artifact-files.e2e.test.ts src/workspace-init.test.ts src/server.normalizeWorkspaceRelativePath.test.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts --outdir dist/opencode-plugins --target node --format esm",
     "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64",
     "start": "bun dist/cli.js",

--- a/apps/server/src/openwork-extensions-plugin-path.ts
+++ b/apps/server/src/openwork-extensions-plugin-path.ts
@@ -1,11 +1,29 @@
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-function pluginPath(name: string): string {
-  const here = dirname(fileURLToPath(import.meta.url));
+declare global {
+  namespace NodeJS {
+    interface Process {
+      resourcesPath?: string;
+    }
+  }
+}
+
+function resourcesPathFromAppAsarPath(path: string): string | null {
+  const match = /[\\/]app\.asar(?:[\\/]|$)/.exec(path);
+  return match ? path.slice(0, match.index) : null;
+}
+
+export function openworkPluginPath(name: string, here = dirname(fileURLToPath(import.meta.url))): string {
+  const resourcesPath = resourcesPathFromAppAsarPath(here);
+  if (resourcesPath) {
+    const electronResourcesPath = process.resourcesPath?.includes("app.asar") ? resourcesPath : process.resourcesPath?.trim();
+    return join(electronResourcesPath || resourcesPath, "opencode-plugins", `${name}.js`);
+  }
+
   const extension = basename(here) === "dist" ? "js" : "ts";
   return join(here, "opencode-plugins", `${name}.${extension}`);
 }
 
-export const openworkExtensionsPreviewPluginPath = () => pluginPath("openwork-extensions-preview");
-export const openworkCapabilitiesKnowledgePluginPath = () => pluginPath("openwork-capabilities-knowledge");
+export const openworkExtensionsPreviewPluginPath = () => openworkPluginPath("openwork-extensions-preview");
+export const openworkCapabilitiesKnowledgePluginPath = () => openworkPluginPath("openwork-capabilities-knowledge");

--- a/apps/server/src/workspace-init.test.ts
+++ b/apps/server/src/workspace-init.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { ensureWorkspaceFiles } from "./workspace-init.js";
-import { openworkExtensionsPreviewPluginPath } from "./openwork-extensions-plugin-path.js";
+import { openworkExtensionsPreviewPluginPath, openworkPluginPath } from "./openwork-extensions-plugin-path.js";
 
 async function withWorkspace(fn: (root: string) => Promise<void>) {
   const root = await mkdtemp(join(tmpdir(), "openwork-workspace-init-"));
@@ -34,6 +34,27 @@ describe("ensureWorkspaceFiles", () => {
     const plugin = await readFile(pluginPath, "utf8");
     expect(pluginPath).toContain(join("opencode-plugins", "openwork-extensions-preview.ts"));
     expect(plugin).toContain("openwork_extension_call");
+  });
+
+  test("uses external resources plugin path in packaged Electron", () => {
+    const previousResourcesPath = process.resourcesPath;
+    const resourcesPath = join("/Applications", "OpenWork.app", "Contents", "Resources");
+    process.resourcesPath = resourcesPath;
+    try {
+      const pluginPath = openworkPluginPath(
+        "openwork-extensions-preview",
+        join(resourcesPath, "app.asar", "server", "dist"),
+      );
+
+      expect(pluginPath).toBe(join(resourcesPath, "opencode-plugins", "openwork-extensions-preview.js"));
+      expect(pluginPath).not.toContain("app.asar");
+    } finally {
+      if (previousResourcesPath) {
+        process.resourcesPath = previousResourcesPath;
+      } else {
+        delete process.resourcesPath;
+      }
+    }
   });
 
   test("does not create workspace extension preview plugin", async () => {


### PR DESCRIPTION
## Summary
- copy bundled OpenWork-managed OpenCode plugins into Electron extraResources at Resources/opencode-plugins
- resolve packaged plugin paths outside app.asar while preserving dev/source paths
- bundle plugin dependencies during server build and add a packaged path test

## Tests
- pnpm --filter openwork-server build ✅
- pnpm --filter openwork-server exec bun test src/workspace-init.test.ts -t "uses shipped extension preview plugin|uses external resources plugin path" ✅ (2 pass)
- pnpm --filter @openwork/desktop build:electron ✅
- pnpm --filter @openwork/desktop exec electron-builder --config electron-builder.yml --dir --mac ✅; verified Resources/opencode-plugins/*.js exists in the packaged .app
- node -e "import('./apps/server/dist/opencode-plugins/openwork-extensions-preview.js').then((m)=>console.log(Object.keys(m).join(',')))" ✅

Note: full src/workspace-init.test.ts currently has two unrelated existing failures around disk-based OpenWork agent files after runtime-agent changes.