### PR TITLE
fix(app): persist step disclosure and cap inline images

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -41,6 +41,7 @@ import { WebsearchTool } from "@/components/tools/websearch"
 import { useMessageList, useSessionErrorMessage } from "@/components/chat/message-list-provider"
 import { ArtifactList } from "@/components/chat/artifact"
 import { TaskSuggestions } from "@/components/chat/task-suggestions"
+import { selectStepGroupOpen, useSessionStepDisclosureStore } from "@/react-app/domains/session/surface/step-disclosure-store"
 import {
   DescriptiveButtonContent,
   DescriptiveButtonDescription,
@@ -170,7 +171,6 @@ function FileMessage({ part }: FileMessageProps) {
         alt={title}
         loading="lazy"
         decoding="async"
-        className="size-full object-cover"
       />
     )
   }
@@ -568,8 +568,11 @@ function MessageGroup({
   messages,
   isStreaming,
 }: AssistantMessageGroupProps) {
-  const { onRevertToUserMessage, onForkAtMessage } = useMessageList()
-  const [open, setOpen] = React.useState(false)
+  const { workspaceId, sessionId, onRevertToUserMessage, onForkAtMessage } = useMessageList()
+  const firstItem = items[0]
+  const stepGroupId = firstItem?.message.id ?? "empty-assistant-group"
+  const open = useSessionStepDisclosureStore((state) => selectStepGroupOpen(state.stepGroupsByWorkspace, workspaceId, sessionId, stepGroupId))
+  const setStepGroupOpen = useSessionStepDisclosureStore((state) => state.setStepGroupOpen)
   // Only run layout animations while the collapsible is expanding/collapsing.
   // Otherwise (e.g. while streaming) layout changes apply instantly.
   const [isAnimating, setIsAnimating] = React.useState(false)
@@ -598,7 +601,7 @@ function MessageGroup({
         open={open}
         onOpenChange={(next) => {
           setIsAnimating(true)
-          setOpen(next)
+          setStepGroupOpen(workspaceId, sessionId, stepGroupId, next)
         }}
       >
         <StepsTrigger className="px-2 md:px-10">

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -83,6 +83,7 @@ function createEmojiAliases() {
 }
 
 const emojiAliases = createEmojiAliases();
+const MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT = 100;
 
 function parseShikiLanguage(lang: string) {
   const normalized = lang.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
@@ -93,14 +94,53 @@ function hasFencedCodeBlock(text: string) {
   return /(^|\n)```/.test(text);
 }
 
+function estimatedRenderedImageHeight(image: HTMLImageElement) {
+  if (!image.naturalWidth || !image.naturalHeight) return 0;
+
+  const renderedWidth = image.clientWidth || image.getBoundingClientRect().width;
+  return renderedWidth > 0
+    ? (image.naturalHeight / image.naturalWidth) * renderedWidth
+    : image.naturalHeight;
+}
+
+function syncMarkdownImagePreviews(root: HTMLElement) {
+  const previews = root.querySelectorAll("[data-openwork-image-preview]");
+
+  for (const preview of previews) {
+    if (!(preview instanceof HTMLElement)) continue;
+
+    const image = preview.querySelector("img");
+    const button = preview.querySelector("[data-openwork-image-toggle]");
+    if (!(image instanceof HTMLImageElement) || !(button instanceof HTMLButtonElement)) continue;
+
+    const previewable = estimatedRenderedImageHeight(image) > MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT;
+    button.hidden = !previewable;
+
+    if (!previewable) {
+      preview.style.maxHeight = "";
+      continue;
+    }
+
+    const expanded = preview.dataset.openworkImagePreview === "expanded";
+    preview.style.maxHeight = expanded ? "" : `${MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT}px`;
+
+    const label = button.querySelector("[data-openwork-image-toggle-label]");
+    if (label) label.textContent = expanded ? "Show less" : "Show full image";
+  }
+}
+
 function sanitizeMarkdownHtml(value: string) {
   return DOMPurify.sanitize(value, {
     ADD_ATTR: [
       "checked",
       "class",
+      "data-openwork-image-preview",
+      "data-openwork-image-toggle",
+      "data-openwork-image-toggle-label",
       "data-openwork-shiki",
       "decoding",
       "disabled",
+      "hidden",
       "loading",
       "rel",
       "start",
@@ -177,7 +217,7 @@ const baseMarkedOptions = {
       const safe = escapeAttribute(safeHref(href));
       const titleAttr = title ? ` title="${escapeAttribute(title)}"` : "";
 
-      return `<img src="${safe}" alt="${escapeAttribute(text)}"${titleAttr} loading="lazy" decoding="async" class="my-4 max-w-full rounded-lg border border-border/70">`;
+      return `<span data-openwork-image-preview="collapsed" class="relative my-4 inline-block max-w-full overflow-hidden rounded-lg border border-border/70 align-top" style="max-height: ${MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT}px"><img src="${safe}" alt="${escapeAttribute(text)}"${titleAttr} loading="lazy" decoding="async" class="block h-auto max-w-full"><button type="button" data-openwork-image-toggle="" hidden class="absolute inset-x-0 bottom-0 flex justify-center bg-gradient-to-t from-background via-background/90 to-transparent pb-2 pt-8"><span data-openwork-image-toggle-label="" class="rounded-full border border-border bg-background/95 px-3 py-1 text-xs font-medium text-foreground shadow-sm">Show full image</span></button></span>`;
     },
     table(token) {
       const header = token.header.map((cell) => this.tablecell({ ...cell, header: true })).join("");
@@ -310,6 +350,53 @@ function MarkdownBlockInner({
       applyTextHighlights(root, highlightQuery ?? "");
     });
   }, [html, highlightQuery]);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const sync = () => syncMarkdownImagePreviews(root);
+
+    sync();
+
+    const handleLoad = (event: Event) => {
+      if (event.target instanceof HTMLImageElement) sync();
+    };
+
+    const handleClick = (event: MouseEvent) => {
+      if (!(event.target instanceof Element)) return;
+
+      const button = event.target.closest("[data-openwork-image-toggle]");
+      if (!(button instanceof HTMLButtonElement)) return;
+
+      const preview = button.closest("[data-openwork-image-preview]");
+      if (!(preview instanceof HTMLElement)) return;
+
+      preview.dataset.openworkImagePreview = preview.dataset.openworkImagePreview === "expanded"
+        ? "collapsed"
+        : "expanded";
+      sync();
+    };
+
+    root.addEventListener("load", handleLoad, true);
+    root.addEventListener("click", handleClick);
+
+    if (globalThis.ResizeObserver === undefined) {
+      return () => {
+        root.removeEventListener("load", handleLoad, true);
+        root.removeEventListener("click", handleClick);
+      };
+    }
+
+    const observer = new ResizeObserver(sync);
+    observer.observe(root);
+
+    return () => {
+      observer.disconnect();
+      root.removeEventListener("load", handleLoad, true);
+      root.removeEventListener("click", handleClick);
+    };
+  }, [html]);
 
   if (!html) {
     return null;

--- a/apps/app/src/components/ui/image.tsx
+++ b/apps/app/src/components/ui/image.tsx
@@ -9,9 +9,12 @@ export type GeneratedImageLike = {
 }
 
 export type ImageProps = GeneratedImageLike &
-  React.ComponentProps<"img"> & {
+  Omit<React.ComponentProps<"img">, "src"> & {
     alt: string
+    previewMaxHeight?: number
   }
+
+const DEFAULT_PREVIEW_MAX_HEIGHT = 100
 
 function getImageSrc({
   base64,
@@ -30,9 +33,14 @@ export const Image = ({
   mediaType = "image/png",
   className,
   alt,
+  previewMaxHeight = DEFAULT_PREVIEW_MAX_HEIGHT,
+  onLoad,
   ...props
 }: ImageProps) => {
   const [objectUrl, setObjectUrl] = React.useState<string | undefined>(undefined)
+  const [expanded, setExpanded] = React.useState(false)
+  const [canExpand, setCanExpand] = React.useState(false)
+  const imageRef = React.useRef<HTMLImageElement | null>(null)
 
   React.useEffect(() => {
     if (uint8Array && mediaType) {
@@ -50,6 +58,42 @@ export const Image = ({
   const base64Src = getImageSrc({ base64, mediaType })
   const imageSrc = src ?? base64Src ?? objectUrl
 
+  const updateCanExpand = React.useCallback((image: HTMLImageElement) => {
+    if (previewMaxHeight <= 0) {
+      setCanExpand(false)
+      return
+    }
+
+    if (!image.naturalWidth || !image.naturalHeight) {
+      setCanExpand(false)
+      return
+    }
+
+    const renderedWidth = image.clientWidth || image.getBoundingClientRect().width
+    const renderedHeight = renderedWidth > 0
+      ? (image.naturalHeight / image.naturalWidth) * renderedWidth
+      : image.naturalHeight
+
+    setCanExpand(renderedHeight > previewMaxHeight)
+  }, [previewMaxHeight])
+
+  React.useEffect(() => {
+    setExpanded(false)
+  }, [imageSrc])
+
+  React.useEffect(() => {
+    const image = imageRef.current
+    if (!image) return
+
+    updateCanExpand(image)
+
+    if (globalThis.ResizeObserver === undefined) return
+
+    const observer = new ResizeObserver(() => updateCanExpand(image))
+    observer.observe(image)
+    return () => observer.disconnect()
+  }, [imageSrc, updateCanExpand])
+
   if (!imageSrc) {
     return (
       <div
@@ -64,13 +108,53 @@ export const Image = ({
     )
   }
 
-  return (
+  const image = (
     <img
+      ref={imageRef}
       src={imageSrc}
       alt={alt}
       className={cn("h-auto max-w-full overflow-hidden rounded-md", className)}
       role="img"
+      onLoad={(event) => {
+        updateCanExpand(event.currentTarget)
+        onLoad?.(event)
+      }}
       {...props}
     />
+  )
+
+  if (previewMaxHeight <= 0) {
+    return image
+  }
+
+  return (
+    <div className="inline-flex max-w-full flex-col items-start gap-1">
+      <div
+        className="relative max-w-full overflow-hidden rounded-md"
+        style={expanded ? undefined : { maxHeight: previewMaxHeight }}
+      >
+        {image}
+        {!expanded && canExpand ? (
+          <div className="absolute inset-x-0 bottom-0 flex justify-center bg-gradient-to-t from-background via-background/90 to-transparent pb-2 pt-8">
+            <button
+              type="button"
+              className="rounded-full border border-border bg-background/95 px-3 py-1 text-xs font-medium text-foreground shadow-sm transition-colors hover:bg-muted"
+              onClick={() => setExpanded(true)}
+            >
+              Show full image
+            </button>
+          </div>
+        ) : null}
+      </div>
+      {expanded && canExpand ? (
+        <button
+          type="button"
+          className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          onClick={() => setExpanded(false)}
+        >
+          Show less
+        </button>
+      ) : null}
+    </div>
   )
 }

--- a/apps/app/src/react-app/domains/session/surface/step-disclosure-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/step-disclosure-store.ts
@@ -1,0 +1,55 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+type StepGroupsByWorkspace = Record<string, Record<string, Record<string, boolean>>>;
+
+type SessionStepDisclosureStore = {
+  stepGroupsByWorkspace: StepGroupsByWorkspace;
+  setStepGroupOpen: (workspaceId: string, sessionId: string, stepGroupId: string, open: boolean) => void;
+};
+
+export function selectStepGroupOpen(
+  stepGroupsByWorkspace: StepGroupsByWorkspace,
+  workspaceId: string,
+  sessionId: string,
+  stepGroupId: string,
+): boolean {
+  return stepGroupsByWorkspace[workspaceId]?.[sessionId]?.[stepGroupId] ?? true;
+}
+
+export const useSessionStepDisclosureStore = create<SessionStepDisclosureStore>()(
+  persist(
+    (set) => ({
+      stepGroupsByWorkspace: {},
+      setStepGroupOpen: (workspaceId, sessionId, stepGroupId, open) => {
+        const workspace = workspaceId.trim();
+        const session = sessionId.trim();
+        const group = stepGroupId.trim();
+        if (!workspace || !session || !group) return;
+
+        set((state) => {
+          const workspaceSessions = state.stepGroupsByWorkspace[workspace] ?? {};
+          const sessionGroups = workspaceSessions[session] ?? {};
+          if (sessionGroups[group] === open) return state;
+
+          return {
+            stepGroupsByWorkspace: {
+              ...state.stepGroupsByWorkspace,
+              [workspace]: {
+                ...workspaceSessions,
+                [session]: {
+                  ...sessionGroups,
+                  [group]: open,
+                },
+              },
+            },
+          };
+        });
+      },
+    }),
+    {
+      name: "openwork:session-step-disclosure:v1",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- Default session steps groups to expanded and persist each group’s expanded/collapsed state by workspace + session.
- Add capped 100px previews for inline image attachments with Show full image / Show less controls.
- Apply the same capped preview treatment to markdown images.

## Tests
- pnpm --dir apps/app typecheck ✅
- pnpm dev ✅
- Electron CDP UI check on http://127.0.0.1:9831 ✅
  - confirmed a steps block defaults expanded
  - collapsed it, switched sessions, returned, and confirmed it stayed collapsed
  - expanded it, switched sessions, returned, and confirmed it stayed expanded

## Evidence
- Screenshot captured locally: /var/folders/6w/z6896bkn5w7fmyy8f_ryk8h40000gn/T/browser-screenshot-1781003228928.png
