### PR TITLE
Fix model promos and OpenCode Zen model state

### DIFF
--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
@@ -11,6 +11,7 @@ export const OPENWORK_MODELS_PROVIDER_ID = "openwork";
 export const OPENWORK_MODELS_PROVIDER_NAME = "OpenWork Models";
 export const OPENWORK_MODELS_PROMO_HIDDEN_KEY = "openwork.openworkModelsPromo.hidden";
 export const OPENWORK_MODELS_PROMO_LAST_SHOWN_KEY = "openwork.openworkModelsPromo.lastShownAt";
+export const OPENWORK_MODELS_STARTUP_PROMO_SHOWN_KEY = "openwork.openworkModelsPromo.startupShown";
 export const openWorkModelsPromoChangedEvent = "openwork-openwork-models-promo-changed";
 export const OPENWORK_MODELS_PROMO_SHOW_DELAY_MS = 4_000;
 export const OPENWORK_MODELS_PROMO_VISIBLE_MS = 14_000;
@@ -56,6 +57,22 @@ export function hideOpenWorkModelsPromo() {
   try {
     window.localStorage.setItem(OPENWORK_MODELS_PROMO_HIDDEN_KEY, "1");
     window.dispatchEvent(new Event(openWorkModelsPromoChangedEvent));
+  } catch {}
+}
+
+export function wasOpenWorkModelsStartupPromoShown() {
+  if (typeof window === "undefined") return true;
+  try {
+    return window.localStorage.getItem(OPENWORK_MODELS_STARTUP_PROMO_SHOWN_KEY) === "1";
+  } catch {
+    return true;
+  }
+}
+
+export function markOpenWorkModelsStartupPromoShown() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(OPENWORK_MODELS_STARTUP_PROMO_SHOWN_KEY, "1");
   } catch {}
 }
 

