### PR TITLE
ci(den-db): automated Drizzle migrations for PlanetScale

### DIFF
--- a/.github/workflows/den-db-check.yml
+++ b/.github/workflows/den-db-check.yml
@@ -1,0 +1,45 @@
+name: Den DB Check
+
+on:
+  pull_request:
+    paths:
+      - "ee/packages/den-db/**"
+
+permissions:
+  contents: read
+
+jobs:
+  migrations-in-sync:
+    name: Schema and migrations in sync
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.4.0
+
+      - name: Install dependencies
+        run: pnpm install --filter "@openwork-ee/den-db..."
+
+      - name: Generate migrations from schema
+        run: pnpm --filter @openwork-ee/den-db db:generate
+
+      - name: Fail if schema changed without a committed migration
+        run: |
+          set -euo pipefail
+          changes="$(git status --porcelain -- ee/packages/den-db/drizzle)"
+          if [ -n "$changes" ]; then
+            echo "$changes"
+            echo "::error::Schema changed without a committed migration. Run 'pnpm --filter @openwork-ee/den-db db:generate' locally and commit the generated files in ee/packages/den-db/drizzle."
+            exit 1
+          fi
+          echo "Migrations are in sync with the schema."

--- a/.github/workflows/den-db-migrate.yml
+++ b/.github/workflows/den-db-migrate.yml
@@ -1,0 +1,104 @@
+name: Den DB Migrate
+
+# Applies Drizzle migrations to the production PlanetScale database.
+#
+# Required GitHub Actions secrets (Settings -> Secrets and variables -> Actions):
+#   DATABASE_HOST       PlanetScale host (e.g. aws.connect.psdb.cloud)
+#   DATABASE_USERNAME   PlanetScale branch password username
+#   DATABASE_PASSWORD   PlanetScale branch password
+#
+# Runs automatically when migration files land on dev, and manually via
+# workflow_dispatch. For a database previously managed with db:push (no
+# __drizzle_migrations table yet), run once manually with baseline=true
+# to record existing migrations as applied without executing them.
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - "ee/packages/den-db/drizzle/**"
+  workflow_dispatch:
+    inputs:
+      baseline:
+        description: "One-time: mark existing migrations as applied without executing them (for a db previously managed via db:push)"
+        type: boolean
+        default: false
+      baseline_through:
+        description: "Baseline through this migration tag (default: latest, e.g. 0020_breezy_siren)"
+        type: string
+        required: false
+      dry_run:
+        description: "Print what would happen without applying migrations"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: den-db-migrate
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: Apply migrations
+    if: github.repository == 'different-ai/openwork'
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+
+    env:
+      DATABASE_HOST: ${{ secrets.DATABASE_HOST }}
+      DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
+      DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+
+    steps:
+      - name: Verify database secrets are configured
+        run: |
+          set -euo pipefail
+          missing=""
+          [ -z "$DATABASE_HOST" ] && missing="$missing DATABASE_HOST"
+          [ -z "$DATABASE_USERNAME" ] && missing="$missing DATABASE_USERNAME"
+          [ -z "$DATABASE_PASSWORD" ] && missing="$missing DATABASE_PASSWORD"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing GitHub Actions secrets:$missing. Add them under Settings -> Secrets and variables -> Actions."
+            exit 1
+          fi
+          echo "Database secrets present."
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.4.0
+
+      - name: Install dependencies
+        run: pnpm install --filter "@openwork-ee/den-db..."
+
+      - name: Baseline existing migrations (one-time)
+        if: github.event_name == 'workflow_dispatch' && inputs.baseline
+        run: |
+          set -euo pipefail
+          extra=""
+          if [ -n "${{ inputs.baseline_through }}" ]; then
+            extra="--through ${{ inputs.baseline_through }}"
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            pnpm --filter @openwork-ee/den-db db:baseline -- $extra
+          else
+            pnpm --filter @openwork-ee/den-db db:baseline -- --yes $extra
+          fi
+
+      - name: Apply migrations
+        if: github.event_name != 'workflow_dispatch' || !inputs.dry_run
+        run: pnpm --filter @openwork-ee/den-db db:migrate
+
+      - name: Dry run note
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+        run: echo "Dry run requested -- skipped 'db:migrate'. Baseline output above (if enabled) shows the plan."

