### PR TITLE
chore: add local two-electron demo launcher

### DIFF
--- a/apps/desktop/scripts/electron-dev.mjs
+++ b/apps/desktop/scripts/electron-dev.mjs
@@ -196,8 +196,10 @@ async function stopAll(exitCode = 0) {
 process.once("SIGINT", () => void stopAll(130));
 process.once("SIGTERM", () => void stopAll(143));
 
-runSync(nodeCmd, [resolve(__dirname, "prepare-sidecar.mjs"), "--force", "--outdir", electronSidecarDir], { cwd: desktopRoot });
-runSync(nodeCmd, [resolve(__dirname, "prepare-computer-use-helper.mjs"), "--force", "--outdir", electronHelperDir], { cwd: desktopRoot });
+if (process.env.OPENWORK_ELECTRON_SKIP_SHARED_PREPARE !== "1") {
+  runSync(nodeCmd, [resolve(__dirname, "prepare-sidecar.mjs"), "--force", "--outdir", electronSidecarDir], { cwd: desktopRoot });
+  runSync(nodeCmd, [resolve(__dirname, "prepare-computer-use-helper.mjs"), "--force", "--outdir", electronHelperDir], { cwd: desktopRoot });
+}
 
 // Build the server TS → JS so Electron can import it in-process
 console.log("[electron-dev] Building openwork-server (tsc)...");

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "OPENWORK_DEV_MODE=1 OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=${OPENWORK_ELECTRON_REMOTE_DEBUG_PORT:-9823} pnpm --filter @openwork/desktop dev",
     "dev:electron": "OPENWORK_DEV_MODE=1 pnpm --filter @openwork/desktop dev:electron",
+    "dev:electron:two": "OPENWORK_DEV_MODE=1 node scripts/dev-two-electron-demo.mjs",
     "dev:sandbox": "bash .devcontainer/dev-sandbox.sh",
     "dev:windows": ".\\scripts\\dev-windows.cmd",
     "dev:windows:x64": ".\\scripts\\dev-windows.cmd x64",

--- a/scripts/dev-local.mjs
+++ b/scripts/dev-local.mjs
@@ -15,6 +15,10 @@ const workerProxyPort = process.env.DEN_WORKER_PROXY_PORT?.trim() || "8789"
 const inferencePort = process.env.INFERENCE_PORT?.trim() || "8791"
 const webPort = process.env.DEN_WEB_PORT?.trim() || "3005"
 const appPort = process.env.OPENWORK_APP_PORT?.trim() || process.env.PORT?.trim() || "5173"
+const extraAppPorts = (process.env.OPENWORK_EXTRA_APP_PORTS?.trim() || "5174")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean)
 const databaseUrl = process.env.DATABASE_URL?.trim() || "mysql://root:password@127.0.0.1:3306/openwork_den"
 const dbEncryptionKey =
   process.env.DEN_DB_ENCRYPTION_KEY?.trim() ||
@@ -28,6 +32,11 @@ function detectWebOrigins() {
     `http://localhost:${appPort}`,
     `http://127.0.0.1:${appPort}`,
   ])
