### PR TITLE
fix(browser): route automation to built-in browser target

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -100,6 +100,13 @@ declare global {
       browser?: {
         show?: (bounds: { x: number; y: number; width: number; height: number }) => Promise<void>;
         hide?: () => Promise<void>;
+        openUrl?: (url: string, provider?: "auto" | "builtin" | "external") => Promise<{
+          provider: "builtin";
+          browser_url: string;
+          target_id: string;
+          tab_id: string;
+          url: string;
+        }>;
         navigate?: (url: string) => Promise<void>;
         back?: () => Promise<void>;
         forward?: () => Promise<void>;

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -232,6 +232,16 @@ function writeHiddenAccessibleTargetIds(workspaceId: string | null | undefined, 
   }
 }
 
+function controlObjectArg(args: unknown) {
+  return args && typeof args === "object" && !Array.isArray(args) ? args : null;
+}
+
+function controlStringArg(args: unknown, key: string) {
+  const object = controlObjectArg(args);
+  const value = object ? Reflect.get(object, key) : null;
+  return typeof value === "string" ? value.trim() : "";
+}
+
 export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
   const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
@@ -395,6 +405,30 @@ export function SessionPage(props: SessionPageProps) {
     }
     toggleCurrentSidePanel("panel");
   }, [panelRailActive, sessionPanelState.tabs, toggleCurrentSidePanel]);
