### PR TITLE
fix: allow switching Google Workspace default account

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1009,6 +1009,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     googleWorkspaceConnectStart: () => requestJson<GoogleWorkspaceConnectStart>(baseUrl, "/experimental/google-workspace/connect/start", { token, hostToken, method: "POST", timeoutMs: timeouts.status }),
     googleWorkspaceConnectStatus: (flowId: string) => requestJson<GoogleWorkspaceConnectStatus>(baseUrl, `/experimental/google-workspace/connect/status/${encodeURIComponent(flowId)}`, { token, hostToken, timeoutMs: timeouts.status }),
     googleWorkspaceDisconnect: (accountId?: string | null) => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/disconnect", { token, hostToken, method: "POST", body: accountId ? { accountId } : {}, timeoutMs: timeouts.status }),
+    googleWorkspaceSetActiveAccount: (accountId: string) => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/active-account", { token, hostToken, method: "POST", body: { accountId }, timeoutMs: timeouts.status }),
     googleWorkspaceTestConnection: () => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/test", { token, hostToken, method: "POST", timeoutMs: 60_000 }),
     googleWorkspaceRunScopeSmokeTest: () => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/smoke-test", { token, hostToken, method: "POST", timeoutMs: 120_000 }),
     callExtensionAction: (payload: OpenworkExtensionActionCall) =>

--- a/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
+++ b/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
@@ -18,7 +18,7 @@ import { usePlatform } from "../../kernel/platform";
 import type { ExtensionConfigContext } from "./extension-registry";
 import { registerExtensionRuntime } from "./extension-registry";
 
-type BusyAction = "status" | "connect" | "disconnect" | "test" | "smoke-test" | "save-secret";
+type BusyAction = "status" | "connect" | "disconnect" | "set-active" | "test" | "smoke-test" | "save-secret";
 type GoogleWorkspaceCommand = () => Promise<unknown>;
 const DESKTOP_ACTION_TIMEOUT_MS = 6 * 60 * 1000;
 const CONNECT_POLL_INTERVAL_MS = 1_000;
@@ -310,9 +310,21 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
                   <div className="truncate text-sm font-medium text-card-foreground">{account.email ?? account.name ?? "Google account"}</div>
                   <div className="text-xs text-muted-foreground">{account.accountId === status?.activeAccountId ? "Default for extension actions" : "Connected"}</div>
                 </div>
-                <Button variant="destructive" size="sm" disabled={Boolean(busyAction)} onClick={() => void runDesktopAction("disconnect", () => openworkServerClient?.googleWorkspaceDisconnect(account.accountId) ?? Promise.resolve(null))}>
-                  Disconnect
-                </Button>
+                <div className="flex flex-wrap gap-2">
+                  {account.accountId && account.accountId !== status?.activeAccountId ? (
+                    <Button variant="outline" size="sm" disabled={Boolean(busyAction)} onClick={() => {
+                      const accountId = account.accountId;
+                      if (!accountId) return;
+                      void runDesktopAction("set-active", () => openworkServerClient?.googleWorkspaceSetActiveAccount(accountId) ?? Promise.resolve(null));
+                    }}>
+                      {busyAction === "set-active" ? <Loader2 className="size-4 animate-spin" /> : null}
+                      Make default
+                    </Button>
+                  ) : null}
+                  <Button variant="destructive" size="sm" disabled={Boolean(busyAction)} onClick={() => void runDesktopAction("disconnect", () => openworkServerClient?.googleWorkspaceDisconnect(account.accountId) ?? Promise.resolve(null))}>
+                    Disconnect
+                  </Button>
+                </div>
               </div>
             ))}
           </CardContent>

