### PR TITLE
feat(google-workspace): advanced UI to set own OAuth client and grant Gmail read

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -626,17 +626,50 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
     return desktopBootstrapConfig;
   }
 
-  try {
-    const bootstrap = await getDesktopBootstrapConfigFromShell() as ShellDesktopBootstrapConfig;
-    applyDesktopBootstrapConfig(resolveDenBootstrapConfig(bootstrap));
-  } catch {
-    desktopBootstrapConfig = resolveDenBootstrapConfig({
-      baseUrl: BUILD_DEN_BASE_URL,
-      apiBaseUrl: BUILD_DEN_API_BASE_URL,
-      requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
-    });
-    syncBootstrapSettingsToLocalStorage(desktopBootstrapConfig);
+  // The shell IPC bridge can be momentarily unavailable at first paint;
+  // retry briefly before giving up so a boot race does not poison the
+  // session with build defaults.
+  const SHELL_BOOTSTRAP_ATTEMPTS = 3;
+  const SHELL_BOOTSTRAP_RETRY_DELAY_MS = 350;
+  for (let attempt = 1; attempt <= SHELL_BOOTSTRAP_ATTEMPTS; attempt += 1) {
+    try {
+      const bootstrap = await getDesktopBootstrapConfigFromShell() as ShellDesktopBootstrapConfig;
+      applyDesktopBootstrapConfig(resolveDenBootstrapConfig(bootstrap));
+      return desktopBootstrapConfig;
+    } catch (error) {
+      console.error("[den-bootstrap] shell read failed", attempt, error);
+      if (attempt < SHELL_BOOTSTRAP_ATTEMPTS) {
+        await new Promise((resolve) => setTimeout(resolve, SHELL_BOOTSTRAP_RETRY_DELAY_MS));
+      }
+    }
   }
+
+  // All quick attempts failed. Keep build defaults in memory only — do NOT
+  // sync them to localStorage: previously synced values from a successful
+  // boot are more trustworthy than build defaults, and clobbering them
+  // silently reverted custom/self-hosted control planes to the production
+  // URL until a manual reload.
+  desktopBootstrapConfig = resolveDenBootstrapConfig({
+    baseUrl: BUILD_DEN_BASE_URL,
+    apiBaseUrl: BUILD_DEN_API_BASE_URL,
+    requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
+  });
+
+  // Heal in the background without blocking boot: once the bridge comes up,
+  // apply the real shell config and notify listeners.
+  void (async () => {
+    for (let attempt = 0; attempt < 15; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+      try {
+        const bootstrap = await getDesktopBootstrapConfigFromShell() as ShellDesktopBootstrapConfig;
+        applyDesktopBootstrapConfig(resolveDenBootstrapConfig(bootstrap));
+        dispatchDenSettingsChanged({ settings: readDenSettings() });
+        return;
+      } catch {
+        // Bridge still unavailable — keep trying.
+      }
+    }
+  })();
 
   return desktopBootstrapConfig;
 }

--- a/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
+++ b/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
@@ -102,6 +102,8 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
   const [busyAction, setBusyAction] = useState<BusyAction | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [clientSecret, setClientSecret] = useState("");
+  const [customClientId, setCustomClientId] = useState("");
+  const [customClientSecret, setCustomClientSecret] = useState("");
   const [gmailRead, setGmailRead] = useState(false);
   const serverAvailable = Boolean(openworkServerClient);
   const hostServerAvailable = Boolean(hostOpenworkServerClient);
@@ -156,22 +158,17 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
     return waitForGoogleWorkspaceConnection(openworkServerClient, flow.flowId, flow.expiresAt);
   };
 
