### PR TITLE
feat(cloud): one-click cloud MCP — auto-configured with first-party token on sign-in

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -150,10 +150,12 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     serverName: "openwork-cloud",
     get description() { return t("mcp.quick_connect_openwork_cloud_desc"); },
     get url() {
+      // The Den MCP server is hosted on the API origin (see
+      // packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx), not the web app.
       try {
-        return `${readDenBootstrapConfig().baseUrl.replace(/\/+$/, "")}/mcp`;
+        return `${readDenBootstrapConfig().apiBaseUrl.replace(/\/+$/, "")}/mcp`;
       } catch {
-        return "https://app.openworklabs.com/mcp";
+        return "https://api.openworklabs.com/mcp";
       }
     },
     type: "remote",

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -111,6 +111,14 @@ export type DenWorkerTokens = {
   workspaceId: string | null;
 };
 
+export type DenMcpToken = {
+  token: string;
+  expiresAt: string;
+  organizationId: string;
+  scopes: string[];
+  resource: string;
+};
+
 export type DenOrgLlmProviderModel = {
   id: string;
   name: string;
@@ -437,6 +445,26 @@ export function normalizeDenBaseUrl(input: string | null | undefined): string | 
     return url.toString().replace(/\/+$/, "");
   } catch {
     return null;
+  }
+}
+
+/**
+ * Origin-level comparison key for Den URLs. Ignores paths (deep links may
+ * carry an `/api/den` proxy path) and treats loopback aliases (127.0.0.1,
+ * [::1]) as `localhost`, matching den-api's own dev-mode resource aliasing.
+ */
+export function denOriginComparisonKey(input: string | null | undefined): string | null {
+  const normalized = normalizeDenBaseUrl(input);
+  if (!normalized) return null;
+  try {
+    const url = new URL(normalized);
+    const host = url.hostname.toLowerCase();
+    if (host === "127.0.0.1" || host === "::1" || host === "[::1]" || host === "0.0.0.0") {
+      url.hostname = "localhost";
+    }
+    return url.origin;
+  } catch {
+    return normalized;
   }
 }
 
@@ -932,6 +960,27 @@ function getWorkerTokens(payload: unknown): DenWorkerTokens | null {
     hostToken: typeof tokens.host === "string" ? tokens.host : null,
     openworkUrl: connect && typeof connect.openworkUrl === "string" ? connect.openworkUrl : null,
     workspaceId: connect && typeof connect.workspaceId === "string" ? connect.workspaceId : null,
+  };
+}
+
+function getMcpToken(payload: unknown): DenMcpToken | null {
+  if (
+    !isRecord(payload) ||
+    typeof payload.token !== "string" ||
+    typeof payload.expiresAt !== "string" ||
+    typeof payload.organizationId !== "string" ||
+    typeof payload.resource !== "string"
+  ) {
+    return null;
+  }
+  return {
+    token: payload.token,
+    expiresAt: payload.expiresAt,
+    organizationId: payload.organizationId,
+    scopes: Array.isArray(payload.scopes)
+      ? payload.scopes.filter((entry): entry is string => typeof entry === "string")
+      : [],
+    resource: payload.resource,
   };
 }
 
@@ -1804,6 +1853,20 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
       return getWorkers(payload);
     },
 
