### PR TITLE
fix(settings): stop 404 console noise from opencode-router agent file poll

### DIFF
--- a/apps/app/src/react-app/domains/settings/state/messaging-view-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/messaging-view-state.ts
@@ -201,6 +201,19 @@ export function useMessagingViewProps(
     setAgentLoading(true);
     setAgentError(null);
     try {
+      // Stat first: avoids a console-visible 404 when the agent file does
+      // not exist yet (e.g. a fresh worktree); stat returns 200 + exists:false.
+      const stat = await client.statWorkspaceFile(
+        id,
+        OPENCODE_ROUTER_AGENT_FILE_PATH,
+      );
+      if (!stat.exists) {
+        setAgentExists(false);
+        setAgentContent("");
+        setAgentDraft("");
+        setAgentBaseUpdatedAt(null);
+        return;
+      }
       const result = (await client.readWorkspaceFile(
         id,
         OPENCODE_ROUTER_AGENT_FILE_PATH,


### PR DESCRIPTION
## Problem

On a clean worktree, the devtools console shows recurring `Failed to load resource: the server responded with a status of 404 (Not Found)` whenever a settings page is open.

Root cause: the messaging settings state polls `loadAgentFile()` every 10s, which issues `GET /workspace/:id/files/content?path=.opencode/agents/opencode-router.md`. On a fresh worktree that file doesn't exist, so the server returns 404 on every poll. The code handles the 404 gracefully, but Chrome still logs each failed request — making it look like a router startup race.

## Fix

Stat the file first via the existing `files/stat` endpoint (returns 200 + `exists: false`) and only fetch content when the file exists. No more 404s in the console.

## Testing

- `pnpm --filter @openwork/app exec tsc --noEmit -p tsconfig.json` — clean.
- No unit tests cover this view; the change is a 13-line guard in `messaging-view-state.ts` using the already-typed `statWorkspaceFile` client method. Reviewer repro: open Settings on a workspace without `.opencode/agents/opencode-router.md` and watch the network/console panel — previously a 404 every 10s, now a 200 stat.

## Note (separate follow-up)

While investigating: `messaging-view-state.ts:410-415` still calls `(client as any).getOpenCodeRouterHealth/...`, but those client methods and the server's `/opencode-router/*` mount were removed in 608fe4a18. If `openwork.messaging.enabled` is ever true, that page throws a TypeError. Not addressed here to keep the diff minimal.