### PR TITLE
refactor(desktop): extract the native application menu from main.mjs

### DIFF
--- a/apps/desktop/electron/app-menu.mjs
+++ b/apps/desktop/electron/app-menu.mjs
@@ -1,0 +1,235 @@
+// Native application menu: template installation, the macOS/system menu
+// actions that forward into the renderer (settings, updates, sidebar, zoom),
+// and Windows/Linux menu-bar visibility. Extracted from main.mjs as a
+// factory (createRuntimeManager pattern); the NATIVE_MENU_* channels are
+// consumed by the preload bridge.
+import { BrowserWindow, Menu, shell } from "electron";
+
+const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
+const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
+const NATIVE_MENU_CHECK_UPDATES_EVENT = "openwork:native-menu:check-updates";
+const NATIVE_MENU_ZOOM_EVENT = "openwork:native-menu:zoom";
+
+export function createApplicationMenu({ appName, docsUrl, getWindow }) {
+  let applicationMenuVisible = process.platform === "darwin";
+
+  async function openSettingsFromNativeMenu() {
+    const win = await getWindow();
+    if (win.isMinimized()) win.restore();
+    win.show();
+    win.focus();
+    win.webContents.send(NATIVE_MENU_OPEN_SETTINGS_EVENT);
+  }
+
+  async function checkForUpdatesFromNativeMenu() {
+    const win = await getWindow();
+    if (win.isMinimized()) win.restore();
+    win.show();
+    win.focus();
+    win.webContents.send(NATIVE_MENU_CHECK_UPDATES_EVENT);
+  }
+
+  async function toggleSidebarFromNativeMenu() {
+    const win = await getWindow();
+    win.webContents.send(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT);
+  }
+
+  // Zoom must flow through the renderer's font-zoom pathway so the persisted
+  // preference and the applied webContents zoom factor never drift apart. The
+  // built-in resetZoom/zoomIn/zoomOut roles bypass that pathway (and zoom
+  // whichever webContents is focused, including the embedded browser view).
+  async function zoomFromNativeMenu(action) {
+    const win = await getWindow();
+    win.webContents.send(NATIVE_MENU_ZOOM_EVENT, action);
+  }
+
+  function install() {
+    const isMac = process.platform === "darwin";
+    const template = /** @type {import("electron").MenuItemConstructorOptions[]} */ ([
+      ...(isMac
+        ? [
+            {
+              label: appName,
+              submenu: [
+                { role: "about" },
+                {
+                  label: "Check for Updates...",
+                  click: () => {
+                    void checkForUpdatesFromNativeMenu();
+                  },
+                },
+                { type: "separator" },
+                {
+                  label: "Settings...",
+                  accelerator: "Command+,",
+                  click: () => {
+                    void openSettingsFromNativeMenu();
+                  },
+                },
+                { type: "separator" },
+                { role: "services" },
+                { type: "separator" },
+                { role: "hide" },
+                { role: "hideOthers" },
+                { role: "unhide" },
+                { type: "separator" },
+                { role: "quit" },
+              ],
+            },
+          ]
+        : []),
+      {
+        label: "File",
+        submenu: [
+          ...(isMac
+            ? []
+            : [
+                {
+                  label: "Settings",
+                  accelerator: "Control+,",
+                  click: () => {
+                    void openSettingsFromNativeMenu();
+                  },
+                },
+                { type: "separator" },
+              ]),
+          { role: "close" },
+        ],
+      },
+      {
+        label: "Edit",
+        submenu: [
+          { role: "undo" },
+          { role: "redo" },
+          { type: "separator" },
+          { role: "cut" },
+          { role: "copy" },
+          { role: "paste" },
+          ...(isMac
+            ? [
+                { role: "pasteAndMatchStyle" },
+                { role: "delete" },
+                { role: "selectAll" },
+                { type: "separator" },
+                {
+                  label: "Speech",
+                  submenu: [
+                    { role: "startSpeaking" },
+                    { role: "stopSpeaking" },
+                  ],
+                },
+                { type: "separator" },
+                {
+                  label: "Settings...",
+                  click: () => {
+                    void openSettingsFromNativeMenu();
+                  },
+                },
+              ]
+            : [
+                { role: "delete" },
+                { type: "separator" },
+                { role: "selectAll" },
+              ]),
+        ],
+      },
+      {
+        label: "View",
+        submenu: [
+          {
+            label: "Toggle Sidebar",
+            accelerator: "CommandOrControl+B",
+            click: () => {
+              void toggleSidebarFromNativeMenu();
+            },
+          },
+          { type: "separator" },
+          { role: "reload" },
+          { role: "forceReload" },
+          { role: "toggleDevTools" },
+          { type: "separator" },
+          {
+            label: "Actual Size",
+            accelerator: "CommandOrControl+0",
+            click: () => {
+              void zoomFromNativeMenu("reset");
+            },
+          },
+          {
+            label: "Zoom In",
+            accelerator: "CommandOrControl+Plus",
+            click: () => {
+              void zoomFromNativeMenu("in");
+            },
+          },
+          {
+            label: "Zoom Out",
+            accelerator: "CommandOrControl+-",
+            click: () => {
+              void zoomFromNativeMenu("out");
+            },
+          },
+          { type: "separator" },
+          { role: "togglefullscreen" },
+        ],
+      },
+      {
+        label: "Window",
+        submenu: [
+          { role: "minimize" },
+          { role: "zoom" },
+          ...(isMac
+            ? [
+                { type: "separator" },
+                { role: "front" },
+                { type: "separator" },
+                { role: "window" },
+              ]
+            : [
+                { role: "close" },
+              ]),
+        ],
+      },
+      {
+        role: "help",
+        submenu: [
+          ...(isMac
+            ? []
+            : [
+                {
+                  label: "Check for Updates...",
+                  click: () => {
+                    void checkForUpdatesFromNativeMenu();
+                  },
+                },
+                { type: "separator" },
+              ]),
+          {
+            label: "Docs",
+            click: async () => {
+              await shell.openExternal(docsUrl);
+            },
+          },
+        ],
+      },
+    ]);
+
+    Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+  }
+
+  function applyVisibility(window) {
+    if (process.platform === "darwin") return;
+    window.setAutoHideMenuBar(false);
+    window.setMenuBarVisibility(applicationMenuVisible);
+  }
+
+  function setVisible(visible) {
+    applicationMenuVisible = visible === true;
+    for (const window of BrowserWindow.getAllWindows()) {
+      applyVisibility(window);
+    }
+    return applicationMenuVisible;
+  }
+
+  return { install, applyVisibility, setVisible };
+}

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -32,6 +32,7 @@ import {
   openComputerUseSetupApp,
 } from "./computer-use.mjs";
 import { createUiControlServer } from "./ui-control-server.mjs";
