### PR TITLE
feat(den): seed starter plugins into the Anthropic marketplace + marketplace logos

### DIFF
--- a/ee/apps/den-api/scripts/seed-demo-org.ts
+++ b/ee/apps/den-api/scripts/seed-demo-org.ts
@@ -494,6 +494,7 @@ async function ensureInvitation(input: {
 async function ensureMarketplace(input: { createdByOrgMembershipId: MemberId; organizationId: OrganizationId }): Promise<MarketplaceId> {
   const name = "Anthropic Knowledge Work Plugins"
   const description = `Demo marketplace seeded from ${GITHUB_REPO}. Plugins are imported into Den DB for local demos; no external integrations are connected.`
+  const logoUrl = "https://cdn.simpleicons.org/anthropic"
   const existing = await db
     .select()
     .from(MarketplaceTable)
@@ -503,7 +504,7 @@ async function ensureMarketplace(input: { createdByOrgMembershipId: MemberId; or
   if (existing[0]) {
     await db
       .update(MarketplaceTable)
-      .set({ createdByOrgMembershipId: input.createdByOrgMembershipId, deletedAt: null, description, status: "active", updatedAt: new Date() })
+      .set({ createdByOrgMembershipId: input.createdByOrgMembershipId, deletedAt: null, description, logoUrl, status: "active", updatedAt: new Date() })
       .where(eq(MarketplaceTable.id, existing[0].id))
     await ensureMarketplaceAccessGrant({ ...input, marketplaceId: existing[0].id, role: "viewer" })
     return existing[0].id
@@ -515,6 +516,7 @@ async function ensureMarketplace(input: { createdByOrgMembershipId: MemberId; or
     deletedAt: null,
     description,
     id,
+    logoUrl,
     name,
     organizationId: input.organizationId,
     status: "active",

--- a/ee/apps/den-api/src/routes/org/plugin-system/default-marketplaces.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/default-marketplaces.ts
@@ -1,0 +1,81 @@
+/**
+ * Static defaults for the marketplaces seeded into every organization.
+ *
+ * The starter plugin catalog mirrors the first-party plugins published in
+ * https://github.com/anthropics/knowledge-work-plugins (.claude-plugin/marketplace.json).
+ * Seeding these entries keeps the starter marketplace useful before an org
+ * connects the repository; when the GitHub connector later imports the repo,
+ * discovery reuses these plugin rows by name and fills in their content.
+ */
+
+export const DEFAULT_OPENWORK_MARKETPLACE_NAME = "OpenWork Marketplace"
+export const DEFAULT_OPENWORK_MARKETPLACE_DESCRIPTION = "Built-in OpenWork AI capabilities available in the desktop app after sign-in."
+export const DEFAULT_OPENWORK_MARKETPLACE_LOGO_URL = "/openwork-mark.svg"
+
+export const DEFAULT_ANTHROPIC_MARKETPLACE_NAME = "Anthropic-Compatible Plugins"
+export const DEFAULT_ANTHROPIC_MARKETPLACE_DESCRIPTION = "Starter marketplace for Claude/Anthropic-compatible plugin repos. Example source: https://github.com/anthropics/knowledge-work-plugins."
+export const DEFAULT_ANTHROPIC_MARKETPLACE_LOGO_URL = "https://cdn.simpleicons.org/anthropic"
+
+export type DefaultMarketplacePluginEntry = {
+  name: string
+  description: string
+}
+
+export const DEFAULT_ANTHROPIC_STARTER_PLUGINS: DefaultMarketplacePluginEntry[] = [
+  {
+    name: "Productivity",
+    description: "Manage tasks, plan your day, and build up memory of important context about your work. Syncs with your calendar, email, and chat to keep everything organized and on track.",
+  },
+  {
+    name: "Enterprise Search",
+    description: "Search across all of your company's tools in one place. Find anything across email, chat, documents, and wikis without switching between apps.",
+  },
+  {
+    name: "Sales",
+    description: "Prospect, craft outreach, and build deal strategy faster. Prep for calls, manage your pipeline, and write personalized messaging that moves deals forward.",
+  },
+  {
+    name: "Customer Support",
+    description: "Triage tickets, draft responses, escalate issues, and build your knowledge base. Research customer context and turn resolved issues into self-service content.",
+  },
+  {
+    name: "Product Management",
+    description: "Write feature specs, plan roadmaps, and synthesize user research faster. Keep stakeholders updated and stay ahead of the competitive landscape.",
+  },
+  {
+    name: "Marketing",
+    description: "Create content, plan campaigns, and analyze performance across marketing channels. Maintain brand voice consistency, track competitors, and report on what's working.",
+  },
+  {
+    name: "Legal",
+    description: "Speed up contract review, NDA triage, and compliance workflows for in-house legal teams. Draft legal briefs, organize precedent research, and manage institutional knowledge.",
+  },
+  {
+    name: "Finance",
+    description: "Streamline finance and accounting workflows, from journal entries and reconciliation to financial statements and variance analysis. Speed up audit prep, month-end close, and keeping your books clean.",
+  },
+  {
+    name: "Data",
+    description: "Write SQL, explore datasets, and generate insights faster. Build visualizations and dashboards, and turn raw data into clear stories for stakeholders.",
+  },
+  {
+    name: "Engineering",
+    description: "Streamline engineering workflows — standups, code review, architecture decisions, incident response, and technical documentation. Works with your existing tools or standalone.",
+  },
+  {
+    name: "Design",
+    description: "Accelerate design workflows — critique, design system management, UX writing, accessibility audits, research synthesis, and dev handoff. From exploration to pixel-perfect specs.",
+  },
+  {
+    name: "Operations",
+    description: "Optimize business operations — vendor management, process documentation, change management, capacity planning, and compliance tracking. Keep your organization running efficiently.",
+  },
+  {
+    name: "Human Resources",
+    description: "Streamline people operations — recruiting, onboarding, performance reviews, compensation analysis, and policy guidance. Maintain compliance and keep your team running smoothly.",
+  },
+  {
+    name: "PDF Viewer",
+    description: "View, annotate, and sign PDFs in a live interactive viewer. Mark up contracts, fill forms with visual feedback, stamp approvals, and place signatures — then download the annotated copy.",
+  },
+]

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -937,7 +937,7 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
         const context = actorContext(c)
         await requirePluginArchCapability(context, "marketplace.create")
         const body = validJson<any>(c)
-        return c.json({ ok: true, item: await createMarketplace({ context, description: body.description, name: body.name }) }, 201)
+        return c.json({ ok: true, item: await createMarketplace({ context, description: body.description, logoUrl: body.logoUrl, name: body.name }) }, 201)
       } catch (error) {
         return routeErrorResponse(c, error)
       }
@@ -984,7 +984,7 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
       try {
         const params = validParam<any>(c)
         const body = validJson<any>(c)
-        return c.json({ ok: true, item: await updateMarketplace({ context: actorContext(c), description: body.description, marketplaceId: params.marketplaceId, name: body.name }) })
+        return c.json({ ok: true, item: await updateMarketplace({ context: actorContext(c), description: body.description, logoUrl: body.logoUrl, marketplaceId: params.marketplaceId, name: body.name }) })
       } catch (error) {
         return routeErrorResponse(c, error)
       }

--- a/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
@@ -225,16 +225,23 @@ export const pluginUpdateSchema = z.object({
   }
 })
 
+export const marketplaceLogoUrlSchema = z.string().trim().min(1).max(1024).refine(
+  (value) => (value.startsWith("/") ? !value.startsWith("//") : /^https:\/\//i.test(value)),
+  { message: "Logo URL must be an https:// URL or a root-relative path." },
+)
+
 export const marketplaceCreateSchema = z.object({
   name: z.string().trim().min(1).max(255),
   description: nullableStringSchema.optional(),
+  logoUrl: marketplaceLogoUrlSchema.nullable().optional(),
 })
 
 export const marketplaceUpdateSchema = z.object({
   name: z.string().trim().min(1).max(255).optional(),
   description: nullableStringSchema.optional(),
+  logoUrl: marketplaceLogoUrlSchema.nullable().optional(),
 }).superRefine((value, ctx) => {
-  if (value.name === undefined && value.description === undefined) {
+  if (value.name === undefined && value.description === undefined && value.logoUrl === undefined) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: "Provide at least one field to update.",
@@ -503,6 +510,7 @@ export const marketplaceSchema = z.object({
   organizationId: denTypeIdSchema("organization"),
   name: z.string().trim().min(1).max(255),
   description: nullableStringSchema,
+  logoUrl: nullableStringSchema,
   status: marketplaceStatusSchema,
   createdByOrgMembershipId: memberIdSchema,
   createdAt: z.string().datetime({ offset: true }),

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -49,6 +49,16 @@ import {
   type GithubDiscoveryTreeEntry,
 } from "./github-discovery.js"
 import { planConnectorImportedResourceCleanup, uniqueIds } from "./connector-cleanup.js"
+import {
+  DEFAULT_ANTHROPIC_MARKETPLACE_DESCRIPTION,
+  DEFAULT_ANTHROPIC_MARKETPLACE_LOGO_URL,
+  DEFAULT_ANTHROPIC_MARKETPLACE_NAME,
+  DEFAULT_ANTHROPIC_STARTER_PLUGINS,
+  DEFAULT_OPENWORK_MARKETPLACE_DESCRIPTION,
+  DEFAULT_OPENWORK_MARKETPLACE_LOGO_URL,
+  DEFAULT_OPENWORK_MARKETPLACE_NAME,
+  type DefaultMarketplacePluginEntry,
+} from "./default-marketplaces.js"
 import { db } from "../../../db.js"
 import { env } from "../../../env.js"
 import { roleIncludesOwner } from "../../../orgs.js"
@@ -342,11 +352,6 @@ type PluginMarketplaceSummary = {
   name: string
 }
 
-const DEFAULT_OPENWORK_MARKETPLACE_NAME = "OpenWork Marketplace"
-const DEFAULT_OPENWORK_MARKETPLACE_DESCRIPTION = "Built-in OpenWork AI capabilities available in the desktop app after sign-in."
-const DEFAULT_ANTHROPIC_MARKETPLACE_NAME = "Anthropic-Compatible Plugins"
-const DEFAULT_ANTHROPIC_MARKETPLACE_DESCRIPTION = "Starter marketplace for Claude/Anthropic-compatible plugin repos. Example source: https://github.com/anthropics/knowledge-work-plugins."
-
 const DEFAULT_OPENWORK_EXTENSION_MANIFESTS = [
   {
     schemaVersion: 1,
@@ -557,6 +562,7 @@ function serializeMarketplace(row: MarketplaceRow, pluginCount?: number) {
     deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
     description: row.description,
     id: row.id,
+    logoUrl: row.logoUrl,
     name: row.name,
     organizationId: row.organizationId,
     pluginCount,
@@ -1658,58 +1664,80 @@ export async function listMarketplaces(input: { context: PluginArchActorContext;
 }
 
 async function ensureDefaultOpenWorkMarketplace(context: PluginArchActorContext) {
-  const organizationId = context.organizationContext.organization.id
-  const createdByOrgMembershipId = context.organizationContext.currentMember.id
   const now = new Date()
-  await ensureDefaultMarketplace({
+  const anthropicMarketplace = await ensureDefaultMarketplace({
     context,
     createdAt: now,
     description: DEFAULT_ANTHROPIC_MARKETPLACE_DESCRIPTION,
+    logoUrl: DEFAULT_ANTHROPIC_MARKETPLACE_LOGO_URL,
     name: DEFAULT_ANTHROPIC_MARKETPLACE_NAME,
+  })
+  await ensureDefaultMarketplacePlugins({
+    context,
+    createdAt: now,
+    entries: DEFAULT_ANTHROPIC_STARTER_PLUGINS,
+    marketplaceId: anthropicMarketplace.id,
   })
 
   const marketplace = await ensureDefaultMarketplace({
     context,
     createdAt: now,
     description: DEFAULT_OPENWORK_MARKETPLACE_DESCRIPTION,
+    logoUrl: DEFAULT_OPENWORK_MARKETPLACE_LOGO_URL,
     name: DEFAULT_OPENWORK_MARKETPLACE_NAME,
   })
+  await ensureDefaultMarketplacePlugins({
+    context,
+    createdAt: now,
+    entries: DEFAULT_OPENWORK_EXTENSION_MANIFESTS.map((manifest) => ({ description: manifest.description, name: manifest.name })),
+    marketplaceId: marketplace.id,
+  })
+}
 
-  for (const manifest of DEFAULT_OPENWORK_EXTENSION_MANIFESTS) {
+async function ensureDefaultMarketplacePlugins(input: {
+  context: PluginArchActorContext
+  createdAt: Date
+  entries: DefaultMarketplacePluginEntry[]
+  marketplaceId: MarketplaceId
+}) {
+  const organizationId = input.context.organizationContext.organization.id
+  const createdByOrgMembershipId = input.context.organizationContext.currentMember.id
+
+  for (const entry of input.entries) {
     let plugin = (await db
       .select()
       .from(PluginTable)
       .where(and(
         eq(PluginTable.organizationId, organizationId),
-        eq(PluginTable.name, manifest.name),
-        eq(PluginTable.description, manifest.description),
+        eq(PluginTable.name, entry.name),
+        eq(PluginTable.description, entry.description),
         isNull(PluginTable.deletedAt),
       ))
       .limit(1))[0]
 
     if (!plugin) {
       const pluginRow = {
-        createdAt: now,
+        createdAt: input.createdAt,
         createdByOrgMembershipId,
         deletedAt: null,
-        description: manifest.description,
+        description: entry.description,
         id: createDenTypeId("plugin"),
-        name: manifest.name,
+        name: entry.name,
         organizationId,
         status: "active" as const,
-        updatedAt: now,
+        updatedAt: input.createdAt,
       }
       await db.insert(PluginTable).values(pluginRow)
       plugin = pluginRow
     }
 
-    await ensureOrgWidePluginAccess({ context, pluginId: plugin.id, role: "viewer" })
+    await ensureOrgWidePluginAccess({ context: input.context, pluginId: plugin.id, role: "viewer" })
 
     const existingMembership = (await db
       .select()
       .from(MarketplacePluginTable)
       .where(and(
-        eq(MarketplacePluginTable.marketplaceId, marketplace.id),
+        eq(MarketplacePluginTable.marketplaceId, input.marketplaceId),
         eq(MarketplacePluginTable.pluginId, plugin.id),
       ))
       .limit(1))[0]
@@ -1722,10 +1750,10 @@ async function ensureDefaultOpenWorkMarketplace(context: PluginArchActorContext)
     }
 
     await db.insert(MarketplacePluginTable).values({
-      createdAt: now,
+      createdAt: input.createdAt,
       createdByOrgMembershipId,
       id: createDenTypeId("marketplacePlugin"),
-      marketplaceId: marketplace.id,
+      marketplaceId: input.marketplaceId,
       membershipSource: "system",
       organizationId,
       pluginId: plugin.id,
@@ -1738,6 +1766,7 @@ async function ensureDefaultMarketplace(input: {
   context: PluginArchActorContext
   createdAt: Date
   description: string
+  logoUrl: string
   name: string
 }) {
   const organizationId = input.context.organizationContext.organization.id
@@ -1760,6 +1789,7 @@ async function ensureDefaultMarketplace(input: {
       deletedAt: null,
       description: input.description,
       id: createDenTypeId("marketplace"),
+      logoUrl: input.logoUrl,
       name: input.name,
       organizationId,
       status: "active" as const,
@@ -1767,6 +1797,9 @@ async function ensureDefaultMarketplace(input: {
     }
     await db.insert(MarketplaceTable).values(marketplaceRow)
     marketplace = marketplaceRow
+  } else if (!marketplace.logoUrl) {
+    await db.update(MarketplaceTable).set({ logoUrl: input.logoUrl }).where(eq(MarketplaceTable.id, marketplace.id))
+    marketplace = { ...marketplace, logoUrl: input.logoUrl }
   }
 
   await ensureOrgWideMarketplaceAccess({ context: input.context, marketplaceId: marketplace.id, role: "viewer" })
@@ -1848,7 +1881,7 @@ export async function getMarketplaceDetail(context: PluginArchActorContext, mark
   return serializeMarketplace(row, memberships.length)
 }
 
-export async function createMarketplace(input: { context: PluginArchActorContext; description?: string | null; name: string }) {
+export async function createMarketplace(input: { context: PluginArchActorContext; description?: string | null; logoUrl?: string | null; name: string }) {
   const now = new Date()
   const row = {
     createdAt: now,
@@ -1856,6 +1889,7 @@ export async function createMarketplace(input: { context: PluginArchActorContext
     deletedAt: null,
     description: normalizeOptionalString(input.description ?? undefined),
     id: createDenTypeId("marketplace"),
+    logoUrl: normalizeOptionalString(input.logoUrl ?? undefined),
     name: input.name.trim(),
     organizationId: input.context.organizationContext.organization.id,
     status: "active" as const,
@@ -1880,11 +1914,12 @@ export async function createMarketplace(input: { context: PluginArchActorContext
   return serializeMarketplace(row, 0)
 }
 
-export async function updateMarketplace(input: { context: PluginArchActorContext; description?: string | null; marketplaceId: MarketplaceId; name?: string }) {
+export async function updateMarketplace(input: { context: PluginArchActorContext; description?: string | null; logoUrl?: string | null; marketplaceId: MarketplaceId; name?: string }) {
   const row = await ensureEditableMarketplace(input.context, input.marketplaceId)
   const updatedAt = new Date()
   await db.update(MarketplaceTable).set({
     description: input.description === undefined ? row.description : normalizeOptionalString(input.description ?? undefined),
+    logoUrl: input.logoUrl === undefined ? row.logoUrl : normalizeOptionalString(input.logoUrl ?? undefined),
     name: input.name?.trim() || row.name,
     updatedAt,
   }).where(eq(MarketplaceTable.id, row.id))

--- a/ee/apps/den-api/test/plugin-system-marketplace-defaults.test.ts
+++ b/ee/apps/den-api/test/plugin-system-marketplace-defaults.test.ts
@@ -1,0 +1,55 @@
+import { beforeAll, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let defaults: typeof import("../src/routes/org/plugin-system/default-marketplaces.js")
+let schemas: typeof import("../src/routes/org/plugin-system/schemas.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  defaults = await import("../src/routes/org/plugin-system/default-marketplaces.js")
+  schemas = await import("../src/routes/org/plugin-system/schemas.js")
+})
+
+test("anthropic starter marketplace seeds a non-empty plugin catalog", () => {
+  expect(defaults.DEFAULT_ANTHROPIC_STARTER_PLUGINS.length).toBeGreaterThan(0)
+
+  const names = defaults.DEFAULT_ANTHROPIC_STARTER_PLUGINS.map((entry) => entry.name)
+  expect(new Set(names).size).toBe(names.length)
+
+  for (const entry of defaults.DEFAULT_ANTHROPIC_STARTER_PLUGINS) {
+    expect(entry.name.trim().length).toBeGreaterThan(0)
+    expect(entry.name.length).toBeLessThanOrEqual(255)
+    expect(entry.description.trim().length).toBeGreaterThan(0)
+  }
+})
+
+test("default marketplace logos pass logo url validation", () => {
+  expect(schemas.marketplaceLogoUrlSchema.safeParse(defaults.DEFAULT_OPENWORK_MARKETPLACE_LOGO_URL).success).toBe(true)
+  expect(schemas.marketplaceLogoUrlSchema.safeParse(defaults.DEFAULT_ANTHROPIC_MARKETPLACE_LOGO_URL).success).toBe(true)
+})
+
+test("marketplace logo url accepts https and root-relative paths only", () => {
+  expect(schemas.marketplaceLogoUrlSchema.safeParse("https://cdn.simpleicons.org/anthropic").success).toBe(true)
+  expect(schemas.marketplaceLogoUrlSchema.safeParse("/openwork-mark.svg").success).toBe(true)
+
+  expect(schemas.marketplaceLogoUrlSchema.safeParse("javascript:alert(1)").success).toBe(false)
+  expect(schemas.marketplaceLogoUrlSchema.safeParse("http://insecure.example/logo.png").success).toBe(false)
+  expect(schemas.marketplaceLogoUrlSchema.safeParse("//protocol-relative.example/logo.png").success).toBe(false)
+  expect(schemas.marketplaceLogoUrlSchema.safeParse("data:image/svg+xml;base64,AAAA").success).toBe(false)
+  expect(schemas.marketplaceLogoUrlSchema.safeParse("").success).toBe(false)
+})
+
+test("marketplace create and update schemas accept logoUrl", () => {
+  expect(schemas.marketplaceCreateSchema.safeParse({ name: "Team Tools", logoUrl: "https://example.com/logo.svg" }).success).toBe(true)
+  expect(schemas.marketplaceCreateSchema.safeParse({ name: "Team Tools", logoUrl: null }).success).toBe(true)
+
+  expect(schemas.marketplaceUpdateSchema.safeParse({ logoUrl: "https://example.com/logo.svg" }).success).toBe(true)
+  expect(schemas.marketplaceUpdateSchema.safeParse({ logoUrl: null }).success).toBe(true)
+  expect(schemas.marketplaceUpdateSchema.safeParse({}).success).toBe(false)
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-data.tsx
@@ -7,6 +7,7 @@ export type DenMarketplace = {
   id: string;
   name: string;
   description: string | null;
+  logoUrl: string | null;
   pluginCount: number;
   createdAt: string;
   updatedAt: string;
@@ -46,6 +47,7 @@ export type MarketplacePluginSummary = {
   description: string | null;
   memberCount: number;
   componentCounts: Record<string, number>;
+  sourceFormat: string | null;
 };
 
 export type MarketplaceResolved = {
@@ -73,6 +75,7 @@ function parseMarketplace(entry: unknown): DenMarketplace | null {
     id,
     name,
     description: asString(entry.description),
+    logoUrl: asString(entry.logoUrl),
     pluginCount: typeof entry.pluginCount === "number" ? entry.pluginCount : 0,
     createdAt,
     updatedAt,
@@ -119,6 +122,7 @@ export function useMarketplace(marketplaceId: string | null) {
               description: asString(entry.description),
               memberCount: typeof entry.memberCount === "number" ? entry.memberCount : 0,
               componentCounts,
+              sourceFormat: isRecord(entry.extension) ? asString(entry.extension.sourceFormat) : null,
             } satisfies MarketplacePluginSummary];
           })
         : [];

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useRef, useState, useEffect } from "react";
-import { ArrowLeft, Check, GitBranch, Github, Globe, Loader2, Plus, Puzzle, Store, Users, X } from "lucide-react";
+import { ArrowLeft, Check, GitBranch, Github, Globe, Loader2, Plus, Puzzle, Users, X } from "lucide-react";
 import { PaperMeshGradient } from "@openwork/ui/react";
 import {
   getGithubIntegrationSetupRoute,
@@ -18,6 +18,7 @@ import {
   useMarketplaceAccess,
   useRevokeMarketplaceAccess,
 } from "./marketplace-data";
+import { MarketplaceLogo } from "./marketplace-logo";
 
 const COMPONENT_TYPE_LABELS: Record<string, { singular: string; plural: string }> = {
   skill: { singular: "skill", plural: "skills" },
@@ -85,7 +86,12 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
             </div>
             <div className="relative flex h-full items-center justify-center">
               <div className="flex h-14 w-14 items-center justify-center rounded-[16px] border border-white/60 bg-white shadow-[0_10px_24px_-10px_rgba(15,23,42,0.3)]">
-                <Store className="h-6 w-6 text-gray-700" aria-hidden />
+                <MarketplaceLogo
+                  logoUrl={marketplace.logoUrl}
+                  name={marketplace.name}
+                  imgClassName="h-9 w-9"
+                  iconClassName="h-6 w-6"
+                />
               </div>
             </div>
           </div>
@@ -556,9 +562,15 @@ function MarketplacePluginCard({
                 </span>
               ))}
             </div>
-          ) : (
+          ) : plugin.memberCount > 0 ? (
             <p className="mt-2 text-[11.5px] text-gray-400">
               {plugin.memberCount} imported object{plugin.memberCount === 1 ? "" : "s"}
+            </p>
+          ) : (
+            <p className="mt-2 text-[11.5px] text-gray-400">
+              {plugin.sourceFormat === "openwork-builtin"
+                ? "Built into the OpenWork desktop app"
+                : "Content imports when the source repository is connected"}
             </p>
           )}
         </div>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-logo.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-logo.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+import { Store } from "lucide-react";
+
+/** Marketplace logo with a graceful fallback to the generic store icon. */
+export function MarketplaceLogo({
+  logoUrl,
+  name,
+  imgClassName,
+  iconClassName,
+}: {
+  logoUrl: string | null;
+  name: string;
+  imgClassName: string;
+  iconClassName: string;
+}) {
+  const [erroredUrl, setErroredUrl] = useState<string | null>(null);
+
+  if (!logoUrl || erroredUrl === logoUrl) {
+    return <Store className={`${iconClassName} text-gray-700`} aria-hidden />;
+  }
+
+  return (
+    <img
+      src={logoUrl}
+      alt={`${name} logo`}
+      onError={() => setErroredUrl(logoUrl)}
+      className={`${imgClassName} object-contain`}
+    />
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplaces-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplaces-screen.tsx
@@ -11,6 +11,7 @@ import { getIntegrationsRoute, getMarketplaceRoute } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { useHasAnyIntegration } from "./integration-data";
 import { formatMarketplaceTimestamp, useMarketplaces } from "./marketplace-data";
+import { MarketplaceLogo } from "./marketplace-logo";
 
 export function MarketplacesScreen() {
   const { orgSlug } = useOrgDashboard();
@@ -85,7 +86,12 @@ export function MarketplacesScreen() {
                   </div>
                   <div className="relative flex h-full items-center justify-center">
                     <div className="flex h-10 w-10 items-center justify-center rounded-[12px] border border-white/60 bg-white shadow-[0_8px_20px_-8px_rgba(15,23,42,0.3)]">
-                      <Store className="h-4 w-4 text-gray-700" aria-hidden />
+                      <MarketplaceLogo
+                        logoUrl={marketplace.logoUrl}
+                        name={marketplace.name}
+                        imgClassName="h-6 w-6"
+                        iconClassName="h-4 w-4"
+                      />
                     </div>
                   </div>
                 </div>

--- a/ee/packages/den-db/drizzle/0022_marketplace_logo_url.sql
+++ b/ee/packages/den-db/drizzle/0022_marketplace_logo_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `marketplace` ADD `logo_url` varchar(1024);

--- a/ee/packages/den-db/drizzle/meta/0022_snapshot.json
+++ b/ee/packages/den-db/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,7306 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "f5e1fab5-f335-4e73-b0a3-cb4f22eaef3f",
+  "prevId": "d306e107-0d3e-4ff6-a2bc-6c0415265f6d",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "account_user_id": {
+          "name": "account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "account_id": {
+          "name": "account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id": {
+          "name": "apikey_config_id",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_reference_id": {
+          "name": "apikey_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key": {
+          "name": "apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "apikey_id": {
+          "name": "apikey_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "jwks": {
+      "name": "jwks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alg": {
+          "name": "alg",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crv": {
+          "name": "crv",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jwks_id": {
+          "name": "jwks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "session_token": {
+          "name": "session_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_id": {
+          "name": "session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_id": {
+          "name": "session_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "user_email": {
+          "name": "user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_id": {
+          "name": "user_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "verification_identifier": {
+          "name": "verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_id": {
+          "name": "verification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_identity": {
+      "name": "external_identity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_provider_id": {
+          "name": "scim_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_json": {
+          "name": "name_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emails_json": {
+          "name": "emails_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes_json": {
+          "name": "attributes_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_scim_sync_at": {
+          "name": "last_scim_sync_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sso_login_at": {
+          "name": "last_sso_login_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "external_identity_org_user": {
+          "name": "external_identity_org_user",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_sso_remote": {
+          "name": "external_identity_org_sso_remote",
+          "columns": [
+            "organization_id",
+            "sso_provider_id",
+            "remote_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_scim_external": {
+          "name": "external_identity_org_scim_external",
+          "columns": [
+            "organization_id",
+            "scim_provider_id",
+            "external_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_email": {
+          "name": "external_identity_org_email",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        },
+        "external_identity_sso_provider": {
+          "name": "external_identity_sso_provider",
+          "columns": [
+            "sso_provider_id"
+          ],
+          "isUnique": false
+        },
+        "external_identity_scim_provider": {
+          "name": "external_identity_scim_provider",
+          "columns": [
+            "scim_provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id": {
+          "name": "oauth_access_token_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_session_id": {
+          "name": "oauth_access_token_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_user_id": {
+          "name": "oauth_access_token_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_reference_id": {
+          "name": "oauth_access_token_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_refresh_id": {
+          "name": "oauth_access_token_refresh_id",
+          "columns": [
+            "refresh_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthAccessToken_id": {
+          "name": "oauthAccessToken_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthClient": {
+      "name": "oauthClient",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id": {
+          "name": "oauth_client_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauth_client_user_id": {
+          "name": "oauth_client_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_client_reference_id": {
+          "name": "oauth_client_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthClient_id": {
+          "name": "oauthClient_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthConsent": {
+      "name": "oauthConsent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id": {
+          "name": "oauth_consent_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_consent_user_id": {
+          "name": "oauth_consent_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_consent_reference_id": {
+          "name": "oauth_consent_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthConsent_id": {
+          "name": "oauthConsent_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthRefreshToken": {
+      "name": "oauthRefreshToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_client_id": {
+          "name": "oauth_refresh_token_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_session_id": {
+          "name": "oauth_refresh_token_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_user_id": {
+          "name": "oauth_refresh_token_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_reference_id": {
+          "name": "oauth_refresh_token_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthRefreshToken_id": {
+          "name": "oauthRefreshToken_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_provider": {
+      "name": "scim_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_token": {
+          "name": "scim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "scim_provider_provider_id": {
+          "name": "scim_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "scim_provider_organization_id": {
+          "name": "scim_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_provider_id": {
+          "name": "scim_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sso_connection": {
+      "name": "sso_connection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'enabled'"
+        },
+        "sign_in_path": {
+          "name": "sign_in_path",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "sso_connection_organization_id": {
+          "name": "sso_connection_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "sso_connection_provider_id": {
+          "name": "sso_connection_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "sso_connection_domain": {
+          "name": "sso_connection_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sso_connection_id": {
+          "name": "sso_connection_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sso_provider": {
+      "name": "sso_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "sso_provider_provider_id": {
+          "name": "sso_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "sso_provider_domain": {
+          "name": "sso_provider_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "sso_provider_organization_id": {
+          "name": "sso_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "sso_provider_user_id": {
+          "name": "sso_provider_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_policy_member": {
+      "name": "desktop_policy_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "desktop_policy_id": {
+          "name": "desktop_policy_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_member_id": {
+          "name": "org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_policy_member_organization_id": {
+          "name": "desktop_policy_member_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_policy_id": {
+          "name": "desktop_policy_member_policy_id",
+          "columns": [
+            "desktop_policy_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_org_member_id": {
+          "name": "desktop_policy_member_org_member_id",
+          "columns": [
+            "org_member_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_team_id": {
+          "name": "desktop_policy_member_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_policy_org_member": {
+          "name": "desktop_policy_member_policy_org_member",
+          "columns": [
+            "desktop_policy_id",
+            "org_member_id"
+          ],
+          "isUnique": true
+        },
+        "desktop_policy_member_policy_team": {
+          "name": "desktop_policy_member_policy_team",
+          "columns": [
+            "desktop_policy_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_policy_member_id": {
+          "name": "desktop_policy_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_policy": {
+      "name": "desktop_policy",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_name": {
+          "name": "policy_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "policy": {
+          "name": "policy",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_object())"
+        },
+        "created_by_org_member_id": {
+          "name": "created_by_org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "desktop_policy_organization_id": {
+          "name": "desktop_policy_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_created_by_member_id": {
+          "name": "desktop_policy_created_by_member_id",
+          "columns": [
+            "created_by_org_member_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_is_enabled": {
+          "name": "desktop_policy_is_enabled",
+          "columns": [
+            "is_enabled"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_deleted_at": {
+          "name": "desktop_policy_deleted_at",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_org_default": {
+          "name": "desktop_policy_org_default",
+          "columns": [
+            "organization_id",
+            "is_default"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_policy_id": {
+          "name": "desktop_policy_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_keys": {
+      "name": "inference_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','revoked')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_keys_key_hash": {
+          "name": "inference_keys_key_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "inference_keys_organization_id": {
+          "name": "inference_keys_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_keys_org_membership_id": {
+          "name": "inference_keys_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "inference_keys_status": {
+          "name": "inference_keys_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_keys_id": {
+          "name": "inference_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_limit_policies": {
+      "name": "inference_org_limit_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "enum('five_hour','weekly','monthly')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset_strategy": {
+          "name": "reset_strategy",
+          "type": "enum('anchored','activity_based')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchor_at": {
+          "name": "anchor_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_bucket_id": {
+          "name": "current_bucket_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_limit_policies_organization_id": {
+          "name": "inference_org_limit_policies_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_org_limit_policies_org_window_type": {
+          "name": "inference_org_limit_policies_org_window_type",
+          "columns": [
+            "organization_id",
+            "window_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_limit_policies_id": {
+          "name": "inference_org_limit_policies_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_upstream_provider_keys": {
+      "name": "inference_org_upstream_provider_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openrouter'"
+        },
+        "external_key_hash": {
+          "name": "external_key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_workspace_id": {
+          "name": "external_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','revoked')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_upstream_provider_keys_organization_id": {
+          "name": "inference_org_upstream_provider_keys_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_org_upstream_provider_keys_external_key_hash": {
+          "name": "inference_org_upstream_provider_keys_external_key_hash",
+          "columns": [
+            "external_key_hash"
+          ],
+          "isUnique": false
+        },
+        "inference_org_upstream_provider_keys_org_provider": {
+          "name": "inference_org_upstream_provider_keys_org_provider",
+          "columns": [
+            "organization_id",
+            "provider"
+          ],
+          "isUnique": true
+        },
+        "inference_org_upstream_provider_keys_status": {
+          "name": "inference_org_upstream_provider_keys_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_upstream_provider_keys_id": {
+          "name": "inference_org_upstream_provider_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_usage_buckets": {
+      "name": "inference_org_usage_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_amount": {
+          "name": "limit_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_amount": {
+          "name": "used_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_usage_buckets_org_window": {
+          "name": "inference_org_usage_buckets_org_window",
+          "columns": [
+            "organization_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        },
+        "inference_org_usage_buckets_policy_id": {
+          "name": "inference_org_usage_buckets_policy_id",
+          "columns": [
+            "policy_id"
+          ],
+          "isUnique": false
+        },
+        "inference_org_usage_buckets_policy_window": {
+          "name": "inference_org_usage_buckets_policy_window",
+          "columns": [
+            "policy_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_usage_buckets_id": {
+          "name": "inference_org_usage_buckets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_usage_ledger_bucket_charges": {
+      "name": "inference_usage_ledger_bucket_charges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ledger_entry_id": {
+          "name": "ledger_entry_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket_id": {
+          "name": "bucket_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "inference_usage_ledger_bucket_charges_bucket_id": {
+          "name": "inference_usage_ledger_bucket_charges_bucket_id",
+          "columns": [
+            "bucket_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_bucket_charges_entry_bucket": {
+          "name": "inference_usage_ledger_bucket_charges_entry_bucket",
+          "columns": [
+            "ledger_entry_id",
+            "bucket_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_usage_ledger_bucket_charges_id": {
+          "name": "inference_usage_ledger_bucket_charges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_usage_ledger_entries": {
+      "name": "inference_usage_ledger_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inference_key_id": {
+          "name": "inference_key_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_job_id": {
+          "name": "external_job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "inference_usage_ledger_entries_organization_id": {
+          "name": "inference_usage_ledger_entries_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_org_membership_id": {
+          "name": "inference_usage_ledger_entries_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_inference_key_id": {
+          "name": "inference_usage_ledger_entries_inference_key_id",
+          "columns": [
+            "inference_key_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_external_event_id": {
+          "name": "inference_usage_ledger_entries_external_event_id",
+          "columns": [
+            "external_event_id"
+          ],
+          "isUnique": true
+        },
+        "inference_usage_ledger_entries_job_event_type": {
+          "name": "inference_usage_ledger_entries_job_event_type",
+          "columns": [
+            "external_job_id",
+            "event_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_usage_ledger_entries_id": {
+          "name": "inference_usage_ledger_entries_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_handoff_grant": {
+      "name": "desktop_handoff_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_handoff_grant_user_id": {
+          "name": "desktop_handoff_grant_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_handoff_grant_expires_at": {
+          "name": "desktop_handoff_grant_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_handoff_grant_id": {
+          "name": "desktop_handoff_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_member_id": {
+          "name": "org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id": {
+          "name": "invitation_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email": {
+          "name": "invitation_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "invitation_status": {
+          "name": "invitation_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "invitation_team_id": {
+          "name": "invitation_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_org_member_id": {
+          "name": "invitation_org_member_id",
+          "columns": [
+            "org_member_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_invite_token": {
+          "name": "invitation_invite_token",
+          "columns": [
+            "invite_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "invitation_id": {
+          "name": "invitation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invited_by_org_member": {
+          "name": "invited_by_org_member",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by_org_member": {
+          "name": "removed_by_org_member",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "member_organization_id": {
+          "name": "member_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_user_id": {
+          "name": "member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "member_invite_id": {
+          "name": "member_invite_id",
+          "columns": [
+            "invite_id"
+          ],
+          "isUnique": false
+        },
+        "member_invited_by_org_member": {
+          "name": "member_invited_by_org_member",
+          "columns": [
+            "invited_by_org_member"
+          ],
+          "isUnique": false
+        },
+        "member_removed_at": {
+          "name": "member_removed_at",
+          "columns": [
+            "removed_at"
+          ],
+          "isUnique": false
+        },
+        "member_removed_by_org_member": {
+          "name": "member_removed_by_org_member",
+          "columns": [
+            "removed_by_org_member"
+          ],
+          "isUnique": false
+        },
+        "member_organization_user": {
+          "name": "member_organization_user",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "member_id": {
+          "name": "member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_role": {
+      "name": "organization_role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_role_organization_id": {
+          "name": "organization_role_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_role_name": {
+          "name": "organization_role_name",
+          "columns": [
+            "organization_id",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_role_id": {
+          "name": "organization_role_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_app_restrictions": {
+          "name": "desktop_app_restrictions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_object())"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_slug": {
+          "name": "organization_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_id": {
+          "name": "organization_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_access": {
+      "name": "llm_provider_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "llm_provider_access_llm_provider_id": {
+          "name": "llm_provider_access_llm_provider_id",
+          "columns": [
+            "llm_provider_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_org_membership_id": {
+          "name": "llm_provider_access_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_team_id": {
+          "name": "llm_provider_access_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_provider_org_membership": {
+          "name": "llm_provider_access_provider_org_membership",
+          "columns": [
+            "llm_provider_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "llm_provider_access_provider_team": {
+          "name": "llm_provider_access_provider_team",
+          "columns": [
+            "llm_provider_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_access_id": {
+          "name": "llm_provider_access_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_model": {
+      "name": "llm_provider_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_config": {
+          "name": "model_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "llm_provider_model_llm_provider_id": {
+          "name": "llm_provider_model_llm_provider_id",
+          "columns": [
+            "llm_provider_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_model_model_id": {
+          "name": "llm_provider_model_model_id",
+          "columns": [
+            "model_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_model_provider_model": {
+          "name": "llm_provider_model_provider_model",
+          "columns": [
+            "llm_provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_model_id": {
+          "name": "llm_provider_model_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider": {
+      "name": "llm_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "enum('models_dev','custom','openwork')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "llm_provider_organization_id": {
+          "name": "llm_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_created_by_org_membership_id": {
+          "name": "llm_provider_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_source": {
+          "name": "llm_provider_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_provider_id": {
+          "name": "llm_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object_access_grant": {
+      "name": "config_object_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_object_access_grant_organization_id": {
+          "name": "config_object_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_config_object_id": {
+          "name": "config_object_access_grant_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_org_membership_id": {
+          "name": "config_object_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_team_id": {
+          "name": "config_object_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_org_wide": {
+          "name": "config_object_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_object_org_membership": {
+          "name": "config_object_access_grant_object_org_membership",
+          "columns": [
+            "config_object_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "config_object_access_grant_object_team": {
+          "name": "config_object_access_grant_object_team",
+          "columns": [
+            "config_object_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_access_grant_id": {
+          "name": "config_object_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object": {
+      "name": "config_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "enum('skill','agent','command','tool','mcp','hook','context','custom')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_mode": {
+          "name": "source_mode",
+          "type": "enum('cloud','import','connector')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_file_name": {
+          "name": "current_file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_file_extension": {
+          "name": "current_file_extension",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_relative_path": {
+          "name": "current_relative_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived','ingestion_error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_object_organization_id": {
+          "name": "config_object_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_type": {
+          "name": "config_object_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "config_object_source_mode": {
+          "name": "config_object_source_mode",
+          "columns": [
+            "source_mode"
+          ],
+          "isUnique": false
+        },
+        "config_object_status": {
+          "name": "config_object_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "config_object_created_by_org_membership_id": {
+          "name": "config_object_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_connector_instance_id": {
+          "name": "config_object_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_current_relative_path": {
+          "name": "config_object_current_relative_path",
+          "columns": [
+            "current_relative_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_id": {
+          "name": "config_object_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object_version": {
+      "name": "config_object_version",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_payload_json": {
+          "name": "normalized_payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_source_text": {
+          "name": "raw_source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "enum('cloud','import','connector','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connector_sync_event_id": {
+          "name": "connector_sync_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_revision_ref": {
+          "name": "source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_deleted_version": {
+          "name": "is_deleted_version",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "config_object_version_organization_id": {
+          "name": "config_object_version_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_config_object_id": {
+          "name": "config_object_version_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_created_by_org_membership_id": {
+          "name": "config_object_version_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_connector_sync_event_id": {
+          "name": "config_object_version_connector_sync_event_id",
+          "columns": [
+            "connector_sync_event_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_source_revision_ref": {
+          "name": "config_object_version_source_revision_ref",
+          "columns": [
+            "source_revision_ref"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_lookup_latest": {
+          "name": "config_object_version_lookup_latest",
+          "columns": [
+            "config_object_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_version_id": {
+          "name": "config_object_version_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_account": {
+      "name": "connector_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_ref": {
+          "name": "external_account_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','disconnected','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_account_organization_id": {
+          "name": "connector_account_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_account_created_by_org_membership_id": {
+          "name": "connector_account_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_account_connector_type": {
+          "name": "connector_account_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_account_status": {
+          "name": "connector_account_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_account_org_type_remote_id": {
+          "name": "connector_account_org_type_remote_id",
+          "columns": [
+            "organization_id",
+            "connector_type",
+            "remote_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_instance_access_grant": {
+      "name": "connector_instance_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instance_access_grant_organization_id": {
+          "name": "connector_instance_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_instance_id": {
+          "name": "connector_instance_access_grant_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_org_membership_id": {
+          "name": "connector_instance_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_team_id": {
+          "name": "connector_instance_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_org_wide": {
+          "name": "connector_instance_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_instance_org_membership": {
+          "name": "connector_instance_access_grant_instance_org_membership",
+          "columns": [
+            "connector_instance_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "connector_instance_access_grant_instance_team": {
+          "name": "connector_instance_access_grant_instance_team",
+          "columns": [
+            "connector_instance_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_instance_access_grant_id": {
+          "name": "connector_instance_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_instance": {
+      "name": "connector_instance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','disabled','archived','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "instance_config_json": {
+          "name": "instance_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "enum('pending','queued','running','completed','failed','partial','ignored')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_cursor": {
+          "name": "last_sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_instance_organization_id": {
+          "name": "connector_instance_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_connector_account_id": {
+          "name": "connector_instance_connector_account_id",
+          "columns": [
+            "connector_account_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_created_by_org_membership_id": {
+          "name": "connector_instance_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_connector_type": {
+          "name": "connector_instance_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_status": {
+          "name": "connector_instance_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_org_name": {
+          "name": "connector_instance_org_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_mapping": {
+      "name": "connector_mapping",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mapping_kind": {
+          "name": "mapping_kind",
+          "type": "enum('path','api','custom')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "enum('skill','agent','command','tool','mcp','hook','context','custom')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_add_to_plugin": {
+          "name": "auto_add_to_plugin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "mapping_config_json": {
+          "name": "mapping_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_mapping_organization_id": {
+          "name": "connector_mapping_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_connector_instance_id": {
+          "name": "connector_mapping_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_connector_target_id": {
+          "name": "connector_mapping_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_object_type": {
+          "name": "connector_mapping_object_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_plugin_id": {
+          "name": "connector_mapping_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_target_selector_object_type": {
+          "name": "connector_mapping_target_selector_object_type",
+          "columns": [
+            "connector_target_id",
+            "selector",
+            "object_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_source_binding": {
+      "name": "connector_source_binding",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_locator": {
+          "name": "external_locator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_stable_ref": {
+          "name": "external_stable_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_source_revision_ref": {
+          "name": "last_seen_source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived','ingestion_error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_source_binding_organization_id": {
+          "name": "connector_source_binding_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_config_object_id": {
+          "name": "connector_source_binding_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_instance_id": {
+          "name": "connector_source_binding_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_target_id": {
+          "name": "connector_source_binding_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_mapping_id": {
+          "name": "connector_source_binding_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_external_locator": {
+          "name": "connector_source_binding_external_locator",
+          "columns": [
+            "external_locator"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_config_object": {
+          "name": "connector_source_binding_config_object",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_source_binding_id": {
+          "name": "connector_source_binding_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_source_tombstone": {
+      "name": "connector_source_tombstone",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_locator": {
+          "name": "external_locator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "former_config_object_id": {
+          "name": "former_config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_in_sync_event_id": {
+          "name": "deleted_in_sync_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_source_revision_ref": {
+          "name": "deleted_source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "connector_source_tombstone_organization_id": {
+          "name": "connector_source_tombstone_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_instance_id": {
+          "name": "connector_source_tombstone_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_target_id": {
+          "name": "connector_source_tombstone_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_mapping_id": {
+          "name": "connector_source_tombstone_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_external_locator": {
+          "name": "connector_source_tombstone_external_locator",
+          "columns": [
+            "external_locator"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_former_config_object_id": {
+          "name": "connector_source_tombstone_former_config_object_id",
+          "columns": [
+            "former_config_object_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_source_tombstone_id": {
+          "name": "connector_source_tombstone_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_sync_event": {
+      "name": "connector_sync_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum('push','installation','installation_repositories','repository','manual_resync')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_ref": {
+          "name": "external_event_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_revision_ref": {
+          "name": "source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','queued','running','completed','failed','partial','ignored')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_sync_event_organization_id": {
+          "name": "connector_sync_event_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_connector_instance_id": {
+          "name": "connector_sync_event_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_connector_target_id": {
+          "name": "connector_sync_event_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_event_type": {
+          "name": "connector_sync_event_event_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_status": {
+          "name": "connector_sync_event_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_source_revision_ref": {
+          "name": "connector_sync_event_source_revision_ref",
+          "columns": [
+            "source_revision_ref"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_external_event_ref": {
+          "name": "connector_sync_event_external_event_ref",
+          "columns": [
+            "external_event_ref"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_sync_event_id": {
+          "name": "connector_sync_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_target": {
+      "name": "connector_target",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "enum('repository_branch')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_target_ref": {
+          "name": "external_target_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_config_json": {
+          "name": "target_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_target_organization_id": {
+          "name": "connector_target_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_target_connector_instance_id": {
+          "name": "connector_target_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_target_connector_type": {
+          "name": "connector_target_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_target_target_kind": {
+          "name": "connector_target_target_kind",
+          "columns": [
+            "target_kind"
+          ],
+          "isUnique": false
+        },
+        "connector_target_instance_remote_id": {
+          "name": "connector_target_instance_remote_id",
+          "columns": [
+            "connector_instance_id",
+            "remote_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace_access_grant": {
+      "name": "marketplace_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_access_grant_organization_id": {
+          "name": "marketplace_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_marketplace_id": {
+          "name": "marketplace_access_grant_marketplace_id",
+          "columns": [
+            "marketplace_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_org_membership_id": {
+          "name": "marketplace_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_team_id": {
+          "name": "marketplace_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_org_wide": {
+          "name": "marketplace_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_marketplace_org_membership": {
+          "name": "marketplace_access_grant_marketplace_org_membership",
+          "columns": [
+            "marketplace_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "marketplace_access_grant_marketplace_team": {
+          "name": "marketplace_access_grant_marketplace_team",
+          "columns": [
+            "marketplace_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_access_grant_id": {
+          "name": "marketplace_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace_plugin": {
+      "name": "marketplace_plugin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_source": {
+          "name": "membership_source",
+          "type": "enum('manual','connector','api','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_plugin_organization_id": {
+          "name": "marketplace_plugin_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_marketplace_id": {
+          "name": "marketplace_plugin_marketplace_id",
+          "columns": [
+            "marketplace_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_plugin_id": {
+          "name": "marketplace_plugin_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_marketplace_plugin": {
+          "name": "marketplace_plugin_marketplace_plugin",
+          "columns": [
+            "marketplace_id",
+            "plugin_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_plugin_id": {
+          "name": "marketplace_plugin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace": {
+      "name": "marketplace",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_organization_id": {
+          "name": "marketplace_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_created_by_org_membership_id": {
+          "name": "marketplace_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_status": {
+          "name": "marketplace_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "marketplace_name": {
+          "name": "marketplace_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_access_grant": {
+      "name": "plugin_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_access_grant_organization_id": {
+          "name": "plugin_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_plugin_id": {
+          "name": "plugin_access_grant_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_org_membership_id": {
+          "name": "plugin_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_team_id": {
+          "name": "plugin_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_org_wide": {
+          "name": "plugin_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_plugin_org_membership": {
+          "name": "plugin_access_grant_plugin_org_membership",
+          "columns": [
+            "plugin_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "plugin_access_grant_plugin_team": {
+          "name": "plugin_access_grant_plugin_team",
+          "columns": [
+            "plugin_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_access_grant_id": {
+          "name": "plugin_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_config_object": {
+      "name": "plugin_config_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_source": {
+          "name": "membership_source",
+          "type": "enum('manual','connector','api','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_config_object_organization_id": {
+          "name": "plugin_config_object_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_plugin_id": {
+          "name": "plugin_config_object_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_config_object_id": {
+          "name": "plugin_config_object_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_connector_mapping_id": {
+          "name": "plugin_config_object_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_plugin_config_object": {
+          "name": "plugin_config_object_plugin_config_object",
+          "columns": [
+            "plugin_id",
+            "config_object_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_config_object_id": {
+          "name": "plugin_config_object_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin": {
+      "name": "plugin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_organization_id": {
+          "name": "plugin_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_created_by_org_membership_id": {
+          "name": "plugin_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_status": {
+          "name": "plugin_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "plugin_name": {
+          "name": "plugin_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill_hub_member": {
+      "name": "skill_hub_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_hub_id": {
+          "name": "skill_hub_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "skill_hub_member_skill_hub_id": {
+          "name": "skill_hub_member_skill_hub_id",
+          "columns": [
+            "skill_hub_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_member_org_membership_id": {
+          "name": "skill_hub_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_member_team_id": {
+          "name": "skill_hub_member_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_member_hub_org_membership": {
+          "name": "skill_hub_member_hub_org_membership",
+          "columns": [
+            "skill_hub_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "skill_hub_member_hub_team": {
+          "name": "skill_hub_member_hub_team",
+          "columns": [
+            "skill_hub_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_hub_member_id": {
+          "name": "skill_hub_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill_hub_skill": {
+      "name": "skill_hub_skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_hub_id": {
+          "name": "skill_hub_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "skill_hub_skill_skill_hub_id": {
+          "name": "skill_hub_skill_skill_hub_id",
+          "columns": [
+            "skill_hub_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_skill_skill_id": {
+          "name": "skill_hub_skill_skill_id",
+          "columns": [
+            "skill_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_skill_hub_skill": {
+          "name": "skill_hub_skill_hub_skill",
+          "columns": [
+            "skill_hub_id",
+            "skill_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_hub_skill_id": {
+          "name": "skill_hub_skill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill_hub": {
+      "name": "skill_hub",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "skill_hub_organization_id": {
+          "name": "skill_hub_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_created_by_org_membership_id": {
+          "name": "skill_hub_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_hub_id": {
+          "name": "skill_hub_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill": {
+      "name": "skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skill_text": {
+          "name": "skill_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared": {
+          "name": "shared",
+          "type": "enum('org','public')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "skill_organization_id": {
+          "name": "skill_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "skill_created_by_org_membership_id": {
+          "name": "skill_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "skill_shared": {
+          "name": "skill_shared",
+          "columns": [
+            "shared"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_id": {
+          "name": "skill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "org_subscriptions": {
+      "name": "org_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('inference','seat')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('incomplete','incomplete_expired','trialing','active','past_due','canceled','unpaid','paused','expired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'incomplete'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_organization_id": {
+          "name": "org_subscriptions_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "org_subscriptions_customer_id": {
+          "name": "org_subscriptions_customer_id",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": false
+        },
+        "org_subscriptions_subscription_id": {
+          "name": "org_subscriptions_subscription_id",
+          "columns": [
+            "stripe_subscription_id"
+          ],
+          "isUnique": true
+        },
+        "org_subscriptions_org_type": {
+          "name": "org_subscriptions_org_type",
+          "columns": [
+            "organization_id",
+            "type"
+          ],
+          "isUnique": true
+        },
+        "org_subscriptions_status": {
+          "name": "org_subscriptions_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_subscriptions_id": {
+          "name": "org_subscriptions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_member": {
+      "name": "team_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "team_member_team_id": {
+          "name": "team_member_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_org_membership_id": {
+          "name": "team_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_team_org_membership": {
+          "name": "team_member_team_org_membership",
+          "columns": [
+            "team_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_member_id": {
+          "name": "team_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team": {
+      "name": "team",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "team_organization_id": {
+          "name": "team_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "team_organization_name": {
+          "name": "team_organization_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_id": {
+          "name": "team_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_event": {
+      "name": "audit_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "audit_event_org_id": {
+          "name": "audit_event_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "audit_event_worker_id": {
+          "name": "audit_event_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "daytona_sandbox": {
+      "name": "daytona_sandbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_volume_id": {
+          "name": "workspace_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_volume_id": {
+          "name": "data_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url": {
+          "name": "signed_preview_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url_expires_at": {
+          "name": "signed_preview_url_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "daytona_sandbox_worker_id": {
+          "name": "daytona_sandbox_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": true
+        },
+        "daytona_sandbox_sandbox_id": {
+          "name": "daytona_sandbox_sandbox_id",
+          "columns": [
+            "sandbox_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daytona_sandbox_id": {
+          "name": "daytona_sandbox_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_bundle": {
+      "name": "worker_bundle",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "worker_bundle_worker_id": {
+          "name": "worker_bundle_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_bundle_id": {
+          "name": "worker_bundle_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_instance": {
+      "name": "worker_instance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_instance_worker_id": {
+          "name": "worker_instance_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_instance_id": {
+          "name": "worker_instance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker": {
+      "name": "worker",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination": {
+          "name": "destination",
+          "type": "enum('local','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_version": {
+          "name": "image_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandbox_backend": {
+          "name": "sandbox_backend",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_org_id": {
+          "name": "worker_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "worker_created_by_user_id": {
+          "name": "worker_created_by_user_id",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "worker_status": {
+          "name": "worker_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "worker_last_heartbeat_at": {
+          "name": "worker_last_heartbeat_at",
+          "columns": [
+            "last_heartbeat_at"
+          ],
+          "isUnique": false
+        },
+        "worker_last_active_at": {
+          "name": "worker_last_active_at",
+          "columns": [
+            "last_active_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_id": {
+          "name": "worker_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_token": {
+      "name": "worker_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "enum('client','host','activity')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "worker_token_worker_id": {
+          "name": "worker_token_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        },
+        "worker_token_token": {
+          "name": "worker_token_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_token_id": {
+          "name": "worker_token_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "admin_allowlist": {
+      "name": "admin_allowlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "admin_allowlist_email": {
+          "name": "admin_allowlist_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "admin_allowlist_id": {
+          "name": "admin_allowlist_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "rate_limit": {
+      "name": "rate_limit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limit_key": {
+          "name": "rate_limit_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_id": {
+          "name": "rate_limit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "telemetry_event": {
+      "name": "telemetry_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_timestamp": {
+          "name": "event_timestamp",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "telemetry_event_org_id_type_ts": {
+          "name": "telemetry_event_org_id_type_ts",
+          "columns": [
+            "org_id",
+            "event_type",
+            "event_timestamp"
+          ],
+          "isUnique": false
+        },
+        "telemetry_event_org_id_member_id": {
+          "name": "telemetry_event_org_id_member_id",
+          "columns": [
+            "org_id",
+            "member_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telemetry_event_id": {
+          "name": "telemetry_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1781286597056,
       "tag": "0021_telemetry_event",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "5",
+      "when": 1781288457546,
+      "tag": "0022_marketplace_logo_url",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/src/schema/sharables/plugin-arch.ts
+++ b/ee/packages/den-db/src/schema/sharables/plugin-arch.ts
@@ -122,6 +122,7 @@ export const MarketplaceTable = mysqlTable(
     organizationId: denTypeIdColumn("organization", "organization_id").notNull(),
     name: varchar("name", { length: 255 }).notNull(),
     description: text("description"),
+    logoUrl: varchar("logo_url", { length: 1024 }),
     status: mysqlEnum("status", marketplaceStatusValues).notNull().default("active"),
     createdByOrgMembershipId: denTypeIdColumn("member", "created_by_org_membership_id").notNull(),
     createdAt: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),


### PR DESCRIPTION
## Why

The default **Anthropic-Compatible Plugins** marketplace was seeded as an empty shell, so every org saw "0 plugins" forever: the GitHub discovery flow routes imports into a marketplace named after the repo's own `marketplace.json`, never the seeded starter. Marketplaces also had no branding — every card showed the same generic store icon.

## What

**Default marketplace is no longer empty**
- New `default-marketplaces.ts` embeds the 14 first-party plugins from [anthropics/knowledge-work-plugins](https://github.com/anthropics/knowledge-work-plugins) (names + descriptions mirror the upstream `.claude-plugin/marketplace.json`)
- Seeding attaches them to the starter marketplace with `membershipSource: "system"` (refactored the existing builtin-attach loop into a shared `ensureDefaultMarketplacePlugins` helper)
- Forward-compatible: `ensureDiscoveryPlugin` matches by name, so a later real GitHub import reuses these plugin rows and fills in content — no duplicates

**Marketplace logo support**
- Nullable `marketplace.logo_url` column + drizzle migration `0022_marketplace_logo_url.sql`
- `logoUrl` on marketplace create/update/serialize; validated to `https://` URLs or root-relative paths only (rejects `javascript:`, `data:`, `http://`, protocol-relative)
- Seeded defaults: Anthropic mark (simpleicons CDN) for the starter marketplace, `/openwork-mark.svg` for OpenWork Marketplace; existing rows with null logo are backfilled
- den-web renders logos on the marketplaces list + detail header via a new `MarketplaceLogo` component with graceful fallback to the store icon
- Plugin cards explain empty content instead of "0 imported objects": "Built into the OpenWork desktop app" (builtins) vs "Content imports when the source repository is connected" (starters)
- Demo seed script also sets the Anthropic logo

## Tests & validation

Commands run:
- `bun test` in `ee/apps/den-api` — **58 pass, 0 fail** (includes 4 new tests in `plugin-system-marketplace-defaults.test.ts`: catalog integrity, logo URL validation, create/update schema acceptance)
- `tsc --noEmit` clean for `@openwork-ee/den-api` and `@openwork-ee/den-web`; `den-db` builds
- Migration verified against a fresh MySQL DB (`db:push` + generated `ALTER TABLE`)

End-to-end on a local stack (fresh DB, `dev:den:api` + `dev:den:web`, real email signup + org creation, driven via headless Chrome CDP):
- Marketplaces list shows **Anthropic-Compatible Plugins · 14 plugins** with the Anthropic logo and **OpenWork Marketplace · 5 plugins** with the OpenWork mark
- Detail page renders the logo header and all 14 starter plugin cards
- `PATCH /v1/marketplaces/:id {"logoUrl": "https://example.com/custom.svg"}` → 200 and persists; `{"logoUrl": "javascript:alert(1)"}` → 400
- Seeding is idempotent across repeated `GET /v1/marketplaces` calls (counts stay 14/5, no duplicates)

Screenshots were captured during validation (marketplaces list, Anthropic detail top + plugin grid, OpenWork detail with builtin copy); reproduce with:
`pnpm dev:den:mysql && pnpm dev:den:db-push && pnpm dev:den:api & pnpm dev:den:web` then sign up and open Dashboard → Marketplaces.

## Notes

- Desktop app untouched; starter plugins appear in the desktop Marketplace tab and "Add" is a graceful no-op (0 files) until the org connects the source repo — follow-up could point that CTA at Integrations
- Follow-up candidate: default `logoUrl` to `https://github.com/{owner}.png` for discovery-created marketplaces

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

