### PR TITLE
ci(den-api): dispatchable env-var workflow for the Render den-api service

### DIFF
--- a/.github/workflows/den-api-env.yml
+++ b/.github/workflows/den-api-env.yml
@@ -1,0 +1,89 @@
+name: Den API Env
+
+# Sets a single environment variable on the production den-api service
+# (Render) and triggers a deploy so it takes effect.
+#
+# Do NOT use this for secret values: workflow_dispatch inputs are visible in
+# the run metadata. Secrets should be set in the Render dashboard directly.
+#
+# Required GitHub Actions secrets:
+#   RENDER_API_KEY                        Render API key
+#   RENDER_DEN_CONTROL_PLANE_SERVICE_ID   Render service id of den-api
+
+on:
+  workflow_dispatch:
+    inputs:
+      key:
+        description: "Environment variable name (e.g. DEN_PLAN_GATING_ENABLED)"
+        type: string
+        required: true
+      value:
+        description: "Environment variable value (non-secret values only)"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: den-api-env
+  cancel-in-progress: false
+
+jobs:
+  set-env:
+    name: Set env var and deploy
+    if: github.repository == 'different-ai/openwork'
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+
+    env:
+      RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+      RENDER_SERVICE_ID: ${{ secrets.RENDER_DEN_CONTROL_PLANE_SERVICE_ID }}
+
+    steps:
+      - name: Verify Render secrets are configured
+        run: |
+          set -euo pipefail
+          missing=""
+          [ -z "$RENDER_API_KEY" ] && missing="$missing RENDER_API_KEY"
+          [ -z "$RENDER_SERVICE_ID" ] && missing="$missing RENDER_DEN_CONTROL_PLANE_SERVICE_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing GitHub Actions secrets:$missing."
+            exit 1
+          fi
+          echo "Render secrets present."
+
+      - name: Update environment variable
+        run: |
+          set -euo pipefail
+          value="$(jq -n --arg v '${{ inputs.value }}' '{value: $v}')"
+          curl -sf -X PUT "https://api.render.com/v1/services/$RENDER_SERVICE_ID/env-vars/${{ inputs.key }}" \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$value" >/dev/null
+          echo "Updated ${{ inputs.key }} on the den-api service."
+
+      - name: Trigger deploy and wait
+        run: |
+          set -euo pipefail
+          deploy_id="$(curl -sf -X POST "https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys" \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" -d '{}' | jq -r '.id')"
+          echo "Deploy triggered: $deploy_id"
+          for _ in $(seq 1 90); do
+            status="$(curl -sf "https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys/$deploy_id" \
+              -H "Authorization: Bearer $RENDER_API_KEY" | jq -r '.status')"
+            echo "deploy status: $status"
+            case "$status" in
+              live)
+                echo "Deploy is live."
+                exit 0
+                ;;
+              build_failed|update_failed|pre_deploy_failed|canceled|deactivated)
+                echo "::error::Deploy failed with status: $status"
+                exit 1
+                ;;
+            esac
+            sleep 10
+          done
+          echo "::error::Deploy did not go live within 15 minutes."
+          exit 1


### PR DESCRIPTION
## What

A `workflow_dispatch` workflow that sets a single (non-secret) environment variable on the production den-api Render service and triggers + waits for a deploy. Uses the existing `RENDER_API_KEY` / `RENDER_DEN_CONTROL_PLANE_SERVICE_ID` secrets.

Immediate use: flipping `DEN_PLAN_GATING_ENABLED=true` to enable enterprise plan gating (#2198) — the grandfathering migration (0023) is already applied to prod, so the flag flip is the last rollout step. Future use: any non-secret den-api config change without dashboard access.

Notes:
- Inputs are visible in run metadata, so the workflow header explicitly forbids secret values
- Deploy is polled to `live` (15 min budget) and fails loudly on `build_failed`/`update_failed`/`pre_deploy_failed`
- `concurrency` group prevents racing env updates

## Tests
- YAML validated
- Will be exercised immediately after merge by dispatching `DEN_PLAN_GATING_ENABLED=true`; evidence on that run

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

