### PR TITLE
fix(den): unblock seeded demo invites

### DIFF
--- a/ee/apps/den-api/scripts/seed-demo-org.ts
+++ b/ee/apps/den-api/scripts/seed-demo-org.ts
@@ -9,6 +9,7 @@ import {
   MarketplacePluginTable,
   MarketplaceTable,
   MemberTable,
+  OrgSubscriptionTable,
   OrganizationTable,
   PluginAccessGrantTable,
   PluginConfigObjectTable,
@@ -409,6 +410,48 @@ async function ensureTeamMember(teamId: TeamId, orgMembershipId: MemberId) {
   const id = createDenTypeId("teamMember")
   await db.insert(TeamMemberTable).values({ id, orgMembershipId, teamId })
   return id
+}
+
+async function ensureDemoSeatSubscription(input: { createdByOrgMembershipId: MemberId; memberCount: number; organizationId: OrganizationId }) {
+  const now = new Date()
+  const currentPeriodEnd = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 30)
+  await db.insert(OrgSubscriptionTable).values({
+    cancel_at_period_end: false,
+    canceled_at: null,
+    created_at: now,
+    created_by_org_membership_id: input.createdByOrgMembershipId,
+    current_period_end: currentPeriodEnd,
+    current_period_start: now,
+    ended_at: null,
+    id: createDenTypeId("orgSubscription"),
+    last_event_id: "demo-seed-seat-subscription",
+    organization_id: input.organizationId,
+    quantity: Math.max(0, input.memberCount - 5),
+    status: "active",
+    stripe_customer_id: `cus_demo_${input.organizationId}`,
+    stripe_price_id: "price_demo_seats",
+    stripe_subscription_id: `sub_demo_seats_${input.organizationId}`,
+    stripe_subscription_item_id: null,
+    type: "seat",
+    updated_at: now,
+  }).onDuplicateKeyUpdate({
+    set: {
+      cancel_at_period_end: false,
+      canceled_at: null,
+      created_by_org_membership_id: input.createdByOrgMembershipId,
+      current_period_end: currentPeriodEnd,
+      current_period_start: now,
+      ended_at: null,
+      last_event_id: "demo-seed-seat-subscription",
+      quantity: Math.max(0, input.memberCount - 5),
+      status: "active",
+      stripe_customer_id: `cus_demo_${input.organizationId}`,
+      stripe_price_id: "price_demo_seats",
+      stripe_subscription_id: `sub_demo_seats_${input.organizationId}`,
+      stripe_subscription_item_id: null,
+      updated_at: now,
+    },
+  })
 }
 
 async function ensureInvitation(input: {
@@ -904,6 +947,7 @@ async function resetDemoOrg() {
     await db.delete(MarketplaceAccessGrantTable).where(inArray(MarketplaceAccessGrantTable.marketplaceId, marketplaceIds))
     await db.delete(MarketplaceTable).where(inArray(MarketplaceTable.id, marketplaceIds))
   }
+  await db.delete(OrgSubscriptionTable).where(eq(OrgSubscriptionTable.organization_id, orgId))
   await db.delete(InvitationTable).where(eq(InvitationTable.organizationId, orgId))
   await db.delete(TeamMemberTable).where(inArray(TeamMemberTable.teamId, (await db.select({ id: TeamTable.id }).from(TeamTable).where(eq(TeamTable.organizationId, orgId))).map((r) => r.id)))
   await db.delete(TeamTable).where(eq(TeamTable.organizationId, orgId))
@@ -1022,6 +1066,10 @@ async function main() {
 
   const ownerMembershipId = memberIdsByEmail.get(DEMO_OWNER_EMAIL.toLowerCase())
   if (!ownerMembershipId) throw new Error("Demo owner membership missing after seed.")
+
+  await ensureDemoSeatSubscription({ createdByOrgMembershipId: ownerMembershipId, memberCount: memberIdsByEmail.size, organizationId })
+  log("✓", "active demo seat subscription")
+  console.log()
 
   log("…", "creating marketplace")
   const marketplaceId = await ensureMarketplace({ createdByOrgMembershipId: ownerMembershipId, organizationId })

--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -475,6 +475,10 @@ export async function getOrgBillingSummary(input: { organizationId: OrgId; inclu
 }
 
 export async function syncInferenceSubscriptionQuantityAfterMemberChange(input: { organizationId: OrgId; memberCount: number }) {
+  if (!env.stripe.secretKey) {
+    return
+  }
+
   const row = await findInferenceSubscriptionByOrg(input.organizationId)
   if (!row || !ACTIVE_STATUSES.has(row.status) || !row.stripe_subscription_item_id) {
     return
@@ -488,6 +492,10 @@ export async function syncInferenceSubscriptionQuantityAfterMemberChange(input: 
 }
 
 export async function syncSeatSubscriptionQuantityAfterMemberChange(input: { organizationId: OrgId; memberCount: number }) {
+  if (!env.stripe.secretKey) {
+    return
+  }
+
   const row = await findSeatSubscriptionByOrg(input.organizationId)
   if (!row || !ACTIVE_STATUSES.has(row.status) || !row.stripe_subscription_item_id) {
     return


### PR DESCRIPTION
## Summary
- Seed Acme demo orgs with an active demo seat subscription so seeded demos can invite a new user past the free-seat threshold.
- Skip Stripe subscription quantity sync when Stripe is not configured, which prevents dev/demo member-change hooks from failing.

## Validation
- `pnpm --filter @openwork-ee/den-api build` passed.
- Daytona Den server: `openwork-plugin-invite-den-20260605`
- Daytona Electron: `openwork-test-20260605-174441`
- Den health passed: `/health` and `/api/den/health`.
- Seeded owner login passed through Den Web and Den API.
- Invited `jordan.plugin@acme.test`, granted Anthropic Knowledge Work Plugins marketplace access, accepted invite, signed into Electron as Jordan, saw assigned cloud plugins, and installed `productivity`.

## Evidence
- Frame proof: https://8090-c8xkzuwpd9mbogja.daytonaproxy01.net/screenshots/plugin-invite-flow/proof.html
- Final frame: https://8090-c8xkzuwpd9mbogja.daytonaproxy01.net/screenshots/plugin-invite-flow/14-electron-productivity-installed.png
- Recording: https://8090-c8xkzuwpd9mbogja.daytonaproxy01.net/recordings/plugin-invite-flow-20260605.mp4

## API/DB assertions
- Jordan marketplace API visibility returned 3 marketplaces: OpenWork Marketplace, Anthropic-Compatible Plugins, Anthropic Knowledge Work Plugins.
- Anthropic Knowledge Work Plugins returned `pluginCount: 14`.
- DB showed `jordan.plugin@acme.test` invitation status `accepted` and the marketplace direct access grant as `viewer`.
- Den API logs showed `/v1/auth/desktop-handoff/exchange`, `/v1/me/orgs`, `/v1/marketplaces?status=active&limit=100`, `/v1/marketplaces/:id/resolved`, and `/v1/plugins/:id/resolved` returning 200.