--- a/ee/packages/den-db/.env.example
+++ b/ee/packages/den-db/.env.example
@@ -1,14 +1,16 @@
-# MySQL mode: if DATABASE_URL is set, den-db uses mysql/mysql2.
-DATABASE_URL=
-
-# Required dedicated DB encryption key for encrypted columns. Minimum 32 chars.
-# Generate one with: openssl rand -base64 128
-DEN_DB_ENCRYPTION_KEY=
-
-# PlanetScale mode: used when DATABASE_URL is not set.
+# Den DB credentials.
+#
+# Local use: copy this file to .env.local (gitignored) and fill in the values.
+# CI use: create GitHub Actions secrets with the SAME names
+#   (Settings -> Secrets and variables -> Actions) for the
+#   .github/workflows/den-db-migrate.yml workflow.
+#
+# PlanetScale connection (host/username/password from a PlanetScale
+# password for the production branch):
 DATABASE_HOST=
 DATABASE_USERNAME=
 DATABASE_PASSWORD=
 
-# Optional explicit env file path for Drizzle commands.
-# OPENWORK_DEN_DB_ENV_PATH=/absolute/path/to/.env.production
+# Alternative: a single MySQL connection URL (takes precedence over the
+# trio above; used by the local docker dev stack):
+# DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_den

--- a/ee/packages/den-db/.env.example
+++ b/ee/packages/den-db/.env.example
@@ -1,16 +1,22 @@
 # Den DB credentials.
 #
 # Local use: copy this file to .env.local (gitignored) and fill in the values.
-# CI use: create GitHub Actions secrets with the SAME names
-#   (Settings -> Secrets and variables -> Actions) for the
-#   .github/workflows/den-db-migrate.yml workflow.
-#
-# PlanetScale connection (host/username/password from a PlanetScale
-# password for the production branch):
+# CI use: the .github/workflows/den-db-migrate.yml workflow reads GitHub
+# Actions secrets with the SAME names (Settings -> Secrets and variables ->
+# Actions): DATABASE_HOST, DATABASE_USERNAME, DATABASE_PASSWORD.
+
+# MySQL mode: if DATABASE_URL is set, den-db uses mysql/mysql2.
+DATABASE_URL=
+
+# Required dedicated DB encryption key for encrypted columns. Minimum 32 chars.
+# Generate one with: openssl rand -base64 128
+DEN_DB_ENCRYPTION_KEY=
+
+# PlanetScale mode: used when DATABASE_URL is not set.
+# Values come from a PlanetScale password for the production branch.
 DATABASE_HOST=
 DATABASE_USERNAME=
 DATABASE_PASSWORD=
 
-# Alternative: a single MySQL connection URL (takes precedence over the
-# trio above; used by the local docker dev stack):
-# DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_den
+# Optional explicit env file path for Drizzle commands.
+# OPENWORK_DEN_DB_ENV_PATH=/absolute/path/to/.env.production

