### PR TITLE
fix(app): restore status bar settings button

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -80,6 +80,8 @@ type OpenSessionTab = {
 type StatusBarOverrides = Pick<
   StatusBarProps,
   | "loading"
+  | "showSettingsButton"
+  | "settingsOpen"
 >;
 
 export type SessionPageHistoryControls = {
@@ -1156,10 +1158,13 @@ export function SessionPage(props: SessionPageProps) {
               clientConnected={props.clientConnected}
               openworkServerStatus={props.openworkServerStatus}
               developerMode={props.developerMode}
+              settingsOpen={props.statusBar?.settingsOpen ?? false}
               onSendFeedback={props.onSendFeedback}
+              onOpenSettings={props.onOpenSettings}
               providerConnectedIds={props.providerConnectedIds}
               mcpConnectedCount={props.mcpConnectedCount}
               loading={props.statusBar?.loading ?? false}
+              showSettingsButton={props.statusBar?.showSettingsButton}
             />
           ) : null}
               </main>

--- a/apps/app/src/react-app/domains/session/chat/status-bar.tsx
+++ b/apps/app/src/react-app/domains/session/chat/status-bar.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowRight, BookOpen, Cloud, MessageCircleMore, Sparkles, X } from "lucide-react";
+import { ArrowRight, BookOpen, Cloud, MessageCircleMore, Settings, Sparkles, X } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
@@ -136,10 +136,13 @@ export type StatusBarProps = {
   clientConnected: boolean;
   openworkServerStatus: OpenworkServerStatus;
   developerMode: boolean;
+  settingsOpen: boolean;
   onSendFeedback: () => void;
+  onOpenSettings: () => void;
   providerConnectedIds: string[];
   mcpConnectedCount: number;
   loading?: boolean;
+  showSettingsButton?: boolean;
   initializing?: boolean;
 };
 
@@ -150,6 +153,7 @@ export function StatusBar(props: StatusBarProps) {
   const { config: shellConfig } = useShellConfig();
   const docsButtonRef = useRef<HTMLButtonElement>(null);
   const feedbackButtonRef = useRef<HTMLButtonElement>(null);
+  const settingsButtonRef = useRef<HTMLButtonElement>(null);
   const [openWorkModelsHintVisible, setOpenWorkModelsHintVisible] = useState(false);
   const hasOpenWorkModels = useMemo(
     () => hasOpenWorkModelsProvider(props.providerConnectedIds),
@@ -249,6 +253,17 @@ export function StatusBar(props: StatusBarProps) {
   }), [props.onSendFeedback]);
   useControlAction(feedbackControlAction);
 
+  const settingsControlAction = useMemo<OpenworkControlAction>(() => ({
+    id: "status.settings.open",
+    label: props.settingsOpen ? "Go back from settings" : "Open settings from the status bar",
+    description: "Use the visible settings button in the status bar.",
+    sideEffect: "navigation",
+    disabled: props.showSettingsButton === false,
+    targetRef: settingsButtonRef,
+    execute: props.onOpenSettings,
+  }), [props.onOpenSettings, props.settingsOpen, props.showSettingsButton]);
+  useControlAction(settingsControlAction);
+
   return (
     <div className="border-t border-border bg-background">
       <div className="flex h-8 items-center justify-between gap-3 px-4 md:px-6">
@@ -336,6 +351,25 @@ export function StatusBar(props: StatusBarProps) {
                 {t("status.feedback")}
               </span>
             </Button>
+          ) : null}
+          {props.showSettingsButton !== false ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={(
+                  <Button
+                    ref={settingsButtonRef}
+                    className="text-muted-foreground gap-2"
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={props.onOpenSettings}
+                    aria-label={props.settingsOpen ? t("status.back") : t("status.settings")}
+                  >
+                    <Settings className="size-3.5" />
+                  </Button>
+                )}
+              />
+              <TooltipContent>{t("status.settings")}</TooltipContent>
+            </Tooltip>
           ) : null}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Restore the status bar settings cog button
- Reconnect the status.settings.open control action and SessionPage wiring

## Tests
- pnpm --filter @openwork/app typecheck

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

