### PR TITLE
fix(computer-use): five quality fixes + CDP-verified e2e benchmark

### DIFF
--- a/apps/desktop/scripts/prepare-computer-use-helper.mjs
+++ b/apps/desktop/scripts/prepare-computer-use-helper.mjs
@@ -41,12 +41,35 @@ function run(command, args, options = {}) {
   return result;
 }
 
+function signingIdentity() {
+  const fromEnv = process.env.OPENWORK_COMPUTER_USE_SIGN_IDENTITY;
+  if (fromEnv) return fromEnv;
+  const result = spawnSync("security", ["find-identity", "-v", "-p", "codesigning"], { encoding: "utf8" });
+  if (result.status !== 0) return "-";
+  const match = result.stdout.match(/"(Developer ID Application: [^"]+)"/);
+  // Prefer a stable Developer ID signature so macOS TCC permission grants
+  // (Accessibility, Screen Recording) survive rebuilds. Ad-hoc signatures are
+  // content hashes, so every rebuild would invalidate existing grants.
+  return match ? match[1] : "-";
+}
+
 function signHelperApp() {
   if (process.platform !== "darwin") return;
-  const result = spawnSync("codesign", ["--force", "--deep", "--sign", "-", appPath], {
+  const identity = signingIdentity();
+  const args = ["--force", "--deep", "--sign", identity];
+  if (identity !== "-") args.push("--options", "runtime");
+  const result = spawnSync("codesign", [...args, appPath], {
     encoding: "utf8",
     stdio: "pipe",
   });
+  if (identity !== "-" && (result.status !== 0 || result.error)) {
+    // Keychain may refuse non-interactive signing; fall back to ad-hoc.
+    const fallback = spawnSync("codesign", ["--force", "--deep", "--sign", "-", appPath], {
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    if (fallback.status === 0) return;
+  }
   if (result.error) {
     if (result.error.code === "ENOENT") {
       throw new Error("codesign is required to prepare the Computer Use helper app");

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/AccessibilityService.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/AccessibilityService.swift
@@ -15,16 +15,19 @@ final class AccessibilityService: @unchecked Sendable {
         "AXOutline", "AXTable", "AXList", "AXGroup",
     ]
 
-    func resolveTarget(appName: String?) throws -> WindowTarget {
-        try resolveTarget(appName: appName, windowTitle: nil)
-    }
+    private let enhancedLock = NSLock()
+    private var enhancedPIDs = Set<pid_t>()
 
-    func resolveTarget(appName: String?, windowTitle: String?) throws -> WindowTarget {
+    func resolveTarget(appName: String?, pid requestedPID: pid_t? = nil, windowTitle: String? = nil) throws -> WindowTarget {
         guard AXIsProcessTrusted() else { throw ComputerUseError.accessibilityDenied }
 
-        let app = try resolveApp(appName: appName)
+        let app = try resolveApp(appName: appName, pid: requestedPID)
         let pid = app.processIdentifier
         let axApp = AXUIElementCreateApplication(pid)
+        if enableEnhancedAccessibility(axApp: axApp, pid: pid) {
+            // Chromium and Electron build the renderer AX tree lazily; give it a moment.
+            Thread.sleep(forTimeInterval: 0.35)
+        }
         let axWindow = firstAXWindow(axApp: axApp, title: windowTitle)
         let title = axWindow.flatMap { axString($0, kAXTitleAttribute) }
         let info = firstCGWindowInfo(pid: pid, title: title)
@@ -93,7 +96,35 @@ final class AccessibilityService: @unchecked Sendable {
         AXUIElementPerformAction(record.element, action as CFString) == .success
     }
 
-    private func resolveApp(appName: String?) throws -> NSRunningApplication {
+    func value(record: AXElementRecord) -> String? {
+        axString(record.element, kAXValueAttribute)
+    }
+
+    /// Chromium browsers and Electron apps only expose web content to AX after an
+    /// assistive client announces itself. VoiceOver does this by setting
+    /// AXEnhancedUserInterface; Electron additionally supports AXManualAccessibility.
+    /// Returns true when the attribute was newly applied to this pid.
+    private func enableEnhancedAccessibility(axApp: AXUIElement, pid: pid_t) -> Bool {
+        enhancedLock.lock()
+        let isNew = enhancedPIDs.insert(pid).inserted
+        enhancedLock.unlock()
+        guard isNew else { return false }
+        // Chromium reacts to the set attempt even though it reports an AXError
+        // (.notImplemented / .attributeUnsupported), so the return codes are
+        // logged for diagnostics but intentionally not treated as failure.
+        let enhanced = AXUIElementSetAttributeValue(axApp, "AXEnhancedUserInterface" as CFString, kCFBooleanTrue)
+        let manual = AXUIElementSetAttributeValue(axApp, "AXManualAccessibility" as CFString, kCFBooleanTrue)
+        fputs("[ComputerUse] enhanced-ax pid=\(pid) AXEnhancedUserInterface=\(enhanced.rawValue) AXManualAccessibility=\(manual.rawValue)\n", stderr)
+        return true
+    }
+
+    private func resolveApp(appName: String?, pid: pid_t?) throws -> NSRunningApplication {
+        if let pid {
+            guard let app = NSRunningApplication(processIdentifier: pid) else {
+                throw ComputerUseError.appNotFound("pid \(pid)")
+            }
+            return app
+        }
         guard let rawName = appName?.trimmingCharacters(in: .whitespacesAndNewlines), !rawName.isEmpty else {
             guard let frontmost = NSWorkspace.shared.frontmostApplication else {
                 throw ComputerUseError.noFrontmostApplication

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/BackgroundInputDispatcher.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/BackgroundInputDispatcher.swift
@@ -72,17 +72,40 @@ enum BackgroundInputDispatcher {
         guard let source = CGEventSource(stateID: .combinedSessionState) else {
             throw ComputerUseError.eventSourceFailed
         }
-        guard let down = CGEvent(keyboardEventSource: source, virtualKey: parsed.keyCode, keyDown: true),
-              let up = CGEvent(keyboardEventSource: source, virtualKey: parsed.keyCode, keyDown: false) else {
-            throw ComputerUseError.eventCreationFailed
+
+        // Post real modifier key events around the main key. Chromium and other
+        // apps ignore bare flag bits on background-posted events, so flags alone
+        // are not enough for combos like command+a.
+        let modifierKeys: [(flag: CGEventFlags, keyCode: CGKeyCode)] = [
+            (.maskCommand, 0x37), (.maskShift, 0x38), (.maskAlternate, 0x3A), (.maskControl, 0x3B),
+        ]
+        let activeModifiers = modifierKeys.filter { parsed.flags.contains($0.flag) }
+
+        var accumulated: CGEventFlags = []
+        for modifier in activeModifiers {
+            accumulated.insert(modifier.flag)
+            try postKey(source: source, pid: pid, keyCode: modifier.keyCode, keyDown: true, flags: accumulated)
+            Thread.sleep(forTimeInterval: 0.005)
         }
 
-        down.flags = parsed.flags
-        up.flags = parsed.flags
-        down.setIntegerValueField(.eventTargetUnixProcessID, value: Int64(pid))
-        up.setIntegerValueField(.eventTargetUnixProcessID, value: Int64(pid))
-        down.postToPid(pid)
-        up.postToPid(pid)
+        try postKey(source: source, pid: pid, keyCode: parsed.keyCode, keyDown: true, flags: parsed.flags)
+        Thread.sleep(forTimeInterval: 0.01)
+        try postKey(source: source, pid: pid, keyCode: parsed.keyCode, keyDown: false, flags: parsed.flags)
+
+        for modifier in activeModifiers.reversed() {
+            accumulated.remove(modifier.flag)
+            Thread.sleep(forTimeInterval: 0.005)
+            try postKey(source: source, pid: pid, keyCode: modifier.keyCode, keyDown: false, flags: accumulated)
+        }
+    }
+
+    private static func postKey(source: CGEventSource, pid: pid_t, keyCode: CGKeyCode, keyDown: Bool, flags: CGEventFlags) throws {
+        guard let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: keyDown) else {
+            throw ComputerUseError.eventCreationFailed
+        }
+        event.flags = flags
+        event.setIntegerValueField(.eventTargetUnixProcessID, value: Int64(pid))
+        event.postToPid(pid)
     }
 
     static func address(_ event: CGEvent, pid: pid_t, windowNumber: Int) {

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/ComputerUseRuntime.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/ComputerUseRuntime.swift
@@ -32,17 +32,18 @@ actor ComputerUseRuntime {
         )
     }
 
-    func snapshot(appName: String?, strict requestedStrict: Bool?) async throws -> AppSnapshot {
+    func snapshot(appName: String?, pid: Int? = nil, windowTitle: String? = nil, strict requestedStrict: Bool?) async throws -> AppSnapshot {
         let effectiveStrict = requestedStrict ?? strictMode
         if !effectiveStrict {
             resetBackgroundActivation()
         }
 
-        var target = try accessibility.resolveTarget(appName: appName)
+        let requestedPID = pid.map(pid_t.init)
+        var target = try accessibility.resolveTarget(appName: appName, pid: requestedPID, windowTitle: windowTitle)
         let backgroundActivated: Bool
         if effectiveStrict, !target.isFrontmost {
             backgroundActivated = try await ensureBackgroundActivation(target: target)
-            target = try accessibility.resolveTarget(appName: appName)
+            target = try accessibility.resolveTarget(appName: appName, pid: requestedPID, windowTitle: windowTitle)
         } else {
             backgroundActivated = false
         }
@@ -58,7 +59,7 @@ actor ComputerUseRuntime {
         return annotatedSnapshot
     }
 
-    func click(snapshotID: String?, ref: String?, index: Int?, imageX: Double?, imageY: Double?, clickCount: Int, strict requestedStrict: Bool?) async throws -> ActionMetadata {
+    func click(snapshotID: String?, ref: String?, index: Int?, imageX: Double?, imageY: Double?, screenX: Double? = nil, screenY: Double? = nil, clickCount: Int, strict requestedStrict: Bool?) async throws -> ActionMetadata {
         let snapshot = try requireSnapshot(snapshotID: snapshotID)
         let effectiveStrict = requestedStrict ?? snapshot.strictMode
         try validateSnapshotForAction(snapshot: snapshot, strict: effectiveStrict)
@@ -76,6 +77,10 @@ actor ComputerUseRuntime {
                 return try await clickPoint(fresh.semantic.frame.center, clickCount: clickCount, strict: effectiveStrict, fallbackUsed: true)
             }
             return try await clickPoint(record.semantic.frame.center, clickCount: clickCount, strict: effectiveStrict, fallbackUsed: true)
+        }
+
+        if let screenX, let screenY {
+            return try await clickPoint(CGPoint(x: screenX, y: screenY), clickCount: clickCount, strict: effectiveStrict, fallbackUsed: false)
         }
 
         if let imageX, let imageY {
@@ -148,8 +153,32 @@ actor ComputerUseRuntime {
             throw ComputerUseError.staleSnapshot("The target element changed. Take a new snapshot before setting its value.")
         }
         AgentCursorOverlay.shared.show(at: fresh.semantic.frame.center)
-        let ok = accessibility.setValue(record: fresh, value: value)
-        return recordAction(ActionMetadata(ok: ok, path: .accessibility, strictMode: snapshot.strictMode, backgroundSafe: true, fallbackUsed: false, message: ok ? "Set \(fresh.semantic.ref) via AXValue." : "Element value is not settable."))
+        let axWriteAccepted = accessibility.setValue(record: fresh, value: value)
+        if axWriteAccepted, valueMatches(record: fresh, expected: value) {
+            return recordAction(ActionMetadata(ok: true, path: .accessibility, strictMode: snapshot.strictMode, backgroundSafe: true, fallbackUsed: false, message: "Set \(fresh.semantic.ref) via AXValue."))
+        }
+
+        // Web inputs (Chromium/Electron) accept AXValue writes without applying
+        // them. Fall back to focus + select-all + retype, then verify.
+        _ = accessibility.focus(record: fresh)
+        try BackgroundInputDispatcher.pressKey(pid: snapshot.pid, combo: "command+a")
+        try BackgroundInputDispatcher.typeText(pid: snapshot.pid, text: value)
+        Thread.sleep(forTimeInterval: 0.08)
+        let verified = valueMatches(record: fresh, expected: value)
+        return recordAction(ActionMetadata(
+            ok: verified,
+            path: .backgroundCGEvent,
+            strictMode: snapshot.strictMode,
+            backgroundSafe: true,
+            fallbackUsed: true,
+            message: verified
+                ? "AXValue write did not stick; set \(fresh.semantic.ref) via select-all + retype fallback."
+                : "Could not verify the value of \(fresh.semantic.ref) after AXValue and retype fallback."
+        ))
+    }
+
+    private func valueMatches(record: AXElementRecord, expected: String) -> Bool {
+        accessibility.value(record: record) == expected
     }
 
     func performAction(snapshotID: String?, ref: String?, index: Int?, action: String) throws -> ActionMetadata {
@@ -291,7 +320,7 @@ actor ComputerUseRuntime {
     }
 
     private func freshRecord(matching record: AXElementRecord, in snapshot: AppSnapshot) -> AXElementRecord? {
-        guard let target = try? accessibility.resolveTarget(appName: snapshot.appName, windowTitle: snapshot.windowTitle) else {
+        guard let target = try? accessibility.resolveTarget(appName: snapshot.appName, pid: snapshot.pid, windowTitle: snapshot.windowTitle) else {
             return nil
         }
         let records = accessibility.records(target: target)

--- a/packages/handsfree/native/HandsFree/Sources/ComputerUse/MCPServer.swift
+++ b/packages/handsfree/native/HandsFree/Sources/ComputerUse/MCPServer.swift
@@ -53,6 +53,8 @@ actor MCPServer {
                 description: "Return target-window screenshot plus compact semantic AX state. Uses strict background activation by default.",
                 properties: [
                     "app": ["type": "string", "description": "Optional running app name. Omit for frontmost app."],
+                    "pid": ["type": "number", "description": "Optional process id. Disambiguates multiple instances of the same app."],
+                    "window_title": ["type": "string", "description": "Optional window title to target a specific window."],
                     "strict": ["type": "boolean", "description": "Keep actions on background-safe AX/postToPid paths. Default true."],
                 ]
             ),
@@ -63,8 +65,10 @@ actor MCPServer {
                     "ref": ["type": "string", "description": "Semantic ref from snapshot, e.g. {e1}."],
                     "snapshot_id": ["type": "string", "description": "Optional snapshot id from the latest snapshot response."],
                     "index": ["type": "number", "description": "Element id or zero-based compatibility index."],
-                    "x": ["type": "number", "description": "Screenshot x coordinate."],
-                    "y": ["type": "number", "description": "Screenshot y coordinate."],
+                    "x": ["type": "number", "description": "Screenshot-image x coordinate (pixels in the snapshot image, e.g. element center.imageX). Not screen pixels."],
+                    "y": ["type": "number", "description": "Screenshot-image y coordinate (pixels in the snapshot image, e.g. element center.imageY). Not screen pixels."],
+                    "screen_x": ["type": "number", "description": "Absolute screen x coordinate (e.g. element center.screenX). Takes precedence over x/y."],
+                    "screen_y": ["type": "number", "description": "Absolute screen y coordinate (e.g. element center.screenY). Takes precedence over x/y."],
                     "click_count": ["type": "number", "description": "1 or 2. Default 1."],
                     "strict": ["type": "boolean", "description": "Override strict mode for this action."],
                 ]
@@ -166,6 +170,8 @@ actor MCPServer {
                     index: intArg(args, "index"),
                     imageX: doubleArg(args, "x"),
                     imageY: doubleArg(args, "y"),
+                    screenX: doubleArg(args, "screen_x"),
+                    screenY: doubleArg(args, "screen_y"),
                     clickCount: intArg(args, "click_count") ?? 1,
                     strict: boolArg(args, "strict")
                 )
@@ -205,7 +211,16 @@ actor MCPServer {
             case "activate_app":
                 return jsonResult(handleActivateApp(args: args))
             case "list_apps":
-                return jsonResult(["ok": true, "apps": runningApps().compactMap(\.localizedName).sorted()])
+                let details = runningApps()
+                    .compactMap { app -> [String: Any]? in
+                        guard let name = app.localizedName else { return nil }
+                        return ["name": name, "pid": Int(app.processIdentifier)]
+                    }
+                return jsonResult([
+                    "ok": true,
+                    "apps": runningApps().compactMap(\.localizedName).sorted(),
+                    "appDetails": details,
+                ])
             case "open_url":
                 return try await jsonResult(handleOpenURL(args: args))
             case "clipboard_read":
@@ -271,7 +286,12 @@ actor MCPServer {
     }
 
     private func snapshotResult(args: [String: Any]) async throws -> [[String: Any]] {
-        let snapshot = try await runtime.snapshot(appName: args["app"] as? String, strict: boolArg(args, "strict"))
+        let snapshot = try await runtime.snapshot(
+            appName: args["app"] as? String,
+            pid: intArg(args, "pid"),
+            windowTitle: args["window_title"] as? String,
+            strict: boolArg(args, "strict")
+        )
         let payload = snapshotPayload(snapshot)
         guard let text = jsonString(payload) else {
             return textResult("Failed to serialize semantic AX snapshot.")

--- a/packages/handsfree/package.json
+++ b/packages/handsfree/package.json
@@ -10,9 +10,10 @@
   },
   "scripts": {
     "check": "pnpm run check:js && pnpm run check:native",
-    "check:js": "node --check bin/openwork-handsfree-computer-use.mjs && node --check src/cua-runner.mjs && node --check src/realtime-tools.mjs",
+    "check:js": "node --check bin/openwork-handsfree-computer-use.mjs && node --check src/cua-runner.mjs && node --check src/realtime-tools.mjs && node --check test/e2e/run.mjs",
     "build:native": "swift build --package-path native/HandsFree -c release --product HandsFreeComputerUse",
-    "check:native": "swift build --package-path native/HandsFree --product HandsFreeComputerUse"
+    "check:native": "swift build --package-path native/HandsFree --product HandsFreeComputerUse",
+    "test:e2e": "node test/e2e/run.mjs"
   },
   "files": [
     "bin",

--- a/packages/handsfree/test/e2e/bench.html
+++ b/packages/handsfree/test/e2e/bench.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CU-BENCH</title>
+<style>
+  body { font-family: -apple-system, sans-serif; margin: 24px; }
+  .grid { display: grid; grid-template-columns: repeat(4, 160px); gap: 12px; margin: 16px 0; }
+  button { padding: 12px; font-size: 14px; }
+  input, textarea { width: 480px; font-size: 14px; padding: 8px; display: block; margin: 8px 0; }
+</style>
+</head>
+<body>
+<h1>Computer Use Benchmark</h1>
+<div class="grid" id="grid"></div>
+<input id="field" placeholder="type here" aria-label="bench-field">
+<textarea id="area" rows="3" aria-label="bench-area" placeholder="textarea here"></textarea>
+<label><input type="checkbox" id="check" aria-label="bench-check"> bench-check</label>
+<script>
+  window.__events = [];
+  const names = ["alpha","bravo","charlie","delta","echo","foxtrot","golf","hotel","india","juliett","kilo","lima"];
+  const grid = document.getElementById("grid");
+  for (const n of names) {
+    const b = document.createElement("button");
+    b.id = "btn-" + n;
+    b.textContent = "btn-" + n;
+    b.addEventListener("click", () => window.__events.push({ t: Date.now(), type: "click", id: b.id }));
+    grid.appendChild(b);
+  }
+  document.getElementById("check").addEventListener("change", (e) =>
+    window.__events.push({ t: Date.now(), type: "check", checked: e.target.checked }));
+</script>
+</body>
+</html>

--- a/packages/handsfree/test/e2e/run.mjs
+++ b/packages/handsfree/test/e2e/run.mjs
@@ -1,0 +1,224 @@
+// Computer-use e2e quality benchmark.
+//
+// Measures snapshot/click/type accuracy and latency against a deterministic
+// local HTML page in Chrome, with ground truth verified independently via the
+// Chrome DevTools Protocol (so accuracy is not measured by the system under
+// test).
+//
+// Requirements (macOS only):
+// - The signed helper app with Accessibility + Screen Recording granted:
+//   run `node apps/desktop/scripts/prepare-computer-use-helper.mjs` and grant
+//   permissions once via the helper's setup GUI.
+// - Google Chrome installed. The test launches a disposable instance with a
+//   temp profile and closes it afterwards. No accessibility flags are passed;
+//   the runtime is expected to enable renderer AX itself.
+//
+// Usage: node packages/handsfree/test/e2e/run.mjs
+
+import { spawn, execSync } from "node:child_process";
+import { createReadStream, createWriteStream, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../../..");
+const HELPER_APP = process.env.OPENWORK_COMPUTER_USE_HELPER
+  ?? join(repoRoot, "apps/desktop/resources/helpers/OpenWork Computer Use.app");
+const PAGE = `file://${join(__dirname, "bench.html")}`;
+const CDP_PORT = Number(process.env.CU_BENCH_CDP_PORT ?? 9224);
+const CHROME_APP = "Google Chrome";
+
+if (process.platform !== "darwin") {
+  console.log("computer-use e2e benchmark is macOS-only; skipping");
+  process.exit(0);
+}
+
+// --- MCP bridge: launch the helper via Launch Services with FIFO stdio so
+// --- TCC permissions attribute to the helper bundle, not this shell.
+const fifoDir = mkdtempSync(join(tmpdir(), "cu-e2e-"));
+const IN = join(fifoDir, "in.fifo");
+const OUT = join(fifoDir, "out.fifo");
+execSync(`mkfifo ${IN} ${OUT}`);
+try { execSync(`pkill -f 'OpenWork Computer Use.app'`); } catch {}
+spawn("open", ["--stdin", IN, "--stdout", OUT, HELPER_APP, "--args", "mcp"], { stdio: "ignore" });
+
+const mcpOut = createReadStream(OUT, { encoding: "utf8" });
+const mcpIn = createWriteStream(IN);
+let mcpBuf = "";
+const mcpPending = new Map();
+mcpOut.on("data", (chunk) => {
+  mcpBuf += chunk;
+  let idx;
+  while ((idx = mcpBuf.indexOf("\n")) >= 0) {
+    const line = mcpBuf.slice(0, idx).trim();
+    mcpBuf = mcpBuf.slice(idx + 1);
+    if (!line) continue;
+    let msg;
+    try { msg = JSON.parse(line); } catch { continue; }
+    if (msg.id != null && mcpPending.has(msg.id)) {
+      mcpPending.get(msg.id)(msg);
+      mcpPending.delete(msg.id);
+    }
+  }
+});
+
+let rpcId = 0;
+function rpc(method, params, timeoutMs = 30000) {
+  const id = ++rpcId;
+  return new Promise((res, rej) => {
+    const t = setTimeout(() => rej(new Error(`mcp timeout: ${method}`)), timeoutMs);
+    mcpPending.set(id, (msg) => { clearTimeout(t); res(msg); });
+    mcpIn.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+  });
+}
+
+const results = { latency: {}, accuracy: {}, paths: {} };
+async function cu(name, args = {}) {
+  const t0 = performance.now();
+  const msg = await rpc("tools/call", { name, arguments: args });
+  (results.latency[name] ??= []).push(performance.now() - t0);
+  const text = msg.result?.content?.find((c) => c.type === "text")?.text;
+  const json = JSON.parse(text ?? "{}");
+  if (json.path) (results.paths[json.path] ??= []).push(name);
+  return json;
+}
+
+// --- disposable Chrome with CDP ground truth ---
+const profileDir = mkdtempSync(join(tmpdir(), "cu-e2e-chrome-"));
+spawn("open", ["-na", CHROME_APP, "--args",
+  `--remote-debugging-port=${CDP_PORT}`, `--user-data-dir=${profileDir}`,
+  "--no-first-run", "--no-default-browser-check", "--window-size=1200,900", PAGE,
+], { stdio: "ignore" });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+async function cdpTargets() {
+  for (let i = 0; i < 30; i++) {
+    try {
+      const r = await fetch(`http://127.0.0.1:${CDP_PORT}/json`);
+      return await r.json();
+    } catch { await sleep(500); }
+  }
+  throw new Error(`Chrome CDP endpoint did not come up on :${CDP_PORT}`);
+}
+
+await rpc("initialize", { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "cu-e2e", version: "0" } });
+mcpIn.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+
+const targets = await cdpTargets();
+const tab = targets.find((t) => t.type === "page" && t.url.includes("bench.html"));
+if (!tab) throw new Error("bench.html tab not found in disposable Chrome");
+const ws = new WebSocket(tab.webSocketDebuggerUrl);
+await new Promise((res, rej) => { ws.onopen = res; ws.onerror = rej; });
+let wsId = 0;
+const wsPending = new Map();
+ws.onmessage = (ev) => {
+  const m = JSON.parse(ev.data);
+  if (m.id && wsPending.has(m.id)) { wsPending.get(m.id)(m); wsPending.delete(m.id); }
+};
+const evaljs = (expression) => new Promise((res, rej) => {
+  const i = ++wsId;
+  const t = setTimeout(() => rej(new Error("cdp timeout")), 15000);
+  wsPending.set(i, (m) => { clearTimeout(t); res(m.result?.result?.value); });
+  ws.send(JSON.stringify({ id: i, method: "Runtime.evaluate", params: { expression, returnByValue: true } }));
+});
+
+await sleep(2000);
+const findEl = (snap, pred) => snap.elements?.find(pred);
+
+let failures = 0;
+const record = (key, ok, total, note = "") => {
+  results.accuracy[key] = `${ok}/${total}`;
+  if (ok !== total) { failures++; if (note) console.log(note); }
+};
+
+// 1. element recall
+let snap = await cu("snapshot", { app: CHROME_APP });
+const buttons = ["btn-alpha","btn-bravo","btn-charlie","btn-delta","btn-echo","btn-foxtrot","btn-golf","btn-hotel","btn-india","btn-juliett","btn-kilo","btn-lima"];
+const expected = [...buttons, "bench-field", "bench-area", "bench-check"];
+const labels = (snap.elements ?? []).map((e) => `${e.label ?? ""} ${e.value ?? ""}`).join(" | ");
+const found = expected.filter((x) => labels.includes(x));
+record("element_recall", found.length, expected.length, `missing: ${expected.filter((x) => !found.includes(x)).join(", ")}`);
+
+// 2. click accuracy across all three addressing modes, CDP-verified
+async function clickRound(key, makeArgs) {
+  let ok = 0;
+  await evaljs("window.__events = []");
+  for (const name of buttons) {
+    const el = findEl(snap, (e) => e.role === "Button" && (e.label ?? "").includes(name));
+    if (!el) continue;
+    const before = (await evaljs("window.__events.length")) ?? 0;
+    await cu("click", { app: CHROME_APP, ...makeArgs(el) });
+    await sleep(150);
+    const last = await evaljs("window.__events[window.__events.length-1]?.id");
+    const after = await evaljs("window.__events.length");
+    if (after === before + 1 && last === name) ok++;
+    else console.log(`${key} MISS: ${name} -> ${last}`);
+  }
+  record(key, ok, buttons.length);
+}
+await clickRound("click_by_ref", (el) => ({ ref: el.ref }));
+snap = await cu("snapshot", { app: CHROME_APP });
+await clickRound("click_by_image_coord", (el) => ({ x: el.center.imageX, y: el.center.imageY }));
+await clickRound("click_by_screen_coord", (el) => ({ screen_x: el.center.screenX, screen_y: el.center.screenY }));
+
+// 3. pid targeting
+const apps = await cu("list_apps");
+const chrome = (apps.appDetails ?? []).find((a) => a.name === CHROME_APP);
+const pidSnap = chrome ? await cu("snapshot", { pid: chrome.pid }) : {};
+record("snapshot_by_pid", pidSnap.windowTitle?.includes("CU-BENCH") ? 1 : 0, 1);
+
+// 4. typing accuracy (incl. symbols), CDP-verified
+const strings = [
+  "The quick brown fox jumps over the lazy dog 0123456789",
+  "~!@#$%^&*()_+-=[]{}|;':\",./<>?",
+  "CamelCase snake_case kebab-case 42.5%",
+];
+let typeOk = 0;
+for (const text of strings) {
+  await evaljs("document.getElementById('field').value=''; document.getElementById('field').focus()");
+  await sleep(100);
+  await cu("type_text", { app: CHROME_APP, text });
+  await sleep(300);
+  if ((await evaljs("document.getElementById('field').value")) === text) typeOk++;
+}
+record("type_text", typeOk, strings.length);
+
+// 5. set_value with verify + retype fallback
+snap = await cu("snapshot", { app: CHROME_APP });
+const field = findEl(snap, (e) => (e.label ?? "").includes("bench-field"));
+await cu("set_value", { app: CHROME_APP, ref: field.ref, value: "set-value-test-42" });
+await sleep(300);
+record("set_value", (await evaljs("document.getElementById('field').value")) === "set-value-test-42" ? 1 : 0, 1);
+
+// 6. background modifier combo: cmd+a + retype
+await cu("snapshot", { app: CHROME_APP });
+await evaljs("document.getElementById('field').focus()");
+await cu("press_key", { app: CHROME_APP, combo: "command+a" });
+await sleep(100);
+await cu("type_text", { app: CHROME_APP, text: "replaced" });
+await sleep(300);
+record("select_all_replace", (await evaljs("document.getElementById('field').value")) === "replaced" ? 1 : 0, 1);
+
+// --- report ---
+console.log("\n========== RESULTS ==========");
+console.log("\n-- Accuracy --");
+for (const [k, v] of Object.entries(results.accuracy)) console.log(`${k.padEnd(24)} ${v}`);
+console.log("\n-- Latency (ms) --");
+for (const [k, v] of Object.entries(results.latency)) {
+  const s = [...v].sort((a, b) => a - b);
+  const avg = Math.round(s.reduce((a, b) => a + b, 0) / s.length);
+  console.log(`${k.padEnd(24)} n=${String(s.length).padEnd(4)} avg=${String(avg).padEnd(6)} min=${Math.round(s[0]).toString().padEnd(6)} max=${Math.round(s[s.length - 1])}`);
+}
+console.log("\n-- Execution paths --");
+for (const [k, v] of Object.entries(results.paths)) console.log(`${k.padEnd(24)} ${v.length}x`);
+
+// --- cleanup ---
+try { execSync(`pkill -f "user-data-dir=${profileDir}"`); } catch {}
+try { execSync(`pkill -f 'OpenWork Computer Use.app'`); } catch {}
+await sleep(1000);
+try { rmSync(fifoDir, { recursive: true, force: true }); } catch {}
+try { rmSync(profileDir, { recursive: true, force: true }); } catch {}
+
+console.log(failures === 0 ? "\nRESULT: PASS" : `\nRESULT: FAIL (${failures} failing checks)`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Quality benchmark of the computer-use runtime against a deterministic Chrome page (ground truth verified independently via CDP, so accuracy is not measured by the system under test) surfaced five issues. All fixed in this PR, with the benchmark checked in as a repeatable e2e suite.

### Fixes
1. **Chromium/Electron renderer AX never enabled** — browsers exposed zero web content to `snapshot` (everything scored 0/15 recall). The runtime now sets `AXEnhancedUserInterface` + `AXManualAccessibility` on first target resolve, like VoiceOver does. Note: Chromium reacts to the set *attempt* while returning `.notImplemented`, so AXError codes are logged but not treated as failure.
2. **Click coordinate-space ambiguity** — `click` x/y are snapshot-image pixels, but the schema said only "screenshot coordinate", inviting misuse with screen pixels. Descriptions clarified; new `screen_x`/`screen_y` args accept absolute screen coordinates (matching `center.screenX/Y` in snapshots).
3. **Modifier combos broken in background mode** — `command+a` had no effect on Chromium because bare CGEvent flag bits are ignored on background-posted events. Now posts real modifier key down/up events around the main key.
4. **`set_value` silently failed on web inputs** — Chrome accepts the AXValue write and ignores it. Now verified by read-back, with a focus + select-all + retype fallback, and an honest `ok`/`fallbackUsed` in the response.
5. **No way to disambiguate app instances/windows** — `snapshot` now accepts `pid` and `window_title`; `list_apps` returns `appDetails` with pids; stale-element re-lookup pins to the snapshot pid.

Plus: `prepare-computer-use-helper.mjs` prefers a stable Developer ID signature (env override: `OPENWORK_COMPUTER_USE_SIGN_IDENTITY`) so macOS TCC grants survive rebuilds; falls back to ad-hoc.

## E2E benchmark results (this branch, Chrome with no accessibility flags)

```
element_recall           15/15
click_by_ref             12/12
click_by_image_coord     12/12
click_by_screen_coord    12/12
snapshot_by_pid          1/1
type_text                3/3
set_value                1/1
select_all_replace       1/1
RESULT: PASS

snapshot avg 212ms (first-enable settle) / 74ms steady-state, click avg 35ms, type avg 24ms
strict mode held throughout: 12x AX path, 30x background postToPid, 0 foreground fallbacks
```

Before this PR the same suite scored 0/15 recall and 0/12 on all click modes against an unflagged Chrome.

## Testing

- `pnpm --filter @openwork/handsfree check` — pass (JS syntax + Swift release build)
- `pnpm --filter @openwork/handsfree test:e2e` — PASS, exit 0 (output above)
- Manual MCP smoke (TextEdit): launch -> snapshot -> type -> snapshot round-trip verified

No video attached: the flow is a headless-ish stdio MCP benchmark; the full numeric output above is the evidence, and the suite is reproducible with `pnpm --filter @openwork/handsfree test:e2e` on a Mac with the helper permissions granted (one-time setup via the helper's GUI).

## Repro

```sh
node apps/desktop/scripts/prepare-computer-use-helper.mjs
open "apps/desktop/resources/helpers/OpenWork Computer Use.app"   # grant Accessibility + Screen Recording once
pnpm --filter @openwork/handsfree test:e2e
```