### PR TITLE
fix(den-api): desktop handoff denBaseUrl includes /api/den on Cloud Run

### DIFF
--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -12,6 +12,7 @@ const EnvSchema = z.object({
   BETTER_AUTH_URL: z.string().min(1),
   DEN_MCP_RESOURCE_URL: z.string().optional(),
   DEN_BETTER_AUTH_TRUSTED_ORIGINS: z.string().optional(),
+  DEN_WEB_APP_HOSTS: z.string().optional(),
   GITHUB_CLIENT_ID: z.string().optional(),
   GITHUB_CLIENT_SECRET: z.string().optional(),
   GITHUB_CONNECTOR_APP_ID: z.string().optional(),
@@ -185,6 +186,10 @@ export const env = {
       ? `http://127.0.0.1:${port}/mcp`
       : undefined,
   betterAuthTrustedOrigins: betterAuthTrustedOrigins.length > 0 ? betterAuthTrustedOrigins : corsOrigins,
+  // Extra hostnames that serve the den-web frontend (and therefore expose
+  // the Den API behind the /api/den proxy path). Entries starting with "."
+  // are treated as suffix matches, e.g. ".example.com".
+  webAppHosts: splitCsv(parsed.DEN_WEB_APP_HOSTS).map((host) => host.toLowerCase()),
   devMode,
   requireEmailVerification,
   github: {

--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -7,6 +7,7 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { jsonValidator, requireUserMiddleware } from "../../middleware/index.js"
 import { db } from "../../db.js"
+import { env } from "../../env.js"
 import { denTypeIdSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 
@@ -75,9 +76,17 @@ function isWebAppHost(hostname: string) {
     }
   }
 
+  const configuredHosts = env.webAppHosts
+  if (configuredHosts.some((host) => (host.startsWith(".") ? normalized.endsWith(host) : normalized === host))) {
+    return true
+  }
+
   return normalized === "app.openworklabs.com"
     || normalized === "app.openwork.software"
     || normalized.startsWith("app.")
+    // Cloud Run hostnames serve the den-web frontend, which only exposes the
+    // Den API behind its /api/den proxy path (see #1807).
+    || normalized.endsWith(".run.app")
 }
 
 function withDenProxyPath(origin: string) {


### PR DESCRIPTION
Fixes #1807

## Problem
`resolveDesktopDenBaseUrl()` only appended the `/api/den` proxy path for a hardcoded host allowlist (`app.openworklabs.com`, `app.*`, private IPs). Cloud Run den-web hostnames (e.g. `den-web-xxx.us-central1.run.app`) got a bare origin in the desktop deep link, so the desktop app hit `https://<den-web>/v1/auth/desktop-handoff/exchange` → 404.

## Fix
- Treat `*.run.app` as a den-web host
- New `DEN_WEB_APP_HOSTS` env var (comma-separated hostnames; entries with a leading `.` match as suffix, e.g. `.example.com`) so self-hosted custom domains can opt in without code changes

## Testing
- `tsc --noEmit` in `ee/apps/den-api` — exit 0
- Host-matching logic checked against 6 cases (Cloud Run host, custom exact host, suffix match, prod host, `evil-run.app` non-match) — all pass
- Could not deploy to Cloud Run locally; repro per #1807: deploy den-api/den-web to Cloud Run, click "Sign in with OpenWork Cloud" — the deep link should now contain `denBaseUrl=https://<den-web>.run.app/api/den`