### PR TITLE
fix(server): register runtime-DB MCPs with the running engine

### DIFF
--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -41,6 +41,7 @@ function startMockOpencode() {
 
       if (url.pathname === "/instance/dispose") return Response.json({ disposed: true });
       if (url.pathname === "/mcp" && request.method === "POST") return Response.json({});
+      if (url.pathname.match(/^\/mcp\/[^/]+\/disconnect$/) && request.method === "POST") return Response.json({});
       return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
     },
   }) as Served;
@@ -175,6 +176,39 @@ describe("runtime MCP engine sync", () => {
       const syncRequest = mock.requests.find((entry) => entry.method === "POST" && entry.pathname === "/mcp");
       expect(syncRequest).toBeDefined();
       expect(syncRequest?.body).toEqual({ name: "posthog", config: { ...POSTHOG_CONFIG, enabled: false } });
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("disconnects a removed MCP from the engine", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    try {
+      const mock = startMockOpencode();
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+
+      const addResponse = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
+        method: "POST",
+        headers: auth(openwork.token),
+        body: JSON.stringify({ name: "posthog", config: POSTHOG_CONFIG }),
+      });
+      expect(addResponse.status).toBe(200);
+      mock.requests.length = 0;
+
+      const removeResponse = await fetch(`${openwork.base}/workspace/ws_1/mcp/posthog`, {
+        method: "DELETE",
+        headers: auth(openwork.token),
+      });
+      expect(removeResponse.status).toBe(200);
+
+      const disconnectRequest = mock.requests.find(
+        (entry) => entry.method === "POST" && entry.pathname === "/mcp/posthog/disconnect",
+      );
+      expect(disconnectRequest).toBeDefined();
+      expect(disconnectRequest?.search).toContain(`directory=${encodeURIComponent(workspaceRoot)}`);
     } finally {
       if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
       else process.env.OPENWORK_RUNTIME_DB = previousDb;

--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
+
+type EngineRequest = {
+  method: string;
+  pathname: string;
+  search: string;
+  body: unknown;
+};
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+async function createWorkspaceRoot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-mcp-engine-sync-"));
+  roots.push(root);
+  return root;
+}
+
+function startMockOpencode() {
+  const requests: EngineRequest[] = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      const body = request.method === "POST" ? await request.json().catch(() => null) : null;
+      requests.push({ method: request.method, pathname: url.pathname, search: url.search, body });
+
+      if (url.pathname === "/instance/dispose") return Response.json({ disposed: true });
+      if (url.pathname === "/mcp" && request.method === "POST") return Response.json({});
+      return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
+    },
+  }) as Served;
+  stops.push(() => server.stop(true));
+  return { server, requests };
+}
+
+async function startOpenworkServer(workspaceRoot: string, opencodeBaseUrl: string) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [
+      {
+        id: "ws_1",
+        name: "Workspace",
+        path: workspaceRoot,
+        preset: "starter",
+        workspaceType: "local",
+        baseUrl: opencodeBaseUrl,
+      },
+    ],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+}
+
+function auth(token: string) {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+const POSTHOG_CONFIG = {
+  type: "remote",
+  url: "https://mcp.posthog.com/mcp",
+  enabled: true,
+  oauth: {},
+};
+
+describe("runtime MCP engine sync", () => {
+  test("hot-adds a runtime MCP into the running engine when added", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    try {
+      const mock = startMockOpencode();
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+
+      const response = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
+        method: "POST",
+        headers: auth(openwork.token),
+        body: JSON.stringify({ name: "posthog", config: POSTHOG_CONFIG }),
+      });
+      expect(response.status).toBe(200);
+
+      const addRequest = mock.requests.find((entry) => entry.method === "POST" && entry.pathname === "/mcp");
+      expect(addRequest).toBeDefined();
+      expect(addRequest?.body).toEqual({ name: "posthog", config: POSTHOG_CONFIG });
+      expect(addRequest?.search).toContain(`directory=${encodeURIComponent(workspaceRoot)}`);
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("re-registers runtime MCPs with the engine after a reload", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    try {
+      const mock = startMockOpencode();
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+
+      const addResponse = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
+        method: "POST",
+        headers: auth(openwork.token),
+        body: JSON.stringify({ name: "posthog", config: POSTHOG_CONFIG }),
+      });
+      expect(addResponse.status).toBe(200);
+      mock.requests.length = 0;
+
+      const reloadResponse = await fetch(`${openwork.base}/workspace/ws_1/engine/reload`, {
+        method: "POST",
+        headers: auth(openwork.token),
+      });
+      expect(reloadResponse.status).toBe(200);
+
+      const disposeIndex = mock.requests.findIndex((entry) => entry.pathname === "/instance/dispose");
+      const syncIndex = mock.requests.findIndex((entry) => entry.method === "POST" && entry.pathname === "/mcp");
+      expect(disposeIndex).toBeGreaterThanOrEqual(0);
+      expect(syncIndex).toBeGreaterThan(disposeIndex);
+      expect(mock.requests[syncIndex]?.body).toEqual({ name: "posthog", config: POSTHOG_CONFIG });
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("pushes toggled enabled state to the engine", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    try {
+      const mock = startMockOpencode();
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+
+      const addResponse = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
+        method: "POST",
+        headers: auth(openwork.token),
+        body: JSON.stringify({ name: "posthog", config: POSTHOG_CONFIG }),
+      });
+      expect(addResponse.status).toBe(200);
+      mock.requests.length = 0;
+
+      const toggleResponse = await fetch(`${openwork.base}/workspace/ws_1/mcp/posthog/enabled`, {
+        method: "POST",
+        headers: auth(openwork.token),
+        body: JSON.stringify({ enabled: false }),
+      });
+      expect(toggleResponse.status).toBe(200);
+
+      const syncRequest = mock.requests.find((entry) => entry.method === "POST" && entry.pathname === "/mcp");
+      expect(syncRequest).toBeDefined();
+      expect(syncRequest?.body).toEqual({ name: "posthog", config: { ...POSTHOG_CONFIG, enabled: false } });
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("MCP add still succeeds when the engine is unreachable", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    try {
+      const openwork = await startOpenworkServer(workspaceRoot, "http://127.0.0.1:9");
+
+      const response = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
+        method: "POST",
+        headers: auth(openwork.token),
+        body: JSON.stringify({ name: "posthog", config: POSTHOG_CONFIG }),
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json() as { items: Array<{ name: string }> };
+      expect(body.items.some((item) => item.name === "posthog")).toBe(true);
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+});

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4049,6 +4049,7 @@ function createRoutes(
       timestamp: Date.now(),
     });
     if (removed) {
+      await disconnectMcpFromOpencodeEngine(config, workspace, name).catch(() => undefined);
       emitReloadEvent(ctx.reloadEvents, workspace, "mcp", {
         type: "mcp",
         name,
@@ -4869,6 +4870,36 @@ async function syncRuntimeMcpToOpencodeEngine(
         body,
       });
     }
+  }
+}
+
+// Counterpart of syncRuntimeMcpToOpencodeEngine for removals: tell the engine
+// to drop the MCP's client so deleted MCPs stop serving tools immediately
+// instead of lingering until the next engine restart. Best-effort.
+async function disconnectMcpFromOpencodeEngine(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  name: string,
+): Promise<void> {
+  const connection = resolveWorkspaceOpencodeConnection(config, workspace);
+  const baseUrl = connection.baseUrl?.trim() ?? "";
+  if (!baseUrl) return;
+
+  const url = new URL(baseUrl);
+  url.pathname = `/mcp/${encodeURIComponent(name)}/disconnect`;
+  url.search = "";
+  const directory = resolveOpencodeDirectory(workspace);
+  if (directory) url.searchParams.set("directory", directory);
+  const headers: Record<string, string> = {};
+  if (connection.authHeader) headers.Authorization = connection.authHeader;
+
+  const response = await fetch(url, { method: "POST", headers, signal: AbortSignal.timeout(15_000) });
+  if (!response.ok) {
+    const body = parseOpencodeErrorBody(await response.text());
+    throw new ApiError(502, "opencode_mcp_disconnect_failed", `Failed to disconnect MCP ${name} from the engine`, {
+      status: response.status,
+      body,
+    });
   }
 }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -71,6 +71,7 @@ import { callExperimentalExtensionAction, listExperimentalExtensionActions } fro
 import {
   mergeOpencodeConfigs,
   readRuntimeOpencodeConfig,
+  runtimeMcpMap,
   type RuntimeOpencodeConfig,
   writeRuntimeOpencodeConfig,
 } from "./runtime-opencode-config-store.js";
@@ -4005,6 +4006,9 @@ function createRoutes(
       paths: [openworkConfigPath(workspace.path)],
     });
     const result = await addMcp(config, workspace.id, name, configPayload);