-  const saveGoogleClientSecret = async () => {
+  const saveOauthEnv = async (entries: { key: string; value: string }[], onSaved: () => void) => {
     if (!hostOpenworkServerClient) {
       setError("Google OAuth settings can only be saved from the local desktop app.");
-      return;
-    }
-    const value = clientSecret.trim();
-    if (!value) {
-      setError("Enter the client secret from your Google OAuth desktop client.");
       return;
     }
     setBusyAction("save-secret");
     setError(null);
     try {
-      await hostOpenworkServerClient.upsertUserEnv([{ key: "GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", value }]);
+      await hostOpenworkServerClient.upsertUserEnv(entries);
       await hostOpenworkServerClient.setUserEnvPendingChanges(true);
-      setClientSecret("");
+      onSaved();
       if (restartLocalServer) {
         const restarted = await restartLocalServer();
         if (!restarted) setError("Saved Google OAuth settings. Restart OpenWork to apply them.");
@@ -184,6 +181,34 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
     } finally {
       setBusyAction(null);
     }
+  };
+
+  const saveGoogleClientSecret = async () => {
+    const value = clientSecret.trim();
+    if (!value) {
+      setError("Enter the client secret from your Google OAuth desktop client.");
+      return;
+    }
+    await saveOauthEnv([{ key: "GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", value }], () => setClientSecret(""));
+  };
+
+  const saveCustomOauthClient = async () => {
+    const id = customClientId.trim();
+    const secret = customClientSecret.trim();
+    if (!id || !secret) {
+      setError("Enter both the client ID and client secret from your own Google OAuth desktop client.");
+      return;
+    }
+    await saveOauthEnv(
+      [
+        { key: "OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_ID", value: id },
+        { key: "GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", value: secret },
+      ],
+      () => {
+        setCustomClientId("");
+        setCustomClientSecret("");
+      },
+    );
   };
 
   const connectedAccounts = status?.accounts.length ? status.accounts : status?.account ? [status.account] : [];
@@ -332,19 +357,6 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
             ))}
           </CardContent>
         ) : null}
-        {status?.customClient ? (
-          <CardContent className={connectedAccounts.length > 0 ? "pt-2" : "pt-6"}>
-            <label className="flex items-start gap-2.5">
-              <Checkbox checked={gmailRead} onCheckedChange={(checked) => setGmailRead(checked === true)} disabled={Boolean(busyAction)} className="mt-0.5" />
-              <span className="min-w-0">
-                <span className="block text-sm font-medium text-card-foreground">Allow reading Gmail</span>
-                <span className="block text-xs leading-relaxed text-muted-foreground">
-                  Also request read access to your Gmail messages on the next connection. Available because you are using your own Google OAuth client.
-                </span>
-              </span>
-            </label>
-          </CardContent>
-        ) : null}
         <CardFooter className="flex-wrap gap-2 justify-between">
           <div className="flex flex-wrap gap-2">
             <Button disabled={Boolean(busyAction) || !canConnect} onClick={() => void runDesktopAction("connect", connectGoogleWorkspace)}>
@@ -367,6 +379,63 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
             </Button>
           </div>
         </CardFooter>
+      </Card>
+
+      <Card variant="outline" size="sm">
+        <CardHeader>
+          <CardTitle>Advanced</CardTitle>
+          <CardDescription>
+            Use your own Google OAuth client to unlock extra permissions, like reading Gmail.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {status?.customClient ? (
+            <Alert>
+              <CheckCircle2 />
+              <AlertTitle>Using your own Google OAuth client</AlertTitle>
+              <AlertDescription>Extra permissions below are available.</AlertDescription>
+            </Alert>
+          ) : (
+            <div className="space-y-3">
+              <Input
+                value={customClientId}
+                onChange={(event) => setCustomClientId(event.target.value)}
+                placeholder="Your Google OAuth desktop client ID"
+                autoComplete="off"
+              />
+              <Input
+                type="password"
+                value={customClientSecret}
+                onChange={(event) => setCustomClientSecret(event.target.value)}
+                placeholder="Your Google OAuth desktop client secret"
+                autoComplete="off"
+              />
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                Create a desktop OAuth client in Google Cloud Console, then paste its client ID and secret. They are saved locally in OpenWork environment settings and applied after the local server restarts.
+              </p>
+              <Button disabled={busyAction === "save-secret" || !customClientId.trim() || !customClientSecret.trim() || !hostServerAvailable} onClick={() => void saveCustomOauthClient()}>
+                {busyAction === "save-secret" ? <Loader2 className="size-4 animate-spin" /> : null}
+                Save and apply
+              </Button>
+            </div>
+          )}
+          <label className="flex items-start gap-2.5">
+            <Checkbox
+              checked={gmailRead}
+              onCheckedChange={(checked) => setGmailRead(checked === true)}
+              disabled={Boolean(busyAction) || status?.customClient !== true}
+              className="mt-0.5"
+            />
+            <span className="min-w-0">
+              <span className="block text-sm font-medium text-card-foreground">Grant read on Gmail</span>
+              <span className="block text-xs leading-relaxed text-muted-foreground">
+                {status?.customClient
+                  ? "Requests read access to your Gmail messages the next time you connect a Google account. Already connected? Disconnect and connect again to grant it."
+                  : "Add your own Google OAuth client above to enable this option."}
+              </span>
+            </span>
+          </label>
+        </CardContent>
       </Card>
     </div>
   );

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1332,6 +1332,22 @@ function desktopBootstrapPath() {
   if (process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH?.trim()) {
     return process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH.trim();
   }
+  // Dev mode swaps process.env.HOME to the sandboxed dev-data home midway
+  // through startup (runtime.mjs buildChildEnv → Object.assign(process.env)),
+  // which changes what os.homedir() returns. Resolve the dev-data home
+  // deterministically so early and late IPC reads target the same file —
+  // otherwise the renderer can bootstrap against the wrong control plane
+  // until a manual reload.
+  if (process.env.OPENWORK_DEV_MODE === "1") {
+    return path.join(
+      app.getPath("userData"),
+      "openwork-dev-data",
+      "home",
+      ".config",
+      "openwork",
+      "desktop-bootstrap.json",
+    );
+  }
   return path.join(os.homedir(), ".config", "openwork", "desktop-bootstrap.json");
 }
 

