### PR TITLE
fix(telemetry): Den session.active never fired — org adoption metrics were always empty

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -18,7 +18,6 @@ import {
   shellInSession,
   unrevertSession,
 } from "../../../../app/lib/opencode-session";
-import { trackSessionActive } from "../../../../app/lib/den-telemetry";
 import { finishPerf, perfNow, recordPerfLog } from "../../../../app/lib/perf-log";
 import { toSessionTransportDirectory } from "../../../../app/lib/session-scope";
 import { workspaceSessionRoute } from "../../../shell/workspace-routes";
@@ -407,7 +406,6 @@ export function createSessionActionsStore(options: {
         mark("session:create:start");
         rawResult = await c.session.create({ directory });
         mark("session:create:ok");
-        trackSessionActive();
       } catch (createErr) {
         mark("session:create:error", {
           error: createErr instanceof Error ? createErr.message : safeStringify(createErr),

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -18,6 +18,7 @@ import type {
 } from "@opencode-ai/sdk/v2/client";
 
 import { captureAnalyticsEvent, markTaskRunStart } from "@/app/lib/analytics";
+import { trackSessionActive } from "@/app/lib/den-telemetry";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { forkSession, listCommands, revertSession, setSessionArchived, shellInSession } from "@/app/lib/opencode-session";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
@@ -2141,6 +2142,10 @@ export function SessionRoute() {
           model_id: local.prefs.defaultModel?.modelID ?? null,
         });
         markTaskRunStart(targetSessionId);
+        // Den org adoption signal (auth-gated inside; no-op when signed out).
+        // Lives here — the live send choke point — because its previous call
+        // site was in the orphaned actions-store and never fired.
+        trackSessionActive();
 
         if (draft.mode === "shell") {
           await shellInSession(opencodeClient, targetSessionId, text);


### PR DESCRIPTION
## Problem

The Den telemetry module (`den-telemetry.ts`) and its `session.active` event — the signal feeding den-api's `GET /v1/telemetry/adoption` org metrics (activeMembers7d/30d, weekly trend) — has **never fired in the live app**. Its only call site was `domains/session/sync/actions-store.ts:410`, which is orphaned code: `SessionActionsProvider`/`useSessionActions` have no consumers anywhere in the React shell. Every org's adoption dashboard has been reading from an empty table.

## Fix

- Call `trackSessionActive()` from the live send choke point in `session-route.tsx`'s `onSendDraft` (the same single funnel #2121 instruments — covers send, steer, and queued drains). The tracker is auth-gated internally: signed-out users are a silent no-op.
- Removed the call + import from the dead actions-store so there's exactly one source of truth.

Stacked on #2121 (touches adjacent lines).

## Testing (end-to-end, real local Den stack)

MySQL + den-api + seeded demo org + live Electron over CDP. Signed in as the demo user, created a task, sent a real message:

```
POST /v1/telemetry/ingest 204            ← first time this endpoint has ever been hit by the app
mysql> SELECT event_type, COUNT(*) FROM telemetry_event;  → session.active | 1
GET /v1/telemetry/adoption → { activeMembers7d: 1, activeMembers30d: 1, members: 17 }
```

- `pnpm typecheck` (apps/app) — passes.