### PR TITLE
feat(workflows): LLM workflow tool — saved multi-step agent pipelines with compiled, shareable outputs

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -17,6 +17,7 @@ export type OpenworkServerCapabilities = {
   plugins: { read: boolean; write: boolean };
   mcp: { read: boolean; write: boolean };
   commands: { read: boolean; write: boolean };
+  workflows?: { read: boolean; write: boolean };
   config: { read: boolean; write: boolean };
   sandbox?: { enabled: boolean; backend: "none" | "docker" | "container" };
   proxy?: { opencode: boolean };
@@ -442,6 +443,45 @@ export type OpenworkInboxUploadResult = {
   ok: boolean;
   path: string;
   bytes: number;
+};
+
+export type OpenworkWorkflowStep = {
+  name: string;
+  prompt: string;
+  agent?: string;
+  model?: string;
+};
+
+export type OpenworkWorkflowItem = {
+  slug: string;
+  name: string;
+  description?: string;
+  inputs: string[];
+  steps: OpenworkWorkflowStep[];
+  outputDir: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type OpenworkWorkflowRunStatus = "pending" | "running" | "completed" | "failed";
+
+export type OpenworkWorkflowRun = {
+  id: string;
+  workflowSlug: string;
+  workflowName: string;
+  status: OpenworkWorkflowRunStatus;
+  sessionId?: string;
+  outputDir: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type OpenworkWorkflowUpsertPayload = {
+  name: string;
+  slug?: string;
+  description?: string;
+  inputs?: string[];
+  steps: Array<{ name?: string; prompt: string; agent?: string; model?: string }>;
 };
 
 export type OpenworkUserEnvItem = {
@@ -1430,6 +1470,54 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         hostToken,
         method: "DELETE",
       }),
+
+    listWorkflows: (workspaceId: string) =>
+      requestJson<{ items: OpenworkWorkflowItem[] }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/workflows`,
+        { token, hostToken },
+      ),
+    getWorkflow: (workspaceId: string, slug: string) =>
+      requestJson<{ item: OpenworkWorkflowItem }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/workflows/${encodeURIComponent(slug)}`,
+        { token, hostToken },
+      ),
+    upsertWorkflow: (workspaceId: string, payload: OpenworkWorkflowUpsertPayload) =>
+      requestJson<{ item: OpenworkWorkflowItem; items: OpenworkWorkflowItem[] }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/workflows`,
+        { token, hostToken, method: "POST", body: payload },
+      ),
+    deleteWorkflow: (workspaceId: string, slug: string) =>
+      requestJson<{ ok: boolean }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/workflows/${encodeURIComponent(slug)}`,
+        { token, hostToken, method: "DELETE" },
+      ),
+    listWorkflowRuns: (workspaceId: string, slug: string) =>
+      requestJson<{ items: OpenworkWorkflowRun[] }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/workflows/${encodeURIComponent(slug)}/runs`,
+        { token, hostToken },
+      ),
+    createWorkflowRun: (workspaceId: string, slug: string) =>
+      requestJson<{ run: OpenworkWorkflowRun; prompt: string }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/workflows/${encodeURIComponent(slug)}/runs`,
+        { token, hostToken, method: "POST", body: {} },
+      ),
+    updateWorkflowRun: (
+      workspaceId: string,
+      slug: string,
+      runId: string,
+      payload: { status?: OpenworkWorkflowRunStatus; sessionId?: string },
+    ) =>
+      requestJson<{ run: OpenworkWorkflowRun }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/workflows/${encodeURIComponent(slug)}/runs/${encodeURIComponent(runId)}`,
+        { token, hostToken, method: "PATCH", body: payload },
+      ),
     uploadInbox: async (workspaceId: string, file: File, options?: { path?: string }) => {
       const id = workspaceId.trim();
       if (!id) throw new Error("workspaceId is required");

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -482,6 +482,8 @@ export type OpenworkWorkflowUpsertPayload = {
   description?: string;
   inputs?: string[];
   steps: Array<{ name?: string; prompt: string; agent?: string; model?: string }>;
+  /** Co-editing guard: server rejects with 409 when the workflow changed since this timestamp. */
+  baseUpdatedAt?: number | null;
 };
 
 export type OpenworkUserEnvItem = {
@@ -1494,6 +1496,12 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         baseUrl,
         `/workspace/${encodeURIComponent(workspaceId)}/workflows/${encodeURIComponent(slug)}`,
         { token, hostToken, method: "DELETE" },
+      ),
+    listAllWorkflowRuns: (workspaceId: string) =>
+      requestJson<{ items: OpenworkWorkflowRun[] }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/workflow-runs`,
+        { token, hostToken },
       ),
     listWorkflowRuns: (workspaceId: string, slug: string) =>
       requestJson<{ items: OpenworkWorkflowRun[] }>(

--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -187,6 +187,7 @@ export const SETTINGS_TAB_VALUES = [
   "cloud-workers",
   "cloud-providers",
   "skills",
+  "workflows",
   "extensions",
   "environment",
   "advanced",

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -18,6 +18,7 @@ import {
   Store,
   Terminal,
   UserCircle,
+  Workflow,
   Wrench,
   Zap,
 } from "lucide-react";
@@ -75,6 +76,8 @@ export function getSettingsTabIcon(tab: SettingsTab) {
       return CloudCog;
     case "skills":
       return Sparkles;
+    case "workflows":
+      return Workflow;
     case "extensions":
       return Puzzle;
     case "environment":
@@ -114,6 +117,8 @@ export function getSettingsTabLabel(tab: SettingsTab) {
       return t("settings.tab_cloud_providers");
     case "skills":
       return t("settings.tab_skills");
+    case "workflows":
+      return "Workflows";
     case "extensions":
       return t("settings.tab_extensions");
     case "environment":
@@ -155,6 +160,8 @@ export function getSettingsTabDescription(tab: SettingsTab) {
       return t("settings.tab_description_cloud_providers");
     case "skills":
       return t("settings.tab_description_skills");
+    case "workflows":
+      return "Repeatable multi-step agent runs with saved prompts and outputs";
     case "extensions":
       return t("settings.tab_description_extensions");
     case "environment":
@@ -177,7 +184,7 @@ export function getSettingsTabDescription(tab: SettingsTab) {
 }
 
 export function getWorkspaceSettingsTabs(): SettingsTab[] {
-  return ["preferences", "permissions", "extensions", "advanced"];
+  return ["preferences", "permissions", "workflows", "extensions", "advanced"];
 }
 
 export function getGlobalSettingsTabs(developerMode: boolean): SettingsTab[] {

--- a/apps/app/src/react-app/domains/workflows/workflows-view.tsx
+++ b/apps/app/src/react-app/domains/workflows/workflows-view.tsx
@@ -12,7 +12,9 @@ import {
   Play,
   Plus,
   RefreshCw,
+  Sparkles,
   Trash2,
+  Users,
   Workflow as WorkflowIcon,
 } from "lucide-react";
 import { toast } from "@/components/ui/sonner";
@@ -34,11 +36,12 @@ import {
   pillSecondaryClass,
   tagClass,
 } from "@/react-app/domains/workspace/modal-styles";
-import type {
-  OpenworkServerClient,
-  OpenworkWorkflowItem,
-  OpenworkWorkflowRun,
-  OpenworkWorkflowRunStatus,
+import {
+  OpenworkServerError,
+  type OpenworkServerClient,
+  type OpenworkWorkflowItem,
+  type OpenworkWorkflowRun,
+  type OpenworkWorkflowRunStatus,
 } from "@/app/lib/openwork-server";
 
 const pageTitleClass = "text-[28px] font-semibold tracking-[-0.5px] text-dls-text";
@@ -48,6 +51,9 @@ const fieldLabelClass = "text-[12px] font-medium text-dls-secondary";
 const textInputClass =
   "w-full rounded-xl border border-dls-border bg-dls-surface px-3 py-2 text-[13px] text-dls-text focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.25)]";
 const textAreaClass = `${textInputClass} min-h-[88px] font-mono text-[12px]`;
+
+/** How often connected clients pick up collaborators' changes. */
+const LIVE_SYNC_INTERVAL_MS = 3_000;
 
 export type WorkflowsViewProps = {
   client: OpenworkServerClient | null;
@@ -74,6 +80,8 @@ type EditorState = {
   description: string;
   inputsText: string;
   steps: EditorStep[];
+  /** updatedAt of the workflow when the editor was opened (co-editing guard). */
+  baseUpdatedAt: number | null;
 };
 
 const emptyEditorState: EditorState = {
@@ -82,6 +90,32 @@ const emptyEditorState: EditorState = {
   description: "",
   inputsText: "",
   steps: [{ name: "", prompt: "" }],
+  baseUpdatedAt: null,
+};
+
+const exampleEditorState: EditorState = {
+  slug: null,
+  name: "Weekly research digest",
+  description: "Turn collected notes into a publishable digest with sources.",
+  inputsText: "notes/\nREADME.md",
+  steps: [
+    {
+      name: "Collect highlights",
+      prompt:
+        "Read every input file. Extract the 5-10 most important findings, each with a one-line summary and the source file it came from.",
+    },
+    {
+      name: "Draft the digest",
+      prompt:
+        "Write a structured digest in Markdown: a short intro, one section per theme, and a sources list. Keep it under 800 words.",
+    },
+    {
+      name: "Quality pass",
+      prompt:
+        "Re-read the draft as a skeptical editor. Fix vague claims, ensure every section cites an input file, and tighten the writing.",
+    },
+  ],
+  baseUpdatedAt: null,
 };
 
 function editorStateFromWorkflow(workflow: OpenworkWorkflowItem): EditorState {
@@ -91,11 +125,16 @@ function editorStateFromWorkflow(workflow: OpenworkWorkflowItem): EditorState {
     description: workflow.description ?? "",
     inputsText: workflow.inputs.join("\n"),
     steps: workflow.steps.map((step) => ({ name: step.name, prompt: step.prompt })),
+    baseUpdatedAt: workflow.updatedAt,
   };
 }
 
 function workflowsQueryKey(workspaceId: string | null) {
   return ["openwork", "workflows", workspaceId];
+}
+
+function allRunsQueryKey(workspaceId: string | null) {
+  return ["openwork", "workflow-runs", workspaceId, "all"];
 }
 
 function workflowRunsQueryKey(workspaceId: string | null, slug: string | null) {
@@ -106,6 +145,10 @@ function describeError(error: unknown): string {
   return error instanceof Error ? error.message : "Something went wrong";
 }
 
+function isConflictError(error: unknown): boolean {
+  return error instanceof OpenworkServerError && error.status === 409;
+}
+
 function formatTimestamp(value: number): string {
   if (!value) return "";
   try {
@@ -113,6 +156,18 @@ function formatTimestamp(value: number): string {
   } catch {
     return "";
   }
+}
+
+function formatRelativeTime(value: number): string {
+  if (!value) return "";
+  const deltaMs = Date.now() - value;
+  if (deltaMs < 45_000) return "just now";
+  const minutes = Math.round(deltaMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
 }
 
 function runStatusBadge(status: OpenworkWorkflowRunStatus) {
@@ -134,6 +189,7 @@ export function WorkflowsView(props: WorkflowsViewProps) {
 
   const [editor, setEditor] = useState<EditorState | null>(null);
   const [editorError, setEditorError] = useState<string | null>(null);
+  const [editorConflict, setEditorConflict] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<OpenworkWorkflowItem | null>(null);
   const [runsTarget, setRunsTarget] = useState<OpenworkWorkflowItem | null>(null);
   const [launchingSlug, setLaunchingSlug] = useState<string | null>(null);
@@ -147,7 +203,20 @@ export function WorkflowsView(props: WorkflowsViewProps) {
       return client.listWorkflows(workspaceId);
     },
     enabled: ready,
-    refetchOnWindowFocus: false,
+    // Live sync: collaborators' edits (and git pulls) show up within seconds.
+    refetchInterval: LIVE_SYNC_INTERVAL_MS,
+    refetchOnWindowFocus: true,
+  });
+
+  const allRunsQuery = useQuery({
+    queryKey: allRunsQueryKey(workspaceId),
+    queryFn: async () => {
+      if (!client || !workspaceId) return { items: [] };
+      return client.listAllWorkflowRuns(workspaceId);
+    },
+    enabled: ready,
+    refetchInterval: LIVE_SYNC_INTERVAL_MS,
+    refetchOnWindowFocus: true,
   });
 
   const runsQuery = useQuery({
@@ -157,11 +226,55 @@ export function WorkflowsView(props: WorkflowsViewProps) {
       return client.listWorkflowRuns(workspaceId, runsTarget.slug);
     },
     enabled: ready && Boolean(runsTarget),
-    refetchOnWindowFocus: false,
+    refetchInterval: LIVE_SYNC_INTERVAL_MS,
+    refetchOnWindowFocus: true,
   });
+
+  const workflows = useMemo(() => workflowsQuery.data?.items ?? [], [workflowsQuery.data]);
+  const runs = runsQuery.data?.items ?? [];
+
+  const latestRunBySlug = useMemo(() => {
+    const map = new Map<string, OpenworkWorkflowRun>();
+    for (const run of allRunsQuery.data?.items ?? []) {
+      const current = map.get(run.workflowSlug);
+      if (!current || run.createdAt > current.createdAt) {
+        map.set(run.workflowSlug, run);
+      }
+    }
+    return map;
+  }, [allRunsQuery.data]);
+
+  /**
+   * Co-editing awareness: if the workflow open in the editor has been saved
+   * by someone else since we opened it, the live-sync poll will surface a
+   * newer updatedAt and we warn before the user even hits save.
+   */
+  const remoteUpdate = useMemo(() => {
+    if (!editor?.slug || editor.baseUpdatedAt === null) return null;
+    const latest = workflows.find((item) => item.slug === editor.slug);
+    if (latest && latest.updatedAt > editor.baseUpdatedAt) return latest;
+    return null;
+  }, [editor, workflows]);
 
   const invalidateWorkflows = () =>
     queryClient.invalidateQueries({ queryKey: workflowsQueryKey(workspaceId) });
+
+  const openEditor = (state: EditorState) => {
+    setEditorError(null);
+    setEditorConflict(false);
+    setEditor(state);
+  };
+
+  const closeEditor = () => {
+    setEditor(null);
+    setEditorError(null);
+    setEditorConflict(false);
+  };
+
+  const loadLatestIntoEditor = (latest: OpenworkWorkflowItem) => {
+    openEditor(editorStateFromWorkflow(latest));
+    toast.info("Loaded the latest version");
+  };
 
   const saveMutation = useMutation({
     mutationFn: async (state: EditorState) => {
@@ -181,15 +294,20 @@ export function WorkflowsView(props: WorkflowsViewProps) {
         description: state.description.trim() || undefined,
         inputs,
         steps,
+        baseUpdatedAt: state.baseUpdatedAt,
       });
     },
     onSuccess: () => {
-      setEditor(null);
-      setEditorError(null);
+      closeEditor();
       toast.success("Workflow saved");
       void invalidateWorkflows();
     },
     onError: (error) => {
+      if (isConflictError(error)) {
+        setEditorConflict(true);
+        setEditorError(null);
+        return;
+      }
       setEditorError(describeError(error));
     },
   });
@@ -230,6 +348,7 @@ export function WorkflowsView(props: WorkflowsViewProps) {
       void queryClient.invalidateQueries({
         queryKey: workflowRunsQueryKey(workspaceId, workflow.slug),
       });
+      void queryClient.invalidateQueries({ queryKey: allRunsQueryKey(workspaceId) });
       props.onOpenSession(sessionId);
     } catch (error) {
       toast.error(describeError(error));
@@ -245,13 +364,11 @@ export function WorkflowsView(props: WorkflowsViewProps) {
       void queryClient.invalidateQueries({
         queryKey: workflowRunsQueryKey(workspaceId, run.workflowSlug),
       });
+      void queryClient.invalidateQueries({ queryKey: allRunsQueryKey(workspaceId) });
     } catch (error) {
       toast.error(describeError(error));
     }
   };
-
-  const workflows = workflowsQuery.data?.items ?? [];
-  const runs = runsQuery.data?.items ?? [];
 
   const editorValid = useMemo(() => {
     if (!editor) return false;
@@ -285,6 +402,10 @@ export function WorkflowsView(props: WorkflowsViewProps) {
     });
   };
 
+  const conflictLatest = editorConflict && editor?.slug
+    ? workflows.find((item) => item.slug === editor.slug) ?? null
+    : null;
+
   return (
     <section className="space-y-8 max-w-3xl w-full">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -295,6 +416,17 @@ export function WorkflowsView(props: WorkflowsViewProps) {
             them with a coding agent. Each run compiles its results into the workspace outbox so
             outputs are saved, versioned, and shareable.
           </p>
+          {ready ? (
+            <p className="mt-2 flex items-center gap-1.5 text-[12px] text-dls-secondary">
+              <span className="relative flex size-2">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500/60" />
+                <span className="relative inline-flex size-2 rounded-full bg-emerald-500" />
+              </span>
+              Synced live
+              <Users size={12} className="ml-1" />
+              shared with everyone in this workspace, versioned with the project
+            </p>
+          ) : null}
         </div>
         <div className="flex flex-wrap gap-3 lg:justify-end">
           <button
@@ -308,10 +440,7 @@ export function WorkflowsView(props: WorkflowsViewProps) {
           </button>
           <button
             type="button"
-            onClick={() => {
-              setEditorError(null);
-              setEditor(emptyEditorState);
-            }}
+            onClick={() => openEditor(emptyEditorState)}
             disabled={!ready || !props.canWrite || props.busy}
             className={pillPrimaryClass}
           >
@@ -341,91 +470,129 @@ export function WorkflowsView(props: WorkflowsViewProps) {
             A workflow is a saved pipeline: context files in, prompt steps in order, build artifacts
             out. Create one for any task you find yourself re-prompting.
           </p>
+          <div className="mt-4 flex justify-center gap-2">
+            <button
+              type="button"
+              className={pillSecondaryClass}
+              onClick={() => openEditor(exampleEditorState)}
+              disabled={!props.canWrite || props.busy}
+            >
+              <Sparkles size={14} />
+              Start from an example
+            </button>
+            <button
+              type="button"
+              className={pillPrimaryClass}
+              onClick={() => openEditor(emptyEditorState)}
+              disabled={!props.canWrite || props.busy}
+            >
+              <Plus size={14} />
+              New workflow
+            </button>
+          </div>
         </div>
       ) : null}
 
       {workflows.length > 0 ? (
         <div className="rounded-[24px] bg-dls-hover p-4">
           <div className="grid grid-cols-1 gap-4">
-            {workflows.map((workflow) => (
-              <div key={workflow.slug} className={`${panelCardClass} flex flex-col gap-4`}>
-                <div className="flex min-w-0 gap-4">
-                  <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover">
-                    <WorkflowIcon size={20} className="text-dls-secondary" />
+            {workflows.map((workflow) => {
+              const latestRun = latestRunBySlug.get(workflow.slug) ?? null;
+              return (
+                <div key={workflow.slug} className={`${panelCardClass} flex flex-col gap-4`}>
+                  <div className="flex min-w-0 gap-4">
+                    <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover">
+                      <WorkflowIcon size={20} className="text-dls-secondary" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h4 className="truncate text-[14px] font-semibold text-dls-text">{workflow.name}</h4>
+                        {latestRun ? runStatusBadge(latestRun.status) : null}
+                      </div>
+                      <p className="mt-1 line-clamp-2 text-[13px] leading-relaxed text-dls-secondary">
+                        {workflow.description || "No description"}
+                      </p>
+                      <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-dls-secondary">
+                        <span className={tagClass}>
+                          <ListChecks size={11} className="mr-1 inline" />
+                          {workflow.steps.length} step{workflow.steps.length === 1 ? "" : "s"}
+                        </span>
+                        <span className={tagClass}>
+                          <FileText size={11} className="mr-1 inline" />
+                          {workflow.inputs.length} input{workflow.inputs.length === 1 ? "" : "s"}
+                        </span>
+                        <span className={`${tagClass} font-mono`} title={workflow.outputDir}>
+                          outputs: {workflow.outputDir.replace(".opencode/openwork/outbox/", "outbox/")}
+                        </span>
+                      </div>
+                    </div>
                   </div>
-                  <div className="min-w-0 flex-1">
-                    <h4 className="truncate text-[14px] font-semibold text-dls-text">{workflow.name}</h4>
-                    <p className="mt-1 line-clamp-2 text-[13px] leading-relaxed text-dls-secondary">
-                      {workflow.description || "No description"}
-                    </p>
-                    <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-dls-secondary">
-                      <span className={tagClass}>
-                        <ListChecks size={11} className="mr-1 inline" />
-                        {workflow.steps.length} step{workflow.steps.length === 1 ? "" : "s"}
-                      </span>
-                      <span className={tagClass}>
-                        <FileText size={11} className="mr-1 inline" />
-                        {workflow.inputs.length} input{workflow.inputs.length === 1 ? "" : "s"}
-                      </span>
-                      <span className={`${tagClass} font-mono`} title={workflow.outputDir}>
-                        outputs: {workflow.outputDir.replace(".opencode/openwork/outbox/", "outbox/")}
-                      </span>
+
+                  <div className="flex flex-wrap items-center justify-between gap-3 border-t border-dls-border pt-4">
+                    <span className="text-[11px] text-dls-secondary">
+                      {latestRun
+                        ? `Last run ${formatRelativeTime(latestRun.createdAt)} · edited ${formatRelativeTime(workflow.updatedAt)}`
+                        : `Edited ${formatRelativeTime(workflow.updatedAt)} · never run`}
+                    </span>
+                    <div className="flex flex-wrap gap-2">
+                      {latestRun?.sessionId ? (
+                        <button
+                          type="button"
+                          className={pillGhostClass}
+                          onClick={() => {
+                            if (latestRun.sessionId) props.onOpenSession(latestRun.sessionId);
+                          }}
+                          title="Open the session for the latest run"
+                        >
+                          <History size={14} />
+                          Last session
+                        </button>
+                      ) : null}
+                      <button
+                        type="button"
+                        className={pillGhostClass}
+                        onClick={() => setRunsTarget(workflow)}
+                        disabled={props.busy}
+                      >
+                        <History size={14} />
+                        Runs
+                      </button>
+                      <button
+                        type="button"
+                        className={pillSecondaryClass}
+                        onClick={() => openEditor(editorStateFromWorkflow(workflow))}
+                        disabled={props.busy || !props.canWrite}
+                      >
+                        <Edit2 size={14} />
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className={pillGhostClass}
+                        onClick={() => setDeleteTarget(workflow)}
+                        disabled={props.busy || !props.canWrite}
+                      >
+                        <Trash2 size={14} />
+                        Delete
+                      </button>
+                      <button
+                        type="button"
+                        className={pillPrimaryClass}
+                        onClick={() => void runWorkflow(workflow)}
+                        disabled={props.busy || !props.canWrite || launchingSlug !== null}
+                      >
+                        {launchingSlug === workflow.slug ? (
+                          <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                          <Play size={14} />
+                        )}
+                        Run
+                      </button>
                     </div>
                   </div>
                 </div>
-
-                <div className="flex flex-wrap items-center justify-between gap-3 border-t border-dls-border pt-4">
-                  <span className="text-[11px] text-dls-secondary">
-                    Updated {formatTimestamp(workflow.updatedAt)}
-                  </span>
-                  <div className="flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      className={pillGhostClass}
-                      onClick={() => setRunsTarget(workflow)}
-                      disabled={props.busy}
-                    >
-                      <History size={14} />
-                      Runs
-                    </button>
-                    <button
-                      type="button"
-                      className={pillSecondaryClass}
-                      onClick={() => {
-                        setEditorError(null);
-                        setEditor(editorStateFromWorkflow(workflow));
-                      }}
-                      disabled={props.busy || !props.canWrite}
-                    >
-                      <Edit2 size={14} />
-                      Edit
-                    </button>
-                    <button
-                      type="button"
-                      className={pillGhostClass}
-                      onClick={() => setDeleteTarget(workflow)}
-                      disabled={props.busy || !props.canWrite}
-                    >
-                      <Trash2 size={14} />
-                      Delete
-                    </button>
-                    <button
-                      type="button"
-                      className={pillPrimaryClass}
-                      onClick={() => void runWorkflow(workflow)}
-                      disabled={props.busy || !props.canWrite || launchingSlug !== null}
-                    >
-                      {launchingSlug === workflow.slug ? (
-                        <Loader2 size={14} className="animate-spin" />
-                      ) : (
-                        <Play size={14} />
-                      )}
-                      Run
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       ) : null}
@@ -433,10 +600,7 @@ export function WorkflowsView(props: WorkflowsViewProps) {
       <Dialog
         open={Boolean(editor)}
         onOpenChange={(open) => {
-          if (!open) {
-            setEditor(null);
-            setEditorError(null);
-          }
+          if (!open) closeEditor();
         }}
       >
         <DialogContent className="flex max-h-[90vh] min-h-0 w-full max-w-3xl flex-col overflow-hidden sm:max-w-3xl">
@@ -450,6 +614,48 @@ export function WorkflowsView(props: WorkflowsViewProps) {
 
           {editor ? (
             <div className="min-h-0 flex-1 space-y-5 overflow-y-auto pr-1">
+              {editorConflict ? (
+                <div
+                  data-testid="workflow-conflict-banner"
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-7/30 bg-amber-1/50 px-4 py-3 text-xs text-amber-12"
+                >
+                  <span>
+                    Someone saved this workflow while you were editing. Your changes were not saved.
+                  </span>
+                  {conflictLatest ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => loadLatestIntoEditor(conflictLatest)}
+                    >
+                      Load latest
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {!editorConflict && remoteUpdate ? (
+                <div
+                  data-testid="workflow-remote-update-banner"
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-sky-7/30 bg-sky-1/50 px-4 py-3 text-xs text-sky-12"
+                >
+                  <span>
+                    <Users size={12} className="mr-1 inline" />
+                    A collaborator just updated this workflow ({formatRelativeTime(remoteUpdate.updatedAt)}).
+                    Saving now will be blocked unless you load their version first.
+                  </span>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => loadLatestIntoEditor(remoteUpdate)}
+                  >
+                    Load latest
+                  </Button>
+                </div>
+              ) : null}
+
               {editorError ? (
                 <div className="rounded-xl border border-red-7/20 bg-red-1/40 px-4 py-3 text-xs text-red-12">
                   {editorError}
@@ -571,19 +777,12 @@ export function WorkflowsView(props: WorkflowsViewProps) {
           ) : null}
 
           <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => {
-                setEditor(null);
-                setEditorError(null);
-              }}
-            >
+            <Button type="button" variant="outline" onClick={closeEditor}>
               Cancel
             </Button>
             <Button
               type="button"
-              disabled={!editorValid || saveMutation.isPending}
+              disabled={!editorValid || saveMutation.isPending || editorConflict}
               onClick={() => {
                 if (editor) saveMutation.mutate(editor);
               }}
@@ -625,7 +824,9 @@ export function WorkflowsView(props: WorkflowsViewProps) {
                   <div className="min-w-0">
                     <div className="flex items-center gap-2">
                       {runStatusBadge(run.status)}
-                      <span className="text-[12px] text-dls-secondary">{formatTimestamp(run.createdAt)}</span>
+                      <span className="text-[12px] text-dls-secondary" title={formatTimestamp(run.createdAt)}>
+                        {formatRelativeTime(run.createdAt)}
+                      </span>
                     </div>
                     <p className="mt-1 truncate font-mono text-[11px] text-dls-secondary" title={run.outputDir}>
                       {run.outputDir}

--- a/apps/app/src/react-app/domains/workflows/workflows-view.tsx
+++ b/apps/app/src/react-app/domains/workflows/workflows-view.tsx
@@ -1,0 +1,690 @@
+/** @jsxImportSource react */
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowDown,
+  ArrowUp,
+  Edit2,
+  FileText,
+  History,
+  ListChecks,
+  Loader2,
+  Play,
+  Plus,
+  RefreshCw,
+  Trash2,
+  Workflow as WorkflowIcon,
+} from "lucide-react";
+import { toast } from "@/components/ui/sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ConfirmModal } from "@/react-app/design-system/modals/confirm-modal";
+import {
+  pillGhostClass,
+  pillPrimaryClass,
+  pillSecondaryClass,
+  tagClass,
+} from "@/react-app/domains/workspace/modal-styles";
+import type {
+  OpenworkServerClient,
+  OpenworkWorkflowItem,
+  OpenworkWorkflowRun,
+  OpenworkWorkflowRunStatus,
+} from "@/app/lib/openwork-server";
+
+const pageTitleClass = "text-[28px] font-semibold tracking-[-0.5px] text-dls-text";
+const panelCardClass =
+  "rounded-[20px] border border-dls-border bg-dls-surface p-5 transition-all hover:border-dls-border hover:shadow-[0_2px_12px_-4px_rgba(0,0,0,0.06)]";
+const fieldLabelClass = "text-[12px] font-medium text-dls-secondary";
+const textInputClass =
+  "w-full rounded-xl border border-dls-border bg-dls-surface px-3 py-2 text-[13px] text-dls-text focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.25)]";
+const textAreaClass = `${textInputClass} min-h-[88px] font-mono text-[12px]`;
+
+export type WorkflowsViewProps = {
+  client: OpenworkServerClient | null;
+  workspaceId: string | null;
+  busy: boolean;
+  canWrite: boolean;
+  /**
+   * Create an agent session seeded with the compiled run prompt.
+   * Returns the new session id, or null when launching failed.
+   */
+  onLaunchRun: (input: { prompt: string; title: string }) => Promise<string | null>;
+  /** Navigate to an existing session (used from run history and after launch). */
+  onOpenSession: (sessionId: string) => void;
+};
+
+type EditorStep = {
+  name: string;
+  prompt: string;
+};
+
+type EditorState = {
+  slug: string | null;
+  name: string;
+  description: string;
+  inputsText: string;
+  steps: EditorStep[];
+};
+
+const emptyEditorState: EditorState = {
+  slug: null,
+  name: "",
+  description: "",
+  inputsText: "",
+  steps: [{ name: "", prompt: "" }],
+};
+
+function editorStateFromWorkflow(workflow: OpenworkWorkflowItem): EditorState {
+  return {
+    slug: workflow.slug,
+    name: workflow.name,
+    description: workflow.description ?? "",
+    inputsText: workflow.inputs.join("\n"),
+    steps: workflow.steps.map((step) => ({ name: step.name, prompt: step.prompt })),
+  };
+}
+
+function workflowsQueryKey(workspaceId: string | null) {
+  return ["openwork", "workflows", workspaceId];
+}
+
+function workflowRunsQueryKey(workspaceId: string | null, slug: string | null) {
+  return ["openwork", "workflow-runs", workspaceId, slug];
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : "Something went wrong";
+}
+
+function formatTimestamp(value: number): string {
+  if (!value) return "";
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return "";
+  }
+}
+
+function runStatusBadge(status: OpenworkWorkflowRunStatus) {
+  switch (status) {
+    case "running":
+      return <Badge variant="secondary">Running</Badge>;
+    case "completed":
+      return <Badge>Completed</Badge>;
+    case "failed":
+      return <Badge variant="destructive">Failed</Badge>;
+    default:
+      return <Badge variant="outline">Pending</Badge>;
+  }
+}
+
+export function WorkflowsView(props: WorkflowsViewProps) {
+  const { client, workspaceId } = props;
+  const queryClient = useQueryClient();
+
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [editorError, setEditorError] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<OpenworkWorkflowItem | null>(null);
+  const [runsTarget, setRunsTarget] = useState<OpenworkWorkflowItem | null>(null);
+  const [launchingSlug, setLaunchingSlug] = useState<string | null>(null);
+
+  const ready = Boolean(client && workspaceId);
+
+  const workflowsQuery = useQuery({
+    queryKey: workflowsQueryKey(workspaceId),
+    queryFn: async () => {
+      if (!client || !workspaceId) return { items: [] };
+      return client.listWorkflows(workspaceId);
+    },
+    enabled: ready,
+    refetchOnWindowFocus: false,
+  });
+
+  const runsQuery = useQuery({
+    queryKey: workflowRunsQueryKey(workspaceId, runsTarget?.slug ?? null),
+    queryFn: async () => {
+      if (!client || !workspaceId || !runsTarget) return { items: [] };
+      return client.listWorkflowRuns(workspaceId, runsTarget.slug);
+    },
+    enabled: ready && Boolean(runsTarget),
+    refetchOnWindowFocus: false,
+  });
+
+  const invalidateWorkflows = () =>
+    queryClient.invalidateQueries({ queryKey: workflowsQueryKey(workspaceId) });
+
+  const saveMutation = useMutation({
+    mutationFn: async (state: EditorState) => {
+      if (!client || !workspaceId) throw new Error("OpenWork server is not connected.");
+      const inputs = state.inputsText
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+      const steps = state.steps
+        .map((step) => ({ name: step.name.trim() || undefined, prompt: step.prompt.trim() }))
+        .filter((step) => step.prompt.length > 0);
+      if (!state.name.trim()) throw new Error("Workflow name is required.");
+      if (steps.length === 0) throw new Error("Add at least one step with a prompt.");
+      return client.upsertWorkflow(workspaceId, {
+        name: state.name.trim(),
+        slug: state.slug ?? undefined,
+        description: state.description.trim() || undefined,
+        inputs,
+        steps,
+      });
+    },
+    onSuccess: () => {
+      setEditor(null);
+      setEditorError(null);
+      toast.success("Workflow saved");
+      void invalidateWorkflows();
+    },
+    onError: (error) => {
+      setEditorError(describeError(error));
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (slug: string) => {
+      if (!client || !workspaceId) throw new Error("OpenWork server is not connected.");
+      return client.deleteWorkflow(workspaceId, slug);
+    },
+    onSuccess: () => {
+      toast.success("Workflow deleted");
+      void invalidateWorkflows();
+    },
+    onError: (error) => {
+      toast.error(describeError(error));
+    },
+  });
+
+  const runWorkflow = async (workflow: OpenworkWorkflowItem) => {
+    if (!client || !workspaceId || launchingSlug) return;
+    setLaunchingSlug(workflow.slug);
+    try {
+      const { run, prompt } = await client.createWorkflowRun(workspaceId, workflow.slug);
+      const sessionId = await props.onLaunchRun({
+        prompt,
+        title: `Workflow: ${workflow.name}`,
+      });
+      if (!sessionId) {
+        await client
+          .updateWorkflowRun(workspaceId, workflow.slug, run.id, { status: "failed" })
+          .catch(() => undefined);
+        toast.error("Could not start an agent session for this run.");
+        return;
+      }
+      await client
+        .updateWorkflowRun(workspaceId, workflow.slug, run.id, { status: "running", sessionId })
+        .catch(() => undefined);
+      void queryClient.invalidateQueries({
+        queryKey: workflowRunsQueryKey(workspaceId, workflow.slug),
+      });
+      props.onOpenSession(sessionId);
+    } catch (error) {
+      toast.error(describeError(error));
+    } finally {
+      setLaunchingSlug(null);
+    }
+  };
+
+  const markRun = async (run: OpenworkWorkflowRun, status: OpenworkWorkflowRunStatus) => {
+    if (!client || !workspaceId) return;
+    try {
+      await client.updateWorkflowRun(workspaceId, run.workflowSlug, run.id, { status });
+      void queryClient.invalidateQueries({
+        queryKey: workflowRunsQueryKey(workspaceId, run.workflowSlug),
+      });
+    } catch (error) {
+      toast.error(describeError(error));
+    }
+  };
+
+  const workflows = workflowsQuery.data?.items ?? [];
+  const runs = runsQuery.data?.items ?? [];
+
+  const editorValid = useMemo(() => {
+    if (!editor) return false;
+    return Boolean(editor.name.trim()) && editor.steps.some((step) => step.prompt.trim());
+  }, [editor]);
+
+  const updateEditorStep = (index: number, patch: Partial<EditorStep>) => {
+    setEditor((current) => {
+      if (!current) return current;
+      const steps = current.steps.map((step, i) => (i === index ? { ...step, ...patch } : step));
+      return { ...current, steps };
+    });
+  };
+
+  const moveEditorStep = (index: number, direction: -1 | 1) => {
+    setEditor((current) => {
+      if (!current) return current;
+      const target = index + direction;
+      if (target < 0 || target >= current.steps.length) return current;
+      const steps = [...current.steps];
+      const [step] = steps.splice(index, 1);
+      steps.splice(target, 0, step);
+      return { ...current, steps };
+    });
+  };
+
+  const removeEditorStep = (index: number) => {
+    setEditor((current) => {
+      if (!current || current.steps.length <= 1) return current;
+      return { ...current, steps: current.steps.filter((_, i) => i !== index) };
+    });
+  };
+
+  return (
+    <section className="space-y-8 max-w-3xl w-full">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <h2 className={pageTitleClass}>Workflows</h2>
+          <p className="mt-2 max-w-2xl text-[14px] leading-relaxed text-dls-secondary">
+            Repeatable multi-step agent runs. Pick input files, write the step prompts once, and run
+            them with a coding agent. Each run compiles its results into the workspace outbox so
+            outputs are saved, versioned, and shareable.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3 lg:justify-end">
+          <button
+            type="button"
+            onClick={() => void workflowsQuery.refetch()}
+            disabled={!ready || workflowsQuery.isFetching}
+            className={pillSecondaryClass}
+          >
+            <RefreshCw size={14} />
+            Refresh
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setEditorError(null);
+              setEditor(emptyEditorState);
+            }}
+            disabled={!ready || !props.canWrite || props.busy}
+            className={pillPrimaryClass}
+          >
+            <Plus size={14} />
+            New workflow
+          </button>
+        </div>
+      </div>
+
+      {!ready ? (
+        <div className="rounded-[20px] border border-dls-border bg-dls-hover px-5 py-4 text-[13px] text-dls-secondary">
+          Connect the OpenWork server for this workspace to manage workflows.
+        </div>
+      ) : null}
+
+      {ready && workflowsQuery.isError ? (
+        <div className="rounded-[20px] border border-red-7/20 bg-red-1/40 px-5 py-4 text-[13px] text-red-12">
+          {describeError(workflowsQuery.error)}
+        </div>
+      ) : null}
+
+      {ready && !workflowsQuery.isLoading && workflows.length === 0 ? (
+        <div className="rounded-[20px] border border-dashed border-dls-border bg-dls-surface px-5 py-10 text-center">
+          <WorkflowIcon size={28} className="mx-auto text-dls-secondary" />
+          <p className="mt-3 text-[14px] font-medium text-dls-text">No workflows yet</p>
+          <p className="mx-auto mt-1 max-w-md text-[13px] text-dls-secondary">
+            A workflow is a saved pipeline: context files in, prompt steps in order, build artifacts
+            out. Create one for any task you find yourself re-prompting.
+          </p>
+        </div>
+      ) : null}
+
+      {workflows.length > 0 ? (
+        <div className="rounded-[24px] bg-dls-hover p-4">
+          <div className="grid grid-cols-1 gap-4">
+            {workflows.map((workflow) => (
+              <div key={workflow.slug} className={`${panelCardClass} flex flex-col gap-4`}>
+                <div className="flex min-w-0 gap-4">
+                  <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover">
+                    <WorkflowIcon size={20} className="text-dls-secondary" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <h4 className="truncate text-[14px] font-semibold text-dls-text">{workflow.name}</h4>
+                    <p className="mt-1 line-clamp-2 text-[13px] leading-relaxed text-dls-secondary">
+                      {workflow.description || "No description"}
+                    </p>
+                    <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-dls-secondary">
+                      <span className={tagClass}>
+                        <ListChecks size={11} className="mr-1 inline" />
+                        {workflow.steps.length} step{workflow.steps.length === 1 ? "" : "s"}
+                      </span>
+                      <span className={tagClass}>
+                        <FileText size={11} className="mr-1 inline" />
+                        {workflow.inputs.length} input{workflow.inputs.length === 1 ? "" : "s"}
+                      </span>
+                      <span className={`${tagClass} font-mono`} title={workflow.outputDir}>
+                        outputs: {workflow.outputDir.replace(".opencode/openwork/outbox/", "outbox/")}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-between gap-3 border-t border-dls-border pt-4">
+                  <span className="text-[11px] text-dls-secondary">
+                    Updated {formatTimestamp(workflow.updatedAt)}
+                  </span>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className={pillGhostClass}
+                      onClick={() => setRunsTarget(workflow)}
+                      disabled={props.busy}
+                    >
+                      <History size={14} />
+                      Runs
+                    </button>
+                    <button
+                      type="button"
+                      className={pillSecondaryClass}
+                      onClick={() => {
+                        setEditorError(null);
+                        setEditor(editorStateFromWorkflow(workflow));
+                      }}
+                      disabled={props.busy || !props.canWrite}
+                    >
+                      <Edit2 size={14} />
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      className={pillGhostClass}
+                      onClick={() => setDeleteTarget(workflow)}
+                      disabled={props.busy || !props.canWrite}
+                    >
+                      <Trash2 size={14} />
+                      Delete
+                    </button>
+                    <button
+                      type="button"
+                      className={pillPrimaryClass}
+                      onClick={() => void runWorkflow(workflow)}
+                      disabled={props.busy || !props.canWrite || launchingSlug !== null}
+                    >
+                      {launchingSlug === workflow.slug ? (
+                        <Loader2 size={14} className="animate-spin" />
+                      ) : (
+                        <Play size={14} />
+                      )}
+                      Run
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <Dialog
+        open={Boolean(editor)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditor(null);
+            setEditorError(null);
+          }
+        }}
+      >
+        <DialogContent className="flex max-h-[90vh] min-h-0 w-full max-w-3xl flex-col overflow-hidden sm:max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>{editor?.slug ? "Edit workflow" : "New workflow"}</DialogTitle>
+            <DialogDescription>
+              Steps run in order inside one agent session. Outputs are written to the workspace
+              outbox as shareable artifacts.
+            </DialogDescription>
+          </DialogHeader>
+
+          {editor ? (
+            <div className="min-h-0 flex-1 space-y-5 overflow-y-auto pr-1">
+              {editorError ? (
+                <div className="rounded-xl border border-red-7/20 bg-red-1/40 px-4 py-3 text-xs text-red-12">
+                  {editorError}
+                </div>
+              ) : null}
+
+              <div className="space-y-1.5">
+                <label className={fieldLabelClass}>Name</label>
+                <input
+                  type="text"
+                  value={editor.name}
+                  onChange={(event) => {
+                    const name = event.currentTarget.value;
+                    setEditor((current) => (current ? { ...current, name } : current));
+                  }}
+                  placeholder="Weekly research digest"
+                  className={textInputClass}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label className={fieldLabelClass}>Description (optional)</label>
+                <input
+                  type="text"
+                  value={editor.description}
+                  onChange={(event) => {
+                    const description = event.currentTarget.value;
+                    setEditor((current) => (current ? { ...current, description } : current));
+                  }}
+                  placeholder="What this workflow produces"
+                  className={textInputClass}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label className={fieldLabelClass}>
+                  Input files - one workspace-relative path per line (optional)
+                </label>
+                <textarea
+                  value={editor.inputsText}
+                  onChange={(event) => {
+                    const inputsText = event.currentTarget.value;
+                    setEditor((current) => (current ? { ...current, inputsText } : current));
+                  }}
+                  placeholder={"docs/notes.md\nresearch/sources/"}
+                  className={textAreaClass}
+                  spellCheck={false}
+                />
+                <p className="text-[11px] text-dls-secondary">
+                  The agent reads these before starting. Drop files into the workspace (or the shared
+                  inbox) to add new context.
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                <label className={fieldLabelClass}>Steps</label>
+                {editor.steps.map((step, index) => (
+                  <div key={index} className="space-y-2 rounded-2xl border border-dls-border bg-dls-hover p-4">
+                    <div className="flex items-center gap-2">
+                      <span className="text-[11px] font-semibold text-dls-secondary">Step {index + 1}</span>
+                      <input
+                        type="text"
+                        value={step.name}
+                        onChange={(event) => updateEditorStep(index, { name: event.currentTarget.value })}
+                        placeholder="Step name (optional)"
+                        className={`${textInputClass} flex-1`}
+                      />
+                      <button
+                        type="button"
+                        className={pillGhostClass}
+                        onClick={() => moveEditorStep(index, -1)}
+                        disabled={index === 0}
+                        title="Move up"
+                      >
+                        <ArrowUp size={13} />
+                      </button>
+                      <button
+                        type="button"
+                        className={pillGhostClass}
+                        onClick={() => moveEditorStep(index, 1)}
+                        disabled={index === editor.steps.length - 1}
+                        title="Move down"
+                      >
+                        <ArrowDown size={13} />
+                      </button>
+                      <button
+                        type="button"
+                        className={pillGhostClass}
+                        onClick={() => removeEditorStep(index)}
+                        disabled={editor.steps.length <= 1}
+                        title="Remove step"
+                      >
+                        <Trash2 size={13} />
+                      </button>
+                    </div>
+                    <textarea
+                      value={step.prompt}
+                      onChange={(event) => updateEditorStep(index, { prompt: event.currentTarget.value })}
+                      placeholder="Prompt for this step..."
+                      className={textAreaClass}
+                      spellCheck={false}
+                    />
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  className={pillSecondaryClass}
+                  onClick={() =>
+                    setEditor((current) =>
+                      current ? { ...current, steps: [...current.steps, { name: "", prompt: "" }] } : current,
+                    )
+                  }
+                >
+                  <Plus size={14} />
+                  Add step
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setEditor(null);
+                setEditorError(null);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={!editorValid || saveMutation.isPending}
+              onClick={() => {
+                if (editor) saveMutation.mutate(editor);
+              }}
+            >
+              {saveMutation.isPending ? <Loader2 size={14} className="animate-spin" /> : null}
+              Save workflow
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(runsTarget)}
+        onOpenChange={(open) => {
+          if (!open) setRunsTarget(null);
+        }}
+      >
+        <DialogContent className="flex max-h-[80vh] min-h-0 w-full max-w-2xl flex-col overflow-hidden sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Runs - {runsTarget?.name}</DialogTitle>
+            <DialogDescription>
+              Each run executes in its own agent session and writes artifacts to{" "}
+              <span className="font-mono">{runsTarget?.outputDir}</span>.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="min-h-0 flex-1 space-y-2 overflow-y-auto">
+            {runsQuery.isLoading ? (
+              <div className="text-[13px] text-dls-secondary">Loading runs...</div>
+            ) : runs.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-dls-border px-4 py-6 text-[13px] text-dls-secondary">
+                No runs yet. Hit Run to execute this workflow with an agent.
+              </div>
+            ) : (
+              runs.map((run) => (
+                <div
+                  key={run.id}
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-dls-border bg-dls-surface px-4 py-3"
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      {runStatusBadge(run.status)}
+                      <span className="text-[12px] text-dls-secondary">{formatTimestamp(run.createdAt)}</span>
+                    </div>
+                    <p className="mt-1 truncate font-mono text-[11px] text-dls-secondary" title={run.outputDir}>
+                      {run.outputDir}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {run.status === "running" ? (
+                      <>
+                        <button
+                          type="button"
+                          className={pillGhostClass}
+                          onClick={() => void markRun(run, "completed")}
+                          disabled={!props.canWrite}
+                        >
+                          Mark completed
+                        </button>
+                        <button
+                          type="button"
+                          className={pillGhostClass}
+                          onClick={() => void markRun(run, "failed")}
+                          disabled={!props.canWrite}
+                        >
+                          Mark failed
+                        </button>
+                      </>
+                    ) : null}
+                    {run.sessionId ? (
+                      <button
+                        type="button"
+                        className={pillSecondaryClass}
+                        onClick={() => {
+                          if (run.sessionId) props.onOpenSession(run.sessionId);
+                        }}
+                      >
+                        Open session
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmModal
+        open={Boolean(deleteTarget)}
+        title="Delete workflow"
+        message={`Delete "${deleteTarget?.name ?? ""}"? Past run outputs in the outbox are kept.`}
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        confirmButtonVariant="destructive"
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={() => {
+          const target = deleteTarget;
+          setDeleteTarget(null);
+          if (target) deleteMutation.mutate(target.slug);
+        }}
+      />
+    </section>
+  );
+}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -68,6 +68,7 @@ import { MessagingView } from "@/react-app/domains/settings/pages/messaging-view
 import { SkillsView } from "@/react-app/domains/settings/pages/skills-view";
 import { WorkflowsView } from "@/react-app/domains/workflows/workflows-view";
 import { saveSessionDraft } from "@/react-app/domains/session/sync/draft-store";
+import { useComposerStateStore } from "@/react-app/domains/session/surface/composer-state-store";
 import { UpdatesView } from "@/react-app/domains/settings/pages/updates-view";
 import { useDebugViewModel } from "@/react-app/domains/settings/state/debug-view-model";
 import { useMessagingViewProps } from "@/react-app/domains/settings/state/messaging-view-state";
@@ -2192,6 +2193,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 const session = unwrap(
                   await opencodeClient.session.create({ directory: selectedWorkspaceRoot || undefined }),
                 );
+                // Hydrate the composer for the new session: the live composer
+                // reads from the in-memory store; the localStorage draft is a
+                // reload-safe fallback.
+                useComposerStateStore.getState().setDraft(session.id, prompt);
                 saveSessionDraft(selectedWorkspaceId, session.id, { text: prompt, mode: "prompt" });
                 writeActiveWorkspaceId(selectedWorkspaceId);
                 writeLastSessionFor(selectedWorkspaceId, session.id);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -5,7 +5,7 @@ import { toast } from "@/components/ui/sonner";
 
 import { SUGGESTED_PLUGINS } from "@/app/constants";
 import type { EnablementContext } from "@/app/enablement";
-import { createClient } from "@/app/lib/opencode";
+import { createClient, unwrap } from "@/app/lib/opencode";
 import {
   createOpenworkServerClient,
   isLoopbackOpenworkServerUrl,
@@ -66,6 +66,8 @@ import { McpView } from "@/react-app/domains/settings/pages/mcp-view";
 import { RecoveryView } from "@/react-app/domains/settings/pages/recovery-view";
 import { MessagingView } from "@/react-app/domains/settings/pages/messaging-view";
 import { SkillsView } from "@/react-app/domains/settings/pages/skills-view";
+import { WorkflowsView } from "@/react-app/domains/workflows/workflows-view";
+import { saveSessionDraft } from "@/react-app/domains/session/sync/draft-store";
 import { UpdatesView } from "@/react-app/domains/settings/pages/updates-view";
 import { useDebugViewModel } from "@/react-app/domains/settings/state/debug-view-model";
 import { useMessagingViewProps } from "@/react-app/domains/settings/state/messaging-view-state";
@@ -132,7 +134,7 @@ import { abortSessionSafe } from "@/app/lib/opencode-session";
 import { useReloadCoordinator } from "./reload-coordinator";
 import { buildFeedbackUrl } from "@/app/lib/feedback";
 import { getDenInferenceUrl } from "@/app/lib/den";
-import { readActiveWorkspaceId, writeActiveWorkspaceId } from "./session-memory";
+import { readActiveWorkspaceId, writeActiveWorkspaceId, writeLastSessionFor } from "./session-memory";
 import { workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
 import { ensureProviderListQuery, getConnectedProviderItems, refreshProviderListQueries } from "@/react-app/domains/connections/provider-list-query";
@@ -362,6 +364,7 @@ function parseSettingsPath(pathname: string): {
     case "preferences":
     case "permissions":
     case "shell":
+    case "workflows":
     case "advanced":
     case "appearance":
     case "environment":
@@ -2173,6 +2176,37 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               props.onClose?.();
               navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId) : "/session");
               return undefined;
+            }}
+          />
+        );
+      case "workflows":
+        return (
+          <WorkflowsView
+            client={selectedWorkspaceEndpoint?.client ?? openworkClient}
+            workspaceId={runtimeWorkspaceId}
+            busy={busy}
+            canWrite={routeOpenworkCapabilities?.workflows?.write ?? true}
+            onLaunchRun={async ({ prompt }) => {
+              if (!opencodeClient || !selectedWorkspaceId) return null;
+              try {
+                const session = unwrap(
+                  await opencodeClient.session.create({ directory: selectedWorkspaceRoot || undefined }),
+                );
+                saveSessionDraft(selectedWorkspaceId, session.id, { text: prompt, mode: "prompt" });
+                writeActiveWorkspaceId(selectedWorkspaceId);
+                writeLastSessionFor(selectedWorkspaceId, session.id);
+                return session.id;
+              } catch {
+                return null;
+              }
+            }}
+            onOpenSession={(sessionId) => {
+              props.onClose?.();
+              navigate(
+                selectedWorkspaceId
+                  ? workspaceSessionRoute(selectedWorkspaceId, sessionId)
+                  : "/session",
+              );
             }}
           />
         );

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -11,6 +11,16 @@ import { addMcp, listMcp, removeMcp, setMcpEnabled } from "./mcp.js";
 import { deleteSkill, listSkills, upsertSkill } from "./skills.js";
 import { installHubSkill, listHubSkills } from "./skill-hub.js";
 import { deleteCommand, listCommands, repairCommands, upsertCommand } from "./commands.js";
+import {
+  createWorkflowRun,
+  deleteWorkflow,
+  listWorkflowRuns,
+  listWorkflows,
+  readWorkflow,
+  updateWorkflowRun,
+  upsertWorkflow,
+  validateWorkflowSlug,
+} from "./workflows.js";
 import { ApiError, formatError } from "./errors.js";
 import { readJsoncFile, updateJsoncTopLevel, writeJsoncFile } from "./jsonc.js";
 import { recordAudit, readAuditEntries, readLastAudit } from "./audit.js";
@@ -1130,6 +1140,7 @@ function buildCapabilities(config: ServerConfig): Capabilities {
     plugins: { read: true, write: writeEnabled },
     mcp: { read: true, write: writeEnabled },
     commands: { read: true, write: writeEnabled },
+    workflows: { read: true, write: writeEnabled },
     config: { read: true, write: writeEnabled },
 
     approvals: { mode: config.approval.mode, timeoutMs: config.approval.timeoutMs },
@@ -4239,6 +4250,120 @@ function createRoutes(
       path: join(workspace.path, ".opencode", "commands", `${sanitizeCommandName(name)}.md`),
     });
     return jsonResponse({ ok: true });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/workflows", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const items = await listWorkflows(workspace.path);
+    return jsonResponse({ items });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/workflows/:slug", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const item = await readWorkflow(workspace.path, String(ctx.params.slug ?? "").trim());
+    return jsonResponse({ item });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/workflows", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const name = String(body.name ?? "");
+    const slug = body.slug ? String(body.slug) : undefined;
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "workflows.upsert",
+      summary: `Upsert workflow ${name || slug || "(unnamed)"}`,
+      paths: [join(workspace.path, ".opencode", "openwork", "workflows")],
+    });
+    const item = await upsertWorkflow(workspace.path, {
+      name,
+      slug,
+      description: body.description ? String(body.description) : undefined,
+      inputs: Array.isArray(body.inputs) ? body.inputs : undefined,
+      steps: body.steps,
+    });
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "workflows.upsert",
+      target: join(workspace.path, ".opencode", "openwork", "workflows", `${item.slug}.json`),
+      summary: `Upserted workflow ${item.name}`,
+      timestamp: Date.now(),
+    });
+    const items = await listWorkflows(workspace.path);
+    return jsonResponse({ item, items });
+  });
+
+  addRoute(routes, "DELETE", "/workspace/:id/workflows/:slug", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const slug = String(ctx.params.slug ?? "").trim();
+    validateWorkflowSlug(slug);
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "workflows.delete",
+      summary: `Delete workflow ${slug}`,
+      paths: [join(workspace.path, ".opencode", "openwork", "workflows", `${slug}.json`)],
+    });
+    const path = await deleteWorkflow(workspace.path, slug);
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "workflows.delete",
+      target: path,
+      summary: `Deleted workflow ${slug}`,
+      timestamp: Date.now(),
+    });
+    return jsonResponse({ ok: true });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/workflows/:slug/runs", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const items = await listWorkflowRuns(workspace.path, String(ctx.params.slug ?? "").trim());
+    return jsonResponse({ items });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/workflows/:slug/runs", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const slug = String(ctx.params.slug ?? "").trim();
+    const result = await createWorkflowRun(workspace.path, slug);
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "workflows.run",
+      target: result.run.outputDir,
+      summary: `Started workflow run ${result.run.id} for ${slug}`,
+      timestamp: Date.now(),
+    });
+    return jsonResponse(result);
+  });
+
+  addRoute(routes, "PATCH", "/workspace/:id/workflows/:slug/runs/:runId", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const statusRaw = typeof body.status === "string" ? body.status : undefined;
+    const status =
+      statusRaw === "pending" || statusRaw === "running" || statusRaw === "completed" || statusRaw === "failed"
+        ? statusRaw
+        : undefined;
+    if (statusRaw !== undefined && status === undefined) {
+      throw new ApiError(400, "invalid_workflow_run", "Invalid workflow run status");
+    }
+    const run = await updateWorkflowRun(workspace.path, String(ctx.params.runId ?? ""), {
+      status,
+      sessionId: body.sessionId ? String(body.sessionId) : undefined,
+    });
+    return jsonResponse({ run });
   });
 
   addRoute(routes, "GET", "/workspace/:id/export", "client", async (ctx) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4258,6 +4258,12 @@ function createRoutes(
     return jsonResponse({ items });
   });
 
+  addRoute(routes, "GET", "/workspace/:id/workflow-runs", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const items = await listWorkflowRuns(workspace.path);
+    return jsonResponse({ items });
+  });
+
   addRoute(routes, "GET", "/workspace/:id/workflows/:slug", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const item = await readWorkflow(workspace.path, String(ctx.params.slug ?? "").trim());
@@ -4283,6 +4289,7 @@ function createRoutes(
       description: body.description ? String(body.description) : undefined,
       inputs: Array.isArray(body.inputs) ? body.inputs : undefined,
       steps: body.steps,
+      baseUpdatedAt: typeof body.baseUpdatedAt === "number" ? body.baseUpdatedAt : undefined,
     });
     await recordAudit(workspace.path, {
       id: shortId(),

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -108,6 +108,7 @@ export interface Capabilities {
   plugins: { read: boolean; write: boolean };
   mcp: { read: boolean; write: boolean };
   commands: { read: boolean; write: boolean };
+  workflows: { read: boolean; write: boolean };
   config: { read: boolean; write: boolean };
 
   approvals: { mode: ApprovalMode; timeoutMs: number };

--- a/apps/server/src/workflows.test.ts
+++ b/apps/server/src/workflows.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ApiError } from "./errors.js";
+import {
+  compileWorkflowRunPrompt,
+  createWorkflowRun,
+  deleteWorkflow,
+  listWorkflowRuns,
+  listWorkflows,
+  readWorkflow,
+  slugifyWorkflowName,
+  updateWorkflowRun,
+  upsertWorkflow,
+} from "./workflows.js";
+
+const makeWorkspace = () => mkdtemp(join(tmpdir(), "openwork-workflows-"));
+
+describe("workflows", () => {
+  test("upsertWorkflow creates a workspace-relative JSON definition", async () => {
+    const workspace = await makeWorkspace();
+
+    const item = await upsertWorkflow(workspace, {
+      name: "Release Notes",
+      description: "Compile release notes from the changelog",
+      inputs: ["docs/changelog.md", "@docs/style.md", "docs/changelog.md"],
+      steps: [
+        { name: "Summarize", prompt: "Summarize the changes." },
+        { prompt: "Write the final release notes.", agent: "writer", model: "anthropic/claude" },
+      ],
+    });
+
+    expect(item.slug).toBe("release-notes");
+    expect(item.inputs).toEqual(["docs/changelog.md", "docs/style.md"]);
+    expect(item.steps).toHaveLength(2);
+    expect(item.steps[1]?.name).toBe("Step 2");
+    expect(item.steps[1]?.agent).toBe("writer");
+    expect(item.outputDir).toBe(".opencode/openwork/outbox/workflows/release-notes");
+
+    const raw = await readFile(
+      join(workspace, ".opencode", "openwork", "workflows", "release-notes.json"),
+      "utf8",
+    );
+    expect(JSON.parse(raw).name).toBe("Release Notes");
+
+    const items = await listWorkflows(workspace);
+    expect(items).toHaveLength(1);
+    expect(items[0]?.slug).toBe("release-notes");
+  });
+
+  test("upsertWorkflow preserves createdAt on update", async () => {
+    const workspace = await makeWorkspace();
+    const first = await upsertWorkflow(workspace, {
+      name: "Digest",
+      steps: [{ prompt: "Do the digest." }],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const second = await upsertWorkflow(workspace, {
+      name: "Digest",
+      steps: [{ prompt: "Do the digest, but better." }],
+    });
+    expect(second.createdAt).toBe(first.createdAt);
+    expect(second.updatedAt).toBeGreaterThanOrEqual(first.updatedAt);
+  });
+
+  test("upsertWorkflow rejects missing steps and escaping inputs", async () => {
+    const workspace = await makeWorkspace();
+    await expect(upsertWorkflow(workspace, { name: "Empty", steps: [] })).rejects.toThrow(ApiError);
+    await expect(
+      upsertWorkflow(workspace, { name: "Escape", inputs: ["../secrets.txt"], steps: [{ prompt: "x" }] }),
+    ).rejects.toThrow(ApiError);
+    await expect(
+      upsertWorkflow(workspace, { name: "NoPrompt", steps: [{ prompt: "   " }] }),
+    ).rejects.toThrow(ApiError);
+  });
+
+  test("slugifyWorkflowName produces kebab-case", () => {
+    expect(slugifyWorkflowName("Weekly Research Digest!")).toBe("weekly-research-digest");
+    expect(slugifyWorkflowName("  --Already--Kebab--  ")).toBe("already-kebab");
+  });
+
+  test("deleteWorkflow removes the definition", async () => {
+    const workspace = await makeWorkspace();
+    await upsertWorkflow(workspace, { name: "Temp", steps: [{ prompt: "x" }] });
+    await deleteWorkflow(workspace, "temp");
+    expect(await listWorkflows(workspace)).toHaveLength(0);
+    await expect(readWorkflow(workspace, "temp")).rejects.toThrow(ApiError);
+  });
+
+  test("compileWorkflowRunPrompt includes inputs, steps, and outputs", async () => {
+    const workspace = await makeWorkspace();
+    const workflow = await upsertWorkflow(workspace, {
+      name: "Report",
+      description: "Build the report",
+      inputs: ["notes/a.md"],
+      steps: [
+        { name: "Outline", prompt: "Draft an outline." },
+        { name: "Write", prompt: "Write the report." },
+      ],
+    });
+
+    const prompt = compileWorkflowRunPrompt(workflow, "run-1");
+    expect(prompt).toContain('workflow "Report"');
+    expect(prompt).toContain("- notes/a.md");
+    expect(prompt).toContain("### Step 1: Outline");
+    expect(prompt).toContain("### Step 2: Write");
+    expect(prompt).toContain(".opencode/openwork/outbox/workflows/report/run-1/");
+    expect(prompt).toContain("run-summary.md");
+  });
+
+  test("run lifecycle: create, update, list", async () => {
+    const workspace = await makeWorkspace();
+    await upsertWorkflow(workspace, { name: "Pipeline", steps: [{ prompt: "Go." }] });
+
+    const { run, prompt } = await createWorkflowRun(workspace, "pipeline");
+    expect(run.status).toBe("pending");
+    expect(run.workflowSlug).toBe("pipeline");
+    expect(run.outputDir.startsWith(".opencode/openwork/outbox/workflows/pipeline/")).toBe(true);
+    expect(prompt).toContain(run.outputDir);
+
+    const updated = await updateWorkflowRun(workspace, run.id, {
+      status: "running",
+      sessionId: "ses_123",
+    });
+    expect(updated.status).toBe("running");
+    expect(updated.sessionId).toBe("ses_123");
+
+    const runs = await listWorkflowRuns(workspace, "pipeline");
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.id).toBe(run.id);
+    expect(runs[0]?.status).toBe("running");
+
+    const allRuns = await listWorkflowRuns(workspace);
+    expect(allRuns).toHaveLength(1);
+
+    await expect(updateWorkflowRun(workspace, "missing", { status: "failed" })).rejects.toThrow(ApiError);
+  });
+
+  test("createWorkflowRun fails for unknown workflow", async () => {
+    const workspace = await makeWorkspace();
+    await expect(createWorkflowRun(workspace, "ghost")).rejects.toThrow(ApiError);
+  });
+});

--- a/apps/server/src/workflows.test.ts
+++ b/apps/server/src/workflows.test.ts
@@ -76,6 +76,48 @@ describe("workflows", () => {
     ).rejects.toThrow(ApiError);
   });
 
+  test("upsertWorkflow rejects stale co-edit writes with workflow_conflict", async () => {
+    const workspace = await makeWorkspace();
+    const first = await upsertWorkflow(workspace, {
+      name: "Shared Doc",
+      steps: [{ prompt: "v1" }],
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    // Collaborator B saves after A opened the editor.
+    await upsertWorkflow(workspace, {
+      name: "Shared Doc",
+      steps: [{ prompt: "v2 from collaborator" }],
+      baseUpdatedAt: first.updatedAt,
+    });
+
+    // Collaborator A still holds the original updatedAt: write must be rejected.
+    let conflict: ApiError | null = null;
+    try {
+      await upsertWorkflow(workspace, {
+        name: "Shared Doc",
+        steps: [{ prompt: "v2 from stale editor" }],
+        baseUpdatedAt: first.updatedAt,
+      });
+    } catch (error) {
+      conflict = error instanceof ApiError ? error : null;
+    }
+    expect(conflict?.status).toBe(409);
+    expect(conflict?.code).toBe("workflow_conflict");
+
+    // The collaborator's version is preserved.
+    const current = await readWorkflow(workspace, "shared-doc");
+    expect(current.steps[0]?.prompt).toBe("v2 from collaborator");
+
+    // Saving without a base token (or with the fresh one) still works.
+    const fresh = await upsertWorkflow(workspace, {
+      name: "Shared Doc",
+      steps: [{ prompt: "v3 merged" }],
+      baseUpdatedAt: current.updatedAt,
+    });
+    expect(fresh.steps[0]?.prompt).toBe("v3 merged");
+  });
+
   test("slugifyWorkflowName produces kebab-case", () => {
     expect(slugifyWorkflowName("Weekly Research Digest!")).toBe("weekly-research-digest");
     expect(slugifyWorkflowName("  --Already--Kebab--  ")).toBe("already-kebab");

--- a/apps/server/src/workflows.ts
+++ b/apps/server/src/workflows.ts
@@ -60,6 +60,13 @@ export type UpsertWorkflowPayload = {
   description?: string;
   inputs?: unknown[];
   steps: unknown;
+  /**
+   * Optimistic-concurrency token for co-editing: the `updatedAt` the editor
+   * was opened with. When provided and the stored workflow has changed since,
+   * the write is rejected with 409 `workflow_conflict` so a collaborator's
+   * edits are never silently overwritten.
+   */
+  baseUpdatedAt?: number | null;
 };
 
 export function slugifyWorkflowName(name: string): string {
@@ -215,6 +222,18 @@ export async function upsertWorkflow(
     : undefined;
 
   const existing = readWorkflowRecord(await readJsonFile<unknown>(workflowPath(workspaceRoot, slug)));
+  if (
+    existing &&
+    typeof payload.baseUpdatedAt === "number" &&
+    existing.updatedAt > payload.baseUpdatedAt
+  ) {
+    throw new ApiError(
+      409,
+      "workflow_conflict",
+      "This workflow was updated by someone else since you opened it",
+      { slug, updatedAt: existing.updatedAt },
+    );
+  }
   const now = Date.now();
   const item: WorkflowItem = {
     slug,

--- a/apps/server/src/workflows.ts
+++ b/apps/server/src/workflows.ts
@@ -1,0 +1,404 @@
+import { readdir, readFile, writeFile, rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { exists, readJsonFile, shortId } from "./utils.js";
+import { projectWorkflowsDir, projectWorkflowRunsDir } from "./workspace-files.js";
+import { ApiError } from "./errors.js";
+
+/**
+ * Workflows: repeatable, multi-step agent runs stored inside the workspace.
+ *
+ * A workflow is a JSON file under `.opencode/openwork/workflows/<slug>.json`:
+ * it declares input files (context), an ordered list of prompt steps, and an
+ * output folder under the workspace outbox. Because definitions live in the
+ * workspace they are versioned with the project (git) and shared with anyone
+ * connected to the same OpenWork server.
+ *
+ * A run materializes a workflow into a single compiled prompt executed by a
+ * real OpenCode agent session. Each run gets a run-scoped output directory in
+ * the workspace outbox so results surface as shareable artifacts.
+ */
+
+const WORKFLOW_SLUG_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const MAX_STEPS = 25;
+const MAX_INPUTS = 100;
+const MAX_RUNS_LISTED = 100;
+
+export type WorkflowStep = {
+  name: string;
+  prompt: string;
+  agent?: string;
+  model?: string;
+};
+
+export interface WorkflowItem {
+  slug: string;
+  name: string;
+  description?: string;
+  inputs: string[];
+  steps: WorkflowStep[];
+  outputDir: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export type WorkflowRunStatus = "pending" | "running" | "completed" | "failed";
+
+export interface WorkflowRunRecord {
+  id: string;
+  workflowSlug: string;
+  workflowName: string;
+  status: WorkflowRunStatus;
+  sessionId?: string;
+  outputDir: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export type UpsertWorkflowPayload = {
+  name: string;
+  slug?: string;
+  description?: string;
+  inputs?: unknown[];
+  steps: unknown;
+};
+
+export function slugifyWorkflowName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
+
+export function validateWorkflowSlug(slug: string): void {
+  if (!slug || slug.length > 64 || !WORKFLOW_SLUG_REGEX.test(slug)) {
+    throw new ApiError(400, "invalid_workflow_slug", "Workflow slug must be kebab-case (1-64 chars)");
+  }
+}
+
+export function defaultWorkflowOutputDir(slug: string): string {
+  return `.opencode/openwork/outbox/workflows/${slug}`;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function normalizeInputPath(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().replace(/^@+/, "").replace(/\\/g, "/").replace(/^\.\//, "");
+  if (!trimmed) return null;
+  if (trimmed.startsWith("/") || trimmed.includes("..")) {
+    throw new ApiError(400, "invalid_workflow_input", `Workflow inputs must be workspace-relative paths: ${trimmed}`);
+  }
+  return trimmed;
+}
+
+function normalizeSteps(steps: unknown): WorkflowStep[] {
+  if (!Array.isArray(steps) || steps.length === 0) {
+    throw new ApiError(400, "invalid_workflow_steps", "Workflow requires at least one step");
+  }
+  if (steps.length > MAX_STEPS) {
+    throw new ApiError(400, "invalid_workflow_steps", `Workflow supports at most ${MAX_STEPS} steps`);
+  }
+  return steps.map((raw, index) => {
+    const step = readRecord(raw) ?? {};
+    const prompt = typeof step.prompt === "string" ? step.prompt.trim() : "";
+    if (!prompt) {
+      throw new ApiError(400, "invalid_workflow_steps", `Step ${index + 1} requires a prompt`);
+    }
+    const name = typeof step.name === "string" && step.name.trim() ? step.name.trim() : `Step ${index + 1}`;
+    const agent = typeof step.agent === "string" && step.agent.trim() ? step.agent.trim() : undefined;
+    const model = typeof step.model === "string" && step.model.trim() ? step.model.trim() : undefined;
+    return { name, prompt, ...(agent ? { agent } : {}), ...(model ? { model } : {}) };
+  });
+}
+
+function readWorkflowRecord(value: unknown): WorkflowItem | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const slug = typeof record.slug === "string" ? record.slug.trim() : "";
+  if (!slug || !WORKFLOW_SLUG_REGEX.test(slug)) return null;
+  const rawSteps = Array.isArray(record.steps) ? record.steps : [];
+  const steps: WorkflowStep[] = [];
+  for (const raw of rawSteps) {
+    if (!raw || typeof raw !== "object") continue;
+    const step = raw as Record<string, unknown>;
+    const prompt = typeof step.prompt === "string" ? step.prompt.trim() : "";
+    if (!prompt) continue;
+    steps.push({
+      name: typeof step.name === "string" && step.name.trim() ? step.name.trim() : `Step ${steps.length + 1}`,
+      prompt,
+      ...(typeof step.agent === "string" && step.agent.trim() ? { agent: step.agent.trim() } : {}),
+      ...(typeof step.model === "string" && step.model.trim() ? { model: step.model.trim() } : {}),
+    });
+  }
+  if (steps.length === 0) return null;
+  const inputs = Array.isArray(record.inputs)
+    ? record.inputs.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    : [];
+  return {
+    slug,
+    name: typeof record.name === "string" && record.name.trim() ? record.name.trim() : slug,
+    ...(typeof record.description === "string" && record.description.trim()
+      ? { description: record.description.trim() }
+      : {}),
+    inputs,
+    steps,
+    outputDir:
+      typeof record.outputDir === "string" && record.outputDir.trim()
+        ? record.outputDir.trim()
+        : defaultWorkflowOutputDir(slug),
+    createdAt: typeof record.createdAt === "number" ? record.createdAt : 0,
+    updatedAt: typeof record.updatedAt === "number" ? record.updatedAt : 0,
+  };
+}
+
+function workflowPath(workspaceRoot: string, slug: string): string {
+  return join(projectWorkflowsDir(workspaceRoot), `${slug}.json`);
+}
+
+function runPath(workspaceRoot: string, runId: string): string {
+  return join(projectWorkflowRunsDir(workspaceRoot), `${runId}.json`);
+}
+
+export async function listWorkflows(workspaceRoot: string): Promise<WorkflowItem[]> {
+  const dir = projectWorkflowsDir(workspaceRoot);
+  if (!(await exists(dir))) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  const items: WorkflowItem[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const parsed = readWorkflowRecord(await readJsonFile<unknown>(join(dir, entry.name)));
+    if (parsed) items.push(parsed);
+  }
+  items.sort((a, b) => a.name.localeCompare(b.name));
+  return items;
+}
+
+export async function readWorkflow(workspaceRoot: string, slug: string): Promise<WorkflowItem> {
+  validateWorkflowSlug(slug);
+  const parsed = readWorkflowRecord(await readJsonFile<unknown>(workflowPath(workspaceRoot, slug)));
+  if (!parsed) {
+    throw new ApiError(404, "workflow_not_found", `Workflow not found: ${slug}`);
+  }
+  return parsed;
+}
+
+export async function upsertWorkflow(
+  workspaceRoot: string,
+  payload: UpsertWorkflowPayload,
+): Promise<WorkflowItem> {
+  const name = typeof payload.name === "string" ? payload.name.trim() : "";
+  if (!name) {
+    throw new ApiError(400, "invalid_workflow_name", "Workflow name is required");
+  }
+  const slug = (payload.slug?.trim() || slugifyWorkflowName(name));
+  validateWorkflowSlug(slug);
+
+  const rawInputs = Array.isArray(payload.inputs) ? payload.inputs : [];
+  if (rawInputs.length > MAX_INPUTS) {
+    throw new ApiError(400, "invalid_workflow_input", `Workflow supports at most ${MAX_INPUTS} inputs`);
+  }
+  const inputs: string[] = [];
+  for (const raw of rawInputs) {
+    const normalized = normalizeInputPath(raw);
+    if (normalized && !inputs.includes(normalized)) inputs.push(normalized);
+  }
+
+  const steps = normalizeSteps(payload.steps);
+  const description = typeof payload.description === "string" && payload.description.trim()
+    ? payload.description.trim()
+    : undefined;
+
+  const existing = readWorkflowRecord(await readJsonFile<unknown>(workflowPath(workspaceRoot, slug)));
+  const now = Date.now();
+  const item: WorkflowItem = {
+    slug,
+    name,
+    ...(description ? { description } : {}),
+    inputs,
+    steps,
+    outputDir: defaultWorkflowOutputDir(slug),
+    createdAt: existing?.createdAt || now,
+    updatedAt: now,
+  };
+
+  await mkdir(projectWorkflowsDir(workspaceRoot), { recursive: true });
+  await writeFile(workflowPath(workspaceRoot, slug), JSON.stringify(item, null, 2) + "\n", "utf8");
+  return item;
+}
+
+export async function deleteWorkflow(workspaceRoot: string, slug: string): Promise<string> {
+  validateWorkflowSlug(slug);
+  const path = workflowPath(workspaceRoot, slug);
+  await rm(path, { force: true });
+  return path;
+}
+
+/**
+ * Compile a workflow into a single agent prompt.
+ *
+ * The compiled prompt is the "build script" for a run: it lists context
+ * inputs, the ordered steps, and where to write outputs so they show up as
+ * workspace artifacts.
+ */
+export function compileWorkflowRunPrompt(workflow: WorkflowItem, runId: string): string {
+  const outputDir = `${workflow.outputDir}/${runId}`;
+  const lines: string[] = [];
+  lines.push(`You are executing the workflow "${workflow.name}" (run ${runId}).`);
+  if (workflow.description) {
+    lines.push("", workflow.description.trim());
+  }
+
+  if (workflow.inputs.length > 0) {
+    lines.push("", "## Context inputs", "", "Read these workspace files before starting:");
+    for (const input of workflow.inputs) {
+      lines.push(`- ${input}`);
+    }
+  }
+
+  lines.push("", "## Steps", "", "Complete each step fully, in order, before moving to the next.");
+  workflow.steps.forEach((step, index) => {
+    lines.push("", `### Step ${index + 1}: ${step.name}`);
+    if (step.agent || step.model) {
+      const hints: string[] = [];
+      if (step.agent) hints.push(`preferred agent: ${step.agent}`);
+      if (step.model) hints.push(`preferred model: ${step.model}`);
+      lines.push(`_(${hints.join(", ")})_`);
+    }
+    lines.push("", step.prompt.trim());
+  });
+
+  lines.push(
+    "",
+    "## Outputs",
+    "",
+    `Write every build artifact for this run into \`${outputDir}/\`.`,
+    `- Save the result of each step as \`${outputDir}/step-<number>-<short-name>.md\` (or an appropriate file type).`,
+    `- Finish by writing \`${outputDir}/run-summary.md\` describing what was produced, decisions made, and any follow-ups.`,
+    "- Do not skip writing outputs: they are the compiled results of this workflow and will be shared.",
+  );
+
+  return lines.join("\n");
+}
+
+function readRunRecord(value: unknown): WorkflowRunRecord | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const id = typeof record.id === "string" ? record.id.trim() : "";
+  const workflowSlug = typeof record.workflowSlug === "string" ? record.workflowSlug.trim() : "";
+  if (!id || !workflowSlug) return null;
+  const status = record.status;
+  const normalizedStatus: WorkflowRunStatus =
+    status === "running" || status === "completed" || status === "failed" ? status : "pending";
+  return {
+    id,
+    workflowSlug,
+    workflowName: typeof record.workflowName === "string" && record.workflowName.trim() ? record.workflowName.trim() : workflowSlug,
+    status: normalizedStatus,
+    ...(typeof record.sessionId === "string" && record.sessionId.trim() ? { sessionId: record.sessionId.trim() } : {}),
+    outputDir: typeof record.outputDir === "string" && record.outputDir.trim() ? record.outputDir.trim() : "",
+    createdAt: typeof record.createdAt === "number" ? record.createdAt : 0,
+    updatedAt: typeof record.updatedAt === "number" ? record.updatedAt : 0,
+  };
+}
+
+export async function createWorkflowRun(
+  workspaceRoot: string,
+  slug: string,
+): Promise<{ run: WorkflowRunRecord; prompt: string }> {
+  const workflow = await readWorkflow(workspaceRoot, slug);
+  const now = Date.now();
+  const run: WorkflowRunRecord = {
+    id: shortId(),
+    workflowSlug: workflow.slug,
+    workflowName: workflow.name,
+    status: "pending",
+    outputDir: `${workflow.outputDir}/${shortRunLabel(now)}`,
+    createdAt: now,
+    updatedAt: now,
+  };
+  // The compiled prompt and the run record must agree on the output folder.
+  const prompt = compileWorkflowRunPrompt({ ...workflow, outputDir: workflow.outputDir }, runLabelFromOutputDir(run.outputDir));
+  await mkdir(projectWorkflowRunsDir(workspaceRoot), { recursive: true });
+  await writeFile(runPath(workspaceRoot, run.id), JSON.stringify(run, null, 2) + "\n", "utf8");
+  return { run, prompt };
+}
+
+function shortRunLabel(timestamp: number): string {
+  const date = new Date(timestamp);
+  const pad = (value: number) => String(value).padStart(2, "0");
+  const suffix = shortId().slice(0, 6);
+  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}-${suffix}`;
+}
+
+function runLabelFromOutputDir(outputDir: string): string {
+  const segments = outputDir.split("/");
+  return segments[segments.length - 1] ?? outputDir;
+}
+
+export type UpdateWorkflowRunPayload = {
+  status?: WorkflowRunStatus;
+  sessionId?: string;
+};
+
+export async function updateWorkflowRun(
+  workspaceRoot: string,
+  runId: string,
+  payload: UpdateWorkflowRunPayload,
+): Promise<WorkflowRunRecord> {
+  const id = runId.trim();
+  if (!id) {
+    throw new ApiError(400, "invalid_workflow_run", "Workflow run id is required");
+  }
+  const existing = readRunRecord(await readJsonFile<unknown>(runPath(workspaceRoot, id)));
+  if (!existing) {
+    throw new ApiError(404, "workflow_run_not_found", `Workflow run not found: ${id}`);
+  }
+  const status = payload.status;
+  if (status !== undefined && status !== "pending" && status !== "running" && status !== "completed" && status !== "failed") {
+    throw new ApiError(400, "invalid_workflow_run", "Invalid workflow run status");
+  }
+  const sessionId = typeof payload.sessionId === "string" && payload.sessionId.trim() ? payload.sessionId.trim() : undefined;
+  const next: WorkflowRunRecord = {
+    ...existing,
+    ...(status ? { status } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    updatedAt: Date.now(),
+  };
+  await writeFile(runPath(workspaceRoot, id), JSON.stringify(next, null, 2) + "\n", "utf8");
+  return next;
+}
+
+export async function listWorkflowRuns(
+  workspaceRoot: string,
+  slug?: string,
+): Promise<WorkflowRunRecord[]> {
+  if (slug) validateWorkflowSlug(slug);
+  const dir = projectWorkflowRunsDir(workspaceRoot);
+  if (!(await exists(dir))) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  const items: WorkflowRunRecord[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const parsed = readRunRecord(await readJsonFile<unknown>(join(dir, entry.name)));
+    if (!parsed) continue;
+    if (slug && parsed.workflowSlug !== slug) continue;
+    items.push(parsed);
+  }
+  items.sort((a, b) => b.createdAt - a.createdAt);
+  return items.slice(0, MAX_RUNS_LISTED);
+}
+
+export async function readWorkflowFileContent(workspaceRoot: string, slug: string): Promise<string> {
+  validateWorkflowSlug(slug);
+  const path = workflowPath(workspaceRoot, slug);
+  if (!(await exists(path))) {
+    throw new ApiError(404, "workflow_not_found", `Workflow not found: ${slug}`);
+  }
+  return readFile(path, "utf8");
+}

--- a/apps/server/src/workspace-files.ts
+++ b/apps/server/src/workspace-files.ts
@@ -28,3 +28,11 @@ export function projectCommandsDir(workspaceRoot: string): string {
 export function projectPluginsDir(workspaceRoot: string): string {
   return join(workspaceRoot, ".opencode", "plugins");
 }
+
+export function projectWorkflowsDir(workspaceRoot: string): string {
+  return join(workspaceRoot, ".opencode", "openwork", "workflows");
+}
+
+export function projectWorkflowRunsDir(workspaceRoot: string): string {
+  return join(projectWorkflowsDir(workspaceRoot), "runs");
+}


### PR DESCRIPTION
## What

Adds **Workflows** to OpenWork: a lightweight LLM workflow tool for the recurring "I have all this stuff I want to process in an iterated way, and the build artifacts matter" pattern (GNU Autotools x Notion).

A workflow is a saved pipeline that lives **inside the workspace**:

- **Input files / context** — workspace-relative paths the agent must read first (works with the shared-folder inbox for drag-in context).
- **Stored prompt steps** — an ordered, reorderable list of named prompt steps.
- **Real coding agents** — a run executes in a full OpenCode agent session, not a bare chat completion.
- **Compiled outputs** — each run gets a run-scoped folder in the workspace outbox (`.opencode/openwork/outbox/workflows/<slug>/<run>/`, incl. a required `run-summary.md`), so results surface through the existing **artifacts** API: downloadable and shareable.
- **Collaboration / VCS** — definitions are JSON files under `.opencode/openwork/workflows/`, so they're versioned with the project in git and visible to everyone connected to the same OpenWork server.

## How it works

`Run` compiles the workflow (inputs + steps + output contract) into a single agent prompt, creates a run record, opens a new session seeded with the compiled prompt for one-keystroke launch, and links the session to the run. Run history deep-links back to the session; outputs land in the outbox as artifacts.

## Changes

**Server (`apps/server`)**
- `src/workflows.ts`: definitions, validation (kebab slugs, workspace-relative inputs only, step caps), prompt compiler, run records.
- Routes: `GET/POST/DELETE /workspace/:id/workflows[/:slug]`, `GET/POST /workspace/:id/workflows/:slug/runs`, `PATCH .../runs/:runId` — with collaborator scope, approvals, and audit entries like skills/commands.
- `workflows: { read, write }` advertised in capabilities.

**App (`apps/app`)**
- New `domains/workflows/workflows-view.tsx` (TanStack Query + shadcn components), wired as a workspace settings tab (`Workflows`) next to Extensions.
- Editor dialog (name, description, inputs, reorderable steps), run history dialog with status + "Open session", delete confirm.
- Typed client methods on the OpenWork server client.

## Tests / verification

- `bun test src/workflows.test.ts` — **8 pass** (CRUD, validation, createdAt preservation, prompt compilation, run lifecycle).
- `pnpm --filter openwork-server typecheck` — clean.
- `pnpm typecheck` (app) — clean.
- Full server suite: 403 pass / 6 fail — the 6 failures are **pre-existing and unrelated** (`'better-sqlite3' is not yet supported in Bun` native-module load errors in `opencode-db`/`runtime-config`/`workspace-init` tests on this machine; none of those files are touched here).
- **End-to-end API smoke test** against a live `openwork-server` (`--approval auto`, temp workspace): create → get → list → start run (compiled prompt verified, see below) → patch run status/session → list runs → invalid status & path-escape inputs rejected → delete; also verified run outputs written to the run output dir appear in `GET /workspace/:id/artifacts`.

<details>
<summary>Compiled prompt produced during the smoke test</summary>

```
You are executing the workflow "Release Notes" (run 20260610-213349-b1b3cb).

## Context inputs

Read these workspace files before starting:
- notes.md

## Steps

Complete each step fully, in order, before moving to the next.

### Step 1: Summarize

Summarize notes.md

### Step 2: Step 2

Write final release notes.

## Outputs

Write every build artifact for this run into `.opencode/openwork/outbox/workflows/release-notes/20260610-213349-b1b3cb/`.
- Save the result of each step as `...step-<number>-<short-name>.md` (or an appropriate file type).
- Finish by writing `...run-summary.md` describing what was produced, decisions made, and any follow-ups.
- Do not skip writing outputs: they are the compiled results of this workflow and will be shared.
```
</details>

I could not capture a desktop video in this environment — to reproduce the UI flow: `pnpm dev`, open a workspace → Settings → Workflows → New workflow → add a step → Run (lands in a new session with the compiled prompt drafted; send to execute).

## Notes / follow-ups

- Per-step agent/model hints are stored in the schema and rendered into the compiled prompt; a per-step picker UI is a natural follow-up.
- Auto-completing runs from session events and a one-click "share run outputs" bundle are obvious next steps.

---

## Update 2: co-editing + Daytona e2e frame proof

### Co-editing (commit `fe5d07c6e`)

Workflows are now collaboration-aware:

- **Live sync** — workflow and run lists poll every 3s, so collaborators' saves (or `git pull`) appear on every connected client within seconds. Header shows a "Synced live" indicator.
- **Optimistic concurrency** — upserts carry a `baseUpdatedAt` token; the server rejects stale writes with **409 `workflow_conflict`** so nobody silently overwrites a teammate. Covered by a bun test.
- **Proactive remote-update banner** — if a collaborator saves while your editor is open, a banner appears *before* you hit save, with one-click **Load latest**.
- **Conflict recovery** — a stale save shows a conflict banner, disables Save, and **Load latest** pulls the collaborator's version into the editor.
- **Last-run status** on each card (badge + relative time + "Last session" shortcut) via new `GET /workspace/:id/workflow-runs`.
- **"Start from an example"** empty state prefills a 3-step research-digest workflow.

Also fixed (commit `07c31d755`): Run now hydrates the in-memory composer store, so the compiled prompt reliably appears in the new session's composer.

### E2E validation on Daytona (real Electron, driven via CDP)

Frame-by-frame HTML proof (11 named frames, inspected before sharing):

**https://8090-eycuunhigfajxagb.daytonaproxy01.net/proof-frames-workflows/index.html**

> Daytona proxy URLs are not permanent. If the link is down, restart sandbox `openwork-test-20260611-064717`, re-serve `/daytona-artifacts` on port 8090, and regenerate via `daytona preview-url`. Frames persist on the `openwork-eval-artifacts` volume at `/daytona-artifacts/proof-frames-workflows/`.

Validated flow (branch `feat/llm-workflows` @ `07c31d755`, sandbox `openwork-test-20260611-064717`):

1. Welcome → create local workspace `/workspace/hello` through the UI
2. Settings → **Workflows** tab (new workspace settings entry)
3. Empty state → **Start from an example** → editor prefilled → **Save** (verified JSON persisted at `.opencode/openwork/workflows/weekly-research-digest.json`)
4. **Run** → run record created → new agent session opens with the compiled prompt (inputs, steps, output contract) in the composer
5. Card shows **Running** badge + "Last run 1m ago" + **Last session** shortcut
6. **Co-edit live sync**: collaborator edit written to the workflow JSON on disk → card updates to "edited by collaborator Bob", 4 steps, "edited just now" with no user action (≤3s)
7. **Remote-update banner**: collaborator saves while the editor is open → warning banner + Load latest (CDP-asserted via `data-testid="workflow-remote-update-banner"`)
8. **409 conflict**: stale Save rejected — "Your changes were not saved", Save disabled, collaborator version preserved; **Load latest** recovers it (asserted: description shows Bob's text, save re-enabled)
9. **Run history** dialog: statuses, relative times, run-scoped output dirs, Open session links

Setup notes (labeled per evidence standard): settings navigation used direct hash routing (no Settings button exposed in the Daytona dev shell outside settings); collaborator edits simulated by writing the workflow JSON file in the workspace — the same path a second connected client or a git pull takes.

### Tests re-run for this update

- `bun test src/workflows.test.ts` — **9 pass** (incl. new `workflow_conflict` co-edit test)
- `pnpm --filter openwork-server typecheck` — clean
- `pnpm typecheck` (app) — clean
