### PR TITLE
fix(den-api): invalidate GitHub discovery cache when the head commit moves

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
@@ -529,6 +529,40 @@ export async function fetchGithubImportFilesWithRevisionGuard(input: {
   return results
 }
 
+/**
+ * Resolve the current head commit SHA of a branch with a single commits API
+ * call. Used as a cheap staleness probe for the discovery cache: a branch
+ * name alone says nothing about content (#1871).
+ */
+export async function getGithubRepositoryHeadSha(input: {
+  branch: string
+  config: GithubConnectorAppConfig
+  fetchFn?: GithubFetch
+  installationId: number
+  repositoryFullName: string
+  token?: string
+}) {
+  const repositoryParts = splitRepositoryFullName(input.repositoryFullName)
+  if (!repositoryParts) {
+    throw new GithubConnectorRequestError("GitHub repository full name is invalid.", 400)
+  }
+
+  const token = input.token ?? await createGithubInstallationAccessToken(input)
+  const commitResponse = await requestGithubJson<{ sha?: string }>({
+    fetchFn: input.fetchFn,
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    path: `/repos/${encodeURIComponent(repositoryParts.owner)}/${encodeURIComponent(repositoryParts.repo)}/commits/${encodeURIComponent(input.branch.trim())}`,
+  })
+
+  const headSha = typeof commitResponse.body.sha === "string" ? commitResponse.body.sha : ""
+  if (!headSha) {
+    throw new GithubConnectorRequestError("GitHub commit response was missing the head sha.", 502, commitResponse.body)
+  }
+  return headSha
+}
+
 export async function getGithubRepositoryTree(input: {
   branch: string
   config: GithubConnectorAppConfig

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -33,6 +33,7 @@ import {
   getGithubAppSummary,
   getGithubConnectorAppConfig,
   getGithubInstallationAccessToken,
+  getGithubRepositoryHeadSha,
   getGithubRepositoryTextFile,
   getGithubRepositoryTree,
   getGithubInstallationSummary,
@@ -3207,11 +3208,24 @@ async function resolveGithubConnectorDiscovery(input: { connectorInstanceId: Con
     && cached.branch === discoveryContext.branch
     && cached.ref === discoveryContext.ref
     && cached.repositoryFullName === discoveryContext.repositoryFullName) {
-    return {
-      autoImportNewPlugins: discoveryContext.autoImportNewPlugins,
-      cache: cached,
-      connectorInstance: serializeConnectorInstance(discoveryContext.connectorInstance),
-      connectorTarget: serializeConnectorTarget(discoveryContext.connectorTarget),
+    // A matching branch/ref says nothing about content: compare the cached
+    // snapshot's commit SHA against the live head, otherwise the discovery
+    // UI stays permanently stuck on the old repository structure after a
+    // push (#1871). The probe is a single commits API call; if it fails
+    // (rate limit, network), prefer availability and serve the cache.
+    const liveHeadSha = await getGithubRepositoryHeadSha({
+      branch: discoveryContext.branch,
+      config: githubConnectorAppConfig(),
+      installationId: discoveryContext.installationId,
+      repositoryFullName: discoveryContext.repositoryFullName,
+    }).catch(() => null)
+    if (liveHeadSha === null || liveHeadSha === cached.sourceRevisionRef) {
+      return {
+        autoImportNewPlugins: discoveryContext.autoImportNewPlugins,
+        cache: cached,
+        connectorInstance: serializeConnectorInstance(discoveryContext.connectorInstance),
+        connectorTarget: serializeConnectorTarget(discoveryContext.connectorTarget),
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #1871 — the GitHub connector discovery cache keyed only on `branch`/`ref`/`repositoryFullName` and never compared the commit SHA. After a push that restructured plugin/marketplace folders (e.g. adding `.claude-plugin/marketplace.json`, moving a skill), the discovery UI stayed permanently stuck on the old tree and reported "0 imported objects", even with successful webhook sync cycles. The only workarounds were deleting the connector or hand-editing `githubDiscoveryCache` in the `connector_target` table.

## Changes

- New `getGithubRepositoryHeadSha` helper (`github-app.ts`): resolves the branch head with a **single** commits API call (`GET /repos/{owner}/{repo}/commits/{branch}`), no tree fetch.
- `resolveGithubConnectorDiscovery` (`store.ts`): on a cache hit, probe the live head SHA and compare with `cached.sourceRevisionRef`:
  - match → serve the cache (unchanged fast path, now costing one lightweight API call),
  - mismatch → recompute discovery and persist the fresh snapshot,
  - probe failure (rate limit / network) → serve the cache; availability over freshness.
- `forceRefresh` paths (webhook auto-import) are untouched.

## Tests run

- `pnpm exec tsc -p tsconfig.json --noEmit` in `ee/apps/den-api` — pass (exit 0).
- No test harness exists for the plugin-system store; no video captured in this environment. Reviewer repro (from the issue):
  1. Connect a repo as a plugin hub; open the discovery UI (caches the state).
  2. Push a commit that restructures the folders.
  3. Re-open the discovery UI → it must now show the new structure without deleting/re-adding the connector.