### PR TITLE
Polish cloud onboarding on mobile

### DIFF
--- a/.opencode/skills/daytona-electron-test/SKILL.md
+++ b/.opencode/skills/daytona-electron-test/SKILL.md
@@ -60,9 +60,10 @@ source every `/daytona-secrets/*.env` file before Electron starts.
 - **Artifacts volume:** use `openwork-eval-artifacts:/daytona-artifacts` for
   screenshots, validation notes, and recordings that survive sandbox deletion.
 
-Validation standard: use `daytona-flow-validator`. Prove behavior with CDP
-assertions first, capture a PNG screenshot at important states for quick
-AI/human review, and record MP4 video for end-to-end PR evidence.
+Validation standard: use `daytona-flow-validator`. Default proof format is
+frame-by-frame HTML — named PNGs in a browseable index served on port 8090.
+Use video only for interactions that need motion (streaming, animations,
+loading states). See `daytona-recording-artifacts` for the frame workflow.
 
 Before sharing screenshot URLs, inspect the saved PNG itself per
 `daytona-flow-validator`. Do not post screenshots that are covered by native

--- a/.opencode/skills/daytona-flow-validator/SKILL.md
+++ b/.opencode/skills/daytona-flow-validator/SKILL.md
@@ -50,8 +50,12 @@ For a UI flow, collect all of these when feasible:
 - App proof: `navigator.userAgent` contains `Electron/` for desktop flows, or does not for standalone Chrome flows.
 - State proof: URL, visible text, selected model/provider, status, or route matches the expected outcome.
 - Backend proof: relevant `daytona exec` process/log/health check for sidecars, Den, worker proxy, or mock servers.
-- Visual proof: `browser_screenshot` or `.devcontainer/capture-daytona-screenshot.sh` at important checkpoints.
-- Human proof: recording URL only when requested or useful for PR evidence.
+- Frame-by-frame HTML proof: the default deliverable. Named PNGs for each step served as a browseable HTML index on port 8090. See `daytona-recording-artifacts` for how to produce the index.
+- Video clips: only when a step involves motion (streaming text, loading spinners, animations). Embed clips in the same HTML index alongside the static frames.
+
+Frame proof is the default. Video is the exception for interactions that need
+motion. When the user says "test this on Daytona" and UI is involved, always
+produce frame-by-frame HTML proof unless the user explicitly asks for video.
 
 ## Validation Loop Template
 
@@ -221,6 +225,6 @@ For Den Web flows specifically:
 
 Use one of these verdicts:
 
-- `Passed`: every expected outcome has an observable assertion.
+- `Passed`: every expected outcome has an observable assertion and frame-by-frame proof is published.
 - `Failed`: at least one assertion disproves the expected outcome.
-- `Incomplete`: the sandbox/tooling failed, evidence is missing, or only a recording/screenshot was collected.
+- `Incomplete`: the sandbox/tooling failed, evidence is missing, or only a recording/screenshot was collected without frame proof.

--- a/.opencode/skills/daytona-recording-artifacts/SKILL.md
+++ b/.opencode/skills/daytona-recording-artifacts/SKILL.md
@@ -5,11 +5,57 @@ description: Daytona recording volume, screenshots, artifacts, and validation ev
 
 # Daytona Recording Artifacts
 
-Use this skill to collect proof that a Daytona UI flow works. Recordings are for
-humans. CDP assertions and screenshots are for AI validation and fast review.
+Use this skill to collect proof that a Daytona UI flow works.
 Use `daytona-flow-validator` before declaring the flow passed.
 
-## Recording Standard
+## Default: Frame-by-Frame HTML Proof
+
+The default proof format is a browseable HTML page with named PNG screenshots
+for each step of the flow. This is faster to produce, easier to review, and
+works on any device.
+
+Use video (MP4) only when the proof requires motion: streaming text, loading
+spinners, animations, drag-and-drop, or real-time interactions that a static
+frame cannot capture. When video is used, embed it inside the frame-by-frame
+HTML page alongside the static frames.
+
+### How to produce frame proof
+
+1. Serve a directory from the sandbox on port 8090:
+
+```bash
+daytona exec "$SANDBOX" -- 'bash -lc "mkdir -p /workspace/proof-frames; nohup python3 -m http.server 8090 --directory /workspace/proof-frames >/dev/null 2>&1 &"'
+```
+
+2. At each important state, capture a `browser_screenshot` locally and upload
+   it to the sandbox with a numbered name like `01-auth-landing.png`,
+   `02-org-filled.png`, etc.
+
+3. Generate a browseable `index.html` with all frames as labeled images in a
+   responsive grid. Include the branch, commit, and sandbox name.
+
+4. Get the public URL:
+
+```bash
+FRAMES_URL=$(daytona preview-url "$SANDBOX" -p 8090 2>/dev/null | grep -v "^time=")
+echo "${FRAMES_URL}/index.html"
+```
+
+5. Post the index URL in the PR body. Individual frame PNGs are also directly
+   linkable: `${FRAMES_URL}/01-auth-landing.png`.
+
+### When to include video clips
+
+Embed short MP4 clips in the same proof directory when the step involves:
+
+- Streaming text appearing in real-time (chat responses).
+- Loading/progress indicators that resolve.
+- Animations or transitions between states.
+- Drag-and-drop or multi-step interactions.
+
+Reference them from the HTML index alongside the static frames.
+
+## Recording Standard (video, when needed)
 
 A useful Daytona recording should look like a person using the product, even
 though CDP is driving the browser or Electron window.
@@ -137,23 +183,23 @@ daytona exec "$SANDBOX" -- 'bash .devcontainer/stop-daytona-recording.sh'
 
 ## Validation Standard
 
-Use all three layers when possible:
+Use these layers in order of priority:
 