+    async mintMcpToken(orgId: string): Promise<DenMcpToken> {
+      const payload = await requestJson<unknown>(baseUrls, "/v1/mcp/token", {
+        method: "POST",
+        token,
+        organizationId: orgId,
+        body: {},
+      });
+      const minted = getMcpToken(payload);
+      if (!minted) {
+        throw new DenApiError(500, "invalid_mcp_token_payload", "MCP token response was missing required values.");
+      }
+      return minted;
+    },
+
     async getWorkerTokens(workerId: string, orgId: string): Promise<DenWorkerTokens> {
       const payload = await requestJson<unknown>(baseUrls, `/v1/workers/${encodeURIComponent(workerId)}/tokens`, {
         method: "POST",
@@ -1999,4 +2062,24 @@ export async function fetchDenOrgSkillsCatalog(
     });
   }
   return Array.from(byId.values()).toSorted((a, b) => a.title.localeCompare(b.title));
+}
+
+/**
+ * Mint an org-scoped MCP access token for the Den cloud MCP using the
+ * current desktop Den session. Returns null when signed out or no active
+ * organization is selected.
+ */
+export async function mintCloudControlMcpToken(): Promise<DenMcpToken | null> {
+  const settings = readDenSettings();
+  const token = settings.authToken?.trim() ?? "";
+  const orgId = settings.activeOrgId?.trim() ?? "";
+  if (!token || !orgId) {
+    return null;
+  }
+  const client = createDenClient({
+    baseUrl: settings.baseUrl,
+    apiBaseUrl: settings.apiBaseUrl ?? null,
+    token,
+  });
+  return client.mintMcpToken(orgId);
 }

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -15,6 +15,8 @@ import {
   createDenClient,
   DenApiError,
   ensureDenActiveOrganization,
+  denOriginComparisonKey,
+  normalizeDenBaseUrl,
   readDenSettings,
   writeDenSettings,
   type DenUser,
@@ -134,7 +136,19 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
         if (!parsed || handledGrantsRef.current.has(parsed.grant)) continue;
         handledGrantsRef.current.add(parsed.grant);
 
-        void createDenClient({ baseUrl: parsed.denBaseUrl })
+        // Keep the configured apiBaseUrl when the deep link targets the
+        // control plane we are already pointed at; deriving from the link's
+        // base URL alone breaks deployments where the advertised proxy path
+        // does not match how this app actually reaches the Den API.
+        const settings = readDenSettings();
+        const targetKey = denOriginComparisonKey(parsed.denBaseUrl);
+        const sameControlPlane =
+          denOriginComparisonKey(settings.baseUrl) === targetKey ||
+          denOriginComparisonKey(settings.apiBaseUrl ?? null) === targetKey;
+        void createDenClient({
+          baseUrl: parsed.denBaseUrl,
+          apiBaseUrl: sameControlPlane ? settings.apiBaseUrl ?? null : null,
+        })
           .exchangeDesktopHandoff(parsed.grant)
           .then((result) => {
             if (!result.token) {

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -9,6 +9,7 @@ import {
   type McpDirectoryInfo,
 } from "../../../app/constants";
 import { extensionResource } from "../../../app/extensions";
+import { mintCloudControlMcpToken, readDenSettings } from "../../../app/lib/den";
 import { createClient, unwrap } from "../../../app/lib/opencode";
 import { finishPerf, perfNow, recordPerfLog } from "../../../app/lib/perf-log";
 import {
@@ -35,6 +36,40 @@ import { isDesktopRuntime, normalizeDirectoryPath, safeStringify } from "../../.
 import type { OpenworkServerStore } from "./openwork-server-store";
 
 type SetStateAction<T> = T | ((current: T) => T);
+
+const CLOUD_MCP_SYNC_MARKER_KEY = "openwork.den.mcp.sync";
+const CLOUD_MCP_REFRESH_MARGIN_MS = 7 * 24 * 60 * 60 * 1000;
+
+type CloudMcpSyncMarker = { orgId: string; expiresAt: string };
+
+function readCloudMcpSyncMarker(): CloudMcpSyncMarker | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(CLOUD_MCP_SYNC_MARKER_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof (parsed as { orgId?: unknown }).orgId === "string" &&
+      typeof (parsed as { expiresAt?: unknown }).expiresAt === "string"
+    ) {
+      return parsed as CloudMcpSyncMarker;
+    }
+  } catch {
+    // Corrupt marker — treat as absent.
+  }
+  return null;
+}
+
+function writeCloudMcpSyncMarker(marker: CloudMcpSyncMarker) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(CLOUD_MCP_SYNC_MARKER_KEY, JSON.stringify(marker));
+  } catch {
+    // Storage unavailable — sync will simply re-run next time.
+  }
+}
 
 export type ConnectionsStoreSnapshot = {
   mcpServers: McpServerEntry[];
@@ -572,6 +607,20 @@ export function createConnectionsStore(options: {
         }
       }
 
+      // Signed-in cloud users connect the Den MCP with a first-party token —
+      // no browser OAuth round-trip. Signed-out users fall back to OAuth.
+      if (entry.serverName === "openwork-cloud") {
+        try {
+          const minted = await mintCloudControlMcpToken();
+          if (minted) {
+            resolvedUrl = minted.resource;
+            resolvedHeaders = { Authorization: `Bearer ${minted.token}` };
+          }
+        } catch {
+          // Minting failed (offline, expired session) — fall back to OAuth.
+        }
+      }
+
       const mcpEntryConfig: Record<string, unknown> = {
         type: entryType,
         enabled: true,
@@ -662,9 +711,9 @@ export function createConnectionsStore(options: {
           entryType === "remote"
             ? {
                 type: "remote" as const,
-                url: entry.url!,
+                url: resolvedUrl ?? entry.url!,
                 enabled: true,
-                ...(entry.oauth ? { oauth: {} } : {}),
+                ...(entry.oauth && !resolvedHeaders ? { oauth: {} } : {}),
               }
             : {
                 type: "local" as const,
@@ -685,7 +734,7 @@ export function createConnectionsStore(options: {
       options.markReloadRequired?.("mcp", { type: "mcp", name: slug, action });
       await refreshMcpServers();
 
-      if (entry.oauth) {
+      if (entry.oauth && !resolvedHeaders) {
         mutateState((current) => ({
           ...current,
           mcpAuthEntry: entry,
@@ -703,6 +752,7 @@ export function createConnectionsStore(options: {
         slug,
       });
     } catch (error) {
+      console.error("[mcp.connect] failed", entry.name, error);
       setStateField(
         "mcpStatus",
         error instanceof Error ? error.message : t("mcp.connect_failed"),
@@ -715,6 +765,43 @@ export function createConnectionsStore(options: {
     } finally {
       setStateField("mcpConnectingName", null);
     }
+  }
+
+  /**
+   * Background reconciliation for the Den cloud MCP: when the desktop is
+   * signed in to OpenWork Cloud with an active org, keep the
+   * `openwork-cloud` MCP entry configured with a fresh first-party token.
+   * Quiet by design — a failed mint never opens the OAuth modal.
+   */
+  async function syncCloudControlMcp(): Promise<"synced" | "unchanged" | "skipped"> {
+    const settings = readDenSettings();
+    const orgId = settings.activeOrgId?.trim() ?? "";
+    if (!orgId || !settings.authToken?.trim()) return "skipped";
+
+    const entry = MCP_QUICK_CONNECT.find((candidate) => candidate.serverName === "openwork-cloud");
+    if (!entry) return "skipped";
+    const slug = entry.id ?? getMcpServerName(entry);
+
+    const marker = readCloudMcpSyncMarker();
+    const markerFresh =
+      marker !== null &&
+      marker.orgId === orgId &&
+      new Date(marker.expiresAt).getTime() - Date.now() > CLOUD_MCP_REFRESH_MARGIN_MS;
+    if (markerFresh && snapshot.mcpServers.some((server) => server.name === slug)) {
+      return "unchanged";
+    }
+
+    // Validate the session up front so a failed mint never reaches
+    // connectMcp's signed-out fallback (which opens the OAuth modal).
+    const minted = await mintCloudControlMcpToken().catch(() => null);
+    if (!minted) return "skipped";
+
+    await connectMcp(entry);
+    if (!snapshot.mcpServers.some((server) => server.name === slug)) {
+      return "skipped";
+    }
+    writeCloudMcpSyncMarker({ orgId, expiresAt: minted.expiresAt });
+    return "synced";
   }
 
   function authorizeMcp(entry: McpServerEntry) {
@@ -1006,6 +1093,7 @@ export function createConnectionsStore(options: {
     readMcpConfigFile,
     refreshMcpServers,
     connectMcp,
+    syncCloudControlMcp,
     authorizeMcp,
     logoutMcpAuth,
     removeMcp,

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_DEN_BASE_URL,
   DenApiError,
   ensureDenActiveOrganization,
+  denOriginComparisonKey,
   normalizeDenBaseUrl,
   readDenSettings,
   resolveDenBaseUrls,
@@ -384,7 +385,18 @@ export function useDenSession({
     setStatusMessage(t("den.signing_in"));
 
     try {
-      const result = await createDenClient({ baseUrl: nextBaseUrl }).exchangeDesktopHandoff(parsed.grant);
+      // When the pasted link targets the control plane we are already
+      // configured for, keep the configured apiBaseUrl. Deriving it from the
+      // link's base URL alone breaks deployments where the advertised proxy
+      // path does not match how this app actually reaches the Den API.
+      const settings = readDenSettings();
+      const targetKey = denOriginComparisonKey(nextBaseUrl);
+      const configuredApiBaseUrl =
+        denOriginComparisonKey(settings.baseUrl) === targetKey ||
+        denOriginComparisonKey(settings.apiBaseUrl ?? null) === targetKey
+          ? settings.apiBaseUrl ?? null
+          : null;
+      const result = await createDenClient({ baseUrl: nextBaseUrl, apiBaseUrl: configuredApiBaseUrl }).exchangeDesktopHandoff(parsed.grant);
       if (!result.token) {
         throw new Error(t("den.error_no_token"));
       }

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1596,6 +1596,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   // the settings route owns the provider-auth store.
   useCloudProviderAutoSync(providerAuthStore.runCloudProviderSync);
 
+  // Keep the Den cloud MCP configured with a fresh first-party token while
+  // signed in: connects on sign-in, re-mints on org switch and before expiry.
+  useCloudProviderAutoSync(() => connectionsStore.syncCloudControlMcp());
+
   useEffect(() => {
     if (route.tab !== "cloud-providers") return;
     void providerAuthStore.runCloudProviderSync("settings_cloud_opened");

--- a/evals/flows/cloud-mcp-auto-config.flow.mjs
+++ b/evals/flows/cloud-mcp-auto-config.flow.mjs
@@ -1,0 +1,87 @@
+/**
+ * After cloud sign-in, the Den cloud MCP ("OpenWork Cloud Control") is
+ * auto-configured with a first-party org-scoped token: no browser OAuth,
+ * entry appears under YOUR APPS, sync marker persisted.
+ *
+ * Requires the programmatic runner (evals/runner) and a reachable Den API:
+ * - OPENWORK_EVAL_DEN_API_URL    Den API base, e.g. http://127.0.0.1:8790
+ * - OPENWORK_EVAL_DEN_TOKEN      Bearer session token for a Den account
+ *
+ * The app under test must be bootstrapped against the same Den control
+ * plane (desktop-bootstrap.json) and signed out at start, or already signed
+ * in to the same account.
+ */
+export default {
+  id: "cloud-mcp-auto-config",
+  title: "Cloud MCP auto-configures with first-party token on sign-in",
+  spec: "evals/cloud-auth-flows.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000 });
+      },
+    },
+    {
+      name: "Sign in via desktop handoff (skipped when already signed in)",
+      run: async (ctx) => {
+        const signedIn = await ctx.eval(
+          "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+        );
+        if (signedIn) {
+          ctx.log("Already signed in; reusing session.");
+          return;
+        }
+
+        const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+        const response = await fetch(`${apiBase}/v1/auth/desktop-handoff`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ desktopScheme: "openwork" }),
+        });
+        ctx.assert(response.ok, `Handoff create failed: ${response.status}`);
+        const payload = await response.json();
+
+        await ctx.navigateHash("/settings/cloud-account");
+        await ctx.clickText("Paste sign-in code", { timeoutMs: 30_000 });
+        await ctx.fill("#den-signin-link", payload.openworkUrl);
+        await ctx.clickText("Finish sign-in");
+        await ctx.waitFor(
+          "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+          { timeoutMs: 30_000, label: "persisted den auth token" },
+        );
+      },
+    },
+    {
+      name: "Active organization resolves",
+      run: async (ctx) => {
+        await ctx.waitFor(
+          "Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())",
+          { timeoutMs: 60_000, label: "active org" },
+        );
+      },
+    },
+    {
+      name: "Cloud MCP auto-config marker is written",
+      run: async (ctx) => {
+        await ctx.waitFor(
+          "Boolean(localStorage.getItem('openwork.den.mcp.sync'))",
+          { timeoutMs: 120_000, label: "openwork.den.mcp.sync marker" },
+        );
+        ctx.log(`marker: ${await ctx.eval("localStorage.getItem('openwork.den.mcp.sync')")}`);
+      },
+    },
+    {
+      name: "OpenWork Cloud Control appears as a configured app",
+      run: async (ctx) => {
+        await ctx.navigateHash("/settings/extensions/mcp");
+        await ctx.waitForText("OpenWork Cloud Control", { timeoutMs: 30_000 });
+        await ctx.screenshot("cloud-mcp-configured");
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## What

Makes the Den cloud MCP a first-class, zero-friction integration. Depends on #2115 (`POST /v1/mcp/token`) at runtime.

### Auto-configuration on cloud sign-in
- New `syncCloudControlMcp()` on the connections store: while signed in with an active org, it keeps the `openwork-cloud` MCP entry configured with a fresh org-scoped token (localStorage marker `openwork.den.mcp.sync`; re-mints on org switch and within 7 days of expiry; quiet by design — a failed mint never opens the OAuth modal).
- Mounted via the existing `useCloudProviderAutoSync` reconciliation hook in the settings route (sign-in, den-settings-changed, interval).

### First-party token on manual connect
- `connectMcp` now mints a token for `openwork-cloud` when a Den session exists (mirroring the `openwork-ui` header-injection pattern) and writes `headers.Authorization` instead of `oauth: {}` — signed-out users still get the OAuth fallback. The post-connect OAuth modal is suppressed when headers were injected, and the SDK hot-add now uses the resolved URL.
- `den.ts`: `client.mintMcpToken(orgId)` + `mintCloudControlMcpToken()` helper.

### Bug fixes found by driving the flow end-to-end
- **Manual paste-code sign-in posted the exchange to the wrong URL** in deployments where the advertised proxy path doesn't match how the app reaches the Den API (the `cloud-auth-flows.md` Flow 2 regression). Both `use-den-session.tsx` and `den-auth-provider.tsx` now keep the *configured* `apiBaseUrl` when the link targets the same control plane (origin-level comparison with loopback aliasing — `denOriginComparisonKey`).
- Cloud MCP tile URL now derives from `apiBaseUrl` (fallback `https://api.openworklabs.com/mcp`, matching the docs) instead of the web-app origin.
- `connectMcp` failures are now logged to console in addition to the status banner.

### Eval
- New coded flow `evals/flows/cloud-mcp-auto-config.flow.mjs` (runner from #2114): handoff sign-in → marker → "OpenWork Cloud Control" visible under YOUR APPS. Env-gated; skips without Den credentials.

## Testing (end-to-end, real local stack)

Local Den stack (MySQL + den-api + seeded demo org) + local Electron, driven over CDP:

1. Pointed desktop bootstrap at the local Den, signed in via paste-code with a real handoff grant → session lands, active org "Acme Robotics" resolves.
2. Auto-sync fired: `POST /v1/mcp/token` 200, marker written, `mcp.connect:done`.
3. Settings → Extensions shows **OpenWork Cloud Control** under YOUR APPS with the standard "Reload required — MCP 'openwork-cloud' was added" coordination.
4. Workspace MCP config verified through the OpenWork server API:
```json
{"name":"openwork-cloud","config":{"type":"remote","enabled":true,"url":"http://127.0.0.1:8790/mcp","headers":{"Authorization":"Bearer ow_mcp_at_..."}},"source":"config.project"}
```
5. `pnpm typecheck` (apps/app) — passes.

Known follow-up (next PR): the configured entry's status pill reads "Sign in needed" until opencode reloads — status truthfulness for header-authed MCP entries lands in the MCP-status PR.

Series: #2114 (eval runner) → #2115 (token exchange) → this.