### PR TITLE
fix(app): refresh cloud provider credentials after import

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1397,6 +1397,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         .filter((id) => id !== localProviderId && id !== existingImported?.providerId);
       options.setDisabledProviders(nextDisabledProviders);
       options.markOpencodeConfigReloadRequired();
+      await refreshProviders({ dispose: true });
       refreshSnapshot();
       emitChange();
       return `${t("status.connected")} ${provider.name}`;

--- a/evals/cloud-signin-client-provisioning-funnel.md
+++ b/evals/cloud-signin-client-provisioning-funnel.md
@@ -107,6 +107,28 @@ Expected outcome:
 - The first value moment is tied to a task or extension action, not only a list
   item changing status.
 
+## Scenario D: provision a custom model provider to clients
+
+1. In Den Web or through Den API, create a custom `@ai-sdk/openai-compatible`
+   provider with an organization-managed API key and at least one known-working
+   model.
+2. In Electron, open Settings -> Cloud Providers.
+3. Confirm the custom provider appears with `Cloud` provenance and `Credential
+   ready`.
+4. Import the provider, reload if prompted, and select its model in the session
+   composer.
+5. Send a short prompt that requires a real model response, for example `Reply
+   exactly: Cloud custom provider value OK`.
+
+Expected outcome:
+
+- The model response completes successfully with the requested text or an
+  equivalent useful answer.
+- The session metadata shows the imported `lpr_*` provider id and selected model.
+- No provider key is written to visible config or screenshots.
+- The run does not fail with provider `401`, missing `Authorization`, or missing
+  API key errors after the provider showed `Credential ready`.
+
 ## Works criteria
 
 The flow works if all of these are true:
@@ -116,6 +138,8 @@ The flow works if all of these are true:
 - At least one org-provisioned skill, provider, extension, or plugin appears in
   the desktop client.
 - The client can start a task using the provisioned capability.
+- If the provisioned capability is a custom cloud provider, the task must reach
+  a real model response, not only show the provider as connected.
 
 ## Good criteria
 


### PR DESCRIPTION
## Summary
- Refresh OpenCode provider state immediately after importing a cloud provider credential, so first use sees the stored org key.
- Document a custom provider regression scenario in the cloud provisioning eval.

## Verification
- `pnpm --filter @openwork/app typecheck` passed
- `git diff --check origin/dev...HEAD` passed
- Daytona Electron/server eval against Den passed with custom cloud provider value task
- Imported provider: `custom_openai_limited_fix_1780497862713` / `lpr_01kt6z2marfk0r3datpsrp6s95`
- Prompt: `Reply exactly: Cloud custom provider value OK`
- Response: `Cloud custom provider value OK`
- Verified no provider `401`, missing `Authorization`, or missing API-key error in the successful run
- Verified `/workspace/cloud-custom-provider-fix/opencode.jsonc` contains no `apiKey` field and no `sk-*` secret

## Daytona Evidence
- Local artifacts: `/Users/benjaminshafii/Shared/custom-cloud-provider-credential-fix-20260603`
- Video: https://8090-ijvdgseep8pnmey8.daytonaproxy01.net/recordings/custom-cloud-provider-credential-fix.mp4
- Final screenshot: https://8090-ijvdgseep8pnmey8.daytonaproxy01.net/screenshots/daytona-screenshot-20260603-144603.png
- Validation JSON: https://8090-ijvdgseep8pnmey8.daytonaproxy01.net/validation/custom-cloud-provider-credential-fix.json