### PR TITLE
feat(den-api): first-party session→MCP token exchange + tool catalog caching

### DIFF
--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -14,6 +14,7 @@ import type { MemberTeamsContext, OrganizationContextVariables, UserOrganization
 import { buildOperationId, emptyResponse, htmlResponse, jsonResponse } from "./openapi.js"
 import { registerAdminRoutes } from "./routes/admin/index.js"
 import { registerAuthRoutes } from "./routes/auth/index.js"
+import { registerMcpTokenRoutes } from "./routes/mcp/index.js"
 import { registerMeRoutes } from "./routes/me/index.js"
 import { registerOrgRoutes } from "./routes/org/index.js"
 import { registerTelemetryRoutes } from "./routes/telemetry/index.js"
@@ -122,6 +123,7 @@ registerOrgRoutes(app)
 registerVersionRoutes(app)
 registerWebhookRoutes(app)
 registerWorkerRoutes(app)
+registerMcpTokenRoutes(app)
 registerMcpRoutes(app)
 registerTelemetryRoutes(app)
 

--- a/ee/apps/den-api/src/mcp/auth.ts
+++ b/ee/apps/den-api/src/mcp/auth.ts
@@ -33,8 +33,13 @@ function readBearerToken(headers: Headers) {
   return match?.[1]?.trim() || null
 }
 
-function hashStoredToken(token: string) {
-  return crypto.createHash("sha256").update(token).digest("base64url")
+/**
+ * Hash an opaque MCP token secret (the part after the `ow_mcp_at_` prefix)
+ * for storage/lookup. Shared with the first-party mint route so the formats
+ * cannot drift.
+ */
+export function hashOpaqueMcpSecret(secret: string) {
+  return crypto.createHash("sha256").update(secret).digest("base64url")
 }
 
 function readStoredScopes(scopes: string) {
@@ -85,7 +90,7 @@ async function verifyOpaqueMcpToken(token: string) {
     return null
   }
 
-  const storedToken = hashStoredToken(token.slice(DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX.length))
+  const storedToken = hashOpaqueMcpSecret(token.slice(DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX.length))
   const [accessToken] = await db
     .select()
     .from(OAuthAccessTokenTable)

--- a/ee/apps/den-api/src/mcp/index.ts
+++ b/ee/apps/den-api/src/mcp/index.ts
@@ -2,8 +2,27 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StreamableHTTPTransport } from "@hono/mcp"
 import type { Hono } from "hono"
 import { getMcpResourceUrl, verifyMcpRequest } from "./auth.js"
-import { buildMcpCatalog, getToolDescription, loadOpenApiDocument } from "./catalog.js"
+import { buildMcpCatalog, getToolDescription, loadOpenApiDocument, type McpToolOperation } from "./catalog.js"
 import { invokeMcpOperation } from "./invoke.js"
+
+const CATALOG_CACHE_TTL_MS = 5 * 60 * 1000
+
+let catalogCache: { catalog: McpToolOperation[]; expiresAt: number } | null = null
+
+/**
+ * The tool catalog is derived from the OpenAPI document, which only changes
+ * on deploy. Cache it briefly instead of self-fetching openapi.json and
+ * rebuilding the catalog on every /mcp request.
+ */
+async function getCatalog(app: Hono, env: unknown) {
+  if (catalogCache && catalogCache.expiresAt > Date.now()) {
+    return catalogCache.catalog
+  }
+  const document = await loadOpenApiDocument(app, env)
+  const catalog = buildMcpCatalog(document)
+  catalogCache = { catalog, expiresAt: Date.now() + CATALOG_CACHE_TTL_MS }
+  return catalog
+}
 
 function protectedResourceMetadata(request: Request) {
   const resource = getMcpResourceUrl(request)
@@ -26,8 +45,7 @@ export function registerMcpRoutes<T extends { Variables: Record<string, unknown>
       return principal
     }
 
-    const document = await loadOpenApiDocument(app as unknown as Hono, c.env)
-    const catalog = buildMcpCatalog(document)
+    const catalog = await getCatalog(app as unknown as Hono, c.env)
     const server = new McpServer({
       name: "openwork-den-api",
       version: "1.0.0",

--- a/ee/apps/den-api/src/routes/mcp/index.ts
+++ b/ee/apps/den-api/src/routes/mcp/index.ts
@@ -1,0 +1,118 @@
+import * as crypto from "node:crypto"
+import { OAuthAccessTokenTable } from "@openwork-ee/den-db/schema"
+import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import type { Hono } from "hono"
+import { describeRoute } from "hono-openapi"
+import { z } from "zod"
+import { DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX, DEN_MCP_RESOURCE } from "../../auth.js"
+import { db } from "../../db.js"
+import { hashOpaqueMcpSecret } from "../../mcp/auth.js"
+import {
+  jsonValidator,
+  requireUserMiddleware,
+  resolveUserOrganizationsMiddleware,
+  type UserOrganizationsContext,
+} from "../../middleware/index.js"
+import { invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
+import type { AuthContextVariables } from "../../session.js"
+
+/**
+ * First-party MCP token exchange.
+ *
+ * A signed-in Den session can mint an org-scoped opaque MCP access token
+ * without the browser OAuth dance. This is not a privilege escalation: the
+ * caller already holds a full session token for the same user, which can do
+ * strictly more than the resulting `mcp:*`-scoped token. The org is the
+ * session's active organization, validated for membership by
+ * `resolveUserOrganizationsMiddleware`.
+ *
+ * Tokens are stored exactly like oauthProvider-issued opaque tokens
+ * (sha256 of the secret in OAuthAccessTokenTable, org in referenceId), so
+ * `verifyOpaqueMcpToken` accepts them with no verification changes.
+ */
+
+const FIRST_PARTY_MCP_CLIENT_ID = "openwork-desktop"
+const MCP_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+const mintMcpTokenSchema = z.object({
+  scopes: z.array(z.enum(["mcp:read", "mcp:write"])).min(1).optional(),
+})
+
+const mcpTokenResponseSchema = z.object({
+  token: z.string(),
+  expiresAt: z.string().datetime(),
+  organizationId: z.string(),
+  scopes: z.array(z.string()),
+  resource: z.string(),
+}).meta({ ref: "McpTokenResponse" })
+
+const organizationRequiredSchema = z.object({
+  error: z.literal("organization_required"),
+  message: z.string(),
+}).meta({ ref: "McpTokenOrganizationRequiredError" })
+
+type McpRouteVariables = AuthContextVariables & Partial<UserOrganizationsContext>
+
+export function registerMcpTokenRoutes<T extends { Variables: McpRouteVariables }>(app: Hono<T>) {
+  app.post(
+    "/v1/mcp/token",
+    describeRoute({
+      // Session-equivalent credential minting must never be exposed as an MCP
+      // tool; the Authentication tag is blocked by the MCP exposure policy.
+      tags: ["Authentication"],
+      summary: "Mint MCP access token",
+      description: "Mints an org-scoped MCP access token for the caller's active organization so first-party clients can connect to the Den MCP server without a separate browser OAuth flow.",
+      responses: {
+        200: jsonResponse("MCP access token minted successfully.", mcpTokenResponseSchema),
+        400: jsonResponse("The token request was invalid or no active organization is selected.", z.union([invalidRequestSchema, organizationRequiredSchema])),
+        401: jsonResponse("The caller must be signed in to mint an MCP token.", unauthorizedSchema),
+      },
+    }),
+    requireUserMiddleware,
+    resolveUserOrganizationsMiddleware,
+    jsonValidator(mintMcpTokenSchema),
+    async (c) => {
+      const user = c.get("user")
+      const session = c.get("session")
+      const orgId = c.get("activeOrganizationId")
+      const input = c.req.valid("json")
+
+      if (!orgId) {
+        return c.json({
+          error: "organization_required",
+          message: "Select an active organization before minting an MCP token.",
+        }, 400)
+      }
+
+      const scopes = input.scopes ?? ["mcp:read", "mcp:write"]
+      const secret = crypto.randomBytes(32).toString("base64url")
+      const expiresAt = new Date(Date.now() + MCP_TOKEN_TTL_MS)
+
+      let sessionId = null
+      try {
+        sessionId = session?.id ? normalizeDenTypeId("session", session.id) : null
+      } catch {
+        sessionId = null
+      }
+
+      await db.insert(OAuthAccessTokenTable).values({
+        id: createDenTypeId("oauthAccessToken"),
+        token: hashOpaqueMcpSecret(secret),
+        clientId: FIRST_PARTY_MCP_CLIENT_ID,
+        sessionId,
+        userId: normalizeDenTypeId("user", user.id),
+        referenceId: normalizeDenTypeId("organization", orgId),
+        expiresAt,
+        scopes: JSON.stringify(scopes),
+      })
+
+      return c.json({
+        token: `${DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX}${secret}`,
+        expiresAt: expiresAt.toISOString(),
+        organizationId: normalizeDenTypeId("organization", orgId),
+        scopes,
+        resource: DEN_MCP_RESOURCE,
+      })
+    },
+  )
+}


### PR DESCRIPTION
## What

### `POST /v1/mcp/token` — first-party MCP token exchange

A signed-in Den session can now mint an org-scoped opaque MCP access token directly, instead of forcing first-party clients (the desktop app) through the full browser OAuth dance (dynamic client registration → org selection → consent) that third-party MCP clients use.

- Auth: standard `requireUserMiddleware` + `resolveUserOrganizationsMiddleware` — the org is the session's active organization, membership-validated by the middleware.
- Token format: identical to oauthProvider-issued opaque tokens — `ow_mcp_at_<secret>` with sha256(secret) stored in `OAuthAccessTokenTable`, org in `referenceId`, scopes as JSON. `verifyOpaqueMcpToken` accepts them with **zero verification changes**. The hash function is now shared (`hashOpaqueMcpSecret` exported from `mcp/auth.ts`) so mint/verify can't drift.
- Scopes: defaults to `mcp:read mcp:write`; body accepts a subset (e.g. `{"scopes":["mcp:read"]}`).
- TTL: 30 days. Response: `{ token, expiresAt, organizationId, scopes, resource }`.
- **Not a privilege escalation**: the caller already holds a full session token for the same user, which can do strictly more than the resulting `mcp:*`-scoped token.
- Tagged `Authentication`, which the MCP exposure policy blocks — the mint route can never appear as an MCP tool itself.

### Tool catalog caching

`ALL /mcp` previously self-fetched `openapi.json` and rebuilt the entire tool catalog on **every request**. The catalog only changes on deploy; it's now cached for 5 minutes.

## Why

Part of making the cloud MCP first-class in the desktop app: the follow-up PR auto-configures the `openwork-cloud` MCP entry with this token on cloud sign-in (no browser round-trip, org always in sync with the app's active org).

## Testing (end-to-end against a real local Den stack)

Ran MySQL (docker) + `db:push` + demo-org seed + den-api locally, then exercised the full path:

```
sign-in: 200 | session token: ok
mint status: 200
scopes: [mcp:read, mcp:write] | org: org_01ktq09ymgecztz5... | prefix ok: true | expires: +30d
mcp initialize: 200 | server: openwork-den-api
tools/list: 200 | tool count: 127
tools/call getV1Me: 200 | returns demo user: true
bad token: 401 | unauthenticated mint: 401 | read-only mint scopes: [mcp:read]
```

- `tsc --noEmit` in `ee/apps/den-api` — passes.
- No DB migration needed (reuses better-auth's `oauthAccessToken` table).

Series: follows #2114 (eval runner). Next: desktop one-click cloud MCP using this endpoint.