### PR TITLE
fix(mcp): stop the cloud MCP 'Reload to connect' nag loop + agent-flow eval spec

### DIFF
--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -771,6 +771,14 @@ export function createConnectionsStore(options: {
     }
   }
 
+  // Guards the unhealthy-status self-heal in syncCloudControlMcp: each
+  // re-mint writes a new token to config, which marks an engine reload as
+  // required. Until that reload happens the status stays needs_auth, so
+  // retrying on every sync tick produced an endless "MCP 'openwork-cloud'
+  // was updated. Reload to connect." nag. One attempt per unhealthy episode;
+  // reset when the entry reports connected again.
+  let cloudMcpUnhealthyRemintAttempted = false;
+
   /**
    * Background reconciliation for the Den cloud MCP: when the desktop is
    * signed in to OpenWork Cloud with an active org, keep the
@@ -792,11 +800,19 @@ export function createConnectionsStore(options: {
       marker.orgId === orgId &&
       new Date(marker.expiresAt).getTime() - Date.now() > CLOUD_MCP_REFRESH_MARGIN_MS;
     // A revoked/expired token surfaces as needs_auth or failed from opencode;
-    // while signed in, that means re-mint instead of standing pat.
+    // while signed in, that means re-mint instead of standing pat — but only
+    // once per unhealthy episode (see cloudMcpUnhealthyRemintAttempted).
     const entryStatus = snapshot.mcpStatuses[slug]?.status;
+    if (entryStatus === "connected") {
+      cloudMcpUnhealthyRemintAttempted = false;
+    }
     const entryUnhealthy = entryStatus === "needs_auth" || entryStatus === "failed";
-    if (markerFresh && !entryUnhealthy && snapshot.mcpServers.some((server) => server.name === slug)) {
+    const shouldRemintForHealth = entryUnhealthy && !cloudMcpUnhealthyRemintAttempted;
+    if (markerFresh && !shouldRemintForHealth && snapshot.mcpServers.some((server) => server.name === slug)) {
       return "unchanged";
+    }
+    if (shouldRemintForHealth) {
+      cloudMcpUnhealthyRemintAttempted = true;
     }
 
     // Validate the session up front so a failed mint never reaches

--- a/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
@@ -489,7 +489,7 @@ export const pluginArchEndpointContracts: Record<string, EndpointContract> = {
   },
   createMarketplace: {
     audience: "admin",
-    description: "Create a private-by-default marketplace.",
+    description: "Create a private-by-default marketplace. Most organizations need only one: list existing marketplaces first and prefer attaching plugins to an existing marketplace; only create a new one when explicitly asked.",
     method: "POST",
     path: pluginArchRoutePaths.marketplaces,
     request: { body: marketplaceCreateSchema },

--- a/evals/README.md
+++ b/evals/README.md
@@ -130,6 +130,10 @@ plugin (configured in `.opencode/opencode.json`). Every tool takes
 - [`cloud-auth-flows.md`](./cloud-auth-flows.md) — desktop cloud sign-in
   (browser handoff + paste-code), expired grants, sign-out cleanup, and org
   switching.
+- [`cloud-mcp-agent-flows.md`](./cloud-mcp-agent-flows.md) — agent-driven org
+  management through the openwork-cloud MCP: org identity, invitations, team
+  assignment, and skill sharing via plugins + marketplaces, with server-side
+  ground-truth assertions.
 - [`cloud-provider-sync-flows.md`](./cloud-provider-sync-flows.md) — org LLM
   provider import, update, delete, refresh timing, and permission boundaries.
 - [`cloud-marketplace-sync-flows.md`](./cloud-marketplace-sync-flows.md) —

--- a/evals/cloud-mcp-agent-flows.md
+++ b/evals/cloud-mcp-agent-flows.md
@@ -1,0 +1,107 @@
+# Cloud MCP agent flows
+
+End-to-end flows where the **agent itself** (composer prompts) operates OpenWork
+Cloud through the `openwork-cloud` MCP. These validate the real product story:
+a signed-in user types plain English and the agent manages their org.
+
+All flows verified 2026-06-09 against a local Den stack (MySQL + den-api +
+den-web, seeded demo org) with the desktop dev app signed in as the org owner
+and the cloud MCP auto-configured (first-party token). Ground truth asserted
+via Den API/DB, not just the transcript.
+
+## Preflight
+
+1. Start the Den stack and seed the demo org (`seed:demo-org`, login
+   `alex@acme.test`). For invitation flows the org needs seat headroom: either
+   fewer members than the free seat count or an active `seat` row in
+   `org_subscriptions`.
+2. Point the desktop at the Den stack (desktop-bootstrap.json), reload the
+   renderer after changing the bootstrap (boot can race and keep stale base
+   URLs in localStorage), then sign in via paste-code.
+3. Open Settings -> Extensions -> MCP and wait for **OpenWork Cloud Control —
+   Ready** (auto-sync mints the token and the entry hot-connects without an
+   engine reload).
+4. A working model provider must be configured (flows below ran on
+   `openwork/kimi-k2.6`).
+
+## Flow 1: Which cloud am I connected to
+
+**Prompt:** "Which OpenWork Cloud organization am I connected to? Use your
+openwork-cloud tools to check."
+
+**Expected:** agent calls `getV1Org` / `getV1Me` and answers with the org name,
+slug, the signed-in user, and their role.
+
+**Verified result:** "You are connected to the Acme Robotics organization
+(slug: acme-robotics-demo). You are signed in as Alex Chen (alex@acme.test)
+and have the owner role."
+
+## Flow 2: Invite a member
+
+**Prompt:** "Add omar@openworklabs.com to my organization as a member using
+your openwork-cloud tools."
+
+**Expected:**
+- If the email's domain is not allowed, the agent first updates the org's
+  allowed email domains (observed: it did this autonomously).
+- If the org is at its free seat limit, the agent surfaces the billing
+  requirement instead of failing silently (observed: clear seat-limit
+  explanation with counts).
+- With seats available: `POST /v1/invitations` 201.
+
+**Assert (ground truth):** `invitation` row with the email, `role: member`,
+`status: pending`.
+
+## Flow 3: Assign a member to a team
+
+**Prompt:** "Assign <member> to the Sales team using your openwork-cloud tools."
+
+**Expected:**
+- For a **pending invitee**, the agent refuses with a correct explanation
+  (only active members can join teams) — observed.
+- For an active member: team membership created.
+
+**Assert:** `team_member` row joins the member to the Sales team.
+
+## Flow 4: Create a skill locally and share it via plugin + marketplace
+
+**Prompt:** "Create a skill called 'weekly-report' (...instructions...) and
+save it as a proper SKILL.md in this workspace. Then share it with my whole
+organization using the proper OpenWork Cloud way: create a plugin containing
+the skill and publish it to our marketplace."
+
+**Expected:**
+- `.opencode/skills/weekly-report/SKILL.md` written in the workspace (the
+  "Skills changed. Reload to apply." toast appears).
+- Cloud side: plugin created, skill config object attached
+  (`sourceMode: cloud`), plugin attached to the marketplace, org-wide viewer
+  grants on plugin + config object.
+
+**Assert:** `plugin`, `plugin_config_object` (+`config_object` of type skill),
+`marketplace_plugin`, and `*_access_grant` rows with `org_wide=1, role=viewer`.
+
+**Known trap (observed):** the agent may create a *duplicate marketplace*
+instead of reusing the existing one, leaving the plugin invisible to other
+members (the duplicate has creator-only grants). The marketplace-create tool
+description now steers agents to list-and-reuse; when grading, check the
+plugin landed in a marketplace **other members can see**.
+
+## Flow 5: The invited member sees the shared plugin
+
+**Steps:** the invited user (Flow 2) creates an account, accepts the
+invitation, then resolves the org marketplace (this is exactly what the
+desktop app consumes).
+
+**Assert:** `GET /v1/marketplaces/:id/resolved` as the new member contains the
+plugin from Flow 4 with its skill content.
+
+**Verified result:** omar (fresh account → accepted invite) sees
+`weekly-report` in OpenWork Marketplace.
+
+## Grading notes
+
+- Always assert server-side effects (API/DB), never just the transcript.
+- Business-rule refusals (seat limits, pending invitees) count as PASS when
+  explained correctly — they prove the MCP surfaces real org policy.
+- Watch for resource duplication (marketplaces, plugins) when re-running:
+  prompts are not idempotent.


### PR DESCRIPTION
## Bug (user-reported)

"MCP 'openwork-cloud' was updated. Reload to connect." kept reappearing.

**Root cause:** the cloud MCP self-heal re-mints when the entry reports `needs_auth`/`failed`. Each re-mint writes a **new token** to config, which marks an engine reload required. Until that reload happens the status stays `needs_auth` — so every sync tick (sign-in, org change, interval) re-minted and re-nagged. Endless loop, especially if you click "Later".

**Fix:** one re-mint attempt per unhealthy episode (`cloudMcpUnhealthyRemintAttempted` in the connections store), reset when the entry reports `connected` again. Expiry/org-switch re-syncs are unaffected.

## Also in this PR

- **`createMarketplace` tool description** now steers agents to list-and-reuse existing marketplaces — during agent E2E testing the agent created a *duplicate* "OpenWork Marketplace" with creator-only grants, making a shared plugin invisible to other members. Tool descriptions are generated from these OpenAPI contracts, so this directly改 improves agent behavior.
- **`evals/cloud-mcp-agent-flows.md`** — codifies the five agent-driven flows that were just validated end-to-end (composer prompts → real Den):
  1. "Which cloud am I connected to" → agent called getV1Org/getV1Me → "Acme Robotics... Alex Chen (owner)" ✅
  2. "Add omar@openworklabs.com to my org" → agent self-served the domain allowlist, surfaced the seat-limit billing rule, then `POST /v1/invitations` **201**; DB: `omar@openworklabs.com | member | pending` ✅
  3. "Assign Priya to Sales" → DB `team_member` row created (and correctly refused for a pending invitee) ✅
  4. "Create a 'weekly-report' skill + share via plugin/marketplace" → local SKILL.md + plugin + skill config object + org-wide grants in DB ✅ (caught the duplicate-marketplace trap above)
  5. Omar signs up, accepts the invite, and **sees weekly-report in his marketplace resolved payload** — the exact endpoint the desktop consumes ✅

All assertions are server-side (Den API/DB), not transcript-based.

## Testing

- Full agent E2E above on a live local Den stack + dev Electron over CDP, model `openwork/kimi-k2.6`.
- Nag fix observed live: post-fix only a single re-mint per unhealthy episode; entry reaches **Ready**.
- `pnpm typecheck` (apps/app) + `tsc --noEmit` (den-api) — pass.