### PR TITLE
refactor(desktop): tighten IPC contract results + begin main.mjs module split

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -49,7 +49,10 @@ export type BrowserProxyState = {
 declare global {
   interface Window {
     __OPENWORK_ELECTRON__?: {
-      invokeDesktop?: (command: string, ...args: unknown[]) => Promise<unknown>;
+      invokeDesktop?: <C extends DesktopCommandName>(
+        command: C,
+        ...args: DesktopCommandArgs<C>
+      ) => Promise<DesktopCommandResult<C>>;
       shell?: {
         openExternal?: (url: string) => Promise<void>;
         relaunch?: () => Promise<void>;
@@ -214,7 +217,13 @@ export const desktopBridge = new Proxy(electronBridge, {
       if (!invokeDesktop) {
         throw new Error(`Electron desktop helper is unavailable: ${prop}`);
       }
-      return invokeDesktop(prop, ...args);
+      // The Proxy is the one dynamic point in the bridge: `prop` is whatever
+      // property was accessed, already constrained by the DesktopBridge
+      // surface this Proxy is exported as.
+      return invokeDesktop(
+        prop as DesktopCommandName,
+        ...(args as DesktopCommandArgs<DesktopCommandName>),
+      );
     };
     target[prop] = fn;
     return fn;

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -340,7 +340,7 @@ export function createConnectionsStore(options: {
     return { next, nextStatuses, engineSync };
   };
 
-  const resolveDesktopCommand = async (commandName: string, fallbackOnError = true) => {
+  const resolveDesktopCommand = async (commandName: "getComputerUseMcpCommand" | "getOpenworkUiMcpCommand", fallbackOnError = true) => {
     try {
       const command = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.(commandName);
       if (Array.isArray(command) && command.every((part) => typeof part === "string") && command.length > 0) {
@@ -373,7 +373,7 @@ export function createConnectionsStore(options: {
   const resolveLocalMcpEnvironment = async (entry: McpDirectoryInfo) => {
     if (entry.serverName !== "openwork-ui") return undefined;
     try {
-      const environment = await (window as any).__OPENWORK_ELECTRON__?.invokeDesktop?.("getOpenworkUiMcpEnvironment");
+      const environment = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("getOpenworkUiMcpEnvironment");
       if (environment && typeof environment === "object" && !Array.isArray(environment)) {
         return Object.fromEntries(
           Object.entries(environment).filter((entry): entry is [string, string] =>
@@ -618,7 +618,7 @@ export function createConnectionsStore(options: {
       let resolvedHeaders: Record<string, string> | undefined;
       if (!resolvedUrl && entry.serverName === "openwork-ui") {
         try {
-          const bridgeInfo = await (window as any).__OPENWORK_ELECTRON__?.invokeDesktop?.("getUiControlBridgeInfo");
+          const bridgeInfo = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("getUiControlBridgeInfo");
           if (bridgeInfo?.baseUrl) {
             resolvedUrl = `${bridgeInfo.baseUrl}/mcp`;
             if (bridgeInfo.token) {

--- a/apps/desktop/electron/computer-use.mjs
+++ b/apps/desktop/electron/computer-use.mjs
@@ -1,0 +1,164 @@
+// Computer-use helper integration: locating the bundled ComputerUse.app,
+// permission checks (spawn --check for a fresh TCC read), running-app
+// listing for @App mentions, and opening the permission-setup GUI.
+// Extracted from main.mjs; consumed only by the desktop IPC registry.
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { app, shell } from "electron";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const COMPUTER_USE_HELPER_APP_NAME = "OpenWork Computer Use.app";
+const COMPUTER_USE_HELPER_EXECUTABLE = "ComputerUse";
+
+function computerUseHelperExecutablePath() {
+  const appPath = computerUseHelperAppPath();
+  const explicitBinary = process.env.OPENWORK_COMPUTER_USE_BINARY?.trim();
+  const candidates = [
+    explicitBinary,
+    appPath ? path.join(appPath, "Contents", "MacOS", COMPUTER_USE_HELPER_EXECUTABLE) : null,
+  ].filter(Boolean);
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function computerUseHelperAppPath() {
+  const explicitApp = process.env.OPENWORK_COMPUTER_USE_APP?.trim();
+  const candidates = [
+    explicitApp,
+    process.resourcesPath ? path.join(process.resourcesPath, "helpers", COMPUTER_USE_HELPER_APP_NAME) : null,
+    path.resolve(__dirname, "..", "resources", "helpers", COMPUTER_USE_HELPER_APP_NAME),
+  ].filter(Boolean);
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function getComputerUseMcpCommand() {
+  const helperExecutable = computerUseHelperExecutablePath();
+  if (helperExecutable) return [helperExecutable, "mcp"];
+
+  if (app.isPackaged) {
+    throw new Error("OpenWork Computer Use is missing from this OpenWork build.");
+  }
+
+  if (process.env.OPENWORK_DEV_MODE === "1") {
+    return ["node", path.resolve(__dirname, "../../..", "packages/handsfree/bin/openwork-handsfree-computer-use.mjs"), "mcp"];
+  }
+  return ["npx", "-y", "@openwork/handsfree", "mcp"];
+}
+
+// ---------------------------------------------------------------------------
+// Permission checks — spawn the binary with --check, read stdout, done.
+// Fresh process = fresh TCC read = always accurate. No HTTP server needed.
+// ---------------------------------------------------------------------------
+
+function resolveComputerUseExecutable() {
+  // 1. Explicit env override.
+  const explicit = process.env.OPENWORK_COMPUTER_USE_BINARY?.trim();
+  if (explicit && existsSync(explicit)) return explicit;
+
+  // 2. .app bundle (packaged builds + pnpm dev).
+  const appPath = computerUseHelperAppPath();
+  if (appPath) {
+    const bin = path.join(appPath, "Contents", "MacOS", COMPUTER_USE_HELPER_EXECUTABLE);
+    if (existsSync(bin)) return bin;
+  }
+
+  // 3. Dev fallback — raw Swift build output.
+  if (!app.isPackaged) {
+    const swiftPkg = path.resolve(__dirname, "../../..", "packages/handsfree/native/HandsFree");
+    const devCandidates = [
+      path.join(swiftPkg, ".build", "release", "HandsFreeComputerUse"),
+      path.join(swiftPkg, ".build", "arm64-apple-macosx", "release", "HandsFreeComputerUse"),
+      path.join(swiftPkg, ".build", "debug", "HandsFreeComputerUse"),
+      path.join(swiftPkg, ".build", "arm64-apple-macosx", "debug", "HandsFreeComputerUse"),
+    ];
+    for (const c of devCandidates) {
+      if (existsSync(c)) return c;
+    }
+  }
+
+  return null;
+}
+
+async function checkComputerUsePermissions() {
+  // Spawn binary --check → read JSON from stdout → exit. Always fresh.
+  const bin = resolveComputerUseExecutable();
+  if (!bin) {
+    return { ok: false, accessibility: false, screenRecording: false, error: "Helper binary not found. Run pnpm dev to build it." };
+  }
+  return spawnCheckPermissions(bin);
+}
+
+function spawnCheckPermissions(bin) {
+  return new Promise((resolve) => {
+    let stdout = "";
+    const child = spawn(bin, ["--check"], { stdio: ["ignore", "pipe", "ignore"], timeout: 5_000 });
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.on("error", () => resolve({ ok: false, accessibility: false, screenRecording: false, error: "Failed to run permission check." }));
+    child.on("close", () => {
+      try {
+        const parsed = JSON.parse(stdout.trim());
+        resolve({
+          ok: parsed?.ok === true,
+          accessibility: parsed?.accessibility === true,
+          screenRecording: parsed?.screenRecording === true,
+        });
+      } catch {
+        resolve({ ok: false, accessibility: false, screenRecording: false, error: "Permission check returned invalid output." });
+      }
+    });
+  });
+}
+
+async function listRunningApps() {
+  // Spawn binary --list-apps → read JSON from stdout → exit. Needs no TCC
+  // permissions, so this works before Computer Use setup is complete.
+  if (process.platform !== "darwin") return { ok: false, apps: [] };
+  const bin = resolveComputerUseExecutable();
+  if (!bin) return { ok: false, apps: [] };
+  return new Promise((resolve) => {
+    let stdout = "";
+    const child = spawn(bin, ["--list-apps"], { stdio: ["ignore", "pipe", "ignore"], timeout: 5_000 });
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.on("error", () => resolve({ ok: false, apps: [] }));
+    child.on("close", () => {
+      try {
+        const parsed = JSON.parse(stdout.trim());
+        const apps = Array.isArray(parsed?.apps) ? parsed.apps.filter((name) => typeof name === "string" && name.trim()) : [];
+        resolve({ ok: parsed?.ok === true, apps });
+      } catch {
+        resolve({ ok: false, apps: [] });
+      }
+    });
+  });
+}
+
+async function openComputerUseSetupApp() {
+  // Open the GUI. Use the .app bundle if available so macOS shows it as
+  // a real app with its own dock icon and permission identity.
+  const appPath = computerUseHelperAppPath();
+  if (appPath) {
+    const result = await shell.openPath(appPath);
+    if (result) console.error("[ComputerUse] shell.openPath error:", result);
+    return;
+  }
+
+  // Fallback: spawn the raw binary (opens the same GUI).
+  const bin = resolveComputerUseExecutable();
+  if (!bin) throw new Error("Helper binary not found. Run pnpm dev to build it.");
+  const child = spawn(bin, [], { detached: true, stdio: "ignore" });
+  child.unref();
+}
+
+export {
+  checkComputerUsePermissions,
+  getComputerUseMcpCommand,
+  listRunningApps,
+  openComputerUseSetupApp,
+};

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -26,6 +26,12 @@ import { createRuntimeManager } from "./runtime.mjs";
 import { registerUpdaterIpc } from "./updater.mjs";
 import { exportWorkspaceConfig, importWorkspaceConfig } from "./workspace-archive.mjs";
 import {
+  checkComputerUsePermissions,
+  getComputerUseMcpCommand,
+  listRunningApps,
+  openComputerUseSetupApp,
+} from "./computer-use.mjs";
+import {
   openworkWorkspaceDisplayName,
   selectOpenworkWorkspaceForConnection,
 } from "./remote-workspace.mjs";
@@ -47,8 +53,6 @@ const APP_IDENTIFIER = isDevMode ? DEV_APP_IDENTIFIER : TAURI_APP_IDENTIFIER;
 const RELEASE_DOWNLOAD_BASE_URL = "https://github.com/different-ai/openwork/releases/latest/download";
 const RELEASE_PAGE_URL = "https://github.com/different-ai/openwork/releases/latest";
 const DOCS_PAGE_URL = "https://openworklabs.com/docs";
-const COMPUTER_USE_HELPER_APP_NAME = "OpenWork Computer Use.app";
-const COMPUTER_USE_HELPER_EXECUTABLE = "ComputerUse";
 const terminalProcesses = new Map();
 let nextTerminalId = 1;
 
@@ -82,148 +86,6 @@ function killTerminalsForWebContents(webContentsId) {
   for (const [terminalId, terminal] of terminalProcesses.entries()) {
     if (terminal.webContentsId === webContentsId) killTerminal(terminalId);
   }
-}
-
-function computerUseHelperExecutablePath() {
-  const appPath = computerUseHelperAppPath();
-  const explicitBinary = process.env.OPENWORK_COMPUTER_USE_BINARY?.trim();
-  const candidates = [
-    explicitBinary,
-    appPath ? path.join(appPath, "Contents", "MacOS", COMPUTER_USE_HELPER_EXECUTABLE) : null,
-  ].filter(Boolean);
-
-  return candidates.find((candidate) => existsSync(candidate)) ?? null;
-}
-
-function computerUseHelperAppPath() {
-  const explicitApp = process.env.OPENWORK_COMPUTER_USE_APP?.trim();
-  const candidates = [
-    explicitApp,
-    process.resourcesPath ? path.join(process.resourcesPath, "helpers", COMPUTER_USE_HELPER_APP_NAME) : null,
-    path.resolve(__dirname, "..", "resources", "helpers", COMPUTER_USE_HELPER_APP_NAME),
-  ].filter(Boolean);
-
-  return candidates.find((candidate) => existsSync(candidate)) ?? null;
-}
-
-function getComputerUseMcpCommand() {
-  const helperExecutable = computerUseHelperExecutablePath();
-  if (helperExecutable) return [helperExecutable, "mcp"];
-
-  if (app.isPackaged) {
-    throw new Error("OpenWork Computer Use is missing from this OpenWork build.");
-  }
-
-  if (process.env.OPENWORK_DEV_MODE === "1") {
-    return ["node", path.resolve(__dirname, "../../..", "packages/handsfree/bin/openwork-handsfree-computer-use.mjs"), "mcp"];
-  }
-  return ["npx", "-y", "@openwork/handsfree", "mcp"];
-}
-
-// ---------------------------------------------------------------------------
-// Permission checks — spawn the binary with --check, read stdout, done.
-// Fresh process = fresh TCC read = always accurate. No HTTP server needed.
-// ---------------------------------------------------------------------------
-
-function resolveComputerUseExecutable() {
-  // 1. Explicit env override.
-  const explicit = process.env.OPENWORK_COMPUTER_USE_BINARY?.trim();
-  if (explicit && existsSync(explicit)) return explicit;
-
-  // 2. .app bundle (packaged builds + pnpm dev).
-  const appPath = computerUseHelperAppPath();
-  if (appPath) {
-    const bin = path.join(appPath, "Contents", "MacOS", COMPUTER_USE_HELPER_EXECUTABLE);
-    if (existsSync(bin)) return bin;
-  }
-
-  // 3. Dev fallback — raw Swift build output.
-  if (!app.isPackaged) {
-    const swiftPkg = path.resolve(__dirname, "../../..", "packages/handsfree/native/HandsFree");
-    const devCandidates = [
-      path.join(swiftPkg, ".build", "release", "HandsFreeComputerUse"),
-      path.join(swiftPkg, ".build", "arm64-apple-macosx", "release", "HandsFreeComputerUse"),
-      path.join(swiftPkg, ".build", "debug", "HandsFreeComputerUse"),
-      path.join(swiftPkg, ".build", "arm64-apple-macosx", "debug", "HandsFreeComputerUse"),
-    ];
-    for (const c of devCandidates) {
-      if (existsSync(c)) return c;
-    }
-  }
-
-  return null;
-}
-
-async function checkComputerUsePermissions() {
-  // Spawn binary --check → read JSON from stdout → exit. Always fresh.
-  const bin = resolveComputerUseExecutable();
-  if (!bin) {
-    return { ok: false, accessibility: false, screenRecording: false, error: "Helper binary not found. Run pnpm dev to build it." };
-  }
-  return spawnCheckPermissions(bin);
-}
-
-function spawnCheckPermissions(bin) {
-  return new Promise((resolve) => {
-    let stdout = "";
-    const child = spawn(bin, ["--check"], { stdio: ["ignore", "pipe", "ignore"], timeout: 5_000 });
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.on("error", () => resolve({ ok: false, accessibility: false, screenRecording: false, error: "Failed to run permission check." }));
-    child.on("close", () => {
-      try {
-        const parsed = JSON.parse(stdout.trim());
-        resolve({
-          ok: parsed?.ok === true,
-          accessibility: parsed?.accessibility === true,
-          screenRecording: parsed?.screenRecording === true,
-        });
-      } catch {
-        resolve({ ok: false, accessibility: false, screenRecording: false, error: "Permission check returned invalid output." });
-      }
-    });
-  });
-}
-
-async function listRunningApps() {
-  // Spawn binary --list-apps → read JSON from stdout → exit. Needs no TCC
-  // permissions, so this works before Computer Use setup is complete.
-  if (process.platform !== "darwin") return { ok: false, apps: [] };
-  const bin = resolveComputerUseExecutable();
-  if (!bin) return { ok: false, apps: [] };
-  return new Promise((resolve) => {
-    let stdout = "";
-    const child = spawn(bin, ["--list-apps"], { stdio: ["ignore", "pipe", "ignore"], timeout: 5_000 });
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.on("error", () => resolve({ ok: false, apps: [] }));
-    child.on("close", () => {
-      try {
-        const parsed = JSON.parse(stdout.trim());
-        const apps = Array.isArray(parsed?.apps) ? parsed.apps.filter((name) => typeof name === "string" && name.trim()) : [];
-        resolve({ ok: parsed?.ok === true, apps });
-      } catch {
-        resolve({ ok: false, apps: [] });
-      }
-    });
-  });
-}
-
-async function openComputerUseSetupApp() {
-  // Open the GUI. Use the .app bundle if available so macOS shows it as
-  // a real app with its own dock icon and permission identity.
-  const appPath = computerUseHelperAppPath();
-  if (appPath) {
-    const result = await shell.openPath(appPath);
-    if (result) console.error("[ComputerUse] shell.openPath error:", result);
-    return;
-  }
-
-  // Fallback: spawn the raw binary (opens the same GUI).
-  const bin = resolveComputerUseExecutable();
-  if (!bin) throw new Error("Helper binary not found. Run pnpm dev to build it.");
-  const child = spawn(bin, [], { detached: true, stdio: "ignore" });
-  child.unref();
 }
 
 // Production Electron shares the same on-disk state folder as the Tauri shell

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -31,6 +31,7 @@ import {
   listRunningApps,
   openComputerUseSetupApp,
 } from "./computer-use.mjs";
+import { createUiControlServer } from "./ui-control-server.mjs";
 import {
   openworkWorkspaceDisplayName,
   selectOpenworkWorkspaceForConnection,
@@ -53,6 +54,12 @@ const APP_IDENTIFIER = isDevMode ? DEV_APP_IDENTIFIER : TAURI_APP_IDENTIFIER;
 const RELEASE_DOWNLOAD_BASE_URL = "https://github.com/different-ai/openwork/releases/latest/download";
 const RELEASE_PAGE_URL = "https://github.com/different-ai/openwork/releases/latest";
 const DOCS_PAGE_URL = "https://openworklabs.com/docs";
+const uiControlServer = createUiControlServer({
+  appName: APP_NAME,
+  appIdentifier: APP_IDENTIFIER,
+  getWindow: () => createMainWindow(),
+});
+
 const terminalProcesses = new Map();
 let nextTerminalId = 1;
 
@@ -388,9 +395,6 @@ const IDLE_ROUTER_INFO = Object.freeze({
 
 let mainWindow = null;
 const pendingDeepLinks = [];
-let uiControlServer = null;
-let uiControlDiscoveryPath = null;
-const uiControlToken = randomBytes(32).toString("hex");
 
 // ── Embedded browser panel ─────────────────────────────────────────────
 const browserTabs = new Map();
@@ -2943,148 +2947,6 @@ async function handleDesktopInvoke(event, command, ...args) {
   return handler(event, ...args);
 }
 
-function sendJsonResponse(response, statusCode, payload) {
-  response.writeHead(statusCode, {
-    "Content-Type": "application/json; charset=utf-8",
-    "Cache-Control": "no-store",
-  });
-  response.end(JSON.stringify(payload));
-}
-
-function readJsonRequestBody(request) {
-  return new Promise((resolve, reject) => {
-    let raw = "";
-    request.setEncoding("utf8");
-    request.on("data", (chunk) => {
-      raw += chunk;
-      if (raw.length > 128_000) {
-        reject(new Error("Request body too large"));
-        request.destroy();
-      }
-    });
-    request.on("end", () => {
-      if (!raw.trim()) {
-        resolve({});
-        return;
-      }
-      try {
-        resolve(JSON.parse(raw));
-      } catch {
-        reject(new Error("Request body must be JSON"));
-      }
-    });
-    request.on("error", reject);
-  });
-}
-
-function authorizedUiControlRequest(request) {
-  const auth = request.headers.authorization ?? "";
-  return auth === `Bearer ${uiControlToken}`;
-}
-
-function jsonForJavaScript(value) {
-  return JSON.stringify(JSON.stringify(value ?? {}));
-}
-
-async function evaluateOpenworkControl(expression, options = {}) {
-  const win = await createMainWindow();
-  if (options.focus === true) {
-    win.show();
-    if (win.isMinimized()) win.restore();
-    win.focus();
-  }
-  return win.webContents.executeJavaScript(expression, true);
-}
-
-async function runOpenworkControlCommand(command, args = {}) {
-  const argsJsonLiteral = jsonForJavaScript(args);
-  if (command === "snapshot") {
-    return evaluateOpenworkControl(`(async () => {
-      const control = window.__openworkControl;
-      if (!control) return { ok: false, error: "OpenWork control surface is not available yet." };
-      control.setEnabled?.(true);
-      return { ok: true, ...control.snapshot() };
-    })()`);
-  }
-  if (command === "actions") {
-    return evaluateOpenworkControl(`(async () => {
-      const control = window.__openworkControl;
-      if (!control) return { ok: false, error: "OpenWork control surface is not available yet." };
-      control.setEnabled?.(true);
-      return { ok: true, actions: control.listActions() };
-    })()`);
-  }
-  if (command === "execute") {
-    return evaluateOpenworkControl(`(async () => {
-      const control = window.__openworkControl;
-      const input = JSON.parse(${argsJsonLiteral});
-      if (!control) return { ok: false, error: "OpenWork control surface is not available yet." };
-      if (!input || typeof input.actionId !== "string" || !input.actionId.trim()) {
-        return { ok: false, error: "Missing OpenWork actionId." };
-      }
-      control.setEnabled?.(true);
-      return control.execute(input.actionId, input.args ?? {});
-    })()`, { focus: true });
-  }
-  return { ok: false, error: `Unknown OpenWork control command: ${command}` };
-}
-
-async function startUiControlServer() {
-  if (uiControlServer) return;
-  uiControlServer = createServer(async (request, response) => {
-    try {
-      const url = new URL(request.url ?? "/", "http://127.0.0.1");
-      if (request.method === "GET" && url.pathname === "/health") {
-        sendJsonResponse(response, 200, { ok: true, app: APP_NAME, version: 1 });
-        return;
-      }
-      if (!authorizedUiControlRequest(request)) {
-        sendJsonResponse(response, 401, { ok: false, error: "Unauthorized" });
-        return;
-      }
-      if (request.method === "GET" && url.pathname === "/snapshot") {
-        sendJsonResponse(response, 200, await runOpenworkControlCommand("snapshot"));
-        return;
-      }
-      if (request.method === "GET" && url.pathname === "/actions") {
-        sendJsonResponse(response, 200, await runOpenworkControlCommand("actions"));
-        return;
-      }
-      if (request.method === "POST" && url.pathname === "/execute") {
-        sendJsonResponse(response, 200, await runOpenworkControlCommand("execute", await readJsonRequestBody(request)));
-        return;
-      }
-      sendJsonResponse(response, 404, { ok: false, error: "Not found" });
-    } catch (error) {
-      sendJsonResponse(response, 500, { ok: false, error: error instanceof Error ? error.message : String(error) });
-    }
-  });
-  await new Promise((resolve, reject) => {
-    uiControlServer.once("error", reject);
-    uiControlServer.listen(0, "127.0.0.1", () => resolve(undefined));
-  });
-  const address = uiControlServer.address();
-  const port = typeof address === "object" && address ? address.port : null;
-  if (!port) throw new Error("Could not start OpenWork UI control bridge.");
-  uiControlDiscoveryPath = path.join(app.getPath("userData"), "openwork-ui-control.json");
-  await writeFile(
-    uiControlDiscoveryPath,
-    `${JSON.stringify({ version: 1, app: APP_NAME, identifier: APP_IDENTIFIER, platform: process.platform, baseUrl: `http://127.0.0.1:${port}`, token: uiControlToken }, null, 2)}\n`,
-    "utf8",
-  );
-  // Make the discovery path available to child processes (server → managed OpenCode → plugin).
-  process.env.OPENWORK_UI_CONTROL_DISCOVERY = uiControlDiscoveryPath;
-}
-
-async function stopUiControlServer() {
-  if (uiControlDiscoveryPath) {
-    await rm(uiControlDiscoveryPath, { force: true }).catch(() => undefined);
-    uiControlDiscoveryPath = null;
-  }
-  if (!uiControlServer) return;
-  await new Promise((resolve) => uiControlServer.close(() => resolve(undefined)));
-  uiControlServer = null;
-}
 
 async function createMainWindow() {
   if (mainWindow) return mainWindow;
@@ -3328,7 +3190,7 @@ if (!app.requestSingleInstanceLock()) {
     event.preventDefault();
     if (runtimeDisposeInProgress) return;
     showShutdownScreen();
-    void Promise.all([disposeRuntimeBeforeQuit(), stopUiControlServer()]).finally(() => app.quit());
+    void Promise.all([disposeRuntimeBeforeQuit(), uiControlServer.stop()]).finally(() => app.quit());
   });
 
   app.on("second-instance", async (_event, argv) => {
@@ -3356,7 +3218,7 @@ if (!app.requestSingleInstanceLock()) {
     // Electron see the same workspace list. Import the short-lived
     // Electron-only filename only when the shared file is missing.
     await migrateLegacyElectronWorkspaceStateIfNeeded();
-    await startUiControlServer().catch((error) => {
+    await uiControlServer.start().catch((error) => {
       console.warn("[ui-control] failed to start", error);
     });
     runtimeBootstrapPromise = bootRuntimeForSelectedWorkspace().catch((error) => ({

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -492,8 +492,17 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   // invocations of engineStart/engineStop/engineRestart race: each call's
   // stopAllRuntimeChildren kills the previous call's freshly-spawned
   // orchestrator daemon, and the prior call then times out its /health probe.
+  /** @type {Promise<unknown>} */
   let runtimeLifecycleQueue = Promise.resolve();
   let lifecycleState = "idle";
+  /**
+   * Serialize engine lifecycle operations; preserves the wrapped function's
+   * return type (untyped, this collapsed runtime-manager inference to
+   * Promise<void> and blocked tightening the DesktopCommandMap results).
+   * @template T
+   * @param {() => Promise<T>} fn
+   * @returns {Promise<T>}
+   */
   function withRuntimeLifecycle(fn) {
     const next = runtimeLifecycleQueue.then(fn, fn);
     runtimeLifecycleQueue = next.catch(() => {});

--- a/apps/desktop/electron/ui-control-server.mjs
+++ b/apps/desktop/electron/ui-control-server.mjs
@@ -1,0 +1,162 @@
+// Local UI-control HTTP bridge: a loopback server exposing /snapshot,
+// /actions, /execute, dispatched to the renderer's window.__openworkControl
+// surface via executeJavaScript. Consumed over HTTP by openwork-ui-mcp.
+// Extracted from main.mjs; state and lifecycle live in this factory
+// (createRuntimeManager pattern).
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+import { rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { app } from "electron";
+
+export function createUiControlServer({ appName, appIdentifier, getWindow }) {
+  let uiControlServer = null;
+  let uiControlDiscoveryPath = null;
+  const uiControlToken = randomBytes(32).toString("hex");
+
+  function sendJsonResponse(response, statusCode, payload) {
+    response.writeHead(statusCode, {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "no-store",
+    });
+    response.end(JSON.stringify(payload));
+  }
+
+  function readJsonRequestBody(request) {
+    return new Promise((resolve, reject) => {
+      let raw = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        raw += chunk;
+        if (raw.length > 128_000) {
+          reject(new Error("Request body too large"));
+          request.destroy();
+        }
+      });
+      request.on("end", () => {
+        if (!raw.trim()) {
+          resolve({});
+          return;
+        }
+        try {
+          resolve(JSON.parse(raw));
+        } catch {
+          reject(new Error("Request body must be JSON"));
+        }
+      });
+      request.on("error", reject);
+    });
+  }
+
+  function authorizedUiControlRequest(request) {
+    const auth = request.headers.authorization ?? "";
+    return auth === `Bearer ${uiControlToken}`;
+  }
+
+  function jsonForJavaScript(value) {
+    return JSON.stringify(JSON.stringify(value ?? {}));
+  }
+
+  async function evaluateOpenworkControl(expression, options = {}) {
+    const win = await getWindow();
+    if (options.focus === true) {
+      win.show();
+      if (win.isMinimized()) win.restore();
+      win.focus();
+    }
+    return win.webContents.executeJavaScript(expression, true);
+  }
+
+  async function runOpenworkControlCommand(command, args = {}) {
+    const argsJsonLiteral = jsonForJavaScript(args);
+    if (command === "snapshot") {
+      return evaluateOpenworkControl(`(async () => {
+        const control = window.__openworkControl;
+        if (!control) return { ok: false, error: "OpenWork control surface is not available yet." };
+        control.setEnabled?.(true);
+        return { ok: true, ...control.snapshot() };
+      })()`);
+    }
+    if (command === "actions") {
+      return evaluateOpenworkControl(`(async () => {
+        const control = window.__openworkControl;
+        if (!control) return { ok: false, error: "OpenWork control surface is not available yet." };
+        control.setEnabled?.(true);
+        return { ok: true, actions: control.listActions() };
+      })()`);
+    }
+    if (command === "execute") {
+      return evaluateOpenworkControl(`(async () => {
+        const control = window.__openworkControl;
+        const input = JSON.parse(${argsJsonLiteral});
+        if (!control) return { ok: false, error: "OpenWork control surface is not available yet." };
+        if (!input || typeof input.actionId !== "string" || !input.actionId.trim()) {
+          return { ok: false, error: "Missing OpenWork actionId." };
+        }
+        control.setEnabled?.(true);
+        return control.execute(input.actionId, input.args ?? {});
+      })()`, { focus: true });
+    }
+    return { ok: false, error: `Unknown OpenWork control command: ${command}` };
+  }
+
+  async function start() {
+    if (uiControlServer) return;
+    uiControlServer = createServer(async (request, response) => {
+      try {
+        const url = new URL(request.url ?? "/", "http://127.0.0.1");
+        if (request.method === "GET" && url.pathname === "/health") {
+          sendJsonResponse(response, 200, { ok: true, app: appName, version: 1 });
+          return;
+        }
+        if (!authorizedUiControlRequest(request)) {
+          sendJsonResponse(response, 401, { ok: false, error: "Unauthorized" });
+          return;
+        }
+        if (request.method === "GET" && url.pathname === "/snapshot") {
+          sendJsonResponse(response, 200, await runOpenworkControlCommand("snapshot"));
+          return;
+        }
+        if (request.method === "GET" && url.pathname === "/actions") {
+          sendJsonResponse(response, 200, await runOpenworkControlCommand("actions"));
+          return;
+        }
+        if (request.method === "POST" && url.pathname === "/execute") {
+          sendJsonResponse(response, 200, await runOpenworkControlCommand("execute", await readJsonRequestBody(request)));
+          return;
+        }
+        sendJsonResponse(response, 404, { ok: false, error: "Not found" });
+      } catch (error) {
+        sendJsonResponse(response, 500, { ok: false, error: error instanceof Error ? error.message : String(error) });
+      }
+    });
+    await new Promise((resolve, reject) => {
+      uiControlServer.once("error", reject);
+      uiControlServer.listen(0, "127.0.0.1", () => resolve(undefined));
+    });
+    const address = uiControlServer.address();
+    const port = typeof address === "object" && address ? address.port : null;
+    if (!port) throw new Error("Could not start OpenWork UI control bridge.");
+    uiControlDiscoveryPath = path.join(app.getPath("userData"), "openwork-ui-control.json");
+    await writeFile(
+      uiControlDiscoveryPath,
+      `${JSON.stringify({ version: 1, app: appName, identifier: appIdentifier, platform: process.platform, baseUrl: `http://127.0.0.1:${port}`, token: uiControlToken }, null, 2)}\n`,
+      "utf8",
+    );
+    // Make the discovery path available to child processes (server → managed OpenCode → plugin).
+    process.env.OPENWORK_UI_CONTROL_DISCOVERY = uiControlDiscoveryPath;
+  }
+
+  async function stop() {
+    if (uiControlDiscoveryPath) {
+      await rm(uiControlDiscoveryPath, { force: true }).catch(() => undefined);
+      uiControlDiscoveryPath = null;
+    }
+    if (!uiControlServer) return;
+    await new Promise((resolve) => uiControlServer.close(() => resolve(undefined)));
+    uiControlServer = null;
+  }
+
+  return { start, stop };
+}

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -285,6 +285,23 @@ export type WorkspaceUpdateRemoteInput = WorkspaceCreateRemoteInput & {
   workspaceId: string;
 };
 
+export type UiControlBridgeInfo = {
+  baseUrl?: string;
+  token?: string;
+};
+
+export type ComputerUsePermissions = {
+  ok: boolean;
+  accessibility: boolean;
+  screenRecording: boolean;
+  error?: string;
+};
+
+export type RunningAppsResult = {
+  ok: boolean;
+  apps: string[];
+};
+
 // ---------------------------------------------------------------------------
 // The command map
 // ---------------------------------------------------------------------------
@@ -357,15 +374,15 @@ export type DesktopCommandMap = {
 
   // App / bridge info
   appBuildInfo: { args: []; result: AppBuildInfo };
-  getUiControlBridgeInfo: { args: []; result: unknown };
-  getOpenworkUiMcpCommand: { args: []; result: unknown };
-  getComputerUseMcpCommand: { args: []; result: unknown };
-  getOpenworkUiMcpEnvironment: { args: []; result: unknown };
+  getUiControlBridgeInfo: { args: []; result: UiControlBridgeInfo | null };
+  getOpenworkUiMcpCommand: { args: []; result: string[] };
+  getComputerUseMcpCommand: { args: []; result: string[] };
+  getOpenworkUiMcpEnvironment: { args: []; result: Record<string, string> };
 
   // Computer use
-  checkComputerUsePermissions: { args: []; result: unknown };
-  listRunningApps: { args: []; result: unknown };
-  openComputerUsePermissionSetup: { args: []; result: unknown };
+  checkComputerUsePermissions: { args: []; result: ComputerUsePermissions };
+  listRunningApps: { args: []; result: RunningAppsResult };
+  openComputerUsePermissionSetup: { args: []; result: ComputerUsePermissions };
   openComputerUsePermissionSettings: { args: []; result: unknown };
 
   // Bootstrap config

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -338,14 +338,12 @@ export type DesktopCommandMap = {
   };
 
   // Engine / runtime lifecycle
-  // TODO: EngineInfo once runtime.mjs return inference is annotated (tsc
-  // currently infers void for the manager methods).
-  engineStart: { args: [projectDir: string, options?: Record<string, unknown>]; result: unknown };
+  engineStart: { args: [projectDir: string, options?: Record<string, unknown>]; result: EngineInfo };
   prepareFreshRuntime: { args: []; result: unknown };
   runtimeBootstrap: { args: []; result: unknown };
   runtimeStatus: { args: []; result: unknown };
-  engineStop: { args: []; result: unknown };
-  engineRestart: { args: [options?: Record<string, unknown>]; result: unknown };
+  engineStop: { args: []; result: EngineInfo };
+  engineRestart: { args: [options?: Record<string, unknown>]; result: EngineInfo };
   engineInfo: { args: []; result: EngineInfo };
   engineDoctor: { args: [projectDir?: string]; result: EngineDoctorResult };
   engineInstall: { args: []; result: unknown };
@@ -389,7 +387,7 @@ export type DesktopCommandMap = {
   openworkServerInfo: { args: []; result: OpenworkServerInfo };
   openworkServerRestart: {
     args: [options?: Record<string, unknown>];
-    result: unknown;
+    result: OpenworkServerInfo;
   };
 
   // Dialogs


### PR DESCRIPTION
## What

Campaign 2 follow-up to #2209: tighten the remaining `unknown` contract results and start splitting main.mjs along its mapped seams (precedent: updater.mjs/migration.mjs sibling modules). Four commits.

| Commit | Change |
|---|---|
| `63dab63a6` | **Engine/server results tightened**: `withRuntimeLifecycle` was untyped, collapsing runtime-manager inference to `Promise<void>`. A JSDoc generic restores inference end-to-end; `engineStart/Stop/Restart` → `EngineInfo`, `openworkServerRestart` → `OpenworkServerInfo`, flowing automatically to the renderer. |
| `713e49161` | **Raw `invokeDesktop` window global typed** (generic over `DesktopCommandName`) + tightened the group its call sites consume (bridge info, MCP commands, computer-use permissions, running apps). `connections/store.ts` reaches zero `as any`; `resolveDesktopCommand` narrows to the two commands actually passed. |
| `ecb871cf9` | **`computer-use.mjs` extracted** (164 lines): helper resolution, --check permission probe, running-app listing, setup launcher. |
| `2baf8f545` | **`ui-control-server.mjs` extracted** (162 lines): the loopback control bridge as a `createUiControlServer` factory with injected `appName/appIdentifier/getWindow`; server state now module-private. |

`main.mjs`: 3,482 (pre-#2209) → **3,256 lines**, with two more seams (app menu, browser tabs, workspace persistence) queued.

## Tests (each commit)

```
pnpm --filter @openwork/desktop typecheck:electron   # clean
pnpm --filter @openwork/desktop check:electron        # 50 methods covered
pnpm --filter @openwork/desktop test                  # 18 pass
pnpm --filter @openwork/app typecheck / test / build  # clean / 58 / clean
```

**Live, after each extraction** (real Electron app via CDP):
- computer-use: `checkComputerUsePermissions` (typed shape), `getComputerUseMcpCommand` (array), `listRunningApps` (2 real apps) through the new module
- ui-control: discovery file written, `/health` ok, authorized `/snapshot` returns a live renderer snapshot (route + actions) through the injected window factory, unauthorized rejected

No video: behavior-preserving extraction; the live CDP/HTTP roundtrips above are the e2e evidence. Repro: `pnpm dev`, then curl the baseUrl/token from `openwork-ui-control.json` in userData.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

