### PR TITLE
feat(mcp): re-land #2117 — truthful MCP status onto dev

### DIFF
--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -633,6 +633,9 @@ export function createConnectionsStore(options: {
         mcpEntryConfig["url"] = resolvedUrl;
         if (resolvedHeaders) {
           mcpEntryConfig["headers"] = resolvedHeaders;
+          // Header-authed entries must not trigger OAuth auto-detection;
+          // otherwise opencode reports "needs_auth" despite valid headers.
+          mcpEntryConfig["oauth"] = false;
         }
         if (entry.oauth && !resolvedHeaders) {
           mcpEntryConfig["oauth"] = {};
@@ -713,6 +716,7 @@ export function createConnectionsStore(options: {
                 type: "remote" as const,
                 url: resolvedUrl ?? entry.url!,
                 enabled: true,
+                ...(resolvedHeaders ? { headers: resolvedHeaders, oauth: false as const } : {}),
                 ...(entry.oauth && !resolvedHeaders ? { oauth: {} } : {}),
               }
             : {
@@ -787,7 +791,11 @@ export function createConnectionsStore(options: {
       marker !== null &&
       marker.orgId === orgId &&
       new Date(marker.expiresAt).getTime() - Date.now() > CLOUD_MCP_REFRESH_MARGIN_MS;
-    if (markerFresh && snapshot.mcpServers.some((server) => server.name === slug)) {
+    // A revoked/expired token surfaces as needs_auth or failed from opencode;
+    // while signed in, that means re-mint instead of standing pat.
+    const entryStatus = snapshot.mcpStatuses[slug]?.status;
+    const entryUnhealthy = entryStatus === "needs_auth" || entryStatus === "failed";
+    if (markerFresh && !entryUnhealthy && snapshot.mcpServers.some((server) => server.name === slug)) {
       return "unchanged";
     }
 

--- a/apps/app/src/react-app/domains/connections/use-mcp-connected-count.ts
+++ b/apps/app/src/react-app/domains/connections/use-mcp-connected-count.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+
+import { unwrap } from "../../../app/lib/opencode";
+import type { Client, McpStatusMap } from "../../../app/types";
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+/**
+ * Live count of connected MCP servers for the active workspace, polled from
+ * opencode's mcp.status. Used by the session status bar so it reflects real
+ * connectivity instead of a hardcoded value.
+ */
+export function useMcpConnectedCount(client: Client | null, directory: string): number {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!client || !directory.trim()) {
+      setCount(0);
+      return;
+    }
+
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const status = unwrap(await client.mcp.status({ directory }));
+        if (cancelled) return;
+        const values = Object.values(status as McpStatusMap);
+        setCount(values.filter((entry) => entry.status === "connected").length);
+      } catch {
+        if (!cancelled) setCount(0);
+      }
+    };
+
+    void refresh();
+    const interval = window.setInterval(() => void refresh(), REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [client, directory]);
+
+  return count;
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -95,6 +95,7 @@ import { firstLineLocalFileParts } from "@/react-app/domains/session/sync/prompt
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
 import { createProviderAuthStore, useProviderAuthStoreSnapshot } from "@/react-app/domains/connections/provider-auth/store";
+import { useMcpConnectedCount } from "@/react-app/domains/connections/use-mcp-connected-count";
 import { useRemoteAccessRestart } from "@/react-app/domains/workspace/remote-access-restart";
 import { RenameWorkspaceModal } from "@/react-app/domains/workspace/rename-workspace-modal";
 import { useRemoteWorkspaceConnectionEditor } from "@/react-app/domains/workspace/use-remote-workspace-connection-editor";
@@ -1556,6 +1557,7 @@ export function SessionRoute() {
         : null,
     [opencodeBaseUrl, selectedWorkspaceError, selectedWorkspaceRoot, selectedWorkspaceServerToken],
   );
+  const mcpConnectedCount = useMcpConnectedCount(opencodeClient, selectedWorkspaceRoot);
   const providerListQuery = useProviderListQuery({
     client: opencodeClient,
     baseUrl: opencodeBaseUrl,
@@ -2877,7 +2879,7 @@ export function SessionRoute() {
       providerConnectedIds={providerConnectedIds}
       hasUsableModel={hasUsableModel}
       providers={providers}
-      mcpConnectedCount={0}
+      mcpConnectedCount={mcpConnectedCount}
       onSendFeedback={() => {
         platform.openLink(
           buildFeedbackUrl({


### PR DESCRIPTION
Re-lands #2117, which was accidentally merged into its stack base (`feat/cloud-mcp-auto-config`) ~15s *after* that branch had already been squash-merged to dev (#2116) — so its changes never reached dev.

Identical content to #2117 (verified: same 3 files, 55 insertions / 2 deletions, applied on top of current dev):
1. Header-authed MCP entries write `oauth: false` + headers in the SDK hot-add → connect immediately, status reads **Ready** instead of "Sign in needed".
2. `mcpConnectedCount` hardcoded `0` → real count via new `useMcpConnectedCount` hook.
3. `syncCloudControlMcp` re-mints when the cloud entry reports `needs_auth`/`failed` while signed in.

E2E evidence in #2117. `pnpm typecheck` (apps/app) passes on this branch.