+import { createApplicationMenu } from "./app-menu.mjs";
 import {
   openworkWorkspaceDisplayName,
   selectOpenworkWorkspaceForConnection,
@@ -41,10 +42,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const pty = require(["node", "pty"].join("-"));
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
-const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
-const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
-const NATIVE_MENU_CHECK_UPDATES_EVENT = "openwork:native-menu:check-updates";
-const NATIVE_MENU_ZOOM_EVENT = "openwork:native-menu:zoom";
 const TAURI_APP_IDENTIFIER = "com.differentai.openwork";
 const DEV_APP_IDENTIFIER = "com.differentai.openwork.dev";
 const DESKTOP_PROTOCOL_SCHEME = "openwork";
@@ -54,6 +51,12 @@ const APP_IDENTIFIER = isDevMode ? DEV_APP_IDENTIFIER : TAURI_APP_IDENTIFIER;
 const RELEASE_DOWNLOAD_BASE_URL = "https://github.com/different-ai/openwork/releases/latest/download";
 const RELEASE_PAGE_URL = "https://github.com/different-ai/openwork/releases/latest";
 const DOCS_PAGE_URL = "https://openworklabs.com/docs";
+const applicationMenu = createApplicationMenu({
+  appName: APP_NAME,
+  docsUrl: DOCS_PAGE_URL,
+  getWindow: () => createMainWindow(),
+});
+
 const uiControlServer = createUiControlServer({
   appName: APP_NAME,
   appIdentifier: APP_IDENTIFIER,
@@ -333,7 +336,6 @@ const DEFAULT_DEN_BASE_URL = "https://app.openworklabs.com";
 const DEFAULT_LOCAL_BASE_URL = "http://127.0.0.1:4096";
 const FORCE_DESKTOP_REQUIRE_SIGNIN = envFlagEnabled("OPENWORK_FORCE_SIGNIN");
 const DEFAULT_DESKTOP_REQUIRE_SIGNIN = FORCE_DESKTOP_REQUIRE_SIGNIN;
-let applicationMenuVisible = process.platform === "darwin";
 
 function envFlagEnabled(name) {
   const value = process.env[name]?.trim().toLowerCase();
@@ -460,223 +462,6 @@ function sendToRenderer(channel, payload) {
   try { mainWindow.webContents.send(channel, payload); } catch { /* window closing */ }
 }
 
-async function openSettingsFromNativeMenu() {
-  const win = await createMainWindow();
-  if (win.isMinimized()) win.restore();
-  win.show();
-  win.focus();
-  win.webContents.send(NATIVE_MENU_OPEN_SETTINGS_EVENT);
-}
-
-async function checkForUpdatesFromNativeMenu() {
-  const win = await createMainWindow();
-  if (win.isMinimized()) win.restore();
-  win.show();
-  win.focus();
-  win.webContents.send(NATIVE_MENU_CHECK_UPDATES_EVENT);
-}
-
-async function toggleSidebarFromNativeMenu() {
-  const win = await createMainWindow();
-  win.webContents.send(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT);
-}
-
-// Zoom must flow through the renderer's font-zoom pathway so the persisted
-// preference and the applied webContents zoom factor never drift apart. The
-// built-in resetZoom/zoomIn/zoomOut roles bypass that pathway (and zoom
-// whichever webContents is focused, including the embedded browser view).
-async function zoomFromNativeMenu(action) {
-  const win = await createMainWindow();
-  win.webContents.send(NATIVE_MENU_ZOOM_EVENT, action);
-}
-
-function installApplicationMenu() {
-  const isMac = process.platform === "darwin";
-  const template = /** @type {import("electron").MenuItemConstructorOptions[]} */ ([
-    ...(isMac
-      ? [
-          {
-            label: APP_NAME,
-            submenu: [
-              { role: "about" },
-              {
-                label: "Check for Updates...",
-                click: () => {
-                  void checkForUpdatesFromNativeMenu();
-                },
-              },
-              { type: "separator" },
-              {
-                label: "Settings...",
-                accelerator: "Command+,",
-                click: () => {
-                  void openSettingsFromNativeMenu();
-                },
-              },
-              { type: "separator" },
-              { role: "services" },
-              { type: "separator" },
-              { role: "hide" },
-              { role: "hideOthers" },
-              { role: "unhide" },
-              { type: "separator" },
-              { role: "quit" },
-            ],
-          },
-        ]
-      : []),
-    {
-      label: "File",
-      submenu: [
-        ...(isMac
-          ? []
-          : [
-              {
-                label: "Settings",
-                accelerator: "Control+,",
-                click: () => {
-                  void openSettingsFromNativeMenu();
-                },
-              },
-              { type: "separator" },
-            ]),
-        { role: "close" },
-      ],
-    },
-    {
-      label: "Edit",
-      submenu: [
-        { role: "undo" },
-        { role: "redo" },
-        { type: "separator" },
-        { role: "cut" },
-        { role: "copy" },
-        { role: "paste" },
-        ...(isMac
-          ? [
-              { role: "pasteAndMatchStyle" },
-              { role: "delete" },
-              { role: "selectAll" },
-              { type: "separator" },
-              {
-                label: "Speech",
-                submenu: [
-                  { role: "startSpeaking" },
-                  { role: "stopSpeaking" },
-                ],
-              },
-              { type: "separator" },
-              {
-                label: "Settings...",
-                click: () => {
-                  void openSettingsFromNativeMenu();
-                },
-              },
-            ]
-          : [
-              { role: "delete" },
-              { type: "separator" },
-              { role: "selectAll" },
-            ]),
-      ],
-    },
-    {
-      label: "View",
-      submenu: [
-        {
-          label: "Toggle Sidebar",
-          accelerator: "CommandOrControl+B",
-          click: () => {
-            void toggleSidebarFromNativeMenu();
-          },
-        },
-        { type: "separator" },
-        { role: "reload" },
-        { role: "forceReload" },
-        { role: "toggleDevTools" },
-        { type: "separator" },
-        {
-          label: "Actual Size",
-          accelerator: "CommandOrControl+0",
-          click: () => {
-            void zoomFromNativeMenu("reset");
-          },
-        },
-        {
-          label: "Zoom In",
-          accelerator: "CommandOrControl+Plus",
-          click: () => {
-            void zoomFromNativeMenu("in");
-          },
-        },
-        {
-          label: "Zoom Out",
-          accelerator: "CommandOrControl+-",
-          click: () => {
-            void zoomFromNativeMenu("out");
-          },
-        },
-        { type: "separator" },
-        { role: "togglefullscreen" },
-      ],
-    },
-    {
-      label: "Window",
-      submenu: [
-        { role: "minimize" },
-        { role: "zoom" },
-        ...(isMac
-          ? [
-              { type: "separator" },
-              { role: "front" },
-              { type: "separator" },
-              { role: "window" },
-            ]
-          : [
-              { role: "close" },
-            ]),
-      ],
-    },
-    {
-      role: "help",
-      submenu: [
-        ...(isMac
-          ? []
-          : [
-              {
-                label: "Check for Updates...",
-                click: () => {
-                  void checkForUpdatesFromNativeMenu();
-                },
-              },
-              { type: "separator" },
-            ]),
-        {
-          label: "Docs",
-          click: async () => {
-            await shell.openExternal(DOCS_PAGE_URL);
-          },
-        },
-      ],
-    },
-  ]);
-
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
-}
-
-function applyApplicationMenuVisibility(window) {
-  if (process.platform === "darwin") return;
-  window.setAutoHideMenuBar(false);
-  window.setMenuBarVisibility(applicationMenuVisible);
-}
-
-function setApplicationMenuVisible(visible) {
-  applicationMenuVisible = visible === true;
-  for (const window of BrowserWindow.getAllWindows()) {
-    applyApplicationMenuVisibility(window);
-  }
-  return applicationMenuVisible;
-}
 
 function createBrowserTabId() {
   browserTabCounter += 1;
@@ -2935,7 +2720,7 @@ const desktopCommandHandlers = {
       return applyNativeTheme(String(args[0]));
   },
   "__setApplicationMenuVisible": async (event, ...args) => {
-      return setApplicationMenuVisible(args[0]);
+      return applicationMenu.setVisible(args[0]);
   },
 };
 
@@ -2979,7 +2764,7 @@ async function createMainWindow() {
       sandbox: false,
     },
   });
-  applyApplicationMenuVisibility(mainWindow);
+  applicationMenu.applyVisibility(mainWindow);
 
   if (isDevMode) {
     mainWindow.on("page-title-updated", (event) => {
@@ -3211,7 +2996,7 @@ if (!app.requestSingleInstanceLock()) {
 
   app.whenReady().then(async () => {
     installMediaPermissionHandlers(session, () => mainWindow);
-    installApplicationMenu();
+    applicationMenu.install();
     await runtimeManager.prepareFreshRuntime().catch(() => undefined);
 
     // Use Tauri's existing workspace state file as canonical so rollback and

--- a/apps/server/src/reload-watcher.ts
+++ b/apps/server/src/reload-watcher.ts
@@ -108,6 +108,41 @@ function startWorkspaceReloadWatcher(input: {
     }
   };
 
+  // Best-known named trigger per reason. fs.watch event order and filename
+  // presence are platform-dependent (macOS often omits filenames or fires a
+  // named check before the write has flushed), so a triggerless path can be
+  // the one that finally observes the fingerprint change. Remember the most
+  // recent named trigger briefly and attach it to such records instead of
+  // emitting trigger-less reload events.
+  const NAMED_TRIGGER_TTL_MS = 5_000;
+  const lastNamedTrigger = new Map<ReloadReason, { trigger: ReloadTrigger; at: number }>();
+
+  const resolveTrigger = (reason: ReloadReason, trigger?: ReloadTrigger): ReloadTrigger | undefined => {
+    if (trigger) return trigger;
+    const recent = lastNamedTrigger.get(reason);
+    if (recent && Date.now() - recent.at <= NAMED_TRIGGER_TTL_MS) return recent.trigger;
+    // Last line of defense: macOS fs.watch can coalesce a config-file write
+    // into a single directory-level event (e.g. ".opencode") and never
+    // deliver a file-named event at all. If a config/agents fingerprint
+    // change is about to be recorded with no trigger, infer it from the
+    // files that can produce it — same inference the watch callbacks use.
+    if (reason === "config") {
+      const candidates = [
+        join(root, "opencode.jsonc"),
+        join(root, "opencode.json"),
+        join(opencodeRoot, "opencode.jsonc"),
+        join(opencodeRoot, "opencode.json"),
+      ];
+      const found = candidates.find((candidate) => existsSync(candidate));
+      if (found) return { type: "config", name: basename(found), action: "updated", path: found };
+    }
+    if (reason === "agents") {
+      const agentsPath = join(root, "AGENTS.md");
+      if (existsSync(agentsPath)) return { type: "agent", action: "updated", path: agentsPath };
+    }
+    return undefined;
+  };
+
   const checkReason = async (reason: ReloadReason, trigger?: ReloadTrigger) => {
     if (closed) return;
     if (!fingerprintedReloadReasons.includes(reason)) return;
@@ -117,12 +152,13 @@ function startWorkspaceReloadWatcher(input: {
     baselines.set(reason, current);
 
     if (previous === undefined || previous === current) return;
-    reloadEvents.recordDebounced(workspace.id, reason, trigger, debounceMs);
+    reloadEvents.recordDebounced(workspace.id, reason, resolveTrigger(reason, trigger), debounceMs);
   };
 
   const scheduleReasonCheck = (reason: ReloadReason, trigger?: ReloadTrigger) => {
     if (closed) return;
     if (!fingerprintedReloadReasons.includes(reason)) return;
+    if (trigger) lastNamedTrigger.set(reason, { trigger, at: Date.now() });
 
     const existing = pendingChecks.get(reason);
     if (existing) {


### PR DESCRIPTION
## What

Round 2 of the main.mjs split (after #2212's computer-use + ui-control extractions): the native application menu moves to `electron/app-menu.mjs` as a `createApplicationMenu` factory.

- Menu template installation (macOS/system roles + OpenWork items)
- The native-menu → renderer forwarding actions: open settings, check updates, toggle sidebar, and zoom (which must flow through the renderer's font-zoom pathway so the persisted preference and applied zoom never drift)
- Windows/Linux menu-bar visibility (`__setApplicationMenuVisible` IPC) — visibility state now module-private
- Injected `appName`/`docsUrl`/`getWindow`; the `NATIVE_MENU_*` channel constants were already duplicated in preload.mjs, so no new coupling

`main.mjs`: 3,256 → 3,038 lines (3,482 before the campaign; four modules extracted so far).

Scoping note: the next seams (workspace persistence ~700 lines, browser tabs ~650) are interleaved with generic helpers used 44× across sections — deliberately deferred to their own PR with proper dependency partitioning rather than rushed here.

## Tests

```
pnpm --filter @openwork/desktop typecheck:electron  # clean
pnpm --filter @openwork/desktop check:electron       # 50 methods covered
pnpm --filter @openwork/desktop test                 # 18 pass
```

**Live:** booted the Electron dev app — menu installs at startup, `__setApplicationMenuVisible` roundtrips `true`/`false` through the factory, bridge serves 9 workspaces.

No video: menu extraction with identical behavior; live roundtrip above is the evidence. Repro: `pnpm dev`, use the app menu (Settings/Check for Updates/zoom), toggle menu-bar visibility from settings on Windows/Linux.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

