### PR TITLE
test(server): real-engine MCP OAuth e2e against mock provider

### DIFF
--- a/apps/server/src/mcp.oauth-flow.e2e.test.ts
+++ b/apps/server/src/mcp.oauth-flow.e2e.test.ts
@@ -1,0 +1,234 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Full MCP OAuth flow e2e:
+ *
+ *   real opencode engine (sidecar binary)
+ *     -> mock OAuth MCP server (scripts/mock-oauth-mcp-server.mjs)
+ *     -> discovery + dynamic client registration + PKCE (S256)
+ *     -> authorization redirect ("the browser")
+ *     -> token exchange (PKCE verified by the mock)
+ *     -> authenticated streamable-HTTP MCP connect (tools/list)
+ *
+ * The test plays the role of the user's browser by following the
+ * authorization URL and the resulting redirect to the engine's loopback
+ * callback. This is the same flow the OpenWork desktop app drives through
+ * the OAuth modal (apps/app .../connections/mcp-auth-modal.tsx).
+ *
+ * Skipped automatically when the opencode sidecar binary is not present
+ * (e.g. CI runners that never ran prepare:sidecar).
+ */
+
+const repoRoot = resolve(import.meta.dir, "../../..");
+const sidecarDir = join(repoRoot, "apps/desktop/resources/sidecars");
+
+function findSidecar(): string | null {
+  const arch = process.arch === "arm64" ? "aarch64" : "x86_64";
+  const candidates =
+    process.platform === "darwin"
+      ? [join(sidecarDir, `opencode-${arch}-apple-darwin`)]
+      : process.platform === "linux"
+        ? [join(sidecarDir, `opencode-${arch}-unknown-linux-gnu`), join(sidecarDir, `opencode-${arch}-unknown-linux-musl`)]
+        : [];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+const enginePath = findSidecar();
+const describeMaybe = enginePath ? describe : describe.skip;
+
+const MCP_NAME = "mock-oauth-flow";
+
+async function waitFor<T>(fn: () => Promise<T | null>, timeoutMs: number, label: string): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown = null;
+  while (Date.now() < deadline) {
+    try {
+      const value = await fn();
+      if (value !== null) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`timed out waiting for ${label}${lastError ? `: ${String(lastError)}` : ""}`);
+}
+
+async function getFreePort(): Promise<number> {
+  const server = Bun.serve({ port: 0, fetch: () => new Response("") });
+  const port = server.port;
+  server.stop(true);
+  return port;
+}
+
+describeMaybe("mcp oauth flow against mock provider", () => {
+  let mockProc: ChildProcess;
+  let engineProc: ChildProcess;
+  let mockPort = 0;
+  let enginePort = 0;
+  let workDir = "";
+  let dataDir = "";
+
+  const mockUrl = () => `http://127.0.0.1:${mockPort}`;
+  const engineUrl = () => `http://127.0.0.1:${enginePort}`;
+
+  async function engineFetch(path: string, init?: RequestInit) {
+    const url = new URL(`${engineUrl()}${path}`);
+    url.searchParams.set("directory", workDir);
+    return fetch(url, init);
+  }
+
+  beforeAll(async () => {
+    mockPort = await getFreePort();
+    enginePort = await getFreePort();
+
+    workDir = mkdtempSync(join(tmpdir(), "mcp-oauth-ws-"));
+    dataDir = mkdtempSync(join(tmpdir(), "mcp-oauth-data-"));
+    writeFileSync(
+      join(workDir, "opencode.jsonc"),
+      JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        mcp: {
+          [MCP_NAME]: { type: "remote", url: `${mockUrl()}/mcp`, enabled: true, oauth: {} },
+        },
+      }),
+    );
+
+    mockProc = spawn("node", [join(repoRoot, "scripts/mock-oauth-mcp-server.mjs")], {
+      env: { ...process.env, PORT: String(mockPort), AUTO_APPROVE: "1" },
+      stdio: "ignore",
+    });
+    await waitFor(
+      async () => {
+        const res = await fetch(`${mockUrl()}/health`);
+        return res.ok ? true : null;
+      },
+      10_000,
+      "mock oauth server",
+    );
+
+    engineProc = spawn(enginePath!, ["serve", "--hostname", "127.0.0.1", "--port", String(enginePort)], {
+      env: {
+        ...process.env,
+        XDG_DATA_HOME: join(dataDir, "xdg-data"),
+        XDG_CONFIG_HOME: join(dataDir, "xdg-config"),
+        XDG_STATE_HOME: join(dataDir, "xdg-state"),
+        XDG_CACHE_HOME: join(dataDir, "xdg-cache"),
+        OPENCODE_DISABLE_AUTOUPDATE: "1",
+      },
+      stdio: "ignore",
+    });
+    await waitFor(
+      async () => {
+        const res = await engineFetch("/mcp");
+        return res.ok ? true : null;
+      },
+      30_000,
+      "opencode engine",
+    );
+  }, 60_000);
+
+  afterAll(() => {
+    engineProc?.kill();
+    mockProc?.kill();
+    rmSync(workDir, { recursive: true, force: true });
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  test(
+    "engine completes browser OAuth (discovery, DCR, PKCE) and connects",
+    async () => {
+      // Initially the MCP requires auth.
+      const before = (await (await engineFetch("/mcp")).json()) as Record<string, { status: string }>;
+      expect(before[MCP_NAME]).toBeDefined();
+      expect(before[MCP_NAME].status).not.toBe("connected");
+
+      // Start the OAuth flow: engine performs discovery + dynamic client
+      // registration and hands back the authorization URL it would open
+      // in the user's browser.
+      const startRes = await engineFetch(`/mcp/${MCP_NAME}/auth`, { method: "POST" });
+      expect(startRes.ok).toBe(true);
+      const started = (await startRes.json()) as { authorizationUrl?: string; url?: string };
+      const authorizationUrl = started.authorizationUrl ?? started.url;
+      expect(authorizationUrl).toBeTruthy();
+      const authUrl = new URL(authorizationUrl!);
+      expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+      expect(authUrl.searchParams.get("code_challenge")).toBeTruthy();
+      expect(authUrl.searchParams.get("state")).toBeTruthy();
+
+      // Play the browser: visit the authorization URL. The mock
+      // auto-approves and 302s to the engine's loopback callback.
+      const authorizeRes = await fetch(authorizationUrl!, { redirect: "manual" });
+      expect(authorizeRes.status).toBe(302);
+      const callbackUrl = authorizeRes.headers.get("location");
+      expect(callbackUrl).toBeTruthy();
+      const cb = new URL(callbackUrl!);
+      expect(cb.searchParams.get("code")).toBeTruthy();
+      expect(cb.searchParams.get("state")).toBe(authUrl.searchParams.get("state"));
+
+      // Follow the redirect into the engine's loopback callback server,
+      // falling back to the manual callback endpoint (the path used for
+      // remote workspaces where the loopback is unreachable).
+      let callbackDelivered = false;
+      try {
+        const res = await fetch(callbackUrl!);
+        callbackDelivered = res.ok;
+      } catch {
+        callbackDelivered = false;
+      }
+      if (!callbackDelivered) {
+        const manual = await engineFetch(`/mcp/${MCP_NAME}/auth/callback`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ code: cb.searchParams.get("code") }),
+        });
+        expect(manual.ok).toBe(true);
+      }
+
+      // The engine exchanges the code (mock verifies PKCE) and connects.
+      const connected = await waitFor(
+        async () => {
+          const res = await engineFetch("/mcp");
+          if (!res.ok) return null;
+          const statuses = (await res.json()) as Record<string, { status: string }>;
+          return statuses[MCP_NAME]?.status === "connected" ? statuses : null;
+        },
+        30_000,
+        "mcp connected status",
+      );
+      expect(connected[MCP_NAME].status).toBe("connected");
+
+      // Tokens are persisted for reuse across restarts.
+      const authFile = join(dataDir, "xdg-data", "opencode", "mcp-auth.json");
+      expect(existsSync(authFile)).toBe(true);
+      const saved = JSON.parse(readFileSync(authFile, "utf8")) as Record<string, { tokens?: { accessToken?: string } }>;
+      expect(saved[MCP_NAME]?.tokens?.accessToken).toStartWith("mock-access-");
+
+      // The mock saw the full, authenticated MCP handshake.
+      const log = (await (await fetch(`${mockUrl()}/requests`)).json()) as {
+        requests: Array<{ method: string; path: string }>;
+      };
+      const paths = log.requests.map((r) => `${r.method} ${r.path}`);
+      expect(paths).toContain("POST /register");
+      expect(paths).toContain("GET /authorize");
+      expect(paths).toContain("POST /token");
+      expect(paths).toContain("POST /mcp");
+    },
+    90_000,
+  );
+
+  test("logout removes stored tokens and drops the connection", async () => {
+    const remove = await engineFetch(`/mcp/${MCP_NAME}/auth`, { method: "DELETE" });
+    expect(remove.ok).toBe(true);
+
+    const authFile = join(dataDir, "xdg-data", "opencode", "mcp-auth.json");
+    const saved = JSON.parse(readFileSync(authFile, "utf8")) as Record<string, unknown>;
+    expect(saved[MCP_NAME]).toBeUndefined();
+  }, 30_000);
+});

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import http from "node:http";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 const host = process.env.HOST || "127.0.0.1";
 const port = Number(process.env.PORT || 3978);
