### PR TITLE
fix: render artifacts inline

### DIFF
--- a/apps/app/scripts/artifacts.test.ts
+++ b/apps/app/scripts/artifacts.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { UIMessage } from "ai";
 
 import type { OpenTarget } from "../src/react-app/domains/session/artifacts/open-target";
-import { getArtifactsFromMessages } from "../src/lib/artifacts";
+import { canPreviewArtifact, getArtifactsFromMessages } from "../src/lib/artifacts";
 
 describe("getArtifactsFromMessages", () => {
   it("includes verified slide deck targets mentioned in assistant summaries", () => {
@@ -57,5 +57,56 @@ describe("getArtifactsFromMessages", () => {
       value: "customers.csv",
       exists: true,
     });
+  });
+
+  it("can list artifacts from assistant text without target fallbacks", () => {
+    const messages: UIMessage[] = [{
+      id: "msg_text",
+      role: "assistant",
+      parts: [{ type: "text", text: "Created reports/artifact-eval.md and src/widget.tsx", state: "done" }],
+    }];
+
+    expect(getArtifactsFromMessages(messages, [], { includeTargetFallbacks: false }).map((artifact) => artifact.path)).toEqual([
+      "src/widget.tsx",
+      "reports/artifact-eval.md",
+    ]);
+  });
+
+  it("orders verified artifacts by newest update time and marks unsupported previews", () => {
+    const messages: UIMessage[] = [{
+      id: "msg_order",
+      role: "assistant",
+      parts: [{ type: "text", text: "Created reports/old.md and reports/new.md and src/widget.tsx", state: "done" }],
+    }];
+    const targets: OpenTarget[] = [
+      {
+        id: "file:reports/old.md",
+        kind: "file",
+        value: "reports/old.md",
+        name: "old.md",
+        preview: "markdown",
+        confidence: 65,
+        reason: "message",
+        exists: true,
+        updatedAt: 1,
+      },
+      {
+        id: "file:reports/new.md",
+        kind: "file",
+        value: "reports/new.md",
+        name: "new.md",
+        preview: "markdown",
+        confidence: 65,
+        reason: "message",
+        exists: true,
+        updatedAt: 2,
+      },
+    ];
+
+    const artifacts = getArtifactsFromMessages(messages, targets, { includeTargetFallbacks: false });
+
+    expect(artifacts.map((artifact) => artifact.path)).toEqual(["reports/new.md", "reports/old.md", "src/widget.tsx"]);
+    expect(canPreviewArtifact(artifacts[0])).toBe(true);
+    expect(canPreviewArtifact(artifacts[2])).toBe(false);
   });
 });

--- a/apps/app/scripts/artifacts.test.ts
+++ b/apps/app/scripts/artifacts.test.ts
@@ -63,11 +63,12 @@ describe("getArtifactsFromMessages", () => {
     const messages: UIMessage[] = [{
       id: "msg_text",
       role: "assistant",
-      parts: [{ type: "text", text: "Created reports/artifact-eval.md and src/widget.tsx", state: "done" }],
+      parts: [{ type: "text", text: "Created reports/artifact-eval.md, decks/update.pptx, and src/widget.tsx", state: "done" }],
     }];
 
     expect(getArtifactsFromMessages(messages, [], { includeTargetFallbacks: false }).map((artifact) => artifact.path)).toEqual([
       "src/widget.tsx",
+      "decks/update.pptx",
       "reports/artifact-eval.md",
     ]);
   });

--- a/apps/app/src/components/chat/artifact.tsx
+++ b/apps/app/src/components/chat/artifact.tsx
@@ -7,13 +7,12 @@ import { ArtifactIcon } from "@/components/chat/artifact-icon";
 import {
   DescriptiveButton,
   DescriptiveButtonContent,
-  DescriptiveButtonDescription,
   DescriptiveButtonIcon,
   DescriptiveButtonTitle,
 } from "@/components/descriptive-button";
 import {
   type ArtifactItem,
-  getArtifactTypeLabel,
+  canPreviewArtifact,
   useArtifacts,
   usePreviewArtifact,
 } from "@/lib/artifacts";