+    // Hot-add into the running engine so connect/auth works without a full
+    // engine restart (the spawn-time injected config cannot pick it up).
+    await syncRuntimeMcpToOpencodeEngine(config, workspace, [name]).catch(() => undefined);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
@@ -4079,6 +4083,7 @@ function createRoutes(
     if (!updated) {
       throw new ApiError(404, "mcp_not_found", `MCP ${name} not found in workspace config`);
     }
+    await syncRuntimeMcpToOpencodeEngine(config, workspace, [name]).catch(() => undefined);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
@@ -4808,12 +4813,63 @@ async function reloadOpencodeEngine(config: ServerConfig, workspace: WorkspaceIn
   if (auth) headers.Authorization = auth;
 
   const response = await fetch(targetUrl, { method: "POST", headers });
-  if (response.ok) return;
-  const body = parseOpencodeErrorBody(await response.text());
-  throw new ApiError(502, "opencode_reload_failed", "OpenCode reload failed", {
-    status: response.status,
-    body,
-  });
+  if (!response.ok) {
+    const body = parseOpencodeErrorBody(await response.text());
+    throw new ApiError(502, "opencode_reload_failed", "OpenCode reload failed", {
+      status: response.status,
+      body,
+    });
+  }
+
+  // Re-register runtime-DB MCPs: dispose re-reads disk configs plus the
+  // OPENCODE_CONFIG_CONTENT env frozen at spawn, so MCPs added since spawn
+  // would otherwise vanish from the engine after a reload.
+  await syncRuntimeMcpToOpencodeEngine(config, workspace).catch(() => undefined);
+}
+
+// Push runtime-DB MCP entries into the running OpenCode engine via its dynamic
+// add endpoint. The engine only reads OPENCODE_CONFIG_CONTENT once at spawn, so
+// MCPs written to the runtime DB afterwards are invisible to it — auth then
+// fails with McpServerNotFoundError even though the config write succeeded.
+// Best-effort: callers treat engine sync as advisory and swallow failures.
+async function syncRuntimeMcpToOpencodeEngine(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  onlyNames?: string[],
+): Promise<void> {
+  const connection = resolveWorkspaceOpencodeConnection(config, workspace);
+  const baseUrl = connection.baseUrl?.trim() ?? "";
+  if (!baseUrl) return;
+
+  const runtimeConfig = await readRuntimeOpencodeConfig(config, workspace.id);
+  const entries = Object.entries(runtimeMcpMap(runtimeConfig)).filter(
+    ([name]) => !onlyNames || onlyNames.includes(name),
+  );
+  if (entries.length === 0) return;
+
+  const url = new URL(baseUrl);
+  url.pathname = "/mcp";
+  url.search = "";
+  const directory = resolveOpencodeDirectory(workspace);
+  if (directory) url.searchParams.set("directory", directory);
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (connection.authHeader) headers.Authorization = connection.authHeader;
+
+  for (const [name, mcpConfig] of entries) {
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ name, config: mcpConfig }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) {
+      const body = parseOpencodeErrorBody(await response.text());
+      throw new ApiError(502, "opencode_mcp_sync_failed", `Failed to register MCP ${name} with the engine`, {
+        status: response.status,
+        body,
+      });
+    }
+  }
 }
 
 async function writeOpenworkConfig(workspaceRoot: string, payload: Record<string, unknown>, merge: boolean): Promise<void> {


### PR DESCRIPTION
## Problem

Connecting an OAuth MCP from the UI (e.g. PostHog) fails with:

```
{"_tag":"McpServerNotFoundError","name":"posthog","message":"MCP server not found: posthog"}
```

## Root cause

`POST /workspace/:id/mcp` writes the MCP to the runtime SQLite DB only. That DB reaches the engine exclusively through `OPENCODE_CONFIG_CONTENT`, an env var built **once at engine spawn** (`embedded.ts`/`cli.ts`). "Reload engine" calls `POST /instance/dispose`, which re-reads disk configs plus the *same frozen env string* — so MCPs added after spawn never reach the running engine, and `mcp.auth.authenticate` fails with `McpServerNotFoundError` until the engine process is fully restarted.

The "Show raw injected JSON" debug panel makes this confusing: it rebuilds the injected config fresh from the runtime DB on every request, so it shows the MCP even though the live engine doesn't have it.

## Fix

New `syncRuntimeMcpToOpencodeEngine()` in `apps/server/src/server.ts` pushes runtime-DB MCP entries into the running engine via its dynamic `POST /mcp` endpoint (which registers into the engine's live instance config — exactly what the MCP auth lookup checks). Called best-effort:

- after **add** (`POST /workspace/:id/mcp`) → connect + OAuth works immediately, no reload needed
- after **enable/disable toggle**
- inside `reloadOpencodeEngine()` after dispose → reload no longer silently drops runtime MCPs

Engine sync failures are swallowed (`.catch(() => undefined)`) so the config write remains the source of truth and the existing reload-notice UX stays as fallback.

## Tests

Commands run:

- `pnpm typecheck` in `apps/server` — clean
- `bun test` in `apps/server` — **196 pass, 2 fail**; the 2 failures (`opencode-db.test.ts` seed tests) fail identically on clean `origin/dev` (verified via `git stash`), unrelated to this change

New e2e coverage in `apps/server/src/mcp.engine-sync.e2e.test.ts` (mock engine):

- hot-adds the MCP into the engine on add (body + directory query asserted)
- re-registers runtime MCPs after `/instance/dispose` on engine reload (order asserted)
- pushes toggled `enabled` state
- add still succeeds when the engine is unreachable

## Not run / for the reviewer

I could not run the full desktop OAuth flow end-to-end (needs a built app + a real PostHog OAuth round-trip), so no video. Repro steps: Settings → Add MCP → `https://mcp.posthog.com/mcp` → Connect. Before: `McpServerNotFoundError` after "We'll open your browser to finish sign-in." After: browser OAuth opens immediately, no "Reload engine" required.

Note: the original report also had a typo'd URL (`https://mcp.posthog.com/mcp.` — trailing dot); that's bad input and out of scope here.