### PR TITLE
ci(den-db): fix Den DB Migrate — pass DATABASE_NAME to drizzle-kit

### DIFF
--- a/.github/workflows/den-db-migrate.yml
+++ b/.github/workflows/den-db-migrate.yml
@@ -6,6 +6,7 @@ name: Den DB Migrate
 #   DATABASE_HOST       PlanetScale host (e.g. aws.connect.psdb.cloud)
 #   DATABASE_USERNAME   PlanetScale branch password username
 #   DATABASE_PASSWORD   PlanetScale branch password
+#   DATABASE_NAME       PlanetScale database name (drizzle-kit migrate connects over the MySQL protocol and needs it)
 #
 # Runs automatically when migration files land on dev, and manually via
 # workflow_dispatch. For a database previously managed with db:push (no
@@ -50,6 +51,7 @@ jobs:
       DATABASE_HOST: ${{ secrets.DATABASE_HOST }}
       DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
       DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+      DATABASE_NAME: ${{ secrets.DATABASE_NAME }}
 
     steps:
       - name: Verify database secrets are configured
@@ -59,6 +61,7 @@ jobs:
           [ -z "$DATABASE_HOST" ] && missing="$missing DATABASE_HOST"
           [ -z "$DATABASE_USERNAME" ] && missing="$missing DATABASE_USERNAME"
           [ -z "$DATABASE_PASSWORD" ] && missing="$missing DATABASE_PASSWORD"
+          [ -z "$DATABASE_NAME" ] && missing="$missing DATABASE_NAME"
           if [ -n "$missing" ]; then
             echo "::error::Missing GitHub Actions secrets:$missing. Add them under Settings -> Secrets and variables -> Actions."
             exit 1

--- a/ee/packages/den-db/drizzle.config.ts
+++ b/ee/packages/den-db/drizzle.config.ts
@@ -16,8 +16,9 @@ function resolveDrizzleDbCredentials() {
   const host = process.env.DATABASE_HOST?.trim()
   const user = process.env.DATABASE_USERNAME?.trim()
   const password = process.env.DATABASE_PASSWORD ?? ""
+  const database = process.env.DATABASE_NAME?.trim()
 
-  if (!host || !user) {
+  if (!host || !user || !database) {
     if (isGenerateCommand()) {
       return {
         host: "127.0.0.1",
@@ -26,13 +27,14 @@ function resolveDrizzleDbCredentials() {
       }
     }
 
-    throw new Error("Provide DATABASE_URL for mysql or DATABASE_HOST/DATABASE_USERNAME/DATABASE_PASSWORD for planetscale")
+    throw new Error("Provide DATABASE_URL for mysql or DATABASE_HOST/DATABASE_USERNAME/DATABASE_PASSWORD/DATABASE_NAME for planetscale")
   }
 
   return {
     host,
     user,
     password,
+    database,
     // PlanetScale requires TLS for MySQL-protocol connections.
     ssl: { rejectUnauthorized: true },
   }


### PR DESCRIPTION
## What

The Den DB Migrate workflow has **never successfully applied migrations to production**. Its only run (triggered by #2195 landing `0022_marketplace_logo_url`) failed with:

```
Error  Please provide required params for MySQL driver:
    [✓] host: '***'
    [✓] user: '***'
    [✓] password: '*****'
    [x] database: undefined
```

Root cause: drizzle-kit's `migrate` connects over the MySQL protocol (mysql2), which requires a `database` name — but the PlanetScale branch of `drizzle.config.ts` never set one, and the workflow didn't pass one. (The baseline script and runtime client use the PlanetScale HTTP driver, which embeds the database in the credentials — that's why nothing else needed it.)

Fix (2 small changes):
- `ee/packages/den-db/drizzle.config.ts`: read `DATABASE_NAME`, include it in the PlanetScale credentials, and fail with a clear message when absent
- `.github/workflows/den-db-migrate.yml`: pass `DATABASE_NAME` from secrets and check it in the verify step (+ document it in the header)

## Required after merge

Add the **`DATABASE_NAME`** GitHub Actions secret (the PlanetScale database name), then `workflow_dispatch` the Den DB Migrate workflow. It should apply the pending `0022_marketplace_logo_url` (and `0023_grandfather_enterprise_plans` once #2198 merges).

## Tests

Verified the config resolves correctly in all three modes by importing it with controlled env:
- `DATABASE_URL=mysql://root:pw@127.0.0.1:3306/testdb` → `OK {"host":"127.0.0.1","port":3306,"user":"root","database":"testdb"}`
- `DATABASE_HOST/USERNAME/PASSWORD/NAME` → `OK {"host":"h.psdb.cloud","user":"u","database":"openwork","ssl":{"rejectUnauthorized":true}}`
- PlanetScale vars without `DATABASE_NAME` → throws `Provide DATABASE_URL for mysql or DATABASE_HOST/DATABASE_USERNAME/DATABASE_PASSWORD/DATABASE_NAME for planetscale`
- `db:generate` fallback path unchanged (no connection needed)

Cannot run the workflow end-to-end from a fork branch without the new secret — reproduction for the reviewer: merge, add the secret, dispatch with `dry_run=true` first (verify step now also checks `DATABASE_NAME`), then run for real.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

