### PR TITLE
fix(mcp): restore MCP quick-connect directory discoverability (regression from #2008)

### DIFF
--- a/apps/app/src/react-app/domains/settings/extension-items.ts
+++ b/apps/app/src/react-app/domains/settings/extension-items.ts
@@ -212,6 +212,21 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
       ...builtInItems.flatMap((item) => item.active && item.builtInEntry ? [item.builtInEntry] : []),
       ...standaloneMcpEntries,
     ],
+    // The MCP quick-connect surface ("Available apps · One-click connect")
+    // needs unconfigured directory entries too — otherwise Notion, Linear,
+    // OpenWork Cloud Control, etc. are undiscoverable for anyone who is not
+    // signed in to cloud (regression from #2008, which narrowed the section
+    // to installed entries only).
+    quickConnectEntries: [
+      ...builtInItems.flatMap((item) => item.active && item.builtInEntry ? [item.builtInEntry] : []),
+      ...standaloneMcpEntries,
+      ...input.quickConnect.filter((entry) => {
+        if (isBuiltInOpenWorkExtension(entry)) return false;
+        const serverName = getMcpServerName(entry);
+        if (groupedMcpServerNames.has(serverName)) return false;
+        return !input.mcpServers.some((server) => server.name === serverName);
+      }),
+    ],
     installedSkills: standaloneSkillItems.flatMap((item) => item.skill ? [item.skill] : []),
     installedCloudPlugins: Object.values(input.importedCloudPlugins),
   };

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2207,7 +2207,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 mcpConnectingName={connectionsSnapshot.mcpConnectingName}
                 selectedMcp={connectionsSnapshot.selectedMcp}
                 setSelectedMcp={(name) => connectionsStore.setSelectedMcp(name)}
-                quickConnect={extensionItems.installedMcpEntries}
+                quickConnect={extensionItems.quickConnectEntries}
                 enablementContext={enablementContext}
                 builtInExtensionsDisabled={builtInExtensionsDisabled}
                 connectMcp={(entry) => {

--- a/evals/flows/settings-extensions-mcp.flow.mjs
+++ b/evals/flows/settings-extensions-mcp.flow.mjs
@@ -1,11 +1,8 @@
 /**
  * The MCP settings view renders: connected built-in apps, the custom-app
- * entry point, and the My Extensions / Marketplace tabs.
- *
- * Note: as of #2008 the quick-connect *directory* (Notion, Linear, OpenWork
- * Cloud Control, ...) only lists configured entries here; discovery moved to
- * the Marketplace tab. Cloud MCP discoverability assertions will be added to
- * this flow when the cloud MCP becomes first-class.
+ * entry point, the My Extensions / Marketplace tabs, and — regression guard
+ * for #2008 — the unconfigured quick-connect directory (Notion, OpenWork
+ * Cloud Control, ...) so MCP discovery works without a cloud sign-in.
  */
 export default {
   id: "settings-extensions-mcp",
@@ -44,6 +41,14 @@ export default {
           "document.body.innerText.toLowerCase().includes('available apps')",
           { timeoutMs: 15_000, label: "available apps section" },
         );
+      },
+    },
+    {
+      name: "Unconfigured directory entries are discoverable",
+      run: async (ctx) => {
+        await ctx.waitForText("OpenWork Cloud Control", { timeoutMs: 15_000 });
+        const hasDirectoryEntry = (await ctx.hasText("Notion")) || (await ctx.hasText("Linear"));
+        ctx.assert(hasDirectoryEntry, "Expected at least one MCP directory entry (Notion/Linear) in quick connect.");
         await ctx.screenshot("mcp-view");
       },
     },


### PR DESCRIPTION
## Problem

Since #2008 narrowed the MCP settings quick-connect section to *installed* entries, the directory tiles (Notion, Linear, Sentry, Stripe, Context7, OpenWork Cloud Control, OpenWork UI Control) were **unreachable everywhere** for signed-out users: "My Extensions" showed only configured entries, and the Marketplace tab both requires cloud sign-in and never listed directory entries. One-click MCP connect was effectively dead for non-cloud users. First flagged by the eval runner in #2114; open since.

## Fix

`buildExtensionItems` now also produces `quickConnectEntries` = installed entries (unchanged ordering: active built-ins + configured servers first) **plus unconfigured, non-builtin directory entries** that aren't grouped into a cloud plugin. The settings MCP view consumes that instead of `installedMcpEntries`. The section is literally headed "Available apps · One-click connect" — it now lives up to it again. Installed-only semantics elsewhere are untouched (`installedMcpEntries` keeps its meaning and consumers).

## Testing (end-to-end, live Electron)

Extended the `settings-extensions-mcp` coded eval with a regression guard asserting OpenWork Cloud Control + Notion/Linear render in the quick-connect section — the exact assertion that caught the regression originally and had to be removed:

```
✓ App booted ✓ Navigate ✓ Tabs + custom app ✓ Available apps section
✓ Unconfigured directory entries are discoverable
Result: PASSED
```

`pnpm typecheck` (apps/app) passes.