### PR TITLE
fix: gate extension marketplace behind sign-in

### DIFF
--- a/apps/app/src/react-app/domains/settings/extension-items.ts
+++ b/apps/app/src/react-app/domains/settings/extension-items.ts
@@ -209,7 +209,7 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
     builtInItems,
     cloudPluginItems: [...cloudPluginItems, ...importedPluginItems],
     installedMcpEntries: [
-      ...builtInItems.flatMap((item) => item.builtInEntry ? [item.builtInEntry] : []),
+      ...builtInItems.flatMap((item) => item.active && item.builtInEntry ? [item.builtInEntry] : []),
       ...standaloneMcpEntries,
     ],
     installedSkills: standaloneSkillItems.flatMap((item) => item.skill ? [item.skill] : []),

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -72,6 +72,10 @@ type BuiltInMarketplaceRow = {
 
 type MarketplaceRow = MarketplacePackageRow | BuiltInMarketplaceRow;
 
+export function shouldShowMarketplaceRows(isSignedIn: boolean, activeOrgId: string) {
+  return isSignedIn && activeOrgId.trim().length > 0;
+}
+
 export type CloudMarketplacesViewProps = {
   extensions: DenSettingsExtensionsStore;
   embedded?: boolean;
@@ -182,6 +186,7 @@ export function CloudMarketplacesView({
   const [detailLoadingId, setDetailLoadingId] = React.useState<string | null>(null);
   const [detailError, setDetailError] = React.useState<string | null>(null);
   const activeOrgId = activeOrg?.id ?? "";
+  const canShowRows = shouldShowMarketplaceRows(isSignedIn, activeOrgId);
 
   const marketplaces = extensions.cloudOrgMarketplaces();
   const importedPlugins = extensions.importedCloudPlugins();
@@ -244,7 +249,7 @@ export function CloudMarketplacesView({
     });
   }, [builtInEntries, enablementContext, extensionItemsByBuiltInId, isBuiltInConnected]);
 
-  const rows = React.useMemo<MarketplaceRow[]>(() => [...builtInRows, ...cloudRows], [builtInRows, cloudRows]);
+  const rows = React.useMemo<MarketplaceRow[]>(() => canShowRows ? [...builtInRows, ...cloudRows] : [], [builtInRows, canShowRows, cloudRows]);
 
   React.useEffect(() => {
     if (rows.length > 0) lastRowsRef.current = rows;
@@ -253,11 +258,11 @@ export function CloudMarketplacesView({
   const displayRows = rows.length > 0 ? rows : busy ? lastRowsRef.current : rows;
 
   const marketplaceOptions = React.useMemo(
-    () => [
+    () => canShowRows ? [
       ...(builtInRows.length > 0 ? [{ id: "openwork-builtins", name: "OpenWork Built-ins" }] : []),
       ...marketplaces.map((marketplace) => ({ id: marketplace.marketplace.id, name: marketplace.marketplace.name })),
-    ],
-    [builtInRows.length, marketplaces],
+    ] : [],
+    [builtInRows.length, canShowRows, marketplaces],
   );
 
   const visibleRows = React.useMemo(() => {
@@ -388,7 +393,7 @@ export function CloudMarketplacesView({
         <SettingsSectionHeaderActions>
           <RefreshButton
             busy={busy}
-            disabled={busy || !activeOrgId}
+            disabled={busy || !canShowRows}
             onRefresh={refresh}
           >
             {t("den.refresh")}
@@ -457,7 +462,7 @@ export function CloudMarketplacesView({
 
       {!busy && displayRows.length === 0 ? (
         <SettingsListEmptyState>
-          {activeOrgId ? "No marketplace extensions are available yet." : "Choose an organization to view marketplace extensions."}
+          {!isSignedIn ? "Sign in to view marketplace extensions." : activeOrgId ? "No marketplace extensions are available yet." : "Choose an organization to view marketplace extensions."}
         </SettingsListEmptyState>
       ) : null}
 

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2232,6 +2232,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 enablementContext={enablementContext}
                 builtInExtensionsDisabled={builtInExtensionsDisabled}
                 builtInConnectingName={connectionsSnapshot.mcpConnectingName}
+                builtInEntries={extensionItems.builtInItems.flatMap((item) => item.builtInEntry ? [item.builtInEntry] : [])}
                 configSlotForBuiltIn={extensionController.configSlotForEntry}
                 isBuiltInConnected={extensionController.isConnected}
                 extensionItems={extensionItems.items}
@@ -2256,6 +2257,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             enablementContext={enablementContext}
             builtInExtensionsDisabled={builtInExtensionsDisabled}
             builtInConnectingName={connectionsSnapshot.mcpConnectingName}
+            builtInEntries={extensionItems.builtInItems.flatMap((item) => item.builtInEntry ? [item.builtInEntry] : [])}
             configSlotForBuiltIn={extensionController.configSlotForEntry}
             isBuiltInConnected={extensionController.isConnected}
             extensionItems={extensionItems.items}

--- a/apps/app/tests/cloud-marketplaces-view.test.ts
+++ b/apps/app/tests/cloud-marketplaces-view.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldShowMarketplaceRows } from "../src/react-app/domains/settings/pages/cloud-marketplaces-view";
+
+describe("Cloud marketplace row visibility", () => {
+  test("hides marketplace rows until a signed-in org is available", () => {
+    expect(shouldShowMarketplaceRows(false, "org_1")).toBe(false);
+    expect(shouldShowMarketplaceRows(true, "")).toBe(false);
+    expect(shouldShowMarketplaceRows(true, "   ")).toBe(false);
+    expect(shouldShowMarketplaceRows(true, "org_1")).toBe(true);
+  });
+});

--- a/apps/app/tests/extension-items.test.ts
+++ b/apps/app/tests/extension-items.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import type { McpDirectoryInfo } from "../src/app/constants";
+import { buildExtensionItems } from "../src/react-app/domains/settings/extension-items";
+
+const connectedBuiltIn: McpDirectoryInfo = {
+  id: "openwork-browser",
+  name: "OpenWork Browser",
+  serverName: "openwork-browser",
+  description: "Connected by default.",
+  oauth: false,
+  kind: "extension",
+  extensionManifest: {
+    schemaVersion: 1,
+    id: "openwork-browser",
+    name: "OpenWork Browser",
+    description: "Connected by default.",
+    source: { format: "openwork-builtin", origin: "builtin", trusted: true },
+    resources: [],
+  },
+};
+
+const availableBuiltIn: McpDirectoryInfo = {
+  id: "computer-use",
+  name: "Computer Use",
+  serverName: "computer-use",
+  description: "Marketplace-only until installed.",
+  oauth: false,
+  kind: "extension",
+  extensionManifest: {
+    schemaVersion: 1,
+    id: "computer-use",
+    name: "Computer Use",
+    description: "Marketplace-only until installed.",
+    source: { format: "openwork-builtin", origin: "builtin", trusted: true },
+    resources: [],
+  },
+};
+
+describe("extension item projection", () => {
+  test("keeps unconnected built-ins out of My Extensions quick connect", () => {
+    const result = buildExtensionItems({
+      quickConnect: [connectedBuiltIn, availableBuiltIn],
+      mcpServers: [],
+      installedSkills: [],
+      importedCloudPlugins: {},
+      cloudMarketplaces: [],
+      enablementContext: {},
+      isBuiltInConnected: (entry) => entry.id === connectedBuiltIn.id,
+    });
+
+    expect(result.installedMcpEntries.map((entry) => entry.name)).toEqual(["OpenWork Browser"]);
+    expect(result.builtInItems.map((item) => item.name)).toEqual(["OpenWork Browser", "Computer Use"]);
+  });
+});


### PR DESCRIPTION
## Summary
- hide unconnected built-in extensions from signed-out My Extensions quick connect
- gate Marketplace rows behind signed-in org state
- pass built-in extension entries into Marketplace so they appear only after the gate opens

## Validation
- pnpm --filter @openwork/app exec bun test tests/cloud-marketplaces-view.test.ts tests/extension-items.test.ts
- pnpm --filter @openwork/app typecheck
- Daytona validation on sandbox openwork-test-20260604-152040: fresh app reached #/welcome after applying the fix; prior sandbox validation confirmed signed-out Marketplace shows the sign-in empty state and no Computer Use/OpenAI Image Gen/Voice Mode/Google Workspace/Ollama cards.

No video captured; screenshot was inspected locally during validation.