--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import type { ServerConfig } from "../types.js";
-import { googleWorkspaceDisconnect, googleWorkspaceStatus } from "./google-workspace.js";
+import { googleWorkspaceDisconnect, googleWorkspaceSetActiveAccount, googleWorkspaceStatus } from "./google-workspace.js";
 
 function createTestConfig(): ServerConfig {
   const tempDir = join(
@@ -119,6 +119,23 @@ describe("Google Workspace extension", () => {
     const status = await googleWorkspaceDisconnect(config, "sub-one");
     expect(status.connected).toBe(true);
     expect(status.accounts.map((account) => account.email)).toEqual(["two@example.com"]);
+    expect(status.activeAccountId).toBe("sub-two");
+  });
+
+  test("can update the active account", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one"), accountRecord("two@example.com", "sub-two")],
+    });
+
+    const status = await googleWorkspaceSetActiveAccount(config, "sub-two");
+    expect(status.account?.email).toBe("two@example.com");
+    expect(status.accounts.map((account) => account.email)).toEqual(["one@example.com", "two@example.com"]);
     expect(status.activeAccountId).toBe("sub-two");
   });
 });

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -595,6 +595,16 @@ export async function googleWorkspaceRunScopeSmokeTest(config: ServerConfig) {
   });
 }
 
+export async function googleWorkspaceSetActiveAccount(config: ServerConfig, accountId: string) {
+  const vault = await readGoogleWorkspaceVault(config);
+  const accounts = googleWorkspaceAccountRecords(vault);
+  const account = accounts.find((entry) => googleWorkspaceAccountId(entry) === accountId);
+  if (!account) throw new ApiError(404, "google_workspace_account_not_found", "Google Workspace account is not connected.");
+  await writeGoogleWorkspaceAccountsVault(config, accounts, accountId);
+  const nextVault = await readGoogleWorkspaceVault(config);
+  return googleWorkspaceStatusPayload(nextVault, { testStatus: "Default Google Workspace account updated." });
+}
+
 export async function googleWorkspaceDisconnect(config: ServerConfig, accountId: string | null = null) {
   const vault = await readGoogleWorkspaceVault(config);
   const accounts = googleWorkspaceAccountRecords(vault);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -63,6 +63,7 @@ import {
   createGoogleWorkspaceConnectFlowManager,
   googleWorkspaceDisconnect,
   googleWorkspaceRunScopeSmokeTest,
+  googleWorkspaceSetActiveAccount,
   googleWorkspaceStatus,
   googleWorkspaceTestConnection,
 } from "./extensions/google-workspace.js";
@@ -2075,6 +2076,14 @@ function createRoutes(
     const body = await readOptionalJsonBody(ctx.request);
     const accountId = typeof body.accountId === "string" && body.accountId.trim() ? body.accountId.trim() : null;
     return jsonResponse(await googleWorkspaceDisconnect(config, accountId));
+  });
+
+  addRoute(routes, "POST", "/experimental/google-workspace/active-account", "client", async (ctx) => {
+    if (ctx.actor?.scope === "viewer") throw new ApiError(403, "forbidden", "Viewer tokens cannot update Google Workspace settings");
+    const body = await readJsonBody(ctx.request);
+    const accountId = typeof body.accountId === "string" && body.accountId.trim() ? body.accountId.trim() : "";
+    if (!accountId) throw new ApiError(400, "invalid_payload", "accountId is required");
+    return jsonResponse(await googleWorkspaceSetActiveAccount(config, accountId));
   });
 
   addRoute(routes, "POST", "/experimental/google-workspace/test", "client", async () => {


### PR DESCRIPTION
## Summary
- Add a Google Workspace active-account endpoint for connected accounts
- Add a "Make default" action in the Google Workspace extension details UI
- Preserve existing disconnect and multi-account behavior

## Validation
- `pnpm --filter openwork-server test src/extensions/google-workspace.test.ts` - passed
- `pnpm --filter openwork-server typecheck` - passed
- `pnpm --filter @openwork/app typecheck` - passed
- Daytona Electron E2E on `google-multi-user-workkase` - passed: seeded two dev Google accounts, opened Settings -> Extensions -> Google Workspace, switched default from `benjamin.shafii@gmail.com` to `ben@openworklabs.com`, asserted UI showed `ben@openworklabs.com` as "Default for extension actions`, and verified `/experimental/google-workspace/status` returned `activeAccountId: openworklabs-sub`.

## Evidence
- Daytona recording: https://8090-altbwkwqkzghkhbf.daytonaproxy01.net/recordings/google-workspace-active-account.mp4
- Daytona screenshot captured: `/daytona-artifacts/screenshots/daytona-screenshot-20260604-193035.png`