--- a/ee/packages/den-db/README.md
+++ b/ee/packages/den-db/README.md
@@ -29,8 +29,54 @@ Run Drizzle migrations against a configured database:
 pnpm --dir ee/packages/den-db db:migrate
 ```
 
+## Automated migrations (CI)
+
+Two GitHub Actions workflows keep schema and database in sync:
+
+- `.github/workflows/den-db-check.yml` — on every PR touching this package,
+  runs `db:generate` and fails if the schema changed without a committed
+  migration.
+- `.github/workflows/den-db-migrate.yml` — applies migrations to the
+  production PlanetScale database when migration files land on `dev`
+  (and via manual `workflow_dispatch`).
+
+The migrate workflow reads these repository secrets (same names as the
+local env vars — see `.env.example`):
+
+| Secret | Value |
+| --- | --- |
+| `DATABASE_HOST` | PlanetScale host (e.g. `aws.connect.psdb.cloud`) |
+| `DATABASE_USERNAME` | PlanetScale branch password username |
+| `DATABASE_PASSWORD` | PlanetScale branch password |
+
+### One-time baseline
+
+A database previously managed with `db:push` has no `__drizzle_migrations`
+table, so the first `db:migrate` would try to replay every migration.
+Record the existing history once (marks migrations as applied without
+executing them):
+
+```bash
+pnpm --dir ee/packages/den-db db:baseline           # dry run
+pnpm --dir ee/packages/den-db db:baseline -- --yes  # record
+```
+
+Or run the `Den DB Migrate` workflow manually with `baseline: true`
+(use `dry_run: true` first to see the plan).
+
+### Migration policy
+
+Migrations run **before** new code deploys, so they must be
+expand/contract safe: additive columns are nullable or defaulted, no
+renames or drops while old code still reads the schema, contract steps
+ship as a later migration once no deployed code references the old shape.
+
 ## Notes
 
+- The migration chain has no `0000` baseline (history starts at `0001`,
+  which alters pre-existing tables), so an empty database cannot be built
+  by replaying migrations. Create fresh databases with `db:push` (dev) and
+  use `db:baseline` + `db:migrate` for databases that already have the schema.
 - `db:generate` is the default path for new migration files.
 - `drizzle/meta/` must stay in sync with the SQL migration history so future generation stays incremental.
 - Only repair `drizzle/meta/` manually when recovering broken Drizzle history.

--- a/ee/packages/den-db/drizzle.config.ts
+++ b/ee/packages/den-db/drizzle.config.ts
@@ -33,6 +33,8 @@ function resolveDrizzleDbCredentials() {
     host,
     user,
     password,
+    // PlanetScale requires TLS for MySQL-protocol connections.
+    ssl: { rejectUnauthorized: true },
   }
 }
 

--- a/ee/packages/den-db/package.json
+++ b/ee/packages/den-db/package.json
@@ -75,6 +75,7 @@
   "scripts": {
     "build": "pnpm run build:utils && tsup",
     "build:utils": "pnpm --dir ../utils run build",
+    "db:baseline": "node --import tsx scripts/baseline-migrations.ts",
     "db:generate": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs generate --config drizzle.config.ts",
     "db:migrate": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs migrate --config drizzle.config.ts",
     "db:push": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs push --config drizzle.config.ts"

--- a/ee/packages/den-db/scripts/baseline-migrations.ts
+++ b/ee/packages/den-db/scripts/baseline-migrations.ts
@@ -1,0 +1,143 @@
+/**
+ * One-time baseline for databases that were previously managed with
+ * `db:push` (state-based) and have no `__drizzle_migrations` table.
+ *
+ * Marks existing migrations as applied WITHOUT executing them, so a
+ * subsequent `db:migrate` only runs migrations newer than the baseline.
+ *
+ * Usage:
+ *   pnpm --filter @openwork-ee/den-db db:baseline              # dry run
+ *   pnpm --filter @openwork-ee/den-db db:baseline -- --yes     # apply
+ *   pnpm --filter @openwork-ee/den-db db:baseline -- --yes --through 0020_breezy_siren
+ *
+ * Connects with DATABASE_URL (mysql2) or DATABASE_HOST/DATABASE_USERNAME/
+ * DATABASE_PASSWORD (PlanetScale HTTP driver) -- same as the rest of den-db.
+ */
+import "../src/load-env.ts"
+import crypto from "node:crypto"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const MIGRATIONS_TABLE = "__drizzle_migrations"
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const drizzleDir = path.join(packageDir, "drizzle")
+
+type JournalEntry = {
+  idx: number
+  when: number
+  tag: string
+}
+
+type Executor = {
+  query: (sql: string, args?: (string | number)[]) => Promise<Record<string, unknown>[]>
+  close: () => Promise<void>
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2)
+  const apply = args.includes("--yes")
+  const throughIndex = args.indexOf("--through")
+  const through = throughIndex >= 0 ? args[throughIndex + 1] : undefined
+  return { apply, through }
+}
+
+async function createExecutor(): Promise<Executor> {
+  const databaseUrl = process.env.DATABASE_URL?.trim()
+
+  if (databaseUrl) {
+    const mysql = await import("mysql2/promise")
+    const connection = await mysql.createConnection(databaseUrl)
+    return {
+      query: async (sql, args = []) => {
+        const [rows] = await connection.query(sql, args)
+        return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : []
+      },
+      close: () => connection.end(),
+    }
+  }
+
+  const host = process.env.DATABASE_HOST?.trim()
+  const username = process.env.DATABASE_USERNAME?.trim()
+  const password = process.env.DATABASE_PASSWORD ?? ""
+
+  if (!host || !username) {
+    throw new Error("Provide DATABASE_URL, or DATABASE_HOST/DATABASE_USERNAME/DATABASE_PASSWORD (see .env.example)")
+  }
+
+  const { Client } = await import("@planetscale/database")
+  const client = new Client({ host, username, password })
+  return {
+    query: async (sql, args = []) => {
+      const result = await client.execute(sql, args)
+      return result.rows as Record<string, unknown>[]
+    },
+    close: async () => {},
+  }
+}
+
+async function main() {
+  const { apply, through } = parseArgs()
+
+  const journal = JSON.parse(readFileSync(path.join(drizzleDir, "meta", "_journal.json"), "utf8")) as {
+    entries: JournalEntry[]
+  }
+  const entries = [...journal.entries].sort((a, b) => a.when - b.when)
+
+  if (entries.length === 0) {
+    console.log("No migrations in journal; nothing to baseline.")
+    return
+  }
+
+  const throughEntry = through ? entries.find((e) => e.tag === through) : entries[entries.length - 1]
+  if (!throughEntry) {
+    throw new Error(`--through tag "${through}" not found in drizzle/meta/_journal.json`)
+  }
+
+  const executor = await createExecutor()
+  try {
+    await executor.query(
+      `create table if not exists \`${MIGRATIONS_TABLE}\` (id serial primary key, hash text not null, created_at bigint)`,
+    )
+
+    const rows = await executor.query(`select max(created_at) as latest from \`${MIGRATIONS_TABLE}\``)
+    const latestRaw = rows[0]?.latest
+    const latest = latestRaw == null ? 0 : Number(latestRaw)
+
+    const pending = entries.filter((e) => e.when > latest && e.when <= throughEntry.when)
+
+    console.log(`Baseline target: ${throughEntry.tag} (when=${throughEntry.when})`)
+    console.log(`Already recorded through: created_at=${latest || "none"}`)
+    console.log(`Entries to mark as applied (without executing): ${pending.length}`)
+    for (const entry of pending) {
+      console.log(`  - ${entry.tag}`)
+    }
+
+    if (pending.length === 0) {
+      console.log("Nothing to do.")
+      return
+    }
+
+    if (!apply) {
+      console.log("\nDry run. Re-run with --yes to record the baseline.")
+      return
+    }
+
+    for (const entry of pending) {
+      const sqlContents = readFileSync(path.join(drizzleDir, `${entry.tag}.sql`), "utf8")
+      const hash = crypto.createHash("sha256").update(sqlContents).digest("hex")
+      await executor.query(`insert into \`${MIGRATIONS_TABLE}\` (hash, created_at) values (?, ?)`, [hash, entry.when])
+      console.log(`Recorded ${entry.tag}`)
+    }
+
+    console.log(`\nBaseline complete. 'db:migrate' will now only apply migrations newer than ${throughEntry.tag}.`)
+  } finally {
+    await executor.close()
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})


