### PR TITLE
feat(browser): proxy support for the built-in browser (agent tool)

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -32,6 +32,10 @@ export type BrowserStatePayload = {
   tabs?: BrowserPanelTab[];
 };
 
+export type BrowserProxyState = {
+  proxy: { rules: string; authenticated: boolean } | null;
+};
+
 // ---------------------------------------------------------------------------
 // Electron bridge surface
 // ---------------------------------------------------------------------------
@@ -119,6 +123,8 @@ declare global {
         selectTab?: (tabId: string) => Promise<string>;
         reorderTabs?: (tabIds: string[]) => Promise<BrowserPanelTab[]>;
         listTabs?: () => Promise<BrowserPanelTab[]>;
+        setProxy?: (proxy?: string | null) => Promise<BrowserProxyState>;
+        getProxy?: () => Promise<BrowserProxyState>;
         showTabContextMenu?: (tabId: string, point?: { x: number; y: number }) => Promise<void>;
         destroy?: () => Promise<void>;
         onStateChange?: (callback: (state: BrowserStatePayload) => void) => () => void;

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -445,6 +445,24 @@ export function SessionPage(props: SessionPageProps) {
     },
   }), [setCurrentSidePanel]);
   useControlAction(openBrowserUrlControlAction);
+  const setBrowserProxyControlAction = useMemo<OpenworkControlAction>(() => ({
+    id: "browser.set_proxy",
+    label: "Set built-in browser proxy",
+    description: "Route all built-in browser traffic through an HTTP/SOCKS proxy (e.g. to browse from another location). Applies to every built-in browser tab until cleared. Pass an empty proxy to restore system network settings.",
+    sideEffect: "mutation",
+    args: [
+      { name: "proxy", type: "string", description: "Proxy URL like http://user:pass@host:8080 or socks5://host:1080, env:NAME to use the OPENWORK_BROWSER_PROXY_NAME environment variable, or empty to clear." },
+    ],
+    previewArgs: { proxy: "env:DE" },
+    disabled: !isElectronRuntime(),
+    execute: async (args) => {
+      const proxy = controlStringArg(args, "proxy") || "";
+      const setProxy = window.__OPENWORK_ELECTRON__?.browser?.setProxy;
+      if (!setProxy) return { ok: false, error: "Built-in browser is not available." };
+      return setProxy(proxy);
+    },
+  }), []);
+  useControlAction(setBrowserProxyControlAction);
   const openArtifactRailPane = useCallback(() => {
     if (!hasArtifactTargets || !props.selectedSessionId) return;
     const activeTab = sessionPanelState.tabs.find((tab) => tab.id === sessionPanelState.activeTabId);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -536,6 +536,9 @@ let activeBrowserTabId = null;
 let browserViewVisible = false;
 let lastBrowserBounds = null;
 let browserTabCounter = 0;
+const BROWSER_SESSION_PARTITION = "persist:openwork-browser";
+// Active proxy for the built-in browser session: { rules, username, password }.
+let browserProxy = null;
 const BROWSER_DEFAULT_URL = "about:blank";
 // URL a user-initiated new tab (the "+" button / opening the browser panel)
 // lands on. The agent's programmatic path keeps BROWSER_DEFAULT_URL.
@@ -1109,6 +1112,70 @@ function handleMenuOverlayChoice(payload) {
   }
 }
 
+// ── Built-in browser proxy ──────────────────────────────────────────────
+// Proxying is session-scoped in Electron, and every built-in browser tab
+// shares BROWSER_SESSION_PARTITION, so one setProxy call covers all tabs
+// (agent CDP traffic included) without touching the rest of the app.
+
+function resolveBrowserProxyInput(input) {
+  const raw = String(input ?? "").trim();
+  const envMatch = raw.match(/^env:([A-Za-z0-9_]+)$/i);
+  if (!envMatch) return raw;
+  const key = `OPENWORK_BROWSER_PROXY_${envMatch[1].toUpperCase()}`;
+  const value = String(process.env[key] ?? "").trim();
+  if (!value) throw new Error(`No proxy configured: set the ${key} environment variable to a proxy URL.`);
+  return value;
+}
+
+function parseBrowserProxyInput(input) {
+  const raw = resolveBrowserProxyInput(input);
+  if (!raw) return null;
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `http://${raw}`;
+  let url;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    throw new Error(`Invalid proxy URL: ${raw}`);
+  }
+  if (!url.hostname || !url.port) {
+    throw new Error("Proxy must include host and port, e.g. http://user:pass@host:8080 or socks5://host:1080.");
+  }
+  const scheme = url.protocol.replace(/:$/, "").toLowerCase();
+  return {
+    rules: `${scheme}://${url.hostname}:${url.port}`,
+    username: decodeURIComponent(url.username),
+    password: decodeURIComponent(url.password),
+  };
+}
+
+function browserProxyState() {
+  return {
+    proxy: browserProxy
+      ? { rules: browserProxy.rules, authenticated: Boolean(browserProxy.username) }
+      : null,
+  };
+}
+
+async function setBrowserProxy(proxyInput) {
+  const browserSession = session.fromPartition(BROWSER_SESSION_PARTITION);
+  const parsed = parseBrowserProxyInput(proxyInput);
+  if (parsed) {
+    await browserSession.setProxy({ proxyRules: parsed.rules, proxyBypassRules: "<local>" });
+  } else {
+    await browserSession.setProxy({ mode: "system" });
+  }
+  browserProxy = parsed;
+  // Drop keep-alive connections so existing tabs cannot bypass the new proxy.
+  await browserSession.closeAllConnections();
+  return browserProxyState();
+}
+
+app.on("login", (event, _webContents, _details, authInfo, callback) => {
+  if (!authInfo?.isProxy || !browserProxy?.username) return;
+  event.preventDefault();
+  callback(browserProxy.username, browserProxy.password);
+});
+
 function createBrowserTab(url = "about:blank", { select = true } = {}) {
   const tabId = createBrowserTabId();
   const view = new WebContentsView({
@@ -1118,7 +1185,7 @@ function createBrowserTab(url = "about:blank", { select = true } = {}) {
       contextIsolation: true,
       nodeIntegration: false,
       preload: path.join(__dirname, "browser-content-preload.cjs"),
-      partition: "persist:openwork-browser",
+      partition: BROWSER_SESSION_PARTITION,
     },
   });
   const tab = { tabId, view, favicon: null };
@@ -3255,6 +3322,8 @@ ipcMain.handle("openwork:browser:closeAllTabs", () => closeAllBrowserTabs());
 ipcMain.handle("openwork:browser:selectTab", (_event, tabId) => selectBrowserTab(String(tabId ?? "")).tabId);
 ipcMain.handle("openwork:browser:reorderTabs", (_event, tabIds) => reorderBrowserTabs(tabIds));
 ipcMain.handle("openwork:browser:listTabs", () => listBrowserTabs());
+ipcMain.handle("openwork:browser:setProxy", (_event, proxy) => setBrowserProxy(proxy));
+ipcMain.handle("openwork:browser:getProxy", () => browserProxyState());
 ipcMain.handle("openwork:browser:tabContextMenu", (_event, tabId, point) => showBrowserTabContextMenu(tabId, point));
 ipcMain.handle("openwork:browser:destroy", () => destroyBrowserView());
 ipcMain.on("openwork:menu-overlay:ready", (event) => {

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -119,6 +119,8 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     selectTab(tabId) { return ipcRenderer.invoke("openwork:browser:selectTab", tabId); },
     reorderTabs(tabIds) { return ipcRenderer.invoke("openwork:browser:reorderTabs", tabIds); },
     listTabs() { return ipcRenderer.invoke("openwork:browser:listTabs"); },
+    setProxy(proxy) { return ipcRenderer.invoke("openwork:browser:setProxy", proxy); },
+    getProxy() { return ipcRenderer.invoke("openwork:browser:getProxy"); },
     showTabContextMenu(tabId, point) { return ipcRenderer.invoke("openwork:browser:tabContextMenu", tabId, point); },
     destroy() { return ipcRenderer.invoke("openwork:browser:destroy"); },
     onStateChange(callback) {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -38,6 +38,10 @@ const browserOpenUrlArgsSchema = z.object({
   provider: z.enum(["auto", "builtin", "external"]).optional().describe("Browser provider. Use builtin or auto; external is reserved for future support."),
 });
 
+const browserSetProxyArgsSchema = z.object({
+  proxy: z.string().describe("Proxy URL like http://user:pass@host:8080 or socks5://host:1080. Prefer env:NAME (resolves the OPENWORK_BROWSER_PROXY_NAME environment variable on the user's machine) so credentials never enter the conversation."),
+});
+
 const OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION =
   "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
 
@@ -270,6 +274,29 @@ export const OpenWorkExtensionsPreview = async () => ({
             actionId: "browser.open_url",
             args: { url: args.url, provider: args.provider ?? "builtin" },
           },
+        });
+        return JSON.stringify(result, null, 2);
+      },
+    },
+    openwork_browser_set_proxy: {
+      description: "Route all OpenWork built-in browser traffic through an HTTP/SOCKS proxy — for example to fetch search results or pages as seen from another location. Applies to every built-in browser tab (including browser_* automation) until cleared with openwork_browser_clear_proxy. If the user has named proxies configured as OPENWORK_BROWSER_PROXY_<NAME> environment variables, pass env:NAME instead of a raw URL.",
+      args: browserSetProxyArgsSchema.shape,
+      async execute(rawArgs: unknown) {
+        const args = browserSetProxyArgsSchema.parse(rawArgs);
+        const result = await uiBridgeRequest("/execute", {
+          method: "POST",
+          body: { actionId: "browser.set_proxy", args: { proxy: args.proxy } },
+        });
+        return JSON.stringify(result, null, 2);
+      },
+    },
+    openwork_browser_clear_proxy: {
+      description: "Clear the OpenWork built-in browser proxy and restore the system network settings.",
+      args: {},
+      async execute() {
+        const result = await uiBridgeRequest("/execute", {
+          method: "POST",
+          body: { actionId: "browser.set_proxy", args: { proxy: "" } },
         });
         return JSON.stringify(result, null, 2);
       },


### PR DESCRIPTION
## What

Adds a power-user primitive to route **built-in browser** traffic through an HTTP/SOCKS proxy — e.g. to fetch SERP data as seen from a particular location (requested in [this tweet](https://x.com/IndieSuperhuman)).

No settings UI: exposed as agent tools through the existing browser plugin path (plugin tool → UI control bridge → renderer control action → Electron IPC → `session.setProxy`).

## How

- `openwork_browser_set_proxy` / `openwork_browser_clear_proxy` tools in `openwork-extensions-preview.ts`
- New `browser.set_proxy` UI control action + `openwork:browser:setProxy/getProxy` IPC
- Proxy is applied to the shared `persist:openwork-browser` session partition, so it covers every built-in browser tab (agent CDP traffic included) and nothing else in the app
- `env:NAME` references resolve `OPENWORK_BROWSER_PROXY_<NAME>` env vars so proxy credentials never pass through the model/conversation
- Authenticated proxies handled via the app `login` event
- `closeAllConnections()` on change so existing keep-alive connections can't bypass the new proxy

## Tests run

- `pnpm --filter @openwork/app typecheck` — pass
- `pnpm --filter openwork-server typecheck` — pass
- `bun test src/workspace-init.test.ts` (apps/server, covers plugin packaging) — 8 pass / 0 fail

## E2E evidence (local Electron dev app, real bridge path)

Started a local logging proxy on `127.0.0.1:18888`, launched `pnpm dev` with `OPENWORK_BROWSER_PROXY_TEST=http://127.0.0.1:18888`, then drove the exact path the plugin tools use (UI control bridge `/execute`):

1. `browser.set_proxy {proxy: "env:TEST"}` → `{"ok":true,...,"result":{"proxy":{"rules":"http://127.0.0.1:18888","authenticated":false}}}`
2. `browser.open_url {url: "https://example.com"}` → proxy log recorded `CONNECT example.com:443`, page rendered (verified title "Example Domain" via CDP eval)
3. `browser.set_proxy {proxy: ""}` → `{"proxy":null}`; subsequent `browser.open_url https://example.org` loaded fine with **zero** new proxy log lines (direct connection restored)

No video captured (headless CLI run); the steps above are reproducible with `curl` against the bridge discovery file at `~/Library/Application Support/com.differentai.openwork.dev/openwork-ui-control.json`.