### PR TITLE
Store cloud plugin installs in OpenWork server DB

### DIFF
--- a/apps/app/scripts/extension-items.test.ts
+++ b/apps/app/scripts/extension-items.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { buildExtensionItems } from "../src/react-app/domains/settings/extension-items";
+
+describe("extension item grouping", () => {
+  test("groups imported cloud plugin resources and suppresses child skill rows", () => {
+    const result = buildExtensionItems({
+      quickConnect: [],
+      mcpServers: [],
+      installedSkills: [
+        {
+          name: "brief-builder",
+          description: "Use for creative briefs",
+          path: "/workspace/project/.opencode/skills/creative-brief-plugin/brief-builder/SKILL.md",
+        },
+      ],
+      importedCloudPlugins: {
+        plugin_1: {
+          pluginId: "plugin_1",
+          marketplaceId: "marketplace_1",
+          name: "Creative Brief Plugin",
+          description: "Brief writing workflow",
+          updatedAt: "2026-06-02T00:00:00.000Z",
+          importedAt: 1,
+          files: [
+            {
+              configObjectId: "config_skill_1",
+              versionId: "version_skill_1",
+              objectType: "skill",
+              title: "Brief Builder",
+              path: ".opencode/skills/creative-brief-plugin/brief-builder/SKILL.md",
+              updatedAt: "2026-06-02T00:00:00.000Z",
+            },
+          ],
+        },
+      },
+      cloudMarketplaces: [],
+      enablementContext: {},
+      isBuiltInConnected: () => false,
+    });
+
+    expect(result.items.map((item) => item.id)).toEqual(["marketplace:installed:plugin_1"]);
+    expect(result.items[0]?.resources).toEqual([
+      {
+        id: "config_skill_1",
+        type: "skill",
+        title: "Brief Builder",
+        path: ".opencode/skills/creative-brief-plugin/brief-builder/SKILL.md",
+      },
+    ]);
+  });
+});

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -2,7 +2,8 @@ import type { Message, Part, Session, Todo } from "@opencode-ai/sdk/v2/client";
 import { desktopFetch } from "./desktop";
 import { isDesktopRuntime } from "../utils";
 import type { ExecResult, OpencodeConfigFile, WorkspaceInfo, WorkspaceList } from "./desktop";
