### PR TITLE
fix(google-workspace): explain why built-in client ID cannot unlock Gmail read

### DIFF
--- a/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
+++ b/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
@@ -24,6 +24,8 @@ type BusyAction = "status" | "connect" | "disconnect" | "set-active" | "test" | 
 type GoogleWorkspaceCommand = () => Promise<unknown>;
 const DESKTOP_ACTION_TIMEOUT_MS = 6 * 60 * 1000;
 const CONNECT_POLL_INTERVAL_MS = 1_000;
+// Must match GOOGLE_WORKSPACE_DESKTOP_CLIENT_ID in apps/server/src/extensions/google-workspace.ts.
+const OPENWORK_BUILTIN_GOOGLE_CLIENT_ID = "929071212606-pmkqimjhm2tnp68kbklnout0irllj99h.apps.googleusercontent.com";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -198,6 +200,10 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
     const secret = customClientSecret.trim();
     if (!id || !secret) {
       setError("Enter both the client ID and client secret from your own Google OAuth desktop client.");
+      return;
+    }
+    if (id === OPENWORK_BUILTIN_GOOGLE_CLIENT_ID) {
+      setError("That is the built-in OpenWork client ID, which cannot unlock Gmail read access. Create your own OAuth client in Google Cloud Console (APIs & Services > Credentials > Create OAuth client ID > Desktop app) and paste its client ID here.");
       return;
     }
     await saveOauthEnv(


### PR DESCRIPTION
## Summary
Follow-up to #2137/#2138. A user pasted the built-in OpenWork desktop client ID into the Advanced 'your own OAuth client' fields. It saved silently, `customClient` stayed false (by design), and the 'Grant read on Gmail' checkbox stayed disabled with no explanation.

Now `saveCustomOauthClient` rejects the built-in client ID up front with a clear message: it cannot unlock Gmail read access, plus the exact Google Cloud Console path to create their own desktop OAuth client. Nothing is written to env settings and no server restart is triggered.

## Testing
- `pnpm typecheck` in `apps/app` — clean
- Verified in the running Electron dev app via CDP: expanded Advanced, filled the built-in client ID + a secret, clicked Save and apply, and confirmed the explanatory error renders and no save occurs.