### PR TITLE
fix(app): persist working Den API base URL after desktop handoff

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -504,7 +504,14 @@ function isWebAppHost(hostname: string): boolean {
     }
   }
 
-  return normalized === "app.openworklabs.com" || normalized === "app.openwork.software" || normalized.startsWith("app.");
+  return (
+    normalized === "app.openworklabs.com" ||
+    normalized === "app.openwork.software" ||
+    normalized.startsWith("app.") ||
+    // Cloud Run hostnames serve the den-web frontend, which only exposes the
+    // Den API behind its `/api/den` proxy path (see #1807/#1808).
+    normalized.endsWith(".run.app")
+  );
 }
 
 function stripDenApiBasePath(input: string | null | undefined): string | null {
@@ -1767,6 +1774,14 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
   const token = options.token?.trim() ?? null;
 
   return {
+    /**
+     * The resolved URLs this client actually talks to. Call sites that
+     * persist Den settings after a successful auth flow should store
+     * `baseUrls.apiBaseUrl` so relaunches reuse the exact endpoint that
+     * worked instead of re-deriving it from the web URL (see #1808).
+     */
+    baseUrls,
+
     async setActiveOrganization(input: { organizationId?: string | null; organizationSlug?: string | null }): Promise<void> {
       await ensureActiveOrganization(baseUrls, token, input);
     },

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -145,18 +145,23 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
         const sameControlPlane =
           denOriginComparisonKey(settings.baseUrl) === targetKey ||
           denOriginComparisonKey(settings.apiBaseUrl ?? null) === targetKey;
-        void createDenClient({
+        const client = createDenClient({
           baseUrl: parsed.denBaseUrl,
           apiBaseUrl: sameControlPlane ? settings.apiBaseUrl ?? null : null,
-        })
+        });
+        void client
           .exchangeDesktopHandoff(parsed.grant)
           .then((result) => {
             if (!result.token) {
               throw new Error("Failed to sign in to OpenWork Cloud.");
             }
 
+            // Persist the API base URL the exchange actually succeeded
+            // against; re-deriving it from the web URL on relaunch breaks
+            // deployments where den-web only proxies under /api/den (#1808).
             writeDenSettings({
               baseUrl: parsed.denBaseUrl,
+              apiBaseUrl: client.baseUrls.apiBaseUrl,
               authToken: result.token,
               activeOrgId: null,
               activeOrgSlug: null,

--- a/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
@@ -125,9 +125,10 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
     setStatusMessage(t("den.signing_in"));
 
     try {
-      const result = await createDenClient({
+      const client = createDenClient({
         baseUrl: nextBaseUrl,
-      }).exchangeDesktopHandoff(parsed.grant);
+      });
+      const result = await client.exchangeDesktopHandoff(parsed.grant);
       if (!result.token) {
         throw new Error(t("den.error_no_token"));
       }
@@ -137,8 +138,11 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
         setBaseUrlDraft(nextBaseUrl);
       }
 
+      // Persist the API base URL the exchange actually succeeded against so
+      // relaunches reuse the same working endpoint (#1808).
       writeDenSettings({
         baseUrl: nextBaseUrl,
+        apiBaseUrl: client.baseUrls.apiBaseUrl,
         authToken: result.token,
         activeOrgId: null,
         activeOrgSlug: null,

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -396,7 +396,8 @@ export function useDenSession({
         denOriginComparisonKey(settings.apiBaseUrl ?? null) === targetKey
           ? settings.apiBaseUrl ?? null
           : null;
-      const result = await createDenClient({ baseUrl: nextBaseUrl, apiBaseUrl: configuredApiBaseUrl }).exchangeDesktopHandoff(parsed.grant);
+      const exchangeClient = createDenClient({ baseUrl: nextBaseUrl, apiBaseUrl: configuredApiBaseUrl });
+      const result = await exchangeClient.exchangeDesktopHandoff(parsed.grant);
       if (!result.token) {
         throw new Error(t("den.error_no_token"));
       }
@@ -406,8 +407,11 @@ export function useDenSession({
         setBaseUrlDraft(nextBaseUrl);
       }
 
+      // Persist the API base URL the exchange actually succeeded against so
+      // relaunches reuse the same working endpoint (#1808).
       writeDenSettings({
         baseUrl: nextBaseUrl,
+        apiBaseUrl: exchangeClient.baseUrls.apiBaseUrl,
         authToken: result.token,
         activeOrgId: null,
         activeOrgSlug: null,


### PR DESCRIPTION
Fixes #1808

## Problem
After a successful desktop handoff sign-in, the app persisted only the web `baseUrl` and re-derived `apiBaseUrl` on relaunch. For den-web hosts outside the hardcoded `isWebAppHost` allowlist (e.g. Cloud Run `*.run.app`, custom domains), the derivation skipped the `/api/den` proxy path, so relaunch called `GET /v1/me` directly on den-web and got a 404.

## Fix
- `createDenClient` now exposes its resolved `baseUrls`
- All three handoff exchange call sites (deep link provider, forced sign-in page, settings manual auth) persist the `apiBaseUrl` the exchange **actually succeeded against**, so relaunch reuses the same working endpoint
- `isWebAppHost` also treats `*.run.app` as a den-web host (mirrors the den-api fix for #1807)

## Testing
- `pnpm --filter @openwork/app typecheck` — passes
- Could not run a full end-to-end Cloud Run deployment locally; repro per #1808: deploy den-api/den-web to separate hosts, sign in via desktop handoff, relaunch the app — it should call `<den-web>/api/den/v1/me` instead of `<den-web>/v1/me`