### PR TITLE
fix(desktop): den bootstrap boot race left stale control-plane URLs + cloud MCP docs

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -626,17 +626,50 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
     return desktopBootstrapConfig;
   }
 
-  try {
-    const bootstrap = await getDesktopBootstrapConfigFromShell() as ShellDesktopBootstrapConfig;
-    applyDesktopBootstrapConfig(resolveDenBootstrapConfig(bootstrap));
-  } catch {
-    desktopBootstrapConfig = resolveDenBootstrapConfig({
-      baseUrl: BUILD_DEN_BASE_URL,
-      apiBaseUrl: BUILD_DEN_API_BASE_URL,
-      requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
-    });
-    syncBootstrapSettingsToLocalStorage(desktopBootstrapConfig);
+  // The shell IPC bridge can be momentarily unavailable at first paint;
+  // retry briefly before giving up so a boot race does not poison the
+  // session with build defaults.
+  const SHELL_BOOTSTRAP_ATTEMPTS = 3;
+  const SHELL_BOOTSTRAP_RETRY_DELAY_MS = 350;
+  for (let attempt = 1; attempt <= SHELL_BOOTSTRAP_ATTEMPTS; attempt += 1) {
+    try {
+      const bootstrap = await getDesktopBootstrapConfigFromShell() as ShellDesktopBootstrapConfig;
+      applyDesktopBootstrapConfig(resolveDenBootstrapConfig(bootstrap));
+      return desktopBootstrapConfig;
+    } catch (error) {
+      console.error("[den-bootstrap] shell read failed", attempt, error);
+      if (attempt < SHELL_BOOTSTRAP_ATTEMPTS) {
+        await new Promise((resolve) => setTimeout(resolve, SHELL_BOOTSTRAP_RETRY_DELAY_MS));
+      }
+    }
   }
+
+  // All quick attempts failed. Keep build defaults in memory only — do NOT
+  // sync them to localStorage: previously synced values from a successful
+  // boot are more trustworthy than build defaults, and clobbering them
+  // silently reverted custom/self-hosted control planes to the production
+  // URL until a manual reload.
+  desktopBootstrapConfig = resolveDenBootstrapConfig({
+    baseUrl: BUILD_DEN_BASE_URL,
+    apiBaseUrl: BUILD_DEN_API_BASE_URL,
+    requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
+  });
+
+  // Heal in the background without blocking boot: once the bridge comes up,
+  // apply the real shell config and notify listeners.
+  void (async () => {
+    for (let attempt = 0; attempt < 15; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+      try {
+        const bootstrap = await getDesktopBootstrapConfigFromShell() as ShellDesktopBootstrapConfig;
+        applyDesktopBootstrapConfig(resolveDenBootstrapConfig(bootstrap));
+        dispatchDenSettingsChanged({ settings: readDenSettings() });
+        return;
+      } catch {
+        // Bridge still unavailable — keep trying.
+      }
+    }
+  })();
 
   return desktopBootstrapConfig;
 }

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1332,6 +1332,22 @@ function desktopBootstrapPath() {
   if (process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH?.trim()) {
     return process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH.trim();
   }
+  // Dev mode swaps process.env.HOME to the sandboxed dev-data home midway
+  // through startup (runtime.mjs buildChildEnv → Object.assign(process.env)),
+  // which changes what os.homedir() returns. Resolve the dev-data home
+  // deterministically so early and late IPC reads target the same file —
+  // otherwise the renderer can bootstrap against the wrong control plane
+  // until a manual reload.
+  if (process.env.OPENWORK_DEV_MODE === "1") {
+    return path.join(
+      app.getPath("userData"),
+      "openwork-dev-data",
+      "home",
+      ".config",
+      "openwork",
+      "desktop-bootstrap.json",
+    );
+  }
   return path.join(os.homedir(), ".config", "openwork", "desktop-bootstrap.json");
 }
 

