### PR TITLE
fix(desktop): make main process authoritative for browser view zoom scaling

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -38,7 +38,6 @@ export type BrowserStatePayload = {
 
 declare global {
   interface Window {
-    __OPENWORK_ZOOM_FACTOR__?: number;
     __OPENWORK_ELECTRON__?: {
       invokeDesktop?: (command: string, ...args: unknown[]) => Promise<unknown>;
       shell?: {

--- a/apps/app/src/react-app/domains/session/panel/utils.ts
+++ b/apps/app/src/react-app/domains/session/panel/utils.ts
@@ -8,28 +8,16 @@ export function getElectronBrowser() {
   return window.__OPENWORK_ELECTRON__?.browser ?? null;
 }
 
-// The renderer uses Electron's webContents.setZoomFactor, which scales the page
-// so getBoundingClientRect() / innerWidth report CSS pixels DIVIDED by the zoom
-// factor (e.g. at zoom 1.5 a 1180 DIP window measures ~786). WebContentsView
-// bounds, however, are in window device-independent pixels. So renderer rects
-// must be multiplied back by the zoom factor to land in the native coordinate
-// space. At zoom = 1 this is the identity.
-function getZoomFactor() {
-  const zoom = window.__OPENWORK_ZOOM_FACTOR__;
-  return typeof zoom === "number" && zoom > 0 ? zoom : 1;
-}
-
+// Bounds and points are sent in renderer CSS pixels. The Electron main process
+// converts them to window device-independent pixels using the authoritative
+// webContents zoom factor at apply time, so the renderer never needs to track
+// (and can never disagree with) the real zoom state.
 export function getNativeMenuPoint(
   el: HTMLElement | null,
   point?: { clientX: number; clientY: number },
 ) {
-  const zoom = getZoomFactor();
-
   if (point) {
-    return {
-      x: Math.round(point.clientX * zoom),
-      y: Math.round(point.clientY * zoom),
-    };
+    return { x: point.clientX, y: point.clientY };
   }
 
   if (!el) {
@@ -39,24 +27,19 @@ export function getNativeMenuPoint(
   const rect = el.getBoundingClientRect();
 
   return {
-    x: Math.round((rect.left + 8) * zoom),
-    y: Math.round((rect.bottom + 4) * zoom),
+    x: rect.left + 8,
+    y: rect.bottom + 4,
   };
 }
 
 export function computeBounds(el: HTMLElement) {
-  // Scale each edge to native DIP, then derive width/height from the rounded
-  // edges so the far edge has no sub-pixel seam at any zoom level.
   const rect = el.getBoundingClientRect();
-  const zoom = getZoomFactor();
-  const x = Math.round(rect.x * zoom);
-  const y = Math.round(rect.y * zoom);
 
   return {
-    x,
-    y,
-    width: Math.round(rect.right * zoom) - x,
-    height: Math.round(rect.bottom * zoom) - y,
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
   };
 }
 

--- a/apps/app/src/react-app/shell/font-zoom.ts
+++ b/apps/app/src/react-app/shell/font-zoom.ts
@@ -12,6 +12,8 @@ import {
 import { setDesktopZoomFactor } from "../../app/lib/desktop";
 import { isDesktopRuntime } from "../../app/utils";
 
+const NATIVE_MENU_ZOOM_EVENT = "openwork:native-menu:zoom";
+
 export function useDesktopFontZoomBehavior() {
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -20,10 +22,6 @@ export function useDesktopFontZoomBehavior() {
     const applyAndPersistFontZoom = (value: number) => {
       const next = normalizeFontZoom(value);
       persistFontZoom(window.localStorage, next);
-
-      // Keep the current desktop zoom available so native WebContentsView bounds
-      // can be converted from renderer CSS pixels to contentView coordinates.
-      window.__OPENWORK_ZOOM_FACTOR__ = next;
 
       void setDesktopZoomFactor(next)
         .then((applied) => {
@@ -42,10 +40,7 @@ export function useDesktopFontZoomBehavior() {
 
     let fontZoom = applyAndPersistFontZoom(readStoredFontZoom(window.localStorage) ?? 1);
 
-    const handleZoomShortcut = (event: KeyboardEvent) => {
-      const action = parseFontZoomShortcut(event);
-      if (!action) return;
-
+    const applyZoomAction = (action: "in" | "out" | "reset") => {
       if (action === "in") {
         fontZoom = applyAndPersistFontZoom(fontZoom + FONT_ZOOM_STEP);
       } else if (action === "out") {
@@ -53,14 +48,32 @@ export function useDesktopFontZoomBehavior() {
       } else {
         fontZoom = applyAndPersistFontZoom(1);
       }
+    };
+
+    const handleZoomShortcut = (event: KeyboardEvent) => {
+      const action = parseFontZoomShortcut(event);
+      if (!action) return;
+
+      applyZoomAction(action);
 
       event.preventDefault();
       event.stopPropagation();
     };
 
+    // Native menu zoom items (View > Zoom In/Out/Actual Size) route through the
+    // same pathway so app zoom always stays consistent and persisted.
+    const handleNativeMenuZoom = (event: Event) => {
+      const detail: unknown = event instanceof CustomEvent ? event.detail : null;
+      if (detail === "in" || detail === "out" || detail === "reset") {
+        applyZoomAction(detail);
+      }
+    };
+
     window.addEventListener("keydown", handleZoomShortcut, true);
+    window.addEventListener(NATIVE_MENU_ZOOM_EVENT, handleNativeMenuZoom);
     return () => {
       window.removeEventListener("keydown", handleZoomShortcut, true);
+      window.removeEventListener(NATIVE_MENU_ZOOM_EVENT, handleNativeMenuZoom);
     };
   }, []);
 }

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -37,6 +37,7 @@ const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
 const NATIVE_MENU_CHECK_UPDATES_EVENT = "openwork:native-menu:check-updates";
+const NATIVE_MENU_ZOOM_EVENT = "openwork:native-menu:zoom";
 const TAURI_APP_IDENTIFIER = "com.differentai.openwork";
 const DEV_APP_IDENTIFIER = "com.differentai.openwork.dev";
 const DESKTOP_PROTOCOL_SCHEME = "openwork";
@@ -534,6 +535,8 @@ const browserTabs = new Map();
 let browserTabOrder = [];
 let activeBrowserTabId = null;
 let browserViewVisible = false;
+// Last browser panel bounds reported by the renderer, in renderer CSS pixels.
+// Converted to window device-independent pixels at every setBounds call.
 let lastBrowserBounds = null;
 let browserTabCounter = 0;
 const BROWSER_DEFAULT_URL = "about:blank";
@@ -607,6 +610,15 @@ async function checkForUpdatesFromNativeMenu() {
 async function toggleSidebarFromNativeMenu() {
   const win = await createMainWindow();
   win.webContents.send(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT);
+}
+
+// Zoom must flow through the renderer's font-zoom pathway so the persisted
+// preference and the applied webContents zoom factor never drift apart. The
+// built-in resetZoom/zoomIn/zoomOut roles bypass that pathway (and zoom
+// whichever webContents is focused, including the embedded browser view).
+async function zoomFromNativeMenu(action) {
+  const win = await createMainWindow();
+  win.webContents.send(NATIVE_MENU_ZOOM_EVENT, action);
 }
 
 function installApplicationMenu() {
@@ -714,9 +726,27 @@ function installApplicationMenu() {
         { role: "forceReload" },
         { role: "toggleDevTools" },
         { type: "separator" },
-        { role: "resetZoom" },
-        { role: "zoomIn" },
-        { role: "zoomOut" },
+        {
+          label: "Actual Size",
+          accelerator: "CommandOrControl+0",
+          click: () => {
+            void zoomFromNativeMenu("reset");
+          },
+        },
+        {
+          label: "Zoom In",
+          accelerator: "CommandOrControl+Plus",
+          click: () => {
+            void zoomFromNativeMenu("in");
+          },
+        },
+        {
+          label: "Zoom Out",
+          accelerator: "CommandOrControl+-",
+          click: () => {
+            void zoomFromNativeMenu("out");
+          },
+        },
         { type: "separator" },
         { role: "togglefullscreen" },
       ],
@@ -1067,7 +1097,7 @@ async function showBrowserTabContextMenu(tabId, point) {
 
   const showSerial = menuOverlayShowSerial + 1;
   menuOverlayShowSerial = showSerial;
-  const request = tabMenuRequest(tab, point);
+  const request = tabMenuRequest(tab, point ? scaleRendererPoint(point) : point);
   const view = await ensureMenuOverlayView();
   if (showSerial !== menuOverlayShowSerial || menuOverlayView !== view) return;
   menuOverlayRequest = request;
@@ -1187,6 +1217,37 @@ function detachBrowserView(view) {
   }
 }
 
+// The renderer reports bounds in CSS pixels, which Electron scales by the main
+// window's zoom factor. Read the factor from the webContents at apply time so
+// the conversion is always correct, no matter how the zoom was changed
+// (shortcuts, native menu, or Chromium's persisted per-origin zoom).
+function mainWindowZoomFactor() {
+  try {
+    const factor = mainWindow?.webContents.getZoomFactor();
+    return typeof factor === "number" && factor > 0 ? factor : 1;
+  } catch {
+    return 1;
+  }
+}
+
+function scaleRendererBounds(bounds) {
+  const zoom = mainWindowZoomFactor();
+  // Round edges (not width/height) so the far edge has no sub-pixel seam.
+  const x = Math.round(bounds.x * zoom);
+  const y = Math.round(bounds.y * zoom);
+  return {
+    x,
+    y,
+    width: Math.round((bounds.x + bounds.width) * zoom) - x,
+    height: Math.round((bounds.y + bounds.height) * zoom) - y,
+  };
+}
+
+function scaleRendererPoint(point) {
+  const zoom = mainWindowZoomFactor();
+  return { x: Math.round(point.x * zoom), y: Math.round(point.y * zoom) };
+}
+
 function attachActiveBrowserView() {
   if (!mainWindow || !browserViewVisible) return;
   const view = getActiveBrowserView();
@@ -1198,7 +1259,7 @@ function attachActiveBrowserView() {
     mainWindow.contentView.addChildView(view);
   }
   if (lastBrowserBounds && lastBrowserBounds.width > 0 && lastBrowserBounds.height > 0) {
-    view.setBounds(lastBrowserBounds);
+    view.setBounds(scaleRendererBounds(lastBrowserBounds));
   }
 }
 
@@ -1297,7 +1358,7 @@ function attachBrowserView(bounds, { preloadDefault = false, ensureTab = false }
   const view = getActiveBrowserView();
   attachActiveBrowserView();
   if (bounds.width > 0 && bounds.height > 0) {
-    view?.setBounds(bounds);
+    view?.setBounds(scaleRendererBounds(bounds));
   }
   const url = view?.webContents.getURL();
   if (preloadDefault && (!url || url === "about:blank")) {
@@ -3241,7 +3302,7 @@ ipcMain.handle("openwork:browser:bounds", (_event, bounds) => {
   lastBrowserBounds = bounds;
   const view = getActiveBrowserView();
   if (view && browserViewVisible && bounds.width > 0 && bounds.height > 0) {
-    view.setBounds(bounds);
+    view.setBounds(scaleRendererBounds(bounds));
   }
 });
 ipcMain.handle("openwork:browser:state", () => browserStatePayload());

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -4,6 +4,7 @@ const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
 const NATIVE_MENU_CHECK_UPDATES_EVENT = "openwork:native-menu:check-updates";
+const NATIVE_MENU_ZOOM_EVENT = "openwork:native-menu:zoom";
 
 function normalizePlatform(value) {
   if (value === "darwin" || value === "linux") return value;
@@ -178,6 +179,11 @@ ipcRenderer.on(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT, () => {
 ipcRenderer.on(NATIVE_MENU_CHECK_UPDATES_EVENT, () => {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new Event(NATIVE_MENU_CHECK_UPDATES_EVENT));
+});
+
+ipcRenderer.on(NATIVE_MENU_ZOOM_EVENT, (_event, action) => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(NATIVE_MENU_ZOOM_EVENT, { detail: action }));
 });
 
 if (!applyShellDocumentMarkers() && typeof document !== "undefined") {


### PR DESCRIPTION
## Problem

Reported by @IndieSuperhuman: the embedded browser agent view loads distorted (offset/oversized), `cmd+-` temporarily fixes it, and resizing the window (fullscreen -> small) distorts it again. Present for several releases.

## Root cause

The renderer positioned the native `WebContentsView` by multiplying DOM rects by a renderer-cached zoom factor (`window.__OPENWORK_ZOOM_FACTOR__`). Two other writers change the *real* webContents zoom without updating that cache:

- The native menu `resetZoom`/`zoomIn`/`zoomOut` roles (Cmd+0/+/- are intercepted by the menu on macOS, in 1.2x steps vs the renderer's 0.1 steps)
- Chromium's persisted per-origin zoom, restored at launch before React runs (-> "this is how the browser agent is *loading*")

Once the cached and real zoom disagree, every bounds computation — including the resize re-sync loop — is proportionally wrong, so the view renders offset/mis-sized and resizing keeps it broken. Pressing the renderer zoom shortcut coincidentally rewrites both values to the same number, which is why `cmd+-` "fixed" it.

The menu roles also zoomed whichever webContents had focus, so Cmd+- inside the browser panel zoomed the *web page* (persisted per-origin) instead of the app.

## Fix

- Renderer now sends plain CSS-pixel bounds/points; the **main process** converts them with `webContents.getZoomFactor()` at every `setBounds` call (including re-attach from cached bounds). Bounds are now correct no matter how, when, or by whom the zoom was changed.
- Replace the three menu zoom roles with menu items that route through the renderer font-zoom pathway (`openwork:native-menu:zoom`), eliminating the second conflicting zoom pathway and the accidental page-zoom of the embedded view.
- Drop the now-unused `__OPENWORK_ZOOM_FACTOR__` global.

## Tests run

- `pnpm typecheck` — pass
- `pnpm --filter @openwork/desktop typecheck:electron` — pass
- `pnpm --filter @openwork/desktop check:electron` — pass (50 bridge methods)
- `node --test apps/desktop/electron/*.test.mjs` — 18 pass, 1 skip, 0 fail

## End-to-end validation (Daytona, real Electron via CDP)

Reproduced the bug on `dev` first (sandbox `openwork-test-20260610-200511`): forcing the real zoom to 0.7 while the cached factor stayed 0.9 rendered the view offset right, oversized, and clipped (matches the user's screenshot); resizing kept it broken; one renderer zoom press re-synced and "fixed" it.

Then validated this branch (sandbox `openwork-test-20260610-203531`, commit 921ffcf23), loading a red-border edge-test page in the browser panel:

| Step | Result |
|---|---|
| Baseline zoom 1.0, maximized | view hugs panel edges |
| Forced raw `setZoomFactor(0.7)` (old repro state) | **still aligned** |
| Resize fullscreen -> 1100x700 at zoom 0.7 | **still aligned** |
| Ctrl+- while embedded view focused | app zooms via single pathway (pref persisted -> 0.9), page zoom untouched (was previously zoomed per-origin) |
| Resize -> 1500x900 at zoom 0.9 | **still aligned** |

Frame-by-frame screenshots captured at each step and inspected (before: distorted at desync; after: aligned in all states). Available locally under /tmp/dz/ (`08-desync-distorted.png` vs `fix-03/04/05-*.png`).