### PR TITLE
feat(google-workspace): opt-in Gmail read scope for custom OAuth clients

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -351,6 +351,7 @@ export type GoogleWorkspaceAccount = {
 export type GoogleWorkspaceAuthStatus = {
   configured: boolean;
   missing: string[];
+  customClient: boolean;
   vault: "encrypted" | "plaintext-dev" | "unavailable";
   connected: boolean;
   account: GoogleWorkspaceAccount | null;
@@ -1006,7 +1007,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     status: () => requestJson<OpenworkServerDiagnostics>(baseUrl, "/status", { token, hostToken, timeoutMs: timeouts.status }),
     capabilities: () => requestJson<OpenworkServerCapabilities>(baseUrl, "/capabilities", { token, hostToken, timeoutMs: timeouts.capabilities }),
     googleWorkspaceStatus: () => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/status", { token, hostToken, timeoutMs: timeouts.status }),
-    googleWorkspaceConnectStart: () => requestJson<GoogleWorkspaceConnectStart>(baseUrl, "/experimental/google-workspace/connect/start", { token, hostToken, method: "POST", timeoutMs: timeouts.status }),
+    googleWorkspaceConnectStart: (options?: { gmailRead?: boolean }) => requestJson<GoogleWorkspaceConnectStart>(baseUrl, "/experimental/google-workspace/connect/start", { token, hostToken, method: "POST", body: { gmailRead: options?.gmailRead === true }, timeoutMs: timeouts.status }),
     googleWorkspaceConnectStatus: (flowId: string) => requestJson<GoogleWorkspaceConnectStatus>(baseUrl, `/experimental/google-workspace/connect/status/${encodeURIComponent(flowId)}`, { token, hostToken, timeoutMs: timeouts.status }),
     googleWorkspaceDisconnect: (accountId?: string | null) => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/disconnect", { token, hostToken, method: "POST", body: accountId ? { accountId } : {}, timeoutMs: timeouts.status }),
     googleWorkspaceSetActiveAccount: (accountId: string) => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/active-account", { token, hostToken, method: "POST", body: { accountId }, timeoutMs: timeouts.status }),

--- a/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
+++ b/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
@@ -12,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import type { GoogleWorkspaceAuthStatus, OpenworkServerClient } from "../../../app/lib/openwork-server";
 import { usePlatform } from "../../kernel/platform";
@@ -65,6 +66,7 @@ function normalizeGoogleWorkspaceAuthStatus(value: unknown): GoogleWorkspaceAuth
   return {
     configured: record.configured === true,
     missing: normalizeStringList(record.missing),
+    customClient: record.customClient === true,
     vault,
     connected: record.connected === true,
     account: normalizeGoogleWorkspaceAccount(record.account),
@@ -100,6 +102,7 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
   const [busyAction, setBusyAction] = useState<BusyAction | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [clientSecret, setClientSecret] = useState("");
+  const [gmailRead, setGmailRead] = useState(false);
   const serverAvailable = Boolean(openworkServerClient);
   const hostServerAvailable = Boolean(hostOpenworkServerClient);
   const canConnect = serverAvailable && status?.configured === true && status.vault !== "unavailable";
@@ -148,7 +151,7 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
 
   const connectGoogleWorkspace = async () => {
     if (!openworkServerClient) return null;
-    const flow = await openworkServerClient.googleWorkspaceConnectStart();
+    const flow = await openworkServerClient.googleWorkspaceConnectStart({ gmailRead: status?.customClient === true && gmailRead });
     platform.openLink(flow.authUrl);
     return waitForGoogleWorkspaceConnection(openworkServerClient, flow.flowId, flow.expiresAt);
   };
@@ -327,6 +330,19 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
                 </div>
               </div>
             ))}
+          </CardContent>
+        ) : null}
+        {status?.customClient ? (
+          <CardContent className={connectedAccounts.length > 0 ? "pt-2" : "pt-6"}>
+            <label className="flex items-start gap-2.5">
+              <Checkbox checked={gmailRead} onCheckedChange={(checked) => setGmailRead(checked === true)} disabled={Boolean(busyAction)} className="mt-0.5" />
+              <span className="min-w-0">
+                <span className="block text-sm font-medium text-card-foreground">Allow reading Gmail</span>
+                <span className="block text-xs leading-relaxed text-muted-foreground">
+                  Also request read access to your Gmail messages on the next connection. Available because you are using your own Google OAuth client.
+                </span>
+              </span>
+            </label>
           </CardContent>
         ) : null}
         <CardFooter className="flex-wrap gap-2 justify-between">

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -25,6 +25,7 @@ const GOOGLE_WORKSPACE_SCOPES = [
   "https://www.googleapis.com/auth/gmail.compose",
   "https://www.googleapis.com/auth/drive.file",
 ];
