### PR TITLE
feat(den): subscribe to OpenWork Models at the point of value

### DIFF
--- a/ee/apps/den-api/src/routes/org/billing.ts
+++ b/ee/apps/den-api/src/routes/org/billing.ts
@@ -32,7 +32,11 @@ function billingReturnUrl(c: { req: { raw: Request } }) {
 }
 
 function checkoutSuccessUrl(c: { req: { raw: Request } }) {
-  return env.stripe.billingSuccessUrl ?? `${getRequestOrigin(c)}/dashboard/billing/stripe/checking?session_id={CHECKOUT_SESSION_ID}`
+  // `return=models` sends the user back to the OpenWork Models page after a
+  // successful inference checkout — that's where they subscribed from and
+  // where the unlocked value (the model lineup) is visible. The billing page
+  // remains the status/portal view.
+  return env.stripe.billingSuccessUrl ?? `${getRequestOrigin(c)}/dashboard/billing/stripe/checking?session_id={CHECKOUT_SESSION_ID}&return=models`
 }
 
 function appendSeatCheckoutParams(input: string) {

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/billing/stripe/checking/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/billing/stripe/checking/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { AlertCircle, CreditCard, Loader2 } from "lucide-react";
 import { DashboardPageTemplate } from "../../../../../_components/ui/dashboard-page-template";
-import { getBillingRoute } from "../../../../../_lib/den-org";
+import { getBillingRoute, getInferenceRoute } from "../../../../../_lib/den-org";
 import { requestJson } from "../../../../../_lib/den-flow";
 import { useOrgDashboard } from "../../../../_providers/org-dashboard-provider";
 
@@ -25,7 +25,17 @@ export default function StripeCheckingPage() {
   const [failed, setFailed] = useState(false);
   const attemptsRef = useRef(0);
   const intervalRef = useRef<number | null>(null);
-  const billingRoute = getBillingRoute(activeOrg?.slug);
+  // Inference checkouts started from the OpenWork Models page carry
+  // `return=models` so the user lands back where they subscribed from and
+  // sees the value unlocked, not the billing status page. Read from
+  // window.location instead of useSearchParams to avoid the Suspense
+  // requirement on this client-only page.
+  const returnTarget = typeof window !== "undefined"
+    ? new URLSearchParams(window.location.search).get("return")
+    : null;
+  const billingRoute = returnTarget === "models"
+    ? getInferenceRoute(activeOrg?.slug)
+    : getBillingRoute(activeOrg?.slug);
 
   useEffect(() => {
     let cancelled = false;

--- a/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { CreditCard } from "lucide-react";
 import { DenButton, buttonVariants } from "../../_components/ui/button";
 import { formatMoneyMinor, formatSubscriptionStatus, getErrorMessage, requestJson } from "../../_lib/den-flow";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { getInferenceRoute } from "../../_lib/den-org";
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 
@@ -119,12 +121,13 @@ function parsePolarBilling(payload: unknown): PolarBilling | null {
 }
 
 export function BillingDashboardScreen() {
+  const router = useRouter();
   const { sessionHydrated, user } = useDenFlow();
-  const { orgContext } = useOrgDashboard();
+  const { activeOrg, orgContext } = useOrgDashboard();
   const [stripeBilling, setStripeBilling] = useState<StripeBilling | null>(null);
   const [polarBilling, setPolarBilling] = useState<PolarBilling | null>(null);
   const [stripeBusy, setStripeBusy] = useState(false);
-  const [stripeActionBusy, setStripeActionBusy] = useState<"checkout" | "seat-checkout" | "portal" | null>(null);
+  const [stripeActionBusy, setStripeActionBusy] = useState<"seat-checkout" | "portal" | null>(null);
   const [stripeError, setStripeError] = useState<string | null>(null);
   const [stripeReturnChecking, setStripeReturnChecking] = useState(false);
 
@@ -202,26 +205,6 @@ export function BillingDashboardScreen() {
       cancelled = true;
     };
   }, [sessionHydrated, user, orgContext?.organization.id]);
-
-  async function startStripeCheckout() {
-    setStripeActionBusy("checkout");
-    setStripeError(null);
-    try {
-      const { response, payload } = await requestJson(
-        "/v1/billing/stripe/checkout",
-        { method: "POST", body: JSON.stringify({ type: "inference" }) },
-        12000,
-      );
-      if (!response.ok) throw new Error(getErrorMessage(payload, `Checkout failed (${response.status}).`));
-      const url = payload && typeof payload === "object" && "url" in payload && typeof payload.url === "string" ? payload.url : null;
-      if (!url) throw new Error("Checkout response did not include a URL.");
-      window.location.href = url;
-    } catch (error) {
-      setStripeError(error instanceof Error ? error.message : "Could not start Stripe checkout.");
-    } finally {
-      setStripeActionBusy(null);
-    }
-  }
 
   async function startSeatCheckout() {
     setStripeActionBusy("seat-checkout");
@@ -408,10 +391,13 @@ export function BillingDashboardScreen() {
         ) : (
           <div className="flex flex-col gap-4 rounded-[16px] border border-blue-100 bg-blue-50 p-5 md:flex-row md:items-center md:justify-between">
             <div>
-              <p className="text-[15px] font-medium text-blue-950">Subscribe to enable OpenWork Models</p>
+              <p className="text-[15px] font-medium text-blue-950">Not subscribed yet</p>
+              <p className="mt-1 text-[13px] leading-5 text-blue-900/70">
+                See the model lineup and subscribe from the OpenWork Models page.
+              </p>
             </div>
-            <DenButton disabled={!isOwner || stripeBilling?.configured === false} loading={stripeActionBusy === "checkout"} onClick={startStripeCheckout}>
-              Subscribe with Stripe
+            <DenButton onClick={() => router.push(getInferenceRoute(activeOrg?.slug))}>
+              View OpenWork Models
             </DenButton>
           </div>
         )}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Sparkles } from "lucide-react";
+import { Check, Sparkles } from "lucide-react";
+import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../_components/ui/button";
 import { getErrorMessage, requestJson } from "../../_lib/den-flow";
@@ -148,13 +149,91 @@ function UsageLimitsCard({ buckets }: { buckets: InferenceUsageBucket[] }) {
   );
 }
 
+const MODEL_LINEUP = Object.entries(INFERENCE_MODEL_ALIASES)
+  .filter(([, model]) => model.enabled)
+  .map(([id, model]) => ({
+    id,
+    name: model.displayName.replace(/^OpenWork:\s*/, ""),
+  }));
+
+const VALUE_POINTS = [
+  "Open-source frontier models, hosted and kept up to date by OpenWork",
+  "No API keys to manage — every member is provisioned automatically",
+  "One subscription covers your whole workspace, with usage limits that scale with your team",
+];
+
+function ModelsValueProp(props: {
+  isOwner: boolean;
+  memberCount: number;
+  subscribeBusy: boolean;
+  onSubscribe: () => void;
+}) {
+  return (
+    <section className="overflow-hidden rounded-3xl border border-gray-200 bg-white shadow-[0_18px_45px_-35px_rgba(15,23,42,0.35)]">
+      <div className="grid gap-8 p-8 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div>
+          <h2 className="text-[24px] font-medium leading-8 tracking-[-0.4px] text-gray-950">
+            The best open-source models, ready for your whole team.
+          </h2>
+          <p className="mt-3 max-w-[560px] text-[14px] leading-6 text-gray-500">
+            OpenWork Models gives every member of your workspace instant access to a hand-picked
+            lineup of OSS frontier models — no provider accounts, no key juggling.
+          </p>
+          <ul className="mt-6 grid gap-3">
+            {VALUE_POINTS.map((point) => (
+              <li key={point} className="flex items-start gap-3 text-[14px] leading-6 text-gray-700">
+                <Check className="mt-1 h-4 w-4 shrink-0 text-blue-600" aria-hidden="true" />
+                <span>{point}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <DenButton
+              type="button"
+              disabled={!props.isOwner}
+              loading={props.subscribeBusy}
+              onClick={props.onSubscribe}
+            >
+              Subscribe with Stripe
+            </DenButton>
+            <p className="text-[13px] leading-5 text-gray-500">
+              $10/user/month · {props.memberCount > 0 ? `${props.memberCount} active member${props.memberCount === 1 ? "" : "s"}` : "billed per active member"} · cancel anytime
+            </p>
+          </div>
+          {props.isOwner ? null : (
+            <p className="mt-3 text-[13px] leading-5 text-amber-700">
+              Only workspace owners can subscribe. Ask an owner to enable OpenWork Models for your team.
+            </p>
+          )}
+        </div>
+        <div className="rounded-2xl border border-gray-100 bg-gray-50 p-5">
+          <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-gray-400">
+            Included models
+          </p>
+          <ul className="mt-3 divide-y divide-gray-100">
+            {MODEL_LINEUP.map((model) => (
+              <li key={model.id} className="py-2.5">
+                <p className="text-[14px] font-medium text-gray-900">{model.name}</p>
+                <p className="text-[12px] text-gray-500">{model.id}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export function InferenceScreen() {
   const router = useRouter();
   const { activeOrg, orgContext, refreshOrgData } = useOrgDashboard();
   const [status, setStatus] = useState<InferenceStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [subscribeBusy, setSubscribeBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const isOwner = orgContext?.currentMember.isOwner === true;
 
   async function loadStatus() {
     setLoading(true);
@@ -179,6 +258,32 @@ export function InferenceScreen() {
   useEffect(() => {
     void loadStatus();
   }, [orgContext?.organization.id]);
+
+  // Subscribe at the point of value: start the Stripe checkout right here
+  // instead of bouncing the user to the billing page. Billing stays the
+  // status/portal view.
+  async function startSubscribeCheckout() {
+    setSubscribeBusy(true);
+    setError(null);
+    try {
+      const { response, payload } = await requestJson(
+        "/v1/billing/stripe/checkout",
+        { method: "POST", body: JSON.stringify({ type: "inference" }) },
+        12000,
+      );
+      if (!response.ok) {
+        throw new Error(getErrorMessage(payload, `Checkout failed (${response.status}).`));
+      }
+      const url = payload && typeof payload === "object" && "url" in payload && typeof payload.url === "string" ? payload.url : null;
+      if (!url) {
+        throw new Error("Checkout response did not include a URL.");
+      }
+      window.location.href = url;
+    } catch (checkoutError) {
+      setError(checkoutError instanceof Error ? checkoutError.message : "Could not start Stripe checkout.");
+      setSubscribeBusy(false);
+    }
+  }
 
   async function toggleEnabled() {
     if (!status) return;
@@ -214,8 +319,10 @@ export function InferenceScreen() {
   }
 
   const enabled = status?.enabled === true;
+  const subscribed = status?.subscribed === true;
+  const showValueProp = !loading && status !== null && !subscribed;
   const cardTitle = enabled ? "OpenWork Models enabled" : "Enable OpenWork Models";
-  const actionLabel = enabled ? "Manage subscription" : status?.subscribed === false ? "Subscribe" : "Enable";
+  const actionLabel = enabled ? "Manage subscription" : "Enable";
 
   return (
     <DashboardPageTemplate
@@ -232,21 +339,30 @@ export function InferenceScreen() {
           </div>
         ) : null}
 
-        <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-[0_18px_45px_-35px_rgba(15,23,42,0.35)]">
-          <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
-            <div className="max-w-[560px]">
-              <div className="mb-3 inline-flex rounded-full border border-blue-100 bg-blue-50 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.12em] text-blue-700">
-                {loading ? "Checking" : enabled ? "Enabled" : "Disabled"}
+        {showValueProp ? (
+          <ModelsValueProp
+            isOwner={isOwner}
+            memberCount={status?.memberCount ?? 0}
+            subscribeBusy={subscribeBusy}
+            onSubscribe={() => void startSubscribeCheckout()}
+          />
+        ) : (
+          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-[0_18px_45px_-35px_rgba(15,23,42,0.35)]">
+            <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
+              <div className="max-w-[560px]">
+                <div className="mb-3 inline-flex rounded-full border border-blue-100 bg-blue-50 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.12em] text-blue-700">
+                  {loading ? "Checking" : enabled ? "Enabled" : "Disabled"}
+                </div>
+                <h2 className="text-[20px] font-medium tracking-[-0.3px] text-gray-950">
+                  {cardTitle}
+                </h2>
               </div>
-              <h2 className="text-[20px] font-medium tracking-[-0.3px] text-gray-950">
-                {cardTitle}
-              </h2>
+              <DenButton type="button" onClick={toggleEnabled} loading={saving || loading} variant={enabled ? "secondary" : "primary"}>
+                {actionLabel}
+              </DenButton>
             </div>
-            <DenButton type="button" onClick={toggleEnabled} loading={saving || loading} variant={enabled ? "secondary" : "primary"}>
-              {actionLabel}
-            </DenButton>
-          </div>
-        </section>
+          </section>
+        )}
 
         {enabled && status ? <UsageLimitsCard buckets={status.buckets} /> : null}
       </div>


### PR DESCRIPTION
## Summary

Monetize where the value is, not on the billing page. Today, every "Use OpenWork Models" touchpoint in the desktop app deep-links to `/dashboard/inference` — and when the org isn't subscribed, that page just bounces the user to the billing page with a bare "Subscribe with Stripe" button and zero explanation of what they're buying.

## Changes

### `/dashboard/inference` (OpenWork Models) — now the value-prop + signup page
When unsubscribed it shows:
- the OSS model lineup, sourced from `INFERENCE_MODEL_ALIASES` (`@openwork/types/den/inference`) — Hy3 Preview, Kimi K2.6, DeepSeek V4 Flash, MiniMax M2.7/M3, GLM-5.1 — so the list never drifts from what's actually served,
- what the subscription covers (hosted OSS frontier models, automatic member provisioning, org-wide usage limits),
- $10/user/month with the active member count,
- a **Subscribe with Stripe** button that starts the checkout right there (`POST /v1/billing/stripe/checkout`, `{type: "inference"}`). Non-owners see a hint to ask an owner instead of a dead button.

When subscribed, the existing Enable/Manage card and usage-limits view are unchanged.

### Billing page — status-focused
The OpenWork Models card keeps its status grid (price / active members / status) and the manage-subscription portal button, but the unsubscribed CTA now links to the models page (**View OpenWork Models**) instead of launching checkout. Seat (OpenWork Users) flow untouched.

### Checkout return lands on the value
Inference checkout success URLs carry `return=models`; the `/dashboard/billing/stripe/checking` poller then redirects back to the models page, where the webhook has already auto-enabled inference — the user immediately sees what they unlocked.

### App touchpoints
All desktop touchpoints (model-select promo, model picker row, status-bar pill, provider-connect modal, settings AI view, startup dialog) already deep-link to `/dashboard/inference` via `getOpenWorkModelsActionUrl`, so they inherit this flow with no app change. (A small companion PR fixes the one outlier: onboarding's "Use OpenWork Models" goes straight to bare sign-up.)

## Tests run

- `pnpm exec tsc --noEmit` in `ee/apps/den-web` — pass.
- `pnpm exec tsc -p tsconfig.json --noEmit` in `ee/apps/den-api` — pass.
- I could not run the Den stack + Stripe test mode in this environment. Reviewer repro:
  1. Org without a models subscription → open **OpenWork Models** in the dashboard → value-prop screen with model lineup + Subscribe with Stripe (owners) appears; no redirect to billing.
  2. Complete a test-mode checkout → land back on the models page with inference enabled.
  3. Billing page → Models card shows status + "View OpenWork Models" link; no checkout button.