### PR TITLE
refactor(app): session-route decomposition — 6 hook extractions, -551 lines

### DIFF
--- a/apps/app/src/react-app/domains/cloud/use-openwork-models-startup-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/use-openwork-models-startup-promo.ts
@@ -1,0 +1,82 @@
+// "OpenWork Models" startup promo: one-shot dialog latch shown shortly after
+// a workspace is ready when the user has no OpenWork Models provider yet.
+// Extracted verbatim from session-route.tsx.
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
+import { usePlatform } from "@/react-app/kernel/platform";
+import { useShellConfig } from "@/react-app/shell/shell-config";
+import { workspaceSettingsRoute } from "@/react-app/shell/workspace-routes";
+import {
+  getOpenWorkModelsActionUrl,
+  hasOpenWorkModelsProvider,
+  hideOpenWorkModelsPromo,
+  isOpenWorkModelsPromoHidden,
+  markOpenWorkModelsStartupPromoShown,
+  openWorkModelsPromoChangedEvent,
+  wasOpenWorkModelsStartupPromoShown,
+} from "./openwork-models-promo";
+
+export type UseOpenWorkModelsStartupPromoInput = {
+  /** True once the workspace's opencode client exists. */
+  clientReady: boolean;
+  workspaceId: string;
+  providerConnectedIds: string[];
+};
+
+export function useOpenWorkModelsStartupPromo(input: UseOpenWorkModelsStartupPromoInput) {
+  const { clientReady, workspaceId, providerConnectedIds } = input;
+  const navigate = useNavigate();
+  const platform = usePlatform();
+  const denAuth = useDenAuth();
+  const { config: shellConfig } = useShellConfig();
+
+  const [open, setOpen] = useState(false);
+  const [promoHidden, setPromoHidden] = useState(isOpenWorkModelsPromoHidden);
+  const scheduledRef = useRef(false);
+
+  useEffect(() => {
+    const handlePromoChanged = () => setPromoHidden(isOpenWorkModelsPromoHidden());
+    window.addEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+    return () => window.removeEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+  }, []);
+
+  const hasOpenWorkModels = useMemo(
+    () => hasOpenWorkModelsProvider(providerConnectedIds),
+    [providerConnectedIds],
+  );
+
+  useEffect(() => {
+    if (!shellConfig.cloudSignin || promoHidden || hasOpenWorkModels) return;
+    if (denAuth.status === "checking" || !clientReady || !workspaceId) return;
+    if (wasOpenWorkModelsStartupPromoShown() || scheduledRef.current) return;
+
+    scheduledRef.current = true;
+    const timeout = window.setTimeout(() => {
+      markOpenWorkModelsStartupPromoShown();
+      setOpen(true);
+    }, 900);
+    return () => window.clearTimeout(timeout);
+  }, [clientReady, denAuth.status, hasOpenWorkModels, promoHidden, shellConfig.cloudSignin, workspaceId]);
+
+  const subscribe = useCallback(() => {
+    setOpen(false);
+    markOpenWorkModelsStartupPromoShown();
+    if (!denAuth.isSignedIn) {
+      navigate(workspaceId ? workspaceSettingsRoute(workspaceId, "cloud-account") : "/settings/cloud-account");
+    }
+    window.setTimeout(() => {
+      platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn));
+    }, 0);
+  }, [denAuth.isSignedIn, navigate, platform, workspaceId]);
+
+  const continueWithout = useCallback(() => {
+    setOpen(false);
+    markOpenWorkModelsStartupPromoShown();
+    hideOpenWorkModelsPromo();
+    setPromoHidden(true);
+  }, []);
+
+  return { open, subscribe, continueWithout };
+}

