### PR TITLE
feat(extensions): Claude Code plugin bundle compatibility (MCP + skills + commands from GitHub)

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -258,6 +258,22 @@ export type OpenworkCloudPluginsResult = {
   plugins: Record<string, CloudImportedPlugin>;
 };
 
+export type OpenworkClaudePluginComponent = {
+  type: "mcp" | "skill" | "command" | "agent";
+  name: string;
+  description: string | null;
+};
+
+export type OpenworkClaudePluginPreview = {
+  pluginId: string;
+  name: string;
+  description: string | null;
+  version: string | null;
+  source: { owner: string; repo: string; ref: string; dir: string | null };
+  components: OpenworkClaudePluginComponent[];
+  warnings: string[];
+};
+
 function arrayBufferToBase64(data: ArrayBuffer): string {
   const bytes = new Uint8Array(data);
   let binary = "";
@@ -1259,6 +1275,22 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         token,
         hostToken,
         method: "DELETE",
+        timeoutMs: timeouts.config,
+      }),
+    previewClaudePlugin: (workspaceId: string, payload: { url: string; ref?: string }) =>
+      requestJson<{ preview: OpenworkClaudePluginPreview }>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/claude-plugins`, {
+        token,
+        hostToken,
+        method: "POST",
+        body: { ...payload, dryRun: true },
+        timeoutMs: timeouts.config,
+      }),
+    installClaudePlugin: (workspaceId: string, payload: { url: string; ref?: string }) =>
+      requestJson<OpenworkCloudPluginInstallResult & { preview: OpenworkClaudePluginPreview }>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/claude-plugins`, {
+        token,
+        hostToken,
+        method: "POST",
+        body: payload,
         timeoutMs: timeouts.config,
       }),
     readOpencodeConfigFile: (workspaceId: string, scope: "project" | "global" = "project") => {

--- a/apps/app/src/react-app/domains/connections/modals/claude-plugin-import-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/modals/claude-plugin-import-modal.tsx
@@ -1,0 +1,228 @@
+/** @jsxImportSource react */
+import { useReducer } from "react";
+import { Download, Loader2, Search } from "lucide-react";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { TextInput } from "../../../design-system/text-input";
+import type { OpenworkClaudePluginPreview } from "../../../../app/lib/openwork-server";
+
+export type ClaudePluginImportModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onPreview: (url: string) => Promise<OpenworkClaudePluginPreview>;
+  onInstall: (url: string) => Promise<{ ok: boolean; message: string }>;
+  /** Called after a successful install so the host view can refresh. */
+  onInstalled?: () => void;
+};
+
+type ModalState = {
+  url: string;
+  preview: OpenworkClaudePluginPreview | null;
+  previewing: boolean;
+  installing: boolean;
+  error: string | null;
+};
+
+const initialState: ModalState = {
+  url: "",
+  preview: null,
+  previewing: false,
+  installing: false,
+  error: null,
+};
+
+function reducer(state: ModalState, patch: Partial<ModalState> | "reset"): ModalState {
+  if (patch === "reset") return initialState;
+  return { ...state, ...patch };
+}
+
+const COMPONENT_LABELS: Record<string, { singular: string; plural: string }> = {
+  mcp: { singular: "MCP server", plural: "MCP servers" },
+  skill: { singular: "Skill", plural: "Skills" },
+  command: { singular: "Command", plural: "Commands" },
+  agent: { singular: "Agent", plural: "Agents" },
+};
+
+export function ClaudePluginImportModal(props: ClaudePluginImportModalProps) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const handleClose = () => {
+    if (state.previewing || state.installing) return;
+    dispatch("reset");
+    props.onClose();
+  };
+
+  const handlePreview = async () => {
+    const url = state.url.trim();
+    if (!url) {
+      dispatch({ error: "Enter a GitHub repository URL." });
+      return;
+    }
+    dispatch({ previewing: true, error: null, preview: null });
+    try {
+      const preview = await props.onPreview(url);
+      dispatch({ preview, previewing: false });
+    } catch (error) {
+      dispatch({
+        previewing: false,
+        error: error instanceof Error ? error.message : "Failed to load plugin preview",
+      });
+    }
+  };
+
+  const handleInstall = async () => {
+    const url = state.url.trim();
+    if (!url || state.installing) return;
+    dispatch({ installing: true, error: null });
+    const result = await props.onInstall(url);
+    if (!result.ok) {
+      dispatch({ installing: false, error: result.message });
+      return;
+    }
+    dispatch("reset");
+    props.onInstalled?.();
+    props.onClose();
+  };
+
+  const preview = state.preview;
+  const groups = preview
+    ? (["mcp", "skill", "command", "agent"] as const)
+        .map((type) => ({
+          type,
+          items: preview.components.filter((component) => component.type === type),
+        }))
+        .filter((group) => group.items.length > 0)
+    : [];
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(open) => {
+        if (!open) handleClose();
+      }}
+    >
+      <DialogContent className="flex max-h-[90vh] min-h-0 w-full max-w-lg flex-col overflow-hidden sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Install a plugin from GitHub</DialogTitle>
+          <DialogDescription>
+            Works with Claude Code plugins: a repo with .claude-plugin/plugin.json bundling an MCP
+            server, skills, and commands.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto">
+          <div className="flex items-end gap-2">
+            <div className="flex-1">
+              <TextInput
+                label="GitHub repository"
+                placeholder="https://github.com/slackapi/slack-mcp-plugin"
+                value={state.url}
+                onChange={(event) => dispatch({ url: event.currentTarget.value, preview: null })}
+              />
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => void handlePreview()}
+              disabled={state.previewing || state.installing}
+            >
+              {state.previewing ? (
+                <Loader2 data-icon="inline-start" className="animate-spin" />
+              ) : (
+                <Search data-icon="inline-start" />
+              )}
+              Preview
+            </Button>
+          </div>
+
+          {state.preview ? (
+            <div className="space-y-3 rounded-xl border border-dls-border bg-dls-hover/40 p-4">
+              <div>
+                <div className="text-sm font-semibold text-dls-text">
+                  {state.preview.name}
+                  {state.preview.version ? (
+                    <span className="ml-2 text-xs font-normal text-dls-secondary">v{state.preview.version}</span>
+                  ) : null}
+                </div>
+                {state.preview.description ? (
+                  <div className="mt-0.5 text-xs text-dls-secondary">{state.preview.description}</div>
+                ) : null}
+                <div className="mt-1 text-[11px] text-dls-secondary">
+                  {state.preview.source.owner}/{state.preview.source.repo} @ {state.preview.source.ref}
+                  {state.preview.source.dir ? ` · ${state.preview.source.dir}` : ""}
+                </div>
+              </div>
+
+              <div>
+                <div className="mb-1.5 text-xs font-medium text-dls-text">Will install</div>
+                <div className="space-y-2">
+                  {groups.map((group) => (
+                    <div key={group.type}>
+                      <div className="text-[11px] font-medium uppercase tracking-wide text-dls-secondary">
+                        {group.items.length === 1
+                          ? `1 ${COMPONENT_LABELS[group.type]?.singular}`
+                          : `${group.items.length} ${COMPONENT_LABELS[group.type]?.plural}`}
+                      </div>
+                      <ul className="mt-0.5 space-y-0.5">
+                        {group.items.map((item) => (
+                          <li key={`${group.type}:${item.name}`} className="text-xs text-dls-text">
+                            <span className="font-medium">{item.name}</span>
+                            {item.description ? (
+                              <span className="text-dls-secondary"> — {item.description}</span>
+                            ) : null}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {state.preview.warnings.length > 0 ? (
+                <div className="rounded-lg border border-amber-6 bg-amber-2 px-3 py-2 text-xs text-amber-11">
+                  {state.preview.warnings.map((warning) => (
+                    <div key={warning}>{warning}</div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {state.error ? (
+            <div className="rounded-lg border border-red-6 bg-red-2 px-3 py-2 text-xs text-red-11">
+              {state.error}
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter className="shrink-0">
+          <DialogClose
+            render={<Button variant="outline" disabled={state.previewing || state.installing} />}
+            disabled={state.previewing || state.installing}
+          >
+            Cancel
+          </DialogClose>
+          <Button
+            onClick={() => void handleInstall()}
+            disabled={!state.preview || state.previewing || state.installing}
+          >
+            {state.installing ? (
+              <Loader2 data-icon="inline-start" className="animate-spin" />
+            ) : (
+              <Download data-icon="inline-start" />
+            )}
+            Install
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/app/src/react-app/domains/connections/modals/claude-plugin-import-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/modals/claude-plugin-import-modal.tsx
@@ -27,6 +27,8 @@ export type ClaudePluginImportModalProps = {
 type ModalState = {
   url: string;
   preview: OpenworkClaudePluginPreview | null;
+  /** URL the current preview was generated from; install always targets this. */
+  previewedUrl: string | null;
   previewing: boolean;
   installing: boolean;
   error: string | null;
@@ -35,14 +37,25 @@ type ModalState = {
 const initialState: ModalState = {
   url: "",
   preview: null,
+  previewedUrl: null,
   previewing: false,
   installing: false,
   error: null,
 };
 
-function reducer(state: ModalState, patch: Partial<ModalState> | "reset"): ModalState {
-  if (patch === "reset") return initialState;
-  return { ...state, ...patch };
+type ModalAction =
+  | Partial<ModalState>
+  | "reset"
+  | { kind: "preview-success"; url: string; preview: OpenworkClaudePluginPreview };
+
+function reducer(state: ModalState, action: ModalAction): ModalState {
+  if (action === "reset") return initialState;
+  if ("kind" in action) {
+    // Ignore preview responses for a URL the user has since edited away from.
+    if (state.url.trim() !== action.url) return { ...state, previewing: false };
+    return { ...state, previewing: false, preview: action.preview, previewedUrl: action.url };
+  }
+  return { ...state, ...action };
 }
 
 const COMPONENT_LABELS: Record<string, { singular: string; plural: string }> = {
@@ -67,10 +80,10 @@ export function ClaudePluginImportModal(props: ClaudePluginImportModalProps) {
       dispatch({ error: "Enter a GitHub repository URL." });
       return;
     }
-    dispatch({ previewing: true, error: null, preview: null });
+    dispatch({ previewing: true, error: null, preview: null, previewedUrl: null });
     try {
       const preview = await props.onPreview(url);
-      dispatch({ preview, previewing: false });
+      dispatch({ kind: "preview-success", url, preview });
     } catch (error) {
       dispatch({
         previewing: false,
@@ -80,12 +93,21 @@ export function ClaudePluginImportModal(props: ClaudePluginImportModalProps) {
   };
 
   const handleInstall = async () => {
-    const url = state.url.trim();
+    // Install exactly what was previewed — never a URL edited after preview.
+    const url = state.previewedUrl;
     if (!url || state.installing) return;
     dispatch({ installing: true, error: null });
-    const result = await props.onInstall(url);
-    if (!result.ok) {
-      dispatch({ installing: false, error: result.message });
+    try {
+      const result = await props.onInstall(url);
+      if (!result.ok) {
+        dispatch({ installing: false, error: result.message });
+        return;
+      }
+    } catch (error) {
+      dispatch({
+        installing: false,
+        error: error instanceof Error ? error.message : "Failed to install plugin",
+      });
       return;
     }
     dispatch("reset");
@@ -126,7 +148,9 @@ export function ClaudePluginImportModal(props: ClaudePluginImportModalProps) {
                 label="GitHub repository"
                 placeholder="https://github.com/slackapi/slack-mcp-plugin"
                 value={state.url}
-                onChange={(event) => dispatch({ url: event.currentTarget.value, preview: null })}
+                onChange={(event) =>
+                  dispatch({ url: event.currentTarget.value, preview: null, previewedUrl: null })
+                }
               />
             </div>
             <Button

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -8,6 +8,7 @@ import {
   Cloud,
   Code2,
   CreditCard,
+  Download,
   ExternalLink,
   FolderOpen,
   Globe,
@@ -44,6 +45,8 @@ import { t } from "../../../../i18n";
 import { Button } from "@/components/ui/button";
 import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
 import { AddMcpModal } from "../../connections/modals/add-mcp-modal";
+import { ClaudePluginImportModal } from "../../connections/modals/claude-plugin-import-modal";
+import type { OpenworkClaudePluginPreview } from "../../../../app/lib/openwork-server";
 import {
   isOpenWorkExtensionEnabled,
   isOpenWorkExtensionHidden,
@@ -112,6 +115,10 @@ export type McpViewProps = {
   enablementContext?: import("../../../../app/enablement").EnablementContext;
   /** Organization policy restriction for OpenWork-provided built-in extensions. */
   builtInExtensionsDisabled?: boolean;
+  /** Preview a Claude Code plugin bundle from a GitHub URL ("Will install" disclosure). */
+  previewClaudePlugin?: (url: string) => Promise<OpenworkClaudePluginPreview>;
+  /** Install a Claude Code plugin bundle from a GitHub URL. */
+  installClaudePlugin?: (url: string) => Promise<{ ok: boolean; message: string }>;
 };
 
 const builtInExtensionDisabledReason = "Disabled by organization";
@@ -235,6 +242,7 @@ export function McpView(props: McpViewProps) {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<ExtensionFilter>("all");
   const [showHidden, setShowHidden] = useState(false);
+  const [claudeImportOpen, setClaudeImportOpen] = useState(false);
   const [, setExtensionStateVersion] = useState(0);
 
   const [localState, dispatchLocal] = useReducer(
@@ -498,7 +506,14 @@ export function McpView(props: McpViewProps) {
         </div>
       ) : null}
 
-      <McpCustomAppCard onOpen={() => setAddMcpModalOpen(true)} />
+      <McpCustomAppCard
+        onOpen={() => setAddMcpModalOpen(true)}
+        onOpenGithubImport={
+          props.previewClaudePlugin && props.installClaudePlugin
+            ? () => setClaudeImportOpen(true)
+            : undefined
+        }
+      />
 
       {/* Search + filter */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -680,6 +695,15 @@ export function McpView(props: McpViewProps) {
         isRemoteWorkspace={props.isRemoteWorkspace}
       />
 
+      {props.previewClaudePlugin && props.installClaudePlugin ? (
+        <ClaudePluginImportModal
+          open={claudeImportOpen}
+          onClose={() => setClaudeImportOpen(false)}
+          onPreview={props.previewClaudePlugin}
+          onInstall={props.installClaudePlugin}
+        />
+      ) : null}
+
       {detailEntry ? (() => {
         const extensionConfigSlot = props.configSlotForEntry?.(detailEntry) ?? null;
         const hasConfigSlot = extensionConfigSlot !== null;
@@ -807,7 +831,7 @@ function McpViewHeader(props: { connectedCount: number }) {
   );
 }
 
-function McpCustomAppCard(props: { onOpen: () => void }) {
+function McpCustomAppCard(props: { onOpen: () => void; onOpenGithubImport?: () => void }) {
   return (
     <div className="rounded-2xl border border-blue-6/30 bg-[linear-gradient(180deg,rgba(59,130,246,0.08),rgba(59,130,246,0.03))] p-5 sm:px-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -815,10 +839,18 @@ function McpCustomAppCard(props: { onOpen: () => void }) {
           <div className="text-base font-semibold text-dls-text">{t("mcp.add_modal_title")}</div>
           <div className="text-sm text-dls-secondary">{t("mcp.custom_app_cta_hint")}</div>
         </div>
-        <Button onClick={props.onOpen}>
-          <Plus size={14} />
-          {t("mcp.add_modal_title")}
-        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          {props.onOpenGithubImport ? (
+            <Button variant="outline" onClick={props.onOpenGithubImport}>
+              <Download size={14} />
+              From GitHub
+            </Button>
+          ) : null}
+          <Button onClick={props.onOpen}>
+            <Plus size={14} />
+            {t("mcp.add_modal_title")}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -39,6 +39,7 @@ import {
   type OpencodeConfigFile,
 } from "../../../../app/lib/desktop";
 import type {
+  OpenworkClaudePluginPreview,
   OpenworkHubRepo,
   OpenworkServerCapabilities,
   OpenworkServerClient,
@@ -1712,6 +1713,39 @@ export function createExtensionsStore(options: {
     }
   }
 
+  async function previewClaudePlugin(url: string): Promise<OpenworkClaudePluginPreview> {
+    const target = await resolveWorkspaceServerTarget();
+    if (!target.openworkClient || !target.openworkWorkspaceId) {
+      throw new Error("OpenWork server unavailable. Connect to install plugins from GitHub.");
+    }
+    const result = await target.openworkClient.previewClaudePlugin(target.openworkWorkspaceId, { url });
+    return result.preview;
+  }
+
+  async function installClaudePlugin(url: string): Promise<{ ok: boolean; message: string }> {
+    options.setBusy(true);
+    options.setError(null);
+    try {
+      const target = await resolveWorkspaceServerTarget();
+      if (!target.openworkClient || !target.openworkWorkspaceId) {
+        throw new Error("OpenWork server unavailable. Connect to install plugins from GitHub.");
+      }
+      const result = await target.openworkClient.installClaudePlugin(target.openworkWorkspaceId, { url });
+      await refreshSkills({ force: true });
+      await refreshImportedCloudPlugins();
+      return {
+        ok: true,
+        message: `Installed ${result.item.name} with ${result.item.files.length} component${result.item.files.length === 1 ? "" : "s"}.`,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : t("skills.unknown_error");
+      options.setError(addOpencodeCacheHint(message));
+      return { ok: false, message };
+    } finally {
+      options.setBusy(false);
+    }
+  }
+
   async function removeCloudOrgPlugin(pluginId: string): Promise<{ ok: boolean; message: string }> {
     options.setBusy(true);
     options.setError(null);
@@ -3097,6 +3131,8 @@ export function createExtensionsStore(options: {
     removeCloudOrgSkillHub,
     importCloudOrgPlugin,
     removeCloudOrgPlugin,
+    previewClaudePlugin,
+    installClaudePlugin,
     revealSkillsFolder,
     uninstallSkill,
     readSkill,

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2236,6 +2236,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 uninstallSkill={(name) => { void extensionsStore.uninstallSkill(name); }}
                 removeCloudPlugin={(pluginId) => { void extensionsStore.removeCloudOrgPlugin(pluginId); }}
                 readSkill={(name) => extensionsStore.readSkill(name)}
+                previewClaudePlugin={(url) => extensionsStore.previewClaudePlugin(url)}
+                installClaudePlugin={(url) => extensionsStore.installClaudePlugin(url)}
                 showHeader={false}
               />
             }

--- a/apps/server/src/claude-plugin-bundle.e2e.test.ts
+++ b/apps/server/src/claude-plugin-bundle.e2e.test.ts
@@ -171,6 +171,18 @@ describe("parseClaudePluginSource", () => {
       ref: "dev",
       dir: "plugins/x",
     });
+    expect(parseClaudePluginSource("https://github.com/a/b?tab=readme-ov-file#install")).toEqual({
+      owner: "a",
+      repo: "b",
+      ref: null,
+      dir: null,
+    });
+    expect(parseClaudePluginSource("https://github.com/a/b/tree/dev/plugins/x?x=1")).toEqual({
+      owner: "a",
+      repo: "b",
+      ref: "dev",
+      dir: "plugins/x",
+    });
     expect(() => parseClaudePluginSource("https://gitlab.com/a/b")).toThrow();
     expect(() => parseClaudePluginSource("not a url")).toThrow();
   });

--- a/apps/server/src/claude-plugin-bundle.e2e.test.ts
+++ b/apps/server/src/claude-plugin-bundle.e2e.test.ts
@@ -61,7 +61,8 @@ const PLUGIN_FILES: Record<string, string> = {
   "README.md": "# Slack plugin",
 };
 
-function startMockGithub() {
+function startMockGithub(options?: { branch?: string }) {
+  const branch = options?.branch ?? "main";
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
@@ -69,16 +70,19 @@ function startMockGithub() {
       const url = new URL(request.url);
       // API: repo info
       if (url.pathname === "/repos/slackapi/slack-mcp-plugin") {
-        return Response.json({ default_branch: "main" });
+        return Response.json({ default_branch: branch });
       }
-      // API: recursive tree
-      if (url.pathname === "/repos/slackapi/slack-mcp-plugin/git/trees/main") {
+      // API: recursive tree (ref may arrive %2F-encoded for slash branches)
+      const treePrefix = "/repos/slackapi/slack-mcp-plugin/git/trees/";
+      if (url.pathname.startsWith(treePrefix)) {
+        const ref = decodeURIComponent(url.pathname.slice(treePrefix.length));
+        if (ref !== branch) return Response.json({ message: "not found" }, { status: 404 });
         return Response.json({
           tree: Object.keys(PLUGIN_FILES).map((path) => ({ path, type: "blob", sha: `sha-${path}` })),
         });
       }
-      // Raw files
-      const rawPrefix = "/slackapi/slack-mcp-plugin/main/";
+      // Raw files (slash-branch refs appear as literal path segments)
+      const rawPrefix = `/slackapi/slack-mcp-plugin/${branch}/`;
       if (url.pathname.startsWith(rawPrefix)) {
         const path = decodeURIComponent(url.pathname.slice(rawPrefix.length));
         const content = PLUGIN_FILES[path];
@@ -106,12 +110,12 @@ function startMockOpencode() {
   return { server, requests };
 }
 
-async function startOpenwork() {
+async function startOpenwork(options?: { branch?: string }) {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "openwork-claude-plugin-"));
   roots.push(workspaceRoot);
   setEnv("OPENWORK_RUNTIME_DB", join(workspaceRoot, "runtime.sqlite"));
 
-  const github = startMockGithub();
+  const github = startMockGithub(options);
   setEnv("OPENWORK_GITHUB_API_BASE", `http://127.0.0.1:${github.port}`);
   setEnv("OPENWORK_GITHUB_RAW_BASE", `http://127.0.0.1:${github.port}`);
 
@@ -158,30 +162,36 @@ describe("parseClaudePluginSource", () => {
       repo: "slack-mcp-plugin",
       ref: null,
       dir: null,
+      treeSegments: null,
     });
     expect(parseClaudePluginSource("github.com/slackapi/slack-mcp-plugin.git")).toEqual({
       owner: "slackapi",
       repo: "slack-mcp-plugin",
       ref: null,
       dir: null,
+      treeSegments: null,
     });
     expect(parseClaudePluginSource("https://github.com/a/b/tree/dev/plugins/x")).toEqual({
       owner: "a",
       repo: "b",
       ref: "dev",
       dir: "plugins/x",
+      treeSegments: ["dev", "plugins", "x"],
     });
-    expect(parseClaudePluginSource("https://github.com/a/b?tab=readme-ov-file#install")).toEqual({
+    // Query strings and hash fragments are ignored.
+    expect(parseClaudePluginSource("https://github.com/a/b?tab=readme-ov-file#readme")).toEqual({
       owner: "a",
       repo: "b",
       ref: null,
       dir: null,
+      treeSegments: null,
     });
     expect(parseClaudePluginSource("https://github.com/a/b/tree/dev/plugins/x?x=1")).toEqual({
       owner: "a",
       repo: "b",
       ref: "dev",
       dir: "plugins/x",
+      treeSegments: ["dev", "plugins", "x"],
     });
     expect(() => parseClaudePluginSource("https://gitlab.com/a/b")).toThrow();
     expect(() => parseClaudePluginSource("not a url")).toThrow();
@@ -210,6 +220,25 @@ describe("claude plugin bundles", () => {
     expect(body.preview.warnings.some((warning) => warning.includes("local-helper"))).toBe(true);
     // Nothing installed on dryRun.
     expect(existsSync(join(openwork.workspaceRoot, ".opencode/skills/slack-plugin"))).toBe(false);
+  });
+
+  test("resolves branch names containing slashes in /tree/ URLs", async () => {
+    const openwork = await startOpenwork({ branch: "release/v1" });
+
+    const response = await fetch(`${openwork.base}/workspace/ws_1/claude-plugins`, {
+      method: "POST",
+      headers: openwork.headers,
+      body: JSON.stringify({
+        url: "https://github.com/slackapi/slack-mcp-plugin/tree/release/v1",
+        dryRun: true,
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json() as { preview: { name: string; source: { ref: string; dir: string | null } } };
+    // "release" fails as a ref, so the resolver falls through to "release/v1".
+    expect(body.preview.source.ref).toBe("release/v1");
+    expect(body.preview.source.dir).toBeNull();
+    expect(body.preview.name).toBe("Slack");
   });
 
   test("installs skills, commands, and MCP servers; uninstall cleans up", async () => {

--- a/apps/server/src/claude-plugin-bundle.e2e.test.ts
+++ b/apps/server/src/claude-plugin-bundle.e2e.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import { parseClaudePluginSource } from "./claude-plugin-bundle.js";
+import type { ServerConfig } from "./types.js";
+
+type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+let previousEnv: Record<string, string | undefined> = {};
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+  for (const [key, value] of Object.entries(previousEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  previousEnv = {};
+});
+
+function setEnv(key: string, value: string) {
+  if (!(key in previousEnv)) previousEnv[key] = process.env[key];
+  process.env[key] = value;
+}
+
+const PLUGIN_FILES: Record<string, string> = {
+  ".claude-plugin/plugin.json": JSON.stringify({
+    name: "slack",
+    displayName: "Slack",
+    description: "Slack integration for searching messages and sending communications",
+    version: "1.0.0",
+  }),
+  ".mcp.json": JSON.stringify({
+    mcpServers: {
+      slack: { url: "https://mcp.slack.com/mcp" },
+      "local-helper": { command: "${CLAUDE_PLUGIN_ROOT}/bin/run" },
+    },
+  }),
+  "skills/slack-search/SKILL.md": [
+    "---",
+    "name: slack-search",
+    "description: Search Slack messages effectively",
+    "---",
+    "",
+    "Use the slack MCP tools to search.",
+  ].join("\n"),
+  "skills/slack-search/references/tips.md": "Extra reference file.",
+  "commands/standup.md": [
+    "---",
+    "description: Compile a standup update from Slack",
+    "---",
+    "",
+    "Summarize recent messages.",
+  ].join("\n"),
+  "README.md": "# Slack plugin",
+};
+
+function startMockGithub() {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      // API: repo info
+      if (url.pathname === "/repos/slackapi/slack-mcp-plugin") {
+        return Response.json({ default_branch: "main" });
+      }
+      // API: recursive tree
+      if (url.pathname === "/repos/slackapi/slack-mcp-plugin/git/trees/main") {
+        return Response.json({
+          tree: Object.keys(PLUGIN_FILES).map((path) => ({ path, type: "blob", sha: `sha-${path}` })),
+        });
+      }
+      // Raw files
+      const rawPrefix = "/slackapi/slack-mcp-plugin/main/";
+      if (url.pathname.startsWith(rawPrefix)) {
+        const path = decodeURIComponent(url.pathname.slice(rawPrefix.length));
+        const content = PLUGIN_FILES[path];
+        if (content !== undefined) return new Response(content);
+      }
+      return Response.json({ message: "not found" }, { status: 404 });
+    },
+  }) as Served;
+  stops.push(() => server.stop(true));
+  return server;
+}
+
+function startMockOpencode() {
+  const requests: Array<{ method: string; pathname: string }> = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      requests.push({ method: request.method, pathname: url.pathname });
+      return Response.json({});
+    },
+  }) as Served;
+  stops.push(() => server.stop(true));
+  return { server, requests };
+}
+
+async function startOpenwork() {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "openwork-claude-plugin-"));
+  roots.push(workspaceRoot);
+  setEnv("OPENWORK_RUNTIME_DB", join(workspaceRoot, "runtime.sqlite"));
+
+  const github = startMockGithub();
+  setEnv("OPENWORK_GITHUB_API_BASE", `http://127.0.0.1:${github.port}`);
+  setEnv("OPENWORK_GITHUB_RAW_BASE", `http://127.0.0.1:${github.port}`);
+
+  const engine = startMockOpencode();
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [
+      {
+        id: "ws_1",
+        name: "Workspace",
+        path: workspaceRoot,
+        preset: "starter",
+        workspaceType: "local",
+        baseUrl: `http://127.0.0.1:${engine.server.port}`,
+      },
+    ],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return {
+    base: `http://127.0.0.1:${server.port}`,
+    headers: { Authorization: "Bearer owt_test_token", "Content-Type": "application/json" },
+    workspaceRoot,
+    engine,
+  };
+}
+
+describe("parseClaudePluginSource", () => {
+  test("parses URL variants", () => {
+    expect(parseClaudePluginSource("https://github.com/slackapi/slack-mcp-plugin")).toEqual({
+      owner: "slackapi",
+      repo: "slack-mcp-plugin",
+      ref: null,
+      dir: null,
+    });
+    expect(parseClaudePluginSource("github.com/slackapi/slack-mcp-plugin.git")).toEqual({
+      owner: "slackapi",
+      repo: "slack-mcp-plugin",
+      ref: null,
+      dir: null,
+    });
+    expect(parseClaudePluginSource("https://github.com/a/b/tree/dev/plugins/x")).toEqual({
+      owner: "a",
+      repo: "b",
+      ref: "dev",
+      dir: "plugins/x",
+    });
+    expect(() => parseClaudePluginSource("https://gitlab.com/a/b")).toThrow();
+    expect(() => parseClaudePluginSource("not a url")).toThrow();
+  });
+});
+
+describe("claude plugin bundles", () => {
+  test("dryRun returns the Will-install preview with warnings", async () => {
+    const openwork = await startOpenwork();
+
+    const response = await fetch(`${openwork.base}/workspace/ws_1/claude-plugins`, {
+      method: "POST",
+      headers: openwork.headers,
+      body: JSON.stringify({ url: "https://github.com/slackapi/slack-mcp-plugin", dryRun: true }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json() as { preview: { name: string; version: string | null; components: Array<{ type: string; name: string }>; warnings: string[] } };
+
+    expect(body.preview.name).toBe("Slack");
+    expect(body.preview.version).toBe("1.0.0");
+    const byType = (type: string) => body.preview.components.filter((entry) => entry.type === type).map((entry) => entry.name);
+    expect(byType("mcp")).toEqual(["slack"]);
+    expect(byType("skill")).toEqual(["slack-search"]);
+    expect(byType("command")).toEqual(["standup"]);
+    // local-helper uses ${CLAUDE_PLUGIN_ROOT} and must be skipped with a warning.
+    expect(body.preview.warnings.some((warning) => warning.includes("local-helper"))).toBe(true);
+    // Nothing installed on dryRun.
+    expect(existsSync(join(openwork.workspaceRoot, ".opencode/skills/slack-plugin"))).toBe(false);
+  });
+
+  test("installs skills, commands, and MCP servers; uninstall cleans up", async () => {
+    const openwork = await startOpenwork();
+
+    const installResponse = await fetch(`${openwork.base}/workspace/ws_1/claude-plugins`, {
+      method: "POST",
+      headers: openwork.headers,
+      body: JSON.stringify({ url: "https://github.com/slackapi/slack-mcp-plugin" }),
+    });
+    expect(installResponse.status).toBe(200);
+    const installBody = await installResponse.json() as { item: { pluginId: string; files: Array<{ objectType: string; path: string }> } };
+    expect(installBody.item.pluginId).toBe("github:slackapi/slack-mcp-plugin");
+
+    // Skill and command land namespaced under .opencode/.
+    const skillPath = join(openwork.workspaceRoot, ".opencode/skills/slack-plugin/slack-search/SKILL.md");
+    const commandPath = join(openwork.workspaceRoot, ".opencode/commands/slack-plugin/standup.md");
+    expect(existsSync(skillPath)).toBe(true);
+    expect(existsSync(commandPath)).toBe(true);
+    expect(await readFile(skillPath, "utf8")).toContain("Search Slack messages effectively");
+
+    // MCP registered in the runtime DB and pushed to the engine.
+    const listResponse = await fetch(`${openwork.base}/workspace/ws_1/mcp`, { headers: openwork.headers });
+    const listBody = await listResponse.json() as { items: Array<{ name: string; source: string }> };
+    const slackEntry = listBody.items.find((entry) => entry.name === "slack");
+    expect(slackEntry?.source).toBe("config.remote");
+    expect(openwork.engine.requests.some((entry) => entry.method === "POST" && entry.pathname === "/mcp")).toBe(true);
+
+    // Uninstall through the shared cloud-plugins route.
+    const removeResponse = await fetch(
+      `${openwork.base}/workspace/ws_1/cloud-plugins/${encodeURIComponent(installBody.item.pluginId)}`,
+      { method: "DELETE", headers: openwork.headers },
+    );
+    expect(removeResponse.status).toBe(200);
+    expect(existsSync(skillPath)).toBe(false);
+    expect(existsSync(commandPath)).toBe(false);
+    const afterRemove = await fetch(`${openwork.base}/workspace/ws_1/mcp`, { headers: openwork.headers });
+    const afterRemoveBody = await afterRemove.json() as { items: Array<{ name: string }> };
+    expect(afterRemoveBody.items.some((entry) => entry.name === "slack")).toBe(false);
+  });
+});

--- a/apps/server/src/claude-plugin-bundle.ts
+++ b/apps/server/src/claude-plugin-bundle.ts
@@ -1,0 +1,426 @@
+/**
+ * Claude Code plugin bundle compatibility.
+ *
+ * Resolves a GitHub repo containing a Claude Code plugin
+ * (`.claude-plugin/plugin.json` + `.mcp.json` + `skills/` + `commands/` +
+ * `agents/`) into the existing CloudPluginResolved shape, so installation
+ * reuses installCloudPlugin: namespacing, Claude frontmatter translation,
+ * MCP registration, the install registry, uninstall, approvals, and reload
+ * events all come for free.
+ *
+ * Format reference: https://code.claude.com/docs/en/plugins-reference
+ */
+import { ApiError } from "./errors.js";
+import { parseFrontmatter } from "./frontmatter.js";
+import type { CloudPluginResolved } from "./cloud-plugins.js";
+
+export type ClaudePluginSource = {
+  owner: string;
+  repo: string;
+  ref: string | null;
+  dir: string | null;
+};
+
+export type ClaudePluginComponent = {
+  type: "mcp" | "skill" | "command" | "agent";
+  name: string;
+  description: string | null;
+};
+
+export type ClaudePluginPreview = {
+  pluginId: string;
+  name: string;
+  description: string | null;
+  version: string | null;
+  source: { owner: string; repo: string; ref: string; dir: string | null };
+  components: ClaudePluginComponent[];
+  warnings: string[];
+};
+
+export type ClaudePluginBundle = {
+  resolved: CloudPluginResolved;
+  preview: ClaudePluginPreview;
+};
+
+function githubApiBase(): string {
+  return (process.env.OPENWORK_GITHUB_API_BASE?.trim() || "https://api.github.com").replace(/\/+$/, "");
+}
+
+function githubRawBase(): string {
+  return (process.env.OPENWORK_GITHUB_RAW_BASE?.trim() || "https://raw.githubusercontent.com").replace(/\/+$/, "");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+// GitHub owners are alphanumeric + hyphen; repos additionally allow dots and underscores.
+const GITHUB_OWNER_RE = /^[A-Za-z0-9-]+$/;
+const GITHUB_REPO_RE = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Accepts `https://github.com/owner/repo`, `github.com/owner/repo`,
+ * `owner/repo`, with optional `.git` suffix and `/tree/<ref>(/<subdir>)`.
+ */
+export function parseClaudePluginSource(input: string): ClaudePluginSource {
+  const trimmed = input.trim();
+  if (!trimmed) throw new ApiError(400, "invalid_plugin_url", "GitHub URL is required");
+  const withoutProtocol = trimmed.replace(/^https?:\/\//, "");
+  const hadHost = /^[A-Za-z0-9.-]+\.[A-Za-z]{2,}\//.test(withoutProtocol);
+  if (hadHost && !withoutProtocol.startsWith("github.com/")) {
+    throw new ApiError(400, "invalid_plugin_url", "Only github.com sources are supported");
+  }
+  const path = hadHost ? withoutProtocol.slice(withoutProtocol.indexOf("/") + 1) : withoutProtocol;
+  const parts = path.split("/").filter(Boolean);
+  const owner = parts[0] ?? "";
+  const repo = (parts[1] ?? "").replace(/\.git$/, "");
+  if (!GITHUB_OWNER_RE.test(owner) || !GITHUB_REPO_RE.test(repo)) {
+    throw new ApiError(400, "invalid_plugin_url", "Expected a GitHub repo URL like https://github.com/owner/repo");
+  }
+  let ref: string | null = null;
+  let dir: string | null = null;
+  if (parts[2] === "tree" && parts[3]) {
+    ref = parts[3];
+    const rest = parts.slice(4);
+    if (rest.length > 0) dir = rest.join("/");
+  }
+  return { owner, repo, ref, dir };
+}
+
+async function fetchGithubJson(url: string): Promise<unknown> {
+  const response = await fetch(url, {
+    headers: { Accept: "application/vnd.github+json", "User-Agent": "openwork-server" },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new ApiError(502, "plugin_fetch_failed", `Failed to fetch plugin data (${response.status}): ${text || url}`);
+  }
+  return response.json();
+}
+
+async function fetchGithubText(url: string): Promise<string> {
+  const response = await fetch(url, {
+    headers: { Accept: "text/plain", "User-Agent": "openwork-server" },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new ApiError(502, "plugin_fetch_failed", `Failed to fetch plugin file (${response.status}): ${text || url}`);
+  }
+  return response.text();
+}
+
+type TreeEntry = { path: string; sha: string };
+
+async function fetchRepoTree(source: ClaudePluginSource, ref: string): Promise<TreeEntry[]> {
+  const url = `${githubApiBase()}/repos/${encodeURIComponent(source.owner)}/${encodeURIComponent(source.repo)}/git/trees/${encodeURIComponent(ref)}?recursive=1`;
+  const tree = await fetchGithubJson(url);
+  const entries = isRecord(tree) && Array.isArray(tree.tree) ? tree.tree : [];
+  return entries.flatMap((entry) => {
+    if (!isRecord(entry) || entry.type !== "blob") return [];
+    if (typeof entry.path !== "string" || typeof entry.sha !== "string") return [];
+    return [{ path: entry.path, sha: entry.sha }];
+  });
+}
+
+async function resolveDefaultBranch(source: ClaudePluginSource): Promise<string> {
+  const url = `${githubApiBase()}/repos/${encodeURIComponent(source.owner)}/${encodeURIComponent(source.repo)}`;
+  try {
+    const info = await fetchGithubJson(url);
+    if (isRecord(info) && typeof info.default_branch === "string" && info.default_branch.trim()) {
+      return info.default_branch.trim();
+    }
+  } catch {
+    // Fall through to "main" below.
+  }
+  return "main";
+}
+
+function rawFileUrl(source: ClaudePluginSource, ref: string, path: string): string {
+  const segments = path.split("/").map((segment) => encodeURIComponent(segment)).join("/");
+  return `${githubRawBase()}/${encodeURIComponent(source.owner)}/${encodeURIComponent(source.repo)}/${encodeURIComponent(ref)}/${segments}`;
+}
+
+// Find the plugin root: the given subdir, the repo root, or the shallowest
+// directory containing `.claude-plugin/plugin.json`.
+function locatePluginRoot(tree: TreeEntry[], dir: string | null): string {
+  const manifestPaths = tree
+    .map((entry) => entry.path)
+    .filter((path) => path === ".claude-plugin/plugin.json" || path.endsWith("/.claude-plugin/plugin.json"));
+  if (dir) {
+    const normalized = dir.replace(/\/+$/, "");
+    const expected = `${normalized}/.claude-plugin/plugin.json`;
+    if (!manifestPaths.includes(expected)) {
+      throw new ApiError(404, "plugin_manifest_not_found", `No .claude-plugin/plugin.json found under ${normalized}/`);
+    }
+    return `${normalized}/`;
+  }
+  if (manifestPaths.length === 0) {
+    throw new ApiError(404, "plugin_manifest_not_found", "No .claude-plugin/plugin.json found in this repository");
+  }
+  manifestPaths.sort((a, b) => a.split("/").length - b.split("/").length || a.localeCompare(b));
+  const shallowest = manifestPaths[0]!;
+  const root = shallowest.slice(0, shallowest.length - ".claude-plugin/plugin.json".length);
+  const sameDepth = manifestPaths.filter((path) => path.split("/").length === shallowest.split("/").length);
+  if (sameDepth.length > 1) {
+    const candidates = sameDepth
+      .map((path) => path.slice(0, path.length - "/.claude-plugin/plugin.json".length))
+      .join(", ");
+    throw new ApiError(400, "plugin_ambiguous", `Multiple plugins found (${candidates}). Add the plugin directory to the URL, e.g. /tree/main/<dir>.`);
+  }
+  return root;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readPathList(value: unknown): string[] {
+  if (typeof value === "string") return value.trim() ? [value.trim()] : [];
+  if (Array.isArray(value)) return value.flatMap((entry) => (typeof entry === "string" && entry.trim() ? [entry.trim()] : []));
+  return [];
+}
+
+function normalizeRelative(root: string, path: string): string {
+  const cleaned = path.replace(/^\.\//, "").replace(/^\/+/, "");
+  if (cleaned.split("/").some((part) => part === "..")) return "";
+  return `${root}${cleaned}`;
+}
+
+async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let index = 0;
+  const workers = new Array(Math.min(limit, items.length)).fill(0).map(async () => {
+    while (index < items.length) {
+      const current = index++;
+      results[current] = await fn(items[current]!);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+const CLAUDE_PLUGIN_ROOT_VAR = "${CLAUDE_PLUGIN_ROOT}";
+
+function mcpConfigReferencesPluginRoot(config: unknown): boolean {
+  if (typeof config === "string") return config.includes(CLAUDE_PLUGIN_ROOT_VAR);
+  if (Array.isArray(config)) return config.some((entry) => mcpConfigReferencesPluginRoot(entry));
+  if (isRecord(config)) return Object.values(config).some((entry) => mcpConfigReferencesPluginRoot(entry));
+  return false;
+}
+
+export async function resolveClaudePluginBundle(input: { url: string; ref?: string }): Promise<ClaudePluginBundle> {
+  const source = parseClaudePluginSource(input.url);
+  const ref = input.ref?.trim() || source.ref || (await resolveDefaultBranch(source));
+  const tree = await fetchRepoTree(source, ref);
+  const root = locatePluginRoot(tree, source.dir);
+  const treeByPath = new Map(tree.map((entry) => [entry.path, entry]));
+  const warnings: string[] = [];
+
+  const manifestPath = `${root}.claude-plugin/plugin.json`;
+  const manifestText = await fetchGithubText(rawFileUrl(source, ref, manifestPath));
+  let manifest: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(manifestText);
+    if (!isRecord(parsed)) throw new Error("not an object");
+    manifest = parsed;
+  } catch {
+    throw new ApiError(400, "invalid_plugin_manifest", `${manifestPath} is not valid JSON`);
+  }
+
+  const pluginName = readString(manifest.displayName) ?? readString(manifest.name);
+  if (!pluginName) {
+    throw new ApiError(400, "invalid_plugin_manifest", `${manifestPath} is missing a plugin name`);
+  }
+  const description = readString(manifest.description);
+  const version = readString(manifest.version);
+  if (manifest.hooks !== undefined) {
+    warnings.push("This plugin declares hooks, which OpenWork does not support yet. Hooks were skipped.");
+  }
+
+  // --- Collect component file paths -----------------------------------------
+  const inTree = (path: string) => treeByPath.has(path);
+
+  const collectMarkdown = (declared: string[], defaultDir: string): string[] => {
+    const roots = declared.length > 0
+      ? declared.map((entry) => normalizeRelative(root, entry)).filter(Boolean)
+      : [`${root}${defaultDir}`];
+    const paths = new Set<string>();
+    for (const entry of roots) {
+      if (entry.endsWith(".md") && inTree(entry)) {
+        paths.add(entry);
+        continue;
+      }
+      const prefix = `${entry.replace(/\/+$/, "")}/`;
+      for (const candidate of treeByPath.keys()) {
+        if (candidate.startsWith(prefix) && candidate.endsWith(".md")) paths.add(candidate);
+      }
+    }
+    return [...paths].sort();
+  };
+
+  const commandPaths = collectMarkdown(readPathList(manifest.commands), "commands");
+  const agentPaths = collectMarkdown(readPathList(manifest.agents), "agents");
+
+  // Skills are directories containing SKILL.md.
+  const skillRoots = readPathList(manifest.skills).map((entry) => normalizeRelative(root, entry)).filter(Boolean);
+  const skillPrefixes = skillRoots.length > 0 ? skillRoots.map((entry) => `${entry.replace(/\/+$/, "")}/`) : [`${root}skills/`];
+  const skillEntrypoints = [...treeByPath.keys()]
+    .filter((path) => skillPrefixes.some((prefix) => path.startsWith(prefix)) && path.endsWith("/SKILL.md"))
+    .sort();
+  const skillExtraFiles = new Map<string, number>();
+  for (const entrypoint of skillEntrypoints) {
+    const skillDir = entrypoint.slice(0, -"SKILL.md".length);
+    const extras = [...treeByPath.keys()].filter((path) => path.startsWith(skillDir) && path !== entrypoint);
+    if (extras.length > 0) skillExtraFiles.set(entrypoint, extras.length);
+  }
+  if (skillExtraFiles.size > 0) {
+    warnings.push(
+      `Some skills bundle extra files beyond SKILL.md (${[...skillExtraFiles.keys()].map((path) => path.split("/").at(-2)).join(", ")}). Only SKILL.md is installed for now.`,
+    );
+  }
+
+  // --- MCP servers -----------------------------------------------------------
+  const mcpServers: Record<string, unknown> = {};
+  const addMcpServers = (value: unknown) => {
+    if (!isRecord(value)) return;
+    const record = isRecord(value.mcpServers) ? value.mcpServers : value;
+    for (const [name, config] of Object.entries(record)) {
+      if (!isRecord(config)) continue;
+      if (mcpConfigReferencesPluginRoot(config)) {
+        warnings.push(`MCP server "${name}" uses \${CLAUDE_PLUGIN_ROOT} (a plugin-local command), which OpenWork does not support yet. It was skipped.`);
+        continue;
+      }
+      mcpServers[name] = config;
+    }
+  };
+
+  const declaredMcp = manifest.mcpServers;
+  if (typeof declaredMcp === "string") {
+    const mcpPath = normalizeRelative(root, declaredMcp);
+    if (mcpPath && inTree(mcpPath)) {
+      const text = await fetchGithubText(rawFileUrl(source, ref, mcpPath));
+      try {
+        addMcpServers(JSON.parse(text));
+      } catch {
+        warnings.push(`${mcpPath} is not valid JSON; its MCP servers were skipped.`);
+      }
+    }
+  } else if (isRecord(declaredMcp)) {
+    addMcpServers(declaredMcp);
+  }
+  const dotMcpPath = `${root}.mcp.json`;
+  if (inTree(dotMcpPath)) {
+    const text = await fetchGithubText(rawFileUrl(source, ref, dotMcpPath));
+    try {
+      addMcpServers(JSON.parse(text));
+    } catch {
+      warnings.push(`${dotMcpPath} is not valid JSON; its MCP servers were skipped.`);
+    }
+  }
+
+  // --- Fetch component contents ----------------------------------------------
+  type FetchedComponent = {
+    type: "skill" | "command" | "agent";
+    path: string;
+    title: string;
+    description: string | null;
+    content: string;
+  };
+
+  const componentInputs = [
+    ...skillEntrypoints.map((path) => ({ type: "skill" as const, path })),
+    ...commandPaths.map((path) => ({ type: "command" as const, path })),
+    ...agentPaths.map((path) => ({ type: "agent" as const, path })),
+  ];
+
+  const fetched = await mapWithConcurrency(componentInputs, 6, async (item): Promise<FetchedComponent> => {
+    const content = await fetchGithubText(rawFileUrl(source, ref, item.path));
+    const { data } = parseFrontmatter(content);
+    const fallbackTitle = item.type === "skill"
+      ? item.path.split("/").at(-2) ?? "skill"
+      : (item.path.split("/").at(-1) ?? "").replace(/\.md$/, "");
+    const frontmatterName = readString(data.name);
+    return {
+      type: item.type,
+      path: item.path,
+      title: item.type === "skill" && frontmatterName ? frontmatterName : fallbackTitle,
+      description: readString(data.description),
+      content,
+    };
+  });
+
+  // --- Assemble CloudPluginResolved -------------------------------------------
+  const dirSuffix = source.dir ? `#${source.dir}` : "";
+  const pluginId = `github:${source.owner}/${source.repo}${dirSuffix}`;
+  const memberships: CloudPluginResolved["memberships"] = fetched.map((component) => ({
+    configObjectId: component.path,
+    configObject: {
+      id: component.path,
+      objectType: component.type,
+      title: component.title,
+      description: component.description,
+      currentRelativePath: null,
+      status: "active",
+      updatedAt: null,
+      latestVersion: {
+        id: treeByPath.get(component.path)?.sha ?? component.path,
+        rawSourceText: component.content,
+        normalizedPayloadJson: null,
+      },
+    },
+  }));
+
+  if (Object.keys(mcpServers).length > 0) {
+    memberships.push({
+      configObjectId: `${pluginId}/mcp`,
+      configObject: {
+        id: `${pluginId}/mcp`,
+        objectType: "mcp",
+        title: `${pluginName} MCP`,
+        description: null,
+        currentRelativePath: null,
+        status: "active",
+        updatedAt: null,
+        latestVersion: {
+          id: treeByPath.get(dotMcpPath)?.sha ?? `${pluginId}/mcp`,
+          rawSourceText: null,
+          normalizedPayloadJson: { mcpServers },
+        },
+      },
+    });
+  }
+
+  if (memberships.length === 0) {
+    throw new ApiError(400, "plugin_empty", "This plugin has no MCP servers, skills, commands, or agents OpenWork can install.");
+  }
+
+  const resolved: CloudPluginResolved = {
+    plugin: {
+      id: pluginId,
+      name: pluginName,
+      description,
+      updatedAt: null,
+    },
+    memberships,
+  };
+
+  const components: ClaudePluginComponent[] = [
+    ...Object.keys(mcpServers).map((name) => ({ type: "mcp" as const, name, description: null })),
+    ...fetched.map((component) => ({ type: component.type, name: component.title, description: component.description })),
+  ];
+
+  return {
+    resolved,
+    preview: {
+      pluginId,
+      name: pluginName,
+      description,
+      version,
+      source: { owner: source.owner, repo: source.repo, ref, dir: source.dir },
+      components,
+      warnings,
+    },
+  };
+}

--- a/apps/server/src/claude-plugin-bundle.ts
+++ b/apps/server/src/claude-plugin-bundle.ts
@@ -19,6 +19,12 @@ export type ClaudePluginSource = {
   repo: string;
   ref: string | null;
   dir: string | null;
+  /**
+   * Raw path segments after `/tree/` when present. Branch names may contain
+   * slashes (e.g. `release/v1`), so the ref/dir split is ambiguous from the
+   * URL alone — the resolver tries candidates against the trees API.
+   */
+  treeSegments: string[] | null;
 };
 
 export type ClaudePluginComponent = {
@@ -60,16 +66,11 @@ const GITHUB_REPO_RE = /^[A-Za-z0-9._-]+$/;
 
 /**
  * Accepts `https://github.com/owner/repo`, `github.com/owner/repo`,
- * `owner/repo`, with optional `.git` suffix, query/hash, and
- * `/tree/<ref>(/<subdir>)`.
- *
- * Known limitation: in `/tree/...` URLs the first path segment is taken as
- * the ref, so branch/tag names containing `/` (e.g. `release/v1.0`) are
- * misread as ref + subdir. Disambiguating requires listing the repo's refs
- * via the GitHub API; not worth it until someone actually hits this.
+ * `owner/repo`, with optional `.git` suffix and `/tree/<ref>(/<subdir>)`.
  */
 export function parseClaudePluginSource(input: string): ClaudePluginSource {
-  const trimmed = input.trim().replace(/[?#].*$/, "");
+  // Drop query strings and hash fragments (e.g. ?tab=readme-ov-file).
+  const trimmed = (input.split(/[?#]/)[0] ?? "").trim();
   if (!trimmed) throw new ApiError(400, "invalid_plugin_url", "GitHub URL is required");
   const withoutProtocol = trimmed.replace(/^https?:\/\//, "");
   const hadHost = /^[A-Za-z0-9.-]+\.[A-Za-z]{2,}\//.test(withoutProtocol);
@@ -85,12 +86,14 @@ export function parseClaudePluginSource(input: string): ClaudePluginSource {
   }
   let ref: string | null = null;
   let dir: string | null = null;
+  let treeSegments: string[] | null = null;
   if (parts[2] === "tree" && parts[3]) {
-    ref = parts[3];
+    treeSegments = parts.slice(3);
+    ref = parts[3] ?? null;
     const rest = parts.slice(4);
     if (rest.length > 0) dir = rest.join("/");
   }
-  return { owner, repo, ref, dir };
+  return { owner, repo, ref, dir, treeSegments };
 }
 
 async function fetchGithubJson(url: string): Promise<unknown> {
@@ -145,7 +148,52 @@ async function resolveDefaultBranch(source: ClaudePluginSource): Promise<string>
 
 function rawFileUrl(source: ClaudePluginSource, ref: string, path: string): string {
   const segments = path.split("/").map((segment) => encodeURIComponent(segment)).join("/");
-  return `${githubRawBase()}/${encodeURIComponent(source.owner)}/${encodeURIComponent(source.repo)}/${encodeURIComponent(ref)}/${segments}`;
+  // Branch names may contain slashes; raw URLs expect them as path segments.
+  const refSegments = ref.split("/").map((segment) => encodeURIComponent(segment)).join("/");
+  return `${githubRawBase()}/${encodeURIComponent(source.owner)}/${encodeURIComponent(source.repo)}/${refSegments}/${segments}`;
+}
+
+// Branch names may contain slashes (release/v1), so a /tree/<...> URL is
+// ambiguous between ref and subdirectory. Try progressively longer refs
+// against the trees API and use the first that resolves.
+async function resolveRefAndTree(
+  source: ClaudePluginSource,
+  explicitRef: string | undefined,
+): Promise<{ ref: string; dir: string | null; tree: TreeEntry[] }> {
+  const candidates: Array<{ ref: string; dir: string | null }> = [];
+  if (explicitRef) {
+    let dir = source.dir;
+    if (source.treeSegments) {
+      const joined = source.treeSegments.join("/");
+      dir = joined === explicitRef
+        ? null
+        : joined.startsWith(`${explicitRef}/`)
+          ? joined.slice(explicitRef.length + 1)
+          : source.dir;
+    }
+    candidates.push({ ref: explicitRef, dir });
+  } else if (source.treeSegments && source.treeSegments.length > 0) {
+    for (let index = 1; index <= source.treeSegments.length; index += 1) {
+      candidates.push({
+        ref: source.treeSegments.slice(0, index).join("/"),
+        dir: index < source.treeSegments.length ? source.treeSegments.slice(index).join("/") : null,
+      });
+    }
+  } else {
+    candidates.push({ ref: await resolveDefaultBranch(source), dir: null });
+  }
+
+  let lastError: unknown = null;
+  for (const candidate of candidates) {
+    try {
+      const tree = await fetchRepoTree(source, candidate.ref);
+      return { ref: candidate.ref, dir: candidate.dir, tree };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  if (lastError instanceof Error) throw lastError;
+  throw new ApiError(404, "plugin_ref_not_found", "Could not resolve the requested branch or tag");
 }
 
 // Find the plugin root: the given subdir, the repo root, or the shallowest
@@ -218,9 +266,8 @@ function mcpConfigReferencesPluginRoot(config: unknown): boolean {
 
 export async function resolveClaudePluginBundle(input: { url: string; ref?: string }): Promise<ClaudePluginBundle> {
   const source = parseClaudePluginSource(input.url);
-  const ref = input.ref?.trim() || source.ref || (await resolveDefaultBranch(source));
-  const tree = await fetchRepoTree(source, ref);
-  const root = locatePluginRoot(tree, source.dir);
+  const { ref, dir, tree } = await resolveRefAndTree(source, input.ref?.trim() || undefined);
+  const root = locatePluginRoot(tree, dir);
   const treeByPath = new Map(tree.map((entry) => [entry.path, entry]));
   const warnings: string[] = [];
 
@@ -358,7 +405,7 @@ export async function resolveClaudePluginBundle(input: { url: string; ref?: stri
   });
 
   // --- Assemble CloudPluginResolved -------------------------------------------
-  const dirSuffix = source.dir ? `#${source.dir}` : "";
+  const dirSuffix = dir ? `#${dir}` : "";
   const pluginId = `github:${source.owner}/${source.repo}${dirSuffix}`;
   const memberships: CloudPluginResolved["memberships"] = fetched.map((component) => ({
     configObjectId: component.path,
@@ -424,7 +471,7 @@ export async function resolveClaudePluginBundle(input: { url: string; ref?: stri
       name: pluginName,
       description,
       version,
-      source: { owner: source.owner, repo: source.repo, ref, dir: source.dir },
+      source: { owner: source.owner, repo: source.repo, ref, dir },
       components,
       warnings,
     },

--- a/apps/server/src/claude-plugin-bundle.ts
+++ b/apps/server/src/claude-plugin-bundle.ts
@@ -60,10 +60,16 @@ const GITHUB_REPO_RE = /^[A-Za-z0-9._-]+$/;
 
 /**
  * Accepts `https://github.com/owner/repo`, `github.com/owner/repo`,
- * `owner/repo`, with optional `.git` suffix and `/tree/<ref>(/<subdir>)`.
+ * `owner/repo`, with optional `.git` suffix, query/hash, and
+ * `/tree/<ref>(/<subdir>)`.
+ *
+ * Known limitation: in `/tree/...` URLs the first path segment is taken as
+ * the ref, so branch/tag names containing `/` (e.g. `release/v1.0`) are
+ * misread as ref + subdir. Disambiguating requires listing the repo's refs
+ * via the GitHub API; not worth it until someone actually hits this.
  */
 export function parseClaudePluginSource(input: string): ClaudePluginSource {
-  const trimmed = input.trim();
+  const trimmed = input.trim().replace(/[?#].*$/, "");
   if (!trimmed) throw new ApiError(400, "invalid_plugin_url", "GitHub URL is required");
   const withoutProtocol = trimmed.replace(/^https?:\/\//, "");
   const hadHost = /^[A-Za-z0-9.-]+\.[A-Za-z]{2,}\//.test(withoutProtocol);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -32,6 +32,7 @@ import {
   syncDesktopCloudResources,
 } from "./desktop-cloud-sync.js";
 import { installCloudPlugin, readCloudPluginResolved, readInstalledCloudPlugins, removeCloudPlugin } from "./cloud-plugins.js";
+import { resolveClaudePluginBundle } from "./claude-plugin-bundle.js";
 import {
   applyMaterializedBlueprintSessions,
   normalizeBlueprintSessionTemplates,
@@ -2627,6 +2628,64 @@ function createRoutes(
     }
 
     return jsonResponse({ item: imported });
+  });
+
+  // Claude Code plugin bundles (MCP + skills + commands + agents) installed
+  // straight from a GitHub repo. `dryRun: true` returns the "Will install"
+  // preview without writing anything; install reuses the cloud-plugin
+  // machinery, so uninstall goes through DELETE /cloud-plugins/:pluginId.
+  addRoute(routes, "POST", "/workspace/:id/claude-plugins", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const url = typeof body.url === "string" ? body.url.trim() : "";
+    if (!url) throw new ApiError(400, "invalid_payload", "GitHub URL is required");
+    const ref = typeof body.ref === "string" && body.ref.trim() ? body.ref.trim() : undefined;
+    const dryRun = body.dryRun === true;
+
+    const bundle = await resolveClaudePluginBundle({ url, ref });
+    if (dryRun) {
+      return jsonResponse({ preview: bundle.preview });
+    }
+
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "cloud_plugins.install",
+      summary: `Install Claude plugin ${bundle.resolved.plugin.name} from ${bundle.preview.source.owner}/${bundle.preview.source.repo}`,
+      paths: [openworkConfigPath(workspace.path), join(workspace.path, ".opencode")],
+    });
+
+    const imported = await installCloudPlugin({
+      serverConfig: config,
+      workspaceId: workspace.id,
+      workspaceRoot: workspace.path,
+      marketplaceId: null,
+      resolved: bundle.resolved,
+    });
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "cloud_plugins.install",
+      target: openworkConfigPath(workspace.path),
+      summary: `Installed Claude plugin ${bundle.resolved.plugin.name} from ${url}`,
+      timestamp: Date.now(),
+    });
+
+    for (const file of imported.files) {
+      emitReloadEvent(ctx.reloadEvents, workspace, file.objectType === "mcp" ? "mcp" : file.objectType === "skill" ? "skills" : file.objectType === "agent" ? "agents" : file.objectType === "command" ? "commands" : "config", {
+        type: file.objectType === "skill" || file.objectType === "agent" || file.objectType === "command" || file.objectType === "mcp" ? file.objectType : "config",
+        name: file.title,
+        action: "added",
+      });
+    }
+
+    // Hot-register any bundled MCP servers with the running engine.
+    await syncRuntimeMcpToOpencodeEngine(config, workspace).catch(() => undefined);
+
+    return jsonResponse({ item: imported, preview: bundle.preview });
   });
 
   addRoute(routes, "DELETE", "/workspace/:id/cloud-plugins/:pluginId", "client", async (ctx) => {


### PR DESCRIPTION
> Stacked on #2184 (uses its engine-sync changes). Retarget to `dev` after that merges.

## What

Makes OpenWork compatible with the **Claude Code plugin bundle format** — the way Anthropic ships integrations like Slack by Salesforce: one repo with `.claude-plugin/plugin.json` bundling an MCP server (connectivity) + skills (expertise) + commands (guided first-run recipes). Includes an Anthropic-style **"Will install" disclosure** before anything is written.

## How

**Server** — `claude-plugin-bundle.ts` resolves a GitHub repo (`owner/repo`, full URLs, `/tree/<ref>/<subdir>`, `.git` suffix) into the existing `CloudPluginResolved` shape. Install therefore reuses `installCloudPlugin` wholesale: namespacing, Claude frontmatter translation (tools/model/agent), MCP registration into the runtime DB, the install registry, and uninstall via the existing `DELETE /cloud-plugins/:pluginId`.

- `POST /workspace/:id/claude-plugins` — `{ url, ref?, dryRun? }`. `dryRun` returns the preview (components grouped by type + warnings) with zero writes; install goes through approval gating, audit, reload events, and hot-registers bundled MCPs with the running engine.
- Graceful degradation with explicit warnings instead of silent failure: `hooks` (unsupported), MCP servers using `\${CLAUDE_PLUGIN_ROOT}` (plugin-local binaries), multi-file skill extras (only SKILL.md installed for now).
- Mock-able GitHub endpoints via `OPENWORK_GITHUB_API_BASE` / `OPENWORK_GITHUB_RAW_BASE` for tests.

**App** — "From GitHub" button on the Extensions custom-app card opens the disclosure modal: paste URL → Preview → plugin name/version/source + grouped "Will install" list (MCP servers / Skills / Commands / Agents, with descriptions) + warnings → Install. Installed bundles show up as extension cards with the existing uninstall path.

## Evidence

**Real-world install of the official Slack plugin** (`bun` smoke against live GitHub):
```
preview status: 200  → name: slack, v1.0.0
components: 1 MCP (slack), 2 skills (slack-messaging, slack-search),
            5 commands (channel-digest, draft-announcement, find-discussions, standup, summarize-channel)
install status: 200
installed: .opencode/skills/slack-plugin/{slack-messaging,slack-search}/SKILL.md
           .opencode/commands/slack-plugin/{5 commands}.md
           opencode.jsonc#mcp.slack
workspace MCPs: exa (config.global), slack (config.remote)
```

## Tests

- `bun test src/claude-plugin-bundle.e2e.test.ts` — 3 pass (URL parsing variants; dryRun preview incl. \${CLAUDE_PLUGIN_ROOT} skip warning; full install/uninstall cycle against a mock GitHub + mock engine, asserting written files, runtime-DB MCP registration, engine push, and cleanup)
- `bun test` (apps/server) — 412 pass / 7 fail (same 7 pre-existing on `dev`)
- `pnpm typecheck` — app clean; server has only the pre-existing `SessionMessagesResponse2` error

No video captured — the end-to-end flow is covered by the live-GitHub smoke above and the e2e tests; to reproduce in-app: Settings → Extensions → "From GitHub" → paste `https://github.com/slackapi/slack-mcp-plugin` → Preview → Install.

## Follow-ups (out of scope)

- Multi-file skills (scripts/, references/) need directory-aware install records
- `userConfig` prompts at enable time (sensitive values → keychain)
- Surfacing bundle commands as composer example prompts
- Marketplace repos with `marketplace.json` listing multiple plugins