### PR TITLE
fix(chat): block model-unreadable attachments and recover poisoned sessions; eval runner behind proxies

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -42,6 +42,7 @@ import { useReactRenderWatchdog } from "@/react-app/shell/react-render-watchdog"
 import { SessionDebugPanel } from "./debug-panel";
 import { deriveRenderedSessionMessages, resolveRenderedSessionSnapshot } from "./session-render-state";
 import { useLocal } from "@/react-app/kernel/local-provider";
+import { isModelReadableAttachment } from "@/react-app/domains/session/sync/attachment-support";
 import { deriveSessionRenderModel } from "@/react-app/domains/session/sync/transition-controller";
 import { useSessionScrollController } from "./scroll-controller";
 import { SessionScrollOverlay } from "./scroll-overlay";
@@ -838,11 +839,21 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return;
     }
     const oversized = files.filter((file) => file.size > 25 * 1024 * 1024);
-    const accepted = files.filter((file) => file.size <= 25 * 1024 * 1024);
+    const sized = files.filter((file) => file.size <= 25 * 1024 * 1024);
     if (oversized.length) {
       toast.warning(
         oversized.length === 1 ? `${oversized[0]?.name ?? "File"} is too large` : `${oversized.length} files are too large`,
         { description: "Files over 25 MB were skipped." },
+      );
+    }
+    const unreadable = sized.filter((file) => !isModelReadableAttachment(file.type));
+    const accepted = sized.filter((file) => isModelReadableAttachment(file.type));
+    if (unreadable.length) {
+      toast.warning(
+        unreadable.length === 1
+          ? `${unreadable[0]?.name ?? "File"} has a format the model can't read`
+          : `${unreadable.length} files have formats the model can't read`,
+        { description: "Convert to PDF, image, or plain text and attach again." },
       );
     }
     if (!accepted.length) return;

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -64,9 +64,10 @@ const fileToDataUrl = (file: File, mimeType: string) =>
 function attachmentMime(attachment: ComposerAttachment) {
   if (attachment.kind === "image") return attachment.mimeType;
   if (attachment.mimeType === "application/pdf") return attachment.mimeType;
-  if (attachment.mimeType === "application/json") return "text/plain";
-  if (attachment.mimeType.startsWith("text/")) return "text/plain";
-  return attachment.mimeType;
+  // Everything else is sent as text. Unsupported binary mimes (e.g. Keynote)
+  // poison the server-side session history: every later prompt replays the
+  // provider's UnsupportedFunctionalityError and the session cannot recover.
+  return "text/plain";
 }
 
 export function createSessionActionsStore(options: {

--- a/apps/app/src/react-app/domains/session/sync/attachment-support.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-support.ts
@@ -1,0 +1,20 @@
+/**
+ * Which attachment media types can be sent to the model as file parts.
+ *
+ * Providers (via opencode + the AI SDK) accept images, PDFs, and text.
+ * Anything else (e.g. Keynote `application/x-iwork-keynote-sffkey`, Office
+ * binaries) is rejected by the provider with an UnsupportedFunctionalityError
+ * — and because the file part lives in server-side session history, every
+ * later message in the session replays the failure. Blocking these at attach
+ * time prevents poisoning the session.
+ *
+ * Empty / `application/octet-stream` types are allowed: browsers report them
+ * for plain source/code files, which are sent as `text/plain`.
+ */
+export function isModelReadableAttachment(mimeType: string) {
+  const mime = mimeType.toLowerCase();
+  if (mime === "" || mime === "application/octet-stream") return true;
+  if (mime.startsWith("image/") || mime.startsWith("text/")) return true;
+  if (mime === "application/pdf" || mime === "application/json") return true;
+  return mime.endsWith("+json") || mime.endsWith("+xml") || mime === "application/xml" || mime === "application/javascript";
+}

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -45,9 +45,18 @@ function defaultErrorMessage(name: string | null, fallback: string) {
   return fallback;
 }
 
+/**
+ * Unsupported file parts live in server-side session history, so the same
+ * provider error replays on every later prompt. Tell the user how to escape.
+ */
+function withAttachmentRecoveryHint(text: string) {
+  if (!text.includes("file part media type") || !text.includes("not supported")) return text;
+  return `${text}\nAn attached file in this conversation uses a format the model can't read. Revert the conversation to before the attachment was sent, or start a new session.`;
+}
+
 export function describeOpencodeSessionError(error: unknown, fallback = "Session failed") {
-  if (error instanceof Error) return error.message || fallback;
-  if (typeof error === "string") return error.trim() || fallback;
+  if (error instanceof Error) return withAttachmentRecoveryHint(error.message || fallback);
+  if (typeof error === "string") return withAttachmentRecoveryHint(error.trim() || fallback);
   if (!error || typeof error !== "object") return fallback;
 
   const data = recordValue(error, "data");
@@ -68,7 +77,7 @@ export function describeOpencodeSessionError(error: unknown, fallback = "Session
   if (code) lines.push(`Code: ${code}`);
   if (retries !== null) lines.push(`Retries: ${retries}`);
   if (responseBody && responseBody !== message) lines.push(`Response: ${responseBody}`);
-  if (lines.some((line) => line !== fallback)) return lines.join("\n");
+  if (lines.some((line) => line !== fallback)) return withAttachmentRecoveryHint(lines.join("\n"));
 
   const serialized = safeStringify(error);
   return serialized && serialized !== "{}" ? serialized : fallback;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -440,9 +440,9 @@ async function fileToDataUrl(file: File, mimeType: string) {
 function attachmentMime(attachment: ComposerAttachment) {
   if (attachment.kind === "image") return attachment.mimeType;
   if (attachment.mimeType === "application/pdf") return attachment.mimeType;
-  if (attachment.mimeType === "application/json") return "text/plain";
-  if (attachment.mimeType.startsWith("text/")) return "text/plain";
-  return attachment.mimeType;
+  // Everything else is sent as text; unsupported binary mimes poison
+  // server-side session history (see sync/attachment-support.ts).
+  return "text/plain";
 }
 
 async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {

--- a/evals/runner/cdp.mjs
+++ b/evals/runner/cdp.mjs
@@ -32,6 +32,21 @@ export async function pickAppTarget(baseUrl) {
 }
 
 /**
+ * Chromium reports webSocketDebuggerUrl with its own local host
+ * (e.g. ws://127.0.0.1:9825/devtools/page/<id>), which breaks when the
+ * endpoint is reached through a proxy (e.g. Daytona preview URLs).
+ * Rebuild the ws URL on the base URL's host and scheme.
+ */
+export function debuggerUrlFor(baseUrl, target) {
+  const base = new URL(baseUrl);
+  const ws = new URL(target.webSocketDebuggerUrl);
+  ws.protocol = base.protocol === "https:" ? "wss:" : "ws:";
+  ws.hostname = base.hostname;
+  ws.port = base.port;
+  return ws.toString();
+}
+
+/**
  * Probe a list of CDP base URL candidates and return the first that responds.
  */
 export async function resolveCdpBaseUrl(candidates) {

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -18,7 +18,7 @@
 import { mkdir, readdir, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
-import { connect, pickAppTarget, resolveCdpBaseUrl } from "./cdp.mjs";
+import { connect, debuggerUrlFor, pickAppTarget, resolveCdpBaseUrl } from "./cdp.mjs";
 import { EvalContext } from "./context.mjs";
 
 const RUNNER_DIR = dirname(fileURLToPath(import.meta.url));
@@ -79,7 +79,7 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
   }
 
   const target = await pickAppTarget(cdpBaseUrl);
-  const client = await connect(target.webSocketDebuggerUrl);
+  const client = await connect(debuggerUrlFor(cdpBaseUrl, target));
   const ctx = new EvalContext({ client, outDir, flowId: flow.id, env });
 
   try {


### PR DESCRIPTION
## Problem

Attaching a file the model can't read (e.g. a Keynote `.key` file, mime `application/x-iwork-keynote-sffkey`) poisons the session permanently:

1. There was no MIME validation at attach time, so the file was sent as a file part.
2. The provider rejects it (`'file part media type application/x-iwork-keynote-sffkey' functionality not supported.`).
3. The file part lives in server-side session history, so **every subsequent prompt replays the same error** — even plain text messages. The session cannot recover.

Separately, the new programmatic eval runner (`pnpm evals`) could not connect to a Daytona sandbox: it dialed Chromium's self-reported `ws://127.0.0.1:9825/...` debugger URL, which breaks behind the Daytona HTTPS preview proxy.

## Changes

- **`sync/attachment-support.ts` (new):** `isModelReadableAttachment()` allowlist — images, PDF, text/JSON-like; empty/`application/octet-stream` allowed (browsers report these for source files, sent as `text/plain`); Keynote/Office binaries blocked.
- **`session-surface.tsx`:** blocks unsupported files at the single attach choke point (picker, drop, paste) with a toast: *"X has a format the model can't read — Convert to PDF, image, or plain text and attach again."*
- **`actions-store.ts` / `session-route.tsx`:** file-part mime fallback now coerces to `text/plain` instead of passing unknown mimes through (defense in depth — never ship a model-unreadable mime).
- **`usechat-adapter.ts`:** sessions already poisoned by this error now get an actionable hint appended (revert to before the attachment, or start a new session).
- **`evals/runner/cdp.mjs` + `run.mjs`:** `debuggerUrlFor()` rewrites the ws debugger URL onto the CDP base host/scheme so `pnpm evals --cdp-url <daytona-preview-url>` works.

The true strip-on-replay fix (filtering unsupported file parts when rebuilding model messages) belongs upstream in opencode; the client cannot edit server-side history.

## Testing

Commands run:

- `pnpm --filter @openwork/app typecheck` — ✅ pass
- `pnpm evals --all --cdp-url https://9825-....daytonaproxy01.net` against a fresh Daytona sandbox (`openwork-test-20260609-153434`, branch dev) — ✅ **4 passed, 0 failed, 2 skipped** (skips are cloud flows requiring `OPENWORK_EVAL_DEN_*` env). Before the runner fix this failed immediately with `CDP websocket failed.`

Live end-to-end validation on the Daytona sandbox (patch hot-reloaded via Vite, driven over CDP):

- Attached a synthetic `pitch-deck.key` (`application/x-iwork-keynote-sffkey`) via the composer file input → warning toast captured via MutationObserver: `pitch-deck.key has a format the model can't read | Convert to PDF, image, or plain text and attach again.` — no attachment chip added, nothing sent. ✅
- Regression: attached `data.csv` (`text/csv`) and `script.mjs` (empty mime) → both attach as chips, no false warnings. ✅

No video captured for this run (validation was assertion-based over CDP); exact repro steps for a reviewer: drop any `.key` file on the composer and observe the toast instead of a stuck session.