### PR TITLE
fix(permissions): collaborator replies + never GC pending permission state

### DIFF
--- a/apps/app/src/react-app/infra/query-client.ts
+++ b/apps/app/src/react-app/infra/query-client.ts
@@ -13,9 +13,22 @@ export function getReactQueryClient(): QueryClient {
     ["react-session-transcript"],
     ["react-session-status"],
     ["react-session-todos"],
-    ["react-session-permissions"],
   ] as const) {
     queryClient.setQueryDefaults(queryKey, { gcTime: 15_000 });
+  }
+
+  // Pending permissions and questions are written with setQueryData only and
+  // observed through a raw cache subscription, so the query has zero
+  // observers and TanStack GC removes it ~15s after creation. That made the
+  // permission dialog auto-dismiss with no resolution while the tool call
+  // stayed "running" forever (#1916). They are cleared explicitly by
+  // permission.replied / question.answered events and clearTrackedSession,
+  // never by GC.
+  for (const queryKey of [
+    ["react-session-permissions"],
+    ["react-session-questions"],
+  ] as const) {
+    queryClient.setQueryDefaults(queryKey, { gcTime: Infinity });
   }
 
   target.__owReactQueryClient = queryClient;

--- a/apps/server/src/opencode-proxy-gate.test.ts
+++ b/apps/server/src/opencode-proxy-gate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { assertOpencodeProxyAllowed } from "./server.js";
+import { ApiError } from "./errors.js";
+import type { Actor, TokenScope } from "./types.js";
+
+const actor = (scope: TokenScope | undefined): Actor => ({ type: "remote", scope });
+
+const PERMISSION_REPLY_PATH = "/opencode/permission/req_123/reply";
+
+describe("assertOpencodeProxyAllowed", () => {
+  test("collaborators can reply to permission requests (#1918)", () => {
+    // The SPA's only credential is the collaborator-scoped client token
+    // (OPENWORK_TOKEN); an owner-only gate made every permission dialog
+    // un-answerable.
+    expect(() =>
+      assertOpencodeProxyAllowed(actor("collaborator"), "POST", PERMISSION_REPLY_PATH),
+    ).not.toThrow();
+  });
+
+  test("owners can reply to permission requests", () => {
+    expect(() =>
+      assertOpencodeProxyAllowed(actor("owner"), "POST", PERMISSION_REPLY_PATH),
+    ).not.toThrow();
+  });
+
+  test("viewers cannot send any mutating request", () => {
+    expect(() =>
+      assertOpencodeProxyAllowed(actor("viewer"), "POST", PERMISSION_REPLY_PATH),
+    ).toThrow(ApiError);
+    expect(() =>
+      assertOpencodeProxyAllowed(actor("viewer"), "POST", "/opencode/session/s1/command"),
+    ).toThrow(ApiError);
+  });
+
+  test("viewers can still read", () => {
+    expect(() =>
+      assertOpencodeProxyAllowed(actor("viewer"), "GET", "/opencode/permission"),
+    ).not.toThrow();
+  });
+
+  test("missing scope defaults to viewer (read-only)", () => {
+    expect(() =>
+      assertOpencodeProxyAllowed(actor(undefined), "POST", PERMISSION_REPLY_PATH),
+    ).toThrow(ApiError);
+    expect(() =>
+      assertOpencodeProxyAllowed(actor(undefined), "GET", "/opencode/permission"),
+    ).not.toThrow();
+  });
+});

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -654,7 +654,7 @@ function normalizeOpencodeProxyPath(proxyPath: string): string {
   return normalized || "/";
 }
 
-function assertOpencodeProxyAllowed(actor: Actor, method: string, proxyPath: string) {
+export function assertOpencodeProxyAllowed(actor: Actor, method: string, proxyPath: string) {
   const m = method.toUpperCase();
   const scope = actor.scope ?? "viewer";
 
@@ -662,12 +662,17 @@ function assertOpencodeProxyAllowed(actor: Actor, method: string, proxyPath: str
     throw new ApiError(403, "forbidden", "Viewer tokens are read-only");
   }
 
-  // Prevent collaborators/viewers from self-approving OpenCode permission requests via the proxy.
-  // OpenCode uses /permission/:requestId/reply (and historically also a session-scoped variant).
-  if (scope !== "owner" && m !== "GET" && m !== "HEAD") {
+  // Prevent viewers from self-approving OpenCode permission requests via the
+  // proxy. OpenCode uses /permission/:requestId/reply (and historically also
+  // a session-scoped variant). Collaborators must be allowed: the SPA's only
+  // credential is the collaborator-scoped client token (OPENWORK_TOKEN), so
+  // an owner-only gate made every interactive permission dialog un-answerable
+  // (403 "Only owner tokens can reply") and left tool calls stuck in
+  // "running" forever (#1918).
+  if (scope === "viewer" && m !== "GET" && m !== "HEAD") {
     const normalized = normalizeOpencodeProxyPath(proxyPath);
     if (/\/permission\/[^/]+\/reply$/.test(normalized)) {
-      throw new ApiError(403, "forbidden", "Only owner tokens can reply to permission requests");
+      throw new ApiError(403, "forbidden", "Viewer tokens cannot reply to permission requests");
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #1916 and #1918 — together these made permission prompts (`"permission": {"bash": "ask"}`, `external_directory`, etc.) fundamentally unusable from the SPA: clicks 403'd, the dialog vanished after ~10s, and the tool call stayed `running` forever.

## Root causes & changes

### #1918 — 403 "Only owner tokens can reply to permission requests"
`assertOpencodeProxyAllowed` (`apps/server/src/server.ts`) blocked `POST /permission/:id/reply` for any non-`owner` scope. But the SPA's only credential is the **collaborator**-scoped client token (`OPENWORK_TOKEN` is hard-mapped to `collaborator` in `tokens.ts`), and the proxy path never checks the host token header. So the legitimate interactive user could never answer a prompt in the default dev-stack config.

→ The gate now blocks only **viewers** (who are already read-only); collaborators and owners can reply.

### #1916 — dialog auto-dismisses after ~10s with no resolution
Pending permissions are written into a TanStack Query entry via `setQueryData` and read through a raw query-cache subscription (`useQueryCacheState`) — so the query has **zero observers**, and the `gcTime: 15_000` default for `["react-session-permissions"]` garbage-collected the entry shortly after creation. The modal unmounted (`activePermission` → null) without any reply ever being sent. There is no server-side timeout; this was pure client-side GC.

→ `["react-session-permissions"]` and `["react-session-questions"]` are now exempt from GC (`gcTime: Infinity`). They're cleared explicitly by `permission.replied` / question events and `clearTrackedSession`, never by the garbage collector. Transcript/status/todos keep the 15s GC (they're re-seeded on demand).

## Tests run

- New unit tests: `bun test src/opencode-proxy-gate.test.ts` in `apps/server` — **5 pass / 0 fail** (collaborator/owner allowed, viewer blocked, missing scope defaults to viewer, GET stays open).
- `pnpm --filter openwork-server typecheck` (apps/server) — pass.
- `pnpm --filter @openwork/app typecheck` — pass.
- No video captured in this environment. Reviewer repro (from the issues):
  1. `packaging/docker/docker-compose.dev.yml` up; workspace `opencode.json` with `{"permission": {"bash": "ask"}}`.
  2. Prompt: `Run bash 'date' and report`.
  3. The dialog must stay up past 15s untouched, and clicking Allow/Deny must resolve the tool call (no 403 toast).