### PR TITLE
feat: source the opencode engine from a self-maintained fork

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -38,11 +38,12 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || '' }}
         run: |
           set -euo pipefail
 
-          repo="${OPENCODE_GITHUB_REPO:-anomalyco/opencode}"
+          pinned_repo="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeRepo||'').trim());")"
+          repo="${OPENCODE_GITHUB_REPO:-${pinned_repo:-anomalyco/opencode}}"
           version="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeVersion||'').trim().replace(/^v/,''));")"
           version="$(echo "$version" | tr -d '\r\n' | sed 's/^v//')"
 

--- a/.github/workflows/engine-bump.yml
+++ b/.github/workflows/engine-bump.yml
@@ -1,0 +1,78 @@
+name: engine-bump
+
+# Follows the OpenWork engine fork's release cadence: when the fork
+# (constants.json `opencodeRepo`) publishes a newer engine release, open a PR
+# bumping `opencodeVersion`. CI on that PR installs the engine from the new
+# release and runs the full test suite — that is the "known works" gate.
+# Nothing auto-merges; the pin only moves when the PR is reviewed and merged.
+#
+# Note: use a PAT (secrets.ENGINE_BUMP_TOKEN) so the bump PR triggers CI;
+# PRs created with the default GITHUB_TOKEN do not start workflow runs.
+
+on:
+  schedule:
+    - cron: "47 7 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for a newer engine release
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.ENGINE_BUMP_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          repo="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeRepo||'').trim());")"
+          current="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeVersion||'').trim());")"
+          if [ -z "$repo" ]; then
+            echo "constants.json has no opencodeRepo; nothing to track"
+            echo "bump=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          latest="$(gh release list --repo "$repo" --limit 30 --json tagName -q '[.[].tagName | select(test("-openwork\\."))][0] // ""')"
+          echo "repo=$repo current=$current latest=$latest"
+          if [ -z "$latest" ] || [ "$latest" = "$current" ]; then
+            echo "bump=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "bump=true" >> "$GITHUB_OUTPUT"
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+
+      - name: Open bump PR
+        if: steps.check.outputs.bump == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.ENGINE_BUMP_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          latest="${{ steps.check.outputs.latest }}"
+          branch="engine-bump/${latest}"
+          if gh pr list --head "$branch" --state open --json number -q '.[0].number' | grep -q .; then
+            echo "Bump PR for $latest already open"
+            exit 0
+          fi
+          git config user.name "openwork-engine-bot"
+          git config user.email "engineering@different.ai"
+          git checkout -b "$branch"
+          node -e "
+            const fs = require('fs');
+            const parsed = JSON.parse(fs.readFileSync('constants.json', 'utf8'));
+            parsed.opencodeVersion = process.argv[1];
+            fs.writeFileSync('constants.json', JSON.stringify(parsed, null, 2) + '\n');
+          " "$latest"
+          git commit -am "chore: bump opencode engine to ${latest}"
+          git push -u origin "$branch"
+          gh pr create \
+            --title "chore: bump opencode engine to ${latest}" \
+            --body "Automated engine bump: \`${{ steps.check.outputs.current }}\` → \`${latest}\` from [\`${{ steps.check.outputs.repo }}\`](https://github.com/${{ steps.check.outputs.repo }}/releases/tag/${latest}).
+
+          CI installs the engine from this release and runs the full suite — green CI is the validation gate. Release notes on the fork list the upstream ref and applied patches."

--- a/.github/workflows/nightly-evals.yml
+++ b/.github/workflows/nightly-evals.yml
@@ -40,10 +40,11 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || '' }}
         run: |
           set -euo pipefail
-          repo="${OPENCODE_GITHUB_REPO:-anomalyco/opencode}"
+          pinned_repo="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeRepo||'').trim());")"
+          repo="${OPENCODE_GITHUB_REPO:-${pinned_repo:-anomalyco/opencode}}"
           version="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeVersion||'').trim().replace(/^v/,''));")"
           if [ -z "$version" ]; then
             echo "Unable to resolve OpenCode version from constants.json." >&2

--- a/.github/workflows/opencode-agents.yml
+++ b/.github/workflows/opencode-agents.yml
@@ -36,7 +36,14 @@ jobs:
       - name: Install opencode
         run: |
           version="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeVersion||'').trim().replace(/^v/,''));")"
