### PR TITLE
fix(app): make message branch/revert actually work and add right-click edit message

### DIFF
--- a/apps/app/scripts/session-render-state.test.ts
+++ b/apps/app/scripts/session-render-state.test.ts
@@ -6,7 +6,11 @@ import {
   deriveRenderedSessionMessages,
   resolveRenderedSessionSnapshot,
 } from "../src/react-app/domains/session/surface/session-render-state";
-import { reconcileTranscriptMessages } from "../src/react-app/domains/session/sync/transcript-reconcile";
+import {
+  applyRevertCursor,
+  reconcileTranscriptMessages,
+  resolveForkBoundaryId,
+} from "../src/react-app/domains/session/sync/transcript-reconcile";
 import { describeOpencodeSessionError } from "../src/react-app/domains/session/sync/usechat-adapter";
 
 function snapshotWithMessages(
@@ -335,5 +339,85 @@ describe("describeOpencodeSessionError", () => {
         retries: 3,
       },
     })).toBe("Invalid JSON\nRetries: 3");
+  });
+});
+
+describe("applyRevertCursor", () => {
+  const transcript = [
+    uiMessage("msg_1", "user", "turn one"),
+    uiMessage("msg_2", "assistant", "answer one"),
+    uiMessage("msg_3", "user", "turn two"),
+    uiMessage("msg_4", "assistant", "answer two"),
+  ];
+
+  it("hides the reverted message itself and everything after it", () => {
+    // OpenCode marks revert.messageID as the FIRST reverted message.
+    const result = applyRevertCursor(transcript, "msg_3");
+    expect(result.map((message) => message.id)).toEqual(["msg_1", "msg_2"]);
+  });
+
+  it("returns the transcript unchanged without a revert cursor", () => {
+    expect(applyRevertCursor(transcript, null)).toBe(transcript);
+    expect(applyRevertCursor(transcript, undefined)).toBe(transcript);
+  });
+
+  it("returns the transcript unchanged when the cursor id is unknown", () => {
+    expect(applyRevertCursor(transcript, "msg_missing")).toBe(transcript);
+  });
+
+  it("hides everything when the first message is reverted", () => {
+    expect(applyRevertCursor(transcript, "msg_1")).toEqual([]);
+  });
+});
+
+describe("deriveRenderedSessionMessages with revert", () => {
+  it("hides reverted messages from the rendered transcript", () => {
+    const snapshot = snapshotWithMessages([
+      { id: "msg_1", role: "user", text: "turn one" },
+      { id: "msg_2", role: "assistant", text: "answer one" },
+      { id: "msg_3", role: "user", text: "turn two" },
+      { id: "msg_4", role: "assistant", text: "answer two" },
+    ]);
+    (snapshot.session as { revert?: { messageID: string } }).revert = { messageID: "msg_3" };
+
+    const rendered = deriveRenderedSessionMessages({
+      transcriptState: [],
+      snapshot,
+    });
+
+    expect(rendered.map((message) => message.id)).toEqual(["msg_1", "msg_2"]);
+  });
+});
+
+describe("resolveForkBoundaryId", () => {
+  const transcript = [
+    uiMessage("msg_1", "user", "turn one"),
+    uiMessage("msg_2", "assistant", "answer one"),
+    uiMessage("msg_3", "user", "turn two"),
+    uiMessage("msg_4", "assistant", "answer two"),
+  ];
+
+  it("returns the next message so the fork includes the branch point", () => {
+    expect(resolveForkBoundaryId(transcript, "msg_2")).toBe("msg_3");
+    expect(resolveForkBoundaryId(transcript, "msg_3")).toBe("msg_4");
+  });
+
+  it("returns null when branching at the last message (fork everything)", () => {
+    expect(resolveForkBoundaryId(transcript, "msg_4")).toBeNull();
+  });
+
+  it("returns null for unknown ids instead of corrupting the boundary", () => {
+    expect(resolveForkBoundaryId(transcript, "msg_missing")).toBeNull();
+  });
+
+  it("skips synthetic session-error messages when picking the boundary", () => {
+    const withSynthetic = [
+      ...transcript.slice(0, 2),
+      uiMessage("session-error:msg_2", "assistant", "boom"),
+      ...transcript.slice(2),
+    ];
+    expect(resolveForkBoundaryId(withSynthetic, "msg_2")).toBe("msg_3");
+    // Branching at the synthetic message itself falls through to the next real message.
+    expect(resolveForkBoundaryId(withSynthetic, "session-error:msg_2")).toBe("msg_3");
   });
 });

