### PR TITLE
docs: add SignPath code signing policy

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -134,6 +134,9 @@ jobs:
               "- Electron builds use the attached latest-mac.yml updater feed."
           fi
 
+          SIGNPATH_RELEASE_NOTE='*Windows Build free code signing provided by [SignPath.io](https://about.signpath.io), certificate by [SignPath Foundation](https://signpath.org)*'
+          printf -v RELEASE_BODY '%s\n\n%s' "$RELEASE_BODY" "$SIGNPATH_RELEASE_NOTE"
+
           draft="${INPUT_DRAFT:-}"
           if [ -z "$draft" ]; then
             if [ "${GITHUB_EVENT_NAME}" = "push" ]; then

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Download the desktop app from [openworklabs.com/download](https://openworklabs.c
 - Windows access is currently handled through the paid support plan on [openworklabs.com/pricing#windows-support](https://openworklabs.com/pricing#windows-support).
 - Hosted OpenWork Cloud workers are launched from the web app after checkout, then connected from the desktop app via `Add a worker` -> `Connect remote`.
 
+## Code signing policy
+
+Free code signing provided by [SignPath.io](https://about.signpath.io), certificate by [SignPath Foundation](https://signpath.org).
+
+- Committers and reviewers: OpenWork repository collaborators with write access and approved maintainers in the [Different AI organization](https://github.com/orgs/different-ai/people).
+- Approvers: [Different AI organization owners](https://github.com/orgs/different-ai/people?query=role%3Aowner).
+- Privacy policy: [OpenWork Privacy Policy](https://openworklabs.com/privacy).
+
 ## Why
 
 Current CLI and GUIs for opencode are anchored around developers. That means a focus on file diffs, tool names, and hard to extend capabilities without relying on exposing some form of cli.


### PR DESCRIPTION
## Summary
- Append the SignPath attribution note to stable release notes in all release-body paths.
- Add a README Code signing policy section with SignPath attribution, roles, and privacy policy.

## Why
- SignPath Foundation terms require a visible code signing policy and attribution on project/download/release pages.

## Issue
- Closes N/A

## Scope
- Release workflow release-body text.
- Root README code signing policy text.

## Out of scope
- Signing configuration or release artifact changes.

## Testing
### Ran
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos-aarch64.yml"); puts "yaml ok"'`

### Result
- pass: whitespace check passed; workflow YAML parsed successfully.

## CI status
- pass: pending
- code-related failures: N/A
- external/env/auth blockers: N/A

## Manual verification
1. Checked SignPath terms at https://signpath.org/terms.
2. Confirmed release workflow appends the note after both custom and default release bodies.
3. Confirmed README includes the required Code signing policy section.

## Evidence
- N/A (docs/workflow-only)

## Risk
- Low: text-only workflow/README update.

## Rollback
- Revert this commit.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

