### PR TITLE
refactor(app): session-route decomposition round 3 — provider-auth wiring, as-never removal

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -33,7 +33,21 @@ import {
 } from "../../../../app/utils/providers";
 import { getReactQueryClient } from "../../../infra/query-client";
 import { ensureProviderListQuery } from "../../../infra/provider-list-query";
-import type { OpenworkServerStore } from "../openwork-server-store";
+import type { OpenworkServerStoreSnapshot } from "../openwork-server-store";
+
+/**
+ * The slice of the openwork-server store this store actually consumes.
+ * The settings route passes the full store; the session route passes a
+ * lightweight endpoint-backed adapter (previously forced through `as never`).
+ */
+export type ProviderAuthOpenworkServer = {
+  getSnapshot: () => Pick<
+    OpenworkServerStoreSnapshot,
+    "openworkServerStatus" | "openworkServerClient"
+  > & {
+    openworkServerCapabilities: { config?: { read?: boolean; write?: boolean } } | null;
+  };
+};
 import {
   denSessionUpdatedEvent,
   type DenSessionUpdatedDetail,
@@ -97,7 +111,7 @@ type CreateProviderAuthStoreOptions = {
   selectedWorkspaceRoot: () => string;
   runtimeWorkspaceId: () => string | null;
   ensureRuntimeWorkspaceId?: () => Promise<string | null | undefined>;
-  openworkServer: OpenworkServerStore;
+  openworkServer: ProviderAuthOpenworkServer;
   setProviders: (value: ProviderListItem[]) => void;
   setProviderDefaults: (value: Record<string, string>) => void;
   setProviderConnectedIds: (value: string[]) => void;

--- a/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
@@ -1,0 +1,178 @@
+// Session-route wiring for the provider-auth store: a stable store instance
+// fed by a latest-values ref, lifecycle (start/dispose), Zen-restriction sync,
+// workspace-change resync, the post-onboarding auto-open latch, and cloud
+// provider auto-sync. Extracted verbatim from session-route.tsx.
+import { useEffect, useMemo, useRef } from "react";
+
+import type { Client, ProviderListItem, WorkspaceDisplay } from "@/app/types";
+import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
+import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
+import { useCloudProviderAutoSync } from "@/react-app/domains/cloud/use-cloud-provider-auto-sync";
+import { useReloadCoordinator } from "@/react-app/shell/reload-coordinator";
+import { type RouteWorkspace, workspaceLabel } from "@/react-app/shell/route-workspaces";
+import { createProviderAuthStore, useProviderAuthStoreSnapshot } from "./store";
+
+const emptyWorkspaceDisplay: WorkspaceDisplay = {
+  id: "",
+  name: "",
+  path: "",
+  preset: "default",
+  workspaceType: "local",
+};
+
+export type UseSessionProviderAuthInput = {
+  opencodeClient: Client | null;
+  providers: ProviderListItem[];
+  providerDefaults: Record<string, string>;
+  providerConnectedIds: string[];
+  disabledProviderIds: string[];
+  selectedWorkspace: RouteWorkspace | null | undefined;
+  selectedWorkspaceEndpoint: ResolvedWorkspaceEndpoint | null;
+  selectedWorkspaceRoot: string;
+  selectedWorkspaceId: string;
+  setProviders: (value: ProviderListItem[]) => void;
+  setProviderDefaults: (value: Record<string, string>) => void;
+  setProviderConnectedIds: (value: string[]) => void;
+  setDisabledProviderIds: (value: string[]) => void;
+};
+
+export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
+  const {
+    opencodeClient,
+    providers,
+    providerDefaults,
+    providerConnectedIds,
+    disabledProviderIds,
+    selectedWorkspace,
+    selectedWorkspaceEndpoint,
+    selectedWorkspaceRoot,
+    selectedWorkspaceId,
+    setProviders,
+    setProviderDefaults,
+    setProviderConnectedIds,
+    setDisabledProviderIds,
+  } = input;
+  const checkDesktopRestriction = useCheckDesktopRestriction();
+  const reloadCoordinator = useReloadCoordinator();
+  const onboardingProviderAuthPendingRef = useRef(false);
+
+  const stateRef = useRef({
+    opencodeClient,
+    providers,
+    providerDefaults,
+    providerConnectedIds,
+    disabledProviderIds,
+    selectedWorkspace,
+    selectedWorkspaceEndpoint,
+    selectedWorkspaceRoot,
+  });
+  stateRef.current = {
+    opencodeClient,
+    providers,
+    providerDefaults,
+    providerConnectedIds,
+    disabledProviderIds,
+    selectedWorkspace,
+    selectedWorkspaceEndpoint,
+    selectedWorkspaceRoot,
+  };
+
+  const store = useMemo(
+    () =>
+      createProviderAuthStore({
+        client: () => stateRef.current.opencodeClient,
+        providers: () => stateRef.current.providers,
+        providerDefaults: () => stateRef.current.providerDefaults,
+        providerConnectedIds: () => stateRef.current.providerConnectedIds,
+        disabledProviders: () => stateRef.current.disabledProviderIds,
+        checkDesktopAppRestriction: checkDesktopRestriction,
+        selectedWorkspaceDisplay: () =>
+          stateRef.current.selectedWorkspace
+            ? ({
+                ...stateRef.current.selectedWorkspace,
+                name: workspaceLabel(stateRef.current.selectedWorkspace),
+              } as WorkspaceDisplay)
+            : emptyWorkspaceDisplay,
+        selectedWorkspaceRoot: () => stateRef.current.selectedWorkspaceRoot,
+        runtimeWorkspaceId: () => stateRef.current.selectedWorkspaceEndpoint?.workspaceId ?? null,
+        openworkServer: {
+          getSnapshot: () => ({
+            openworkServerStatus: stateRef.current.selectedWorkspaceEndpoint ? "connected" : "disconnected",
+            openworkServerClient: stateRef.current.selectedWorkspaceEndpoint?.client ?? null,
+            openworkServerCapabilities: stateRef.current.selectedWorkspaceEndpoint
+              ? {
+                  config: { read: true, write: true },
+                }
+              : null,
+          }),
+        },
+        setProviders,
+        setProviderDefaults,
+        setProviderConnectedIds,
+        setDisabledProviders: setDisabledProviderIds,
+        markOpencodeConfigReloadRequired: () => {
+          reloadCoordinator.markReloadRequired("config", {
+            type: "config",
+            name: "opencode.json",
+            action: "updated",
+          });
+        },
+      }),
+    [checkDesktopRestriction, reloadCoordinator],
+  );
+
+  useEffect(() => {
+    store.start();
+    return () => {
+      store.dispose();
+    };
+  }, [store]);
+
+  useEffect(() => {
+    if (!opencodeClient || !selectedWorkspaceId) return;
+
+    void store
+      .ensureProjectProviderDisabledState(
+        "opencode",
+        checkDesktopRestriction({ restriction: "allowZenModel" }),
+      )
+      .catch((error) => {
+        console.warn("[desktop-app-restrictions] failed to sync Zen restriction", error);
+      });
+  }, [checkDesktopRestriction, disabledProviderIds, opencodeClient, selectedWorkspaceId, selectedWorkspaceRoot, store]);
+
+  useEffect(() => {
+    store.syncFromOptions();
+  }, [
+    opencodeClient,
+    selectedWorkspace?.id,
+    selectedWorkspace?.workspaceType,
+    selectedWorkspaceEndpoint?.workspaceId,
+    selectedWorkspaceRoot,
+    store,
+  ]);
+
+  // After onboarding, auto-open the provider modal if no providers are connected.
+  // The welcome route appends ?onboarding=1 to the session URL after workspace creation.
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (!hash.includes("onboarding=1")) return;
+    // Strip the param so it doesn't re-trigger.
+    window.location.hash = hash.replace(/[?&]onboarding=1/, "");
+    onboardingProviderAuthPendingRef.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!onboardingProviderAuthPendingRef.current) return;
+    if (!selectedWorkspaceEndpoint) return;
+    onboardingProviderAuthPendingRef.current = false;
+    store.openProviderAuthModal({ returnFocusTarget: "composer" });
+  }, [selectedWorkspaceEndpoint, store]);
+
+  // Session is where forced sign-in lands. Keep org-managed cloud providers in
+  // sync here so sign-in applies opencode.json changes before Settings opens.
+  useCloudProviderAutoSync(store.runCloudProviderSync);
+  const snapshot = useProviderAuthStoreSnapshot(store);
+
+  return { store, snapshot };
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1284,7 +1284,7 @@ export function SessionRoute() {
                 }
               : null,
           }),