### PR DESCRIPTION
## What

Automated database migrations for the Den stack (PlanetScale prod). No telemetry/analytics changes in this PR — clean off `dev`.

### New workflows

- **`.github/workflows/den-db-check.yml`** — on every PR touching `ee/packages/den-db/**`: runs `db:generate` and fails if it produces changes (schema edited without a committed migration). No secrets needed.
- **`.github/workflows/den-db-migrate.yml`** — applies `db:migrate` to production:
  - automatically on push to `dev` when `ee/packages/den-db/drizzle/**` changes
  - manually via `workflow_dispatch`, with `baseline` / `baseline_through` / `dry_run` inputs
  - guarded: fails fast with a clear message if secrets are missing; `concurrency` group prevents overlapping runs; skipped on forks

### Required GitHub Actions secrets (fill these in)

Same names as the local env vars in `ee/packages/den-db/.env.example`:

| Secret | Value |
| --- | --- |
| `DATABASE_HOST` | PlanetScale host (e.g. `aws.connect.psdb.cloud`) |
| `DATABASE_USERNAME` | PlanetScale branch password username |
| `DATABASE_PASSWORD` | PlanetScale branch password |

### Supporting changes

- **`db:baseline` script** (`ee/packages/den-db/scripts/baseline-migrations.ts`): prod was historically managed with `db:push`, so it has no `__drizzle_migrations` table — the first `db:migrate` would replay all 20 migrations and fail. The baseline records existing migrations as applied **without executing them** (matches drizzle's exact tracking semantics: sha256 hash + journal `when` timestamp). Dry-run by default, `--yes` to write, `--through <tag>` to baseline partially.
- **`drizzle.config.ts`**: the `DATABASE_HOST/USERNAME/PASSWORD` credential path now sets `ssl: { rejectUnauthorized: true }` — PlanetScale requires TLS for MySQL-protocol connections, previously this path would fail from CI.
- **README**: workflow docs, baseline guide, expand/contract migration policy (migrations run before code deploys).

### Rollout (after merging)

1. Fill the three secrets in repo settings.
2. Run **Den DB Migrate** manually once with `baseline: true, dry_run: true` → check the printed plan (should list 0001–0020).
3. Re-run with `baseline: true, dry_run: false` → records the baseline and runs `db:migrate` (no-op).
4. Done — future migration files landing on `dev` apply automatically. (PR #2148's `0021` telemetry migration would be the first real consumer.)

## Tests

Commands run (all locally, since prod secrets are intentionally not mine to set):

- `pnpm --filter @openwork-ee/den-db db:generate` on a clean tree → "No schema changes", `git status --porcelain -- ee/packages/den-db/drizzle` empty → **check workflow logic verified**
- Simulated prod (local Docker MySQL `openwork_den`, created via `db:push`, no `__drizzle_migrations` table — same state as prod):
  - `db:baseline` (dry run) → printed plan listing all 20 migrations
  - `db:baseline -- --yes` → recorded 20 rows (`count=20`, `max(created_at)=1780426749385` = journal `when` of `0020`)
  - `db:migrate` → "migrations applied successfully" with nothing to replay ✓
- Negative test: full replay on an **empty** DB fails at `0001` (`ALTER TABLE worker ... doesn't exist`) — confirms the chain has no `0000` baseline; documented in the README (fresh DBs use `db:push`, existing DBs use baseline + migrate).

Not tested (requires the PlanetScale secrets): the TLS connection from CI to PlanetScale itself. The `dry_run` dispatch input exists exactly so the first prod run can be validated safely — happy to run it once the secrets are filled.

No video: CLI/CI-only change; full command transcripts above reproduce everything.