### PR TITLE
ci(den-db): wait for DDL window after safe-migrations toggle

### DIFF
--- a/.github/workflows/den-db-migrate.yml
+++ b/.github/workflows/den-db-migrate.yml
@@ -116,6 +116,28 @@ jobs:
             exit 1
           fi
 
+          # The toggle propagates to the connection gateway asynchronously, so
+          # probe with a real DDL statement until the window is actually open.
+          ddl_open=0
+          for attempt in $(seq 1 18); do
+            if (cd ee/packages/den-db && node --input-type=module -e "
+              const { Client } = await import('@planetscale/database');
+              const client = new Client({ host: process.env.DATABASE_HOST, username: process.env.DATABASE_USERNAME, password: process.env.DATABASE_PASSWORD });
+              await client.execute('CREATE TABLE IF NOT EXISTS __ddl_probe (id int)');
+              await client.execute('DROP TABLE IF EXISTS __ddl_probe');
+            " 2>/tmp/ddl-probe-err); then
+              ddl_open=1
+              echo "DDL window open (attempt $attempt)."
+              break
+            fi
+            echo "DDL still blocked (attempt $attempt): $(tail -1 /tmp/ddl-probe-err 2>/dev/null || true)"
+            sleep 10
+          done
+          if [ "$ddl_open" -ne 1 ]; then
+            echo "::error::DDL window did not open within 3 minutes after disabling safe migrations."
+            exit 1
+          fi
+
       - name: Baseline existing migrations (one-time)
         if: github.event_name == 'workflow_dispatch' && inputs.baseline
         run: |


### PR DESCRIPTION
## What

Follow-up to #2206. The first end-to-end run proved the toggle loop works (state `true` → disabled → re-enabled + verified `true`), but the baseline step still hit `direct DDL is disabled`: PlanetScale propagates the safe-migrations toggle to its connection gateway asynchronously, and the migration step ran ~2s after the disable.

Fix: after disabling, probe with a real DDL statement (`CREATE TABLE IF NOT EXISTS __ddl_probe` / `DROP TABLE`) via the same `@planetscale/database` HTTP client the baseline script uses, retrying every 10s for up to 3 minutes, and fail loudly if the window never opens.

## Tests

- YAML validated
- Evidence of the race from run 27447521191: disable succeeded, baseline failed with `direct DDL is disabled` seconds later, re-enable verified `true` — exactly the propagation gap this closes
- Will validate end-to-end by dispatching `baseline=true, dry_run=true` immediately after merge

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