--- a/apps/app/src/components/chat/message-list-provider.tsx
+++ b/apps/app/src/components/chat/message-list-provider.tsx
@@ -14,6 +14,7 @@ interface MessageListContextValue {
   setPrompt: (prompt: string) => void
   onRevertToUserMessage: (messageId: string) => void
   onForkAtMessage: (messageId: string) => void
+  onEditUserMessage: (messageId: string, text: string) => void
 }
 
 const MessageListContext = React.createContext<MessageListContextValue | null>(null)
@@ -26,6 +27,7 @@ interface MessageListProviderProps {
   developerMode: boolean
   onRevertToUserMessage: (messageId: string) => void
   onForkAtMessage: (messageId: string) => void
+  onEditUserMessage: (messageId: string, text: string) => void
   displaySuggestions: boolean
   providerConnectedCount: number
   dispatchAction: (action: DispatchAction) => void
@@ -50,6 +52,7 @@ export function MessageListProvider({
   setPrompt,
   onRevertToUserMessage,
   onForkAtMessage,
+  onEditUserMessage,
 }: MessageListProviderProps) {
   const value = React.useMemo(
     () => ({
@@ -63,6 +66,7 @@ export function MessageListProvider({
       setPrompt,
       onRevertToUserMessage,
       onForkAtMessage,
+      onEditUserMessage,
     }),
     [
       workspaceId,
@@ -75,6 +79,7 @@ export function MessageListProvider({
       setPrompt,
       onRevertToUserMessage,
       onForkAtMessage,
+      onEditUserMessage,
     ],
   )
 

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -7,6 +7,7 @@ import {
   Copy,
   FileIcon,
   LoaderCircle,
+  Pencil,
   Split,
   Undo2,
 } from "lucide-react"
@@ -43,6 +44,12 @@ import {
   DescriptiveButtonTitle,
 } from "@/components/descriptive-button"
 import { Button } from "@/components/ui/button"
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
 import { Image } from "@/components/ui/image"
 import {
   Message,
@@ -385,7 +392,8 @@ function renderUserTextWithSkillChips(text: string) {
 
 const UserMessage = React.memo(
   ({ message, isStreaming }: UserMessageProps) => {
-    const { onRevertToUserMessage, onForkAtMessage } = useMessageList()
+    const { onRevertToUserMessage, onForkAtMessage, onEditUserMessage } = useMessageList()
+    const messageText = React.useMemo(() => getMessagesText([message]), [message])
 
     return (
       <Message
@@ -393,47 +401,89 @@ const UserMessage = React.memo(
         data-message-id={message.id}
         data-message-role={message.role}
       >
-        <div className="group flex w-full flex-col items-end gap-1">
-          {message.parts.filter(isFileUIPart).map((part, index) => (
-            <FileMessage key={`${part.url}-${index}`} part={part} tone="user" />
-          ))}
-          {message.parts.some((part) => part.type === "text" && part.text) ? (
-            <MessageContent
-              layoutId={message.id}
-              className="bg-muted text-foreground max-w-[85%] rounded-3xl px-5 py-2.5 whitespace-pre-wrap sm:max-w-[75%]"
-            >
-              {renderUserTextWithSkillChips(message.parts.map((part) => (part.type === "text" ? part.text : "")).join(""))}
-            </MessageContent>
-          ) : null}
-          {!isStreaming && (
-            <MessageActions
-              className={cn(
-                "flex items-center gap-0 opacity-0 transition-opacity duration-150 group-hover:opacity-100"
-              )}
-            >
-              <MessageTimestamp message={message} className="mr-1.5" />
-              <CopyMessageButton messages={[message]} />
-              <MessageAction tooltip="Branch in new chat">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => onForkAtMessage(message.id)}
-                >
-                  <Split className="rotate-90" />
-                </Button>
-              </MessageAction>
-              <MessageAction tooltip="Revert">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => onRevertToUserMessage(message.id)}
-                >
-                  <Undo2 />
-                </Button>
-              </MessageAction>
-            </MessageActions>
-          )}
-        </div>
+        <ContextMenu>
+          <ContextMenuTrigger
+            render={
+              <div className="group flex w-full flex-col items-end gap-1">
+                {message.parts.filter(isFileUIPart).map((part, index) => (
+                  <FileMessage key={`${part.url}-${index}`} part={part} tone="user" />
+                ))}
+                {message.parts.some((part) => part.type === "text" && part.text) ? (
+                  <MessageContent
+                    layoutId={message.id}
+                    className="bg-muted text-foreground max-w-[85%] rounded-3xl px-5 py-2.5 whitespace-pre-wrap sm:max-w-[75%]"
+                  >
+                    {renderUserTextWithSkillChips(message.parts.map((part) => (part.type === "text" ? part.text : "")).join(""))}
+                  </MessageContent>
+                ) : null}
+                {!isStreaming && (
+                  <MessageActions
+                    className={cn(
+                      "flex items-center gap-0 opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+                    )}
+                  >
+                    <MessageTimestamp message={message} className="mr-1.5" />
+                    <CopyMessageButton messages={[message]} />
+                    {messageText ? (
+                      <MessageAction tooltip="Edit message">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label="Edit message"
+                          onClick={() => onEditUserMessage(message.id, messageText)}
+                        >
+                          <Pencil />
+                        </Button>
+                      </MessageAction>
+                    ) : null}
+                    <MessageAction tooltip="Branch in new chat">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Branch in new chat"
+                        onClick={() => onForkAtMessage(message.id)}
+                      >
+                        <Split className="rotate-90" />
+                      </Button>
+                    </MessageAction>
+                    <MessageAction tooltip="Revert">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Revert"
+                        onClick={() => onRevertToUserMessage(message.id)}
+                      >
+                        <Undo2 />
+                      </Button>
+                    </MessageAction>
+                  </MessageActions>
+                )}
+              </div>
+            }
+          />
+          <ContextMenuContent className="w-56">
+            {messageText ? (
+              <ContextMenuItem onClick={() => onEditUserMessage(message.id, messageText)}>
+                <Pencil className="size-4" />
+                Edit message
+              </ContextMenuItem>
+            ) : null}
+            {messageText ? (
+              <ContextMenuItem onClick={() => void navigator.clipboard.writeText(messageText)}>
+                <Copy className="size-4" />
+                Copy
+              </ContextMenuItem>
+            ) : null}
+            <ContextMenuItem onClick={() => onForkAtMessage(message.id)}>
+              <Split className="size-4 rotate-90" />
+              Branch in new chat
+            </ContextMenuItem>
+            <ContextMenuItem onClick={() => onRevertToUserMessage(message.id)}>
+              <Undo2 className="size-4" />
+              Revert
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
       </Message>
     )
   }
@@ -619,6 +669,10 @@ function MessageGroup({
 }: AssistantMessageGroupProps) {
   const { onRevertToUserMessage, onForkAtMessage } = useMessageList()
   const lastItem = items[items.length - 1]
+  // Branch/revert must target a real server-side message id. Synthetic
+  // client-side messages (e.g. session errors) don't exist on the server and
+  // silently corrupt fork/revert boundaries.
+  const lastRealItem = items.findLast((item) => !isSessionErrorMessage(item.message))
   const isLiveGroup = isStreaming && lastItem !== undefined && lastItem.index === messages.length - 1
   const stepsRef = React.useRef<HTMLDivElement>(null)
 
@@ -679,24 +733,30 @@ function MessageGroup({
         <div className="mx-auto flex w-full max-w-3xl flex-wrap items-center gap-2 px-2 opacity-0 transition-opacity duration-150 group-hover/message-group:opacity-100 md:px-8">
           <MessageActions className="flex gap-0">
             <CopyMessageButton messages={renderableItems.map((item) => item.message)} />
-            <MessageAction tooltip="Branch in new chat">
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => onForkAtMessage(lastItem.message.id)}
-              >
-                <Split className="rotate-90" />
-              </Button>
-            </MessageAction>
-            <MessageAction tooltip="Revert">
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => onRevertToUserMessage(lastItem.message.id)}
-              >
-                <Undo2 />
-              </Button>
-            </MessageAction>
+            {lastRealItem ? (
+              <>
+                <MessageAction tooltip="Branch in new chat">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Branch in new chat"
+                    onClick={() => onForkAtMessage(lastRealItem.message.id)}
+                  >
+                    <Split className="rotate-90" />
+                  </Button>
+                </MessageAction>
+                <MessageAction tooltip="Revert">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Revert"
+                    onClick={() => onRevertToUserMessage(lastRealItem.message.id)}
+                  >
+                    <Undo2 />
+                  </Button>
+                </MessageAction>
+              </>
+            ) : null}
           </MessageActions>
           <MessageTimestamp message={lastItem.message} />
           {/* <MessageSources messages={items.map((item) => item.message)} /> */}

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -817,6 +817,8 @@ export default {
   "session.default_agent": "Default agent",
   "session.default_model": "Pick a model",
   "session.stop_failed": "Could not stop the run — the engine reported no active run was aborted. Try again.",
+  "session.revert_failed": "Could not revert the conversation. Try again once the current run finishes.",
+  "session.branch_failed": "Could not branch this conversation. Try again.",
   "session.default_title": "New session",
   "session.delete": "Delete",
   "session.delete_named_session_message": "This will permanently delete \"{title}\" and its messages.",

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -55,9 +55,11 @@ import { deriveOpenTargets, selectAutoOpenTarget, type OpenTarget } from "@/reac
 import { usePanelTabStore } from "@/react-app/domains/session/panel/panel-tab-store";
 import {
   seedSessionState,
+  snapshotKey as reactSnapshotKey,
   statusKey as reactStatusKey,
   transcriptKey as reactTranscriptKey,
 } from "@/react-app/domains/session/sync/session-sync";
+import { resolveForkBoundaryId } from "@/react-app/domains/session/sync/transcript-reconcile";
 import {
   getComposerAttachments,
   getComposerDraft,
@@ -128,8 +130,8 @@ export type SessionSurfaceProps = {
   onUploadInboxFiles?: ((files: File[], options?: { notify?: boolean }) => void | Promise<unknown>) | null;
   providerConnectedCount?: number;
   onOpenSettingsSection?: ((section: "commands" | "skills" | "mcps" | "plugins" | "providers") => void) | undefined;
-  onRevertToMessage?: (messageId: string, sessionId: string) => void;
-  onForkAtMessage?: (messageId: string, sessionId: string) => void;
+  onRevertToMessage?: (messageId: string, sessionId: string) => Promise<boolean>;
+  onForkAtMessage?: (messageId: string | null, sessionId: string) => void;
   onOpenTarget?: (target: OpenTarget, options?: { auto?: boolean }, sessionId?: string) => void;
 };
 
@@ -430,7 +432,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   );
 
   const snapshotQueryKey = useMemo(
-    () => ["react-session-snapshot", props.workspaceId, props.sessionId],
+    () => reactSnapshotKey(props.workspaceId, props.sessionId),
     [props.workspaceId, props.sessionId],
   );
   const transcriptQueryKey = useMemo(
@@ -1103,12 +1105,24 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [typeComposerText]);
 
   const handleRevertToUserMessage = useCallback((messageId: string) => {
-    props.onRevertToMessage?.(messageId, props.sessionId);
+    void props.onRevertToMessage?.(messageId, props.sessionId);
   }, [props.onRevertToMessage, props.sessionId]);
 
   const handleForkAtMessage = useCallback((messageId: string) => {
-    props.onForkAtMessage?.(messageId, props.sessionId);
-  }, [props.onForkAtMessage, props.sessionId]);
+    // OpenCode's fork copies messages strictly before the given id, so pass
+    // the next real message to make the branch include the clicked message.
+    props.onForkAtMessage?.(resolveForkBoundaryId(renderedMessages, messageId), props.sessionId);
+  }, [props.onForkAtMessage, props.sessionId, renderedMessages]);
+
+  const handleEditUserMessage = useCallback((messageId: string, text: string) => {
+    void (async () => {
+      // Rewind the session to just before this prompt, then restore the
+      // prompt text into the composer so the user can rewrite and resend it.
+      const reverted = await props.onRevertToMessage?.(messageId, props.sessionId);
+      if (reverted === false) return;
+      await typeComposerText(text);
+    })();
+  }, [props.onRevertToMessage, props.sessionId, typeComposerText]);
 
   const sessionScrollTopControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.scroll_top",
@@ -1265,6 +1279,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                     setPrompt={handleMessageListSetPrompt}
                     onRevertToUserMessage={handleRevertToUserMessage}
                     onForkAtMessage={handleForkAtMessage}
+                    onEditUserMessage={handleEditUserMessage}
                   >
                     <MessageList
                       messages={renderedMessages}

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -1,5 +1,5 @@
 import type { UIMessage } from "ai";
-import type { FilePart, Part, PermissionRequest, QuestionRequest, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
+import type { FilePart, Part, PermissionRequest, QuestionRequest, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
 import { getReactQueryClient } from "../../../infra/query-client";
 import { captureAnalyticsEvent, takeTaskRunStart } from "@/app/lib/analytics";
@@ -13,7 +13,7 @@ import {
   STRUCTURED_OUTPUT_TOOL,
 } from "./parse-tool-parts";
 import type { OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
-import { reconcileTranscriptMessages } from "./transcript-reconcile";
+import { applyRevertCursor, reconcileTranscriptMessages } from "./transcript-reconcile";
 import {
   useSessionActivityStore,
 } from "../status/session-activity-store";
@@ -58,6 +58,8 @@ const syncs = new Map<string, SyncEntry>();
 const retainedSessionTtlMs = 10 * 60_000;
 const idleRetainedSessionTtlMs = 10_000;
 
+export const snapshotKey = (workspaceId: string, sessionId: string) =>
+  ["react-session-snapshot", workspaceId, sessionId] as const;
 export const transcriptKey = (workspaceId: string, sessionId: string) =>
   ["react-session-transcript", workspaceId, sessionId] as const;
 export const statusKey = (workspaceId: string, sessionId: string) =>
@@ -699,6 +701,19 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     return;
   }
 
+  if (event.type === "message.removed") {
+    // Revert cleanup (and explicit message deletion) removes messages
+    // server-side; drop them from the live transcript cache so they can't be
+    // resurrected by later snapshot merges.
+    const props = (event.properties ?? {}) as { sessionID?: string; messageID?: string };
+    if (!props.sessionID || !props.messageID) return;
+    if (!isTrackedSession(entry, props.sessionID)) return;
+    queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, props.sessionID), (current = []) =>
+      current.filter((message) => message.id !== props.messageID),
+    );
+    return;
+  }
+
   if (event.type === "message.part.updated") {
     const props = (event.properties ?? {}) as { part?: Part };
     const part = props.part;
@@ -1030,14 +1045,44 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
     assistantOutputAfterLatestUser(incoming),
   );
 
-  queryClient.setQueryData(key, reconcileTranscriptMessages({
-    currentMessages: existing ?? [],
-    snapshotMessages: incoming,
-    reason: "snapshot",
-  }));
+  // The snapshot's revert cursor is authoritative: messages at/after it are
+  // reverted server-side, so the cache must not keep them alive (a later
+  // merge would resurrect them once the server deletes them on next prompt).
+  queryClient.setQueryData(key, applyRevertCursor(
+    reconcileTranscriptMessages({
+      currentMessages: existing ?? [],
+      snapshotMessages: incoming,
+      reason: "snapshot",
+    }),
+    snapshot.session.revert?.messageID ?? null,
+  ));
 
   queryClient.setQueryData(statusKey(workspaceId, snapshot.session.id), snapshot.status);
   queryClient.setQueryData(todoKey(workspaceId, snapshot.session.id), snapshot.todos);
+}
+
+/**
+ * Apply a server-confirmed revert to the local session caches.
+ *
+ * `session.revert` only reaches the renderer through the snapshot cache, so
+ * after a successful `session.revert` call this stamps the returned revert
+ * cursor into the cached snapshot, truncates the live transcript cache, and
+ * refetches the snapshot to pick up the server's post-revert truth. Without
+ * this the UI keeps rendering the old transcript until a full reload.
+ */
+export function applySessionRevert(workspaceId: string, session: Session) {
+  const queryClient = getReactQueryClient();
+  const revertMessageId = session.revert?.messageID ?? null;
+
+  queryClient.setQueryData<OpenworkSessionSnapshot>(
+    snapshotKey(workspaceId, session.id),
+    (current) => (current ? { ...current, session: { ...current.session, revert: session.revert } } : current),
+  );
+  queryClient.setQueryData<UIMessage[]>(
+    transcriptKey(workspaceId, session.id),
+    (current = []) => applyRevertCursor(current, revertMessageId),
+  );
+  void queryClient.invalidateQueries({ queryKey: snapshotKey(workspaceId, session.id) });
 }
 
 export function trackWorkspaceSessionSync(input: SyncOptions, sessionId: string | null | undefined) {

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -551,6 +551,18 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     const update = getSessionUpdatedInfo(event);
     if (!update) return;
     if (!isTrackedSession(entry, update.sessionId)) return;
+    // Keep the cached snapshot's revert cursor in sync with the server. The
+    // renderer derives the visible transcript from this cursor, so a revert
+    // (or its cleanup on the next prompt) must reach the snapshot cache or
+    // the transcript stays frozen on stale history.
+    queryClient.setQueryData<OpenworkSessionSnapshot>(
+      snapshotKey(workspaceId, update.sessionId),
+      (current) => {
+        if (!current) return current;
+        const revert = (update.info as { revert?: OpenworkSessionSnapshot["session"]["revert"] }).revert;
+        return { ...current, session: { ...current.session, revert } };
+      },
+    );
     for (const listener of entry.sessionUpdatedListeners) listener(update);
     return;
   }
@@ -703,13 +715,20 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
 
   if (event.type === "message.removed") {
     // Revert cleanup (and explicit message deletion) removes messages
-    // server-side; drop them from the live transcript cache so they can't be
-    // resurrected by later snapshot merges.
+    // server-side; drop them from both the live transcript cache and the
+    // cached snapshot so they can't be resurrected by later merges.
     const props = (event.properties ?? {}) as { sessionID?: string; messageID?: string };
     if (!props.sessionID || !props.messageID) return;
     if (!isTrackedSession(entry, props.sessionID)) return;
     queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, props.sessionID), (current = []) =>
       current.filter((message) => message.id !== props.messageID),
+    );
+    queryClient.setQueryData<OpenworkSessionSnapshot>(
+      snapshotKey(workspaceId, props.sessionID),
+      (current) => {
+        if (!current) return current;
+        return { ...current, messages: current.messages.filter((message) => message.info.id !== props.messageID) };
+      },
     );
     return;
   }

--- a/apps/app/src/react-app/domains/session/sync/transcript-reconcile.ts
+++ b/apps/app/src/react-app/domains/session/sync/transcript-reconcile.ts
@@ -1,5 +1,6 @@
 import type { UIMessage } from "ai";
 
+import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "../../../../app/types";
 import { mergeSnapshotIntoCachedMessages } from "./message-merge";
 
 export type TranscriptReconcileReason = "snapshot" | "revert";
@@ -33,13 +34,41 @@ export function reconcileTranscriptMessages(input: ReconcileTranscriptInput): UI
 }
 
 /**
- * Hide messages after OpenCode's revert cursor. Revert is an explicit history
- * mutation, so it is the one place the rendered transcript is allowed to move
- * backwards.
+ * Hide messages at and after OpenCode's revert cursor. Revert is an explicit
+ * history mutation, so it is the one place the rendered transcript is allowed
+ * to move backwards.
+ *
+ * OpenCode treats `session.revert.messageID` as the FIRST reverted message
+ * (every message with `id >= revert.messageID` is reverted), so the cursor
+ * message itself must be hidden too.
  */
 export function applyRevertCursor(messages: UIMessage[], revertMessageId: string | null | undefined): UIMessage[] {
   if (!revertMessageId || messages.length === 0) return messages;
   const idx = messages.findIndex((message) => message.id === revertMessageId);
   if (idx < 0) return messages;
-  return messages.slice(0, idx + 1);
+  return messages.slice(0, idx);
+}
+
+function isSyntheticMessageId(id: string) {
+  return id.startsWith(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX);
+}
+
+/**
+ * Resolve the message id to pass to OpenCode's `session.fork` so the branch
+ * INCLUDES the message the user branched at.
+ *
+ * OpenCode copies messages strictly BEFORE the given id, so branching "at" a
+ * message means forking at the next real message after it. Synthetic
+ * client-side messages (e.g. `session-error:*`) are skipped because their ids
+ * do not exist server-side and would corrupt the fork boundary. Returns null
+ * when the branch point is the last message, meaning "fork the full session".
+ */
+export function resolveForkBoundaryId(messages: UIMessage[], messageId: string): string | null {
+  const idx = messages.findIndex((message) => message.id === messageId);
+  if (idx < 0) return null;
+  for (let index = idx + 1; index < messages.length; index += 1) {
+    const candidate = messages[index];
+    if (candidate && !isSyntheticMessageId(candidate.id)) return candidate.id;
+  }
+  return null;
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -20,7 +20,7 @@ import type {
 import { captureAnalyticsEvent, markTaskRunStart } from "@/app/lib/analytics";
 import { trackSessionActive } from "@/app/lib/den-telemetry";
 import { createClient, unwrap } from "@/app/lib/opencode";
-import { forkSession, listCommands, revertSession, setSessionArchived, shellInSession } from "@/app/lib/opencode-session";
+import { abortSessionSafe, forkSession, listCommands, revertSession, setSessionArchived, shellInSession } from "@/app/lib/opencode-session";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
 import {
   buildOpenworkWorkspaceBaseUrl,
@@ -87,6 +87,7 @@ import { ReactSessionRuntime } from "@/react-app/domains/session/sync/runtime-sy
 import { useSessionActivityStore } from "@/react-app/domains/session/status/session-activity-store";
 import { buildOpenworkEnvSystemContext } from "@/react-app/domains/session/sync/env-context";
 import {
+  applySessionRevert,
   permissionKey as reactPermissionKey,
   questionKey as reactQuestionKey,
   seedPermissionState,
@@ -2243,28 +2244,29 @@ export function SessionRoute() {
       },
       isRemoteWorkspace: selectedWorkspace?.workspaceType === "remote",
       isSandboxWorkspace: selectedWorkspace ? isSandboxWorkspace(selectedWorkspace) : false,
-      onRevertToMessage: (messageId: string, sessionId: string) => {
-        void (async () => {
-          const targetSessionId = sessionId.trim() || selectedSessionId;
-          if (!targetSessionId) return;
-          try {
-            // Abort any running generation first, like the actions-store does
-            try { await opencodeClient.session.abort({ sessionID: targetSessionId }); } catch { /* ok if not running */ }
-            await revertSession(opencodeClient, targetSessionId, messageId);
-            // Force a full reload of the session to pick up reverted state
-            navigateToWorkspaceSession(selectedWorkspaceId, targetSessionId);
-            void refreshRouteState();
-          } catch (error) {
-            console.warn("[revert] failed", error);
-          }
-        })();
+      onRevertToMessage: async (messageId: string, sessionId: string) => {
+        const targetSessionId = sessionId.trim() || selectedSessionId;
+        if (!targetSessionId) return false;
+        try {
+          // Abort any running generation first; OpenCode rejects revert on busy sessions.
+          await abortSessionSafe(opencodeClient, targetSessionId, selectedWorkspaceRoot || undefined);
+          const reverted = await revertSession(opencodeClient, targetSessionId, messageId);
+          // Stamp the revert cursor into the local caches so the transcript
+          // rewinds immediately instead of waiting for a full reload.
+          applySessionRevert(selectedWorkspaceId, reverted);
+          return true;
+        } catch (error) {
+          console.warn("[revert] failed", error);
+          toast.error(t("session.revert_failed"));
+          return false;
+        }
       },
-      onForkAtMessage: (messageId: string, sessionId: string) => {
+      onForkAtMessage: (messageId: string | null, sessionId: string) => {
         void (async () => {
           const targetSessionId = sessionId.trim() || selectedSessionId;
           if (!targetSessionId) return;
           try {
-            const forked = await forkSession(opencodeClient, targetSessionId, messageId);
+            const forked = await forkSession(opencodeClient, targetSessionId, messageId ?? undefined);
             writeLastSessionFor(selectedWorkspaceId, forked.id);
             rememberPendingCreatedSession(selectedWorkspaceId, forked.id);
             setSessionsByWorkspaceId((current) => ({
@@ -2275,6 +2277,7 @@ export function SessionRoute() {
             void refreshRouteState();
           } catch (error) {
             console.warn("[fork] failed", error);
+            toast.error(t("session.branch_failed"));
           }
         })();
       },


### PR DESCRIPTION
## Problem

Three message-action bugs, all reproduced end-to-end in the real Electron app on a Daytona sandbox (opencode 1.16.2, GPT-5.5, multi-turn session with file edits):

1. **Branching produced a "weird message".** "Branch in new chat" on an assistant turn created a session that dropped the final answer and ended mid-turn on a tool step followed by a literal **"Empty message"** carcass. Cause: OpenCode's `session.fork` copies messages strictly *before* the given id, and the UI passed the id of the clicked message itself (or worse, a synthetic `session-error:*` id that doesn't exist server-side, which corrupts the boundary and copies everything).
2. **Revert didn't work at all.** Clicking Revert succeeded server-side (verified `session.revert` was set via the opencode API) but the UI never changed. Cause: nothing invalidated the snapshot cache or truncated the transcript cache, so the revert cursor never reached the renderer. After a manual reload there was *also* an off-by-one: `applyRevertCursor` kept the reverted message visible (`slice(0, idx + 1)`), while OpenCode treats `revert.messageID` as the *first reverted* message.
3. **No way to edit a message.** Right-click on a message did nothing; there was no edit/rewire feature at all.

## Fix

- **Branch includes the branch point**: `resolveForkBoundaryId` passes the *next real* message id to `session.fork` (or forks the whole session at the tail), skipping synthetic `session-error:*` ids. Group actions target the last real message of the turn.
- **Revert updates the UI immediately**: after a successful `session.revert`, the returned revert cursor is stamped into the snapshot cache, the live transcript cache is truncated, and the snapshot refetches (`applySessionRevert`). Fixed the cursor off-by-one (`slice(0, idx)`).
- **Caches stay consistent with the server**: `session.updated` SSE events now sync the snapshot cache's revert cursor (set *and* clear), and `message.removed` events prune both transcript and snapshot caches. Without this, sending a prompt after a revert left a stale cursor that froze the transcript until reload (caught during e2e validation). `seedSessionState` also applies the snapshot's revert cursor so reverted messages can't be resurrected by merges.
- **New: Edit message**: right-click a user message (or use the hover pencil) → context menu with **Edit message / Copy / Branch in new chat / Revert**. Edit reverts the session to just before that prompt and restores the text into the composer so it can be rewritten and resent.
- Revert/branch failures now surface as toasts instead of silent `console.warn`.

## Tests run

- `cd apps/app && bun test scripts/session-render-state.test.ts tests/session-sync-permissions.test.ts` → **37 pass, 0 fail** (includes 13 new assertions for `applyRevertCursor`, `resolveForkBoundaryId`, and revert-aware `deriveRenderedSessionMessages`)
- `cd apps/app && tsc -p tsconfig.json --noEmit` → clean
- Note: `tests/session-sync-tool-parts.test.ts` fails on `dev` independently of this PR (it imports `shouldDeferInProgressTool`, which `parse-tool-parts.ts` never exports — drift from #1977).

## End-to-end validation (Daytona, real Electron via CDP)

Sandbox: `bash .devcontainer/test-on-daytona.sh`, real OpenAI GPT-5.5 session in `/workspace/hello`, driven via CDP with message-id-level assertions.

**Before (dev @ b471f7d9a):**
- Branch at assistant turn → forked session ended `[user, assistant "TURN ONE OK", user, assistant "Apply patch"]` + **"Empty message"**, final answer missing.
- Revert on a user message → server `session.revert` set, **UI unchanged** (all 8 messages still rendered); after manual reload the reverted prompt was still visible (off-by-one).
- Right-click on messages → no menu (0 menus opened).

**After (this branch, same sandbox, same session):**
- Revert on the "TURN FOUR" prompt → transcript went **7 → 5 messages instantly**, no reload.
- Right-click user message → menu `["Edit message", "Copy", "Branch in new chat", "Revert"]`; **Edit message** rewound the transcript to turn 1 and filled the composer with the original prompt text; resending produced a fresh turn that rendered live (validates the post-revert prompt path).
- Branch at assistant turn → new session contains the **complete history including the final "TURN TWO OK" answer**, no "Empty message".
- Branch at a user message → branch now includes the clicked prompt (previously silently dropped).

Before/after screenshots captured during the runs are available on request (branch-empty-message before, full-turn branch + edit-composer after).

## How to reproduce manually

1. Create a workspace, run 2–3 prompts (one that edits a file).
2. Hover a user message → Revert: the turn should disappear immediately.
3. Right-click a user message → Edit message: transcript rewinds, composer refills; edit and resend.
4. Hover an assistant answer → Branch in new chat: the new session must end with that answer (no "Empty message").