### PR TITLE
fix(server): adaptive thinking payload for Claude 5-family models

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "dev": "OPENWORK_DEV_MODE=1 bun src/cli.ts",
     "test": "bun test",
     "test:artifacts": "bun test src/artifact-files.e2e.test.ts src/workspace-init.test.ts src/server.normalizeWorkspaceRelativePath.test.ts",
-    "build": "tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts --outdir dist/opencode-plugins --target node --format esm",
+    "build": "tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts --outdir dist/opencode-plugins --target node --format esm",
     "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64",
     "start": "bun dist/cli.js",

--- a/apps/server/src/opencode-plugins/openwork-anthropic-adaptive-thinking.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-anthropic-adaptive-thinking.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { OpenWorkAnthropicAdaptiveThinking } from "./openwork-anthropic-adaptive-thinking.js";
+
+async function runHook(apiId: string, options: Record<string, unknown>) {
+  const hooks = await OpenWorkAnthropicAdaptiveThinking();
+  const output: { options: Record<string, unknown> } = { options };
+  await hooks["chat.params"]({ model: { id: apiId, api: { id: apiId } } }, output);
+  return output.options;
+}
+
+describe("OpenWorkAnthropicAdaptiveThinking chat.params", () => {
+  test("rewrites legacy enabled thinking to adaptive for Claude 5-family ids", async () => {
+    expect(await runHook("claude-fable-5", { thinking: { type: "enabled", budgetTokens: 16000 } })).toEqual({
+      thinking: { type: "adaptive" },
+      effort: "high",
+    });
+    expect(await runHook("claude-fable-5-20260601", { thinking: { type: "enabled", budgetTokens: 31999 } })).toEqual({
+      thinking: { type: "adaptive" },
+      effort: "max",
+    });
+    expect(await runHook("claude-opus-5", { thinking: { type: "enabled", budgetTokens: 16000 } })).toEqual({
+      thinking: { type: "adaptive" },
+      effort: "high",
+    });
+  });
+
+  test("keeps an existing effort", async () => {
+    expect(
+      await runHook("claude-fable-5", { thinking: { type: "enabled", budgetTokens: 16000 }, effort: "low" }),
+    ).toEqual({ thinking: { type: "adaptive" }, effort: "low" });
+  });
+
+  test("leaves adaptive payloads untouched", async () => {
+    expect(await runHook("claude-fable-5", { thinking: { type: "adaptive" }, effort: "high" })).toEqual({
+      thinking: { type: "adaptive" },
+      effort: "high",
+    });
+  });
+
+  test("leaves 4.x and older models untouched", async () => {
+    const legacy = { thinking: { type: "enabled", budgetTokens: 16000 } };
+    expect(await runHook("claude-sonnet-4-5", structuredClone(legacy))).toEqual(legacy);
+    expect(await runHook("claude-opus-4-1-20250805", structuredClone(legacy))).toEqual(legacy);
+    expect(await runHook("claude-3-5-sonnet-20241022", structuredClone(legacy))).toEqual(legacy);
+  });
+
+  test("no-ops when options carry no thinking config", async () => {
+    expect(await runHook("claude-fable-5", { temperature: 0.2 })).toEqual({ temperature: 0.2 });
+  });
+
+  test("module exposes only the plugin factory", async () => {
+    const mod = await import("./openwork-anthropic-adaptive-thinking.js");
+    expect(Object.keys(mod)).toEqual(["OpenWorkAnthropicAdaptiveThinking"]);
+  });
+});

--- a/apps/server/src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts
+++ b/apps/server/src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts
@@ -1,0 +1,60 @@
+/**
+ * OpenWork Anthropic Adaptive Thinking Plugin
+ *
+ * Newer Anthropic models (Claude 5 family, e.g. "claude-fable-5") reject the
+ * legacy extended-thinking payload `thinking: { type: "enabled", budgetTokens }`
+ * with:
+ *
+ *   "thinking.type.enabled" is not supported for this model. Use
+ *   "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
+ *
+ * The bundled OpenCode sidecar only emits the adaptive shape for model ids it
+ * recognizes (Opus 4.6/4.7+, Sonnet 4.6). For newer ids it falls back to the
+ * legacy shape, which fails. This plugin rewrites the legacy payload to
+ * `thinking: { type: "adaptive" }` plus an `effort` level for models that
+ * require it, just before the request is sent.
+ */
+
+const LEGACY_HIGH_BUDGET_TOKENS = 16000;
+
+/**
+ * Claude ids with a bare major version of 5 or higher (e.g. "claude-fable-5",
+ * "claude-opus-5") require adaptive thinking. Versioned 4.x ids
+ * ("claude-sonnet-4-5", "claude-opus-4-6") never match major >= 5 here;
+ * the ones that support adaptive already get it from the sidecar.
+ */
+function requiresAdaptiveThinking(apiId: string): boolean {
+  const match = /claude-[a-z]+-(\d+)(?:[.@-]|$)/i.exec(apiId);
+  if (!match) return false;
+  return Number(match[1]) >= 5;
+}
+
+function readBudgetTokens(thinking: Record<string, unknown>): number | null {
+  const budget = thinking.budgetTokens;
+  return typeof budget === "number" ? budget : null;
+}
+
+function rewriteLegacyThinkingOptions(apiId: string, options: Record<string, unknown>): void {
+  const thinking = options.thinking;
+  if (typeof thinking !== "object" || thinking === null || Array.isArray(thinking)) return;
+  const record: Record<string, unknown> = { ...thinking };
+  if (record.type !== "enabled") return;
+  if (!requiresAdaptiveThinking(apiId)) return;
+  const budget = readBudgetTokens(record);
+  options.thinking = { type: "adaptive" };
+  if (options.effort === undefined) {
+    options.effort = budget !== null && budget > LEGACY_HIGH_BUDGET_TOKENS ? "max" : "high";
+  }
+}
+
+// Single export: the OpenCode plugin loader treats every export of a plugin
+// module as a plugin factory, so helpers must stay module-private.
+export const OpenWorkAnthropicAdaptiveThinking = async () => ({
+  "chat.params": async (
+    input: { model: { id: string; api?: { id?: string } } },
+    output: { options: Record<string, unknown> },
+  ) => {
+    const apiId = input.model.api?.id ?? input.model.id;
+    rewriteLegacyThinkingOptions(apiId, output.options);
+  },
+});

