### PR TITLE
fix(app): onboarding 'Use OpenWork Models' lands on the value-prop page

### DIFF
--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
@@ -37,10 +37,15 @@ export function hasOpenWorkModelsProvider(providerIds: readonly string[]) {
   return providerIds.some((id) => id.trim().toLowerCase() === OPENWORK_MODELS_PROVIDER_ID);
 }
 
-export function getOpenWorkModelsActionUrl(isSignedIn: boolean) {
+export function getOpenWorkModelsActionUrl(
+  isSignedIn: boolean,
+  authMode: "sign-in" | "sign-up" = "sign-in",
+) {
   const settings = readDenSettings();
   const baseUrl = settings.baseUrl || readDenBootstrapConfig().baseUrl;
-  return isSignedIn ? getDenInferenceUrl(baseUrl) : buildDenAuthUrl(baseUrl, "sign-in");
+  // Signed-in users go straight to the OpenWork Models page — the value-prop
+  // + subscribe surface — never to a bare auth or billing page.
+  return isSignedIn ? getDenInferenceUrl(baseUrl) : buildDenAuthUrl(baseUrl, authMode);
 }
 
 export function isOpenWorkModelsPromoHidden() {

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -19,13 +19,14 @@ import { WelcomePage } from "../domains/onboarding/welcome-page";
 import { ProviderSelectionStep } from "../domains/onboarding/provider-selection-step";
 import { CreateWorkspaceModal } from "../domains/workspace/create-workspace-modal";
 import {
+  getOpenWorkModelsActionUrl,
   hideOpenWorkModelsPromo,
   markOpenWorkModelsStartupPromoShown,
 } from "../domains/cloud/openwork-models-promo";
+import { useDenAuth } from "../domains/cloud/den-auth-provider";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { captureAnalyticsEvent } from "../../app/lib/analytics";
 import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../../app/lib/openwork-server";
-import { buildDenAuthUrl, readDenSettings } from "../../app/lib/den";
 import { writeActiveWorkspaceId, writeLastSessionFor } from "./session-memory";
 import { workspaceSessionRoute } from "./workspace-routes";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
@@ -110,6 +111,7 @@ export function WelcomeRoute() {
   const navigate = useNavigate();
   const local = useLocal();
   const platform = usePlatform();
+  const denAuth = useDenAuth();
   const [state, dispatch] = useReducer(welcomeReducer, initialWelcomeState);
   const [manualFolder, setManualFolder] = useState("");
 
@@ -327,9 +329,10 @@ export function WelcomeRoute() {
       {state.providerStep ? (
         <ProviderSelectionStep
           onOpenWorkModels={() => {
-            const settings = readDenSettings();
-            platform.openLink(buildDenAuthUrl(settings.baseUrl, "sign-up"));
-            // Navigate to session after opening sign-up — user will complete in browser
+            // Land on the OpenWork Models value-prop page when already
+            // signed in to Den; otherwise start sign-up. Previously this
+            // always opened a bare sign-up page — payment before value.
+            platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn, "sign-up"));
             const route = state.pendingWorkspaceId
               ? workspaceSessionRoute(state.pendingWorkspaceId, state.pendingSessionId)
               : "/session";


### PR DESCRIPTION
## Summary

Companion to #2162 (subscribe to OpenWork Models at the point of value). The onboarding provider step ("Power your first task" → **Use OpenWork Models**) was the one touchpoint that bypassed `getOpenWorkModelsActionUrl` and always opened a bare Den **sign-up** page — even for users already signed in to Den. That's payment/auth before value, and matches the gap documented in `evals/onboarding-welcome-flows.md` Flow 28 ("OpenWork Models path explains payment before value").

## Changes

- `getOpenWorkModelsActionUrl` accepts an optional auth mode (`"sign-in"` default, unchanged for existing callers).
- The welcome route now uses it: signed-in users land directly on `/dashboard/inference` — the value-prop + Subscribe-with-Stripe page from #2162 — and signed-out users go to sign-up as before.

## Tests run

- `pnpm --filter @openwork/app typecheck` — pass (exit 0).
- Reviewer repro: complete desktop auth handoff with Den, relaunch onboarding (fresh profile with `hasCompletedOnboarding` unset), click **Use OpenWork Models** → browser must open the OpenWork Models page, not the sign-up form.