### PR TITLE
refactor(server): extract operation routes

### DIFF
--- a/apps/server/src/routes/operations.ts
+++ b/apps/server/src/routes/operations.ts
@@ -1,0 +1,71 @@
+import { recordAudit } from "../audit.js";
+import { ApiError } from "../errors.js";
+import type { ServerConfig, TokenScope, WorkspaceInfo } from "../types.js";
+import { shortId } from "../utils.js";
+import { addRoute, type RequestContext, type Route } from "./registry.js";
+
+type JsonResponse = (data: unknown, status?: number) => Response;
+type ReadJsonBody = (request: Request) => Promise<Record<string, unknown>>;
+
+interface RegisterOperationRoutesOptions {
+  routes: Route[];
+  config: ServerConfig;
+  jsonResponse: JsonResponse;
+  readJsonBody: ReadJsonBody;
+  requireClientScope: (ctx: RequestContext, required: TokenScope) => void;
+  resolveWorkspace: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
+  reloadOpencodeEngine: (config: ServerConfig, workspace: WorkspaceInfo) => Promise<void>;
+}
+
+export function registerOperationRoutes(options: RegisterOperationRoutesOptions): void {
+  const {
+    routes,
+    config,
+    jsonResponse,
+    readJsonBody,
+    requireClientScope,
+    resolveWorkspace,
+    reloadOpencodeEngine,
+  } = options;
+
+  addRoute(routes, "GET", "/workspace/:id/events", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const sinceRaw = ctx.url.searchParams.get("since");
+    const since = sinceRaw ? Number(sinceRaw) : undefined;
+    const items = ctx.reloadEvents.list(workspace.id, since);
+    return jsonResponse({ items, cursor: ctx.reloadEvents.cursor(), workspaceId: workspace.id, disabled: false });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/engine/reload", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    requireClientScope(ctx, "collaborator");
+
+    await reloadOpencodeEngine(config, workspace);
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "engine.reload",
+      target: workspace.baseUrl ?? "opencode",
+      summary: "Reloaded workspace engine",
+      timestamp: Date.now(),
+    });
+
+    return jsonResponse({ ok: true, reloadedAt: Date.now() });
+  });
+
+  addRoute(routes, "GET", "/approvals", "host", async (ctx) => {
+    return jsonResponse({ items: ctx.approvals.list() });
+  });
+
+  addRoute(routes, "POST", "/approvals/:id", "host", async (ctx) => {
+    const body = await readJsonBody(ctx.request);
+    const reply = body.reply === "allow" ? "allow" : "deny";
+    const result = ctx.approvals.respond(ctx.params.id, reply);
+    if (!result) {
+      throw new ApiError(404, "approval_not_found", "Approval request not found");
+    }
+    return jsonResponse({ ok: true, allowed: result.allowed });
+  });
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -58,6 +58,7 @@ import { createReadStream } from "node:fs";
 import { Readable } from "node:stream";
 import { serve, type ServeResult } from "./serve-node.js";
 import { registerCoreRoutes } from "./routes/core.js";
+import { registerOperationRoutes } from "./routes/operations.js";
 import { addRoute, matchRoute, type AuthMode, type RequestContext, type Route } from "./routes/registry.js";
 import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerWorkspaceRoutes } from "./routes/workspaces.js";
@@ -2266,31 +2267,14 @@ function createRoutes(
     return jsonResponse({ updatedAt: Date.now() });
   });
 
-  addRoute(routes, "GET", "/workspace/:id/events", "client", async (ctx) => {
-    const workspace = await resolveWorkspace(config, ctx.params.id);
-    const sinceRaw = ctx.url.searchParams.get("since");
-    const since = sinceRaw ? Number(sinceRaw) : undefined;
-    const items = ctx.reloadEvents.list(workspace.id, since);
-    return jsonResponse({ items, cursor: ctx.reloadEvents.cursor(), workspaceId: workspace.id, disabled: false });
-  });
-
-  addRoute(routes, "POST", "/workspace/:id/engine/reload", "client", async (ctx) => {
-    const workspace = await resolveWorkspace(config, ctx.params.id);
-    requireClientScope(ctx, "collaborator");
-
-      await reloadOpencodeEngine(config, workspace);
-
-    await recordAudit(workspace.path, {
-      id: shortId(),
-      workspaceId: workspace.id,
-      actor: ctx.actor ?? { type: "remote" },
-      action: "engine.reload",
-      target: workspace.baseUrl ?? "opencode",
-      summary: "Reloaded workspace engine",
-      timestamp: Date.now(),
-    });
-
-    return jsonResponse({ ok: true, reloadedAt: Date.now() });
+  registerOperationRoutes({
+    routes,
+    config,
+    jsonResponse,
+    readJsonBody,
+    requireClientScope,
+    resolveWorkspace,
+    reloadOpencodeEngine,
   });
 
   addRoute(routes, "GET", "/workspace/:id/inbox", "client", async (ctx) => {
@@ -3558,20 +3542,6 @@ function createRoutes(
       timestamp: Date.now(),
     });
     return jsonResponse(result);
-  });
-
-  addRoute(routes, "GET", "/approvals", "host", async (ctx) => {
-    return jsonResponse({ items: ctx.approvals.list() });
-  });
-
-  addRoute(routes, "POST", "/approvals/:id", "host", async (ctx) => {
-    const body = await readJsonBody(ctx.request);
-    const reply = body.reply === "allow" ? "allow" : "deny";
-    const result = ctx.approvals.respond(ctx.params.id, reply);
-    if (!result) {
-      throw new ApiError(404, "approval_not_found", "Approval request not found");
-    }
-    return jsonResponse({ ok: true, allowed: result.allowed });
   });
 
   return routes;


### PR DESCRIPTION
## Summary
- Extract workspace events and engine reload routes into `apps/server/src/routes/operations.ts`.
- Move host approval list/reply routes into the same operational route registrar.
- Keep the existing auth, approval, audit, and reload behavior unchanged.

## Verification
- `pnpm --filter openwork-server typecheck` -> pass
- `pnpm --filter openwork-server test` -> 223 pass / 6 skip / 0 fail
- `git diff --check` -> pass
- Live HTTP smoke against a real `startServer` instance and mock OpenCode reload endpoint -> `{"ok":true,"port":52009,"mockPort":52008,"endpoints":["events","engine-reload","approvals","approval-reply-404"]}`

## Evidence
- No video captured because this is a server-only route refactor with no UI surface.
- Reproduction steps: run the verification commands above; the live smoke exercised the extracted HTTP endpoints end to end.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

