### PR TITLE
fix(desktop): keep workspace share port sticky

### DIFF
--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -64,6 +64,24 @@ export function seedWorkspacePathsForEmbeddedServer(workspacePaths, serverConfig
   return serverConfigExists ? [] : workspacePaths;
 }
 
+export function selectStickyOpenworkPortWorkspace(requestedWorkspacePaths = [], serverWorkspacePaths = []) {
+  for (const value of [...requestedWorkspacePaths, ...serverWorkspacePaths]) {
+    const workspacePath = String(value ?? "").trim();
+    if (workspacePath) return workspacePath;
+  }
+  return "";
+}
+
+export function commandMatchesPackagedSidecar(command, sidecarDirs = []) {
+  const value = String(command ?? "");
+  if (!sidecarDirs.some((dir) => String(dir ?? "").trim() && value.includes(dir))) {
+    return false;
+  }
+  return value.includes("openwork-orchestrator") ||
+    value.includes("openwork-server") ||
+    /(?:^|[/\\])opencode[^/\\\s]*\s+serve\b/.test(value);
+}
+
 function nowMs() {
   return Date.now();
 }
@@ -622,12 +640,24 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     await savePortState(state);
   }
 
-  async function resolveOpenworkPort(host, workspaceKey) {
-    const preferredPort = await readPreferredOpenworkPort(workspaceKey);
-    if (preferredPort && (await portAvailable(host, preferredPort))) {
-      return preferredPort;
+  async function waitForPortAvailable(host, port, timeoutMs = 2000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (await portAvailable(host, port)) return true;
+      await new Promise((resolve) => setTimeout(resolve, 100));
     }
-    return findFreePort(host);
+    return portAvailable(host, port);
+  }
+
+  async function resolveOpenworkPort(host, workspaceKey, currentPort = null) {
+    const preferredPort = await readPreferredOpenworkPort(workspaceKey);
+    if (currentPort && (await waitForPortAvailable(host, currentPort))) {
+      return { port: currentPort, preferredPort };
+    }
+    if (preferredPort && (await waitForPortAvailable(host, preferredPort))) {
+      return { port: preferredPort, preferredPort };
+    }
+    return { port: await findFreePort(host), preferredPort };
   }
 
   async function ensureDevModePaths() {
@@ -924,13 +954,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   }
 
   function processMatchesSidecar(command) {
-    const value = String(command ?? "");
-    return sidecarDirs.some((dir) => value.includes(dir)) &&
-      (
-        value.includes("openwork-orchestrator") ||
-        value.includes("openwork-server") ||
-        value.includes("opencode serve")
-      );
+    return commandMatchesPackagedSidecar(command, sidecarDirs);
   }
 
   function killProcessId(pid, signal = "SIGTERM") {
@@ -1034,6 +1058,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   let inProcessServer = null;
 
   async function startOpenworkServer(options) {
+    const currentPort = openworkServerState.port;
     // Stop any previously running in-process server
     if (inProcessServer) {
       try { await inProcessServer.stop(); } catch { /* ignore */ }
@@ -1060,12 +1085,13 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     // the server config loader will ignore server.json and lose server-created
     // workspaces after restart.
     const serverConfigPath = resolveOpenworkServerConfigPath(process.env);
+    const requestedWorkspacePaths = (options.workspacePaths ?? []).filter((value) => value.trim().length > 0);
     const workspacePaths = seedWorkspacePathsForEmbeddedServer(
-      options.workspacePaths.filter((value) => value.trim().length > 0),
+      requestedWorkspacePaths,
       existsSync(serverConfigPath),
     );
-    const activeWorkspace = workspacePaths[0] ?? "";
-    const port = await resolveOpenworkPort(host, activeWorkspace);
+    const activeWorkspace = selectStickyOpenworkPortWorkspace(requestedWorkspacePaths, workspacePaths);
+    const portSelection = await resolveOpenworkPort(host, activeWorkspace, currentPort);
     const tokens = await loadOrCreateWorkspaceTokens(activeWorkspace);
 
     // One call: resolve config, spawn managed OpenCode, start HTTP server.
@@ -1089,7 +1115,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     // below is authoritative.
     const handle = await startEmbeddedServer({
       host,
-      port,
+      port: portSelection.port,
       corsOrigins: ["*"],
       approvalMode: "auto",
       configPath: serverConfigPath,
@@ -1161,7 +1187,9 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
         appendOutput(openworkServerState, "lastStderr", `OpenWork server workspace probe: ${error instanceof Error ? error.message : String(error)}\n`);
       }
     }
-    await persistPreferredOpenworkPort(activeWorkspace, boundPort);
+    if (!portSelection.preferredPort || boundPort === portSelection.preferredPort) {
+      await persistPreferredOpenworkPort(activeWorkspace, boundPort);
+    }
     return snapshotOpenworkServerState(openworkServerState);
   }
 
@@ -1858,7 +1886,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     engineDoctor,
     engineInstall,
     openworkServerInfo,
-    openworkServerRestart,
+    openworkServerRestart: (options) => withRuntimeLifecycle(() => openworkServerRestart(options)),
     orchestratorStatus,
     orchestratorWorkspaceActivate,
     orchestratorInstanceDispose,

--- a/apps/desktop/electron/runtime.test.mjs
+++ b/apps/desktop/electron/runtime.test.mjs
@@ -2,9 +2,11 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  commandMatchesPackagedSidecar,
   prioritizeWorkspacePaths,
   resolveOpenworkServerConfigPath,
   seedWorkspacePathsForEmbeddedServer,
+  selectStickyOpenworkPortWorkspace,
 } from "./runtime.mjs";
 
 describe("prioritizeWorkspacePaths", () => {
@@ -35,6 +37,44 @@ describe("seedWorkspacePathsForEmbeddedServer", () => {
     assert.deepEqual(
       seedWorkspacePathsForEmbeddedServer(["/workspace/first"], false),
       ["/workspace/first"],
+    );
+  });
+});
+
+describe("selectStickyOpenworkPortWorkspace", () => {
+  it("uses the requested workspace even when server config owns workspace loading", () => {
+    assert.equal(
+      selectStickyOpenworkPortWorkspace(["/workspace/current"], []),
+      "/workspace/current",
+    );
+  });
+
+  it("falls back to server workspace paths when no requested path is available", () => {
+    assert.equal(
+      selectStickyOpenworkPortWorkspace([], ["/workspace/from-server"]),
+      "/workspace/from-server",
+    );
+  });
+});
+
+describe("commandMatchesPackagedSidecar", () => {
+  it("matches packaged opencode sidecars with platform suffixes", () => {
+    assert.equal(
+      commandMatchesPackagedSidecar(
+        "/Applications/OpenWork.app/Contents/Resources/sidecars/opencode-aarch64-apple-darwin serve --hostname 127.0.0.1 --port 49174 --cors *",
+        ["/Applications/OpenWork.app/Contents/Resources/sidecars"],
+      ),
+      true,
+    );
+  });
+
+  it("does not match unrelated opencode processes outside sidecar directories", () => {
+    assert.equal(
+      commandMatchesPackagedSidecar(
+        "/usr/local/bin/opencode serve --hostname 127.0.0.1 --port 49174",
+        ["/Applications/OpenWork.app/Contents/Resources/sidecars"],
+      ),
+      false,
     );
   });
 });

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -41,6 +41,7 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
     managedOpencode = await createManagedOpencodeServer({
       bin: process.env.OPENWORK_OPENCODE_BIN,
       cwd: managedOpencodeCwd,
+      excludedPorts: [config.port],
       env: {
         ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
         ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
@@ -92,7 +93,7 @@ if (args.verbose) {
 }
 
 const shutdown = () => {
-  managedOpencode?.close();
+  void managedOpencode?.close();
   (server as { stop?: (closeActiveConnections?: boolean) => void }).stop?.(true);
 };
 

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -64,6 +64,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
       managedOpencode = await createManagedOpencodeServer({
         bin: options.opencodeBin || process.env.OPENWORK_OPENCODE_BIN,
         cwd,
+        excludedPorts: [config.port],
         env: {
           ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
           ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
@@ -101,7 +102,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
     config,
     managedOpencodeExecution: managedOpencode?.execution ?? null,
     async stop() {
-      managedOpencode?.close();
+      await managedOpencode?.close();
       await server.stop();
     },
   };

--- a/apps/server/src/managed-opencode.ts
+++ b/apps/server/src/managed-opencode.ts
@@ -8,7 +8,7 @@ export type ManagedOpencodeServer = {
   password: string;
   pid: number | null;
   execution: OpencodeExecutionSnapshot;
-  close: () => void;
+  close: () => Promise<void>;
 };
 
 export type OpencodeExecutionEnvEntry = {
@@ -30,7 +30,7 @@ function randomSecret(): string {
   return randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
 }
 
-async function findFreePort(hostname: string): Promise<number> {
+async function findFreePortOnce(hostname: string): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
     server.once("error", reject);
@@ -44,16 +44,28 @@ async function findFreePort(hostname: string): Promise<number> {
   });
 }
 
+async function findFreePort(hostname: string, excludedPorts: number[] = []): Promise<number> {
+  const excluded = new Set(
+    excludedPorts.filter((port) => Number.isInteger(port) && port > 0 && port <= 65535),
+  );
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const port = await findFreePortOnce(hostname);
+    if (!excluded.has(port)) return port;
+  }
+  throw new Error("Failed to resolve free port outside the excluded set");
+}
+
 export async function createManagedOpencodeServer(options: {
   bin?: string;
   cwd: string;
   hostname?: string;
   port?: number;
+  excludedPorts?: number[];
   timeoutMs?: number;
   env?: Record<string, string | undefined>;
 }): Promise<ManagedOpencodeServer> {
   const hostname = options.hostname ?? "127.0.0.1";
-  const port = options.port ?? await findFreePort(hostname);
+  const port = options.port ?? await findFreePort(hostname, options.excludedPorts);
   const username = randomSecret();
   const password = randomSecret();
   const args = ["serve", "--hostname", hostname, "--port", String(port), "--cors", "*"];
@@ -80,6 +92,11 @@ export async function createManagedOpencodeServer(options: {
     cwd: options.cwd,
     env,
     stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let closePromise: Promise<void> | null = null;
+  const exited = new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
   });
 
   const url = await new Promise<string>((resolve, reject) => {
@@ -121,7 +138,23 @@ export async function createManagedOpencodeServer(options: {
       env: injectedEnv,
     },
     close() {
-      if (!child.killed) child.kill();
+      closePromise ??= (async () => {
+        if (child.exitCode !== null) return;
+        if (!child.killed) child.kill("SIGTERM");
+        const timeout = new Promise<void>((resolve) => {
+          setTimeout(() => resolve(), 1000);
+        });
+        await Promise.race([exited, timeout]);
+        if (child.exitCode === null) {
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // Process already exited.
+          }
+          await Promise.race([exited, new Promise<void>((resolve) => setTimeout(() => resolve(), 500))]);
+        }
+      })();
+      return closePromise;
     },
   };
 }


### PR DESCRIPTION
## Summary
- keep desktop OpenWork share ports keyed to the selected workspace even when server.json owns workspace loading
- prevent managed OpenCode from randomly taking the reserved OpenWork port
- serialize OpenWork server restarts and await managed OpenCode shutdown to avoid duplicate listeners
- improve packaged sidecar cleanup for suffixed opencode binaries

## Tests
- pnpm --filter openwork-server typecheck
- node --test apps/desktop/electron/runtime.test.mjs
- Manual: ran `OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9831 pnpm dev`, used the control UI to open Settings > Debug, verified sticky share port stayed `57862` across remote access enable/enable-again/disable, and confirmed no duplicate listener on the prior random port with `lsof`.