@@ -22,34 +21,57 @@ interface ArtifactButtonProps {
   artifact: ArtifactItem
 }
 
+const MAX_ARTIFACT_TITLE_LENGTH = 20;
+
+function compactArtifactTitle(name: string) {
+  return name.length > MAX_ARTIFACT_TITLE_LENGTH
+    ? `${name.slice(0, MAX_ARTIFACT_TITLE_LENGTH - 1)}…`
+    : name;
+}
+
 function ArtifactButton({ artifact }: ArtifactButtonProps) {
   const previewArtifact = usePreviewArtifact();
+  const canOpen = canPreviewArtifact(artifact);
+  const title = compactArtifactTitle(artifact.name);
+
+  const content = (
+    <>
+      <DescriptiveButtonIcon className="size-5">
+        <ArtifactIcon className="size-4 shrink-0" type={artifact.type} />
+      </DescriptiveButtonIcon>
+      <DescriptiveButtonContent className="min-w-0 flex-none">
+        <DescriptiveButtonTitle className="max-w-32 text-xs font-medium" title={artifact.name}>{title}</DescriptiveButtonTitle>
+      </DescriptiveButtonContent>
+      {canOpen ? <ArrowUpRightIcon className="size-3.5 shrink-0 text-muted-foreground" /> : null}
+    </>
+  );
+
+  if (!canOpen) {
+    return (
+      <div className="flex h-auto w-fit max-w-full flex-none shrink-0 items-center justify-start gap-1.5 rounded-xl border border-border px-2 py-1.5 text-left whitespace-nowrap">
+        {content}
+      </div>
+    );
+  }
 
   return (
     <DescriptiveButton
-      className="px-2 py-1 items-center gap-2"
+      className="w-fit max-w-full flex-none items-center gap-1.5 rounded-xl px-2 py-1.5 whitespace-nowrap"
       onClick={() => previewArtifact(artifact)}
+      title={`Open ${artifact.name}`}
     >
-      <DescriptiveButtonIcon>
-        <ArtifactIcon className="size-6 shrink-0" type={artifact.type} />
-      </DescriptiveButtonIcon>
-      <DescriptiveButtonContent className="gap-0">
-        <DescriptiveButtonTitle>{artifact.name}</DescriptiveButtonTitle>
-        <DescriptiveButtonDescription className="text-xs">
-          {getArtifactTypeLabel(artifact.type)}
-        </DescriptiveButtonDescription>
-      </DescriptiveButtonContent>
-      <ArrowUpRightIcon className="size-4 shrink-0 text-muted-foreground me-2" />
+      {content}
     </DescriptiveButton>
   );
 }
 
 interface ArtifactListProps {
   messages: UIMessage[]
+  includeTargetFallbacks?: boolean
 }
 
-export function ArtifactList({ messages }: ArtifactListProps) {
-  const artifacts = useArtifacts(messages);
+export function ArtifactList({ messages, includeTargetFallbacks = false }: ArtifactListProps) {
+  const artifacts = useArtifacts(messages, { includeTargetFallbacks });
 
   if (artifacts.length === 0) {
     return null;
@@ -57,7 +79,7 @@ export function ArtifactList({ messages }: ArtifactListProps) {
 
   return (
     <div className="mx-auto w-full max-w-3xl px-2 md:px-10">
-      <div className="grid min-w-0 gap-2 @xl/message-list:grid-cols-2">
+      <div className="no-scrollbar flex min-w-0 flex-nowrap gap-2 overflow-x-auto pb-1">
         {artifacts.map((artifact) => (
           <ArtifactButton key={artifact.id} artifact={artifact} />
         ))}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -563,11 +563,7 @@ function getRenderableMessage(message: UIMessage) {
   return parts.length > 0 ? { ...message, parts } : null;
 }
 
-function MessageArtifacts(props: { message: UIMessage; isLastMessage: boolean }) {
-  if (props.isLastMessage) {
-    return null;
-  }
-
+function MessageArtifacts(props: { message: UIMessage }) {
   return <ArtifactList messages={[props.message]} includeTargetFallbacks={false} />;
 }
 
@@ -637,7 +633,7 @@ function MessageGroup({
                   isStreaming={isLastMessage && isStreaming}
                   isLastStep={isLastStep}
                 />
-                <MessageArtifacts message={item.message} isLastMessage={isLastMessage} />
+                <MessageArtifacts message={item.message} />
               </motion.div>
             )
           })}
@@ -664,7 +660,7 @@ function MessageGroup({
                   isLastStep={index === items.length}
                 />
               ) : null}
-              <MessageArtifacts message={message} isLastMessage={isLastMessage} />
+              <MessageArtifacts message={message} />
             </motion.div>
           )
         }) : null}
