### PR TITLE
feat(mcp): truthful MCP status — header-authed entries, live connected count, 401 re-mint

### DIFF
--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -633,6 +633,9 @@ export function createConnectionsStore(options: {
         mcpEntryConfig["url"] = resolvedUrl;
         if (resolvedHeaders) {
           mcpEntryConfig["headers"] = resolvedHeaders;
+          // Header-authed entries must not trigger OAuth auto-detection;
+          // otherwise opencode reports "needs_auth" despite valid headers.
+          mcpEntryConfig["oauth"] = false;
         }
         if (entry.oauth && !resolvedHeaders) {
           mcpEntryConfig["oauth"] = {};
@@ -713,6 +716,7 @@ export function createConnectionsStore(options: {
                 type: "remote" as const,
                 url: resolvedUrl ?? entry.url!,
                 enabled: true,
+                ...(resolvedHeaders ? { headers: resolvedHeaders, oauth: false as const } : {}),
                 ...(entry.oauth && !resolvedHeaders ? { oauth: {} } : {}),
               }
             : {
@@ -787,7 +791,11 @@ export function createConnectionsStore(options: {
       marker !== null &&
       marker.orgId === orgId &&
       new Date(marker.expiresAt).getTime() - Date.now() > CLOUD_MCP_REFRESH_MARGIN_MS;
-    if (markerFresh && snapshot.mcpServers.some((server) => server.name === slug)) {
+    // A revoked/expired token surfaces as needs_auth or failed from opencode;
+    // while signed in, that means re-mint instead of standing pat.
+    const entryStatus = snapshot.mcpStatuses[slug]?.status;
+    const entryUnhealthy = entryStatus === "needs_auth" || entryStatus === "failed";
+    if (markerFresh && !entryUnhealthy && snapshot.mcpServers.some((server) => server.name === slug)) {
       return "unchanged";
     }
 

--- a/apps/app/src/react-app/domains/connections/use-mcp-connected-count.ts
+++ b/apps/app/src/react-app/domains/connections/use-mcp-connected-count.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+
+import { unwrap } from "../../../app/lib/opencode";
+import type { Client, McpStatusMap } from "../../../app/types";
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+/**
+ * Live count of connected MCP servers for the active workspace, polled from
+ * opencode's mcp.status. Used by the session status bar so it reflects real
+ * connectivity instead of a hardcoded value.
+ */
+export function useMcpConnectedCount(client: Client | null, directory: string): number {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!client || !directory.trim()) {
+      setCount(0);
+      return;
+    }
+
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const status = unwrap(await client.mcp.status({ directory }));
+        if (cancelled) return;
+        const values = Object.values(status as McpStatusMap);
+        setCount(values.filter((entry) => entry.status === "connected").length);
+      } catch {
+        if (!cancelled) setCount(0);
+      }
+    };
+
+    void refresh();
+    const interval = window.setInterval(() => void refresh(), REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [client, directory]);
+
+  return count;
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -95,6 +95,7 @@ import { firstLineLocalFileParts } from "@/react-app/domains/session/sync/prompt
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
 import { createProviderAuthStore, useProviderAuthStoreSnapshot } from "@/react-app/domains/connections/provider-auth/store";
+import { useMcpConnectedCount } from "@/react-app/domains/connections/use-mcp-connected-count";
 import { useRemoteAccessRestart } from "@/react-app/domains/workspace/remote-access-restart";
 import { RenameWorkspaceModal } from "@/react-app/domains/workspace/rename-workspace-modal";
 import { useRemoteWorkspaceConnectionEditor } from "@/react-app/domains/workspace/use-remote-workspace-connection-editor";
@@ -1556,6 +1557,7 @@ export function SessionRoute() {
         : null,
     [opencodeBaseUrl, selectedWorkspaceError, selectedWorkspaceRoot, selectedWorkspaceServerToken],
   );
+  const mcpConnectedCount = useMcpConnectedCount(opencodeClient, selectedWorkspaceRoot);
   const providerListQuery = useProviderListQuery({
     client: opencodeClient,
     baseUrl: opencodeBaseUrl,
@@ -2877,7 +2879,7 @@ export function SessionRoute() {
       providerConnectedIds={providerConnectedIds}
       hasUsableModel={hasUsableModel}
       providers={providers}
-      mcpConnectedCount={0}
+      mcpConnectedCount={mcpConnectedCount}
       onSendFeedback={() => {
         platform.openLink(
           buildFeedbackUrl({


### PR DESCRIPTION
## What

Stacked on #2116 (one-click cloud MCP). Three truthfulness fixes:

1. **Header-authed MCP entries no longer show "Sign in needed".** Entries connected with injected `Authorization` headers (cloud control, openwork-ui) now write `oauth: false` so opencode skips OAuth auto-detection, and the SDK hot-add includes the headers — the server connects immediately, no reload, status reads **Ready**.
2. **`mcpConnectedCount` was hardcoded to `0`** in the session route, so the chat status bar never showed MCP connectivity. New `useMcpConnectedCount` hook polls `mcp.status` for the active workspace (60s interval) and feeds the real count.
3. **Revoked/expired cloud token self-heals.** `syncCloudControlMcp` now treats a `needs_auth`/`failed` status on the `openwork-cloud` entry as a re-mint trigger while signed in, instead of standing pat on a fresh marker.

## Testing (end-to-end, real local stack)

Continued the #2116 setup (local Den + seeded org + Electron over CDP). The configured cloud entry was in `needs_auth` (the exact bug):

- Triggered sync → re-mint fired → config rewritten with headers + `oauth: false` → MCP view flipped to **"OpenWork Cloud Control — Ready"** without an app reload.
- Session status bar now renders **"1 MCP connected"** (previously impossible: hardcoded 0).
- `pnpm typecheck` (apps/app) — passes.

Series: #2114 → #2115 → #2116 → this.