### PR TITLE
feat(composer): recall sent prompts with ArrowUp/ArrowDown

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
@@ -19,16 +19,25 @@ export type ComposerSessionState = {
 
 export type ComposerStateStore = {
   sessions: Record<string, ComposerSessionState>;
+  /**
+   * Sent-prompt history per session, oldest first. Kept outside
+   * `sessions` because `clearSession` resets the composer after every
+   * send and must not wipe the recall history (#2012).
+   */
+  history: Record<string, string[]>;
   setDraft: (sessionId: string, draft: string) => void;
   setAttachments: (sessionId: string, attachments: ComposerAttachment[]) => void;
   setMentions: (sessionId: string, mentions: Record<string, ComposerMentionKind>) => void;
   setPasteParts: (sessionId: string, pasteParts: ComposerPastePart[]) => void;
+  appendHistory: (sessionId: string, text: string) => void;
   clearSession: (sessionId: string) => void;
 };
 
 const EMPTY_ATTACHMENTS: ComposerAttachment[] = [];
 const EMPTY_MENTIONS: Record<string, ComposerMentionKind> = {};
 const EMPTY_PASTE_PARTS: ComposerPastePart[] = [];
+const EMPTY_HISTORY: string[] = [];
+const HISTORY_LIMIT = 50;
 
 function createEmptyComposerSession(): ComposerSessionState {
   return {
@@ -45,6 +54,7 @@ function getWritableSession(state: ComposerStateStore, sessionId: string): Compo
 
 export const useComposerStateStore = create<ComposerStateStore>((set) => ({
   sessions: {},
+  history: {},
   setDraft: (sessionId, draft) => set((state) => {
     const current = getWritableSession(state, sessionId);
     if (current.draft === draft) return state;
@@ -64,6 +74,16 @@ export const useComposerStateStore = create<ComposerStateStore>((set) => ({
     const current = getWritableSession(state, sessionId);
     if (current.pasteParts === pasteParts) return state;
     return { sessions: { ...state.sessions, [sessionId]: { ...current, pasteParts } } };
+  }),
+  appendHistory: (sessionId, text) => set((state) => {
+    const trimmed = text.trim();
+    if (!trimmed) return state;
+    const current = state.history[sessionId] ?? EMPTY_HISTORY;
+    // Skip consecutive duplicates so spamming the same prompt does not
+    // fill the recall buffer.
+    if (current[current.length - 1] === trimmed) return state;
+    const next = [...current, trimmed].slice(-HISTORY_LIMIT);
+    return { history: { ...state.history, [sessionId]: next } };
   }),
   clearSession: (sessionId) => set((state) => {
     if (!state.sessions[sessionId]) return state;
@@ -87,4 +107,8 @@ export function getComposerMentions(state: ComposerStateStore, sessionId: string
 
 export function getComposerPasteParts(state: ComposerStateStore, sessionId: string): ComposerPastePart[] {
   return state.sessions[sessionId]?.pasteParts ?? EMPTY_PASTE_PARTS;
+}
+
+export function getComposerHistory(state: ComposerStateStore, sessionId: string): string[] {
+  return state.history[sessionId] ?? EMPTY_HISTORY;
 }

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -87,6 +87,8 @@ type ComposerProps = {
   recentFiles: string[];
   searchFiles: (query: string) => Promise<string[]>;
   onInsertMention: (kind: ComposerMentionKind, value: string) => void;
+  /** Sent-prompt history (oldest first) recalled with ArrowUp/ArrowDown (#2012). */
+  inputHistory?: string[];
   onPasteText: (text: string) => void;
   onUnsupportedFileLinks: (links: string[]) => void;
   pastedText: PastedTextChip[];
@@ -340,6 +342,22 @@ export function ReactSessionComposer(props: ComposerProps) {
   useEffect(() => {
     if (!props.busy) disarmEscape();
   }, [props.busy, disarmEscape]);
+
+  // Input history recall (#2012): ArrowUp on an empty composer recalls the
+  // previous sent prompt; repeated ArrowUp/ArrowDown walk the history.
+  // Editing the recalled text exits recall mode, and ArrowDown past the
+  // newest entry restores whatever was typed before recall started.
+  const historyPosRef = useRef<number | null>(null);
+  const historyExpectedRef = useRef<string | null>(null);
+  const historyStashRef = useRef("");
+
+  useEffect(() => {
+    if (historyPosRef.current === null) return;
+    if (props.draft !== historyExpectedRef.current) {
+      historyPosRef.current = null;
+      historyExpectedRef.current = null;
+    }
+  }, [props.draft]);
 
   useEffect(() => () => {
     if (escapeTimerRef.current) clearTimeout(escapeTimerRef.current);
@@ -857,6 +875,45 @@ export function ReactSessionComposer(props: ComposerProps) {
       event.preventDefault();
       setToolMenuOpen(false);
       return;
+    }
+
+    // Input history recall (#2012). Only when no menu is consuming the
+    // arrow keys and IME composition is not active.
+    if (
+      (event.key === "ArrowUp" || event.key === "ArrowDown") &&
+      !imeActive &&
+      !agentMenuOpen &&
+      !toolMenuOpen &&
+      (!activeMenu || !activeItems.length)
+    ) {
+      const history = props.inputHistory ?? [];
+      const position = historyPosRef.current;
+      if (event.key === "ArrowUp") {
+        const startRecall = position === null && props.draft.trim() === "" && history.length > 0;
+        const continueRecall = position !== null && position > 0;
+        if (startRecall || continueRecall) {
+          const nextPos = position === null ? history.length - 1 : position - 1;
+          if (position === null) historyStashRef.current = props.draft;
+          historyPosRef.current = nextPos;
+          historyExpectedRef.current = history[nextPos];
+          event.preventDefault();
+          props.onDraftChange(history[nextPos]);
+          return;
+        }
+      } else if (position !== null) {
+        event.preventDefault();
+        const nextPos = position + 1;
+        if (nextPos >= history.length) {
+          historyPosRef.current = null;
+          historyExpectedRef.current = null;
+          props.onDraftChange(historyStashRef.current);
+        } else {
+          historyPosRef.current = nextPos;
+          historyExpectedRef.current = history[nextPos];
+          props.onDraftChange(history[nextPos]);
+        }
+        return;
+      }
     }
 
     if (!activeMenu || !activeItems.length) return;

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -61,6 +61,7 @@ import {
 import {
   getComposerAttachments,
   getComposerDraft,
+  getComposerHistory,
   getComposerMentions,
   getComposerPasteParts,
   useComposerStateStore,
@@ -402,6 +403,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const setComposerMentions = useComposerStateStore((state) => state.setMentions);
   const setComposerPasteParts = useComposerStateStore((state) => state.setPasteParts);
   const clearComposerSession = useComposerStateStore((state) => state.clearSession);
+  const inputHistory = useComposerStateStore((state) => getComposerHistory(state, props.sessionId));
+  const appendComposerHistory = useComposerStateStore((state) => state.appendHistory);
   const [error, setError] = useState<SessionError | null>(null);
   const [sending, setSending] = useState(false);
   // Locally queued follow-up drafts. OpenCode has no server-side queue, so we
@@ -716,6 +719,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // up the new message — so this is safe to call while the agent is busy.
   const sendDraft = useCallback(async (nextDraft: ComposerDraft, draftAttachments: ComposerAttachment[]) => {
     setError(null);
+    // Record the prompt for Up/Down recall in the composer (#2012).
+    appendComposerHistory(props.sessionId, nextDraft.text);
     useSessionActivityStore.getState().setRunStatus(props.workspaceId, props.sessionId, { type: "busy" });
     setSending(true);
     setAwaitingAssistantBaseline(renderedMessages.length);
@@ -733,7 +738,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       setSending(false);
       throw nextError;
     }
-  }, [props.onSendDraft, props.sessionId, props.workspaceId, renderedMessages.length, setComposerDraft]);
+  }, [appendComposerHistory, props.onSendDraft, props.sessionId, props.workspaceId, renderedMessages.length, setComposerDraft]);
 
   const clearComposer = useCallback(() => {
     clearComposerSession(props.sessionId);
@@ -1313,6 +1318,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         recentFiles={props.recentFiles}
         searchFiles={props.searchFiles}
         onInsertMention={handleInsertMention}
+        inputHistory={inputHistory}
         onPasteText={handlePasteText}
         onUnsupportedFileLinks={handleUnsupportedFileLinks}
         pastedText={pasteParts}


### PR DESCRIPTION
## Summary

Fixes #2012 — terminal-style input history in the session composer.

## Behavior

- **ArrowUp** on an empty composer recalls the last sent prompt; repeated ArrowUp walks further back.
- **ArrowDown** walks forward; past the newest entry it restores whatever was typed before recall started.
- Editing the recalled text exits recall mode (arrows go back to normal caret movement).
- Recall never fires while the mention (`@`), slash (`/`), agent, or plug menus are open, or during IME composition (guards reuse the composer's existing menu/IME state).

## Implementation

- History is recorded per session in the Zustand composer state store on every send — send, steer, and queue-drain all flow through `sendDraft`. Capped at 50 entries, consecutive duplicates skipped.
- Stored outside the per-session composer record because `clearSession` resets the composer after each send and must not wipe recall history.
- Navigation state is refs-only in the composer (`historyPosRef` / expected-text guard), so no extra renders.

## Tests run

- `pnpm --filter @openwork/app typecheck` — pass (exit 0).
- No video captured in this environment. Reviewer repro:
  1. Send a few prompts in a session.
  2. With the composer empty, press ArrowUp repeatedly → prompts come back newest-first.
  3. Press ArrowDown past the newest → composer returns to empty (or the in-progress draft).
  4. Type `@` or `/` → arrows navigate the menu, not history.