### PR TITLE
Restored .deb and .rpm packaging targets missed out from Tauri -> Electron migration

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -65,6 +65,11 @@ mac:
     - zip
 linux:
   icon: resources/icons/icon.png
+  desktop:
+    Name: OpenWork
+    Comment: Open-source alternative to Claude Cowork
+    Categories: Development;
+    StartupWMClass: openwork
   extraResources:
     - from: resources/sidecars
       to: sidecars
@@ -80,6 +85,8 @@ linux:
         - versions.json-x86_64-unknown-linux-gnu
   target:
     - AppImage
+    - deb
+    - rpm
     - tar.gz
 win:
   icon: resources/icons/icon.ico


### PR DESCRIPTION
## Summary
Restored .deb and .rpm Linux packaging targets that were present in the
Tauri build but not carried over when electron-builder.yml was written
for the Electron migration. Also added a linux.desktop metadata block
so both formats register correctly in system app launchers after install.

## Why
v0.11.207 shipped openwork-desktop-linux-amd64.deb and
openwork-desktop-linux-aarch64.rpm as release artifacts. The Electron
migration dropped both. Ubuntu/Debian and Fedora/RHEL users currently
have no native package format available and no system launcher entry
after installing the app. This restores what was there before.

## Issue
Closes #2084 

## Scope
apps/desktop/electron-builder.yml, linux block only.

Added deb and rpm to linux.target alongside the existing AppImage and
tar.gz entries.

Added linux.desktop block with Name, Comment, Categories, and
StartupWMClass so installed packages register in system app launchers
under the Development category.

## Out of scope
Windows and macOS packaging blocks are untouched. AUR packaging is a
separate workflow and is not affected. Snap and Flatpak targets are not
included. Updater feed configuration for the new formats is not handled
here and can follow separately if needed.

## Testing
### Ran
- git diff apps/desktop/electron-builder.yml to confirm only the linux
  block was modified and no other sections were touched
- COREPACK_ENABLE_PROJECT_SPEC=0 pnpm typecheck passes since this is a
  YAML config change with no TypeScript involved

### Result
- pass/fail: pass
- if fail, exact files/errors: N/A

## CI status
- pass: pending, awaiting CI run on this PR
- code-related failures: none expected since this is a pure build config
  change and the new targets build independently from existing ones
- external/env/auth blockers: none

## Manual verification
1. After CI builds Linux artifacts, confirm a .deb file appears in the
   release assets for amd64
2. Confirm an .rpm file appears in release assets for aarch64
3. Install the .deb on Ubuntu and confirm OpenWork appears in the system
   app launcher under the Development category with the correct name

## Evidence
Prior Tauri release confirming these formats were already shipped to
users before the migration:
https://github.com/different-ai/openwork/releases/tag/v0.11.207

No UI changes so no screenshot is applicable.

## Risk
Low. Two new build targets are added alongside AppImage and tar.gz which
remain unchanged. If deb or rpm builds fail in CI they fail independently
and do not affect the existing AppImage or tar.gz outputs.

## Rollback
Remove deb and rpm from linux.target and remove the linux.desktop block
in apps/desktop/electron-builder.yml. Each is a straightforward line
deletion with no downstream effects.