### PR TITLE
feat(evals): programmatic eval runner with machine-checkable flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ opencode.jsonc
 .claude/*
 .security
 transcript-analysis
+# Eval runner output
+evals/results/

--- a/evals/README.md
+++ b/evals/README.md
@@ -12,6 +12,30 @@ They are not unit tests. They intentionally exercise the running stack
 (OpenCode + OpenWork server + React UI) so regressions in wiring — not just
 types — get caught.
 
+## Coded flows (programmatic runner)
+
+A growing subset of flows is codified under [`flows/`](./flows) and executed by
+the zero-dependency runner in [`runner/`](./runner) with machine-checkable
+assertions, poll-until-condition waits (no fixed sleeps), and JSON + markdown
+reports with screenshots.
+
+```bash
+pnpm evals --list                 # show available coded flows
+pnpm evals --all                  # run everything runnable
+pnpm evals --flow app-smoke       # run one flow
+pnpm evals --all --cdp-url http://127.0.0.1:9825   # explicit CDP endpoint
+```
+
+The runner probes `http://127.0.0.1:9825` (Daytona) then `:9823` (local
+`pnpm dev`) by default. Flows that need cloud credentials declare
+`requiredEnv` and are skipped (not failed) when the env is missing — e.g.
+`cloud-signin-handoff` needs `OPENWORK_EVAL_DEN_API_URL` and
+`OPENWORK_EVAL_DEN_TOKEN`. Reports land in `evals/results/<run-id>/`
+(gitignored). A non-zero exit code means at least one flow failed.
+
+The markdown specs below remain the source narrative; when codifying a flow,
+link the spec via the flow's `spec` field.
+
 ## How to run
 
 ### Option A: On Daytona (recommended)

--- a/evals/flows/app-smoke.flow.mjs
+++ b/evals/flows/app-smoke.flow.mjs
@@ -1,0 +1,47 @@
+/**
+ * Smoke: the app boots, the automation control API is live, and a known route
+ * renders real content.
+ */
+export default {
+  id: "app-smoke",
+  title: "App boots and renders a known route",
+  spec: "evals/react-session-flows.md",
+  steps: [
+    {
+      name: "CDP target is the Electron app (or dev web build)",
+      run: async (ctx) => {
+        const userAgent = await ctx.eval("navigator.userAgent");
+        ctx.assert(typeof userAgent === "string" && userAgent.length > 0, "No userAgent.");
+        ctx.log(`userAgent: ${userAgent}`);
+      },
+    },
+    {
+      name: "Automation control API becomes available",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 30_000,
+          label: "window.__openworkControl",
+        });
+      },
+    },
+    {
+      name: "App reports a known route",
+      run: async (ctx) => {
+        const route = await ctx.waitFor(
+          "window.__openworkControl.snapshot().route",
+          { label: "control snapshot route" },
+        );
+        ctx.log(`route: ${JSON.stringify(route)}`);
+      },
+    },
+    {
+      name: "UI rendered meaningful content",
+      run: async (ctx) => {
+        await ctx.waitFor("document.body.innerText.trim().length > 40", {
+          label: "rendered body text",
+        });
+        await ctx.screenshot("booted");
+      },
+    },
+  ],
+};

--- a/evals/flows/cloud-account-renders.flow.mjs
+++ b/evals/flows/cloud-account-renders.flow.mjs
@@ -1,0 +1,45 @@
+/**
+ * The Cloud Account settings surface renders a coherent state: either the
+ * signed-out panel (sign in, create account, paste sign-in code) or the
+ * signed-in account section. Catches blank/crashed cloud surfaces.
+ */
+export default {
+  id: "cloud-account-renders",
+  title: "Cloud Account settings renders signed-in or signed-out state",
+  spec: "evals/cloud-auth-flows.md",
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000 });
+      },
+    },
+    {
+      name: "Navigate to Settings -> Cloud -> Account",
+      run: async (ctx) => {
+        await ctx.navigateHash("/settings/cloud-account");
+        await ctx.waitFor(
+          "window.location.hash.includes('/settings/cloud-account')",
+          { label: "cloud account route" },
+        );
+      },
+    },
+    {
+      name: "Signed-in or signed-out state renders",
+      run: async (ctx) => {
+        await ctx.waitFor(
+          `(() => {
+            const text = document.body.innerText;
+            const signedOut = text.includes("Paste sign-in code");
+            const signedIn = text.includes("Sign out");
+            return signedOut || signedIn;
+          })()`,
+          { timeoutMs: 30_000, label: "cloud account state (signed in or out)" },
+        );
+        const signedIn = await ctx.hasText("Sign out");
+        ctx.log(`cloud account state: ${signedIn ? "signed in" : "signed out"}`);
+        await ctx.screenshot("cloud-account");
+      },
+    },
+  ],
+};

