### PR TITLE
fix(den): preserve session cookies on reload

### DIFF
--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -179,7 +179,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
     return token;
   });
-  const [sessionHydrated, setSessionHydrated] = useState(true);
+  const [sessionHydrated, setSessionHydrated] = useState(false);
   const [desktopAuthRequested, setDesktopAuthRequested] = useState(false);
   const [desktopAuthScheme, setDesktopAuthScheme] = useState("openwork");
   const [desktopRedirectBusy, setDesktopRedirectBusy] = useState(false);


### PR DESCRIPTION
## Summary
- Start Den session hydration as pending instead of already complete
- Prevent dashboard guards from calling signOut before cookie-backed session refresh finishes on hard reload/manual navigation

## Test
- pnpm --filter @openwork-ee/den-web build

## Evidence
- No video captured; this is a one-line auth guard timing fix verified by the den-web production build.