### PR TITLE
fix: bump bundled opencode

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -50,7 +50,7 @@
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@heroicons/react": "^2.2.0",
     "@lexical/react": "^0.35.0",
-    "@opencode-ai/sdk": "^1.15.12",
+    "@opencode-ai/sdk": "^1.16.2",
     "@openwork/types": "workspace:*",
     "@openwork/ui": "workspace:*",
     "@paper-design/shaders-react": "0.0.72",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,7 +24,7 @@
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.15.12",
+    "@opencode-ai/sdk": "^1.16.2",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
     "electron-updater": "^6.3.9",

--- a/apps/opencode-router/package.json
+++ b/apps/opencode-router/package.json
@@ -44,7 +44,7 @@
     "test:npx": "bun scripts/test-npx.mjs"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.15.12",
+    "@opencode-ai/sdk": "^1.16.2",
     "@slack/socket-mode": "^2.0.5",
     "@slack/web-api": "^7.13.0",
     "commander": "^12.1.0",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.15.12",
+    "@opencode-ai/sdk": "^1.16.2",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
     "opencode-router": "0.15.2",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -46,7 +46,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.15.12",
+    "@opencode-ai/sdk": "^1.16.2",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
     "jsonc-parser": "^3.2.1",

--- a/constants.json
+++ b/constants.json
@@ -1,3 +1,3 @@
 {
-  "opencodeVersion": "v1.15.12"
+  "opencodeVersion": "v1.16.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^0.35.0
         version: 0.35.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.30)
       '@opencode-ai/sdk':
-        specifier: ^1.15.12
-        version: 1.15.12
+        specifier: ^1.16.2
+        version: 1.16.2
       '@openwork/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -218,8 +218,8 @@ importers:
   apps/desktop:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.15.12
-        version: 1.15.12
+        specifier: ^1.16.2
+        version: 1.16.2
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -258,8 +258,8 @@ importers:
   apps/opencode-router:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.15.12
-        version: 1.15.12
+        specifier: ^1.16.2
+        version: 1.16.2
       '@slack/socket-mode':
         specifier: ^2.0.5
         version: 2.0.5
@@ -292,8 +292,8 @@ importers:
   apps/orchestrator:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.15.12
-        version: 1.15.12
+        specifier: ^1.16.2
+        version: 1.16.2
       '@opentui/core':
         specifier: 0.1.77
         version: 0.1.77(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
@@ -338,8 +338,8 @@ importers:
   apps/server:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.15.12
-        version: 1.15.12
+        specifier: ^1.16.2
+        version: 1.16.2
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -2848,8 +2848,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opencode-ai/sdk@1.15.12':
-    resolution: {integrity: sha512-lOaBNX93dkakZe6C42ttX1bkSx3K2c6+Yv+w8Qv02v5rPlu1vCXbmdfYDh9/bw+oq+NKPSaBm9d6kPA19hA5Lg==}
+  '@opencode-ai/sdk@1.16.2':
+    resolution: {integrity: sha512-Z/xZ7q79dYeE0afqIk/yFEcRNGEQFcE+H8ssYivUiy+xGZ1mGwT72jpaQZKBwPn3JH4sRCu4KA2lcktBQfcOjg==}
 
   '@opentelemetry/api-logs@0.207.0':
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
@@ -11524,7 +11524,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opencode-ai/sdk@1.15.12':
+  '@opencode-ai/sdk@1.16.2':
     dependencies:
       cross-spawn: 7.0.6
 


### PR DESCRIPTION
## Summary
- Bump bundled OpenCode sidecar from v1.15.12 to v1.16.2
- Update @opencode-ai/sdk consumers to ^1.16.2
- Refresh pnpm lockfile

## Why
Users reported Windows desktop crashes when sending a chat message with `SQLiteError: NOT NULL constraint failed: session_message.seq`. OpenCode v1.16.x includes the newer session_message projection schema expected by migrated databases.

## Validation
- `pnpm --filter openwork-server typecheck` — passed
- `pnpm --filter @openwork/desktop typecheck:electron` — passed
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter openwork-orchestrator typecheck` — passed
- `pnpm --filter opencode-router build` — passed
- Manual desktop smoke: ran `pnpm dev`, attached to Electron CDP, created a clean isolated workspace/session, sent a prompt through the composer, received a completed assistant response, and checked UI/logs for `SQLiteError`, `NOT NULL constraint`, and `session_message.seq` — none found.

## Evidence
No video captured. Manual CDP smoke test completed locally as described above.