### PR TITLE
refactor(google-workspace): hide advanced OAuth options behind accordion

### DIFF
--- a/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
+++ b/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { CalendarDays, CheckCircle2, FileText, Loader2, MailPlus, ShieldCheck, XCircle } from "lucide-react";
 
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -381,62 +382,62 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
         </CardFooter>
       </Card>
 
-      <Card variant="outline" size="sm">
-        <CardHeader>
-          <CardTitle>Advanced</CardTitle>
-          <CardDescription>
-            Use your own Google OAuth client to unlock extra permissions, like reading Gmail.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {status?.customClient ? (
-            <Alert>
-              <CheckCircle2 />
-              <AlertTitle>Using your own Google OAuth client</AlertTitle>
-              <AlertDescription>Extra permissions below are available.</AlertDescription>
-            </Alert>
-          ) : (
-            <div className="space-y-3">
-              <Input
-                value={customClientId}
-                onChange={(event) => setCustomClientId(event.target.value)}
-                placeholder="Your Google OAuth desktop client ID"
-                autoComplete="off"
+      <Accordion>
+        <AccordionItem value="advanced">
+          <AccordionTrigger>Advanced</AccordionTrigger>
+          <AccordionContent className="space-y-4">
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              Use your own Google OAuth client to unlock extra permissions, like reading Gmail.
+            </p>
+            {status?.customClient ? (
+              <Alert>
+                <CheckCircle2 />
+                <AlertTitle>Using your own Google OAuth client</AlertTitle>
+                <AlertDescription>Extra permissions below are available.</AlertDescription>
+              </Alert>
+            ) : (
+              <div className="space-y-3">
+                <Input
+                  value={customClientId}
+                  onChange={(event) => setCustomClientId(event.target.value)}
+                  placeholder="Your Google OAuth desktop client ID"
+                  autoComplete="off"
+                />
+                <Input
+                  type="password"
+                  value={customClientSecret}
+                  onChange={(event) => setCustomClientSecret(event.target.value)}
+                  placeholder="Your Google OAuth desktop client secret"
+                  autoComplete="off"
+                />
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  Create a desktop OAuth client in Google Cloud Console, then paste its client ID and secret. They are saved locally in OpenWork environment settings and applied after the local server restarts.
+                </p>
+                <Button disabled={busyAction === "save-secret" || !customClientId.trim() || !customClientSecret.trim() || !hostServerAvailable} onClick={() => void saveCustomOauthClient()}>
+                  {busyAction === "save-secret" ? <Loader2 className="size-4 animate-spin" /> : null}
+                  Save and apply
+                </Button>
+              </div>
+            )}
+            <label className="flex items-start gap-2.5">
+              <Checkbox
+                checked={gmailRead}
+                onCheckedChange={(checked) => setGmailRead(checked === true)}
+                disabled={Boolean(busyAction) || status?.customClient !== true}
+                className="mt-0.5"
               />
-              <Input
-                type="password"
-                value={customClientSecret}
-                onChange={(event) => setCustomClientSecret(event.target.value)}
-                placeholder="Your Google OAuth desktop client secret"
-                autoComplete="off"
-              />
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                Create a desktop OAuth client in Google Cloud Console, then paste its client ID and secret. They are saved locally in OpenWork environment settings and applied after the local server restarts.
-              </p>
-              <Button disabled={busyAction === "save-secret" || !customClientId.trim() || !customClientSecret.trim() || !hostServerAvailable} onClick={() => void saveCustomOauthClient()}>
-                {busyAction === "save-secret" ? <Loader2 className="size-4 animate-spin" /> : null}
-                Save and apply
-              </Button>
-            </div>
-          )}
-          <label className="flex items-start gap-2.5">
-            <Checkbox
-              checked={gmailRead}
-              onCheckedChange={(checked) => setGmailRead(checked === true)}
-              disabled={Boolean(busyAction) || status?.customClient !== true}
-              className="mt-0.5"
-            />
-            <span className="min-w-0">
-              <span className="block text-sm font-medium text-card-foreground">Grant read on Gmail</span>
-              <span className="block text-xs leading-relaxed text-muted-foreground">
-                {status?.customClient
-                  ? "Requests read access to your Gmail messages the next time you connect a Google account. Already connected? Disconnect and connect again to grant it."
-                  : "Add your own Google OAuth client above to enable this option."}
+              <span className="min-w-0">
+                <span className="block text-sm font-medium text-card-foreground">Grant read on Gmail</span>
+                <span className="block text-xs leading-relaxed text-muted-foreground">
+                  {status?.customClient
+                    ? "Requests read access to your Gmail messages the next time you connect a Google account. Already connected? Disconnect and connect again to grant it."
+                    : "Add your own Google OAuth client above to enable this option."}
+                </span>
               </span>
-            </span>
-          </label>
-        </CardContent>
-      </Card>
+            </label>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Follow-up to #2137. The Advanced section (own Google OAuth client + 'Grant read on Gmail' checkbox) in the Google Workspace settings panel is now hidden behind an accordion for progressive disclosure — collapsed by default, expandable with one click. Uses the existing `@/components/ui/accordion` (Base UI) component.

## Testing
- `pnpm typecheck` in `apps/app` — clean
- Verified in the running Electron dev app via CDP: Settings → Extensions → Google Workspace → View details. Confirmed the Advanced accordion is collapsed by default (`aria-expanded=false`, content hidden from the DOM), and that expanding it reveals the client ID/secret inputs, Save and apply, and the Grant read on Gmail checkbox. Screenshot captured during verification.