### PR TITLE
feat(workspace): pre-flight connection check before saving a remote worker

### DIFF
--- a/apps/app/src/react-app/domains/workspace/create-workspace-modal.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-modal.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useReducer,
   useRef,
+  useState,
   type SetStateAction,
 } from "react";
 import { ArrowLeft, FolderPlus, Globe, Loader2 } from "lucide-react";
@@ -32,6 +33,7 @@ import {
   tagClass,
 } from "./modal-styles";
 import { WorkspaceOptionCard } from "./option-card";
+import { preflightRemoteWorkspaceConnection } from "./remote-workspace-diagnostics";
 import { RemoteWorkspaceFields } from "./remote-workspace-fields";
 import type {
   CreateWorkspaceModalProps,
@@ -41,6 +43,8 @@ import type {
 
 export function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
   const remoteUrlRef = useRef<HTMLInputElement | null>(null);
+  const [preflightBusy, setPreflightBusy] = useState(false);
+  const [preflightError, setPreflightError] = useState<string | null>(null);
 
   const [localState, dispatchLocal] = useReducer(
     createWorkspaceLocalReducer,
@@ -76,6 +80,7 @@ export function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
   const showClose = props.showClose ?? true;
   const submitting = props.submitting ?? false;
   const remoteSubmitting = props.remoteSubmitting ?? false;
+  const remoteBusy = remoteSubmitting || preflightBusy;
   const workerSubmitting = props.workerSubmitting ?? false;
   const progress = props.submittingProgress ?? null;
   const workerDisabled = Boolean(props.workerDisabled);
@@ -89,7 +94,7 @@ export function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
   );
   const hasSelectedFolder = Boolean(selectedFolder?.trim());
   const localError = (props.localError ?? "").trim() || null;
-  const remoteError = (props.remoteError ?? "").trim() || null;
+  const remoteError = preflightError ?? ((props.remoteError ?? "").trim() || null);
   const elapsedSeconds = useMemo(() => {
     if (!progress?.startedAt) return 0;
     return Math.max(0, Math.floor((now - progress.startedAt) / 1000));
@@ -121,6 +126,8 @@ export function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
   useEffect(() => {
     if (!props.open) return;
     dispatchLocal({ type: "reset" });
+    setPreflightBusy(false);
+    setPreflightError(null);
   }, [props.open]);
 
   // Tick the "elapsed" clock while submitting.
@@ -157,6 +164,17 @@ export function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
 
   const handleRemoteSubmit = async () => {
     if (!props.onConfirmRemote) return;
+    setPreflightBusy(true);
+    setPreflightError(null);
+    const preflight = await preflightRemoteWorkspaceConnection({
+      hostUrl: remoteUrl,
+      token: remoteToken,
+    });
+    setPreflightBusy(false);
+    if (!preflight.ok) {
+      setPreflightError(preflight.message);
+      return;
+    }
     await Promise.resolve(
       props.onConfirmRemote({
         openworkHostUrl: remoteUrl.trim(),
@@ -187,7 +205,7 @@ export function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
           {screen !== "chooser" ? (
             <Button
               onClick={() => setScreen("chooser")}
-              disabled={submitting || remoteSubmitting}
+              disabled={submitting || remoteBusy}
               variant="ghost"
               size="icon"
               aria-label={t("dashboard.modal_back")}
@@ -300,7 +318,7 @@ export function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
                 }
                 displayName={remoteDisplayName}
                 onDisplayNameInput={setRemoteDisplayName}
-                submitting={remoteSubmitting}
+                submitting={remoteBusy}
                 hostInputRef={remoteUrlRef}
                 title={t("dashboard.remote_server_details_title")}
                 description={t("dashboard.remote_server_details_hint")}
@@ -314,17 +332,17 @@ export function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
               ) : null}
               <div className="flex justify-end gap-3">
                 <DialogClose
-                  disabled={remoteSubmitting}
-                  render={<Button variant="outline" disabled={remoteSubmitting} />}
+                  disabled={remoteBusy}
+                  render={<Button variant="outline" disabled={remoteBusy} />}
                 >
                   {t("common.cancel")}
                 </DialogClose>
                 <Button
                   type="button"
-                  disabled={!remoteUrl.trim() || remoteSubmitting}
+                  disabled={!remoteUrl.trim() || remoteBusy}
                   onClick={() => void handleRemoteSubmit()}
                 >
-                  {remoteSubmitting ? (
+                  {remoteBusy ? (
                     <span className="inline-flex items-center gap-2">
                       <Loader2 size={16} className="animate-spin" />
                       {t("dashboard.connecting")}

--- a/apps/app/src/react-app/domains/workspace/remote-workspace-diagnostics.ts
+++ b/apps/app/src/react-app/domains/workspace/remote-workspace-diagnostics.ts
@@ -218,6 +218,49 @@ export function resolveRemoteWorkspaceConnectionTarget(workspace: WorkspaceInfo)
   };
 }
 
+export type RemoteWorkspacePreflightResult = { ok: true } | { ok: false; message: string };
+
+/**
+ * Quick reachability check before persisting a new remote worker connection.
+ * Unlike `testRemoteWorkspaceConnection`, the token is optional (the connect
+ * form allows token-less servers) and no workspace entry needs to exist yet.
+ */
+export async function preflightRemoteWorkspaceConnection(input: {
+  hostUrl: string;
+  token?: string | null;
+}): Promise<RemoteWorkspacePreflightResult> {
+  const normalized = normalizeOpenworkServerUrl(trim(input.hostUrl));
+  if (!normalized || !isValidHttpEndpoint(normalized)) {
+    return { ok: false, message: "Enter a valid worker URL starting with http:// or https://." };
+  }
+
+  const baseUrl = stripOpenworkWorkspaceMount(normalized);
+  const label = endpointLabel(baseUrl);
+  const token = trim(input.token);
+  const client = createOpenworkServerClient({ baseUrl, token: token || undefined });
+
+  try {
+    const health = await client.health();
+    if (!health?.ok) {
+      return { ok: false, message: `Cannot reach ${label}. The server responded but reported an unhealthy status. Check the URL and try again.` };
+    }
+  } catch (error) {
+    return { ok: false, message: `Cannot reach ${label}. ${describeUnknownError(error)} Check the URL and try again.` };
+  }
+
+  if (token) {
+    try {
+      await client.capabilities();
+    } catch (error) {
+      if (isServerErrorStatus(error, [401, 403])) {
+        return { ok: false, message: `Token was rejected by ${label}. Check the token and try again.` };
+      }
+    }
+  }
+
+  return { ok: true };
+}
+
 export async function testRemoteWorkspaceConnection(
   workspace: WorkspaceInfo,
   options: TestOptions = {},


### PR DESCRIPTION
## Problem

The "Connect remote" form persisted a workspace entry on any non-empty URL string. No URL validation, no reachability check, no token check — even though a full diagnostics utility (`testRemoteWorkspaceConnection`) already existed for *post-hoc* troubleshooting. A typo'd URL or wrong token created a broken sidebar entry the user only discovered later through connection errors. When the URL embeds a workspace mount, the server skips discovery entirely and persists a dead workspace without any error.

## Fix

New `preflightRemoteWorkspaceConnection({ hostUrl, token })` in `remote-workspace-diagnostics.ts`, reusing the module's existing normalization/health/capabilities helpers. Unlike the full diagnostics it doesn't require a token (the form allows token-less servers) or an existing workspace entry. Checks:

1. URL is a valid http(s) endpoint → "Enter a valid worker URL ..."
2. `GET /health` reachable + healthy → "Cannot reach <host> ..."
3. If a token was entered, `GET /capabilities` doesn't 401/403 → "Token was rejected by <host> ..."

`CreateWorkspaceModal` (shared by session, settings, and welcome routes) runs the pre-flight on submit and shows the failure in the existing error slot; nothing is persisted until it passes. The submit button/cancel reuse the existing "Connecting..." busy state during the check.

## Testing

- `pnpm typecheck` in `apps/app` — passes.
- Reviewer repro: create workspace -> "Remote custom":
  - Enter `not-a-url` → inline "Enter a valid worker URL..." (previously: submitted and failed downstream).
  - Enter an unreachable https URL → "Cannot reach <host>..." with no workspace entry created.
  - Enter a valid worker URL + wrong token → "Token was rejected by <host>...".
  - Valid URL + token → connects as before.

Part of the provisioning-flow fix series (4/6). Related: #2108, #2109, #2110.