### PR TITLE
fix(server): skip file initialization for remote workspaces

### DIFF
--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -28,15 +28,18 @@ let managedOpencode: ManagedOpencodeServer | null = null;
 
 if (!config.readOnly) {
   for (const workspace of config.workspaces) {
+    if (workspace.workspaceType === "remote") {
+      continue;
+    }
     await ensureWorkspaceFiles(workspace.path, workspace.preset ?? "starter");
   }
 }
 
 if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
-  const workspace = config.workspaces[0];
-  if (workspace?.path) {
+  const localWorkspace = config.workspaces.find((w) => w.workspaceType !== "remote" && w.path);
+  const managedOpencodeCwd = process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim() || localWorkspace?.path;
+  if (managedOpencodeCwd) {
     const openworkRuntimeConfig = buildOpenworkRuntimeConfig();
-    const managedOpencodeCwd = process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim() || workspace.path;
     await mkdir(managedOpencodeCwd, { recursive: true });
     managedOpencode = await createManagedOpencodeServer({
       bin: process.env.OPENWORK_OPENCODE_BIN,

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -48,17 +48,20 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
 
   if (!config.readOnly) {
     for (const workspace of config.workspaces) {
+      if (workspace.workspaceType === "remote") {
+        continue;
+      }
       await ensureWorkspaceFiles(workspace.path, workspace.preset ?? "starter");
     }
   }
 
   if (!config.opencodeBaseUrl && options.manageOpencode) {
-    const workspace = config.workspaces[0];
-    if (workspace?.path) {
+    const localWorkspace = config.workspaces.find((w) => w.workspaceType !== "remote" && w.path);
+    const cwd = options.opencodeCwd
+      || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
+      || localWorkspace?.path;
+    if (cwd) {
       const openworkRuntimeConfig = buildOpenworkRuntimeConfig();
-      const cwd = options.opencodeCwd
-        || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
-        || workspace.path;
       await mkdir(cwd, { recursive: true });
 
       managedOpencode = await createManagedOpencodeServer({


### PR DESCRIPTION
## Summary
- Skip local workspace file initialization (`ensureWorkspaceFiles`) for remote workspaces (`workspaceType === "remote"`) in both the CLI (`cli.ts`) and embedded server (`embedded.ts`) startup paths.
- Fix Managed OpenCode server startup to correctly boot in remote-only configurations when a fallback working directory (`opencodeCwd` or `OPENWORK_MANAGED_OPENCODE_CWD`) is explicitly provided, instead of incorrectly blocking on the absence of a local workspace.
- Select the first non-remote workspace using `.find()` when resolving the default local path fallback.

## Why
- When running OpenWork with remote workspaces, the local server process attempts to initialize workspace assets on the local file system using the remote workspace's file path. Since the path only exists on the remote machine, it triggers `ENOENT` directory creation errors and causes the server/client startup to crash.
- Gating Managed OpenCode startup entirely on finding a non-remote workspace prevented it from starting even when valid working directory overrides (`opencodeCwd` / `OPENWORK_MANAGED_OPENCODE_CWD`) were explicitly configured for remote-only environments.

## Issue
- Closes #

## Scope
- `apps/server/src/cli.ts`: Filter out remote workspaces during startup initialization, resolve the CWD prior to gating, and select the first local workspace using `.find()`.
- `apps/server/src/embedded.ts`: Same filtering, lookup, and conditional CWD gating improvements.

## Out of scope
- Local directory initialization logic (`workspace-init.ts`).
- Desktop UI workspace settings.

## Testing
### Ran
- `pnpm --filter openwork-server typecheck`
- `bun test src/workspace-init.test.ts`

### Result
- pass/fail: pass
- if fail, exact files/errors: N/A

## CI status
- pass: yes (types compile successfully)
- code-related failures: N/A
- external/env/auth blockers: N/A

## Manual verification
1. Configure a server instance or desktop configuration containing only remote workspaces and supply a `OPENWORK_MANAGED_OPENCODE_CWD` environment variable.
2. Launch the application.
3. Verify that the server boots up without attempting to create local starter files for the remote path, and successfully starts the Managed OpenCode server in the specified CWD.

## Evidence
- video/screenshot link, or `N/A (docs-only)`: N/A

## Risk
- Low. The change introduces minor checks to safely bypass filesystem mutations on remote paths, and checks for valid working directories instead of blocking on local workspace configurations.

## Rollback
- Revert changes to `apps/server/src/cli.ts` and `apps/server/src/embedded.ts`.