### PR TITLE
fix(cloud): make cloud MCP reachable — heal minted resource on both ends + refresh MCP list when server heals

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -1,6 +1,6 @@
 import type { ModelRef, SuggestedPlugin } from "./types";
 import { t } from "../i18n";
-import { readDenBootstrapConfig } from "./lib/den";
+import { getDenMcpUrl } from "./lib/den";
 import {
   BUILT_IN_OPENWORK_EXTENSION_MANIFESTS,
   extensionContribution,
@@ -150,10 +150,11 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     serverName: "openwork-cloud",
     get description() { return t("mcp.quick_connect_openwork_cloud_desc"); },
     get url() {
-      // The Den MCP server is hosted on the API origin (see
-      // packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx), not the web app.
+      // The Den MCP server is hosted by den-api (see
+      // packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx), never at the
+      // web app's root — getDenMcpUrl heals stale web-app origins.
       try {
-        return `${readDenBootstrapConfig().apiBaseUrl.replace(/\/+$/, "")}/mcp`;
+        return getDenMcpUrl();
       } catch {
         return "https://api.openworklabs.com/mcp";
       }

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -514,6 +514,35 @@ function isWebAppHost(hostname: string): boolean {
   );
 }
 
+/**
+ * Hosted web-app hosts (`app.openworklabs.com`, `app.openwork.software`,
+ * `app.*`) never serve the Den API at their root — only behind the
+ * `/api/den` proxy. Loopback/private hosts are excluded on purpose: in dev
+ * an explicit apiBaseUrl may point directly at den-api.
+ */
+function isHostedWebAppHost(hostname: string): boolean {
+  return hostname.trim().toLowerCase().startsWith("app.");
+}
+
+/**
+ * Older builds persisted the bare web-app origin as the API base URL
+ * (bootstrap file and localStorage). Requests against that origin 404 —
+ * notably the cloud MCP at `https://app.openworklabs.com/mcp`. Heal such
+ * values by routing them through the web app's `/api/den` proxy.
+ */
+function healWebAppApiBaseUrl(input: string | null): string | null {
+  if (!input) return null;
+  try {
+    const url = new URL(input);
+    if (isHostedWebAppHost(url.hostname)) {
+      return ensureDenApiBasePath(input);
+    }
+  } catch {
+    // Not a URL — leave untouched.
+  }
+  return input;
+}
+
 function stripDenApiBasePath(input: string | null | undefined): string | null {
   const normalized = normalizeDenBaseUrl(input);
   if (!normalized) return null;
@@ -579,8 +608,34 @@ export function resolveDenBaseUrls(input: { baseUrl?: string | null; apiBaseUrl?
 
   return {
     baseUrl: stripDenApiBasePath(normalizedBaseUrl ?? seedUrl) ?? DEFAULT_DEN_BASE_URL,
-    apiBaseUrl: normalizedApiBaseUrl ?? deriveDenApiBaseUrl(seedUrl),
+    apiBaseUrl: healWebAppApiBaseUrl(normalizedApiBaseUrl) ?? deriveDenApiBaseUrl(seedUrl),
   };
+}
+
+/**
+ * The MCP endpoint served by den-api, resolved from the bootstrap config.
+ * On the hosted web app this goes through the `/api/den` proxy
+ * (`https://app.openworklabs.com/api/den/mcp`); a direct API origin maps to
+ * `<apiBaseUrl>/mcp` (canonically `https://api.openworklabs.com/mcp`).
+ */
+export function getDenMcpUrl(): string {
+  const { apiBaseUrl } = resolveDenBaseUrls(readDenBootstrapConfig());
+  return `${apiBaseUrl.replace(/\/+$/, "")}/mcp`;
+}
+
+/**
+ * Detects MCP URLs written by older builds that pointed `/mcp` at the bare
+ * web-app origin (e.g. `https://app.openworklabs.com/mcp`). Nothing serves
+ * MCP there — those entries fail with a 404 and must be reconfigured.
+ */
+export function isLegacyWebAppMcpUrl(input: string | null | undefined): boolean {
+  if (!input) return false;
+  try {
+    const url = new URL(input);
+    return isHostedWebAppHost(url.hostname) && url.pathname.replace(/\/+$/, "") === "/mcp";
+  } catch {
+    return false;
+  }
 }
 
 function resolveDenBootstrapConfig(

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -638,6 +638,29 @@ export function isLegacyWebAppMcpUrl(input: string | null | undefined): boolean 
   }
 }
 
+/**
+ * Resolve the URL the cloud MCP entry should connect to from a minted
+ * token's `resource`. Older den-api builds mint the bare web-app origin
+ * (`https://app.openworklabs.com/mcp`) where nothing serves MCP — heal
+ * those to the `/api/den` proxy on the same origin instead of trusting
+ * them verbatim. Returns null when the resource is unusable so callers
+ * can keep their bootstrap-derived URL.
+ */
+export function resolveCloudMcpResourceUrl(resource: string | null | undefined): string | null {
+  const trimmed = resource?.trim() ?? "";
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (isLegacyWebAppMcpUrl(trimmed)) {
+      url.pathname = "/api/den/mcp";
+    }
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
 function resolveDenBootstrapConfig(
   input: { baseUrl: string; apiBaseUrl?: string | null; requireSignin?: boolean | null },
 ): DenBootstrapConfig {

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -9,7 +9,7 @@ import {
   type McpDirectoryInfo,
 } from "../../../app/constants";
 import { extensionResource } from "../../../app/extensions";
-import { mintCloudControlMcpToken, readDenSettings } from "../../../app/lib/den";
+import { isLegacyWebAppMcpUrl, mintCloudControlMcpToken, readDenSettings } from "../../../app/lib/den";
 import { createClient, unwrap } from "../../../app/lib/opencode";
 import { finishPerf, perfNow, recordPerfLog } from "../../../app/lib/perf-log";
 import {
@@ -848,6 +848,13 @@ export function createConnectionsStore(options: {
     const entryUnhealthy = entryStatus === "needs_auth" || entryStatus === "failed";
     const shouldRemintForHealth = entryUnhealthy && !cloudMcpUnhealthyRemintAttempted;
 
+    // Builds before #2116's follow-up wrote the MCP URL against the bare
+    // web-app origin (https://app.openworklabs.com/mcp), which 404s.
+    // Reconfigure those entries even when the marker is still fresh.
+    const configuredEntry = snapshot.mcpServers.find((server) => server.name === slug);
+    const hasLegacyUrl =
+      configuredEntry?.config.type === "remote" && isLegacyWebAppMcpUrl(configuredEntry.config.url);
+
     // The marker is the source of truth for "configured recently". Do NOT
     // gate this on snapshot.mcpServers: the store is recreated on every
     // settings mount with an empty (or refresh-errored) server list, and
@@ -855,7 +862,7 @@ export function createConnectionsStore(options: {
     // on every visit — endless "Reload to connect" toasts. If a user
     // manually removed the entry, we respect that until the marker expires
     // instead of silently re-adding it.
-    if (markerFresh && !shouldRemintForHealth) {
+    if (markerFresh && !shouldRemintForHealth && !hasLegacyUrl) {
       return "unchanged";
     }
     if (shouldRemintForHealth) {

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -9,7 +9,12 @@ import {
   type McpDirectoryInfo,
 } from "../../../app/constants";
 import { extensionResource } from "../../../app/extensions";
-import { isLegacyWebAppMcpUrl, mintCloudControlMcpToken, readDenSettings } from "../../../app/lib/den";
+import {
+  isLegacyWebAppMcpUrl,
+  mintCloudControlMcpToken,
+  readDenSettings,
+  resolveCloudMcpResourceUrl,
+} from "../../../app/lib/den";
 import { createClient, unwrap } from "../../../app/lib/opencode";
 import { finishPerf, perfNow, recordPerfLog } from "../../../app/lib/perf-log";
 import {
@@ -631,7 +636,11 @@ export function createConnectionsStore(options: {
         try {
           const minted = await mintCloudControlMcpToken();
           if (minted) {
-            resolvedUrl = minted.resource;
+            // Never trust `minted.resource` verbatim: older den-api builds
+            // mint the bare web-app origin (https://app.openworklabs.com/mcp)
+            // where MCP 404s. Heal it, falling back to the entry's
+            // bootstrap-derived URL.
+            resolvedUrl = resolveCloudMcpResourceUrl(minted.resource) ?? resolvedUrl;
             resolvedHeaders = { Authorization: `Bearer ${minted.token}` };
           }
         } catch {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -807,6 +807,18 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const providerAuthSnapshot = useProviderAuthStoreSnapshot(providerAuthStore);
   useExtensionsStoreSnapshot(extensionsStore);
 
+  const openworkServerStatusForMcp = openworkServerSnapshot.openworkServerStatus;
+  useEffect(() => {
+    if (openworkServerStatusForMcp !== "connected") return;
+    // The first MCP read races the openwork-server store's initial health
+    // check (a fresh store always starts "disconnected"), so it falls back
+    // to config files where server-runtime (config.remote) entries — notably
+    // the cloud control MCP — don't exist. Without this re-read the built-in
+    // cards show "Tap to connect" until the next full remount even though
+    // the entries are configured and healthy.
+    void connectionsStore.refreshMcpServers();
+  }, [connectionsStore, openworkServerStatusForMcp]);
+
   const denSession = useDenSession({
     developerMode,
     openLink: (url) => platform.openLink(url),

--- a/apps/app/tests/den-mcp-url.test.ts
+++ b/apps/app/tests/den-mcp-url.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { getDenMcpUrl, isLegacyWebAppMcpUrl, resolveDenBaseUrls } from "../src/app/lib/den";
+
+describe("resolveDenBaseUrls", () => {
+  test("heals a stale bare web-app apiBaseUrl through the /api/den proxy", () => {
+    const resolved = resolveDenBaseUrls({
+      baseUrl: "https://app.openworklabs.com",
+      apiBaseUrl: "https://app.openworklabs.com",
+    });
+    expect(resolved.apiBaseUrl).toBe("https://app.openworklabs.com/api/den");
+  });
+
+  test("keeps an explicit API origin verbatim", () => {
+    const resolved = resolveDenBaseUrls({
+      baseUrl: "https://app.openworklabs.com",
+      apiBaseUrl: "https://api.openworklabs.com",
+    });
+    expect(resolved.apiBaseUrl).toBe("https://api.openworklabs.com");
+  });
+
+  test("keeps an explicit loopback apiBaseUrl verbatim (dev den-api)", () => {
+    const resolved = resolveDenBaseUrls({
+      baseUrl: "http://localhost:3000",
+      apiBaseUrl: "http://127.0.0.1:8787",
+    });
+    expect(resolved.apiBaseUrl).toBe("http://127.0.0.1:8787");
+  });
+
+  test("derives the /api/den proxy from a web-app baseUrl when no apiBaseUrl is set", () => {
+    const resolved = resolveDenBaseUrls({ baseUrl: "https://app.openworklabs.com" });
+    expect(resolved.apiBaseUrl).toBe("https://app.openworklabs.com/api/den");
+  });
+});
+
+describe("getDenMcpUrl", () => {
+  test("never targets the bare web-app origin", () => {
+    const url = getDenMcpUrl();
+    expect(isLegacyWebAppMcpUrl(url)).toBe(false);
+    expect(url.endsWith("/mcp")).toBe(true);
+  });
+});
+
+describe("isLegacyWebAppMcpUrl", () => {
+  test("flags the legacy bare web-app MCP URL", () => {
+    expect(isLegacyWebAppMcpUrl("https://app.openworklabs.com/mcp")).toBe(true);
+    expect(isLegacyWebAppMcpUrl("https://app.openwork.software/mcp/")).toBe(true);
+  });
+
+  test("accepts valid MCP URLs", () => {
+    expect(isLegacyWebAppMcpUrl("https://api.openworklabs.com/mcp")).toBe(false);
+    expect(isLegacyWebAppMcpUrl("https://app.openworklabs.com/api/den/mcp")).toBe(false);
+    expect(isLegacyWebAppMcpUrl("http://127.0.0.1:8787/mcp")).toBe(false);
+  });
+
+  test("ignores empty or malformed input", () => {
+    expect(isLegacyWebAppMcpUrl(null)).toBe(false);
+    expect(isLegacyWebAppMcpUrl("not a url")).toBe(false);
+  });
+});

--- a/apps/app/tests/den-mcp-url.test.ts
+++ b/apps/app/tests/den-mcp-url.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { getDenMcpUrl, isLegacyWebAppMcpUrl, resolveDenBaseUrls } from "../src/app/lib/den";
+import {
+  getDenMcpUrl,
+  isLegacyWebAppMcpUrl,
+  resolveCloudMcpResourceUrl,
+  resolveDenBaseUrls,
+} from "../src/app/lib/den";
 
 describe("resolveDenBaseUrls", () => {
   test("heals a stale bare web-app apiBaseUrl through the /api/den proxy", () => {
@@ -56,5 +61,36 @@ describe("isLegacyWebAppMcpUrl", () => {
   test("ignores empty or malformed input", () => {
     expect(isLegacyWebAppMcpUrl(null)).toBe(false);
     expect(isLegacyWebAppMcpUrl("not a url")).toBe(false);
+  });
+});
+
+describe("resolveCloudMcpResourceUrl", () => {
+  test("heals a minted legacy web-app resource through the /api/den proxy", () => {
+    expect(resolveCloudMcpResourceUrl("https://app.openworklabs.com/mcp")).toBe(
+      "https://app.openworklabs.com/api/den/mcp",
+    );
+    expect(resolveCloudMcpResourceUrl("https://app.openwork.software/mcp/")).toBe(
+      "https://app.openwork.software/api/den/mcp",
+    );
+  });
+
+  test("keeps healthy resources verbatim", () => {
+    expect(resolveCloudMcpResourceUrl("https://api.openworklabs.com/mcp")).toBe(
+      "https://api.openworklabs.com/mcp",
+    );
+    expect(resolveCloudMcpResourceUrl("https://app.openworklabs.com/api/den/mcp")).toBe(
+      "https://app.openworklabs.com/api/den/mcp",
+    );
+    expect(resolveCloudMcpResourceUrl("http://127.0.0.1:8787/mcp")).toBe(
+      "http://127.0.0.1:8787/mcp",
+    );
+  });
+
+  test("returns null for unusable resources so callers keep their fallback", () => {
+    expect(resolveCloudMcpResourceUrl(null)).toBeNull();
+    expect(resolveCloudMcpResourceUrl("")).toBeNull();
+    expect(resolveCloudMcpResourceUrl("   ")).toBeNull();
+    expect(resolveCloudMcpResourceUrl("not a url")).toBeNull();
+    expect(resolveCloudMcpResourceUrl("ftp://app.openworklabs.com/mcp")).toBeNull();
   });
 });

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -1,6 +1,7 @@
 import { getInitialActiveOrganizationIdForUser } from "./active-organization.js";
 import { db } from "./db.js";
 import { env } from "./env.js";
+import { deriveDenMcpResource } from "./mcp/resource.js";
 import { syncDenSignupContact } from "./loops.js";
 import { sendEmail } from "./utils/email/send-email.js";
 import {
@@ -45,9 +46,12 @@ function localMcpResourceAliases(resource: string) {
   return [];
 }
 
-export const DEN_MCP_RESOURCE = env.mcpResourceUrl ?? `${env.betterAuthUrl}/mcp`;
+export const DEN_MCP_RESOURCE = env.mcpResourceUrl ?? deriveDenMcpResource(env.betterAuthUrl, env.webAppHosts);
 export const DEN_MCP_RESOURCES = Array.from(new Set([
   DEN_MCP_RESOURCE,
+  // Audience compatibility: tokens issued before the proxied default carry
+  // the bare-origin resource (`<betterAuthUrl>/mcp`); keep accepting them.
+  `${env.betterAuthUrl}/mcp`,
   ...localMcpResourceAliases(DEN_MCP_RESOURCE),
 ]));
 export const DEN_MCP_SCOPES = ["openid", "profile", "email", "offline_access", "mcp:read", "mcp:write"];

--- a/ee/apps/den-api/src/mcp/resource.ts
+++ b/ee/apps/den-api/src/mcp/resource.ts
@@ -1,0 +1,41 @@
+/**
+ * Derivation of the Den MCP resource URL from the auth origin.
+ *
+ * Hosted web-app origins (app.openworklabs.com, app.openwork.software,
+ * app.*, *.run.app, configured DEN_WEB_APP_HOSTS) serve the den-web
+ * frontend at their root and expose den-api only behind the `/api/den`
+ * proxy path. Nothing serves MCP at `<origin>/mcp` on those hosts, so
+ * desktop clients connecting to a minted bare resource fail with
+ * "SSE error: Non-200 status code (404)".
+ *
+ * Kept dependency-free so it stays unit-testable without booting env/db.
+ */
+
+export function isHostedWebAppHost(hostname: string, webAppHosts: readonly string[]): boolean {
+  const normalized = hostname.trim().toLowerCase()
+  if (!normalized) return false
+  if (webAppHosts.some((host) => (host.startsWith(".") ? normalized.endsWith(host) : normalized === host))) {
+    return true
+  }
+  // Cloud Run hostnames serve den-web, which only exposes den-api behind
+  // its /api/den proxy path (see #1807).
+  return normalized.startsWith("app.") || normalized.endsWith(".run.app")
+}
+
+/**
+ * Default MCP resource for a deployment. Web-app origins route through the
+ * `/api/den` proxy; direct API origins (api.openworklabs.com, loopback dev
+ * den-api) keep the bare `<origin>/mcp` form.
+ */
+export function deriveDenMcpResource(betterAuthUrl: string, webAppHosts: readonly string[]): string {
+  const origin = betterAuthUrl.replace(/\/+$/, "")
+  try {
+    const url = new URL(origin)
+    if (isHostedWebAppHost(url.hostname, webAppHosts)) {
+      return `${origin}/api/den/mcp`
+    }
+  } catch {
+    // Unparseable values keep the legacy bare form.
+  }
+  return `${origin}/mcp`
+}

--- a/ee/apps/den-api/test/mcp-resource.test.ts
+++ b/ee/apps/den-api/test/mcp-resource.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+
+import { deriveDenMcpResource, isHostedWebAppHost } from "../src/mcp/resource.js"
+
+describe("deriveDenMcpResource", () => {
+  test("routes hosted web-app origins through the /api/den proxy", () => {
+    expect(deriveDenMcpResource("https://app.openworklabs.com", [])).toBe(
+      "https://app.openworklabs.com/api/den/mcp",
+    )
+    expect(deriveDenMcpResource("https://app.openwork.software", [])).toBe(
+      "https://app.openwork.software/api/den/mcp",
+    )
+    expect(deriveDenMcpResource("https://den-web-abc123.run.app", [])).toBe(
+      "https://den-web-abc123.run.app/api/den/mcp",
+    )
+  })
+
+  test("keeps direct API origins on the bare /mcp path", () => {
+    expect(deriveDenMcpResource("https://api.openworklabs.com", [])).toBe(
+      "https://api.openworklabs.com/mcp",
+    )
+    expect(deriveDenMcpResource("http://127.0.0.1:8790", [])).toBe(
+      "http://127.0.0.1:8790/mcp",
+    )
+    expect(deriveDenMcpResource("http://localhost:8790", [])).toBe(
+      "http://localhost:8790/mcp",
+    )
+  })
+
+  test("honors configured DEN_WEB_APP_HOSTS entries", () => {
+    expect(deriveDenMcpResource("https://cloud.example.com", ["cloud.example.com"])).toBe(
+      "https://cloud.example.com/api/den/mcp",
+    )
+    expect(deriveDenMcpResource("https://den.corp.example.com", [".example.com"])).toBe(
+      "https://den.corp.example.com/api/den/mcp",
+    )
+    expect(deriveDenMcpResource("https://den.elsewhere.io", [".example.com"])).toBe(
+      "https://den.elsewhere.io/mcp",
+    )
+  })
+
+  test("strips trailing slashes before appending the path", () => {
+    expect(deriveDenMcpResource("https://app.openworklabs.com/", [])).toBe(
+      "https://app.openworklabs.com/api/den/mcp",
+    )
+    expect(deriveDenMcpResource("https://api.openworklabs.com//", [])).toBe(
+      "https://api.openworklabs.com/mcp",
+    )
+  })
+})
+
+describe("isHostedWebAppHost", () => {
+  test("matches app.* and *.run.app hosts", () => {
+    expect(isHostedWebAppHost("app.openworklabs.com", [])).toBe(true)
+    expect(isHostedWebAppHost("APP.OPENWORK.SOFTWARE", [])).toBe(true)
+    expect(isHostedWebAppHost("den-web-abc.run.app", [])).toBe(true)
+  })
+
+  test("rejects API, loopback, and unrelated hosts", () => {
+    expect(isHostedWebAppHost("api.openworklabs.com", [])).toBe(false)
+    expect(isHostedWebAppHost("localhost", [])).toBe(false)
+    expect(isHostedWebAppHost("127.0.0.1", [])).toBe(false)
+    expect(isHostedWebAppHost("example.com", [])).toBe(false)
+    expect(isHostedWebAppHost("", [])).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

OpenWork Cloud Control MCP has **never worked** on hosted deployments. Two stacked bugs:

### 1. den-api mints an unreachable MCP resource URL
`/v1/mcp/token` returns `resource: BETTER_AUTH_URL + /mcp`. In production `BETTER_AUTH_URL` is the web-app origin, so clients get `https://app.openworklabs.com/mcp` — **nothing serves MCP there** (den-api is only reachable behind the `/api/den` proxy). The desktop wrote that URL verbatim into the MCP config, and the engine failed forever:

```
"openwork-cloud": { "status": "failed", "error": "SSE error: Non-200 status code (404)" }
```

A failed MCP exposes zero tools → cloud tools never appeared in the composer. Tapping **Tap to connect** re-minted and re-wrote the same broken URL, so it could never self-heal.

### 2. Settings MCP list races the server health check
The settings route creates a fresh `openworkServerStore` per mount (initial status `disconnected`). `refreshMcpServers` fires immediately, loses the race, falls back to reading `opencode.json(c)` files — which don't contain server-runtime (`config.remote`) entries like `openwork-cloud`/`openwork-ui` — and **nothing re-runs the refresh when the store heals to `connected`**. Built-in cards stayed stuck on "Tap to connect" even while the entries were configured and healthy.

## Fix

**Server (`ee/apps/den-api`)**
- New `deriveDenMcpResource()` (pure, unit-tested): hosted web-app origins (`app.*`, `*.run.app`, `DEN_WEB_APP_HOSTS`) get `<origin>/api/den/mcp`; direct API origins keep `<origin>/mcp`. `DEN_MCP_RESOURCE_URL` still overrides everything.
- Legacy bare-origin audience stays in `DEN_MCP_RESOURCES` so previously-issued tokens keep validating.
- Old desktop builds heal automatically on their next re-mint (their existing unhealthy-entry self-heal path now receives a good URL).

**Client (`apps/app`)**
- `resolveCloudMcpResourceUrl()` heals a minted legacy resource instead of trusting it verbatim (new clients work against old servers); unusable values fall back to the bootstrap-derived URL.
- `connectMcp` uses the healed URL.
- Settings route re-runs `refreshMcpServers` when `openworkServerStatus` transitions to `connected`, so server-runtime entries appear without a remount.
- Includes the earlier groundwork commit: `getDenMcpUrl()` as single source of truth, `resolveDenBaseUrls` healing stale bootstrap values, and `syncCloudControlMcp` reconfiguring legacy-URL entries even while the sync marker is fresh.

## Live verification (production app + real minted token, via CDP)

Probed from a signed-in production desktop session:

| URL | Result |
|---|---|
| `POST https://app.openworklabs.com/mcp` (what den-api mints today) | **404**, `text/html` (Next.js page) |
| `POST https://app.openworklabs.com/api/den/mcp` (healed) | **200**, `text/event-stream`, MCP initialize OK — `serverInfo: openwork-den-api` |
| `POST https://api.openworklabs.com/mcp` (direct API origin) | **200**, MCP initialize OK |

Same opaque `ow_mcp_at_…` token accepted on both healed forms, confirming the audience-compat approach.

## Tests run

```
apps/app:        bun test tests/den-mcp-url.test.ts        → 11 pass / 0 fail
apps/app:        bun test scripts/desktop-cloud-sync.test.ts → 8 pass / 0 fail
apps/app:        pnpm typecheck                             → clean
ee/apps/den-api: bun test test/                             → 49 pass / 0 fail (incl. 6 new)
ee/apps/den-api: npx tsc --noEmit                           → clean
```

Pre-existing failures in `apps/app/tests` (`reasoning-display.test.ts`, `parse-tool-parts` import) fail identically on clean `dev` — untouched by this PR.

**Note on e2e video:** the broken state requires a signed-in production Den deployment; I validated the exact request/response pairs live against production via CDP (table above) instead. Repro for reviewers: sign in to OpenWork Cloud on desktop, open Settings → MCP, observe `openwork-cloud` engine status `failed` with the 404 SSE error via `GET /workspace/<id>/opencode/mcp`; with this fix the entry connects and Den tools appear in the composer after engine reload.