@@ -741,7 +737,7 @@ export function MessageList({ messages, status, retryStatus }: MessageListProps)
               isStreaming={isLastMessage && isStreaming}
               isLastStep={isLastStep}
             />
-            <MessageArtifacts message={item.message} isLastMessage={isLastMessage} />
+            <MessageArtifacts message={item.message} />
           </div>
         )
       })}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -552,10 +552,24 @@ const isMessageEmptyGroup = (messages: UIMessageWithIndex[]) =>
 
 const getRenderableMessages = (messages: UIMessageWithIndex[]) =>
   messages.flatMap((item) => {
-    const parts = item.message.parts.filter((part) => part.type === "text" || part.type === "file");
+    const renderableMessage = getRenderableMessage(item.message);
 
-    return parts.length > 0 ? [{ ...item, message: { ...item.message, parts } }] : []
+    return renderableMessage ? [{ ...item, message: renderableMessage }] : []
   })
+
+function getRenderableMessage(message: UIMessage) {
+  const parts = message.parts.filter((part) => part.type === "text" || part.type === "file");
+
+  return parts.length > 0 ? { ...message, parts } : null;
+}
+
+function MessageArtifacts(props: { message: UIMessage; isLastMessage: boolean }) {
+  if (props.isLastMessage) {
+    return null;
+  }
+
+  return <ArtifactList messages={[props.message]} includeTargetFallbacks={false} />;
+}
 
 interface AssistantMessageGroupProps {
   items: UIMessageWithIndex[]
@@ -623,30 +637,38 @@ function MessageGroup({
                   isStreaming={isLastMessage && isStreaming}
                   isLastStep={isLastStep}
                 />
+                <MessageArtifacts message={item.message} isLastMessage={isLastMessage} />
               </motion.div>
             )
           })}
         </StepsContent>
       </Steps>
       <AnimatePresence initial={false}>
-        {!open ? renderableItems.map(({ index, message }) => (
-          <motion.div
-            key={message.id}
-            layoutId={`msg-${message.id}`}
-            layout
-            transition={layoutTransition}
-            onLayoutAnimationComplete={() => setIsAnimating(false)}
-          >
-            <MessageComponent
-              message={message}
-              isStreaming={index === messages.length - 1 && isStreaming}
-              isLastMessage={index === messages.length - 1}
-              isLastStep={index === items.length}
-            />
-          </motion.div>
-        )) : null}
+        {!open ? items.map(({ index, message }) => {
+          const renderableMessage = getRenderableMessage(message)
+          const isLastMessage = index === messages.length - 1
+
+          return (
+            <motion.div
+              key={message.id}
+              layoutId={`msg-${message.id}`}
+              layout
+              transition={layoutTransition}
+              onLayoutAnimationComplete={() => setIsAnimating(false)}
+            >
+              {renderableMessage ? (
+                <MessageComponent
+                  message={renderableMessage}
+                  isStreaming={isLastMessage && isStreaming}
+                  isLastMessage={isLastMessage}
+                  isLastStep={index === items.length}
+                />
+              ) : null}
+              <MessageArtifacts message={message} isLastMessage={isLastMessage} />
+            </motion.div>
+          )
+        }) : null}
       </AnimatePresence>
