### PR TITLE
chore(daytona): improve testing toolbox

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -23,18 +23,21 @@ bash .devcontainer/test-on-daytona.sh [branch-or-commit]
 The test script creates a sandbox from the reusable `openwork-eval-vnc` snapshot
 when present, checks out the target ref, skips `pnpm install` if the lockfile is
 unchanged, starts XFCE/noVNC, Vite, and Electron, then prints the noVNC and CDP
-URLs. If the snapshot is missing, it falls back to the VNC Dockerfile path. The
+URLs. If the snapshot is missing, it fails fast and tells you to create it. The
 snapshot intentionally does not bake `node_modules`; installs use the reusable
 `openwork-eval-pnpm-store` volume so the image stays under Daytona's 20 GB limit.
 
-For OpenAI/provider evals, create the reusable Daytona secrets volume once:
+For provider evals, create/populate the reusable Daytona secrets volume once:
 
 ```bash
 bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken
+bash .devcontainer/setup-daytona-secrets-volume.sh .anthropic anthropic.env
 ```
 
 Future Daytona test sandboxes mount `openwork-eval-secrets:/daytona-secrets`
-and source `/daytona-secrets/openai.env` automatically before Electron starts.
+and source every `/daytona-secrets/*.env` file automatically before Electron
+starts. Use this volume for provider keys and other eval-only secrets; never
+commit those files into the repo.
 
 For downloadable eval artifacts or optional video recording, use:
 
@@ -46,8 +49,9 @@ bash .devcontainer/test-on-daytona.sh [branch-or-commit] --record-video
 The artifacts flow mounts `openwork-eval-artifacts:/daytona-artifacts`, starts a
 static download server on port 8090, and prints a Daytona preview URL. Recording
 writes mp4 files to `/daytona-artifacts/recordings` and prints the direct video
-URL. Stop recording with the printed `pkill -INT -f "ffmpeg.*x11grab"` command so
-ffmpeg finalizes the file cleanly.
+URL. Screenshots write png files to `/daytona-artifacts/screenshots` for quick
+AI/human validation checkpoints. Stop recording with
+`.devcontainer/stop-daytona-recording.sh` so ffmpeg finalizes the file cleanly.
 
 Do not use the generic `daytona create https://github.com/different-ai/openwork`
 flow for Electron/noVNC tests. The default resource size is too small and the
@@ -91,7 +95,32 @@ client and talks to the server through public Daytona preview URLs.
    applies Daytona-safe Chromium flags, and starts Electron on display `:99`.
 7. **CDP on port 9825** enables Chrome MCP and browser-tool automation.
 8. Optional artifact capture mounts `/daytona-artifacts`, serves it on port 8090,
-   and records display `:99` with ffmpeg when `--record-video` is passed.
+   records display `:99` with ffmpeg when `--record-video` is passed, and can
+   capture screenshot checkpoints with `.devcontainer/capture-daytona-screenshot.sh`.
+
+## Validation Evidence
+
+Use three layers of evidence for Daytona UI work:
+
+- **CDP assertions:** use browser tools against port 9825 to inspect text, URL,
+  state, and accessibility snapshots. This is the primary AI validation path.
+- **Screenshots:** run `daytona exec "$SANDBOX" -- 'bash .devcontainer/capture-daytona-screenshot.sh'` after important states. These png files live in `/daytona-artifacts/screenshots`.
+- **Recordings:** start with `--record-video --recording-name <name>` for flows
+  that need PR evidence. These mp4 files live in `/daytona-artifacts/recordings`.
+
+Recordings prove the flow to humans. CDP assertions and screenshots give the AI
+fast checkpoints to decide whether behavior is correct before reporting success.
+
+## AI Skills
+
+The Daytona toolbox is exposed to opencode through focused skills:
+
+- `daytona-dev`: overview of the Daytona setup and when to use each piece.
+- `daytona-cloud-server`: Den Web/API, worker proxy, marketplace, cloud auth, and org policy flows.
+- `daytona-secrets-volume`: add and verify provider keys or eval-only secrets in `/daytona-secrets`.
+- `daytona-electron-test`: run and drive the real Electron app through CDP/noVNC.
+- `daytona-recording-artifacts`: screenshots, recordings, before/after videos, and PR evidence.
+- `run-evals`: orchestrates evals and pulls in the relevant Daytona skill based on the flow.
 
 ## Testing the customization system
 