--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -7,7 +7,42 @@ OpenWork Cloud exposes a hosted MCP server at `https://api.openworklabs.com/mcp`
 
 The server uses OAuth. Your MCP client opens a browser, you sign in to OpenWork Cloud, choose the organization to authorize, and the client stores the returned token.
 
+## In the OpenWork desktop app
+
+If you use the OpenWork desktop app, there is nothing to configure. When you
+sign in to OpenWork Cloud, the app connects the `openwork-cloud` MCP for you
+with a token scoped to your active organization — no browser OAuth round-trip.
+You can see it under **Settings → Extensions** as **OpenWork Cloud Control**
+with a Ready status. Switching organizations refreshes the token
+automatically.
+
+## What you can ask the agent
+
+Once connected, your agent manages the organization from plain English in the
+composer. These flows are exercised end to end against a live OpenWork Cloud
+deployment (see `evals/cloud-mcp-agent-flows.md` in the repository):
+
+- **Check your cloud identity** — "Which OpenWork Cloud organization am I
+  connected to?" The agent reports the organization, your account, and your
+  role.
+- **Invite teammates** — "Add omar@example.com to my organization." The agent
+  sends the invitation, updates the allowed email domains when needed, and
+  surfaces seat-limit billing rules instead of failing silently.
+- **Manage teams** — "Assign Priya to the Sales team." Works for active
+  members; the agent explains when someone still has a pending invitation.
+- **Share skills with your org** — "Create a skill that writes weekly status
+  reports and share it with my whole organization." The agent writes the
+  `SKILL.md` locally, then creates a plugin, attaches the skill, publishes it
+  to your marketplace, and grants org-wide access — teammates see it in their
+  marketplace and install it with one click.
+
+Org policy still applies: invitations respect seat limits and domain rules,
+and resource creation follows your organization's roles.
+
 ## MCP config
+
+The manual configuration below is for **other MCP clients** (or the desktop
+app when signed out).
 
 Add this server to your MCP config:
 


### PR DESCRIPTION
## Summary
Follow-up to #2128. That PR added the `gmail.readonly` opt-in, but the checkbox was only visible when a custom OAuth client ID was already set via env var — there was no way to do that from the UI.

This adds an **Advanced** card to the Google Workspace settings panel:
- Inputs for your own Google OAuth desktop client ID + secret. Saving writes `OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_ID` and `GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET` to local env settings and restarts the local server.
- A **Grant read on Gmail** checkbox. Disabled (with a hint) while on the built-in OpenWork client; enabled once your own client is active. The server still rejects the scope for the built-in client, so this remains UI + server enforced.
- Refactored the env-save logic into a shared `saveOauthEnv` helper used by both the existing secret-only card and the new advanced card.

## Testing
- `pnpm typecheck` in `apps/app` — clean
- Verified in the running Electron dev app via CDP: opened Settings → Extensions → Google Workspace → View details; confirmed the Advanced card renders with client ID/secret inputs, Save and apply, and the disabled 'Grant read on Gmail' checkbox with the enable hint (screenshot below was captured during verification).

Not run: full OAuth round-trip with a real custom Google client (needs real Google Cloud credentials). Reviewer repro: paste a desktop client ID/secret in Advanced → Save and apply → checkbox becomes active → Connect requests gmail.readonly.