--- a/apps/server/src/openwork-extensions-plugin-path.ts
+++ b/apps/server/src/openwork-extensions-plugin-path.ts
@@ -27,3 +27,4 @@ export function openworkPluginPath(name: string, here = dirname(fileURLToPath(im
 
 export const openworkExtensionsPreviewPluginPath = () => openworkPluginPath("openwork-extensions-preview");
 export const openworkCapabilitiesKnowledgePluginPath = () => openworkPluginPath("openwork-capabilities-knowledge");
+export const openworkAnthropicAdaptiveThinkingPluginPath = () => openworkPluginPath("openwork-anthropic-adaptive-thinking");

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -5,7 +5,11 @@
  * plugins, and any other config that should be injected at runtime rather
  * than written to disk. Both cli.ts and embedded.ts use this.
  */
-import { openworkExtensionsPreviewPluginPath, openworkCapabilitiesKnowledgePluginPath } from "./openwork-extensions-plugin-path.js";
+import {
+  openworkExtensionsPreviewPluginPath,
+  openworkCapabilitiesKnowledgePluginPath,
+  openworkAnthropicAdaptiveThinkingPluginPath,
+} from "./openwork-extensions-plugin-path.js";
 import type { ServerConfig } from "./types.js";
 import { readRuntimeOpencodeConfig, runtimeDisabledProviderList, runtimeMcpMap, runtimePluginList } from "./runtime-opencode-config-store.js";
 
@@ -64,6 +68,7 @@ export async function buildOpenworkRuntimeConfigObject(
       "opencode-chrome-devtools",
       openworkExtensionsPreviewPluginPath(),
       openworkCapabilitiesKnowledgePluginPath(),
+      openworkAnthropicAdaptiveThinkingPluginPath(),
       ...runtimePluginList(runtimeConfig),
     ],
     ...(disabledProviders.length ? { disabled_providers: disabledProviders } : {}),


### PR DESCRIPTION
## Problem

Sending messages with newer Anthropic models (e.g. `claude-fable-5`) and an extended-thinking variant fails with a 400 on every message:

> "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.

## Root cause

The bundled opencode sidecar (v1.16.2, latest) only emits `thinking: { type: "adaptive" }` for model ids it recognizes (Opus 4.6/4.7+, Sonnet 4.6) in `ProviderTransform.variants`. Unrecognized newer ids fall back to the legacy `thinking: { type: "enabled", budgetTokens }` payload, which Claude 5-family models reject. No opencode release fixes this yet.

## Fix

New bundled opencode plugin `openwork-anthropic-adaptive-thinking` with a `chat.params` hook that rewrites the legacy payload to `{ thinking: { type: "adaptive" }, effort }` (budget 16000 -> `high`, larger -> `max`) for Claude ids with a bare major version >= 5. 4.x and older ids are untouched (they would reject `adaptive`). Injected into every managed sidecar via the runtime config plugin list (`OPENCODE_CONFIG_CONTENT`), so desktop, CLI, and packaged builds all get it with no disk writes.

The plugin module has a single export because the opencode plugin loader treats every export as a plugin factory.

## Tests

- `bun test src/opencode-plugins/openwork-anthropic-adaptive-thinking.test.ts` — 6 pass (rewrite, effort mapping, existing-effort respected, adaptive/older-model no-ops, single-export invariant)
- `bun test src/workspace-init.test.ts` — 8 pass
- `pnpm typecheck` and `pnpm build` in `apps/server` — clean
- Smoke test of built JS via node: legacy payload -> `{"thinking":{"type":"adaptive"},"effort":"max"}`
- Pre-existing unrelated failure on clean `origin/dev`: 1 test in `src/runtime-opencode-config-store.test.ts` (verified via stash before/after)

## Not run

Live end-to-end send against `claude-fable-5` through the packaged Electron app (requires full desktop build + API key). Repro for reviewer: run the app from this branch, select claude-fable-5 with an extended-thinking variant, send a message — it should respond instead of returning the 400.