### PR TITLE
fix(den): import custom provider opencode configs

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -35,6 +35,7 @@
     "dotenv": "^16.4.5",
     "hono": "^4.7.2",
     "hono-openapi": "^1.3.0",
+    "jsonc-parser": "^3.2.1",
     "nanoid": "^5.1.11",
     "openapi-types": "^12.1.3",
     "stripe": "^22.1.1",

--- a/ee/apps/den-api/src/llm/custom-provider.ts
+++ b/ee/apps/den-api/src/llm/custom-provider.ts
@@ -1,0 +1,155 @@
+import { parse, type ParseError } from "jsonc-parser"
+import { z } from "zod"
+
+type JsonRecord = Record<string, unknown>
+
+export type NormalizedCustomProvider = {
+  providerId: string
+  providerConfig: JsonRecord
+  models: Array<{
+    id: string
+    name: string
+    config: JsonRecord
+  }>
+}
+
+export class CustomProviderConfigError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "CustomProviderConfigError"
+  }
+}
+
+const customModelSchema = z.object({
+  id: z.string().trim().min(1).max(255),
+  name: z.string().trim().min(1).max(255),
+}).passthrough()
+
+const customProviderSchema = z.object({
+  id: z.string().trim().min(1).max(255),
+  name: z.string().trim().min(1).max(255),
+  npm: z.string().trim().min(1).max(255),
+  env: z.array(z.string().trim().min(1).max(255)).min(1),
+  doc: z.string().trim().min(1).max(2048).optional(),
+  api: z.string().trim().min(1).max(2048).optional(),
+  models: z.array(customModelSchema).min(1),
+}).passthrough()
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : null
+}
+
+function parseCustomProviderText(text: string) {
+  const errors: ParseError[] = []
+  const parsed = parse(text, errors, { allowTrailingComma: true })
+  if (errors.length > 0) {
+    throw new CustomProviderConfigError("Custom provider config must be valid JSON or JSONC.")
+  }
+  return parsed
+}
+
+function unwrapOpencodeProviderConfig(value: unknown) {
+  if (!isRecord(value) || !isRecord(value.provider)) {
+    return value
+  }
+
+  const providers = Object.entries(value.provider).filter((entry): entry is [string, JsonRecord] => isRecord(entry[1]))
+  if (providers.length === 1) {
+    return providers[0][1]
+  }
+
+  if (providers.length === 0) {
+    throw new CustomProviderConfigError("provider must contain one provider block.")
+  }
+
+  throw new CustomProviderConfigError("Custom provider config contains multiple providers. Paste one provider block or remove the others.")
+}
+
+function normalizeModelArray(models: unknown[]) {
+  return models.map((model) => {
+    if (typeof model === "string") {
+      return { id: model, name: model }
+    }
+    return model
+  })
+}
+
+function normalizeModelMap(models: JsonRecord) {
+  return Object.entries(models).map(([modelId, model]) => {
+    if (!isRecord(model)) {
+      return { id: modelId, name: modelId }
+    }
+
+    return {
+      ...model,
+      id: readString(model.id) ?? modelId,
+      name: readString(model.name) ?? modelId,
+    }
+  })
+}
+
+function normalizeModels(value: unknown) {
+  if (Array.isArray(value)) {
+    return normalizeModelArray(value)
+  }
+
+  if (isRecord(value)) {
+    return normalizeModelMap(value)
+  }
+
+  return value
+}
+
+function normalizeProviderShape(value: unknown) {
+  const provider = unwrapOpencodeProviderConfig(value)
+  if (!isRecord(provider)) {
+    return provider
+  }
+
+  return {
+    ...provider,
+    models: normalizeModels(provider.models),
+  }
+}
+
+function formatIssuePath(path: PropertyKey[]) {
+  return path.length > 0 ? path.map((part) => String(part)).join(".") : "config"
+}
+
+function formatZodIssues(error: z.ZodError) {
+  return error.issues
+    .slice(0, 3)
+    .map((issue) => `${formatIssuePath(issue.path)}: ${issue.message}`)
+    .join("; ")
+}
+
+export function normalizeCustomProviderConfig(input: {
+  customConfigText?: string
+  customConfig?: unknown
+}): NormalizedCustomProvider {
+  const rawConfig = input.customConfigText !== undefined
+    ? parseCustomProviderText(input.customConfigText)
+    : input.customConfig
+
+  const normalizedConfig = normalizeProviderShape(rawConfig)
+  const customProvider = customProviderSchema.safeParse(normalizedConfig)
+  if (!customProvider.success) {
+    throw new CustomProviderConfigError(formatZodIssues(customProvider.error) || "Custom provider config is invalid.")
+  }
+
+  const { models, ...providerConfig } = customProvider.data
+
+  return {
+    providerId: customProvider.data.id,
+    providerConfig,
+    models: models.map((model) => ({
+      id: model.id,
+      name: model.name,
+      config: model,
+    })),
+  }
+}

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -13,6 +13,7 @@ import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
+import { CustomProviderConfigError, normalizeCustomProviderConfig } from "../../llm/custom-provider.js"
 import {
   jsonValidator,
   paramValidator,
@@ -27,7 +28,6 @@ import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, 
 import type { OrgRouteVariables } from "./shared.js"
 import { idParamSchema, memberHasRole } from "./shared.js"
 
-type JsonRecord = Record<string, unknown>
 type LlmProviderId = typeof LlmProviderTable.$inferSelect.id
 type LlmProviderAccessId = typeof LlmProviderAccessTable.$inferSelect.id
 type MemberId = typeof MemberTable.$inferSelect.id
@@ -55,27 +55,13 @@ const llmProviderListQuerySchema = z.object({
   scope: z.enum(["usable", "manageable"]).optional().default("usable"),
 })
 
-const customModelSchema = z.object({
-  id: z.string().trim().min(1).max(255),
-  name: z.string().trim().min(1).max(255),
-}).passthrough()
-
-const customProviderSchema = z.object({
-  id: z.string().trim().min(1).max(255),
-  name: z.string().trim().min(1).max(255),
-  npm: z.string().trim().min(1).max(255),
-  env: z.array(z.string().trim().min(1).max(255)).min(1),
-  doc: z.string().trim().min(1).max(2048),
-  api: z.string().trim().min(1).max(2048).optional(),
-  models: z.array(customModelSchema).min(1),
-}).passthrough()
-
 const llmProviderWriteSchema = z.object({
   name: z.string().trim().min(1).max(255),
   source: z.enum(["models_dev", "custom"]),
   providerId: z.string().trim().min(1).max(255).optional(),
   modelIds: z.array(z.string().trim().min(1).max(255)).min(1).optional(),
   customConfigText: z.string().trim().min(1).optional(),
+  customConfig: z.unknown().optional(),
   apiKey: z.string().trim().max(65535).optional(),
   memberIds: z.array(denTypeIdSchema("member")).max(500).optional().default([]),
   teamIds: z.array(denTypeIdSchema("team")).max(500).optional().default([]),
@@ -98,7 +84,7 @@ const llmProviderWriteSchema = z.object({
     }
   }
 
-  if (value.source === "custom" && !value.customConfigText) {
+  if (value.source === "custom" && !value.customConfigText && value.customConfig === undefined) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["customConfigText"],
@@ -306,35 +292,26 @@ async function normalizeLlmProviderInput(input: z.infer<typeof llmProviderWriteS
     }
   }
 
-  let parsed: unknown
   try {
-    parsed = JSON.parse(input.customConfigText ?? "")
-  } catch {
-    throw createFailure(400, "invalid_custom_provider_config", "Custom provider config must be valid JSON.")
-  }
+    const customProvider = normalizeCustomProviderConfig({
+      customConfigText: input.customConfigText,
+      customConfig: input.customConfig,
+    })
 
-  const customProvider = customProviderSchema.safeParse(parsed)
-  if (!customProvider.success) {
-    throw createFailure(
-      400,
-      "invalid_custom_provider_config",
-      customProvider.error.issues[0]?.message ?? "Custom provider config is invalid.",
-    )
-  }
+    return {
+      source: input.source,
+      providerId: customProvider.providerId,
+      name: input.name,
+      providerConfig: customProvider.providerConfig,
+      models: customProvider.models,
+      apiKey: input.apiKey?.trim() || null,
+    }
+  } catch (error) {
+    if (error instanceof CustomProviderConfigError) {
+      throw createFailure(400, "invalid_custom_provider_config", error.message)
+    }
 
-  const { models, ...providerConfig } = customProvider.data
-
-  return {
-    source: input.source,
-    providerId: customProvider.data.id,
-    name: input.name,
-    providerConfig: providerConfig as JsonRecord,
-    models: models.map((model) => ({
-      id: model.id,
-      name: model.name,
-      config: model as JsonRecord,
-    })),
-    apiKey: input.apiKey?.trim() || null,
+    throw error
   }
 }
 
@@ -696,7 +673,7 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
     describeRoute({
       tags: ["LLM Providers"],
       summary: "Create organization LLM provider",
-      description: "Creates a new organization-scoped LLM provider from either a models.dev provider template or a pasted custom configuration.",
+      description: "Creates a new organization-scoped LLM provider from either a models.dev provider template, pasted JSON/JSONC custom configuration, or MCP-supplied customConfig object.",
       responses: {
         201: jsonResponse("Organization LLM provider created successfully.", llmProviderResponseSchema),
         400: jsonResponse("The provider creation request was invalid.", invalidRequestSchema),
@@ -807,7 +784,7 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
     describeRoute({
       tags: ["LLM Providers"],
       summary: "Update organization LLM provider",
-      description: "Updates an existing organization LLM provider, including its provider config, selected models, secret, and access grants.",
+      description: "Updates an existing organization LLM provider, including its provider config, selected models, secret, and access grants. Custom providers accept JSON/JSONC text or an MCP-supplied customConfig object.",
       responses: {
         200: jsonResponse("Organization LLM provider updated successfully.", llmProviderResponseSchema),
         400: jsonResponse("The provider update request was invalid.", invalidRequestSchema),

--- a/ee/apps/den-api/test/llm-provider-normalization.test.ts
+++ b/ee/apps/den-api/test/llm-provider-normalization.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "bun:test"
+import { CustomProviderConfigError, normalizeCustomProviderConfig } from "../src/llm/custom-provider.js"
+
+test("normalizes a full opencode JSONC config with provider and models maps", () => {
+  const normalized = normalizeCustomProviderConfig({
+    customConfigText: `{
+      // Support attachment format: full opencode config, not a bare provider.
+      "$schema": "https://opencode.ai/config.json",
+      "provider": {
+        "meettie": {
+          "id": "meettie-gateway",
+          "api": "https://llm.meettie.com/v1",
+          "env": ["MEETTIE_GATEWAY_API_KEY"],
+          "npm": "@ai-sdk/anthropic",
+          "name": "Meettie LLM Gateway (Anthropic Protocol)",
+          "models": {
+            "tie-auto": {
+              "name": "Meettie Claude 3 Haiku (2024-03-07)",
+              "limit": { "input": 200000, "output": 8192, "context": 200000 },
+            },
+          },
+        },
+      },
+    }`,
+  })
+
+  expect(normalized.providerId).toBe("meettie-gateway")
+  expect(normalized.providerConfig).toEqual({
+    id: "meettie-gateway",
+    api: "https://llm.meettie.com/v1",
+    env: ["MEETTIE_GATEWAY_API_KEY"],
+    npm: "@ai-sdk/anthropic",
+    name: "Meettie LLM Gateway (Anthropic Protocol)",
+  })
+  expect(normalized.models).toEqual([
+    {
+      id: "tie-auto",
+      name: "Meettie Claude 3 Haiku (2024-03-07)",
+      config: {
+        id: "tie-auto",
+        name: "Meettie Claude 3 Haiku (2024-03-07)",
+        limit: { input: 200000, output: 8192, context: 200000 },
+      },
+    },
+  ])
+})
+
+test("accepts MCP object input without JSON string escaping", () => {
+  const normalized = normalizeCustomProviderConfig({
+    customConfig: {
+      provider: {
+        meettie: {
+          id: "meettie-gateway",
+          api: "https://llm.meettie.com/v1",
+          env: ["MEETTIE_GATEWAY_API_KEY"],
+          npm: "@ai-sdk/anthropic",
+          name: "Meettie LLM Gateway (Anthropic Protocol)",
+          models: {
+            "tie-auto": { name: "Tie Auto" },
+          },
+        },
+      },
+    },
+  })
+
+  expect(normalized.models[0]?.id).toBe("tie-auto")
+  expect(normalized.models[0]?.name).toBe("Tie Auto")
+})
+
+test("keeps accepting models.dev-style provider configs without doc", () => {
+  const normalized = normalizeCustomProviderConfig({
+    customConfigText: JSON.stringify({
+      id: "meettie-gateway",
+      api: "https://llm.meettie.com/v1",
+      env: ["MEETTIE_GATEWAY_API_KEY"],
+      npm: "@ai-sdk/anthropic",
+      name: "Meettie LLM Gateway (Anthropic Protocol)",
+      models: [{ id: "tie-auto", name: "Tie Auto" }],
+    }),
+  })
+
+  expect(normalized.providerId).toBe("meettie-gateway")
+  expect(normalized.providerConfig.doc).toBeUndefined()
+})
+
+test("returns field paths for invalid custom provider configs", () => {
+  expect(() => normalizeCustomProviderConfig({ customConfigText: JSON.stringify({ models: [] }) })).toThrow(
+    new CustomProviderConfigError("id: Invalid input: expected string, received undefined; name: Invalid input: expected string, received undefined; npm: Invalid input: expected string, received undefined"),
+  )
+})
+
+test("rejects full opencode configs with multiple providers", () => {
+  expect(() => normalizeCustomProviderConfig({
+    customConfig: {
+      provider: {
+        first: { id: "first", name: "First", npm: "@ai-sdk/anthropic", env: ["FIRST_KEY"], models: ["first-model"] },
+        second: { id: "second", name: "Second", npm: "@ai-sdk/anthropic", env: ["SECOND_KEY"], models: ["second-model"] },
+      },
+    },
+  })).toThrow(new CustomProviderConfigError("Custom provider config contains multiple providers. Paste one provider block or remove the others."))
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
@@ -580,7 +580,7 @@ export function LlmProviderEditorScreen({
                 ) : (
                     <div className="mt-8 grid gap-3">
                         <span className="text-[14px] font-medium text-gray-700">
-                            Custom provider JSON
+                            Custom provider JSON / JSONC
                         </span>
                         <DenTextarea
                             value={customConfigText}
@@ -590,11 +590,12 @@ export function LlmProviderEditorScreen({
                             rows={18}
                         />
                         <p className="text-[13px] text-gray-500">
-                            Use the models.dev-style schema and include a{" "}
+                            Paste a models.dev provider, a single provider block,
+                            or a full{" "}
                             <code className="rounded bg-gray-100 px-1 py-0.5">
-                                models
-                            </code>{" "}
-                            array.
+                                opencode.jsonc
+                            </code>
+                            . Model maps are imported automatically.
                         </p>
                     </div>
                 )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,9 @@ importers:
       hono-openapi:
         specifier: ^1.3.0
         version: 1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.8))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(hono@4.12.8)(openapi-types@12.1.3)
+      jsonc-parser:
+        specifier: ^3.2.1
+        version: 3.3.1
       nanoid:
         specifier: ^5.1.11
         version: 5.1.11


### PR DESCRIPTION
## Summary
- accept JSONC custom provider imports and full opencode.json/opencode.jsonc provider configs
- normalize opencode provider/model maps into the existing provider/model storage shape
- make custom provider doc optional, add clearer validation paths, and allow MCP callers to pass a customConfig object without JSON-stringifying
- update the custom provider UI copy to explain JSONC/opencode import support

## Tests
- pnpm exec bun test test/llm-provider-normalization.test.ts
- pnpm exec bun test test/mcp-invoke-body.test.ts
- pnpm --filter @openwork-ee/den-api build
- pnpm --filter @openwork-ee/den-web build

## E2E evidence
- Before fix, Daytona Den Web reproduced the customer error when pasting the full opencode.jsonc config.
- This PR adds targeted normalization coverage for that exact input and the MCP object-input path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

