### PR TITLE
perf(den): skip unchanged GitHub files and parallelize plugin import fetches

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
@@ -486,6 +486,49 @@ export async function getGithubRepositoryTextFile(input: {
   return Buffer.from(response.body.content.replace(/\n/g, ""), "base64").toString("utf8")
 }
 
+export type GithubImportFilePlan = {
+  lastSeenSourceRevisionRef: string | null
+  path: string
+  sourceFileRevisionRef: string | null
+  sourceRevisionRef: string
+}
+
+export type GithubImportFileFetchResult =
+  | { error: unknown; status: "failed" }
+  | { rawSourceText: string | null; status: "fetched" }
+  | { status: "skipped_unchanged" }
+
+export async function fetchGithubImportFilesWithRevisionGuard(input: {
+  concurrencyLimit?: number
+  fetchFile: (path: string) => Promise<string | null>
+  files: GithubImportFilePlan[]
+}): Promise<GithubImportFileFetchResult[]> {
+  const results = new Array<GithubImportFileFetchResult>(input.files.length)
+  let nextIndex = 0
+  const workerCount = Math.max(1, Math.min(input.concurrencyLimit ?? 6, input.files.length))
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < input.files.length) {
+      const index = nextIndex
+      nextIndex += 1
+      const file = input.files[index]
+      if (file.lastSeenSourceRevisionRef !== null
+        && (file.lastSeenSourceRevisionRef === file.sourceFileRevisionRef || file.lastSeenSourceRevisionRef === file.sourceRevisionRef)) {
+        // The bound source file already matches this revision: skip the contents API call entirely.
+        results[index] = { status: "skipped_unchanged" }
+        continue
+      }
+      try {
+        results[index] = { rawSourceText: await input.fetchFile(file.path), status: "fetched" }
+      } catch (error) {
+        // One file failing must not abort the others; the caller decides how to surface it.
+        results[index] = { error, status: "failed" }
+      }
+    }
+  })
+  await Promise.all(workers)
+  return results
+}
+
 export async function getGithubRepositoryTree(input: {
   branch: string
   config: GithubConnectorAppConfig

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -27,6 +27,7 @@ import { requirePluginArchResourceRole, resolvePluginArchResourceRole } from "./
 import {
   buildGithubAppInstallUrl,
   createGithubInstallStateToken,
+  fetchGithubImportFilesWithRevisionGuard,
   GithubConnectorConfigError,
   GithubConnectorRequestError,
   getGithubAppSummary,
@@ -107,6 +108,7 @@ type GithubConnectorDiscoveryTreeSummary = {
 }
 
 type GithubDiscoveryImportPlan = {
+  fileShaByPath?: Record<string, string>
   objectType: ConnectorMappingRow["objectType"]
   paths: string[]
   selector: string
@@ -2806,11 +2808,21 @@ function buildGithubConnectorDiscoverySteps(input: {
 function buildGithubDiscoveryImportPlans(input: { discoveredPlugins: GithubDiscoveredPlugin[]; treeEntries: GithubDiscoveryTreeEntry[] }) {
   return Object.fromEntries(input.discoveredPlugins.map((plugin) => [
     plugin.key,
-    discoveryMappingsForPlugin(plugin).map((mapping) => ({
-      objectType: mapping.objectType,
-      paths: importableGithubPathsForMapping({ mapping, treeEntries: input.treeEntries }).map((entry) => entry.path),
-      selector: mapping.selector,
-    } satisfies GithubDiscoveryImportPlan)),
+    discoveryMappingsForPlugin(plugin).map((mapping) => {
+      const entries = importableGithubPathsForMapping({ mapping, treeEntries: input.treeEntries })
+      const fileShaByPath: Record<string, string> = {}
+      for (const entry of entries) {
+        if (entry.sha) {
+          fileShaByPath[entry.path] = entry.sha
+        }
+      }
+      return {
+        fileShaByPath,
+        objectType: mapping.objectType,
+        paths: entries.map((entry) => entry.path),
+        selector: mapping.selector,
+      } satisfies GithubDiscoveryImportPlan
+    }),
   ])) satisfies Record<string, GithubDiscoveryImportPlan[]>
 }
 
@@ -3340,6 +3352,24 @@ function importedObjectMetadata(input: { objectType: ConnectorMappingRow["object
   }
 }
 
+async function findActiveConnectorSourceBinding(input: {
+  connectorMappingId: ConnectorMappingId
+  externalLocator: string
+  organizationId: OrganizationId
+}) {
+  const rows = await db
+    .select()
+    .from(ConnectorSourceBindingTable)
+    .where(and(
+      eq(ConnectorSourceBindingTable.organizationId, input.organizationId),
+      eq(ConnectorSourceBindingTable.connectorMappingId, input.connectorMappingId),
+      eq(ConnectorSourceBindingTable.externalLocator, input.externalLocator),
+      isNull(ConnectorSourceBindingTable.deletedAt),
+    ))
+    .limit(1)
+  return rows[0] ?? null
+}
+
 async function materializeGithubImportedObject(input: {
   connectorInstance: ReturnType<typeof serializeConnectorInstance>
   connectorMapping: ReturnType<typeof serializeConnectorMapping>
@@ -3348,6 +3378,7 @@ async function materializeGithubImportedObject(input: {
   context: PluginArchActorContext
   externalLocator: string
   rawSourceText: string
+  sourceFileRevisionRef?: string | null
   sourceRevisionRef: string
 }) {
   const organizationId = input.context.organizationContext.organization.id
@@ -3376,18 +3407,16 @@ async function materializeGithubImportedObject(input: {
   const fileName = input.externalLocator.split("/").filter(Boolean).at(-1) ?? input.externalLocator
   const fileExtension = fileName.includes(".") ? fileName.split(".").at(-1) ?? null : null
 
-  const existingBinding = await db
-    .select()
-    .from(ConnectorSourceBindingTable)
-    .where(and(
-      eq(ConnectorSourceBindingTable.organizationId, organizationId),
-      eq(ConnectorSourceBindingTable.connectorMappingId, input.connectorMapping.id),
-      eq(ConnectorSourceBindingTable.externalLocator, input.externalLocator),
-      isNull(ConnectorSourceBindingTable.deletedAt),
-    ))
-    .limit(1)
+  // Prefer the per-file blob sha when the tree snapshot provides one so an unchanged file can be
+  // skipped even when the head commit moved; fall back to the head revision otherwise.
+  const bindingRevisionRef = input.sourceFileRevisionRef ?? input.sourceRevisionRef
+  const existingBinding = await findActiveConnectorSourceBinding({
+    connectorMappingId: input.connectorMapping.id,
+    externalLocator: input.externalLocator,
+    organizationId,
+  })
 
-  if (!existingBinding[0]) {
+  if (!existingBinding) {
     const configObjectId = createDenTypeId("configObject")
     const versionId = createDenTypeId("configObjectVersion")
     await db.transaction(async (tx) => {
@@ -3462,7 +3491,7 @@ async function materializeGithubImportedObject(input: {
         externalLocator: input.externalLocator,
         externalStableRef: input.externalLocator,
         id: createDenTypeId("connectorSourceBinding"),
-        lastSeenSourceRevisionRef: input.sourceRevisionRef,
+        lastSeenSourceRevisionRef: bindingRevisionRef,
         organizationId,
         remoteId: input.connectorTarget.remoteId,
         status: "active",
@@ -3473,8 +3502,8 @@ async function materializeGithubImportedObject(input: {
     return getConfigObjectDetail(input.context, configObjectId)
   }
 
-  const binding = existingBinding[0]
-  if (binding.lastSeenSourceRevisionRef !== input.sourceRevisionRef) {
+  const binding = existingBinding
+  if (binding.lastSeenSourceRevisionRef !== bindingRevisionRef && binding.lastSeenSourceRevisionRef !== input.sourceRevisionRef) {
     const versionId = createDenTypeId("configObjectVersion")
     await db.transaction(async (tx) => {
       await tx.update(ConfigObjectTable).set({
@@ -3535,7 +3564,7 @@ async function materializeGithubImportedObject(input: {
 
       await tx.update(ConnectorSourceBindingTable).set({
         deletedAt: null,
-        lastSeenSourceRevisionRef: input.sourceRevisionRef,
+        lastSeenSourceRevisionRef: bindingRevisionRef,
         status: "active",
         updatedAt: now,
       }).where(eq(ConnectorSourceBindingTable.id, binding.id))
@@ -3550,7 +3579,7 @@ async function materializeGithubImportPlans(input: {
   connectorSyncEventId?: ConnectorSyncEventId
   connectorTarget: ReturnType<typeof serializeConnectorTarget>
   context: PluginArchActorContext
-  importPlans: Array<{ mapping: ReturnType<typeof serializeConnectorMapping>; paths: string[] }>
+  importPlans: Array<{ fileShaByPath?: Record<string, string>; mapping: ReturnType<typeof serializeConnectorMapping>; paths: string[] }>
   sourceRevisionRef: string
 }) {
   const config = githubConnectorAppConfig()
@@ -3570,36 +3599,68 @@ async function materializeGithubImportPlans(input: {
     config,
     installationId,
   })
+  const organizationId = input.context.organizationContext.organization.id
+  const plannedFiles = input.importPlans.flatMap((plan) => plan.paths.map((path) => ({
+    mapping: plan.mapping,
+    path,
+    sourceFileRevisionRef: plan.fileShaByPath?.[path] ?? null,
+  })))
+  const existingBindings = await Promise.all(plannedFiles.map((file) => findActiveConnectorSourceBinding({
+    connectorMappingId: file.mapping.id,
+    externalLocator: file.path,
+    organizationId,
+  })))
+  const fetchResults = await fetchGithubImportFilesWithRevisionGuard({
+    fetchFile: (path) => getGithubRepositoryTextFile({
+      config,
+      installationId,
+      path,
+      ref: branch,
+      repositoryFullName,
+      token,
+    }),
+    files: plannedFiles.map((file, index) => ({
+      lastSeenSourceRevisionRef: existingBindings[index]?.lastSeenSourceRevisionRef ?? null,
+      path: file.path,
+      sourceFileRevisionRef: file.sourceFileRevisionRef,
+      sourceRevisionRef: input.sourceRevisionRef,
+    })),
+  })
+
   const materializedConfigObjects: ReturnType<typeof serializeConfigObject>[] = []
-  for (const plan of input.importPlans) {
-    for (const path of plan.paths) {
-      let rawSourceText: string | null
-      try {
-        rawSourceText = await getGithubRepositoryTextFile({
-          config,
-          installationId,
-          path,
-          ref: branch,
-          repositoryFullName,
-          token,
-        })
-      } catch (error) {
-        wrapGithubConnectorError(error)
-      }
-      if (!rawSourceText) {
-        continue
-      }
-      materializedConfigObjects.push(await materializeGithubImportedObject({
-        connectorInstance: input.connectorInstance,
-        connectorMapping: plan.mapping,
-        connectorSyncEventId: input.connectorSyncEventId,
-        connectorTarget: input.connectorTarget,
-        context: input.context,
-        externalLocator: path,
-        rawSourceText,
-        sourceRevisionRef: input.sourceRevisionRef,
-      }))
+  let firstFetchFailure: { error: unknown } | null = null
+  for (const [index, file] of plannedFiles.entries()) {
+    const result = fetchResults[index]
+    if (result.status === "failed") {
+      firstFetchFailure = firstFetchFailure ?? { error: result.error }
+      continue
     }
+    if (result.status === "skipped_unchanged") {
+      // The file content is already materialized at this revision: no fetch, no new version.
+      const binding = existingBindings[index]
+      if (binding) {
+        materializedConfigObjects.push(await getConfigObjectDetail(input.context, binding.configObjectId))
+      }
+      continue
+    }
+    if (!result.rawSourceText) {
+      continue
+    }
+    materializedConfigObjects.push(await materializeGithubImportedObject({
+      connectorInstance: input.connectorInstance,
+      connectorMapping: file.mapping,
+      connectorSyncEventId: input.connectorSyncEventId,
+      connectorTarget: input.connectorTarget,
+      context: input.context,
+      externalLocator: file.path,
+      rawSourceText: result.rawSourceText,
+      sourceFileRevisionRef: file.sourceFileRevisionRef,
+      sourceRevisionRef: input.sourceRevisionRef,
+    }))
+  }
+
+  if (firstFetchFailure) {
+    wrapGithubConnectorError(firstFetchFailure.error)
   }
 
   return materializedConfigObjects
@@ -3861,7 +3922,7 @@ export async function applyGithubConnectorDiscovery(input: { autoImportNewPlugin
 
   const plugins = [] as Array<ReturnType<typeof serializePlugin>>
   const mappings = [] as Array<ReturnType<typeof serializeConnectorMapping>>
-  const importPlans = [] as Array<{ mapping: ReturnType<typeof serializeConnectorMapping>; paths: string[] }>
+  const importPlans = [] as Array<{ fileShaByPath?: Record<string, string>; mapping: ReturnType<typeof serializeConnectorMapping>; paths: string[] }>
   for (const discoveredPlugin of selectedPlugins) {
     const plugin = await ensureDiscoveryPlugin({
       context: input.context,
@@ -3888,7 +3949,7 @@ export async function applyGithubConnectorDiscovery(input: { autoImportNewPlugin
         selector: plan.selector,
       })
       mappings.push(mapping)
-      importPlans.push({ mapping, paths: plan.paths })
+      importPlans.push({ fileShaByPath: plan.fileShaByPath, mapping, paths: plan.paths })
     }
   }
 

--- a/ee/apps/den-api/test/github-connector-app.test.ts
+++ b/ee/apps/den-api/test/github-connector-app.test.ts
@@ -4,9 +4,12 @@ import {
   buildGithubAppInstallUrl,
   createGithubInstallStateToken,
   createGithubAppJwt,
+  fetchGithubImportFilesWithRevisionGuard,
   getGithubAppSummary,
   getGithubConnectorAppConfig,
   getGithubInstallationSummary,
+  getGithubRepositoryTextFile,
+  GithubConnectorRequestError,
   listGithubInstallationRepositories,
   normalizeGithubPrivateKey,
   validateGithubInstallationTarget,
@@ -140,6 +143,92 @@ describe("github connector app helpers", () => {
       repositorySelection: "all",
       settingsUrl: null,
     })
+  })
+
+  test("skips content fetches for files already seen at the current revision", async () => {
+    const contentRequests: string[] = []
+    const fetchFile = (path: string) => getGithubRepositoryTextFile({
+      config: { appId: "123456", privateKey: privateKeyPem },
+      fetchFn: async (url) => {
+        contentRequests.push(String(url))
+        const content = Buffer.from(`# imported from ${path}`).toString("base64")
+        return new Response(JSON.stringify({ content, encoding: "base64" }), { status: 200 })
+      },
+      installationId: 777,
+      path,
+      ref: "main",
+      repositoryFullName: "different-ai/openwork",
+      token: "installation-token",
+    })
+
+    const results = await fetchGithubImportFilesWithRevisionGuard({
+      fetchFile,
+      files: [
+        // Same per-file blob sha: unchanged even though the head commit moved.
+        { lastSeenSourceRevisionRef: "blob-a", path: "skills/a/SKILL.md", sourceFileRevisionRef: "blob-a", sourceRevisionRef: "head-2" },
+        // Legacy binding storing the head sha: unchanged when the head sha matches.
+        { lastSeenSourceRevisionRef: "head-2", path: "skills/b/SKILL.md", sourceFileRevisionRef: null, sourceRevisionRef: "head-2" },
+        // Blob sha changed: must be refetched.
+        { lastSeenSourceRevisionRef: "blob-c-old", path: "skills/c/SKILL.md", sourceFileRevisionRef: "blob-c-new", sourceRevisionRef: "head-2" },
+        // No binding yet: must be fetched.
+        { lastSeenSourceRevisionRef: null, path: "skills/d/SKILL.md", sourceFileRevisionRef: "blob-d", sourceRevisionRef: "head-2" },
+      ],
+    })
+
+    expect(results).toEqual([
+      { status: "skipped_unchanged" },
+      { status: "skipped_unchanged" },
+      { rawSourceText: "# imported from skills/c/SKILL.md", status: "fetched" },
+      { rawSourceText: "# imported from skills/d/SKILL.md", status: "fetched" },
+    ])
+    expect(contentRequests).toEqual([
+      "https://api.github.com/repos/different-ai/openwork/contents/skills/c/SKILL.md?ref=main",
+      "https://api.github.com/repos/different-ai/openwork/contents/skills/d/SKILL.md?ref=main",
+    ])
+  })
+
+  test("parallel fetching matches sequential results, keeps ordering, and isolates per-file failures", async () => {
+    const files = Array.from({ length: 12 }, (_, index) => ({
+      lastSeenSourceRevisionRef: null,
+      path: `skills/skill-${index}/SKILL.md`,
+      sourceFileRevisionRef: null,
+      sourceRevisionRef: "head-1",
+    }))
+    let fetchCount = 0
+    let inFlight = 0
+    let maxInFlight = 0
+    const fetchFile = async (path: string) => {
+      fetchCount += 1
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      // Stagger completion so results can settle out of order.
+      await new Promise((resolve) => setTimeout(resolve, path.includes("skill-2") || path.includes("skill-9") ? 15 : 1))
+      inFlight -= 1
+      if (path.includes("skill-7")) {
+        throw new GithubConnectorRequestError("GitHub file request failed.", 500)
+      }
+      return path.includes("skill-4") ? null : `content of ${path}`
+    }
+
+    const parallel = await fetchGithubImportFilesWithRevisionGuard({ fetchFile, files })
+    const parallelMaxInFlight = maxInFlight
+    expect(fetchCount).toBe(12)
+    expect(parallelMaxInFlight).toBeGreaterThan(1)
+    expect(parallelMaxInFlight).toBeLessThanOrEqual(6)
+
+    maxInFlight = 0
+    inFlight = 0
+    const sequential = await fetchGithubImportFilesWithRevisionGuard({ concurrencyLimit: 1, fetchFile, files })
+    expect(maxInFlight).toBe(1)
+
+    // Deterministic ordering: results line up with the input order regardless of completion order.
+    expect(parallel).toEqual(sequential)
+    expect(parallel[7]).toEqual({ error: new GithubConnectorRequestError("GitHub file request failed.", 500), status: "failed" })
+    expect(parallel.map((result) => result.status)).toEqual([
+      "fetched", "fetched", "fetched", "fetched", "fetched", "fetched", "fetched", "failed", "fetched", "fetched", "fetched", "fetched",
+    ])
+    expect(parallel[4]).toEqual({ rawSourceText: null, status: "fetched" })
+    expect(parallel[0]).toEqual({ rawSourceText: "content of skills/skill-0/SKILL.md", status: "fetched" })
   })
 
   test("validates repository identity and branch existence against GitHub", async () => {


### PR DESCRIPTION
## What

Makes the Den cloud GitHub→plugin import pipeline incremental and parallel:

- **Pre-fetch revision guard**: before fetching file content during materialization, the existing ConnectorSourceBinding's `lastSeenSourceRevisionRef` is compared against the per-file blob sha (from the tree snapshot, falling back to head sha). Unchanged files are never refetched — a push touching 1 file in a 50-component plugin now costs 1 contents-API call instead of 50.
- **Concurrency-limited parallel fetching** (limit 6, zero-dependency worker pool) with deterministic result ordering; a single failing file no longer aborts sibling files (still surfaced as failed in summaries).
- Bindings now store blob shas when available; guard accepts either blob or head sha, so mixed old/new bindings never produce spurious versions.

## Tests

- `bun test` (full den-api suite): **43 pass / 0 fail** — locally and inside a Daytona sandbox
- `pnpm exec tsc --noEmit` (den-api): clean
- New tests: unchanged files produce zero contents-API requests (counted via fake GitHub server); parallel (limit 6) result deep-equals sequential (limit 1); failure isolation; in-flight concurrency bounded
- Daytona UI eval suite (regression smoke): 4 pass / 0 fail / 2 skip (cloud-cred flows)

## Evidence

Daytona run recording: https://8090-zftpox4th8a2wmxo.daytonaproxy01.net/recordings/discovery-throughput.mp4

## Caveats

First sync after deploy refetches once while bindings migrate from head-sha to blob-sha refs; old discovery caches fall back to head-sha comparison (less granular, never incorrect).