### PR TITLE
fix(settings): Cloud Workers 'Open' button was hard-stubbed to always fail

### DIFF
--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -488,6 +488,15 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const refreshMcpServersRef = useRef<(() => void | Promise<void>) | null>(null);
   const notifyMcpReloadingRef = useRef<(() => void) | null>(null);
   const pollMcpServersAfterReloadRef = useRef<(() => void | Promise<void>) | null>(null);
+  const createRemoteWorkspaceFlowRef = useRef<
+    | ((input: {
+        openworkHostUrl?: string | null;
+        openworkToken?: string | null;
+        directory?: string | null;
+        displayName?: string | null;
+      }) => Promise<boolean>)
+    | null
+  >(null);
   const remoteWorkspaceCheckRunRef = useRef<Record<string, string>>({});
   const remoteWorkspaceCheckRunCounterRef = useRef(0);
   const [providers, setProviders] = useState<ProviderListItem[]>([]);
@@ -711,7 +720,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             return false;
           }
         },
-        createRemoteWorkspaceFlow: async () => false,
+        createRemoteWorkspaceFlow: async (input) =>
+          createRemoteWorkspaceFlowRef.current ? createRemoteWorkspaceFlowRef.current(input) : false,
       }),
     [],
   );
@@ -2004,6 +2014,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       setCreateWorkspaceRemoteBusy(false);
     }
   };
+  createRemoteWorkspaceFlowRef.current = handleCreateRemoteWorkspace;
 
   const handleReconnectMessagingServer = useCallback(async () => {
     const ok = await openworkServerStore.reconnectOpenworkServer();
@@ -2267,7 +2278,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       case "cloud-workers":
         return (
           <CloudWorkersView
-            connectRemoteWorkspace={async () => false}
+            connectRemoteWorkspace={handleCreateRemoteWorkspace}
             onOpenAccount={openCloudAccountSettings}
           />
         );


### PR DESCRIPTION
## Problem

Two provisioning-flow callbacks in the React settings route were stubbed to `async () => false`:

1. `CloudWorkersView` received `connectRemoteWorkspace={async () => false}` (settings-route.tsx). Every click on **Open** for a cloud worker fetched tokens successfully, then dead-ended with "Failed to open {name} in OpenWork." The settings Cloud Workers tab could never open a worker.
2. `createRemoteWorkspaceFlow` in the openwork-server-store options was also stubbed, so the auto-attach of a remote workspace after a successful manual server connection test silently no-op'd on web deployments.

## Fix

The route already contains a fully working `handleCreateRemoteWorkspace` (used by the create-workspace modal). This PR wires it to both call sites:

- `CloudWorkersView` now receives the real handler.
- The server store calls it through a ref (same pattern as `refreshMcpServersRef`), since the store is created in a `useMemo` before the handler exists.

No new behavior introduced — just connecting existing, tested plumbing.

## Testing

- `pnpm typecheck` in `apps/app` — passes.
- Could not capture an end-to-end video: opening a cloud worker requires a signed-in Den session with a provisioned (healthy) Daytona worker. Repro steps for the reviewer:
  1. Sign in to Cloud in the desktop app, ensure org has a healthy worker.
  2. Settings -> Cloud -> Workers -> **Open** on a worker.
  3. Before: always errors with "Failed to open ...". After: connects the remote workspace and shows the success toast.

Part of a provisioning-flow fix series (1/6). Follow-ups: error propagation in connect-remote handlers, provisioning auto-refresh polling, pre-flight URL validation, den-api provisioning watchdog, dead-code cleanup.