+const GMAIL_READONLY_SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
 
 export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
   {
@@ -133,7 +134,8 @@ function googleWorkspaceCredentials() {
   const missing: string[] = [];
   if (!clientId) missing.push(GOOGLE_WORKSPACE_CLIENT_ID_ENV);
   if (!clientSecret && !tokenBrokerUrl) missing.push(GOOGLE_WORKSPACE_CLIENT_SECRET_ENV);
-  return { clientId, clientSecret, tokenBrokerUrl, missing };
+  const customClient = clientId !== GOOGLE_WORKSPACE_DESKTOP_CLIENT_ID;
+  return { clientId, clientSecret, tokenBrokerUrl, missing, customClient };
 }
 
 function googleWorkspaceDir(config: ServerConfig): string {
@@ -312,6 +314,7 @@ function googleWorkspaceStatusPayload(record: Record<string, unknown> | null = n
   return {
     configured: credentials.missing.length === 0,
     missing: credentials.missing,
+    customClient: credentials.customClient,
     vault: googleWorkspaceVaultMode(),
     connected: googleWorkspaceAccountRecords(record).length > 0,
     account: googleWorkspaceSafeAccount(primary?.account),
@@ -657,11 +660,15 @@ export function createGoogleWorkspaceConnectFlowManager(config: ServerConfig) {
     flows.delete(flowId);
   };
 
-  const start = async () => {
+  const start = async (options: { gmailRead?: boolean } = {}) => {
     const credentials = googleWorkspaceCredentials();
     if (credentials.missing.length > 0) {
       throw new ApiError(400, "google_oauth_not_configured", `Missing Google OAuth configuration: ${credentials.missing.join(", ")}`);
     }
+    if (options.gmailRead && !credentials.customClient) {
+      throw new ApiError(400, "google_gmail_read_requires_custom_client", "Gmail read access is only available when using your own Google OAuth client.");
+    }
+    const scopes = options.gmailRead ? [...GOOGLE_WORKSPACE_SCOPES, GMAIL_READONLY_SCOPE] : GOOGLE_WORKSPACE_SCOPES;
     const flowId = base64Url(randomBytes(18));
     const state = base64Url(randomBytes(24));
     const pkce = createGoogleWorkspacePkce();
@@ -709,7 +716,7 @@ export function createGoogleWorkspaceConnectFlowManager(config: ServerConfig) {
             const record = {
               version: 1,
               account,
-              scopes: typeof token.scope === "string" ? token.scope.split(/\s+/).filter(Boolean) : GOOGLE_WORKSPACE_SCOPES,
+              scopes: typeof token.scope === "string" ? token.scope.split(/\s+/).filter(Boolean) : scopes,
               token: {
                 accessToken: token.access_token,
                 refreshToken: typeof token.refresh_token === "string" ? token.refresh_token : null,
@@ -750,7 +757,7 @@ export function createGoogleWorkspaceConnectFlowManager(config: ServerConfig) {
     authorizationUrl.searchParams.set("client_id", credentials.clientId);
     authorizationUrl.searchParams.set("redirect_uri", redirectUri);
     authorizationUrl.searchParams.set("response_type", "code");
-    authorizationUrl.searchParams.set("scope", GOOGLE_WORKSPACE_SCOPES.join(" "));
+    authorizationUrl.searchParams.set("scope", scopes.join(" "));
     authorizationUrl.searchParams.set("access_type", "offline");
     authorizationUrl.searchParams.set("prompt", "consent");
     authorizationUrl.searchParams.set("state", state);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2064,7 +2064,8 @@ function createRoutes(
 
   addRoute(routes, "POST", "/experimental/google-workspace/connect/start", "client", async (ctx) => {
     if (ctx.actor?.scope === "viewer") throw new ApiError(403, "forbidden", "Viewer tokens cannot connect Google Workspace");
-    return jsonResponse(await googleWorkspaceConnectFlows.start(), 201);
+    const body = await readOptionalJsonBody(ctx.request);
+    return jsonResponse(await googleWorkspaceConnectFlows.start({ gmailRead: body.gmailRead === true }), 201);
   });
 
   addRoute(routes, "GET", "/experimental/google-workspace/connect/status/:flowId", "client", async (ctx) => {


### PR DESCRIPTION
## Summary
- Adds an "Allow reading Gmail" checkbox to the Google Workspace settings panel that requests the `gmail.readonly` scope on the next connection.
- The checkbox is only shown — and the scope only granted — when the user brings their own Google OAuth client (`OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_ID` differs from the built-in OpenWork desktop client ID). The built-in OpenWork-owned client never requests Gmail read access.
- Enforced server-side: `connect/start` rejects `gmailRead` with `400 google_gmail_read_requires_custom_client` when the built-in client is in use, so it is not just hidden in the UI.

## Changes
- `apps/server/src/extensions/google-workspace.ts`: `GMAIL_READONLY_SCOPE`, `customClient` in credentials/status payload, `start({ gmailRead })` with guard.
- `apps/server/src/server.ts`: `/experimental/google-workspace/connect/start` accepts optional `{ gmailRead: true }` body.
- `apps/app/src/app/lib/openwork-server.ts`: `customClient` on `GoogleWorkspaceAuthStatus`; `googleWorkspaceConnectStart(options?)`.
- `apps/app/src/react-app/domains/settings/google-workspace-config.tsx`: checkbox rendered only when `status.customClient` is true; flag passed when starting the OAuth flow.

## Testing
- `bun test src/extensions/google-workspace.test.ts` (apps/server) — 4 pass, 0 fail
- `pnpm typecheck` in `apps/server` — clean
- `pnpm typecheck` in `apps/app` — clean

Not run: end-to-end OAuth flow (requires real Google credentials with a custom client ID env var), so no video/screenshots. To reproduce manually: set `OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_ID` + secret, restart, open Google Workspace settings — the checkbox appears; unset them and it disappears.