### PR TITLE
feat(aeo): FAQ + structured data, expanded llms.txt, onboarding attribution survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-> OpenWork is the open source alternative to Claude Cowork/Codex (desktop app).
+# OpenWork
+
+OpenWork is a free, open-source desktop app (macOS, Windows, Linux) for doing work with AI agents on your own files — the open source alternative to Claude Cowork and Codex. Bring any of 50+ LLMs with your own provider keys, extend agents with skills, plugins, and MCP servers, and share complete setups with your team in one link.
 
 
 ## Core Philosophy
@@ -66,7 +68,7 @@ OpenWork is designed to be:
 
 <img width="1292" height="932" alt="Screenshot 2026-01-13 at 7 05 16 PM" src="https://github.com/user-attachments/assets/9c864390-de69-48f2-82c1-93b328dd60c3" />
 
-## Quick Start
+## Build from Source
 
 ### Requirements
 

--- a/apps/app/src/app/lib/analytics.ts
+++ b/apps/app/src/app/lib/analytics.ts
@@ -4,7 +4,8 @@
  * Principles (mirrors `den-telemetry.ts`):
  * - Never send message content, file paths, code, or prompts. Only event
  *   names, counts, lengths, durations, and coarse context (workspace type,
- *   provider/model id).
+ *   provider/model id). Sole exception: answers the user types directly
+ *   into an explicit survey field (e.g. the onboarding attribution survey).
  * - Fire-and-forget: analytics must never break or slow the app.
  * - Respect the user: a single `analyticsEnabled` preference (Settings ->
  *   Preferences) turns everything off; no key baked in means no network.