-        } as never,
+        },
         setProviders,
         setProviderDefaults,
         setProviderConnectedIds,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -105,12 +105,11 @@ import { useModelPicker } from "@/react-app/domains/session/modals/use-model-pic
 import { appMentionInstruction } from "@/react-app/domains/session/surface/composer/app-mentions";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
-import { createProviderAuthStore, useProviderAuthStoreSnapshot } from "@/react-app/domains/connections/provider-auth/store";
+import { useSessionProviderAuth } from "@/react-app/domains/connections/provider-auth/use-session-provider-auth";
 import { useMcpConnectedCount } from "@/react-app/domains/connections/use-mcp-connected-count";
 import { useRemoteAccessRestart } from "@/react-app/domains/workspace/remote-access-restart";
 import { RenameWorkspaceModal } from "@/react-app/domains/workspace/rename-workspace-modal";
 import { useRemoteWorkspaceConnectionEditor } from "@/react-app/domains/workspace/use-remote-workspace-connection-editor";
-import { useCloudProviderAutoSync } from "@/react-app/domains/cloud/use-cloud-provider-auto-sync";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
 import { OpenWorkModelsStartupDialog } from "@/react-app/domains/cloud/openwork-models-startup-dialog";
 import { OPENWORK_MODEL_PREVIEWS } from "@/react-app/domains/cloud/openwork-models-promo";
