### PR TITLE
fix(chat): tool parts with partial input white-screened the entire app

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -85,7 +85,35 @@ interface ToolMessageProps {
   part: ToolUIPart | DynamicToolUIPart
 }
 
-const ToolMessage = ({ part }: ToolMessageProps) => {
+/**
+ * Error boundary around tool-part rendering. Tool inputs from streamed or
+ * interrupted runs can violate their type contracts (partial/undefined
+ * input); without this boundary a single bad part unmounts the entire app
+ * (white screen). Seen in production on v0.15.3 via a todowrite part with
+ * missing input.todos.
+ */
+class ToolMessage extends React.Component<ToolMessageProps, { failed: boolean }> {
+  state = { failed: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error("[tool-part] render failed", error)
+  }
+
+  render() {
+    if (this.state.failed) {
+      return (
+        <div className="text-xs text-muted-foreground">Tool step unavailable</div>
+      )
+    }
+    return <ToolMessageInner part={this.props.part} />
+  }
+}
+
+const ToolMessageInner = ({ part }: ToolMessageProps) => {
   if (isBashToolPart(part)) {
     return <BashTool part={part} />
   }

--- a/apps/app/src/components/tools/glob.tsx
+++ b/apps/app/src/components/tools/glob.tsx
@@ -9,7 +9,7 @@ interface GlobToolProps {
 }
 
 function getGlobToolTitle(part: GlobToolPart): string | null {
-  const pattern = part.input.pattern.trim()
+  const pattern = part.input?.pattern?.trim() ?? ""
 
   if (part.state === "output-error") {
     return pattern
@@ -25,7 +25,7 @@ function getGlobToolTitle(part: GlobToolPart): string | null {
 }
 
 function getGlobToolDetail(part: GlobToolPart): string | undefined {
-  const root = part.input.path?.trim()
+  const root = part.input?.path?.trim()
   if (!root) {
     return undefined
   }

--- a/apps/app/src/components/tools/grep.tsx
+++ b/apps/app/src/components/tools/grep.tsx
@@ -9,7 +9,7 @@ interface GrepToolProps {
 }
 
 function getGrepToolTitle(part: GrepToolPart): string | null {
-  const pattern = part.input.pattern.trim()
+  const pattern = part.input?.pattern?.trim() ?? ""
 
   if (part.state === "output-error") {
     return pattern
@@ -25,7 +25,7 @@ function getGrepToolTitle(part: GrepToolPart): string | null {
 }
 
 function getGrepToolDetail(part: GrepToolPart): string | undefined {
-  const root = part.input.path?.trim()
+  const root = part.input?.path?.trim()
   if (!root) {
     return undefined
   }

--- a/apps/app/src/components/tools/question.tsx
+++ b/apps/app/src/components/tools/question.tsx
@@ -9,20 +9,20 @@ interface QuestionToolProps {
 }
 
 function getFirstQuestionLabel(part: QuestionToolPart) {
-  const first = part.input.questions[0]
+  const first = part.input?.questions?.[0]
   if (!first) {
     return undefined
   }
 
-  const header = first.header.trim()
-  const question = first.question.trim()
+  const header = first.header?.trim() ?? ""
+  const question = first.question?.trim() ?? ""
   const label = header || question
   return label ? truncateText(label, 56) : undefined
 }
 
 function getQuestionToolTitle(part: QuestionToolPart): string | null {
   const label = getFirstQuestionLabel(part)
-  const count = part.input.questions.length
+  const count = part.input?.questions?.length ?? 0
 
   if (part.state === "output-error") {
     return label ?? "Asked a question"
@@ -40,7 +40,7 @@ function getQuestionToolTitle(part: QuestionToolPart): string | null {
 }
 
 function getQuestionToolDetail(part: QuestionToolPart): string | undefined {
-  const count = part.input.questions.length
+  const count = part.input?.questions?.length ?? 0
 
   if (part.state === "output-available") {
     return "Answered"

--- a/apps/app/src/components/tools/skill.tsx
+++ b/apps/app/src/components/tools/skill.tsx
@@ -8,7 +8,7 @@ interface SkillToolProps {
 }
 
 function getSkillToolTitle(part: SkillToolPart): string | null {
-  const name = part.input.name.trim()
+  const name = part.input?.name?.trim() ?? ""
 
   if (part.state === "output-error") {
     return name ? `Load skill ${name} attempted` : "Load skill attempted"

--- a/apps/app/src/components/tools/todowrite.tsx
+++ b/apps/app/src/components/tools/todowrite.tsx
@@ -8,7 +8,9 @@ interface TodoWriteToolProps {
 }
 
 function getTodoWriteToolTitle(part: TodoWriteToolPart): string | null {
-  const count = part.input.todos.length
+  // Streamed/interrupted tool calls can surface with partial input despite
+  // the type contract; an unguarded read here white-screened the whole app.
+  const count = part.input?.todos?.length ?? 0
 
   if (part.state === "output-error") {
     return "Update todo list attempted"


### PR DESCRIPTION
## Problem (live production incident, v0.15.3)

A `todowrite` tool part with missing `input.todos` threw `Cannot read properties of undefined (reading 'length')` during render, unmounting the **entire React tree** — total white screen, reproducible on every reload of the poisoned session. Diagnosed by attaching CDP to the live broken production instance and extracting the crashing function from the shipped bundle (`getTodoWriteToolTitle`).

Root cause: tool-part types promise `input` is fully populated, but streamed/interrupted tool calls persist with partial input. Five tool components read input properties unguarded; and there was **no error boundary** anywhere over the transcript, so one bad part = dead app.

(The incident was triggered when the embedded server restarted on a new port and the renderer's error state exposed the poisoned session — the stale-port recovery is a separate follow-up.)

## Fix

1. **Defensive guards** in all five crash-capable title helpers: `todowrite` (the live crash), `skill`, `glob`, `grep`, `question` (`bash`/`webfetch`/`websearch` render via JSX and are safe; `edit`/`file`/`lsp` go through the already-safe `parseFilename`).
2. **Error boundary on `ToolMessage`** (the single dispatch point for every tool part): any future render failure degrades to a "Tool step unavailable" placeholder + console.error instead of unmounting the app.

## Testing (against the real poisoned production profile)

- Copied the affected production userData (2.7GB) to an isolated profile, launched a packaged build of this fix against it (`OPENWORK_ELECTRON_USERDATA` override).
- Navigated to the exact session that white-screens v0.15.3: **renders fully** — root mounted, complete transcript, correct "Update todo list" title, **zero exceptions** (verified via CDP `Runtime.exceptionThrown` capture).
- Control: the same session on stock v0.15.3 crashes deterministically on every load with the exact stack from the field report.
- `pnpm typecheck` (apps/app) — passes.

**Recommend cherry-picking to a 0.15.4 stable patch** — every v0.15.3 user with an interrupted todowrite call in their last-open session is one reload away from a permanent white screen.