### PR TITLE
fix(session): make Stop actually stop the run

### DIFF
--- a/apps/app/src/app/lib/opencode-session.ts
+++ b/apps/app/src/app/lib/opencode-session.ts
@@ -16,20 +16,40 @@ import { unwrap } from "./opencode";
 // ---------------------------------------------------------------------------
 
 /**
- * Abort an active session. Silently succeeds if the session is already idle.
+ * Abort an active session. Resolves to the server's answer: `true` when a
+ * live run was aborted, `false` when nothing matched (already idle, or the
+ * session lives in a different project/directory scope). Callers that show
+ * "stopped" feedback must check the result — a `200: false` response is NOT
+ * a successful stop (#2014).
+ *
+ * Pass the workspace `directory` whenever the prompt was sent through a
+ * directory-scoped client; omitting it can resolve the abort against the
+ * server's default project where no matching run exists.
  */
-export async function abortSession(client: Client, sessionID: string): Promise<void> {
-  unwrap(await client.session.abort({ sessionID }));
+export async function abortSession(
+  client: Client,
+  sessionID: string,
+  directory?: string,
+): Promise<boolean> {
+  return unwrap(await client.session.abort({ sessionID, directory })) === true;
 }
 
 /**
- * Abort an active session, swallowing errors (useful before revert/undo).
+ * Abort an active session, swallowing transport errors (useful before
+ * revert/undo). Returns `false` when the abort failed or nothing was
+ * aborted, so callers can avoid declaring success on a no-op.
  */
-export async function abortSessionSafe(client: Client, sessionID: string): Promise<void> {
+export async function abortSessionSafe(
+  client: Client,
+  sessionID: string,
+  directory?: string,
+): Promise<boolean> {
   try {
-    await client.session.abort({ sessionID });
+    return await abortSession(client, sessionID, directory);
   } catch {
-    // intentional: abort may fail if session is already idle
+    // The session may already be idle or the server unreachable; callers
+    // treat `false` as "nothing was aborted".
+    return false;
   }
 }
 

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -808,6 +808,7 @@ export default {
   "session.create_or_connect_workspace": "Create or connect a workspace",
   "session.default_agent": "Default agent",
   "session.default_model": "Pick a model",
+  "session.stop_failed": "Could not stop the run — the engine reported no active run was aborted. Try again.",
   "session.default_title": "New session",
   "session.delete": "Delete",
   "session.delete_named_session_message": "This will permanently delete \"{title}\" and its messages.",

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -786,14 +786,26 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const handleAbort = useCallback(async () => {
     if (!chatStreaming) return;
     setError(null);
-    try {
-      await abortSessionSafe(opencodeClient, props.sessionId);
-      captureAnalyticsEvent("task_run_stopped", {});
-      await snapshotQuery.refetch();
-    } catch (nextError) {
-      setError({ message: nextError instanceof Error ? nextError.message : "Failed to stop run." });
+    // Stop means stop: drop queued follow-ups before aborting, otherwise the
+    // queue-drain effect below re-prompts the agent the moment the abort
+    // lands and the session reports idle (#2014).
+    setQueuedDrafts([]);
+    // The prompt was sent through a directory-scoped client (session-route
+    // passes the workspace root), so the abort must target the same scope —
+    // without it the server resolves the default project, finds no live run,
+    // and answers `200: false` while the stream keeps going (#2014).
+    const aborted = await abortSessionSafe(
+      opencodeClient,
+      props.sessionId,
+      props.workspaceRoot.trim() || undefined,
+    );
+    if (!aborted) {
+      setError({ message: t("session.stop_failed") });
+      return;
     }
-  }, [chatStreaming, opencodeClient, props.sessionId, snapshotQuery.refetch]);
+    captureAnalyticsEvent("task_run_stopped", {});
+    await snapshotQuery.refetch();
+  }, [chatStreaming, opencodeClient, props.sessionId, props.workspaceRoot, snapshotQuery.refetch]);
 
   const handleDismissError = useCallback(() => {
     setError(null);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2528,9 +2528,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         reloadBlocked={activeReloadBlockingSessions.length > 0}
         activeSessions={activeReloadBlockingSessions}
         isRemoteWorkspace={selectedWorkspace?.workspaceType === "remote"}
-        onForceStopSession={(sessionId) => {
-          if (!activeClient) return undefined;
-          return abortSessionSafe(activeClient, sessionId);
+        onForceStopSession={async (sessionId) => {
+          if (!activeClient) return;
+          await abortSessionSafe(activeClient, sessionId);
         }}
         onReloadEngine={reloadCoordinator.reloadWorkspaceEngine}
         modalState={{


### PR DESCRIPTION
## Summary

Fixes #2014 — clicking Stop showed success feedback while the agent kept generating.

Three compounding bugs:

1. **Wrong scope.** The prompt is sent through a directory-scoped client (session-route creates it with the workspace root, so every request carries the directory), but the Stop abort went through the session surface's own client created **without** a directory (`session-surface.tsx`). The server resolved the abort against the default project, found no matching live run, and answered `200: false` — while the real run kept streaming.
2. **Success assumed.** `abortSessionSafe` swallowed *every* failure (not just already-idle), and the abort endpoint's `200: boolean` response was never checked — `unwrap()` only tests for `undefined`, so `data: false` passed as success. `handleAbort` then unconditionally recorded `task_run_stopped`; its catch block was dead code.
3. **Auto-resume.** Queued follow-ups ("Send when agent finishes", ⌘⏎) were not cleared on Stop. A successful abort transitions the session to idle, and the queue-drain effect immediately re-prompted the agent — another genuine "keeps running after Stop" path.

## Changes

- `abortSession` / `abortSessionSafe` (`apps/app/src/app/lib/opencode-session.ts`) accept an optional workspace `directory` and return the server's boolean (`true` = a live run was aborted).
- `handleAbort` (`session-surface.tsx`) clears queued drafts before aborting, passes the workspace root, and shows an inline error ("Could not stop the run…") instead of declaring success when the engine reports nothing was aborted.
- settings-route force-stop callback adjusted for the new return type (its client is already directory-scoped).

## Tests run

- `pnpm --filter @openwork/app typecheck` — pass (exit 0).
- I could not capture an end-to-end video in this environment. Reviewer repro:
  1. Start a long-running prompt in a workspace (non-default directory matters).
  2. Click **Stop** while streaming → output should halt; no "stopped" state while text keeps flowing.
  3. Queue a follow-up (⌘⏎) during a run, then click Stop → the queued message must NOT auto-send.
  4. `node apps/app/scripts/permissions.mjs` / `test:sessions` integration scripts also exercise abort paths if you have a live engine.