### PR TITLE
fix(ci): install Bun in nightly eval smoke workflow

### DIFF
--- a/.github/workflows/nightly-evals.yml
+++ b/.github/workflows/nightly-evals.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           version: 11.4.0
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
       - name: Install OpenCode CLI
         shell: bash
         env:


### PR DESCRIPTION
## Why

The nightly eval smoke run failed: https://github.com/different-ai/openwork/actions/runs/27261110025/job/80506786376

```
OpenCode sidecar updated to 1.16.2.
/bin/sh: 1: bun: not found
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @openwork/desktop@0.15.4 dev: node ./scripts/electron-dev.mjs
```

`pnpm dev` runs `apps/desktop/scripts/prepare-sidecar.mjs`, which builds the orchestrator sidecar with `bun` (spawnSync at prepare-sidecar.mjs:441). The nightly-evals runner never installs Bun, so the Electron app never starts and CDP never comes up.

## Fix

Add the same `oven-sh/setup-bun@v2` (1.3.9) step already used by `build-electron-desktop.yml`.

## Testing

- `yaml-lint .github/workflows/nightly-evals.yml` — passes.
- This is CI-only YAML; the real verification is a workflow_dispatch run of Nightly Eval Smoke after merge (workflow runs from the default branch for scheduled/dispatch triggers).