### PR TITLE
feat: add hidden integrated terminal

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -59,6 +59,8 @@
     "@shikijs/transformers": "^4.0.2",
     "@tanstack/react-query": "^5.90.3",
     "@tanstack/react-virtual": "^3.13.23",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "ai": "^6.0.146",
     "boring-avatars": "^2.0.4",
     "class-variance-authority": "^0.7.1",

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -125,6 +125,14 @@ declare global {
         onPanelOpened?: (callback: () => void) => () => void;
         onPanelClosed?: (callback: () => void) => () => void;
       };
+      terminal?: {
+        create?: (options: { cwd: string; cols: number; rows: number }) => Promise<{ terminalId: string }>;
+        write?: (terminalId: string, data: string) => Promise<void>;
+        resize?: (terminalId: string, cols: number, rows: number) => Promise<void>;
+        kill?: (terminalId: string) => Promise<void>;
+        onData?: (callback: (payload: { terminalId: string; data: string }) => void) => () => void;
+        onExit?: (callback: (payload: { terminalId: string; exitCode: number | null; signal?: number }) => void) => () => void;
+      };
       meta?: {
         initialDeepLinks?: string[];
         platform?: "darwin" | "linux" | "windows";

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -56,6 +56,7 @@ import { isElectronRuntime } from "../../../../app/utils";
 import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, type OpenTarget } from "../artifacts/open-target";
 import { VoicePanel } from "../voice/voice-panel";
 import { SidePanel } from "../panel/side-panel";
+import { TerminalDock } from "../terminal/terminal-dock";
 import { useActivePanelTab, usePanelTabStore, useSessionPanelState } from "../panel/panel-tab-store";
 import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
