### PR TITLE
Add split-screen session tabs

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,7 +2,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { FileText, Globe, Mic2, Settings2, Zap } from "lucide-react";
+import { Columns2, FileText, Globe, Mic2, Settings2, X, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { OPENWORK_EXTENSION_CATALOG } from "../../../../app/constants";
@@ -69,6 +69,11 @@ const STARTUP_SKELETON_ROWS = [
 ];
 const GLOBAL_VOICE_SIDE_PANEL_KEY = "__openwork_voice__";
 const EMPTY_TRANSCRIPT_TARGETS: OpenTarget[] = [];
+
+type OpenSessionTab = {
+  workspaceId: string;
+  sessionId: string;
+};
 
 type StatusBarOverrides = Pick<
   StatusBarProps,
@@ -199,6 +204,13 @@ function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | 
   return match ? getDisplaySessionTitle(match.title) : "";
 }
 
+function sessionExistsInWorkspace(groups: WorkspaceSessionGroup[], workspaceId: string, sessionId: string | null | undefined) {
+  if (!sessionId) return false;
+  return groups.some((group) => (
+    group.workspace.id === workspaceId && group.sessions.some((session) => session.id === sessionId)
+  ));
+}
+
 function isTrackableAccessibleTarget(target: OpenTarget) {
   return isCollectibleArtifactTarget(target) || isLocalhostBrowserTarget(target);
 }
@@ -299,6 +311,8 @@ export function SessionPage(props: SessionPageProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteBusy, setDeleteBusy] = useState(false);
   const [sessionActionId, setSessionActionId] = useState<string | null>(null);
+  const [sessionTabs, setSessionTabs] = useState<OpenSessionTab[]>([]);
+  const [splitSessionId, setSplitSessionId] = useState<string | null>(null);
   const [createGroupOpen, setCreateGroupOpen] = useState(false);
   const [createGroupLabel, setCreateGroupLabel] = useState("");
   const [createGroupWorkspaceId, setCreateGroupWorkspaceId] = useState<string | null>(null);
@@ -367,7 +381,7 @@ export function SessionPage(props: SessionPageProps) {
     if (/^wss?:\/\//i.test(target.value)) return target.value.replace(/^ws:/i, "http:").replace(/^wss:/i, "https:");
     return target.value;
   }, []);
