### PR TITLE
fix(google-workspace): save custom client ID under non-reserved env key

### DIFF
--- a/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
+++ b/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
@@ -208,7 +208,7 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
     }
     await saveOauthEnv(
       [
-        { key: "OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_ID", value: id },
+        { key: "GOOGLE_WORKSPACE_OAUTH_CLIENT_ID", value: id },
         { key: "GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", value: secret },
       ],
       () => {


### PR DESCRIPTION
## Summary
Saving your own OAuth client in the Advanced section failed with 'Environment variable name is reserved for OpenWork internals'. The UI wrote `OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_ID`, but the user env store rejects all `OPENWORK_`/`OPENCODE_` prefixed keys (and skips them at injection time anyway — `apps/server/src/env-file.ts`).

Switch the UI to `GOOGLE_WORKSPACE_OAUTH_CLIENT_ID`, which `googleWorkspaceCredentials()` already reads as a fallback (`apps/server/src/extensions/google-workspace.ts:131`) — the same pattern the client secret (`GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET`) already uses successfully.

One-line diff.

## Testing
- `pnpm typecheck` in `apps/app` — clean
- Verified key policy directly: `isReservedEnvKey("GOOGLE_WORKSPACE_OAUTH_CLIENT_ID") === false`, `isValidEnvKey(...) === true`, while the `OPENWORK_`-prefixed name is reserved (reproduces the bug).
- The secret key already flows through this exact save path successfully in production, so the ID now follows the proven path.