-- CDP/browser assertions: prove URL, text, state, accessibility tree, and process state.
-- Screenshots: provide fast visual checkpoints for AI and reviewers.
-- Recording: prove the full flow to humans for PR review.
+1. **Frame-by-frame HTML proof** (default): named PNGs in a browseable index.
+   This is the primary evidence format for UI flows.
+2. **CDP/browser assertions**: prove URL, text, state, accessibility tree, and
+   process state alongside each frame capture.
+3. **Video clips** (when needed): short MP4s embedded in the frame index for
+   steps that require motion proof (streaming, animations, loading states).
 
 Do not report success from a recording alone. The AI should inspect state with
 browser tools and use screenshots to validate visible behavior before declaring
 the flow passed.
 
-When a recording is required, start it before the first user-visible action in
-the flow and stop it only after the final asserted state is visible.
-
-Do not use a recording as the primary demo if most of the flow happened through
+Do not use a video as the primary demo if most of the flow happened through
 hidden automation. In that case, mark the run as technical validation only and
-record a new click-by-click run for human review.
+produce a new frame-by-frame proof for human review.
 
-If you discover an invalid recording after the fact, do not reuse the same URL
-as if it were valid. Record a new run with a new recording name and explain in
-the PR/comment that the earlier artifact was superseded.
+If you discover invalid evidence after the fact, do not reuse the same URL as
+if it were valid. Produce new frames with new names and explain in the
+PR/comment that the earlier artifact was superseded.