-          curl -fsSL https://opencode.ai/install | bash -s -- --version "$version" --no-modify-path
+          repo="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeRepo||'anomalyco/opencode').trim());")"
+          tmp_dir="$(mktemp -d)"
+          curl -fsSL --retry 5 --retry-delay 2 -o "$tmp_dir/opencode.tar.gz" \
+            "https://github.com/${repo}/releases/download/v${version}/opencode-linux-x64-baseline.tar.gz"
+          tar -xzf "$tmp_dir/opencode.tar.gz" -C "$tmp_dir"
+          mkdir -p "$HOME/.opencode/bin"
+          install -m 0755 "$tmp_dir/opencode" "$HOME/.opencode/bin/opencode"
+          echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
       - name: Triage issue
         env:
@@ -72,7 +79,14 @@ jobs:
       - name: Install opencode
         run: |
           version="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeVersion||'').trim().replace(/^v/,''));")"
-          curl -fsSL https://opencode.ai/install | bash -s -- --version "$version" --no-modify-path
+          repo="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeRepo||'anomalyco/opencode').trim());")"
+          tmp_dir="$(mktemp -d)"
+          curl -fsSL --retry 5 --retry-delay 2 -o "$tmp_dir/opencode.tar.gz" \
+            "https://github.com/${repo}/releases/download/v${version}/opencode-linux-x64-baseline.tar.gz"
+          tar -xzf "$tmp_dir/opencode.tar.gz" -C "$tmp_dir"
+          mkdir -p "$HOME/.opencode/bin"
+          install -m 0755 "$tmp_dir/opencode" "$HOME/.opencode/bin/opencode"
+          echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
       - name: Build prompt
         env:

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -920,6 +920,28 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     if (!version) {
       throw new Error("constants.json is missing opencodeVersion");
     }
+    const repo = String(payload?.opencodeRepo ?? "").trim();
+    // OpenWork engine builds (vX.Y.Z-openwork.N) only exist as GitHub release
+    // assets on the pinned repo; the opencode.ai installer cannot resolve them.
+    if (repo && version.includes("-openwork.")) {
+      const assets = {
+        "darwin-arm64": "opencode-darwin-arm64.zip",
+        "darwin-x64": "opencode-darwin-x64-baseline.zip",
+        "linux-arm64": "opencode-linux-arm64.tar.gz",
+        "linux-x64": "opencode-linux-x64-baseline.tar.gz",
+        "win32-x64": "opencode-windows-x64-baseline.zip",
+        "win32-arm64": "opencode-windows-arm64.zip",
+      };
+      const asset = assets[`${process.platform}-${process.arch}`];
+      if (asset) {
+        const url = `https://github.com/${repo}/releases/download/v${version}/${asset}`;
+        const extract = asset.endsWith(".tar.gz")
+          ? `tar -xzf /tmp/${asset} -C "$HOME/.opencode/bin"`
+          : `unzip -o /tmp/${asset} -d "$HOME/.opencode/bin"`;
+        return `mkdir -p "$HOME/.opencode/bin" && curl -fsSL ${url} -o /tmp/${asset} && ${extract}`;
+      }
+      return `Download opencode v${version} from https://github.com/${repo}/releases/tag/v${version}`;
+    }
     return `curl -fsSL https://opencode.ai/install | bash -s -- --version ${version} --no-modify-path`;
   }
 