+  const openBrowserUrlControlAction = useMemo<OpenworkControlAction>(() => ({
+    id: "browser.open_url",
+    label: "Open URL in built-in browser",
+    description: "Create or select an OpenWork built-in browser tab, navigate it to a URL, and return the CDP handle for browser automation.",
+    sideEffect: "navigation",
+    requiresArgs: true,
+    args: [
+      { name: "url", type: "string", required: true, description: "The website URL to open." },
+      { name: "provider", type: "string", description: "Browser provider. Use builtin or auto. External is reserved for future support." },
+    ],
+    previewArgs: { url: "https://example.com", provider: "builtin" },
+    disabled: !isElectronRuntime(),
+    execute: async (args) => {
+      const url = controlStringArg(args, "url");
+      if (!url) return { ok: false, error: "Missing URL." };
+      const provider = controlStringArg(args, "provider") || "builtin";
+      if (provider !== "auto" && provider !== "builtin") {
+        return { ok: false, error: `Browser provider is not available yet: ${provider}` };
+      }
+      setCurrentSidePanel("panel");
+      return window.__OPENWORK_ELECTRON__?.browser?.openUrl?.(url, provider);
+    },
+  }), [setCurrentSidePanel]);
+  useControlAction(openBrowserUrlControlAction);
   const openArtifactRailPane = useCallback(() => {
     if (!hasArtifactTargets || !props.selectedSessionId) return;
     const activeTab = sessionPanelState.tabs.find((tab) => tab.id === sessionPanelState.activeTabId);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -479,6 +479,8 @@ const BROWSER_DEFAULT_URL = "about:blank";
 // URL a user-initiated new tab (the "+" button / opening the browser panel)
 // lands on. The agent's programmatic path keeps BROWSER_DEFAULT_URL.
 const BROWSER_NEW_TAB_URL = "https://www.google.com";
+const BROWSER_TARGET_RESOLVE_TIMEOUT_MS = 2500;
+const BROWSER_TARGET_RESOLVE_INTERVAL_MS = 80;
 const MENU_OVERLAY_HTML = "overlay.html";
 const MENU_OVERLAY_WIDTH = 196;
 const MENU_OVERLAY_HEIGHT = 176;
@@ -681,6 +683,82 @@ function normalizeBrowserUrl(url, fallback = BROWSER_DEFAULT_URL) {
   const target = typeof url === "string" && url.trim() ? url.trim() : fallback;
   if (!target || target === "about:blank") return "about:blank";
   return /^https?:\/\//i.test(target) ? target : `https://${target}`;
+}
+
+function isMainWindowAllowedNavigation(url) {
+  if (!url) return true;
+  if (url.startsWith("file://") || url.startsWith("data:")) return true;
+  try {
+    const target = new URL(url);
+    if (target.hostname === "127.0.0.1" || target.hostname === "localhost") return true;
+    const currentUrl = mainWindow?.webContents.getURL();
+    if (!currentUrl || currentUrl === "about:blank") return true;
+    const current = new URL(currentUrl);
+    return target.origin === current.origin;
+  } catch {
+    return true;
+  }
+}
+
+function routeBlockedMainWindowNavigation(url) {
+  if (!/^https?:\/\//i.test(String(url ?? ""))) return;
+  void openBrowserUrlForAutomation(url).catch((error) => {
+    console.warn("[browser] failed to route blocked main-window navigation", error);
+  });
+}
+
+function cdpBrowserUrl() {
+  return `http://127.0.0.1:${remoteDebugPort}`;
+}
+
+function browserTargetMarkerUrl(tabId) {
+  const marker = `openwork-browser-tab:${tabId}`;
+  const html = `<!doctype html><title>${marker}</title><meta name="openwork-browser-tab" content="${tabId}"><body>${marker}</body>`;
+  return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
+}
+
+async function listCdpTargets() {
+  if (!remoteDebugPort || remoteDebugPort <= 0) return [];
+  const response = await fetch(`${cdpBrowserUrl()}/json/list`, { signal: AbortSignal.timeout(1000) });
+  if (!response.ok) throw new Error(`CDP target list failed: HTTP ${response.status}`);
+  const targets = await response.json();
+  return Array.isArray(targets) ? targets : [];
+}
+
+async function resolveBrowserCdpTargetId(tabId) {
+  const marker = encodeURIComponent(`openwork-browser-tab:${tabId}`);
+  const deadline = Date.now() + BROWSER_TARGET_RESOLVE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const targets = await listCdpTargets().catch(() => []);
+    const target = targets.find((candidate) => (
+      candidate?.type === "page" &&
+      typeof candidate.id === "string" &&
+      typeof candidate.url === "string" &&
+      candidate.url.includes(marker)
+    ));
+    if (target?.id) return target.id;
+    await new Promise((resolve) => setTimeout(resolve, BROWSER_TARGET_RESOLVE_INTERVAL_MS));
+  }
+  throw new Error("Could not resolve built-in browser CDP target.");
+}
+
+async function openBrowserUrlForAutomation(rawUrl, provider = "auto") {
+  const requestedProvider = String(provider || "auto").trim().toLowerCase();
+  if (requestedProvider && requestedProvider !== "auto" && requestedProvider !== "builtin") {
+    throw new Error(`Browser provider is not available yet: ${requestedProvider}`);
+  }
+  const url = normalizeBrowserUrl(rawUrl);
+  const tab = createBrowserTab("about:blank", { select: true });
+  await tab.view.webContents.loadURL(browserTargetMarkerUrl(tab.tabId));
+  const targetId = await resolveBrowserCdpTargetId(tab.tabId);
+  await tab.view.webContents.loadURL(url);
+  return {
+    provider: "builtin",
+    browser_url: cdpBrowserUrl(),
+    target_id: targetId,
+    tab_id: tab.tabId,
+    url,
+  };
 }
 
 function getBrowserTab(tabId = activeBrowserTabId) {
@@ -2897,6 +2975,12 @@ async function createMainWindow() {
     return { action: "allow" };
   });
 
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    if (isMainWindowAllowedNavigation(url)) return;
+    event.preventDefault();
+    routeBlockedMainWindowNavigation(url);
+  });
+
   const startUrl = process.env.OPENWORK_ELECTRON_START_URL?.trim() || process.env.ELECTRON_START_URL?.trim();
   if (startUrl) {
     await mainWindow.loadURL(startUrl);
@@ -2935,6 +3019,7 @@ ipcMain.handle("openwork:system:askMicrophoneAccess", async () => {
 // ── Embedded browser IPC ────────────────────────────────────────────────
 ipcMain.handle("openwork:browser:show", (_event, bounds) => attachBrowserView(bounds));
 ipcMain.handle("openwork:browser:hide", () => hideBrowserView());
+ipcMain.handle("openwork:browser:openUrl", (_event, url, provider) => openBrowserUrlForAutomation(url, provider));
 ipcMain.handle("openwork:browser:navigate", (_event, url) => {
   const view = getActiveBrowserView() ?? createBrowserTab("about:blank", { select: true }).view;
   view.webContents.loadURL(normalizeBrowserUrl(url));

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -105,6 +105,7 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
   browser: {
     show(bounds) { return ipcRenderer.invoke("openwork:browser:show", bounds); },
     hide() { return ipcRenderer.invoke("openwork:browser:hide"); },
+    openUrl(url, provider) { return ipcRenderer.invoke("openwork:browser:openUrl", url, provider); },
     navigate(url) { return ipcRenderer.invoke("openwork:browser:navigate", url); },
     back() { return ipcRenderer.invoke("openwork:browser:back"); },
     forward() { return ipcRenderer.invoke("openwork:browser:forward"); },

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
@@ -64,7 +64,8 @@ Here is what you can help users with:
 - The voice model can control the UI on the user's behalf (same actions the agent has access to).
 
 ## Browsing the Web
-- The built-in browser (chrome-devtools) lets the agent navigate, click, type, and screenshot web pages.
+- The built-in browser lets the agent navigate, click, type, and screenshot web pages.
+- For reliable browser automation, first open the page with \`openwork_browser_open_url\`, then use the returned \`browser_url\` and \`target_id\` with browser snapshot/click/fill/eval tools.
 - The browser panel is visible on the right side of the session view.
 
 ## Cross-chat Session Memory

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -33,6 +33,11 @@ const uiExecuteArgsSchema = z.object({
   args: z.record(z.string(), z.unknown()).optional().describe("JSON arguments for the action, if required."),
 });
 
+const browserOpenUrlArgsSchema = z.object({
+  url: z.string().describe("The website URL to open in the OpenWork built-in browser."),
+  provider: z.enum(["auto", "builtin", "external"]).optional().describe("Browser provider. Use builtin or auto; external is reserved for future support."),
+});
+
 const OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION =
   "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
 
@@ -54,8 +59,8 @@ Answer only from the returned transcript. If multiple sessions match, ask a shor
 Do NOT use browser_navigate, browser_click, or browser_snapshot to interact with the OpenWork app itself. Those are for browsing external websites.
 
 ## Built-in Browser (external websites)
-For web browsing tasks, use the browser_* tools with browser_url "http://127.0.0.1:${process.env.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT?.trim() || "9222"}".
-Always call browser_list first, then use the target that is NOT the OpenWork app (avoid targets with title "OpenWork" or URLs containing ":5173/#/").`;
+For web browsing tasks, ALWAYS start with openwork_browser_open_url. It creates/selects a built-in OpenWork browser tab and returns browser_url plus target_id. Use that exact browser_url and target_id for every later browser_snapshot, browser_click, browser_fill, browser_eval, and browser_screenshot call.
+Do not call browser_navigate without a target_id returned by openwork_browser_open_url. Do not use browser_* tools on the OpenWork app target (avoid targets with title "OpenWork" or URLs containing ":5173/#/").`;
 
 // ── UI control bridge discovery ──
 
@@ -250,6 +255,21 @@ export const OpenWorkExtensionsPreview = async () => ({
         const result = await uiBridgeRequest("/execute", {
           method: "POST",
           body: { actionId, args: args ?? {} },
+        });
+        return JSON.stringify(result, null, 2);
+      },
+    },
+    openwork_browser_open_url: {
+      description: "Open a URL in the OpenWork built-in browser and return the exact CDP browser_url and target_id to use for browser_* automation tools. Always use this before browser_snapshot/click/fill/eval for web browsing tasks.",
+      args: browserOpenUrlArgsSchema.shape,
+      async execute(rawArgs: unknown) {
+        const args = browserOpenUrlArgsSchema.parse(rawArgs);
+        const result = await uiBridgeRequest("/execute", {
+          method: "POST",
+          body: {
+            actionId: "browser.open_url",
+            args: { url: args.url, provider: args.provider ?? "builtin" },
+          },
         });
         return JSON.stringify(result, null, 2);
       },


### PR DESCRIPTION
## Summary
- Add a safe browser.open_url UI-control action that opens the built-in browser and returns browser_url + target_id
- Add an openwork_browser_open_url agent tool that calls the UI action before browser_* automation
- Update OpenWork browser guidance so agents use the returned target handle instead of guessing from browser_list
- Add normal main-window navigation routing for non-CDP external navigations

## Verification
- pnpm --filter @openwork/app typecheck: pass
- pnpm --filter openwork-server typecheck: pass
- pnpm --filter @openwork/desktop typecheck:electron: pass
- pnpm --filter openwork-server build: pass
- pnpm --filter @openwork/app test:browser-entry: pass
- Live Electron eval on isolated ports app=5192/cdp=9387: browser.open_url returned target_id E4ABC51F3405AA91839B5C41CE438A7C for https://example.com, browser_snapshot on that target returned Example Domain, and the OpenWork app target stayed on /workspace/ws_7adae83402a5/session

## Notes
- This PR intentionally keeps opencode-chrome-devtools unchanged and adds an explicit OpenWork target bootstrap step. A future follow-up can hard-wrap raw browser_* tools so direct browser_navigate against the app target is impossible even if the model ignores instructions.