### PR TITLE
docs: add cloud client provisioning funnel eval

### DIFF
--- a/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
+++ b/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
@@ -28,9 +28,9 @@ export function ProviderSelectionStep({
 
       <div className="relative z-10 w-full max-w-md px-6">
         <PageHeader className="mb-8 text-center">
-          <PageTitle>Choose your AI models</PageTitle>
+          <PageTitle>Power your first task</PageTitle>
           <PageDescription>
-            Pick how you want to power your workspace.
+            Connect a model, then try a real task in chat so you can see OpenWork work.
           </PageDescription>
         </PageHeader>
 
@@ -43,10 +43,10 @@ export function ProviderSelectionStep({
             <SparklesIcon className="mt-0.5 size-5 shrink-0 text-blue-10" />
             <div>
               <div className="text-sm font-medium text-foreground">
-                Get started with OpenWork Models
+                Use OpenWork Models
               </div>
               <div className="mt-0.5 text-xs text-muted-foreground">
-                Sign up for OpenWork Cloud to access managed AI models.
+                Pay through OpenWork Cloud and skip API key setup.
               </div>
             </div>
           </button>
@@ -62,7 +62,7 @@ export function ProviderSelectionStep({
                 Bring your own API key
               </div>
               <div className="mt-0.5 text-xs text-muted-foreground">
-                Connect an existing provider like Anthropic, OpenAI, or Google.
+                Connect OpenAI, Anthropic, Google, or another provider, then run your first task.
               </div>
             </div>
           </button>
@@ -70,7 +70,7 @@ export function ProviderSelectionStep({
           <div className="pt-1 text-center">
             <Button variant="ghost" size="sm" onClick={onSkip}>
               <SkipForwardIcon className="mr-1.5 size-3.5" />
-              Skip for now
+              Skip and use the free model
             </Button>
           </div>
         </div>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -610,6 +610,7 @@ export function SessionRoute() {
   const [openWorkModelsStartupOpen, setOpenWorkModelsStartupOpen] = useState(false);
   const [openWorkModelsPromoHidden, setOpenWorkModelsPromoHidden] = useState(isOpenWorkModelsPromoHidden);
   const openWorkModelsStartupScheduledRef = useRef(false);
+  const onboardingProviderAuthPendingRef = useRef(false);
   // Bump to re-filter provider list when den session changes (sign-in/out)
   const [denSessionVersion, setDenSessionVersion] = useState(0);
   useEffect(() => {
@@ -1699,15 +1700,15 @@ export function SessionRoute() {
     if (!hash.includes("onboarding=1")) return;
     // Strip the param so it doesn't re-trigger.
     window.location.hash = hash.replace(/[?&]onboarding=1/, "");
-    // Give the provider store a moment to hydrate, then check.
-    const timer = window.setTimeout(() => {
-      if (userProviderConnectedIds.length === 0) {
-        sessionProviderAuthStore.openProviderAuthModal();
-      }
-    }, 1500);
-    return () => window.clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    onboardingProviderAuthPendingRef.current = true;
   }, []);
+
+  useEffect(() => {
+    if (!onboardingProviderAuthPendingRef.current) return;
+    if (!selectedWorkspaceEndpoint) return;
+    onboardingProviderAuthPendingRef.current = false;
+    sessionProviderAuthStore.openProviderAuthModal({ returnFocusTarget: "composer" });
+  }, [selectedWorkspaceEndpoint, sessionProviderAuthStore]);
 
   // Session is where forced sign-in lands. Keep org-managed cloud providers in
   // sync here so sign-in applies opencode.json changes before Settings opens.
@@ -2858,7 +2859,7 @@ export function SessionRoute() {
         );
       }}
       onOpenSettings={() => handleOpenSettings("/settings/general")}
-      onOpenProviderAuth={() => sessionProviderAuthStore.openProviderAuthModal()}
+      onOpenProviderAuth={() => sessionProviderAuthStore.openProviderAuthModal({ returnFocusTarget: "composer" })}
       providerAuthModal={sessionProviderAuthSnapshot.providerAuthModalOpen ? {
         open: true,
         loading: false,
@@ -2876,8 +2877,20 @@ export function SessionRoute() {
           ),
         ),
         onSelect: sessionProviderAuthStore.startProviderAuth,
-        onSubmitApiKey: sessionProviderAuthStore.submitProviderApiKey,
-        onConnectCloudProvider: sessionProviderAuthStore.connectCloudProvider,
+        onSubmitApiKey: async (providerId, apiKey) => {
+          const result = await sessionProviderAuthStore.submitProviderApiKey(providerId, apiKey);
+          setRecentProviderIds(new Set([providerId]));
+          setModelPickerQuery("");
+          setModelPickerOpen(true);
+          return result;
+        },
+        onConnectCloudProvider: async (cloudProviderId) => {
+          const result = await sessionProviderAuthStore.connectCloudProvider(cloudProviderId);
+          setRecentProviderIds(new Set([cloudProviderId]));
+          setModelPickerQuery("");
+          setModelPickerOpen(true);
+          return result;
+        },
         onSubmitOAuth: sessionProviderAuthStore.completeProviderAuthOAuth,
         onRefreshProviders: sessionProviderAuthStore.refreshProviders,
         onClose: () => sessionProviderAuthStore.closeProviderAuthModal(),
@@ -3170,6 +3183,7 @@ export function SessionRoute() {
             : null,
         }));
         setModelPickerOpen(false);
+        focusPromptSoon();
       }}
       disabledProviders={disabledProviderIds}
       onBehaviorChange={() => {}}

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -18,6 +18,10 @@ import { usePlatform } from "../kernel/platform";
 import { WelcomePage } from "../domains/onboarding/welcome-page";
 import { ProviderSelectionStep } from "../domains/onboarding/provider-selection-step";
 import { CreateWorkspaceModal } from "../domains/workspace/create-workspace-modal";
+import {
+  hideOpenWorkModelsPromo,
+  markOpenWorkModelsStartupPromoShown,
+} from "../domains/cloud/openwork-models-promo";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../../app/lib/openwork-server";
 import { buildDenAuthUrl, readDenSettings } from "../../app/lib/den";
@@ -311,6 +315,8 @@ export function WelcomeRoute() {
             if (state.pendingSessionId) focusPromptSoon();
           }}
           onBringYourOwn={() => {
+            markOpenWorkModelsStartupPromoShown();
+            hideOpenWorkModelsPromo();
             const route = state.pendingWorkspaceId
               ? workspaceSessionRoute(state.pendingWorkspaceId, state.pendingSessionId)
               : "/session";

--- a/evals/README.md
+++ b/evals/README.md
@@ -93,6 +93,9 @@ takes `browser_url` as the first argument.
 - [`cloud-admin-to-member-assignment-flows.md`](./cloud-admin-to-member-assignment-flows.md)
   — admin assigns providers/policies to a member, member desktop receives and
   uses them, then removal restores/cleans up UI state.
+- [`cloud-signin-client-provisioning-funnel.md`](./cloud-signin-client-provisioning-funnel.md)
+  — founder funnel from website sign-in to provisioning skills/plugins/providers
+  and validating the capability appears and produces value in the desktop client.
 - [`workspace-layout-state-flows.md`](./workspace-layout-state-flows.md) —
   persisted sidebar/browser layout, legacy layout migration, and workspace-safe
   layout state.

--- a/evals/cloud-signin-client-provisioning-funnel.md
+++ b/evals/cloud-signin-client-provisioning-funnel.md
@@ -1,0 +1,166 @@
+# Cloud sign-in to client provisioning funnel
+
+This eval verifies the founder funnel from web sign-in to a provisioned desktop
+client. It is intentionally product-oriented: the pass criteria cover both
+whether the flow works and whether a new customer understands how value reaches
+their client app.
+
+## Goal
+
+Validate that a workspace owner can:
+
+- Sign in from the website.
+- Create or select an organization.
+- Provision one useful capability for clients, such as a skill, provider, or
+  marketplace extension.
+- Open the desktop app and see that provisioned capability available without
+  manual local setup.
+- Execute or start a task that demonstrates the capability.
+
+## Recommended Daytona setup
+
+Use two sandboxes so the cloud server and desktop client behave like separate
+surfaces:
+
+```bash
+bash .devcontainer/test-server-on-daytona.sh dev
+```
+
+Save the printed Den Web and Den API URLs, then start Electron against them:
+
+```bash
+bash .devcontainer/test-on-daytona.sh dev \
+  --den-base-url <DEN_WEB_URL> \
+  --den-api-base-url <DEN_API_URL> \
+  --require-signin \
+  --record-video \
+  --recording-name cloud-signin-client-provisioning-funnel
+```
+
+Seed demo org, members, marketplace packages, policies, and at least one
+predefined skill/provider bundle before running the desktop half. Prefer a seed
+profile named `client-provisioning-demo` so future evals are repeatable.
+
+## Funnel checkpoints
+
+Record each checkpoint with a timestamp, screenshot, and pass/fail note:
+
+| Checkpoint | Expected signal |
+| --- | --- |
+| `website_signin_visible` | Website shows sign-in/create-account CTA. |
+| `website_signin_complete` | User lands in an org dashboard, not a generic marketing page. |
+| `org_selected` | Active organization is visible and understandable. |
+| `provisioning_surface_visible` | Admin can find marketplace/plugins/skills/providers from the dashboard. |
+| `capability_selected` | Selected capability explains what it will do for clients. |
+| `capability_assigned` | Dashboard confirms the capability is assigned/enabled for members or clients. |
+| `desktop_handoff_started` | User sees a clear route to connect the desktop client. |
+| `desktop_handoff_complete` | Desktop app shows the same org/account. |
+| `client_capability_visible` | Provisioned skill/plugin/provider appears in desktop with org/cloud labeling. |
+| `client_task_started` | User can start a task using the provisioned capability. |
+| `client_task_value` | The task produces a visible useful output or clear next action. |
+
+## Scenario A: website sign-in to desktop handoff
+
+1. Open Den Web in a browser from the printed `DEN_WEB_URL`.
+2. Sign in with the seeded owner account.
+3. Confirm the user lands on the organization dashboard.
+4. Start the desktop handoff flow from the web dashboard if available.
+5. In Electron, complete sign-in using the handoff URL or paste-code flow.
+6. Confirm the desktop Account page shows the same organization.
+
+Expected outcome:
+
+- The user can tell they are signed in on both web and desktop.
+- There is no ambiguous “download app” dead end in the eval. If download is
+  present, note it but skip the binary download.
+
+## Scenario B: provision a predefined skill to clients
+
+1. In Den Web, open the provisioning or marketplace surface.
+2. Select a seeded skill bundle, for example `Client Research Starter`.
+3. Enable or assign it to the demo member/client group.
+4. In Electron, refresh or wait for sync.
+5. Open Settings -> Skills or the relevant client-visible surface.
+6. Confirm the skill appears with cloud/org provenance.
+7. Start a chat task that uses or references the provisioned skill.
+
+Expected outcome:
+
+- The desktop client sees the skill without copying files locally.
+- The user understands the admin action changed what the client can do.
+- The task reaches a useful response, not only a “skill installed” state.
+
+## Scenario C: provision a marketplace extension/plugin to clients
+
+1. In Den Web, open Marketplace or Extensions.
+2. Select a seeded marketplace package.
+3. Assign it to the demo member/client group.
+4. In Electron, open Settings -> Extensions -> Marketplace.
+5. Confirm the package appears as assigned, installed, managed, or available.
+6. If setup is required, verify the client sees clear setup instructions.
+7. Start a task or action that proves the extension is usable.
+
+Expected outcome:
+
+- The desktop client can tell what was provisioned by the organization.
+- The provisioning flow has a clear final state.
+- The first value moment is tied to a task or extension action, not only a list
+  item changing status.
+
+## Works criteria
+
+The flow works if all of these are true:
+
+- Web sign-in succeeds with the seeded account.
+- Desktop handoff succeeds.
+- At least one org-provisioned skill, provider, extension, or plugin appears in
+  the desktop client.
+- The client can start a task using the provisioned capability.
+
+## Good criteria
+
+The flow is good if all of these are true:
+
+- The user can explain what they provisioned and who receives it.
+- The web dashboard provides a clear next step to open or connect the client.
+- The desktop client explains that the capability came from the organization.
+- The first useful task is available within one obvious step after provisioning.
+- The flow does not require copying config, editing files, or guessing where to
+  refresh.
+
+## Self-optimizing loop
+
+After every run, write `/daytona-artifacts/validation/cloud-signin-client-provisioning-funnel.json` with:
+
+```json
+{
+  "scenario": "cloud-signin-client-provisioning-funnel",
+  "commit": "<git sha>",
+  "checkpoints": [
+    { "name": "website_signin_visible", "ok": true, "seconds": 12 },
+    { "name": "client_task_value", "ok": false, "seconds": null, "blocker": "Capability visible but no task CTA" }
+  ],
+  "friction": [
+    { "severity": "high", "surface": "desktop", "note": "Client capability appears but does not explain what to do next." }
+  ],
+  "nextRunChanges": [
+    "Seed a capability with an obvious sample task CTA.",
+    "Assert cloud/org provenance label in desktop list item."
+  ]
+}
+```
+
+Use the `nextRunChanges` array to update this eval before the next run. The eval
+should improve itself by capturing the shortest successful path, known blockers,
+and the next assertion to add.
+
+## Evidence package
+
+Each run should publish these artifacts:
+
+- Raw web recording.
+- Raw desktop recording.
+- Screenshots for all checkpoint states.
+- Validation JSON.
+- Founder summary: conversion path, blockers, time to value.
+- Designer summary: screen sequence, missing guidance, copy issues.

--- a/evals/onboarding-welcome-flows.md
+++ b/evals/onboarding-welcome-flows.md
@@ -33,6 +33,37 @@ Before running any eval:
 
 3. Reload the app. It should redirect to `/welcome`.
 
+## Founder / designer review bar
+
+These evals are not just smoke tests. A passing recording must prove two things:
+
+- **The main flow works**: the user reaches chat, selects a usable model, runs a task, and sees a response.
+- **The main flow is good**: the recording makes the user intent, product value, and friction visible without needing code context.
+
+For each recorded onboarding scenario, capture:
+
+- Raw video from first visible welcome screen through first completed task response.
+- Screenshots at welcome, model/provider choice, provider connected, model selected, task submitted, and response complete.
+- A timestamp table with: welcome visible, workspace selected, provider choice visible, provider connected, model selected, first task submitted, first response complete.
+- Funnel metrics: total time to first task response, click count, reload count, blocking errors, and user-visible dead ends.
+- Friction notes written in product language, for example: “user leaves chat for settings,” “reload required before value,” or “payment/sign-in appears before value is demonstrated.”
+- Any automation boundary, especially native folder picker workarounds in CDP. Do not hide these from founder/design review.
+
+Recommended first task prompt for value validation:
+
+```text
+Create a short welcome checklist for this OpenWork workspace. Use exactly three bullets and mention one thing I can do next.
+```
+
+Pass criteria for every value-flow recording:
+
+- The user can understand why they are choosing this model/provider path.
+- The flow returns to chat or keeps chat visibly accessible after provider setup.
+- A usable model is selected before the task is run.
+- The task is submitted from the composer with the normal “Run task” action.
+- The recording shows a model response, not just provider setup.
+- The summary identifies any friction severe enough to block activation.
+
 ---
 
 ## Flow 20 — Welcome screen renders on first launch
@@ -51,7 +82,7 @@ Steps:
    - "Your computer, but it works for you." subtitle.
    - Six capability cards: spreadsheets, browser, files, automate,
      content, APIs.
-   - A "Get started" button.
+   - A "Pick a folder to get started" button on desktop.
 5. No sidebar, no session chrome, no loading overlay.
 
 Tool recipe:
@@ -63,7 +94,7 @@ Pass criteria:
 - URL is `/welcome`.
 - Heading "Welcome to OpenWork" is visible.
 - All six capability cards are present.
-- "Get started" button is visible and clickable.
+- "Pick a folder to get started" button is visible and clickable on desktop.
 - No sidebar or session layout is rendered.
 
 Known regressions this catches:
@@ -74,34 +105,35 @@ Known regressions this catches:
 
 ---
 
-## Flow 21 — Get started opens workspace creation modal
+## Flow 21 — Welcome CTA starts workspace creation
 
-**Why**: The "Get started" button is the single CTA on the welcome
-page. It must open the `CreateWorkspaceModal` with the chooser screen
-(local / remote / cloud).
+**Why**: The welcome CTA is the single first-run action. On desktop it
+opens the native folder picker directly; on non-desktop it falls back to
+the `CreateWorkspaceModal` chooser.
 
 Steps:
-1. From `/welcome`, click "Get started".
-2. Expect: the `CreateWorkspaceModal` overlay appears.
-3. Expect: the modal shows two option cards:
+1. From `/welcome`, click "Pick a folder to get started".
+2. Desktop expect: native folder picker opens with title "Authorize folder".
+3. Non-desktop expect: the `CreateWorkspaceModal` overlay appears.
+4. Non-desktop expect: the modal shows two option cards:
    - "Local workspace"
    - "Connect custom remote"
-4. Click the close button (X).
-5. Expect: modal closes, welcome page is still visible.
+5. If the modal appears, click the close button (X).
+6. Expect: modal closes, welcome page is still visible.
 
 Tool recipe:
 ```
 chrome-devtools_take_snapshot
-chrome-devtools_click { uid: <Get started button> }
+chrome-devtools_click { uid: <Pick a folder button> }
 chrome-devtools_take_snapshot
 chrome-devtools_click { uid: <Close modal button> }
 chrome-devtools_take_snapshot
 ```
 
 Pass criteria:
-- Modal opens on "Get started" click.
-- Both workspace type options are visible.
-- Closing the modal returns to the welcome page (stays on `/welcome`).
+- Desktop native picker or non-desktop modal opens from the welcome CTA.
+- Non-desktop modal shows both workspace type options.
+- Closing the modal or cancelling the picker returns to the welcome page.
 
 Known regressions this catches:
 - `CreateWorkspaceModal` not rendering because `open` prop isn't wired.
@@ -273,7 +305,76 @@ Pass criteria:
 
 ---
 
+## Flow 27 — Bring your own API key reaches first task value
+
+**Why**: Provider setup is not the product value. The user should connect a provider, pick a usable model, and run a first task in chat without being stranded in settings.
+
+Steps:
+1. Start from a clean first-run app at `/welcome` with no workspaces.
+2. Create a local workspace through the welcome CTA.
+3. On “Power your first task,” choose “Bring your own API key.”
+4. Expect: the provider connector opens from the session surface and keeps composer return focus.
+5. Connect OpenAI with a valid temporary key, or use an explicitly labeled test key only when validating UI copy.
+6. Expect: after saving the key, the model picker opens automatically.
+7. Select an OpenAI model.
+8. Expect: the app returns to the composer.
+9. Submit the recommended first task prompt.
+10. Expect: a model response appears in the chat transcript.
+
+Founder/designer pass criteria:
+- The recording shows why the user is connecting a provider and what they do next.
+- The user does not need to discover a toast to continue to model selection.
+- The user reaches a completed response in chat.
+- Friction is recorded if the flow leaves chat, requires a reload, or hides the next step.
+
+---
+
+## Flow 28 — OpenWork Models path explains payment before value
+
+**Why**: OpenWork Models is the preferred business path, but it must make the tradeoff clear: pay/sign in through OpenWork Cloud to skip API keys, then return to task execution.
+
+Steps:
+1. Start from a clean first-run app at `/welcome` with no workspaces.
+2. Create a local workspace through the welcome CTA.
+3. On “Power your first task,” choose “Use OpenWork Models.”
+4. Expect: the user sees the OpenWork Models value proposition and sign-in/payment CTA.
+5. If a paid/signed-in test account is available, complete sign-in, select an OpenWork model, and run the recommended first task prompt.
+6. If no paid/signed-in test account is available, record the exact stop point and mark the run as “funnel blocked before task value.”
+
+Founder/designer pass criteria:
+- The recording clearly shows the paid path and what value it unlocks.
+- The summary states whether payment/sign-in blocks first task execution.
+- If blocked, the summary proposes the smallest product fix, such as demo credits, a trial task, or an inline fallback to bring-your-own-key.
+
+---
+
+## Flow 29 — Ollama local model reaches first task value
+
+**Why**: Local model onboarding should prove that users can understand setup requirements, connect an available local model, reload if needed, and still reach chat value.
+
+Steps:
+1. Start from a clean first-run app at `/welcome` with no workspaces.
+2. Create a local workspace through the welcome CTA.
+3. Choose “Skip and use the free model” or enter the workspace, then open Extensions.
+4. Open the Ollama setup card.
+5. Expect: the UI explains whether Ollama is running and lists available local models.
+6. Select an available model and click “Add to workspace.”
+7. If a reload is required, click “Reload now” and include that in the friction metrics.
+8. Confirm AI Providers shows “Ollama (local).”
+9. Select the Ollama model, return to chat, and submit the recommended first task prompt.
+10. Expect: a response appears, or the summary marks model-runtime failure separately from onboarding UI failure.
+
+Founder/designer pass criteria:
+- The recording shows the local-model prerequisite in plain language.
+- The reload requirement is measured as funnel friction.
+- The user reaches a completed chat response when a real local model is available.
+- If the eval uses a mock Ollama endpoint, the recording and summary label it clearly and do not claim model-quality success.
+
+---
+
 ## Change log
 
 - 2026-04-29 — initial doc for the onboarding welcome feature
   (Flows 20-26).
+- 2026-06-03 — added founder/designer value-flow criteria and first task
+  activation evals (Flows 27-29).


### PR DESCRIPTION
## Summary
- Add a product-oriented eval spec for website sign-in -> org provisioning -> desktop client value validation.
- Define funnel checkpoints, Daytona setup, pass/good criteria, self-optimizing validation JSON, and evidence package.
- Link the new eval from evals/README.md.

## Validation
- git diff --check: passed
- GitHub checks: OpenWork Tests ubuntu/macOS passed, i18n audit passed, Vercel previews passed, Cubic reviewer passed.
- Daytona e2e run on this PR branch: passed for the supported models.dev provider path.

## Daytona Evidence
- Server sandbox: openwork-server-20260602-225922
- Electron sandbox: openwork-test-20260602-230200
- Seeded org: Acme Robotics / acme-robotics-demo
- Seeded marketplace: 1 marketplace, 14 plugins, 71 config objects
- Workspace: ws_f51fb82f61fe at /workspace/cloud-funnel-value
- Successful provider: lpr_01kt62s5mhesg9q7my2n9w1fzf, Funnel ModelsDev GPT-5.5 1780468192401
- Successful session: ses_173d1ca1bffeX4S26dFZLfb0YC
- Task result: assistant returned exactly `Cloud provisioning value OK`
- Session metadata: providerID `lpr_01kt62s5mhesg9q7my2n9w1fzf`, model `gpt-5.5`, variant `medium`

## Artifacts
- Recording: https://8090-behsmuzeam5laawc.daytonaproxy01.net/recordings/cloud-signin-client-provisioning-funnel-2073.mp4
- Validation JSON: https://8090-behsmuzeam5laawc.daytonaproxy01.net/validation/cloud-signin-client-provisioning-funnel.json
- Local artifacts: `/Users/benjaminshafii/Shared/cloud-signin-client-provisioning-funnel-2073`

## Findings From Run
- Native folder picker remains a CDP automation boundary; the run used Electron `workspaceCreate` bridge after creating the folder.
- API-created workspace alone did not populate Electron runtime workspace state, so opencode did not start until the Electron bridge/restart path.
- Custom cloud provider showed `Cloud` / `Credential ready`, but task execution failed with OpenAI 401 because runtime did not send an API key.
- The models.dev OpenAI provider path did reach value successfully.
- The OpenWork Models upsell interrupted the post-workspace provisioning path and is recorded as funnel friction.