### PR TITLE
fix(app): expose session retry errors

### DIFF
--- a/apps/app/scripts/session-render-state.test.ts
+++ b/apps/app/scripts/session-render-state.test.ts
@@ -7,6 +7,7 @@ import {
   resolveRenderedSessionSnapshot,
 } from "../src/react-app/domains/session/surface/session-render-state";
 import { reconcileTranscriptMessages } from "../src/react-app/domains/session/sync/transcript-reconcile";
+import { describeOpencodeSessionError } from "../src/react-app/domains/session/sync/usechat-adapter";
 
 function snapshotWithMessages(
   messages: Array<{ id: string; role: "user" | "assistant"; text: string; created?: number }>,
@@ -303,5 +304,36 @@ describe("deriveRenderedSessionMessages", () => {
       transcriptState: [],
       snapshot,
     })[0]?.parts[0]).toMatchObject({ text: "current session" });
+  });
+});
+
+describe("describeOpencodeSessionError", () => {
+  it("includes API error status and response details", () => {
+    expect(describeOpencodeSessionError({
+      name: "APIError",
+      data: {
+        message: "Service unavailable",
+        statusCode: 503,
+        isRetryable: true,
+        responseBody: "upstream overloaded",
+      },
+    })).toBe("Service unavailable\nStatus: 503\nResponse: upstream overloaded");
+  });
+
+  it("uses named error defaults when opencode omits a message", () => {
+    expect(describeOpencodeSessionError({
+      name: "MessageOutputLengthError",
+      data: {},
+    })).toBe("The model reached its output limit before finishing");
+  });
+
+  it("surfaces structured output retry counts", () => {
+    expect(describeOpencodeSessionError({
+      name: "StructuredOutputError",
+      data: {
+        message: "Invalid JSON",
+        retries: 3,
+      },
+    })).toBe("Invalid JSON\nRetries: 3");
   });
 });

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   Copy,
   FileIcon,
+  LoaderCircle,
   Split,
   Undo2,
 } from "lucide-react"
@@ -22,6 +23,9 @@ import {
   type FileUIPart,
   type UIMessage,
 } from "ai"
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
+import { openDesktopUrl } from "@/app/lib/desktop"
+import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types"
 import { ApplyPatchTool } from "@/components/tools/apply-patch"
 import { BashTool } from "@/components/tools/bash"
 import { EditTool } from "@/components/tools/edit"
@@ -138,6 +142,16 @@ const ToolMessage = ({ part }: ToolMessageProps) => {
 }
 
 const isEmptyMessage = (message: UIMessage): boolean => message.parts.length === 0