@@ -178,6 +179,8 @@ export type SessionPageProps = {
   onAccessibleTargetsChange?: (targets: OpenTarget[]) => void;
   /** Settings content rendered inside the right pane when the settings rail icon is active. */
   settingsSlot?: React.ReactNode;
+  terminalOpen?: boolean;
+  onTerminalOpenChange?: (open: boolean) => void;
 };
 
 function getSidebarInitialLoading(props: SessionPageSidebarProps) {
@@ -822,8 +825,9 @@ export function SessionPage(props: SessionPageProps) {
             </div>
           </header>
 
-          <div className="flex min-h-0 flex-1 overflow-hidden">
-            <div className="relative min-w-0 flex-1 overflow-hidden bg-dls-surface mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
+          <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1 overflow-hidden">
+            <ResizablePanel minSize="180px" className="min-h-0">
+            <div className="relative h-full min-w-0 overflow-hidden bg-dls-surface mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
               {showStartupSkeleton ? (
                 <div className="px-6 py-14" role="status" aria-live="polite">
                   <div className="mx-auto max-w-2xl space-y-6">
@@ -1114,7 +1118,20 @@ export function SessionPage(props: SessionPageProps) {
                 </div>
               ) : null}
             </div>
-          </div>
+            </ResizablePanel>
+            {props.terminalOpen ? (
+              <>
+                <ResizableHandle withHandle />
+                <ResizablePanel defaultSize="280px" minSize="160px" maxSize="55%" className="min-h-0">
+                  <TerminalDock
+                    workspaceRoot={props.selectedWorkspaceRoot}
+                    isRemoteWorkspace={props.selectedWorkspaceDisplay.workspaceType === "remote"}
+                    onClose={() => props.onTerminalOpenChange?.(false)}
+                  />
+                </ResizablePanel>
+              </>
+            ) : null}
+          </ResizablePanelGroup>
 
           {shellConfig.statusBar ? (
             <StatusBar

--- a/apps/app/src/react-app/domains/session/terminal/terminal-dock.tsx
+++ b/apps/app/src/react-app/domains/session/terminal/terminal-dock.tsx
@@ -1,0 +1,131 @@
+/** @jsxImportSource react */
+import { useEffect, useRef, useState } from "react";
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+import { X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { isElectronRuntime } from "../../../../app/utils";
+
+type TerminalDockProps = {
+  workspaceRoot: string;
+  isRemoteWorkspace: boolean;
+  onClose: () => void;
+};
+
+export function TerminalDock({ workspaceRoot, isRemoteWorkspace, onClose }: TerminalDockProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const terminalIdRef = useRef<string | null>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const [status, setStatus] = useState("Starting terminal...");
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    if (!isElectronRuntime()) {
+      setStatus("Terminal is available in the desktop app.");
+      return;
+    }
+    if (isRemoteWorkspace) {
+      setStatus("Remote workspace terminals are not wired yet.");
+      return;
+    }
+
+    const bridge = window.__OPENWORK_ELECTRON__?.terminal;
+    if (!bridge?.create || !bridge.write || !bridge.resize || !bridge.kill || !bridge.onData || !bridge.onExit) {
+      setStatus("Terminal bridge is unavailable.");
+      return;
+    }
+    const createTerminal = bridge.create;
+    const writeTerminal = bridge.write;
+    const resizeTerminal = bridge.resize;
+    const killTerminal = bridge.kill;
+    const onTerminalData = bridge.onData;
+    const onTerminalExit = bridge.onExit;
+
+    let disposed = false;
+    const fitAddon = new FitAddon();
+    const terminal = new Terminal({
+      cursorBlink: true,
+      convertEol: true,
+      fontFamily: "'SFMono-Regular', 'Cascadia Code', 'Liberation Mono', Menlo, monospace",
+      fontSize: 12,
+      theme: {
+        background: "#0b0d12",
+        foreground: "#d7dde8",
+        cursor: "#ffffff",
+        selectionBackground: "#334155",
+      },
+    });
+    terminal.loadAddon(fitAddon);
+    terminal.open(containerRef.current);
+    terminal.focus();
+    fitAddon.fit();
+    terminalRef.current = terminal;
+    fitRef.current = fitAddon;
+
+    const removeDataListener = onTerminalData(({ terminalId, data }) => {
+      if (terminalIdRef.current !== terminalId) return;
+      terminal.write(data);
+    });
+    const removeExitListener = onTerminalExit(({ terminalId, exitCode }) => {
+      if (terminalIdRef.current !== terminalId) return;
+      setStatus(`Terminal exited${exitCode === null ? "" : ` with code ${exitCode}`}.`);
+      terminalIdRef.current = null;
+    });
+    const inputDisposable = terminal.onData((data) => {
+      const terminalId = terminalIdRef.current;
+      if (!terminalId) return;
+      void writeTerminal(terminalId, data);
+    });
+
+    const fitAndResize = () => {
+      fitAddon.fit();
+      const terminalId = terminalIdRef.current;
+      if (!terminalId) return;
+      void resizeTerminal(terminalId, terminal.cols, terminal.rows);
+    };
+    const resizeObserver = new ResizeObserver(fitAndResize);
+    resizeObserver.observe(containerRef.current);
+
+    void createTerminal({ cwd: workspaceRoot, cols: terminal.cols, rows: terminal.rows }).then(({ terminalId }) => {
+      if (disposed) {
+        void killTerminal(terminalId);
+        return;
+      }
+      terminalIdRef.current = terminalId;
+      setStatus(workspaceRoot);
+      fitAndResize();
+    }).catch((error) => {
+      setStatus(error instanceof Error ? error.message : "Could not start terminal.");
+    });
+
+    return () => {
+      disposed = true;
+      resizeObserver.disconnect();
+      inputDisposable.dispose();
+      removeDataListener();
+      removeExitListener();
+      const terminalId = terminalIdRef.current;
+      terminalIdRef.current = null;
+      if (terminalId) void killTerminal(terminalId);
+      terminal.dispose();
+      terminalRef.current = null;
+      fitRef.current = null;
+    };
+  }, [isRemoteWorkspace, workspaceRoot]);
+
+  return (
+    <section className="flex h-full min-h-0 flex-col border-t border-border bg-[#0b0d12] text-white" aria-label="Terminal">
+      <header className="flex h-9 shrink-0 items-center justify-between border-b border-white/10 bg-black/35 px-3 text-xs">
+        <div className="min-w-0 truncate text-white/75">Terminal · {status}</div>
+        <Button variant="ghost" size="icon-sm" className="text-white/70 hover:bg-white/10 hover:text-white" onClick={onClose}>
+          <X className="size-4" />
+          <span className="sr-only">Hide terminal</span>
+        </Button>
+      </header>
+      <div ref={containerRef} className="min-h-0 flex-1 px-2 py-1 [&_.xterm]:h-full" />
+    </section>
+  );
+}

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -91,6 +91,7 @@ export type CommandPaletteProps = {
   onHideAccessibleTarget?: (target: AccessibleTargetOption) => void;
   /** Optional: sessions for the second mode. */
   sessions: SessionOption[];
+  extraItems?: PaletteItem[];
 };
 
 /**
@@ -151,6 +152,7 @@ export function CommandPalette(props: CommandPaletteProps) {
         setMode("accessible-items");
       },
     },
+    ...(props.extraItems ?? []),
     {
       id: "open-settings",
       title: t("settings.tab_general"),

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -118,7 +118,7 @@ import {
 } from "@/react-app/domains/workspace/remote-workspace-diagnostics";
 import { useShareWorkspaceState } from "@/react-app/domains/workspace/share-workspace-state";
 import { ModelPickerModal } from "@/react-app/domains/session/modals/model-picker-modal";
-import { CommandPalette, type AccessibleTargetOption, type SessionOption as PaletteSessionOption } from "./command-palette";
+import { CommandPalette, type PaletteItem, type SessionOption as PaletteSessionOption } from "./command-palette";
 import { getDisplaySessionTitle } from "@/app/lib/session-title";
 import { useBootState } from "./boot-state";
 import {
@@ -588,6 +588,7 @@ export function SessionRoute() {
   const [renameWorkspaceTitle, setRenameWorkspaceTitle] = useState("");
   const [renameWorkspaceBusy, setRenameWorkspaceBusy] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [terminalOpen, setTerminalOpen] = useState(false);
   const [paletteAccessibleTargets, setPaletteAccessibleTargets] = useState<OpenTarget[]>([]);
   // Model picker modal state (ported from settings-route; previously the
   // session "Pick a model" button navigated to /settings/general, which is a
@@ -2518,6 +2519,7 @@ export function SessionRoute() {
   // Global shortcuts:
   //   Cmd/Ctrl+N  -> new task in selected workspace
   //   Cmd/Ctrl+K  -> toggle command palette
+  //   Cmd/Ctrl+J  -> toggle terminal panel (matches VS Code)
   const handleGlobalShortcut = useEffectEvent((event: KeyboardEvent) => {
     const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
     const mod = isMac ? event.metaKey : event.ctrlKey;
@@ -2542,6 +2544,11 @@ export function SessionRoute() {
     if (key === "k") {
       event.preventDefault();
       setCommandPaletteOpen((value) => !value);
+      return;
+    }
+    if (key === "j") {
+      event.preventDefault();
+      setTerminalOpen((value) => !value);
     }
   });
 
@@ -2654,6 +2661,20 @@ export function SessionRoute() {
     });
     return out;
   }, [sessionsByWorkspaceId, selectedWorkspaceId, workspaces]);
+
+  const terminalPaletteItems = useMemo<PaletteItem[]>(() => [
+    {
+      id: "terminal.toggle",
+      title: terminalOpen ? "Hide terminal" : "Show terminal",
+      detail: "Toggle the integrated terminal panel for this workspace",
+      meta: "Cmd/Ctrl+J",
+      searchText: "terminal shell command line console show hide toggle",
+      action: () => {
+        setCommandPaletteOpen(false);
+        setTerminalOpen((value) => !value);
+      },
+    },
+  ], [terminalOpen]);
 
   const handleReorderWorkspaces = useCallback((workspaceIds: string[]) => {
     const activeWorkspaceIds = new Set(workspacesRef.current.map((workspace) => workspace.id));
@@ -2915,6 +2936,8 @@ export function SessionRoute() {
           }}
         />
       }
+      terminalOpen={terminalOpen}
+      onTerminalOpenChange={setTerminalOpen}
       sidebar={{
         workspaceSessionGroups,
         selectedWorkspaceId,
@@ -3171,6 +3194,7 @@ export function SessionRoute() {
         }
       }}
       sessions={paletteSessionOptions}
+      extraItems={terminalPaletteItems}
     />
     <ModelPickerModal
       open={modelPickerOpen}

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -22,6 +22,9 @@ extraResources:
     filter:
       - "*.js"
 asar: true
+asarUnpack:
+  - node_modules/.pnpm/@lydell+node-pty*/**
+  - node_modules/node-pty/**
 npmRebuild: false
 afterPack: scripts/electron-after-pack.cjs
 afterSign: scripts/electron-after-sign.cjs

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -31,6 +31,8 @@ import {
 } from "./remote-workspace.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const pty = require(["node", "pty"].join("-"));
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
@@ -45,6 +47,40 @@ const RELEASE_PAGE_URL = "https://github.com/different-ai/openwork/releases/late
 const DOCS_PAGE_URL = "https://openworklabs.com/docs";
 const COMPUTER_USE_HELPER_APP_NAME = "OpenWork Computer Use.app";
 const COMPUTER_USE_HELPER_EXECUTABLE = "ComputerUse";
+const terminalProcesses = new Map();
+let nextTerminalId = 1;
+
+function defaultTerminalShell() {
+  if (process.platform === "win32") return process.env.COMSPEC || "powershell.exe";
+  return process.env.SHELL || (process.platform === "darwin" ? "/bin/zsh" : "/bin/bash");
+}
+
+async function resolveTerminalCwd(cwd) {
+  const fallback = os.homedir();
+  if (typeof cwd !== "string" || !cwd.trim()) return fallback;
+  const candidate = path.resolve(cwd);
+  const info = await stat(candidate).catch(() => null);
+  return info?.isDirectory() ? candidate : fallback;
+}
+
+function terminalForSender(event, terminalId) {
+  const terminal = terminalProcesses.get(String(terminalId ?? ""));
+  if (!terminal || terminal.webContentsId !== event.sender.id) return null;
+  return terminal;
+}
+
+function killTerminal(terminalId) {
+  const terminal = terminalProcesses.get(terminalId);
+  if (!terminal) return;
+  terminalProcesses.delete(terminalId);
+  try { terminal.process.kill(); } catch { /* already gone */ }
+}
+
+function killTerminalsForWebContents(webContentsId) {
+  for (const [terminalId, terminal] of terminalProcesses.entries()) {
+    if (terminal.webContentsId === webContentsId) killTerminal(terminalId);
+  }
+}
 
 function computerUseHelperExecutablePath() {
   const appPath = computerUseHelperAppPath();
@@ -3013,6 +3049,56 @@ ipcMain.handle("openwork:system:askMicrophoneAccess", async () => {
   const granted = await systemPreferences.askForMediaAccess("microphone");
   const after = systemPreferences.getMediaAccessStatus("microphone");
   return { platform: process.platform, before, after, granted };
+});
+
+// ── Terminal IPC ────────────────────────────────────────────────────────
+ipcMain.handle("openwork:terminal:create", async (event, options = {}) => {
+  const cwd = await resolveTerminalCwd(options?.cwd);
+  const cols = Number.isFinite(options?.cols) ? Math.max(20, Math.floor(options.cols)) : 80;
+  const rows = Number.isFinite(options?.rows) ? Math.max(5, Math.floor(options.rows)) : 24;
+  const terminalId = `term_${nextTerminalId++}`;
+  const shellPath = defaultTerminalShell();
+  const child = pty.spawn(shellPath, [], {
+    name: "xterm-256color",
+    cols,
+    rows,
+    cwd,
+    env: {
+      ...process.env,
+      TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+      OPENWORK_TERMINAL: "1",
+    },
+  });
+
+  terminalProcesses.set(terminalId, { process: child, webContentsId: event.sender.id });
+  event.sender.once("destroyed", () => killTerminalsForWebContents(event.sender.id));
+  child.onData((data) => {
+    if (event.sender.isDestroyed()) return;
+    event.sender.send("openwork:terminal:data", { terminalId, data });
+  });
+  child.onExit(({ exitCode, signal }) => {
+    terminalProcesses.delete(terminalId);
+    if (event.sender.isDestroyed()) return;
+    event.sender.send("openwork:terminal:exit", { terminalId, exitCode, signal });
+  });
+
+  return { terminalId };
+});
+ipcMain.handle("openwork:terminal:write", (event, terminalId, data) => {
+  const terminal = terminalForSender(event, terminalId);
+  if (!terminal || typeof data !== "string") return;
+  terminal.process.write(data);
+});
+ipcMain.handle("openwork:terminal:resize", (event, terminalId, cols, rows) => {
+  const terminal = terminalForSender(event, terminalId);
+  if (!terminal || !Number.isFinite(cols) || !Number.isFinite(rows)) return;
+  terminal.process.resize(Math.max(20, Math.floor(cols)), Math.max(5, Math.floor(rows)));
+});
+ipcMain.handle("openwork:terminal:kill", (event, terminalId) => {
+  const terminal = terminalForSender(event, terminalId);
+  if (!terminal) return;
+  killTerminal(String(terminalId));
 });
 
 // ── Embedded browser IPC ────────────────────────────────────────────────

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -136,6 +136,22 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
       return () => ipcRenderer.removeListener("openwork:browser:panel-closed", handler);
     },
   },
+  terminal: {
+    create(options) { return ipcRenderer.invoke("openwork:terminal:create", options); },
+    write(terminalId, data) { return ipcRenderer.invoke("openwork:terminal:write", terminalId, data); },
+    resize(terminalId, cols, rows) { return ipcRenderer.invoke("openwork:terminal:resize", terminalId, cols, rows); },
+    kill(terminalId) { return ipcRenderer.invoke("openwork:terminal:kill", terminalId); },
+    onData(callback) {
+      const handler = (_event, payload) => callback(payload);
+      ipcRenderer.on("openwork:terminal:data", handler);
+      return () => ipcRenderer.removeListener("openwork:terminal:data", handler);
+    },
+    onExit(callback) {
+      const handler = (_event, payload) => callback(payload);
+      ipcRenderer.on("openwork:terminal:exit", handler);
+      return () => ipcRenderer.removeListener("openwork:terminal:exit", handler);
+    },
+  },
   meta: {
     initialDeepLinks: [],
     platform: normalizePlatform(process.platform),

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -30,6 +30,7 @@
     "electron-updater": "^6.3.9",
     "jsonc-parser": "^3.2.1",
     "minimatch": "^10.0.1",
+    "node-pty": "npm:@lydell/node-pty@1.2.0-beta.12",
     "yaml": "^2.6.1",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,12 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.13.23
         version: 3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       ai:
         specifier: ^6.0.146
         version: 6.0.146(zod@4.3.6)
@@ -229,6 +235,9 @@ importers:
       minimatch:
         specifier: ^10.0.1
         version: 10.1.1
+      node-pty:
+        specifier: npm:@lydell/node-pty@1.2.0-beta.12
+        version: '@lydell/node-pty@1.2.0-beta.12'
       yaml:
         specifier: ^2.6.1
         version: 2.8.2
@@ -2551,6 +2560,39 @@ packages:
   '@lezer/markdown@1.6.3':
     resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
 
+  '@lydell/node-pty-darwin-arm64@1.2.0-beta.12':
+    resolution: {integrity: sha512-tqaifcY9Cr41SblO1+FLzh8oxxtkNhuW9Dhl22lKme9BreYvKvxEZcdPIXTuqkJc5tagOEC4QHShKmJjLyLXLQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@lydell/node-pty-darwin-x64@1.2.0-beta.12':
+    resolution: {integrity: sha512-4LrS5pCJwqHKDVf1zS2gyNV0m4hKAXch+XZNhbZ6LY8uwVL8BhchzQBO40Os5anuRxRCWzHpw4Sp64Ie8q7E4Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@lydell/node-pty-linux-arm64@1.2.0-beta.12':
+    resolution: {integrity: sha512-Sx+A71x5BDGHt9ansfrtGxwq2VFVDWvJUAdlUL0Hv0qeiJUfts+hgopx+CgT4PSwahKjdEgtu0+FAfY9rICKRw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@lydell/node-pty-linux-x64@1.2.0-beta.12':
+    resolution: {integrity: sha512-bJzs94njofYhGg/UDqW1nj0dtvvu+2OvxMY+RlLS1T17VgcktKoIR6PuenTwE5HJ/D6StCPADmXcT0nNsCKmIQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@lydell/node-pty-win32-arm64@1.2.0-beta.12':
+    resolution: {integrity: sha512-p7POgjVEiFaBC3/y+AKuV1FzePCsJ6HmZDv2XK+jBZSfwP8+uBAw181ZiKYN1YuRa/XpmBGaWezcI8hZkbW++g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@lydell/node-pty-win32-x64@1.2.0-beta.12':
+    resolution: {integrity: sha512-IDFa00g7qUDGUYgByrUBJtC+mOjYVt/8KYyWivCg5JjGOHbBUACUQZLl0jTWmnr+tld/UyTpX90a2PY6oTVtRw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@lydell/node-pty@1.2.0-beta.12':
+    resolution: {integrity: sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==}
+
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
     engines: {node: '>= 12.13.0'}
@@ -4376,6 +4418,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -11249,6 +11297,33 @@ snapshots:
       '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
 
+  '@lydell/node-pty-darwin-arm64@1.2.0-beta.12':
+    optional: true
+
+  '@lydell/node-pty-darwin-x64@1.2.0-beta.12':
+    optional: true
+
+  '@lydell/node-pty-linux-arm64@1.2.0-beta.12':
+    optional: true
+
+  '@lydell/node-pty-linux-x64@1.2.0-beta.12':
+    optional: true
+
+  '@lydell/node-pty-win32-arm64@1.2.0-beta.12':
+    optional: true
+
+  '@lydell/node-pty-win32-x64@1.2.0-beta.12':
+    optional: true
+
+  '@lydell/node-pty@1.2.0-beta.12':
+    optionalDependencies:
+      '@lydell/node-pty-darwin-arm64': 1.2.0-beta.12
+      '@lydell/node-pty-darwin-x64': 1.2.0-beta.12
+      '@lydell/node-pty-linux-arm64': 1.2.0-beta.12
+      '@lydell/node-pty-linux-x64': 1.2.0-beta.12
+      '@lydell/node-pty-win32-arm64': 1.2.0-beta.12
+      '@lydell/node-pty-win32-x64': 1.2.0-beta.12
+
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
       cross-spawn: 7.0.6
@@ -13067,6 +13142,10 @@ snapshots:
   '@xmldom/is-dom-node@1.0.1': {}
 
   '@xmldom/xmldom@0.8.13': {}
+
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   abbrev@1.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,5 +24,6 @@ allowBuilds:
   electron: true
   esbuild: true
   msw: false
+  node-pty: true
   protobufjs: true
   sharp: true


### PR DESCRIPTION
## Summary
- Adds a hidden integrated terminal available from the command palette and `Cmd/Ctrl+J`.
- Backs the renderer with xterm + a narrow Electron IPC bridge to a real PTY.
- Uses the `@lydell/node-pty` alias because `node-pty@1.1.0` loaded but failed to fork locally with `posix_spawnp failed`.

## Validation
- `pnpm --filter @openwork/app typecheck` passed.
- `pnpm --filter @openwork/desktop typecheck:electron` passed.
- `pnpm --filter @openwork/app build` passed.
- Desktop PTY smoke passed: `node -e "import('node-pty').then(...)"` printed `PASS openwork-terminal-proof`.

## Daytona Proof
Sandbox: `openwork-test-20260604-152359`

Recording:
- https://8090-mlzktgfcqzp4bmaf.daytonaproxy01.net/recordings/hidden-terminal-proof.mp4

Frame-by-frame screenshots:
1. Session loaded, terminal hidden: https://8090-mlzktgfcqzp4bmaf.daytonaproxy01.net/screenshots/daytona-screenshot-20260604-222719.png
2. Command palette shows `Show terminal`: https://8090-mlzktgfcqzp4bmaf.daytonaproxy01.net/screenshots/daytona-screenshot-20260604-222740.png
3. Terminal opened in `/workspace/terminal-proof`: https://8090-mlzktgfcqzp4bmaf.daytonaproxy01.net/screenshots/daytona-screenshot-20260604-222807.png
4. Terminal command output visible: https://8090-mlzktgfcqzp4bmaf.daytonaproxy01.net/screenshots/daytona-screenshot-20260604-222904.png
5. Terminal hidden again via `Ctrl+J`: https://8090-mlzktgfcqzp4bmaf.daytonaproxy01.net/screenshots/daytona-screenshot-20260604-222924.png
6. Final assertion screenshot: https://8090-mlzktgfcqzp4bmaf.daytonaproxy01.net/screenshots/daytona-screenshot-20260604-223031.png

CDP assertions:
- Real Electron app: `navigator.userAgent.includes("Electron/") === true`.
- Terminal bridge exposed: `Boolean(window.__OPENWORK_ELECTRON__?.terminal) === true`.
- Hidden state after `Ctrl+J`: `!document.body.innerText.includes("Terminal ·") === true`.
- Reopened terminal and executed command: output included `assert-terminal-ok:/workspace/terminal-proof`.

Recording duration after finalization: `221.666667` seconds.
