### PR TITLE
fix(evals): skip analytics-task-events on un-onboarded profiles

### DIFF
--- a/evals/flows/analytics-task-events.flow.mjs
+++ b/evals/flows/analytics-task-events.flow.mjs
@@ -6,12 +6,32 @@
  * instrumentation without any analytics backend or network access.
  *
  * Requires an onboarded profile with at least one workspace (so the
- * session.create_task control action is available).
+ * session.create_task control action is available). On fresh profiles the
+ * app sits on the welcome screen and the flow skips instead of failing.
  */
 export default {
   id: "analytics-task-events",
   title: "Analytics events fire for app open and task creation",
   spec: "evals/react-session-flows.md",
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 60_000,
+      label: "control API",
+    });
+    const state = await ctx.waitFor(
+      `(() => {
+        const control = window.__openworkControl;
+        if (control.snapshot().route.startsWith("/welcome")) return "welcome";
+        const action = control.listActions().find((a) => a.id === "session.create_task");
+        if (action && !action.disabled) return "ready";
+        return null;
+      })()`,
+      { timeoutMs: 30_000, label: "session.create_task enabled (or welcome screen)" },
+    );
+    return state === "welcome"
+      ? "Profile is not onboarded (welcome screen, no workspace); session.create_task is unavailable."
+      : null;
+  },
   steps: [
     {
       name: "App booted",

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -89,6 +89,27 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
   const ctx = new EvalContext({ client, outDir, flowId: flow.id, env });
 
   try {
+    if (typeof flow.precondition === "function") {
+      const startedAt = Date.now();
+      try {
+        const skipReason = await flow.precondition(ctx);
+        if (skipReason) {
+          result.status = "skipped";
+          result.skipReason = String(skipReason);
+          return result;
+        }
+      } catch (error) {
+        result.status = "failed";
+        result.steps.push({
+          name: "Precondition",
+          status: "failed",
+          durationMs: Date.now() - startedAt,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        await ctx.screenshot("failure").catch(() => undefined);
+        return result;
+      }
+    }
     for (const step of flow.steps) {
       const stepResult = { name: step.name, status: "passed", durationMs: 0, error: null };
       const startedAt = Date.now();


### PR DESCRIPTION
## Why

After #2144 fixed the missing Bun install, the Nightly Eval Smoke verification run (https://github.com/different-ai/openwork/actions/runs/27281736308) got further but still failed:

```
✗ Create a task via control action (30130ms) — Timed out after 30000ms waiting for: session.create_task action available
```

CI boots a pristine app (no profile, no workspace), so the app redirects to `/welcome`. `SessionRoute` — the only registrar of `session.create_task` — never stays mounted, and the flow times out. The flow's own doc comment already says it requires an onboarded profile; CI just doesn't satisfy it. This matches the workflow's stated philosophy that flows skip cleanly when their prerequisites are absent.

## Fix

- `evals/runner/run.mjs`: support an optional `flow.precondition(ctx)` that returns a skip reason (flow reported as skipped) and treats precondition errors as a clean per-flow failure instead of crashing the runner.
- `evals/flows/analytics-task-events.flow.mjs`: skip when the app is on the welcome screen; otherwise wait for an **enabled** `session.create_task` action (checking `disabled` also avoids the race where the action registers transiently before the welcome redirect, and would fail at execute).

## Testing

Ran locally against real Electron dev builds via CDP:

1. **Pristine profile (reproduces CI):** `OPENWORK_ELECTRON_USERDATA=$(mktemp -d) OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9824 pnpm dev`, then `node evals/runner/run.mjs --flow analytics-task-events --cdp-url http://127.0.0.1:9824`:
   ```
   ⏭ skipped: Profile is not onboarded (welcome screen, no workspace); session.create_task is unavailable.
   Result: PASSED — 0 passed, 0 failed, 1 skipped
   ```
2. **Onboarded dev profile:** same flow passes end-to-end:
   ```
   ✓ App booted / ✓ app_opened captured / ✓ Create a task via control action (404ms) / ✓ task_created captured
   Result: PASSED — 1 passed, 0 failed, 0 skipped
   ```
3. `node evals/runner/run.mjs --all --cdp-url ...` on the pristine app: analytics flow skips, app-smoke / cloud-account-renders / settings-extensions-mcp pass. `extensions-marketplace-updates` flaked once when run in sequence locally (passes in isolation and passed in CI) — pre-existing, unrelated to this change.

No video captured (headed local Electron run); reproduce with the commands above. Final verification will be a `workflow_dispatch` of Nightly Eval Smoke after merge.