### PR TITLE
feat(app): emit task lifecycle telemetry events to Den (Analytics Layer 2)

### DIFF
--- a/apps/app/src/app/lib/den-telemetry.ts
+++ b/apps/app/src/app/lib/den-telemetry.ts
@@ -16,9 +16,16 @@ import { type DenSettings, readDenSettings, resolveDenBaseUrls } from "./den";
 const INGEST_PATH = "/v1/telemetry/ingest";
 const INGEST_TIMEOUT_MS = 5_000;
 
-type TelemetryEvent = {
+type TelemetryEventFields = {
+  sessionId?: string;
+  durationMs?: number;
+  success?: boolean;
+};
+
+type TelemetryEvent = TelemetryEventFields & {
   type: string;
   timestamp: string;
+  source: "app";
 };
 
 let pendingEvents: TelemetryEvent[] = [];
@@ -89,13 +96,15 @@ function scheduleFlush(): void {
  * Track a telemetry event. The event is batched and flushed periodically.
  * If the user is not signed into Den, the event is silently dropped.
  */
-export function trackTelemetryEvent(type: string): void {
+export function trackTelemetryEvent(type: string, fields: TelemetryEventFields = {}): void {
   const settings = readDenSettings();
   if (!settings.authToken) return;
 
   pendingEvents.push({
     type,
     timestamp: new Date().toISOString(),
+    source: "app",
+    ...fields,
   });
 
   if (pendingEvents.length >= MAX_BATCH_SIZE) {
@@ -109,8 +118,30 @@ export function trackTelemetryEvent(type: string): void {
  * Track that the user started an OpenCode session.
  * This is the primary "are people actually using the app" signal.
  */
-export function trackSessionActive(): void {
-  trackTelemetryEvent("session.active");
+export function trackSessionActive(sessionId?: string): void {
+  trackTelemetryEvent("session.active", { sessionId });
+}
+
+/**
+ * Track that a task run started in a session.
+ * Carries only an opaque session id -- never prompt text or file paths.
+ */
+export function trackTaskStarted(sessionId: string): void {
+  trackTelemetryEvent("task.started", { sessionId });
+}
+
+/**
+ * Track that a task run finished successfully.
+ */
+export function trackTaskCompleted(sessionId: string, durationMs: number): void {
+  trackTelemetryEvent("task.completed", { sessionId, durationMs, success: true });
+}
+
+/**
+ * Track that a task run errored.
+ */
+export function trackTaskFailed(sessionId: string, durationMs: number): void {
+  trackTelemetryEvent("task.failed", { sessionId, durationMs, success: false });
 }
 
 /**

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -3,6 +3,7 @@ import type { FilePart, Part, PermissionRequest, QuestionRequest, Session, Sessi
 
 import { getReactQueryClient } from "../../../infra/query-client";
 import { captureAnalyticsEvent, takeTaskRunStart } from "@/app/lib/analytics";
+import { trackTaskCompleted, trackTaskFailed } from "@/app/lib/den-telemetry";
 import { createClient } from "@/app/lib/opencode";
 import { normalizeEvent } from "@/app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX, type OpencodeEvent, type PendingPermission, type PendingQuestion } from "@/app/types";
@@ -583,6 +584,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
         captureAnalyticsEvent("task_run_errored", {
           duration_ms: Date.now() - runStartedAt,
         });
+        trackTaskFailed(sessionId, Date.now() - runStartedAt);
       }
       useSessionActivityStore.getState().setError(workspaceId, sessionId, errorText);
       if (isTrackedSession(entry, sessionId)) {
@@ -831,6 +833,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       captureAnalyticsEvent("task_run_completed", {
         duration_ms: Date.now() - runStartedAt,
       });
+      trackTaskCompleted(props.sessionID, Date.now() - runStartedAt);
     }
     useSessionActivityStore.getState().setRunStatus(workspaceId, props.sessionID, idleStatus);
     const tracked = isTrackedSession(entry, props.sessionID);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -16,7 +16,7 @@ import type {
 } from "@opencode-ai/sdk/v2/client";
 
 import { captureAnalyticsEvent, markTaskRunStart } from "@/app/lib/analytics";
-import { trackSessionActive } from "@/app/lib/den-telemetry";
+import { trackSessionActive, trackTaskStarted } from "@/app/lib/den-telemetry";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { abortSessionSafe, forkSession, listCommands, revertSession, setSessionArchived, shellInSession } from "@/app/lib/opencode-session";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
@@ -790,10 +790,11 @@ export function SessionRoute() {
           model_id: local.prefs.defaultModel?.modelID ?? null,
         });
         markTaskRunStart(targetSessionId);
-        // Den org adoption signal (auth-gated inside; no-op when signed out).
+        // Den org adoption signals (auth-gated inside; no-op when signed out).
         // Lives here — the live send choke point — because its previous call
         // site was in the orphaned actions-store and never fired.
-        trackSessionActive();
+        trackSessionActive(targetSessionId);
+        trackTaskStarted(targetSessionId);
 
         if (draft.mode === "shell") {
           await shellInSession(opencodeClient, targetSessionId, text);


### PR DESCRIPTION
## What

Third PR of the **OpenWork Analytics** stack (with #2148 server and #2149 dashboard). The desktop/web app now emits real Layer 2 usage signals to `POST /v1/telemetry/ingest`:

- `apps/app/src/app/lib/den-telemetry.ts`: events carry `source: "app"`, optional `sessionId`, `durationMs`, `success`; new helpers `trackTaskStarted/Completed/Failed`
- Send path (`session-route.tsx`): `task.started` on each send; `session.active` now carries the session id so the server can count **distinct sessions per week**
- Run lifecycle (`session-sync.ts`): `task.completed` / `task.failed` with run duration on `session.idle` / `session.error`, reusing the existing `markTaskRunStart`/`takeTaskRunStart` bookkeeping (so it only fires for runs this client instrumented, deduped across workspace syncs)

Privacy unchanged: auth-gated (no-op when signed out of Den), fire-and-forget, batched; only event names, opaque session ids, durations, and success flags — never prompts, code, or file paths.

**Compatibility:** safe to merge independently of #2148 — the current server's zod ingest schema strips unknown fields, so older servers simply ignore the new fields; with #2148 deployed they're stored and aggregated.

## Tests

Commands run:

- `pnpm typecheck` (`@openwork/app`) — passes
- `bun test` in `apps/app` — 109 pass / 4 fail; the 4 failures (`artifact-spreadsheet`, `artifacts`) are **pre-existing on the base commit** (verified by running the same tests on an untouched `origin/dev` worktree — same failures)
- The exact event payload shape produced here (`task.started`/`task.completed`/`task.failed` with `sessionId`/`durationMs`/`success`) was verified end-to-end against the new server in #2148: ingested via `POST /v1/telemetry/ingest` (204), stored, and correctly aggregated by `GET /v1/telemetry/analytics` (distinct sessions, success rates, avg duration)

No video for this PR: the change is invisible in the UI (background telemetry). To reproduce manually: run the local Den stack (`pnpm dev:den`) with #2148, sign in to Den in the app, send a prompt, and watch rows appear in `telemetry_event` and the numbers move on the #2149 Analytics page.