+
+type RetryStatus = Extract<SessionStatus, { type: "retry" }>
+
+function isSessionErrorMessage(message: UIMessage) {
+  return message.id.startsWith(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX)
+}
+
+function retryDelaySeconds(status: RetryStatus) {
+  return Math.max(0, Math.round((status.next - Date.now()) / 1000))
+}
 
 interface FileMessageProps {
   part: FileUIPart
@@ -397,6 +411,10 @@ type MessageComponentProps = {
 
 const MessageComponent = React.memo(
   ({ message, isLastMessage, isStreaming, isLastStep }: MessageComponentProps) => {
+    if (isSessionErrorMessage(message)) {
+      return <ErrorMessage error={getMessagesText([message]) || "Session failed"} />
+    }
+
     if (isEmptyMessage(message) && !isStreaming) {
       return (
         <EmptyMessage
@@ -456,18 +474,78 @@ interface ErrorMessageProps {
   error: string | null
 }
 
-const ErrorMessage = React.memo(({ error }: ErrorMessageProps) => (
-  <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
-    <div className="group flex w-full flex-col items-start gap-0">
-      <div className="text-foreground flex min-w-0 flex-1 flex-row items-center gap-2 rounded-lg border-2 border-red-300 bg-red-300/20 px-2 py-1">
-        <AlertTriangle size={16} className="text-destructive" />
-        <p className="text-destructive">{error}</p>
+function ErrorMessage({ error }: ErrorMessageProps) {
+  return (
+    <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
+      <div className="group flex w-full flex-col items-start gap-0">
+        <div className="text-foreground flex min-w-0 flex-1 flex-row items-start gap-2 rounded-lg border-2 border-red-300 bg-red-300/20 px-2 py-1">
+          <AlertTriangle size={16} className="mt-0.5 shrink-0 text-destructive" />
+          <p className="whitespace-pre-wrap text-destructive">{error}</p>
+        </div>
       </div>
-    </div>
-  </Message>
-))
+    </Message>
+  )
+}
 
-ErrorMessage.displayName = "ErrorMessage"
+interface RetryMessageProps {
+  status: RetryStatus
+}
+
+function RetryActionButton(props: { link: string; label: string }) {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="h-7 border-amber-500/70 bg-amber-50 text-xs text-amber-950 hover:bg-amber-100"
+      onClick={() => void openDesktopUrl(props.link)}
+    >
+      {props.label}
+    </Button>
+  )
+}
+
+const RetryMessage = React.memo(({ status }: RetryMessageProps) => {
+  const [seconds, setSeconds] = React.useState(() => retryDelaySeconds(status))
+
+  React.useEffect(() => {
+    const update = () => setSeconds(retryDelaySeconds(status))
+    update()
+    const timer = window.setInterval(update, 1000)
+    return () => window.clearInterval(timer)
+  }, [status])
+
+  const info = seconds > 0
+    ? `Retrying in ${seconds}s · attempt ${status.attempt}`
+    : `Retrying · attempt ${status.attempt}`
+  const action = status.action
+
+  return (
+    <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
+      <div className="group flex w-full flex-col items-start gap-0">
+        <div className="text-foreground flex min-w-0 flex-1 flex-col gap-2 rounded-lg border-2 border-amber-300 bg-amber-300/20 px-3 py-2">
+          <div className="flex items-start gap-2">
+            <LoaderCircle size={16} className="mt-0.5 shrink-0 animate-spin text-amber-700" />
+            <div className="min-w-0 space-y-1">
+              <p className="whitespace-pre-wrap text-sm font-medium text-amber-900">{status.message}</p>
+              <p className="text-xs text-amber-800">{info}</p>
+            </div>
+          </div>
+          {action ? (
+            <div className="ml-6 space-y-1 border-t border-amber-400/60 pt-2">
+              <p className="text-xs font-medium text-amber-950">{action.title}</p>
+              <p className="text-xs text-amber-900">{action.message}</p>
+              {action.link ? (
+                <RetryActionButton link={action.link} label={action.label} />
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </Message>
+  )
+})
+
+RetryMessage.displayName = "RetryMessage"
 
 const isMessageEmptyGroup = (messages: UIMessageWithIndex[]) =>
   messages.every(message => isEmptyMessage(message.message));
@@ -604,12 +682,14 @@ function MessageGroup({
 interface MessageListProps {
   messages: UIMessage[]
   status: ThreadStatus
+  retryStatus?: RetryStatus | null
 }
 
-export function MessageList({ messages, status }: MessageListProps) {
+export function MessageList({ messages, status, retryStatus }: MessageListProps) {
   const isStreaming = status === "streaming" || status === "retrying"
   const items = React.useMemo(() => groupMessages(messages, status), [messages, status]);
   const error = useSessionErrorMessage();
+  const hasSessionErrorMessage = React.useMemo(() => messages.some(isSessionErrorMessage), [messages])
 
   return (
     <div className={cn("flex flex-col gap-2 @container/message-list")}>
@@ -644,7 +724,8 @@ export function MessageList({ messages, status }: MessageListProps) {
       })}
 
       {status === "streaming" && <LoadingMessage />}
-      {error ? <ErrorMessage error={error} /> : null}
+      {retryStatus ? <RetryMessage status={retryStatus} /> : null}
+      {error && !hasSessionErrorMessage ? <ErrorMessage error={error} /> : null}
     </div>
   )
 }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1239,7 +1239,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
                     onRevertToUserMessage={handleRevertToUserMessage}
                     onForkAtMessage={handleForkAtMessage}
                   >
-                    <MessageList messages={renderedMessages} status={status} />
+                    <MessageList
+                      messages={renderedMessages}
+                      status={status}
+                      retryStatus={liveStatus.type === "retry" ? liveStatus : null}
+                    />
                   </MessageListProvider>
                 </OpenTargetProvider>
               </DevProfiler>

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -36,6 +36,15 @@ function firstNumberValue(records: unknown[], keys: string[]) {
   return null;
 }
 
+function defaultErrorMessage(name: string | null, fallback: string) {
+  if (name === "ProviderAuthError") return "Provider authentication failed";
+  if (name === "MessageOutputLengthError") return "The model reached its output limit before finishing";
+  if (name === "StructuredOutputError") return "The model could not produce valid structured output";
+  if (name === "ContextOverflowError") return "The conversation is too large for the model context window";
+  if (name === "MessageAbortedError") return "The message was interrupted";
+  return fallback;
+}
+
 export function describeOpencodeSessionError(error: unknown, fallback = "Session failed") {
   if (error instanceof Error) return error.message || fallback;
   if (typeof error === "string") return error.trim() || fallback;
@@ -45,16 +54,19 @@ export function describeOpencodeSessionError(error: unknown, fallback = "Session
   const cause = recordValue(error, "cause");
   const causeData = recordValue(cause, "data");
   const records = [error, data, cause, causeData].filter(Boolean);
+  const name = firstStringValue(records, ["name", "type"]);
   const message = firstStringValue(records, ["message", "detail", "reason", "error"]);
   const status = firstNumberValue(records, ["statusCode", "status"]);
   const provider = firstStringValue(records, ["providerID", "providerId", "provider"]);
   const code = firstStringValue(records, ["code", "errorCode"]);
+  const retries = firstNumberValue(records, ["retries", "retryCount"]);
   const responseBody = firstStringValue(records, ["responseBody", "body", "response"]);
 
-  const lines = [message ?? fallback];
+  const lines = [message ?? defaultErrorMessage(name, fallback)];
   if (status && !lines[0]?.includes(String(status))) lines.push(`Status: ${status}`);
   if (provider && !lines[0]?.includes(provider)) lines.push(`Provider: ${provider}`);
   if (code) lines.push(`Code: ${code}`);
+  if (retries !== null) lines.push(`Retries: ${retries}`);
   if (responseBody && responseBody !== message) lines.push(`Response: ${responseBody}`);
   if (lines.some((line) => line !== fallback)) return lines.join("\n");
 


### PR DESCRIPTION
## Summary
- show OpenCode retry statuses in the desktop chat instead of a blank assistant area
- render synthetic session errors as error cards with preserved multiline details
- improve formatting for OpenCode named error payloads and structured-output retry counts

## Tests
- `bun test scripts/session-render-state.test.ts` ✅
- `pnpm --dir apps/app typecheck` ✅
- `git diff --check` ✅

## Evidence
- No screenshot/video captured; this is a state-rendering fix for OpenCode retry status. To reproduce, force a retryable provider error and confirm the retry card remains visible with message/countdown/action instead of a blank chat.
