### PR TITLE
ci(evals): re-land #2118 — nightly eval smoke + evals doc hygiene onto dev

### DIFF
--- a/.github/workflows/nightly-evals.yml
+++ b/.github/workflows/nightly-evals.yml
@@ -1,0 +1,108 @@
+name: Nightly Eval Smoke
+
+# Runs the coded UI eval flows (evals/flows) against a real Electron app
+# under Xvfb every night, and on demand. Flows that need cloud credentials
+# declare requiredEnv and are skipped automatically when secrets are absent.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  eval-smoke:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.4.0
+
+      - name: Install OpenCode CLI
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+        run: |
+          set -euo pipefail
+          repo="${OPENCODE_GITHUB_REPO:-anomalyco/opencode}"
+          version="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeVersion||'').trim().replace(/^v/,''));")"
+          if [ -z "$version" ]; then
+            echo "Unable to resolve OpenCode version from constants.json." >&2
+            exit 1
+          fi
+          url="https://github.com/${repo}/releases/download/v${version}/opencode-linux-x64-baseline.tar.gz"
+          tmp_dir="$RUNNER_TEMP/opencode"
+          mkdir -p "$tmp_dir/extracted"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 -H "Authorization: Bearer ${GITHUB_TOKEN}" -o "$tmp_dir/opencode.tar.gz" "$url"
+          tar -xzf "$tmp_dir/opencode.tar.gz" -C "$tmp_dir/extracted"
+          install_dir="$HOME/.opencode/bin"
+          mkdir -p "$install_dir"
+          cp "$tmp_dir/extracted/opencode" "$install_dir/opencode"
+          chmod 755 "$install_dir/opencode"
+          echo "$install_dir" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Xvfb
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb
+
+      - name: Start Electron app under Xvfb
+        shell: bash
+        env:
+          OPENWORK_DEV_MODE: "1"
+          ELECTRON_DISABLE_SANDBOX: "1"
+          OPENWORK_ELECTRON_REMOTE_DEBUG_PORT: "9823"
+          DAYTONA_ELECTRON_EXTRA_LAUNCH_ARGS: "--no-sandbox --disable-gpu --disable-dev-shm-usage --enable-unsafe-swiftshader"
+        run: |
+          set -euo pipefail
+          Xvfb :99 -screen 0 1600x1000x24 &
+          export DISPLAY=:99
+          nohup pnpm dev > /tmp/openwork-dev.log 2>&1 &
+          echo "Waiting for Electron CDP on :9823..."
+          for i in $(seq 1 36); do
+            if curl -sf http://127.0.0.1:9823/json/list > /dev/null 2>&1; then
+              echo "CDP ready after ~$((i*5))s"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Electron CDP did not come up." >&2
+          tail -100 /tmp/openwork-dev.log >&2
+          exit 1
+
+      - name: Run eval flows
+        shell: bash
+        env:
+          OPENWORK_EVAL_CDP_URL: "http://127.0.0.1:9823"
+          # Optional cloud coverage: flows skip cleanly when unset.
+          OPENWORK_EVAL_DEN_API_URL: ${{ secrets.OPENWORK_EVAL_DEN_API_URL }}
+          OPENWORK_EVAL_DEN_TOKEN: ${{ secrets.OPENWORK_EVAL_DEN_TOKEN }}
+        run: pnpm evals --all
+
+      - name: Upload eval reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results
+          path: |
+            evals/results/
+            /tmp/openwork-dev.log
+          retention-days: 14
+          if-no-files-found: warn

--- a/evals/README.md
+++ b/evals/README.md
@@ -67,8 +67,9 @@ Open the app and follow the step lists by hand.
 
 ## Tool reference
 
-Evals use the OpenCode browser tools (`.opencode/tools/browser.ts`). Every tool
-takes `browser_url` as the first argument.
+Evals use the CDP browser tools provided by the `opencode-chrome-devtools`
+plugin (configured in `.opencode/opencode.json`). Every tool takes
+`browser_url` as the first argument.
 
 | Tool | Description |
 |------|-------------|
@@ -126,3 +127,20 @@ takes `browser_url` as the first argument.
 - [`environment-variable-flows.md`](./environment-variable-flows.md) — local
   environment variable CRUD, masking, validation, apply/restart behavior, and
   remote-workspace secret boundaries.
+- [`cloud-auth-flows.md`](./cloud-auth-flows.md) — desktop cloud sign-in
+  (browser handoff + paste-code), expired grants, sign-out cleanup, and org
+  switching.
+- [`cloud-provider-sync-flows.md`](./cloud-provider-sync-flows.md) — org LLM
+  provider import, update, delete, refresh timing, and permission boundaries.
+- [`cloud-marketplace-sync-flows.md`](./cloud-marketplace-sync-flows.md) —
+  marketplace plugin import/update/removal sync between Den and the desktop.
+- [`cloud-org-membership-flows.md`](./cloud-org-membership-flows.md) — org
+  invitations, role updates, member removal, and domain restrictions.
+- [`cloud-worker-flows.md`](./cloud-worker-flows.md) — legacy cloud worker
+  launch/connect flows (feature being sunset; kept for regression context).
+- [`daytona-server-failure-recovery-flows.md`](./daytona-server-failure-recovery-flows.md)
+  — Den API/Web/proxy/MySQL outage and recovery behavior.
+- [`default-openwork-marketplace-onboarding-flow.md`](./default-openwork-marketplace-onboarding-flow.md)
+  — default Marketplace provisioning funnel from sign-in to chat handoff.
+- [`den-marketplace-guided-onboarding-flow.md`](./den-marketplace-guided-onboarding-flow.md)
+  — guided browser + desktop marketplace onboarding with pass criteria.

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -448,9 +448,8 @@ Known regressions this catches:
 
 ## Desktop (Tauri) specifics
 
-The same evals run against the Tauri desktop app (`pnpm dev`). Use the shared
-`evals/desktop-runner.md` (companion doc) for the AppleScript + cliclick
-runner. Key differences:
+The same evals run against the desktop app (`pnpm dev`) over CDP — see
+`evals/README.md` for the runner options. Key differences:
 
 - Focus-within reveals the `+` and `…` buttons on every workspace row, not just
   on hover. Clicking the row first (or pressing Tab) ensures they're


### PR DESCRIPTION
Re-lands #2118 directly onto dev. The original was stacked on `feat/eval-runner`, which got squash-merged (#2114) out from under it, leaving the PR pointing at a stale base.

Identical content (clean cherry-pick of the original commit, 3 files / 130 insertions):
- `.github/workflows/nightly-evals.yml` — nightly + dispatchable eval smoke: Electron under Xvfb, `pnpm evals --all`, optional Den secrets for cloud coverage (skip cleanly when absent), reports/screenshots uploaded as artifacts.
- `evals/README.md` — fixed nonexistent tool reference, added the 8 missing spec files to the index.
- `evals/react-session-flows.md` — removed citation of nonexistent `desktop-runner.md`.

Testing in #2118: YAML lints clean (re-verified on this branch); the exact CI command ran green against a live local Electron.