--- a/.devcontainer/capture-daytona-screenshot.sh
+++ b/.devcontainer/capture-daytona-screenshot.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Capture a single Daytona Electron display frame as a PNG artifact. Screenshots
+# are for quick AI/human validation; videos are still the durable PR evidence.
+
+OUTPUT="/daytona-artifacts/screenshots/daytona-screenshot-$(date +%Y%m%d-%H%M%S).png"
+SIZE="1920x1080"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      shift
+      OUTPUT="${1:?missing output path}"
+      ;;
+    --size)
+      shift
+      SIZE="${1:?missing screenshot size}"
+      ;;
+    --help|-h)
+      printf '%s\n' \
+        "Usage: capture-daytona-screenshot.sh [--output PATH] [--size WxH]" \
+        "" \
+        "Captures DISPLAY, defaulting to :99, and writes a PNG file."
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      echo "Unexpected argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "ERROR: ffmpeg is required for Daytona screenshots." >&2
+  exit 1
+fi
+
+if [[ ! "$SIZE" =~ ^[0-9]+x[0-9]+$ ]]; then
+  echo "ERROR: screenshot size must use WxH format, for example 1920x1080" >&2
+  exit 1
+fi
+
+FINAL_OUTPUT="$OUTPUT"
+CAPTURE_OUTPUT="$OUTPUT"
+if [[ "$OUTPUT" = /daytona-artifacts/* ]]; then
+  CAPTURE_OUTPUT="/tmp/daytona-screenshot-$(basename "$OUTPUT")"
+fi
+
+mkdir -p "$(dirname "$CAPTURE_OUTPUT")"
+ffmpeg -y -f x11grab -video_size "$SIZE" -i "${DISPLAY:-:99}" -frames:v 1 "$CAPTURE_OUTPUT" >/tmp/daytona-screenshot.log 2>&1
+
+if [ "$CAPTURE_OUTPUT" != "$FINAL_OUTPUT" ]; then
+  mkdir -p "$(dirname "$FINAL_OUTPUT")"
+  cp "$CAPTURE_OUTPUT" "$FINAL_OUTPUT"
+fi
+
+echo "Screenshot saved: $FINAL_OUTPUT"

--- a/.devcontainer/setup-daytona-secrets-volume.sh
+++ b/.devcontainer/setup-daytona-secrets-volume.sh
@@ -2,16 +2,22 @@
 set -euo pipefail
 
 # Create the reusable Daytona secrets volume once. If a local env file is
-# provided, copy it into the mounted volume as openai.env without printing it.
+# provided, copy it into the mounted volume without printing it.
 #
 # Usage:
-#   bash .devcontainer/setup-daytona-secrets-volume.sh [.newtoken]
+#   bash .devcontainer/setup-daytona-secrets-volume.sh [.newtoken] [openai.env]
 
 VOLUME_NAME="${DAYTONA_SECRETS_VOLUME:-openwork-eval-secrets}"
 MOUNT_PATH="${DAYTONA_SECRETS_MOUNT:-/daytona-secrets}"
 LOCAL_ENV_FILE="${1:-.newtoken}"
+DEST_ENV_FILE="${2:-openai.env}"
 SANDBOX="openwork-secrets-setup-$(date +%Y%m%d-%H%M%S)"
 SNAPSHOT_NAME="${DAYTONA_EVAL_SNAPSHOT:-openwork-eval-vnc}"
+
+if [[ ! "$DEST_ENV_FILE" =~ ^[A-Za-z0-9._-]+\.env$ ]]; then
+  echo "ERROR: destination env file must be a simple .env filename, for example openai.env" >&2
+  exit 1
+fi
 
 cleanup() {
   yes | daytona delete "$SANDBOX" >/dev/null 2>&1 || true
@@ -61,8 +67,9 @@ if [ "$exec_ready" -ne 1 ]; then
   exit 1
 fi
 
-daytona exec "$SANDBOX" -- "bash -lc 'mkdir -p \"$MOUNT_PATH\" && umask 177 && printf %s \"$SECRET_ENV_B64\" | base64 -d > \"$MOUNT_PATH/openai.env\"'" >/dev/null
-daytona exec "$SANDBOX" -- "bash -lc 'test -s \"$MOUNT_PATH/openai.env\" && chmod 600 \"$MOUNT_PATH/openai.env\"'" >/dev/null
+daytona exec "$SANDBOX" -- "bash -lc 'mkdir -p \"$MOUNT_PATH\" && umask 177 && printf %s \"$SECRET_ENV_B64\" | base64 -d > \"$MOUNT_PATH/$DEST_ENV_FILE\"'" >/dev/null
+daytona exec "$SANDBOX" -- "bash -lc 'test -s \"$MOUNT_PATH/$DEST_ENV_FILE\" && chmod 600 \"$MOUNT_PATH/$DEST_ENV_FILE\"'" >/dev/null
 
 echo "Volume ready: $VOLUME_NAME"
-echo "Secret env installed at ${MOUNT_PATH}/openai.env"
+echo "Secret env installed at ${MOUNT_PATH}/${DEST_ENV_FILE}"
+echo "Electron sources every ${MOUNT_PATH}/*.env file by default."

--- a/.devcontainer/start-daytona-electron.sh
+++ b/.devcontainer/start-daytona-electron.sh
@@ -32,10 +32,26 @@ PY
   exit 0
 fi
 
-DAYTONA_SECRETS_ENV="${DAYTONA_SECRETS_ENV:-/daytona-secrets/openai.env}"
+DAYTONA_SECRETS_ENV="${DAYTONA_SECRETS_ENV:-/daytona-secrets}"
 DAYTONA_ELECTRON_EXTRA_LAUNCH_ARGS="${DAYTONA_ELECTRON_EXTRA_LAUNCH_ARGS:---disable-gpu --disable-dev-shm-usage --enable-unsafe-swiftshader}"
 
-if [ -f "$DAYTONA_SECRETS_ENV" ]; then
+source_secret_env_file() {
+  local env_file="$1"
+  if [ -f "$env_file" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$env_file"
+    set +a
+  fi
+}
+
+if [ -d "$DAYTONA_SECRETS_ENV" ]; then
+  shopt -s nullglob
+  for env_file in "$DAYTONA_SECRETS_ENV"/*.env; do
+    source_secret_env_file "$env_file"
+  done
+  shopt -u nullglob
+elif [ -f "$DAYTONA_SECRETS_ENV" ]; then
   set -a
   # shellcheck disable=SC1090
   source "$DAYTONA_SECRETS_ENV"

--- a/.devcontainer/test-on-daytona.sh
+++ b/.devcontainer/test-on-daytona.sh
@@ -97,7 +97,7 @@ MAX_WAIT=90
 DAYTONA_EVAL_SNAPSHOT="${DAYTONA_EVAL_SNAPSHOT:-openwork-eval-vnc}"
 DAYTONA_SECRETS_VOLUME="${DAYTONA_SECRETS_VOLUME:-openwork-eval-secrets}"
 DAYTONA_SECRETS_MOUNT="${DAYTONA_SECRETS_MOUNT:-/daytona-secrets}"
-DAYTONA_SECRETS_ENV="${DAYTONA_SECRETS_ENV:-${DAYTONA_SECRETS_MOUNT}/openai.env}"
+DAYTONA_SECRETS_ENV="${DAYTONA_SECRETS_ENV:-${DAYTONA_SECRETS_MOUNT}}"
 DAYTONA_ARTIFACTS_VOLUME="${DAYTONA_ARTIFACTS_VOLUME:-openwork-eval-artifacts}"
 DAYTONA_ARTIFACTS_MOUNT="${DAYTONA_ARTIFACTS_MOUNT:-/daytona-artifacts}"
 DAYTONA_ELECTRON_EXTRA_LAUNCH_ARGS="${DAYTONA_ELECTRON_EXTRA_LAUNCH_ARGS:---disable-gpu --disable-dev-shm-usage --enable-unsafe-swiftshader}"
@@ -212,7 +212,7 @@ fi
 if [ "$ARTIFACTS_ENABLED" -eq 1 ]; then
   echo ""
   echo "==> Starting artifacts download server..."
-  daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; mkdir -p \"$DAYTONA_ARTIFACTS_MOUNT/recordings\"; nohup python3 -m http.server $ARTIFACTS_PORT --directory \"$DAYTONA_ARTIFACTS_MOUNT\" >/tmp/daytona-artifacts.log 2>&1 &'"
+  daytona exec "$SANDBOX" -- "bash -lc 'set -euo pipefail; mkdir -p \"$DAYTONA_ARTIFACTS_MOUNT/recordings\" \"$DAYTONA_ARTIFACTS_MOUNT/screenshots\" \"$DAYTONA_ARTIFACTS_MOUNT/validation\"; nohup python3 -m http.server $ARTIFACTS_PORT --directory \"$DAYTONA_ARTIFACTS_MOUNT\" >/tmp/daytona-artifacts.log 2>&1 &'"
 fi
 
 echo ""
@@ -261,7 +261,7 @@ else
   echo "==> opencode sidecar: not running (workspace may need creation first)"
 fi
 
-echo "==> Secrets env: ${DAYTONA_SECRETS_ENV} (sourced if present)"
+echo "==> Secrets env: ${DAYTONA_SECRETS_ENV} (file or directory, sourced if present)"
 if [ -n "$DEN_BASE_URL" ]; then
   echo "==> Den base URL: $DEN_BASE_URL"
 fi
@@ -285,12 +285,14 @@ echo "  Electron CDP:  $CDP_URL"
 echo "  noVNC visual:  $NOVNC_URL"
 if [ "$ARTIFACTS_ENABLED" -eq 1 ]; then
   echo "  Artifacts:     $ARTIFACTS_URL"
+  echo "  Screenshot:"
+  echo "    daytona exec $SANDBOX -- 'bash .devcontainer/capture-daytona-screenshot.sh'"
 fi
 if [ "$RECORD_VIDEO" -eq 1 ]; then
   echo "  Recording:     $RECORDING_URL"
   echo ""
   echo "  Stop recording:"
-  echo "    daytona exec $SANDBOX -- 'pkill -INT -f \"ffmpeg.*x11grab\"'"
+  echo "    daytona exec $SANDBOX -- 'bash .devcontainer/stop-daytona-recording.sh'"
 fi
 echo ""
 echo "  Connect browser tools:"

--- a/.opencode/skills/daytona-cloud-server/SKILL.md
+++ b/.opencode/skills/daytona-cloud-server/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: daytona-cloud-server
+description: Daytona cloud server and Den sandbox setup. Use when the user says Daytona server, cloud server, Den server, marketplace server, worker proxy, cloud auth, org policies, or connect Electron to a Daytona server.
+---
+
+# Daytona Cloud Server
+
+Use this skill when the user needs the hosted/server side of OpenWork running in
+Daytona. This is separate from the Electron desktop sandbox.
+
+## What This Covers
+
+- Den Web on port `3005`.
+- Den API on port `8788`.
+- Worker proxy on port `8789`.
+- MySQL inside the server sandbox.
+- Public Daytona preview URLs for Electron to consume.
+- Marketplace, org policy, cloud auth, and server-managed extension flows.
+
+## Start Server Sandbox
+
+From the repo root:
+
+```bash
+bash .devcontainer/test-server-on-daytona.sh [branch-or-commit]
+```
+
+The helper creates a separate server sandbox, starts MySQL, Den API, Den Web,
+and worker proxy, waits for health checks, then prints URLs.
+
+If dependencies or the base image changed, refresh the server snapshot:
+
+```bash
+bash .devcontainer/create-daytona-openwork-server-snapshot.sh
+```
+
+## Connect Electron To Server
+
+Start a second Daytona sandbox for Electron and point it at the server URLs:
+
+```bash
+bash .devcontainer/test-on-daytona.sh [branch-or-commit] \
+  --den-base-url <DEN_WEB_URL> \
+  --den-api-base-url <DEN_API_URL>
+```
+
+For flows that must require cloud sign-in, add `--require-signin`.
+
+## Validate Server Health
+
+Use the public URLs printed by the helper:
+
+```bash
+curl -sf <DEN_WEB_URL>/api/den/health
+curl -sf <DEN_API_URL>/health
+```
+
+Inspect logs if health checks fail:
+
+```bash
+daytona exec "$SERVER_SANDBOX" -- 'tail -120 /tmp/den-api.log'
+daytona exec "$SERVER_SANDBOX" -- 'tail -120 /tmp/den-web.log'
+daytona exec "$SERVER_SANDBOX" -- 'tail -120 /tmp/den-worker-proxy.log'
+daytona exec "$SERVER_SANDBOX" -- 'tail -120 /tmp/den-db-push.log'
+```
+
+## When To Use Two Sandboxes
+
+Use two sandboxes when testing cloud behavior end-to-end: server sandbox for Den
+and a separate Electron sandbox for the desktop client. This matches production
+better than trying to run everything inside one desktop sandbox.
+
+Use this for marketplace install/remove/search/filter, org-managed extensions,
+desktop handoff auth, cloud restrictions, and worker proxy flows.
+
+## Evidence
+
+Pair this with the `daytona-recording-artifacts` skill. Server proof should
+include health-check output, relevant logs, CDP assertions from Electron, and a
+recording or screenshot artifact for human review.

--- a/.opencode/skills/daytona-dev/SKILL.md
+++ b/.opencode/skills/daytona-dev/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: daytona-dev
+description: Daytona development environment overview. Use when the user asks about Daytona setup, Daytona toolbox, dev environment, noVNC, CDP, server sandbox, secrets volume, Electron sandbox, or artifacts volume.
+---
+
 # Skill: Daytona Dev Environment
 
 Launch the OpenWork Electron app in a Daytona cloud sandbox. The real desktop
@@ -18,8 +23,24 @@ browser.
 bash .devcontainer/test-on-daytona.sh [branch-or-commit]
 ```
 
-The helper uses the VNC snapshot when available, falls back to the VNC Dockerfile
-when needed, starts noVNC/Vite/Electron, and prints the URLs.
+The helper uses the VNC snapshot, starts noVNC/Vite/Electron, and prints the
+URLs. If the snapshot is missing, create it with
+`bash .devcontainer/create-daytona-openwork-snapshot.sh`.
+
+Use the Daytona setup as four reusable pieces. Prefer the focused skills when a
+request names one piece directly:
+
+- `test-server-on-daytona.sh` for the cloud Den server sandbox.
+- `openwork-eval-secrets:/daytona-secrets` for provider keys and eval-only secrets.
+- `test-on-daytona.sh` for the real Electron/noVNC/CDP sandbox.
+- `openwork-eval-artifacts:/daytona-artifacts` for screenshots, validation notes, and recordings.
+
+Focused skills:
+
+- `daytona-cloud-server` for cloud server and Den flows.
+- `daytona-secrets-volume` for adding or verifying secrets.
+- `daytona-electron-test` for real Electron UI validation.
+- `daytona-recording-artifacts` for screenshots, recordings, and PR evidence.
 
 Or SSH in after the helper prints the sandbox name:
 
@@ -89,6 +110,9 @@ daytona exec openwork-dev 'tail -50 /tmp/start-vnc.log'
 
 # Take a screenshot via CDP
 daytona exec openwork-dev 'curl -s http://127.0.0.1:9825/json/list'
+
+# Capture a persistent screenshot artifact
+daytona exec openwork-dev 'bash .devcontainer/capture-daytona-screenshot.sh'
 
 # Restart just the Electron app
 daytona exec openwork-dev 'bash -lc "pkill -f electron || true; pkill -f electron-dev || true"'

--- a/.opencode/skills/daytona-electron-test/SKILL.md
+++ b/.opencode/skills/daytona-electron-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daytona-electron-test
-description: "Test the real Electron app on Daytona: create sandbox, start services, connect via CDP, create workspaces, drive sessions, and verify settings. Use when the user says 'test on Daytona', 'run the app on Daytona', 'Daytona dry run', 'test Electron remotely', or 'reproduce on Daytona'."
+description: "Daytona Electron sandbox testing with CDP/noVNC. Use when the user says test on Daytona, run Electron on Daytona, Daytona dry run, test Electron remotely, reproduce on Daytona, or validate a real desktop flow."
 ---
 
 # Skill: Daytona Electron Test
@@ -30,9 +30,38 @@ It prints the CDP and noVNC URLs at the end. Then use `browser_list` to connect.
 Refresh the snapshot with `bash .devcontainer/create-daytona-openwork-snapshot.sh`
 when dependencies or base setup change. The snapshot excludes `node_modules`;
 dependency installs reuse the `openwork-eval-pnpm-store` volume.
-For OpenAI flows, create the reusable secrets volume once with
+For provider flows, create/populate the reusable secrets volume once with
 `bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken`; future Daytona
-sandboxes mount `openwork-eval-secrets:/daytona-secrets` automatically.
+sandboxes mount `openwork-eval-secrets:/daytona-secrets` automatically and
+source every `/daytona-secrets/*.env` file before Electron starts.
+
+## Related Daytona Skills
+
+- `daytona-cloud-server`: Den Web/API, worker proxy, marketplace, cloud auth,
+  org policy, and two-sandbox server + Electron tests.
+- `daytona-secrets-volume`: provider keys and eval-only secrets in
+  `openwork-eval-secrets:/daytona-secrets`.
+- `daytona-recording-artifacts`: screenshots, recordings, validation artifacts,
+  before/after videos, and PR evidence.
+
+## Daytona Testing Toolbox
+
+- **Cloud server:** use `.devcontainer/test-server-on-daytona.sh` for Den Web,
+  Den API, worker proxy, org policies, marketplace, and cloud auth flows.
+- **Secrets volume:** use `openwork-eval-secrets:/daytona-secrets` for provider
+  keys and eval-only credentials. Add more files with
+  `bash .devcontainer/setup-daytona-secrets-volume.sh <local-env> <name>.env`.
+- **Electron sandbox:** use `.devcontainer/test-on-daytona.sh` for the real
+  desktop app, noVNC visual access, and CDP automation on port 9825.
+- **Artifacts volume:** use `openwork-eval-artifacts:/daytona-artifacts` for
+  screenshots, validation notes, and recordings that survive sandbox deletion.
+
+Validation standard: prove behavior with CDP assertions first, capture a PNG
+screenshot at important states for quick AI/human review, and record MP4 video
+for end-to-end PR evidence.
+
+When the user asks specifically about server, secrets, recordings, screenshots,
+or evidence, use the focused skill above instead of relying only on this runbook.
 
 ## Manual debugging
 
@@ -285,19 +314,22 @@ daytona exec "$SANDBOX" -- "bash -lc 'DISPLAY=:99 xdotool search --name OpenWork
 daytona exec "$SANDBOX" -- "bash -lc 'DISPLAY=:99 xdotool search --name OpenWork windowactivate'"
 ```
 
-## API keys for provider evals
+## API keys and eval secrets
 
 Do not edit workspace config or print keys. Create/populate the reusable
 Daytona volume once from the repo root:
 
 ```bash
 bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken
+bash .devcontainer/setup-daytona-secrets-volume.sh .anthropic anthropic.env
 ```
 
 Every Daytona eval sandbox mounts `openwork-eval-secrets:/daytona-secrets` and
-`/opt/openwork-daytona/start-daytona-electron.sh` sources
-`/daytona-secrets/openai.env` before Electron starts. If you update the volume while a sandbox is already
-running, restart Electron so the env is reloaded:
+`/opt/openwork-daytona/start-daytona-electron.sh` sources every
+`/daytona-secrets/*.env` file before Electron starts. Keep provider keys, test
+OAuth credentials, and other eval-only secrets there instead of workspace files.
+If you update the volume while a sandbox is already running, restart Electron so
+the env is reloaded:
 
 ```bash
 # Step 1: kill Electron/runtime children
@@ -491,6 +523,26 @@ echo "AFTER:  ${ARTIFACTS_URL}/recordings/my-feature-after.mp4"
 
 Include these URLs in your PR description.
 
+## Screenshot validation checkpoints
+
+Use screenshots for fast validation while driving the UI. They complement, but
+do not replace, CDP assertions or recordings.
+
+```bash
+daytona exec "$SANDBOX" -- 'bash .devcontainer/capture-daytona-screenshot.sh'
+```
+
+Screenshots are saved to `/daytona-artifacts/screenshots` when the artifacts
+volume is mounted. Get the download URL from port 8090:
+
+```bash
+ARTIFACTS_URL=$(daytona preview-url "$SANDBOX" -p 8090 2>/dev/null | grep -v "^time=")
+echo "${ARTIFACTS_URL}/screenshots/<filename>.png"
+```
+
+Use this pattern for each critical UI state: run a CDP assertion, capture a
+screenshot, then continue the recording.
+
 ### Key recording commands reference
 
 | Action | Command |
@@ -499,6 +551,7 @@ Include these URLs in your PR description.
 | Start recording (mid-sandbox) | `daytona exec $SANDBOX -- "bash -lc 'cd /workspace && DISPLAY=:99 .devcontainer/start-daytona-recording.sh --detach --output /daytona-artifacts/recordings/NAME.mp4'"` |
 | Stop recording | `daytona exec $SANDBOX -- 'bash .devcontainer/stop-daytona-recording.sh'` |
 | List recordings | `daytona exec $SANDBOX -- 'ls -lah /daytona-artifacts/recordings/'` |
+| Capture screenshot | `daytona exec $SANDBOX -- 'bash .devcontainer/capture-daytona-screenshot.sh'` |
 | Get download URL | `daytona preview-url $SANDBOX -p 8090` then append `/recordings/NAME.mp4` |
 
 ### Notes
@@ -507,9 +560,8 @@ Include these URLs in your PR description.
   reusable across sandboxes). They persist after `daytona delete`.
 - The `start-daytona-recording.sh` script records to a temp file first, then
   copies to the artifacts volume on stop — this avoids NFS write issues.
-- Always use `stop-daytona-recording.sh` (or `pkill -INT -f "ffmpeg.*x11grab"`)
-  to stop. SIGINT lets ffmpeg finalize the mp4 container properly. SIGKILL
-  produces a corrupt file.
+- Always use `stop-daytona-recording.sh` to stop. It sends SIGINT so ffmpeg
+  finalizes the mp4 container properly. SIGKILL produces a corrupt file.
 - Default resolution is 1920x1080 at 15fps. Override with `--size 1280x800
   --fps 10` for smaller files.
 

--- a/.opencode/skills/daytona-recording-artifacts/SKILL.md
+++ b/.opencode/skills/daytona-recording-artifacts/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: daytona-recording-artifacts
+description: Daytona recording volume, screenshots, artifacts, and validation evidence. Use when the user says record Daytona, recording volume, artifacts volume, screenshots, proof, PR evidence, before/after video, or validate behavior visually.
+---
+
+# Daytona Recording Artifacts
+
+Use this skill to collect proof that a Daytona UI flow works. Recordings are for
+humans. CDP assertions and screenshots are for AI validation and fast review.
+
+## The Volume
+
+The reusable Daytona volume is:
+
+```text
+openwork-eval-artifacts:/daytona-artifacts
+```
+
+The helper serves it on port `8090` when `--artifacts-volume` or
+`--record-video` is used.
+
+Expected layout:
+
+```text
+/daytona-artifacts/recordings
+/daytona-artifacts/screenshots
+/daytona-artifacts/validation
+```
+
+## Start With Artifacts
+
+For screenshots and validation notes without video:
+
+```bash
+bash .devcontainer/test-on-daytona.sh [branch-or-commit] --artifacts-volume
+```
+
+For full human-review evidence:
+
+```bash
+bash .devcontainer/test-on-daytona.sh [branch-or-commit] --record-video --recording-name <name>
+```
+
+`--record-video` implies `--artifacts-volume`.
+
+## Capture Screenshot Checkpoints
+
+Capture a persistent screenshot from the Daytona display:
+
+```bash
+daytona exec "$SANDBOX" -- 'bash .devcontainer/capture-daytona-screenshot.sh'
+```
+
+Use this after important states: welcome screen, workspace created, settings
+connected, task response visible, error state reproduced, or final success.
+
+## Stop Recording
+
+Always stop with the helper so ffmpeg finalizes the MP4 cleanly:
+
+```bash
+daytona exec "$SANDBOX" -- 'bash .devcontainer/stop-daytona-recording.sh'
+```
+
+Do not use `kill -9`; it can corrupt the file.
+
+## Get Artifact URLs
+
+Get the artifacts base URL:
+
+```bash
+ARTIFACTS_URL=$(daytona preview-url "$SANDBOX" -p 8090 2>/dev/null | grep -v "^time=")
+```
+
+Then append paths:
+
+```bash
+echo "${ARTIFACTS_URL}/recordings/<name>.mp4"
+echo "${ARTIFACTS_URL}/screenshots/<name>.png"
+```
+
+## Before And After Flow
+
+Use before/after recordings for UI regressions or design changes:
+
+```bash
+bash .devcontainer/test-on-daytona.sh dev --record-video --recording-name my-feature-before
+daytona exec "$SANDBOX" -- 'bash .devcontainer/stop-daytona-recording.sh'
+daytona exec "$SANDBOX" -- "bash -lc 'cd /workspace && git fetch origin feat/my-branch:feat/my-branch && git checkout feat/my-branch'"
+daytona exec "$SANDBOX" -- "bash -lc 'cd /workspace && DISPLAY=:99 .devcontainer/start-daytona-recording.sh --detach --output /daytona-artifacts/recordings/my-feature-after.mp4'"
+daytona exec "$SANDBOX" -- 'bash .devcontainer/stop-daytona-recording.sh'
+```
+
+## Validation Standard
+
+Use all three layers when possible:
+
+- CDP/browser assertions: prove URL, text, state, accessibility tree, and process state.
+- Screenshots: provide fast visual checkpoints for AI and reviewers.
+- Recording: prove the full flow to humans for PR review.
+
+Do not report success from a recording alone. The AI should inspect state with
+browser tools and use screenshots to validate visible behavior before declaring
+the flow passed.

--- a/.opencode/skills/daytona-secrets-volume/SKILL.md
+++ b/.opencode/skills/daytona-secrets-volume/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: daytona-secrets-volume
+description: Daytona secrets volume setup. Use when the user says Daytona secrets, add provider key, OpenAI key, Anthropic key, eval secrets, /daytona-secrets, or openwork-eval-secrets.
+---
+
+# Daytona Secrets Volume
+
+Use this skill when Daytona tests need provider keys or other eval-only secrets.
+Never commit secrets to the repo and never print secret values.
+
+## The Volume
+
+The reusable Daytona volume is:
+
+```text
+openwork-eval-secrets:/daytona-secrets
+```
+
+Electron sandboxes mount it automatically through `.devcontainer/test-on-daytona.sh`.
+The Electron starter sources every file matching:
+
+```text
+/daytona-secrets/*.env
+```
+
+## Add A Secret File
+
+Create a local env file, then copy it into the volume:
+
+```bash
+bash .devcontainer/setup-daytona-secrets-volume.sh <local-env-file> <name>.env
+```
+
+Examples:
+
+```bash
+bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken openai.env
+bash .devcontainer/setup-daytona-secrets-volume.sh .anthropic anthropic.env
+bash .devcontainer/setup-daytona-secrets-volume.sh .google google.env
+```
+
+The destination must be a simple `.env` filename such as `openai.env`. The
+script copies the file without printing it and sets restrictive permissions.
+
+## Expected Env File Shape
+
+Use normal shell env format:
+
+```bash
+OPENAI_API_KEY=...
+ANTHROPIC_API_KEY=...
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+```
+
+Only include variables needed by evals. Keep files small and purpose-specific.
+
+## Reload Existing Sandbox
+
+If the sandbox is already running, restart Electron so it reloads `/daytona-secrets/*.env`:
+
+```bash
+daytona exec "$SANDBOX" -- "bash -lc 'pkill -f electron || true; pkill -f electron-dev || true; pkill -f opencode || true'"
+sleep 3
+daytona exec "$SANDBOX" -- "bash -lc 'cd /workspace && bash /opt/openwork-daytona/start-daytona-electron.sh --detach'"
+```
+
+Do not chain the kill and restart in one `daytona exec` command. The `pkill`
+pattern can terminate the exec wrapper itself.
+
+## Verify Without Printing Secrets
+
+Check only filenames or whether expected variables are present:
+
+```bash
+daytona exec "$SANDBOX" -- 'ls -la /daytona-secrets'
+daytona exec "$SANDBOX" -- "bash -lc 'set -a; source /daytona-secrets/openai.env; test -n \"${OPENAI_API_KEY:-}\"'"
+```
+
+Never run commands that print token values.

--- a/.opencode/skills/run-evals/SKILL.md
+++ b/.opencode/skills/run-evals/SKILL.md
@@ -18,10 +18,17 @@ Run the OpenWork UI evaluation flows against a real Electron app. Prefer a fresh
 - `daytona` CLI installed and logged in (`daytona login`)
 - Using the "Different AI" org (`daytona organization use "Different AI"`)
 - The `.devcontainer/` files exist in the repo
-- Optional OpenAI coverage: reusable Daytona volume `openwork-eval-secrets`
-  populated once with `bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken`
+- Optional provider coverage: reusable Daytona volume `openwork-eval-secrets`
+  populated with `.env` files using `bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken`
 
 ## Workflow
+
+Use these Daytona skills when an eval touches a specific area:
+
+- `daytona-electron-test` for the real Electron app, CDP, noVNC, workspace creation, and UI driving.
+- `daytona-cloud-server` for Den server, cloud auth, marketplace, org policy, and worker proxy evals.
+- `daytona-secrets-volume` for adding or checking provider keys and eval secrets.
+- `daytona-recording-artifacts` for screenshots, recordings, before/after videos, and PR evidence.
 
 ### Preferred path: helper script
 
@@ -33,11 +40,11 @@ bash .devcontainer/test-on-daytona.sh <branch-or-commit>
 ```
 
 The helper creates a fresh VNC-capable Daytona sandbox from the reusable
-`openwork-eval-vnc` snapshot when present, falls back to the VNC Dockerfile when
-needed, mounts the reusable `openwork-eval-secrets:/daytona-secrets` volume,
-mounts the reusable `openwork-eval-pnpm-store` pnpm cache volume, starts
-XFCE/noVNC, Vite, and Electron with Daytona-safe graphics flags, waits for CDP,
-then prints the CDP and noVNC URLs.
+`openwork-eval-vnc` snapshot, mounts the reusable
+`openwork-eval-secrets:/daytona-secrets` volume, mounts the reusable
+`openwork-eval-pnpm-store` pnpm cache volume, starts XFCE/noVNC, Vite, and
+Electron with Daytona-safe graphics flags, waits for CDP, then prints the CDP
+and noVNC URLs. If the snapshot is missing, create it before rerunning.
 
 Refresh the snapshot when dependencies or base setup change:
 
@@ -48,14 +55,16 @@ bash .devcontainer/create-daytona-openwork-snapshot.sh
 The snapshot intentionally excludes `node_modules` to stay below Daytona's 20 GB
 snapshot limit. Dependency installs reuse the pnpm store volume.
 
-For OpenAI/provider eval coverage, create/populate the volume once before the
+For provider eval coverage, create/populate the volume once before the
 first run:
 
 ```bash
 bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken
+bash .devcontainer/setup-daytona-secrets-volume.sh .anthropic anthropic.env
 ```
 
-Do not print the key. Future eval sandboxes reuse the same volume.
+Do not print keys. Future eval sandboxes reuse the same volume and source every
+`/daytona-secrets/*.env` file before Electron starts.
 
 ### Verify helper output
 
@@ -119,6 +128,16 @@ browser_evaluate({ browser_url: URL, expression: "document.body.innerText.substr
 browser_screenshot({ browser_url: URL })
 ```
 
+Also capture persistent Daytona screenshots at critical checkpoints when the
+artifacts volume is mounted:
+
+```bash
+daytona exec "$SANDBOX" -- 'bash .devcontainer/capture-daytona-screenshot.sh'
+```
+
+Use browser snapshots/assertions for AI validation, screenshots for visual
+checkpoints, and recordings for human PR evidence.
+
 ### Recording eval runs
 
 Always record eval runs so they can be attached to PRs. Use the built-in
@@ -148,6 +167,9 @@ echo "${ARTIFACTS_URL}/recordings/<name>.mp4"
 Recordings are saved to the persistent `openwork-eval-artifacts` volume and
 survive sandbox deletion. Always use `stop-daytona-recording.sh` (not
 `kill -9`) so ffmpeg finalizes the mp4 properly.
+
+Screenshots are saved to `/daytona-artifacts/screenshots` and are served by the
+same port 8090 artifacts URL.
 
 For before/after comparison recordings, see the "Recording before/after
 comparisons" section in the `daytona-electron-test` skill.

--- a/evals/daytona-flows.md
+++ b/evals/daytona-flows.md
@@ -14,21 +14,22 @@ daytona organization use "Different AI"
 bash .devcontainer/test-on-daytona.sh [branch-or-commit]
 ```
 
-Use the helper. It creates from the reusable `openwork-eval-vnc` snapshot when
-available, falls back to the Daytona VNC Dockerfile when needed, mounts secrets,
-mounts the reusable pnpm store volume, checks out the requested ref,
-conditionally installs deps, starts services, waits for CDP, and prints the
-CDP/noVNC URLs.
+Use the helper. It creates from the reusable `openwork-eval-vnc` snapshot,
+mounts secrets, mounts the reusable pnpm store volume, checks out the requested
+ref, conditionally installs deps, starts services, waits for CDP, and prints the
+CDP/noVNC URLs. If the snapshot is missing, create it with
+`bash .devcontainer/create-daytona-openwork-snapshot.sh`.
 
 The reusable `openwork-eval-secrets` volume is mounted at `/daytona-secrets`.
-Create/populate it once with `bash .devcontainer/setup-daytona-secrets-volume.sh
-.newtoken`; future eval sandboxes reuse it and source `/daytona-secrets/openai.env`
-before Electron starts. The Electron starter also applies Daytona-safe Chromium
-flags via `ELECTRON_EXTRA_LAUNCH_ARGS`.
+Create/populate it with `bash .devcontainer/setup-daytona-secrets-volume.sh
+.newtoken`; future eval sandboxes reuse it and source every
+`/daytona-secrets/*.env` file before Electron starts. The Electron starter also
+applies Daytona-safe Chromium flags via `ELECTRON_EXTRA_LAUNCH_ARGS`.
 
 To persist downloadable artifacts, pass `--artifacts-volume`. The helper mounts
 the reusable `openwork-eval-artifacts` volume at `/daytona-artifacts`, starts a
-static download server, and prints its Daytona preview URL.
+static download server, and prints its Daytona preview URL. Capture screenshot
+checkpoints with `daytona exec <sandbox> -- 'bash .devcontainer/capture-daytona-screenshot.sh'`.
 
 To record the Electron display, pass `--record-video`:
 
@@ -41,12 +42,12 @@ bash .devcontainer/test-on-daytona.sh [branch-or-commit] --record-video
 the stop command:
 
 ```bash
-daytona exec <sandbox> -- 'pkill -INT -f "ffmpeg.*x11grab"'
+daytona exec <sandbox> -- 'bash .devcontainer/stop-daytona-recording.sh'
 ```
 
-Use `SIGINT` so ffmpeg finalizes the mp4 cleanly before downloading it. Optional
-recording controls are `--recording-name <name>`, `--recording-fps <fps>`, and
-`--recording-size <WxH>`.
+The stop helper sends `SIGINT` so ffmpeg finalizes the mp4 cleanly before
+downloading it. Optional recording controls are `--recording-name <name>`,
+`--recording-fps <fps>`, and `--recording-size <WxH>`.
 
 ### 2. Get the CDP proxy URL
 


### PR DESCRIPTION
## Summary
- split Daytona guidance into focused skills for cloud server, secrets volume, Electron testing, and recording/artifacts
- generalize Daytona secrets loading to source every /daytona-secrets/*.env file
- add a persistent screenshot artifact helper and document CDP + screenshot + recording validation evidence

## Validation
- git diff --cached --check
- bash -n .devcontainer/start-daytona-electron.sh .devcontainer/setup-daytona-secrets-volume.sh .devcontainer/capture-daytona-screenshot.sh .devcontainer/test-on-daytona.sh
- checked Daytona skill frontmatter for .opencode/skills/daytona*/SKILL.md and run-evals

## Evidence
- No Daytona sandbox/video run for this docs/script-only change; commands above verify the changed scripts and skills.