### PR TITLE
fix(den-api): accept JSON-encoded string bodies in Cloud MCP tool forwarding

### DIFF
--- a/ee/apps/den-api/src/mcp/catalog.ts
+++ b/ee/apps/den-api/src/mcp/catalog.ts
@@ -145,7 +145,7 @@ function buildInputGuidance(input: McpToolOperation) {
   }
 
   if (hasJsonRequestBody(input.operation)) {
-    sections.push("Request body: put JSON body fields under `body`. Do not wrap them in `requestBody`.")
+    sections.push("Request body: put JSON body fields under `body` as a JSON object (not a JSON-encoded string). Do not wrap them in `requestBody`.")
   }
 
   if (sections.length === 0) {

--- a/ee/apps/den-api/src/mcp/invoke.ts
+++ b/ee/apps/den-api/src/mcp/invoke.ts
@@ -20,6 +20,27 @@ function encodeQueryValue(value: unknown) {
   return JSON.stringify(value)
 }
 
+/**
+ * MCP clients sometimes pass `body` as a JSON-encoded string instead of an
+ * object (the tool input schema accepts unknown). Forwarding that string
+ * as-is double-encodes the payload and route validators reject it with
+ * "expected object, received string". Parse such strings back into JSON.
+ */
+export function normalizeToolBody(body: unknown): unknown {
+  if (typeof body !== "string") {
+    return body
+  }
+  const trimmed = body.trim()
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return body
+  }
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return body
+  }
+}
+
 function buildPath(template: string, values: Record<string, unknown>) {
   return template.replace(/\{([^}]+)\}/g, (_match, key: string) => {
     const value = values[key]
@@ -56,7 +77,7 @@ function buildInternalRequest(input: {
   let body: BodyInit | undefined
   if (input.operation.method !== "GET" && input.operation.method !== "HEAD" && input.toolInput.body !== undefined) {
     headers.set("content-type", "application/json")
-    body = JSON.stringify(input.toolInput.body)
+    body = JSON.stringify(normalizeToolBody(input.toolInput.body))
   }
 
   return new Request(url, {

--- a/ee/apps/den-api/test/mcp-invoke-body.test.ts
+++ b/ee/apps/den-api/test/mcp-invoke-body.test.ts
@@ -1,0 +1,107 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, expect, test } from "bun:test"
+import { Hono } from "hono"
+import { z } from "zod"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let invokeModule: typeof import("../src/mcp/invoke.js")
+let validationModule: typeof import("../src/middleware/validation.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  invokeModule = await import("../src/mcp/invoke.js")
+  validationModule = await import("../src/middleware/validation.js")
+})
+
+const principal = {
+  userId: createDenTypeId("user"),
+  organizationId: createDenTypeId("organization"),
+  scopes: new Set(["mcp:read", "mcp:write"]),
+  payload: {},
+}
+
+const inviteOperation = {
+  name: "postV1Invitations",
+  method: "POST",
+  path: "/v1/invitations",
+  operation: {},
+  inputSchema: z.object({}),
+}
+
+function createInviteApp() {
+  const inviteMemberSchema = z.object({
+    email: z.string().email(),
+    role: z.string().trim().min(1).max(64),
+  })
+  const app = new Hono()
+  app.post("/v1/invitations", validationModule.jsonValidator(inviteMemberSchema), (c) => {
+    return c.json({ received: c.req.valid("json") }, 200)
+  })
+  return app
+}
+
+test("normalizeToolBody parses JSON-encoded string bodies into objects", () => {
+  expect(invokeModule.normalizeToolBody('{"email":"ben+demogods@openworklabs.com","role":"member"}')).toEqual({
+    email: "ben+demogods@openworklabs.com",
+    role: "member",
+  })
+  expect(invokeModule.normalizeToolBody('  [{"a":1}]  ')).toEqual([{ a: 1 }])
+})
+
+test("normalizeToolBody leaves objects and non-JSON strings untouched", () => {
+  const body = { email: "x@y.com", role: "admin" }
+  expect(invokeModule.normalizeToolBody(body)).toBe(body)
+  expect(invokeModule.normalizeToolBody("plain text")).toBe("plain text")
+  expect(invokeModule.normalizeToolBody("{not valid json")).toBe("{not valid json")
+  expect(invokeModule.normalizeToolBody(undefined)).toBeUndefined()
+  expect(invokeModule.normalizeToolBody(42)).toBe(42)
+})
+
+test("invitation POST forwarded with an object body passes route validation", async () => {
+  const result = await invokeModule.invokeMcpOperation({
+    app: createInviteApp(),
+    env: {},
+    operation: inviteOperation,
+    principal,
+    toolInput: { body: { email: "ben+demogods@openworklabs.com", role: "member" } },
+  })
+
+  expect(result.isError).toBe(false)
+  expect(JSON.parse(result.content[0]?.text ?? "")).toEqual({
+    received: { email: "ben+demogods@openworklabs.com", role: "member" },
+  })
+})
+
+test("invitation POST forwarded with a JSON-encoded string body no longer fails with 'expected object, received string'", async () => {
+  const result = await invokeModule.invokeMcpOperation({
+    app: createInviteApp(),
+    env: {},
+    operation: inviteOperation,
+    principal,
+    toolInput: { body: '{"email":"ben+demogods@openworklabs.com","role":"member"}' },
+  })
+
+  expect(result.isError).toBe(false)
+  expect(JSON.parse(result.content[0]?.text ?? "")).toEqual({
+    received: { email: "ben+demogods@openworklabs.com", role: "member" },
+  })
+})
+
+test("genuinely invalid bodies are still rejected by route validation", async () => {
+  const result = await invokeModule.invokeMcpOperation({
+    app: createInviteApp(),
+    env: {},
+    operation: inviteOperation,
+    principal,
+    toolInput: { body: '{"email":"not-an-email"}' },
+  })
+
+  expect(result.isError).toBe(true)
+  expect(result.content[0]?.text).toContain("invalid_request")
+})


### PR DESCRIPTION
## Problem

The Cloud MCP invitation endpoint (and any other POST/PUT/PATCH tool) rejects requests with a serialization error:

```
expected object, received string
```

This happens regardless of how the client formats the body, and reads aren't affected.

## Root cause

- The generated MCP tool input schema declares `body` as `z.unknown()` (`ee/apps/den-api/src/mcp/catalog.ts`), so MCP clients (LLMs) can legally pass the body as a **JSON-encoded string** instead of an object.
- The forwarder then runs `JSON.stringify(toolInput.body)` (`ee/apps/den-api/src/mcp/invoke.ts`), double-encoding the payload.
- The downstream route validator (e.g. `inviteMemberSchema` on `POST /v1/invitations`) parses the request body, sees a JSON *string* instead of an object, and rejects with `expected object, received string`.

## Fix

- Add `normalizeToolBody()` in `invoke.ts`: if the tool body is a string that looks like a JSON object/array, parse it before forwarding. Objects and genuinely non-JSON strings are passed through untouched, so invalid bodies are still rejected by route validation.
- Clarify the tool description guidance in `catalog.ts` to tell clients to pass `body` as a JSON object, not a JSON-encoded string.

## Tests

New test file `ee/apps/den-api/test/mcp-invoke-body.test.ts`:

- unit tests for `normalizeToolBody` (string parsing, passthrough of objects / non-JSON strings / non-strings)
- end-to-end `invokeMcpOperation` against a Hono route using the real `jsonValidator` + invitation body schema:
  - object body → 200
  - JSON-encoded string body → 200 (regression test; fails without the fix)
  - invalid body → still 400 `invalid_request`

Ran locally (clean worktree off `origin/dev`):

```
cd ee/apps/den-api && bun test test/
54 pass, 0 fail (134 expect() calls)

pnpm exec tsc --noEmit -p tsconfig.json   # clean
```

Also verified the regression test fails without the `invoke.ts` change (3 fail when the fix is stashed).

No video: this is a server-side serialization fix with no UI surface; reproduction is covered by the regression test above.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

