### PR TITLE
fix: mobile sidebar drawer, above-fold onboarding

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-overview-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-overview-screen.tsx
@@ -2,12 +2,15 @@
 
 import { useEffect, useState } from "react";
 import {
+  ArrowRight,
   ChevronRight,
   Download,
   Gauge,
   Monitor,
   Users,
 } from "lucide-react";
+import Link from "next/link";
+import { getMarketplacesRoute } from "../../_lib/den-org";
 import { useQuery } from "@tanstack/react-query";
 import { requestJson } from "../../_lib/den-flow";
 import { useDenFlow } from "../../_providers/den-flow-provider";
@@ -221,8 +224,21 @@ export function DashboardOverviewScreen() {
         Run locally for free. Keep data on your machine and move to shared workflows when ready.
       </p>
 
+      {/* Extensions banner */}
+      <section className="mt-5 rounded-[18px] border border-[#d7e2f5] bg-gradient-to-br from-[#F4F8FF] to-[#EEF3FF] p-5">
+        <h2 className="text-[16px] font-semibold tracking-[-0.02em] text-[#07192C]">Download the app to unlock extensions</h2>
+        <p className="mt-1.5 text-[13px] leading-6 text-[#526582]">
+          Sign in with this account to get Computer Use, Browser, Image Gen, Google Workspace, and your team&apos;s marketplace extensions — all built in.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Link href={getMarketplacesRoute(activeOrg?.slug ?? "")} className="inline-flex items-center gap-1.5 rounded-full border border-[#d8e0ec] bg-white px-3.5 py-1.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-gray-50">
+            View all extensions <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
+        </div>
+      </section>
+
       {/* Download OpenWork */}
-      <section className="mt-5 overflow-hidden rounded-[18px] border border-[#e3e7ee] bg-[#07192C]">
+      <section className="mt-4 overflow-hidden rounded-[18px] border border-[#e3e7ee] bg-[#07192C]">
         <div className="px-6 py-5">
           <div className="flex items-center gap-2.5">
             <Download className="h-5 w-5 text-white/80" />

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { ArrowRight, Download, Github, Monitor, Puzzle, Sparkles, Store, Zap } from "lucide-react";
 import {
   getGithubIntegrationRoute,
@@ -14,57 +15,203 @@ import { useMarketplaces } from "./marketplace-data";
 const ANTHROPIC_KNOWLEDGE_WORK_REPO = "https://github.com/anthropics/knowledge-work-plugins";
 const OPENWORK_MCP_DOCS = "https://github.com/different-ai/openwork/blob/dev/docs/mcp-ui-control-profile.md";
 
+type OnboardingStep = 0 | 1 | 2;
+
+function StepDots({ current, total }: { current: number; total: number }) {
+  return (
+    <div className="flex items-center justify-center gap-2">
+      {Array.from({ length: total }, (_, i) => (
+        <div
+          key={i}
+          className={`h-1.5 rounded-full transition-all ${
+            i === current ? "w-6 bg-white" : "w-1.5 bg-white/30"
+          }`}
+        />
+      ))}
+    </div>
+  );
+}
+
+function StepDotsLight({ current, total }: { current: number; total: number }) {
+  return (
+    <div className="flex items-center justify-center gap-2">
+      {Array.from({ length: total }, (_, i) => (
+        <div
+          key={i}
+          className={`h-1.5 rounded-full transition-all ${
+            i === current ? "w-6 bg-[#07192C]" : "w-1.5 bg-gray-300"
+          }`}
+        />
+      ))}
+    </div>
+  );
+}
+
 export function MarketplaceOnboardingScreen() {
   const { activeOrg, orgSlug } = useOrgDashboard();
   const { data: marketplaces = [], isLoading } = useMarketplaces();
+  const [step, setStep] = useState<OnboardingStep>(0);
+
+  const orgName = activeOrg?.name ?? "Your team";
 
   return (
     <div className="mx-auto max-w-[1120px] px-3 pb-8 pt-3 sm:px-6 sm:pb-10 sm:pt-4 md:px-8">
 
-      {/* ── Mobile: single-screen onboarding ──────────────────────── */}
-      <div className="flex min-h-[calc(100dvh-3.5rem)] flex-col sm:hidden">
-        <section className="flex-1 overflow-hidden rounded-[24px] border border-[#dfe5f0] bg-[#07192C] text-white shadow-sm">
-          <div className="flex h-full flex-col justify-between p-5">
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.26em] text-cyan-200">OpenWork Cloud</p>
-              <h1 className="mt-2 text-[28px] font-semibold leading-[0.98] tracking-[-0.045em]">
-                You&apos;re all set.
-              </h1>
-              <p className="mt-2 text-[14px] leading-6 text-white/60">
-                2 starter marketplaces are ready for {activeOrg?.name ?? "your team"}.
-              </p>
-            </div>
-
-            <div className="mt-4 rounded-[18px] border border-white/10 bg-white/[0.06] p-4">
-              <div className="flex items-center gap-2.5">
-                <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-300/90 text-[#07192C]">
-                  <Sparkles className="h-4 w-4" />
+      {/* ── Mobile: stepped onboarding ────────────────────────────── */}
+      <div className="sm:hidden">
+        {step === 0 ? (
+          <div className="flex min-h-[calc(100dvh-3.5rem)] flex-col">
+            <section className="flex flex-1 flex-col overflow-hidden rounded-[24px] bg-[#07192C] text-white shadow-sm">
+              <div className="flex flex-1 flex-col justify-between p-5">
+                <div>
+                  <StepDots current={0} total={3} />
+                  <h1 className="mt-5 text-[28px] font-semibold leading-[0.98] tracking-[-0.05em]">
+                    You&apos;re all set.
+                  </h1>
+                  <p className="mt-2 text-[14px] leading-6 text-white/60">
+                    {orgName} is ready. We set up two starter marketplaces for your team.
+                  </p>
                 </div>
-                <p className="text-[13px] font-semibold">OpenWork Models</p>
-              </div>
-              <p className="mt-2 text-[13px] leading-5 text-white/55">
-                Below-market-rate AI. No keys needed to start, or bring your own.
-              </p>
-              <div className="mt-3 flex gap-2">
-                <Link href="/dashboard/inference" className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-full bg-white px-3 py-2 text-[12px] font-semibold text-[#07192C]">
-                  <Zap className="h-3.5 w-3.5" /> Enable
-                </Link>
-                <Link href="/dashboard/custom-llm-providers" className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-full border border-white/20 px-3 py-2 text-[12px] font-semibold text-white">
-                  Own keys
-                </Link>
-              </div>
-            </div>
 
-            <div className="mt-4 grid gap-2">
-              <Link href={getMarketplacesRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-4 py-2.5 text-[13px] font-semibold text-[#07192C]">
-                View marketplaces <ArrowRight className="h-4 w-4" />
-              </Link>
-              <Link href={getOrgDashboardRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-[13px] font-semibold text-white">
-                Go to dashboard
-              </Link>
-            </div>
+                <div className="mt-5 rounded-[18px] border border-white/10 bg-white/[0.06] p-4">
+                  <div className="flex items-center gap-2.5">
+                    <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-300/90 text-[#07192C]">
+                      <Sparkles className="h-4 w-4" />
+                    </div>
+                    <p className="text-[13px] font-semibold">OpenWork Models</p>
+                  </div>
+                  <p className="mt-2 text-[13px] leading-5 text-white/55">
+                    Below-market-rate AI. No API keys needed to start, or bring your own.
+                  </p>
+                  <div className="mt-3 flex gap-2">
+                    <Link href="/dashboard/inference" className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-full bg-white px-3 py-2 text-[12px] font-semibold text-[#07192C]">
+                      <Zap className="h-3.5 w-3.5" /> Enable
+                    </Link>
+                    <Link href="/dashboard/custom-llm-providers" className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-full border border-white/20 px-3 py-2 text-[12px] font-semibold text-white">
+                      Own keys
+                    </Link>
+                  </div>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => setStep(1)}
+                  className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/15 px-4 py-3 text-[14px] font-semibold text-white transition hover:bg-white/10"
+                >
+                  Next <ArrowRight className="h-4 w-4" />
+                </button>
+              </div>
+            </section>
           </div>
-        </section>
+        ) : step === 1 ? (
+          <div className="flex min-h-[calc(100dvh-3.5rem)] flex-col">
+            <section className="flex flex-1 flex-col overflow-hidden rounded-[24px] border border-[#d7e2f5] bg-gradient-to-br from-[#F4F8FF] to-[#EEF3FF] shadow-sm">
+              <div className="flex flex-1 flex-col justify-between p-5">
+                <div>
+                  <StepDotsLight current={1} total={3} />
+                  <h1 className="mt-5 text-[28px] font-semibold leading-[0.98] tracking-[-0.05em] text-[#07192C]">
+                    Download the app.
+                  </h1>
+                  <p className="mt-2 text-[14px] leading-6 text-[#526582]">
+                    Sign in with this account to unlock built-in extensions.
+                  </p>
+                </div>
+
+                <div className="mt-5 space-y-3">
+                  {[
+                    { icon: Monitor, name: "Computer Use", desc: "Control Mac apps with AI" },
+                    { icon: Monitor, name: "Browser", desc: "Automate the built-in browser" },
+                    { icon: Monitor, name: "Image Gen", desc: "Generate images with GPT" },
+                    { icon: Monitor, name: "Google Workspace", desc: "Calendar, Drive, Gmail" },
+                  ].map((ext) => (
+                    <div key={ext.name} className="flex items-center gap-3 rounded-2xl bg-white/80 px-4 py-3">
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#07192C] text-white">
+                        <ext.icon className="h-4 w-4" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-[14px] font-semibold text-[#07192C]">{ext.name}</p>
+                        <p className="text-[12px] text-[#526582]">{ext.desc}</p>
+                      </div>
+                    </div>
+                  ))}
+                  <p className="px-1 text-[12px] text-[#526582]">
+                    Plus your team&apos;s marketplace extensions.
+                  </p>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => setStep(2)}
+                  className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-full bg-[#07192C] px-4 py-3 text-[14px] font-semibold text-white shadow-[0_14px_32px_-20px_rgba(1,22,39,0.45)]"
+                >
+                  Next <ArrowRight className="h-4 w-4" />
+                </button>
+              </div>
+            </section>
+          </div>
+        ) : (
+          <div className="flex min-h-[calc(100dvh-3.5rem)] flex-col">
+            <section className="flex flex-1 flex-col overflow-hidden rounded-[24px] border border-gray-200 bg-white shadow-sm">
+              <div className="flex flex-1 flex-col justify-between p-5">
+                <div>
+                  <StepDotsLight current={2} total={3} />
+                  <h1 className="mt-5 text-[28px] font-semibold leading-[0.98] tracking-[-0.05em] text-[#07192C]">
+                    Create your own.
+                  </h1>
+                  <p className="mt-2 text-[14px] leading-6 text-[#526582]">
+                    Import plugins from a GitHub repo and share them with your team through a marketplace.
+                  </p>
+                </div>
+
+                <div className="mt-5 space-y-3">
+                  <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
+                    <div className="flex items-center gap-2.5">
+                      <Github className="h-5 w-5 text-[#07192C]" />
+                      <p className="text-[14px] font-semibold text-[#07192C]">Try the starter repo</p>
+                    </div>
+                    <p className="mt-2 text-[13px] leading-5 text-[#526582]">
+                      Fork <span className="font-medium text-[#07192C]">anthropics/knowledge-work-plugins</span>, connect your GitHub, and import the example plugins.
+                    </p>
+                    <a
+                      href={ANTHROPIC_KNOWLEDGE_WORK_REPO}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="mt-3 inline-flex items-center gap-1.5 text-[13px] font-semibold text-[#164B8F]"
+                    >
+                      Open on GitHub <ArrowRight className="h-3.5 w-3.5" />
+                    </a>
+                  </div>
+
+                  <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
+                    <div className="flex items-center gap-2.5">
+                      <Puzzle className="h-5 w-5 text-[#07192C]" />
+                      <p className="text-[14px] font-semibold text-[#07192C]">Or use the MCP</p>
+                    </div>
+                    <p className="mt-2 text-[13px] leading-5 text-[#526582]">
+                      Ask any AI app to package and distribute plugins through OpenWork.
+                    </p>
+                    <pre className="mt-2 rounded-lg bg-[#07192C] px-3 py-2 text-[11px] text-cyan-100"><code>npx openwork-ui-mcp</code></pre>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-2">
+                  <Link
+                    href={getGithubIntegrationRoute(orgSlug)}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-[#07192C] px-4 py-3 text-[14px] font-semibold text-white shadow-[0_14px_32px_-20px_rgba(1,22,39,0.45)]"
+                  >
+                    Connect GitHub <ArrowRight className="h-4 w-4" />
+                  </Link>
+                  <Link
+                    href={getOrgDashboardRoute(orgSlug)}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-gray-200 px-4 py-3 text-[14px] font-semibold text-gray-700"
+                  >
+                    Go to dashboard
+                  </Link>
+                </div>
+              </div>
+            </section>
+          </div>
+        )}
       </div>
 
       {/* ── Desktop/tablet: full onboarding layout ────────────────── */}
@@ -78,7 +225,7 @@ export function MarketplaceOnboardingScreen() {
                 You&apos;re all set.
               </h1>
               <p className="mt-3 max-w-xl text-[15px] leading-7 text-white/65">
-                We set up two starter marketplaces for {activeOrg?.name ?? "your team"}.
+                We set up two starter marketplaces for {orgName}.
               </p>
               <div className="mt-5 flex flex-wrap gap-3">
                 <Link href={getMarketplacesRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-4 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-white/90">
@@ -97,7 +244,7 @@ export function MarketplaceOnboardingScreen() {
                 </div>
                 <div>
                   <p className="text-[14px] font-semibold">Get the desktop app</p>
-                  <p className="mt-0.5 text-[12px] leading-5 text-white/55">Download OpenWork and sign in with this same account to sync your team extensions.</p>
+                  <p className="mt-0.5 text-[12px] leading-5 text-white/55">Sign in to unlock Computer Use, Browser, Image Gen, Google Workspace, and your team&apos;s extensions.</p>
                 </div>
               </div>
             </div>
@@ -138,7 +285,7 @@ export function MarketplaceOnboardingScreen() {
           {(isLoading ? [] : marketplaces).map((marketplace) => {
             const isOpenWork = marketplace.name === "OpenWork Marketplace";
             const description = isOpenWork
-              ? "Built-in tools like Browser, Image Gen, and Google Workspace."
+              ? "Built-in tools like Computer Use, Browser, Image Gen, and Google Workspace."
               : marketplace.pluginCount > 0
                 ? marketplace.description
                 : "Connect a GitHub repo to import plugins here.";
@@ -180,7 +327,7 @@ export function MarketplaceOnboardingScreen() {
           <ActionCard
             icon={<Github className="h-5 w-5" />}
             title="Import from GitHub"
-            body="Connect a repo and import plugins to your marketplace."
+            body="Fork the starter repo and import plugins to your marketplace."
             href={getGithubIntegrationRoute(orgSlug)}
             label="Connect GitHub"
           />
@@ -199,7 +346,7 @@ export function MarketplaceOnboardingScreen() {
             <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#6C7890]">Starter repo</p>
             <h2 className="mt-2 text-[18px] font-semibold tracking-[-0.03em] text-[#07192C]">Try Knowledge Work Plugins</h2>
             <p className="mt-2 text-[13px] leading-6 text-[#5C6B86]">
-              A GitHub repo with example plugins. Connect it to see how import works.
+              A GitHub repo with example plugins. Fork it and connect to see how import works.
             </p>
             <a href={ANTHROPIC_KNOWLEDGE_WORK_REPO} target="_blank" rel="noreferrer" className="mt-3 inline-flex max-w-full items-center gap-2 text-[13px] font-semibold text-[#164B8F] transition hover:text-[#0F376C]">
               Open on GitHub <ArrowRight className="h-4 w-4" />

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -41,7 +41,7 @@ export function MarketplaceOnboardingScreen() {
             </div>
           </div>
 
-          <div className="rounded-[20px] border border-white/10 bg-white/[0.06] p-4 sm:rounded-[22px] sm:p-5">
+          <div className="hidden rounded-[20px] border border-white/10 bg-white/[0.06] p-4 sm:block sm:rounded-[22px] sm:p-5">
             <div className="flex items-center gap-3">
               <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-cyan-300 text-[#07192C]">
                 <Monitor className="h-5 w-5" />
@@ -56,29 +56,29 @@ export function MarketplaceOnboardingScreen() {
       </section>
 
       {/* ── OpenWork Models pitch ────────────────────────────────── */}
-      <section className="mt-4 overflow-hidden rounded-[24px] border border-[#d7e2f5] bg-gradient-to-br from-[#F4F8FF] to-[#EEF3FF] p-5 shadow-sm sm:mt-6 sm:rounded-[28px] sm:p-6 md:p-8">
-        <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-center md:gap-8">
+      <section className="mt-3 overflow-hidden rounded-[20px] border border-[#d7e2f5] bg-gradient-to-br from-[#F4F8FF] to-[#EEF3FF] p-4 shadow-sm sm:mt-6 sm:rounded-[28px] sm:p-6 md:p-8">
+        <div className="grid gap-3 md:grid-cols-[1fr_auto] md:items-center md:gap-8">
           <div>
             <div className="flex items-center gap-2">
-              <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[#07192C] text-amber-300">
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#07192C] text-amber-300 sm:h-9 sm:w-9 sm:rounded-xl">
                 <Sparkles className="h-4 w-4" />
               </div>
-              <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#41618F]">OpenWork Models</p>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#41618F] sm:text-[12px]">OpenWork Models</p>
             </div>
-            <h2 className="mt-3 text-[20px] font-semibold tracking-[-0.03em] text-[#07192C] sm:text-[24px]">
+            <h2 className="mt-2 text-[18px] font-semibold tracking-[-0.03em] text-[#07192C] sm:mt-3 sm:text-[24px]">
               Below-market-rate AI models, ready to go.
             </h2>
-            <p className="mt-2 text-[13px] leading-6 text-[#526582] sm:text-[14px]">
+            <p className="mt-1.5 text-[13px] leading-5 text-[#526582] sm:mt-2 sm:leading-6 sm:text-[14px]">
               The best open-source and frontier models to get work done. No API keys needed to start.
               Prefer your own provider? Bring your own keys instead.
             </p>
           </div>
-          <div className="flex flex-col gap-2 sm:flex-row md:flex-col">
-            <Link href={`/dashboard/inference`} className="inline-flex items-center justify-center gap-2 rounded-full bg-[#07192C] px-5 py-2.5 text-[13px] font-semibold text-white shadow-[0_14px_32px_-20px_rgba(1,22,39,0.45)] transition hover:bg-black">
-              <Zap className="h-4 w-4" /> Enable OpenWork Models
+          <div className="flex gap-2 sm:flex-row md:flex-col">
+            <Link href={`/dashboard/inference`} className="inline-flex flex-1 items-center justify-center gap-2 rounded-full bg-[#07192C] px-4 py-2 text-[13px] font-semibold text-white shadow-[0_14px_32px_-20px_rgba(1,22,39,0.45)] transition hover:bg-black sm:px-5 sm:py-2.5 md:flex-none">
+              <Zap className="h-4 w-4" /> Enable models
             </Link>
-            <Link href={`/dashboard/custom-llm-providers`} className="inline-flex items-center justify-center gap-2 rounded-full border border-[#d8e0ec] px-5 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-white">
-              Use your own keys
+            <Link href={`/dashboard/custom-llm-providers`} className="inline-flex flex-1 items-center justify-center gap-2 rounded-full border border-[#d8e0ec] px-4 py-2 text-[13px] font-semibold text-[#07192C] transition hover:bg-white sm:px-5 sm:py-2.5 md:flex-none">
+              Own keys
             </Link>
           </div>
         </div>
@@ -144,8 +144,8 @@ export function MarketplaceOnboardingScreen() {
         />
       </section>
 
-      {/* ── Starter repo + MCP (compact) ─────────────────────────── */}
-      <section className="mt-4 grid gap-3 sm:mt-6 sm:gap-4 lg:grid-cols-2">
+      {/* ── Starter repo + MCP (compact, hidden on mobile) ────────── */}
+      <section className="mt-4 hidden gap-3 sm:mt-6 sm:grid sm:gap-4 lg:grid-cols-2">
         <div className="rounded-[20px] border border-[#e2e7f0] bg-white p-5 shadow-sm sm:rounded-[22px] sm:p-6">
           <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#6C7890]">Starter repo</p>
           <h2 className="mt-2 text-[18px] font-semibold tracking-[-0.03em] text-[#07192C]">Try Knowledge Work Plugins</h2>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -20,155 +20,204 @@ export function MarketplaceOnboardingScreen() {
 
   return (
     <div className="mx-auto max-w-[1120px] px-3 pb-8 pt-3 sm:px-6 sm:pb-10 sm:pt-4 md:px-8">
-      {/* ── Hero ─────────────────────────────────────────────────── */}
-      <section className="overflow-hidden rounded-[24px] border border-[#dfe5f0] bg-[#07192C] text-white shadow-sm sm:rounded-[28px]">
-        <div className="grid gap-5 p-5 sm:gap-6 sm:p-6 md:grid-cols-[1.3fr_0.7fr] md:p-10">
-          <div>
-            <p className="text-[12px] font-semibold uppercase tracking-[0.26em] text-cyan-200">OpenWork Cloud</p>
-            <h1 className="mt-3 max-w-2xl text-[28px] font-semibold leading-[1.02] tracking-[-0.045em] sm:text-[36px] md:text-[46px]">
-              You&apos;re all set.
-            </h1>
-            <p className="mt-2 max-w-xl text-[14px] leading-6 text-white/65 sm:mt-3 sm:text-[15px] sm:leading-7">
-              We set up two starter marketplaces for {activeOrg?.name ?? "your team"}.
-            </p>
-            <div className="mt-4 grid gap-3 sm:mt-5 sm:flex sm:flex-wrap">
-              <Link href={getMarketplacesRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-4 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-white/90">
+
+      {/* ── Mobile: single-screen onboarding ──────────────────────── */}
+      <div className="flex min-h-[calc(100dvh-3.5rem)] flex-col sm:hidden">
+        <section className="flex-1 overflow-hidden rounded-[24px] border border-[#dfe5f0] bg-[#07192C] text-white shadow-sm">
+          <div className="flex h-full flex-col justify-between p-5">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.26em] text-cyan-200">OpenWork Cloud</p>
+              <h1 className="mt-2 text-[28px] font-semibold leading-[0.98] tracking-[-0.045em]">
+                You&apos;re all set.
+              </h1>
+              <p className="mt-2 text-[14px] leading-6 text-white/60">
+                2 starter marketplaces are ready for {activeOrg?.name ?? "your team"}.
+              </p>
+            </div>
+
+            <div className="mt-4 rounded-[18px] border border-white/10 bg-white/[0.06] p-4">
+              <div className="flex items-center gap-2.5">
+                <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-300/90 text-[#07192C]">
+                  <Sparkles className="h-4 w-4" />
+                </div>
+                <p className="text-[13px] font-semibold">OpenWork Models</p>
+              </div>
+              <p className="mt-2 text-[13px] leading-5 text-white/55">
+                Below-market-rate AI. No keys needed to start, or bring your own.
+              </p>
+              <div className="mt-3 flex gap-2">
+                <Link href="/dashboard/inference" className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-full bg-white px-3 py-2 text-[12px] font-semibold text-[#07192C]">
+                  <Zap className="h-3.5 w-3.5" /> Enable
+                </Link>
+                <Link href="/dashboard/custom-llm-providers" className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-full border border-white/20 px-3 py-2 text-[12px] font-semibold text-white">
+                  Own keys
+                </Link>
+              </div>
+            </div>
+
+            <div className="mt-4 grid gap-2">
+              <Link href={getMarketplacesRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-4 py-2.5 text-[13px] font-semibold text-[#07192C]">
                 View marketplaces <ArrowRight className="h-4 w-4" />
               </Link>
-              <Link href={getOrgDashboardRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-[13px] font-semibold text-white transition hover:bg-white/10">
+              <Link href={getOrgDashboardRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-[13px] font-semibold text-white">
                 Go to dashboard
               </Link>
             </div>
           </div>
+        </section>
+      </div>
 
-          <div className="hidden rounded-[20px] border border-white/10 bg-white/[0.06] p-4 sm:block sm:rounded-[22px] sm:p-5">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-cyan-300 text-[#07192C]">
-                <Monitor className="h-5 w-5" />
-              </div>
-              <div>
-                <p className="text-[14px] font-semibold">Get the desktop app</p>
-                <p className="mt-0.5 text-[12px] leading-5 text-white/55">Download OpenWork and sign in with this same account to sync your team extensions.</p>
+      {/* ── Desktop/tablet: full onboarding layout ────────────────── */}
+      <div className="hidden sm:block">
+        {/* Hero */}
+        <section className="overflow-hidden rounded-[28px] border border-[#dfe5f0] bg-[#07192C] text-white shadow-sm">
+          <div className="grid gap-6 p-6 md:grid-cols-[1.3fr_0.7fr] md:p-10">
+            <div>
+              <p className="text-[12px] font-semibold uppercase tracking-[0.26em] text-cyan-200">OpenWork Cloud</p>
+              <h1 className="mt-4 max-w-2xl text-[36px] font-semibold leading-[1.02] tracking-[-0.045em] md:text-[46px]">
+                You&apos;re all set.
+              </h1>
+              <p className="mt-3 max-w-xl text-[15px] leading-7 text-white/65">
+                We set up two starter marketplaces for {activeOrg?.name ?? "your team"}.
+              </p>
+              <div className="mt-5 flex flex-wrap gap-3">
+                <Link href={getMarketplacesRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-4 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-white/90">
+                  View marketplaces <ArrowRight className="h-4 w-4" />
+                </Link>
+                <Link href={getOrgDashboardRoute(orgSlug)} className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 px-4 py-2.5 text-[13px] font-semibold text-white transition hover:bg-white/10">
+                  Go to dashboard
+                </Link>
               </div>
             </div>
-          </div>
-        </div>
-      </section>
 
-      {/* ── OpenWork Models pitch ────────────────────────────────── */}
-      <section className="mt-3 overflow-hidden rounded-[20px] border border-[#d7e2f5] bg-gradient-to-br from-[#F4F8FF] to-[#EEF3FF] p-4 shadow-sm sm:mt-6 sm:rounded-[28px] sm:p-6 md:p-8">
-        <div className="grid gap-3 md:grid-cols-[1fr_auto] md:items-center md:gap-8">
-          <div>
-            <div className="flex items-center gap-2">
-              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#07192C] text-amber-300 sm:h-9 sm:w-9 sm:rounded-xl">
-                <Sparkles className="h-4 w-4" />
-              </div>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#41618F] sm:text-[12px]">OpenWork Models</p>
-            </div>
-            <h2 className="mt-2 text-[18px] font-semibold tracking-[-0.03em] text-[#07192C] sm:mt-3 sm:text-[24px]">
-              Below-market-rate AI models, ready to go.
-            </h2>
-            <p className="mt-1.5 text-[13px] leading-5 text-[#526582] sm:mt-2 sm:leading-6 sm:text-[14px]">
-              The best open-source and frontier models to get work done. No API keys needed to start.
-              Prefer your own provider? Bring your own keys instead.
-            </p>
-          </div>
-          <div className="flex gap-2 sm:flex-row md:flex-col">
-            <Link href={`/dashboard/inference`} className="inline-flex flex-1 items-center justify-center gap-2 rounded-full bg-[#07192C] px-4 py-2 text-[13px] font-semibold text-white shadow-[0_14px_32px_-20px_rgba(1,22,39,0.45)] transition hover:bg-black sm:px-5 sm:py-2.5 md:flex-none">
-              <Zap className="h-4 w-4" /> Enable models
-            </Link>
-            <Link href={`/dashboard/custom-llm-providers`} className="inline-flex flex-1 items-center justify-center gap-2 rounded-full border border-[#d8e0ec] px-4 py-2 text-[13px] font-semibold text-[#07192C] transition hover:bg-white sm:px-5 sm:py-2.5 md:flex-none">
-              Own keys
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Starter marketplace cards ────────────────────────────── */}
-      <section className="mt-4 grid gap-3 sm:mt-6 sm:gap-4 md:grid-cols-2">
-        {(isLoading ? [] : marketplaces).map((marketplace) => {
-          const isOpenWork = marketplace.name === "OpenWork Marketplace";
-          const description = isOpenWork
-            ? "Built-in tools like Browser, Image Gen, and Google Workspace."
-            : marketplace.pluginCount > 0
-              ? marketplace.description
-              : "Connect a GitHub repo to import plugins here.";
-          return (
-            <Link
-              key={marketplace.id}
-              href={`${getMarketplacesRoute(orgSlug)}/${encodeURIComponent(marketplace.id)}`}
-              className="rounded-[20px] border border-[#e2e7f0] bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md sm:rounded-[22px] sm:p-5"
-            >
+            <div className="rounded-[22px] border border-white/10 bg-white/[0.06] p-5">
               <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#EDF4FF] text-[#164B8F]">
-                  <Store className="h-4 w-4" />
+                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-cyan-300 text-[#07192C]">
+                  <Monitor className="h-5 w-5" />
                 </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-baseline justify-between gap-2">
-                    <h2 className="truncate text-[15px] font-semibold tracking-[-0.02em] text-[#07192C]">{isOpenWork ? "OpenWork Marketplace" : "Community Plugins"}</h2>
-                    <span className="shrink-0 text-[12px] font-medium text-[#667695]">{marketplace.pluginCount} ext{marketplace.pluginCount === 1 ? "" : "s"}</span>
+                <div>
+                  <p className="text-[14px] font-semibold">Get the desktop app</p>
+                  <p className="mt-0.5 text-[12px] leading-5 text-white/55">Download OpenWork and sign in with this same account to sync your team extensions.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* OpenWork Models */}
+        <section className="mt-6 overflow-hidden rounded-[28px] border border-[#d7e2f5] bg-gradient-to-br from-[#F4F8FF] to-[#EEF3FF] p-6 shadow-sm md:p-8">
+          <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-center md:gap-8">
+            <div>
+              <div className="flex items-center gap-2">
+                <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[#07192C] text-amber-300">
+                  <Sparkles className="h-4 w-4" />
+                </div>
+                <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#41618F]">OpenWork Models</p>
+              </div>
+              <h2 className="mt-3 text-[24px] font-semibold tracking-[-0.03em] text-[#07192C]">
+                Below-market-rate AI models, ready to go.
+              </h2>
+              <p className="mt-2 text-[14px] leading-6 text-[#526582]">
+                The best open-source and frontier models to get work done. No API keys needed to start.
+                Prefer your own provider? Bring your own keys instead.
+              </p>
+            </div>
+            <div className="flex flex-row gap-2 md:flex-col">
+              <Link href="/dashboard/inference" className="inline-flex items-center justify-center gap-2 rounded-full bg-[#07192C] px-5 py-2.5 text-[13px] font-semibold text-white shadow-[0_14px_32px_-20px_rgba(1,22,39,0.45)] transition hover:bg-black">
+                <Zap className="h-4 w-4" /> Enable OpenWork Models
+              </Link>
+              <Link href="/dashboard/custom-llm-providers" className="inline-flex items-center justify-center gap-2 rounded-full border border-[#d8e0ec] px-5 py-2.5 text-[13px] font-semibold text-[#07192C] transition hover:bg-white">
+                Use your own keys
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* Starter marketplace cards */}
+        <section className="mt-6 grid gap-4 md:grid-cols-2">
+          {(isLoading ? [] : marketplaces).map((marketplace) => {
+            const isOpenWork = marketplace.name === "OpenWork Marketplace";
+            const description = isOpenWork
+              ? "Built-in tools like Browser, Image Gen, and Google Workspace."
+              : marketplace.pluginCount > 0
+                ? marketplace.description
+                : "Connect a GitHub repo to import plugins here.";
+            return (
+              <Link
+                key={marketplace.id}
+                href={`${getMarketplacesRoute(orgSlug)}/${encodeURIComponent(marketplace.id)}`}
+                className="rounded-[22px] border border-[#e2e7f0] bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[#EDF4FF] text-[#164B8F]">
+                    <Store className="h-4 w-4" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline justify-between gap-2">
+                      <h2 className="truncate text-[16px] font-semibold tracking-[-0.02em] text-[#07192C]">{isOpenWork ? "OpenWork Marketplace" : "Community Plugins"}</h2>
+                      <span className="shrink-0 text-[12px] font-medium text-[#667695]">{marketplace.pluginCount} ext{marketplace.pluginCount === 1 ? "" : "s"}</span>
+                    </div>
                   </div>
                 </div>
-              </div>
-              {description ? <p className="mt-2.5 text-[13px] leading-6 text-[#5C6B86]">{description}</p> : null}
-            </Link>
-          );
-        })}
-        {isLoading ? (
-          <div className="rounded-[22px] border border-[#e2e7f0] bg-white p-5 text-[13px] text-[#667695] shadow-sm">Loading...</div>
-        ) : null}
-      </section>
+                {description ? <p className="mt-2.5 text-[13px] leading-6 text-[#5C6B86]">{description}</p> : null}
+              </Link>
+            );
+          })}
+          {isLoading ? (
+            <div className="rounded-[22px] border border-[#e2e7f0] bg-white p-5 text-[13px] text-[#667695] shadow-sm">Loading...</div>
+          ) : null}
+        </section>
 
-      {/* ── Next steps ───────────────────────────────────────────── */}
-      <section className="mt-4 grid gap-3 sm:mt-6 sm:gap-4 lg:grid-cols-3">
-        <ActionCard
-          icon={<Download className="h-5 w-5" />}
-          title="Get the app"
-          body="Free download. Sign in to unlock your team marketplaces."
-          href={getOrgDashboardRoute(orgSlug)}
-          label="Download"
-        />
-        <ActionCard
-          icon={<Github className="h-5 w-5" />}
-          title="Import from GitHub"
-          body="Connect a repo and import plugins to your marketplace."
-          href={getGithubIntegrationRoute(orgSlug)}
-          label="Connect GitHub"
-        />
-        <ActionCard
-          icon={<Puzzle className="h-5 w-5" />}
-          title="Add integrations"
-          body="Package skills, agents, or MCPs as plugins."
-          href={getIntegrationsRoute(orgSlug)}
-          label="Browse integrations"
-        />
-      </section>
+        {/* Next steps */}
+        <section className="mt-6 grid gap-4 lg:grid-cols-3">
+          <ActionCard
+            icon={<Download className="h-5 w-5" />}
+            title="Get the app"
+            body="Free download. Sign in to unlock your team marketplaces."
+            href={getOrgDashboardRoute(orgSlug)}
+            label="Download"
+          />
+          <ActionCard
+            icon={<Github className="h-5 w-5" />}
+            title="Import from GitHub"
+            body="Connect a repo and import plugins to your marketplace."
+            href={getGithubIntegrationRoute(orgSlug)}
+            label="Connect GitHub"
+          />
+          <ActionCard
+            icon={<Puzzle className="h-5 w-5" />}
+            title="Add integrations"
+            body="Package skills, agents, or MCPs as plugins."
+            href={getIntegrationsRoute(orgSlug)}
+            label="Browse integrations"
+          />
+        </section>
 
-      {/* ── Starter repo + MCP (compact, hidden on mobile) ────────── */}
-      <section className="mt-4 hidden gap-3 sm:mt-6 sm:grid sm:gap-4 lg:grid-cols-2">
-        <div className="rounded-[20px] border border-[#e2e7f0] bg-white p-5 shadow-sm sm:rounded-[22px] sm:p-6">
-          <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#6C7890]">Starter repo</p>
-          <h2 className="mt-2 text-[18px] font-semibold tracking-[-0.03em] text-[#07192C]">Try Knowledge Work Plugins</h2>
-          <p className="mt-2 text-[13px] leading-6 text-[#5C6B86]">
-            A GitHub repo with example plugins. Connect it to see how import works.
-          </p>
-          <a href={ANTHROPIC_KNOWLEDGE_WORK_REPO} target="_blank" rel="noreferrer" className="mt-3 inline-flex max-w-full items-center gap-2 text-[13px] font-semibold text-[#164B8F] transition hover:text-[#0F376C]">
-            Open on GitHub <ArrowRight className="h-4 w-4" />
-          </a>
-        </div>
-
-        <div className="rounded-[20px] border border-[#d7e2f5] bg-[#F4F8FF] p-5 shadow-sm sm:rounded-[22px] sm:p-6">
-          <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#41618F]">Use with any AI app</p>
-          <h2 className="mt-2 text-[18px] font-semibold tracking-[-0.03em] text-[#07192C]">OpenWork MCP</h2>
-          <p className="mt-2 text-[13px] leading-6 text-[#526582]">
-            Add the MCP server to Claude, Cursor, or any app that supports MCP.
-          </p>
-          <pre className="mt-3 overflow-x-auto rounded-xl bg-[#07192C] px-4 py-3 text-[12px] leading-6 text-cyan-100"><code>npx openwork-ui-mcp</code></pre>
-          <a href={OPENWORK_MCP_DOCS} target="_blank" rel="noreferrer" className="mt-3 inline-flex items-center gap-2 text-[13px] font-semibold text-[#164B8F] transition hover:text-[#0F376C]">
-            Read docs <ArrowRight className="h-4 w-4" />
-          </a>
-        </div>
-      </section>
+        {/* Starter repo + MCP */}
+        <section className="mt-6 grid gap-4 lg:grid-cols-2">
+          <div className="rounded-[22px] border border-[#e2e7f0] bg-white p-6 shadow-sm">
+            <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#6C7890]">Starter repo</p>
+            <h2 className="mt-2 text-[18px] font-semibold tracking-[-0.03em] text-[#07192C]">Try Knowledge Work Plugins</h2>
+            <p className="mt-2 text-[13px] leading-6 text-[#5C6B86]">
+              A GitHub repo with example plugins. Connect it to see how import works.
+            </p>
+            <a href={ANTHROPIC_KNOWLEDGE_WORK_REPO} target="_blank" rel="noreferrer" className="mt-3 inline-flex max-w-full items-center gap-2 text-[13px] font-semibold text-[#164B8F] transition hover:text-[#0F376C]">
+              Open on GitHub <ArrowRight className="h-4 w-4" />
+            </a>
+          </div>
+          <div className="rounded-[22px] border border-[#d7e2f5] bg-[#F4F8FF] p-6 shadow-sm">
+            <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#41618F]">Use with any AI app</p>
+            <h2 className="mt-2 text-[18px] font-semibold tracking-[-0.03em] text-[#07192C]">OpenWork MCP</h2>
+            <p className="mt-2 text-[13px] leading-6 text-[#526582]">
+              Add the MCP server to Claude, Cursor, or any app that supports MCP.
+            </p>
+            <pre className="mt-3 overflow-x-auto rounded-xl bg-[#07192C] px-4 py-3 text-[12px] leading-6 text-cyan-100"><code>npx openwork-ui-mcp</code></pre>
+            <a href={OPENWORK_MCP_DOCS} target="_blank" rel="noreferrer" className="mt-3 inline-flex items-center gap-2 text-[13px] font-semibold text-[#164B8F] transition hover:text-[#0F376C]">
+              Read docs <ArrowRight className="h-4 w-4" />
+            </a>
+          </div>
+        </section>
+      </div>
     </div>
   );
 }
@@ -181,7 +230,7 @@ function ActionCard({ icon, title, body, href, label }: {
   label: string;
 }) {
   return (
-    <Link href={href} className="flex items-start gap-4 rounded-[20px] border border-[#e2e7f0] bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md sm:rounded-[22px] sm:p-5">
+    <Link href={href} className="flex items-start gap-4 rounded-[22px] border border-[#e2e7f0] bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-[#cfd8e8] hover:shadow-md">
       <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-[#07192C] text-white">{icon}</div>
       <div className="min-w-0">
         <h2 className="text-[15px] font-semibold tracking-[-0.02em] text-[#07192C]">{title}</h2>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -14,6 +14,7 @@ import {
   KeyRound,
   Laptop,
   LogOut,
+  Menu,
   MessageSquare,
   Puzzle,
   Shield,
@@ -21,6 +22,7 @@ import {
   Sparkles,
   Store,
   Users,
+  X,
 } from "lucide-react";
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import {
@@ -373,72 +375,105 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
     </div>
   );
 
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const sidebarContent = (
+    <div className="flex flex-1 flex-col">
+      <div className="border-b border-gray-100 px-4 pb-4 pt-5">
+        <div className="flex items-center justify-between gap-3">
+          <OpenWorkMark />
+          <button
+            type="button"
+            className="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 md:hidden"
+            onClick={() => setSidebarOpen(false)}
+            aria-label="Close menu"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+      </div>
+
+      <nav className="flex-1 px-3 py-5">
+        <p className="px-3 pb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+          Navigation
+        </p>
+        <div className="space-y-1">
+          {navItems.map((item) => {
+            const isDashboardRoot =
+              activeOrg && item.href === getOrgDashboardRoute(activeOrg.slug);
+            const selected =
+              item.href !== "#" &&
+              (isDashboardRoot
+                ? pathname === item.href
+                : pathname === item.href || pathname.startsWith(`${item.href}/`));
+
+            return (
+              <Link
+                key={item.label}
+                href={item.href}
+                onClick={() => setSidebarOpen(false)}
+                className={`flex items-center justify-between gap-3 rounded-xl px-3 py-2.5 text-[13px] tracking-[-0.1px] transition-colors ${
+                  selected
+                    ? "bg-gray-100 text-gray-900"
+                    : "text-gray-500 hover:bg-gray-50 hover:text-gray-700"
+                }`}
+              >
+                <span className="flex items-center gap-3">
+                  <item.icon className="h-4 w-4" strokeWidth={1.8} />
+                  {item.label}
+                </span>
+                {item.badge ? (
+                  <span className="rounded-full bg-white px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em] text-gray-500">
+                    {item.badge}
+                  </span>
+                ) : null}
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
+
+      <div className="mt-auto p-3">
+        {orgSwitcher}
+
+        {orgBusy ? (
+          <p className="mt-3 px-2 text-[11px] text-gray-400">Refreshing workspace…</p>
+        ) : null}
+        {orgError ? (
+          <p className="mt-3 px-2 text-[11px] font-medium text-rose-600">{orgError}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+
   return (
     <div className="flex min-h-screen flex-col bg-[#fafafa] md:flex-row">
-      <aside className="w-full shrink-0 border-b border-gray-100 bg-white md:flex md:min-h-screen md:w-[260px] md:flex-col md:border-b-0 md:border-r">
-        <div className="flex flex-1 flex-col">
-          <div className="border-b border-gray-100 px-4 pb-4 pt-5">
-            <div className="flex items-center justify-between gap-3">
-              <OpenWorkMark />
-              {orgBusy ? <span className="text-xs text-gray-400">Refreshing...</span> : null}
-            </div>
-          </div>
-
-          <nav className="flex-1 px-3 py-5">
-            <p className="px-3 pb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-gray-400">
-              Navigation
-            </p>
-            <div className="space-y-1">
-              {navItems.map((item) => {
-                const isDashboardRoot =
-                  activeOrg && item.href === getOrgDashboardRoute(activeOrg.slug);
-                const selected =
-                  item.href !== "#" &&
-                  (isDashboardRoot
-                    ? pathname === item.href
-                    : pathname === item.href || pathname.startsWith(`${item.href}/`));
-
-                return (
-                  <Link
-                    key={item.label}
-                    href={item.href}
-                    className={`flex items-center justify-between gap-3 rounded-xl px-3 py-2.5 text-[13px] tracking-[-0.1px] transition-colors ${
-                      selected
-                        ? "bg-gray-100 text-gray-900"
-                        : "text-gray-500 hover:bg-gray-50 hover:text-gray-700"
-                    }`}
-                  >
-                    <span className="flex items-center gap-3">
-                      <item.icon className="h-4 w-4" strokeWidth={1.8} />
-                      {item.label}
-                    </span>
-                    {item.badge ? (
-                      <span className="rounded-full bg-white px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em] text-gray-500">
-                        {item.badge}
-                      </span>
-                    ) : null}
-                  </Link>
-                );
-              })}
-            </div>
-          </nav>
-
-          <div className="mt-auto p-3">
-            {orgSwitcher}
-
-            {orgBusy ? (
-              <p className="mt-3 px-2 text-[11px] text-gray-400">Refreshing workspace…</p>
-            ) : null}
-            {orgError ? (
-              <p className="mt-3 px-2 text-[11px] font-medium text-rose-600">{orgError}</p>
-            ) : null}
-          </div>
-        </div>
+      {/* Desktop sidebar — always visible at md+ */}
+      <aside className="hidden shrink-0 border-r border-gray-100 bg-white md:flex md:min-h-screen md:w-[260px] md:flex-col">
+        {sidebarContent}
       </aside>
 
+      {/* Mobile sidebar — off-canvas drawer */}
+      {sidebarOpen ? (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <div className="absolute inset-0 bg-black/30" onClick={() => setSidebarOpen(false)} aria-hidden />
+          <aside className="relative z-10 flex h-full w-[280px] max-w-[85vw] flex-col overflow-y-auto bg-white shadow-xl">
+            {sidebarContent}
+          </aside>
+        </div>
+      ) : null}
+
       <div className="flex min-w-0 flex-1 flex-col">
-        <header className="flex h-14 shrink-0 items-center justify-between border-b border-gray-100 bg-white px-5 md:px-6">
-          <div className="flex items-center gap-2">
+        <header className="flex h-14 shrink-0 items-center justify-between border-b border-gray-100 bg-white px-4 md:px-6">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              className="rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 md:hidden"
+              onClick={() => setSidebarOpen(true)}
+              aria-label="Open menu"
+            >
+              <Menu className="h-5 w-5" />
+            </button>
             <span className="text-[14px] tracking-[-0.1px] text-gray-900">
               {pageTitle}
             </span>
@@ -452,7 +487,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
               className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700"
             >
               <MessageSquare className="h-4 w-4" />
-              Feedback
+              <span className="hidden sm:inline">Feedback</span>
             </a>
             <a
               href={OPENWORK_DOCS_URL}
@@ -461,7 +496,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
               className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700"
             >
               <FileText className="h-4 w-4" />
-              Docs
+              <span className="hidden sm:inline">Docs</span>
             </a>
           </div>
         </header>


### PR DESCRIPTION
## Summary

Replaces the single long-scroll mobile onboarding with a **3-step full-screen flow**. Each step fills the viewport — no scrolling needed.

### Step 1: You're all set + OpenWork Models
Dark card. Confirms org is ready. OpenWork Models pitch with Enable / Own keys buttons. "Next" to continue.

### Step 2: Download the app
Light blue card. Lists what signing into the desktop app unlocks: Computer Use, Browser, Image Gen, Google Workspace, plus team marketplace extensions. "Next" to continue.

### Step 3: Create your own
White card. Explains how to import plugins from GitHub (fork the starter repo) or use the OpenWork MCP from any AI app. "Connect GitHub" primary CTA, "Go to dashboard" secondary.

### Also included
- Dashboard sidebar: off-canvas hamburger drawer on mobile (was full-width stacked nav).
- Dashboard overview: extensions banner explaining what the desktop app unlocks.
- Desktop layout: unchanged — shows the full onboarding page with all sections.

## Validation

- `pnpm --filter @openwork-ee/den-web build`: passed.

## Daytona Proof

Frame-by-frame proof:

- https://8090-iupesdwgr0l5wfpw.daytonaproxy01.net/index.html

Individual frames:

- Step 1: https://8090-iupesdwgr0l5wfpw.daytonaproxy01.net/01-youre-all-set.png
- Step 2: https://8090-iupesdwgr0l5wfpw.daytonaproxy01.net/02-download-the-app.png
- Step 3: https://8090-iupesdwgr0l5wfpw.daytonaproxy01.net/03-create-your-own.png

Live Den Web:

- https://3005-lsayievrxnyocdsi.daytonaproxy01.net

## Files changed

- `org-dashboard-shell.tsx`: mobile sidebar → hamburger drawer
- `marketplace-onboarding-screen.tsx`: 3-step mobile flow, desktop unchanged
- `dashboard-overview-screen.tsx`: extensions banner