--- a/evals/flows/cloud-signin-handoff.flow.mjs
+++ b/evals/flows/cloud-signin-handoff.flow.mjs
@@ -1,0 +1,68 @@
+/**
+ * Codifies evals/cloud-auth-flows.md Flow 1 (happy path) via the paste-code
+ * fallback: create a desktop handoff grant through the Den API, paste the
+ * deep link into Settings -> Cloud -> Account, and assert the session lands.
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_API_URL    Den API base, e.g. https://api.example.com
+ * - OPENWORK_EVAL_DEN_TOKEN      Bearer session token for a Den account
+ */
+export default {
+  id: "cloud-signin-handoff",
+  title: "Cloud sign-in via desktop handoff paste code",
+  spec: "evals/cloud-auth-flows.md#flow-1-cloud-sign-in-happy-path",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000 });
+      },
+    },
+    {
+      name: "Create desktop handoff grant via Den API",
+      run: async (ctx) => {
+        const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+        const response = await fetch(`${apiBase}/v1/auth/desktop-handoff`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ desktopScheme: "openwork" }),
+        });
+        ctx.assert(response.ok, `Handoff create failed: ${response.status} ${await response.text()}`);
+        const payload = await response.json();
+        ctx.assert(typeof payload.openworkUrl === "string" && payload.openworkUrl.length > 0, "No openworkUrl in handoff response.");
+        ctx.handoffUrl = payload.openworkUrl;
+        ctx.log("Handoff grant created.");
+      },
+    },
+    {
+      name: "Open Settings -> Cloud -> Account (signed out)",
+      run: async (ctx) => {
+        await ctx.navigateHash("/settings/cloud-account");
+        await ctx.waitForText("Paste sign-in code", { timeoutMs: 30_000 });
+      },
+    },
+    {
+      name: "Paste deep link and finish sign-in",
+      run: async (ctx) => {
+        await ctx.clickText("Paste sign-in code");
+        await ctx.fill("#den-signin-link", ctx.handoffUrl);
+        await ctx.clickText("Finish sign-in");
+      },
+    },
+    {
+      name: "Session is connected",
+      run: async (ctx) => {
+        await ctx.waitForText("Sign out", { timeoutMs: 45_000 });
+        const token = await ctx.eval(
+          "localStorage.getItem('openwork.den.authToken') ?? ''",
+        );
+        ctx.assert(typeof token === "string" && token.trim().length > 0, "No persisted den auth token.");
+        await ctx.screenshot("signed-in");
+      },
+    },
+  ],
+};

--- a/evals/flows/settings-extensions-mcp.flow.mjs
+++ b/evals/flows/settings-extensions-mcp.flow.mjs
@@ -1,0 +1,51 @@
+/**
+ * The MCP settings view renders: connected built-in apps, the custom-app
+ * entry point, and the My Extensions / Marketplace tabs.
+ *
+ * Note: as of #2008 the quick-connect *directory* (Notion, Linear, OpenWork
+ * Cloud Control, ...) only lists configured entries here; discovery moved to
+ * the Marketplace tab. Cloud MCP discoverability assertions will be added to
+ * this flow when the cloud MCP becomes first-class.
+ */
+export default {
+  id: "settings-extensions-mcp",
+  title: "MCP settings view renders apps and entry points",
+  spec: "evals/browser-extension-flows.md",
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000 });
+      },
+    },
+    {
+      name: "Navigate to Settings -> Extensions -> MCP",
+      run: async (ctx) => {
+        await ctx.navigateHash("/settings/extensions/mcp");
+        await ctx.waitFor(
+          "window.location.hash.includes('/settings/extensions/mcp')",
+          { label: "settings MCP route" },
+        );
+      },
+    },
+    {
+      name: "Extensions surface renders tabs and custom app entry",
+      run: async (ctx) => {
+        await ctx.waitForText("My Extensions", { timeoutMs: 30_000 });
+        await ctx.waitForText("Marketplace");
+        await ctx.waitForText("Add Custom App");
+      },
+    },
+    {
+      name: "Available apps section renders",
+      run: async (ctx) => {
+        // CSS text-transform can change innerText casing; compare lowercased.
+        await ctx.waitFor(
+          "document.body.innerText.toLowerCase().includes('available apps')",
+          { timeoutMs: 15_000, label: "available apps section" },
+        );
+        await ctx.screenshot("mcp-view");
+      },
+    },
+  ],
+};

