### PR TITLE
feat(cloud-plugins): translate Claude agent/command frontmatter and fix fallback removal parity

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -177,6 +177,12 @@ export type OpenworkWorkspaceFileWriteResult = {
   revision?: string;
 };
 
+export type OpenworkWorkspaceFileDeleteResult = {
+  ok: boolean;
+  path: string;
+  code?: string;
+};
+
 export type OpenworkAuthorizedFoldersResponse = {
   folders: string[];
   hiddenCount: number;
@@ -1523,6 +1529,48 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
           body: payload,
         },
       ),
+
+    deleteWorkspaceFiles: async (
+      workspaceId: string,
+      files: Array<{ path: string; recursive?: boolean }>,
+    ): Promise<OpenworkWorkspaceFileDeleteResult[]> => {
+      if (files.length === 0) return [];
+      const created = await requestJson<{ session: { id: string } }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/files/sessions`,
+        { token, hostToken, method: "POST", body: { write: true } },
+      );
+      const sessionId = created.session.id;
+      try {
+        const result = await requestJson<{ items: Array<{ ok?: boolean; path?: string; code?: string }> }>(
+          baseUrl,
+          `/files/sessions/${encodeURIComponent(sessionId)}/ops`,
+          {
+            token,
+            hostToken,
+            method: "POST",
+            body: {
+              operations: files.map((file) => ({
+                type: "delete",
+                path: file.path,
+                recursive: file.recursive === true,
+              })),
+            },
+          },
+        );
+        return result.items.map((item, index) => ({
+          ok: item.ok === true,
+          path: typeof item.path === "string" ? item.path : files[index]?.path ?? "",
+          ...(typeof item.code === "string" ? { code: item.code } : {}),
+        }));
+      } finally {
+        await requestJson<{ ok: boolean }>(baseUrl, `/files/sessions/${encodeURIComponent(sessionId)}`, {
+          token,
+          hostToken,
+          method: "DELETE",
+        }).catch(() => undefined);
+      }
+    },
 
     writeWorkspaceBinaryFile: (
       workspaceId: string,

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -159,6 +159,126 @@ function extractSkillBodyMarkdown(skillText: string): string {
   return rest.slice(end + 4).replace(/^\s*\n?/, "");
 }
 
+function stripYamlScalarQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseClaudeFrontmatter(text: string): { data: Record<string, unknown>; body: string } {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) return { data: {}, body: trimmed };
+  const data: Record<string, unknown> = {};
+  let listKey: string | null = null;
+  for (const line of (match[1] ?? "").split(/\r?\n/)) {
+    if (listKey) {
+      const listItem = line.match(/^\s+-\s*(.*)$/);
+      if (listItem) {
+        const entry = stripYamlScalarQuotes(listItem[1] ?? "");
+        const current = data[listKey];
+        if (entry && Array.isArray(current)) current.push(entry);
+        continue;
+      }
+    }
+    const keyMatch = line.match(/^([A-Za-z0-9_-]+):(.*)$/);
+    if (!keyMatch) continue;
+    const key = keyMatch[1] ?? "";
+    const value = (keyMatch[2] ?? "").trim();
+    if (!value) {
+      data[key] = [];
+      listKey = key;
+      continue;
+    }
+    listKey = null;
+    data[key] = value === "true" ? true : value === "false" ? false : stripYamlScalarQuotes(value);
+  }
+  return { data, body: trimmed.slice(match[0].length) };
+}
+
+const OPENCODE_MODEL_ID_RE = /^[^\s/]+\/[^\s]+$/;
+
+function translateClaudeTools(value: unknown): Record<string, boolean> | null {
+  const names = typeof value === "string"
+    ? value.split(",")
+    : Array.isArray(value)
+      ? value.flatMap((entry) => (typeof entry === "string" ? [entry] : []))
+      : null;
+  if (names) {
+    const tools: Record<string, boolean> = {};
+    for (const raw of names) {
+      const name = raw.trim().toLowerCase();
+      if (name) tools[name] = true;
+    }
+    return Object.keys(tools).length ? tools : null;
+  }
+  if (isRecord(value)) {
+    const tools: Record<string, boolean> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      const name = key.trim().toLowerCase();
+      if (name && typeof entry === "boolean") tools[name] = entry;
+    }
+    return Object.keys(tools).length ? tools : null;
+  }
+  return null;
+}
+
+function translateClaudeModel(value: unknown): string | null {
+  const model = readNonEmptyString(value);
+  return model && OPENCODE_MODEL_ID_RE.test(model) ? model : null;
+}
+
+function buildCloudPluginFrontmatter(data: Record<string, string | boolean | Record<string, boolean>>): string {
+  const lines: string[] = ["---"];
+  for (const [key, value] of Object.entries(data)) {
+    if (typeof value === "string") {
+      lines.push(`${key}: ${JSON.stringify(value)}`);
+    } else if (typeof value === "boolean") {
+      lines.push(`${key}: ${value}`);
+    } else {
+      lines.push(`${key}:`);
+      for (const [name, enabled] of Object.entries(value)) {
+        lines.push(`  ${JSON.stringify(name)}: ${enabled}`);
+      }
+    }
+  }
+  lines.push("---");
+  return lines.join("\n") + "\n";
+}
+
+function buildCloudAgentContent(description: string, rawSourceText: string): string {
+  const { data, body } = parseClaudeFrontmatter(rawSourceText);
+  const safeDescription = (readNonEmptyString(data.description) ?? description).replace(/\s+/g, " ").trim();
+  const model = translateClaudeModel(data.model);
+  const tools = translateClaudeTools(data.tools);
+  const frontmatter = buildCloudPluginFrontmatter({
+    description: safeDescription,
+    ...(model ? { model } : {}),
+    ...(tools ? { tools } : {}),
+  });
+  return frontmatter + "\n" + body.replace(/^\s*\n?/, "");
+}
+
+function buildCloudCommandContent(name: string, description: string, rawSourceText: string): string {
+  const { data, body } = parseClaudeFrontmatter(rawSourceText);
+  const safeDescription = (readNonEmptyString(data.description) ?? description).replace(/\s+/g, " ").trim();
+  const model = translateClaudeModel(data.model);
+  const agent = readNonEmptyString(data.agent);
+  const frontmatter = buildCloudPluginFrontmatter({
+    name,
+    description: safeDescription,
+    ...(agent ? { agent } : {}),
+    ...(model ? { model } : {}),
+    ...(typeof data.subtask === "boolean" ? { subtask: data.subtask } : {}),
+  });
+  return frontmatter + "\n" + body.replace(/^\s*\n?/, "");
+}
+
 function slugifyOpencodeSkillName(title: string): string {
   let base = title
     .trim()
@@ -1031,6 +1151,29 @@ export function createExtensionsStore(options: {
     throw new Error("OpenWork server unavailable. Connect to import plugin files into this workspace.");
   };
 
+  const deletePluginWorkspaceFiles = async (files: Array<{ path: string; recursive?: boolean }>) => {
+    if (files.length === 0) return;
+    const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
+      await resolveWorkspaceServerTarget();
+    if (
+      hasOpenworkTarget &&
+      openworkClient &&
+      openworkWorkspaceId &&
+      openworkSnapshot.openworkServerCapabilities?.config?.write !== false &&
+      typeof openworkClient.deleteWorkspaceFiles === "function"
+    ) {
+      const results = await openworkClient.deleteWorkspaceFiles(openworkWorkspaceId, files);
+      const failed = results.filter((result) => !result.ok && result.code !== "file_not_found");
+      if (failed.length > 0) {
+        throw new Error(
+          `Failed to remove ${failed.length} imported plugin file${failed.length === 1 ? "" : "s"} from the workspace.`,
+        );
+      }
+      return;
+    }
+    throw new Error("OpenWork server unavailable. Connect to remove imported plugin files from this workspace.");
+  };
+
   const applyCloudOrgPluginImport = async (
     marketplaceId: string | null,
     resolved: DenOrgPluginResolved,
@@ -1069,11 +1212,16 @@ export function createExtensionsStore(options: {
 
       const path = getPluginObjectInstallPath(object, namespace);
       let content = version.rawSourceText;
+      const rawDesc = (object.description?.trim() || object.title).trim();
+      const description = rawDesc.slice(0, 1024) || object.title.slice(0, 1024);
       if (object.objectType === "skill") {
-        const rawDesc = (object.description?.trim() || object.title).trim();
-        const description = rawDesc.slice(0, 1024) || object.title.slice(0, 1024) || "Skill";
         const installName = path.match(/^\.opencode\/skills\/[^/]+\/([^/]+)\/SKILL\.md$/)?.[1] ?? slugifyConfigObjectName(object.title, object.id);
-        content = buildCloudSkillContent(installName, description, extractSkillBodyMarkdown(content));
+        content = buildCloudSkillContent(installName, description || "Skill", extractSkillBodyMarkdown(content));
+      } else if (object.objectType === "agent") {
+        content = buildCloudAgentContent(description, content);
+      } else if (object.objectType === "command") {
+        const fileName = path.match(/\/([^/]+)\.md$/)?.[1] ?? object.title;
+        content = buildCloudCommandContent(slugifyConfigObjectName(fileName, object.id), description, content);
       }
       await writePluginWorkspaceFile(path, content);
 
@@ -1562,17 +1710,20 @@ export function createExtensionsStore(options: {
       const imported = snapshot.importedCloudPlugins[pluginId];
       if (!imported) throw new Error("Marketplace package is not installed in this workspace.");
 
-      const removedSkillNames = imported.files.flatMap((file) => {
-        if (file.objectType !== "skill") return [];
-        const name = file.path.match(/^\.opencode\/skills\/(?:[^/]+\/)?([^/]+)\/SKILL\.md$/)?.[1];
-        return name ? [name] : [];
-      });
-      await Promise.all(removedSkillNames.map((name) => deleteWorkspaceSkill(name).catch(() => undefined)));
-      const removedMcpNames = imported.files.flatMap((file) => {
-        const name = file.objectType === "mcp" ? cloudPluginMcpNameFromPath(file.path) : null;
-        return name ? [name] : [];
-      });
+      const removedMcpNames: string[] = [];
+      const fileDeletes: Array<{ path: string; recursive?: boolean }> = [];
+      for (const file of imported.files) {
+        const mcpName = file.objectType === "mcp" ? cloudPluginMcpNameFromPath(file.path) : null;
+        if (mcpName) {
+          removedMcpNames.push(mcpName);
+          continue;
+        }
+        if (!file.path.startsWith(".opencode/")) continue;
+        const skillDir = file.path.match(/^(\.opencode\/skills\/[^/]+\/[^/]+)\/SKILL\.md$/)?.[1];
+        fileDeletes.push(skillDir ? { path: skillDir, recursive: true } : { path: file.path });
+      }
       await Promise.all(removedMcpNames.map((name) => deletePluginMcpConfig(name)));
+      await deletePluginWorkspaceFiles(fileDeletes);
 
       const nextPlugins = { ...snapshot.importedCloudPlugins };
       delete nextPlugins[pluginId];
@@ -1581,8 +1732,7 @@ export function createExtensionsStore(options: {
       if (removedMcpNames.length > 0) {
         options.markReloadRequired?.("mcp", { type: "mcp", name: imported.name, action: "removed" });
       }
-      const removedManagedCount = removedSkillNames.length + removedMcpNames.length;
-      if (imported.files.length > removedManagedCount) {
+      if (fileDeletes.length > 0) {
         options.markReloadRequired?.("config", { type: "config", name: imported.name, action: "removed" });
       }
       await Promise.all([
@@ -1590,10 +1740,7 @@ export function createExtensionsStore(options: {
         refreshCloudOrgMarketplaces({ force: true }),
       ]);
 
-      const partial = imported.files.length > removedManagedCount
-        ? " Non-skill and non-MCP files remain in the workspace and can be removed manually."
-        : "";
-      return { ok: true, message: `Removed ${imported.name}.${partial}` };
+      return { ok: true, message: `Removed ${imported.name}.` };
     } catch (error) {
       const message = error instanceof Error ? error.message : t("skills.unknown_error");
       options.setError(addOpencodeCacheHint(message));

--- a/apps/server/src/cloud-plugins.test.ts
+++ b/apps/server/src/cloud-plugins.test.ts
@@ -120,4 +120,163 @@ describe("cloud plugin installs", () => {
       await expectMissing(skillPath);
     });
   });
+
+  test("translates Claude agent and command frontmatter and removes every installed file", async () => {
+    await withWorkspace(async ({ root, config }) => {
+      const agentSource = [
+        "---",
+        "name: Code-Reviewer",
+        "description: Reviews pull requests",
+        "tools: Read, Grep, Bash",
+        "model: sonnet",
+        "---",
+        "",
+        "Review the diff carefully.",
+      ].join("\n");
+      const commandSource = [
+        "---",
+        "description: Generate release notes",
+        "model: opus",
+        "allowed-tools: Bash(git log:*)",
+        "---",
+        "",
+        "Summarize commits since the last tag.",
+      ].join("\n");
+
+      const imported = await installCloudPlugin({
+        serverConfig: config,
+        workspaceId: WORKSPACE_ID,
+        workspaceRoot: root,
+        marketplaceId: null,
+        resolved: {
+          plugin: {
+            id: "plugin_2",
+            name: "Review Plugin",
+            description: "Review workflow",
+            updatedAt: null,
+          },
+          memberships: [
+            {
+              configObjectId: "config_agent_1",
+              configObject: {
+                id: "config_agent_1",
+                objectType: "agent",
+                title: "Fancy Code Reviewer!",
+                description: "Agent that reviews code",
+                currentRelativePath: null,
+                status: "active",
+                updatedAt: null,
+                latestVersion: { id: "version_agent_1", rawSourceText: agentSource, normalizedPayloadJson: null },
+              },
+            },
+            {
+              configObjectId: "config_command_1",
+              configObject: {
+                id: "config_command_1",
+                objectType: "command",
+                title: "Release Notes",
+                description: "Writes release notes",
+                currentRelativePath: null,
+                status: "active",
+                updatedAt: null,
+                latestVersion: { id: "version_command_1", rawSourceText: commandSource, normalizedPayloadJson: null },
+              },
+            },
+            {
+              configObjectId: "config_context_1",
+              configObject: {
+                id: "config_context_1",
+                objectType: "context",
+                title: "Style Guide",
+                description: null,
+                currentRelativePath: null,
+                status: "active",
+                updatedAt: null,
+                latestVersion: { id: "version_context_1", rawSourceText: "# Style Guide", normalizedPayloadJson: null },
+              },
+            },
+          ],
+        },
+      });
+
+      const agentPath = join(root, ".opencode", "agents", "review-plugin", "fancy-code-reviewer.md");
+      const commandPath = join(root, ".opencode", "commands", "review-plugin", "release-notes.md");
+      const contextPath = join(root, ".opencode", "context", "review-plugin", "style-guide.md");
+      expect(imported.files.map((file) => file.path).sort()).toEqual([
+        ".opencode/agents/review-plugin/fancy-code-reviewer.md",
+        ".opencode/commands/review-plugin/release-notes.md",
+        ".opencode/context/review-plugin/style-guide.md",
+      ]);
+
+      const agentContent = await readFile(agentPath, "utf8");
+      expect(agentContent).toContain("description: Reviews pull requests");
+      expect(agentContent).toContain("tools:");
+      expect(agentContent).toContain("read: true");
+      expect(agentContent).toContain("grep: true");
+      expect(agentContent).toContain("bash: true");
+      expect(agentContent).not.toContain("model:");
+      expect(agentContent).not.toContain("Read, Grep, Bash");
+      expect(agentContent).toContain("Review the diff carefully.");
+
+      const commandContent = await readFile(commandPath, "utf8");
+      expect(commandContent).toContain("name: release-notes");
+      expect(commandContent).toContain("description: Generate release notes");
+      expect(commandContent).not.toContain("model:");
+      expect(commandContent).not.toContain("allowed-tools");
+      expect(commandContent).toContain("Summarize commits since the last tag.");
+
+      await removeCloudPlugin({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root, pluginId: "plugin_2" });
+      expect((await readInstalledCloudPlugins(config, WORKSPACE_ID)).plugins.plugin_2).toBeUndefined();
+      await expectMissing(agentPath);
+      await expectMissing(commandPath);
+      await expectMissing(contextPath);
+    });
+  });
+
+  test("keeps fully qualified model ids and tool lists when translating agent frontmatter", async () => {
+    await withWorkspace(async ({ root, config }) => {
+      const agentSource = [
+        "---",
+        "description: Triage agent",
+        "model: opencode/claude-haiku-4-5",
+        "tools:",
+        "  - Read",
+        "  - WebFetch",
+        "---",
+        "",
+        "Triage issues.",
+      ].join("\n");
+
+      await installCloudPlugin({
+        serverConfig: config,
+        workspaceId: WORKSPACE_ID,
+        workspaceRoot: root,
+        marketplaceId: null,
+        resolved: {
+          plugin: { id: "plugin_3", name: "Triage Plugin", description: null, updatedAt: null },
+          memberships: [
+            {
+              configObjectId: "config_agent_2",
+              configObject: {
+                id: "config_agent_2",
+                objectType: "agent",
+                title: "Triage",
+                description: null,
+                currentRelativePath: null,
+                status: "active",
+                updatedAt: null,
+                latestVersion: { id: "version_agent_2", rawSourceText: agentSource, normalizedPayloadJson: null },
+              },
+            },
+          ],
+        },
+      });
+
+      const agentPath = join(root, ".opencode", "agents", "triage-plugin", "triage.md");
+      const agentContent = await readFile(agentPath, "utf8");
+      expect(agentContent).toContain("model: opencode/claude-haiku-4-5");
+      expect(agentContent).toContain("read: true");
+      expect(agentContent).toContain("webfetch: true");
+    });
+  });
 });

--- a/apps/server/src/cloud-plugins.ts
+++ b/apps/server/src/cloud-plugins.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import type { ServerConfig } from "./types.js";
 import { ApiError } from "./errors.js";
+import { parseFrontmatter, buildFrontmatter } from "./frontmatter.js";
 import { addMcp, removeMcp } from "./mcp.js";
 import { ensureDir } from "./utils.js";
 
@@ -281,6 +282,71 @@ function buildCloudSkillContent(name: string, description: string, body: string)
     "",
     normalizedBody,
   ].join("\n");
+}
+
+const OPENCODE_MODEL_ID_RE = /^[^\s/]+\/[^\s]+$/;
+
+function translateClaudeTools(value: unknown): Record<string, boolean> | null {
+  const names = typeof value === "string"
+    ? value.split(",")
+    : Array.isArray(value)
+      ? value.flatMap((entry) => (typeof entry === "string" ? [entry] : []))
+      : null;
+  if (names) {
+    const tools: Record<string, boolean> = {};
+    for (const raw of names) {
+      const name = raw.trim().toLowerCase();
+      if (name) tools[name] = true;
+    }
+    return Object.keys(tools).length ? tools : null;
+  }
+  if (isRecord(value)) {
+    const tools: Record<string, boolean> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      const name = key.trim().toLowerCase();
+      if (name && typeof entry === "boolean") tools[name] = entry;
+    }
+    return Object.keys(tools).length ? tools : null;
+  }
+  return null;
+}
+
+function translateClaudeModel(value: unknown): string | null {
+  const model = readString(value);
+  return model && OPENCODE_MODEL_ID_RE.test(model) ? model : null;
+}
+
+function cloudConfigObjectDescription(object: CloudPluginConfigObject): string {
+  const rawDesc = (object.description?.trim() || object.title).trim();
+  return rawDesc.slice(0, 1024) || object.title.slice(0, 1024);
+}
+
+function buildCloudAgentContent(description: string, rawSourceText: string): string {
+  const { data, body } = parseFrontmatter(rawSourceText.trim());
+  const safeDescription = (readString(data.description) ?? description).replace(/\s+/g, " ").trim();
+  const model = translateClaudeModel(data.model);
+  const tools = translateClaudeTools(data.tools);
+  const frontmatter = buildFrontmatter({
+    description: safeDescription,
+    ...(model ? { model } : {}),
+    ...(tools ? { tools } : {}),
+  });
+  return frontmatter + "\n" + body.replace(/^\s*\n?/, "");
+}
+
+function buildCloudCommandContent(name: string, description: string, rawSourceText: string): string {
+  const { data, body } = parseFrontmatter(rawSourceText.trim());
+  const safeDescription = (readString(data.description) ?? description).replace(/\s+/g, " ").trim();
+  const model = translateClaudeModel(data.model);
+  const agent = readString(data.agent);
+  const frontmatter = buildFrontmatter({
+    name,
+    description: safeDescription,
+    ...(agent ? { agent } : {}),
+    ...(model ? { model } : {}),
+    ...(typeof data.subtask === "boolean" ? { subtask: data.subtask } : {}),
+  });
+  return frontmatter + "\n" + body.replace(/^\s*\n?/, "");
 }
 
 function pluginMcpName(rawName: string, namespace: string, fallback: string, namespaceName: boolean): string {
@@ -568,10 +634,14 @@ export async function installCloudPlugin(input: {
     const path = getPluginObjectInstallPath(object, namespace);
     let content = version.rawSourceText;
     if (object.objectType === "skill") {
-      const rawDesc = (object.description?.trim() || object.title).trim();
-      const description = rawDesc.slice(0, 1024) || object.title.slice(0, 1024) || "Skill";
+      const description = cloudConfigObjectDescription(object) || "Skill";
       const installName = path.match(/^\.opencode\/skills\/[^/]+\/([^/]+)\/SKILL\.md$/)?.[1] ?? slugifyConfigObjectName(object.title, object.id);
       content = buildCloudSkillContent(installName, description, extractSkillBodyMarkdown(content));
+    } else if (object.objectType === "agent") {
+      content = buildCloudAgentContent(cloudConfigObjectDescription(object), content);
+    } else if (object.objectType === "command") {
+      const fileName = path.match(/\/([^/]+)\.md$/)?.[1] ?? object.title;
+      content = buildCloudCommandContent(slugifyConfigObjectName(fileName, object.id), cloudConfigObjectDescription(object), content);
     }
     await writePluginWorkspaceFile(input.workspaceRoot, path, content);
     files.push({


### PR DESCRIPTION
## What

Improves the Claude-plugin → OpenCode mapping layer:

- **Agent/command frontmatter translation** (mirroring existing skill handling): Claude `tools: "Read, Grep, Bash"` → OpenCode tools map `{read: true, grep: true, bash: true}`; model aliases (`sonnet`/`opus`/`haiku`) dropped instead of written as invalid ids; names slugified; `agent`/`subtask` carried over; markdown body untouched. Format grounded in repo evidence (`.opencode/agents/*.md`, `openwork-runtime-config.ts`, `commands.ts`)
- **Fallback removal parity**: the renderer fallback now deletes every file the import wrote (agents/commands/hooks/tools/context — previously only skills + MCPs, orphaning the rest). Uses existing file-session endpoints via a new `deleteWorkspaceFiles` client method, so it works against deployed servers
- Same translation applied in the renderer fallback import path (matching the existing duplication pattern)

## Tests

- `bun test src/cloud-plugins.test.ts` (apps/server): 3 pass / 30 expects — locally and on Daytona
- Full apps/server suite: 187 pass, 2 pre-existing failures (bun + better-sqlite3, confirmed identical on baseline via stash)
- `pnpm typecheck` (apps/server, apps/app): clean
- Daytona coded eval suite (regression smoke incl. extensions surfaces): 4 pass / 0 fail / 2 skip

## Evidence

Daytona run recording: https://8090-cejnmtpmhbchqzx9.daytonaproxy01.net/recordings/claude-mapping-parity.mp4

## Caveats

Renderer-side frontmatter parser is a minimal flat-YAML parser (nested maps ignored → tools treated as absent); server side uses the real yaml parser. Fallback removal now fails loudly (record kept for retry) instead of silently orphaning files.