### PR TITLE
feat(desktop): native Check for Updates menu item + Settings under Edit/File

### DIFF
--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -5,6 +5,7 @@ import type { DenDesktopConfig } from "../../../../app/lib/den";
 import { isAlphaUpdateAllowed, isUpdateAllowed } from "../../../../app/lib/version-gate";
 import type { ReleaseChannel } from "../../../../app/types";
 import { isElectronRuntime, safeStringify } from "../../../../app/utils";
+import { useUpdateCheckRequestStore } from "./update-check-request";
 
 export type SettingsUpdateStatus = {
   state: "idle" | "checking" | "available" | "downloading" | "ready" | "error";
@@ -244,6 +245,14 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     autoCheckKeyRef.current = key;
     void checkForUpdates();
   }, [appVersion, checkForUpdates, releaseChannel, updateAutoCheck, updateEnv?.supported]);
+
+  // Run a check when the native "Check for Updates..." menu item was used.
+  const updateCheckRequestedAt = useUpdateCheckRequestStore((state) => state.requestedAt);
+  useEffect(() => {
+    if (updateCheckRequestedAt == null) return;
+    useUpdateCheckRequestStore.getState().clearUpdateCheckRequest();
+    void checkForUpdates();
+  }, [checkForUpdates, updateCheckRequestedAt]);
 
   const installUpdateAndRestart = useCallback(async () => {
     const bridge = electronUpdaterBridge();

--- a/apps/app/src/react-app/domains/settings/state/update-check-request.ts
+++ b/apps/app/src/react-app/domains/settings/state/update-check-request.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+
+/**
+ * Bridges the native "Check for Updates..." menu item to the settings
+ * updater state. The menu handler navigates to /settings/updates and
+ * records a request here; `useElectronUpdaterState` consumes it once
+ * mounted, so the check runs regardless of mount ordering.
+ */
+type UpdateCheckRequestStore = {
+  requestedAt: number | null;
+  requestUpdateCheck: () => void;
+  clearUpdateCheckRequest: () => void;
+};
+
+export const useUpdateCheckRequestStore = create<UpdateCheckRequestStore>((set) => ({
+  requestedAt: null,
+  requestUpdateCheck: () => set({ requestedAt: Date.now() }),
+  clearUpdateCheckRequest: () => set({ requestedAt: null }),
+}));

--- a/apps/app/src/react-app/shell/app-menu.tsx
+++ b/apps/app/src/react-app/shell/app-menu.tsx
@@ -2,10 +2,12 @@
 import { useEffect, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { useUpdateCheckRequestStore } from "../domains/settings/state/update-check-request";
 import { useUiStateStore } from "./ui-state-store";
 
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
+const NATIVE_MENU_CHECK_UPDATES_EVENT = "openwork:native-menu:check-updates";
 
 export function AppMenuProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
@@ -13,12 +15,18 @@ export function AppMenuProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const openSettings = () => navigate("/settings/general");
+    const checkUpdates = () => {
+      useUpdateCheckRequestStore.getState().requestUpdateCheck();
+      navigate("/settings/updates");
+    };
 
     window.addEventListener(NATIVE_MENU_OPEN_SETTINGS_EVENT, openSettings);
     window.addEventListener(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT, toggleSidebar);
+    window.addEventListener(NATIVE_MENU_CHECK_UPDATES_EVENT, checkUpdates);
     return () => {
       window.removeEventListener(NATIVE_MENU_OPEN_SETTINGS_EVENT, openSettings);
       window.removeEventListener(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT, toggleSidebar);
+      window.removeEventListener(NATIVE_MENU_CHECK_UPDATES_EVENT, checkUpdates);
     };
   }, [navigate, toggleSidebar]);
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -36,6 +36,7 @@ const pty = require(["node", "pty"].join("-"));
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
+const NATIVE_MENU_CHECK_UPDATES_EVENT = "openwork:native-menu:check-updates";
 const TAURI_APP_IDENTIFIER = "com.differentai.openwork";
 const DEV_APP_IDENTIFIER = "com.differentai.openwork.dev";
 const DESKTOP_PROTOCOL_SCHEME = "openwork";
@@ -571,6 +572,14 @@ async function openSettingsFromNativeMenu() {
   win.webContents.send(NATIVE_MENU_OPEN_SETTINGS_EVENT);
 }
 
+async function checkForUpdatesFromNativeMenu() {
+  const win = await createMainWindow();
+  if (win.isMinimized()) win.restore();
+  win.show();
+  win.focus();
+  win.webContents.send(NATIVE_MENU_CHECK_UPDATES_EVENT);
+}
+
 async function toggleSidebarFromNativeMenu() {
   const win = await createMainWindow();
   win.webContents.send(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT);
@@ -585,6 +594,12 @@ function installApplicationMenu() {
             label: APP_NAME,
             submenu: [
               { role: "about" },
+              {
+                label: "Check for Updates...",
+                click: () => {
+                  void checkForUpdatesFromNativeMenu();
+                },
+              },
               { type: "separator" },
               {
                 label: "Settings...",
@@ -608,6 +623,18 @@ function installApplicationMenu() {
     {
       label: "File",
       submenu: [
+        ...(isMac
+          ? []
+          : [
+              {
+                label: "Settings",
+                accelerator: "Control+,",
+                click: () => {
+                  void openSettingsFromNativeMenu();
+                },
+              },
+              { type: "separator" },
+            ]),
         { role: "close" },
       ],
     },
@@ -632,6 +659,13 @@ function installApplicationMenu() {
                   { role: "startSpeaking" },
                   { role: "stopSpeaking" },
                 ],
+              },
+              { type: "separator" },
+              {
+                label: "Settings...",
+                click: () => {
+                  void openSettingsFromNativeMenu();
+                },
               },
             ]
           : [
@@ -683,6 +717,17 @@ function installApplicationMenu() {
     {
       role: "help",
       submenu: [
+        ...(isMac
+          ? []
+          : [
+              {
+                label: "Check for Updates...",
+                click: () => {
+                  void checkForUpdatesFromNativeMenu();
+                },
+              },
+              { type: "separator" },
+            ]),
         {
           label: "Docs",
           click: async () => {

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -3,6 +3,7 @@ import { contextBridge, ipcRenderer } from "electron";
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
+const NATIVE_MENU_CHECK_UPDATES_EVENT = "openwork:native-menu:check-updates";
 
 function normalizePlatform(value) {
   if (value === "darwin" || value === "linux") return value;
@@ -172,6 +173,11 @@ ipcRenderer.on(NATIVE_MENU_OPEN_SETTINGS_EVENT, () => {
 ipcRenderer.on(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT, () => {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new Event(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT));
+});
+
+ipcRenderer.on(NATIVE_MENU_CHECK_UPDATES_EVENT, () => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(NATIVE_MENU_CHECK_UPDATES_EVENT));
 });
 
 if (!applyShellDocumentMarkers() && typeof document !== "undefined") {


### PR DESCRIPTION
Closes the feedback from Alejandro Letayf (settings entry in the menu bar) and adds a native "Check for Updates..." menu item per-platform.

## What changed

**Settings in the native menu**
- macOS: `Settings...` added at the bottom of the **Edit** menu (requested feedback). The standard `OpenWork > Settings...` (Cmd+,) item is unchanged.
- Windows/Linux: `Settings` (Ctrl+,) added under **File** — previously there was no Settings menu item at all on these platforms.

**Check for Updates...**
- macOS: added to the app menu directly under `About OpenWork` (standard placement: Chrome, VS Code, etc.).
- Windows/Linux: added under **Help** (standard placement there).
- Clicking it focuses the window, navigates to **Settings > Updates**, and immediately triggers an update check through the existing electron-updater IPC flow — no duplicated update logic.

## How it works

`menu click -> main sends openwork:native-menu:check-updates -> preload re-dispatches as window event -> AppMenuProvider records a pending request (tiny zustand store) + navigates to /settings/updates -> useElectronUpdaterState consumes the request on mount and runs checkForUpdates()`

The store-based handoff makes the check run correctly regardless of whether the settings route was already mounted when the menu item was clicked.

## Tests run

- `pnpm typecheck` (apps/app) — pass
- `pnpm typecheck:electron` (apps/desktop) — pass
- `pnpm check:electron` bridge check — pass (50 renderer methods covered)
- `node --check` on `main.mjs` / `preload.mjs` — pass
- Live smoke test on the local Electron dev app via CDP: dispatched `openwork:native-menu:check-updates` in the renderer -> app navigated to the Updates settings view (`#/workspace/<id>/settings/updates`) and the updater state mounted and ran.

Native menu items themselves are template-only changes in `installApplicationMenu()`; I could not capture the native macOS menu bar via screenshot/AppleScript from this environment (no accessibility permission for the shell), so to verify visually: launch `pnpm dev` and open the **OpenWork**, **Edit**, and (on Win/Linux) **File**/**Help** menus.