--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -7,7 +7,42 @@ OpenWork Cloud exposes a hosted MCP server at `https://api.openworklabs.com/mcp`
 
 The server uses OAuth. Your MCP client opens a browser, you sign in to OpenWork Cloud, choose the organization to authorize, and the client stores the returned token.
 
+## In the OpenWork desktop app
+
+If you use the OpenWork desktop app, there is nothing to configure. When you
+sign in to OpenWork Cloud, the app connects the `openwork-cloud` MCP for you
+with a token scoped to your active organization — no browser OAuth round-trip.
+You can see it under **Settings → Extensions** as **OpenWork Cloud Control**
+with a Ready status. Switching organizations refreshes the token
+automatically.
+
+## What you can ask the agent
+
+Once connected, your agent manages the organization from plain English in the
+composer. These flows are exercised end to end against a live OpenWork Cloud
+deployment (see `evals/cloud-mcp-agent-flows.md` in the repository):
+
+- **Check your cloud identity** — "Which OpenWork Cloud organization am I
+  connected to?" The agent reports the organization, your account, and your
+  role.
+- **Invite teammates** — "Add omar@example.com to my organization." The agent
+  sends the invitation, updates the allowed email domains when needed, and
+  surfaces seat-limit billing rules instead of failing silently.
+- **Manage teams** — "Assign Priya to the Sales team." Works for active
+  members; the agent explains when someone still has a pending invitation.
+- **Share skills with your org** — "Create a skill that writes weekly status
+  reports and share it with my whole organization." The agent writes the
+  `SKILL.md` locally, then creates a plugin, attaches the skill, publishes it
+  to your marketplace, and grants org-wide access — teammates see it in their
+  marketplace and install it with one click.
+
+Org policy still applies: invitations respect seat limits and domain rules,
+and resource creation follows your organization's roles.
+
 ## MCP config
+
+The manual configuration below is for **other MCP clients** (or the desktop
+app when signed out).
 
 Add this server to your MCP config:
 


### PR DESCRIPTION
## Bug (the parked follow-up)

After changing `desktop-bootstrap.json`, the app kept using the previous control plane until a manual reload — and could silently revert custom/self-hosted URLs to production defaults.

**Root cause (two parts):**
1. **Main process**: `desktopBootstrapPath()` used `os.homedir()`, but dev mode swaps `process.env.HOME` to the sandboxed dev-data home **midway through startup** (`runtime.mjs` `buildChildEnv` → `Object.assign(process.env, serverEnv)`). Early IPC reads resolved the *real* home's bootstrap file; later reads resolved the sandboxed one — two different files, timing-dependent.
2. **Renderer**: when the shell read failed, the fallback **synced build defaults into localStorage**, clobbering correct previously-synced values (this is the silent revert-to-prod path).

**Fix:**
- `main.mjs`: resolve the dev-mode bootstrap path deterministically from `userData/openwork-dev-data/home` so every IPC read targets the same file regardless of when HOME mutates.
- `den.ts`: 3 quick retries on shell read; on failure keep build defaults **in memory only** (never clobber localStorage) and heal in the background (retries for 30s, applies + dispatches den-settings-changed when the bridge recovers). Failures are logged.

## Verified

- **Before**: true cold boot (verified no zombie processes) with a custom bootstrap → localStorage stuck on `app.openworklabs.com` until manual reload. Reproduced 3×.
- **After**: true cold boot → localStorage syncs `http://localhost:8790` on first load. ✅
- Warm reloads unchanged; `pnpm evals --flow app-smoke` passes; `pnpm typecheck` (apps/app) passes.

## Also: cloud MCP docs

`packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx` now documents that the desktop connects the cloud MCP automatically on sign-in (no OAuth round-trip) and lists the agent workflows validated end-to-end (org identity, invitations, team assignment, skill sharing via plugins + marketplaces) with a pointer to `evals/cloud-mcp-agent-flows.md`.