### PR TITLE
feat(den): host the den-admin analytics MCP on den-api at /mcp/admin

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -165,6 +165,26 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     iconSrc: "/openwork-mark.svg",
   },
   {
+    get name() { return t("mcp.quick_connect_openwork_admin_title"); },
+    serverName: "openwork-admin",
+    get description() { return t("mcp.quick_connect_openwork_admin_desc"); },
+    get url() {
+      // den-api serves the admin MCP at /mcp/admin, next to the org-scoped
+      // /mcp endpoint. Access is enforced server-side via the platform-admin
+      // allowlist, so this entry stays hidden from the default catalog.
+      try {
+        return `${getDenMcpUrl()}/admin`;
+      } catch {
+        return "https://api.openworklabs.com/mcp/admin";
+      }
+    },
+    type: "remote",
+    oauth: true,
+    kind: "mcp",
+    iconSrc: "/openwork-mark.svg",
+    defaultHidden: true,
+  },
+  {
     get name() { return t("mcp.quick_connect_openwork_ui_title"); },
     serverName: "openwork-ui",
     get description() { return t("mcp.quick_connect_openwork_ui_desc"); },

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -644,6 +644,8 @@ export default {
   "mcp.quick_connect_linear_title": "Linear",
   "mcp.quick_connect_notion_desc": "Pages, databases, and project docs in sync.",
   "mcp.quick_connect_notion_title": "Notion",
+  "mcp.quick_connect_openwork_admin_desc": "Read-only Den analytics for OpenWork platform admins: growth, retention, company lookups, and ad-hoc queries. Requires an allowlisted admin account. Try: \"What's our weekly signup growth?\"",
+  "mcp.quick_connect_openwork_admin_title": "OpenWork Admin Analytics",
   "mcp.quick_connect_openwork_cloud_desc": "Manage your org, workers, skills, providers, and team config from chat. Try: \"List all workers in my org\" or \"Push this skill to the team.\"",
   "mcp.quick_connect_openwork_cloud_title": "OpenWork Cloud Control",
   "mcp.quick_connect_openwork_ui_desc": "Let agents see and drive the OpenWork app. Navigate sessions, type into the composer, open settings. Try: \"Take a snapshot of what I see\" or \"Create a new session and type hello.\"",

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -630,17 +630,22 @@ export function createConnectionsStore(options: {
         }
       }
 
-      // Signed-in cloud users connect the Den MCP with a first-party token —
+      // Signed-in cloud users connect the Den MCPs with a first-party token —
       // no browser OAuth round-trip. Signed-out users fall back to OAuth.
-      if (entry.serverName === "openwork-cloud") {
+      // The same minted token works for both /mcp (openwork-cloud) and
+      // /mcp/admin (openwork-admin); den-api enforces the platform-admin
+      // allowlist on the admin endpoint server-side.
+      if (entry.serverName === "openwork-cloud" || entry.serverName === "openwork-admin") {
         try {
           const minted = await mintCloudControlMcpToken();
           if (minted) {
-            // Never trust `minted.resource` verbatim: older den-api builds
-            // mint the bare web-app origin (https://app.openworklabs.com/mcp)
-            // where MCP 404s. Heal it, falling back to the entry's
-            // bootstrap-derived URL.
-            resolvedUrl = resolveCloudMcpResourceUrl(minted.resource) ?? resolvedUrl;
+            if (entry.serverName === "openwork-cloud") {
+              // Never trust `minted.resource` verbatim: older den-api builds
+              // mint the bare web-app origin (https://app.openworklabs.com/mcp)
+              // where MCP 404s. Heal it, falling back to the entry's
+              // bootstrap-derived URL.
+              resolvedUrl = resolveCloudMcpResourceUrl(minted.resource) ?? resolvedUrl;
+            }
             resolvedHeaders = { Authorization: `Bearer ${minted.token}` };
           }
         } catch {

--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -9,6 +9,7 @@ import { requestId } from "hono/request-id"
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
 import { z } from "zod"
 import { env } from "./env.js"
+import { registerAdminMcpRoutes } from "./mcp/admin.js"
 import { registerMcpRoutes } from "./mcp/index.js"
 import type { MemberTeamsContext, OrganizationContextVariables, UserOrganizationsContext } from "./middleware/index.js"
 import { buildOperationId, emptyResponse, htmlResponse, jsonResponse } from "./openapi.js"
@@ -125,6 +126,7 @@ registerWebhookRoutes(app)
 registerWorkerRoutes(app)
 registerMcpTokenRoutes(app)
 registerMcpRoutes(app)
+registerAdminMcpRoutes(app)
 registerTelemetryRoutes(app)
 
 app.get(

--- a/ee/apps/den-api/src/mcp/admin-tools.ts
+++ b/ee/apps/den-api/src/mcp/admin-tools.ts
@@ -1,0 +1,594 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { sql, type SQL } from "@openwork-ee/den-db/drizzle"
+import { z } from "zod"
+import { db } from "../db.js"
+import { denApiAppVersion } from "../version.js"
+
+/**
+ * den-admin MCP toolset: read-only Den analytics for allowlisted platform
+ * admins, served over streamable HTTP at /mcp/admin (see ./admin.ts).
+ *
+ * This is the server-hosted successor of ee/packages/den-admin-mcp (the
+ * stdio break-glass variant that talks straight to MySQL). Tool names and
+ * payloads are kept compatible; bump DEN_ADMIN_MCP_VERSION when they change
+ * so `den_admin_version` can be used to spot stale deploys.
+ *
+ * Hardening: every statement goes through the shared read-only guard, raw
+ * `den_query` results are row-capped, and all queries race a wall-clock
+ * timeout so one expensive SELECT cannot pin an API worker indefinitely.
+ */
+
+export const DEN_ADMIN_MCP_VERSION = "0.2.0"
+
+const QUERY_TIMEOUT_MS = 15_000
+const DEFAULT_ROW_LIMIT = 200
+const MAX_ROW_LIMIT = 1000
+
+const SERVER_STARTED_AT = new Date().toISOString()
+
+type Row = Record<string, unknown>
+
+/**
+ * `db` is drizzle over either mysql2 (returns `[rows, fields]`) or
+ * PlanetScale serverless (returns `{ rows }`). Normalize both shapes.
+ */
+export function normalizeRows(result: unknown): Row[] {
+  if (Array.isArray(result)) {
+    const first: unknown = result[0]
+    if (Array.isArray(first)) {
+      return first as Row[]
+    }
+    return result as Row[]
+  }
+  if (typeof result === "object" && result !== null && Array.isArray((result as { rows?: unknown }).rows)) {
+    return (result as { rows: Row[] }).rows
+  }
+  return []
+}
+
+async function rows(query: SQL): Promise<Row[]> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Query exceeded the ${QUERY_TIMEOUT_MS}ms time limit`)),
+      QUERY_TIMEOUT_MS,
+    )
+  })
+  try {
+    const result: unknown = await Promise.race([db.execute(query), timeout])
+    return normalizeRows(result)
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+const n = (value: unknown) => {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+/** Inline a zod-validated integer into SQL (interval/limit positions reject placeholders on some drivers). */
+function intLiteral(value: number): SQL {
+  if (!Number.isInteger(value)) {
+    throw new Error("Expected an integer")
+  }
+  return sql.raw(String(value))
+}
+
+function idList(ids: string[]): SQL {
+  return sql.join(ids.map((id) => sql`${id}`), sql`, `)
+}
+
+function toTime(value: unknown): number | null {
+  if (value instanceof Date) {
+    const time = value.getTime()
+    return Number.isNaN(time) ? null : time
+  }
+  if (typeof value === "string" && value.trim()) {
+    const time = Date.parse(value)
+    return Number.isNaN(time) ? null : time
+  }
+  return null
+}
+
+function toIso(value: unknown): string | null {
+  const time = toTime(value)
+  return time === null ? null : new Date(time).toISOString()
+}
+
+type ToolResult = { content: Array<{ type: "text"; text: string }>; isError?: boolean }
+
+function ok(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] }
+}
+
+async function run(fn: () => Promise<unknown>): Promise<ToolResult> {
+  try {
+    return ok(await fn())
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { content: [{ type: "text", text: `Error: ${message}` }], isError: true }
+  }
+}
+
+function isMissingTable(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false
+  }
+  const record = error as Record<string, unknown>
+  if (record.code === "ER_NO_SUCH_TABLE") {
+    return true
+  }
+  if (typeof record.message === "string" && /table '.*' doesn't exist/i.test(record.message)) {
+    return true
+  }
+  return isMissingTable(record.cause)
+}
+
+// --- activity (sign-in session days UNION session.active telemetry days) ---
+// Matches den-api /v1/admin/overview: a user is "active" on a day if they
+// have a sign-in session day or a session.active telemetry event that day.
+
+async function activeUserCount(days: number): Promise<number> {
+  const interval = intLiteral(days)
+  try {
+    const result = await rows(sql`SELECT COUNT(DISTINCT uid) AS count FROM (
+        SELECT s.user_id AS uid FROM session s
+         WHERE s.updated_at >= DATE_SUB(NOW(), INTERVAL ${interval} DAY)
+        UNION
+        SELECT m.user_id FROM telemetry_event t
+          JOIN member m ON m.id = t.member_id
+         WHERE m.user_id IS NOT NULL
+           AND t.event_timestamp >= DATE_SUB(NOW(), INTERVAL ${interval} DAY)
+      ) activity`)
+    return n(result[0]?.count)
+  } catch (error) {
+    if (!isMissingTable(error)) throw error
+    const result = await rows(sql`SELECT COUNT(DISTINCT user_id) AS count FROM session
+       WHERE updated_at >= DATE_SUB(NOW(), INTERVAL ${interval} DAY)`)
+    return n(result[0]?.count)
+  }
+}
+
+async function activityDays(): Promise<Row[]> {
+  try {
+    return await rows(sql`SELECT s.user_id AS uid, DATE(s.updated_at) AS day FROM session s
+        UNION
+        SELECT m.user_id, DATE(t.event_timestamp) FROM telemetry_event t
+          JOIN member m ON m.id = t.member_id
+         WHERE m.user_id IS NOT NULL`)
+  } catch (error) {
+    if (!isMissingTable(error)) throw error
+    return rows(sql`SELECT user_id AS uid, DATE(updated_at) AS day FROM session GROUP BY uid, day`)
+  }
+}
+
+async function lastActiveByUser(userIds: string[]): Promise<Map<string, number>> {
+  const result = new Map<string, number>()
+  if (userIds.length === 0) return result
+  const merge = (userId: unknown, value: unknown) => {
+    if (typeof userId !== "string") return
+    const time = toTime(value)
+    if (time === null) return
+    const previous = result.get(userId)
+    if (previous === undefined || time > previous) result.set(userId, time)
+  }
+  const sessionRows = await rows(
+    sql`SELECT user_id, MAX(updated_at) AS last FROM session WHERE user_id IN (${idList(userIds)}) GROUP BY user_id`,
+  )
+  for (const row of sessionRows) merge(row.user_id, row.last)
+  try {
+    const telemetryRows = await rows(
+      sql`SELECT m.user_id AS user_id, MAX(t.event_timestamp) AS last FROM telemetry_event t
+           JOIN member m ON m.id = t.member_id
+          WHERE m.user_id IN (${idList(userIds)}) GROUP BY m.user_id`,
+    )
+    for (const row of telemetryRows) merge(row.user_id, row.last)
+  } catch (error) {
+    if (!isMissingTable(error)) throw error
+  }
+  return result
+}
+
+const lastActiveIso = (lastActive: Map<string, number>, userId: unknown): string | null => {
+  if (typeof userId !== "string") return null
+  const time = lastActive.get(userId)
+  return time === undefined ? null : new Date(time).toISOString()
+}
+
+type Membership = { organization: unknown; slug: unknown; role: unknown }
+
+async function membershipsByUser(userIds: string[]): Promise<Map<string, Membership[]>> {
+  const result = new Map<string, Membership[]>()
+  if (userIds.length === 0) return result
+  const memberRows = await rows(
+    sql`SELECT m.user_id, m.role, o.name, o.slug FROM member m
+         JOIN organization o ON o.id = m.organization_id
+        WHERE m.user_id IN (${idList(userIds)}) AND m.removed_at IS NULL`,
+  )
+  for (const row of memberRows) {
+    if (typeof row.user_id !== "string") continue
+    const list = result.get(row.user_id) ?? []
+    list.push({ organization: row.name, slug: row.slug, role: row.role })
+    result.set(row.user_id, list)
+  }
+  return result
+}
+
+async function describeUsers(userRows: Row[]) {
+  const ids = userRows
+    .map((row) => row.id)
+    .filter((id): id is string => typeof id === "string")
+  const [lastActive, memberships] = await Promise.all([
+    lastActiveByUser(ids),
+    membershipsByUser(ids),
+  ])
+  return userRows.map((row) => ({
+    name: row.name,
+    email: row.email,
+    signedUpAt: row.created_at,
+    lastActiveAt: lastActiveIso(lastActive, row.id),
+    organizations: (typeof row.id === "string" ? memberships.get(row.id) : undefined) ?? [],
+  }))
+}
+
+// --- read-only guard for den_query ---
+
+const FORBIDDEN_SQL =
+  /\b(insert|update|delete|drop|alter|create|truncate|rename|replace|grant|revoke|call|load|handler|lock|unlock|set|use|outfile|dumpfile|for\s+update)\b/i
+
+export function assertReadOnlySql(input: string): string {
+  const sqlText = input.trim().replace(/;+\s*$/, "")
+  if (sqlText.includes(";")) throw new Error("Only a single SQL statement is allowed")
+  if (!/^(select|with|show|describe|explain)\b/i.test(sqlText)) {
+    throw new Error("Only SELECT/WITH/SHOW/DESCRIBE/EXPLAIN statements are allowed")
+  }
+  if (FORBIDDEN_SQL.test(sqlText)) {
+    throw new Error("Statement contains a forbidden keyword (read-only access)")
+  }
+  return sqlText
+}
+
+/** Append a LIMIT to bare SELECT/WITH statements and clamp the cap. */
+export function applyDefaultRowLimit(sqlText: string, limit?: number): { sql: string; cap: number } {
+  const cap = Math.max(1, Math.min(limit ?? DEFAULT_ROW_LIMIT, MAX_ROW_LIMIT))
+  if (/^(select|with)\b/i.test(sqlText) && !/\blimit\s+\d+/i.test(sqlText)) {
+    return { sql: `${sqlText} LIMIT ${cap}`, cap }
+  }
+  return { sql: sqlText, cap }
+}
+
+export function buildAdminMcpVersionInfo() {
+  return {
+    name: "den-admin",
+    transport: "streamable-http",
+    toolsetVersion: DEN_ADMIN_MCP_VERSION,
+    denApi: denApiAppVersion,
+    node: process.version,
+    serverStartedAt: SERVER_STARTED_AT,
+  }
+}
+
+// --- tool registration ---
+
+export function registerAdminMcpTools(server: McpServer) {
+  server.registerTool(
+    "den_admin_version",
+    {
+      description:
+        "Report the den-admin MCP toolset version, den-api build versions, and process start time so you can verify which build is deployed.",
+    },
+    async () => run(async () => buildAdminMcpVersionInfo()),
+  )
+
+  server.registerTool(
+    "den_overview",
+    {
+      description:
+        "High-level Den admin overview: total users/organizations/members, new users (7d/30d), active users (DAU/WAU/MAU), pending invitations, and subscriptions by status.",
+    },
+    async () =>
+      run(async () => {
+        const [users, orgs, members, invitations, subscriptions, dau, wau, mau] = await Promise.all([
+          rows(sql`SELECT COUNT(*) AS total,
+                  SUM(created_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)) AS new7d,
+                  SUM(created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)) AS new30d
+                FROM user`),
+          rows(sql`SELECT COUNT(*) AS total FROM organization`),
+          rows(sql`SELECT COUNT(*) AS total FROM member WHERE removed_at IS NULL`),
+          rows(sql`SELECT COUNT(*) AS pending FROM invitation WHERE status = 'pending'`),
+          rows(sql`SELECT type, status, COUNT(*) AS count FROM org_subscriptions GROUP BY type, status`),
+          activeUserCount(1),
+          activeUserCount(7),
+          activeUserCount(30),
+        ])
+        return {
+          users: {
+            total: n(users[0]?.total),
+            newLast7d: n(users[0]?.new7d),
+            newLast30d: n(users[0]?.new30d),
+          },
+          organizations: n(orgs[0]?.total),
+          activeMembers: n(members[0]?.total),
+          pendingInvitations: n(invitations[0]?.pending),
+          activeUsers: { daily: dau, weekly: wau, monthly: mau },
+          subscriptions: subscriptions.map((row) => ({
+            type: row.type,
+            status: row.status,
+            count: n(row.count),
+          })),
+          note: "active = sign-in session day or session.active telemetry event",
+        }
+      }),
+  )
+
+  server.registerTool(
+    "den_growth",
+    {
+      description:
+        "Signup growth series for users or organizations, bucketed by day/week/month, with period-over-period growth rates and cumulative totals.",
+      inputSchema: z.object({
+        metric: z.enum(["users", "organizations"]).default("users").describe("What to count"),
+        interval: z.enum(["day", "week", "month"]).default("week").describe("Bucket size"),
+        periods: z.number().int().min(1).max(36).default(12).describe("How many periods back"),
+      }),
+    },
+    async ({ metric, interval, periods }) =>
+      run(async () => {
+        const table = sql.raw(metric === "organizations" ? "organization" : "user")
+        const format = { day: "%Y-%m-%d", week: "%x-W%v", month: "%Y-%m" }[interval]
+        const unit = sql.raw({ day: "DAY", week: "WEEK", month: "MONTH" }[interval])
+        const span = intLiteral(periods)
+        const [series, before] = await Promise.all([
+          rows(sql`SELECT DATE_FORMAT(created_at, ${format}) AS period, COUNT(*) AS count FROM ${table}
+              WHERE created_at >= DATE_SUB(NOW(), INTERVAL ${span} ${unit})
+              GROUP BY period ORDER BY period`),
+          rows(sql`SELECT COUNT(*) AS count FROM ${table}
+              WHERE created_at < DATE_SUB(NOW(), INTERVAL ${span} ${unit})`),
+        ])
+        let cumulative = n(before[0]?.count)
+        let previous: number | null = null
+        const buckets = series.map((row) => {
+          const count = n(row.count)
+          cumulative += count
+          const growthPercent =
+            previous === null || previous === 0
+              ? null
+              : Math.round(((count - previous) / previous) * 1000) / 10
+          previous = count
+          return { period: row.period, new: count, cumulative, growthPercent }
+        })
+        const complete = buckets.slice(0, -1)
+        const latest = complete[complete.length - 1]
+        return {
+          metric,
+          interval,
+          startingTotal: n(before[0]?.count),
+          buckets,
+          latestCompletePeriod: latest ?? null,
+          note: "last bucket is the current in-progress period; growthPercent compares new signups vs the previous bucket; periods with zero signups are omitted",
+        }
+      }),
+  )
+
+  server.registerTool(
+    "den_retention",
+    {
+      description:
+        "Weekly cohort retention: users grouped by ISO signup week, with the percentage active in each week after signup (activity = sign-in session days + session.active telemetry).",
+      inputSchema: z.object({
+        weeks: z.number().int().min(2).max(26).default(8).describe("How many signup-week cohorts"),
+      }),
+    },
+    async ({ weeks }) =>
+      run(async () => {
+        const users = await rows(
+          sql`SELECT id, DATE(created_at) AS day, DATE_FORMAT(created_at, '%x-W%v') AS week
+             FROM user WHERE created_at >= DATE_SUB(NOW(), INTERVAL ${intLiteral(weeks)} WEEK)`,
+        )
+        const activity = await activityDays()
+        const WEEK_MS = 7 * 86_400_000
+        const signupByUser = new Map<string, { week: string; time: number }>()
+        for (const row of users) {
+          const time = toTime(row.day)
+          if (typeof row.id !== "string" || typeof row.week !== "string" || time === null) continue
+          signupByUser.set(row.id, { week: row.week, time })
+        }
+        const cohorts = new Map<string, { size: number; retained: Map<number, Set<string>> }>()
+        for (const signup of signupByUser.values()) {
+          const cohort = cohorts.get(signup.week) ?? { size: 0, retained: new Map() }
+          cohort.size += 1
+          cohorts.set(signup.week, cohort)
+        }
+        for (const row of activity) {
+          if (typeof row.uid !== "string") continue
+          const signup = signupByUser.get(row.uid)
+          const dayTime = toTime(row.day)
+          if (!signup || dayTime === null) continue
+          const offset = Math.floor((dayTime - signup.time) / WEEK_MS)
+          if (offset < 0) continue
+          const cohort = cohorts.get(signup.week)
+          if (!cohort) continue
+          const usersAtOffset = cohort.retained.get(offset) ?? new Set<string>()
+          usersAtOffset.add(row.uid)
+          cohort.retained.set(offset, usersAtOffset)
+        }
+        const result = [...cohorts.entries()]
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([week, cohort]) => {
+            const byWeek: Record<string, { users: number; percent: number }> = {}
+            for (const [offset, retainedUsers] of [...cohort.retained.entries()].sort((a, b) => a[0] - b[0])) {
+              byWeek[`week${offset}`] = {
+                users: retainedUsers.size,
+                percent: Math.round((retainedUsers.size / cohort.size) * 1000) / 10,
+              }
+            }
+            return { cohort: week, signups: cohort.size, retention: byWeek }
+          })
+        return {
+          cohorts: result,
+          note: "week0 = signup week; weekN = active N weeks after signup",
+        }
+      }),
+  )
+
+  server.registerTool(
+    "den_company_users",
+    {
+      description:
+        "Find users related to a company: matches organizations by name/slug/allowed email domains, and users by email domain. Returns members with role, signup date, and last activity.",
+      inputSchema: z.object({
+        company: z.string().min(1).describe("Company name, org slug, or email domain (e.g. 'acme', 'acme.test')"),
+        limit: z.number().int().min(1).max(200).default(50).describe("Max users per group"),
+      }),
+    },
+    async ({ company, limit }) =>
+      run(async () => {
+        const query = company.includes("@") ? company.split("@").pop() ?? company : company
+        const like = `%${query}%`
+        const cap = intLiteral(limit)
+        const organizations = await rows(
+          sql`SELECT id, name, slug, created_at FROM organization
+            WHERE name LIKE ${like} OR slug LIKE ${like} OR allowed_email_domains LIKE ${like} LIMIT 10`,
+        )
+        const orgResults = []
+        for (const org of organizations) {
+          const memberRows = await rows(
+            sql`SELECT u.id, u.name, u.email, u.created_at, m.role, m.joined_at FROM member m
+               JOIN user u ON u.id = m.user_id
+              WHERE m.organization_id = ${org.id} AND m.removed_at IS NULL
+              ORDER BY m.joined_at LIMIT ${cap}`,
+          )
+          const lastActive = await lastActiveByUser(
+            memberRows.map((row) => row.id).filter((id): id is string => typeof id === "string"),
+          )
+          orgResults.push({
+            organization: org.name,
+            slug: org.slug,
+            createdAt: org.created_at,
+            members: memberRows.map((row) => ({
+              name: row.name,
+              email: row.email,
+              role: row.role,
+              joinedAt: row.joined_at,
+              lastActiveAt: lastActiveIso(lastActive, row.id),
+            })),
+          })
+        }
+        const domainRows = await rows(
+          sql`SELECT id, name, email, created_at FROM user
+            WHERE email LIKE ${`%@%${query}%`} ORDER BY created_at DESC LIMIT ${cap}`,
+        )
+        return {
+          organizations: orgResults,
+          usersByEmailDomain: await describeUsers(domainRows),
+        }
+      }),
+  )
+
+  server.registerTool(
+    "den_users_search",
+    {
+      description:
+        "Search users by name or email substring. Returns signup date, last activity, and organization memberships.",
+      inputSchema: z.object({
+        query: z.string().min(1).describe("Name or email substring"),
+        limit: z.number().int().min(1).max(100).default(20),
+      }),
+    },
+    async ({ query, limit }) =>
+      run(async () => {
+        const like = `%${query}%`
+        const userRows = await rows(
+          sql`SELECT id, name, email, created_at FROM user
+            WHERE email LIKE ${like} OR name LIKE ${like} ORDER BY created_at DESC LIMIT ${intLiteral(limit)}`,
+        )
+        return { users: await describeUsers(userRows) }
+      }),
+  )
+
+  server.registerTool(
+    "den_org_overview",
+    {
+      description:
+        "Deep dive on one organization (by slug or name): members by role, pending invitations, teams, subscriptions, and active members in the last 7/30 days.",
+      inputSchema: z.object({
+        org: z.string().min(1).describe("Organization slug or name"),
+      }),
+    },
+    async ({ org }) =>
+      run(async () => {
+        const matches = await rows(
+          sql`SELECT id, name, slug, allowed_email_domains, created_at FROM organization
+            WHERE slug = ${org} OR name LIKE ${`%${org}%`} LIMIT 1`,
+        )
+        const found = matches[0]
+        if (!found) throw new Error(`No organization matching "${org}"`)
+        const [roleRows, invitations, teams, subscriptions, memberRows] = await Promise.all([
+          rows(sql`SELECT role, COUNT(*) AS count FROM member
+              WHERE organization_id = ${found.id} AND removed_at IS NULL GROUP BY role`),
+          rows(sql`SELECT email, role, status, created_at FROM invitation
+              WHERE organization_id = ${found.id} AND status = 'pending' ORDER BY created_at DESC LIMIT 50`),
+          rows(sql`SELECT COUNT(*) AS count FROM team WHERE organization_id = ${found.id}`),
+          rows(sql`SELECT type, status, quantity, current_period_end FROM org_subscriptions
+              WHERE organization_id = ${found.id}`),
+          rows(sql`SELECT u.id, u.name, u.email, u.created_at, m.role FROM member m
+               JOIN user u ON u.id = m.user_id
+              WHERE m.organization_id = ${found.id} AND m.removed_at IS NULL LIMIT 100`),
+        ])
+        const lastActive = await lastActiveByUser(
+          memberRows.map((row) => row.id).filter((id): id is string => typeof id === "string"),
+        )
+        const activeSince = (days: number) => {
+          const cutoff = Date.now() - days * 86_400_000
+          return memberRows.filter((row) => {
+            const last = typeof row.id === "string" ? lastActive.get(row.id) : undefined
+            return last !== undefined && last >= cutoff
+          }).length
+        }
+        return {
+          organization: {
+            name: found.name,
+            slug: found.slug,
+            createdAt: found.created_at,
+            allowedEmailDomains: found.allowed_email_domains,
+          },
+          membersByRole: roleRows.map((row) => ({ role: row.role, count: n(row.count) })),
+          activeMembersLast7d: activeSince(7),
+          activeMembersLast30d: activeSince(30),
+          teams: n(teams[0]?.count),
+          pendingInvitations: invitations,
+          subscriptions,
+          members: memberRows.map((row) => ({
+            name: row.name,
+            email: row.email,
+            role: row.role,
+            lastActiveAt: lastActiveIso(lastActive, row.id),
+          })),
+        }
+      }),
+  )
+
+  server.registerTool(
+    "den_query",
+    {
+      description:
+        "Escape hatch: run a single read-only SQL statement (SELECT/WITH/SHOW/DESCRIBE/EXPLAIN) against the Den database. Useful tables: user, session, organization, member, invitation, team, org_subscriptions, telemetry_event, worker, audit_event. Avoid encrypted columns (scim_provider.scim_token, sso_provider.*_config, llm_provider.api_key, config_object_version payloads, inference upstream keys).",
+      inputSchema: z.object({
+        sql: z.string().min(1).describe("A single read-only SQL statement"),
+        limit: z.number().int().min(1).max(MAX_ROW_LIMIT).optional().describe("Row limit appended when the query has none"),
+      }),
+    },
+    async ({ sql: sqlText, limit }) =>
+      run(async () => {
+        const safe = applyDefaultRowLimit(assertReadOnlySql(sqlText), limit)
+        const result = await rows(sql.raw(safe.sql))
+        const capped = result.slice(0, MAX_ROW_LIMIT)
+        return {
+          rowCount: capped.length,
+          ...(result.length > capped.length ? { truncated: true } : {}),
+          rows: capped,
+        }
+      }),
+  )
+}

--- a/ee/apps/den-api/src/mcp/admin.ts
+++ b/ee/apps/den-api/src/mcp/admin.ts
@@ -1,0 +1,65 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StreamableHTTPTransport } from "@hono/mcp"
+import { eq } from "@openwork-ee/den-db/drizzle"
+import { AuthUserTable } from "@openwork-ee/den-db/schema"
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import type { Hono } from "hono"
+import { db } from "../db.js"
+import { isAdminEmailAllowed } from "../middleware/admin.js"
+import { getMcpResourceUrl, verifyMcpRequest } from "./auth.js"
+import { DEN_ADMIN_MCP_VERSION, registerAdminMcpTools } from "./admin-tools.js"
+
+/**
+ * Streamable-HTTP MCP endpoint for the den-admin analytics toolset.
+ *
+ * Auth is two layers:
+ * 1. The same bearer MCP tokens as /mcp (`verifyMcpRequest`), so the desktop
+ *    app's first-party minted token works here with no extra setup.
+ * 2. The platform-admin allowlist (`AdminAllowlistTable`) checked against the
+ *    token's user — the same gate as /v1/admin/overview. Non-admins get 403.
+ *
+ * This intentionally does NOT reuse the /mcp OpenAPI tool catalog: admin
+ * tools are hand-written read-only analytics (see ./admin-tools.ts), and the
+ * /mcp exposure policy keeps blocking everything tagged Admin.
+ */
+export function registerAdminMcpRoutes<T extends { Variables: Record<string, unknown> }>(app: Hono<T>) {
+  app.all("/mcp/admin", async (c) => {
+    const principal = await verifyMcpRequest(c.req.raw.headers, getMcpResourceUrl(c.req.raw))
+    if (principal instanceof Response) {
+      return principal
+    }
+
+    let userId: ReturnType<typeof normalizeDenTypeId<"user">> | null = null
+    try {
+      userId = normalizeDenTypeId("user", principal.userId)
+    } catch {
+      userId = null
+    }
+
+    const user = userId
+      ? (await db
+          .select({ email: AuthUserTable.email })
+          .from(AuthUserTable)
+          .where(eq(AuthUserTable.id, userId))
+          .limit(1))[0]
+      : undefined
+
+    if (!user || !(await isAdminEmailAllowed(user.email))) {
+      return c.json({
+        error: "admin_required",
+        message: "The den-admin MCP is restricted to allowlisted platform admins.",
+      }, 403)
+    }
+
+    const server = new McpServer({
+      name: "den-admin",
+      version: DEN_ADMIN_MCP_VERSION,
+    })
+    registerAdminMcpTools(server)
+
+    const transport = new StreamableHTTPTransport()
+    await server.connect(transport)
+    const response = await transport.handleRequest(c)
+    return response ?? new Response(null, { status: 204 })
+  })
+}

--- a/ee/apps/den-api/src/middleware/admin.ts
+++ b/ee/apps/den-api/src/middleware/admin.ts
@@ -9,6 +9,24 @@ function normalizeEmail(value: string | null | undefined) {
   return value?.trim().toLowerCase() ?? ""
 }
 
+/** Whether an email is on the platform-admin allowlist. Shared by the admin routes middleware and the den-admin MCP endpoint. */
+export async function isAdminEmailAllowed(email: string | null | undefined): Promise<boolean> {
+  const normalized = normalizeEmail(email)
+  if (!normalized) {
+    return false
+  }
+
+  await ensureAdminAllowlistSeeded()
+
+  const allowed = await db
+    .select({ id: AdminAllowlistTable.id })
+    .from(AdminAllowlistTable)
+    .where(eq(AdminAllowlistTable.email, normalized))
+    .limit(1)
+
+  return allowed.length > 0
+}
+
 export const requireAdminMiddleware: MiddlewareHandler<{ Variables: AuthContextVariables }> = async (c, next) => {
   const user = c.get("user")
   if (!user?.id) {
@@ -20,15 +38,7 @@ export const requireAdminMiddleware: MiddlewareHandler<{ Variables: AuthContextV
     return c.json({ error: "admin_email_required" }, 403) as never
   }
 
-  await ensureAdminAllowlistSeeded()
-
-  const allowed = await db
-    .select({ id: AdminAllowlistTable.id })
-    .from(AdminAllowlistTable)
-    .where(eq(AdminAllowlistTable.email, email))
-    .limit(1)
-
-  if (allowed.length === 0) {
+  if (!(await isAdminEmailAllowed(email))) {
     return c.json({ error: "forbidden" }, 403) as never
   }
 

--- a/ee/apps/den-api/test/admin-mcp.test.ts
+++ b/ee/apps/den-api/test/admin-mcp.test.ts
@@ -1,0 +1,103 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let adminTools: typeof import("../src/mcp/admin-tools.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  adminTools = await import("../src/mcp/admin-tools.js")
+})
+
+describe("assertReadOnlySql", () => {
+  test("allows read statements and strips trailing semicolons", () => {
+    expect(adminTools.assertReadOnlySql("SELECT 1;")).toBe("SELECT 1")
+    expect(adminTools.assertReadOnlySql("  explain select id from user  ")).toBe("explain select id from user")
+    expect(adminTools.assertReadOnlySql("SHOW TABLES")).toBe("SHOW TABLES")
+    expect(adminTools.assertReadOnlySql("WITH x AS (SELECT 1) SELECT * FROM x")).toBe(
+      "WITH x AS (SELECT 1) SELECT * FROM x",
+    )
+  })
+
+  test("rejects writes", () => {
+    expect(() => adminTools.assertReadOnlySql("DELETE FROM user")).toThrow()
+    expect(() => adminTools.assertReadOnlySql("UPDATE user SET name = 'x'")).toThrow()
+    expect(() => adminTools.assertReadOnlySql("INSERT INTO user VALUES (1)")).toThrow()
+    expect(() => adminTools.assertReadOnlySql("DROP TABLE user")).toThrow()
+  })
+
+  test("rejects multiple statements", () => {
+    expect(() => adminTools.assertReadOnlySql("SELECT 1; SELECT 2")).toThrow(
+      "Only a single SQL statement is allowed",
+    )
+  })
+
+  test("rejects forbidden keywords smuggled into read statements", () => {
+    expect(() => adminTools.assertReadOnlySql("SELECT * FROM user FOR UPDATE")).toThrow()
+    expect(() => adminTools.assertReadOnlySql("SELECT 1 INTO OUTFILE '/tmp/x'")).toThrow()
+    expect(() => adminTools.assertReadOnlySql("WITH x AS (SELECT 1) DELETE FROM user")).toThrow()
+  })
+})
+
+describe("applyDefaultRowLimit", () => {
+  test("appends the default limit to bare SELECTs", () => {
+    expect(adminTools.applyDefaultRowLimit("SELECT id FROM user")).toEqual({
+      sql: "SELECT id FROM user LIMIT 200",
+      cap: 200,
+    })
+  })
+
+  test("keeps an explicit LIMIT untouched", () => {
+    expect(adminTools.applyDefaultRowLimit("SELECT id FROM user LIMIT 5").sql).toBe(
+      "SELECT id FROM user LIMIT 5",
+    )
+  })
+
+  test("clamps the requested limit to the max row cap", () => {
+    expect(adminTools.applyDefaultRowLimit("SELECT id FROM user", 50_000)).toEqual({
+      sql: "SELECT id FROM user LIMIT 1000",
+      cap: 1000,
+    })
+  })
+
+  test("does not append LIMIT to SHOW/DESCRIBE statements", () => {
+    expect(adminTools.applyDefaultRowLimit("SHOW TABLES").sql).toBe("SHOW TABLES")
+  })
+})
+
+describe("normalizeRows", () => {
+  test("handles mysql2 [rows, fields] tuples", () => {
+    const rows = [{ id: 1 }, { id: 2 }]
+    expect(adminTools.normalizeRows([rows, [{ name: "id" }]])).toEqual(rows)
+    expect(adminTools.normalizeRows([[], []])).toEqual([])
+  })
+
+  test("handles PlanetScale { rows } payloads", () => {
+    const rows = [{ id: 1 }]
+    expect(adminTools.normalizeRows({ rows })).toEqual(rows)
+  })
+
+  test("returns empty for unknown shapes", () => {
+    expect(adminTools.normalizeRows(null)).toEqual([])
+    expect(adminTools.normalizeRows({ insertId: 3 })).toEqual([])
+  })
+})
+
+describe("buildAdminMcpVersionInfo", () => {
+  test("reports toolset and den-api versions for deploy verification", () => {
+    const info = adminTools.buildAdminMcpVersionInfo()
+    expect(info.name).toBe("den-admin")
+    expect(info.transport).toBe("streamable-http")
+    expect(info.toolsetVersion).toBe(adminTools.DEN_ADMIN_MCP_VERSION)
+    expect(info.toolsetVersion).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(typeof info.denApi.latestAppVersion).toBe("string")
+    expect(typeof info.denApi.minAppVersion).toBe("string")
+    expect(info.node).toBe(process.version)
+    expect(Date.parse(info.serverStartedAt)).not.toBeNaN()
+  })
+})

--- a/ee/packages/den-admin-mcp/README.md
+++ b/ee/packages/den-admin-mcp/README.md
@@ -4,10 +4,21 @@ Read-only admin analytics MCP server for the OpenWork Den database. Ask OpenWork
 things like "what's our weekly growth rate?", "show retention for the last 8
 weeks", or "who at acme.test is active?" and the agent answers from real data.
 
+> **Prefer the hosted endpoint.** den-api serves the same toolset over
+> streamable HTTP at `/mcp/admin` (see `ee/apps/den-api/src/mcp/admin.ts`),
+> authenticated with the desktop's first-party MCP token and gated by the
+> platform-admin allowlist — no `DATABASE_URL` on client machines. In the app,
+> connect "OpenWork Admin Analytics" from Settings -> Connections -> MCP
+> (under Show hidden). This stdio package remains the break-glass/dev variant
+> for when den-api itself is down. Keep tool payloads and
+> `DEN_ADMIN_MCP_VERSION` in sync between the two; `den_admin_version` reports
+> which build and transport you are talking to.
+
 ## Tools
 
 | Tool | What it answers |
 |---|---|
+| `den_admin_version` | Toolset version + transport, to spot stale deploys |
 | `den_overview` | Totals, new users 7d/30d, DAU/WAU/MAU, subscriptions |
 | `den_growth` | Signup growth series (day/week/month) + growth rates |
 | `den_retention` | Weekly signup cohorts x weeks-active retention matrix |

--- a/ee/packages/den-admin-mcp/index.mjs
+++ b/ee/packages/den-admin-mcp/index.mjs
@@ -178,7 +178,24 @@ function assertReadOnly(input) {
 
 // --- MCP server ---
 
-const server = new McpServer({ name: "den-admin", version: "0.1.0" });
+// Keep in sync with package.json and the server-hosted toolset version in
+// ee/apps/den-api/src/mcp/admin-tools.ts (DEN_ADMIN_MCP_VERSION).
+const DEN_ADMIN_MCP_VERSION = "0.2.0";
+
+const server = new McpServer({ name: "den-admin", version: DEN_ADMIN_MCP_VERSION });
+
+server.tool(
+  "den_admin_version",
+  "Report the den-admin MCP version and runtime so you can verify which build is running.",
+  {},
+  async () =>
+    run(async () => ({
+      name: "den-admin",
+      transport: "stdio",
+      toolsetVersion: DEN_ADMIN_MCP_VERSION,
+      node: process.version,
+    })),
+);
 
 server.tool(
   "den_overview",

--- a/ee/packages/den-admin-mcp/package.json
+++ b/ee/packages/den-admin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openwork-ee/den-admin-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Read-only admin analytics MCP server for the OpenWork Den database — growth, retention, company/user lookups",
   "private": true,
   "type": "module",

--- a/ee/packages/den-admin-mcp/scripts/smoke.mjs
+++ b/ee/packages/den-admin-mcp/scripts/smoke.mjs
@@ -102,8 +102,9 @@ try {
 
   const list = await request("tools/list", {});
   const toolNames = (list.result?.tools ?? []).map((tool) => tool.name).sort();
-  report("tools/list", toolNames.length === 7, toolNames.join(", "));
+  report("tools/list", toolNames.length === 8, toolNames.join(", "));
 
+  await callTool("den_admin_version", {});
   await callTool("den_overview", {});
   await callTool("den_growth", { metric: "users", interval: "month", periods: 6 });
   await callTool("den_retention", { weeks: 8 });

--- a/ee/packages/den-db/src/drizzle.ts
+++ b/ee/packages/den-db/src/drizzle.ts
@@ -1,1 +1,2 @@
 export { and, asc, count, desc, eq, gt, gte, inArray, isNotNull, isNull, or, sql } from "drizzle-orm"
+export type { SQL } from "drizzle-orm"


### PR DESCRIPTION
## What

Hosts the den-admin analytics MCP on den-api as a streamable-HTTP endpoint at `/mcp/admin`, so platform admins get the toolset with **zero client-side config** — no `DATABASE_URL` or env vars on laptops. Also adds a `den_admin_version` tool to both variants so stale deploys are easy to spot.

### Server (den-api)
- `src/mcp/admin.ts` — new `ALL /mcp/admin` MCP endpoint. Two auth layers: the same bearer MCP tokens as `/mcp` (first-party desktop minting works unchanged), then the platform-admin allowlist (same gate as `/v1/admin/overview`). Non-admins get `403 admin_required`.
- `src/mcp/admin-tools.ts` — all 7 analytics tools ported to drizzle (works in mysql2 and PlanetScale modes) plus `den_admin_version` (toolset version, den-api build versions, transport, process start time). Hardening: SELECT-only guard, 15s query timeout, 1000-row cap on `den_query`.
- `src/middleware/admin.ts` — extracted shared `isAdminEmailAllowed()`.

### Desktop app
- Hidden quick-connect entry **"OpenWork Admin Analytics"** (`openwork-admin`) under Show hidden, pointing at `<den-api>/mcp/admin`.
- Reuses the existing `openwork-cloud` first-party token minting, so allowlisted admins connect with one click.

### Stdio package (break-glass variant)
- Matching `den_admin_version` tool (reports `transport: "stdio"` vs `"streamable-http"`), bumped to 0.2.0, README points to the hosted endpoint as the paved path.

## Tests run

- `bun test` in `ee/apps/den-api` — **70 pass / 0 fail** (12 new tests: read-only guard, row-limit clamping, row normalization, version info)
- `tsc --noEmit` clean for den-api and `apps/app`
- Stdio smoke (`node scripts/smoke.mjs` against seeded local MySQL) — all checks passed (8 tools)
- Local E2E against a live den-api + seeded DB: 401 without token, 403 non-allowlisted, all 8 tools return real data, `den_query` guard rejects `DELETE` and multi-statements, `/mcp` unaffected

## Daytona validation (two-sandbox, real Electron + Den server on this branch)

- Server sandbox `openwork-server-20260612-133308` running this branch; health checks green; demo org seeded; `alex@acme.test` allowlisted as platform admin
- Electron sandbox `openwork-test-20260612-133539` bootstrapped against the Daytona Den server (verified `desktop-bootstrap` URLs, not production)
- Desktop handoff sign-in → Acme Robotics org → Settings → Extensions → Show hidden → connected "OpenWork Admin Analytics" with one click (no env vars)
- den-api logs show the OpenCode engine completing the MCP handshake on `/mcp/admin` (initialize 200, notification 202, SSE GET 200, tools/list 200 — 9× 200 total incl. post-reload reconnect)
- Unauthenticated request against the Daytona endpoint → 401

📹 **Recording** (535s): https://8090-5btg7xh0q9rcf7d8.daytonaproxy01.net/recordings/den-admin-mcp.mp4 (sandbox-hosted; expires with sandbox cleanup)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