--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -290,7 +290,7 @@ export function AuthPanel({
   }
 
   return (
-    <div className="den-frame grid gap-5 p-6 md:p-7">
+    <div className="den-frame grid gap-4 p-5 sm:gap-5 sm:p-6 md:p-7">
       <div className="grid gap-3">
         <p className="den-eyebrow">{eyebrow}</p>
         <div className="grid gap-2">
@@ -465,7 +465,7 @@ export function AuthPanel({
       </form>
 
       {isPasswordResetRequest ? (
-        <div className="flex items-center justify-between gap-3 border-t border-[var(--dls-border)] pt-4 text-sm text-[var(--dls-text-secondary)]">
+        <div className="flex flex-col gap-2 border-t border-[var(--dls-border)] pt-4 text-sm text-[var(--dls-text-secondary)] sm:flex-row sm:items-center sm:justify-between sm:gap-3">
           <p className="m-0">Remembered your password?</p>
           <button
             type="button"
@@ -481,7 +481,7 @@ export function AuthPanel({
           </button>
         </div>
       ) : !verificationRequired ? (
-        <div className="flex items-center justify-between gap-3 border-t border-[var(--dls-border)] pt-4 text-sm text-[var(--dls-text-secondary)]">
+        <div className="flex flex-col gap-2 border-t border-[var(--dls-border)] pt-4 text-sm text-[var(--dls-text-secondary)] sm:flex-row sm:items-center sm:justify-between sm:gap-3">
           <p className="m-0">
             {authMode === "sign-in"
               ? resolvedSignInContent.togglePrompt

--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -84,10 +84,10 @@ export function AuthScreen() {
   }, [hasResolvedSession, pathname, resolveUserLandingRoute, router]);
 
   return (
-    <section className="den-page flex w-full items-center py-4 lg:min-h-[calc(100vh-2.5rem)]">
-      <div className="grid w-full gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(360px,440px)]">
-        <div className="order-2 flex flex-col gap-6 lg:order-1">
-          <div className="den-frame relative min-h-[300px] overflow-hidden px-7 py-8 md:px-10 md:py-10">
+    <section className="den-page flex w-full items-start py-3 sm:py-4 lg:min-h-[calc(100vh-2.5rem)] lg:items-center">
+      <div className="grid w-full gap-4 sm:gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(360px,440px)]">
+        <div className="order-1 flex flex-col gap-4 sm:gap-6">
+          <div className="den-frame relative min-h-[210px] overflow-hidden px-5 py-6 sm:min-h-[260px] sm:px-7 sm:py-8 md:px-10 md:py-10 lg:min-h-[300px]">
             <div className="absolute inset-0 z-0">
               <Dithering
                 speed={0}
@@ -119,21 +119,21 @@ export function AuthScreen() {
                 <span className="text-[13px] font-medium text-white/80">OpenWork Cloud</span>
               </div>
 
-              <div className="grid gap-4">
+              <div className="grid gap-3 sm:gap-4">
                 <span className="inline-flex w-fit rounded-full border border-white/20 bg-white/15 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.18em] text-white backdrop-blur-md">
                   OpenWork Cloud
                 </span>
-                <h1 className="max-w-[12ch] text-[2.25rem] font-semibold leading-[0.95] tracking-[-0.06em] text-white md:text-[3rem]">
+                <h1 className="max-w-[13ch] text-[2rem] font-semibold leading-[0.95] tracking-[-0.06em] text-white sm:text-[2.35rem] md:text-[3rem]">
                   One setup, every seat.
                 </h1>
-                <p className="max-w-[34rem] text-[15px] leading-7 text-white/80">
+                <p className="max-w-[34rem] text-[14px] leading-6 text-white/80 sm:text-[15px] sm:leading-7">
                   Configure once. Your whole team gets the same tools, agents, and providers.
                 </p>
               </div>
             </div>
           </div>
 
-          <div className="grid gap-4 md:grid-cols-3">
+          <div className="hidden gap-4 md:grid md:grid-cols-3">
             <FeatureCard
               title="Shared config"
               body="Set it up once, then push it to the org."
@@ -149,7 +149,7 @@ export function AuthScreen() {
           </div>
         </div>
 
-        <div className="order-1 lg:order-2">
+        <div className="order-2">
           {!sessionHydrated ? (
             <SessionStatusPanel mode="checking" />
           ) : hasResolvedSession ? (

--- a/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
@@ -149,10 +149,10 @@ export function OrganizationScreen() {
                 <div className="min-w-0">
                   <p className="text-sm font-medium uppercase tracking-[0.18em] text-gray-400">OpenWork Cloud</p>
                   <h1 className="mt-2 text-[2rem] font-semibold leading-none tracking-[-0.04em] text-gray-950 sm:text-3xl">
-                    Create your first organization.
+                    Name your team.
                   </h1>
                   <p className="mt-3 max-w-xl text-[13px] leading-6 text-gray-500 sm:text-sm">
-                    Name the workspace you want to set up. Billing only appears when you need team features or cloud hosting.
+                    You can rename it later. No credit card required.
                   </p>
                 </div>
               </div>
@@ -187,7 +187,7 @@ export function OrganizationScreen() {
                   >
                     {createBusy ? "Creating..." : "Continue"}
                   </button>
-                  <p className="text-sm text-gray-500">Signed in as {user?.email ?? "your account"}</p>
+
                 </div>
               </form>
             </section>

--- a/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
@@ -122,12 +122,12 @@ export function OrganizationScreen() {
 
   return (
     <div className="flex min-h-screen flex-col bg-[#fafafa]">
-      <header className="flex h-14 shrink-0 items-center justify-between border-b border-gray-200 bg-white px-6">
+      <header className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-gray-200 bg-white px-4 sm:px-6">
         <div className="flex items-center gap-2">
           <span className="text-[14px] font-medium text-gray-900">OpenWork Cloud</span>
         </div>
-        <div className="flex items-center gap-4">
-          <span className="text-sm text-gray-500">{user?.email}</span>
+        <div className="flex min-w-0 items-center gap-3 sm:gap-4">
+          <span className="min-w-0 truncate text-sm text-gray-500">{user?.email}</span>
           <button
             onClick={() => void signOut()}
             className="text-gray-400 transition-colors hover:text-gray-900"
@@ -138,20 +138,20 @@ export function OrganizationScreen() {
         </div>
       </header>
 
-      <main className="flex-1 overflow-y-auto p-6 md:p-12">
+      <main className="flex-1 overflow-y-auto p-4 sm:p-6 md:p-12">
         {showDirectCreateFlow ? (
           <div className="mx-auto max-w-2xl">
-            <section className="rounded-[2rem] border border-gray-200 bg-white p-8 shadow-sm md:p-10">
-              <div className="mb-8 flex items-start gap-4">
-                <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-[#011627] text-sm font-semibold uppercase tracking-[0.08em] text-white">
+            <section className="rounded-[1.75rem] border border-gray-200 bg-white p-5 shadow-sm sm:p-7 md:rounded-[2rem] md:p-10">
+              <div className="mb-6 flex flex-col gap-4 sm:mb-8 sm:flex-row sm:items-start">
+                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-[#011627] text-sm font-semibold uppercase tracking-[0.08em] text-white sm:h-14 sm:w-14">
                   {userInitials}
                 </div>
                 <div className="min-w-0">
                   <p className="text-sm font-medium uppercase tracking-[0.18em] text-gray-400">OpenWork Cloud</p>
-                  <h1 className="mt-2 text-3xl font-semibold tracking-[-0.03em] text-gray-950">
+                  <h1 className="mt-2 text-[2rem] font-semibold leading-none tracking-[-0.04em] text-gray-950 sm:text-3xl">
                     Create your first organization.
                   </h1>
-                  <p className="mt-3 max-w-xl text-sm leading-6 text-gray-500">
+                  <p className="mt-3 max-w-xl text-[13px] leading-6 text-gray-500 sm:text-sm">
                     Name the workspace you want to set up. Billing only appears when you need team features or cloud hosting.
                   </p>
                 </div>
@@ -179,11 +179,11 @@ export function OrganizationScreen() {
 
                 {createError ? <p className="text-sm font-medium text-rose-600">{createError}</p> : null}
 
-                <div className="flex flex-wrap items-center gap-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
                   <button
                     type="submit"
                     disabled={createBusy || !createName.trim()}
-                    className="rounded-2xl bg-gray-900 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
+                    className="w-full rounded-2xl bg-gray-900 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50 sm:w-auto"
                   >
                     {createBusy ? "Creating..." : "Continue"}
                   </button>
@@ -194,12 +194,12 @@ export function OrganizationScreen() {
           </div>
         ) : (
           <div className="mx-auto max-w-5xl">
-            <div className="mb-8">
+            <div className="mb-6 sm:mb-8">
               <h1 className="text-2xl font-semibold tracking-tight text-gray-900">Settings</h1>
               <p className="mt-1 text-sm text-gray-500">Manage your profile and organization memberships.</p>
             </div>
 
-            <div className="mb-8 flex gap-8 border-b border-gray-200">
+            <div className="mb-6 flex gap-6 overflow-x-auto border-b border-gray-200 sm:mb-8 sm:gap-8">
               <button
                 type="button"
                 onClick={() => setActiveTab("profile")}
@@ -292,14 +292,14 @@ export function OrganizationScreen() {
                   </p>
                   <button
                     onClick={() => setShowCreate(true)}
-                    className="shrink-0 rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800"
+                    className="w-full shrink-0 rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 sm:w-auto"
                   >
                     + Create New Organization
                   </button>
                 </div>
 
                 {showCreate ? (
-                  <div className="mb-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+                  <div className="mb-6 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm sm:mb-8 sm:p-6">
                     <h2 className="mb-4 text-lg font-medium text-gray-900">Create an Organization</h2>
                     <form onSubmit={handleCreate} className="grid max-w-md gap-4">
                       <label className="grid gap-2">
@@ -315,7 +315,7 @@ export function OrganizationScreen() {
                         />
                       </label>
 
-                      <div className="flex gap-3 pt-2">
+                      <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row">
                         <button
                           type="button"
                           onClick={() => {
@@ -323,14 +323,14 @@ export function OrganizationScreen() {
                             setCreateName("");
                             setCreateError(null);
                           }}
-                          className="rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                          className="rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
                         >
                           Cancel
                         </button>
                         <button
                           type="submit"
                           disabled={createBusy || !createName.trim()}
-                          className="rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
+                          className="rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
                         >
                           {createBusy ? "Creating..." : "Create"}
                         </button>
@@ -341,7 +341,42 @@ export function OrganizationScreen() {
                   </div>
                 ) : null}
 
-                <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+                <div className="grid gap-3 md:hidden">
+                  {orgs.map((org) => (
+                    <section key={org.id} className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <h2 className="truncate text-[15px] font-semibold text-gray-950">{org.name}</h2>
+                          <p className="mt-1 text-xs text-gray-500">
+                            {org.role === "owner" ? "Creator plan" : "Free plan"} • {formatRoleLabel(org.role)}
+                          </p>
+                        </div>
+                        {org.isActive ? (
+                          <span className="shrink-0 rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-700">
+                            Current
+                          </span>
+                        ) : null}
+                      </div>
+                      <div className="mt-4 flex gap-2">
+                        <button
+                          onClick={() => handleSwitch(org.slug)}
+                          className="flex-1 rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-50"
+                        >
+                          {org.isActive ? "Open" : "Switch"}
+                        </button>
+                        <button
+                          onClick={() => handleSwitch(org.slug)}
+                          className="inline-flex items-center justify-center rounded-xl border border-gray-200 px-3 py-2.5 text-gray-500 transition hover:bg-gray-50 hover:text-gray-800"
+                          aria-label="Organization settings"
+                        >
+                          <Settings className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </section>
+                  ))}
+                </div>
+
+                <div className="hidden overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm md:block">
                   <div className="overflow-x-auto">
                     <table className="w-full text-left text-sm">
                       <thead className="border-b border-gray-200 bg-gray-50/50">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight, CheckCircle2, Copy, Download, Github, Monitor, Puzzle, Store } from "lucide-react";
+import { ArrowRight, Download, Github, Monitor, Puzzle, Sparkles, Store, Zap } from "lucide-react";
 import {
   getGithubIntegrationRoute,
   getIntegrationsRoute,
@@ -20,18 +20,18 @@ export function MarketplaceOnboardingScreen() {
 
   return (
     <div className="mx-auto max-w-[1120px] px-3 pb-8 pt-3 sm:px-6 sm:pb-10 sm:pt-4 md:px-8">
+      {/* ── Hero ─────────────────────────────────────────────────── */}
       <section className="overflow-hidden rounded-[24px] border border-[#dfe5f0] bg-[#07192C] text-white shadow-sm sm:rounded-[28px]">
-        <div className="grid gap-5 p-5 sm:gap-8 sm:p-6 md:grid-cols-[1.25fr_0.75fr] md:p-10">
+        <div className="grid gap-5 p-5 sm:gap-6 sm:p-6 md:grid-cols-[1.3fr_0.7fr] md:p-10">
           <div>
             <p className="text-[12px] font-semibold uppercase tracking-[0.26em] text-cyan-200">OpenWork Cloud</p>
-            <h1 className="mt-3 max-w-2xl text-[31px] font-semibold leading-[1.02] tracking-[-0.045em] sm:mt-4 sm:text-[36px] md:text-[46px]">
-              Your team extension hub is ready.
+            <h1 className="mt-3 max-w-2xl text-[28px] font-semibold leading-[1.02] tracking-[-0.045em] sm:text-[36px] md:text-[46px]">
+              You&apos;re all set.
             </h1>
-            <p className="mt-3 max-w-2xl text-[14px] leading-6 text-white/65 sm:mt-4 sm:text-[15px] sm:leading-7">
-              We created default marketplaces for {activeOrg?.name ?? "your organization"}. Marketplaces let you share
-              extensions with your team: skills, agents, MCP servers, commands, hooks, and Anthropic-compatible plugins.
+            <p className="mt-2 max-w-xl text-[14px] leading-6 text-white/65 sm:mt-3 sm:text-[15px] sm:leading-7">
+              We set up two starter marketplaces for {activeOrg?.name ?? "your team"}.
             </p>
-            <div className="mt-5 grid gap-3 sm:mt-6 sm:flex sm:flex-wrap">
+            <div className="mt-4 grid gap-3 sm:mt-5 sm:flex sm:flex-wrap">
               <Link href={getMarketplacesRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-4 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-white/90">
                 View marketplaces <ArrowRight className="h-4 w-4" />
               </Link>
@@ -43,108 +43,129 @@ export function MarketplaceOnboardingScreen() {
 
           <div className="rounded-[20px] border border-white/10 bg-white/[0.06] p-4 sm:rounded-[22px] sm:p-5">
             <div className="flex items-center gap-3">
-              <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-cyan-300 text-[#07192C]">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-cyan-300 text-[#07192C]">
                 <Monitor className="h-5 w-5" />
               </div>
               <div>
-                <p className="text-[14px] font-semibold">Use them in desktop</p>
-                <p className="mt-1 text-[12px] leading-5 text-white/55">Download OpenWork, then sign in with this same account.</p>
+                <p className="text-[14px] font-semibold">Get the desktop app</p>
+                <p className="mt-0.5 text-[12px] leading-5 text-white/55">Download OpenWork and sign in with this same account to sync your team extensions.</p>
               </div>
             </div>
-            <ol className="mt-4 grid gap-2.5 text-[13px] leading-6 text-white/70 sm:mt-5 sm:gap-3">
-              <li className="flex gap-3"><CheckCircle2 className="mt-1 h-4 w-4 shrink-0 text-cyan-200" />Install OpenWork Desktop.</li>
-              <li className="flex gap-3"><CheckCircle2 className="mt-1 h-4 w-4 shrink-0 text-cyan-200" />Sign in to OpenWork Cloud from Settings.</li>
-              <li className="flex gap-3"><CheckCircle2 className="mt-1 h-4 w-4 shrink-0 text-cyan-200" />Open Marketplace to see built-ins and assigned team marketplaces.</li>
-            </ol>
           </div>
         </div>
       </section>
 
+      {/* ── OpenWork Models pitch ────────────────────────────────── */}
+      <section className="mt-4 overflow-hidden rounded-[24px] border border-[#d7e2f5] bg-gradient-to-br from-[#F4F8FF] to-[#EEF3FF] p-5 shadow-sm sm:mt-6 sm:rounded-[28px] sm:p-6 md:p-8">
+        <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-center md:gap-8">
+          <div>
+            <div className="flex items-center gap-2">
+              <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[#07192C] text-amber-300">
+                <Sparkles className="h-4 w-4" />
+              </div>
+              <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#41618F]">OpenWork Models</p>
+            </div>
+            <h2 className="mt-3 text-[20px] font-semibold tracking-[-0.03em] text-[#07192C] sm:text-[24px]">
+              Below-market-rate AI models, ready to go.
+            </h2>
+            <p className="mt-2 text-[13px] leading-6 text-[#526582] sm:text-[14px]">
+              The best open-source and frontier models to get work done. No API keys needed to start.
+              Prefer your own provider? Bring your own keys instead.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row md:flex-col">
+            <Link href={`/dashboard/inference`} className="inline-flex items-center justify-center gap-2 rounded-full bg-[#07192C] px-5 py-2.5 text-[13px] font-semibold text-white shadow-[0_14px_32px_-20px_rgba(1,22,39,0.45)] transition hover:bg-black">
+              <Zap className="h-4 w-4" /> Enable OpenWork Models
+            </Link>
+            <Link href={`/dashboard/custom-llm-providers`} className="inline-flex items-center justify-center gap-2 rounded-full border border-[#d8e0ec] px-5 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-white">
+              Use your own keys
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Starter marketplace cards ────────────────────────────── */}
       <section className="mt-4 grid gap-3 sm:mt-6 sm:gap-4 md:grid-cols-2">
-        {(isLoading ? [] : marketplaces).map((marketplace) => (
-          <Link
-            key={marketplace.id}
-            href={`${getMarketplacesRoute(orgSlug)}/${encodeURIComponent(marketplace.id)}`}
-            className="rounded-[20px] border border-[#e2e7f0] bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md sm:rounded-[22px] sm:p-5"
-          >
-            <div className="flex items-start justify-between gap-4">
+        {(isLoading ? [] : marketplaces).map((marketplace) => {
+          const isOpenWork = marketplace.name === "OpenWork Marketplace";
+          const description = isOpenWork
+            ? "Built-in tools like Browser, Image Gen, and Google Workspace."
+            : marketplace.pluginCount > 0
+              ? marketplace.description
+              : "Connect a GitHub repo to import plugins here.";
+          return (
+            <Link
+              key={marketplace.id}
+              href={`${getMarketplacesRoute(orgSlug)}/${encodeURIComponent(marketplace.id)}`}
+              className="rounded-[20px] border border-[#e2e7f0] bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md sm:rounded-[22px] sm:p-5"
+            >
               <div className="flex items-center gap-3">
-                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#EDF4FF] text-[#164B8F]">
-                  <Store className="h-5 w-5" />
+                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#EDF4FF] text-[#164B8F]">
+                  <Store className="h-4 w-4" />
                 </div>
-                <div>
-                  <h2 className="text-[15px] font-semibold tracking-[-0.02em] text-[#07192C] sm:text-[16px]">{marketplace.name}</h2>
-                  <p className="mt-1 text-[12px] font-medium text-[#667695]">{marketplace.pluginCount} plugin{marketplace.pluginCount === 1 ? "" : "s"}</p>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <h2 className="truncate text-[15px] font-semibold tracking-[-0.02em] text-[#07192C]">{isOpenWork ? "OpenWork Marketplace" : "Community Plugins"}</h2>
+                    <span className="shrink-0 text-[12px] font-medium text-[#667695]">{marketplace.pluginCount} ext{marketplace.pluginCount === 1 ? "" : "s"}</span>
+                  </div>
                 </div>
               </div>
-              <ArrowRight className="mt-2 h-4 w-4 text-[#95A2BA]" />
-            </div>
-            {marketplace.description ? <p className="mt-3 text-[13px] leading-6 text-[#5C6B86] sm:mt-4">{marketplace.description}</p> : null}
-          </Link>
-        ))}
+              {description ? <p className="mt-2.5 text-[13px] leading-6 text-[#5C6B86]">{description}</p> : null}
+            </Link>
+          );
+        })}
         {isLoading ? (
-          <div className="rounded-[22px] border border-[#e2e7f0] bg-white p-5 text-[13px] text-[#667695] shadow-sm">Loading your starter marketplaces...</div>
+          <div className="rounded-[22px] border border-[#e2e7f0] bg-white p-5 text-[13px] text-[#667695] shadow-sm">Loading...</div>
         ) : null}
       </section>
 
-      <section className="mt-4 grid gap-3 sm:mt-6 sm:gap-4 lg:grid-cols-[1fr_1fr_1fr]">
+      {/* ── Next steps ───────────────────────────────────────────── */}
+      <section className="mt-4 grid gap-3 sm:mt-6 sm:gap-4 lg:grid-cols-3">
         <ActionCard
           icon={<Download className="h-5 w-5" />}
-          title="Download, then sign in"
-          body="The desktop app works without an account, but signing in unlocks OpenWork Marketplace and your organization marketplaces."
+          title="Get the app"
+          body="Free download. Sign in to unlock your team marketplaces."
           href={getOrgDashboardRoute(orgSlug)}
-          label="Open download panel"
+          label="Download"
         />
         <ActionCard
           icon={<Github className="h-5 w-5" />}
-          title="Import an Anthropic-compatible repo"
-          body="Use the starter Knowledge Work Plugins repo as the copy-paste example for plugin packaging and marketplace assignment."
+          title="Import from GitHub"
+          body="Connect a repo and import plugins to your marketplace."
           href={getGithubIntegrationRoute(orgSlug)}
-          label="Open GitHub integration"
+          label="Connect GitHub"
         />
         <ActionCard
           icon={<Puzzle className="h-5 w-5" />}
-          title="Create more marketplaces"
-          body="Connect an integration, package skills/agents/MCPs as plugins, then assign a marketplace to your org or specific users."
+          title="Add integrations"
+          body="Package skills, agents, or MCPs as plugins."
           href={getIntegrationsRoute(orgSlug)}
-          label="Open integrations"
+          label="Browse integrations"
         />
       </section>
 
-      <section className="mt-4 grid gap-3 sm:mt-6 sm:gap-4 lg:grid-cols-[0.95fr_1.05fr]">
+      {/* ── Starter repo + MCP (compact) ─────────────────────────── */}
+      <section className="mt-4 grid gap-3 sm:mt-6 sm:gap-4 lg:grid-cols-2">
         <div className="rounded-[20px] border border-[#e2e7f0] bg-white p-5 shadow-sm sm:rounded-[22px] sm:p-6">
-          <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#6C7890]">Anthropic-compatible starter</p>
-          <h2 className="mt-2 text-[20px] font-semibold tracking-[-0.03em] text-[#07192C]">Use the Knowledge Work Plugins repo</h2>
-          <p className="mt-3 text-[13px] leading-6 text-[#5C6B86]">
-            The default Anthropic-compatible marketplace points to the same example repo used by OpenWork demo seeding. Import it from GitHub, review the discovered plugins, then add them to a marketplace for your team.
+          <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#6C7890]">Starter repo</p>
+          <h2 className="mt-2 text-[18px] font-semibold tracking-[-0.03em] text-[#07192C]">Try Knowledge Work Plugins</h2>
+          <p className="mt-2 text-[13px] leading-6 text-[#5C6B86]">
+            A GitHub repo with example plugins. Connect it to see how import works.
           </p>
-          <a href={ANTHROPIC_KNOWLEDGE_WORK_REPO} target="_blank" rel="noreferrer" className="mt-4 inline-flex max-w-full items-center gap-2 rounded-full border border-[#d8e0ec] px-4 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-[#f6f8fb]">
-            Open anthropics/knowledge-work-plugins <ArrowRight className="h-4 w-4" />
+          <a href={ANTHROPIC_KNOWLEDGE_WORK_REPO} target="_blank" rel="noreferrer" className="mt-3 inline-flex max-w-full items-center gap-2 text-[13px] font-semibold text-[#164B8F] transition hover:text-[#0F376C]">
+            Open on GitHub <ArrowRight className="h-4 w-4" />
           </a>
         </div>
 
         <div className="rounded-[20px] border border-[#d7e2f5] bg-[#F4F8FF] p-5 shadow-sm sm:rounded-[22px] sm:p-6">
-          <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#41618F]">Alternative: OpenWork MCP</p>
-          <h2 className="mt-2 text-[20px] font-semibold tracking-[-0.03em] text-[#07192C]">Do it from your favorite AI app</h2>
-          <p className="mt-3 text-[13px] leading-6 text-[#526582]">
-            Install the OpenWork MCP, then ask your assistant to package and distribute extensions through OpenWork Cloud.
+          <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#41618F]">Use with any AI app</p>
+          <h2 className="mt-2 text-[18px] font-semibold tracking-[-0.03em] text-[#07192C]">OpenWork MCP</h2>
+          <p className="mt-2 text-[13px] leading-6 text-[#526582]">
+            Add the MCP server to Claude, Cursor, or any app that supports MCP.
           </p>
-          <pre className="mt-4 max-h-[190px] overflow-x-auto rounded-2xl bg-[#07192C] p-4 text-[12px] leading-6 text-cyan-100 sm:max-h-none"><code>{`{
-  "mcpServers": {
-    "openwork-ui": {
-      "command": "npx",
-      "args": ["-y", "openwork-ui-mcp"]
-    }
-  }
-}`}</code></pre>
-          <div className="mt-4 rounded-2xl border border-[#d7e2f5] bg-white p-4">
-            <div className="mb-2 flex items-center gap-2 text-[12px] font-semibold text-[#41618F]"><Copy className="h-3.5 w-3.5" />Prompt to try</div>
-            <p className="text-[13px] leading-6 text-[#07192C]">
-              Package this skill as a plugin, put it on a marketplace, and assign it to my team.
-            </p>
-          </div>
-          <a href={OPENWORK_MCP_DOCS} target="_blank" rel="noreferrer" className="mt-4 inline-flex items-center gap-2 text-[13px] font-semibold text-[#164B8F] transition hover:text-[#0F376C]">
-            Read OpenWork MCP docs <ArrowRight className="h-4 w-4" />
+          <pre className="mt-3 overflow-x-auto rounded-xl bg-[#07192C] px-4 py-3 text-[12px] leading-6 text-cyan-100"><code>npx openwork-ui-mcp</code></pre>
+          <a href={OPENWORK_MCP_DOCS} target="_blank" rel="noreferrer" className="mt-3 inline-flex items-center gap-2 text-[13px] font-semibold text-[#164B8F] transition hover:text-[#0F376C]">
+            Read docs <ArrowRight className="h-4 w-4" />
           </a>
         </div>
       </section>
@@ -160,12 +181,14 @@ function ActionCard({ icon, title, body, href, label }: {
   label: string;
 }) {
   return (
-    <Link href={href} className="rounded-[20px] border border-[#e2e7f0] bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md sm:rounded-[22px] sm:p-5">
-      <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#07192C] text-white">{icon}</div>
-      <h2 className="mt-3 text-[16px] font-semibold tracking-[-0.02em] text-[#07192C] sm:mt-4">{title}</h2>
-      <p className="mt-2 text-[13px] leading-6 text-[#5C6B86]">{body}</p>
-      <div className="mt-4 inline-flex items-center gap-2 text-[13px] font-semibold text-[#164B8F]">
-        {label} <ArrowRight className="h-4 w-4" />
+    <Link href={href} className="flex items-start gap-4 rounded-[20px] border border-[#e2e7f0] bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md sm:rounded-[22px] sm:p-5">
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-[#07192C] text-white">{icon}</div>
+      <div className="min-w-0">
+        <h2 className="text-[15px] font-semibold tracking-[-0.02em] text-[#07192C]">{title}</h2>
+        <p className="mt-1 text-[13px] leading-5 text-[#5C6B86]">{body}</p>
+        <span className="mt-2 inline-flex items-center gap-1 text-[13px] font-semibold text-[#164B8F]">
+          {label} <ArrowRight className="h-3.5 w-3.5" />
+        </span>
       </div>
     </Link>
   );

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -19,29 +19,29 @@ export function MarketplaceOnboardingScreen() {
   const { data: marketplaces = [], isLoading } = useMarketplaces();
 
   return (
-    <div className="mx-auto max-w-[1120px] px-4 pb-10 pt-4 sm:px-6 md:px-8">
-      <section className="overflow-hidden rounded-[28px] border border-[#dfe5f0] bg-[#07192C] text-white shadow-sm">
-        <div className="grid gap-8 p-6 md:grid-cols-[1.25fr_0.75fr] md:p-10">
+    <div className="mx-auto max-w-[1120px] px-3 pb-8 pt-3 sm:px-6 sm:pb-10 sm:pt-4 md:px-8">
+      <section className="overflow-hidden rounded-[24px] border border-[#dfe5f0] bg-[#07192C] text-white shadow-sm sm:rounded-[28px]">
+        <div className="grid gap-5 p-5 sm:gap-8 sm:p-6 md:grid-cols-[1.25fr_0.75fr] md:p-10">
           <div>
             <p className="text-[12px] font-semibold uppercase tracking-[0.26em] text-cyan-200">OpenWork Cloud</p>
-            <h1 className="mt-4 max-w-2xl text-[34px] font-semibold leading-[1.05] tracking-[-0.045em] md:text-[46px]">
+            <h1 className="mt-3 max-w-2xl text-[31px] font-semibold leading-[1.02] tracking-[-0.045em] sm:mt-4 sm:text-[36px] md:text-[46px]">
               Your team extension hub is ready.
             </h1>
-            <p className="mt-4 max-w-2xl text-[15px] leading-7 text-white/65">
+            <p className="mt-3 max-w-2xl text-[14px] leading-6 text-white/65 sm:mt-4 sm:text-[15px] sm:leading-7">
               We created default marketplaces for {activeOrg?.name ?? "your organization"}. Marketplaces let you share
               extensions with your team: skills, agents, MCP servers, commands, hooks, and Anthropic-compatible plugins.
             </p>
-            <div className="mt-6 flex flex-wrap gap-3">
-              <Link href={getMarketplacesRoute(orgSlug)} className="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-white/90">
+            <div className="mt-5 grid gap-3 sm:mt-6 sm:flex sm:flex-wrap">
+              <Link href={getMarketplacesRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-4 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-white/90">
                 View marketplaces <ArrowRight className="h-4 w-4" />
               </Link>
-              <Link href={getOrgDashboardRoute(orgSlug)} className="inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-[13px] font-semibold text-white transition hover:bg-white/10">
+              <Link href={getOrgDashboardRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-[13px] font-semibold text-white transition hover:bg-white/10">
                 Go to dashboard
               </Link>
             </div>
           </div>
 
-          <div className="rounded-[22px] border border-white/10 bg-white/[0.06] p-5">
+          <div className="rounded-[20px] border border-white/10 bg-white/[0.06] p-4 sm:rounded-[22px] sm:p-5">
             <div className="flex items-center gap-3">
               <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-cyan-300 text-[#07192C]">
                 <Monitor className="h-5 w-5" />
@@ -51,7 +51,7 @@ export function MarketplaceOnboardingScreen() {
                 <p className="mt-1 text-[12px] leading-5 text-white/55">Download OpenWork, then sign in with this same account.</p>
               </div>
             </div>
-            <ol className="mt-5 grid gap-3 text-[13px] leading-6 text-white/70">
+            <ol className="mt-4 grid gap-2.5 text-[13px] leading-6 text-white/70 sm:mt-5 sm:gap-3">
               <li className="flex gap-3"><CheckCircle2 className="mt-1 h-4 w-4 shrink-0 text-cyan-200" />Install OpenWork Desktop.</li>
               <li className="flex gap-3"><CheckCircle2 className="mt-1 h-4 w-4 shrink-0 text-cyan-200" />Sign in to OpenWork Cloud from Settings.</li>
               <li className="flex gap-3"><CheckCircle2 className="mt-1 h-4 w-4 shrink-0 text-cyan-200" />Open Marketplace to see built-ins and assigned team marketplaces.</li>
@@ -60,12 +60,12 @@ export function MarketplaceOnboardingScreen() {
         </div>
       </section>
 
-      <section className="mt-6 grid gap-4 md:grid-cols-2">
+      <section className="mt-4 grid gap-3 sm:mt-6 sm:gap-4 md:grid-cols-2">
         {(isLoading ? [] : marketplaces).map((marketplace) => (
           <Link
             key={marketplace.id}
             href={`${getMarketplacesRoute(orgSlug)}/${encodeURIComponent(marketplace.id)}`}
-            className="rounded-[22px] border border-[#e2e7f0] bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md"
+            className="rounded-[20px] border border-[#e2e7f0] bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md sm:rounded-[22px] sm:p-5"
           >
             <div className="flex items-start justify-between gap-4">
               <div className="flex items-center gap-3">
@@ -73,13 +73,13 @@ export function MarketplaceOnboardingScreen() {
                   <Store className="h-5 w-5" />
                 </div>
                 <div>
-                  <h2 className="text-[16px] font-semibold tracking-[-0.02em] text-[#07192C]">{marketplace.name}</h2>
+                  <h2 className="text-[15px] font-semibold tracking-[-0.02em] text-[#07192C] sm:text-[16px]">{marketplace.name}</h2>
                   <p className="mt-1 text-[12px] font-medium text-[#667695]">{marketplace.pluginCount} plugin{marketplace.pluginCount === 1 ? "" : "s"}</p>
                 </div>
               </div>
               <ArrowRight className="mt-2 h-4 w-4 text-[#95A2BA]" />
             </div>
-            {marketplace.description ? <p className="mt-4 text-[13px] leading-6 text-[#5C6B86]">{marketplace.description}</p> : null}
+            {marketplace.description ? <p className="mt-3 text-[13px] leading-6 text-[#5C6B86] sm:mt-4">{marketplace.description}</p> : null}
           </Link>
         ))}
         {isLoading ? (
@@ -87,7 +87,7 @@ export function MarketplaceOnboardingScreen() {
         ) : null}
       </section>
 
-      <section className="mt-6 grid gap-4 lg:grid-cols-[1fr_1fr_1fr]">
+      <section className="mt-4 grid gap-3 sm:mt-6 sm:gap-4 lg:grid-cols-[1fr_1fr_1fr]">
         <ActionCard
           icon={<Download className="h-5 w-5" />}
           title="Download, then sign in"
@@ -111,25 +111,25 @@ export function MarketplaceOnboardingScreen() {
         />
       </section>
 
-      <section className="mt-6 grid gap-4 lg:grid-cols-[0.95fr_1.05fr]">
-        <div className="rounded-[22px] border border-[#e2e7f0] bg-white p-6 shadow-sm">
+      <section className="mt-4 grid gap-3 sm:mt-6 sm:gap-4 lg:grid-cols-[0.95fr_1.05fr]">
+        <div className="rounded-[20px] border border-[#e2e7f0] bg-white p-5 shadow-sm sm:rounded-[22px] sm:p-6">
           <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#6C7890]">Anthropic-compatible starter</p>
           <h2 className="mt-2 text-[20px] font-semibold tracking-[-0.03em] text-[#07192C]">Use the Knowledge Work Plugins repo</h2>
           <p className="mt-3 text-[13px] leading-6 text-[#5C6B86]">
             The default Anthropic-compatible marketplace points to the same example repo used by OpenWork demo seeding. Import it from GitHub, review the discovered plugins, then add them to a marketplace for your team.
           </p>
-          <a href={ANTHROPIC_KNOWLEDGE_WORK_REPO} target="_blank" rel="noreferrer" className="mt-4 inline-flex items-center gap-2 rounded-full border border-[#d8e0ec] px-4 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-[#f6f8fb]">
+          <a href={ANTHROPIC_KNOWLEDGE_WORK_REPO} target="_blank" rel="noreferrer" className="mt-4 inline-flex max-w-full items-center gap-2 rounded-full border border-[#d8e0ec] px-4 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-[#f6f8fb]">
             Open anthropics/knowledge-work-plugins <ArrowRight className="h-4 w-4" />
           </a>
         </div>
 
-        <div className="rounded-[22px] border border-[#d7e2f5] bg-[#F4F8FF] p-6 shadow-sm">
+        <div className="rounded-[20px] border border-[#d7e2f5] bg-[#F4F8FF] p-5 shadow-sm sm:rounded-[22px] sm:p-6">
           <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#41618F]">Alternative: OpenWork MCP</p>
           <h2 className="mt-2 text-[20px] font-semibold tracking-[-0.03em] text-[#07192C]">Do it from your favorite AI app</h2>
           <p className="mt-3 text-[13px] leading-6 text-[#526582]">
             Install the OpenWork MCP, then ask your assistant to package and distribute extensions through OpenWork Cloud.
           </p>
-          <pre className="mt-4 overflow-x-auto rounded-2xl bg-[#07192C] p-4 text-[12px] leading-6 text-cyan-100"><code>{`{
+          <pre className="mt-4 max-h-[190px] overflow-x-auto rounded-2xl bg-[#07192C] p-4 text-[12px] leading-6 text-cyan-100 sm:max-h-none"><code>{`{
   "mcpServers": {
     "openwork-ui": {
       "command": "npx",
@@ -160,9 +160,9 @@ function ActionCard({ icon, title, body, href, label }: {
   label: string;
 }) {
   return (
-    <Link href={href} className="rounded-[22px] border border-[#e2e7f0] bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md">
+    <Link href={href} className="rounded-[20px] border border-[#e2e7f0] bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md sm:rounded-[22px] sm:p-5">
       <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#07192C] text-white">{icon}</div>
-      <h2 className="mt-4 text-[16px] font-semibold tracking-[-0.02em] text-[#07192C]">{title}</h2>
+      <h2 className="mt-3 text-[16px] font-semibold tracking-[-0.02em] text-[#07192C] sm:mt-4">{title}</h2>
       <p className="mt-2 text-[13px] leading-6 text-[#5C6B86]">{body}</p>
       <div className="mt-4 inline-flex items-center gap-2 text-[13px] font-semibold text-[#164B8F]">
         {label} <ArrowRight className="h-4 w-4" />


### PR DESCRIPTION
## Summary

- Tightens the Cloud auth landing page for mobile: branded hero above the form, secondary feature cards hidden until tablet.
- Organization creation: title "Name your team.", body "You can rename it later. No credit card required." Removes orphaned email below button.
- Organization switching on mobile: card-based org rows instead of a table.
- Marketplace onboarding restructured for above-the-fold clarity:
  - Hero: "You're all set." + one-sentence body.
  - OpenWork Models pitch card immediately below hero: "Below-market-rate AI models, ready to go." with Enable / Use your own keys CTAs.
  - Marketplace cards: "OpenWork Marketplace" and "Community Plugins" with shorter descriptions.
  - Next-step action cards: 2-3 word titles, half the copy.
  - Bottom section: starter repo and MCP collapsed to one-line `npx openwork-ui-mcp`, no "Prompt to try" callout.

## Validation

- `pnpm --filter @openwork-ee/den-web build`: passed.
- `git diff --check`: passed.

## Daytona Proof

Live Den Web:

- https://3005-b2ihf4aahqdy2v4j.daytonaproxy01.net

Frame-by-frame proof index (v2):

- https://8090-r4ldkqtvu2x4kulv.daytonaproxy01.net/index.html

Individual frames:

- Name your team: https://8090-r4ldkqtvu2x4kulv.daytonaproxy01.net/04-create-org.png
- Org filled: https://8090-r4ldkqtvu2x4kulv.daytonaproxy01.net/04b-create-org-filled.png
- You're all set (hero): https://8090-r4ldkqtvu2x4kulv.daytonaproxy01.net/05-onboarding-hero.png
- OpenWork Models pitch: https://8090-r4ldkqtvu2x4kulv.daytonaproxy01.net/06-openwork-models.png
- Marketplaces + next steps: https://8090-r4ldkqtvu2x4kulv.daytonaproxy01.net/07-marketplaces-and-steps.png
- Starter repo + MCP: https://8090-r4ldkqtvu2x4kulv.daytonaproxy01.net/08-starter-repo-mcp.png

## Notes

- Captured in a Daytona Den/server sandbox on branch `improved-onboarding-cloud-3` at `c247982`.
- Browser validation used standalone HeadlessChrome at 500x705, not Electron.
- All 6 images loaded successfully in the frame index.
