### PR TITLE
fix(den-web): restore first-worker launch on signup onboarding

### DIFF
--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -1945,7 +1945,13 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     }
 
     onboardingAutoLaunchKeyRef.current = autoLaunchKey;
-    markOnboardingComplete();
+    // Launch the first worker through the canonical POST /v1/workers path;
+    // the Den API selects the configured provisioner (render/daytona/static)
+    // server-side. PR #1181 replaced this with a bare markOnboardingComplete,
+    // which let signup finish with zero workers (#1961). launchWorker marks
+    // onboarding complete itself on success; on failure onboarding stays
+    // pending so the user sees the error and can retry.
+    void launchWorker({ source: "signup_auto", workerNameOverride: onboardingIntent?.workerName ?? DEFAULT_WORKER_NAME });
   }, [billingSummary?.featureGateEnabled, billingSummary?.hasActivePlan, launchBusy, onboardingIntent?.workerName, onboardingPending, ownedWorkerCount, user?.id]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #1961 — PR #1181 removed the generic first-worker launch trigger from signup onboarding (`void launchWorker({ source: \"signup_auto\", ... })` → `markOnboardingComplete()`), described as stopping automatic *sandbox* creation. But that path was the canonical `POST /v1/workers` entry point with `destination: \"cloud\"` — the Den API picks the configured provisioner (`render`, `daytona`, `static`) server-side. Removing it meant new signups could complete onboarding with **zero workers** and no automatic attach, surfacing most clearly on static/on-prem deployments.

## Change

One-line restore (plus a comment) in `ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx`:

- The auto-launch effect (no owned workers, billing eligible, not already launched for this user/intent) now calls `launchWorker({ source: \"signup_auto\", workerNameOverride: onboardingIntent?.workerName ?? DEFAULT_WORKER_NAME })` again.
- `launchWorker` already calls `markOnboardingComplete()` on success; on failure onboarding stays pending so the user sees the launch error and can retry — same as the pre-#1181 behavior.
- The existing guards are untouched: users with `ownedWorkerCount > 0` still skip the launch and complete onboarding immediately, and `onboardingAutoLaunchKeyRef` still prevents duplicate launches.

## Tests run

- `pnpm exec tsc --noEmit` in `ee/apps/den-web` — pass (exit 0).
- No video captured in this environment. Reviewer repro:
  1. Fresh Den org / new user signup on a stack with any provisioner configured (static is the clearest).
  2. Complete signup → a first worker must be created via `POST /v1/workers` ("Creating your first worker..." status) and onboarding completes after launch.
  3. Sign up a user in an org that already has workers → no auto-launch, onboarding completes immediately (unchanged).