--- a/evals/runner/cdp.mjs
+++ b/evals/runner/cdp.mjs
@@ -1,0 +1,124 @@
+/**
+ * Minimal Chrome DevTools Protocol client for the eval runner.
+ *
+ * Zero dependencies: uses the global fetch + WebSocket available in Node 22+.
+ * Mirrors the pattern proven in apps/app/scripts/voice-cdp.mjs.
+ */
+
+export async function listTargets(baseUrl) {
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}/json/list`);
+  if (!response.ok) {
+    throw new Error(`Could not list CDP targets at ${baseUrl}: ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function pickAppTarget(baseUrl) {
+  const targets = await listTargets(baseUrl);
+  const pages = targets.filter((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  const target =
+    pages.find((page) => page.title === "OpenWork") ??
+    pages.find(
+      (page) =>
+        page.url.includes("localhost") ||
+        page.url.includes("127.0.0.1") ||
+        page.url.includes("[::1]"),
+    ) ??
+    pages[0];
+  if (!target) {
+    throw new Error(`No CDP page target found at ${baseUrl}.`);
+  }
+  return target;
+}
+
+/**
+ * Probe a list of CDP base URL candidates and return the first that responds.
+ */
+export async function resolveCdpBaseUrl(candidates) {
+  const errors = [];
+  for (const candidate of candidates) {
+    try {
+      await listTargets(candidate);
+      return candidate;
+    } catch (error) {
+      errors.push(`${candidate}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  throw new Error(
+    `No CDP endpoint reachable. Tried:\n  ${errors.join("\n  ")}\n` +
+      "Start the app first (pnpm dev) or pass --cdp-url.",
+  );
+}
+
+export function connect(webSocketDebuggerUrl) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(webSocketDebuggerUrl);
+    let nextId = 1;
+    const pending = new Map();
+    let opened = false;
+
+    const rejectPending = (error) => {
+      for (const callbacks of pending.values()) callbacks.reject(error);
+      pending.clear();
+    };
+
+    socket.addEventListener("open", () => {
+      opened = true;
+      resolve({
+        close: () => socket.close(),
+        send(method, params = {}) {
+          const id = nextId++;
+          return new Promise((innerResolve, innerReject) => {
+            pending.set(id, { resolve: innerResolve, reject: innerReject });
+            try {
+              socket.send(JSON.stringify({ id, method, params }));
+            } catch (error) {
+              pending.delete(id);
+              innerReject(error);
+            }
+          });
+        },
+      });
+    });
+    socket.addEventListener("message", (event) => {
+      const message = JSON.parse(String(event.data));
+      if (!message.id) return;
+      const callbacks = pending.get(message.id);
+      if (!callbacks) return;
+      pending.delete(message.id);
+      if (message.error) callbacks.reject(new Error(message.error.message));
+      else callbacks.resolve(message.result);
+    });
+    socket.addEventListener("error", () => {
+      const error = new Error("CDP websocket failed.");
+      rejectPending(error);
+      if (!opened) reject(error);
+    });
+    socket.addEventListener("close", () => {
+      const error = new Error("CDP websocket closed.");
+      rejectPending(error);
+      if (!opened) reject(error);
+    });
+  });
+}
+
+export async function evaluate(client, expression, { awaitPromise = false } = {}) {
+  const result = await client.send("Runtime.evaluate", {
+    expression,
+    awaitPromise,
+    returnByValue: true,
+  });
+  if (result.exceptionDetails) {
+    throw new Error(
+      result.exceptionDetails.exception?.description ??
+        result.exceptionDetails.text ??
+        "Evaluation failed.",
+    );
+  }
+  return result.result?.value;
+}
+
+export async function captureScreenshot(client) {
+  const result = await client.send("Page.captureScreenshot", { format: "png" });
+  return Buffer.from(result.data, "base64");
+}

--- a/evals/runner/context.mjs
+++ b/evals/runner/context.mjs
@@ -1,0 +1,161 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { captureScreenshot, evaluate } from "./cdp.mjs";
+
+const DEFAULT_TIMEOUT_MS = 20_000;
+const POLL_INTERVAL_MS = 250;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export class EvalError extends Error {}
+
+/**
+ * Per-flow execution context handed to every step's `run(ctx)`.
+ *
+ * Helpers favor poll-until-condition over fixed sleeps so flows stay fast on
+ * fast machines and resilient on slow sandboxes.
+ */
+export class EvalContext {
+  constructor({ client, outDir, flowId, env }) {
+    this.client = client;
+    this.outDir = outDir;
+    this.flowId = flowId;
+    this.env = env;
+    this.screenshots = [];
+    this.logs = [];
+    this.screenshotIndex = 0;
+  }
+
+  log(message) {
+    this.logs.push(`[${new Date().toISOString()}] ${message}`);
+  }
+
+  async eval(expression, options = {}) {
+    return evaluate(this.client, expression, options);
+  }
+
+  assert(condition, message) {
+    if (!condition) throw new EvalError(message);
+  }
+
+  /**
+   * Poll a JS expression until it returns truthy. Returns the final value.
+   */
+  async waitFor(expression, { timeoutMs = DEFAULT_TIMEOUT_MS, label } = {}) {
+    const startedAt = Date.now();
+    let lastError = null;
+    while (Date.now() - startedAt < timeoutMs) {
+      try {
+        const value = await this.eval(expression);
+        if (value) return value;
+        lastError = null;
+      } catch (error) {
+        lastError = error;
+      }
+      await sleep(POLL_INTERVAL_MS);
+    }
+    const what = label ?? expression;
+    throw new EvalError(
+      `Timed out after ${timeoutMs}ms waiting for: ${what}` +
+        (lastError ? ` (last error: ${lastError.message})` : ""),
+    );
+  }
+
+  /**
+   * Poll until the page's visible text contains `text`.
+   */
+  async waitForText(text, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+    await this.waitFor(
+      `document.body.innerText.includes(${JSON.stringify(text)})`,
+      { timeoutMs, label: `visible text ${JSON.stringify(text)}` },
+    );
+  }
+
+  async hasText(text) {
+    return Boolean(
+      await this.eval(`document.body.innerText.includes(${JSON.stringify(text)})`),
+    );
+  }
+
+  /**
+   * Click the first element matching `selector` whose trimmed text contains
+   * `text`. Polls until the element exists and is clicked.
+   */
+  async clickText(text, { selector = "button, [role=button], a", timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+    const expression = `(() => {
+      const candidates = document.querySelectorAll(${JSON.stringify(selector)});
+      for (const el of candidates) {
+        const label = (el.textContent ?? "").trim();
+        if (label.includes(${JSON.stringify(text)})) {
+          el.scrollIntoView({ block: "center" });
+          el.click();
+          return label;
+        }
+      }
+      return null;
+    })()`;
+    const clicked = await this.waitFor(expression, {
+      timeoutMs,
+      label: `clickable element with text ${JSON.stringify(text)}`,
+    });
+    this.log(`Clicked: ${clicked}`);
+    return clicked;
+  }
+
+  /**
+   * Fill a controlled React input via the native value setter + input event.
+   */
+  async fill(selector, value, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+    await this.waitFor(`Boolean(document.querySelector(${JSON.stringify(selector)}))`, {
+      timeoutMs,
+      label: `input ${selector}`,
+    });
+    await this.eval(`(() => {
+      const input = document.querySelector(${JSON.stringify(selector)});
+      const setter = Object.getOwnPropertyDescriptor(
+        input instanceof HTMLTextAreaElement
+          ? HTMLTextAreaElement.prototype
+          : HTMLInputElement.prototype,
+        "value",
+      ).set;
+      setter.call(input, ${JSON.stringify(value)});
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      return true;
+    })()`);
+    this.log(`Filled ${selector}`);
+  }
+
+  /**
+   * Navigate the app via hash routing (the convention used by all evals).
+   */
+  async navigateHash(path) {
+    const hash = path.startsWith("#") ? path : `#${path}`;
+    await this.eval(`(() => { window.location.hash = ${JSON.stringify(hash)}; return true; })()`);
+    this.log(`Navigated to ${hash}`);
+  }
+
+  /**
+   * Execute a registered window.__openworkControl action.
+   */
+  async control(actionId, args) {
+    const result = await this.eval(
+      `window.__openworkControl.execute(${JSON.stringify(actionId)}, ${JSON.stringify(args ?? null)})`,
+      { awaitPromise: true },
+    );
+    if (!result?.ok) {
+      throw new EvalError(`Control action ${actionId} failed: ${result?.error ?? "unknown"}`);
+    }
+    return result.result;
+  }
+
+  async screenshot(name) {
+    this.screenshotIndex += 1;
+    const fileName = `${this.flowId}-${String(this.screenshotIndex).padStart(2, "0")}-${name}.png`;
+    const buffer = await captureScreenshot(this.client);
+    await writeFile(join(this.outDir, fileName), buffer);
+    this.screenshots.push(fileName);
+    this.log(`Screenshot: ${fileName}`);
+    return fileName;
+  }
+}

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * OpenWork eval runner.
+ *
+ * Executes coded eval flows (evals/flows/*.flow.mjs) against a live app over
+ * CDP, with machine-checkable assertions and JSON + markdown reports.
+ *
+ * Usage:
+ *   node evals/runner/run.mjs --list
+ *   node evals/runner/run.mjs --flow app-smoke [--flow another]
+ *   node evals/runner/run.mjs --all
+ *   node evals/runner/run.mjs --all --cdp-url http://127.0.0.1:9825
+ *
+ * The CDP endpoint defaults to probing http://127.0.0.1:9825 (Daytona) then
+ * http://127.0.0.1:9823 (local pnpm dev). Override with --cdp-url or
+ * OPENWORK_EVAL_CDP_URL.
+ */
+import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { connect, pickAppTarget, resolveCdpBaseUrl } from "./cdp.mjs";
+import { EvalContext } from "./context.mjs";
+
+const RUNNER_DIR = dirname(fileURLToPath(import.meta.url));
+const FLOWS_DIR = join(RUNNER_DIR, "..", "flows");
+const DEFAULT_RESULTS_DIR = join(RUNNER_DIR, "..", "results");
+const DEFAULT_CDP_CANDIDATES = ["http://127.0.0.1:9825", "http://127.0.0.1:9823"];
+
+function parseArgs(argv) {
+  const args = { flows: [], all: false, list: false, cdpUrl: null, out: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--flow") args.flows.push(argv[++index]);
+    else if (value === "--all") args.all = true;
+    else if (value === "--list") args.list = true;
+    else if (value === "--cdp-url") args.cdpUrl = argv[++index];
+    else if (value === "--out") args.out = argv[++index];
+    else if (value === "--help" || value === "-h") args.help = true;
+    else throw new Error(`Unknown argument: ${value}`);
+  }
+  return args;
+}
+
+async function loadFlows() {
+  const entries = await readdir(FLOWS_DIR);
+  const flows = [];
+  for (const entry of entries.sort()) {
+    if (!entry.endsWith(".flow.mjs")) continue;
+    const module = await import(pathToFileURL(join(FLOWS_DIR, entry)).href);
+    const flow = module.default;
+    if (!flow?.id || !Array.isArray(flow.steps)) {
+      throw new Error(`Flow file ${entry} must default-export { id, title, steps }.`);
+    }
+    flows.push({ ...flow, file: entry });
+  }
+  return flows;
+}
+
+function missingEnv(flow, env) {
+  return (flow.requiredEnv ?? []).filter((name) => !env[name]?.trim());
+}
+
+async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
+  const result = {
+    id: flow.id,
+    title: flow.title,
+    spec: flow.spec ?? null,
+    status: "passed",
+    skipReason: null,
+    steps: [],
+    logs: [],
+  };
+
+  const missing = missingEnv(flow, env);
+  if (missing.length > 0) {
+    result.status = "skipped";
+    result.skipReason = `Missing env: ${missing.join(", ")}`;
+    return result;
+  }
+
+  const target = await pickAppTarget(cdpBaseUrl);
+  const client = await connect(target.webSocketDebuggerUrl);
+  const ctx = new EvalContext({ client, outDir, flowId: flow.id, env });
+
+  try {
+    for (const step of flow.steps) {
+      const stepResult = { name: step.name, status: "passed", durationMs: 0, error: null };
+      const startedAt = Date.now();
+      try {
+        await step.run(ctx);
+      } catch (error) {
+        stepResult.status = "failed";
+        stepResult.error = error instanceof Error ? error.message : String(error);
+        result.status = "failed";
+      }
+      stepResult.durationMs = Date.now() - startedAt;
+      result.steps.push(stepResult);
+      if (stepResult.status === "failed") {
+        await ctx.screenshot("failure").catch(() => undefined);
+        break;
+      }
+    }
+  } finally {
+    result.screenshots = ctx.screenshots;
+    result.logs = ctx.logs;
+    client.close();
+  }
+
+  return result;
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    `# Eval run ${report.runId}`,
+    "",
+    `- Started: ${report.startedAt}`,
+    `- CDP: ${report.cdpUrl}`,
+    `- Result: ${report.summary.failed > 0 ? "FAILED" : "PASSED"} (${report.summary.passed} passed, ${report.summary.failed} failed, ${report.summary.skipped} skipped)`,
+    "",
+  ];
+  for (const flow of report.flows) {
+    const icon = flow.status === "passed" ? "✅" : flow.status === "skipped" ? "⏭️" : "❌";
+    lines.push(`## ${icon} ${flow.id} — ${flow.title}`);
+    if (flow.spec) lines.push(`Spec: ${flow.spec}`);
+    if (flow.skipReason) lines.push(`Skipped: ${flow.skipReason}`);
+    lines.push("");
+    for (const step of flow.steps ?? []) {
+      const stepIcon = step.status === "passed" ? "✅" : "❌";
+      lines.push(`- ${stepIcon} ${step.name} (${step.durationMs}ms)${step.error ? ` — ${step.error}` : ""}`);
+    }
+    if (flow.screenshots?.length) {
+      lines.push("", `Screenshots: ${flow.screenshots.join(", ")}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log("Usage: node evals/runner/run.mjs [--list | --all | --flow <id> ...] [--cdp-url <url>] [--out <dir>]");
+    return;
+  }
+
+  const flows = await loadFlows();
+
+  if (args.list) {
+    for (const flow of flows) {
+      const gates = flow.requiredEnv?.length ? ` (requires env: ${flow.requiredEnv.join(", ")})` : "";
+      console.log(`${flow.id} — ${flow.title}${gates}`);
+    }
+    return;
+  }
+
+  const selected = args.all
+    ? flows
+    : flows.filter((flow) => args.flows.includes(flow.id));
+  if (selected.length === 0) {
+    throw new Error(
+      args.flows.length > 0
+        ? `No flows matched: ${args.flows.join(", ")}. Use --list to see available flows.`
+        : "Nothing to run. Pass --all, or --flow <id>. Use --list to see available flows.",
+    );
+  }
+
+  const envCdp = process.env.OPENWORK_EVAL_CDP_URL?.trim();
+  const cdpBaseUrl = args.cdpUrl ?? (envCdp || (await resolveCdpBaseUrl(DEFAULT_CDP_CANDIDATES)));
+
+  const runId = new Date().toISOString().replace(/[:.]/g, "-");
+  const outDir = join(args.out ?? DEFAULT_RESULTS_DIR, runId);
+  await mkdir(outDir, { recursive: true });
+
+  const report = {
+    runId,
+    startedAt: new Date().toISOString(),
+    cdpUrl: cdpBaseUrl,
+    flows: [],
+    summary: { passed: 0, failed: 0, skipped: 0 },
+  };
+
+  for (const flow of selected) {
+    console.log(`▶ ${flow.id} — ${flow.title}`);
+    const result = await runFlow(flow, { cdpBaseUrl, outDir, env: process.env });
+    report.flows.push(result);
+    report.summary[result.status] += 1;
+    for (const step of result.steps) {
+      const icon = step.status === "passed" ? "  ✓" : "  ✗";
+      console.log(`${icon} ${step.name} (${step.durationMs}ms)${step.error ? ` — ${step.error}` : ""}`);
+    }
+    if (result.skipReason) console.log(`  ⏭ skipped: ${result.skipReason}`);
+  }
+
+  report.finishedAt = new Date().toISOString();
+  await writeFile(join(outDir, "report.json"), JSON.stringify(report, null, 2));
+  await writeFile(join(outDir, "report.md"), renderMarkdown(report));
+
+  console.log("");
+  console.log(
+    `Result: ${report.summary.failed > 0 ? "FAILED" : "PASSED"} — ${report.summary.passed} passed, ${report.summary.failed} failed, ${report.summary.skipped} skipped`,
+  );
+  console.log(`Report: ${join(outDir, "report.md")}`);
+
+  if (report.summary.failed > 0) process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:session-switch": "pnpm --filter @openwork/app test:session-switch",
     "test:fs-engine": "pnpm --filter @openwork/app test:fs-engine",
     "test:e2e": "pnpm --filter @openwork/app test:e2e",
+    "evals": "node evals/runner/run.mjs",
     "test:orchestrator": "pnpm --filter openwork-orchestrator test:router",
     "bump:patch": "pnpm --filter @openwork/app bump:patch",
     "bump:minor": "pnpm --filter @openwork/app bump:minor",


### PR DESCRIPTION
## What

A zero-dependency programmatic runner for UI evals, so flows execute with machine-checkable assertions instead of agent judgment over prose specs.

- `evals/runner/` — CDP client (native fetch + WebSocket, same pattern as `apps/app/scripts/voice-cdp.mjs`), per-flow context with poll-until-condition helpers (`waitFor`, `waitForText`, `clickText`, `fill` with React native-setter, `navigateHash`, `control` for `window.__openworkControl`, `screenshot`), and a CLI (`pnpm evals --list | --all | --flow <id>`).
- `evals/flows/*.flow.mjs` — first four coded flows:
  - `app-smoke` — boot, control API, route, rendered content
  - `cloud-account-renders` — Cloud Account surface renders signed-in/out state (catches blank/crashed cloud surfaces)
  - `settings-extensions-mcp` — MCP settings tabs, custom-app entry, available-apps section
  - `cloud-signin-handoff` — codifies `cloud-auth-flows.md` Flow 1: creates a desktop handoff grant via Den API, pastes the deep link, asserts the session lands. Env-gated (`OPENWORK_EVAL_DEN_API_URL`, `OPENWORK_EVAL_DEN_TOKEN`) — skips, not fails, without credentials.
- Reports: `evals/results/<run-id>/report.{json,md}` + screenshots (gitignored). Non-zero exit on failure.
- No fixed sleeps anywhere — all waits poll a condition with a timeout.
- CDP endpoint auto-probes `:9825` (Daytona) then `:9823` (local `pnpm dev`).

Markdown specs remain the source narrative; coded flows link back via `spec`.

## Testing (end-to-end, local Electron)

Ran `pnpm dev` and `pnpm evals --all` against the live app:

```
Result: PASSED — 3 passed, 0 failed, 1 skipped
▶ app-smoke ✓✓✓✓   ▶ cloud-account-renders ✓✓✓   ▶ settings-extensions-mcp ✓✓✓✓
▶ cloud-signin-handoff ⏭ skipped: Missing env
```

Reports + screenshots verified in `evals/results/`. The runner also immediately caught a real product regression while being built: since #2008 the MCP quick-connect directory (Notion, Linear, OpenWork Cloud Control) is no longer discoverable anywhere — "My Extensions" only lists configured entries and the Marketplace tab requires cloud sign-in and only renders marketplace/builtin items. Fix tracked separately as part of the cloud MCP integration series.

Next in series: den-api session→MCP token exchange, one-click cloud MCP on sign-in, MCP status truthfulness, nightly CI eval smoke.