### PR TITLE
ci(den-db): keep safe migrations enabled — CI toggles DDL only during migration runs

### DIFF
--- a/.github/workflows/den-db-migrate.yml
+++ b/.github/workflows/den-db-migrate.yml
@@ -3,10 +3,17 @@ name: Den DB Migrate
 # Applies Drizzle migrations to the production PlanetScale database.
 #
 # Required GitHub Actions secrets (Settings -> Secrets and variables -> Actions):
-#   DATABASE_HOST       PlanetScale host (e.g. aws.connect.psdb.cloud)
-#   DATABASE_USERNAME   PlanetScale branch password username
-#   DATABASE_PASSWORD   PlanetScale branch password
-#   DATABASE_NAME       PlanetScale database name (drizzle-kit migrate connects over the MySQL protocol and needs it)
+#   DATABASE_HOST                  PlanetScale host (e.g. aws.connect.psdb.cloud)
+#   DATABASE_USERNAME              PlanetScale branch password username
+#   DATABASE_PASSWORD              PlanetScale branch password
+#   DATABASE_NAME                  PlanetScale database name (drizzle-kit migrate connects over the MySQL protocol and needs it)
+#   PLANETSCALE_SERVICE_TOKEN_ID   PlanetScale service token id (used to toggle safe migrations)
+#   PLANETSCALE_SERVICE_TOKEN      PlanetScale service token secret
+#
+# Safe migrations stays enabled on the production branch at all times. This
+# workflow briefly disables it (direct DDL) while applying reviewed migration
+# files, then re-enables it in an always() step — so ad-hoc manual DDL stays
+# blocked outside CI runs.
 #
 # Runs automatically when migration files land on dev, and manually via
 # workflow_dispatch. For a database previously managed with db:push (no
@@ -52,6 +59,10 @@ jobs:
       DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
       DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
       DATABASE_NAME: ${{ secrets.DATABASE_NAME }}
+      PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
+      PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+      PLANETSCALE_ORG: ben-prologe
+      PLANETSCALE_BRANCH: main
 
     steps:
       - name: Verify database secrets are configured
@@ -62,6 +73,8 @@ jobs:
           [ -z "$DATABASE_USERNAME" ] && missing="$missing DATABASE_USERNAME"
           [ -z "$DATABASE_PASSWORD" ] && missing="$missing DATABASE_PASSWORD"
           [ -z "$DATABASE_NAME" ] && missing="$missing DATABASE_NAME"
+          [ -z "$PLANETSCALE_SERVICE_TOKEN_ID" ] && missing="$missing PLANETSCALE_SERVICE_TOKEN_ID"
+          [ -z "$PLANETSCALE_SERVICE_TOKEN" ] && missing="$missing PLANETSCALE_SERVICE_TOKEN"
           if [ -n "$missing" ]; then
             echo "::error::Missing GitHub Actions secrets:$missing. Add them under Settings -> Secrets and variables -> Actions."
             exit 1
@@ -84,6 +97,25 @@ jobs:
       - name: Install dependencies
         run: pnpm install --filter "@openwork-ee/den-db..."
 
+      - name: Setup pscale CLI
+        id: setup-pscale
+        uses: planetscale/setup-pscale-action@v1
+
+      - name: Disable safe migrations (allow DDL for this run only)
+        run: |
+          set -euo pipefail
+          state="$(pscale branch show "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" --format json | jq -r '.safe_migrations')"
+          echo "safe_migrations before run: $state"
+          if [ "$state" = "true" ]; then
+            pscale branch safe-migrations disable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG"
+            echo "Safe migrations disabled for the duration of this run."
+          elif [ "$state" = "false" ]; then
+            echo "Safe migrations already disabled; will re-enable at the end of this run."
+          else
+            echo "::error::Could not read safe_migrations state for $DATABASE_NAME/$PLANETSCALE_BRANCH."
+            exit 1
+          fi
+
       - name: Baseline existing migrations (one-time)
         if: github.event_name == 'workflow_dispatch' && inputs.baseline
         run: |
@@ -101,6 +133,18 @@ jobs:
       - name: Apply migrations
         if: github.event_name != 'workflow_dispatch' || !inputs.dry_run
         run: pnpm --filter @openwork-ee/den-db db:migrate
+
+      - name: Re-enable safe migrations
+        if: always() && steps.setup-pscale.conclusion == 'success'
+        run: |
+          set -euo pipefail
+          pscale branch safe-migrations enable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG"
+          state="$(pscale branch show "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" --format json | jq -r '.safe_migrations')"
+          echo "safe_migrations after run: $state"
+          if [ "$state" != "true" ]; then
+            echo "::error::Safe migrations is NOT re-enabled on $DATABASE_NAME/$PLANETSCALE_BRANCH. Re-enable it manually: pscale branch safe-migrations enable $DATABASE_NAME $PLANETSCALE_BRANCH --org $PLANETSCALE_ORG"
+            exit 1
+          fi
 
       - name: Dry run note
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run


### PR DESCRIPTION
## What

Follow-up to #2205. The Den DB Migrate workflow failed with `direct DDL is disabled` because PlanetScale **safe migrations** is enabled on `main` — which we want to keep (it blocks ad-hoc manual DDL).

This makes the workflow compatible while keeping safe migrations on at all times outside CI runs:

1. **Setup pscale CLI** (`planetscale/setup-pscale-action@v1`, authed via service-token env vars)
2. **Disable safe migrations** right before applying — reads current state via `pscale branch show --format json` first, fails loudly if the state can't be read
3. Run baseline / `db:migrate` as before
4. **Re-enable safe migrations** in an `always()` step (guarded on pscale setup having succeeded), then *verifies* the state is back to enabled and fails the run if not — so a failed re-enable can never pass silently

The DDL window is the duration of the migration steps (~1–2 min), executes only PR-reviewed migration files (gated by the existing "Schema and migrations in sync" check), and overlapping runs are prevented by the existing `den-db-migrate` concurrency group.

## Required secrets (new)

- `PLANETSCALE_SERVICE_TOKEN_ID` / `PLANETSCALE_SERVICE_TOKEN` — service token with access to the `openword-den` database (needs branch read + safe-migrations toggle permissions). Org (`ben-prologe`) and branch (`main`) are plain env vars in the workflow.

## Tests

- YAML validated (`yaml.safe_load`)
- `pscale branch safe-migrations enable|disable <db> <branch>` and `pscale branch show <db> <branch>` command shapes verified against pscale CLI v(latest) locally
- Cannot exercise the workflow end-to-end until the service-token secrets exist; reproduction for reviewer: add secrets, dispatch with `baseline=true, dry_run=true` — expect: state read → disable → baseline plan printed → re-enable → state verified `true`.

## Why not deploy requests ("full" safe-migrations flow)?

Considered and deliberately deferred: deploy requests carry schema only, so drizzle's `__drizzle_migrations` tracking and data migrations (e.g. the grandfathering UPDATE in #2198) would need custom reconciliation, and a mixed DDL+DML migration file would silently drop its DML on the discarded branch. This toggle keeps the protection that matters day-to-day (no ad-hoc DDL) without that permanent maintenance liability. Revisit when table sizes make online cutover/revert worth the complexity.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

