### PR TITLE
fix(workspace): stop swallowing server errors when connecting workspaces

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -794,6 +794,15 @@ export class OpenworkServerError extends Error {
   }
 }
 
+/**
+ * Preserve actionable server-side error messages (e.g. "no workspace matching
+ * <url>", invalid token) while mapping transport failures (network down,
+ * timeout) to a generic "server unavailable" message.
+ */
+export function toOpenworkConnectionError(error: unknown, unavailableMessage: string): Error {
+  return error instanceof OpenworkServerError ? error : new Error(unavailableMessage);
+}
+
 function buildHeaders(
   token?: string,
   hostToken?: string,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -24,6 +24,7 @@ import {
   buildOpenworkWorkspaceBaseUrl,
   createOpenworkServerClient,
   readOpenworkServerSettings,
+  toOpenworkConnectionError,
   type OpenworkServerClient,
   type OpenworkWorkspaceInfo,
 } from "@/app/lib/openwork-server";
@@ -2732,13 +2733,15 @@ export function SessionRoute() {
       let list: WorkspaceList | null = null;
       let createdOnServer = false;
       if (client) {
-        list = await client
-          .createLocalWorkspace({ folderPath: folder, name: workspaceName, preset })
-          .then((serverList) => {
-            createdOnServer = true;
-            return serverList;
-          })
-          .catch(() => null);
+        try {
+          list = await client.createLocalWorkspace({ folderPath: folder, name: workspaceName, preset });
+          createdOnServer = true;
+        } catch (error) {
+          throw toOpenworkConnectionError(
+            error,
+            "OpenWork server is unavailable. Start or reconnect the server before creating a workspace.",
+          );
+        }
       }
       if (!list) {
         throw new Error("OpenWork server is unavailable. Start or reconnect the server before creating a workspace.");
@@ -2809,7 +2812,14 @@ export function SessionRoute() {
       };
       let list: WorkspaceList | null = null;
       if (client) {
-        list = await client.createRemoteWorkspace(payload).catch(() => null);
+        try {
+          list = await client.createRemoteWorkspace(payload);
+        } catch (error) {
+          throw toOpenworkConnectionError(
+            error,
+            "OpenWork server is unavailable. Start or reconnect the server before connecting a remote workspace.",
+          );
+        }
       }
       if (!list) {
         throw new Error("OpenWork server is unavailable. Start or reconnect the server before connecting a remote workspace.");

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -10,6 +10,7 @@ import {
   createOpenworkServerClient,
   isLoopbackOpenworkServerUrl,
   readOpenworkServerSettings,
+  toOpenworkConnectionError,
   type OpenworkServerCapabilities,
   type OpenworkServerClient,
   type OpenworkWorkspaceInfo,
@@ -1941,9 +1942,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       const workspaceName = folderNameFromPath(folder);
       let list: WorkspaceList | null = null;
       if (openworkClient) {
-        list = await openworkClient
-          .createLocalWorkspace({ folderPath: folder, name: workspaceName, preset })
-          .catch(() => null);
+        try {
+          list = await openworkClient.createLocalWorkspace({ folderPath: folder, name: workspaceName, preset });
+        } catch (error) {
+          throw toOpenworkConnectionError(
+            error,
+            "OpenWork server is unavailable. Start or reconnect the server before creating a workspace.",
+          );
+        }
       }
       if (!list) {
         throw new Error("OpenWork server is unavailable. Start or reconnect the server before creating a workspace.");
@@ -1984,7 +1990,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       };
       let list: WorkspaceList | null = null;
       if (openworkClient) {
-        list = await openworkClient.createRemoteWorkspace(payload).catch(() => null);
+        try {
+          list = await openworkClient.createRemoteWorkspace(payload);
+        } catch (error) {
+          throw toOpenworkConnectionError(
+            error,
+            "OpenWork server is unavailable. Start or reconnect the server before connecting a remote workspace.",
+          );
+        }
       }
       if (!list) {
         throw new Error("OpenWork server is unavailable. Start or reconnect the server before connecting a remote workspace.");

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -23,7 +23,7 @@ import {
   markOpenWorkModelsStartupPromoShown,
 } from "../domains/cloud/openwork-models-promo";
 import { resolveOpenworkConnection } from "./openwork-connection";
-import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../../app/lib/openwork-server";
+import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient, toOpenworkConnectionError } from "../../app/lib/openwork-server";
 import { buildDenAuthUrl, readDenSettings } from "../../app/lib/den";
 import { writeActiveWorkspaceId, writeLastSessionFor } from "./session-memory";
 import { workspaceSessionRoute } from "./workspace-routes";
@@ -149,8 +149,11 @@ export function WelcomeRoute() {
             serverBaseUrl = normalizedBaseUrl;
             serverToken = resolvedToken;
           }
-        } catch {
-          list = null;
+        } catch (error) {
+          throw toOpenworkConnectionError(
+            error,
+            "OpenWork server is unavailable. Start or reconnect the server before creating a workspace.",
+          );
         }
         if (!list) {
           throw new Error("OpenWork server is unavailable. Start or reconnect the server before creating a workspace.");
@@ -239,8 +242,11 @@ export function WelcomeRoute() {
               hostToken: resolvedHostToken || undefined,
             }).createRemoteWorkspace(payload);
           }
-        } catch {
-          list = null;
+        } catch (error) {
+          throw toOpenworkConnectionError(
+            error,
+            "OpenWork server is unavailable. Start or reconnect the server before connecting a remote workspace.",
+          );
         }
         if (!list) {
           throw new Error("OpenWork server is unavailable. Start or reconnect the server before connecting a remote workspace.");


### PR DESCRIPTION
## Problem

All six workspace-creation handlers (local + remote, across session/settings/welcome routes) swallowed every error from the OpenWork server:

```ts
list = await client.createRemoteWorkspace(payload).catch(() => null);
if (!list) throw new Error("OpenWork server is unavailable. Start or reconnect the server ...");
```

The server returns precise, actionable 400s (e.g. `openwork_workspace_not_found`: "OpenWork server has no workspace matching <url>", invalid baseUrl, bad token), and the client already throws `OpenworkServerError` carrying that message — but the UI converted **every** failure, including a typo'd URL or wrong token, into "server is unavailable", pointing users at the wrong fix.

## Fix

New helper `toOpenworkConnectionError(error, unavailableMessage)` in `apps/app/src/app/lib/openwork-server.ts`:
- `OpenworkServerError` (server replied with a real error) → preserve the server's message.
- Anything else (network down, timeout) → keep the existing "server unavailable" guidance.

Applied to all six call sites:
- `session-route.tsx` — `handleCreateWorkspace`, `handleCreateRemoteWorkspace`
- `settings-route.tsx` — `handleCreateWorkspace`, `handleCreateRemoteWorkspace`
- `welcome-route.tsx` — `handleCreateWorkspaceFolder`, `handleCreateRemote`

No behavior change for genuine transport failures.

## Testing

- `pnpm typecheck` in `apps/app` — passes.
- Reviewer repro: in the create-workspace modal choose "Remote custom", enter a reachable server URL with a wrong token or a URL the server rejects. Before: "OpenWork server is unavailable...". After: the server's actual message (e.g. "OpenWork server has no workspace matching ...").

Part of the provisioning-flow fix series (2/6). Builds on #2108.