### PR TITLE
fix(cloud): show worker provisioning failure reason and fix status mapping

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -97,6 +97,7 @@ export type DenWorkerSummary = {
   workerId: string;
   workerName: string;
   status: string;
+  statusReason: string | null;
   instanceUrl: string | null;
   provider: string | null;
   isMine: boolean;
@@ -910,6 +911,7 @@ function getWorkers(payload: unknown): DenWorkerSummary[] {
         workerId: entry.id,
         workerName: entry.name,
         status: typeof entry.status === "string" ? entry.status : "unknown",
+        statusReason: typeof entry.statusReason === "string" && entry.statusReason.trim() ? entry.statusReason : null,
         instanceUrl: instance && typeof instance.url === "string" ? instance.url : null,
         provider: instance && typeof instance.provider === "string" ? instance.provider : null,
         isMine: Boolean(entry.isMine),

--- a/apps/app/src/react-app/domains/settings/cloud/sections.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/sections.tsx
@@ -82,6 +82,7 @@ export type CloudWorker = {
   workerId: string;
   workerName: string;
   status: string;
+  statusReason: string | null;
   instanceUrl: string | null;
   provider: string | null;
   isMine: boolean;
@@ -127,6 +128,7 @@ function workerStatusMeta(status: string) {
 
   switch (normalized) {
     case "healthy":
+    case "ready":
       return { label: t("dashboard.worker_status_ready"), tone: "ready" as const, canOpen: true };
     case "provisioning":
       return { label: t("dashboard.worker_status_starting"), tone: "warning" as const, canOpen: false };
@@ -140,7 +142,7 @@ function workerStatusMeta(status: string) {
           ? `${normalized.slice(0, 1).toUpperCase()}${normalized.slice(1)}`
           : t("dashboard.worker_status_unknown"),
         tone: "neutral" as const,
-        canOpen: normalized === "ready",
+        canOpen: false,
       };
   }
 }
@@ -328,6 +330,11 @@ function CloudWorkerListItem({ openingWorkerId, worker, onOpenWorker }: CloudWor
             worker.instanceUrl,
           ].filter(Boolean).join(" · ")}
         </SettingsListItemDescription>
+        {status.tone === "error" && worker.statusReason ? (
+          <SettingsListItemDescription className="text-red-11">
+            {worker.statusReason}
+          </SettingsListItemDescription>
+        ) : null}
       </SettingsListItemContent>
       <Button
         variant="outline"


### PR DESCRIPTION
## Problem

1. When cloud worker provisioning fails, the desktop shows only an "Attention" badge — no explanation, no way for the user to know what went wrong. (den-api now persists the reason as `statusReason` — #2112.)
2. `workerStatusMeta` had a vocabulary mismatch with den-api: the default branch allowed opening workers with status `"ready"` — a status den-api never emits (`provisioning | healthy | failed` only) — while any genuinely unknown status fell through inconsistently.

## Fix

- `den.ts`: `DenWorkerSummary` now carries `statusReason` (parsed defensively from `/v1/workers`; older servers without the field simply yield `null`).
- `sections.tsx`:
  - `CloudWorkerListItem` renders the failure reason under the worker row (red text) when the status tone is error.
  - `workerStatusMeta`: `"ready"` is now an explicit alias of `healthy` (openable, green); the default branch for unknown statuses no longer allows opening.

Backward compatible: servers that don't send `statusReason` render exactly as before.

## Testing

- `pnpm typecheck` in `apps/app` — passes.
- Reviewer repro: with #2112 deployed, force a provisioning failure (e.g. bad Daytona credentials) → Settings -> Cloud -> Workers shows the "Attention" worker with the actual provisioning error underneath instead of an unexplained badge.

Part of the provisioning-flow fix series (6/6). Related: #2108, #2109, #2110, #2111, #2112.