@@ -197,14 +196,6 @@ function isTransientStartupError(message: string | null | undefined) {
     value.includes("not ready")
   );
 }
-
-const emptyWorkspaceDisplay: WorkspaceDisplay = {
-  id: "",
-  name: "",
-  path: "",
-  preset: "default",
-  workspaceType: "local",
-};
 
 function describeTaskCreateError(error: unknown) {
   const message = describeRouteError(error);
@@ -417,7 +408,6 @@ export function SessionRoute() {
     [providerConnectedIds],
   );
   const [disabledProviderIds, setDisabledProviderIds] = useState<string[]>([]);
-  const onboardingProviderAuthPendingRef = useRef(false);
   // Bump to re-filter provider list when den session changes (sign-in/out)
   const [denSessionVersion, setDenSessionVersion] = useState(0);
   useEffect(() => {
@@ -1235,123 +1225,22 @@ export function SessionRoute() {
     providerConnectedIds,
   });
 
-  const sessionProviderAuthStateRef = useRef({
-    opencodeClient: opencodeClient as Client | null,
-    providers,
-    providerDefaults,
-    providerConnectedIds,
-    disabledProviderIds,
-    selectedWorkspace,
-    selectedWorkspaceEndpoint,
-    selectedWorkspaceRoot,
-  });
-  sessionProviderAuthStateRef.current = {
-    opencodeClient,
-    providers,
-    providerDefaults,
-    providerConnectedIds,
-    disabledProviderIds,
-    selectedWorkspace,
-    selectedWorkspaceEndpoint,
-    selectedWorkspaceRoot,
-  };
-
-  const sessionProviderAuthStore = useMemo(
-    () =>
-      createProviderAuthStore({
-        client: () => sessionProviderAuthStateRef.current.opencodeClient,
-        providers: () => sessionProviderAuthStateRef.current.providers,
-        providerDefaults: () => sessionProviderAuthStateRef.current.providerDefaults,
-        providerConnectedIds: () => sessionProviderAuthStateRef.current.providerConnectedIds,
-        disabledProviders: () => sessionProviderAuthStateRef.current.disabledProviderIds,
-        checkDesktopAppRestriction: checkDesktopRestriction,
-        selectedWorkspaceDisplay: () =>
-          sessionProviderAuthStateRef.current.selectedWorkspace
-            ? ({
-                ...sessionProviderAuthStateRef.current.selectedWorkspace,
-                name: workspaceLabel(sessionProviderAuthStateRef.current.selectedWorkspace),
-              } as WorkspaceDisplay)
-            : emptyWorkspaceDisplay,
-        selectedWorkspaceRoot: () => sessionProviderAuthStateRef.current.selectedWorkspaceRoot,
-        runtimeWorkspaceId: () => sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint?.workspaceId ?? null,
-        openworkServer: {
-          getSnapshot: () => ({
-            openworkServerStatus: sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint ? "connected" : "disconnected",
-            openworkServerClient: sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint?.client ?? null,
-            openworkServerCapabilities: sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint
-              ? {
-                  config: { read: true, write: true },
-                }
-              : null,
-          }),
-        },
-        setProviders,
-        setProviderDefaults,
-        setProviderConnectedIds,
-        setDisabledProviders: setDisabledProviderIds,
-        markOpencodeConfigReloadRequired: () => {
-          reloadCoordinator.markReloadRequired("config", {
-            type: "config",
-            name: "opencode.json",
-            action: "updated",
-          });
-        },
-      }),
-    [checkDesktopRestriction, reloadCoordinator],
-  );
-
-  useEffect(() => {
-    sessionProviderAuthStore.start();
-    return () => {
-      sessionProviderAuthStore.dispose();
-    };
-  }, [sessionProviderAuthStore]);
-
-  useEffect(() => {
-    if (!opencodeClient || !selectedWorkspaceId) return;
-
-    void sessionProviderAuthStore
-      .ensureProjectProviderDisabledState(
-        "opencode",
-        checkDesktopRestriction({ restriction: "allowZenModel" }),
-      )
-      .catch((error) => {
-        console.warn("[desktop-app-restrictions] failed to sync Zen restriction", error);
-      });
-  }, [checkDesktopRestriction, disabledProviderIds, opencodeClient, selectedWorkspaceId, selectedWorkspaceRoot, sessionProviderAuthStore]);
-
-  useEffect(() => {
-    sessionProviderAuthStore.syncFromOptions();
-  }, [
-    opencodeClient,
-    selectedWorkspace?.id,
-    selectedWorkspace?.workspaceType,
-    selectedWorkspaceEndpoint?.workspaceId,
-    selectedWorkspaceRoot,
-    sessionProviderAuthStore,
-  ]);
-
-  // After onboarding, auto-open the provider modal if no providers are connected.
-  // The welcome route appends ?onboarding=1 to the session URL after workspace creation.
-  useEffect(() => {
-    const hash = window.location.hash;
-    if (!hash.includes("onboarding=1")) return;
-    // Strip the param so it doesn't re-trigger.
-    window.location.hash = hash.replace(/[?&]onboarding=1/, "");
-    onboardingProviderAuthPendingRef.current = true;
-  }, []);
-
-  useEffect(() => {
-    if (!onboardingProviderAuthPendingRef.current) return;
-    if (!selectedWorkspaceEndpoint) return;
-    onboardingProviderAuthPendingRef.current = false;
-    sessionProviderAuthStore.openProviderAuthModal({ returnFocusTarget: "composer" });
-  }, [selectedWorkspaceEndpoint, sessionProviderAuthStore]);
-
-  // Session is where forced sign-in lands. Keep org-managed cloud providers in
-  // sync here so sign-in applies opencode.json changes before Settings opens.
-  useCloudProviderAutoSync(sessionProviderAuthStore.runCloudProviderSync);
-  const sessionProviderAuthSnapshot = useProviderAuthStoreSnapshot(sessionProviderAuthStore);
+  const { store: sessionProviderAuthStore, snapshot: sessionProviderAuthSnapshot } =
+    useSessionProviderAuth({
+      opencodeClient,
+      providers,
+      providerDefaults,
+      providerConnectedIds,
+      disabledProviderIds,
+      selectedWorkspace,
+      selectedWorkspaceEndpoint,
+      selectedWorkspaceRoot,
+      selectedWorkspaceId,
+      setProviders,
+      setProviderDefaults,
+      setProviderConnectedIds,
+      setDisabledProviderIds,
+    });
   const {
     activePermission,
     permissionReplyBusy,


### PR DESCRIPTION
## What

Continues #2200/#2201 (step 10 of the session-route decomposition). Two commits.

| Commit | Change |
|---|---|
| `85566d85a` | **Type the provider-auth store's openwork-server dependency**: `createProviderAuthStore` demanded the full `OpenworkServerStore` while only ever calling `getSnapshot()` and reading three fields (status, client, capabilities.config). The session route's endpoint-backed adapter was forced through `as never`. New `ProviderAuthOpenworkServer` narrows the option to the actual structural need — the settings route's full store still satisfies it; the session adapter typechecks without the cast. |
| `c672bd9f5` | **Extract useSessionProviderAuth** (`domains/connections/provider-auth/use-session-provider-auth.ts`): latest-values ref, store creation, start/dispose lifecycle, Zen-restriction sync, workspace-change resync, the `?onboarding=1` auto-open latch, cloud provider auto-sync, snapshot subscription. Verbatim move; the provider quartet + setters are explicit inputs; restriction checker and reload coordinator self-acquired. |

Decomposition tally: `session-route.tsx` **3,328 → 2,564** (-23%) · `as any`/`: any` 24 → 0 · `as never` 1 → 0 · 10 extracted domain hooks/modules.

## Tests (after each commit)

```
pnpm --filter @openwork/app typecheck   # clean
pnpm --filter @openwork/app test        # 58 pass, 0 fail
pnpm --filter @openwork/app build       # clean
pnpm --filter @openwork/app test:e2e    # 23/23 assertions ok
```

No video: behavior-preserving refactor, no UI change. Reviewer repro: commands above.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