-      <ArtifactList messages={items.map((item) => item.message)} />
       {lastTextMessage && !isStreaming && (
         <div className="mx-auto flex w-full max-w-3xl flex-wrap items-center gap-2 px-2 opacity-0 transition-opacity duration-150 group-hover/message-group:opacity-100 md:px-8">
           <MessageActions className="flex gap-0">
@@ -719,6 +741,7 @@ export function MessageList({ messages, status, retryStatus }: MessageListProps)
               isStreaming={isLastMessage && isStreaming}
               isLastStep={isLastStep}
             />
+            <MessageArtifacts message={item.message} isLastMessage={isLastMessage} />
           </div>
         )
       })}

--- a/apps/app/src/lib/artifacts.ts
+++ b/apps/app/src/lib/artifacts.ts
@@ -17,7 +17,17 @@ export type ArtifactItem = {
   path: string
   type: ArtifactType
   messageId: string
+  messageIndex: number
+  updatedAt?: number
   legacy_target: OpenTarget
+}
+
+type ArtifactEntry = ArtifactItem & {
+  sequence: number
+}
+
+type GetArtifactsOptions = {
+  includeTargetFallbacks?: boolean
 }
 
 const WORKSPACES_PREFIX_PATTERN = /^workspaces\/[^/]+\//i;
@@ -124,6 +134,10 @@ export function getArtifactTypeLabel(type: ArtifactType) {
   return ARTIFACT_TYPE_LABELS[type];
 }
 
