### PR TITLE
refactor(desktop): typed Electron IPC — DesktopCommandMap contract, command registry, CI gates

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -123,5 +123,11 @@ jobs:
       - name: Run server unit tests
         run: pnpm --filter openwork-server test
 
+      - name: Run desktop unit tests
+        run: pnpm --filter @openwork/desktop test
+
+      - name: Typecheck Electron main against the IPC contract
+        run: pnpm --filter @openwork/desktop typecheck:electron
+
       - name: Run e2e tests
         run: pnpm --filter @openwork/app test:e2e

--- a/apps/app/src/app/lib/desktop-types.ts
+++ b/apps/app/src/app/lib/desktop-types.ts
@@ -1,237 +1,47 @@
 // Type definitions for the desktop bridge.
-// These types were previously colocated with the Tauri bridge implementation.
-// They are runtime-agnostic and shared by the Electron bridge.
+// The payload shapes and the per-command contract live in
+// packages/types/src/desktop-ipc.ts (shared with the Electron main process);
+// this module re-exports them as the app-side import path.
 
 import type { WorkspaceWire } from "@openwork/types/workspace";
 
-export type EngineInfo = {
-  running: boolean;
-  runtime: "direct";
-  baseUrl: string | null;
-  projectDir: string | null;
-  hostname: string | null;
-  port: number | null;
-  opencodeUsername: string | null;
-  opencodePassword: string | null;
-  opencodeBinPath: string | null;
-  opencodeBinSource: string | null;
-  pid: number | null;
-  lastStdout: string | null;
-  lastStderr: string | null;
-  execution: OpencodeExecutionSnapshot | null;
-};
-
-export type OpencodeExecutionEnvEntry = {
-  name: string;
-  value: string;
-  redacted: boolean;
-};
-
-export type OpencodeExecutionSnapshot = {
-  command: string;
-  args: string[];
-  cwd: string;
-  env: OpencodeExecutionEnvEntry[];
-};
-
-export type OpenworkServerInfo = {
-  running: boolean;
-  remoteAccessEnabled: boolean;
-  host: string | null;
-  port: number | null;
-  baseUrl: string | null;
-  connectUrl: string | null;
-  mdnsUrl: string | null;
-  lanUrl: string | null;
-  clientToken: string | null;
-  ownerToken: string | null;
-  hostToken: string | null;
-  managedOpencodeBinPath: string | null;
-  managedOpencodeBinSource: string | null;
-  pid: number | null;
-  lastStdout: string | null;
-  lastStderr: string | null;
-  managedOpencodeExecution: OpencodeExecutionSnapshot | null;
-};
-
-export type EngineDoctorResult = {
-  found: boolean;
-  inPath: boolean;
-  resolvedPath: string | null;
-  resolvedSource: string | null;
-  version: string | null;
-  supportsServe: boolean;
-  notes: string[];
-  serveHelpStatus: number | null;
-  serveHelpStdout: string | null;
-  serveHelpStderr: string | null;
-};
+export type {
+  AppBuildInfo,
+  CacheResetResult,
+  DesktopBootstrapConfig,
+  DesktopCommandArgs,
+  DesktopCommandInvokers,
+  DesktopCommandMap,
+  DesktopCommandName,
+  DesktopCommandResult,
+  DesktopFetchInit,
+  DesktopFetchResult,
+  EngineDoctorResult,
+  EngineInfo,
+  ExecResult,
+  LocalSkillCard,
+  LocalSkillContent,
+  OpencodeCommandDraft,
+  OpencodeConfigFile,
+  OpencodeExecutionEnvEntry,
+  OpencodeExecutionSnapshot,
+  OpenworkDockerCleanupResult,
+  OpenworkServerInfo,
+  OrchestratorDetachedHost,
+  SandboxDebugProbeResult,
+  SandboxDoctorResult,
+  UpdaterEnvironment,
+  WorkspaceCreateInput,
+  WorkspaceCreateRemoteInput,
+  WorkspaceExportSummary,
+  WorkspaceList,
+  WorkspaceOpenworkConfig,
+  WorkspaceUpdateRemoteInput,
+} from "@openwork/types/desktop-ipc";
 
 // Canonical wire shape shared with openwork-server and the desktop bridge.
 // Single source of truth: packages/types/src/workspace.ts.
 export type WorkspaceInfo = WorkspaceWire;
-
-export type WorkspaceList = {
-  selectedId?: string;
-  watchedId?: string | null;
-  activeId?: string | null;
-  workspaces: WorkspaceInfo[];
-};
-
-export type WorkspaceExportSummary = {
-  outputPath: string;
-  included: number;
-  excluded: string[];
-};
-
-export type OpencodeCommandDraft = {
-  name: string;
-  description?: string;
-  template: string;
-  agent?: string;
-  model?: string;
-  subtask?: boolean;
-};
-
-export type WorkspaceOpenworkConfig = {
-  version: number;
-  workspace?: {
-    name?: string | null;
-    createdAt?: number | null;
-    preset?: string | null;
-  } | null;
-  authorizedRoots: string[];
-  reload?: {
-    auto?: boolean;
-    resume?: boolean;
-  } | null;
-};
-
-export type AppBuildInfo = {
-  version: string;
-  gitSha?: string | null;
-  buildEpoch?: string | null;
-  openworkDevMode?: boolean;
-  os?: string | null;
-  arch?: string | null;
-};
-
-export type DesktopBootstrapConfig = {
-  baseUrl: string;
-  apiBaseUrl?: string | null;
-  requireSignin: boolean;
-};
-
-export type OrchestratorDetachedHost = {
-  openworkUrl: string;
-  token: string;
-  ownerToken?: string | null;
-  hostToken: string;
-  port: number;
-  sandboxBackend?: "docker" | "microsandbox" | null;
-  sandboxRunId?: string | null;
-  sandboxContainerName?: string | null;
-};
-
-export type SandboxDoctorResult = {
-  installed: boolean;
-  daemonRunning: boolean;
-  permissionOk: boolean;
-  ready: boolean;
-  clientVersion?: string | null;
-  serverVersion?: string | null;
-  error?: string | null;
-  debug?: {
-    candidates: string[];
-    selectedBin?: string | null;
-    versionCommand?: {
-      status: number;
-      stdout: string;
-      stderr: string;
-    } | null;
-    infoCommand?: {
-      status: number;
-      stdout: string;
-      stderr: string;
-    } | null;
-  } | null;
-};
-
-export type OpenworkDockerCleanupResult = {
-  candidates: string[];
-  removed: string[];
-  errors: string[];
-};
-
-export type SandboxDebugProbeResult = {
-  startedAt: number;
-  finishedAt: number;
-  runId: string;
-  workspacePath: string;
-  ready: boolean;
-  doctor: SandboxDoctorResult;
-  detachedHost?: OrchestratorDetachedHost | null;
-  dockerInspect?: {
-    status: number;
-    stdout: string;
-    stderr: string;
-  } | null;
-  dockerLogs?: {
-    status: number;
-    stdout: string;
-    stderr: string;
-  } | null;
-  cleanup: {
-    containerName?: string | null;
-    containerRemoved: boolean;
-    removeResult?: {
-      status: number;
-      stdout: string;
-      stderr: string;
-    } | null;
-    workspaceRemoved: boolean;
-    errors: string[];
-  };
-  error?: string | null;
-};
-
-export type ExecResult = {
-  ok: boolean;
-  status: number;
-  stdout: string;
-  stderr: string;
-};
-
-export type LocalSkillCard = {
-  name: string;
-  path: string;
-  description?: string;
-  trigger?: string;
-};
-
-export type LocalSkillContent = {
-  path: string;
-  content: string;
-};
-
-export type OpencodeConfigFile = {
-  path: string;
-  exists: boolean;
-  content: string | null;
-};
-
-export type UpdaterEnvironment = {
-  supported: boolean;
-  reason: string | null;
-  executablePath: string | null;
-  appBundlePath: string | null;
-};
-
-export type CacheResetResult = {
-  removed: string[];
-  missing: string[];
-  errors: string[];
-};
 
 // Browser tab state mirrored across the desktop IPC bridge. Owned here (the
 // framework-agnostic layer); the session panel store re-exports it.

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -24,7 +24,13 @@ export type {
   CacheResetResult,
 } from "./desktop-types";
 
