### PR TITLE
fix(desktop): keep agent browsing out of the app window and on-screen

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1132,9 +1132,22 @@ function createBrowserTab(url = "about:blank", { select = true } = {}) {
     return { action: "deny" };
   });
   view.webContents.on("did-start-navigation", (_event, targetUrl, isInPlace, isMainFrame) => {
-    if (isMainFrame && !isInPlace && targetUrl !== "about:blank") {
-      sendToRenderer("openwork:browser:panel-opened");
+    if (!isMainFrame || isInPlace) return;
+    const target = String(targetUrl ?? "");
+    // data: loads are internal plumbing (CDP target-marker pages), not
+    // user-visible navigations — don't surface the panel for them.
+    if (target === "about:blank" || target.startsWith("data:")) return;
+    // Agent-driven CDP navigation can target a background tab whose view is
+    // detached. Bring that tab on screen, otherwise navigation "succeeds"
+    // while the visible tab stays on about:blank (#2015).
+    if (activeBrowserTabId !== tabId) {
+      try {
+        selectBrowserTab(tabId);
+      } catch {
+        // The tab may be mid-close; the panel-opened event below still fires.
+      }
     }
+    sendToRenderer("openwork:browser:panel-opened");
   });
   view.webContents.on("did-navigate", () => sendBrowserState());
   view.webContents.on("did-navigate-in-page", () => sendBrowserState());
@@ -3102,6 +3115,23 @@ async function createMainWindow() {
   mainWindow.webContents.on("will-navigate", (event, url) => {
     if (isMainWindowAllowedNavigation(url)) return;
     event.preventDefault();
+    routeBlockedMainWindowNavigation(url);
+  });
+
+  // `will-navigate` does NOT fire for CDP `Page.navigate` (it behaves like
+  // loadURL), so agent automation that picks the wrong CDP target — the app
+  // window itself is the first page target when no browser tab exists — used
+  // to replace the entire workspace UI with the website, with no way back
+  // (#2000). Catch those at `did-start-navigation`, cancel the load, and
+  // reroute the URL into a built-in browser tab instead.
+  mainWindow.webContents.on("did-start-navigation", (_event, url, isInPlace, isMainFrame) => {
+    if (!isMainFrame || isInPlace) return;
+    if (isMainWindowAllowedNavigation(url)) return;
+    try {
+      mainWindow?.webContents.stop();
+    } catch {
+      // best effort — routing below still gives the user a way back
+    }
     routeBlockedMainWindowNavigation(url);
   });
 


### PR DESCRIPTION
## Summary

Fixes #2000 and #2015 — the remaining built-in-browser gaps at HEAD after the Puppeteer→CDP migration (#1707/#1861) and the post-0.14.0 fixes (#2020/#2022/#2079).

## Root causes & changes (`apps/desktop/electron/main.mjs`)

### #2000 — browser takes over the whole app window, no way back
The `will-navigate` guard added in #2079 routes blocked main-window navigations into a browser tab — but **`will-navigate` never fires for CDP `Page.navigate`**, which behaves like `loadURL`. The agent's `opencode-chrome-devtools` plugin defaults to the *first* page target when `target_id` is omitted, and when no browser tab exists yet that target is the OpenWork main window itself. Result: the workspace UI replaced wholesale by the website, with no close control (and no app menu on Windows).

→ Added a `did-start-navigation` guard on the main window that cancels disallowed external main-frame loads (`webContents.stop()`) and reroutes the URL into a built-in browser tab via the existing `routeBlockedMainWindowNavigation`.

### #2015 — browser shows about:blank while navigation "succeeds"
Only the active tab's `WebContentsView` is attached to the window; background tabs stay alive but detached. Agent CDP navigation of a background tab returns full success (snapshots/screenshots work offscreen) while the visible active tab sits on `about:blank`.

→ Tab `did-start-navigation` now auto-selects the navigated tab so it becomes visible. `data:` loads (the internal CDP target-marker pages) no longer trigger the panel.

## Tests run

- `pnpm --filter @openwork/desktop typecheck:electron` — pass.
- `pnpm --filter @openwork/desktop check:electron` — pass (bridge covers 50 renderer methods).
- `node --check apps/desktop/electron/main.mjs` — pass.
- I could not run a Windows desktop build in this environment. Reviewer repro:
  1. Fresh session, no browser tab open. Have the agent call `browser_navigate` without `target_id` (or prompt a browse task) → the app window must NOT be replaced; the site must open in the side-panel browser.
  2. Open two browser tabs; navigate the background tab via CDP → it should be brought on screen instead of leaving the active tab blank.