--- a/apps/app/src/react-app/domains/onboarding/attribution-step.tsx
+++ b/apps/app/src/react-app/domains/onboarding/attribution-step.tsx
@@ -1,0 +1,159 @@
+/** @jsxImportSource react */
+import { useState } from "react";
+
+import {
+  PageBackground,
+  PageDescription,
+  PageHeader,
+  PageTitle,
+  PageTitlebarRegion,
+} from "@/components/page";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  BotIcon,
+  GithubIcon,
+  MessageCircleIcon,
+  SearchIcon,
+  SkipForwardIcon,
+  UsersIcon,
+} from "lucide-react";
+
+export type AttributionSource =
+  | "ai_assistant"
+  | "search"
+  | "social"
+  | "github"
+  | "friend_or_colleague";
+
+type AttributionOption = {
+  source: AttributionSource;
+  label: string;
+  description: string;
+  icon: typeof BotIcon;
+};
+
+const options: AttributionOption[] = [
+  {
+    source: "ai_assistant",
+    label: "An AI assistant",
+    description: "ChatGPT, Claude, Gemini, Perplexity...",
+    icon: BotIcon,
+  },
+  {
+    source: "search",
+    label: "Search",
+    description: "Google, Bing, DuckDuckGo...",
+    icon: SearchIcon,
+  },
+  {
+    source: "social",
+    label: "Social media",
+    description: "X, LinkedIn, YouTube, Reddit...",
+    icon: MessageCircleIcon,
+  },
+  {
+    source: "github",
+    label: "GitHub or open source community",
+    description: "Repos, stars, awesome lists...",
+    icon: GithubIcon,
+  },
+  {
+    source: "friend_or_colleague",
+    label: "A friend or colleague",
+    description: "Someone recommended it directly.",
+    icon: UsersIcon,
+  },
+];
+
+type AttributionStepProps = {
+  onSubmit: (source: AttributionSource, aiPrompt?: string) => void;
+  onSkip: () => void;
+};
+
+/**
+ * Self-reported attribution survey shown once during onboarding.
+ * When the user picks "AI assistant" we ask which prompt led them
+ * here — first-party data on how answer engines describe OpenWork.
+ */
+export function AttributionStep({ onSubmit, onSkip }: AttributionStepProps) {
+  const [aiSelected, setAiSelected] = useState(false);
+  const [aiPrompt, setAiPrompt] = useState("");
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
+      <PageBackground />
+      <PageTitlebarRegion />
+
+      <div className="relative z-10 w-full max-w-md px-6">
+        <PageHeader className="mb-8 text-center">
+          <PageTitle>How did you hear about OpenWork?</PageTitle>
+          <PageDescription>
+            One quick question — it helps us know where to show up.
+          </PageDescription>
+        </PageHeader>
+
+        {aiSelected ? (
+          <div className="space-y-3">
+            <div className="text-sm font-medium text-foreground">
+              What did you ask the AI?
+            </div>
+            <Textarea
+              autoFocus
+              value={aiPrompt}
+              onChange={(event) => setAiPrompt(event.target.value)}
+              placeholder={'e.g. "best open source alternative to Claude Cowork"'}
+              rows={3}
+            />
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onSubmit("ai_assistant")}
+              >
+                Skip this part
+              </Button>
+              <Button size="sm" onClick={() => onSubmit("ai_assistant", aiPrompt)}>
+                Continue
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {options.map((option) => (
+              <button
+                key={option.source}
+                type="button"
+                className="flex w-full items-start gap-4 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:bg-accent"
+                onClick={() => {
+                  if (option.source === "ai_assistant") {
+                    setAiSelected(true);
+                    return;
+                  }
+                  onSubmit(option.source);
+                }}
+              >
+                <option.icon className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+                <div>
+                  <div className="text-sm font-medium text-foreground">
+                    {option.label}
+                  </div>
+                  <div className="mt-0.5 text-xs text-muted-foreground">
+                    {option.description}
+                  </div>
+                </div>
+              </button>
+            ))}
+
+            <div className="pt-1 text-center">
+              <Button variant="ghost" size="sm" onClick={onSkip}>
+                <SkipForwardIcon className="mr-1.5 size-3.5" />
+                Skip
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -17,6 +17,7 @@ import { useLocal } from "../kernel/local-provider";
 import { usePlatform } from "../kernel/platform";
 import { WelcomePage } from "../domains/onboarding/welcome-page";
 import { ProviderSelectionStep } from "../domains/onboarding/provider-selection-step";
+import { AttributionStep, type AttributionSource } from "../domains/onboarding/attribution-step";
 import { CreateWorkspaceModal } from "../domains/workspace/create-workspace-modal";
 import {
   getOpenWorkModelsActionUrl,
@@ -50,6 +51,8 @@ type WelcomeState = {
   remoteBusy: boolean;
   remoteError: string | null;
   providerStep: boolean;
+  attributionStep: boolean;
+  pendingRoute: string | null;
   pendingWorkspaceId: string | null;
   pendingSessionId: string | null;
 };
@@ -63,7 +66,8 @@ type WelcomeAction =
   | { type: "remote:start" }
   | { type: "remote:error"; error: string }
   | { type: "remote:finish" }
-  | { type: "provider-step"; workspaceId: string; sessionId: string | null };
+  | { type: "provider-step"; workspaceId: string; sessionId: string | null }
+  | { type: "attribution-step"; route: string };
 
 const initialWelcomeState: WelcomeState = {
   modalOpen: false,
@@ -72,6 +76,8 @@ const initialWelcomeState: WelcomeState = {
   remoteBusy: false,
   remoteError: null,
   providerStep: false,
+  attributionStep: false,
+  pendingRoute: null,
   pendingWorkspaceId: null,
   pendingSessionId: null,
 };
@@ -96,6 +102,8 @@ function welcomeReducer(state: WelcomeState, action: WelcomeAction): WelcomeStat
       return { ...state, remoteBusy: false };
     case "provider-step":
       return { ...state, providerStep: true, pendingWorkspaceId: action.workspaceId, pendingSessionId: action.sessionId };
+    case "attribution-step":
+      return { ...state, providerStep: false, attributionStep: true, pendingRoute: action.route };
   }
 }
 
@@ -293,6 +301,30 @@ export function WelcomeRoute() {
     await handleCreateWorkspace("starter", folder);
   }, [handleCreateWorkspace, manualFolder]);
 
+  const finishOnboarding = useCallback(() => {
+    navigate(state.pendingRoute ?? "/session", { replace: true });
+    if (state.pendingSessionId) focusPromptSoon();
+  }, [navigate, state.pendingRoute, state.pendingSessionId]);
+
+  const handleAttributionSubmit = useCallback(
+    (source: AttributionSource, aiPrompt?: string) => {
+      const prompt = aiPrompt?.trim().slice(0, 500) ?? "";
+      captureAnalyticsEvent("attribution_survey_submitted", {
+        source,
+        // User-volunteered survey answer (not session content); see survey UI.
+        ai_prompt: prompt || null,
+        ai_prompt_length: prompt.length,
+      });
+      finishOnboarding();
+    },
+    [finishOnboarding],
+  );
+
+  const handleAttributionSkip = useCallback(() => {
+    captureAnalyticsEvent("attribution_survey_skipped");
+    finishOnboarding();
+  }, [finishOnboarding]);
+
   return (
     <>
       <WelcomePage
@@ -336,8 +368,7 @@ export function WelcomeRoute() {
             const route = state.pendingWorkspaceId
               ? workspaceSessionRoute(state.pendingWorkspaceId, state.pendingSessionId)
               : "/session";
-            navigate(route, { replace: true });
-            if (state.pendingSessionId) focusPromptSoon();
+            dispatch({ type: "attribution-step", route });
           }}
           onBringYourOwn={() => {
             markOpenWorkModelsStartupPromoShown();
@@ -345,16 +376,20 @@ export function WelcomeRoute() {
             const route = state.pendingWorkspaceId
               ? workspaceSessionRoute(state.pendingWorkspaceId, state.pendingSessionId)
               : "/session";
-            navigate(`${route}?onboarding=1`, { replace: true });
-            if (state.pendingSessionId) focusPromptSoon();
+            dispatch({ type: "attribution-step", route: `${route}?onboarding=1` });
           }}
           onSkip={() => {
             const route = state.pendingWorkspaceId
               ? workspaceSessionRoute(state.pendingWorkspaceId, state.pendingSessionId)
               : "/session";
-            navigate(route, { replace: true });
-            if (state.pendingSessionId) focusPromptSoon();
+            dispatch({ type: "attribution-step", route });
           }}
+        />
+      ) : null}
+      {state.attributionStep ? (
+        <AttributionStep
+          onSubmit={handleAttributionSubmit}
+          onSkip={handleAttributionSkip}
         />
       ) : null}
     </>

