### PR TITLE
fix(cloud): auto-refresh provisioning workers in settings

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/cloud-workers-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-workers-view.tsx
@@ -43,6 +43,7 @@ export function CloudWorkersView({
       try {
         const nextWorkers = await client.listWorkers(activeOrgId, 20);
         setWorkers(nextWorkers);
+        setWorkersError(null);
         if (!quiet) {
           toast.info(
             nextWorkers.length > 0
@@ -66,8 +67,22 @@ export function CloudWorkersView({
 
   React.useEffect(() => {
     if (!user || !activeOrgId) return;
+    setWorkersError(null);
     void refreshWorkers(true);
   }, [activeOrgId, refreshWorkers, user]);
+
+  // Poll quietly while any worker is still provisioning so "Starting" flips
+  // to "Ready" without a manual refresh.
+  const hasProvisioningWorker = workers.some(
+    (worker) => worker.status.trim().toLowerCase() === "provisioning",
+  );
+  React.useEffect(() => {
+    if (!hasProvisioningWorker || !user || !activeOrgId) return;
+    const timer = window.setInterval(() => {
+      void refreshWorkers(true);
+    }, 5000);
+    return () => window.clearInterval(timer);
+  }, [activeOrgId, hasProvisioningWorker, refreshWorkers, user]);
 
   const openWorker = React.useCallback(
     async (workerId: string, workerName: string) => {


### PR DESCRIPTION
## Problem

The Cloud Workers settings tab fetched the worker list once per org change. A worker in `provisioning` state showed as "Starting" forever unless the user manually clicked Refresh — den-api even returns a `launch.pollAfterMs: 5000` hint that the desktop never used.

Additionally, stale error notices survived refreshes: `refreshWorkers(quiet)` only cleared the error banner on non-quiet refreshes, so a previous org's error could stay on screen after a successful background reload.

## Fix

In `cloud-workers-view.tsx`:
- While any listed worker has status `provisioning`, poll `refreshWorkers(true)` every 5s (matching den-api's poll hint). The interval is cleaned up as soon as no worker is provisioning, or on org change/unmount.
- Clear `workersError` on every successful fetch and when switching orgs.

## Testing

- `pnpm typecheck` in `apps/app` — passes.
- Reviewer repro: create a worker in Cloud, open Settings -> Cloud -> Workers while it provisions. Before: stuck on "Starting" until manual refresh. After: flips to "Ready" automatically within ~5s of the backend reporting healthy.

Part of the provisioning-flow fix series (3/6). Related: #2108, #2109.