-  const openTarget = useCallback((target: OpenTarget, options?: { auto?: boolean }) => {
+  const openTarget = useCallback((target: OpenTarget, options?: { auto?: boolean }, sourceSessionId?: string) => {
     if (target.kind === "url" || target.preview === "browser") {
       const url = browserUrlForTarget(target);
       if (isElectronRuntime()) {
@@ -378,9 +392,10 @@ export function SessionPage(props: SessionPageProps) {
       }
       return;
     }
-    if (!props.selectedSessionId || !isCollectibleArtifactTarget(target)) return;
+    const sessionId = sourceSessionId ?? props.selectedSessionId;
+    if (!sessionId || !isCollectibleArtifactTarget(target)) return;
     if (options?.auto && activePanelTab?.id === target.id) return;
-    openTab(props.selectedSessionId, {
+    openTab(sessionId, {
       id: target.id,
       type: "artifact",
       label: target.name,
@@ -546,6 +561,28 @@ export function SessionPage(props: SessionPageProps) {
     () => sessionTitleForId(props.sidebar.workspaceSessionGroups, props.selectedSessionId),
     [props.selectedSessionId, props.sidebar.workspaceSessionGroups],
   );
+  useEffect(() => {
+    setSessionTabs((current) => {
+      const currentWorkspaceTabs = current.filter((tab) => tab.workspaceId === props.selectedWorkspaceId);
+      const next = props.selectedSessionId && !currentWorkspaceTabs.some((tab) => tab.sessionId === props.selectedSessionId)
+        ? [...currentWorkspaceTabs, { workspaceId: props.selectedWorkspaceId, sessionId: props.selectedSessionId }]
+        : currentWorkspaceTabs;
+      return next.filter((tab) => (
+        tab.sessionId === props.selectedSessionId ||
+        sessionExistsInWorkspace(props.sidebar.workspaceSessionGroups, tab.workspaceId, tab.sessionId)
+      ));
+    });
+  }, [props.selectedSessionId, props.selectedWorkspaceId, props.sidebar.workspaceSessionGroups]);
+  useEffect(() => {
+    if (!splitSessionId) return;
+    if (splitSessionId === props.selectedSessionId) {
+      setSplitSessionId(null);
+      return;
+    }
+    if (!sessionExistsInWorkspace(props.sidebar.workspaceSessionGroups, props.selectedWorkspaceId, splitSessionId)) {
+      setSplitSessionId(null);
+    }
+  }, [props.selectedSessionId, props.selectedWorkspaceId, props.sidebar.workspaceSessionGroups, splitSessionId]);
   const sessionActionTitle = useMemo(
     () => sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionActionId),
     [props.sidebar.workspaceSessionGroups, sessionActionId],
@@ -606,6 +643,29 @@ export function SessionPage(props: SessionPageProps) {
       reactSessionToken &&
       props.surface,
   );
+  const canRenderSplitSurface = Boolean(canRenderReactSurface && splitSessionId && splitSessionId !== props.selectedSessionId);
+
+  const openSessionTab = useCallback((workspaceId: string, sessionId: string) => {
+    setSessionTabs((current) => {
+      const next = current.filter((tab) => tab.workspaceId === workspaceId);
+      if (next.some((tab) => tab.sessionId === sessionId)) return next;
+      return [...next, { workspaceId, sessionId }];
+    });
+    props.sidebar.onOpenSession(workspaceId, sessionId);
+  }, [props.sidebar]);
+
+  const closeSessionTab = useCallback((sessionId: string) => {
+    setSessionTabs((current) => current.filter((tab) => tab.sessionId !== sessionId));
+    setSplitSessionId((current) => current === sessionId ? null : current);
+    if (sessionId !== props.selectedSessionId) return;
+
+    const nextTab = sessionTabs.find((tab) => tab.sessionId !== sessionId && tab.workspaceId === props.selectedWorkspaceId);
+    if (nextTab) {
+      props.sidebar.onOpenSession(nextTab.workspaceId, nextTab.sessionId);
+      return;
+    }
+    props.sidebar.onSelectWorkspace(props.selectedWorkspaceId);
+  }, [props.selectedSessionId, props.selectedWorkspaceId, props.sidebar, sessionTabs]);
 
   useEffect(() => {
     if (!showSessionLoadingState) {
@@ -683,7 +743,7 @@ export function SessionPage(props: SessionPageProps) {
           workspaceConnectionStateById={props.sidebar.workspaceConnectionStateById}
           newTaskDisabled={props.sidebar.newTaskDisabled}
           onSelectWorkspace={props.sidebar.onSelectWorkspace}
-          onOpenSession={props.sidebar.onOpenSession}
+          onOpenSession={openSessionTab}
           onPrefetchSession={props.sidebar.onPrefetchSession}
           onCreateTaskInWorkspace={props.sidebar.onCreateTaskInWorkspace}
           onOpenRenameSession={props.onRenameSession ? openRenameModal : undefined}
@@ -808,29 +868,98 @@ export function SessionPage(props: SessionPageProps) {
               ) : null}
 
               {!showDelayedSessionLoadingState && canRenderReactSurface ? (
-                <SessionSurface
-                  // Spread `surface` first so the explicit per-workspace
-                  // routing props below CAN'T be silently overridden by
-                  // anything that leaks into `surface`. SessionSurface's
-                  // server target (client/workspaceId/sessionId/opencodeBaseUrl/openworkToken)
-                  // must come from the resolved workspace endpoint passed by
-                  // SessionRoute, not from anything in `surface`.
-                  {...props.surface!}
-                  client={props.openworkServerClient!}
-                  workspaceId={props.runtimeWorkspaceId!}
-                  sessionId={props.selectedSessionId!}
-                  opencodeBaseUrl={reactSessionBaseUrl}
-                  openworkToken={reactSessionToken}
-                  todos={props.todos}
-                  activePermission={props.activePermission}
-                  permissionReplyBusy={props.permissionReplyBusy}
-                  respondPermission={props.respondPermission}
-                  activeQuestion={props.activeQuestion}
-                  questionReplyBusy={props.questionReplyBusy}
-                  respondQuestion={props.respondQuestion}
-                  safeStringify={props.safeStringify}
-                  onOpenTarget={openTarget}
-                />
+                <div className="flex h-full min-h-0 flex-col">
+                  {sessionTabs.length > 0 ? (
+                    <div className="flex h-10 shrink-0 items-center gap-1 overflow-x-auto border-b border-border bg-background/80 px-2 mac:backdrop-blur-xl">
+                      {sessionTabs.map((tab) => {
+                        const title = sessionTitleForId(props.sidebar.workspaceSessionGroups, tab.sessionId) || t("session.default_title");
+                        const active = tab.sessionId === props.selectedSessionId;
+                        const split = tab.sessionId === splitSessionId;
+                        return (
+                          <div
+                            key={tab.sessionId}
+                            className={cn(
+                              "group flex max-w-56 shrink-0 items-center gap-1 rounded-lg border px-2 py-1 text-xs transition-colors",
+                              active
+                                ? "border-border bg-dls-surface text-dls-text shadow-sm"
+                                : "border-transparent text-dls-secondary hover:bg-dls-hover hover:text-dls-text",
+                              split && "border-primary/30 bg-primary/10 text-primary",
+                            )}
+                          >
+                            <button
+                              type="button"
+                              className="min-w-0 flex-1 truncate text-left"
+                              onClick={() => props.sidebar.onOpenSession(tab.workspaceId, tab.sessionId)}
+                              title={title}
+                            >
+                              {title}
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded p-0.5 text-dls-secondary hover:bg-dls-hover hover:text-dls-text disabled:pointer-events-none disabled:opacity-40"
+                              onClick={() => setSplitSessionId(split ? null : tab.sessionId)}
+                              disabled={active}
+                              title={split ? "Close split" : "Open in split view"}
+                              aria-label={split ? "Close split" : "Open in split view"}
+                            >
+                              <Columns2 size={13} />
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded p-0.5 text-dls-secondary opacity-80 hover:bg-dls-hover hover:text-dls-text group-hover:opacity-100"
+                              onClick={() => closeSessionTab(tab.sessionId)}
+                              title="Close tab"
+                              aria-label="Close tab"
+                            >
+                              <X size={13} />
+                            </button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ) : null}
+                  <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+                    <div className={cn("min-h-0 min-w-0 flex-1", canRenderSplitSurface && "lg:border-r lg:border-border")}>
+                      <SessionSurface
+                        // Spread `surface` first so the explicit per-workspace
+                        // routing props below CAN'T be silently overridden by
+                        // anything that leaks into `surface`. SessionSurface's
+                        // server target (client/workspaceId/sessionId/opencodeBaseUrl/openworkToken)
+                        // must come from the resolved workspace endpoint passed by
+                        // SessionRoute, not from anything in `surface`.
+                        {...props.surface!}
+                        client={props.openworkServerClient!}
+                        workspaceId={props.runtimeWorkspaceId!}
+                        sessionId={props.selectedSessionId!}
+                        opencodeBaseUrl={reactSessionBaseUrl}
+                        openworkToken={reactSessionToken}
+                        todos={props.todos}
+                        activePermission={props.activePermission}
+                        permissionReplyBusy={props.permissionReplyBusy}
+                        respondPermission={props.respondPermission}
+                        activeQuestion={props.activeQuestion}
+                        questionReplyBusy={props.questionReplyBusy}
+                        respondQuestion={props.respondQuestion}
+                        safeStringify={props.safeStringify}
+                        onOpenTarget={openTarget}
+                      />
+                    </div>
+                    {canRenderSplitSurface ? (
+                      <div className="min-h-0 min-w-0 flex-1 border-t border-border lg:border-t-0">
+                        <SessionSurface
+                          {...props.surface!}
+                          client={props.openworkServerClient!}
+                          workspaceId={props.runtimeWorkspaceId!}
+                          sessionId={splitSessionId!}
+                          opencodeBaseUrl={reactSessionBaseUrl}
+                          openworkToken={reactSessionToken}
+                          todos={[]}
+                          onOpenTarget={openTarget}
+                        />
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
               ) : null}
 
               {!showDelayedSessionLoadingState && !canRenderReactSurface && !showStartupSkeleton ? (

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -95,7 +95,7 @@ export type SessionSurfaceProps = {
   selectedModel: ModelRef;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
-  onSendDraft: (draft: ComposerDraft) => void;
+  onSendDraft: (draft: ComposerDraft, sessionId: string) => void;
   onDraftChange: (draft: ComposerDraft) => void;
   attachmentsEnabled: boolean;
   attachmentsDisabledReason: string | null;
@@ -124,9 +124,9 @@ export type SessionSurfaceProps = {
   onUploadInboxFiles?: ((files: File[], options?: { notify?: boolean }) => void | Promise<unknown>) | null;
   providerConnectedCount?: number;
   onOpenSettingsSection?: ((section: "commands" | "skills" | "mcps" | "plugins" | "providers") => void) | undefined;
-  onRevertToMessage?: (messageId: string) => void;
-  onForkAtMessage?: (messageId: string) => void;
-  onOpenTarget?: (target: OpenTarget, options?: { auto?: boolean }) => void;
+  onRevertToMessage?: (messageId: string, sessionId: string) => void;
+  onForkAtMessage?: (messageId: string, sessionId: string) => void;
+  onOpenTarget?: (target: OpenTarget, options?: { auto?: boolean }, sessionId?: string) => void;
 };
 
 function messageToReadableText(message: UIMessage) {
@@ -583,8 +583,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
     if (!autoOpenTarget || chatStreaming) return;
     if (autoOpenedTargetRef.current === autoOpenTarget.id) return;
     autoOpenedTargetRef.current = autoOpenTarget.id;
-    props.onOpenTarget?.(autoOpenTarget, { auto: true });
-  }, [autoOpenTarget, chatStreaming, props.onOpenTarget]);
+    props.onOpenTarget?.(autoOpenTarget, { auto: true }, props.sessionId);
+  }, [autoOpenTarget, chatStreaming, props.onOpenTarget, props.sessionId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -716,7 +716,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setSending(true);
     setAwaitingAssistantBaseline(renderedMessages.length);
     try {
-      await props.onSendDraft(nextDraft);
+      await props.onSendDraft(nextDraft, props.sessionId);
       draftAttachments.forEach(revokeAttachmentPreview);
       setSending(false);
     } catch (nextError) {
@@ -1040,12 +1040,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [typeComposerText]);
 
   const handleRevertToUserMessage = useCallback((messageId: string) => {
-    props.onRevertToMessage?.(messageId);
-  }, [props.onRevertToMessage]);
+    props.onRevertToMessage?.(messageId, props.sessionId);
+  }, [props.onRevertToMessage, props.sessionId]);
 
   const handleForkAtMessage = useCallback((messageId: string) => {
-    props.onForkAtMessage?.(messageId);
-  }, [props.onForkAtMessage]);
+    props.onForkAtMessage?.(messageId, props.sessionId);
+  }, [props.onForkAtMessage, props.sessionId]);
 
   const sessionScrollTopControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.scroll_top",

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2120,19 +2120,21 @@ export function SessionRoute() {
       onOpenSettingsSection: (section: "commands" | "skills" | "mcps" | "plugins" | "providers") => {
         handleOpenSettings(section === "skills" ? "/settings/skills" : section === "mcps" ? "/settings/extensions/mcp" : section === "plugins" ? "/settings/extensions/plugins" : section === "providers" ? "/settings/ai" : "/settings/general");
       },
-      onSendDraft: async (draft: ComposerDraft) => {
+      onSendDraft: async (draft: ComposerDraft, sessionId: string) => {
+        const targetSessionId = sessionId.trim() || selectedSessionId;
+        if (!targetSessionId) return;
         const text = (draft.resolvedText ?? draft.text).trim();
         if (!text && draft.attachments.length === 0) return;
         if (selectedModelUnavailable) throw new Error("Selected model is unavailable. Choose another model before sending.");
 
         if (draft.mode === "shell") {
-          await shellInSession(opencodeClient, selectedSessionId, text);
+          await shellInSession(opencodeClient, targetSessionId, text);
           return;
         }
 
         if (draft.command) {
           const result = await opencodeClient.session.command({
-            sessionID: selectedSessionId,
+            sessionID: targetSessionId,
             command: draft.command.name,
             arguments: draft.command.arguments,
           });
@@ -2149,11 +2151,11 @@ export function SessionRoute() {
           port: openworkServerHostInfoState?.port ?? null,
         });
         const envSystemContext = await buildOpenworkEnvSystemContext(client, {
-          cacheKey: selectedSessionId,
+          cacheKey: targetSessionId,
           runtimeKey: envRuntimeKey,
         });
         const result = await opencodeClient.session.promptAsync({
-          sessionID: selectedSessionId,
+          sessionID: targetSessionId,
           parts,
           model: local.prefs.defaultModel ?? undefined,
           agent: selectedAgent ?? undefined,
@@ -2199,24 +2201,28 @@ export function SessionRoute() {
       },
       isRemoteWorkspace: selectedWorkspace?.workspaceType === "remote",
       isSandboxWorkspace: selectedWorkspace ? isSandboxWorkspace(selectedWorkspace) : false,
-      onRevertToMessage: (messageId: string) => {
+      onRevertToMessage: (messageId: string, sessionId: string) => {
         void (async () => {
+          const targetSessionId = sessionId.trim() || selectedSessionId;
+          if (!targetSessionId) return;
           try {
             // Abort any running generation first, like the actions-store does
-            try { await opencodeClient.session.abort({ sessionID: selectedSessionId }); } catch { /* ok if not running */ }
-            await revertSession(opencodeClient, selectedSessionId, messageId);
+            try { await opencodeClient.session.abort({ sessionID: targetSessionId }); } catch { /* ok if not running */ }
+            await revertSession(opencodeClient, targetSessionId, messageId);
             // Force a full reload of the session to pick up reverted state
-            navigateToWorkspaceSession(selectedWorkspaceId, selectedSessionId);
+            navigateToWorkspaceSession(selectedWorkspaceId, targetSessionId);
             void refreshRouteState();
           } catch (error) {
             console.warn("[revert] failed", error);
           }
         })();
       },
-      onForkAtMessage: (messageId: string) => {
+      onForkAtMessage: (messageId: string, sessionId: string) => {
         void (async () => {
+          const targetSessionId = sessionId.trim() || selectedSessionId;
+          if (!targetSessionId) return;
           try {
-            const forked = await forkSession(opencodeClient, selectedSessionId, messageId);
+            const forked = await forkSession(opencodeClient, targetSessionId, messageId);
             writeLastSessionFor(selectedWorkspaceId, forked.id);
             rememberPendingCreatedSession(selectedWorkspaceId, forked.id);
             setSessionsByWorkspaceId((current) => ({


### PR DESCRIPTION
## Summary
- Add local session tabs in the session page
- Allow opening an inactive tab as a side-by-side split chat pane
- Make session surface callbacks target the pane session so send/revert/fork use the correct conversation

## Validation
- pnpm --filter @openwork/app typecheck: passed
- Daytona Electron frame-by-frame eval: passed
  - One session tab visible after onboarding
  - Two session tabs visible after creating a second session
  - Split button renders two side-by-side chat panes
  - Independent left/right drafts retained in separate composers

## Evidence
- Screenshot: https://8090-bqywhllivd8cbami.daytonaproxy01.net/screenshots/daytona-screenshot-20260604-202039.png
- Recording: https://8090-bqywhllivd8cbami.daytonaproxy01.net/recordings/split-screen-chat-tabs.mp4
- Recording duration verified: 337.266667s