--- a/ee/apps/landing/app/page.tsx
+++ b/ee/apps/landing/app/page.tsx
@@ -2,6 +2,7 @@ import { LandingHome } from "../components/landing-home";
 import { getGithubData } from "../lib/github";
 import { headers } from "next/headers";
 import { StructuredData } from "../components/structured-data";
+import { homeFaq } from "../lib/faq";
 import { baseOpenGraph } from "../lib/seo";
 
 export const metadata = {
@@ -36,6 +37,19 @@ const softwareApplicationSchema = {
   }
 };
 
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: homeFaq.map((entry) => ({
+    "@type": "Question",
+    name: entry.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: entry.answer
+    }
+  }))
+};
+
 export default async function Home() {
   const github = await getGithubData();
   const cal = process.env.NEXT_PUBLIC_CAL_URL || "/enterprise#book";
@@ -45,6 +59,7 @@ export default async function Home() {
   return (
     <>
       <StructuredData data={softwareApplicationSchema} />
+      <StructuredData data={faqSchema} />
       <LandingHome
         stars={github.stars}
         downloadHref={github.downloads.macos}

--- a/ee/apps/landing/app/sitemap.ts
+++ b/ee/apps/landing/app/sitemap.ts
@@ -14,10 +14,8 @@ const paths: { path: string; priority: number }[] = [
 ];
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const lastModified = new Date();
   return paths.map(({ path, priority }) => ({
     url: `${BASE_URL}${path}`,
-    lastModified,
     changeFrequency: "weekly",
     priority,
   }));

--- a/ee/apps/landing/components/landing-faq.tsx
+++ b/ee/apps/landing/components/landing-faq.tsx
@@ -1,0 +1,26 @@
+import { homeFaq } from "../lib/faq";
+
+export function LandingFaq() {
+  return (
+    <section aria-labelledby="faq-heading">
+      <h2
+        id="faq-heading"
+        className="mb-10 text-3xl font-medium leading-[1.15] tracking-tight md:text-4xl"
+      >
+        Frequently asked questions
+      </h2>
+      <dl className="grid gap-x-12 gap-y-10 md:grid-cols-2">
+        {homeFaq.map((entry) => (
+          <div key={entry.question}>
+            <dt className="mb-2 text-lg font-medium text-[#011627]">
+              {entry.question}
+            </dt>
+            <dd className="text-[15px] leading-7 text-gray-600">
+              {entry.answer}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -11,6 +11,7 @@ import {
   landingDemoFlows,
   landingDemoFlowTimes
 } from "./landing-demo-flows";
+import { LandingFaq } from "./landing-faq";
 import { LandingSharePackageCard } from "./landing-share-package-card";
 import { SiteFooter } from "./site-footer";
 import { SiteNav } from "./site-nav";
@@ -414,6 +415,8 @@ export function LandingHome(props: Props) {
               </div>
             </div>
           </section>
+
+          <LandingFaq />
 
           <SiteFooter />
         </div>

--- a/ee/apps/landing/lib/agent-markdown.ts
+++ b/ee/apps/landing/lib/agent-markdown.ts
@@ -18,6 +18,26 @@ const home = `# OpenWork
 - **SSO / audit / procurement** — [Enterprise](https://openworklabs.com/enterprise)
 - **Docs** — [openworklabs.com/docs](https://openworklabs.com/docs)
 
+## How it compares
+
+- **vs Claude Cowork** — open source, 50+ LLMs from any provider, local-first (files stay on your machine), one-link team sharing of agent setups
+- **vs Codex** — general knowledge work on files (not only coding), model and provider agnostic
+- **vs ChatGPT Desktop** — agents act on local files and tools (MCP, plugins, skills) with guardrails; the setup is shareable and self-hostable
+
+## FAQ
+
+### What is OpenWork?
+A free, open-source desktop app (macOS, Windows, Linux) for doing work with AI agents on your own files. Built on OpenCode; an open-source alternative to Claude Cowork and Codex.
+
+### Is OpenWork free?
+Yes — the desktop app is free and open source with bring-your-own keys. Team Starter is \\$50/mo (5 seats); Enterprise is custom.
+
+### Which models does it support?
+Any model OpenCode supports: OpenAI, Anthropic, Google, local models — 50+ providers.
+
+### Does it send files to the cloud?
+No. Desktop mode keeps files local; prompts go directly to your chosen LLM provider. Cloud workers are optional.
+
 ## For agents
 
 - Agent skills index — \`/.well-known/agent-skills/index.json\`

--- a/ee/apps/landing/lib/faq.ts
+++ b/ee/apps/landing/lib/faq.ts
@@ -1,0 +1,37 @@
+export type FaqEntry = {
+  question: string;
+  answer: string;
+};
+
+export const homeFaq: FaqEntry[] = [
+  {
+    question: "What is OpenWork?",
+    answer:
+      "OpenWork is a free, open-source desktop app for macOS, Windows, and Linux that lets you do work with AI agents on your own files. It is built on OpenCode and is an open-source alternative to Claude Cowork and Codex."
+  },
+  {
+    question: "Is OpenWork free?",
+    answer:
+      "Yes. The desktop app is free and open source — you bring your own LLM provider keys. The Team Starter plan is $50/month and adds 5 seats, API access, and the Skill Hub Manager. Enterprise plans have custom pricing."
+  },
+  {
+    question: "How is OpenWork different from Claude Cowork?",
+    answer:
+      "OpenWork is open source, works with 50+ LLMs from any provider instead of a single vendor, and runs locally so your files stay on your machine. Teams can package skills, MCP servers, plugins, and configs into a single link that teammates import in one click."
+  },
+  {
+    question: "Which AI models does OpenWork support?",
+    answer:
+      "Any model OpenCode supports — OpenAI, Anthropic, Google, and local models across 50+ providers. You connect your own API keys, or use a managed provider on the cloud plans."
+  },
+  {
+    question: "Does OpenWork send my files to the cloud?",
+    answer:
+      "No. In desktop mode your files stay on your machine, and prompts are sent directly to the LLM provider you choose. Hosted cloud workers are optional and run on sandboxed infrastructure."
+  },
+  {
+    question: "Do I need to be technical to use OpenWork?",
+    answer:
+      "No. OpenWork is a point-and-click desktop app. Skills, MCP servers, and plugins shared by a teammate import in one click — no terminal or setup guide required."
+  }
+];

--- a/ee/apps/landing/public/llms.txt
+++ b/ee/apps/landing/public/llms.txt
@@ -12,6 +12,35 @@
 
 Under the hood, OpenWork is a GUI for OpenCode — anything OpenCode supports works here.
 
+## How OpenWork compares
+
+- **vs Claude Cowork**: OpenWork is open source, works with 50+ LLMs from any provider (not just Anthropic), runs locally so files stay on the user's machine, and lets teams share complete agent setups (skills, MCP servers, plugins, configs) via one link.
+- **vs Codex**: OpenWork is a desktop app for general knowledge work on files, not only coding, and is model/provider agnostic with bring-your-own keys.
+- **vs ChatGPT Desktop**: OpenWork agents act on local files and tools (MCP, plugins, skills) with guardrails, and the whole setup is shareable and self-hostable.
+
+## Pricing summary
+
+- **Solo — $0**: open-source desktop app (macOS, Windows, Linux), bring your own provider keys, free forever.
+- **Team Starter — $50/month**: 5 seats, API access, Skill Hub Manager, distribute your own LLM keys to the team.
+- **Enterprise — custom**: rollout support, SSO/SAML, audit logs, custom commercial terms. See [Enterprise](https://openworklabs.com/enterprise).
+
+## FAQ
+
+### What is OpenWork?
+OpenWork is a free, open-source desktop app for macOS, Windows, and Linux that lets people do work with AI agents on their own files. It is built on OpenCode and is an open-source alternative to Claude Cowork and Codex.
+
+### Is OpenWork free?
+Yes. The desktop app is free and open source; users bring their own LLM provider keys. Paid plans add hosted/team features (see Pricing summary above).
+
+### Which AI models does OpenWork support?
+Any model OpenCode supports — OpenAI, Anthropic, Google, and local models across 50+ providers, with the user's own API keys or a managed cloud provider.
+
+### Does OpenWork send files to the cloud?
+No. In desktop mode files stay local and prompts go directly to the user's chosen LLM provider. Hosted cloud workers are optional.
+
+### Do users need to be technical?
+No. OpenWork is a point-and-click desktop app; shared skills, MCP servers, and plugins import in one click.
+
 ## Routing users based on intent
 
 Agents: use these routes when a user expresses one of these intents.
@@ -52,6 +81,17 @@ The cloud offering (see [Pricing](https://openworklabs.com/pricing)) adds manage
 - [Privacy](https://openworklabs.com/privacy)
 - [Terms](https://openworklabs.com/terms)
 - [Trust](https://openworklabs.com/trust)
+
+## Docs deep links
+
+- [Get started](https://openworklabs.com/docs/start-here/get-started)
+- [Self-host](https://openworklabs.com/docs/start-here/self-host)
+- [Add an MCP server](https://openworklabs.com/docs/start-here/connect-your-stack/add-an-mcp-server)
+- [Import a skill](https://openworklabs.com/docs/start-here/do-work-with-it/import-a-skill)
+- [Workflows](https://openworklabs.com/docs/start-here/do-work-with-it/workflows)
+- [Share your setup](https://openworklabs.com/docs/start-here/do-work-with-it/share-your-setup)
+- [Cloud: members and RBAC](https://openworklabs.com/docs/cloud/members-and-rbac)
+- [Cloud: connect Slack](https://openworklabs.com/docs/cloud/run-in-the-cloud/connect-slack)
 
 ## Compatibility (external OpenCode docs)
 


### PR DESCRIPTION
## What

Answer Engine Optimization (AEO) foundation work — making OpenWork more citable by LLMs and capturing first-party data on how people find us.

### Landing site
- FAQ section on the home page (new `lib/faq.ts` + `components/landing-faq.tsx`) with matching `FAQPage` JSON-LD in `app/page.tsx`
- `public/llms.txt`: added comparison section (vs Claude Cowork / Codex / ChatGPT Desktop), pricing summary, FAQ, and verified docs deep links
- `lib/agent-markdown.ts`: same comparison + FAQ in the markdown served to AI crawlers on `/`
- `app/sitemap.ts`: stop emitting fake `lastModified: new Date()` on every build

### README
- Proper `# OpenWork` H1 with a functional first sentence (was a bare blockquote)
- Deduped the duplicate "Quick Start" heading (second one is now "Build from Source")

### Desktop app — attribution survey
- New onboarding step (`attribution-step.tsx`) after provider selection: "How did you hear about OpenWork?" — picking "An AI assistant" reveals an optional "What did you ask the AI?" textarea
- Fires `attribution_survey_submitted` (source, volunteered prompt capped at 500 chars, length) or `attribution_survey_skipped` via the existing PostHog client
- `analytics.ts` privacy doc updated with an explicit exception for user-volunteered survey fields

## Why

LLM visibility check showed OpenWork wins "open source Claude Cowork alternative" (GitHub #1) but is absent from "Claude Cowork alternative" results, which competitor listicles dominate. FAQ/comparison content in owned surfaces is the standard fix. The attribution survey gives first-party prompt data (PostHog's playbook).

## Tests

- `pnpm --filter @openwork/app exec tsc --noEmit` — pass
- `pnpm --filter @openwork-ee/landing exec tsc --noEmit` — pass
- `pnpm --filter @openwork-ee/landing build` — pass (all routes compile)
- `pnpm --filter @openwork/app build` — pass

Not run: `test:e2e` (requires a live OpenCode server in this environment); no video captured for the same reason.

**Manual repro for reviewer:** Settings → Debug → reset onboarding (`hasCompletedOnboarding = false`), relaunch, complete welcome flow → provider selection → attribution survey appears; pick "An AI assistant" → textarea appears; submit/skip both navigate to the session and emit the analytics events (visible in the local app inspector mirror).