### PR TITLE
feat(ee): den-admin-mcp — read-only admin analytics MCP server

### DIFF
--- a/ee/packages/den-admin-mcp/README.md
+++ b/ee/packages/den-admin-mcp/README.md
@@ -1,0 +1,58 @@
+# den-admin-mcp
+
+Read-only admin analytics MCP server for the OpenWork Den database. Ask OpenWork
+things like "what's our weekly growth rate?", "show retention for the last 8
+weeks", or "who at acme.test is active?" and the agent answers from real data.
+
+## Tools
+
+| Tool | What it answers |
+|---|---|
+| `den_overview` | Totals, new users 7d/30d, DAU/WAU/MAU, subscriptions |
+| `den_growth` | Signup growth series (day/week/month) + growth rates |
+| `den_retention` | Weekly signup cohorts x weeks-active retention matrix |
+| `den_company_users` | Users related to a company (org match + email domain) |
+| `den_users_search` | Find users by name/email, with orgs + last activity |
+| `den_org_overview` | One org: members by role, invites, subscription, activity |
+| `den_query` | Guarded read-only SQL escape hatch (SELECT-only, auto LIMIT) |
+
+Activity definitions match den-api `/v1/admin/overview`: a user is active on a
+day if they have a sign-in session day or a `session.active` telemetry event.
+
+## Setup
+
+Only `DATABASE_URL` is required. No den-api needs to run; no encryption key is
+needed (analytics tables have no encrypted columns). For defense in depth,
+create a read-only MySQL user:
+
+```sql
+CREATE USER 'den_readonly'@'%' IDENTIFIED BY '...';
+GRANT SELECT ON openwork_den.* TO 'den_readonly'@'%';
+```
+
+## Register in OpenWork
+
+Add to `opencode.json` (workspace) or `~/.config/opencode/opencode.jsonc`
+(global), or via Settings -> Connections -> MCP in the app:
+
+```jsonc
+{
+  "mcp": {
+    "den-admin": {
+      "type": "local",
+      "command": ["node", "/path/to/ee/packages/den-admin-mcp/index.mjs"],
+      "environment": { "DATABASE_URL": "mysql://den_readonly:...@host:3306/openwork_den" },
+      "enabled": true
+    }
+  }
+}
+```
+
+## Test
+
+Boots the server over real stdio JSON-RPC and exercises every tool:
+
+```sh
+# defaults to the local dev database (docker compose mysql + seed:demo-org)
+pnpm --filter @openwork-ee/den-admin-mcp test
+```

