### PR TITLE
fix(mcp): stop enabled MCPs from reverting to off after engine disposes

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -285,6 +285,12 @@ export type OpenworkMcpItem = {
   disabledByTools?: boolean;
 };
 
+export type OpenworkMcpEngineSync = {
+  status: "ok" | "failed";
+  at: number;
+  failures: Array<{ name: string; status?: number; message?: string }>;
+};
+
 export type OpenworkWorkspaceExport = {
   workspaceId: string;
   exportedAt: number;
@@ -1369,7 +1375,11 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         },
       ),
     listMcp: (workspaceId: string) =>
-      requestJson<{ items: OpenworkMcpItem[] }>(baseUrl, `/workspace/${workspaceId}/mcp`, { token, hostToken }),
+      requestJson<{ items: OpenworkMcpItem[]; engineSync?: OpenworkMcpEngineSync | null }>(
+        baseUrl,
+        `/workspace/${workspaceId}/mcp`,
+        { token, hostToken },
+      ),
     addMcp: (workspaceId: string, payload: { name: string; config: Record<string, unknown> }) =>
       requestJson<{ items: OpenworkMcpItem[] }>(baseUrl, `/workspace/${workspaceId}/mcp`, {
         token,

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1168,10 +1168,34 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     if (!c) return null;
 
     if (optionsArg?.dispose) {
+      // Prefer the OpenWork server engine reload: it disposes the engine AND
+      // re-registers runtime-DB MCPs. A direct dispose makes the engine
+      // rebuild from the OPENCODE_CONFIG_CONTENT snapshot frozen at spawn,
+      // silently dropping any MCPs enabled since (toggles "turn off").
+      let reloaded = false;
       try {
-        unwrap(await c.instance.dispose());
+        const openworkSnapshot = options.openworkServer.getSnapshot();
+        const openworkClient = openworkSnapshot.openworkServerClient;
+        if (openworkSnapshot.openworkServerStatus === "connected" && openworkClient) {
+          const workspaceId =
+            options.runtimeWorkspaceId()?.trim() ||
+            (await options.ensureRuntimeWorkspaceId?.())?.trim() ||
+            "";
+          if (workspaceId) {
+            await openworkClient.reloadEngine(workspaceId);
+            reloaded = true;
+          }
+        }
       } catch {
-        // ignore dispose failures and try reading current state anyway
+        // fall back to a direct engine dispose below
+      }
+
+      if (!reloaded) {
+        try {
+          unwrap(await c.instance.dispose());
+        } catch {
+          // ignore dispose failures and try reading current state anyway
+        }
       }
 
       try {

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1169,9 +1169,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
     if (optionsArg?.dispose) {
       // Prefer the OpenWork server engine reload: it disposes the engine AND
-      // re-registers runtime-DB MCPs. A direct dispose makes the engine
-      // rebuild from the OPENCODE_CONFIG_CONTENT snapshot frozen at spawn,
-      // silently dropping any MCPs enabled since (toggles "turn off").
+      // re-registers runtime-DB MCPs, so non-primary workspaces and pending
+      // changes are picked up instead of silently dropping (toggles "turn
+      // off").
       let reloaded = false;
       try {
         const openworkSnapshot = options.openworkServer.getSnapshot();

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -312,6 +312,7 @@ export function createConnectionsStore(options: {
       config: entry.config as McpServerEntry["config"],
       source: entry.source,
     }));
+    const engineSync = response.engineSync ?? null;
 
     let nextStatuses: McpStatusMap = {};
     const activeClient = options.client();
@@ -328,9 +329,10 @@ export function createConnectionsStore(options: {
       count: next.length,
       names: next.map((entry) => entry.name),
       sources: next.map((entry) => entry.source ?? "unknown"),
+      engineSyncStatus: engineSync?.status ?? null,
     });
 
-    return { next, nextStatuses };
+    return { next, nextStatuses, engineSync };
   };
 
   const resolveDesktopCommand = async (commandName: string, fallbackOnError = true) => {
@@ -390,12 +392,19 @@ export function createConnectionsStore(options: {
       setStateField("mcpStatus", null);
       const serverResult = await listMcpFromOpenworkServer(projectDir);
       if (serverResult) {
+        // Surface engine registration failures instead of leaving users
+        // staring at an MCP that silently shows as disconnected.
+        const failedNames = serverResult.engineSync?.status === "failed"
+          ? serverResult.engineSync.failures.map((failure) => failure.name).join(", ")
+          : "";
         mutateState((current) => ({
           ...current,
           mcpServers: serverResult.next,
           mcpLastUpdatedAt: Date.now(),
           mcpStatuses: serverResult.nextStatuses,
-          mcpStatus: serverResult.next.length ? null : "No MCP servers configured yet.",
+          mcpStatus: failedNames
+            ? `Some MCPs could not be registered with the engine: ${failedNames}. They may appear disconnected — try reloading the engine.`
+            : serverResult.next.length ? null : "No MCP servers configured yet.",
         }));
         return;
       }

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -464,10 +464,19 @@ export function createConnectionsStore(options: {
         ? parseMcpServersFromContent(projectConfig.content)
         : [];
       const projectNames = new Set(projectServers.map((entry) => entry.name));
-      const next = [
+      const fileServers = [
         ...globalServers.filter((entry) => !projectNames.has(entry.name)),
         ...projectServers,
       ];
+      // Runtime-DB MCPs (source "config.remote") only exist on the OpenWork
+      // server. Keep the last-known entries instead of silently dropping them
+      // while the server is briefly unreachable (startup race) — otherwise
+      // enabled MCPs like openwork-ui render as "off".
+      const fileNames = new Set(fileServers.map((entry) => entry.name));
+      const runtimeServers = state.mcpServers.filter(
+        (entry) => entry.source === "config.remote" && !fileNames.has(entry.name),
+      );
+      const next = [...fileServers, ...runtimeServers];
 
       recordPerfLog(options.developerMode(), "mcp.refresh", "desktop-project-fallback-result", {
         globalConfigPath: globalConfig.path,
@@ -477,7 +486,7 @@ export function createConnectionsStore(options: {
         sources: next.map((entry) => entry.source ?? "unknown"),
       });
 
-      if (!globalConfig.exists && !projectConfig.exists) {
+      if (!globalConfig.exists && !projectConfig.exists && runtimeServers.length === 0) {
         mutateState((current) => ({
           ...current,
           mcpServers: [],

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -253,7 +253,7 @@ export function AdvancedRuntimeMigrationSection(props: AdvancedRuntimeMigrationS
             <div className="space-y-2 rounded-xl border border-blue-6/50 bg-blue-2/40 p-3">
               <div className="font-medium text-gray-12">Effective injected OpenCode config</div>
               <div className="text-[11px] text-gray-9">
-                This is the OpenWork-built config object injected through `OPENCODE_CONFIG_CONTENT`. It includes OpenWork defaults plus runtime DB values.
+                This is the OpenWork-built config object injected through the server-managed `OPENCODE_CONFIG` file. It includes OpenWork defaults plus runtime DB values and is rewritten on every runtime config change.
               </div>
               <RuntimeConfigSummary config={props.configStatus.effectiveRuntime ?? props.configStatus.runtime} />
               <details className="rounded-lg bg-gray-3 p-2">

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -4,7 +4,7 @@ import { mkdir } from "node:fs/promises";
 
 import { parseCliArgs, printHelp, resolveServerConfig } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
-import { createServerLogger, startServer } from "./server.js";
+import { createServerLogger, startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
 import { buildOpenworkRuntimeConfig } from "./openwork-runtime-config.js";
 import pkg from "../package.json" with { type: "json" };
@@ -64,6 +64,13 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
 }
 
 const server = await startServer(config);
+
+// OPENCODE_CONFIG_CONTENT above only covers workspaces[0] with the state
+// frozen before spawn. Push every workspace's runtime-DB MCPs into the
+// engine so they aren't invisible until a manual reload. Best-effort.
+if (managedOpencode) {
+  void syncAllWorkspacesRuntimeMcpToEngine(config);
+}
 
 const url = `http://${config.host}:${server.port}`;
 logger.log("info", `OpenWork server listening on ${url}`);

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -6,7 +6,7 @@ import { parseCliArgs, printHelp, resolveServerConfig } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
 import { createServerLogger, startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
-import { buildOpenworkRuntimeConfig } from "./openwork-runtime-config.js";
+import { keepOpenworkRuntimeConfigFileFresh, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import pkg from "../package.json" with { type: "json" };
 
 const args = parseCliArgs(process.argv.slice(2));
@@ -35,7 +35,11 @@ if (!config.readOnly) {
 if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
   const workspace = config.workspaces[0];
   if (workspace?.path) {
-    const openworkRuntimeConfig = await buildOpenworkRuntimeConfig(config, workspace.id);
+    // Server-managed config file: the engine re-reads it from disk on every
+    // instance rebuild, and keepOpenworkRuntimeConfigFileFresh rewrites it
+    // on every runtime-DB write — so disposes always pick up current state.
+    const runtimeConfigPath = await writeOpenworkRuntimeConfigFile(config, workspace.id);
+    keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
     const managedOpencodeCwd = process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim() || workspace.path;
     await mkdir(managedOpencodeCwd, { recursive: true });
     managedOpencode = await createManagedOpencodeServer({
@@ -47,7 +51,7 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
         ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
         OPENWORK_SERVER_URL: serverUrl,
         OPENWORK_SERVER_TOKEN: config.token,
-        OPENCODE_CONFIG_CONTENT: openworkRuntimeConfig,
+        OPENCODE_CONFIG: runtimeConfigPath,
       },
     });
     config.opencodeBaseUrl = managedOpencode.url;
@@ -65,9 +69,9 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
 
 const server = await startServer(config);
 
-// OPENCODE_CONFIG_CONTENT above only covers workspaces[0] with the state
-// frozen before spawn. Push every workspace's runtime-DB MCPs into the
-// engine so they aren't invisible until a manual reload. Best-effort.
+// The runtime config file above only covers workspaces[0]. Push every
+// workspace's runtime-DB MCPs into the engine so they aren't invisible
+// until a manual reload. Best-effort.
 if (managedOpencode) {
   void syncAllWorkspacesRuntimeMcpToEngine(config);
 }

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -10,7 +10,7 @@ import { resolveServerConfig, type CliArgs } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer, type OpencodeExecutionSnapshot } from "./managed-opencode.js";
 import { startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
-import { buildOpenworkRuntimeConfig } from "./openwork-runtime-config.js";
+import { keepOpenworkRuntimeConfigFileFresh, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import type { ServeResult } from "./serve-node.js";
 import type { ServerConfig } from "./types.js";
 
@@ -55,7 +55,11 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
   if (!config.opencodeBaseUrl && options.manageOpencode) {
     const workspace = config.workspaces[0];
     if (workspace?.path) {
-      const openworkRuntimeConfig = await buildOpenworkRuntimeConfig(config, workspace.id);
+      // Server-managed config file: the engine re-reads it from disk on every
+      // instance rebuild, and keepOpenworkRuntimeConfigFileFresh rewrites it
+      // on every runtime-DB write — so disposes always pick up current state.
+      const runtimeConfigPath = await writeOpenworkRuntimeConfigFile(config, workspace.id);
+      keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
       const cwd = options.opencodeCwd
         || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
         || workspace.path;
@@ -70,7 +74,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
           ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
           OPENWORK_SERVER_URL: serverUrl,
           OPENWORK_SERVER_TOKEN: config.token,
-          OPENCODE_CONFIG_CONTENT: openworkRuntimeConfig,
+          OPENCODE_CONFIG: runtimeConfigPath,
           OPENCODE_MODELS_URL: opencodeModelsUrl,
         },
       });
@@ -96,9 +100,9 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
 
   const server = await startServer(config);
 
-  // OPENCODE_CONFIG_CONTENT above only covers workspaces[0] with the state
-  // frozen before spawn. Push every workspace's runtime-DB MCPs into the
-  // engine so they aren't invisible until a manual reload. Best-effort.
+  // The runtime config file above only covers workspaces[0]. Push every
+  // workspace's runtime-DB MCPs into the engine so they aren't invisible
+  // until a manual reload. Best-effort.
   if (managedOpencode) {
     void syncAllWorkspacesRuntimeMcpToEngine(config);
   }

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -8,7 +8,7 @@
 import { mkdir } from "node:fs/promises";
 import { resolveServerConfig, type CliArgs } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer, type OpencodeExecutionSnapshot } from "./managed-opencode.js";
-import { startServer } from "./server.js";
+import { startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
 import { ensureWorkspaceFiles } from "./workspace-init.js";
 import { buildOpenworkRuntimeConfig } from "./openwork-runtime-config.js";
 import type { ServeResult } from "./serve-node.js";
@@ -95,6 +95,13 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
   }
 
   const server = await startServer(config);
+
+  // OPENCODE_CONFIG_CONTENT above only covers workspaces[0] with the state
+  // frozen before spawn. Push every workspace's runtime-DB MCPs into the
+  // engine so they aren't invisible until a manual reload. Best-effort.
+  if (managedOpencode) {
+    void syncAllWorkspacesRuntimeMcpToEngine(config);
+  }
 
   return {
     port: server.port,

--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -3,7 +3,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { startServer } from "./server.js";
+import { startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
+import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
 type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
@@ -29,7 +30,7 @@ async function createWorkspaceRoot() {
   return root;
 }
 
-function startMockOpencode() {
+function startMockOpencode(options?: { failMcpNames?: string[] }) {
   const requests: EngineRequest[] = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -40,7 +41,13 @@ function startMockOpencode() {
       requests.push({ method: request.method, pathname: url.pathname, search: url.search, body });
 
       if (url.pathname === "/instance/dispose") return Response.json({ disposed: true });
-      if (url.pathname === "/mcp" && request.method === "POST") return Response.json({});
+      if (url.pathname === "/mcp" && request.method === "POST") {
+        const name = (body as { name?: string } | null)?.name;
+        if (name && options?.failMcpNames?.includes(name)) {
+          return Response.json({ code: "mcp_invalid", message: "Invalid MCP config" }, { status: 500 });
+        }
+        return Response.json({});
+      }
       if (url.pathname.match(/^\/mcp\/[^/]+\/disconnect$/) && request.method === "POST") return Response.json({});
       return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
     },
@@ -209,6 +216,85 @@ describe("runtime MCP engine sync", () => {
       );
       expect(disconnectRequest).toBeDefined();
       expect(disconnectRequest?.search).toContain(`directory=${encodeURIComponent(workspaceRoot)}`);
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("reload keeps registering remaining MCPs when one entry fails", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    try {
+      const mock = startMockOpencode({ failMcpNames: ["bad"] });
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+
+      for (const [name, config] of [["bad", POSTHOG_CONFIG], ["posthog", POSTHOG_CONFIG]] as const) {
+        const response = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
+          method: "POST",
+          headers: auth(openwork.token),
+          body: JSON.stringify({ name, config }),
+        });
+        expect(response.status).toBe(200);
+      }
+      mock.requests.length = 0;
+
+      const reloadResponse = await fetch(`${openwork.base}/workspace/ws_1/engine/reload`, {
+        method: "POST",
+        headers: auth(openwork.token),
+      });
+      expect(reloadResponse.status).toBe(200);
+
+      const syncedNames = mock.requests
+        .filter((entry) => entry.method === "POST" && entry.pathname === "/mcp")
+        .map((entry) => (entry.body as { name?: string } | null)?.name);
+      // "bad" fails with a 500 but must not block the entries after it.
+      expect(syncedNames).toContain("bad");
+      expect(syncedNames).toContain("posthog");
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("startup sync pushes runtime MCPs for every workspace", async () => {
+    const rootA = await createWorkspaceRoot();
+    const rootB = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(rootA, "runtime.sqlite");
+    try {
+      const mock = startMockOpencode();
+      const baseUrl = `http://127.0.0.1:${mock.server.port}`;
+      const config: ServerConfig = {
+        host: "127.0.0.1",
+        port: 0,
+        token: "owt_test_token",
+        hostToken: "owt_host_token",
+        approval: { mode: "auto", timeoutMs: 1000 },
+        corsOrigins: ["*"],
+        workspaces: [
+          { id: "ws_1", name: "A", path: rootA, preset: "starter", workspaceType: "local", baseUrl },
+          { id: "ws_2", name: "B", path: rootB, preset: "starter", workspaceType: "local", baseUrl },
+        ],
+        authorizedRoots: [rootA, rootB],
+        readOnly: false,
+        startedAt: Date.now(),
+        tokenSource: "cli",
+        hostTokenSource: "cli",
+        logFormat: "pretty",
+        logRequests: false,
+      };
+
+      await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({ ...current, mcp: { posthog: POSTHOG_CONFIG } }));
+      await writeRuntimeOpencodeConfig(config, "ws_2", (current) => ({ ...current, mcp: { stripe: POSTHOG_CONFIG } }));
+
+      await syncAllWorkspacesRuntimeMcpToEngine(config);
+
+      const syncs = mock.requests.filter((entry) => entry.method === "POST" && entry.pathname === "/mcp");
+      const byName = new Map(syncs.map((entry) => [(entry.body as { name?: string } | null)?.name, entry.search]));
+      expect(byName.get("posthog")).toContain(`directory=${encodeURIComponent(rootA)}`);
+      expect(byName.get("stripe")).toContain(`directory=${encodeURIComponent(rootB)}`);
     } finally {
       if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
       else process.env.OPENWORK_RUNTIME_DB = previousDb;

--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -16,6 +16,9 @@ type EngineRequest = {
   body: unknown;
 };
 
+// Keep the engine sync retry backoff tiny so failure-path tests stay fast.
+process.env.OPENWORK_MCP_SYNC_RETRY_DELAY_MS = "10";
+
 const stops: Array<() => void | Promise<void>> = [];
 const roots: string[] = [];
 
@@ -252,6 +255,21 @@ describe("runtime MCP engine sync", () => {
       // "bad" fails with a 500 but must not block the entries after it.
       expect(syncedNames).toContain("bad");
       expect(syncedNames).toContain("posthog");
+      // 5xx entries are retried once.
+      expect(syncedNames.filter((name) => name === "bad").length).toBe(2);
+
+      // The failure is surfaced on the MCP list endpoint instead of being
+      // swallowed silently.
+      const listResponse = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
+        headers: auth(openwork.token),
+      });
+      expect(listResponse.status).toBe(200);
+      const listBody = await listResponse.json() as {
+        engineSync?: { status: string; failures: Array<{ name: string }> } | null;
+      };
+      expect(listBody.engineSync?.status).toBe("failed");
+      expect(listBody.engineSync?.failures.map((failure) => failure.name)).toContain("bad");
+      expect(listBody.engineSync?.failures.map((failure) => failure.name)).not.toContain("posthog");
     } finally {
       if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
       else process.env.OPENWORK_RUNTIME_DB = previousDb;

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  keepOpenworkRuntimeConfigFileFresh,
+  openworkRuntimeConfigFilePath,
+  writeOpenworkRuntimeConfigFile,
+} from "./openwork-runtime-config.js";
+import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+
+const roots: string[] = [];
+const cleanups: Array<() => void> = [];
+let previousDb: string | undefined;
+
+afterEach(async () => {
+  while (cleanups.length) cleanups.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+  if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+  else process.env.OPENWORK_RUNTIME_DB = previousDb;
+});
+
+async function setup() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-runtime-config-file-"));
+  roots.push(root);
+  previousDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [
+      { id: "ws_1", name: "Workspace", path: root, preset: "starter", workspaceType: "local" },
+    ],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  return { root, config };
+}
+
+async function readConfigFile(config: ServerConfig): Promise<Record<string, unknown>> {
+  const raw = await readFile(openworkRuntimeConfigFilePath(config), "utf8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+describe("openwork runtime config file", () => {
+  test("writes runtime-DB MCPs and openwork defaults into the file", async () => {
+    const { config } = await setup();
+    await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({
+      ...current,
+      mcp: { posthog: { type: "remote", url: "https://mcp.posthog.com/mcp", enabled: true } },
+    }));
+
+    const path = await writeOpenworkRuntimeConfigFile(config, "ws_1");
+    expect(path).toBe(openworkRuntimeConfigFilePath(config));
+
+    const parsed = await readConfigFile(config);
+    const mcp = parsed.mcp as Record<string, Record<string, unknown>>;
+    expect(mcp.posthog?.enabled).toBe(true);
+    expect(parsed.default_agent).toBe("openwork");
+    expect(Array.isArray(parsed.plugin)).toBe(true);
+  });
+
+  test("keepOpenworkRuntimeConfigFileFresh rewrites the file on runtime-DB writes", async () => {
+    const { config } = await setup();
+    await writeOpenworkRuntimeConfigFile(config, "ws_1");
+    cleanups.push(keepOpenworkRuntimeConfigFileFresh(config, "ws_1"));
+
+    await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({
+      ...current,
+      mcp: { stripe: { type: "remote", url: "https://mcp.stripe.com", enabled: false } },
+    }));
+
+    // The refresh is fire-and-forget; poll briefly for the rewrite.
+    let mcp: Record<string, Record<string, unknown>> = {};
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      const parsed = await readConfigFile(config);
+      mcp = (parsed.mcp ?? {}) as Record<string, Record<string, unknown>>;
+      if (mcp.stripe) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    expect(mcp.stripe?.enabled).toBe(false);
+  });
+
+  test("writes for other workspaces do not rewrite the primary file", async () => {
+    const { config } = await setup();
+    await writeOpenworkRuntimeConfigFile(config, "ws_1");
+    cleanups.push(keepOpenworkRuntimeConfigFileFresh(config, "ws_1"));
+
+    await writeRuntimeOpencodeConfig(config, "ws_other", (current) => ({
+      ...current,
+      mcp: { other: { type: "remote", url: "https://example.com/mcp", enabled: true } },
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const parsed = await readConfigFile(config);
+    const mcp = (parsed.mcp ?? {}) as Record<string, Record<string, unknown>>;
+    expect(mcp.other).toBeUndefined();
+  });
+});

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -1,17 +1,34 @@
 /**
- * Runtime OpenCode configuration injected via OPENCODE_CONFIG_CONTENT.
+ * Runtime OpenCode configuration injected via a server-managed config file
+ * passed to the engine as OPENCODE_CONFIG.
  *
  * This is the single source of truth for the openwork agent definition,
  * plugins, and any other config that should be injected at runtime rather
- * than written to disk. Both cli.ts and embedded.ts use this.
+ * than written to the user's own config files. Both cli.ts and embedded.ts
+ * use this.
+ *
+ * The engine re-reads the OPENCODE_CONFIG file from disk on every instance
+ * rebuild (e.g. /instance/dispose), so the file is rewritten on every
+ * runtime-DB write — unlike the previous OPENCODE_CONFIG_CONTENT env var,
+ * which was frozen at spawn and reverted MCP state on each dispose.
  */
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 import {
   openworkExtensionsPreviewPluginPath,
   openworkCapabilitiesKnowledgePluginPath,
   openworkAnthropicAdaptiveThinkingPluginPath,
 } from "./openwork-extensions-plugin-path.js";
 import type { ServerConfig } from "./types.js";
-import { readRuntimeOpencodeConfig, runtimeDisabledProviderList, runtimeMcpMap, runtimePluginList } from "./runtime-opencode-config-store.js";
+import {
+  onRuntimeOpencodeConfigWrite,
+  readRuntimeOpencodeConfig,
+  runtimeDisabledProviderList,
+  runtimeMcpMap,
+  runtimePluginList,
+  runtimeStorageDir,
+} from "./runtime-opencode-config-store.js";
 
 const OPENWORK_AGENT_PROMPT = `You are OpenWork.
 
@@ -78,4 +95,46 @@ export async function buildOpenworkRuntimeConfigObject(
 
 export async function buildOpenworkRuntimeConfig(config?: ServerConfig, workspaceId?: string): Promise<string> {
   return JSON.stringify(await buildOpenworkRuntimeConfigObject(config, workspaceId));
+}
+
+export function openworkRuntimeConfigFilePath(config: ServerConfig): string {
+  return join(runtimeStorageDir(config), "runtime-opencode-config.json");
+}
+
+// Serialize file writes per path so a slow older write can never land after
+// (and clobber) a newer one. Content is built inside the queued job so each
+// job reads the latest runtime-DB state.
+const fileWriteQueue = new Map<string, Promise<void>>();
+
+/**
+ * Rebuild the engine-visible runtime config file from the runtime DB.
+ * Atomic (temp file + rename) so the engine never reads a partial file
+ * mid-dispose.
+ */
+export async function writeOpenworkRuntimeConfigFile(config: ServerConfig, workspaceId: string): Promise<string> {
+  const path = openworkRuntimeConfigFilePath(config);
+  const job = async () => {
+    const content = await buildOpenworkRuntimeConfig(config, workspaceId);
+    await mkdir(runtimeStorageDir(config), { recursive: true });
+    const tmp = `${path}.${randomUUID()}.tmp`;
+    await writeFile(tmp, content, "utf8");
+    await rename(tmp, path);
+  };
+  const previous = fileWriteQueue.get(path) ?? Promise.resolve();
+  const next = previous.then(job, job);
+  fileWriteQueue.set(path, next);
+  await next;
+  return path;
+}
+
+/**
+ * Keep the runtime config file in sync with the runtime DB so every engine
+ * instance rebuild reads fresh state instead of a spawn-time snapshot.
+ * Returns an unsubscribe function.
+ */
+export function keepOpenworkRuntimeConfigFileFresh(config: ServerConfig, workspaceId: string): () => void {
+  return onRuntimeOpencodeConfigWrite((writeConfig, writtenWorkspaceId) => {
+    if (writtenWorkspaceId !== workspaceId) return;
+    void writeOpenworkRuntimeConfigFile(writeConfig, workspaceId).catch(() => undefined);
+  });
 }

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -60,6 +60,25 @@ function runtimeDbPath(config: ServerConfig): string {
   return join(configDir, "runtime.sqlite");
 }
 
+/** Directory holding runtime state (the SQLite DB and derived files). */
+export function runtimeStorageDir(config: ServerConfig): string {
+  return dirname(runtimeDbPath(config));
+}
+
+export type RuntimeOpencodeConfigWriteListener = (config: ServerConfig, workspaceId: string) => void;
+
+const writeListeners = new Set<RuntimeOpencodeConfigWriteListener>();
+
+/**
+ * Observe runtime config writes. Used to keep derived state (e.g. the
+ * engine-visible runtime config file) in sync with the DB. Returns an
+ * unsubscribe function. Listeners must not throw.
+ */
+export function onRuntimeOpencodeConfigWrite(listener: RuntimeOpencodeConfigWriteListener): () => void {
+  writeListeners.add(listener);
+  return () => writeListeners.delete(listener);
+}
+
 async function openRuntimeDb(path: string): Promise<RuntimeOpencodeDb> {
   await ensureDir(dirname(path));
   if (typeof process.versions.bun === "string") {
@@ -155,6 +174,7 @@ export async function writeRuntimeOpencodeConfig(
   const now = Date.now();
   const configJson = JSON.stringify(next);
   db.upsert({ workspaceId, configJson, updatedAt: now });
+  for (const listener of writeListeners) listener(config, workspaceId);
   return next;
 }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4856,20 +4856,40 @@ async function syncRuntimeMcpToOpencodeEngine(
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (connection.authHeader) headers.Authorization = connection.authHeader;
 
+  // Keep going past per-entry failures: one dead or invalid MCP must not
+  // block re-registration of every entry after it (e.g. openwork-ui) on
+  // each engine reload.
+  const failures: Array<{ name: string; status?: number; body?: unknown; message?: string }> = [];
   for (const [name, mcpConfig] of entries) {
-    const response = await fetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ name, config: mcpConfig }),
-      signal: AbortSignal.timeout(15_000),
-    });
-    if (!response.ok) {
-      const body = parseOpencodeErrorBody(await response.text());
-      throw new ApiError(502, "opencode_mcp_sync_failed", `Failed to register MCP ${name} with the engine`, {
-        status: response.status,
-        body,
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ name, config: mcpConfig }),
+        signal: AbortSignal.timeout(15_000),
       });
+      if (!response.ok) {
+        failures.push({ name, status: response.status, body: parseOpencodeErrorBody(await response.text()) });
+      }
+    } catch (error) {
+      failures.push({ name, message: error instanceof Error ? error.message : String(error) });
     }
+  }
+  if (failures.length > 0) {
+    const names = failures.map((failure) => failure.name).join(", ");
+    throw new ApiError(502, "opencode_mcp_sync_failed", `Failed to register MCPs with the engine: ${names}`, {
+      failures,
+    });
+  }
+}
+
+// Re-push every workspace's runtime-DB MCPs into the engine. Used at startup:
+// OPENCODE_CONFIG_CONTENT is built from workspaces[0] only and frozen at
+// spawn, so other workspaces' runtime MCPs (and writes that raced the spawn)
+// are invisible to the engine until something re-syncs them. Best-effort.
+export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig): Promise<void> {
+  for (const workspace of config.workspaces) {
+    await syncRuntimeMcpToOpencodeEngine(config, workspace).catch(() => undefined);
   }
 }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3986,7 +3986,7 @@ function createRoutes(
   addRoute(routes, "GET", "/workspace/:id/mcp", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const items = await listMcp(config, workspace.id, workspace.path);
-    return jsonResponse({ items });
+    return jsonResponse({ items, engineSync: engineMcpSyncState(workspace.id) });
   });
 
   addRoute(routes, "POST", "/workspace/:id/mcp", "client", async (ctx) => {
@@ -4006,8 +4006,8 @@ function createRoutes(
       paths: [openworkConfigPath(workspace.path)],
     });
     const result = await addMcp(config, workspace.id, name, configPayload);
-    // Hot-add into the running engine so connect/auth works without a full
-    // engine restart (the spawn-time injected config cannot pick it up).
+    // Hot-add into the running engine so connect/auth works immediately,
+    // without waiting for an engine instance rebuild.
     await syncRuntimeMcpToOpencodeEngine(config, workspace, [name]).catch(() => undefined);
     await recordAudit(workspace.path, {
       id: shortId(),
@@ -4822,17 +4822,18 @@ async function reloadOpencodeEngine(config: ServerConfig, workspace: WorkspaceIn
     });
   }
 
-  // Re-register runtime-DB MCPs: dispose re-reads disk configs plus the
-  // OPENCODE_CONFIG_CONTENT env frozen at spawn, so MCPs added since spawn
-  // would otherwise vanish from the engine after a reload.
+  // Re-register runtime-DB MCPs: dispose rebuilds engine state from disk
+  // configs (including the server-managed runtime config file for the
+  // primary workspace), but other workspaces' runtime MCPs only reach the
+  // engine through this dynamic push.
   await syncRuntimeMcpToOpencodeEngine(config, workspace).catch(() => undefined);
 }
 
 // Push runtime-DB MCP entries into the running OpenCode engine via its dynamic
-// add endpoint. The engine only reads OPENCODE_CONFIG_CONTENT once at spawn, so
-// MCPs written to the runtime DB afterwards are invisible to it — auth then
-// fails with McpServerNotFoundError even though the config write succeeded.
-// Best-effort: callers treat engine sync as advisory and swallow failures.
+// add endpoint, so adds/toggles take effect without waiting for an engine
+// instance rebuild. Best-effort: callers treat engine sync as advisory and
+// swallow failures; outcomes are recorded per workspace (engineMcpSyncState)
+// and logged so failures aren't silent.
 async function syncRuntimeMcpToOpencodeEngine(
   config: ServerConfig,
   workspace: WorkspaceInfo,
@@ -4859,8 +4860,44 @@ async function syncRuntimeMcpToOpencodeEngine(
   // Keep going past per-entry failures: one dead or invalid MCP must not
   // block re-registration of every entry after it (e.g. openwork-ui) on
   // each engine reload.
-  const failures: Array<{ name: string; status?: number; body?: unknown; message?: string }> = [];
+  const failures: EngineMcpSyncFailure[] = [];
   for (const [name, mcpConfig] of entries) {
+    const failure = await postMcpEntryWithRetry(url, headers, name, mcpConfig);
+    if (failure) failures.push(failure);
+  }
+
+  recordEngineMcpSyncResult(workspace.id, {
+    syncedNames: entries.map(([name]) => name),
+    failures,
+    // A full sync covered every runtime entry, so its result replaces any
+    // previously recorded failures (e.g. for since-removed MCPs).
+    replace: !onlyNames,
+  });
+
+  if (failures.length > 0) {
+    const names = failures.map((failure) => failure.name).join(", ");
+    createServerLogger(config).log("warn", `Engine MCP sync failed for workspace ${workspace.id}: ${names}`, {
+      "workspace.id": workspace.id,
+      "mcp.failed": names,
+    });
+    throw new ApiError(502, "opencode_mcp_sync_failed", `Failed to register MCPs with the engine: ${names}`, {
+      failures,
+    });
+  }
+}
+
+// POST one MCP entry to the engine, retrying once on 5xx/network errors
+// (the engine is often mid-rebuild right after a dispose). 4xx responses
+// are not retried — they won't change.
+async function postMcpEntryWithRetry(
+  url: URL,
+  headers: Record<string, string>,
+  name: string,
+  mcpConfig: Record<string, unknown>,
+): Promise<EngineMcpSyncFailure | null> {
+  let failure: EngineMcpSyncFailure | null = null;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, engineMcpSyncRetryDelayMs()));
     try {
       const response = await fetch(url, {
         method: "POST",
@@ -4868,25 +4905,56 @@ async function syncRuntimeMcpToOpencodeEngine(
         body: JSON.stringify({ name, config: mcpConfig }),
         signal: AbortSignal.timeout(15_000),
       });
-      if (!response.ok) {
-        failures.push({ name, status: response.status, body: parseOpencodeErrorBody(await response.text()) });
-      }
+      if (response.ok) return null;
+      failure = { name, status: response.status, body: parseOpencodeErrorBody(await response.text()) };
+      if (response.status < 500) return failure;
     } catch (error) {
-      failures.push({ name, message: error instanceof Error ? error.message : String(error) });
+      failure = { name, message: error instanceof Error ? error.message : String(error) };
     }
   }
-  if (failures.length > 0) {
-    const names = failures.map((failure) => failure.name).join(", ");
-    throw new ApiError(502, "opencode_mcp_sync_failed", `Failed to register MCPs with the engine: ${names}`, {
-      failures,
-    });
-  }
+  return failure;
+}
+
+// Read lazily so tests can shrink the delay at runtime.
+function engineMcpSyncRetryDelayMs(): number {
+  const parsed = Number(process.env.OPENWORK_MCP_SYNC_RETRY_DELAY_MS ?? "750");
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 750;
+}
+
+export type EngineMcpSyncFailure = { name: string; status?: number; body?: unknown; message?: string };
+export type EngineMcpSyncState = { status: "ok" | "failed"; at: number; failures: EngineMcpSyncFailure[] };
+
+// Last engine sync outcome per workspace, surfaced on GET /workspace/:id/mcp
+// so the UI can explain why an enabled MCP shows as disconnected instead of
+// failing silently.
+const engineMcpSyncStateByWorkspace = new Map<string, EngineMcpSyncState>();
+
+function recordEngineMcpSyncResult(
+  workspaceId: string,
+  result: { syncedNames: string[]; failures: EngineMcpSyncFailure[]; replace: boolean },
+): void {
+  const previous = engineMcpSyncStateByWorkspace.get(workspaceId);
+  // Partial syncs (onlyNames) shouldn't clear recorded failures for entries
+  // they didn't touch; merge by name instead.
+  const remaining = result.replace
+    ? []
+    : (previous?.failures ?? []).filter((failure) => !result.syncedNames.includes(failure.name));
+  const merged = [...remaining, ...result.failures];
+  engineMcpSyncStateByWorkspace.set(workspaceId, {
+    status: merged.length > 0 ? "failed" : "ok",
+    at: Date.now(),
+    failures: merged,
+  });
+}
+
+export function engineMcpSyncState(workspaceId: string): EngineMcpSyncState | null {
+  return engineMcpSyncStateByWorkspace.get(workspaceId) ?? null;
 }
 
 // Re-push every workspace's runtime-DB MCPs into the engine. Used at startup:
-// OPENCODE_CONFIG_CONTENT is built from workspaces[0] only and frozen at
-// spawn, so other workspaces' runtime MCPs (and writes that raced the spawn)
-// are invisible to the engine until something re-syncs them. Best-effort.
+// the runtime config file injected via OPENCODE_CONFIG covers workspaces[0]
+// only, so other workspaces' runtime MCPs are invisible to the engine until
+// something re-syncs them. Best-effort.
 export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig): Promise<void> {
   for (const workspace of config.workspaces) {
     await syncRuntimeMcpToOpencodeEngine(config, workspace).catch(() => undefined);


### PR DESCRIPTION
## Problem

Users report MCP toggles — including **OpenWork UI control** — keep turning off, and MCP installs failing (see also user report on X). Traced it: SQLite runtime state never flips to `false`; the **engine's view** reverts.

## Root causes & fixes

1. **Direct dispose with no re-sync** — provider auth flows (`refreshProviders({dispose:true})`) called `instance.dispose()` directly on the opencode engine. The engine rebuilds from the `OPENCODE_CONFIG_CONTENT` snapshot frozen at spawn, dropping every runtime-DB MCP enabled since. Now routed through the OpenWork server's `POST /workspace/:id/engine/reload` (which re-registers runtime MCPs), with fallback to direct dispose when no server is reachable.
2. **Sync aborted on first failure** — `syncRuntimeMcpToOpencodeEngine` threw on the first non-OK entry, so one dead remote MCP (e.g. an unreachable `posthog`/`openwork-cloud`) silently blocked re-registration of everything after it — including `openwork-ui` — on every reload. It now continues past per-entry failures and aggregates errors. This also explains "can't install any MCPs" when one configured MCP is down.
3. **Spawn injection only covered `workspaces[0]`** — runtime-DB MCPs for other workspaces were invisible until a manual reload. `embedded.ts`/`cli.ts` now push every workspace's runtime MCPs into the engine at startup (best-effort, exported `syncAllWorkspacesRuntimeMcpToEngine`).
4. **Renderer fallback hid runtime-DB MCPs** — when the OpenWork server was briefly unreachable (startup race), the file-only fallback dropped `config.remote` entries, rendering enabled MCPs as off. Last-known runtime entries are now kept in the fallback.

## Cloud safety

- Den/cloud servers run the same `startServer`; the reload route + sync fix apply there too.
- Startup sync only fires when a managed engine was spawned (`managedOpencode` non-null), so cloud servers pointing at external engines are unaffected.
- Provider-auth reload falls back to direct dispose when the OpenWork server isn't connected.

## Tests

- `bun test src/mcp.engine-sync.e2e.test.ts` — 7 pass (2 new: partial-failure reload sync, multi-workspace startup sync)
- `bun test` (apps/server) — 406 pass / 7 fail; the same 7 failures pre-exist on clean `dev` (verified via `git stash`)
- `pnpm typecheck` (apps/app) — clean
- `pnpm typecheck` (apps/server) — 1 pre-existing error on `dev` (`SessionMessagesResponse2` SDK export, unrelated)
- `bun test scripts/desktop-cloud-sync.test.ts` (apps/app) — 8 pass

No video captured: the trigger (engine dispose during provider auth) is exercised by the new e2e tests against a mock engine. To reproduce manually: enable OpenWork UI control, then connect/disconnect any model provider — before this fix the MCP drops from the engine.