+export function canPreviewArtifact(artifact: ArtifactItem) {
+  return isCollectibleArtifactTarget(artifact.legacy_target);
+}
+
 function getArtifactName(path: string) {
   const segments = path.split(/[/\\]/);
   
@@ -202,10 +216,32 @@ function parseApplyPatchPaths(patchText: string) {
   return paths;
 }
 
+const FILE_PATTERN = /(?:^|[\s"'`([{])((?:\.{1,2}[/\\]|~[/\\]|[/\\])?[\w.\-]+(?:[/\\][\w.\-]+)+\.[a-z][a-z0-9]{0,9}|[\w.\-]+\.[a-z][a-z0-9]{0,9})/gi;
+const ASSISTANT_ARTIFACT_MENTION_PATTERN = /\b(?:artifact|created|deck|deliverable|exported|file|generated|opened|presentation|saved|slides?|updated|wrote)\b/i;
+
+function getArtifactPathsFromText(text: string) {
+  if (!ASSISTANT_ARTIFACT_MENTION_PATTERN.test(text)) return [];
+  const paths: string[] = [];
+
+  FILE_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(FILE_PATTERN)) {
+    if (match[1] && isPreviewSupported(getFileExtension(match[1]) ?? "")) {
+      paths.push(match[1]);
+    }
+  }
+
+  return paths;
+}
+
 function getArtifactPathsFromMessage(message: UIMessage) {
   const paths: (string | undefined)[] = [];
 
   for (const part of message.parts) {
+    if (part.type === "text" && message.role === "assistant") {
+      paths.push(...getArtifactPathsFromText(part.text));
+      continue;
+    }
+
     if (part.type === "source-document") {
       if (part.filename) {
         paths.push(part.filename);
@@ -233,20 +269,26 @@ function getArtifactPathsFromMessage(message: UIMessage) {
     }
   }
 
-  return paths.map((path) => path?.trim().toLowerCase()).filter((path) => path) as string[];
+  return paths.flatMap((path) => {
+    const normalized = path?.trim().toLowerCase();
+    return normalized ? [normalized] : [];
+  });
 }
 
 function addArtifact(
-  artifacts: Map<string, ArtifactItem>,
+  artifacts: Map<string, ArtifactEntry>,
   path: string,
   messageId: string,
+  messageIndex: number,
+  sequence: number,
   verifiedTargets: OpenTarget[],
   verifiedTarget?: OpenTarget,
 ) {
   const normalized = normalizeArtifactPath(path);
   const key = normalized.toLowerCase();
-  const name = verifiedTarget?.name ?? getArtifactName(normalized);
   const type = getArtifactType(normalized);
+  const legacyTarget = verifiedTarget ?? openTargetFromArtifactPath(normalized, getArtifactName(normalized), type, verifiedTargets);
+  const name = legacyTarget.name;
 
   artifacts.set(key, {
     id: key,
@@ -254,35 +296,52 @@ function addArtifact(
     path: normalized,
     type,
     messageId,
-    legacy_target: verifiedTarget ?? openTargetFromArtifactPath(normalized, name, type, verifiedTargets),
+    messageIndex,
+    sequence,
+    updatedAt: legacyTarget.updatedAt,
+    legacy_target: legacyTarget,
   });
 }
 
-export function getArtifactsFromMessages(messages: UIMessage[], openTargets: OpenTarget[] = []) {
-  const artifacts = new Map<string, ArtifactItem>();
+export function getArtifactsFromMessages(messages: UIMessage[], openTargets: OpenTarget[] = [], options: GetArtifactsOptions = {}) {
+  const artifacts = new Map<string, ArtifactEntry>();
+  let sequence = 0;
 
-  for (const message of messages) {
+  messages.forEach((message, messageIndex) => {
     for (const path of getArtifactPathsFromMessage(message)) {
-      addArtifact(artifacts, path, message.id, openTargets);
+      addArtifact(artifacts, path, message.id, messageIndex, sequence, openTargets);
+      sequence += 1;
+    }
+  });
+
+  if (options.includeTargetFallbacks ?? true) {
+    const fallbackMessageId = messages[messages.length - 1]?.id ?? "open-target";
+    for (const target of openTargets) {
+      if (isCollectibleArtifactTarget(target)) {
+        addArtifact(artifacts, target.value, fallbackMessageId, messages.length, sequence, openTargets, target);
+        sequence += 1;
+      }
     }
   }
 
-  const fallbackMessageId = messages[messages.length - 1]?.id ?? "open-target";
-  for (const target of openTargets) {
-    if (isCollectibleArtifactTarget(target)) {
-      addArtifact(artifacts, target.value, fallbackMessageId, openTargets, target);
-    }
-  }
+  return [...artifacts.values()].sort((left, right) => {
+    const updatedAtDelta = (right.updatedAt ?? 0) - (left.updatedAt ?? 0);
+    if (updatedAtDelta !== 0) return updatedAtDelta;
 
-  return [...artifacts.values()];
+    const messageDelta = right.messageIndex - left.messageIndex;
+    if (messageDelta !== 0) return messageDelta;
+
+    return right.sequence - left.sequence;
+  });
 }
 
-export function useArtifacts(messages: UIMessage[]) {
+export function useArtifacts(messages: UIMessage[], options: GetArtifactsOptions = {}) {
   const { openTargets } = useOpenTargets();
+  const includeTargetFallbacks = options.includeTargetFallbacks ?? false;
 
   return React.useMemo(
-    () => getArtifactsFromMessages(messages, openTargets),
-    [messages, openTargets],
+    () => getArtifactsFromMessages(messages, openTargets, { includeTargetFallbacks }),
+    [includeTargetFallbacks, messages, openTargets],
   );
 }
 

--- a/apps/app/src/lib/artifacts.ts
+++ b/apps/app/src/lib/artifacts.ts
@@ -225,7 +225,7 @@ function getArtifactPathsFromText(text: string) {
 
   FILE_PATTERN.lastIndex = 0;
   for (const match of text.matchAll(FILE_PATTERN)) {
-    if (match[1] && isPreviewSupported(getFileExtension(match[1]) ?? "")) {
+    if (match[1] && getArtifactType(match[1]) !== "unknown") {
       paths.push(match[1]);
     }
   }


### PR DESCRIPTION
## Summary
- render artifact chips inline with their source messages instead of as an aggregated bottom row
- compact artifact chips into one horizontally scrollable row with smaller icons and truncated titles
- hide open affordances for unsupported/unverified artifacts and sort artifacts newest-first

## Tests
- pnpm --dir apps/app test:open-target
- bun test apps/app/scripts/artifacts.test.ts
- pnpm --dir apps/app typecheck

## Evidence
- No video/screenshot captured; validated with focused tests and typecheck.