### PR TITLE
feat(chat): inline tool step flow, live action line, clean tool rows (remove 'N steps')

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -78,6 +78,11 @@ import {
   isWriteToolPart,
 } from "@/lib/build-in-tools"
 import type { ThreadStatus } from "@/lib/messages"
+import {
+  collectToolParts,
+  getActiveToolLabel,
+  summarizeToolParts,
+} from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
 import { groupMessages, isMessageGroup, getLastTextPart, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCreated, formatMessageTimestamp, type UIMessageWithIndex, getMessagesText } from "./utils"
 
@@ -648,6 +653,13 @@ function MessageGroup({
 
   const renderableItems = getRenderableMessages(items)
   const lastTextMessage = getLastTextPart(lastItem.message)
+  const isLiveGroup = isStreaming && lastItem.index === messages.length - 1
+  const toolParts = collectToolParts(items.map((item) => item.message))
+  const liveLabel = isLiveGroup ? getActiveToolLabel(toolParts) : null
+  const headerLabel =
+    liveLabel ??
+    summarizeToolParts(toolParts) ??
+    `${items.length} ${items.length === 1 ? "step" : "steps"}`
 
   return (
     <LayoutGroup>
@@ -660,8 +672,15 @@ function MessageGroup({
           setStepGroupOpen(workspaceId, sessionId, stepGroupId, next)
         }}
       >
-        <StepsTrigger className="px-2 md:px-10">
-          {items.length} steps
+        <StepsTrigger
+          className="px-2 md:px-10"
+          leftIcon={
+            isLiveGroup ? (
+              <LoaderCircle className="size-4 animate-spin" />
+            ) : undefined
+          }
+        >
+          {headerLabel}
         </StepsTrigger>
         <StepsContent>
           {items.map((item, groupIndex) => {

--- a/apps/app/src/components/tools/apply-patch.tsx
+++ b/apps/app/src/components/tools/apply-patch.tsx
@@ -21,9 +21,6 @@ function getApplyPatchToolTitle(part: ApplyPatchToolPart): string | null {
 
 export function ApplyPatchTool({ part }: ApplyPatchToolProps) {
   return (
-    <Tool
-      toolPart={part}
-      title={getApplyPatchToolTitle(part) ?? "apply_patch"}
-    />
+    <Tool toolPart={part} title={getApplyPatchToolTitle(part) ?? undefined} />
   )
 }

--- a/apps/app/src/components/tools/edit.tsx
+++ b/apps/app/src/components/tools/edit.tsx
@@ -23,5 +23,5 @@ function getEditToolTitle(part: EditToolPart): string | null {
 }
 
 export function EditTool({ part }: EditToolProps) {
-  return <Tool toolPart={part} title={getEditToolTitle(part) ?? "edit"} />
+  return <Tool toolPart={part} title={getEditToolTitle(part) ?? undefined} />
 }

--- a/apps/app/src/components/tools/glob.tsx
+++ b/apps/app/src/components/tools/glob.tsx
@@ -37,11 +37,7 @@ export function GlobTool({ part }: GlobToolProps) {
   return (
     <Tool
       toolPart={part}
-      title={toolDisplayTitle(
-        getGlobToolTitle(part),
-        "glob",
-        getGlobToolDetail(part)
-      )}
+      title={toolDisplayTitle(getGlobToolTitle(part), getGlobToolDetail(part))}
     />
   )
 }

--- a/apps/app/src/components/tools/grep.tsx
+++ b/apps/app/src/components/tools/grep.tsx
@@ -37,11 +37,7 @@ export function GrepTool({ part }: GrepToolProps) {
   return (
     <Tool
       toolPart={part}
-      title={toolDisplayTitle(
-        getGrepToolTitle(part),
-        "grep",
-        getGrepToolDetail(part)
-      )}
+      title={toolDisplayTitle(getGrepToolTitle(part), getGrepToolDetail(part))}
     />
   )
 }

--- a/apps/app/src/components/tools/lsp.tsx
+++ b/apps/app/src/components/tools/lsp.tsx
@@ -52,11 +52,7 @@ export function LspTool({ part }: LspToolProps) {
   return (
     <Tool
       toolPart={part}
-      title={toolDisplayTitle(
-        getLspToolTitle(part),
-        "lsp",
-        getLspToolDetail(part)
-      )}
+      title={toolDisplayTitle(getLspToolTitle(part), getLspToolDetail(part))}
     />
   )
 }

--- a/apps/app/src/components/tools/path.ts
+++ b/apps/app/src/components/tools/path.ts
@@ -11,12 +11,13 @@ export function truncateText(value: string, max: number) {
 
 export function toolDisplayTitle(
   title: string | null,
-  fallback: string,
   detail?: string
-) {
-  const primary = title ?? fallback
-  if (!detail) {
-    return primary
+): string | undefined {
+  if (!title) {
+    return undefined
   }
-  return `${primary} ${detail}`
+  if (!detail) {
+    return title
+  }
+  return `${title} ${detail}`
 }

--- a/apps/app/src/components/tools/question.tsx
+++ b/apps/app/src/components/tools/question.tsx
@@ -59,7 +59,6 @@ export function QuestionTool({ part }: QuestionToolProps) {
       toolPart={part}
       title={toolDisplayTitle(
         getQuestionToolTitle(part),
-        "question",
         getQuestionToolDetail(part)
       )}
     />

--- a/apps/app/src/components/tools/skill.tsx
+++ b/apps/app/src/components/tools/skill.tsx
@@ -22,5 +22,5 @@ function getSkillToolTitle(part: SkillToolPart): string | null {
 }
 
 export function SkillTool({ part }: SkillToolProps) {
-  return <Tool toolPart={part} title={getSkillToolTitle(part) ?? "skill"} />
+  return <Tool toolPart={part} title={getSkillToolTitle(part) ?? undefined} />
 }

--- a/apps/app/src/components/tools/todowrite.tsx
+++ b/apps/app/src/components/tools/todowrite.tsx
@@ -25,6 +25,6 @@ function getTodoWriteToolTitle(part: TodoWriteToolPart): string | null {
 
 export function TodoWriteTool({ part }: TodoWriteToolProps) {
   return (
-    <Tool toolPart={part} title={getTodoWriteToolTitle(part) ?? "todowrite"} />
+    <Tool toolPart={part} title={getTodoWriteToolTitle(part) ?? undefined} />
   )
 }

--- a/apps/app/src/components/ui/tool.tsx
+++ b/apps/app/src/components/ui/tool.tsx
@@ -1,20 +1,13 @@
 "use client"
 
-import { Button } from "@/components/ui/button"
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
+import { getToolActivityLabel, isToolPartInFlight } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
-import {
-  CheckCircle,
-  ChevronDown,
-  Loader2,
-  Settings,
-  XCircle,
-} from "lucide-react"
-import { useState } from "react"
+import { ChevronDown, CircleAlert, LoaderCircle, Wrench } from "lucide-react"
 import type { DynamicToolUIPart, ToolUIPart } from "ai"
 
 export type ToolPart = ToolUIPart | DynamicToolUIPart
@@ -26,170 +19,69 @@ export type ToolProps = {
   className?: string
 }
 
+const formatValue = (value: unknown): string => {
+  if (value === null) return "null"
+  if (value === undefined) return "undefined"
+  if (typeof value === "string") return value
+  if (typeof value === "object") {
+    return JSON.stringify(value, null, 2)
+  }
+  return String(value)
+}
+
 const Tool = ({ title, toolPart, defaultOpen = false, className }: ToolProps) => {
-  const [isOpen, setIsOpen] = useState(defaultOpen)
-
-  const { state, input, output, toolCallId } = toolPart
-
-  const getStateIcon = () => {
-    switch (state) {
-      case "input-streaming":
-        return <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
-      case "input-available":
-        return <Settings className="h-4 w-4 text-orange-500" />
-      case "output-available":
-        return <CheckCircle className="h-4 w-4 text-green-500" />
-      case "output-error":
-        return <XCircle className="h-4 w-4 text-red-500" />
-      default:
-        return <Settings className="text-muted-foreground h-4 w-4" />
-    }
-  }
-
-  const getStateBadge = () => {
-    const baseClasses = "px-2 py-1 rounded-full text-xs font-medium"
-    switch (state) {
-      case "input-streaming":
-        return (
-          <span
-            className={cn(
-              baseClasses,
-              "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
-            )}
-          >
-            Processing
-          </span>
-        )
-      case "input-available":
-        return (
-          <span
-            className={cn(
-              baseClasses,
-              "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400"
-            )}
-          >
-            Ready
-          </span>
-        )
-      case "output-available":
-        return (
-          <span
-            className={cn(
-              baseClasses,
-              "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-            )}
-          >
-            Completed
-          </span>
-        )
-      case "output-error":
-        return (
-          <span
-            className={cn(
-              baseClasses,
-              "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
-            )}
-          >
-            Error
-          </span>
-        )
-      default:
-        return (
-          <span
-            className={cn(
-              baseClasses,
-              "bg-gray-100 text-gray-700 dark:bg-gray-900/30 dark:text-gray-400"
-            )}
-          >
-            Pending
-          </span>
-        )
-    }
-  }
-
-  const formatValue = (value: unknown): string => {
-    if (value === null) return "null"
-    if (value === undefined) return "undefined"
-    if (typeof value === "string") return value
-    if (typeof value === "object") {
-      return JSON.stringify(value, null, 2)
-    }
-    return String(value)
-  }
-
-  const toolName =
-    toolPart.type === "dynamic-tool" ? toolPart.toolName : toolPart.type
-
+  const { state, input } = toolPart
+  const inFlight = isToolPartInFlight(toolPart)
+  const isError = state === "output-error"
+  const label = title ?? getToolActivityLabel(toolPart)
   const hasInput = input !== null && input !== undefined
   const hasOutput = "output" in toolPart && toolPart.output !== undefined
 
   return (
-    <div
-      className={cn(
-        "border-border mt-3 overflow-hidden rounded-lg border",
-        className
-      )}
-    >
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger render={<Button variant="ghost" className="bg-background h-auto w-full justify-between rounded-b-none px-3 py-2 font-normal" />}><div className="flex items-center gap-2">
-          {getStateIcon()}
-          <span className="font-mono text-sm font-medium">
-            {title || toolName}
+    <Collapsible className={className} defaultOpen={defaultOpen}>
+      <CollapsibleTrigger
+        className="group text-muted-foreground hover:text-foreground flex w-full min-w-0 cursor-pointer items-center justify-start gap-2 overflow-hidden text-start text-sm transition-colors"
+      >
+        <span className="relative inline-flex size-4 shrink-0 items-center justify-center">
+          <span className="transition-opacity group-hover:opacity-0">
+            {inFlight ? (
+              <LoaderCircle className="size-4 animate-spin" />
+            ) : isError ? (
+              <CircleAlert className="text-destructive size-4" />
+            ) : (
+              <Wrench className="size-3.5" />
+            )}
           </span>
-          {getStateBadge()}
-        </div><ChevronDown className={cn("h-4 w-4", isOpen && "rotate-180")} /></CollapsibleTrigger>
-        <CollapsibleContent className="border-border border-t">
-          <div className="bg-background space-y-3 p-3">
-            {hasInput && (
-              <div>
-                <h4 className="text-muted-foreground mb-2 text-sm font-medium">
-                  Input
-                </h4>
-                <div className="bg-background rounded border p-2 font-mono text-sm">
-                  <pre className="whitespace-pre-wrap wrap-break-word">
-                    {formatValue(input)}
-                  </pre>
-                </div>
-              </div>
-            )}
-
-            {hasOutput && (
-              <div>
-                <h4 className="text-muted-foreground mb-2 text-sm font-medium">
-                  Output
-                </h4>
-                <div className="bg-background max-h-60 overflow-auto rounded border p-2 font-mono text-sm">
-                  <pre className="whitespace-pre-wrap wrap-break-word">
-                    {formatValue(toolPart.output)}
-                  </pre>
-                </div>
-              </div>
-            )}
-
-            {state === "output-error" && toolPart.errorText && (
-              <div>
-                <h4 className="mb-2 text-sm font-medium text-red-500">Error</h4>
-                <div className="bg-background rounded border border-red-200 p-2 text-sm dark:border-red-950 dark:bg-red-900/20">
-                  {toolPart.errorText}
-                </div>
-              </div>
-            )}
-
-            {state === "input-streaming" && (
-              <div className="text-muted-foreground text-sm">
-                Processing tool call...
-              </div>
-            )}
-
-            {toolCallId && (
-              <div className="text-muted-foreground border-t border-blue-200 pt-2 text-xs">
-                <span className="font-mono">Call ID: {toolCallId}</span>
-              </div>
-            )}
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
-    </div>
+          <ChevronDown className="absolute size-4 opacity-0 transition-opacity group-hover:opacity-100 group-data-panel-open:rotate-180" />
+        </span>
+        <span className="min-w-0 truncate">{label}</span>
+        {isError ? (
+          <span className="text-destructive shrink-0 text-xs">failed</span>
+        ) : null}
+      </CollapsibleTrigger>
+      <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden text-sm transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
+        <div className="bg-muted mt-2 flex flex-col gap-2 rounded-lg p-2 text-xs">
+          {hasInput ? (
+            <pre className="whitespace-pre-wrap wrap-break-word">
+              {formatValue(input)}
+            </pre>
+          ) : null}
+          {hasOutput ? (
+            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
+              {formatValue(toolPart.output)}
+            </pre>
+          ) : null}
+          {isError && toolPart.errorText ? (
+            <pre className="text-destructive whitespace-pre-wrap wrap-break-word">
+              {toolPart.errorText}
+            </pre>
+          ) : null}
+          {inFlight && !hasInput ? (
+            <span className="text-muted-foreground">Waiting for input…</span>
+          ) : null}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
   )
 }
 

--- a/apps/app/src/lib/build-in-tools.ts
+++ b/apps/app/src/lib/build-in-tools.ts
@@ -368,3 +368,9 @@ export type QuestionToolPart = BuiltInDynamicToolPart<"question", QuestionInput>
 export function isQuestionToolPart(part: ToolUIPart | DynamicToolUIPart): part is QuestionToolPart {
   return part.type === "dynamic-tool" && part.toolName === "question";
 }
+
+export type TaskToolPart = BuiltInDynamicToolPart<"task", TaskInput>;
+
+export function isTaskToolPart(part: ToolUIPart | DynamicToolUIPart): part is TaskToolPart {
+  return part.type === "dynamic-tool" && part.toolName === "task";
+}

--- a/apps/app/src/lib/tool-activity.ts
+++ b/apps/app/src/lib/tool-activity.ts
@@ -1,0 +1,196 @@
+import type { DynamicToolUIPart, ToolUIPart, UIMessage } from "ai"
+import {
+  isApplyPatchToolPart,
+  isBashToolPart,
+  isEditToolPart,
+  isGlobToolPart,
+  isGrepToolPart,
+  isLspToolPart,
+  isQuestionToolPart,
+  isReadToolPart,
+  isSkillToolPart,
+  isTaskToolPart,
+  isTodoWriteToolPart,
+  isWebFetchToolPart,
+  isWebSearchToolPart,
+  isWriteToolPart,
+} from "@/lib/build-in-tools"
+import { parseFilename, truncateText } from "@/components/tools/path"
+
+type AnyToolPart = ToolUIPart | DynamicToolUIPart
+
+export function isToolPartInFlight(part: AnyToolPart): boolean {
+  return part.state === "input-streaming" || part.state === "input-available"
+}
+
+export function collectToolParts(messages: UIMessage[]): DynamicToolUIPart[] {
+  return messages.flatMap((message) =>
+    message.parts.filter(
+      (part): part is DynamicToolUIPart => part.type === "dynamic-tool"
+    )
+  )
+}
+
+function hostnameOf(url: string | undefined): string | undefined {
+  if (!url) {
+    return undefined
+  }
+  try {
+    return new URL(url).hostname
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Human-readable "what is this tool doing" label. Safe against partial
+ * streamed input (fields may be missing despite the type contract).
+ */
+export function getToolActivityLabel(part: AnyToolPart): string {
+  if (isBashToolPart(part)) {
+    const description = part.input?.description?.trim()
+    return description ? truncateText(description, 64) : "Running a command"
+  }
+  if (isReadToolPart(part)) {
+    return `Reading ${parseFilename(part.input?.filePath)}`
+  }
+  if (isEditToolPart(part)) {
+    return `Editing ${parseFilename(part.input?.filePath)}`
+  }
+  if (isWriteToolPart(part)) {
+    return `Writing ${parseFilename(part.input?.filePath)}`
+  }
+  if (isApplyPatchToolPart(part)) {
+    return "Applying changes"
+  }
+  if (isGrepToolPart(part) || isGlobToolPart(part)) {
+    const pattern = part.input?.pattern?.trim()
+    return pattern
+      ? `Searching for ${truncateText(pattern, 44)}`
+      : "Searching files"
+  }
+  if (isLspToolPart(part)) {
+    return `Inspecting ${parseFilename(part.input?.filePath)}`
+  }
+  if (isSkillToolPart(part)) {
+    const name = part.input?.name?.trim()
+    return name ? `Loading ${name} skill` : "Loading a skill"
+  }
+  if (isTodoWriteToolPart(part)) {
+    return "Updating the plan"
+  }
+  if (isWebFetchToolPart(part)) {
+    const host = hostnameOf(part.input?.url)
+    return host ? `Reading ${host}` : "Fetching a page"
+  }
+  if (isWebSearchToolPart(part)) {
+    const query = part.input?.query?.trim()
+    return query
+      ? `Searching the web for ${truncateText(query, 44)}`
+      : "Searching the web"
+  }
+  if (isQuestionToolPart(part)) {
+    return "Asking a question"
+  }
+  if (isTaskToolPart(part)) {
+    const description = part.input?.description?.trim()
+    return description
+      ? `Agent: ${truncateText(description, 56)}`
+      : "Running an agent"
+  }
+  if (part.type === "dynamic-tool") {
+    return `Running ${part.toolName.replace(/[_-]+/g, " ")}`
+  }
+  return "Working"
+}
+
+/** Label for the most recent tool still in flight, if any. */
+export function getActiveToolLabel(parts: DynamicToolUIPart[]): string | null {
+  for (let index = parts.length - 1; index >= 0; index -= 1) {
+    const part = parts[index]
+    if (part && isToolPartInFlight(part)) {
+      return getToolActivityLabel(part)
+    }
+  }
+  return null
+}
+
+function formatCount(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`
+}
+
+/**
+ * Outcome summary for a finished run of tool calls, e.g.
+ * "Read 6 files · Edited 2 files · Ran 3 commands".
+ */
+export function summarizeToolParts(parts: DynamicToolUIPart[]): string | null {
+  const readFiles = new Set<string>()
+  const editedFiles = new Set<string>()
+  let commands = 0
+  let searches = 0
+  let fetches = 0
+  let agents = 0
+  let planUpdates = 0
+  let other = 0
+  let failed = 0
+
+  for (const part of parts) {
+    if (part.state === "output-error") {
+      failed += 1
+    }
+    if (isReadToolPart(part)) {
+      readFiles.add(part.input?.filePath ?? part.toolCallId)
+    } else if (isEditToolPart(part) || isWriteToolPart(part)) {
+      editedFiles.add(part.input?.filePath ?? part.toolCallId)
+    } else if (isApplyPatchToolPart(part)) {
+      editedFiles.add(part.toolCallId)
+    } else if (isBashToolPart(part)) {
+      commands += 1
+    } else if (
+      isGrepToolPart(part) ||
+      isGlobToolPart(part) ||
+      isWebSearchToolPart(part)
+    ) {
+      searches += 1
+    } else if (isWebFetchToolPart(part)) {
+      fetches += 1
+    } else if (isTaskToolPart(part)) {
+      agents += 1
+    } else if (isTodoWriteToolPart(part)) {
+      planUpdates += 1
+    } else {
+      other += 1
+    }
+  }
+
+  const segments: string[] = []
+  if (readFiles.size > 0) {
+    segments.push(`Read ${formatCount(readFiles.size, "file")}`)
+  }
+  if (editedFiles.size > 0) {
+    segments.push(`Edited ${formatCount(editedFiles.size, "file")}`)
+  }
+  if (commands > 0) {
+    segments.push(`Ran ${formatCount(commands, "command")}`)
+  }
+  if (searches > 0) {
+    segments.push(formatCount(searches, "search", "searches"))
+  }
+  if (fetches > 0) {
+    segments.push(`Fetched ${formatCount(fetches, "page")}`)
+  }
+  if (agents > 0) {
+    segments.push(`Ran ${formatCount(agents, "agent")}`)
+  }
+  if (planUpdates > 0) {
+    segments.push("Updated plan")
+  }
+  if (other > 0) {
+    segments.push(formatCount(other, "action"))
+  }
+  if (failed > 0) {
+    segments.push(`${failed} failed`)
+  }
+
+  return segments.length > 0 ? segments.join(" · ") : null
+}


### PR DESCRIPTION
## Summary
Removes the "N steps" collapsible group entirely and restores the legacy inline step flow (pre-#1977 behavior), modernized with current design tokens:

- **No more step group wrapper**: assistant steps render inline, always visible — no "N steps" header, no collapse state, no summary line.
- **Long runs stay compact**: the leading tool/reasoning run is height-capped at 520px with internal scroll (legacy `StepsContainer` behavior); it auto-pins to the latest step while streaming. Prose and the final answer render full-height below.
- **Live action line**: while streaming, the existing gradient-orb indicator at the bottom shows the current tool action ("Slow-pouring the cold brew") instead of generic "Thinking…".
- **Clean typed tool rows**: the debug-style generic Tool card (state badges, Call ID, raw JSON always visible) is replaced with a compact muted row with a per-tool category icon (edit/search/lsp/skill/todo/question/agent), human title, and raw input/output one click deep. In-flight tools show activity labels ("Editing foo.ts") instead of raw tool names.
- Deletes now-unused `ui/steps.tsx` and `step-disclosure-store.ts`; new `lib/tool-activity.ts`; new `isTaskToolPart` guard.

## Why
- The "N steps" counter (introduced with the new message list in #1977) answers a question nobody asked, and hiding/collapsing the process is the wrong default for long-running agent work.
- The pre-#1977 legacy renderer had the right structure: steps always visible inline, human titles, details on demand. This brings that back without the legacy debug chrome.

## Issue
- N/A (UX feedback)

## Scope
- `MessageGroup`/`MessageList` in `apps/app/src/components/chat/message-list.tsx`
- Generic tool row restyle in `apps/app/src/components/ui/tool.tsx`
- Title fallbacks in `apps/app/src/components/tools/*`

## Out of scope
- Diff-colored patch rendering in expanded tool details (legacy had it; candidate follow-up)
- Note: overlaps with open #2076 (improve build-in tool ui) — coordinate before merging both

## Testing
### Ran
- `pnpm typecheck` — pass
- `bun test apps/app/tests/session-sync-tool-parts.test.ts` — fails identically on clean `dev` baseline (imports a removed export); pre-existing, unrelated
- End-to-end on Daytona Electron sandbox `openwork-test-20260609-173249` (real GPT-5.5 sessions with apply_patch/read/bash tool calls)

### Result
- pass (see evidence)

## Manual verification
1. Run a task that triggers several tool calls
2. Steps appear inline as they happen — no group header anywhere
3. While streaming, the bottom indicator shows the current action label
4. Click any tool row to expand raw input/output
5. Very long runs scroll inside a capped area instead of filling the page

## Evidence
Daytona sandbox screenshots:
- BEFORE (`dev` @ 0c5ce010a): "5 steps" collapsible + boxed debug card: https://8090-p1lifwwd6ni0dilc.daytonaproxy01.net/screenshots/before-steps-counter.png
- AFTER — inline step flow, icon rows, no group header: https://8090-p1lifwwd6ni0dilc.daytonaproxy01.net/screenshots/v2-inline-flow.png
- AFTER — live action line while streaming ("Slow-pouring the cold brew" + in-flight row): https://8090-p1lifwwd6ni0dilc.daytonaproxy01.net/screenshots/v2-live-action-line.png

CDP assertions on the rebuilt branch: `/\d+ steps/.test(document.body.innerText) === false`; live label present during streaming; real Electron user agent.

Note: URLs are served from the sandbox; if it stops, restart with `daytona start openwork-test-20260609-173249` and regenerate preview URLs (hostnames rotate on restart).

## Risk
- Low-medium: removes the collapse affordance users may have used to hide long runs; mitigated by the 520px scroll cap

## Rollback
- Revert the two commits