--- a/ee/packages/den-admin-mcp/index.mjs
+++ b/ee/packages/den-admin-mcp/index.mjs
@@ -1,0 +1,494 @@
+#!/usr/bin/env node
+// den-admin-mcp — read-only admin analytics MCP server for the OpenWork Den database.
+//
+// Tools: den_overview, den_growth, den_retention, den_company_users,
+//        den_users_search, den_org_overview, den_query
+//
+// Config: DATABASE_URL (mysql://user:pass@host:3306/openwork_den).
+// Only SELECT statements are ever issued. For defense in depth, point it at a
+// read-only MySQL user. Activity definitions match den-api /v1/admin/overview:
+// a user is "active" on a day if they have a sign-in session day or a
+// `session.active` telemetry event that day.
+//
+// Register in OpenWork (opencode.json):
+//   { "mcp": { "den-admin": { "type": "local",
+//       "command": ["node", "/path/to/ee/packages/den-admin-mcp/index.mjs"],
+//       "environment": { "DATABASE_URL": "mysql://..." }, "enabled": true } } }
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import mysql from "mysql2/promise";
+import { z } from "zod";
+
+const DEFAULT_ROW_LIMIT = Number(process.env.DEN_ADMIN_MCP_ROW_LIMIT || 200);
+
+let pool = null;
+function getPool() {
+  if (!pool) {
+    const url = process.env.DATABASE_URL;
+    if (!url) {
+      throw new Error(
+        "DATABASE_URL is required (e.g. mysql://root:password@127.0.0.1:3306/openwork_den)",
+      );
+    }
+    pool = mysql.createPool({ uri: url, connectionLimit: 4, dateStrings: true });
+  }
+  return pool;
+}
+
+async function rows(sqlText, params = []) {
+  const [result] = await getPool().query(sqlText, params);
+  return result;
+}
+
+const n = (value) => Number(value ?? 0);
+
+function ok(data) {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+}
+
+function fail(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+}
+
+async function run(fn) {
+  try {
+    return ok(await fn());
+  } catch (error) {
+    return fail(error);
+  }
+}
+
+function isMissingTable(error) {
+  return error && typeof error === "object" && error.code === "ER_NO_SUCH_TABLE";
+}
+
+// --- activity (sign-in session days UNION session.active telemetry days) ---
+
+async function activeUserCount(days) {
+  const withTelemetry = `SELECT COUNT(DISTINCT uid) AS count FROM (
+      SELECT s.user_id AS uid FROM session s
+       WHERE s.updated_at >= DATE_SUB(NOW(), INTERVAL ${days} DAY)
+      UNION
+      SELECT m.user_id FROM telemetry_event t
+        JOIN member m ON m.id = t.member_id
+       WHERE m.user_id IS NOT NULL
+         AND t.event_timestamp >= DATE_SUB(NOW(), INTERVAL ${days} DAY)
+    ) activity`;
+  try {
+    return n((await rows(withTelemetry))[0]?.count);
+  } catch (error) {
+    if (!isMissingTable(error)) throw error;
+    const sessionsOnly = `SELECT COUNT(DISTINCT user_id) AS count FROM session
+       WHERE updated_at >= DATE_SUB(NOW(), INTERVAL ${days} DAY)`;
+    return n((await rows(sessionsOnly))[0]?.count);
+  }
+}
+
+async function activityDays() {
+  const withTelemetry = `SELECT s.user_id AS uid, DATE(s.updated_at) AS day FROM session s
+      UNION
+      SELECT m.user_id, DATE(t.event_timestamp) FROM telemetry_event t
+        JOIN member m ON m.id = t.member_id
+       WHERE m.user_id IS NOT NULL`;
+  try {
+    return await rows(withTelemetry);
+  } catch (error) {
+    if (!isMissingTable(error)) throw error;
+    return rows(`SELECT user_id AS uid, DATE(updated_at) AS day FROM session GROUP BY uid, day`);
+  }
+}
+
+async function lastActiveByUser(userIds) {
+  const result = new Map();
+  if (userIds.length === 0) return result;
+  const merge = (userId, value) => {
+    if (!value) return;
+    const previous = result.get(userId);
+    if (!previous || value > previous) result.set(userId, value);
+  };
+  const sessionRows = await rows(
+    `SELECT user_id, MAX(updated_at) AS last FROM session WHERE user_id IN (?) GROUP BY user_id`,
+    [userIds],
+  );
+  for (const row of sessionRows) merge(row.user_id, row.last);
+  try {
+    const telemetryRows = await rows(
+      `SELECT m.user_id AS user_id, MAX(t.event_timestamp) AS last FROM telemetry_event t
+         JOIN member m ON m.id = t.member_id
+        WHERE m.user_id IN (?) GROUP BY m.user_id`,
+      [userIds],
+    );
+    for (const row of telemetryRows) merge(row.user_id, row.last);
+  } catch (error) {
+    if (!isMissingTable(error)) throw error;
+  }
+  return result;
+}
+
+async function membershipsByUser(userIds) {
+  const result = new Map();
+  if (userIds.length === 0) return result;
+  const memberRows = await rows(
+    `SELECT m.user_id, m.role, o.name, o.slug FROM member m
+       JOIN organization o ON o.id = m.organization_id
+      WHERE m.user_id IN (?) AND m.removed_at IS NULL`,
+    [userIds],
+  );
+  for (const row of memberRows) {
+    const list = result.get(row.user_id) ?? [];
+    list.push({ organization: row.name, slug: row.slug, role: row.role });
+    result.set(row.user_id, list);
+  }
+  return result;
+}
+
+async function describeUsers(userRows) {
+  const ids = userRows.map((row) => row.id);
+  const [lastActive, memberships] = await Promise.all([
+    lastActiveByUser(ids),
+    membershipsByUser(ids),
+  ]);
+  return userRows.map((row) => ({
+    name: row.name,
+    email: row.email,
+    signedUpAt: row.created_at,
+    lastActiveAt: lastActive.get(row.id) ?? null,
+    organizations: memberships.get(row.id) ?? [],
+  }));
+}
+
+// --- read-only guard for den_query ---
+
+const FORBIDDEN_SQL =
+  /\b(insert|update|delete|drop|alter|create|truncate|rename|replace|grant|revoke|call|load|handler|lock|unlock|set|use|outfile|dumpfile|for\s+update)\b/i;
+
+function assertReadOnly(input) {
+  const sqlText = input.trim().replace(/;+\s*$/, "");
+  if (sqlText.includes(";")) throw new Error("Only a single SQL statement is allowed");
+  if (!/^(select|with|show|describe|explain)\b/i.test(sqlText)) {
+    throw new Error("Only SELECT/WITH/SHOW/DESCRIBE/EXPLAIN statements are allowed");
+  }
+  if (FORBIDDEN_SQL.test(sqlText)) {
+    throw new Error("Statement contains a forbidden keyword (read-only access)");
+  }
+  return sqlText;
+}
+
+// --- MCP server ---
+
+const server = new McpServer({ name: "den-admin", version: "0.1.0" });
+
+server.tool(
+  "den_overview",
+  "High-level Den admin overview: total users/organizations/members, new users (7d/30d), active users (DAU/WAU/MAU), pending invitations, and subscriptions by status.",
+  {},
+  async () =>
+    run(async () => {
+      const [users, orgs, members, invitations, subscriptions, dau, wau, mau] =
+        await Promise.all([
+          rows(`SELECT COUNT(*) AS total,
+                  SUM(created_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)) AS new7d,
+                  SUM(created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)) AS new30d
+                FROM user`),
+          rows(`SELECT COUNT(*) AS total FROM organization`),
+          rows(`SELECT COUNT(*) AS total FROM member WHERE removed_at IS NULL`),
+          rows(`SELECT COUNT(*) AS pending FROM invitation WHERE status = 'pending'`),
+          rows(`SELECT type, status, COUNT(*) AS count FROM org_subscriptions GROUP BY type, status`),
+          activeUserCount(1),
+          activeUserCount(7),
+          activeUserCount(30),
+        ]);
+      return {
+        users: {
+          total: n(users[0]?.total),
+          newLast7d: n(users[0]?.new7d),
+          newLast30d: n(users[0]?.new30d),
+        },
+        organizations: n(orgs[0]?.total),
+        activeMembers: n(members[0]?.total),
+        pendingInvitations: n(invitations[0]?.pending),
+        activeUsers: { daily: dau, weekly: wau, monthly: mau },
+        subscriptions: subscriptions.map((row) => ({
+          type: row.type,
+          status: row.status,
+          count: n(row.count),
+        })),
+        note: "active = sign-in session day or session.active telemetry event",
+      };
+    }),
+);
+
+server.tool(
+  "den_growth",
+  "Signup growth series for users or organizations, bucketed by day/week/month, with period-over-period growth rates and cumulative totals.",
+  {
+    metric: z.enum(["users", "organizations"]).default("users").describe("What to count"),
+    interval: z.enum(["day", "week", "month"]).default("week").describe("Bucket size"),
+    periods: z.number().int().min(1).max(36).default(12).describe("How many periods back"),
+  },
+  async ({ metric, interval, periods }) =>
+    run(async () => {
+      const table = metric === "organizations" ? "organization" : "user";
+      const format = { day: "%Y-%m-%d", week: "%x-W%v", month: "%Y-%m" }[interval];
+      const unit = { day: "DAY", week: "WEEK", month: "MONTH" }[interval];
+      const [series, before] = await Promise.all([
+        rows(
+          `SELECT DATE_FORMAT(created_at, ?) AS period, COUNT(*) AS count FROM ${table}
+            WHERE created_at >= DATE_SUB(NOW(), INTERVAL ${periods} ${unit})
+            GROUP BY period ORDER BY period`,
+          [format],
+        ),
+        rows(
+          `SELECT COUNT(*) AS count FROM ${table}
+            WHERE created_at < DATE_SUB(NOW(), INTERVAL ${periods} ${unit})`,
+        ),
+      ]);
+      let cumulative = n(before[0]?.count);
+      let previous = null;
+      const buckets = series.map((row) => {
+        const count = n(row.count);
+        cumulative += count;
+        const growthPercent =
+          previous === null || previous === 0
+            ? null
+            : Math.round(((count - previous) / previous) * 1000) / 10;
+        previous = count;
+        return { period: row.period, new: count, cumulative, growthPercent };
+      });
+      const complete = buckets.slice(0, -1);
+      const latest = complete[complete.length - 1];
+      return {
+        metric,
+        interval,
+        startingTotal: n(before[0]?.count),
+        buckets,
+        latestCompletePeriod: latest ?? null,
+        note: "last bucket is the current in-progress period; growthPercent compares new signups vs the previous bucket; periods with zero signups are omitted",
+      };
+    }),
+);
+
+server.tool(
+  "den_retention",
+  "Weekly cohort retention: users grouped by ISO signup week, with the percentage active in each week after signup (activity = sign-in session days + session.active telemetry).",
+  {
+    weeks: z.number().int().min(2).max(26).default(8).describe("How many signup-week cohorts"),
+  },
+  async ({ weeks }) =>
+    run(async () => {
+      const users = await rows(
+        `SELECT id, DATE(created_at) AS day, DATE_FORMAT(created_at, '%x-W%v') AS week
+           FROM user WHERE created_at >= DATE_SUB(NOW(), INTERVAL ${weeks} WEEK)`,
+      );
+      const activity = await activityDays();
+      const DAY_MS = 86_400_000;
+      const signupByUser = new Map(
+        users.map((row) => [row.id, { week: row.week, time: Date.parse(row.day) }]),
+      );
+      const cohorts = new Map();
+      for (const row of users) {
+        const cohort = cohorts.get(row.week) ?? { size: 0, retained: new Map() };
+        cohort.size += 1;
+        cohorts.set(row.week, cohort);
+      }
+      for (const row of activity) {
+        const signup = signupByUser.get(row.uid);
+        if (!signup || !row.day) continue;
+        const offset = Math.floor((Date.parse(row.day) - signup.time) / (7 * DAY_MS));
+        if (offset < 0) continue;
+        const cohort = cohorts.get(signup.week);
+        const usersAtOffset = cohort.retained.get(offset) ?? new Set();
+        usersAtOffset.add(row.uid);
+        cohort.retained.set(offset, usersAtOffset);
+      }
+      const result = [...cohorts.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([week, cohort]) => {
+          const byWeek = {};
+          for (const [offset, retainedUsers] of [...cohort.retained.entries()].sort(
+            (a, b) => a[0] - b[0],
+          )) {
+            byWeek[`week${offset}`] = {
+              users: retainedUsers.size,
+              percent: Math.round((retainedUsers.size / cohort.size) * 1000) / 10,
+            };
+          }
+          return { cohort: week, signups: cohort.size, retention: byWeek };
+        });
+      return {
+        cohorts: result,
+        note: "week0 = signup week; weekN = active N weeks after signup",
+      };
+    }),
+);
+
+server.tool(
+  "den_company_users",
+  "Find users related to a company: matches organizations by name/slug/allowed email domains, and users by email domain. Returns members with role, signup date, and last activity.",
+  {
+    company: z.string().min(1).describe("Company name, org slug, or email domain (e.g. 'acme', 'acme.test')"),
+    limit: z.number().int().min(1).max(200).default(50).describe("Max users per group"),
+  },
+  async ({ company, limit }) =>
+    run(async () => {
+      const query = company.includes("@") ? company.split("@").pop() : company;
+      const like = `%${query}%`;
+      const organizations = await rows(
+        `SELECT id, name, slug, created_at FROM organization
+          WHERE name LIKE ? OR slug LIKE ? OR allowed_email_domains LIKE ? LIMIT 10`,
+        [like, like, like],
+      );
+      const orgResults = [];
+      for (const org of organizations) {
+        const memberRows = await rows(
+          `SELECT u.id, u.name, u.email, u.created_at, m.role, m.joined_at FROM member m
+             JOIN user u ON u.id = m.user_id
+            WHERE m.organization_id = ? AND m.removed_at IS NULL
+            ORDER BY m.joined_at LIMIT ${limit}`,
+          [org.id],
+        );
+        const lastActive = await lastActiveByUser(memberRows.map((row) => row.id));
+        orgResults.push({
+          organization: org.name,
+          slug: org.slug,
+          createdAt: org.created_at,
+          members: memberRows.map((row) => ({
+            name: row.name,
+            email: row.email,
+            role: row.role,
+            joinedAt: row.joined_at,
+            lastActiveAt: lastActive.get(row.id) ?? null,
+          })),
+        });
+      }
+      const domainRows = await rows(
+        `SELECT id, name, email, created_at FROM user
+          WHERE email LIKE ? ORDER BY created_at DESC LIMIT ${limit}`,
+        [`%@%${query}%`],
+      );
+      return {
+        organizations: orgResults,
+        usersByEmailDomain: await describeUsers(domainRows),
+      };
+    }),
+);
+
+server.tool(
+  "den_users_search",
+  "Search users by name or email substring. Returns signup date, last activity, and organization memberships.",
+  {
+    query: z.string().min(1).describe("Name or email substring"),
+    limit: z.number().int().min(1).max(100).default(20),
+  },
+  async ({ query, limit }) =>
+    run(async () => {
+      const like = `%${query}%`;
+      const userRows = await rows(
+        `SELECT id, name, email, created_at FROM user
+          WHERE email LIKE ? OR name LIKE ? ORDER BY created_at DESC LIMIT ${limit}`,
+        [like, like],
+      );
+      return { users: await describeUsers(userRows) };
+    }),
+);
+
+server.tool(
+  "den_org_overview",
+  "Deep dive on one organization (by slug or name): members by role, pending invitations, teams, subscriptions, and active members in the last 7/30 days.",
+  {
+    org: z.string().min(1).describe("Organization slug or name"),
+  },
+  async ({ org }) =>
+    run(async () => {
+      const matches = await rows(
+        `SELECT id, name, slug, allowed_email_domains, created_at FROM organization
+          WHERE slug = ? OR name LIKE ? LIMIT 1`,
+        [org, `%${org}%`],
+      );
+      const found = matches[0];
+      if (!found) throw new Error(`No organization matching "${org}"`);
+      const [roleRows, invitations, teams, subscriptions, memberRows] = await Promise.all([
+        rows(
+          `SELECT role, COUNT(*) AS count FROM member
+            WHERE organization_id = ? AND removed_at IS NULL GROUP BY role`,
+          [found.id],
+        ),
+        rows(
+          `SELECT email, role, status, created_at FROM invitation
+            WHERE organization_id = ? AND status = 'pending' ORDER BY created_at DESC LIMIT 50`,
+          [found.id],
+        ),
+        rows(`SELECT COUNT(*) AS count FROM team WHERE organization_id = ?`, [found.id]),
+        rows(
+          `SELECT type, status, quantity, current_period_end FROM org_subscriptions
+            WHERE organization_id = ?`,
+          [found.id],
+        ),
+        rows(
+          `SELECT u.id, u.name, u.email, u.created_at, m.role FROM member m
+             JOIN user u ON u.id = m.user_id
+            WHERE m.organization_id = ? AND m.removed_at IS NULL LIMIT 100`,
+          [found.id],
+        ),
+      ]);
+      const lastActive = await lastActiveByUser(memberRows.map((row) => row.id));
+      const activeSince = (days) => {
+        const cutoff = Date.now() - days * 86_400_000;
+        return memberRows.filter((row) => {
+          const last = lastActive.get(row.id);
+          return last && Date.parse(last) >= cutoff;
+        }).length;
+      };
+      return {
+        organization: {
+          name: found.name,
+          slug: found.slug,
+          createdAt: found.created_at,
+          allowedEmailDomains: found.allowed_email_domains,
+        },
+        membersByRole: roleRows.map((row) => ({ role: row.role, count: n(row.count) })),
+        activeMembersLast7d: activeSince(7),
+        activeMembersLast30d: activeSince(30),
+        teams: n(teams[0]?.count),
+        pendingInvitations: invitations,
+        subscriptions,
+        members: memberRows.map((row) => ({
+          name: row.name,
+          email: row.email,
+          role: row.role,
+          lastActiveAt: lastActive.get(row.id) ?? null,
+        })),
+      };
+    }),
+);
+
+server.tool(
+  "den_query",
+  "Escape hatch: run a single read-only SQL statement (SELECT/WITH/SHOW/DESCRIBE/EXPLAIN) against the Den database. Useful tables: user, session, organization, member, invitation, team, org_subscriptions, telemetry_event, worker, audit_event. Avoid encrypted columns (scim_provider.scim_token, sso_provider.*_config, llm_provider.api_key, config_object_version payloads, inference upstream keys).",
+  {
+    sql: z.string().min(1).describe("A single read-only SQL statement"),
+    limit: z.number().int().min(1).max(1000).optional().describe("Row limit appended when the query has none"),
+  },
+  async ({ sql: sqlText, limit }) =>
+    run(async () => {
+      let safe = assertReadOnly(sqlText);
+      if (/^(select|with)\b/i.test(safe) && !/\blimit\s+\d+/i.test(safe)) {
+        safe += ` LIMIT ${limit ?? DEFAULT_ROW_LIMIT}`;
+      }
+      const result = await rows(safe);
+      return { rowCount: result.length, rows: result };
+    }),
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("[den-admin-mcp] ready (stdio), read-only analytics for Den");
+}
+
+main().catch((error) => {
+  console.error("[den-admin-mcp] fatal:", error);
+  process.exit(1);
+});

