### PR TITLE
feat(den): admin backoffice activity (DAU/recurring) + invite metrics, telemetry migration backfill

### DIFF
--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -208,6 +208,8 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         })
         .from(AuthSessionTable)
         .groupBy(AuthSessionTable.userId, sessionDayExpr),
+      // Non-fatal: telemetry_event may be missing in environments that never
+      // ran its migration; activity then degrades to sign-in days only.
       db
         .select({
           userId: MemberTable.userId,
@@ -217,7 +219,8 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         .from(TelemetryEventTable)
         .innerJoin(MemberTable, eq(TelemetryEventTable.member_id, MemberTable.id))
         .where(gte(TelemetryEventTable.event_timestamp, activityWindowStart))
-        .groupBy(MemberTable.userId, telemetryDayExpr),
+        .groupBy(MemberTable.userId, telemetryDayExpr)
+        .catch(() => []),
       db
         .select({
           inviterId: InvitationTable.inviterId,

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -1,5 +1,14 @@
-import { asc, desc, eq, isNotNull, sql } from "@openwork-ee/den-db/drizzle"
-import { AuthAccountTable, AuthSessionTable, AuthUserTable, WorkerTable, AdminAllowlistTable } from "@openwork-ee/den-db/schema"
+import { asc, desc, eq, gte, isNotNull, sql } from "@openwork-ee/den-db/drizzle"
+import {
+  AuthAccountTable,
+  AuthSessionTable,
+  AuthUserTable,
+  InvitationTable,
+  MemberTable,
+  TelemetryEventTable,
+  WorkerTable,
+  AdminAllowlistTable,
+} from "@openwork-ee/den-db/schema"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
@@ -67,6 +76,39 @@ function normalizeProvider(providerId: string) {
   return normalized
 }
 
+function toDayKey(value: Date | string | null): string | null {
+  if (!value) {
+    return null
+  }
+
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.toISOString().slice(0, 10)
+}
+
+function toTimestamp(value: Date | string | null): number | null {
+  if (!value) {
+    return null
+  }
+
+  const date = value instanceof Date ? value : new Date(value)
+  const time = date.getTime()
+  return Number.isNaN(time) ? null : time
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) {
+    return null
+  }
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
 function parseBooleanQuery(value: string | undefined): boolean {
   if (!value) {
     return false
@@ -117,7 +159,14 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
     const query = c.req.valid("query")
     const includeBilling = parseBooleanQuery(query.includeBilling)
 
-    const [admins, users, workerStatsRows, sessionStatsRows, accountRows] = await Promise.all([
+    const activityWindowDays = 90
+    const seriesWindowDays = 30
+    const activityWindowStart = new Date(Date.now() - activityWindowDays * 24 * 60 * 60 * 1000)
+
+    const sessionDayExpr = sql<string>`date_format(${AuthSessionTable.createdAt}, '%Y-%m-%d')`
+    const telemetryDayExpr = sql<string>`date_format(${TelemetryEventTable.event_timestamp}, '%Y-%m-%d')`
+
+    const [admins, users, workerStatsRows, sessionStatsRows, accountRows, sessionDayRows, telemetryDayRows, inviteStatsRows] = await Promise.all([
       db
         .select({
           email: AdminAllowlistTable.email,
@@ -152,6 +201,31 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
           providerId: AuthAccountTable.providerId,
         })
         .from(AuthAccountTable),
+      db
+        .select({
+          userId: AuthSessionTable.userId,
+          day: sessionDayExpr,
+        })
+        .from(AuthSessionTable)
+        .groupBy(AuthSessionTable.userId, sessionDayExpr),
+      db
+        .select({
+          userId: MemberTable.userId,
+          day: telemetryDayExpr,
+          lastEventAt: sql<Date | null>`max(${TelemetryEventTable.event_timestamp})`,
+        })
+        .from(TelemetryEventTable)
+        .innerJoin(MemberTable, eq(TelemetryEventTable.member_id, MemberTable.id))
+        .where(gte(TelemetryEventTable.event_timestamp, activityWindowStart))
+        .groupBy(MemberTable.userId, telemetryDayExpr),
+      db
+        .select({
+          inviterId: InvitationTable.inviterId,
+          invitesSent: sql<number>`count(*)`,
+          firstInviteAt: sql<Date | null>`min(${InvitationTable.createdAt})`,
+        })
+        .from(InvitationTable)
+        .groupBy(InvitationTable.inviterId),
     ])
 
     const workerStatsByUser = new Map<UserId, {
@@ -194,6 +268,98 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
       providersByUser.set(row.userId, existing)
     }
 
+    type ActivityStats = {
+      days: Set<string>
+      lastTelemetryAt: number | null
+    }
+
+    const activityByUser = new Map<UserId, ActivityStats>()
+    const getActivity = (userId: UserId): ActivityStats => {
+      let stats = activityByUser.get(userId)
+      if (!stats) {
+        stats = { days: new Set(), lastTelemetryAt: null }
+        activityByUser.set(userId, stats)
+      }
+      return stats
+    }
+
+    const seriesStartKey = toDayKey(new Date(Date.now() - (seriesWindowDays - 1) * 24 * 60 * 60 * 1000)) ?? ""
+    const activeUsersByDay = new Map<string, Set<UserId>>()
+    const markActiveDay = (day: string, userId: UserId) => {
+      if (day < seriesStartKey) {
+        return
+      }
+
+      const set = activeUsersByDay.get(day) ?? new Set<UserId>()
+      set.add(userId)
+      activeUsersByDay.set(day, set)
+    }
+
+    for (const row of sessionDayRows) {
+      if (!row.day) {
+        continue
+      }
+
+      getActivity(row.userId).days.add(row.day)
+      markActiveDay(row.day, row.userId)
+    }
+
+    for (const row of telemetryDayRows) {
+      if (!row.userId) {
+        continue
+      }
+
+      const stats = getActivity(row.userId)
+      if (row.day) {
+        stats.days.add(row.day)
+        markActiveDay(row.day, row.userId)
+      }
+
+      const eventTime = toTimestamp(row.lastEventAt)
+      if (eventTime !== null && (stats.lastTelemetryAt === null || eventTime > stats.lastTelemetryAt)) {
+        stats.lastTelemetryAt = eventTime
+      }
+    }
+
+    const inviteStatsByUser = new Map<UserId, { invitesSent: number; firstInviteAt: Date | string | null }>()
+    for (const row of inviteStatsRows) {
+      inviteStatsByUser.set(row.inviterId, {
+        invitesSent: toNumber(row.invitesSent),
+        firstInviteAt: row.firstInviteAt,
+      })
+    }
+
+    const signupsByDay = new Map<string, number>()
+    for (const entry of users) {
+      const day = toDayKey(entry.createdAt)
+      if (day) {
+        signupsByDay.set(day, (signupsByDay.get(day) ?? 0) + 1)
+      }
+    }
+
+    const todayKey = toDayKey(new Date())
+    const activitySeries: Array<{ day: string; activeUsers: number; signups: number }> = []
+    const active7d = new Set<UserId>()
+    const active30d = new Set<UserId>()
+    for (let offset = seriesWindowDays - 1; offset >= 0; offset -= 1) {
+      const day = toDayKey(new Date(Date.now() - offset * 24 * 60 * 60 * 1000))
+      if (!day) {
+        continue
+      }
+
+      const activeSet = activeUsersByDay.get(day)
+      activitySeries.push({ day, activeUsers: activeSet?.size ?? 0, signups: signupsByDay.get(day) ?? 0 })
+      if (activeSet) {
+        for (const id of activeSet) {
+          active30d.add(id)
+          if (offset <= 6) {
+            active7d.add(id)
+          }
+        }
+      }
+    }
+    const activeUsers1d = todayKey ? (activeUsersByDay.get(todayKey)?.size ?? 0) : 0
+
     const defaultBilling = {
       status: "unavailable" as const,
       featureGateEnabled: false,
@@ -230,6 +396,24 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
       }
       const authProviders = Array.from(providersByUser.get(entry.id) ?? []).sort()
 
+      const activity = activityByUser.get(entry.id)
+      const activeDayCount = activity ? activity.days.size : 0
+
+      const lastSeenTime = toTimestamp(sessionStats.lastSeenAt)
+      const lastTelemetryAt = activity ? activity.lastTelemetryAt : null
+      const lastActiveTime = lastTelemetryAt === null
+        ? lastSeenTime
+        : lastSeenTime === null
+          ? lastTelemetryAt
+          : Math.max(lastSeenTime, lastTelemetryAt)
+
+      const inviteStats = inviteStatsByUser.get(entry.id)
+      const signupTime = toTimestamp(entry.createdAt)
+      const firstInviteTime = toTimestamp(inviteStats ? inviteStats.firstInviteAt : null)
+      const hoursToFirstInvite = signupTime !== null && firstInviteTime !== null
+        ? Math.max(0, Math.round(((firstInviteTime - signupTime) / (60 * 60 * 1000)) * 10) / 10)
+        : null
+
       return {
         id: entry.id,
         name: entry.name,
@@ -239,6 +423,12 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         updatedAt: entry.updatedAt,
         lastSeenAt: sessionStats.lastSeenAt,
         sessionCount: sessionStats.sessionCount,
+        activeDayCount,
+        isRecurring: activeDayCount >= 2,
+        lastActiveAt: lastActiveTime === null ? null : new Date(lastActiveTime),
+        invitesSent: inviteStats ? inviteStats.invitesSent : 0,
+        firstInviteAt: inviteStats ? inviteStats.firstInviteAt : null,
+        hoursToFirstInvite,
         authProviders,
         workerCount: workerStats.workerCount,
         cloudWorkerCount: workerStats.cloudWorkerCount,
@@ -281,6 +471,14 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
           accumulator.recentUsers30d += 1
         }
 
+        if (entry.isRecurring) {
+          accumulator.recurringUsers += 1
+        }
+
+        if (entry.invitesSent > 0) {
+          accumulator.inviters += 1
+        }
+
         return accumulator
       },
       {
@@ -295,8 +493,17 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         paidUsers: 0,
         unpaidUsers: 0,
         billingUnavailableUsers: 0,
+        recurringUsers: 0,
+        inviters: 0,
       },
     )
+
+    const inviteHours: number[] = []
+    for (const row of userRows) {
+      if (row.hoursToFirstInvite !== null) {
+        inviteHours.push(row.hoursToFirstInvite)
+      }
+    }
 
     return c.json({
       viewer: {
@@ -313,6 +520,11 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         unpaidUsers: includeBilling ? summary.unpaidUsers : null,
         billingUnavailableUsers: includeBilling ? summary.billingUnavailableUsers : null,
         usersWithoutWorkers: summary.totalUsers - summary.usersWithWorkers,
+        activeUsers1d,
+        activeUsers7d: active7d.size,
+        activeUsers30d: active30d.size,
+        medianHoursToFirstInvite: median(inviteHours),
+        activitySeries,
       },
       users: userRows,
       generatedAt: new Date().toISOString(),

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -6,6 +6,8 @@ type AccessState = "loading" | "ready" | "signed-out" | "forbidden" | "error";
 type WorkerFilter = "all" | "with-workers" | "without-workers";
 type BillingFilter = "all" | "paid" | "unpaid" | "unavailable";
 type ViewMode = "users" | "companies";
+type ActivityFilter = "all" | "active-7d" | "active-30d" | "recurring" | "inactive-30d";
+type SortMode = "newest" | "recently-active" | "most-sign-ins" | "most-active-days" | "fastest-invite";
 
 type AdminBillingStatus = {
   status: "paid" | "unpaid" | "unavailable";
@@ -20,6 +22,12 @@ type AdminBillingStatus = {
 type AdminEntry = {
   email: string;
   note: string | null;
+};
+
+type ActivityPoint = {
+  day: string;
+  activeUsers: number;
+  signups: number;
 };
 
 type AdminSummary = {
@@ -37,6 +45,13 @@ type AdminSummary = {
   billingUnavailableUsers: number | null;
   adminCount: number;
   billingLoaded: boolean;
+  activeUsers1d: number;
+  activeUsers7d: number;
+  activeUsers30d: number;
+  recurringUsers: number;
+  inviters: number;
+  medianHoursToFirstInvite: number | null;
+  activitySeries: ActivityPoint[];
 };
 
 type AdminUser = {
@@ -48,6 +63,12 @@ type AdminUser = {
   updatedAt: string | null;
   lastSeenAt: string | null;
   sessionCount: number;
+  activeDayCount: number;
+  isRecurring: boolean;
+  lastActiveAt: string | null;
+  invitesSent: number;
+  firstInviteAt: string | null;
+  hoursToFirstInvite: number | null;
   authProviders: string[];
   workerCount: number;
   cloudWorkerCount: number;
@@ -107,6 +128,32 @@ function parseBillingStatus(value: unknown): AdminBillingStatus | null {
   };
 }
 
+function parseActivitySeries(value: unknown): ActivityPoint[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const points: ActivityPoint[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+
+    const day = toStringValue(entry.day);
+    if (!day) {
+      continue;
+    }
+
+    points.push({
+      day,
+      activeUsers: toNumberValue(entry.activeUsers),
+      signups: toNumberValue(entry.signups)
+    });
+  }
+
+  return points;
+}
+
 function parseAdminPayload(payload: unknown): AdminPayload | null {
   if (!isRecord(payload) || !isRecord(payload.summary) || !Array.isArray(payload.users) || !Array.isArray(payload.admins)) {
     return null;
@@ -134,6 +181,12 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
         updatedAt: toStringValue(value.updatedAt),
         lastSeenAt: toStringValue(value.lastSeenAt),
         sessionCount: toNumberValue(value.sessionCount),
+        activeDayCount: toNumberValue(value.activeDayCount),
+        isRecurring: value.isRecurring === true,
+        lastActiveAt: toStringValue(value.lastActiveAt),
+        invitesSent: toNumberValue(value.invitesSent),
+        firstInviteAt: toStringValue(value.firstInviteAt),
+        hoursToFirstInvite: toNullableNumberValue(value.hoursToFirstInvite),
         authProviders,
         workerCount: toNumberValue(value.workerCount),
         cloudWorkerCount: toNumberValue(value.cloudWorkerCount),
@@ -178,7 +231,14 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
       unpaidUsers: toNullableNumberValue(summary.unpaidUsers),
       billingUnavailableUsers: toNullableNumberValue(summary.billingUnavailableUsers),
       adminCount: toNumberValue(summary.adminCount),
-      billingLoaded: summary.billingLoaded === true
+      billingLoaded: summary.billingLoaded === true,
+      activeUsers1d: toNumberValue(summary.activeUsers1d),
+      activeUsers7d: toNumberValue(summary.activeUsers7d),
+      activeUsers30d: toNumberValue(summary.activeUsers30d),
+      recurringUsers: toNumberValue(summary.recurringUsers),
+      inviters: toNumberValue(summary.inviters),
+      medianHoursToFirstInvite: toNullableNumberValue(summary.medianHoursToFirstInvite),
+      activitySeries: parseActivitySeries(summary.activitySeries)
     },
     users,
     generatedAt: toStringValue(payload.generatedAt)
@@ -308,6 +368,35 @@ function formatRelativeTime(value: string | null): string {
   return `${Math.floor(diffMonths / 12)}y ago`;
 }
 
+function isWithinDays(value: string | null, days: number): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return false;
+  }
+
+  return Date.now() - date.getTime() <= days * 24 * 60 * 60 * 1000;
+}
+
+function formatHours(hours: number | null): string {
+  if (hours === null) {
+    return "-";
+  }
+
+  if (hours < 1) {
+    return "<1h";
+  }
+
+  if (hours < 48) {
+    return `${Math.round(hours)}h`;
+  }
+
+  return `${Math.round(hours / 24)}d`;
+}
+
 function formatProvider(provider: string): string {
   return provider
     .split(/[-_]/g)
@@ -362,6 +451,7 @@ type DomainGroup = {
   users: AdminUser[];
   verifiedCount: number;
   workerCount: number;
+  activeCount7d: number;
   latestSignupAt: string | null;
   isPersonal: boolean;
 };
@@ -376,6 +466,7 @@ function buildDomainGroups(users: AdminUser[]): DomainGroup[] {
       users: [],
       verifiedCount: 0,
       workerCount: 0,
+      activeCount7d: 0,
       latestSignupAt: null,
       isPersonal: PERSONAL_EMAIL_DOMAINS.has(domain)
     };
@@ -383,6 +474,9 @@ function buildDomainGroups(users: AdminUser[]): DomainGroup[] {
     group.users.push(user);
     if (user.emailVerified) {
       group.verifiedCount += 1;
+    }
+    if (isWithinDays(user.lastActiveAt, 7)) {
+      group.activeCount7d += 1;
     }
     group.workerCount += user.workerCount;
     if (user.createdAt && (!group.latestSignupAt || user.createdAt > group.latestSignupAt)) {
@@ -456,6 +550,37 @@ function StatCard({ label, value, detail }: { label: string; value: string; deta
   );
 }
 
+function ActivityChart({ series }: { series: ActivityPoint[] }) {
+  if (series.length === 0) {
+    return null;
+  }
+
+  const maxActive = Math.max(1, ...series.map((point) => point.activeUsers));
+
+  return (
+    <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-slate-500">Active users · last 30 days</p>
+        <p className="text-xs text-slate-500">Sign-ins + app activity · hover bars for daily detail</p>
+      </div>
+      <div className="mt-3 flex h-16 items-end gap-[3px]">
+        {series.map((point) => (
+          <div
+            key={point.day}
+            title={`${point.day}: ${point.activeUsers} active · ${point.signups} signup${point.signups === 1 ? "" : "s"}`}
+            className={`flex-1 rounded-t transition ${point.activeUsers > 0 ? "bg-slate-900/80 hover:bg-slate-950" : "bg-slate-200"}`}
+            style={{ height: `${point.activeUsers > 0 ? Math.max(8, Math.round((point.activeUsers / maxActive) * 100)) : 4}%` }}
+          />
+        ))}
+      </div>
+      <div className="mt-2 flex justify-between text-[0.66rem] text-slate-400">
+        <span>{series[0].day}</span>
+        <span>{series[series.length - 1].day}</span>
+      </div>
+    </div>
+  );
+}
+
 function MetaCell({ label, value }: { label: string; value: string }) {
   return (
     <div>
@@ -496,6 +621,8 @@ export function DenAdminPanel() {
   const [query, setQuery] = useState("");
   const [viewMode, setViewMode] = useState<ViewMode>("users");
   const [hidePersonalDomains, setHidePersonalDomains] = useState(true);
+  const [activityFilter, setActivityFilter] = useState<ActivityFilter>("all");
+  const [sortMode, setSortMode] = useState<SortMode>("newest");
   const [workerFilter, setWorkerFilter] = useState<WorkerFilter>("all");
   const [billingFilter, setBillingFilter] = useState<BillingFilter>("all");
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
@@ -558,12 +685,28 @@ export function DenAdminPanel() {
     }
 
     const normalizedQuery = query.trim().toLowerCase();
-    return payload.users.filter((user) => {
+    const matches = payload.users.filter((user) => {
       if (workerFilter === "with-workers" && user.workerCount === 0) {
         return false;
       }
 
       if (workerFilter === "without-workers" && user.workerCount > 0) {
+        return false;
+      }
+
+      if (activityFilter === "active-7d" && !isWithinDays(user.lastActiveAt, 7)) {
+        return false;
+      }
+
+      if (activityFilter === "active-30d" && !isWithinDays(user.lastActiveAt, 30)) {
+        return false;
+      }
+
+      if (activityFilter === "recurring" && !user.isRecurring) {
+        return false;
+      }
+
+      if (activityFilter === "inactive-30d" && isWithinDays(user.lastActiveAt, 30)) {
         return false;
       }
 
@@ -580,7 +723,30 @@ export function DenAdminPanel() {
       const haystack = [user.name ?? "", user.email, user.id, ...user.authProviders].join(" ").toLowerCase();
       return haystack.includes(normalizedQuery);
     });
-  }, [billingFilter, payload, query, workerFilter]);
+
+    if (sortMode === "newest") {
+      return matches;
+    }
+
+    // Server timestamps are ISO 8601, so lexicographic order is chronological.
+    return [...matches].sort((a, b) => {
+      if (sortMode === "recently-active") {
+        return (b.lastActiveAt ?? "").localeCompare(a.lastActiveAt ?? "");
+      }
+
+      if (sortMode === "most-sign-ins") {
+        return b.sessionCount - a.sessionCount;
+      }
+
+      if (sortMode === "most-active-days") {
+        return b.activeDayCount - a.activeDayCount;
+      }
+
+      const aHours = a.hoursToFirstInvite ?? Number.POSITIVE_INFINITY;
+      const bHours = b.hoursToFirstInvite ?? Number.POSITIVE_INFINITY;
+      return aHours - bHours;
+    });
+  }, [activityFilter, billingFilter, payload, query, sortMode, workerFilter]);
 
   const domainGroups = useMemo(() => {
     return payload ? buildDomainGroups(payload.users) : [];
@@ -614,10 +780,11 @@ export function DenAdminPanel() {
 
     if (viewMode === "companies") {
       downloadCsv(`den-companies-${date}.csv`, [
-        ["domain", "users", "verified", "workers", "latest_signup", "personal", "emails"],
+        ["domain", "users", "active_7d", "verified", "workers", "latest_signup", "personal", "emails"],
         ...filteredDomains.map((group) => [
           group.domain,
           String(group.users.length),
+          String(group.activeCount7d),
           String(group.verifiedCount),
           String(group.workerCount),
           group.latestSignupAt ?? "",
@@ -629,15 +796,19 @@ export function DenAdminPanel() {
     }
 
     downloadCsv(`den-users-${date}.csv`, [
-      ["email", "name", "domain", "verified", "signed_up", "last_seen", "sessions", "workers", "providers"],
+      ["email", "name", "domain", "verified", "signed_up", "last_active", "sign_ins", "active_days", "recurring", "invites_sent", "hours_to_first_invite", "workers", "providers"],
       ...filteredUsers.map((user) => [
         user.email,
         user.name ?? "",
         getEmailDomain(user.email),
         user.emailVerified ? "yes" : "no",
         user.createdAt ?? "",
-        user.lastSeenAt ?? "",
+        user.lastActiveAt ?? "",
         String(user.sessionCount),
+        String(user.activeDayCount),
+        user.isRecurring ? "yes" : "no",
+        String(user.invitesSent),
+        user.hoursToFirstInvite === null ? "" : String(user.hoursToFirstInvite),
         String(user.workerCount),
         user.authProviders.join("; ")
       ])
@@ -748,12 +919,17 @@ export function DenAdminPanel() {
 
         <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
           <StatCard label="Users" value={String(payload.summary.totalUsers)} detail={`${payload.summary.recentUsers7d} new in 7d`} />
+          <StatCard label="Active today" value={String(payload.summary.activeUsers1d)} detail={`${payload.summary.activeUsers7d} in 7d · ${payload.summary.activeUsers30d} in 30d`} />
+          <StatCard label="Recurring" value={String(payload.summary.recurringUsers)} detail="Active on 2+ days" />
+          <StatCard label="Inviters" value={String(payload.summary.inviters)} detail={`Median time to invite ${formatHours(payload.summary.medianHoursToFirstInvite)}`} />
           <StatCard label="Verified" value={String(payload.summary.verifiedUsers)} detail={`${payload.summary.totalUsers - payload.summary.verifiedUsers} still unverified`} />
           <StatCard label="Worker creators" value={String(payload.summary.usersWithWorkers)} detail={`${payload.summary.usersWithoutWorkers} without workers`} />
           <StatCard label="Workers" value={String(payload.summary.totalWorkers)} detail={`${payload.summary.cloudWorkers} cloud / ${payload.summary.localWorkers} local`} />
           <StatCard label="Billing" value={payload.summary.billingLoaded ? String(payload.summary.paidUsers ?? 0) : "On demand"} detail={billingDetail} />
           <StatCard label="Admins" value={String(payload.summary.adminCount)} detail="Whitelisted operator accounts" />
         </div>
+
+        <ActivityChart series={payload.summary.activitySeries} />
 
         <div className="mt-5 flex flex-wrap gap-2">
           {payload.admins.map((admin) => (
@@ -817,7 +993,7 @@ export function DenAdminPanel() {
           </div>
         ) : (
         <div className="mt-4 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-          <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_13rem_13rem]">
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-[minmax(0,1fr)_10.5rem_11.5rem_10.5rem_10.5rem]">
             <label className="grid gap-2">
               <span className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Search users</span>
               <input
@@ -826,6 +1002,36 @@ export function DenAdminPanel() {
                 placeholder="Email, name, user id, provider"
                 className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-slate-400"
               />
+            </label>
+
+            <label className="grid gap-2">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Activity</span>
+              <select
+                value={activityFilter}
+                onChange={(event) => setActivityFilter(event.target.value as ActivityFilter)}
+                className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-slate-400"
+              >
+                <option value="all">All users</option>
+                <option value="active-7d">Active in 7d</option>
+                <option value="active-30d">Active in 30d</option>
+                <option value="recurring">Recurring</option>
+                <option value="inactive-30d">Inactive 30d+</option>
+              </select>
+            </label>
+
+            <label className="grid gap-2">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Sort</span>
+              <select
+                value={sortMode}
+                onChange={(event) => setSortMode(event.target.value as SortMode)}
+                className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-slate-400"
+              >
+                <option value="newest">Newest signup</option>
+                <option value="recently-active">Recently active</option>
+                <option value="most-sign-ins">Most sign-ins</option>
+                <option value="most-active-days">Most active days</option>
+                <option value="fastest-invite">Fastest to invite</option>
+              </select>
             </label>
 
             <label className="grid gap-2">
@@ -911,8 +1117,9 @@ export function DenAdminPanel() {
                   </div>
                 </div>
 
-                <div className="mt-4 grid gap-4 sm:grid-cols-3">
+                <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
                   <MetaCell label="Latest signup" value={group.latestSignupAt ? `${formatRelativeTime(group.latestSignupAt)} · ${formatDateTime(group.latestSignupAt)}` : "-"} />
+                  <MetaCell label="Active 7d" value={`${group.activeCount7d} of ${group.users.length}`} />
                   <MetaCell label="Verified" value={`${group.verifiedCount} of ${group.users.length}`} />
                   <MetaCell label="Workers" value={String(group.workerCount)} />
                 </div>
@@ -942,6 +1149,11 @@ export function DenAdminPanel() {
                           Verified
                         </span>
                       ) : null}
+                      {user.isRecurring ? (
+                        <span className="inline-flex items-center rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[0.66rem] font-semibold uppercase tracking-[0.14em] text-sky-700">
+                          Recurring
+                        </span>
+                      ) : null}
                     </div>
                     <p className="mt-1 truncate text-sm text-slate-500">{user.email}</p>
                   </div>
@@ -954,10 +1166,12 @@ export function DenAdminPanel() {
                   </div>
                 </div>
 
-                <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-6">
                   <MetaCell label="Signed up" value={formatDateTime(user.createdAt)} />
-                  <MetaCell label="Last seen" value={user.lastSeenAt ? `${formatRelativeTime(user.lastSeenAt)} · ${formatDateTime(user.lastSeenAt)}` : "No sessions yet"} />
-                  <MetaCell label="Sessions" value={String(user.sessionCount)} />
+                  <MetaCell label="Last active" value={formatRelativeTime(user.lastActiveAt)} />
+                  <MetaCell label="Sign-ins" value={String(user.sessionCount)} />
+                  <MetaCell label="Active days" value={String(user.activeDayCount)} />
+                  <MetaCell label="Invites" value={user.invitesSent > 0 ? `${user.invitesSent} · first after ${formatHours(user.hoursToFirstInvite)}` : "None"} />
                   <MetaCell label="Workers" value={`${user.cloudWorkerCount} cloud / ${user.localWorkerCount} local`} />
                 </div>
 

--- a/ee/packages/den-db/drizzle/0021_telemetry_event.sql
+++ b/ee/packages/den-db/drizzle/0021_telemetry_event.sql
@@ -1,0 +1,13 @@
+-- Backfill: telemetry_event shipped (#1658) without a migration file and only
+-- exists in databases that ran `db:push`. Idempotent so it is safe either way.
+CREATE TABLE IF NOT EXISTS `telemetry_event` (
+	`id` varchar(64) NOT NULL,
+	`org_id` varchar(64) NOT NULL,
+	`member_id` varchar(64) NOT NULL,
+	`event_type` varchar(64) NOT NULL,
+	`event_timestamp` timestamp(3) NOT NULL,
+	`created_at` timestamp(3) NOT NULL DEFAULT (now()),
+	CONSTRAINT `telemetry_event_id` PRIMARY KEY(`id`),
+	INDEX `telemetry_event_org_id_type_ts` (`org_id`,`event_type`,`event_timestamp`),
+	INDEX `telemetry_event_org_id_member_id` (`org_id`,`member_id`)
+);

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1780426749385,
       "tag": "0020_breezy_siren",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "5",
+      "when": 1781286597056,
+      "tag": "0021_telemetry_event",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Re-lands the two commits from #2187 that were stranded when it was squash-merged early (only the Companies-view commit made it to dev). Clean cherry-picks; no overlap with anything merged since.

## What

### Activity + invite metrics (API `GET /v1/admin/overview` + `/admin` UI)
- **Activity**: merges auth-session sign-in days with `session.active` telemetry (member → user join, 90d window). Summary gains `activeUsers1d/7d/30d`, `recurringUsers` (active 2+ days), and a 30-day `activitySeries` (active users + signups/day)
- **Invites**: per-user `invitesSent`, `firstInviteAt`, `hoursToFirstInvite` (signup → first org invite); summary `inviters` + `medianHoursToFirstInvite`
- UI: Active today / Recurring / Inviters cards, CSS-only 30-day chart, Activity filter (7d/30d/recurring/inactive) + Sort (recently active, most sign-ins, most active days, fastest to invite), per-user activity/invite cells, Recurring badge, Active-7d per company, CSV columns
- Perf: 3 grouped queries in the existing `Promise.all` (no N+1), single-pass aggregation, day-bucket map bounded to the series window, lexicographic ISO sort comparators

### Migration backfill (found while answering "do we need a migration?")
- `telemetry_event` (#1658) shipped schema-only — created via `db:push`, no migration file, no journal entry. Added idempotent `0021_telemetry_event.sql` (`CREATE TABLE IF NOT EXISTS` with inline indexes + journal entry)
- Admin overview treats the telemetry query as non-fatal: missing table degrades activity to sign-in days instead of 500ing the backoffice

## Testing (from #2187, all on these exact changes)
- `tsc --noEmit` clean in den-api and den-web; `node scripts/build.mjs` + `next build` exit 0
- CDP smoke test with stubbed payload: cards/chart render; `active-7d` filter → exactly the 5 expected users; `recurring`+`most-sign-ins` → ben(80) > sam(22) > dana(9) > ana(6); `fastest-invite` → dana(2.4h) > ben(18h) > sam(50.7h); CSVs contain the new columns
- Migration applied twice against MySQL 8 in Docker: second run no-ops, `SHOW CREATE TABLE` matches the Drizzle schema

## Data caveats
Sign-ins = better-auth session creations; telemetry only ingested for users with an active org (solo users show via sessions only); time-to-invite counts org invitations (not SCIM/SSO provisioning); UTC day bucketing.

**Deploy note**: needs the Render den-api deploy (not just Vercel). If prod never got `telemetry_event` via `db:push`, run `db:migrate` to enable app-activity DAU — overview works either way.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