--- a/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
+++ b/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
@@ -1,0 +1,164 @@
+// Model picker modal state: lazy option loading (with "Recently added"
+// provider flagging), open-event/localStorage triggers from the new-providers
+// toast, and org-restriction filtering. Extracted verbatim from
+// session-route.tsx; settings-route carries a sibling copy that should adopt
+// this hook next.
+import { useEffect, useMemo, useState } from "react";
+
+import { isDesktopProviderBlocked } from "@/app/cloud/desktop-app-restrictions";
+import type { Client, ModelOption } from "@/app/types";
+import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
+import {
+  ensureProviderListQuery,
+  getConnectedProviderItems,
+} from "@/react-app/infra/provider-list-query";
+import { getReactQueryClient } from "@/react-app/infra/query-client";
+import {
+  openModelPickerEvent,
+  pendingModelPickerProviderIdsKey,
+} from "@/react-app/shell/new-providers-toast";
+
+export type UseModelPickerInput = {
+  client: Client | null;
+  baseUrl: string;
+  workspaceRoot: string;
+};
+
+export function useModelPicker(input: UseModelPickerInput) {
+  const { client, baseUrl, workspaceRoot } = input;
+  const checkDesktopRestriction = useCheckDesktopRestriction();
+
+  const [open, setOpen] = useState(false);
+  const [compactOpen, setCompactOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
+  // Provider IDs that were just added — used to highlight them as
+  // "Recently added" in the model picker even after they've been
+  // marked as seen in localStorage.
+  const [recentProviderIds, setRecentProviderIds] = useState<Set<string>>(new Set());
+
+  // Open model picker when the global toast's "Pick a new default?" is clicked
+  useEffect(() => {
+    const handler = (event: Event) => {
+      try {
+        window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
+      } catch {}
+      const detail = (event as CustomEvent<{ newProviderIds?: string[]; initialTab?: "default" | "available" }>).detail;
+      const ids = detail?.newProviderIds;
+      if (ids && ids.length > 0) {
+        setRecentProviderIds(new Set(ids));
+      }
+      setOpen(true);
+    };
+    window.addEventListener(openModelPickerEvent, handler);
+    return () => window.removeEventListener(openModelPickerEvent, handler);
+  }, []);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(pendingModelPickerProviderIdsKey);
+      if (!raw) return;
+      window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
+      const parsed = JSON.parse(raw);
+      const ids = Array.isArray(parsed) ? parsed : parsed?.newProviderIds;
+      if (Array.isArray(ids) && ids.every((id) => typeof id === "string")) {
+        setRecentProviderIds(new Set(ids));
+      }
+      setOpen(true);
+    } catch {
+      // Ignore malformed pending-picker state.
+    }
+  }, []);
+
+  // Load the picker list lazily the first time the modal opens. Uses the
+  // cached catalog when available, otherwise re-fetches.
+  useEffect(() => {
+    if (!open || !client) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await ensureProviderListQuery(getReactQueryClient(), {
+          client,
+          baseUrl,
+          directory: workspaceRoot || undefined,
+        });
+        if (cancelled || !data?.all) return;
+        // Flag models from recently-added providers so they appear in
+        // the "Recently added" section at the top of the picker.
+        // Two sources: (1) providers not yet in the localStorage seen-set,
+        // (2) providers passed via the openModelPickerEvent from the toast.
+        let seenIds: Set<string>;
+        try {
+          const raw = window.localStorage.getItem("openwork.seenProviderIds");
+          seenIds = new Set(raw ? JSON.parse(raw) : []);
+        } catch {
+          seenIds = new Set();
+        }
+        const options: ModelOption[] = [];
+        for (const provider of getConnectedProviderItems(data)) {
+          const modelIds = Object.keys(provider.models);
+          const isNew = !seenIds.has(provider.id) || recentProviderIds.has(provider.id);
+          for (const id of modelIds) {
+            const model = provider.models[id];
+            options.push({
+              providerID: provider.id,
+              modelID: id,
+              title: model.name || id,
+              description: provider.name,
+              behaviorTitle: "Reasoning",
+              behaviorLabel: "Default",
+              behaviorDescription: "",
+              behaviorValue: null,
+              isFree: false,
+              isConnected: true,
+              isRecommended: isNew,
+              source: /^lpr_/i.test(provider.id) ? "cloud" as const : undefined,
+            });
+          }
+        }
+        setModelOptions(options);
+      } catch {
+        // Silent: the picker surfaces an empty list rather than blocking the UI.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, baseUrl, client, recentProviderIds, workspaceRoot]);
+
+  // Apply org-level restrictions (dev #1505) on top of the raw model list
+  // so the picker never surfaces blocked options:
+  //   - `allowZenModel` hides the built-in OpenCode provider entries when false
+  //   - `allowCustomProviders` hides providers that OpenCode does not report
+  //     as connected through the provider list endpoint.
+  const options = useMemo(() => {
+    const restrictToCloud = checkDesktopRestriction({
+      restriction: "allowCustomProviders",
+    });
+    return modelOptions.filter((option) => {
+      if (
+        isDesktopProviderBlocked({
+          providerId: option.providerID,
+          checkRestriction: checkDesktopRestriction,
+        })
+      ) {
+        return false;
+      }
+      if (restrictToCloud && !option.isConnected) {
+        return false;
+      }
+      return true;
+    });
+  }, [checkDesktopRestriction, modelOptions]);
+
+  return {
+    open,
+    setOpen,
+    compactOpen,
+    setCompactOpen,
+    query,
+    setQuery,
+    options,
+    setRecentProviderIds,
+  };
+}

--- a/apps/app/src/react-app/domains/session/surface/use-model-behavior.ts
+++ b/apps/app/src/react-app/domains/session/surface/use-model-behavior.ts
@@ -1,0 +1,69 @@
+// Provider catalog cache + behavior (reasoning/thinking variant) options for
+// the active default model — what the composer renders as its variant pill.
+// Extracted verbatim from session-route.tsx; the catalog is also consumed by
+// the model picker's lazy option loader until that moves into its own hook.
+import { useEffect, useMemo, useState } from "react";
+
+import { getModelBehaviorSummary } from "@/app/lib/model-behavior";
+import type { ModelRef, ProviderListItem } from "@/app/types";
+import { t } from "@/i18n";
+
+type ProviderModel = ProviderListItem["models"][string];
+
+export type ProviderCatalog = Record<string, Record<string, ProviderModel>>;
+
+const emptyModelBehaviorOptions: { value: string | null; label: string }[] = [];
+
+export type UseModelBehaviorInput = {
+  /** Result of useProviderListQuery().data — refreshed by the route. */
+  providerList: { all: ProviderListItem[] } | undefined;
+  defaultModel: ModelRef | null;
+  modelVariant: string | null;
+};
+
+export function useModelBehavior(input: UseModelBehaviorInput) {
+  const { providerList, defaultModel, modelVariant } = input;
+  const [providerCatalog, setProviderCatalog] = useState<ProviderCatalog>({});
+
+  // Prefetch the full provider catalog once so `getModelBehaviorSummary` has
+  // everything it needs to expose the reasoning/thinking variants the active
+  // model supports — without waiting for the model picker to open. Cached
+  // as providerID → modelID → ProviderModel.
+  useEffect(() => {
+    if (!providerList?.all) return;
+    const next: ProviderCatalog = {};
+    for (const provider of providerList.all) {
+      next[provider.id] = { ...(provider.models ?? {}) };
+    }
+    setProviderCatalog(next);
+  }, [providerList]);
+
+  // Compute behavior (reasoning/thinking variant) options for the current
+  // default model.
+  const { modelVariantLabel, modelBehaviorOptions, modelVariantValue } = useMemo(() => {
+    const variant = modelVariant ?? null;
+    if (!defaultModel) {
+      return {
+        modelVariantLabel: t("settings.default_label"),
+        modelBehaviorOptions: emptyModelBehaviorOptions,
+        modelVariantValue: null,
+      };
+    }
+    const model = providerCatalog[defaultModel.providerID]?.[defaultModel.modelID];
+    if (!model) {
+      return {
+        modelVariantLabel: variant ?? t("settings.default_label"),
+        modelBehaviorOptions: emptyModelBehaviorOptions,
+        modelVariantValue: variant,
+      };
+    }
+    const summary = getModelBehaviorSummary(defaultModel.providerID, model, variant);
+    return {
+      modelVariantLabel: summary.label,
+      modelBehaviorOptions: summary.options,
+      modelVariantValue: summary.value,
+    };
+  }, [defaultModel, modelVariant, providerCatalog]);
+
+  return { providerCatalog, modelVariantLabel, modelBehaviorOptions, modelVariantValue };
+}

--- a/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
+++ b/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
@@ -1,0 +1,176 @@
+// Pending permissions, questions, and todos for the selected session:
+// query-cache subscriptions, snapshot seeding, and reply handlers.
+// Extracted verbatim from session-route.tsx (cluster had no readers of its
+// internals besides the JSX).
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { unwrap } from "@/app/lib/opencode";
+import type { Client, PendingPermission, PendingQuestion, TodoItem } from "@/app/types";
+import { t } from "@/i18n";
+import { getReactQueryClient } from "@/react-app/infra/query-client";
+import { useQueryCacheState } from "@/react-app/infra/query-cache-state";
+import { describeRouteError } from "@/react-app/shell/route-workspaces";
+import {
+  permissionKey,
+  questionKey,
+  seedPermissionState,
+  seedQuestionState,
+  todoKey,
+} from "./session-sync";
+
+const emptyPendingPermissions: PendingPermission[] = [];
+const emptyPendingQuestions: PendingQuestion[] = [];
+const emptyTodos: TodoItem[] = [];
+
+export type UseSessionInteractionsInput = {
+  client: Client | null;
+  workspaceId: string;
+  sessionId: string | null;
+  workspaceRoot: string;
+};
+
+export function useSessionInteractions(input: UseSessionInteractionsInput) {
+  const { client, workspaceId, sessionId, workspaceRoot } = input;
+
+  const [permissionReplyBusy, setPermissionReplyBusy] = useState(false);
+  const permissionReplyBusyRef = useRef(false);
+  const [questionReplyBusy, setQuestionReplyBusy] = useState(false);
+  const questionReplyBusyRef = useRef(false);
+
+  const permissionQueryKey = useMemo(
+    () => (workspaceId && sessionId ? permissionKey(workspaceId, sessionId) : null),
+    [sessionId, workspaceId],
+  );
+  const pendingPermissions = useQueryCacheState<PendingPermission[]>(
+    permissionQueryKey,
+    emptyPendingPermissions,
+  );
+  const questionQueryKey = useMemo(
+    () => (workspaceId && sessionId ? questionKey(workspaceId, sessionId) : null),
+    [sessionId, workspaceId],
+  );
+  const pendingQuestions = useQueryCacheState<PendingQuestion[]>(
+    questionQueryKey,
+    emptyPendingQuestions,
+  );
+  const todoQueryKey = useMemo(
+    () => (workspaceId && sessionId ? todoKey(workspaceId, sessionId) : null),
+    [sessionId, workspaceId],
+  );
+  const todos = useQueryCacheState<TodoItem[]>(todoQueryKey, emptyTodos);
+
+  useEffect(() => {
+    if (!client || !workspaceId || !sessionId) return;
+    let cancelled = false;
+    const directory = workspaceRoot || undefined;
+    void (async () => {
+      const snapshotStartedAt = Date.now();
+      try {
+        const list = unwrap(await client.permission.list({ directory }));
+        if (!cancelled) {
+          seedPermissionState(workspaceId, sessionId, list, { snapshotStartedAt });
+        }
+      } catch {
+        // Keep event-synced permission state if the snapshot read fails.
+        // Hiding a pending approval can block the running task.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, sessionId, workspaceId, workspaceRoot]);
+
+  useEffect(() => {
+    if (!client || !workspaceId || !sessionId) return;
+    let cancelled = false;
+    const directory = workspaceRoot || undefined;
+    void (async () => {
+      const snapshotStartedAt = Date.now();
+      try {
+        const list = unwrap(await client.question.list({ directory }));
+        if (!cancelled) {
+          seedQuestionState(workspaceId, sessionId, list, { snapshotStartedAt });
+        }
+      } catch {
+        // Keep event-synced question state if the snapshot read fails.
+        // Hiding a pending question can block the running task.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, sessionId, workspaceId, workspaceRoot]);
+
+  const activePermission = pendingPermissions[0] ?? null;
+  const respondPermission = useCallback(
+    async (requestID: string, reply: "once" | "always" | "reject") => {
+      if (!client || !workspaceId || !sessionId) return;
+      if (permissionReplyBusyRef.current) return;
+      permissionReplyBusyRef.current = true;
+      setPermissionReplyBusy(true);
+      try {
+        unwrap(
+          await client.permission.reply({
+            requestID,
+            reply,
+            directory: workspaceRoot || undefined,
+          }),
+        );
+        getReactQueryClient().setQueryData<PendingPermission[]>(
+          permissionKey(workspaceId, sessionId),
+          (current = []) => current.filter((permission) => permission.id !== requestID),
+        );
+      } catch (error) {
+        toast.error(t("app.error_request_failed"), {
+          description: describeRouteError(error),
+        });
+      } finally {
+        permissionReplyBusyRef.current = false;
+        setPermissionReplyBusy(false);
+      }
+    },
+    [client, sessionId, workspaceId, workspaceRoot],
+  );
+
+  const activeQuestion = pendingQuestions[0] ?? null;
+  const respondQuestion = useCallback(
+    async (requestID: string, answers: string[][]) => {
+      if (!client || !workspaceId || !sessionId) return;
+      if (questionReplyBusyRef.current) return;
+      questionReplyBusyRef.current = true;
+      setQuestionReplyBusy(true);
+      try {
+        unwrap(
+          await client.question.reply({
+            requestID,
+            answers,
+            directory: workspaceRoot || undefined,
+          }),
+        );
+        getReactQueryClient().setQueryData<PendingQuestion[]>(
+          questionKey(workspaceId, sessionId),
+          (current = []) => current.filter((question) => question.id !== requestID),
+        );
+      } catch (error) {
+        toast.error(t("app.error_request_failed"), {
+          description: describeRouteError(error),
+        });
+      } finally {
+        questionReplyBusyRef.current = false;
+        setQuestionReplyBusy(false);
+      }
+    },
+    [client, sessionId, workspaceId, workspaceRoot],
+  );
+
+  return {
+    activePermission,
+    permissionReplyBusy,
+    respondPermission,
+    activeQuestion,
+    questionReplyBusy,
+    respondQuestion,
+    todos,
+  };
+}

--- a/apps/app/src/react-app/infra/query-cache-state.ts
+++ b/apps/app/src/react-app/infra/query-cache-state.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from "react";
+
+import { getReactQueryClient } from "./query-client";
+
+/**
+ * Subscribe to a TanStack Query cache entry as plain external state.
+ * Pass a null key to pin the fallback (used while route params are missing).
+ */
+export function useQueryCacheState<T>(queryKey: readonly unknown[] | null, fallback: T): T {
+  const queryClient = getReactQueryClient();
+  return useSyncExternalStore(
+    (callback) => (queryKey ? queryClient.getQueryCache().subscribe(callback) : () => {}),
+    () => (queryKey ? queryClient.getQueryData<T>(queryKey) ?? fallback : fallback),
+    () => fallback,
+  );
+}

--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -1,0 +1,196 @@
+// Shared pure helpers for the workspace-scoped routes (session-route,
+// settings-route). These were duplicated in both route files and had drifted:
+// settings-route was missing the remote-workspace clobber fix in
+// mergeRouteWorkspaces and used older session-status logic. One copy now.
+
+import type { OpenworkWorkspaceInfo } from "@/app/lib/openwork-server";
+import type { WorkspaceInfo } from "@/app/lib/desktop-types";
+import type { WorkspaceSessionGroup } from "@/app/types";
+import {
+  normalizeDirectoryPath,
+  normalizeSessionStatus,
+  safeStringify,
+} from "@/app/utils";
+import { t } from "@/i18n";
+
+export type RouteWorkspace = OpenworkWorkspaceInfo & {
+  displayNameResolved: string;
+};
+
+export function mapDesktopWorkspace(workspace: WorkspaceInfo): RouteWorkspace {
+  return {
+    ...workspace,
+    displayNameResolved:
+      workspace.displayName?.trim() ||
+      workspace.name?.trim() ||
+      workspace.path?.trim() ||
+      t("session.workspace_fallback"),
+  };
+}
+
+export function workspaceLabel(workspace: OpenworkWorkspaceInfo) {
+  return (
+    workspace.displayName?.trim() ||
+    workspace.openworkWorkspaceName?.trim() ||
+    workspace.name?.trim() ||
+    workspace.path?.trim() ||
+    t("session.workspace_fallback")
+  );
+}
+
+export function workspaceExportFilename(workspace: OpenworkWorkspaceInfo) {
+  const slug = workspaceLabel(workspace).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return `${slug || "workspace"}-openwork-export.json`;
+}
+
+export function downloadWorkspaceJson(filename: string, payload: unknown) {
+  if (typeof document === "undefined") return;
+  const blob = new Blob([`${JSON.stringify(payload, null, 2)}\n`], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function folderNameFromPath(path: string) {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  const parts = normalized.split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? "workspace";
+}
+
+export function describeRouteError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  const serialized = safeStringify(error);
+  return serialized && serialized !== "{}" ? serialized : t("app.unknown_error");
+}
+
+export function describeWorkspaceCreateError(error: unknown) {
+  const message = describeRouteError(error);
+  const lower = message.toLowerCase();
+  if (
+    lower.includes("operation timed out") ||
+    lower.includes("os error 60") ||
+    lower.includes("etimedout")
+  ) {
+    return `${message}\n\nOpenWork could not read the workspace config before the filesystem timed out. This often happens when the folder is still syncing from iCloud Drive or another remote folder. Wait for the folder to finish downloading, move the workspace to a local folder, or try again.`;
+  }
+  return message;
+}
+
+export function mergeRouteWorkspaces(
+  serverWorkspaces: OpenworkWorkspaceInfo[],
+  desktopWorkspaces: RouteWorkspace[],
+): RouteWorkspace[] {
+  const desktopById = new Map(desktopWorkspaces.map((workspace) => [workspace.id, workspace]));
+  const desktopByPath = new Map(
+    desktopWorkspaces.flatMap((workspace) => {
+      const path = normalizeDirectoryPath(workspace.path ?? "");
+      return path ? [[path, workspace] as const] : [];
+    }),
+  );
+
+  // If a server workspace's id matches a desktop workspace marked as remote,
+  // skip the server's view entirely. The local OpenWork server may have stale
+  // registrations from earlier (buggy) activate calls that show up here as
+  // `workspaceType: "local"`, which would otherwise clobber the desktop's
+  // remote routing fields and send workspace-scoped requests back to the
+  // local server.
+  const remoteDesktopIds = new Set(
+    desktopWorkspaces.flatMap((workspace) => workspace.workspaceType === "remote" ? [workspace.id] : []),
+  );
+  const filteredServer = serverWorkspaces.filter((workspace) => !remoteDesktopIds.has(workspace.id));
+
+  const mergedServer = filteredServer.map((workspace) => {
+    const match =
+      desktopById.get(workspace.id) ??
+      desktopByPath.get(normalizeDirectoryPath(workspace.path ?? ""));
+    // For local workspaces, prefer the server's view (which knows things like
+    // `path` and per-workspace runtime fields) and only fall back to the
+    // desktop's display name when the server doesn't provide one.
+    const merged = match
+      ? {
+          ...workspace,
+          displayName: workspace.displayName?.trim()
+            ? workspace.displayName
+            : match.displayName,
+          name: match.name?.trim() ? match.name : workspace.name,
+        }
+      : workspace;
+    return {
+      ...merged,
+      displayNameResolved: workspaceLabel(merged),
+    };
+  });
+
+  const mergedIds = new Set(mergedServer.map((workspace) => workspace.id));
+  const mergedPaths = new Set(
+    mergedServer.flatMap((workspace) => {
+      const path = normalizeDirectoryPath(workspace.path ?? "");
+      return path ? [path] : [];
+    }),
+  );
+
+  const missingDesktop = desktopWorkspaces.filter((workspace) => {
+    if (mergedIds.has(workspace.id)) return false;
+    const normalizedPath = normalizeDirectoryPath(workspace.path ?? "");
+    if (normalizedPath && mergedPaths.has(normalizedPath)) return false;
+    return true;
+  });
+
+  return [...mergedServer, ...missingDesktop];
+}
+
+export function orderRouteWorkspaces(workspaces: RouteWorkspace[], orderIds: string[]): RouteWorkspace[] {
+  if (orderIds.length === 0) return workspaces;
+
+  const workspaceById = new Map(workspaces.map((workspace) => [workspace.id, workspace]));
+  const ordered: RouteWorkspace[] = [];
+  const usedIds = new Set<string>();
+
+  for (const id of orderIds) {
+    const workspace = workspaceById.get(id);
+    if (!workspace || usedIds.has(id)) continue;
+    ordered.push(workspace);
+    usedIds.add(id);
+  }
+
+  for (const workspace of workspaces) {
+    if (usedIds.has(workspace.id)) continue;
+    ordered.push(workspace);
+  }
+
+  return ordered;
+}
+
+export function toSessionGroups(
+  workspaces: RouteWorkspace[],
+  sessionsByWorkspaceId: Record<string, any[]>,
+  errorsByWorkspaceId: Record<string, string | null>,
+  loadingWorkspaceIds: Set<string>,
+): WorkspaceSessionGroup[] {
+  return workspaces.map((workspace) => ({
+    workspace,
+    sessions: (sessionsByWorkspaceId[workspace.id] ?? []) as WorkspaceSessionGroup["sessions"],
+    status: loadingWorkspaceIds.has(workspace.id)
+      ? "loading"
+      : errorsByWorkspaceId[workspace.id]
+        ? "error"
+        : "ready",
+    error: errorsByWorkspaceId[workspace.id],
+  }));
+}
+
+export function isActiveSessionStatus(status: unknown) {
+  return status === "running" || status === "retry" || status === "busy" || status === "streaming";
+}
+
+export function getSessionStatus(session: any) {
+  const status = session?.status ?? session?.state ?? session?.runStatus ?? null;
+  return typeof status === "string" ? status : normalizeSessionStatus(status);
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -102,6 +102,7 @@ import {
 } from "@/react-app/domains/session/sync/session-sync";
 import { firstLineLocalFileParts } from "@/react-app/domains/session/sync/prompt-file-parts";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
+import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
 import { appMentionInstruction } from "@/react-app/domains/session/surface/composer/app-mentions";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
@@ -148,7 +149,6 @@ import { readDenSettings } from "@/app/lib/den";
 import { denSessionUpdatedEvent } from "@/app/lib/den-session-events";
 
 import { openModelPickerEvent, pendingModelPickerProviderIdsKey } from "./new-providers-toast";
-import { getModelBehaviorSummary } from "@/app/lib/model-behavior";
 import { filterProviderList } from "@/app/utils/providers";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
 import { resolveOpenworkConnection } from "./openwork-connection";
@@ -230,8 +230,6 @@ function focusPromptSoon() {
   const focus = () => window.dispatchEvent(new Event("openwork:focusPrompt"));
   [0, 80, 240, 600].forEach((delay) => window.setTimeout(focus, delay));
 }
-
-const emptyModelBehaviorOptions: { value: string | null; label: string }[] = [];
 
 // All workspace-scoped server URLs/clients/tokens come from
 // `resolveWorkspaceEndpoint` in apps/app/src/app/lib/workspace-endpoint.ts.
@@ -485,7 +483,6 @@ export function SessionRoute() {
   // Provider catalog cache. Used to compute the reasoning/thinking variant
   // options for whichever model is currently selected so the composer's
   // behavior pill actually shows its options (bug: was empty before).
-  const [providerCatalog, setProviderCatalog] = useState<Record<string, Record<string, any>>>({});
   const [openworkServerHostInfoState, setOpenworkServerHostInfoState] = useState<OpenworkServerInfo | null>(null);
   useReactRenderWatchdog("SessionRoute", {
     selectedSessionId,
@@ -1352,6 +1349,12 @@ export function SessionRoute() {
     baseUrl: opencodeBaseUrl,
     directory: selectedWorkspaceRoot || undefined,
   });
+  const { providerCatalog, modelVariantLabel, modelBehaviorOptions, modelVariantValue } =
+    useModelBehavior({
+      providerList: providerListQuery.data,
+      defaultModel: local.prefs.defaultModel,
+      modelVariant: local.prefs.modelVariant ?? null,
+    });
   const selectedModelUnavailable = Boolean(
     local.prefs.defaultModel &&
       (
@@ -1590,48 +1593,6 @@ export function SessionRoute() {
   const modelLabel = local.prefs.defaultModel
     ? resolveModelDisplayName(local.prefs.defaultModel.modelID)
     : t("session.default_model");
-
-  // Prefetch the full provider catalog once so `getModelBehaviorSummary` has
-  // everything it needs to expose the reasoning/thinking variants the active
-  // model supports — without waiting for the model picker to open. Cached
-  // as providerID → modelID → ProviderModel.
-  useEffect(() => {
-    const data = providerListQuery.data;
-    if (!data?.all) return;
-    const next: Record<string, Record<string, any>> = {};
-    for (const provider of data.all) {
-      next[provider.id] = { ...(provider.models ?? {}) };
-    }
-    setProviderCatalog(next);
-  }, [providerListQuery.data]);
-
-  // Compute behavior (reasoning/thinking variant) options for the current
-  // default model. This is what the composer renders as its variant pill.
-  const { modelVariantLabel, modelBehaviorOptions, modelVariantValue } = useMemo(() => {
-    const ref = local.prefs.defaultModel;
-    const variant = local.prefs.modelVariant ?? null;
-    if (!ref) {
-      return {
-        modelVariantLabel: t("settings.default_label"),
-        modelBehaviorOptions: emptyModelBehaviorOptions,
-        modelVariantValue: null,
-      };
-    }
-    const model = providerCatalog[ref.providerID]?.[ref.modelID];
-    if (!model) {
-      return {
-        modelVariantLabel: variant ?? t("settings.default_label"),
-        modelBehaviorOptions: emptyModelBehaviorOptions,
-        modelVariantValue: variant,
-      };
-    }
-    const summary = getModelBehaviorSummary(ref.providerID, model, variant);
-    return {
-      modelVariantLabel: summary.label,
-      modelBehaviorOptions: summary.options,
-      modelVariantValue: summary.value,
-    };
-  }, [local.prefs.defaultModel, local.prefs.modelVariant, providerCatalog]);
 
   // Load the picker list lazily the first time the modal opens. Uses the
   // cached catalog when available, otherwise re-fetches.

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -77,6 +77,21 @@ import {
   safeStringify,
 } from "@/app/utils";
 import { t } from "@/i18n";
+import {
+  type RouteWorkspace,
+  describeRouteError,
+  describeWorkspaceCreateError,
+  downloadWorkspaceJson,
+  folderNameFromPath,
+  getSessionStatus,
+  isActiveSessionStatus,
+  mapDesktopWorkspace,
+  mergeRouteWorkspaces,
+  orderRouteWorkspaces,
+  toSessionGroups,
+  workspaceExportFilename,
+  workspaceLabel,
+} from "@/react-app/shell/route-workspaces";
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { usePlatform } from "@/react-app/kernel/platform";
 import { SessionPage } from "@/react-app/domains/session/chat/session-page";
@@ -169,21 +184,6 @@ import {
   useProviderListQuery,
 } from "@/react-app/infra/provider-list-query";
 
-type RouteWorkspace = OpenworkWorkspaceInfo & {
-  displayNameResolved: string;
-};
-
-function mapDesktopWorkspace(workspace: WorkspaceInfo): RouteWorkspace {
-  return {
-    ...workspace,
-    displayNameResolved:
-      workspace.displayName?.trim() ||
-      workspace.name?.trim() ||
-      workspace.path?.trim() ||
-      t("session.workspace_fallback"),
-  };
-}
-
 /**
  * Serialize an SDK error value into a string that parseSessionError can parse.
  * Preserves the original shape (name, data, message) as JSON when possible,
@@ -204,12 +204,6 @@ function serializeSDKError(error: unknown): string {
   return String(error);
 }
 
-function folderNameFromPath(path: string) {
-  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
-  const parts = normalized.split("/").filter(Boolean);
-  return parts[parts.length - 1] ?? "workspace";
-}
-
 function isTransientStartupError(message: string | null | undefined) {
   const value = (message ?? "").toLowerCase();
   return (
@@ -218,34 +212,6 @@ function isTransientStartupError(message: string | null | undefined) {
     value.includes("connection") ||
     value.includes("not ready")
   );
-}
-
-function workspaceLabel(workspace: OpenworkWorkspaceInfo) {
-  return (
-    workspace.displayName?.trim() ||
-    workspace.openworkWorkspaceName?.trim() ||
-    workspace.name?.trim() ||
-    workspace.path?.trim() ||
-    t("session.workspace_fallback")
-  );
-}
-
-function workspaceExportFilename(workspace: OpenworkWorkspaceInfo) {
-  const slug = workspaceLabel(workspace).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
-  return `${slug || "workspace"}-openwork-export.json`;
-}
-
-function downloadWorkspaceJson(filename: string, payload: unknown) {
-  if (typeof document === "undefined") return;
-  const blob = new Blob([`${JSON.stringify(payload, null, 2)}\n`], { type: "application/json" });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
 }
 
 const emptyWorkspaceDisplay: WorkspaceDisplay = {
@@ -257,27 +223,6 @@ const emptyWorkspaceDisplay: WorkspaceDisplay = {
 };
 
 const reloadAfterOrgOnboardingKey = "openwork.reloadAfterOrgOnboarding";
-
-function describeRouteError(error: unknown) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  const serialized = safeStringify(error);
-  return serialized && serialized !== "{}" ? serialized : t("app.unknown_error");
-}
-
-function describeWorkspaceCreateError(error: unknown) {
-  const message = describeRouteError(error);
-  const lower = message.toLowerCase();
-  if (
-    lower.includes("operation timed out") ||
-    lower.includes("os error 60") ||
-    lower.includes("etimedout")
-  ) {
-    return `${message}\n\nOpenWork could not read the workspace config before the filesystem timed out. This often happens when the folder is still syncing from iCloud Drive or another remote folder. Wait for the folder to finish downloading, move the workspace to a local folder, or try again.`;
-  }
-  return message;
-}
 
 function describeTaskCreateError(error: unknown) {
   const message = describeRouteError(error);
@@ -316,121 +261,9 @@ function useQueryCacheState<T>(queryKey: readonly unknown[] | null, fallback: T)
   );
 }
 
-function mergeRouteWorkspaces(
-  serverWorkspaces: OpenworkWorkspaceInfo[],
-  desktopWorkspaces: RouteWorkspace[],
-): RouteWorkspace[] {
-  const desktopById = new Map(desktopWorkspaces.map((workspace) => [workspace.id, workspace]));
-  const desktopByPath = new Map(
-    desktopWorkspaces.flatMap((workspace) => {
-      const path = normalizeDirectoryPath(workspace.path ?? "");
-      return path ? [[path, workspace] as const] : [];
-    }),
-  );
-
-  // If a server workspace's id matches a desktop workspace marked as remote,
-  // skip the server's view entirely. The local OpenWork server may have stale
-  // registrations from earlier (buggy) activate calls that show up here as
-  // `workspaceType: "local"`, which would otherwise clobber the desktop's
-  // remote routing fields and send workspace-scoped requests back to the
-  // local server.
-  const remoteDesktopIds = new Set(
-    desktopWorkspaces.flatMap((workspace) => workspace.workspaceType === "remote" ? [workspace.id] : []),
-  );
-  const filteredServer = serverWorkspaces.filter((workspace) => !remoteDesktopIds.has(workspace.id));
-
-  const mergedServer = filteredServer.map((workspace) => {
-    const match =
-      desktopById.get(workspace.id) ??
-      desktopByPath.get(normalizeDirectoryPath(workspace.path ?? ""));
-    // For local workspaces, prefer the server's view (which knows things like
-    // `path` and per-workspace runtime fields) and only fall back to the
-    // desktop's display name when the server doesn't provide one.
-    const merged = match
-      ? {
-          ...workspace,
-          displayName: workspace.displayName?.trim()
-            ? workspace.displayName
-            : match.displayName,
-          name: match.name?.trim() ? match.name : workspace.name,
-        }
-      : workspace;
-    return {
-      ...merged,
-      displayNameResolved: workspaceLabel(merged),
-    };
-  });
-
-  const mergedIds = new Set(mergedServer.map((workspace) => workspace.id));
-  const mergedPaths = new Set(
-    mergedServer.flatMap((workspace) => {
-      const path = normalizeDirectoryPath(workspace.path ?? "");
-      return path ? [path] : [];
-    }),
-  );
-
-  const missingDesktop = desktopWorkspaces.filter((workspace) => {
-    if (mergedIds.has(workspace.id)) return false;
-    const normalizedPath = normalizeDirectoryPath(workspace.path ?? "");
-    if (normalizedPath && mergedPaths.has(normalizedPath)) return false;
-    return true;
-  });
-
-  return [...mergedServer, ...missingDesktop];
-}
-
-function orderRouteWorkspaces(workspaces: RouteWorkspace[], orderIds: string[]): RouteWorkspace[] {
-  if (orderIds.length === 0) return workspaces;
-
-  const workspaceById = new Map(workspaces.map((workspace) => [workspace.id, workspace]));
-  const ordered: RouteWorkspace[] = [];
-  const usedIds = new Set<string>();
-
-  for (const id of orderIds) {
-    const workspace = workspaceById.get(id);
-    if (!workspace || usedIds.has(id)) continue;
-    ordered.push(workspace);
-    usedIds.add(id);
-  }
-
-  for (const workspace of workspaces) {
-    if (usedIds.has(workspace.id)) continue;
-    ordered.push(workspace);
-  }
-
-  return ordered;
-}
-
-function toSessionGroups(
-  workspaces: RouteWorkspace[],
-  sessionsByWorkspaceId: Record<string, any[]>,
-  errorsByWorkspaceId: Record<string, string | null>,
-  loadingWorkspaceIds: Set<string>,
-): WorkspaceSessionGroup[] {
-  return workspaces.map((workspace) => ({
-    workspace,
-    sessions: (sessionsByWorkspaceId[workspace.id] ?? []) as WorkspaceSessionGroup["sessions"],
-    status: loadingWorkspaceIds.has(workspace.id)
-      ? "loading"
-      : errorsByWorkspaceId[workspace.id]
-        ? "error"
-        : "ready",
-    error: errorsByWorkspaceId[workspace.id],
-  }));
-}
-
 // All workspace-scoped server URLs/clients/tokens come from
 // `resolveWorkspaceEndpoint` in apps/app/src/app/lib/workspace-endpoint.ts.
 // Don't compose `<baseUrl>/workspace/<id>` here.
-
-function isActiveSessionStatus(status: unknown) {
-  return status === "running" || status === "retry" || status === "busy" || status === "streaming";
-}
-
-function getSessionStatus(session: any) {
-  const status = session?.status ?? session?.state ?? session?.runStatus ?? null;
-  return typeof status === "string" ? status : normalizeSessionStatus(status);
-}
 
 async function fileToDataUrl(file: File, mimeType: string) {
   return await new Promise<string>((resolve, reject) => {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -113,16 +113,8 @@ import { useRemoteWorkspaceConnectionEditor } from "@/react-app/domains/workspac
 import { useCloudProviderAutoSync } from "@/react-app/domains/cloud/use-cloud-provider-auto-sync";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
 import { OpenWorkModelsStartupDialog } from "@/react-app/domains/cloud/openwork-models-startup-dialog";
-import {
-  getOpenWorkModelsActionUrl,
-  hasOpenWorkModelsProvider,
-  hideOpenWorkModelsPromo,
-  isOpenWorkModelsPromoHidden,
-  markOpenWorkModelsStartupPromoShown,
-  OPENWORK_MODEL_PREVIEWS,
-  openWorkModelsPromoChangedEvent,
-  wasOpenWorkModelsStartupPromoShown,
-} from "@/react-app/domains/cloud/openwork-models-promo";
+import { OPENWORK_MODEL_PREVIEWS } from "@/react-app/domains/cloud/openwork-models-promo";
+import { useOpenWorkModelsStartupPromo } from "@/react-app/domains/cloud/use-openwork-models-startup-promo";
 import {
   diagnoseRemoteWorkspaceTaskLoadFailure,
   getRemoteWorkspaceConnectionKey,
@@ -441,9 +433,6 @@ export function SessionRoute() {
     [providerConnectedIds],
   );
   const [disabledProviderIds, setDisabledProviderIds] = useState<string[]>([]);
-  const [openWorkModelsStartupOpen, setOpenWorkModelsStartupOpen] = useState(false);
-  const [openWorkModelsPromoHidden, setOpenWorkModelsPromoHidden] = useState(isOpenWorkModelsPromoHidden);
-  const openWorkModelsStartupScheduledRef = useRef(false);
   const onboardingProviderAuthPendingRef = useRef(false);
   // Bump to re-filter provider list when den session changes (sign-in/out)
   const [denSessionVersion, setDenSessionVersion] = useState(0);
@@ -453,34 +442,6 @@ export function SessionRoute() {
     return () => window.removeEventListener(denSessionUpdatedEvent, handler);
   }, []);
 
-  useEffect(() => {
-    const handlePromoChanged = () => setOpenWorkModelsPromoHidden(isOpenWorkModelsPromoHidden());
-    window.addEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
-    return () => window.removeEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
-  }, []);
-
-  const hasOpenWorkModels = useMemo(
-    () => hasOpenWorkModelsProvider(providerConnectedIds),
-    [providerConnectedIds],
-  );
-
-  const subscribeToOpenWorkModels = useCallback(() => {
-    setOpenWorkModelsStartupOpen(false);
-    markOpenWorkModelsStartupPromoShown();
-    if (!denAuth.isSignedIn) {
-      navigate(selectedWorkspaceId ? workspaceSettingsRoute(selectedWorkspaceId, "cloud-account") : "/settings/cloud-account");
-    }
-    window.setTimeout(() => {
-      platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn));
-    }, 0);
-  }, [denAuth.isSignedIn, navigate, platform, selectedWorkspaceId]);
-
-  const continueWithoutOpenWorkModels = useCallback(() => {
-    setOpenWorkModelsStartupOpen(false);
-    markOpenWorkModelsStartupPromoShown();
-    hideOpenWorkModelsPromo();
-    setOpenWorkModelsPromoHidden(true);
-  }, []);
   // Provider IDs that were just added — used to highlight them as
   // "Recently added" in the model picker even after they've been
   // marked as seen in localStorage.
@@ -1415,18 +1376,11 @@ export function SessionRoute() {
     opencodeClient && selectedWorkspaceId && !loading && !selectedWorkspaceError && !selectedModelUnavailable,
   );
 
-  useEffect(() => {
-    if (!shellConfig.cloudSignin || openWorkModelsPromoHidden || hasOpenWorkModels) return;
-    if (denAuth.status === "checking" || !opencodeClient || !selectedWorkspaceId) return;
-    if (wasOpenWorkModelsStartupPromoShown() || openWorkModelsStartupScheduledRef.current) return;
-
-    openWorkModelsStartupScheduledRef.current = true;
-    const timeout = window.setTimeout(() => {
-      markOpenWorkModelsStartupPromoShown();
-      setOpenWorkModelsStartupOpen(true);
-    }, 900);
-    return () => window.clearTimeout(timeout);
-  }, [denAuth.status, hasOpenWorkModels, opencodeClient, openWorkModelsPromoHidden, selectedWorkspaceId, shellConfig.cloudSignin]);
+  const openWorkModelsPromo = useOpenWorkModelsStartupPromo({
+    clientReady: Boolean(opencodeClient),
+    workspaceId: selectedWorkspaceId,
+    providerConnectedIds,
+  });
 
   const sessionProviderAuthStateRef = useRef({
     opencodeClient: opencodeClient as Client | null,
@@ -2893,11 +2847,11 @@ export function SessionRoute() {
       onAccessibleTargetsChange={setPaletteAccessibleTargets}
     />
     <OpenWorkModelsStartupDialog
-      open={openWorkModelsStartupOpen}
+      open={openWorkModelsPromo.open}
       isSignedIn={denAuth.isSignedIn}
       models={OPENWORK_MODEL_PREVIEWS}
-      onSubscribe={subscribeToOpenWorkModels}
-      onContinueWithout={continueWithoutOpenWorkModels}
+      onSubscribe={openWorkModelsPromo.subscribe}
+      onContinueWithout={openWorkModelsPromo.continueWithout}
     />
     <CreateWorkspaceModal
       open={createWorkspaceOpen}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2,7 +2,6 @@
 import {
   useCallback,
   useEffect,
-  useEffectEvent,
   useMemo,
   useRef,
   useState,
@@ -154,6 +153,7 @@ import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { useReloadCoordinator } from "./reload-coordinator";
 import { useShellConfig } from "./shell-config";
+import { useShellShortcuts } from "./use-shell-shortcuts";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
 import { useSessionControlActions } from "@/react-app/domains/session/control/session-control-actions";
 import { legacySessionRoute, workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
@@ -409,9 +409,6 @@ export function SessionRoute() {
   const [renameWorkspaceId, setRenameWorkspaceId] = useState<string | null>(null);
   const [renameWorkspaceTitle, setRenameWorkspaceTitle] = useState("");
   const [renameWorkspaceBusy, setRenameWorkspaceBusy] = useState(false);
-  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
-  const [sessionSearchOpen, setSessionSearchOpen] = useState(false);
-  const [terminalOpen, setTerminalOpen] = useState(false);
   const [paletteAccessibleTargets, setPaletteAccessibleTargets] = useState<OpenTarget[]>([]);
   const [providers, setProviders] = useState<ProviderListItem[]>([]);
   const [providerDefaults, setProviderDefaults] = useState<Record<string, string>>({});
@@ -1308,15 +1305,6 @@ export function SessionRoute() {
     baseUrl: opencodeBaseUrl,
     workspaceRoot: selectedWorkspaceRoot,
   });
-  useReactRenderWatchdog("SessionRoute", {
-    selectedSessionId,
-    selectedWorkspaceId,
-    loading,
-    workspaceCount: workspaces.length,
-    sessionGroupCount: Object.keys(sessionsByWorkspaceId).length,
-    commandPaletteOpen,
-    modelPickerOpen: modelPicker.open,
-  });
   const selectedModelUnavailable = Boolean(
     local.prefs.defaultModel &&
       (
@@ -2052,53 +2040,27 @@ export function SessionRoute() {
     }
   }, [baseUrl, loading, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, token, workspaces]);
 
-  // Global shortcuts:
-  //   Cmd/Ctrl+N        -> new task in selected workspace
-  //   Cmd/Ctrl+K        -> toggle command palette
-  //   Cmd/Ctrl+J        -> toggle terminal panel (matches VS Code)
-  //   Cmd/Ctrl+Shift+F  -> search every session (titles + messages)
-  const handleGlobalShortcut = useEffectEvent((event: KeyboardEvent) => {
-    const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
-    const mod = isMac ? event.metaKey : event.ctrlKey;
-    if (!mod) return;
-    if (event.shiftKey && !event.altKey && event.key?.toLowerCase() === "f") {
-      event.preventDefault();
-      setSessionSearchOpen((value) => !value);
-      return;
-    }
-    if (event.shiftKey || event.altKey) return;
-
-    const target = event.target as HTMLElement | null;
-    const inEditable =
-      !!target &&
-      (target.tagName === "INPUT" ||
-        target.tagName === "TEXTAREA" ||
-        target.isContentEditable);
-
-    const key = event.key?.toLowerCase();
-    if (key === "n" && !inEditable) {
-      event.preventDefault();
-      if (canCreateTask && selectedWorkspaceId) {
-        void handleCreateTaskInWorkspace(selectedWorkspaceId);
-      }
-      return;
-    }
-    if (key === "k") {
-      event.preventDefault();
-      setCommandPaletteOpen((value) => !value);
-      return;
-    }
-    if (key === "j") {
-      event.preventDefault();
-      setTerminalOpen((value) => !value);
-    }
+  const {
+    commandPaletteOpen,
+    setCommandPaletteOpen,
+    sessionSearchOpen,
+    setSessionSearchOpen,
+    terminalOpen,
+    setTerminalOpen,
+  } = useShellShortcuts({
+    canCreateTask,
+    workspaceId: selectedWorkspaceId,
+    onCreateTask: handleCreateTaskInWorkspace,
   });
-
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => handleGlobalShortcut(event);
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, []);
+  useReactRenderWatchdog("SessionRoute", {
+    selectedSessionId,
+    selectedWorkspaceId,
+    loading,
+    workspaceCount: workspaces.length,
+    sessionGroupCount: Object.keys(sessionsByWorkspaceId).length,
+    commandPaletteOpen,
+    modelPickerOpen: modelPicker.open,
+  });
 
   const navigateToSessionForControl = useCallback((sessionId: string) => {
     const owner = Object.entries(sessionsByWorkspaceId).find(([, sessions]) =>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -103,6 +103,7 @@ import {
 import { firstLineLocalFileParts } from "@/react-app/domains/session/sync/prompt-file-parts";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
+import { useModelPicker } from "@/react-app/domains/session/modals/use-model-picker";
 import { appMentionInstruction } from "@/react-app/domains/session/surface/composer/app-mentions";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
@@ -148,7 +149,6 @@ import { useReactRenderWatchdog } from "./react-render-watchdog";
 import { readDenSettings } from "@/app/lib/den";
 import { denSessionUpdatedEvent } from "@/app/lib/den-session-events";
 
-import { openModelPickerEvent, pendingModelPickerProviderIdsKey } from "./new-providers-toast";
 import { filterProviderList } from "@/app/utils/providers";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
 import { resolveOpenworkConnection } from "./openwork-connection";
@@ -413,14 +413,6 @@ export function SessionRoute() {
   const [sessionSearchOpen, setSessionSearchOpen] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [paletteAccessibleTargets, setPaletteAccessibleTargets] = useState<OpenTarget[]>([]);
-  // Model picker modal state (ported from settings-route; previously the
-  // session "Pick a model" button navigated to /settings/general, which is a
-  // dead-end). Loads providers lazily when the modal opens.
-  const [modelPickerOpen, setModelPickerOpen] = useState(false);
-  // initialTab removed — model picker no longer has tabs
-  const [compactModelPickerOpen, setCompactModelPickerOpen] = useState(false);
-  const [modelPickerQuery, setModelPickerQuery] = useState("");
-  const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
   const [providers, setProviders] = useState<ProviderListItem[]>([]);
   const [providerDefaults, setProviderDefaults] = useState<Record<string, string>>({});
   const [providerConnectedIds, setProviderConnectedIds] = useState<string[]>([]);
@@ -441,41 +433,6 @@ export function SessionRoute() {
   }, []);
 
   // Provider IDs that were just added — used to highlight them as
-  // "Recently added" in the model picker even after they've been
-  // marked as seen in localStorage.
-  const [recentProviderIds, setRecentProviderIds] = useState<Set<string>>(new Set());
-  // Open model picker when the global toast's "Pick a new default?" is clicked
-  useEffect(() => {
-    const handler = (event: Event) => {
-      try {
-        window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
-      } catch {}
-      const detail = (event as CustomEvent<{ newProviderIds?: string[]; initialTab?: "default" | "available" }>).detail;
-      const ids = detail?.newProviderIds;
-      if (ids && ids.length > 0) {
-        setRecentProviderIds(new Set(ids));
-      }
-      setModelPickerOpen(true);
-    };
-    window.addEventListener(openModelPickerEvent, handler);
-    return () => window.removeEventListener(openModelPickerEvent, handler);
-  }, []);
-
-  useEffect(() => {
-    try {
-      const raw = window.localStorage.getItem(pendingModelPickerProviderIdsKey);
-      if (!raw) return;
-      window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
-      const parsed = JSON.parse(raw);
-      const ids = Array.isArray(parsed) ? parsed : parsed?.newProviderIds;
-      if (Array.isArray(ids) && ids.every((id) => typeof id === "string")) {
-        setRecentProviderIds(new Set(ids));
-      }
-      setModelPickerOpen(true);
-    } catch {
-      window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
-    }
-  }, []);
   useEffect(() => {
     setPaletteAccessibleTargets([]);
   }, [selectedSessionId, selectedWorkspaceId]);
@@ -484,15 +441,6 @@ export function SessionRoute() {
   // options for whichever model is currently selected so the composer's
   // behavior pill actually shows its options (bug: was empty before).
   const [openworkServerHostInfoState, setOpenworkServerHostInfoState] = useState<OpenworkServerInfo | null>(null);
-  useReactRenderWatchdog("SessionRoute", {
-    selectedSessionId,
-    selectedWorkspaceId,
-    loading,
-    workspaceCount: workspaces.length,
-    sessionGroupCount: Object.keys(sessionsByWorkspaceId).length,
-    commandPaletteOpen,
-    modelPickerOpen,
-  });
   const [openworkServerSettingsVersion, setOpenworkServerSettingsVersion] = useState(0);
   const [engineReloadVersion, setEngineReloadVersion] = useState(0);
   const [routeEngineInfo, setRouteEngineInfo] = useState<EngineInfo | null>(null);
@@ -1355,6 +1303,20 @@ export function SessionRoute() {
       defaultModel: local.prefs.defaultModel,
       modelVariant: local.prefs.modelVariant ?? null,
     });
+  const modelPicker = useModelPicker({
+    client: opencodeClient,
+    baseUrl: opencodeBaseUrl,
+    workspaceRoot: selectedWorkspaceRoot,
+  });
+  useReactRenderWatchdog("SessionRoute", {
+    selectedSessionId,
+    selectedWorkspaceId,
+    loading,
+    workspaceCount: workspaces.length,
+    sessionGroupCount: Object.keys(sessionsByWorkspaceId).length,
+    commandPaletteOpen,
+    modelPickerOpen: modelPicker.open,
+  });
   const selectedModelUnavailable = Boolean(
     local.prefs.defaultModel &&
       (
@@ -1594,87 +1556,6 @@ export function SessionRoute() {
     ? resolveModelDisplayName(local.prefs.defaultModel.modelID)
     : t("session.default_model");
 
-  // Load the picker list lazily the first time the modal opens. Uses the
-  // cached catalog when available, otherwise re-fetches.
-  useEffect(() => {
-    if (!modelPickerOpen || !opencodeClient) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await ensureProviderListQuery(getReactQueryClient(), {
-          client: opencodeClient,
-          baseUrl: opencodeBaseUrl,
-          directory: selectedWorkspaceRoot || undefined,
-        });
-        if (cancelled || !data?.all) return;
-        // Flag models from recently-added providers so they appear in
-        // the "Recently added" section at the top of the picker.
-        // Two sources: (1) providers not yet in the localStorage seen-set,
-        // (2) providers passed via the openModelPickerEvent from the toast.
-        let seenIds: Set<string>;
-        try {
-          const raw = window.localStorage.getItem("openwork.seenProviderIds");
-          seenIds = new Set(raw ? JSON.parse(raw) : []);
-        } catch {
-          seenIds = new Set();
-        }
-        const options: ModelOption[] = [];
-        for (const provider of getConnectedProviderItems(data)) {
-          const modelIds = Object.keys(provider.models);
-          const isNew = !seenIds.has(provider.id) || recentProviderIds.has(provider.id);
-          for (const id of modelIds) {
-            const model = provider.models[id];
-            options.push({
-              providerID: provider.id,
-              modelID: id,
-              title: model.name || id,
-              description: provider.name,
-              behaviorTitle: "Reasoning",
-              behaviorLabel: "Default",
-              behaviorDescription: "",
-              behaviorValue: null,
-              isFree: false,
-              isConnected: true,
-              isRecommended: isNew,
-              source: /^lpr_/i.test(provider.id) ? "cloud" as const : undefined,
-            });
-          }
-        }
-        setModelOptions(options);
-      } catch {
-        // Silent: the picker surfaces an empty list rather than blocking the UI.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [modelPickerOpen, opencodeBaseUrl, opencodeClient, recentProviderIds, selectedWorkspaceRoot]);
-
-  // Apply org-level restrictions (dev #1505) on top of the raw model list
-  // so the picker never surfaces blocked options:
-  //   - `allowZenModel` hides the built-in OpenCode provider entries when false
-  //   - `allowCustomProviders` hides providers that OpenCode does not report
-  //     as connected through the provider list endpoint.
-  const allowedModelOptions = useMemo(() => {
-    const restrictToCloud = checkDesktopRestriction({
-      restriction: "allowCustomProviders",
-    });
-    return modelOptions.filter((option) => {
-      if (
-        isDesktopProviderBlocked({
-          providerId: option.providerID,
-          checkRestriction: checkDesktopRestriction,
-        })
-      ) {
-        return false;
-      }
-      if (restrictToCloud && !option.isConnected) {
-        return false;
-      }
-      return true;
-    });
-  }, [checkDesktopRestriction, modelOptions]);
-
   const listSlashCommands = useCallback(async (): Promise<SlashCommandOption[]> => {
     // engineReloadVersion is included so the callback identity changes after
     // an engine reload, which invalidates the composer's command list cache
@@ -1736,13 +1617,13 @@ export function SessionRoute() {
       developerMode: false,
       modelLabel,
       onModelClick: () => {
-        setModelPickerQuery("");
-        setModelPickerOpen(true);
+        modelPicker.setQuery("");
+        modelPicker.setOpen(true);
       },
-      modelPickerOpen: compactModelPickerOpen,
+      modelPickerOpen: modelPicker.compactOpen,
       modelUnavailable: selectedModelUnavailable,
       selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
-      onModelPickerOpenChange: setCompactModelPickerOpen,
+      onModelPickerOpenChange: modelPicker.setCompactOpen,
       onModelChange: (model: ModelRef) => {
         local.setPrefs((previous) => ({
           ...previous,
@@ -1751,7 +1632,7 @@ export function SessionRoute() {
             ? previous.modelVariant
             : null,
         }));
-        setCompactModelPickerOpen(false);
+        modelPicker.setCompactOpen(false);
       },
       providerConnectedCount: hasUsableModel ? 1 : providerConnectedIds.length,
       onOpenSettingsSection: (section: "commands" | "skills" | "mcps" | "plugins" | "providers") => {
@@ -1899,7 +1780,7 @@ export function SessionRoute() {
     };
   }, [
     client,
-    compactModelPickerOpen,
+    modelPicker.compactOpen,
     handleOpenSettings,
     hasUsableModel,
     local,
@@ -2231,7 +2112,7 @@ export function SessionRoute() {
   }, [navigateToWorkspaceSession, selectedWorkspaceId]);
 
   const openModelPickerForControl = useCallback(() => {
-    setModelPickerOpen(true);
+    modelPicker.setOpen(true);
   }, []);
 
   useSessionControlActions({
@@ -2590,16 +2471,16 @@ export function SessionRoute() {
         onSelect: sessionProviderAuthStore.startProviderAuth,
         onSubmitApiKey: async (providerId, apiKey) => {
           const result = await sessionProviderAuthStore.submitProviderApiKey(providerId, apiKey);
-          setRecentProviderIds(new Set([providerId]));
-          setModelPickerQuery("");
-          setModelPickerOpen(true);
+          modelPicker.setRecentProviderIds(new Set([providerId]));
+          modelPicker.setQuery("");
+          modelPicker.setOpen(true);
           return result;
         },
         onConnectCloudProvider: async (cloudProviderId) => {
           const result = await sessionProviderAuthStore.connectCloudProvider(cloudProviderId);
-          setRecentProviderIds(new Set([cloudProviderId]));
-          setModelPickerQuery("");
-          setModelPickerOpen(true);
+          modelPicker.setRecentProviderIds(new Set([cloudProviderId]));
+          modelPicker.setQuery("");
+          modelPicker.setOpen(true);
           return result;
         },
         onSubmitOAuth: sessionProviderAuthStore.completeProviderAuthOAuth,
@@ -2891,11 +2772,11 @@ export function SessionRoute() {
       onOpenSession={(workspaceId, sessionId) => navigateToWorkspaceSession(workspaceId, sessionId)}
     />
     <ModelPickerModal
-      open={modelPickerOpen}
-      options={allowedModelOptions}
+      open={modelPicker.open}
+      options={modelPicker.options}
 
-      query={modelPickerQuery}
-      setQuery={setModelPickerQuery}
+      query={modelPicker.query}
+      setQuery={modelPicker.setQuery}
       target="default"
       current={local.prefs.defaultModel ?? ({ providerID: "", modelID: "" } satisfies ModelRef)}
       onSelect={(next: ModelRef) => {
@@ -2906,7 +2787,7 @@ export function SessionRoute() {
             ? previous.modelVariant
             : null,
         }));
-        setModelPickerOpen(false);
+        modelPicker.setOpen(false);
         focusPromptSoon();
       }}
       disabledProviders={disabledProviderIds}
@@ -2924,10 +2805,10 @@ export function SessionRoute() {
         } catch {}
       }}
       onOpenSettings={() => {
-        setModelPickerOpen(false);
+        modelPicker.setOpen(false);
         handleOpenSettings("/settings/general");
       }}
-      onClose={() => { setModelPickerOpen(false); setRecentProviderIds(new Set()); }}
+      onClose={() => { modelPicker.setOpen(false); modelPicker.setRecentProviderIds(new Set()); }}
     />
     </WorkspaceProvider>
   );

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
 } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "@/components/ui/sonner";
@@ -55,10 +54,7 @@ import type {
   ComposerPart,
   ModelOption,
   ModelRef,
-  PendingPermission,
-  PendingQuestion,
   SlashCommandOption,
-  TodoItem,
   WorkspacePreset,
   WorkspaceConnectionState,
   Client,
@@ -103,13 +99,9 @@ import { useSessionActivityStore } from "@/react-app/domains/session/status/sess
 import { buildOpenworkEnvSystemContext } from "@/react-app/domains/session/sync/env-context";
 import {
   applySessionRevert,
-  permissionKey as reactPermissionKey,
-  questionKey as reactQuestionKey,
-  seedPermissionState,
-  seedQuestionState,
-  todoKey as reactTodoKey,
 } from "@/react-app/domains/session/sync/session-sync";
 import { firstLineLocalFileParts } from "@/react-app/domains/session/sync/prompt-file-parts";
+import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { appMentionInstruction } from "@/react-app/domains/session/surface/composer/app-mentions";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
@@ -247,19 +239,7 @@ function focusPromptSoon() {
   [0, 80, 240, 600].forEach((delay) => window.setTimeout(focus, delay));
 }
 
-const emptyPendingPermissions: PendingPermission[] = [];
-const emptyPendingQuestions: PendingQuestion[] = [];
-const emptyTodos: TodoItem[] = [];
 const emptyModelBehaviorOptions: { value: string | null; label: string }[] = [];
-
-function useQueryCacheState<T>(queryKey: readonly unknown[] | null, fallback: T): T {
-  const queryClient = getReactQueryClient();
-  return useSyncExternalStore(
-    (callback) => (queryKey ? queryClient.getQueryCache().subscribe(callback) : () => {}),
-    () => (queryKey ? queryClient.getQueryData<T>(queryKey) ?? fallback : fallback),
-    () => fallback,
-  );
-}
 
 // All workspace-scoped server URLs/clients/tokens come from
 // `resolveWorkspaceEndpoint` in apps/app/src/app/lib/workspace-endpoint.ts.
@@ -541,10 +521,6 @@ export function SessionRoute() {
     setPaletteAccessibleTargets([]);
   }, [selectedSessionId, selectedWorkspaceId]);
 
-  const [permissionReplyBusy, setPermissionReplyBusy] = useState(false);
-  const permissionReplyBusyRef = useRef(false);
-  const [questionReplyBusy, setQuestionReplyBusy] = useState(false);
-  const questionReplyBusyRef = useRef(false);
   // Provider catalog cache. Used to compute the reasoning/thinking variant
   // options for whichever model is currently selected so the composer's
   // behavior pill actually shows its options (bug: was empty before).
@@ -1569,138 +1545,20 @@ export function SessionRoute() {
   // sync here so sign-in applies opencode.json changes before Settings opens.
   useCloudProviderAutoSync(sessionProviderAuthStore.runCloudProviderSync);
   const sessionProviderAuthSnapshot = useProviderAuthStoreSnapshot(sessionProviderAuthStore);
-  const permissionQueryKey = useMemo(
-    () =>
-      selectedWorkspaceId && selectedSessionId
-        ? reactPermissionKey(selectedWorkspaceId, selectedSessionId)
-        : null,
-    [selectedSessionId, selectedWorkspaceId],
-  );
-  const pendingPermissions = useQueryCacheState<PendingPermission[]>(
-    permissionQueryKey,
-    emptyPendingPermissions,
-  );
-  const questionQueryKey = useMemo(
-    () =>
-      selectedWorkspaceId && selectedSessionId
-        ? reactQuestionKey(selectedWorkspaceId, selectedSessionId)
-        : null,
-    [selectedSessionId, selectedWorkspaceId],
-  );
-  const pendingQuestions = useQueryCacheState<PendingQuestion[]>(
-    questionQueryKey,
-    emptyPendingQuestions,
-  );
-  const todoQueryKey = useMemo(
-    () =>
-      selectedWorkspaceId && selectedSessionId
-        ? reactTodoKey(selectedWorkspaceId, selectedSessionId)
-        : null,
-    [selectedSessionId, selectedWorkspaceId],
-  );
-  const todos = useQueryCacheState<TodoItem[]>(todoQueryKey, emptyTodos);
-  useEffect(() => {
-    if (!opencodeClient || !selectedWorkspaceId || !selectedSessionId) return;
-    let cancelled = false;
-    const directory = selectedWorkspaceRoot || undefined;
-    void (async () => {
-      const snapshotStartedAt = Date.now();
-      try {
-        const list = unwrap(await opencodeClient.permission.list({ directory }));
-        if (!cancelled) {
-          seedPermissionState(selectedWorkspaceId, selectedSessionId, list, { snapshotStartedAt });
-        }
-      } catch {
-        // Keep event-synced permission state if the snapshot read fails.
-        // Hiding a pending approval can block the running task.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [opencodeClient, selectedSessionId, selectedWorkspaceId, selectedWorkspaceRoot]);
-
-  useEffect(() => {
-    if (!opencodeClient || !selectedWorkspaceId || !selectedSessionId) return;
-    let cancelled = false;
-    const directory = selectedWorkspaceRoot || undefined;
-    void (async () => {
-      const snapshotStartedAt = Date.now();
-      try {
-        const list = unwrap(await opencodeClient.question.list({ directory }));
-        if (!cancelled) {
-          seedQuestionState(selectedWorkspaceId, selectedSessionId, list, { snapshotStartedAt });
-        }
-      } catch {
-        // Keep event-synced question state if the snapshot read fails.
-        // Hiding a pending question can block the running task.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [opencodeClient, selectedSessionId, selectedWorkspaceId, selectedWorkspaceRoot]);
-
-  const activePermission = pendingPermissions[0] ?? null;
-  const respondPermission = useCallback(
-    async (requestID: string, reply: "once" | "always" | "reject") => {
-      if (!opencodeClient || !selectedWorkspaceId || !selectedSessionId) return;
-      if (permissionReplyBusyRef.current) return;
-      permissionReplyBusyRef.current = true;
-      setPermissionReplyBusy(true);
-      try {
-        unwrap(
-          await opencodeClient.permission.reply({
-            requestID,
-            reply,
-            directory: selectedWorkspaceRoot || undefined,
-          }),
-        );
-        getReactQueryClient().setQueryData<PendingPermission[]>(
-          reactPermissionKey(selectedWorkspaceId, selectedSessionId),
-          (current = []) => current.filter((permission) => permission.id !== requestID),
-        );
-      } catch (error) {
-        toast.error(t("app.error_request_failed"), {
-          description: describeRouteError(error),
-        });
-      } finally {
-        permissionReplyBusyRef.current = false;
-        setPermissionReplyBusy(false);
-      }
-    },
-    [opencodeClient, selectedSessionId, selectedWorkspaceId, selectedWorkspaceRoot],
-  );
-  const activeQuestion = pendingQuestions[0] ?? null;
-  const respondQuestion = useCallback(
-    async (requestID: string, answers: string[][]) => {
-      if (!opencodeClient || !selectedWorkspaceId || !selectedSessionId) return;
-      if (questionReplyBusyRef.current) return;
-      questionReplyBusyRef.current = true;
-      setQuestionReplyBusy(true);
-      try {
-        unwrap(
-          await opencodeClient.question.reply({
-            requestID,
-            answers,
-            directory: selectedWorkspaceRoot || undefined,
-          }),
-        );
-        getReactQueryClient().setQueryData<PendingQuestion[]>(
-          reactQuestionKey(selectedWorkspaceId, selectedSessionId),
-          (current = []) => current.filter((question) => question.id !== requestID),
-        );
-      } catch (error) {
-        toast.error(t("app.error_request_failed"), {
-          description: describeRouteError(error),
-        });
-      } finally {
-        questionReplyBusyRef.current = false;
-        setQuestionReplyBusy(false);
-      }
-    },
-    [opencodeClient, selectedSessionId, selectedWorkspaceId, selectedWorkspaceRoot],
-  );
+  const {
+    activePermission,
+    permissionReplyBusy,
+    respondPermission,
+    activeQuestion,
+    questionReplyBusy,
+    respondQuestion,
+    todos,
+  } = useSessionInteractions({
+    client: opencodeClient,
+    workspaceId: selectedWorkspaceId,
+    sessionId: selectedSessionId,
+    workspaceRoot: selectedWorkspaceRoot,
+  });
   const showPreparingStatus =
     effectiveLoading ||
     (!canCreateTask && !routeError && !selectedWorkspaceError);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -32,6 +32,21 @@ import type {
 } from "@/app/types";
 import { getWorkspaceTaskLoadErrorDisplay } from "@/app/utils";
 import { currentLocale, t, setLocale, type Language } from "@/i18n";
+import {
+  type RouteWorkspace,
+  describeRouteError,
+  describeWorkspaceCreateError,
+  downloadWorkspaceJson,
+  folderNameFromPath,
+  getSessionStatus,
+  isActiveSessionStatus,
+  mapDesktopWorkspace,
+  mergeRouteWorkspaces,
+  orderRouteWorkspaces,
+  toSessionGroups,
+  workspaceExportFilename,
+  workspaceLabel,
+} from "@/react-app/shell/route-workspaces";
 import { createConnectionsStore, useConnectionsStoreSnapshot } from "@/react-app/domains/connections/store";
 import { createOpenworkServerStore, useOpenworkServerStoreSnapshot } from "@/react-app/domains/connections/openwork-server-store";
 import { createProviderAuthStore, useProviderAuthStoreSnapshot } from "@/react-app/domains/connections/provider-auth/store";
@@ -143,10 +158,6 @@ import {
 } from "@/react-app/domains/settings/openai-image-extension";
 import { OLLAMA_PROVIDER_CONFIG, type LocalProviderInstallInput } from "@/react-app/domains/settings/openai-image-extension";
 
-type RouteWorkspace = OpenworkWorkspaceInfo & {
-  displayNameResolved: string;
-};
-
 const ROUTE_OPENWORK_CAPABILITIES: OpenworkServerCapabilities = {
   skills: { read: true, write: true, source: "openwork" },
   plugins: { read: true, write: true },
@@ -154,17 +165,6 @@ const ROUTE_OPENWORK_CAPABILITIES: OpenworkServerCapabilities = {
   commands: { read: true, write: true },
   config: { read: true, write: true },
 };
-
-function mapDesktopWorkspace(workspace: WorkspaceInfo): RouteWorkspace {
-  return {
-    ...workspace,
-    displayNameResolved:
-      workspace.displayName?.trim() ||
-      workspace.name?.trim() ||
-      workspace.path?.trim() ||
-      t("session.workspace_fallback"),
-  };
-}
 
 function isOpenWorkCloudProvider(provider: {
   providerId?: string | null;
@@ -176,82 +176,12 @@ function isOpenWorkCloudProvider(provider: {
   );
 }
 
-function describeRouteError(error: unknown) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  const serialized = safeStringify(error);
-  return serialized && serialized !== "{}" ? serialized : t("app.unknown_error");
-}
-
-function describeWorkspaceCreateError(error: unknown) {
-  const message = describeRouteError(error);
-  const lower = message.toLowerCase();
-  if (
-    lower.includes("operation timed out") ||
-    lower.includes("os error 60") ||
-    lower.includes("etimedout")
-  ) {
-    return `${message}\n\nOpenWork could not read the workspace config before the filesystem timed out. This often happens when the folder is still syncing from iCloud Drive or another remote folder. Wait for the folder to finish downloading, move the workspace to a local folder, or try again.`;
-  }
-  return message;
-}
-
 function normalizeComputerUsePermissions(value: unknown) {
   if (typeof value !== "object" || value === null) return null;
   return {
     accessibility: "accessibility" in value && value.accessibility === true,
     screenRecording: "screenRecording" in value && value.screenRecording === true,
   };
-}
-
-function mergeRouteWorkspaces(
-  serverWorkspaces: OpenworkWorkspaceInfo[],
-  desktopWorkspaces: RouteWorkspace[],
-): RouteWorkspace[] {
-  const desktopById = new Map(desktopWorkspaces.map((workspace) => [workspace.id, workspace]));
-  const desktopByPath = new Map(
-    desktopWorkspaces.flatMap((workspace) => {
-      const path = normalizeDirectoryPath(workspace.path ?? "");
-      return path ? [[path, workspace] as const] : [];
-    }),
-  );
-
-  const mergedServer = serverWorkspaces.map((workspace) => {
-    const match =
-      desktopById.get(workspace.id) ??
-      desktopByPath.get(normalizeDirectoryPath(workspace.path ?? ""));
-    const merged = match
-      ? {
-          ...workspace,
-          displayName: workspace.displayName?.trim()
-            ? workspace.displayName
-            : match.displayName,
-          name: match.name?.trim() ? match.name : workspace.name,
-        }
-      : workspace;
-    return {
-      ...merged,
-      displayNameResolved: workspaceLabel(merged),
-    };
-  });
-
-  const mergedIds = new Set(mergedServer.map((workspace) => workspace.id));
-  const mergedPaths = new Set(
-    mergedServer.flatMap((workspace) => {
-      const path = normalizeDirectoryPath(workspace.path ?? "");
-      return path ? [path] : [];
-    }),
-  );
-
-  const missingDesktop = desktopWorkspaces.filter((workspace) => {
-    if (mergedIds.has(workspace.id)) return false;
-    const normalizedPath = normalizeDirectoryPath(workspace.path ?? "");
-    if (normalizedPath && mergedPaths.has(normalizedPath)) return false;
-    return true;
-  });
-
-  return [...mergedServer, ...missingDesktop];
 }
 
 function reconcileSelectedWorkspaceId(
@@ -283,64 +213,9 @@ function reconcileSelectedWorkspaceId(
   return serverList.activeId?.trim() || desktopSelectedId || workspaces[0]?.id || "";
 }
 
-function folderNameFromPath(path: string) {
-  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
-  const parts = normalized.split("/").filter(Boolean);
-  return parts[parts.length - 1] ?? "workspace";
-}
-
 const SETTINGS_HIDE_TITLEBAR_KEY = "openwork.react.settings.hide-titlebar";
 const SETTINGS_UPDATE_AUTO_CHECK_KEY = "openwork.react.settings.update-auto-check";
 const SETTINGS_UPDATE_AUTO_DOWNLOAD_KEY = "openwork.react.settings.update-auto-download";
-
-function workspaceLabel(workspace: OpenworkWorkspaceInfo) {
-  return (
-    workspace.displayName?.trim() ||
-    workspace.openworkWorkspaceName?.trim() ||
-    workspace.name?.trim() ||
-    workspace.path?.trim() ||
-    t("session.workspace_fallback")
-  );
-}
-
-function workspaceExportFilename(workspace: OpenworkWorkspaceInfo) {
-  const slug = workspaceLabel(workspace).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
-  return `${slug || "workspace"}-openwork-export.json`;
-}
-
-function downloadWorkspaceJson(filename: string, payload: unknown) {
-  if (typeof document === "undefined") return;
-  const blob = new Blob([`${JSON.stringify(payload, null, 2)}\n`], { type: "application/json" });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
-}
-
-function toSessionGroups(
-  workspaces: RouteWorkspace[],
-  sessionsByWorkspaceId: Record<string, any[]>,
-  errorsByWorkspaceId: Record<string, string | null>,
-): WorkspaceSessionGroup[] {
-  return workspaces.map((workspace) => ({
-    workspace,
-    sessions: (sessionsByWorkspaceId[workspace.id] ?? []) as WorkspaceSessionGroup["sessions"],
-    status: errorsByWorkspaceId[workspace.id] ? "error" : "ready",
-    error: errorsByWorkspaceId[workspace.id],
-  }));
-}
-
-function isActiveSessionStatus(status: unknown) {
-  return status === "running" || status === "retry" || status === "busy";
-}
-
-function getSessionStatus(session: any) {
-  return session?.status ?? session?.state ?? session?.runStatus ?? null;
-}
 
 function parseSettingsPath(pathname: string): {
   tab: SettingsTab;
@@ -927,7 +802,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   });
 
   const workspaceSessionGroups = useMemo(
-    () => toSessionGroups(workspaces, sessionsByWorkspaceId, errorsByWorkspaceId),
+    // Settings has no per-workspace loading state; the empty set keeps the
+    // previous behavior (error -> "error", otherwise "ready").
+    () => toSessionGroups(workspaces, sessionsByWorkspaceId, errorsByWorkspaceId, new Set()),
     [errorsByWorkspaceId, sessionsByWorkspaceId, workspaces],
   );
 

--- a/apps/app/src/react-app/shell/use-shell-shortcuts.ts
+++ b/apps/app/src/react-app/shell/use-shell-shortcuts.ts
@@ -1,0 +1,74 @@
+// Shell panel open-state (command palette, session search, terminal) plus the
+// global keyboard shortcuts that toggle them. Extracted verbatim from
+// session-route.tsx.
+import { useEffect, useEffectEvent, useState } from "react";
+
+export type UseShellShortcutsInput = {
+  canCreateTask: boolean;
+  workspaceId: string;
+  onCreateTask: (workspaceId: string) => void | Promise<void>;
+};
+
+export function useShellShortcuts(input: UseShellShortcutsInput) {
+  const { canCreateTask, workspaceId, onCreateTask } = input;
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [sessionSearchOpen, setSessionSearchOpen] = useState(false);
+  const [terminalOpen, setTerminalOpen] = useState(false);
+
+  // Global shortcuts:
+  //   Cmd/Ctrl+N        -> new task in selected workspace
+  //   Cmd/Ctrl+K        -> toggle command palette
+  //   Cmd/Ctrl+J        -> toggle terminal panel (matches VS Code)
+  //   Cmd/Ctrl+Shift+F  -> search every session (titles + messages)
+  const handleGlobalShortcut = useEffectEvent((event: KeyboardEvent) => {
+    const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+    const mod = isMac ? event.metaKey : event.ctrlKey;
+    if (!mod) return;
+    if (event.shiftKey && !event.altKey && event.key?.toLowerCase() === "f") {
+      event.preventDefault();
+      setSessionSearchOpen((value) => !value);
+      return;
+    }
+    if (event.shiftKey || event.altKey) return;
+
+    const target = event.target as HTMLElement | null;
+    const inEditable =
+      !!target &&
+      (target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable);
+
+    const key = event.key?.toLowerCase();
+    if (key === "n" && !inEditable) {
+      event.preventDefault();
+      if (canCreateTask && workspaceId) {
+        void onCreateTask(workspaceId);
+      }
+      return;
+    }
+    if (key === "k") {
+      event.preventDefault();
+      setCommandPaletteOpen((value) => !value);
+      return;
+    }
+    if (key === "j") {
+      event.preventDefault();
+      setTerminalOpen((value) => !value);
+    }
+  });
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => handleGlobalShortcut(event);
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  return {
+    commandPaletteOpen,
+    setCommandPaletteOpen,
+    sessionSearchOpen,
+    setSessionSearchOpen,
+    terminalOpen,
+    setTerminalOpen,
+  };
+}


### PR DESCRIPTION
## What

Phase 2 of the architecture refactor (follow-up to #2199): decomposing the `session-route.tsx` god-component (3,328 lines, 32 effects, one component) into domain hooks. Six extractions, one commit each, every commit independently gated and revertable.

| Commit | Extraction | Notes |
|---|---|---|
| `c66c4014c` | `shell/route-workspaces.ts` — the helper family both routes duplicated (RouteWorkspace, mapDesktopWorkspace, mergeRouteWorkspaces, toSessionGroups, getSessionStatus, describe*Error, export/download helpers) | The copies had **drifted**: settings-route was missing the mergeRouteWorkspaces fix that stops stale local-server registrations from clobbering desktop remote workspaces (latent bug, fixed by unification); also older getSessionStatus/isActiveSessionStatus. -290 duplicated lines |
| `28157d200` | `domains/session/sync/use-session-interactions.ts` — permissions/questions/todos (busy state, cache subscriptions, seed effects, reply handlers) + generic `infra/query-cache-state.ts` | Verbatim move; 4 stable inputs |
| `86de215d1` | `domains/cloud/use-openwork-models-startup-promo.ts` — startup promo latch | Self-acquires denAuth/platform/navigate (use-den-session pattern) |
| `539efdf50` | `domains/session/surface/use-model-behavior.ts` — provider catalog prefetch + variant pill computation | Catalog now typed `Record<providerID, Record<modelID, ProviderModel>>` instead of `Record<string, Record<string, any>>` |
| `2a3339230` | `domains/session/modals/use-model-picker.ts` — picker state, lazy option loader, new-provider toast triggers, org-restriction filtering | settings-route adoption queued as follow-up |
| `3468f9787` | `shell/use-shell-shortcuts.ts` — palette/search/terminal state + global Cmd-N/K/J/Shift-F keydown (useEffectEvent) | Reads canCreateTask at event time, exactly as before |

**`session-route.tsx`: 3,328 → 2,777 lines (-551).** All moves are verbatim (behavior-preserving); the only intentional behavior change is settings-route inheriting the newer merge/status helpers (the drift fix called out above).

## Tests (ran locally after EVERY commit, not just at the end)

```
pnpm --filter @openwork/app typecheck   # clean
pnpm --filter @openwork/app test        # 58 pass, 0 fail
pnpm --filter @openwork/app build       # vite production build clean
pnpm --filter @openwork/app test:e2e    # 23/23 assertions ok (boots real app + opencode)
```

Live checks: vite dev server serves the new module graph (200s) per step.

No video: behavior-preserving refactor with no UI change — the per-commit e2e runs are the end-to-end evidence. Reviewer repro: commands above on any commit in the stack.

## Follow-ups queued (tracker)

useEngineReload · useWorkspaceSessions (types the session lists, kills ~21 `any`s) · useWorkspaceModals · useSessionProviderAuth · core useWorkspaceRouteState · settings-route adopts useModelPicker

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