-import type { DenResourceSnapshot } from "./den";
+import type { DenOrgMarketplace, DenOrgPluginResolved, DenResourceSnapshot } from "./den";
+import type { CloudImportedMarketplace, CloudImportedPlugin } from "../cloud/import-state";
 
 export type OpenworkServerCapabilities = {
   skills: { read: boolean; write: boolean; source: "openwork" | "opencode" };
@@ -240,6 +241,15 @@ export type OpenworkDesktopCloudSyncState = {
 export type OpenworkDesktopCloudSyncResult = {
   changes: OpenworkDesktopCloudSyncChange[];
   state: OpenworkDesktopCloudSyncState;
+};
+
+export type OpenworkCloudPluginInstallResult = {
+  item: CloudImportedPlugin;
+};
+
+export type OpenworkCloudPluginsResult = {
+  marketplaces: Record<string, CloudImportedMarketplace>;
+  plugins: Record<string, CloudImportedPlugin>;
 };
 
 function arrayBufferToBase64(data: ArrayBuffer): string {
@@ -1214,6 +1224,27 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         hostToken,
         method: "POST",
         body: { snapshot },
+        timeoutMs: timeouts.config,
+      }),
+    listCloudPlugins: (workspaceId: string) =>
+      requestJson<OpenworkCloudPluginsResult>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/cloud-plugins`, {
+        token,
+        hostToken,
+        timeoutMs: timeouts.config,
+      }),
+    installCloudPlugin: (workspaceId: string, payload: { marketplaceId: string | null; marketplace?: DenOrgMarketplace | null; resolved: DenOrgPluginResolved }) =>
+      requestJson<OpenworkCloudPluginInstallResult>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/cloud-plugins`, {
+        token,
+        hostToken,
+        method: "POST",
+        body: payload,
+        timeoutMs: timeouts.config,
+      }),
+    removeCloudPlugin: (workspaceId: string, pluginId: string) =>
+      requestJson<OpenworkCloudPluginInstallResult>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/cloud-plugins/${encodeURIComponent(pluginId)}`, {
+        token,
+        hostToken,
+        method: "DELETE",
         timeoutMs: timeouts.config,
       }),
     readOpencodeConfigFile: (workspaceId: string, scope: "project" | "global" = "project") => {

--- a/apps/app/src/react-app/domains/settings/extension-items.ts
+++ b/apps/app/src/react-app/domains/settings/extension-items.ts
@@ -83,6 +83,8 @@ function childKeysForPlugin(plugin: CloudImportedPlugin) {
     }
     if (file.objectType === "skill") {
       skillPaths.add(file.path);
+      const name = file.path.match(/^\.opencode\/skills\/(?:[^/]+\/)?([^/]+)\/SKILL\.md$/)?.[1];
+      if (name) skillNames.add(name);
       skillNames.add(file.title);
     }
   }
@@ -175,7 +177,7 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
   });
 
   const standaloneSkillItems = input.installedSkills.filter((skill) => {
-    if (groupedSkillPaths.has(skill.path)) return false;
+    if ([...groupedSkillPaths].some((path) => skill.path.endsWith(path))) return false;
     if (groupedSkillNames.has(skill.name)) return false;
     return true;
   }).map((skill): ExtensionItem => ({

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -558,6 +558,13 @@ export function createExtensionsStore(options: {
 
   const refreshImportedCloudPlugins = async () => {
     try {
+      const target = await resolveWorkspaceServerTarget();
+      if (target.openworkClient && target.openworkWorkspaceId) {
+        const result = await target.openworkClient.listCloudPlugins(target.openworkWorkspaceId);
+        setStateField("importedCloudMarketplaces", result.marketplaces);
+        setStateField("importedCloudPlugins", result.plugins);
+        return result.plugins;
+      }
       const config = await readWorkspaceOpenworkConfigRecord();
       const cloudImports = readWorkspaceCloudImports(config);
       setStateField("importedCloudMarketplaces", cloudImports.marketplaces);
@@ -1494,6 +1501,26 @@ export function createExtensionsStore(options: {
       if (!token || !orgId) throw new Error("Sign in to OpenWork Cloud and choose an organization first.");
       const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
       const resolved = await client.getOrgPluginResolved(orgId, plugin);
+      const target = await resolveWorkspaceServerTarget();
+      if (target.openworkClient && target.openworkWorkspaceId) {
+        const marketplace = marketplaceId ? findCloudMarketplace(marketplaceId) : null;
+        const result = await target.openworkClient.installCloudPlugin(target.openworkWorkspaceId, {
+          marketplaceId,
+          marketplace,
+          resolved,
+        });
+        await refreshSkills({ force: true });
+        await refreshCloudOrgMarketplaces({ force: true });
+        void refreshDesktopCloudSync({
+          openworkClient: target.openworkClient,
+          workspaceId: target.openworkWorkspaceId,
+        }).catch(() => null);
+        return {
+          ok: true,
+          message: `Imported ${plugin.name} with ${result.item.files.length} file${result.item.files.length === 1 ? "" : "s"}.`,
+          files: result.item.files,
+        };
+      }
       const files = await applyCloudOrgPluginImport(marketplaceId, resolved);
       await refreshSkills({ force: true });
       await refreshCloudOrgMarketplaces({ force: true });
@@ -1517,6 +1544,21 @@ export function createExtensionsStore(options: {
     setStateField("cloudOrgMarketplacesStatus", null);
 
     try {
+      const target = await resolveWorkspaceServerTarget();
+      if (target.openworkClient && target.openworkWorkspaceId) {
+        const result = await target.openworkClient.removeCloudPlugin(target.openworkWorkspaceId, pluginId);
+        await refreshSkills({ force: true });
+        await refreshCloudOrgMarketplaces({ force: true });
+        void refreshDesktopCloudSync({
+          openworkClient: target.openworkClient,
+          workspaceId: target.openworkWorkspaceId,
+        }).catch(() => null);
+        return {
+          ok: true,
+          message: `Removed ${result.item.name}.`,
+        };
+      }
+
       const imported = snapshot.importedCloudPlugins[pluginId];
       if (!imported) throw new Error("Marketplace package is not installed in this workspace.");
 

--- a/apps/server/src/cloud-plugins.test.ts
+++ b/apps/server/src/cloud-plugins.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installCloudPlugin, readInstalledCloudPlugins, removeCloudPlugin } from "./cloud-plugins.js";
+import { readRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+
+const WORKSPACE_ID = "ws_cloud_plugin_test";
+
+function serverConfig(root: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    hostToken: "host-token",
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [{ id: WORKSPACE_ID, name: "Test", path: root, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  } satisfies ServerConfig;
+}
+
+async function withWorkspace(fn: (input: { root: string; config: ServerConfig }) => Promise<void>) {
+  const root = await mkdtemp(join(tmpdir(), "openwork-cloud-plugin-"));
+  const previousDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  try {
+    await fn({ root, config: serverConfig(root) });
+  } finally {
+    if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+    else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function expectMissing(path: string): Promise<void> {
+  await expect(stat(path)).rejects.toThrow();
+}
+
+describe("cloud plugin installs", () => {
+  test("stores installed plugin state in the server DB and projects runtime resources", async () => {
+    await withWorkspace(async ({ root, config }) => {
+      const imported = await installCloudPlugin({
+        serverConfig: config,
+        workspaceId: WORKSPACE_ID,
+        workspaceRoot: root,
+        marketplaceId: "marketplace_1",
+        marketplace: { id: "marketplace_1", name: "Team Marketplace", updatedAt: "2026-06-01T00:00:00.000Z" },
+        resolved: {
+          plugin: {
+            id: "plugin_1",
+            name: "Creative Brief Plugin",
+            description: "Brief writing workflow",
+            updatedAt: "2026-06-02T00:00:00.000Z",
+          },
+          memberships: [
+            {
+              configObjectId: "config_skill_1",
+              configObject: {
+                id: "config_skill_1",
+                objectType: "skill",
+                title: "Brief Builder",
+                description: "Use for creative briefs",
+                currentRelativePath: null,
+                status: "active",
+                updatedAt: "2026-06-02T00:00:00.000Z",
+                latestVersion: {
+                  id: "version_skill_1",
+                  rawSourceText: "# Brief Builder\n\nWhen asked for OWP_BRIEF_TEST_TOKEN, reply with the installed plugin token.",
+                  normalizedPayloadJson: null,
+                },
+              },
+            },
+            {
+              configObjectId: "config_mcp_1",
+              configObject: {
+                id: "config_mcp_1",
+                objectType: "mcp",
+                title: "Brief MCP",
+                description: null,
+                currentRelativePath: null,
+                status: "active",
+                updatedAt: "2026-06-02T00:00:00.000Z",
+                latestVersion: {
+                  id: "version_mcp_1",
+                  rawSourceText: JSON.stringify({ mcpServers: { brief: { url: "https://example.com/mcp" } } }),
+                  normalizedPayloadJson: { mcpServers: { brief: { url: "https://example.com/mcp" } } },
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      expect(imported.pluginId).toBe("plugin_1");
+      expect(imported.files.map((file) => file.objectType).sort()).toEqual(["mcp", "skill"]);
+
+      const installed = await readInstalledCloudPlugins(config, WORKSPACE_ID);
+      expect(installed.plugins.plugin_1?.name).toBe("Creative Brief Plugin");
+      expect(installed.marketplaces.marketplace_1?.pluginIds).toEqual(["plugin_1"]);
+
+      const skillPath = join(root, ".opencode", "skills", "creative-brief-plugin", "brief-builder", "SKILL.md");
+      expect(await readFile(skillPath, "utf8")).toContain("OWP_BRIEF_TEST_TOKEN");
+      expect((await readRuntimeOpencodeConfig(config, WORKSPACE_ID)).mcp?.brief).toMatchObject({
+        type: "remote",
+        url: "https://example.com/mcp",
+      });
+
+      await removeCloudPlugin({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root, pluginId: "plugin_1" });
+      expect((await readInstalledCloudPlugins(config, WORKSPACE_ID)).plugins.plugin_1).toBeUndefined();
+      expect((await readRuntimeOpencodeConfig(config, WORKSPACE_ID)).mcp?.brief).toBeUndefined();
+      await expectMissing(skillPath);
+    });
+  });
+});

--- a/apps/server/src/cloud-plugins.ts
+++ b/apps/server/src/cloud-plugins.ts
@@ -1,0 +1,669 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { eq } from "drizzle-orm";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import type { ServerConfig } from "./types.js";
+import { ApiError } from "./errors.js";
+import { addMcp, removeMcp } from "./mcp.js";
+import { ensureDir } from "./utils.js";
+
+const OPENCODE_SKILL_NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const OPENCODE_MCP_NAME_RE = /^[A-Za-z0-9_][A-Za-z0-9_-]*$/;
+const OPENCODE_MCP_IMPORT_PATH_PREFIX = "opencode.jsonc#mcp.";
+
+type CloudPluginConfigObjectType = "skill" | "agent" | "command" | "tool" | "mcp" | "hook" | "context" | "custom";
+
+type CloudPluginConfigObjectVersion = {
+  id: string;
+  rawSourceText: string | null;
+  normalizedPayloadJson: Record<string, unknown> | null;
+};
+
+type CloudPluginConfigObject = {
+  id: string;
+  objectType: CloudPluginConfigObjectType;
+  title: string;
+  description: string | null;
+  currentRelativePath: string | null;
+  status: string;
+  updatedAt: string | null;
+  latestVersion: CloudPluginConfigObjectVersion | null;
+};
+
+type CloudPluginMembership = {
+  configObjectId: string;
+  configObject?: CloudPluginConfigObject;
+};
+
+export type CloudPluginResolved = {
+  plugin: {
+    id: string;
+    name: string;
+    description: string | null;
+    updatedAt: string | null;
+  };
+  memberships: CloudPluginMembership[];
+};
+
+export type CloudImportedPluginFile = {
+  configObjectId: string;
+  versionId: string | null;
+  objectType: string;
+  title: string;
+  path: string;
+  updatedAt: string | null;
+};
+
+export type CloudImportedPlugin = {
+  pluginId: string;
+  marketplaceId: string | null;
+  name: string;
+  description: string | null;
+  updatedAt: string | null;
+  files: CloudImportedPluginFile[];
+  importedAt: number | null;
+};
+
+type WorkspaceCloudImports = {
+  skillHubs: Record<string, unknown>;
+  skills: Record<string, unknown>;
+  providers: Record<string, unknown>;
+  marketplaces: Record<string, { marketplaceId: string; name: string; updatedAt: string | null; pluginIds: string[]; importedAt: number | null }>;
+  plugins: Record<string, CloudImportedPlugin>;
+};
+
+const cloudPluginInstallConfigs = sqliteTable("cloud_plugin_install_configs", {
+  workspaceId: text("workspace_id").primaryKey(),
+  configJson: text("config_json").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});
+
+type CloudPluginDb = {
+  get: (workspaceId: string) => { configJson: string } | undefined;
+  upsert: (value: { workspaceId: string; configJson: string; updatedAt: number }) => void;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value.trim() || null : null;
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.flatMap((entry) => {
+    const text = readString(entry);
+    return text ? [text] : [];
+  }) : [];
+}
+
+function readStringRecord(value: unknown): Record<string, string> | null {
+  if (!isRecord(value)) return null;
+  const output: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    const text = readString(entry);
+    if (text) output[key] = text;
+  }
+  return Object.keys(output).length ? output : null;
+}
+
+function parseJsonRecord(text: string | null): Record<string, unknown> | null {
+  if (!text) return null;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeConfigObjectType(value: unknown): CloudPluginConfigObjectType | null {
+  switch (value) {
+    case "skill":
+    case "agent":
+    case "command":
+    case "tool":
+    case "mcp":
+    case "hook":
+    case "context":
+    case "custom":
+      return value;
+    default:
+      return null;
+  }
+}
+
+function normalizeConfigObjectVersion(value: unknown): CloudPluginConfigObjectVersion | null {
+  if (!isRecord(value) || typeof value.id !== "string") return null;
+  return {
+    id: value.id,
+    rawSourceText: typeof value.rawSourceText === "string" ? value.rawSourceText : null,
+    normalizedPayloadJson: isRecord(value.normalizedPayloadJson) ? value.normalizedPayloadJson : null,
+  };
+}
+
+function normalizeConfigObject(value: unknown): CloudPluginConfigObject | null {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.title !== "string") return null;
+  const objectType = normalizeConfigObjectType(value.objectType);
+  if (!objectType) return null;
+  return {
+    id: value.id,
+    objectType,
+    title: value.title,
+    description: typeof value.description === "string" ? value.description : null,
+    currentRelativePath: typeof value.currentRelativePath === "string" ? value.currentRelativePath : null,
+    status: typeof value.status === "string" ? value.status : "active",
+    updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : null,
+    latestVersion: normalizeConfigObjectVersion(value.latestVersion),
+  };
+}
+
+function normalizeCloudPluginResolved(value: unknown): CloudPluginResolved | null {
+  if (!isRecord(value) || !isRecord(value.plugin) || !Array.isArray(value.memberships)) return null;
+  if (typeof value.plugin.id !== "string" || typeof value.plugin.name !== "string") return null;
+  const memberships = value.memberships.flatMap((entry) => {
+    if (!isRecord(entry) || typeof entry.configObjectId !== "string") return [];
+    const configObject = normalizeConfigObject(entry.configObject);
+    return [{ configObjectId: entry.configObjectId, ...(configObject ? { configObject } : {}) }];
+  });
+  return {
+    plugin: {
+      id: value.plugin.id,
+      name: value.plugin.name,
+      description: typeof value.plugin.description === "string" ? value.plugin.description : null,
+      updatedAt: typeof value.plugin.updatedAt === "string" ? value.plugin.updatedAt : null,
+    },
+    memberships,
+  };
+}
+
+export function readCloudPluginResolved(value: unknown): CloudPluginResolved {
+  const resolved = normalizeCloudPluginResolved(value);
+  if (!resolved) throw new ApiError(400, "invalid_cloud_plugin", "resolved cloud plugin is required");
+  return resolved;
+}
+
+function extractSkillBodyMarkdown(skillText: string): string {
+  const trimmed = skillText.trim();
+  if (!trimmed.startsWith("---")) return trimmed;
+  const rest = trimmed.slice(3);
+  const end = rest.indexOf("\n---");
+  if (end === -1) return trimmed;
+  return rest.slice(end + 4).replace(/^\s*\n?/, "");
+}
+
+function slugifyConfigObjectName(title: string, fallback: string): string {
+  let base = title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!base) base = "skill";
+  if (base.length > 64) base = base.slice(0, 64).replace(/-+$/g, "");
+  if (!OPENCODE_SKILL_NAME_RE.test(base)) base = "skill";
+  if (base === "skill" && fallback) return slugifyConfigObjectName(fallback, "");
+  return base;
+}
+
+function pluginNamespace(pluginName: string, pluginId: string): string {
+  const base = slugifyConfigObjectName(pluginName, pluginId);
+  return `${base.replace(/-plugin$/, "")}-plugin`;
+}
+
+function normalizePluginSourcePath(path: string, objectType: string, namespace: string): string {
+  const parts = path.trim().replace(/^\/+/, "").split("/").filter(Boolean);
+  if (parts.length === 0 || parts.some((part) => part === ".." || part === ".")) return "";
+
+  const folderByType: Record<string, string> = {
+    agent: "agents",
+    command: "commands",
+    context: "context",
+    hook: "hooks",
+    mcp: "mcps",
+    skill: "skills",
+    tool: "tools",
+  };
+  const folder = folderByType[objectType];
+  if (!folder) return "";
+  const opencodeIndex = parts.findIndex((part) => part === ".opencode");
+  const searchParts = opencodeIndex >= 0 ? parts.slice(opencodeIndex + 1) : parts;
+  const folderIndex = searchParts.findIndex((part) => part === folder);
+  if (folderIndex < 0 || folderIndex === searchParts.length - 1) return "";
+  const rest = searchParts.slice(folderIndex + 1);
+  if (rest[0] === namespace) return [".opencode", folder, ...rest].join("/");
+  return [".opencode", folder, namespace, ...rest].join("/");
+}
+
+function getPluginObjectInstallPath(object: CloudPluginConfigObject, namespace: string): string {
+  const existing = normalizePluginSourcePath(object.currentRelativePath ?? "", object.objectType, namespace);
+  if (existing) {
+    if (object.objectType === "skill") {
+      const parts = existing.split("/").filter(Boolean);
+      const lastPart = parts.at(-1) ?? "";
+      const skillName = /^SKILL\.md$/i.test(lastPart)
+        ? parts.at(-2) ?? slugifyConfigObjectName(object.title, object.id)
+        : lastPart || slugifyConfigObjectName(object.title, object.id);
+      return `.opencode/skills/${namespace}/${skillName}/SKILL.md`;
+    }
+    return existing;
+  }
+  const name = slugifyConfigObjectName(object.title, object.id);
+  switch (object.objectType) {
+    case "skill":
+      return `.opencode/skills/${namespace}/${name}/SKILL.md`;
+    case "agent":
+      return `.opencode/agents/${namespace}/${name}.md`;
+    case "command":
+      return `.opencode/commands/${namespace}/${name}.md`;
+    case "mcp":
+      return `.opencode/mcps/${namespace}/${name}.json`;
+    case "hook":
+      return `.opencode/hooks/${namespace}/${name}.json`;
+    case "tool":
+      return `.opencode/tools/${namespace}/${name}.ts`;
+    case "context":
+      return `.opencode/context/${namespace}/${name}.md`;
+    default:
+      return `.opencode/plugins/${namespace}/${name}.txt`;
+  }
+}
+
+function buildCloudSkillContent(name: string, description: string, body: string): string {
+  const safeDescription = description.replace(/\s+/g, " ").trim();
+  const normalizedBody = body.replace(/^\s*\n?/, "");
+  return [
+    "---",
+    `name: ${JSON.stringify(name)}`,
+    `description: ${JSON.stringify(safeDescription)}`,
+    "---",
+    "",
+    normalizedBody,
+  ].join("\n");
+}
+
+function pluginMcpName(rawName: string, namespace: string, fallback: string, namespaceName: boolean): string {
+  const trimmed = rawName.trim();
+  const base = OPENCODE_MCP_NAME_RE.test(trimmed) ? trimmed : slugifyConfigObjectName(trimmed || fallback, fallback);
+  if (!namespaceName) return base;
+  const namespaced = base.startsWith(`${namespace}-`) ? base : `${namespace}-${base}`;
+  return OPENCODE_MCP_NAME_RE.test(namespaced) ? namespaced : slugifyConfigObjectName(namespaced, fallback);
+}
+
+function mcpCommandFromConfig(config: Record<string, unknown>): string[] {
+  if (Array.isArray(config.command)) return readStringArray(config.command);
+  const command = readString(config.command);
+  if (!command) return [];
+  return [command, ...readStringArray(config.args)];
+}
+
+function normalizePluginMcpConfig(input: unknown): Record<string, unknown> | null {
+  if (!isRecord(input)) return null;
+  const enabled = typeof input.enabled === "boolean"
+    ? input.enabled
+    : typeof input.disabled === "boolean"
+      ? !input.disabled
+      : true;
+  const url = readString(input.url);
+  if (url) {
+    const config: Record<string, unknown> = { type: "remote", url, enabled };
+    const headers = readStringRecord(input.headers);
+    if (headers) config.headers = headers;
+    if (isRecord(input.oauth)) config.oauth = input.oauth;
+    if (input.oauth === true) config.oauth = {};
+    return config;
+  }
+
+  const command = mcpCommandFromConfig(input);
+  if (command.length > 0) {
+    const config: Record<string, unknown> = { type: "local", command, enabled };
+    const environment = readStringRecord(input.environment) ?? readStringRecord(input.env);
+    if (environment) config.environment = environment;
+    return config;
+  }
+
+  return null;
+}
+
+function pluginMcpConfigsFromPayload(object: CloudPluginConfigObject, namespace: string) {
+  const version = object.latestVersion;
+  const payload = version?.normalizedPayloadJson ?? parseJsonRecord(version?.rawSourceText ?? null);
+  if (!payload) return [];
+
+  const configs = new Map<string, { name: string; config: Record<string, unknown>; path: string }>();
+  const addConfig = (rawName: string, rawConfig: unknown, namespaceName: boolean) => {
+    const config = normalizePluginMcpConfig(rawConfig);
+    if (!config) return;
+    const name = pluginMcpName(rawName, namespace, object.id, namespaceName);
+    configs.set(name, {
+      name,
+      config,
+      path: `${OPENCODE_MCP_IMPORT_PATH_PREFIX}${name}`,
+    });
+  };
+
+  if (isRecord(payload.mcp)) {
+    for (const [name, config] of Object.entries(payload.mcp)) addConfig(name, config, false);
+  }
+  if (isRecord(payload.mcpServers)) {
+    for (const [name, config] of Object.entries(payload.mcpServers)) addConfig(name, config, false);
+  }
+  if (configs.size === 0) addConfig(object.title, payload, true);
+
+  return [...configs.values()];
+}
+
+function readCloudImports(config: Record<string, unknown>): WorkspaceCloudImports {
+  const root = isRecord(config.cloudImports) ? config.cloudImports : {};
+  const marketplaces = isRecord(root.marketplaces) ? Object.fromEntries(Object.entries(root.marketplaces).flatMap(([key, value]) => {
+    if (!isRecord(value)) return [];
+    const marketplaceId = readString(value.marketplaceId) ?? key.trim();
+    const name = readString(value.name) ?? marketplaceId;
+    if (!marketplaceId || !name) return [];
+    return [[marketplaceId, {
+      marketplaceId,
+      name,
+      updatedAt: readString(value.updatedAt),
+      pluginIds: readStringArray(value.pluginIds),
+      importedAt: typeof value.importedAt === "number" && Number.isFinite(value.importedAt) ? value.importedAt : null,
+    }]];
+  })) : {};
+  const plugins = isRecord(root.plugins) ? Object.fromEntries(Object.entries(root.plugins).flatMap(([key, value]) => {
+    if (!isRecord(value)) return [];
+    const pluginId = readString(value.pluginId) ?? key.trim();
+    const name = readString(value.name) ?? pluginId;
+    if (!pluginId || !name) return [];
+    const files = Array.isArray(value.files) ? value.files.flatMap((file) => {
+      if (!isRecord(file)) return [];
+      const configObjectId = readString(file.configObjectId);
+      const objectType = readString(file.objectType);
+      const title = readString(file.title) ?? configObjectId;
+      const path = readString(file.path);
+      if (!configObjectId || !objectType || !title || !path) return [];
+      return [{
+        configObjectId,
+        versionId: readString(file.versionId),
+        objectType,
+        title,
+        path,
+        updatedAt: readString(file.updatedAt),
+      }];
+    }) : [];
+    return [[pluginId, {
+      pluginId,
+      marketplaceId: readString(value.marketplaceId),
+      name,
+      description: readString(value.description),
+      updatedAt: readString(value.updatedAt),
+      files,
+      importedAt: typeof value.importedAt === "number" && Number.isFinite(value.importedAt) ? value.importedAt : null,
+    }]];
+  })) : {};
+  return {
+    skillHubs: isRecord(root.skillHubs) ? root.skillHubs : {},
+    skills: isRecord(root.skills) ? root.skills : {},
+    providers: isRecord(root.providers) ? root.providers : {},
+    marketplaces,
+    plugins,
+  };
+}
+
+function runtimeDbPath(config: ServerConfig): string {
+  const override = process.env.OPENWORK_RUNTIME_DB?.trim();
+  if (override) return resolve(override);
+  const configPath = config.configPath?.trim();
+  const configDir = configPath ? dirname(configPath) : resolve(homedir(), ".config", "openwork");
+  return resolve(configDir, "runtime.sqlite");
+}
+
+async function openCloudPluginDb(path: string): Promise<CloudPluginDb> {
+  await ensureDir(dirname(path));
+  if (typeof process.versions.bun === "string") {
+    const { Database } = await import("bun:sqlite");
+    const { drizzle } = await import("drizzle-orm/bun-sqlite");
+    const sqlite = new Database(path, { create: true });
+    sqlite.run("CREATE TABLE IF NOT EXISTS cloud_plugin_install_configs (workspace_id TEXT PRIMARY KEY NOT NULL, config_json TEXT NOT NULL, updated_at INTEGER NOT NULL)");
+    const db = drizzle(sqlite);
+    return {
+      get: (workspaceId) => db
+        .select()
+        .from(cloudPluginInstallConfigs)
+        .where(eq(cloudPluginInstallConfigs.workspaceId, workspaceId))
+        .get(),
+      upsert: ({ workspaceId, configJson, updatedAt }) => {
+        db
+          .insert(cloudPluginInstallConfigs)
+          .values({ workspaceId, configJson, updatedAt })
+          .onConflictDoUpdate({
+            target: cloudPluginInstallConfigs.workspaceId,
+            set: { configJson, updatedAt },
+          })
+          .run();
+      },
+    };
+  }
+  const { DatabaseSync } = await import("node:sqlite");
+  const sqlite = new DatabaseSync(path);
+  sqlite.exec("CREATE TABLE IF NOT EXISTS cloud_plugin_install_configs (workspace_id TEXT PRIMARY KEY NOT NULL, config_json TEXT NOT NULL, updated_at INTEGER NOT NULL)");
+  const get = sqlite.prepare("SELECT config_json AS configJson FROM cloud_plugin_install_configs WHERE workspace_id = ?");
+  const upsert = sqlite.prepare("INSERT INTO cloud_plugin_install_configs (workspace_id, config_json, updated_at) VALUES (?, ?, ?) ON CONFLICT(workspace_id) DO UPDATE SET config_json = excluded.config_json, updated_at = excluded.updated_at");
+  return {
+    get: (workspaceId) => {
+      const row = get.get(workspaceId);
+      if (!isRecord(row) || typeof row.configJson !== "string") return undefined;
+      return { configJson: row.configJson };
+    },
+    upsert: ({ workspaceId, configJson, updatedAt }) => {
+      upsert.run(workspaceId, configJson, updatedAt);
+    },
+  };
+}
+
+const dbByPath = new Map<string, Promise<CloudPluginDb>>();
+
+async function cloudPluginDb(config: ServerConfig): Promise<CloudPluginDb> {
+  const path = runtimeDbPath(config);
+  const existing = dbByPath.get(path);
+  if (existing) return existing;
+  const db = openCloudPluginDb(path);
+  dbByPath.set(path, db);
+  return db;
+}
+
+export async function readInstalledCloudPlugins(config: ServerConfig, workspaceId: string): Promise<WorkspaceCloudImports> {
+  const db = await cloudPluginDb(config);
+  const row = db.get(workspaceId);
+  if (!row) return readCloudImports({});
+  try {
+    return readCloudImports({ cloudImports: JSON.parse(row.configJson) });
+  } catch {
+    return readCloudImports({});
+  }
+}
+
+async function writeInstalledCloudPlugins(
+  config: ServerConfig,
+  workspaceId: string,
+  updater: (current: WorkspaceCloudImports) => WorkspaceCloudImports,
+): Promise<WorkspaceCloudImports> {
+  const db = await cloudPluginDb(config);
+  const next = updater(await readInstalledCloudPlugins(config, workspaceId));
+  db.upsert({ workspaceId, configJson: JSON.stringify(next), updatedAt: Date.now() });
+  return next;
+}
+
+function resolveWorkspaceInstallPath(workspaceRoot: string, relativePath: string): string {
+  const normalized = relativePath.trim().replace(/^\/+/, "");
+  const parts = normalized.split("/").filter(Boolean);
+  if (!normalized.startsWith(".opencode/") || parts.some((part) => part === "." || part === "..")) {
+    throw new ApiError(400, "invalid_cloud_plugin_path", `Invalid cloud plugin path: ${relativePath}`);
+  }
+  const root = resolve(workspaceRoot);
+  const candidate = resolve(root, normalized);
+  if (candidate !== root && !candidate.startsWith(`${root}/`)) {
+    throw new ApiError(400, "invalid_cloud_plugin_path", `Invalid cloud plugin path: ${relativePath}`);
+  }
+  return candidate;
+}
+
+async function writePluginWorkspaceFile(workspaceRoot: string, path: string, content: string): Promise<void> {
+  const absolutePath = resolveWorkspaceInstallPath(workspaceRoot, path);
+  await mkdir(dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, content.endsWith("\n") ? content : `${content}\n`, "utf8");
+}
+
+async function removePluginWorkspaceFile(workspaceRoot: string, path: string): Promise<void> {
+  if (!path.startsWith(".opencode/")) return;
+  const absolutePath = resolveWorkspaceInstallPath(workspaceRoot, path);
+  if (/^\.opencode\/skills\/[^/]+\/[^/]+\/SKILL\.md$/.test(path)) {
+    await rm(dirname(absolutePath), { recursive: true, force: true });
+    return;
+  }
+  await rm(absolutePath, { force: true });
+}
+
+function cloudPluginMcpNameFromPath(path: string): string | null {
+  if (!path.startsWith(OPENCODE_MCP_IMPORT_PATH_PREFIX)) return null;
+  const name = path.slice(OPENCODE_MCP_IMPORT_PATH_PREFIX.length).trim();
+  return OPENCODE_MCP_NAME_RE.test(name) ? name : null;
+}
+
+export async function installCloudPlugin(input: {
+  serverConfig: ServerConfig;
+  workspaceId: string;
+  workspaceRoot: string;
+  marketplaceId: string | null;
+  marketplace?: { id: string; name: string; updatedAt: string | null } | null;
+  resolved: CloudPluginResolved;
+}): Promise<CloudImportedPlugin> {
+  const namespace = pluginNamespace(input.resolved.plugin.name, input.resolved.plugin.id);
+  const cloudImports = await readInstalledCloudPlugins(input.serverConfig, input.workspaceId);
+  const existing = cloudImports.plugins[input.resolved.plugin.id];
+  const files: CloudImportedPluginFile[] = [];
+
+  for (const membership of input.resolved.memberships) {
+    const object = membership.configObject;
+    const version = object?.latestVersion ?? null;
+    if (!object || object.status !== "active") continue;
+
+    if (object.objectType === "mcp") {
+      const configs = pluginMcpConfigsFromPayload(object, namespace);
+      for (const config of configs) {
+        await addMcp(input.serverConfig, input.workspaceId, config.name, config.config);
+        files.push({
+          configObjectId: object.id,
+          versionId: version?.id ?? null,
+          objectType: object.objectType,
+          title: object.title,
+          path: config.path,
+          updatedAt: object.updatedAt,
+        });
+      }
+      continue;
+    }
+
+    if (version?.rawSourceText == null) continue;
+
+    const path = getPluginObjectInstallPath(object, namespace);
+    let content = version.rawSourceText;
+    if (object.objectType === "skill") {
+      const rawDesc = (object.description?.trim() || object.title).trim();
+      const description = rawDesc.slice(0, 1024) || object.title.slice(0, 1024) || "Skill";
+      const installName = path.match(/^\.opencode\/skills\/[^/]+\/([^/]+)\/SKILL\.md$/)?.[1] ?? slugifyConfigObjectName(object.title, object.id);
+      content = buildCloudSkillContent(installName, description, extractSkillBodyMarkdown(content));
+    }
+    await writePluginWorkspaceFile(input.workspaceRoot, path, content);
+    files.push({
+      configObjectId: object.id,
+      versionId: version.id,
+      objectType: object.objectType,
+      title: object.title,
+      path,
+      updatedAt: object.updatedAt,
+    });
+  }
+
+  const nextPaths = new Set(files.map((file) => file.path));
+  const removedMcpNames = (existing?.files ?? []).flatMap((file) => {
+    const name = file.objectType === "mcp" && !nextPaths.has(file.path) ? cloudPluginMcpNameFromPath(file.path) : null;
+    return name ? [name] : [];
+  });
+  await Promise.all(removedMcpNames.map((name) => removeMcp(input.serverConfig, input.workspaceId, name)));
+
+  const imported: CloudImportedPlugin = {
+    pluginId: input.resolved.plugin.id,
+    marketplaceId: input.marketplaceId,
+    name: input.resolved.plugin.name,
+    description: input.resolved.plugin.description,
+    updatedAt: input.resolved.plugin.updatedAt,
+    files,
+    importedAt: existing?.importedAt ?? Date.now(),
+  };
+
+  const nextPlugins = {
+    ...cloudImports.plugins,
+    [input.resolved.plugin.id]: imported,
+  };
+
+  let nextMarketplaces = cloudImports.marketplaces;
+  if (input.marketplaceId) {
+    const existingMarketplace = cloudImports.marketplaces[input.marketplaceId];
+    const pluginIds = new Set(existingMarketplace?.pluginIds ?? []);
+    pluginIds.add(input.resolved.plugin.id);
+    nextMarketplaces = {
+      ...cloudImports.marketplaces,
+      [input.marketplaceId]: {
+        marketplaceId: input.marketplaceId,
+        name: input.marketplace?.name ?? existingMarketplace?.name ?? input.marketplaceId,
+        updatedAt: input.marketplace?.updatedAt ?? existingMarketplace?.updatedAt ?? null,
+        pluginIds: [...pluginIds].sort(),
+        importedAt: existingMarketplace?.importedAt ?? Date.now(),
+      },
+    };
+  }
+
+  await writeInstalledCloudPlugins(input.serverConfig, input.workspaceId, (current) => ({
+    ...current,
+    marketplaces: nextMarketplaces,
+    plugins: nextPlugins,
+  }));
+
+  return imported;
+}
+
+export async function removeCloudPlugin(input: {
+  serverConfig: ServerConfig;
+  workspaceId: string;
+  workspaceRoot: string;
+  pluginId: string;
+}): Promise<CloudImportedPlugin> {
+  const cloudImports = await readInstalledCloudPlugins(input.serverConfig, input.workspaceId);
+  const imported = cloudImports.plugins[input.pluginId];
+  if (!imported) throw new ApiError(404, "cloud_plugin_not_installed", "Marketplace package is not installed in this workspace.");
+
+  await Promise.all(imported.files.map(async (file) => {
+    const mcpName = file.objectType === "mcp" ? cloudPluginMcpNameFromPath(file.path) : null;
+    if (mcpName) {
+      await removeMcp(input.serverConfig, input.workspaceId, mcpName);
+      return;
+    }
+    await removePluginWorkspaceFile(input.workspaceRoot, file.path);
+  }));
+
+  const nextPlugins = { ...cloudImports.plugins };
+  delete nextPlugins[input.pluginId];
+  const nextMarketplaces = Object.fromEntries(Object.entries(cloudImports.marketplaces).flatMap(([marketplaceId, marketplace]) => {
+    const pluginIds = marketplace.pluginIds.filter((id) => id !== input.pluginId);
+    if (pluginIds.length === 0) return [];
+    return [[marketplaceId, { ...marketplace, pluginIds }]];
+  }));
+
+  await writeInstalledCloudPlugins(input.serverConfig, input.workspaceId, (current) => ({
+    ...current,
+    marketplaces: nextMarketplaces,
+    plugins: nextPlugins,
+  }));
+
+  return imported;
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -31,6 +31,7 @@ import {
   readDesktopCloudSyncState,
   syncDesktopCloudResources,
 } from "./desktop-cloud-sync.js";
+import { installCloudPlugin, readCloudPluginResolved, readInstalledCloudPlugins, removeCloudPlugin } from "./cloud-plugins.js";
 import {
   applyMaterializedBlueprintSessions,
   normalizeBlueprintSessionTemplates,
@@ -2533,7 +2534,8 @@ function createRoutes(
         await readOpenworkConfig(workspace.path),
         await readOpenworkWorkspaceConfig(config, workspace.id),
       );
-      const next = syncDesktopCloudResources({ openwork, snapshot });
+      const cloudImports = await readInstalledCloudPlugins(config, workspace.id);
+      const next = syncDesktopCloudResources({ openwork: { ...openwork, cloudImports }, snapshot });
       await writeOpenworkWorkspaceConfig(config, workspace.id, () => next.openwork);
       await recordAudit(workspace.path, {
         id: shortId(),
@@ -2547,6 +2549,109 @@ function createRoutes(
       return next;
     });
     return jsonResponse({ changes: result.changes, state: result.state });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/cloud-plugins", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const cloudImports = await readInstalledCloudPlugins(config, workspace.id);
+    return jsonResponse({ marketplaces: cloudImports.marketplaces, plugins: cloudImports.plugins });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/cloud-plugins", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const resolved = readCloudPluginResolved(body.resolved);
+    const marketplace = body.marketplace && typeof body.marketplace === "object" && !Array.isArray(body.marketplace)
+      ? Object.fromEntries(Object.entries(body.marketplace))
+      : null;
+    const marketplaceId = typeof body.marketplaceId === "string" && body.marketplaceId.trim()
+      ? body.marketplaceId.trim()
+      : null;
+
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "cloud_plugins.install",
+      summary: `Install cloud plugin ${resolved.plugin.name}`,
+      paths: [openworkConfigPath(workspace.path), join(workspace.path, ".opencode")],
+    });
+
+    const imported = await installCloudPlugin({
+      serverConfig: config,
+      workspaceId: workspace.id,
+      workspaceRoot: workspace.path,
+      marketplaceId,
+      marketplace: marketplaceId
+        ? {
+            id: marketplaceId,
+            name: typeof marketplace?.name === "string" ? marketplace.name : marketplaceId,
+            updatedAt: typeof marketplace?.updatedAt === "string" ? marketplace.updatedAt : null,
+          }
+        : null,
+      resolved,
+    });
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "cloud_plugins.install",
+      target: openworkConfigPath(workspace.path),
+      summary: `Installed cloud plugin ${resolved.plugin.name}`,
+      timestamp: Date.now(),
+    });
+
+    for (const file of imported.files) {
+      emitReloadEvent(ctx.reloadEvents, workspace, file.objectType === "mcp" ? "mcp" : file.objectType === "skill" ? "skills" : file.objectType === "agent" ? "agents" : file.objectType === "command" ? "commands" : "config", {
+        type: file.objectType === "skill" || file.objectType === "agent" || file.objectType === "command" || file.objectType === "mcp" ? file.objectType : "config",
+        name: file.title,
+        action: "added",
+      });
+    }
+
+    return jsonResponse({ item: imported });
+  });
+
+  addRoute(routes, "DELETE", "/workspace/:id/cloud-plugins/:pluginId", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const pluginId = ctx.params.pluginId ?? "";
+
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "cloud_plugins.remove",
+      summary: `Remove cloud plugin ${pluginId}`,
+      paths: [openworkConfigPath(workspace.path), join(workspace.path, ".opencode")],
+    });
+
+    const removed = await removeCloudPlugin({
+      serverConfig: config,
+      workspaceId: workspace.id,
+      workspaceRoot: workspace.path,
+      pluginId,
+    });
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "cloud_plugins.remove",
+      target: openworkConfigPath(workspace.path),
+      summary: `Removed cloud plugin ${removed.name}`,
+      timestamp: Date.now(),
+    });
+
+    for (const file of removed.files) {
+      emitReloadEvent(ctx.reloadEvents, workspace, file.objectType === "mcp" ? "mcp" : file.objectType === "skill" ? "skills" : file.objectType === "agent" ? "agents" : file.objectType === "command" ? "commands" : "config", {
+        type: file.objectType === "skill" || file.objectType === "agent" || file.objectType === "command" || file.objectType === "mcp" ? file.objectType : "config",
+        name: file.title,
+        action: "removed",
+      });
+    }
+
+    return jsonResponse({ item: removed });
   });
 
   addRoute(routes, "GET", "/workspace/:id/authorized-folders", "client", async (ctx) => {


### PR DESCRIPTION
## Summary
- Add OpenWork server-managed cloud plugin install store in the runtime SQLite DB (`cloud_plugin_install_configs`).
- Add `/workspace/:id/cloud-plugins` read/install/remove endpoints and app client methods.
- Route marketplace install/remove through the server so installed plugin state comes from the OpenWork server DB, while projecting current OpenCode-compatible skill/MCP resources for runtime use.
- Fix Extensions aggregation so imported marketplace plugins display as one plugin row and suppress their underlying child skill rows.

## Verification
- `pnpm --filter openwork-server test src/cloud-plugins.test.ts` passed
- `pnpm --filter @openwork/app exec bun test scripts/extension-items.test.ts` passed
- `pnpm --filter openwork-server typecheck` passed
- `pnpm --filter @openwork/app typecheck` passed
- `pnpm --filter openwork-server build` passed
- `pnpm --filter @openwork/app build` passed

## Daytona Proof
Server sandbox:
- `bash .devcontainer/test-server-on-daytona.sh task/dev-followup` passed
- Seeded Acme Robotics demo org and Anthropic knowledge-work plugin marketplace

Electron sandbox:
- `bash .devcontainer/test-on-daytona.sh task/dev-followup --den-base-url https://3005-1klb6o55uh5cekqv.daytonaproxy01.net --den-api-base-url https://8788-mq2hwwx4k4flwfny.daytonaproxy01.net --record-video --recording-name cloud-plugin-server-db` passed

Validated by CDP:
- Marketplace showed seeded Anthropic plugins.
- Installed `productivity`; Marketplace list changed to `Installed`.
- Server DB endpoint returned installed plugin: `GET /workspace/ws_bb5b99dcc362/cloud-plugins` -> `productivity`, 11 files.
- Extensions page showed one `productivity` plugin row and no standalone `Task Management` child skill row.
- Runtime projection showed skills `memory-management`, `start`, `task-management` and plugin MCPs.
- Chat prompt triggered installed `task-management` skill and received a skill-specific answer.

Artifacts:
- Recording: https://8090-atef5higwg7arwbt.daytonaproxy01.net/recordings/cloud-plugin-server-db.mp4
- Screenshot: https://8090-atef5higwg7arwbt.daytonaproxy01.net/screenshots/daytona-screenshot-20260603-193819.png

Note: Daytona artifact URLs are sandbox preview URLs and may require active sandbox/session access.
