### PR TITLE
fix(telemetry): re-land #2122 — fire Den session.active from the live send path

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -18,7 +18,6 @@ import {
   shellInSession,
   unrevertSession,
 } from "../../../../app/lib/opencode-session";
-import { trackSessionActive } from "../../../../app/lib/den-telemetry";
 import { finishPerf, perfNow, recordPerfLog } from "../../../../app/lib/perf-log";
 import { toSessionTransportDirectory } from "../../../../app/lib/session-scope";
 import { workspaceSessionRoute } from "../../../shell/workspace-routes";
@@ -407,7 +406,6 @@ export function createSessionActionsStore(options: {
         mark("session:create:start");
         rawResult = await c.session.create({ directory });
         mark("session:create:ok");
-        trackSessionActive();
       } catch (createErr) {
         mark("session:create:error", {
           error: createErr instanceof Error ? createErr.message : safeStringify(createErr),

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -18,6 +18,7 @@ import type {
 } from "@opencode-ai/sdk/v2/client";
 
 import { captureAnalyticsEvent, markTaskRunStart } from "@/app/lib/analytics";
+import { trackSessionActive } from "@/app/lib/den-telemetry";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { forkSession, listCommands, revertSession, setSessionArchived, shellInSession } from "@/app/lib/opencode-session";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
@@ -2141,6 +2142,10 @@ export function SessionRoute() {
           model_id: local.prefs.defaultModel?.modelID ?? null,
         });
         markTaskRunStart(targetSessionId);
+        // Den org adoption signal (auth-gated inside; no-op when signed out).
+        // Lives here — the live send choke point — because its previous call
+        // site was in the orphaned actions-store and never fired.
+        trackSessionActive();
 
         if (draft.mode === "shell") {
           await shellInSession(opencodeClient, targetSessionId, text);


### PR DESCRIPTION
Re-lands #2122 (GitHub auto-closed it when its stack base `feat/desktop-analytics` was deleted on #2121's merge). Clean cherry-pick onto current dev — same 2 files, 5 insertions / 2 deletions.

**Problem:** `session.active` — the only signal feeding den-api's org adoption metrics — was called solely from the orphaned `actions-store.ts` and never fired. Adoption dashboards have been reading an empty table.

**Fix:** call `trackSessionActive()` from the live `onSendDraft` choke point (auth-gated no-op when signed out); removed from the dead store.

**E2E proof (in #2122):** real local Den stack + live Electron — `POST /v1/telemetry/ingest 204`, `telemetry_event` row written, `GET /v1/telemetry/adoption → activeMembers7d: 1`. Typecheck passes on this branch.