+
+  for (const port of extraAppPorts) {
+    origins.add(`http://localhost:${port}`)
+    origins.add(`http://127.0.0.1:${port}`)
+  }
 
   for (const entries of Object.values(os.networkInterfaces())) {
     for (const entry of entries || []) {

--- a/scripts/dev-two-electron-demo.mjs
+++ b/scripts/dev-two-electron-demo.mjs
@@ -69,11 +69,16 @@ function startElectron(label, env) {
   const prefix = `[${label}]`;
   child.stdout.on("data", (chunk) => process.stdout.write(`${prefix} ${chunk}`));
   child.stderr.on("data", (chunk) => process.stderr.write(`${prefix} ${chunk}`));
+  child.once("error", (error) => {
+    if (stopping) return;
+    console.error(`${prefix} failed to start: ${error.message}`);
+    void stopAll(1);
+  });
   child.once("exit", (code, signal) => {
     if (stopping) return;
-    const detail = signal ? `signal ${signal}` : `exit ${code ?? 1}`;
+    const detail = signal ? `signal ${signal}` : `exit ${code ?? 0}`;
     console.error(`${prefix} stopped with ${detail}`);
-    void stopAll(1);
+    void stopAll(signal ? 1 : (code ?? 0));
   });
 
   return child;

--- a/scripts/dev-two-electron-demo.mjs
+++ b/scripts/dev-two-electron-demo.mjs
@@ -1,0 +1,170 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const desktopRoot = path.join(repoRoot, "apps", "desktop");
+const desktopScriptsRoot = path.join(desktopRoot, "scripts");
+const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const demoRoot = path.join(os.homedir(), ".openwork", "two-electron-demo");
+
+function argValue(name, fallback) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return fallback;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function flag(name) {
+  return process.argv.includes(name);
+}
+
+function runSync(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    shell: process.platform === "win32" && /\.(cmd|bat)$/i.test(command),
+    ...options,
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function prepareSharedElectronResources() {
+  runSync(
+    process.execPath,
+    [
+      path.join(desktopScriptsRoot, "prepare-sidecar.mjs"),
+      "--force",
+      "--outdir",
+      path.join(desktopRoot, "resources", "sidecars"),
+    ],
+    { cwd: desktopRoot },
+  );
+  runSync(
+    process.execPath,
+    [
+      path.join(desktopScriptsRoot, "prepare-computer-use-helper.mjs"),
+      "--force",
+      "--outdir",
+      path.join(desktopRoot, "resources", "helpers"),
+    ],
+    { cwd: desktopRoot },
+  );
+}
+
+function startElectron(label, env) {
+  const child = spawn(pnpmCmd, ["dev:electron"], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32",
+  });
+
+  const prefix = `[${label}]`;
+  child.stdout.on("data", (chunk) => process.stdout.write(`${prefix} ${chunk}`));
+  child.stderr.on("data", (chunk) => process.stderr.write(`${prefix} ${chunk}`));
+  child.once("exit", (code, signal) => {
+    if (stopping) return;
+    const detail = signal ? `signal ${signal}` : `exit ${code ?? 1}`;
+    console.error(`${prefix} stopped with ${detail}`);
+    void stopAll(1);
+  });
+
+  return child;
+}
+
+function stopChild(child) {
+  if (!child || child.exitCode !== null) return;
+  try {
+    if (process.platform !== "win32") {
+      process.kill(-child.pid, "SIGINT");
+    } else {
+      child.kill("SIGINT");
+    }
+  } catch {
+    child.kill("SIGINT");
+  }
+}
+
+let stopping = false;
+let children = [];
+
+async function stopAll(exitCode = 0) {
+  if (stopping) return;
+  stopping = true;
+  for (const child of children) stopChild(child);
+  setTimeout(() => process.exit(exitCode), 1500).unref();
+}
+
+async function writeBootstrap(filePath, requireSignin, baseUrl, apiBaseUrl) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(
+    filePath,
+    `${JSON.stringify({ baseUrl, apiBaseUrl, requireSignin }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+async function main() {
+  if (flag("--help") || flag("-h")) {
+    console.log(`Usage: pnpm dev:electron:two [options]\n\nStarts two isolated Electron dev instances for a local Den demo.\n\nOptions:\n  --den-web-url <url>     Den Web URL (default: http://localhost:3005)\n  --den-api-url <url>     Den API URL (default: http://localhost:8788)\n  --admin-port <port>     Admin Vite port (default: 5173)\n  --consumer-port <port>  Consumer Vite port (default: 5174)\n  --admin-cdp <port>      Admin Electron CDP port (default: 9823)\n  --consumer-cdp <port>   Consumer Electron CDP port (default: 9824)\n`);
+    return;
+  }
+
+  const denWebUrl = argValue("--den-web-url", "http://localhost:3005");
+  const denApiUrl = argValue("--den-api-url", "http://localhost:8788");
+  const adminPort = argValue("--admin-port", "5173");
+  const consumerPort = argValue("--consumer-port", "5174");
+  const adminCdp = argValue("--admin-cdp", "9823");
+  const consumerCdp = argValue("--consumer-cdp", "9824");
+  const adminBootstrap = path.join(demoRoot, "admin-bootstrap.json");
+  const consumerBootstrap = path.join(demoRoot, "consumer-bootstrap.json");
+
+  await writeBootstrap(adminBootstrap, false, denWebUrl, denApiUrl);
+  await writeBootstrap(consumerBootstrap, true, denWebUrl, denApiUrl);
+  await mkdir(path.join(demoRoot, "admin-userdata"), { recursive: true });
+  await mkdir(path.join(demoRoot, "consumer-userdata"), { recursive: true });
+
+  prepareSharedElectronResources();
+
+  children = [
+    startElectron("admin", {
+      OPENWORK_ELECTRON_USERDATA: path.join(demoRoot, "admin-userdata"),
+      OPENWORK_DESKTOP_BOOTSTRAP_PATH: adminBootstrap,
+      OPENWORK_ELECTRON_SKIP_SHARED_PREPARE: "1",
+      OPENWORK_ELECTRON_REMOTE_DEBUG_PORT: adminCdp,
+      PORT: adminPort,
+    }),
+    startElectron("consumer", {
+      OPENWORK_ELECTRON_USERDATA: path.join(demoRoot, "consumer-userdata"),
+      OPENWORK_DESKTOP_BOOTSTRAP_PATH: consumerBootstrap,
+      OPENWORK_ELECTRON_SKIP_SHARED_PREPARE: "1",
+      OPENWORK_ELECTRON_REMOTE_DEBUG_PORT: consumerCdp,
+      PORT: consumerPort,
+    }),
+  ];
+
+  console.log("\nTwo Electron demo is starting.");
+  console.log(`Den Web:       ${denWebUrl}`);
+  console.log(`Den API:       ${denApiUrl}`);
+  console.log(`Admin CDP:     http://127.0.0.1:${adminCdp}`);
+  console.log(`Consumer CDP:  http://127.0.0.1:${consumerCdp}`);
+  console.log(`Admin data:    ${path.join(demoRoot, "admin-userdata")}`);
+  console.log(`Consumer data: ${path.join(demoRoot, "consumer-userdata")}`);
+  console.log(`Den startup:   OPENWORK_EXTRA_APP_PORTS=${adminPort},${consumerPort} pnpm dev:den`);
+  console.log("Press Ctrl-C to stop both instances.\n");
+}
+
+process.once("SIGINT", () => void stopAll(130));
+process.once("SIGTERM", () => void stopAll(143));
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  void stopAll(1);
+});


### PR DESCRIPTION
## Summary
- add `pnpm dev:electron:two` to launch isolated admin and consumer Electron dev instances against a local Den server
- prepare shared Electron sidecar/helper resources once to avoid concurrent codesign races
- include local Den trusted origins for the second Electron UI port via `OPENWORK_EXTRA_APP_PORTS`

## How to run locally
1. Start Den: `OPENWORK_EXTRA_APP_PORTS=5173,5174 pnpm dev:den`
2. Seed demo org: `pnpm dev:den:seed-demo`
3. Launch two Electron instances: `pnpm dev:electron:two`
4. Use admin CDP `http://127.0.0.1:9823` and consumer CDP `http://127.0.0.1:9824`

## Verification
- `pnpm dev:electron:two --help` passed
- `git diff --check` passed
- Local Den verified healthy: `curl http://localhost:8788/health` and `curl http://localhost:3005/api/den/health`
- Seeded isolated local demo DB `openwork_den_two_demo` successfully: 17 members, 12 teams, 14 plugins, 71 config objects
- Launched two local Electron instances with `pnpm dev:electron:two --admin-port 5183 --consumer-port 5184 --admin-cdp 9833 --consumer-cdp 9834`
- Verified via CDP:
  - admin: `http://localhost:5183/#/welcome`, bootstrap `requireSignin: false`
  - consumer: `http://localhost:5184/#/signin`, bootstrap `requireSignin: true`
- Verified consumer local Den handoff using raw grant:
  - signed in as `alex@acme.test`
  - reached `#/onboarding`
  - loaded `Acme Robotics` / `acme-robotics-demo`
  - showed `3 MARKETPLACES`
  - continued to workspace

## Local screenshot evidence
- admin welcome: `/var/folders/8j/hhcc8zs100d3fd654fjkk9580000gn/T/browser-screenshot-1780721038640.png`
- consumer signin: `/var/folders/8j/hhcc8zs100d3fd654fjkk9580000gn/T/browser-screenshot-1780721038719.png`
- consumer org picker: `/var/folders/8j/hhcc8zs100d3fd654fjkk9580000gn/T/browser-screenshot-1780721222634.png`
- consumer marketplaces onboarding: `/var/folders/8j/hhcc8zs100d3fd654fjkk9580000gn/T/browser-screenshot-1780721239853.png`
- consumer workspace: `/var/folders/8j/hhcc8zs100d3fd654fjkk9580000gn/T/browser-screenshot-1780721270226.png`

Note: browser deep-link URLs generated by the API include the API handoff base; for the manual paste flow, paste the raw `grant` value so the desktop uses its configured local Den bootstrap.