### PR TITLE
fix(app): add missing computer use config guard

### DIFF
--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -132,6 +132,10 @@ export function ComputerUseConfig({
 
   // Clear a stale setup error, then re-read permissions.
   const verify = () => {
+    if (!hasDesktopBridge()) {
+      return;
+    }
+
     resetGrant();
     void refetch();
   };


### PR DESCRIPTION
## Summary
- Adds a missing guard in Computer Use config so permission checks only run when the desktop bridge is available.