@@ -54,11 +54,12 @@ async function readForm(req) {
   return Object.fromEntries(new URLSearchParams(raw));
 }
 
-function record(req, pathname) {
+function record(req, url) {
   const entry = {
     id: requests.length + 1,
     method: req.method,
-    path: pathname,
+    path: url.pathname,
+    url: `${url.pathname}${url.search}`,
     at: new Date().toISOString(),
   };
   requests.push(entry);
@@ -99,6 +100,7 @@ function redirectWithCode(res, params) {
   codes.set(code, {
     clientId: params.get("client_id") || "mock-client",
     codeChallenge: params.get("code_challenge") || null,
+    codeChallengeMethod: params.get("code_challenge_method") || "plain",
     scope: params.get("scope") || "mcp:read mcp:write",
   });
 
@@ -152,9 +154,23 @@ async function issueToken(req, res) {
   const form = await readForm(req);
   const grantType = form.grant_type || "authorization_code";
 
-  if (grantType === "authorization_code" && !codes.has(form.code)) {
-    json(res, 400, { error: "invalid_grant" });
-    return;
+  if (grantType === "authorization_code") {
+    const grant = codes.get(form.code);
+    if (!grant) {
+      json(res, 400, { error: "invalid_grant" });
+      return;
+    }
+    if (grant.codeChallenge) {
+      const verifier = form.code_verifier || "";
+      const expected =
+        grant.codeChallengeMethod === "S256"
+          ? createHash("sha256").update(verifier).digest("base64url")
+          : verifier;
+      if (expected !== grant.codeChallenge) {
+        json(res, 400, { error: "invalid_grant", error_description: "PKCE verification failed" });
+        return;
+      }
+    }
   }
 
   if (form.code) codes.delete(form.code);
@@ -244,7 +260,7 @@ async function handleMcp(req, res) {
 const server = http.createServer(async (req, res) => {
   try {
     const url = new URL(req.url || "/", issuer);
-    record(req, url.pathname);
+    record(req, url);
 
     if (req.method === "OPTIONS") {
       json(res, 204, {});


### PR DESCRIPTION
## What

Closes the test gap on the remote MCP OAuth path: nothing exercised `scripts/mock-oauth-mcp-server.mjs` and zero tests covered OAuth (auth start/callback, token persistence, logout).

- **`scripts/mock-oauth-mcp-server.mjs`**: now verifies PKCE (S256/plain) on token exchange — a broken client can no longer pass — and records full request URLs so harnesses can replay the authorization URL in a driven browser.
- **`apps/server/src/mcp.oauth-flow.e2e.test.ts`** (new): spawns the **real opencode sidecar engine** + the mock provider and walks the entire remote-MCP OAuth flow over HTTP:
  `401 → discovery → dynamic client registration → authorization redirect (PKCE S256 + state) → loopback callback (with manual /auth/callback fallback, the remote-workspace paste path from #747) → token exchange → authenticated streamable-HTTP connect → persisted mcp-auth.json tokens → logout removes tokens`
- Skips cleanly when the sidecar binary is absent (CI runners that never ran `prepare:sidecar`).

## Tests run

- `bun test src/mcp.oauth-flow.e2e.test.ts` — **2 pass**, ran 3x consecutively, no flakes (~1s per run)
- `bun test src/mcp.remote-connect.e2e.test.ts src/mcp.engine-sync.e2e.test.ts src/validators.test.ts` — **29 pass**
- Full `apps/server` suite: 401 pass / 5 fail — the 5 failures (`opencode-db`, `workspace-init` seeding) are **pre-existing**: they fail identically on an untouched `dev` checkout and are unrelated to MCP.

## End-to-end verification (live Electron app)

Ran the full flow twice in an isolated dev instance (fresh userdata, worktree build), with the mock at `AUTO_APPROVE=0` so a real approval click was required:

1. Settings → Extensions → Add Custom App → remote URL + 'requires sign-in' → Add App
2. Engine performed 401 → OAuth discovery → dynamic client registration → **opened the system browser** to the approve page
3. Clicked **Approve OpenWork** in a real (CDP-driven) Chrome → redirect to the engine loopback → 'Authorization Successful'
4. Engine log: `saved oauth tokens → StreamableHTTP connected → toolCount=1`; UI shows **Ready**; engine API reports `{"status":"connected"}`; tokens persisted in `mcp-auth.json`
5. **Log out** → tokens removed, status Paused → **Sign in** → browser opens again → second Approve click → reconnected (Ready)

No video capture for this run; exact repro steps:
```sh
AUTO_APPROVE=0 PORT=3978 node scripts/mock-oauth-mcp-server.mjs
pnpm dev   # add custom app: http://127.0.0.1:3978/mcp with sign-in checked, click Approve in the browser
cd apps/server && bun test src/mcp.oauth-flow.e2e.test.ts
```