--- a/apps/app/src/react-app/domains/cloud/openwork-models-startup-dialog.tsx
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-startup-dialog.tsx
@@ -1,0 +1,87 @@
+/** @jsxImportSource react */
+import { ArrowRight, KeyRound, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ProviderIcon } from "../../design-system/provider-icon";
+import {
+  OPENWORK_MODELS_PROVIDER_ID,
+  OPENWORK_MODELS_PROVIDER_NAME,
+  type OpenWorkModelPreview,
+} from "./openwork-models-promo";
+
+type OpenWorkModelsStartupDialogProps = {
+  open: boolean;
+  isSignedIn: boolean;
+  models: OpenWorkModelPreview[];
+  onSubscribe: () => void;
+  onContinueWithout: () => void;
+};
+
+export function OpenWorkModelsStartupDialog(props: OpenWorkModelsStartupDialogProps) {
+  const featuredModels = props.models.slice(0, 3);
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(open) => {
+        if (!open) props.onContinueWithout();
+      }}
+    >
+      <DialogContent className="w-full max-w-lg overflow-hidden sm:max-w-lg">
+        <DialogHeader>
+          <div className="mb-2 flex size-11 items-center justify-center rounded-2xl border border-blue-6 bg-blue-2 text-blue-11">
+            <ProviderIcon providerId={OPENWORK_MODELS_PROVIDER_ID} providerName={OPENWORK_MODELS_PROVIDER_NAME} size={22} />
+          </div>
+          <DialogTitle>Use OpenWork Models without API keys</DialogTitle>
+          <DialogDescription>
+            OpenWork Models gives your workspace hosted frontier models managed by OpenWork Cloud. You can still use your own providers whenever you prefer.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="grid gap-2 sm:grid-cols-3">
+            {featuredModels.map((model) => (
+              <div key={model.id} className="rounded-xl border border-dls-border bg-dls-surface px-3 py-2">
+                <div className="truncate text-xs font-medium text-dls-text">{model.title}</div>
+                <div className="mt-0.5 truncate text-[11px] text-dls-secondary">{model.subtitle}</div>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid gap-2 text-xs text-dls-secondary sm:grid-cols-2">
+            <div className="flex gap-2 rounded-xl bg-dls-hover/50 p-3">
+              <Sparkles className="mt-0.5 size-3.5 shrink-0 text-blue-11" />
+              <span>Managed model access for OpenWork tasks and shared workflows.</span>
+            </div>
+            <div className="flex gap-2 rounded-xl bg-dls-hover/50 p-3">
+              <KeyRound className="mt-0.5 size-3.5 shrink-0 text-blue-11" />
+              <span>No Anthropic, OpenAI, or Google API key setup required.</span>
+            </div>
+          </div>
+
+          <p className="text-xs text-dls-secondary">
+            Pricing is handled through OpenWork Cloud. Continue without it to use OpenCode Zen or your own provider keys.
+          </p>
+        </div>
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button variant="ghost" onClick={props.onContinueWithout}>
+            Continue without OpenWork Models
+          </Button>
+          <Button onClick={props.onSubscribe}>
+            {props.isSignedIn ? "Subscribe" : "Sign in to subscribe"}
+            <ArrowRight className="ml-1.5 size-3.5" />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -145,6 +145,7 @@ export type SessionPageProps = {
   busyHint: string | null;
   startupPhase: BootPhase;
   providerConnectedIds: string[];
+  hasUsableModel?: boolean;
   providers?: ProviderListItem[];
   mcpConnectedCount: number;
   onSendFeedback: () => void;
@@ -519,7 +520,7 @@ export function SessionPage(props: SessionPageProps) {
     props.selectedWorkspaceDisplay.displayName?.trim() ||
     props.selectedWorkspaceDisplay.name?.trim() ||
     t("session.workspace_fallback");
-  const providerCount = props.providerConnectedIds.length;
+  const providerCount = props.hasUsableModel ? 1 : props.providerConnectedIds.length;
   const messageCountVisible = props.selectedSessionId ? 1 : 0;
   const showWorkspaceSetupEmptyState = props.workspaces.length === 0 && !props.selectedSessionId;
   const showStartupSkeleton =

--- a/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import { Button } from "@/components/ui/button";
 import type { ReactNode } from "react";
+import { ArrowRight, CheckCircle2, KeyRound, X } from "lucide-react";
 
 import { t } from "@/i18n";
 import { ProviderIcon } from "../../../design-system/provider-icon";
@@ -42,6 +43,7 @@ export type AiSettingsViewProps = {
   cloudProviderIds?: Set<string>;
   showOpenWorkModelsSubscribe?: boolean;
   onSubscribeOpenWorkModels?: () => void | Promise<void>;
+  onDismissOpenWorkModels?: () => void | Promise<void>;
   cloudProvidersView?: ReactNode;
 };
 
@@ -92,22 +94,47 @@ export function AiSettingsView(props: AiSettingsViewProps) {
         </LayoutSectionItem>
 
         {props.showOpenWorkModelsSubscribe ? (
-          <LayoutSectionItem className="flex-row flex-wrap items-center justify-between gap-3 rounded-2xl border border-blue-6 bg-blue-2/30 px-4 py-3">
-            <div className="flex min-w-0 items-center gap-3">
-              <ProviderIcon providerId="openwork" size={20} className="text-blue-11" />
-              <div className="min-w-0">
-                <div className="truncate text-sm font-medium text-dls-text">OpenWork Models</div>
-                <div className="text-xs text-muted-foreground">
-                  Frontier intelligence, hand picked for your team&apos;s most ambitious work.
+          <LayoutSectionItem className="relative overflow-hidden rounded-2xl border border-blue-6 bg-blue-2/30 px-4 py-4">
+            <button
+              type="button"
+              className="absolute right-3 top-3 flex size-7 items-center justify-center rounded-full text-blue-11 transition-colors hover:bg-blue-3/70"
+              onClick={() => void props.onDismissOpenWorkModels?.()}
+              aria-label="Dismiss OpenWork Models banner"
+            >
+              <X className="size-3.5" />
+            </button>
+            <div className="flex flex-col gap-4 pr-8 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex min-w-0 gap-3">
+                <ProviderIcon providerId="openwork" size={22} className="mt-0.5 shrink-0 text-blue-11" />
+                <div className="min-w-0 space-y-2">
+                  <div>
+                    <div className="text-sm font-medium text-dls-text">OpenWork Models</div>
+                    <div className="mt-0.5 text-xs text-muted-foreground">
+                      Hosted frontier models for OpenWork tasks without managing provider API keys.
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-[11px] text-blue-11">
+                    <span className="inline-flex items-center gap-1 rounded-full border border-blue-6 bg-blue-3 px-2 py-0.5">
+                      <CheckCircle2 className="size-3" /> Managed by OpenWork Cloud
+                    </span>
+                    <span className="inline-flex items-center gap-1 rounded-full border border-blue-6 bg-blue-3 px-2 py-0.5">
+                      <KeyRound className="size-3" /> No API key setup
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Pricing is handled through OpenWork Cloud. You can continue using OpenCode Zen or your own providers.
+                  </p>
                 </div>
               </div>
+              <Button
+                className="shrink-0"
+                onClick={() => void props.onSubscribeOpenWorkModels?.()}
+                disabled={props.busy || props.providerAuthBusy}
+              >
+                Subscribe
+                <ArrowRight className="ml-1.5 size-3.5" />
+              </Button>
             </div>
-            <Button
-              onClick={() => void props.onSubscribeOpenWorkModels?.()}
-              disabled={props.busy || props.providerAuthBusy}
-            >
-              Subscribe
-            </Button>
           </LayoutSectionItem>
         ) : null}
 

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -99,6 +99,18 @@ import { useRemoteAccessRestart } from "@/react-app/domains/workspace/remote-acc
 import { RenameWorkspaceModal } from "@/react-app/domains/workspace/rename-workspace-modal";
 import { useRemoteWorkspaceConnectionEditor } from "@/react-app/domains/workspace/use-remote-workspace-connection-editor";
 import { useCloudProviderAutoSync } from "@/react-app/domains/cloud/use-cloud-provider-auto-sync";
+import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
+import { OpenWorkModelsStartupDialog } from "@/react-app/domains/cloud/openwork-models-startup-dialog";
+import {
+  getOpenWorkModelsActionUrl,
+  hasOpenWorkModelsProvider,
+  hideOpenWorkModelsPromo,
+  isOpenWorkModelsPromoHidden,
+  markOpenWorkModelsStartupPromoShown,
+  OPENWORK_MODEL_PREVIEWS,
+  openWorkModelsPromoChangedEvent,
+  wasOpenWorkModelsStartupPromoShown,
+} from "@/react-app/domains/cloud/openwork-models-promo";
 import {
   diagnoseRemoteWorkspaceTaskLoadFailure,
   getRemoteWorkspaceConnectionKey,
@@ -135,6 +147,7 @@ import { filterProviderList } from "@/app/utils/providers";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { useReloadCoordinator } from "./reload-coordinator";
+import { useShellConfig } from "./shell-config";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
 import { useSessionControlActions } from "@/react-app/domains/session/control/session-control-actions";
 import { legacySessionRoute, workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
@@ -499,6 +512,8 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
 export function SessionRoute() {
   const navigate = useNavigate();
   const platform = usePlatform();
+  const denAuth = useDenAuth();
+  const { config: shellConfig } = useShellConfig();
   const local = useLocal();
   const reloadCoordinator = useReloadCoordinator();
   const checkDesktopRestriction = useCheckDesktopRestriction();
@@ -592,12 +607,44 @@ export function SessionRoute() {
     [providerConnectedIds],
   );
   const [disabledProviderIds, setDisabledProviderIds] = useState<string[]>([]);
+  const [openWorkModelsStartupOpen, setOpenWorkModelsStartupOpen] = useState(false);
+  const [openWorkModelsPromoHidden, setOpenWorkModelsPromoHidden] = useState(isOpenWorkModelsPromoHidden);
+  const openWorkModelsStartupScheduledRef = useRef(false);
   // Bump to re-filter provider list when den session changes (sign-in/out)
   const [denSessionVersion, setDenSessionVersion] = useState(0);
   useEffect(() => {
     const handler = () => setDenSessionVersion((v) => v + 1);
     window.addEventListener(denSessionUpdatedEvent, handler);
     return () => window.removeEventListener(denSessionUpdatedEvent, handler);
+  }, []);
+
+  useEffect(() => {
+    const handlePromoChanged = () => setOpenWorkModelsPromoHidden(isOpenWorkModelsPromoHidden());
+    window.addEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+    return () => window.removeEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+  }, []);
+
+  const hasOpenWorkModels = useMemo(
+    () => hasOpenWorkModelsProvider(providerConnectedIds),
+    [providerConnectedIds],
+  );
+
+  const subscribeToOpenWorkModels = useCallback(() => {
+    setOpenWorkModelsStartupOpen(false);
+    markOpenWorkModelsStartupPromoShown();
+    if (!denAuth.isSignedIn) {
+      navigate(selectedWorkspaceId ? workspaceSettingsRoute(selectedWorkspaceId, "cloud-account") : "/settings/cloud-account");
+    }
+    window.setTimeout(() => {
+      platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn));
+    }, 0);
+  }, [denAuth.isSignedIn, navigate, platform, selectedWorkspaceId]);
+
+  const continueWithoutOpenWorkModels = useCallback(() => {
+    setOpenWorkModelsStartupOpen(false);
+    markOpenWorkModelsStartupPromoShown();
+    hideOpenWorkModelsPromo();
+    setOpenWorkModelsPromoHidden(true);
   }, []);
   // Provider IDs that were just added — used to highlight them as
   // "Recently added" in the model picker even after they've been
@@ -1531,9 +1578,23 @@ export function SessionRoute() {
         )
       ),
   );
+  const hasUsableModel = Boolean(local.prefs.defaultModel && !selectedModelUnavailable);
   const canCreateTask = Boolean(
     opencodeClient && selectedWorkspaceId && !loading && !selectedWorkspaceError && !selectedModelUnavailable,
   );
+
+  useEffect(() => {
+    if (!shellConfig.cloudSignin || openWorkModelsPromoHidden || hasOpenWorkModels) return;
+    if (denAuth.status === "checking" || !opencodeClient || !selectedWorkspaceId) return;
+    if (wasOpenWorkModelsStartupPromoShown() || openWorkModelsStartupScheduledRef.current) return;
+
+    openWorkModelsStartupScheduledRef.current = true;
+    const timeout = window.setTimeout(() => {
+      markOpenWorkModelsStartupPromoShown();
+      setOpenWorkModelsStartupOpen(true);
+    }, 900);
+    return () => window.clearTimeout(timeout);
+  }, [denAuth.status, hasOpenWorkModels, opencodeClient, openWorkModelsPromoHidden, selectedWorkspaceId, shellConfig.cloudSignin]);
 
   const sessionProviderAuthStateRef = useRef({
     opencodeClient: opencodeClient as Client | null,
@@ -2054,7 +2115,7 @@ export function SessionRoute() {
         }));
         setCompactModelPickerOpen(false);
       },
-      providerConnectedCount: userProviderConnectedIds.length,
+      providerConnectedCount: hasUsableModel ? 1 : providerConnectedIds.length,
       onOpenSettingsSection: (section: "commands" | "skills" | "mcps" | "plugins" | "providers") => {
         handleOpenSettings(section === "skills" ? "/settings/skills" : section === "mcps" ? "/settings/extensions/mcp" : section === "plugins" ? "/settings/extensions/plugins" : section === "providers" ? "/settings/ai" : "/settings/general");
       },
@@ -2182,6 +2243,7 @@ export function SessionRoute() {
     client,
     compactModelPickerOpen,
     handleOpenSettings,
+    hasUsableModel,
     local,
     listSlashCommands,
     modelBehaviorOptions,
@@ -2191,6 +2253,7 @@ export function SessionRoute() {
     navigate,
     opencodeBaseUrl,
     opencodeClient,
+    providerConnectedIds,
     selectedAgent,
     selectedSessionId,
     selectedModelUnavailable,
@@ -2783,7 +2846,8 @@ export function SessionRoute() {
       headerStatus={canCreateTask ? t("status.connected") : t("session.loading_detail")}
       busyHint={effectiveLoading ? t("session.loading_detail") : null}
       startupPhase={effectiveLoading ? "nativeInit" : "ready"}
-      providerConnectedIds={userProviderConnectedIds}
+      providerConnectedIds={providerConnectedIds}
+      hasUsableModel={hasUsableModel}
       providers={providers}
       mcpConnectedCount={0}
       onSendFeedback={() => {
@@ -3016,6 +3080,13 @@ export function SessionRoute() {
       statusBar={{ loading: showPreparingStatus }}
       notFoundMessage={routeNotFoundMessage}
       onAccessibleTargetsChange={setPaletteAccessibleTargets}
+    />
+    <OpenWorkModelsStartupDialog
+      open={openWorkModelsStartupOpen}
+      isSignedIn={denAuth.isSignedIn}
+      models={OPENWORK_MODEL_PREVIEWS}
+      onSubscribe={subscribeToOpenWorkModels}
+      onContinueWithout={continueWithoutOpenWorkModels}
     />
     <CreateWorkspaceModal
       open={createWorkspaceOpen}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -97,6 +97,11 @@ import { useCheckDesktopRestriction, useDesktopConfig } from "@/react-app/domain
 import { useRestrictionNotice } from "@/react-app/domains/cloud/restriction-notice-provider";
 import { useCloudProviderAutoSync } from "@/react-app/domains/cloud/use-cloud-provider-auto-sync";
 import {
+  hideOpenWorkModelsPromo,
+  isOpenWorkModelsPromoHidden,
+  openWorkModelsPromoChangedEvent,
+} from "@/react-app/domains/cloud/openwork-models-promo";
+import {
   isDesktopRuntime,
   isElectronRuntime,
   isMacPlatform,
@@ -813,7 +818,19 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       Object.values(providerAuthSnapshot.importedCloudProviders ?? {}).some(isOpenWorkCloudProvider),
     [providerAuthSnapshot.cloudOrgProviders, providerAuthSnapshot.importedCloudProviders],
   );
-  const showOpenWorkModelsSubscribe = !cloudSession.isSignedIn || !hasOpenWorkCloudProvider;
+  const [openWorkModelsPromoHidden, setOpenWorkModelsPromoHidden] = useState(isOpenWorkModelsPromoHidden);
+  const showOpenWorkModelsSubscribe = (!cloudSession.isSignedIn || !hasOpenWorkCloudProvider) && !openWorkModelsPromoHidden;
+
+  useEffect(() => {
+    const handlePromoChanged = () => setOpenWorkModelsPromoHidden(isOpenWorkModelsPromoHidden());
+    window.addEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+    return () => window.removeEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+  }, []);
+
+  const dismissOpenWorkModelsPromo = useCallback(() => {
+    hideOpenWorkModelsPromo();
+    setOpenWorkModelsPromoHidden(true);
+  }, []);
 
   const subscribeToOpenWorkModels = useCallback(() => {
     providerAuthStore.closeProviderAuthModal();
@@ -2099,6 +2116,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             )}
             showOpenWorkModelsSubscribe={showOpenWorkModelsSubscribe}
             onSubscribeOpenWorkModels={subscribeToOpenWorkModels}
+            onDismissOpenWorkModels={dismissOpenWorkModelsPromo}
             cloudProvidersView={
               <CloudProvidersView
                 embedded


### PR DESCRIPTION
## Summary
- replace the misleading startup model messaging with a dismissible OpenWork Models dialog
- make the Settings AI Providers OpenWork Models banner dismissible with clearer value/cost copy
- treat a valid selected default model, including OpenCode Zen, as usable so the app does not show "No AI model connected" or "Connect a model" copy incorrectly

## Verification
- pnpm --filter @openwork/app typecheck
- Daytona Electron: confirmed real Electron via user agent, created workspace ws_784cb2801565, verified startup dialog dismisses, verified OpenCode default model shows the normal starter state, verified Settings banner dismisses and persists hidden state

## Evidence
- Screenshot: ~/Shared/openwork-models-settings-dismissed.png