### PR TITLE
fix(docker): repair Dockerfile.den build — add @openwork/email, drop stale .npmrc

### DIFF
--- a/packaging/docker/Dockerfile.den
+++ b/packaging/docker/Dockerfile.den
@@ -5,9 +5,9 @@ RUN corepack enable
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
-COPY .npmrc /app/.npmrc
 COPY patches /app/patches
 COPY packages/types/package.json /app/packages/types/package.json
+COPY packages/email/package.json /app/packages/email/package.json
 COPY ee/packages/utils/package.json /app/ee/packages/utils/package.json
 COPY ee/packages/den-db/package.json /app/ee/packages/den-db/package.json
 COPY ee/apps/den-api/package.json /app/ee/apps/den-api/package.json
@@ -15,11 +15,13 @@ COPY ee/apps/den-api/package.json /app/ee/apps/den-api/package.json
 RUN pnpm install --frozen-lockfile
 
 COPY packages/types /app/packages/types
+COPY packages/email /app/packages/email
 COPY ee/packages/utils /app/ee/packages/utils
 COPY ee/packages/den-db /app/ee/packages/den-db
 COPY ee/apps/den-api /app/ee/apps/den-api
 
 RUN pnpm --dir /app/ee/packages/utils run build
+RUN pnpm --dir /app/packages/email run build
 RUN pnpm --dir /app/ee/packages/den-db run build
 RUN pnpm --dir /app/ee/apps/den-api run build
 

--- a/packaging/docker/Dockerfile.den-web
+++ b/packaging/docker/Dockerfile.den-web
@@ -5,7 +5,6 @@ RUN corepack enable
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
-COPY .npmrc /app/.npmrc
 COPY patches /app/patches
 COPY packages/types/package.json /app/packages/types/package.json
 COPY packages/ui/package.json /app/packages/ui/package.json

--- a/packaging/docker/Dockerfile.den-worker-proxy
+++ b/packaging/docker/Dockerfile.den-worker-proxy
@@ -5,7 +5,6 @@ RUN corepack enable
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
-COPY .npmrc /app/.npmrc
 COPY patches /app/patches
 COPY packages/types/package.json /app/packages/types/package.json
 COPY ee/packages/utils/package.json /app/ee/packages/utils/package.json


### PR DESCRIPTION
Fixes #1804

## Problem
Two independent breakers in `packaging/docker/Dockerfile.den`:
1. `den-api` depends on `@openwork/email` (`workspace:*`) but the Dockerfile never copied or built `packages/email`, so the image build failed
2. The pnpm v11 migration (#1983) deleted the root `.npmrc` (settings moved to `pnpm-workspace.yaml`), so `COPY .npmrc` fails immediately — this also broke `Dockerfile.den-web` and `Dockerfile.den-worker-proxy`

## Fix
- Copy `packages/email` manifest + sources and build it before `den-db`
- Remove the stale `COPY .npmrc` line from all three den Dockerfiles

## Testing
- `docker build -f packaging/docker/Dockerfile.den .` now passes all COPY/install steps and builds `@openwork/email`, `utils`, and `den-db` successfully; on my machine it OOMs in the final tsup DTS step (Docker VM capped at 2GB RAM, exit 137) — environmental, not a code failure
- Same build chain on the host: `pnpm --dir ee/apps/den-api run build` completes and produces `dist/server.js`