### PR TITLE
feat(app): deep search across all sessions and message content

### DIFF
--- a/apps/app/src/react-app/domains/session/search/session-search.ts
+++ b/apps/app/src/react-app/domains/session/search/session-search.ts
@@ -1,0 +1,191 @@
+import type { OpenworkSessionMessage } from "@/app/lib/openwork-server";
+
+/** A session that can be deep-searched. */
+export type SearchableSession = {
+  workspaceId: string;
+  sessionId: string;
+  title: string;
+  workspaceTitle: string;
+  updatedAt: number;
+};
+
+export type SessionSearchSnippet = {
+  before: string;
+  match: string;
+  after: string;
+};
+
+export type SessionSearchMatch = {
+  session: SearchableSession;
+  /** Whether the query matched the title or a message body. */
+  kind: "title" | "message";
+  role?: "user" | "assistant";
+  snippet?: SessionSearchSnippet;
+};
+
+export type SessionSearchProgress = {
+  scanned: number;
+  total: number;
+  done: boolean;
+};
+
+type CacheEntry = {
+  updatedAt: number;
+  /** One entry per message that contains searchable text. */
+  texts: Array<{ role: "user" | "assistant"; text: string; lower: string }>;
+};
+
+export type SessionMessageFetcher = (
+  workspaceId: string,
+  sessionId: string,
+) => Promise<OpenworkSessionMessage[]>;
+
+const SNIPPET_BEFORE = 36;
+const SNIPPET_AFTER = 72;
+const DEFAULT_CONCURRENCY = 6;
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ");
+}
+
+/** Build a compact snippet centered on the first occurrence of the query. */
+export function buildSnippet(text: string, index: number, length: number): SessionSearchSnippet {
+  const start = Math.max(0, index - SNIPPET_BEFORE);
+  const end = Math.min(text.length, index + length + SNIPPET_AFTER);
+  const before = `${start > 0 ? "…" : ""}${collapseWhitespace(text.slice(start, index)).trimStart()}`;
+  const after = `${collapseWhitespace(text.slice(index + length, end)).trimEnd()}${end < text.length ? "…" : ""}`;
+  return { before, match: text.slice(index, index + length), after };
+}
+
+function toCacheEntry(updatedAt: number, messages: OpenworkSessionMessage[]): CacheEntry {
+  const texts: CacheEntry["texts"] = [];
+  for (const message of messages) {
+    const role = message.info.role;
+    if (role !== "user" && role !== "assistant") continue;
+    for (const part of message.parts) {
+      if (part.type !== "text") continue;
+      if (part.synthetic || part.ignored) continue;
+      const text = part.text.trim();
+      if (!text) continue;
+      texts.push({ role, text, lower: text.toLowerCase() });
+    }
+  }
+  return { updatedAt, texts };
+}
+
+function matchEntry(
+  session: SearchableSession,
+  entry: CacheEntry,
+  queryLower: string,
+): SessionSearchMatch | null {
+  // Prefer the user's own prompts: they are usually what people remember typing.
+  let fallback: SessionSearchMatch | null = null;
+  for (const item of entry.texts) {
+    const index = item.lower.indexOf(queryLower);
+    if (index < 0) continue;
+    const match: SessionSearchMatch = {
+      session,
+      kind: "message",
+      role: item.role,
+      snippet: buildSnippet(item.text, index, queryLower.length),
+    };
+    if (item.role === "user") return match;
+    if (!fallback) fallback = match;
+  }
+  return fallback;
+}
+
+export type SessionSearchRun = {
+  /** Resolves when the scan completes or is cancelled. */
+  done: Promise<void>;
+  cancel: () => void;
+};
+
+export type SessionSearcher = {
+  search: (options: {
+    query: string;
+    sessions: SearchableSession[];
+    onMatch: (match: SessionSearchMatch) => void;
+    onProgress: (progress: SessionSearchProgress) => void;
+    concurrency?: number;
+  }) => SessionSearchRun;
+  /** Drop every cached transcript (e.g. when the server connection changes). */
+  clear: () => void;
+};
+
+/**
+ * Deep-search engine for session transcripts.
+ *
+ * Transcripts are fetched lazily with a small concurrency cap and cached by
+ * `sessionId + updatedAt`, so repeated keystrokes only hit the network for
+ * sessions that changed since the last scan.
+ */
+export function createSessionSearcher(fetchMessages: SessionMessageFetcher): SessionSearcher {
+  const cache = new Map<string, CacheEntry>();
+
+  const getEntry = async (session: SearchableSession): Promise<CacheEntry> => {
+    const cached = cache.get(session.sessionId);
+    if (cached && cached.updatedAt === session.updatedAt) return cached;
+    let entry: CacheEntry;
+    try {
+      const messages = await fetchMessages(session.workspaceId, session.sessionId);
+      entry = toCacheEntry(session.updatedAt, messages);
+    } catch {
+      // Unreachable session (stale workspace, server hiccup): record an empty
+      // entry so one bad session cannot stall every later keystroke.
+      entry = toCacheEntry(session.updatedAt, []);
+    }
+    cache.set(session.sessionId, entry);
+    return entry;
+  };
+
+  return {
+    search({ query, sessions, onMatch, onProgress, concurrency = DEFAULT_CONCURRENCY }) {
+      const queryLower = query.trim().toLowerCase();
+      let cancelled = false;
+
+      // Scan newest sessions first so the most relevant hits stream in early.
+      const queue = [...sessions].sort((a, b) => b.updatedAt - a.updatedAt);
+      const total = queue.length;
+      let scanned = 0;
+
+      const report = () => {
+        if (cancelled) return;
+        onProgress({ scanned, total, done: scanned >= total });
+      };
+
+      const worker = async () => {
+        while (!cancelled) {
+          const session = queue.shift();
+          if (!session) return;
+          const entry = await getEntry(session);
+          if (cancelled) return;
+          scanned += 1;
+          const match = matchEntry(session, entry, queryLower);
+          if (match) onMatch(match);
+          report();
+        }
+      };
+
+      const done = (async () => {
+        if (!queryLower) {
+          scanned = total;
+          report();
+          return;
+        }
+        report();
+        await Promise.all(
+          Array.from({ length: Math.max(1, concurrency) }, () => worker()),
+        );
+      })();
+
+      return {
+        done,
+        cancel: () => {
+          cancelled = true;
+        },
+      };
+    },
+    clear: () => cache.clear(),
+  };
+}

