### PR TITLE
refactor(app): session-route decomposition round 2 — engine reload, typed sessions (zero any), settings picker adoption

### DIFF
--- a/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
+++ b/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
@@ -22,10 +22,12 @@ export type UseModelPickerInput = {
   client: Client | null;
   baseUrl: string;
   workspaceRoot: string;
+  /** Optional: surface option-load failures (settings shows a toast; the session route stays silent). */
+  onLoadError?: (error: unknown) => void;
 };
 
 export function useModelPicker(input: UseModelPickerInput) {
-  const { client, baseUrl, workspaceRoot } = input;
+  const { client, baseUrl, workspaceRoot, onLoadError } = input;
   const checkDesktopRestriction = useCheckDesktopRestriction();
 
   const [open, setOpen] = useState(false);
@@ -117,8 +119,10 @@ export function useModelPicker(input: UseModelPickerInput) {
           }
         }
         setModelOptions(options);
-      } catch {
-        // Silent: the picker surfaces an empty list rather than blocking the UI.
+      } catch (error) {
+        // Default: silent — the picker surfaces an empty list rather than
+        // blocking the UI. Callers can opt into surfacing the failure.
+        onLoadError?.(error);
       }
     })();
     return () => {

--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -3,6 +3,8 @@
 // settings-route was missing the remote-workspace clobber fix in
 // mergeRouteWorkspaces and used older session-status logic. One copy now.
 
+import type { Session } from "@opencode-ai/sdk/v2/client";
+
 import type { OpenworkWorkspaceInfo } from "@/app/lib/openwork-server";
 import type { WorkspaceInfo } from "@/app/lib/desktop-types";
 import type { WorkspaceSessionGroup } from "@/app/types";
@@ -15,6 +17,18 @@ import { t } from "@/i18n";
 
 export type RouteWorkspace = OpenworkWorkspaceInfo & {
   displayNameResolved: string;
+};
+
+/**
+ * Sessions as the routes handle them: SDK sessions from
+ * openwork-server's listSessions, optionally enriched with run-status
+ * fields that the sidebar probes defensively via getSessionStatus.
+ */
+export type RouteSession = Session & {
+  status?: unknown;
+  state?: unknown;
+  runStatus?: unknown;
+  slug?: string | null;
 };
 
 export function mapDesktopWorkspace(workspace: WorkspaceInfo): RouteWorkspace {
@@ -170,13 +184,13 @@ export function orderRouteWorkspaces(workspaces: RouteWorkspace[], orderIds: str
 
 export function toSessionGroups(
   workspaces: RouteWorkspace[],
-  sessionsByWorkspaceId: Record<string, any[]>,
+  sessionsByWorkspaceId: Record<string, RouteSession[]>,
   errorsByWorkspaceId: Record<string, string | null>,
   loadingWorkspaceIds: Set<string>,
 ): WorkspaceSessionGroup[] {
   return workspaces.map((workspace) => ({
     workspace,
-    sessions: (sessionsByWorkspaceId[workspace.id] ?? []) as WorkspaceSessionGroup["sessions"],
+    sessions: sessionsByWorkspaceId[workspace.id] ?? [],
     status: loadingWorkspaceIds.has(workspace.id)
       ? "loading"
       : errorsByWorkspaceId[workspace.id]
@@ -190,7 +204,7 @@ export function isActiveSessionStatus(status: unknown) {
   return status === "running" || status === "retry" || status === "busy" || status === "streaming";
 }
 
-export function getSessionStatus(session: any) {
+export function getSessionStatus(session: RouteSession | null | undefined) {
   const status = session?.status ?? session?.state ?? session?.runStatus ?? null;
   return typeof status === "string" ? status : normalizeSessionStatus(status);
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -72,6 +72,7 @@ import {
 import { t } from "@/i18n";
 import {
   type RouteWorkspace,
+  type RouteSession,
   describeRouteError,
   describeWorkspaceCreateError,
   downloadWorkspaceJson,
@@ -348,7 +349,7 @@ export function SessionRoute() {
   const [token, setToken] = useState("");
   const [workspaces, setWorkspaces] = useState<RouteWorkspace[]>([]);
   const [workspaceOrderIds, setWorkspaceOrderIds] = useState<string[]>(() => readWorkspaceOrderIds());
-  const [sessionsByWorkspaceId, setSessionsByWorkspaceId] = useState<Record<string, any[]>>({});
+  const [sessionsByWorkspaceId, setSessionsByWorkspaceId] = useState<Record<string, RouteSession[]>>({});
   const [errorsByWorkspaceId, setErrorsByWorkspaceId] = useState<Record<string, string | null>>({});
   const [workspaceConnectionOverrides, setWorkspaceConnectionOverrides] = useState<Record<string, WorkspaceConnectionState>>({});
   const [routeError, setRouteError] = useState<string | null>(null);
@@ -392,7 +393,7 @@ export function SessionRoute() {
   const workspaceOrderIdsRef = useRef(workspaceOrderIds);
   const remoteWorkspaceCheckRunRef = useRef<Record<string, string>>({});
   const remoteWorkspaceCheckRunCounterRef = useRef(0);
-  const sessionsByWorkspaceIdRef = useRef<Record<string, any[]>>({});
+  const sessionsByWorkspaceIdRef = useRef<Record<string, RouteSession[]>>({});
   const pendingCreatedSessionIdsRef = useRef<Record<string, Record<string, number>>>({});
   const startupRetryTimerRef = useRef<number | null>(null);
   const [retryingWorkspaceIds, setRetryingWorkspaceIds] = useState<string[]>([]);
@@ -446,7 +447,7 @@ export function SessionRoute() {
     () =>
       Object.values(sessionsByWorkspaceId)
         .flat()
-        .flatMap((session: any) => {
+        .flatMap((session) => {
           if (!isActiveSessionStatus(getSessionStatus(session))) return [];
           const id = String(session?.id ?? "");
           if (!id) return [];
@@ -461,7 +462,7 @@ export function SessionRoute() {
   );
   const activeSelectedWorkspaceSessionIds = useMemo(
     () =>
-      (sessionsByWorkspaceId[selectedWorkspaceId] ?? []).flatMap((session: any) => {
+      (sessionsByWorkspaceId[selectedWorkspaceId] ?? []).flatMap((session) => {
         if (!isActiveSessionStatus(getSessionStatus(session))) return [];
         const id = String(session?.id ?? "").trim();
         return id ? [id] : [];
@@ -477,12 +478,12 @@ export function SessionRoute() {
       [id]: Date.now(),
     };
   }, []);
-  const mergeFetchedSessionsWithPending = useCallback((workspaceId: string, fetched: any[], current: any[]) => {
+  const mergeFetchedSessionsWithPending = useCallback((workspaceId: string, fetched: RouteSession[], current: RouteSession[]) => {
     const pending = pendingCreatedSessionIdsRef.current[workspaceId];
     if (!pending) return fetched;
 
     const now = Date.now();
-    const fetchedIds = new Set(fetched.flatMap((session: any) => session?.id ? [String(session.id)] : []));
+    const fetchedIds = new Set(fetched.flatMap((session) => session?.id ? [String(session.id)] : []));
     const pendingIds = Object.keys(pending);
 
     for (const id of pendingIds) {
@@ -491,7 +492,7 @@ export function SessionRoute() {
       }
     }
 
-    const preserved = current.filter((session: any) => {
+    const preserved = current.filter((session) => {
       const id = String(session?.id ?? "");
       if (!id || fetchedIds.has(id)) return false;
       const createdAt = pending[id];
@@ -554,7 +555,7 @@ export function SessionRoute() {
           const fetchedItems = response.items ?? [];
           const workspaceRoot = normalizeDirectoryPath(workspace.path ?? "");
           const items = workspaceRoot && !isRemoteOpenworkWorkspace
-            ? fetchedItems.filter((session: any) =>
+            ? fetchedItems.filter((session) =>
                 normalizeDirectoryPath(session?.directory ?? "") === workspaceRoot,
               )
             : fetchedItems;
@@ -736,7 +737,7 @@ export function SessionRoute() {
         "";
       if (selectedSessionId) {
         const match = cachedEntries.find((entry) =>
-          entry.sessions.some((session: any) => session?.id === selectedSessionId),
+          entry.sessions.some((session) => session?.id === selectedSessionId),
         );
         if (match?.workspaceId) nextWorkspaceId = match.workspaceId;
       }
@@ -856,7 +857,7 @@ export function SessionRoute() {
     if (!selectedWorkspaceId) return;
     setSessionsByWorkspaceId((current) => {
       const list = current[selectedWorkspaceId] ?? [];
-      const index = list.findIndex((session: any) => session?.id === update.sessionId);
+      const index = list.findIndex((session) => session?.id === update.sessionId);
       if (index < 0) return current;
       const nextSession = { ...list[index], ...update.info, id: update.sessionId };
       if (JSON.stringify(nextSession) === JSON.stringify(list[index])) return current;
@@ -990,7 +991,7 @@ export function SessionRoute() {
       sessionsByWorkspaceId: Object.fromEntries(
         Object.entries(sessionsByWorkspaceId).map(([wsId, items]) => [
           wsId,
-          (items ?? []).map((session: any) => ({
+          (items ?? []).map((session) => ({
             id: session?.id ?? null,
             title: session?.title ?? null,
             directory: session?.directory ?? null,
@@ -1035,7 +1036,7 @@ export function SessionRoute() {
     const remembered = readLastSessionFor(selectedWorkspaceId);
     if (!remembered) return;
     const sessions = sessionsByWorkspaceId[selectedWorkspaceId] ?? [];
-    if (!sessions.some((session: any) => session?.id === remembered)) return;
+    if (!sessions.some((session) => session?.id === remembered)) return;
     navigateToWorkspaceSession(selectedWorkspaceId, remembered, { replace: true });
   }, [
     loading,
@@ -1103,7 +1104,7 @@ export function SessionRoute() {
     const sessionId = selectedSessionId?.trim() ?? "";
     if (sessionId) {
       const owner = workspaceSessionGroups.find((group) =>
-        group.sessions.some((session: any) => session?.id === sessionId),
+        group.sessions.some((session) => session?.id === sessionId),
       );
       if (owner?.workspace.id) return owner.workspace.id;
     }
@@ -1161,7 +1162,7 @@ export function SessionRoute() {
   const selectedWorkspaceError = errorsByWorkspaceId[selectedWorkspaceId] ?? null;
   const selectedSessionKnown = Boolean(
     selectedSessionId &&
-      (sessionsByWorkspaceId[selectedWorkspaceId] ?? []).some((session: any) => session?.id === selectedSessionId),
+      (sessionsByWorkspaceId[selectedWorkspaceId] ?? []).some((session) => session?.id === selectedSessionId),
   );
   const routeNotFoundMessage = (() => {
     if (loading) return null;
@@ -1483,7 +1484,7 @@ export function SessionRoute() {
     let sessionOwnedByOtherWorkspace = false;
     for (const [workspaceId, sessions] of Object.entries(sessionsByWorkspaceId)) {
       if (workspaceId === selectedWorkspaceId) continue;
-      if ((sessions ?? []).some((session: any) => session?.id === selectedSessionId)) {
+      if ((sessions ?? []).some((session) => session?.id === selectedSessionId)) {
         sessionOwnedByOtherWorkspace = true;
         break;
       }
@@ -1645,7 +1646,7 @@ export function SessionRoute() {
             rememberPendingCreatedSession(selectedWorkspaceId, forked.id);
             setSessionsByWorkspaceId((current) => ({
               ...current,
-              [selectedWorkspaceId]: [forked as any, ...(current[selectedWorkspaceId] ?? [])],
+              [selectedWorkspaceId]: [forked, ...(current[selectedWorkspaceId] ?? [])],
             }));
             navigateToWorkspaceSession(selectedWorkspaceId, forked.id);
             void refreshRouteState();
@@ -1906,7 +1907,7 @@ export function SessionRoute() {
       setSessionsByWorkspaceId((current) => {
         const next = {
           ...current,
-          [workspaceId]: [session as any, ...(current[workspaceId] ?? [])],
+          [workspaceId]: [session, ...(current[workspaceId] ?? [])],
         };
         sessionsByWorkspaceIdRef.current = next;
         return next;
@@ -1963,7 +1964,7 @@ export function SessionRoute() {
 
   const navigateToSessionForControl = useCallback((sessionId: string) => {
     const owner = Object.entries(sessionsByWorkspaceId).find(([, sessions]) =>
-      (sessions ?? []).some((session: any) => session?.id === sessionId),
+      (sessions ?? []).some((session) => session?.id === sessionId),
     )?.[0];
     navigateToWorkspaceSession(owner || selectedWorkspaceId, sessionId);
   }, [navigateToWorkspaceSession, selectedWorkspaceId, sessionsByWorkspaceId]);
@@ -2197,7 +2198,7 @@ export function SessionRoute() {
           setSessionsByWorkspaceId((current) => {
             const next = {
               ...current,
-              [targetWorkspaceId]: [session as any, ...(current[targetWorkspaceId] ?? [])],
+              [targetWorkspaceId]: [session, ...(current[targetWorkspaceId] ?? [])],
             };
             sessionsByWorkspaceIdRef.current = next;
             return next;
@@ -2408,7 +2409,7 @@ export function SessionRoute() {
           const remembered = readLastSessionFor(workspaceId);
           if (remembered && remembered !== selectedSessionId) {
             const known = sessionsByWorkspaceId[workspaceId];
-            if (known?.some((session: any) => session?.id === remembered)) {
+            if (known?.some((session) => session?.id === remembered)) {
               navigateToWorkspaceSession(workspaceId, remembered);
             } else {
               navigateToWorkspaceSession(workspaceId);
@@ -2449,7 +2450,7 @@ export function SessionRoute() {
               rememberPendingCreatedSession(workspaceId, session.id);
               setSessionsByWorkspaceId((current) => ({
                 ...current,
-                [workspaceId]: [session as any, ...(current[workspaceId] ?? [])],
+                [workspaceId]: [session, ...(current[workspaceId] ?? [])],
               }));
               navigateToWorkspaceSession(workspaceId, session.id);
               focusPromptSoon();

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -34,7 +34,6 @@ import {
 } from "@/app/lib/workspace-endpoint";
 import { buildOpenworkEnvRuntimeKey } from "@/app/lib/openwork-env-runtime";
 import {
-  engineInfo,
   revealDesktopItemInDir,
   pickDirectory,
   resolveWorkspaceListSelectedId,
@@ -42,7 +41,6 @@ import {
   workspaceForget,
   workspaceSetRuntimeActive,
   workspaceSetSelected,
-  type EngineInfo,
   type OpenworkServerInfo,
   type WorkspaceInfo,
   type WorkspaceList,
@@ -154,6 +152,7 @@ import { resolveOpenworkConnection } from "./openwork-connection";
 import { useReloadCoordinator } from "./reload-coordinator";
 import { useShellConfig } from "./shell-config";
 import { useShellShortcuts } from "./use-shell-shortcuts";
+import { useEngineReload } from "./use-engine-reload";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
 import { useSessionControlActions } from "@/react-app/domains/session/control/session-control-actions";
 import { legacySessionRoute, workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
@@ -205,8 +204,6 @@ const emptyWorkspaceDisplay: WorkspaceDisplay = {
   preset: "default",
   workspaceType: "local",
 };
-
-const reloadAfterOrgOnboardingKey = "openwork.reloadAfterOrgOnboarding";
 
 function describeTaskCreateError(error: unknown) {
   const message = describeRouteError(error);
@@ -391,7 +388,6 @@ export function SessionRoute() {
   // One-way latch for "a refreshRouteState is currently running"; prevents
   // overlapping route refreshes from queueing up when the user clicks fast.
   const refreshInFlightRef = useRef(false);
-  const reloadEventCursorByWorkspaceRef = useRef<Record<string, number | null>>({});
   const workspacesRef = useRef<RouteWorkspace[]>([]);
   const workspaceOrderIdsRef = useRef(workspaceOrderIds);
   const remoteWorkspaceCheckRunRef = useRef<Record<string, string>>({});
@@ -439,24 +435,12 @@ export function SessionRoute() {
   // behavior pill actually shows its options (bug: was empty before).
   const [openworkServerHostInfoState, setOpenworkServerHostInfoState] = useState<OpenworkServerInfo | null>(null);
   const [openworkServerSettingsVersion, setOpenworkServerSettingsVersion] = useState(0);
-  const [engineReloadVersion, setEngineReloadVersion] = useState(0);
-  const [routeEngineInfo, setRouteEngineInfo] = useState<EngineInfo | null>(null);
   const reconnectAttemptedWorkspaceIdRef = useRef("");
 
   const openworkServerSettings = useMemo(
     () => readOpenworkServerSettings(),
     [openworkServerSettingsVersion],
   );
-
-  const shareWorkspaceState = useShareWorkspaceState({
-    workspaces,
-    openworkServerHostInfo: openworkServerHostInfoState,
-    openworkServerSettings,
-    engineInfo: routeEngineInfo,
-    exportWorkspaceBusy: false,
-    openLink: (url) => platform.openLink(url),
-    workspaceLabel,
-  });
 
   const activeReloadBlockingSessions = useMemo(
     () =>
@@ -847,96 +831,26 @@ export function SessionRoute() {
     onSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
   });
 
-  const reloadWorkspaceEngineFromUi = useCallback(async () => {
-    if (!client || !selectedWorkspaceId) {
-      setRouteError(t("app.error_connect_first"));
-      return false;
-    }
-    const endpoint = endpointForWorkspace(selectedWorkspace);
-    if (!endpoint) {
-      setRouteError(t("app.error_connect_first"));
-      return false;
-    }
-    await endpoint.client.reloadEngine(endpoint.workspaceId);
-    await refreshProviderListQueries(getReactQueryClient());
-    setEngineReloadVersion((v) => v + 1);
-    try {
-      window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
-    } catch {
-      // ignore browser event dispatch failures
-    }
-    await refreshRouteState();
-    return true;
-  }, [client, endpointForWorkspace, refreshRouteState, selectedWorkspace, selectedWorkspaceId]);
+  const { engineReloadVersion, routeEngineInfo } = useEngineReload({
+    client,
+    workspaceId: selectedWorkspaceId,
+    workspace: selectedWorkspace,
+    endpointForWorkspace,
+    activeReloadBlockingSessions,
+    onError: setRouteError,
+    refreshRouteState,
+  });
 
-  useEffect(() => {
-    return reloadCoordinator.registerWorkspaceReloadControls({
-      canReloadWorkspaceEngine: () => Boolean(client && selectedWorkspaceId),
-      reloadWorkspaceEngine: reloadWorkspaceEngineFromUi,
-      activeSessions: () => activeReloadBlockingSessions,
-    });
-  }, [activeReloadBlockingSessions, client, reloadCoordinator, reloadWorkspaceEngineFromUi, selectedWorkspaceId]);
+  const shareWorkspaceState = useShareWorkspaceState({
+    workspaces,
+    openworkServerHostInfo: openworkServerHostInfoState,
+    openworkServerSettings,
+    engineInfo: routeEngineInfo,
+    exportWorkspaceBusy: false,
+    openLink: (url) => platform.openLink(url),
+    workspaceLabel,
+  });
 
-  useEffect(() => {
-    if (!reloadCoordinator.canReloadWorkspaceEngine) return;
-    try {
-      if (window.localStorage.getItem(reloadAfterOrgOnboardingKey) !== "1") return;
-    } catch {
-      return;
-    }
-    if (!reloadCoordinator.reloadPending) {
-      reloadCoordinator.markReloadRequired("config", {
-        type: "config",
-        name: "opencode.json",
-        action: "updated",
-      });
-      return;
-    }
-    try {
-      window.localStorage.removeItem(reloadAfterOrgOnboardingKey);
-    } catch {}
-    void reloadCoordinator.reloadWorkspaceEngine();
-  }, [reloadCoordinator, reloadCoordinator.canReloadWorkspaceEngine, reloadCoordinator.reloadPending]);
-
-  useEffect(() => {
-    if (!client || !selectedWorkspaceId) return;
-    const endpoint = endpointForWorkspace(selectedWorkspace);
-    if (!endpoint) return;
-    let cancelled = false;
-
-    const pollReloadEvents = async () => {
-      const currentCursor = reloadEventCursorByWorkspaceRef.current[selectedWorkspaceId];
-      try {
-        const response = await endpoint.client.listReloadEvents(
-          endpoint.workspaceId,
-          typeof currentCursor === "number" ? { since: currentCursor } : undefined,
-        );
-        if (cancelled) return;
-        reloadEventCursorByWorkspaceRef.current[selectedWorkspaceId] =
-          typeof response.cursor === "number"
-            ? response.cursor
-            : Math.max(currentCursor ?? 0, ...((response.items ?? []).map((item: any) => Number(item.seq) || 0)));
-        // The first poll establishes the server cursor so historical reload
-        // events don't show a stale toast on route entry. Subsequent polls mark
-        // new filesystem/server-side mutations, including skills created by an
-        // agent while the session page is open.
-        if (currentCursor === undefined || currentCursor === null) return;
-        for (const event of response.items ?? []) {
-          reloadCoordinator.markReloadRequired(event.reason, event.trigger);
-        }
-      } catch {
-        // Reload-event polling is best-effort; normal route health checks still
-        // surface connection failures.
-      }
-    };
-
-    void pollReloadEvents();
-    const interval = window.setInterval(() => void pollReloadEvents(), 3000);
-    return () => {
-      cancelled = true;
-      window.clearInterval(interval);
-    };
-  }, [client, endpointForWorkspace, reloadCoordinator, selectedWorkspace, selectedWorkspaceId]);
 
   const handleRuntimeSessionUpdated = useCallback((update: { sessionId: string; info: Record<string, unknown> }) => {
     if (!selectedWorkspaceId) return;
@@ -1048,21 +962,6 @@ export function SessionRoute() {
       }
     };
   }, [refreshRouteState]);
-
-  useEffect(() => {
-    if (!isDesktopRuntime()) return;
-    let cancelled = false;
-    void engineInfo()
-      .then((info) => {
-        if (!cancelled) setRouteEngineInfo(info as EngineInfo | null);
-      })
-      .catch(() => {
-        if (!cancelled) setRouteEngineInfo(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   // Inspector wiring: publish the route's current state so an external
   // operator (or an AI driver using browser tools) can call

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -32,6 +32,7 @@ import type {
 } from "@/app/types";
 import { getWorkspaceTaskLoadErrorDisplay } from "@/app/utils";
 import { currentLocale, t, setLocale, type Language } from "@/i18n";
+import { useModelPicker } from "@/react-app/domains/session/modals/use-model-picker";
 import {
   type RouteWorkspace,
   type RouteSession,
@@ -139,7 +140,7 @@ import {
   testRemoteWorkspaceConnection,
 } from "@/react-app/domains/workspace/remote-workspace-diagnostics";
 import { ModelPickerModal } from "@/react-app/domains/session/modals/model-picker-modal";
-import type { ModelOption, ModelRef } from "@/app/types";
+import type { ModelRef } from "@/app/types";
 import { workspaceSwatchColor } from "@/react-app/domains/session/sidebar/utils";
 import { recordInspectorEvent } from "../../app/lib/app-inspector";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
@@ -151,8 +152,7 @@ import { getDenInferenceUrl } from "@/app/lib/den";
 import { readActiveWorkspaceId, writeActiveWorkspaceId } from "./session-memory";
 import { workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
-import { ensureProviderListQuery, getConnectedProviderItems, refreshProviderListQueries } from "@/react-app/infra/provider-list-query";
-import { openModelPickerEvent, pendingModelPickerProviderIdsKey } from "./new-providers-toast";
+import { refreshProviderListQueries } from "@/react-app/infra/provider-list-query";
 import {
   OPENAI_IMAGE_EXTENSION_ID,
   OPENAI_IMAGE_MODEL,
@@ -398,10 +398,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [autoCompactContext, setAutoCompactContext] = useState(true);
   const [autoCompactContextBusy, setAutoCompactContextBusy] = useState(false);
   const [autoCompactContextLoaded, setAutoCompactContextLoaded] = useState(false);
-  const [modelPickerOpen, setModelPickerOpen] = useState(false);
-  // initialTab removed — model picker no longer has tabs
-  const [modelPickerQuery, setModelPickerQuery] = useState("");
-  const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
   const [localProviderBusy, setLocalProviderBusy] = useState(false);
   const [localProviderStatus, setLocalProviderStatus] = useState<string | null>(null);
   const [localProviderError, setLocalProviderError] = useState<string | null>(null);
@@ -833,6 +829,22 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     setActiveClient(opencodeClient);
   }, [opencodeClient]);
 
+  const handleModelPickerLoadError = useCallback((error: unknown) => {
+    toast.error(error instanceof Error ? error.message : t("app.unknown_error"));
+  }, []);
+  const modelPicker = useModelPicker({
+    client: opencodeClient,
+    baseUrl: opencodeBaseUrl,
+    workspaceRoot: selectedWorkspaceRoot,
+    onLoadError: handleModelPickerLoadError,
+  });
+  // Settings refreshes provider auth whenever the picker opens (the session
+  // route does not need this; its provider state is kept fresh elsewhere).
+  useEffect(() => {
+    if (!modelPicker.open) return;
+    void providerAuthStore.refreshProviders();
+  }, [modelPicker.open, providerAuthStore]);
+
   useEffect(() => {
     const refresh = () => setExtensionStateVersion((value) => value + 1);
     window.addEventListener(OPENWORK_EXTENSION_STATE_CHANGED, refresh);
@@ -1053,89 +1065,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       setLocalProviderBusy(false);
     }
   }, [local, openworkClient, reloadCoordinator, runtimeWorkspaceId, selectedWorkspaceEndpoint]);
-
-  useEffect(() => {
-    const openFromPending = (raw: string | null) => {
-      if (!raw) return false;
-      setModelPickerQuery("");
-      setModelPickerOpen(true);
-      return true;
-    };
-
-    try {
-      const raw = window.localStorage.getItem(pendingModelPickerProviderIdsKey);
-      if (openFromPending(raw)) {
-        window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
-      }
-    } catch {
-      window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
-    }
-
-    const handler = () => {
-      setModelPickerQuery("");
-      setModelPickerOpen(true);
-      try {
-        window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
-      } catch {}
-    };
-    window.addEventListener(openModelPickerEvent, handler);
-    return () => window.removeEventListener(openModelPickerEvent, handler);
-  }, []);
-
-  useEffect(() => {
-    if (!modelPickerOpen || !opencodeClient) return;
-    let cancelled = false;
-    void providerAuthStore.refreshProviders();
-    void (async () => {
-      try {
-        const data = await ensureProviderListQuery(getReactQueryClient(), {
-          client: opencodeClient,
-          baseUrl: opencodeBaseUrl,
-          directory: selectedWorkspaceRoot || undefined,
-        });
-        if (cancelled || !data?.all) return;
-        let seenIds: Set<string>;
-        try {
-          const raw = window.localStorage.getItem("openwork.seenProviderIds");
-          seenIds = new Set(raw ? JSON.parse(raw) : []);
-        } catch {
-          seenIds = new Set();
-        }
-        const options: ModelOption[] = [];
-        for (const provider of getConnectedProviderItems(data)) {
-          const modelIds = Object.keys(provider.models);
-          const isNew = !seenIds.has(provider.id);
-          for (const id of modelIds) {
-            const model = provider.models[id];
-            options.push({
-              providerID: provider.id,
-              modelID: id,
-              title: model.name || id,
-              description: provider.name,
-              behaviorTitle: "Reasoning",
-              behaviorLabel: "Default",
-              behaviorDescription: "",
-              behaviorValue: null,
-              isFree: false,
-              isConnected: true,
-              isRecommended: isNew,
-              source: /^lpr_/i.test(provider.id) ? "cloud" as const : undefined,
-            });
-          }
-        }
-        setModelOptions(options);
-      } catch (error) {
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : t("app.unknown_error"),
-        );
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [modelPickerOpen, opencodeBaseUrl, opencodeClient, selectedWorkspaceRoot]);
 
   useEffect(() => {
     local.setUi((previous) => ({ ...previous, view: "settings", tab: route.tab }));
@@ -2434,10 +2363,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         onCompleteMcpAuthModal={() => connectionsStore.completeMcpAuthModal()}
       />
       <ModelPickerModal
-        open={modelPickerOpen}
-        options={modelOptions}
-        query={modelPickerQuery}
-        setQuery={setModelPickerQuery}
+        open={modelPicker.open}
+        options={modelPicker.options}
+        query={modelPicker.query}
+        setQuery={modelPicker.setQuery}
         target="default"
         current={
           local.prefs.defaultModel ?? { providerID: "", modelID: "" }
@@ -2450,11 +2379,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               ? prev.modelVariant
               : null,
           }));
-          setModelPickerOpen(false);
+          modelPicker.setOpen(false);
         }}
         onBehaviorChange={() => {}}
         onOpenSettings={() => {}}
-        onClose={() => setModelPickerOpen(false)}
+        onClose={() => modelPicker.setOpen(false)}
       />
     </>
   );

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -34,6 +34,7 @@ import { getWorkspaceTaskLoadErrorDisplay } from "@/app/utils";
 import { currentLocale, t, setLocale, type Language } from "@/i18n";
 import {
   type RouteWorkspace,
+  type RouteSession,
   describeRouteError,
   describeWorkspaceCreateError,
   downloadWorkspaceJson,
@@ -299,7 +300,7 @@ function findSessionWorkspaceId(
 ) {
   const id = sessionId?.trim();
   if (!id) return null;
-  return entries.find((entry) => entry.sessions.some((session: any) => session?.id === id))?.workspaceId ?? null;
+  return entries.find((entry) => entry.sessions.some((session) => session?.id === id))?.workspaceId ?? null;
 }
 
 function settingsPathForRoute(route: ReturnType<typeof parseSettingsPath>) {
@@ -334,7 +335,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
 
   const [loading, setLoading] = useState(true);
   const [workspaces, setWorkspaces] = useState<RouteWorkspace[]>([]);
-  const [sessionsByWorkspaceId, setSessionsByWorkspaceId] = useState<Record<string, any[]>>({});
+  const [sessionsByWorkspaceId, setSessionsByWorkspaceId] = useState<Record<string, RouteSession[]>>({});
   const [errorsByWorkspaceId, setErrorsByWorkspaceId] = useState<Record<string, string | null>>({});
   const [workspaceConnectionOverrides, setWorkspaceConnectionOverrides] = useState<Record<string, WorkspaceConnectionState>>({});
   const [legacySelectedWorkspaceId, setLegacySelectedWorkspaceId] = useState(() => navigationWorkspaceId ?? readActiveWorkspaceId() ?? "");
@@ -501,7 +502,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     () =>
       Object.values(sessionsByWorkspaceId)
         .flat()
-        .flatMap((session: any) => {
+        .flatMap((session) => {
           if (!isActiveSessionStatus(getSessionStatus(session))) return [];
           const id = String(session?.id ?? "");
           if (!id) return [];
@@ -1214,7 +1215,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             const response = await client.listSessions(workspace.id, { limit: 200 });
             const workspaceRoot = normalizeDirectoryPath(workspace.path ?? "");
             const items = workspaceRoot
-              ? (response.items ?? []).filter((session: any) =>
+              ? (response.items ?? []).filter((session) =>
                   normalizeDirectoryPath(session?.directory ?? "") === workspaceRoot,
                 )
               : (response.items ?? []);

--- a/apps/app/src/react-app/shell/use-engine-reload.ts
+++ b/apps/app/src/react-app/shell/use-engine-reload.ts
@@ -1,0 +1,158 @@
+// Engine reload wiring for the session route: UI-triggered engine reload,
+// reload-coordinator registration, the post-org-onboarding reload latch,
+// server reload-event polling, and desktop engine info. Extracted verbatim
+// from session-route.tsx; reload events are now typed (OpenworkReloadEvent)
+// instead of `any`.
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { engineInfo } from "@/app/lib/desktop";
+import type { EngineInfo } from "@/app/lib/desktop-types";
+import { isDesktopRuntime } from "@/app/lib/runtime-env";
+import type { OpenworkServerClient } from "@/app/lib/openwork-server";
+import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
+import { t } from "@/i18n";
+import { useReloadCoordinator } from "./reload-coordinator";
+import { refreshProviderListQueries } from "@/react-app/infra/provider-list-query";
+import { getReactQueryClient } from "@/react-app/infra/query-client";
+import type { RouteWorkspace } from "./route-workspaces";
+
+const reloadAfterOrgOnboardingKey = "openwork.reloadAfterOrgOnboarding";
+
+export type UseEngineReloadInput = {
+  client: OpenworkServerClient | null;
+  workspaceId: string;
+  workspace: RouteWorkspace | null | undefined;
+  endpointForWorkspace: (
+    workspace: RouteWorkspace | null | undefined,
+  ) => ResolvedWorkspaceEndpoint | null;
+  activeReloadBlockingSessions: { id: string; title: string }[];
+  onError: (message: string) => void;
+  refreshRouteState: () => Promise<void>;
+};
+
+export function useEngineReload(input: UseEngineReloadInput) {
+  const {
+    client,
+    workspaceId,
+    workspace,
+    endpointForWorkspace,
+    activeReloadBlockingSessions,
+    onError,
+    refreshRouteState,
+  } = input;
+  const reloadCoordinator = useReloadCoordinator();
+  const [engineReloadVersion, setEngineReloadVersion] = useState(0);
+  const [routeEngineInfo, setRouteEngineInfo] = useState<EngineInfo | null>(null);
+  const reloadEventCursorByWorkspaceRef = useRef<Record<string, number | null>>({});
+
+  const reloadWorkspaceEngineFromUi = useCallback(async () => {
+    if (!client || !workspaceId) {
+      onError(t("app.error_connect_first"));
+      return false;
+    }
+    const endpoint = endpointForWorkspace(workspace);
+    if (!endpoint) {
+      onError(t("app.error_connect_first"));
+      return false;
+    }
+    await endpoint.client.reloadEngine(endpoint.workspaceId);
+    await refreshProviderListQueries(getReactQueryClient());
+    setEngineReloadVersion((v) => v + 1);
+    try {
+      window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
+    } catch {
+      // ignore browser event dispatch failures
+    }
+    await refreshRouteState();
+    return true;
+  }, [client, endpointForWorkspace, onError, refreshRouteState, workspace, workspaceId]);
+
+  useEffect(() => {
+    return reloadCoordinator.registerWorkspaceReloadControls({
+      canReloadWorkspaceEngine: () => Boolean(client && workspaceId),
+      reloadWorkspaceEngine: reloadWorkspaceEngineFromUi,
+      activeSessions: () => activeReloadBlockingSessions,
+    });
+  }, [activeReloadBlockingSessions, client, reloadCoordinator, reloadWorkspaceEngineFromUi, workspaceId]);
+
+  useEffect(() => {
+    if (!reloadCoordinator.canReloadWorkspaceEngine) return;
+    try {
+      if (window.localStorage.getItem(reloadAfterOrgOnboardingKey) !== "1") return;
+    } catch {
+      return;
+    }
+    if (!reloadCoordinator.reloadPending) {
+      reloadCoordinator.markReloadRequired("config", {
+        type: "config",
+        name: "opencode.json",
+        action: "updated",
+      });
+      return;
+    }
+    try {
+      window.localStorage.removeItem(reloadAfterOrgOnboardingKey);
+    } catch {}
+    void reloadCoordinator.reloadWorkspaceEngine();
+  }, [reloadCoordinator, reloadCoordinator.canReloadWorkspaceEngine, reloadCoordinator.reloadPending]);
+
+  useEffect(() => {
+    if (!client || !workspaceId) return;
+    const endpoint = endpointForWorkspace(workspace);
+    if (!endpoint) return;
+    let cancelled = false;
+
+    const pollReloadEvents = async () => {
+      const currentCursor = reloadEventCursorByWorkspaceRef.current[workspaceId];
+      try {
+        const response = await endpoint.client.listReloadEvents(
+          endpoint.workspaceId,
+          typeof currentCursor === "number" ? { since: currentCursor } : undefined,
+        );
+        if (cancelled) return;
+        reloadEventCursorByWorkspaceRef.current[workspaceId] =
+          typeof response.cursor === "number"
+            ? response.cursor
+            : Math.max(currentCursor ?? 0, ...((response.items ?? []).map((item) => Number(item.seq) || 0)));
+        // The first poll establishes the server cursor so historical reload
+        // events don't show a stale toast on route entry. Subsequent polls mark
+        // new filesystem/server-side mutations, including skills created by an
+        // agent while the session page is open.
+        if (currentCursor === undefined || currentCursor === null) return;
+        for (const event of response.items ?? []) {
+          reloadCoordinator.markReloadRequired(event.reason, event.trigger);
+        }
+      } catch {
+        // Reload-event polling is best-effort; normal route health checks still
+        // surface connection failures.
+      }
+    };
+
+    void pollReloadEvents();
+    const interval = window.setInterval(() => void pollReloadEvents(), 3000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [client, endpointForWorkspace, reloadCoordinator, workspace, workspaceId]);
+
+  useEffect(() => {
+    if (!isDesktopRuntime()) return;
+    let cancelled = false;
+    void engineInfo()
+      .then((info) => {
+        // Pre-existing cast: the desktop bridge is a dynamic Proxy, so
+        // engineInfo() returns unknown until the IPC surface is typed
+        // (queued: DesktopCommandMap).
+        if (!cancelled) setRouteEngineInfo(info as EngineInfo | null);
+      })
+      .catch(() => {
+        if (!cancelled) setRouteEngineInfo(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { engineReloadVersion, routeEngineInfo };
+}


### PR DESCRIPTION
## What

Continues #2200 (steps 7–9 of the session-route decomposition). Three commits, each independently gated and revertable.

| Commit | Change |
|---|---|
| `8451b3bd4` | **useEngineReload** (`shell/use-engine-reload.ts`): UI-triggered engine reload, reload-coordinator registration, post-org-onboarding reload latch, reload-event polling (per-workspace cursor), desktop engine info. Reload events now flow through their existing `OpenworkReloadEvent` type instead of `(item: any)`. `shareWorkspaceState` relocated below the hook (its outputs are only consumed later; behavior unchanged). |
| `04ce94089` | **RouteSession typing**: `sessionsByWorkspaceId` was `Record<string, any[]>` in both routes even though `listSessions` has returned typed SDK `Session[]` all along. New `RouteSession` (SDK Session + the defensive run-status fields the sidebar probes). Kills 4 `session as any` inserts and 14 `(session: any)` lambdas — **session-route.tsx now contains zero `as any`/`: any`** (24 at survey time, highest in the repo). |
| `d62e5c8e8` | **settings-route adopts useModelPicker** (-99 lines): settings carried a drifted copy of the picker + option loader that rendered the RAW model list — **models from org-blocked providers (dev #1505 desktop policy) were selectable from Settings** while the session route filtered them. Adopting the shared hook closes the hole. Settings-specific behavior preserved: `refreshProviders()` on open + error toast via the hook's new optional `onLoadError`. |

Running tally for the decomposition: `session-route.tsx` 3,328 → 2,677 · `settings-route.tsx` 2,595 → 2,402 · third latent bug fixed by deduplication (after the settings remote-clobber fix in #2200 and the macOS reload-trigger fix in #2199).

## Tests (ran after every commit)

```
pnpm --filter @openwork/app typecheck   # clean
pnpm --filter @openwork/app test        # 58 pass, 0 fail
pnpm --filter @openwork/app build       # vite production build clean
pnpm --filter @openwork/app test:e2e    # 23/23 assertions ok (real app + opencode)
```

No video: behavior-preserving refactor (the one intentional change is the restriction-filter fix described above, UI-visible only when org policies block providers). Reviewer repro: commands above; for the policy fix, set a desktop policy blocking a provider and open Settings → model picker.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