--- a/ee/packages/den-admin-mcp/package.json
+++ b/ee/packages/den-admin-mcp/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@openwork-ee/den-admin-mcp",
+  "version": "0.1.0",
+  "description": "Read-only admin analytics MCP server for the OpenWork Den database — growth, retention, company/user lookups",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "den-admin-mcp": "index.mjs"
+  },
+  "files": [
+    "index.mjs"
+  ],
+  "scripts": {
+    "check": "node --check index.mjs && node --check scripts/smoke.mjs",
+    "test": "sh -lc 'DATABASE_URL=${DATABASE_URL:-mysql://root:password@127.0.0.1:3306/openwork_den} node scripts/smoke.mjs'"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "mysql2": "^3.11.3",
+    "zod": "^3.25.76"
+  }
+}

--- a/ee/packages/den-admin-mcp/scripts/smoke.mjs
+++ b/ee/packages/den-admin-mcp/scripts/smoke.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Smoke test: boots index.mjs as a real stdio MCP server and exercises every
+// tool over JSON-RPC against the database at DATABASE_URL. Exits non-zero on
+// any failure. Usage: DATABASE_URL=mysql://... node scripts/smoke.mjs
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const serverPath = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "index.mjs");
+const child = spawn(process.execPath, [serverPath], {
+  stdio: ["pipe", "pipe", "inherit"],
+  env: process.env,
+});
+
+let buffer = "";
+let nextId = 1;
+const pending = new Map();
+
+child.stdout.on("data", (chunk) => {
+  buffer += chunk.toString();
+  let index;
+  while ((index = buffer.indexOf("\n")) >= 0) {
+    const line = buffer.slice(0, index).trim();
+    buffer = buffer.slice(index + 1);
+    if (!line) continue;
+    const message = JSON.parse(line);
+    const waiter = pending.get(message.id);
+    if (waiter) {
+      pending.delete(message.id);
+      waiter(message);
+    }
+  }
+});
+
+function request(method, params) {
+  const id = nextId++;
+  child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timeout waiting for ${method}`)), 30_000);
+    pending.set(id, (message) => {
+      clearTimeout(timer);
+      resolve(message);
+    });
+  });
+}
+
+function notify(method, params) {
+  child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+}
+
+let failures = 0;
+
+function report(label, passed, detail) {
+  failures += passed ? 0 : 1;
+  console.log(`${passed ? "PASS" : "FAIL"}  ${label}${detail ? ` — ${detail}` : ""}`);
+}
+
+async function callTool(name, args, { expectError = false } = {}) {
+  const response = await request("tools/call", { name, arguments: args });
+  const result = response.result;
+  const isError = Boolean(result?.isError);
+  const text = result?.content?.[0]?.text ?? "";
+  const passed = expectError ? isError : !isError && text.length > 0;
+  report(`tools/call ${name}`, passed, passed ? summarize(name, text) : text.slice(0, 200));
+  return text;
+}
+
+function summarize(name, text) {
+  try {
+    const data = JSON.parse(text);
+    switch (name) {
+      case "den_overview":
+        return `users=${data.users.total} orgs=${data.organizations} dau=${data.activeUsers.daily} wau=${data.activeUsers.weekly} mau=${data.activeUsers.monthly}`;
+      case "den_growth":
+        return `buckets=${data.buckets.length} latestComplete=${JSON.stringify(data.latestCompletePeriod)}`;
+      case "den_retention":
+        return `cohorts=${data.cohorts.length} first=${JSON.stringify(data.cohorts[0] ?? null).slice(0, 120)}`;
+      case "den_company_users":
+        return `orgs=${data.organizations.length} members=${data.organizations[0]?.members.length ?? 0} domainUsers=${data.usersByEmailDomain.length}`;
+      case "den_users_search":
+        return `users=${data.users.length} first=${data.users[0]?.email ?? "none"}`;
+      case "den_org_overview":
+        return `org=${data.organization.slug} members7d=${data.activeMembersLast7d} roles=${JSON.stringify(data.membersByRole)}`;
+      case "den_query":
+        return `rows=${data.rowCount}`;
+      default:
+        return text.slice(0, 80);
+    }
+  } catch {
+    return text.slice(0, 80);
+  }
+}
+
+try {
+  const init = await request("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "den-admin-mcp-smoke", version: "0.1.0" },
+  });
+  report("initialize", init.result?.serverInfo?.name === "den-admin");
+  notify("notifications/initialized", {});
+
+  const list = await request("tools/list", {});
+  const toolNames = (list.result?.tools ?? []).map((tool) => tool.name).sort();
+  report("tools/list", toolNames.length === 7, toolNames.join(", "));
+
+  await callTool("den_overview", {});
+  await callTool("den_growth", { metric: "users", interval: "month", periods: 6 });
+  await callTool("den_retention", { weeks: 8 });
+  await callTool("den_company_users", { company: "acme" });
+  await callTool("den_users_search", { query: "alex" });
+  await callTool("den_org_overview", { org: "acme-robotics-demo" });
+  await callTool("den_query", { sql: "SELECT COUNT(*) AS users FROM user" });
+  await callTool("den_query", { sql: "DELETE FROM user" }, { expectError: true });
+  await callTool("den_query", { sql: "SELECT 1; SELECT 2" }, { expectError: true });
+} catch (error) {
+  failures += 1;
+  console.error("FAIL ", error);
+} finally {
+  child.kill();
+}
+
+console.log(failures === 0 ? "\nSMOKE: all checks passed" : `\nSMOKE: ${failures} failure(s)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -669,6 +669,18 @@ importers:
         specifier: 5.4.5
         version: 5.4.5
 
+  ee/packages/den-admin-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
+      mysql2:
+        specifier: ^3.11.3
+        version: 3.17.4
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+
   ee/packages/den-db:
     dependencies:
       '@openwork-ee/utils':


### PR DESCRIPTION
## What

New `ee/packages/den-admin-mcp`: a stdio MCP server exposing Den admin analytics as tools, so you can ask OpenWork itself things like *"what's our weekly growth rate?"*, *"show 8-week retention"*, or *"who at acme.test is active?"*.

Single-file `index.mjs` modeled on `packages/openwork-ui-mcp` (`@modelcontextprotocol/sdk` + `StdioServerTransport`). Queries MySQL directly via `mysql2` — read-only, only needs `DATABASE_URL`, no running den-api required, never touches encrypted columns.

## Tools

| Tool | Answers |
|---|---|
| `den_overview` | totals, new users 7d/30d, DAU/WAU/MAU, subscriptions by status |
| `den_growth` | signup series (day/week/month) + period-over-period growth % |
| `den_retention` | weekly signup cohorts x weeks-active matrix |
| `den_company_users` | users related to a company (org name/slug/allowed domains + email domain) |
| `den_users_search` | name/email search with orgs + last activity |
| `den_org_overview` | one org: members by role, invites, subscription, 7d/30d activity |
| `den_query` | guarded escape hatch: single SELECT/WITH/SHOW/DESCRIBE/EXPLAIN only, auto `LIMIT` |

Activity definition matches the new den-api `/v1/admin/overview` (#2193): sign-in session days ∪ `session.active` telemetry (member→user join), degrading gracefully when `telemetry_event` is missing.

## Register in OpenWork

```jsonc
{ "mcp": { "den-admin": {
    "type": "local",
    "command": ["node", "/path/to/ee/packages/den-admin-mcp/index.mjs"],
    "environment": { "DATABASE_URL": "mysql://den_readonly:...@host:3306/openwork_den" },
    "enabled": true } } }
```

README includes a `GRANT SELECT`-only MySQL user snippet for prod defense in depth.

## Tests

```
pnpm --filter @openwork-ee/den-admin-mcp check   # node --check on server + smoke
pnpm --filter @openwork-ee/den-admin-mcp test    # live stdio JSON-RPC smoke
```

Smoke boots the real server as a child process and drives it over stdio JSON-RPC against the seeded local MySQL (`dev:den:mysql` + `seed:demo-org`) — **11/11 PASS**:

```
PASS  initialize
PASS  tools/list — den_company_users, den_growth, den_org_overview, den_overview, den_query, den_retention, den_users_search
PASS  tools/call den_overview — users=17 orgs=2 dau=0 wau=14 mau=14
PASS  tools/call den_growth — buckets=1 latestComplete=null
PASS  tools/call den_retention — cohorts=1 first={"cohort":"2026-W24","signups":17,"retention":{"week0":{"users":10,"percent":58.8}}}
PASS  tools/call den_company_users — orgs=1 members=17 domainUsers=17
PASS  tools/call den_users_search — users=1 first=alex@acme.test
PASS  tools/call den_org_overview — org=acme-robotics-demo members7d=14 roles=[{"role":"owner","count":1},{"role":"admin","count":2},{"role":"member","count":14}]
PASS  tools/call den_query — rows=1
PASS  tools/call den_query — Error: Only SELECT/WITH/SHOW/DESCRIBE/EXPLAIN statements are allowed   (DELETE rejected)
PASS  tools/call den_query — Error: Only a single SQL statement is allowed                          (multi-statement rejected)

SMOKE: all checks passed
```

No video attached: this is a headless stdio MCP server with no UI flow — the smoke output above is the end-to-end evidence. Reviewer repro: `pnpm dev:den:mysql && pnpm dev:den:db-push && pnpm dev:den:seed-demo && pnpm --filter @openwork-ee/den-admin-mcp test`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