--- a/apps/desktop/scripts/prepare-sidecar.mjs
+++ b/apps/desktop/scripts/prepare-sidecar.mjs
@@ -34,17 +34,27 @@ const sidecarOverride = process.env.OPENWORK_SIDECAR_DIR?.trim() || readArg("--o
 const sidecarDir = sidecarOverride ? resolve(sidecarOverride) : join(__dirname, "..", "src-tauri", "sidecars");
 const constantsPath = resolve(__dirname, "..", "..", "..", "constants.json");
 
+const pinnedOpencodeRepo = (() => {
+  try {
+    const parsed = JSON.parse(readFileSync(constantsPath, "utf8"));
+    return typeof parsed.opencodeRepo === "string" ? parsed.opencodeRepo.trim() || null : null;
+  } catch {
+    return null;
+  }
+})();
+
 const opencodeGithubRepo = (() => {
+  const fallback = pinnedOpencodeRepo || "anomalyco/opencode";
   const raw =
     process.env.OPENCODE_GITHUB_REPO?.trim() ||
     process.env.OPENWORK_OPENCODE_GITHUB_REPO?.trim() ||
-    "anomalyco/opencode";
+    fallback;
   const normalized = raw
     .replace(/^https:\/\/github\.com\//i, "")
     .replace(/\.git$/i, "")
     .trim();
   if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(normalized)) {
-    return "anomalyco/opencode";
+    return fallback;
   }
   return normalized;
 })();

--- a/apps/orchestrator/script/build.ts
+++ b/apps/orchestrator/script/build.ts
@@ -109,7 +109,7 @@ async function buildOnce(entrypoint: string, outdir: string, filename: string, t
   try {
     const constants = JSON.parse(
       readFileSync(resolve("..", "..", "constants.json"), "utf8"),
-    ) as { opencodeVersion?: string };
+    ) as { opencodeVersion?: string; opencodeRepo?: string };
     if (
       typeof constants.opencodeVersion === "string" &&
       constants.opencodeVersion.trim()
@@ -117,6 +117,9 @@ async function buildOnce(entrypoint: string, outdir: string, filename: string, t
       define.__OPENWORK_PINNED_OPENCODE_VERSION__ = `\"${constants.opencodeVersion
         .trim()
         .replace(/^v/, "")}\"`;
+    }
+    if (typeof constants.opencodeRepo === "string" && constants.opencodeRepo.trim()) {
+      define.__OPENWORK_PINNED_OPENCODE_REPO__ = `\"${constants.opencodeRepo.trim()}\"`;
     }
   } catch {
     // ignore

--- a/apps/orchestrator/src/cli.ts
+++ b/apps/orchestrator/src/cli.ts
@@ -128,6 +128,21 @@ const FALLBACK_VERSION = "0.1.0";
 
 declare const __OPENWORK_ORCHESTRATOR_VERSION__: string | undefined;
 declare const __OPENWORK_PINNED_OPENCODE_VERSION__: string | undefined;
+declare const __OPENWORK_PINNED_OPENCODE_REPO__: string | undefined;
+
+function pinnedOpencodeRepo(): string {
+  const fromEnv =
+    process.env.OPENWORK_OPENCODE_GITHUB_REPO?.trim() ||
+    process.env.OPENCODE_GITHUB_REPO?.trim();
+  if (fromEnv) return fromEnv;
+  if (
+    typeof __OPENWORK_PINNED_OPENCODE_REPO__ === "string" &&
+    __OPENWORK_PINNED_OPENCODE_REPO__.trim()
+  ) {
+    return __OPENWORK_PINNED_OPENCODE_REPO__.trim();
+  }
+  return "anomalyco/opencode";
+}
 const DEFAULT_OPENWORK_PORT = 8787;
 const DEFAULT_APPROVAL_TIMEOUT = 30000;
 const MANAGED_OPENCODE_CREDENTIAL_LENGTH = 512;
@@ -2119,7 +2134,7 @@ async function resolveOpencodeDownload(
   const version = expectedVersion.startsWith("v")
     ? expectedVersion.slice(1)
     : expectedVersion;
-  const url = `https://github.com/anomalyco/opencode/releases/download/v${version}/${asset}`;
+  const url = `https://github.com/${pinnedOpencodeRepo()}/releases/download/v${version}/${asset}`;
   const targetDir = join(sidecar.dir, "opencode", version, sidecar.target);
   const targetPath = join(
     targetDir,

--- a/constants.json
+++ b/constants.json
@@ -1,3 +1,4 @@
 {
-  "opencodeVersion": "v1.16.2"
+  "opencodeVersion": "v1.16.2-openwork.0",
+  "opencodeRepo": "different-ai/opencode"
 }

--- a/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
+++ b/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
@@ -17,6 +17,7 @@ FROM node:22-bookworm-slim
 
 ARG OPENWORK_ORCHESTRATOR_VERSION=0.11.151
 ARG OPENCODE_VERSION
+ARG OPENCODE_GITHUB_REPO=anomalyco/opencode
 ARG OPENCODE_DOWNLOAD_URL=
 
 RUN apt-get update \
@@ -36,7 +37,7 @@ RUN set -eux; \
   esac; \
   url="$OPENCODE_DOWNLOAD_URL"; \
   if [ -z "$url" ]; then \
-    url="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/${asset}"; \
+    url="https://github.com/${OPENCODE_GITHUB_REPO}/releases/download/v${OPENCODE_VERSION}/${asset}"; \
   fi; \
   tmpdir="$(mktemp -d)"; \
   curl -fsSL "$url" -o "$tmpdir/$asset"; \

--- a/ee/apps/den-worker-runtime/scripts/install-opencode.mjs
+++ b/ee/apps/den-worker-runtime/scripts/install-opencode.mjs
@@ -62,7 +62,8 @@ function resolveOpencodeVersion() {
   if (!version) {
     throw new Error(`Pinned OpenCode version is missing from ${versionPath}`);
   }
-  return version;
+  const repo = String(parsed.opencodeRepo ?? "").trim() || "anomalyco/opencode";
+  return { version, repo };
 }
 
 function resolveAssetName() {
@@ -153,7 +154,7 @@ function findBinary(searchRoot) {
   throw new Error(`Unable to find ${outputName} inside extracted archive`);
 }
 
-const version = resolveOpencodeVersion();
+const { version, repo: opencodeRepo } = resolveOpencodeVersion();
 const versionLabel = version;
 
 if (
@@ -168,7 +169,7 @@ if (
 const assetName = resolveAssetName();
 const downloadUrl = process.env.OPENWORK_OPENCODE_DOWNLOAD_URL?.trim()
   || (version
-    ? `https://github.com/anomalyco/opencode/releases/download/v${version}/${assetName}`
+    ? `https://github.com/${opencodeRepo}/releases/download/v${version}/${assetName}`
     : null);
 if (!downloadUrl) {
   throw new Error("Pinned OpenCode version is required to bundle the worker runtime");

--- a/packaging/docker/Dockerfile.microsandbox
+++ b/packaging/docker/Dockerfile.microsandbox
@@ -19,6 +19,7 @@ FROM node:22-bookworm-slim
 ARG OPENWORK_ORCHESTRATOR_VERSION
 ARG OPENWORK_SERVER_VERSION
 ARG OPENCODE_VERSION
+ARG OPENCODE_GITHUB_REPO=anomalyco/opencode
 ARG OPENCODE_DOWNLOAD_URL=
 
 RUN apt-get update \
@@ -42,7 +43,7 @@ RUN set -eux; \
   esac; \
   url="$OPENCODE_DOWNLOAD_URL"; \
   if [ -z "$url" ]; then \
-    url="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/${asset}"; \
+    url="https://github.com/${OPENCODE_GITHUB_REPO}/releases/download/v${OPENCODE_VERSION}/${asset}"; \
   fi; \
   tmpdir="$(mktemp -d)"; \
   curl -fsSL "$url" -o "$tmpdir/$asset"; \

--- a/scripts/build-microsandbox-openwork-image.sh
+++ b/scripts/build-microsandbox-openwork-image.sh
@@ -7,6 +7,7 @@ DOCKERFILE="$ROOT_DIR/packaging/docker/Dockerfile.microsandbox"
 IMAGE_REF="${1:-openwork-microsandbox:dev}"
 DOCKER_PLATFORM="${DOCKER_PLATFORM:-}"
 OPENCODE_VERSION="${OPENCODE_VERSION:-$(node -e 'const fs=require("fs"); const parsed=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(parsed.opencodeVersion || "").trim().replace(/^v/, ""));' "$ROOT_DIR/constants.json")}"
+OPENCODE_GITHUB_REPO="${OPENCODE_GITHUB_REPO:-$(node -e 'const fs=require("fs"); const parsed=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(parsed.opencodeRepo || "anomalyco/opencode").trim());' "$ROOT_DIR/constants.json")}"
 OPENWORK_ORCHESTRATOR_VERSION="${OPENWORK_ORCHESTRATOR_VERSION:-$(node -e 'const fs=require("fs"); const pkg=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(pkg.version));' "$ROOT_DIR/apps/orchestrator/package.json")}"
 OPENWORK_SERVER_VERSION="${OPENWORK_SERVER_VERSION:-$(node -e 'const fs=require("fs"); const pkg=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(pkg.version));' "$ROOT_DIR/apps/server/package.json")}"
 
@@ -17,6 +18,7 @@ args=(
   --build-arg "OPENWORK_ORCHESTRATOR_VERSION=$OPENWORK_ORCHESTRATOR_VERSION"
   --build-arg "OPENWORK_SERVER_VERSION=$OPENWORK_SERVER_VERSION"
   --build-arg "OPENCODE_VERSION=$OPENCODE_VERSION"
+  --build-arg "OPENCODE_GITHUB_REPO=$OPENCODE_GITHUB_REPO"
 )
 
 if [ -n "$DOCKER_PLATFORM" ]; then

--- a/scripts/create-daytona-openwork-snapshot.sh
+++ b/scripts/create-daytona-openwork-snapshot.sh
@@ -36,6 +36,7 @@ LOCAL_IMAGE_TAG="${DAYTONA_LOCAL_IMAGE_TAG:-openwork-daytona-snapshot:${SNAPSHOT
 
 OPENWORK_ORCHESTRATOR_VERSION="${OPENWORK_ORCHESTRATOR_VERSION:-$(node -e 'const fs=require("fs"); const pkg=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(pkg.version));' "$ROOT_DIR/apps/orchestrator/package.json")}"
 OPENCODE_VERSION="$(node -e 'const fs=require("fs"); const parsed=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(parsed.opencodeVersion || "").trim().replace(/^v/, ""));' "$ROOT_DIR/constants.json")"
+OPENCODE_GITHUB_REPO="${OPENCODE_GITHUB_REPO:-$(node -e 'const fs=require("fs"); const parsed=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(parsed.opencodeRepo || "anomalyco/opencode").trim());' "$ROOT_DIR/constants.json")}"
 
 echo "Building local image $LOCAL_IMAGE_TAG" >&2
 echo "- openwork-orchestrator@$OPENWORK_ORCHESTRATOR_VERSION" >&2
@@ -47,6 +48,7 @@ docker buildx build \
   -f "$DOCKERFILE" \
   --build-arg "OPENWORK_ORCHESTRATOR_VERSION=$OPENWORK_ORCHESTRATOR_VERSION" \
   --build-arg "OPENCODE_VERSION=$OPENCODE_VERSION" \
+  --build-arg "OPENCODE_GITHUB_REPO=$OPENCODE_GITHUB_REPO" \
   --load \
   "$ROOT_DIR"
 


### PR DESCRIPTION
## What

Switches the bundled opencode engine from `anomalyco/opencode` releases to our own fork [`different-ai/opencode`](https://github.com/different-ai/opencode), pinned at [`v1.16.2-openwork.0`](https://github.com/different-ai/opencode/releases/tag/v1.16.2-openwork.0) — an identical rebuild of upstream `v1.16.2` (zero patches), built by the fork's own `engine-release` workflow with upstream-identical asset names.

## Why

We want to carry our own engine patches and control rollout timing without waiting on upstream, while still following upstream's release cadence.

## How rollout works from now on

- **Single pin**: `constants.json` now holds both `opencodeVersion` and `opencodeRepo`. Every consumer reads it: desktop sidecar (`prepare-sidecar.mjs`), orchestrator runtime downloads (was hardcoded), Daytona/microsandbox images, den-worker bundler, CI engine installs.
- **Cadence**: the fork's `upstream-sync` workflow (daily cron) fast-forwards its `dev` mirror and auto-builds `vX.Y.Z-openwork.0` whenever upstream publishes a release.
- **Validation gate**: new `engine-bump.yml` here opens a PR bumping `opencodeVersion` when the fork has a newer release; CI on that PR installs the engine from the new release and runs the full suite. Nothing auto-merges. (Set `ENGINE_BUMP_TOKEN` PAT secret so bump PRs trigger CI.)
- **Patches**: `.patch` files in the fork's `openwork/patches/` are applied with `git am` on top of the upstream tag at build time; release notes record the upstream ref.

## Signing

- macOS: bun embeds an ad-hoc signature at compile time (verified: binary runs on Apple Silicon); `prepare-sidecar` re-codesigns and the release workflow signs + notarizes the app bundle. No change.
- Linux/Docker: n/a.
- Windows: fork CLI exes are unsigned (upstream used their Azure Trusted Signing). Known cosmetic regression inside the installed app; follow-up if we want our own cert.

## Tested (commands + results)

- Fork release build: [engine-release run](https://github.com/different-ai/opencode/actions) — success, all 12 assets published with upstream naming.
- `opencode --version` → `1.16.2-openwork.0`; `opencode serve` health → `{"healthy":true,"version":"1.16.2-openwork.0"}`.
- `node scripts/prepare-sidecar.mjs --force` against this branch → downloaded from the fork, version check passed, codesigned, `versions.json` written (sha256 recorded).
- Full E2E: OpenWork server (managed engine = fork binary) → add posthog MCP → engine reports `{"posthog":{"status":"needs_auth"}}`.
- `pnpm typecheck` in `apps/orchestrator` — clean; `node --check` on all edited .mjs scripts; `bash -n` on edited shell scripts.
- **This PR's own CI is the final gate**: `ci-tests.yml` now installs the engine from `different-ai/opencode v1.16.2-openwork.0` and runs the suite against it.

## Known follow-ups

- No download-time sha256 verification on engine fetch paths (pre-existing; worth adding now that we own the supply chain).
- `opencode-chrome-devtools` plugin still fetched unpinned from npm at runtime (pre-existing).
- README install instructions still reference `opencode.ai/install` (docs only).