### PR TITLE
feat(inference): add MiniMax M3 model

### DIFF
--- a/ee/apps/inference/src/models/openwork-dev.json
+++ b/ee/apps/inference/src/models/openwork-dev.json
@@ -81,6 +81,25 @@
           "cache_write": 0.375
         }
       },
+      "minimax/minimax-m3": {
+        "id": "minimax/minimax-m3",
+        "name": "MiniMax-M3",
+        "family": "minimax",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": false,
+        "temperature": true,
+        "release_date": "2026-06-01",
+        "last_updated": "2026-06-01",
+        "modalities": {
+          "input": ["text", "image", "video"],
+          "output": ["text"]
+        },
+        "open_weights": true,
+        "limit": { "context": 524288, "output": 512000 },
+        "cost": { "input": 0.3, "output": 1.2, "cache_read": 0.06 }
+      },
       "z-ai/glm-5.1": {
         "id": "z-ai/glm-5.1",
         "name": "GLM-5.1",

--- a/ee/apps/inference/src/models/openwork-prod.json
+++ b/ee/apps/inference/src/models/openwork-prod.json
@@ -81,6 +81,25 @@
           "cache_write": 0.375
         }
       },
+      "minimax/minimax-m3": {
+        "id": "minimax/minimax-m3",
+        "name": "MiniMax-M3",
+        "family": "minimax",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": false,
+        "temperature": true,
+        "release_date": "2026-06-01",
+        "last_updated": "2026-06-01",
+        "modalities": {
+          "input": ["text", "image", "video"],
+          "output": ["text"]
+        },
+        "open_weights": true,
+        "limit": { "context": 524288, "output": 512000 },
+        "cost": { "input": 0.3, "output": 1.2, "cache_read": 0.06 }
+      },
       "z-ai/glm-5.1": {
         "id": "z-ai/glm-5.1",
         "name": "GLM-5.1",

--- a/packages/types/src/den/inference.ts
+++ b/packages/types/src/den/inference.ts
@@ -78,6 +78,12 @@ export const INFERENCE_MODEL_ALIASES = {
     enabled: true,
     usageFactor: 1,
   },
+  "minimax/minimax-m3": {
+    upstreamModel: "minimax/minimax-m3",
+    displayName: "OpenWork: MiniMax M3",
+    enabled: true,
+    usageFactor: 1,
+  },
   "z-ai/glm-5.1": {
     upstreamModel: "z-ai/glm-5.1",
     displayName: "OpenWork: GLM-5.1",


### PR DESCRIPTION
## Summary
- add MiniMax M3 to OpenWork dev/prod inference model metadata
- expose MiniMax M3 through OpenWork inference model aliases

## Validation
- pnpm --filter @openwork-ee/inference build — passed

## Evidence
- Metadata-only change; no UI recording captured.