--- a/apps/app/src/react-app/domains/session/search/session-search.ts
+++ b/apps/app/src/react-app/domains/session/search/session-search.ts
@@ -33,6 +33,8 @@ type CacheEntry = {
   updatedAt: number;
   /** One entry per message that contains searchable text. */
   texts: Array<{ role: "user" | "assistant"; text: string; lower: string }>;
+  /** Set when the transcript fetch failed; retried after a short cool-down. */
+  failedAt?: number;
 };
 
 export type SessionMessageFetcher = (
@@ -43,6 +45,7 @@ export type SessionMessageFetcher = (
 const SNIPPET_BEFORE = 36;
 const SNIPPET_AFTER = 72;
 const DEFAULT_CONCURRENCY = 6;
+const FAILURE_RETRY_MS = 30_000;
 
 function collapseWhitespace(value: string): string {
   return value.replace(/\s+/g, " ");
@@ -125,15 +128,20 @@ export function createSessionSearcher(fetchMessages: SessionMessageFetcher): Ses
 
   const getEntry = async (session: SearchableSession): Promise<CacheEntry> => {
     const cached = cache.get(session.sessionId);
-    if (cached && cached.updatedAt === session.updatedAt) return cached;
+    if (cached && cached.updatedAt === session.updatedAt) {
+      const failureFresh =
+        cached.failedAt !== undefined && Date.now() - cached.failedAt < FAILURE_RETRY_MS;
+      if (cached.failedAt === undefined || failureFresh) return cached;
+    }
     let entry: CacheEntry;
     try {
       const messages = await fetchMessages(session.workspaceId, session.sessionId);
       entry = toCacheEntry(session.updatedAt, messages);
     } catch {
       // Unreachable session (stale workspace, server hiccup): record an empty
-      // entry so one bad session cannot stall every later keystroke.
-      entry = toCacheEntry(session.updatedAt, []);
+      // entry with a cool-down so one bad session cannot stall every later
+      // keystroke, but still gets retried once the cool-down expires.
+      entry = { ...toCacheEntry(session.updatedAt, []), failedAt: Date.now() };
     }
     cache.set(session.sessionId, entry);
     return entry;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2696,8 +2696,11 @@ export function SessionRoute() {
 
   const sessionSearchFetcher = useMemo<SessionMessageFetcher | null>(() => {
     if (!client) return null;
+    // Cap the transcript fetch to keep multi-workspace scans fast; matches in
+    // anything older than the most recent 400 messages are traded away for
+    // responsiveness.
     return async (workspaceId: string, sessionId: string) =>
-      (await client.getSessionMessages(workspaceId, sessionId, { limit: 200 })).items;
+      (await client.getSessionMessages(workspaceId, sessionId, { limit: 400 })).items;
   }, [client]);
 
   const sessionSearchPaletteItem = useMemo<PaletteItem>(() => ({

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -122,6 +122,8 @@ import {
 import { useShareWorkspaceState } from "@/react-app/domains/workspace/share-workspace-state";
 import { ModelPickerModal } from "@/react-app/domains/session/modals/model-picker-modal";
 import { CommandPalette, type PaletteItem, type SessionOption as PaletteSessionOption } from "./command-palette";
+import { SessionSearchDialog } from "./session-search-dialog";
+import type { SessionMessageFetcher } from "@/react-app/domains/session/search/session-search";
 import { getDisplaySessionTitle } from "@/app/lib/session-title";
 import { useBootState } from "./boot-state";
 import {
@@ -591,6 +593,7 @@ export function SessionRoute() {
   const [renameWorkspaceTitle, setRenameWorkspaceTitle] = useState("");
   const [renameWorkspaceBusy, setRenameWorkspaceBusy] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [sessionSearchOpen, setSessionSearchOpen] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [paletteAccessibleTargets, setPaletteAccessibleTargets] = useState<OpenTarget[]>([]);
   // Model picker modal state (ported from settings-route; previously the
@@ -2540,13 +2543,19 @@ export function SessionRoute() {
   }, [baseUrl, loading, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, token, workspaces]);
 
   // Global shortcuts:
-  //   Cmd/Ctrl+N  -> new task in selected workspace
-  //   Cmd/Ctrl+K  -> toggle command palette
-  //   Cmd/Ctrl+J  -> toggle terminal panel (matches VS Code)
+  //   Cmd/Ctrl+N        -> new task in selected workspace
+  //   Cmd/Ctrl+K        -> toggle command palette
+  //   Cmd/Ctrl+J        -> toggle terminal panel (matches VS Code)
+  //   Cmd/Ctrl+Shift+F  -> search every session (titles + messages)
   const handleGlobalShortcut = useEffectEvent((event: KeyboardEvent) => {
     const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
     const mod = isMac ? event.metaKey : event.ctrlKey;
     if (!mod) return;
+    if (event.shiftKey && !event.altKey && event.key?.toLowerCase() === "f") {
+      event.preventDefault();
+      setSessionSearchOpen((value) => !value);
+      return;
+    }
     if (event.shiftKey || event.altKey) return;
 
     const target = event.target as HTMLElement | null;
@@ -2684,6 +2693,24 @@ export function SessionRoute() {
     });
     return out;
   }, [sessionsByWorkspaceId, selectedWorkspaceId, workspaces]);
+
+  const sessionSearchFetcher = useMemo<SessionMessageFetcher | null>(() => {
+    if (!client) return null;
+    return async (workspaceId: string, sessionId: string) =>
+      (await client.getSessionMessages(workspaceId, sessionId, { limit: 200 })).items;
+  }, [client]);
+
+  const sessionSearchPaletteItem = useMemo<PaletteItem>(() => ({
+    id: "session-search.open",
+    title: "Search session messages",
+    detail: "Deep search every session, including message content",
+    meta: "Cmd/Ctrl+Shift+F",
+    searchText: "search find sessions messages history transcript content",
+    action: () => {
+      setCommandPaletteOpen(false);
+      setSessionSearchOpen(true);
+    },
+  }), []);
 
   const terminalPaletteItems = useMemo<PaletteItem[]>(() => [
     {
@@ -3219,7 +3246,14 @@ export function SessionRoute() {
         }
       }}
       sessions={paletteSessionOptions}
-      extraItems={terminalPaletteItems}
+      extraItems={[sessionSearchPaletteItem, ...terminalPaletteItems]}
+    />
+    <SessionSearchDialog
+      open={sessionSearchOpen}
+      onClose={() => setSessionSearchOpen(false)}
+      sessions={paletteSessionOptions}
+      fetchMessages={sessionSearchFetcher}
+      onOpenSession={(workspaceId, sessionId) => navigateToWorkspaceSession(workspaceId, sessionId)}
     />
     <ModelPickerModal
       open={modelPickerOpen}

--- a/apps/app/src/react-app/shell/session-search-dialog.tsx
+++ b/apps/app/src/react-app/shell/session-search-dialog.tsx
@@ -1,0 +1,268 @@
+/** @jsxImportSource react */
+import { useEffect, useMemo, useState } from "react";
+import fuzzysort from "fuzzysort";
+import { ClockIcon, Loader2Icon, MessageSquareTextIcon, TypeIcon } from "lucide-react";
+
+import {
+  Command,
+  CommandDialog,
+  CommandDialogPopup,
+  CommandDialogTitle,
+  CommandEmpty,
+  CommandFooter,
+  CommandHeader,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandPanel,
+  CommandShortcut,
+} from "@/components/ui/command";
+import { formatRelativeTime } from "@/app/utils";
+import {
+  createSessionSearcher,
+  type SearchableSession,
+  type SessionMessageFetcher,
+  type SessionSearchMatch,
+  type SessionSearchProgress,
+  type SessionSearchSnippet,
+} from "@/react-app/domains/session/search/session-search";
+
+const MIN_QUERY_LENGTH = 2;
+const DEBOUNCE_MS = 200;
+const RECENT_LIMIT = 15;
+const TITLE_LIMIT = 10;
+const RESULT_LIMIT = 50;
+
+type ResultItem = {
+  id: string;
+  kind: "recent" | "title" | "message";
+  session: SearchableSession;
+  role?: "user" | "assistant";
+  snippet?: SessionSearchSnippet;
+};
+
+export type SessionSearchDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  /** Every session across workspaces, newest first preferred. */
+  sessions: SearchableSession[];
+  /** Loads a session transcript. Null while the server is unavailable. */
+  fetchMessages: SessionMessageFetcher | null;
+  onOpenSession: (workspaceId: string, sessionId: string) => void;
+};
+
+function useDebouncedValue(value: string, delayMs: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    if (!value) {
+      setDebounced("");
+      return;
+    }
+    const timer = window.setTimeout(() => setDebounced(value), delayMs);
+    return () => window.clearTimeout(timer);
+  }, [value, delayMs]);
+  return debounced;
+}
+
+function resultIcon(kind: ResultItem["kind"]) {
+  if (kind === "message") {
+    return <MessageSquareTextIcon className="size-4 text-muted-foreground" />;
+  }
+  if (kind === "title") {
+    return <TypeIcon className="size-4 text-muted-foreground" />;
+  }
+  return <ClockIcon className="size-4 text-muted-foreground" />;
+}
+
+function SnippetLine(props: { item: ResultItem }) {
+  const { item } = props;
+  if (item.snippet) {
+    return (
+      <div className="truncate text-muted-foreground text-xs">
+        {item.role === "user" ? "You: " : item.role === "assistant" ? "Agent: " : null}
+        {item.snippet.before}
+        <span className="rounded-[3px] bg-primary/15 font-medium text-foreground">
+          {item.snippet.match}
+        </span>
+        {item.snippet.after}
+      </div>
+    );
+  }
+  return (
+    <div className="truncate text-muted-foreground text-xs">
+      {item.session.workspaceTitle}
+    </div>
+  );
+}
+
+/**
+ * Deep search across every session: titles match instantly, transcripts are
+ * scanned in the background and stream in as they are found (Cmd/Ctrl+Shift+F).
+ */
+export function SessionSearchDialog(props: SessionSearchDialogProps) {
+  const [query, setQuery] = useState("");
+  const [matches, setMatches] = useState<SessionSearchMatch[]>([]);
+  const [progress, setProgress] = useState<SessionSearchProgress | null>(null);
+
+  const debouncedQuery = useDebouncedValue(query.trim(), DEBOUNCE_MS);
+  const deepQuery = debouncedQuery.length >= MIN_QUERY_LENGTH ? debouncedQuery : "";
+
+  // The searcher caches transcripts by session id + updatedAt, so it must
+  // outlive individual keystrokes and dialog open/close cycles.
+  const searcher = useMemo(
+    () => (props.fetchMessages ? createSessionSearcher(props.fetchMessages) : null),
+    [props.fetchMessages],
+  );
+
+  useEffect(() => {
+    if (!props.open) {
+      setQuery("");
+    }
+  }, [props.open]);
+
+  useEffect(() => {
+    setMatches([]);
+    if (!props.open || !searcher || !deepQuery) {
+      setProgress(null);
+      return;
+    }
+    const collected: SessionSearchMatch[] = [];
+    const run = searcher.search({
+      query: deepQuery,
+      sessions: props.sessions,
+      onMatch: (match) => {
+        collected.push(match);
+        setMatches([...collected]);
+      },
+      onProgress: setProgress,
+    });
+    return () => run.cancel();
+  }, [props.open, props.sessions, searcher, deepQuery]);
+
+  const items = useMemo<ResultItem[]>(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      return [...props.sessions]
+        .sort((a, b) => b.updatedAt - a.updatedAt)
+        .slice(0, RECENT_LIMIT)
+        .map((session) => ({
+          id: `recent:${session.workspaceId}:${session.sessionId}`,
+          kind: "recent" as const,
+          session,
+        }));
+    }
+
+    const out: ResultItem[] = [];
+    const seen = new Set<string>();
+
+    const titleHits = fuzzysort.go(trimmed, props.sessions, {
+      keys: ["title", "workspaceTitle"],
+      limit: TITLE_LIMIT,
+    });
+    for (const hit of titleHits) {
+      const session = hit.obj;
+      seen.add(session.sessionId);
+      out.push({
+        id: `title:${session.workspaceId}:${session.sessionId}`,
+        kind: "title",
+        session,
+      });
+    }
+
+    const messageHits = [...matches].sort(
+      (a, b) => b.session.updatedAt - a.session.updatedAt,
+    );
+    for (const match of messageHits) {
+      if (seen.has(match.session.sessionId)) continue;
+      seen.add(match.session.sessionId);
+      out.push({
+        id: `message:${match.session.workspaceId}:${match.session.sessionId}`,
+        kind: "message",
+        session: match.session,
+        role: match.role,
+        snippet: match.snippet,
+      });
+    }
+    return out.slice(0, RESULT_LIMIT);
+  }, [matches, props.sessions, query]);
+
+  const trimmedQuery = query.trim();
+  const searching = Boolean(deepQuery) && progress !== null && !progress.done;
+  const emptyText = !trimmedQuery
+    ? "No sessions yet."
+    : trimmedQuery.length < MIN_QUERY_LENGTH
+      ? "Keep typing to search message content…"
+      : searching
+        ? "Searching messages…"
+        : "No sessions or messages match your search.";
+
+  const statusText = !trimmedQuery
+    ? "Recent sessions"
+    : searching
+      ? `Searching messages… ${progress.scanned}/${progress.total}`
+      : `${items.length.toLocaleString()} ${items.length === 1 ? "result" : "results"}`;
+
+  return (
+    <CommandDialog
+      open={props.open}
+      onOpenChange={(open) => {
+        if (!open) props.onClose();
+      }}
+    >
+      <CommandDialogPopup>
+        <CommandDialogTitle>Search sessions</CommandDialogTitle>
+        <Command
+          items={items}
+          filter={null}
+          value={query}
+          onValueChange={setQuery}
+        >
+          <CommandHeader>
+            <CommandInput
+              className="w-full"
+              placeholder="Search all sessions and messages…"
+            />
+          </CommandHeader>
+          <CommandPanel>
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandList>
+              {(item: ResultItem) => (
+                <CommandItem
+                  key={item.id}
+                  value={item.id}
+                  onClick={() => {
+                    props.onClose();
+                    props.onOpenSession(item.session.workspaceId, item.session.sessionId);
+                  }}
+                >
+                  <span className="mr-2 shrink-0">{resultIcon(item.kind)}</span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline gap-2">
+                      <span className="truncate font-medium">{item.session.title}</span>
+                      {item.kind === "message" ? (
+                        <span className="shrink-0 truncate text-[11px] text-muted-foreground/72">
+                          {item.session.workspaceTitle}
+                        </span>
+                      ) : null}
+                    </div>
+                    <SnippetLine item={item} />
+                  </div>
+                  <CommandShortcut className="ps-3">
+                    {formatRelativeTime(item.session.updatedAt)}
+                  </CommandShortcut>
+                </CommandItem>
+              )}
+            </CommandList>
+          </CommandPanel>
+          <CommandFooter>
+            <span className="inline-flex items-center gap-1.5">
+              {searching ? <Loader2Icon className="size-3 animate-spin" /> : null}
+              {statusText}
+            </span>
+            <span>↑↓ to navigate · ↵ to open</span>
+          </CommandFooter>
+        </Command>
+      </CommandDialogPopup>
+    </CommandDialog>
+  );
+}


### PR DESCRIPTION
## What

A new **session search** that searches every session across all workspaces — titles *and* full message content — opened with **Cmd/Ctrl+Shift+F** or via the command palette ("Search session messages").

- Title matches are instant (fuzzysort, already a dependency).
- Message content is deep-searched: transcripts stream in with a 6-way concurrency cap and results appear as they're found, newest sessions first.
- Transcripts are cached by `sessionId + updatedAt`, so repeat keystrokes only refetch sessions that changed.
- Each content hit shows a highlighted snippet with a You:/Agent: prefix, workspace label, and relative time; user prompts are preferred over agent replies.
- Empty query shows recent sessions; the footer shows live scan progress (`Searching messages… 12/40`).
- Enter/click navigates straight to the session (cross-workspace).

## How

- `domains/session/search/session-search.ts` — pure search engine (cache, worker pool, snippet builder, cancellation).
- `shell/session-search-dialog.tsx` — reuses the existing `@/components/ui/command` kit (Base UI Autocomplete with `filter={null}` for externally controlled results).
- `shell/session-route.tsx` — Cmd/Ctrl+Shift+F shortcut, palette entry, message fetcher via the existing OpenWork server client (`getSessionMessages`).

No new dependencies, no `any`, no server changes.

## Testing

- `pnpm --dir apps/app typecheck` — pass
- `pnpm --dir apps/app build` — pass
- Manual E2E via Electron CDP on the local dev app (validated end to end):
  - Cmd+Shift+F opens the dialog showing recent sessions
  - Typing `count` returned a title match ("Count 1 to 40") + a message-content match with snippet
  - Typing `password` returned a content-only hit with the match highlighted in the snippet ("Agent: …**Password** field…")
  - Enter navigated to the matched session in a different workspace and closed the dialog
  - Command palette entry "Search session messages" opens the dialog

I could not attach the screen recording from this environment; reproduce with: `pnpm dev`, press Cmd+Shift+F, and type any phrase from an old session's transcript.