-import type { WorkspaceList } from "./desktop-types";
+import type {
+  DesktopCommandArgs,
+  DesktopCommandInvokers,
+  DesktopCommandName,
+  DesktopCommandResult,
+  WorkspaceList,
+} from "./desktop-types";
 import type { BrowserPanelTab } from "./desktop-types";
 
 export type BrowserStatePayload = {
@@ -151,12 +157,15 @@ declare global {
 // Helpers
 // ---------------------------------------------------------------------------
 
-async function invokeElectronHelper<T>(command: string, ...args: unknown[]): Promise<T> {
+async function invokeElectronHelper<C extends DesktopCommandName>(
+  command: C,
+  ...args: DesktopCommandArgs<C>
+): Promise<DesktopCommandResult<C>> {
   const invokeDesktop = window.__OPENWORK_ELECTRON__?.invokeDesktop;
   if (!invokeDesktop) {
     throw new Error(`Electron desktop helper is unavailable: ${command}`);
   }
-  return (await invokeDesktop(command, ...args)) as T;
+  return (await invokeDesktop(command, ...args)) as DesktopCommandResult<C>;
 }
 
 // Pure utility — resolves the selected workspace ID from a workspace list
@@ -173,11 +182,21 @@ export function resolveWorkspaceListSelectedId(
 
 // All bridge methods are implemented via invokeDesktop IPC. The Proxy
 // automatically maps property access to `invokeDesktop(propertyName, ...args)`.
+// Per-command signatures come from the shared DesktopCommandMap contract
+// (packages/types/src/desktop-ipc.ts), so every destructured export below is
+// precisely typed against what the Electron main process implements.
+
+type DesktopBridge = DesktopCommandInvokers & {
+  resolveWorkspaceListSelectedId: typeof resolveWorkspaceListSelectedId;
+};
 
 type DesktopBridgeFn = (...args: unknown[]) => Promise<unknown>;
 
 const electronBridge: Record<string, DesktopBridgeFn> = {};
 
+// The cast is inherent to the Proxy pattern: the target is an empty cache and
+// members are fabricated on access. The contract typing above is what keeps
+// it honest (command names + signatures are checked on both sides).
 export const desktopBridge = new Proxy(electronBridge, {
   get(target, prop) {
     if (typeof prop !== "string") return undefined;
@@ -190,11 +209,17 @@ export const desktopBridge = new Proxy(electronBridge, {
     const cached = target[prop];
     if (cached) return cached;
 
-    const fn = (...args: unknown[]) => invokeElectronHelper(prop, ...args);
+    const fn = async (...args: unknown[]) => {
+      const invokeDesktop = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+      if (!invokeDesktop) {
+        throw new Error(`Electron desktop helper is unavailable: ${prop}`);
+      }
+      return invokeDesktop(prop, ...args);
+    };
     target[prop] = fn;
     return fn;
   },
-});
+}) as unknown as DesktopBridge;
 
 // ---------------------------------------------------------------------------
 // desktopFetch — proxies non-loopback requests through Electron main process
@@ -243,12 +268,7 @@ export const desktopFetch: typeof globalThis.fetch = async (input, init) => {
     body = typeof init?.body === "string" ? init.body : undefined;
   }
 
-  const result = await invokeElectronHelper<{
-    status: number;
-    statusText: string;
-    headers: [string, string][];
-    body: string;
-  }>("__fetch", url, { method, headers, body });
+  const result = await invokeElectronHelper("__fetch", url, { method, headers, body });
 
   // Response constructor rejects bodies for null-body status codes, so we
   // must pass null instead of an empty string for those.
@@ -285,12 +305,7 @@ export async function desktopFetchViaMain(input: RequestInfo | URL, init?: Reque
     body = typeof init?.body === "string" ? init.body : undefined;
   }
 
-  const result = await invokeElectronHelper<{
-    status: number;
-    statusText: string;
-    headers: [string, string][];
-    body: string;
-  }>("__fetch", url, { method, headers, body, timeoutMs });
+  const result = await invokeElectronHelper("__fetch", url, { method, headers, body, timeoutMs });
 
   const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
   const responseBody = NULL_BODY_STATUSES.has(result.status) ? null : result.body;
@@ -318,14 +333,14 @@ export async function openDesktopUrl(url: string): Promise<void> {
 }
 
 export async function openDesktopPath(target: string): Promise<void> {
-  const result = await invokeElectronHelper<string | null>("__openPath", target);
+  const result = await invokeElectronHelper("__openPath", target);
   if (typeof result === "string" && result.trim()) {
     throw new Error(result);
   }
 }
 
 export async function revealDesktopItemInDir(target: string): Promise<void> {
-  await invokeElectronHelper<void>("__revealItemInDir", target);
+  await invokeElectronHelper("__revealItemInDir", target);
 }
 
 export async function relaunchDesktopApp(): Promise<void> {
@@ -333,15 +348,15 @@ export async function relaunchDesktopApp(): Promise<void> {
 }
 
 export async function getDesktopHomeDir(): Promise<string> {
-  return invokeElectronHelper<string>("__homeDir");
+  return invokeElectronHelper("__homeDir");
 }
 
 export async function joinDesktopPath(...parts: string[]): Promise<string> {
-  return invokeElectronHelper<string>("__joinPath", ...parts);
+  return invokeElectronHelper("__joinPath", ...parts);
 }
 
 export async function setDesktopZoomFactor(value: number): Promise<boolean> {
-  return invokeElectronHelper<boolean>("__setZoomFactor", value);
+  return invokeElectronHelper("__setZoomFactor", value);
 }
 
 export async function subscribeDesktopDeepLinks(

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2459,23 +2459,30 @@ function applyNativeTheme(mode) {
   return true;
 }
 
-async function handleDesktopInvoke(event, command, ...args) {
-  switch (command) {
-    case "workspaceBootstrap":
+// Desktop IPC command registry. Every command invokable from the renderer's
+// desktopBridge Proxy (apps/app/src/app/lib/desktop.ts) has exactly one
+// entry here; handlers receive the ipcMain event followed by the renderer
+// arguments. Converted from a 570-line switch so the surface can be typed
+// against the shared DesktopCommandMap contract and split into modules.
+const desktopCommandHandlers = {
+  "workspaceBootstrap": async (event, ...args) => {
       return readWorkspaceState();
-    case "workspaceSetSelected":
+  },
+  "workspaceSetSelected": async (event, ...args) => {
       return mutateWorkspaceState((state) => {
         const workspaceId = typeof args[0] === "string" ? args[0] : "";
         state.selectedId = workspaceId;
         state.activeId = workspaceId || null;
         return state;
       });
-    case "workspaceSetRuntimeActive":
+  },
+  "workspaceSetRuntimeActive": async (event, ...args) => {
       return mutateWorkspaceState((state) => {
         state.watchedId = typeof args[0] === "string" && args[0].trim() ? args[0] : null;
         return state;
       });
-    case "workspaceCreate": {
+  },
+  "workspaceCreate": async (event, ...args) => {
       const input = args[0] ?? {};
       const rawFolderPath = String(input.folderPath ?? "").trim();
       if (!rawFolderPath) throw new Error("folderPath is required");
@@ -2504,8 +2511,8 @@ async function handleDesktopInvoke(event, command, ...args) {
         state.watchedId = workspace.id;
         return state;
       });
-    }
-    case "workspaceCreateRemote": {
+  },
+  "workspaceCreateRemote": async (event, ...args) => {
       const input = args[0] ?? {};
       const baseUrl = String(input.baseUrl ?? "").trim();
       if (!baseUrl) throw new Error("baseUrl is required");
@@ -2574,8 +2581,8 @@ async function handleDesktopInvoke(event, command, ...args) {
         state.activeId = workspace.id;
         return state;
       });
-    }
-    case "workspaceUpdateRemote": {
+  },
+  "workspaceUpdateRemote": async (event, ...args) => {
       const input = args[0] ?? {};
       const workspaceId = String(input.workspaceId ?? "").trim();
       if (!workspaceId) throw new Error("workspaceId is required");
@@ -2642,8 +2649,8 @@ async function handleDesktopInvoke(event, command, ...args) {
         );
         return state;
       });
-    }
-    case "workspaceUpdateDisplayName": {
+  },
+  "workspaceUpdateDisplayName": async (event, ...args) => {
       const input = args[0] ?? {};
       const workspaceId = String(input.workspaceId ?? "").trim();
       if (!workspaceId) throw new Error("workspaceId is required");
@@ -2653,8 +2660,8 @@ async function handleDesktopInvoke(event, command, ...args) {
         );
         return state;
       });
-    }
-    case "workspaceForget": {
+  },
+  "workspaceForget": async (event, ...args) => {
       const workspaceId = String(args[0] ?? "").trim();
       if (!workspaceId) throw new Error("workspaceId is required");
       return mutateWorkspaceState((state) => {
@@ -2664,8 +2671,8 @@ async function handleDesktopInvoke(event, command, ...args) {
         if (state.watchedId === workspaceId) state.watchedId = null;
         return state;
       });
-    }
-    case "workspaceAddAuthorizedRoot": {
+  },
+  "workspaceAddAuthorizedRoot": async (event, ...args) => {
       const input = args[0] ?? {};
       const workspacePath = String(input.workspacePath ?? "").trim();
       const authorizedRoot = String(input.folderPath ?? input.authorizedRoot ?? "").trim();
@@ -2680,15 +2687,17 @@ async function handleDesktopInvoke(event, command, ...args) {
         config.authorizedRoots.push(authorizedRoot);
       }
       return writeWorkspaceOpenworkConfig(workspacePath, config);
-    }
-    case "workspaceOpenworkRead":
+  },
+  "workspaceOpenworkRead": async (event, ...args) => {
       return readWorkspaceOpenworkConfig(String(args[0]?.workspacePath ?? "").trim());
-    case "workspaceOpenworkWrite":
+  },
+  "workspaceOpenworkWrite": async (event, ...args) => {
       return writeWorkspaceOpenworkConfig(
         String(args[0]?.workspacePath ?? "").trim(),
         args[0]?.config ?? defaultWorkspaceOpenworkConfig(""),
       );
-    case "workspaceExportConfig": {
+  },
+  "workspaceExportConfig": async (event, ...args) => {
       const input = args[0] ?? {};
       const workspaceId = String(input.workspaceId ?? "").trim();
       const outputPath = String(input.outputPath ?? "").trim();
@@ -2698,8 +2707,8 @@ async function handleDesktopInvoke(event, command, ...args) {
       const workspace = state.workspaces.find((entry) => entry.id === workspaceId);
       if (!workspace) throw new Error("Unknown workspaceId");
       return exportWorkspaceConfig({ workspace, outputPath });
-    }
-    case "workspaceImportConfig": {
+  },
+  "workspaceImportConfig": async (event, ...args) => {
       const input = args[0] ?? {};
       const archivePath = String(input.archivePath ?? "").trim();
       const targetDirRaw = String(input.targetDir ?? "").trim();
@@ -2730,124 +2739,147 @@ async function handleDesktopInvoke(event, command, ...args) {
         state.watchedId = workspace.id;
         return state;
       });
-    }
-    case "opencodeCommandList":
+  },
+  "opencodeCommandList": async (event, ...args) => {
       return listCommandNames(String(args[0]?.scope ?? "").trim(), String(args[0]?.projectDir ?? "").trim());
-    case "opencodeCommandWrite":
+  },
+  "opencodeCommandWrite": async (event, ...args) => {
       return writeCommandFile(
         String(args[0]?.scope ?? "").trim(),
         String(args[0]?.projectDir ?? "").trim(),
         args[0]?.command ?? {},
       );
-    case "opencodeCommandDelete":
+  },
+  "opencodeCommandDelete": async (event, ...args) => {
       return deleteCommandFile(
         String(args[0]?.scope ?? "").trim(),
         String(args[0]?.projectDir ?? "").trim(),
         String(args[0]?.name ?? "").trim(),
       );
-    case "engineStart": {
+  },
+  "engineStart": async (event, ...args) => {
       const projectDir = String(args[0] ?? "").trim();
       const options = args[1] ?? {};
       return runtimeManager.engineStart(projectDir, options);
-    }
-    case "prepareFreshRuntime":
+  },
+  "prepareFreshRuntime": async (event, ...args) => {
       return runtimeManager.prepareFreshRuntime();
-    case "runtimeBootstrap":
+  },
+  "runtimeBootstrap": async (event, ...args) => {
       return ensureRuntimeBootstrap();
-    case "runtimeStatus":
+  },
+  "runtimeStatus": async (event, ...args) => {
       return runtimeManager.runtimeStatus();
-    case "engineStop":
+  },
+  "engineStop": async (event, ...args) => {
       return runtimeManager.engineStop();
-    case "engineRestart":
+  },
+  "engineRestart": async (event, ...args) => {
       return runtimeManager.engineRestart(args[0] ?? {});
-    case "engineInfo":
+  },
+  "engineInfo": async (event, ...args) => {
       return runtimeManager.engineInfo();
-    case "engineDoctor":
+  },
+  "engineDoctor": async (event, ...args) => {
       return engineDoctor(args[0]);
-    case "engineInstall":
+  },
+  "engineInstall": async (event, ...args) => {
       return runtimeManager.engineInstall();
-    case "orchestratorStatus": {
+  },
+  "orchestratorStatus": async (event, ...args) => {
       return runtimeManager.orchestratorStatus();
-    }
-    case "orchestratorWorkspaceActivate": {
+  },
+  "orchestratorWorkspaceActivate": async (event, ...args) => {
       return runtimeManager.orchestratorWorkspaceActivate(args[0] ?? {});
-    }
-    case "orchestratorInstanceDispose":
+  },
+  "orchestratorInstanceDispose": async (event, ...args) => {
       return runtimeManager.orchestratorInstanceDispose(String(args[0] ?? "").trim());
-    case "appBuildInfo":
+  },
+  "appBuildInfo": async (event, ...args) => {
       return {
         version: app.getVersion(),
         gitSha: process.env.OPENWORK_GIT_SHA ?? null,
         buildEpoch: process.env.OPENWORK_BUILD_EPOCH ?? null,
         openworkDevMode: process.env.OPENWORK_DEV_MODE === "1",
       };
-    case "getUiControlBridgeInfo":
+  },
+  "getUiControlBridgeInfo": async (event, ...args) => {
       try {
         const raw = await readFile(path.join(app.getPath("userData"), "openwork-ui-control.json"), "utf8");
         return JSON.parse(raw);
       } catch {
         return null;
       }
-    case "getOpenworkUiMcpCommand": {
+  },
+  "getOpenworkUiMcpCommand": async (event, ...args) => {
       if (process.env.OPENWORK_DEV_MODE === "1") {
         return ["node", path.resolve(__dirname, "../../..", "packages/openwork-ui-mcp/index.mjs")];
       }
       return ["npx", "-y", "openwork-ui-mcp"];
-    }
-    case "getComputerUseMcpCommand": {
+  },
+  "getComputerUseMcpCommand": async (event, ...args) => {
       return getComputerUseMcpCommand();
-    }
-    case "checkComputerUsePermissions": {
+  },
+  "checkComputerUsePermissions": async (event, ...args) => {
       // Spawn --check → fresh TCC read → always accurate.
       return checkComputerUsePermissions();
-    }
-    case "listRunningApps": {
+  },
+  "listRunningApps": async (event, ...args) => {
       // Running regular macOS apps for composer @App mentions.
       return listRunningApps();
-    }
-    case "openComputerUsePermissionSetup": {
+  },
+  "openComputerUsePermissionSetup": async (event, ...args) => {
       // Open the GUI app. Returns immediately — React shows "verify" CTA.
       await openComputerUseSetupApp();
       // Return a fresh check so the UI shows the current state.
       return checkComputerUsePermissions();
-    }
-    case "openComputerUsePermissionSettings": {
+  },
+  "openComputerUsePermissionSettings": async (event, ...args) => {
       // Legacy: open the setup app (same as above).
       await openComputerUseSetupApp();
       return checkComputerUsePermissions();
-    }
-    case "getOpenworkUiMcpEnvironment": {
+  },
+  "getOpenworkUiMcpEnvironment": async (event, ...args) => {
       return {
         OPENWORK_UI_CONTROL_DISCOVERY: path.join(app.getPath("userData"), "openwork-ui-control.json"),
       };
-    }
-    case "getDesktopBootstrapConfig":
+  },
+  "getDesktopBootstrapConfig": async (event, ...args) => {
       return getDesktopBootstrapConfig();
-    case "debugDesktopBootstrapConfig":
+  },
+  "debugDesktopBootstrapConfig": async (event, ...args) => {
       return debugDesktopBootstrapConfig();
-    case "setDesktopBootstrapConfig":
+  },
+  "setDesktopBootstrapConfig": async (event, ...args) => {
       return setDesktopBootstrapConfig(args[0] ?? {});
-    case "nukeOpenworkAndOpencodeConfigAndExit": {
+  },
+  "nukeOpenworkAndOpencodeConfigAndExit": async (event, ...args) => {
       await rm(app.getPath("userData"), { recursive: true, force: true });
       app.exit(0);
       return undefined;
-    }
-    case "orchestratorStartDetached": {
+  },
+  "orchestratorStartDetached": async (event, ...args) => {
       return runtimeManager.orchestratorStartDetached(args[0] ?? {});
-    }
-    case "sandboxDoctor":
+  },
+  "sandboxDoctor": async (event, ...args) => {
       return runtimeManager.sandboxDoctor();
-    case "sandboxStop":
+  },
+  "sandboxStop": async (event, ...args) => {
       return runtimeManager.sandboxStop(String(args[0] ?? "").trim());
-    case "sandboxCleanupOpenworkContainers":
+  },
+  "sandboxCleanupOpenworkContainers": async (event, ...args) => {
       return runtimeManager.sandboxCleanupOpenworkContainers();
-    case "sandboxDebugProbe":
+  },
+  "sandboxDebugProbe": async (event, ...args) => {
       return runtimeManager.sandboxDebugProbe();
-    case "openworkServerInfo":
+  },
+  "openworkServerInfo": async (event, ...args) => {
       return runtimeManager.openworkServerInfo();
-    case "openworkServerRestart":
+  },
+  "openworkServerRestart": async (event, ...args) => {
       return runtimeManager.openworkServerRestart(args[0] ?? {});
-    case "pickDirectory": {
+  },
+  "pickDirectory": async (event, ...args) => {
       const options = args[0] ?? {};
       /** @type {import("electron").OpenDialogOptions["properties"]} */
       const properties = options.multiple
@@ -2860,8 +2892,8 @@ async function handleDesktopInvoke(event, command, ...args) {
       });
       if (result.canceled) return null;
       return options.multiple ? result.filePaths : (result.filePaths[0] ?? null);
-    }
-    case "pickFile": {
+  },
+  "pickFile": async (event, ...args) => {
       const options = args[0] ?? {};
       /** @type {import("electron").OpenDialogOptions["properties"]} */
       const properties = options.multiple ? ["openFile", "multiSelections"] : ["openFile"];
@@ -2873,8 +2905,8 @@ async function handleDesktopInvoke(event, command, ...args) {
       });
       if (result.canceled) return null;
       return options.multiple ? result.filePaths : (result.filePaths[0] ?? null);
-    }
-    case "saveFile": {
+  },
+  "saveFile": async (event, ...args) => {
       const options = args[0] ?? {};
       const result = await dialog.showSaveDialog(activeWindowFromEvent(event), {
         title: options.title,
@@ -2882,8 +2914,8 @@ async function handleDesktopInvoke(event, command, ...args) {
         filters: options.filters,
       });
       return result.canceled ? null : (result.filePath ?? null);
-    }
-    case "importSkill": {
+  },
+  "importSkill": async (event, ...args) => {
       const projectDir = String(args[0] ?? "").trim();
       const sourceDir = String(args[1] ?? "").trim();
       const overwrite = args[2]?.overwrite === true;
@@ -2901,8 +2933,8 @@ async function handleDesktopInvoke(event, command, ...args) {
       }
       await cp(sourceDir, destination, { recursive: true });
       return execResult(true, `Imported skill to ${destination}`);
-    }
-    case "installSkillTemplate": {
+  },
+  "installSkillTemplate": async (event, ...args) => {
       const projectDir = String(args[0] ?? "").trim();
       const name = validateSkillName(args[1]);
       const content = String(args[2] ?? "");
@@ -2918,18 +2950,19 @@ async function handleDesktopInvoke(event, command, ...args) {
       await mkdir(destination, { recursive: true });
       await writeFile(path.join(destination, "SKILL.md"), content, "utf8");
       return execResult(true, `Installed skill to ${destination}`);
-    }
-    case "listLocalSkills":
+  },
+  "listLocalSkills": async (event, ...args) => {
       return listLocalSkills(String(args[0] ?? "").trim());
-    case "readLocalSkill": {
+  },
+  "readLocalSkill": async (event, ...args) => {
       const projectDir = String(args[0] ?? "").trim();
       const skillPath = await findSkillFile(projectDir, args[1]);
       if (!skillPath) {
         throw new Error("Skill not found");
       }
       return { path: skillPath, content: await readFile(skillPath, "utf8") };
-    }
-    case "writeLocalSkill": {
+  },
+  "writeLocalSkill": async (event, ...args) => {
       const projectDir = String(args[0] ?? "").trim();
       const skillPath = await findSkillFile(projectDir, args[1]);
       if (!skillPath) {
@@ -2939,8 +2972,8 @@ async function handleDesktopInvoke(event, command, ...args) {
       const next = content.endsWith("\n") ? content : `${content}\n`;
       await writeFile(skillPath, next, "utf8");
       return execResult(true, `Saved skill ${path.basename(path.dirname(skillPath))}`);
-    }
-    case "uninstallSkill": {
+  },
+  "uninstallSkill": async (event, ...args) => {
       const projectDir = String(args[0] ?? "").trim();
       const skillPath = await findSkillFile(projectDir, args[1]);
       if (!skillPath) {
@@ -2948,8 +2981,8 @@ async function handleDesktopInvoke(event, command, ...args) {
       }
       await rm(path.dirname(skillPath), { recursive: true, force: true });
       return execResult(true, `Removed skill ${args[1]}`);
-    }
-    case "updaterEnvironment": {
+  },
+  "updaterEnvironment": async (event, ...args) => {
       const executablePath = app.isPackaged ? app.getPath("exe") : process.execPath;
       return {
         supported: true,
@@ -2960,38 +2993,43 @@ async function handleDesktopInvoke(event, command, ...args) {
             ? path.resolve(executablePath, "../../..")
             : path.dirname(executablePath),
       };
-    }
-    case "readOpencodeConfig":
+  },
+  "readOpencodeConfig": async (event, ...args) => {
       return readOpencodeConfig(String(args[0] ?? "").trim(), String(args[1] ?? "").trim());
-    case "writeOpencodeConfig":
+  },
+  "writeOpencodeConfig": async (event, ...args) => {
       return writeOpencodeConfig(
         String(args[0] ?? "").trim(),
         String(args[1] ?? "").trim(),
         String(args[2] ?? ""),
       );
-    case "resetOpenworkState": {
+  },
+  "resetOpenworkState": async (event, ...args) => {
       await rm(workspaceStatePath(), { force: true });
       await rm(desktopBootstrapPath(), { force: true });
       return undefined;
-    }
-    case "resetOpencodeCache":
+  },
+  "resetOpencodeCache": async (event, ...args) => {
       return { removed: [], missing: [], errors: [] };
-    case "opencodeMcpAuth":
+  },
+  "opencodeMcpAuth": async (event, ...args) => {
       return runtimeManager.opencodeMcpAuth(String(args[0] ?? "").trim(), String(args[1] ?? "").trim());
-    case "setWindowDecorations":
+  },
+  "setWindowDecorations": async (event, ...args) => {
       return undefined;
-    case "__openPath": {
+  },
+  "__openPath": async (event, ...args) => {
       const target = String(args[0] ?? "").trim();
       if (!target) return "Path is required.";
       return shell.openPath(target);
-    }
-    case "__revealItemInDir": {
+  },
+  "__revealItemInDir": async (event, ...args) => {
       const target = String(args[0] ?? "").trim();
       if (!target) return undefined;
       shell.showItemInFolder(target);
       return undefined;
-    }
-    case "__fetch": {
+  },
+  "__fetch": async (event, ...args) => {
       const url = String(args[0] ?? "").trim();
       const init = args[1] ?? {};
       if (!url) throw new Error("URL is required.");
@@ -3008,12 +3046,14 @@ async function handleDesktopInvoke(event, command, ...args) {
         headers: Array.from(response.headers.entries()),
         body: await response.text(),
       };
-    }
-    case "__homeDir":
+  },
+  "__homeDir": async (event, ...args) => {
       return os.homedir();
-    case "__joinPath":
+  },
+  "__joinPath": async (event, ...args) => {
       return path.join(...args.map((value) => String(value ?? "")));
-    case "__setZoomFactor": {
+  },
+  "__setZoomFactor": async (event, ...args) => {
       const factor = Number(args[0]);
       const window = activeWindowFromEvent(event);
       if (!window || !Number.isFinite(factor) || factor <= 0) {
@@ -3021,14 +3061,21 @@ async function handleDesktopInvoke(event, command, ...args) {
       }
       window.webContents.setZoomFactor(factor);
       return true;
-    }
-    case "__setNativeTheme":
+  },
+  "__setNativeTheme": async (event, ...args) => {
       return applyNativeTheme(String(args[0]));
-    case "__setApplicationMenuVisible":
+  },
+  "__setApplicationMenuVisible": async (event, ...args) => {
       return setApplicationMenuVisible(args[0]);
-    default:
-      throw new Error(`Electron desktop bridge method is not implemented yet: ${command}`);
+  },
+};
+
+async function handleDesktopInvoke(event, command, ...args) {
+  const handler = desktopCommandHandlers[command];
+  if (!handler) {
+    throw new Error(`Electron desktop bridge method is not implemented yet: ${command}`);
   }
+  return handler(event, ...args);
 }
 
 function sendJsonResponse(response, statusCode, payload) {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2462,8 +2462,11 @@ function applyNativeTheme(mode) {
 // Desktop IPC command registry. Every command invokable from the renderer's
 // desktopBridge Proxy (apps/app/src/app/lib/desktop.ts) has exactly one
 // entry here; handlers receive the ipcMain event followed by the renderer
-// arguments. Converted from a 570-line switch so the surface can be typed
-// against the shared DesktopCommandMap contract and split into modules.
+// arguments. The @type below asserts this registry against the shared
+// DesktopCommandMap contract (packages/types/src/desktop-ipc.ts): a missing,
+// extra, or renamed command fails `pnpm --filter @openwork/desktop
+// typecheck:electron`.
+/** @type {import("@openwork/types/desktop-ipc").DesktopCommandHandlers<import("electron").IpcMainInvokeEvent>} */
 const desktopCommandHandlers = {
   "workspaceBootstrap": async (event, ...args) => {
       return readWorkspaceState();

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,6 +33,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@openwork/types": "workspace:*",
     "electron": "^35.0.0",
     "electron-builder": "^25.1.8",
     "electron-devtools-installer": "^4.0.0"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,7 +19,8 @@
     "electron": "pnpm exec electron ./electron/main.mjs",
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
-    "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs"
+    "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
+    "test": "node --test electron/runtime.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.17.3",

--- a/apps/desktop/scripts/check-electron-bridge.mjs
+++ b/apps/desktop/scripts/check-electron-bridge.mjs
@@ -30,7 +30,8 @@ const bridgeMethods = destructure[1]
   .filter((name) => !clientOnlyBridgeMethods.has(name));
 
 const electronHandlers = new Set(
-  Array.from(electronMainSource.matchAll(/case\s+"([^"]+)"\s*:/g)).map((match) => match[1]),
+  // Registry entries look like `"workspaceCreate": async (event, ...args) =>`.
+  Array.from(electronMainSource.matchAll(/^  "([^"]+)": async \(event/gm)).map((match) => match[1]),
 );
 
 const missing = bridgeMethods.filter((name) => !electronHandlers.has(name));

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,6 +27,11 @@
       "types": "./src/workspace.ts",
       "development": "./src/workspace.ts",
       "default": "./src/workspace.ts"
+    },
+    "./desktop-ipc": {
+      "types": "./src/desktop-ipc.ts",
+      "development": "./src/desktop-ipc.ts",
+      "default": "./src/desktop-ipc.ts"
     }
   },
   "files": [

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -437,7 +437,13 @@ export type DesktopCommandMap = {
     args: [scope: string, projectDir: string, content: string];
     result: ExecResult;
   };
-  resetOpenworkState: { args: []; result: unknown };
+  /**
+   * The renderer passes its reset-modal mode, but the main process currently
+   * IGNORES it and always removes workspace state + bootstrap config; only
+   * the renderer's localStorage cleanup is mode-scoped. Follow-up: decide
+   * whether "onboarding" should preserve desktop workspace state.
+   */
+  resetOpenworkState: { args: [mode?: "onboarding" | "all"]; result: unknown };
   resetOpencodeCache: { args: []; result: CacheResetResult };
   opencodeMcpAuth: { args: [action: string, name: string]; result: ExecResult };
   setWindowDecorations: { args: [decorated: boolean]; result: unknown };
@@ -448,7 +454,7 @@ export type DesktopCommandMap = {
   __fetch: { args: [url: string, init?: DesktopFetchInit]; result: DesktopFetchResult };
   __homeDir: { args: []; result: string };
   __joinPath: { args: [...segments: string[]]; result: string };
-  __setZoomFactor: { args: [factor: number]; result: unknown };
+  __setZoomFactor: { args: [factor: number]; result: boolean };
   __setNativeTheme: { args: [theme: string]; result: unknown };
   __setApplicationMenuVisible: { args: [visible: boolean]; result: unknown };
 };

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -1,0 +1,485 @@
+/**
+ * Shared contract for the Electron desktop IPC bridge.
+ *
+ * Producer: apps/desktop/electron/main.mjs — `desktopCommandHandlers`, typed
+ * via JSDoc against `DesktopCommandHandlers` so missing/extra/renamed
+ * commands fail `typecheck:electron`.
+ * Consumer: apps/app/src/app/lib/desktop.ts — the `desktopBridge` Proxy and
+ * its named exports derive per-command signatures from `DesktopCommandMap`.
+ *
+ * Every command sent over the `openwork:desktop` channel has exactly one
+ * entry here: `args` is the tuple the renderer passes, `result` what the
+ * main process resolves. Results marked `unknown` are not yet modeled —
+ * tighten them instead of widening call sites.
+ */
+import type { WorkspaceWire } from "./workspace.js";
+
+// ---------------------------------------------------------------------------
+// Payload shapes (moved from apps/app/src/app/lib/desktop-types.ts, which
+// re-exports them — keep that file as the app-side import path).
+// ---------------------------------------------------------------------------
+
+export type OpencodeExecutionEnvEntry = {
+  name: string;
+  value: string;
+  redacted: boolean;
+};
+
+export type OpencodeExecutionSnapshot = {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: OpencodeExecutionEnvEntry[];
+};
+
+export type EngineInfo = {
+  running: boolean;
+  runtime: "direct";
+  baseUrl: string | null;
+  projectDir: string | null;
+  hostname: string | null;
+  port: number | null;
+  opencodeUsername: string | null;
+  opencodePassword: string | null;
+  opencodeBinPath: string | null;
+  opencodeBinSource: string | null;
+  pid: number | null;
+  lastStdout: string | null;
+  lastStderr: string | null;
+  execution: OpencodeExecutionSnapshot | null;
+};
+
+export type OpenworkServerInfo = {
+  running: boolean;
+  remoteAccessEnabled: boolean;
+  host: string | null;
+  port: number | null;
+  baseUrl: string | null;
+  connectUrl: string | null;
+  mdnsUrl: string | null;
+  lanUrl: string | null;
+  clientToken: string | null;
+  ownerToken: string | null;
+  hostToken: string | null;
+  managedOpencodeBinPath: string | null;
+  managedOpencodeBinSource: string | null;
+  pid: number | null;
+  lastStdout: string | null;
+  lastStderr: string | null;
+  managedOpencodeExecution: OpencodeExecutionSnapshot | null;
+};
+
+export type EngineDoctorResult = {
+  found: boolean;
+  inPath: boolean;
+  resolvedPath: string | null;
+  resolvedSource: string | null;
+  version: string | null;
+  supportsServe: boolean;
+  notes: string[];
+  serveHelpStatus: number | null;
+  serveHelpStdout: string | null;
+  serveHelpStderr: string | null;
+};
+
+export type WorkspaceList = {
+  selectedId?: string;
+  watchedId?: string | null;
+  activeId?: string | null;
+  workspaces: WorkspaceWire[];
+};
+
+export type WorkspaceExportSummary = {
+  outputPath: string;
+  included: number;
+  excluded: string[];
+};
+
+export type OpencodeCommandDraft = {
+  name: string;
+  description?: string;
+  template: string;
+  agent?: string;
+  model?: string;
+  subtask?: boolean;
+};
+
+export type WorkspaceOpenworkConfig = {
+  version: number;
+  workspace?: {
+    name?: string | null;
+    createdAt?: number | null;
+    preset?: string | null;
+  } | null;
+  authorizedRoots: string[];
+  reload?: {
+    auto?: boolean;
+    resume?: boolean;
+  } | null;
+};
+
+export type AppBuildInfo = {
+  version: string;
+  gitSha?: string | null;
+  buildEpoch?: string | null;
+  openworkDevMode?: boolean;
+  os?: string | null;
+  arch?: string | null;
+};
+
+export type DesktopBootstrapConfig = {
+  baseUrl: string;
+  apiBaseUrl?: string | null;
+  requireSignin: boolean;
+};
+
+export type OrchestratorDetachedHost = {
+  openworkUrl: string;
+  token: string;
+  ownerToken?: string | null;
+  hostToken: string;
+  port: number;
+  /** "none" | "docker" | "microsandbox" today; kept open like WorkspaceWire. */
+  sandboxBackend?: string | null;
+  sandboxRunId?: string | null;
+  sandboxContainerName?: string | null;
+};
+
+export type SandboxDoctorResult = {
+  installed: boolean;
+  daemonRunning: boolean;
+  permissionOk: boolean;
+  ready: boolean;
+  clientVersion?: string | null;
+  serverVersion?: string | null;
+  error?: string | null;
+  debug?: {
+    candidates: string[];
+    selectedBin?: string | null;
+    versionCommand?: {
+      status: number;
+      stdout: string;
+      stderr: string;
+    } | null;
+    infoCommand?: {
+      status: number;
+      stdout: string;
+      stderr: string;
+    } | null;
+  } | null;
+};
+
+export type OpenworkDockerCleanupResult = {
+  candidates: string[];
+  removed: string[];
+  errors: string[];
+};
+
+export type SandboxDebugProbeResult = {
+  startedAt: number;
+  finishedAt: number;
+  runId: string;
+  workspacePath: string;
+  ready: boolean;
+  doctor: SandboxDoctorResult;
+  detachedHost?: OrchestratorDetachedHost | null;
+  dockerInspect?: {
+    status: number;
+    stdout: string;
+    stderr: string;
+  } | null;
+  dockerLogs?: {
+    status: number;
+    stdout: string;
+    stderr: string;
+  } | null;
+  cleanup: {
+    containerName?: string | null;
+    containerRemoved: boolean;
+    removeResult?: {
+      status: number;
+      stdout: string;
+      stderr: string;
+    } | null;
+    workspaceRemoved: boolean;
+    errors: string[];
+  };
+  error?: string | null;
+};
+
+export type ExecResult = {
+  ok: boolean;
+  status: number;
+  stdout: string;
+  stderr: string;
+};
+
+export type LocalSkillCard = {
+  name: string;
+  path: string;
+  description?: string;
+  trigger?: string;
+};
+
+export type LocalSkillContent = {
+  path: string;
+  content: string;
+};
+
+export type OpencodeConfigFile = {
+  path: string;
+  exists: boolean;
+  content: string | null;
+};
+
+export type UpdaterEnvironment = {
+  supported: boolean;
+  reason: string | null;
+  executablePath: string | null;
+  appBundlePath: string | null;
+};
+
+export type CacheResetResult = {
+  removed: string[];
+  missing: string[];
+  errors: string[];
+};
+
+export type DesktopFetchInit = {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  timeoutMs?: number;
+};
+
+export type DesktopFetchResult = {
+  status: number;
+  statusText: string;
+  headers: [string, string][];
+  body: string;
+};
+
+export type WorkspaceCreateInput = {
+  folderPath: string;
+  name?: string | null;
+  preset?: string | null;
+};
+
+export type WorkspaceCreateRemoteInput = {
+  baseUrl: string;
+  remoteType?: "openwork" | "opencode" | null;
+  directory?: string | null;
+  displayName?: string | null;
+  openworkHostUrl?: string | null;
+  openworkToken?: string | null;
+  openworkClientToken?: string | null;
+  openworkHostToken?: string | null;
+  openworkWorkspaceId?: string | null;
+  openworkWorkspaceName?: string | null;
+  sandboxBackend?: string | null;
+  sandboxRunId?: string | null;
+  sandboxContainerName?: string | null;
+};
+
+export type WorkspaceUpdateRemoteInput = WorkspaceCreateRemoteInput & {
+  workspaceId: string;
+};
+
+// ---------------------------------------------------------------------------
+// The command map
+// ---------------------------------------------------------------------------
+
+export type DesktopCommandMap = {
+  // Workspace state
+  workspaceBootstrap: { args: []; result: WorkspaceList };
+  workspaceSetSelected: { args: [workspaceId: string]; result: WorkspaceList };
+  workspaceSetRuntimeActive: { args: [workspaceId: string | null]; result: WorkspaceList };
+  workspaceCreate: { args: [input: WorkspaceCreateInput]; result: WorkspaceList };
+  workspaceCreateRemote: { args: [input: WorkspaceCreateRemoteInput]; result: WorkspaceList };
+  workspaceUpdateRemote: { args: [input: WorkspaceUpdateRemoteInput]; result: WorkspaceList };
+  workspaceUpdateDisplayName: {
+    args: [input: { workspaceId: string; displayName?: string | null }];
+    result: WorkspaceList;
+  };
+  workspaceForget: { args: [workspaceId: string]; result: WorkspaceList };
+  workspaceAddAuthorizedRoot: {
+    args: [input: { workspacePath: string; folderPath?: string; authorizedRoot?: string }];
+    result: unknown;
+  };
+  workspaceOpenworkRead: {
+    args: [input: { workspacePath: string }];
+    result: WorkspaceOpenworkConfig;
+  };
+  workspaceOpenworkWrite: {
+    args: [input: { workspacePath: string; config: WorkspaceOpenworkConfig }];
+    result: unknown;
+  };
+  workspaceExportConfig: {
+    args: [input: { workspaceId: string; outputPath: string }];
+    result: WorkspaceExportSummary;
+  };
+  workspaceImportConfig: {
+    args: [input: { archivePath: string; targetDir: string; name?: string | null }];
+    result: unknown;
+  };
+
+  // Opencode custom commands
+  opencodeCommandList: {
+    args: [input: { scope: string; projectDir?: string }];
+    result: string[];
+  };
+  opencodeCommandWrite: {
+    args: [input: { scope: string; projectDir?: string; command: OpencodeCommandDraft }];
+    result: unknown;
+  };
+  opencodeCommandDelete: {
+    args: [input: { scope: string; projectDir?: string; name: string }];
+    result: unknown;
+  };
+
+  // Engine / runtime lifecycle
+  // TODO: EngineInfo once runtime.mjs return inference is annotated (tsc
+  // currently infers void for the manager methods).
+  engineStart: { args: [projectDir: string, options?: Record<string, unknown>]; result: unknown };
+  prepareFreshRuntime: { args: []; result: unknown };
+  runtimeBootstrap: { args: []; result: unknown };
+  runtimeStatus: { args: []; result: unknown };
+  engineStop: { args: []; result: unknown };
+  engineRestart: { args: [options?: Record<string, unknown>]; result: unknown };
+  engineInfo: { args: []; result: EngineInfo };
+  engineDoctor: { args: [projectDir?: string]; result: EngineDoctorResult };
+  engineInstall: { args: []; result: unknown };
+  orchestratorStatus: { args: []; result: unknown };
+  orchestratorWorkspaceActivate: { args: [input?: Record<string, unknown>]; result: unknown };
+  orchestratorInstanceDispose: { args: [instanceId: string]; result: unknown };
+  orchestratorStartDetached: {
+    args: [input?: Record<string, unknown>];
+    result: OrchestratorDetachedHost;
+  };
+
+  // App / bridge info
+  appBuildInfo: { args: []; result: AppBuildInfo };
+  getUiControlBridgeInfo: { args: []; result: unknown };
+  getOpenworkUiMcpCommand: { args: []; result: unknown };
+  getComputerUseMcpCommand: { args: []; result: unknown };
+  getOpenworkUiMcpEnvironment: { args: []; result: unknown };
+
+  // Computer use
+  checkComputerUsePermissions: { args: []; result: unknown };
+  listRunningApps: { args: []; result: unknown };
+  openComputerUsePermissionSetup: { args: []; result: unknown };
+  openComputerUsePermissionSettings: { args: []; result: unknown };
+
+  // Bootstrap config
+  getDesktopBootstrapConfig: { args: []; result: DesktopBootstrapConfig };
+  debugDesktopBootstrapConfig: { args: []; result: unknown };
+  setDesktopBootstrapConfig: {
+    args: [config: Partial<DesktopBootstrapConfig>];
+    result: DesktopBootstrapConfig;
+  };
+  nukeOpenworkAndOpencodeConfigAndExit: { args: []; result: unknown };
+
+  // Sandbox
+  sandboxDoctor: { args: []; result: SandboxDoctorResult };
+  sandboxStop: { args: [runId: string]; result: unknown };
+  sandboxCleanupOpenworkContainers: { args: []; result: OpenworkDockerCleanupResult };
+  sandboxDebugProbe: { args: []; result: SandboxDebugProbeResult };
+
+  // Openwork server sidecar
+  openworkServerInfo: { args: []; result: OpenworkServerInfo };
+  openworkServerRestart: {
+    args: [options?: Record<string, unknown>];
+    result: unknown;
+  };
+
+  // Dialogs
+  pickDirectory: {
+    args: [options?: { title?: string; defaultPath?: string; multiple?: boolean }];
+    result: string | string[] | null;
+  };
+  pickFile: {
+    args: [
+      options?: {
+        title?: string;
+        defaultPath?: string;
+        multiple?: boolean;
+        filters?: { name: string; extensions: string[] }[];
+      },
+    ];
+    result: string | string[] | null;
+  };
+  saveFile: {
+    args: [options?: { title?: string; defaultPath?: string; filters?: { name: string; extensions: string[] }[] }];
+    result: string | null;
+  };
+
+  // Skills
+  importSkill: {
+    args: [projectDir: string, sourceDir: string, options?: { overwrite?: boolean }];
+    result: ExecResult;
+  };
+  installSkillTemplate: {
+    args: [projectDir: string, name: string, content: string, options?: { overwrite?: boolean }];
+    result: ExecResult;
+  };
+  listLocalSkills: { args: [projectDir: string]; result: LocalSkillCard[] };
+  readLocalSkill: { args: [projectDir: string, skillName: string]; result: LocalSkillContent };
+  writeLocalSkill: {
+    args: [projectDir: string, skillName: string, content: string];
+    result: ExecResult;
+  };
+  uninstallSkill: { args: [projectDir: string, skillName: string]; result: ExecResult };
+
+  // Updater / config / resets
+  updaterEnvironment: { args: []; result: UpdaterEnvironment };
+  readOpencodeConfig: { args: [scope: string, projectDir?: string]; result: OpencodeConfigFile };
+  writeOpencodeConfig: {
+    args: [scope: string, projectDir: string, content: string];
+    result: ExecResult;
+  };
+  resetOpenworkState: { args: []; result: unknown };
+  resetOpencodeCache: { args: []; result: CacheResetResult };
+  opencodeMcpAuth: { args: [action: string, name: string]; result: ExecResult };
+  setWindowDecorations: { args: [decorated: boolean]; result: unknown };
+
+  // Window / OS utilities (dunder commands)
+  __openPath: { args: [target: string]; result: unknown };
+  __revealItemInDir: { args: [target: string]; result: unknown };
+  __fetch: { args: [url: string, init?: DesktopFetchInit]; result: DesktopFetchResult };
+  __homeDir: { args: []; result: string };
+  __joinPath: { args: [...segments: string[]]; result: string };
+  __setZoomFactor: { args: [factor: number]; result: unknown };
+  __setNativeTheme: { args: [theme: string]; result: unknown };
+  __setApplicationMenuVisible: { args: [visible: boolean]; result: unknown };
+};
+
+export type DesktopCommandName = keyof DesktopCommandMap;
+
+export type DesktopCommandArgs<C extends DesktopCommandName> = DesktopCommandMap[C]["args"];
+
+export type DesktopCommandResult<C extends DesktopCommandName> = DesktopCommandMap[C]["result"];
+
+/**
+ * Main-process handler registry shape. `Event` is electron's
+ * IpcMainInvokeEvent (kept generic so this package does not depend on
+ * electron types).
+ *
+ * Args are deliberately loose (`any[]`) on this side: IPC input crosses a
+ * trust boundary, so handlers validate/normalize whatever arrives with
+ * defensive dynamic access (`String(args[0] ?? "")`, `input.foo ?? null`)
+ * rather than assuming the renderer's tuple. `unknown[]` would force ~50
+ * narrowing rewrites in the plain-JS main process for no runtime gain.
+ * Key parity and result types are still enforced.
+ */
+export type DesktopCommandHandlers<Event = unknown> = {
+  [C in DesktopCommandName]: (
+    event: Event,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...args: any[]
+  ) => Promise<DesktopCommandResult<C>>;
+};
+
+/** Renderer-side bridge: one async function per command. */
+export type DesktopCommandInvokers = {
+  [C in DesktopCommandName]: (...args: DesktopCommandArgs<C>) => Promise<DesktopCommandResult<C>>;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@openwork/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       electron:
         specifier: ^35.0.0
         version: 35.7.5


### PR DESCRIPTION
## What

Campaign 1 from the architecture tracker: the Electron IPC boundary — 72 commands previously dispatched through a 570-line untyped switch, with renderer signatures `(...args: unknown[]) => Promise<unknown>` everywhere. Four commits:

| Commit | Change |
|---|---|
| `838f98315` | **Command registry**: the switch in `handleDesktopInvoke` becomes a `desktopCommandHandlers` object (verbatim bodies, same dispatch semantics, unknown commands throw the same error). `check-electron-bridge.mjs` reads registry keys (also stops harvesting unrelated menu-overlay cases). |
| `a298403fc` | **`DesktopCommandMap` contract** (`packages/types/src/desktop-ipc.ts`): all 72 commands typed (args tuple + result) + the payload shapes move from the renderer into the shared package (renderer `desktop-types.ts` re-exports — single source of truth). Main registry asserted via JSDoc `@type DesktopCommandHandlers` — missing/extra/renamed commands fail `typecheck:electron` (negative-tested). Handler args stay `any[]` deliberately: IPC input crosses a trust boundary and the defensive normalization style is correct; keys + results are enforced. |
| `1edf7edd8` | **Renderer derivation**: `invokeElectronHelper` generic over command name; all 50 `desktopBridge` exports + dunder wrappers now precisely typed. One documented Proxy cast remains (inherent to fabricated members). |
| `c1be4b40d` | **CI gates**: desktop node:test suite (was unrunnable by script, invisible to CI) + `typecheck:electron` added to ci-tests.yml. |

## Real drift found by the contract (encoded truthfully, zero behavior change)

- `pickDirectory`/`pickFile` support `multiple: true` and return `string[]` too — old renderer type said `string | null`
- `writeOpencodeConfig` returns an `ExecResult`, not `OpencodeConfigFile`
- `orchestratorStartDetached` emits `sandboxBackend: "none"`, which the old union excluded
- `setDesktopZoomFactor` returns `boolean` (was untyped)
- **`resetOpenworkState(mode)`: both renderer call sites pass the reset-modal mode (`"onboarding" | "all"`) but the main process ignores it** — it always wipes workspace state + bootstrap config; only localStorage cleanup is mode-scoped. Documented in the contract with a follow-up note (product call whether onboarding resets should preserve desktop state).

## Tests

```
pnpm --filter @openwork/desktop typecheck:electron   # clean (+ negative tripwire test)
pnpm --filter @openwork/desktop check:electron        # 50 renderer methods covered
pnpm --filter @openwork/desktop test                  # 18 pass, 0 fail (node:test)
pnpm --filter @openwork/app typecheck && test && build  # clean / 58 pass / clean
```

**Live (both before and after the renderer typing):** booted the real Electron dev app via CDP and roundtripped commands through the actual bridge — `workspaceBootstrap` (9 live workspaces), `appBuildInfo`, `getDesktopHomeDir`, `setDesktopZoomFactor` (typed `true`), `readOpencodeConfig` (correct shape); unknown command correctly rejected with the registry's error.

No video: IPC-level refactor with no UI change — the live CDP roundtrips above are the end-to-end evidence. Reviewer repro: `pnpm dev`, then in devtools console `await window.__OPENWORK_ELECTRON__.invokeDesktop("appBuildInfo")`.

## Follow-ups queued

Tighten `unknown` results (annotate runtime.mjs returns) · type the raw `invokeDesktop` window global for the few direct call sites · split main.mjs along its now-mapped seams · decide resetOpenworkState mode semantics

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

