### PR TITLE
fix(app): refresh updated artifact previews

### DIFF
--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -78,6 +78,7 @@ export function ArtifactPanel({ sessionId, tab, client, workspaceId, workspaceRo
   );
 }
 
+
 function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspace = false, target, onClose }: ArtifactPanelViewProps) {
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
@@ -86,7 +87,7 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
   const externalPath = useMemo(() => target.kind === "file" ? absoluteWorkspacePath(workspaceRoot, target.value) : target.value, [target.kind, target.value, workspaceRoot]);
 
   const { data, error, isError, isLoading } = useQuery<ArtifactQueryState>({
-    queryKey: ["artifact-panel", workspaceId, target.id] as const,
+    queryKey: ["artifact-panel", workspaceId, target.id, target.updatedAt ?? null] as const,
     queryFn: async () => {
       if (target.kind === "url") {
         throw new Error("URLs open in browser tabs.");
@@ -369,4 +370,3 @@ function SheetEditor({ className, ...props }: SheetEditorProps) {
     </Suspense>
   );
 }
-

--- a/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
+++ b/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
@@ -119,7 +119,14 @@ function reconcileOpenArtifactTabs(
 function isSameTranscriptArtifactTargets(left: OpenTarget[], right: OpenTarget[]) {
   return (
     left.length === right.length &&
-    left.every((target, index) => target.id === right[index]?.id)
+    left.every((target, index) => {
+      const next = right[index];
+      return next !== undefined &&
+        target.id === next.id &&
+        target.exists === next.exists &&
+        target.size === next.size &&
+        target.updatedAt === next.updatedAt;
+    })
   );
 }
 

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -71,6 +71,15 @@ const EMPTY_TRANSCRIPT: UIMessage[] = [];
 const IDLE_STATUS: SessionStatus = { type: "idle" };
 const DEFAULT_COMPOSER_CONTROL_TEXT = "Help me outline the next OpenWork task.";
 
+function messageArtifactRefreshFingerprint(messages: UIMessage[]) {
+  return messages
+    .map((message) => {
+      const textLength = message.parts.reduce((total, part) => part.type === "text" ? total + part.text.length : total, 0);
+      return `${message.id}:${message.parts.length}:${textLength}`;
+    })
+    .join("|");
+}
+
 type SessionError = {
   message: string;
   kind?: "model-not-found" | "generic";
@@ -556,9 +565,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
     [snapshot, transcriptState],
   );
   const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
+  const artifactRefreshFingerprint = useMemo(() => messageArtifactRefreshFingerprint(renderedMessages), [renderedMessages]);
   const openTargetsFingerprint = useMemo(
-    () => openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|"),
-    [openTargets],
+    () => `${artifactRefreshFingerprint}::${openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|")}`,
+    [artifactRefreshFingerprint, openTargets],
   );
   const autoOpenTarget = selectAutoOpenTarget(verifiedOpenTargets);
   const pendingSessionLoad = !snapshot && snapshotQuery.isLoading && renderedMessages.length === 0;


### PR DESCRIPTION
## Summary
- include artifact file updatedAt in the artifact panel query key so same-path edits refetch
- keep transcript artifact state fresh when exists/size/updatedAt metadata changes
- rerun artifact resolution when transcript content changes even if the same filename is mentioned

## Daytona Repro / Verification
- Created isolated worktree: /Users/benjaminshafii/openwork-enterprise/_repos/_worktrees/openwork-static-html-cache
- Started Daytona Electron sandbox: openwork-test-20260603-093908
- Reproduced the same-path stale-cache pattern with pretty-growth-chart.html: renaming changed the artifact ID, while same filename reused cached preview state
- Applied the fix inside the Daytona sandbox and confirmed same-path writes produce a changed updatedAt and therefore a changed artifact-panel query key

## Tests
- pnpm --filter @openwork/app typecheck
- Daytona sandbox: pnpm --filter @openwork/app typecheck