### PR TITLE
feat(app): sync session groups server-side

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -500,6 +500,27 @@ export type OpenworkReloadEvent = {
   timestamp: number;
 };
 
+export type OpenworkSessionGroupDefinition = {
+  id: string;
+  label: string;
+};
+
+export type OpenworkSessionGroupState = {
+  groups: OpenworkSessionGroupDefinition[];
+  assignments: Record<string, string>;
+};
+
+export type OpenworkSessionGroupEvent = {
+  id: string;
+  seq: number;
+  workspaceId: string;
+  type: "session_groups.updated";
+  action: "created" | "updated" | "deleted" | "assigned" | "reordered" | "imported";
+  groupId?: string;
+  sessionId?: string;
+  timestamp: number;
+};
+
 // Fallback for explicit server-mode URL derivation. Desktop local workers replace this
 // with the persisted runtime-discovered port once the host reports it.
 export const DEFAULT_OPENWORK_SERVER_PORT = 8787;
@@ -1115,6 +1136,56 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         baseUrl,
         `/workspace/${encodeURIComponent(workspaceId)}/sessions${suffix}`,
         { token, hostToken, timeoutMs: timeouts.sessionRead },
+      );
+    },
+    getSessionGroups: (workspaceId: string) =>
+      requestJson<{ state: OpenworkSessionGroupState; updatedAt: number | null }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/session-groups`,
+        { token, hostToken, timeoutMs: timeouts.sessionRead },
+      ),
+    putSessionGroups: (workspaceId: string, state: OpenworkSessionGroupState) =>
+      requestJson<{ state: OpenworkSessionGroupState; updatedAt: number }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/session-groups`,
+        { token, hostToken, method: "PUT", body: { state }, timeoutMs: timeouts.config },
+      ),
+    createSessionGroup: (workspaceId: string, input: { id?: string; label: string }) =>
+      requestJson<{ state: OpenworkSessionGroupState; updatedAt: number }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/session-groups`,
+        { token, hostToken, method: "POST", body: input, timeoutMs: timeouts.config },
+      ),
+    reorderSessionGroups: (workspaceId: string, groupIds: string[]) =>
+      requestJson<{ state: OpenworkSessionGroupState; updatedAt: number }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/session-groups/reorder`,
+        { token, hostToken, method: "PATCH", body: { groupIds }, timeoutMs: timeouts.config },
+      ),
+    assignSessionGroup: (workspaceId: string, sessionId: string, groupId: string | null) =>
+      requestJson<{ state: OpenworkSessionGroupState; updatedAt: number }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/session-groups/assignments/${encodeURIComponent(sessionId)}`,
+        { token, hostToken, method: "PATCH", body: { groupId }, timeoutMs: timeouts.config },
+      ),
+    renameSessionGroup: (workspaceId: string, groupId: string, label: string) =>
+      requestJson<{ state: OpenworkSessionGroupState; updatedAt: number }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/session-groups/${encodeURIComponent(groupId)}`,
+        { token, hostToken, method: "PATCH", body: { label }, timeoutMs: timeouts.config },
+      ),
+    removeSessionGroup: (workspaceId: string, groupId: string) =>
+      requestJson<{ state: OpenworkSessionGroupState; updatedAt: number }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/session-groups/${encodeURIComponent(groupId)}`,
+        { token, hostToken, method: "DELETE", timeoutMs: timeouts.config },
+      ),
+    listSessionGroupEvents: (workspaceId: string, options?: { since?: number }) => {
+      const query = typeof options?.since === "number" ? `?since=${options.since}` : "";
+      return requestJson<{ items: OpenworkSessionGroupEvent[]; cursor?: number }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/session-groups/events${query}`,
+        { token, hostToken },
       );
     },
     getSession: (workspaceId: string, sessionId: string) =>

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1567,6 +1567,7 @@ export default {
   "session_management.archived_count_other": "Archived ({count})",
   "session_management.move_to_group": "Move to group",
   "session_management.no_group": "No group",
+  "session_management.create_group": "Create a Group",
   "session_management.new_group": "New group...",
   "session_management.new_group_prompt": "Name this group (e.g. Done, In progress):",
   "session_management.remove_group": "Remove group",

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1016,7 +1016,27 @@ function WorkspaceSidebarGroup({
                           className="text-muted-foreground text-xs"
                           onClick={() => showMoreSessions(workspace.id, activeRootCount)}
                         >
-                          <span className="truncate">{showMoreLabel}</span>
+                          <span className="flex min-w-0 items-center gap-1">
+                            <span className="truncate">{showMoreLabel}</span>
+                            <span aria-hidden className="shrink-0">⋅</span>
+                            <span
+                              role="button"
+                              tabIndex={0}
+                              className="shrink-0 hover:text-foreground"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                ctx.onOpenCreateGroupModal?.(workspace.id);
+                              }}
+                              onKeyDown={(event) => {
+                                if (event.key !== "Enter" && event.key !== " ") return;
+                                event.preventDefault();
+                                event.stopPropagation();
+                                ctx.onOpenCreateGroupModal?.(workspace.id);
+                              }}
+                            >
+                              {t("session_management.create_group")}
+                            </span>
+                          </span>
                         </SidebarMenuSubButton>
                       </SidebarMenuSubItem>
                     ) : null}

--- a/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
@@ -39,11 +39,18 @@ type SessionGroupMutationSuccess = {
   state: SessionGroupServerState;
 };
 
+type SessionGroupDeferredServerSync = {
+  version: number;
+  state: SessionGroupServerState;
+};
+
 type SessionGroupSyncStatus = {
-  nextVersion: number;
+  nextMutationVersion: number;
+  nextServerSyncVersion: number;
   pendingMutations: number;
   lastAppliedMutationVersion: number;
   latestMutationSuccess?: SessionGroupMutationSuccess;
+  deferredServerSync?: SessionGroupDeferredServerSync;
 };
 
 type SessionManagementState = {
@@ -78,7 +85,8 @@ export function setSessionGroupSyncHandler(handler: SessionGroupSyncHandler | nu
 
 function syncStatus(workspaceId: string): SessionGroupSyncStatus {
   sessionGroupSyncStatusByWorkspace[workspaceId] ??= {
-    nextVersion: 0,
+    nextMutationVersion: 0,
+    nextServerSyncVersion: 0,
     pendingMutations: 0,
     lastAppliedMutationVersion: 0,
   };
@@ -87,17 +95,29 @@ function syncStatus(workspaceId: string): SessionGroupSyncStatus {
 
 function beginSessionGroupMutation(workspaceId: string): number {
   const status = syncStatus(workspaceId);
-  status.nextVersion += 1;
+  status.nextMutationVersion += 1;
   status.pendingMutations += 1;
-  return status.nextVersion;
+  return status.nextMutationVersion;
+}
+
+export function beginSessionGroupServerSync(workspaceId: string): number {
+  const status = syncStatus(workspaceId);
+  status.nextServerSyncVersion += 1;
+  return status.nextServerSyncVersion;
 }
 
 export function applySessionGroupServerState(
   workspaceId: string,
   state: SessionGroupServerState | null,
+  version: number,
 ): void {
   if (!state) return;
-  if (syncStatus(workspaceId).pendingMutations > 0) return;
+  const status = syncStatus(workspaceId);
+  if (version !== status.nextServerSyncVersion) return;
+  if (status.pendingMutations > 0) {
+    status.deferredServerSync = { version, state };
+    return;
+  }
   useSessionManagementStore.getState().replaceWorkspaceGroups(workspaceId, state);
 }
 
@@ -114,9 +134,17 @@ function completeSessionGroupMutation(
   if (status.pendingMutations > 0) return;
 
   const success = status.latestMutationSuccess;
-  if (!success || success.version <= status.lastAppliedMutationVersion) return;
-  status.lastAppliedMutationVersion = success.version;
-  useSessionManagementStore.getState().replaceWorkspaceGroups(workspaceId, success.state);
+  if (success && success.version > status.lastAppliedMutationVersion) {
+    status.lastAppliedMutationVersion = success.version;
+    status.deferredServerSync = undefined;
+    useSessionManagementStore.getState().replaceWorkspaceGroups(workspaceId, success.state);
+    return;
+  }
+
+  const deferred = status.deferredServerSync;
+  if (!deferred || deferred.version !== status.nextServerSyncVersion) return;
+  status.deferredServerSync = undefined;
+  useSessionManagementStore.getState().replaceWorkspaceGroups(workspaceId, deferred.state);
 }
 
 function reportSyncError(error: unknown): void {

--- a/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
@@ -34,6 +34,18 @@ type SessionGroupSyncHandler = {
   removeGroup: (workspaceId: string, groupId: string) => Promise<SessionGroupServerState | null>;
 };
 
+type SessionGroupMutationSuccess = {
+  version: number;
+  state: SessionGroupServerState;
+};
+
+type SessionGroupSyncStatus = {
+  nextVersion: number;
+  pendingMutations: number;
+  lastAppliedMutationVersion: number;
+  latestMutationSuccess?: SessionGroupMutationSuccess;
+};
+
 type SessionManagementState = {
   pinnedIds: string[];
   orderByWorkspace: Record<string, string[]>;
@@ -58,26 +70,53 @@ type SessionManagementStore = SessionManagementState & SessionManagementActions;
 const EMPTY_GROUP_STATE: WorkspaceGroupState = { groups: [], assignments: {} };
 
 let sessionGroupSyncHandler: SessionGroupSyncHandler | null = null;
-const sessionGroupSyncVersionByWorkspace: Record<string, number> = {};
+const sessionGroupSyncStatusByWorkspace: Record<string, SessionGroupSyncStatus> = {};
 
 export function setSessionGroupSyncHandler(handler: SessionGroupSyncHandler | null): void {
   sessionGroupSyncHandler = handler;
 }
 
-export function nextSessionGroupSyncVersion(workspaceId: string): number {
-  const next = (sessionGroupSyncVersionByWorkspace[workspaceId] ?? 0) + 1;
-  sessionGroupSyncVersionByWorkspace[workspaceId] = next;
-  return next;
+function syncStatus(workspaceId: string): SessionGroupSyncStatus {
+  sessionGroupSyncStatusByWorkspace[workspaceId] ??= {
+    nextVersion: 0,
+    pendingMutations: 0,
+    lastAppliedMutationVersion: 0,
+  };
+  return sessionGroupSyncStatusByWorkspace[workspaceId];
+}
+
+function beginSessionGroupMutation(workspaceId: string): number {
+  const status = syncStatus(workspaceId);
+  status.nextVersion += 1;
+  status.pendingMutations += 1;
+  return status.nextVersion;
 }
 
 export function applySessionGroupServerState(
   workspaceId: string,
   state: SessionGroupServerState | null,
-  version?: number,
 ): void {
   if (!state) return;
-  if (typeof version === "number" && sessionGroupSyncVersionByWorkspace[workspaceId] !== version) return;
+  if (syncStatus(workspaceId).pendingMutations > 0) return;
   useSessionManagementStore.getState().replaceWorkspaceGroups(workspaceId, state);
+}
+
+function completeSessionGroupMutation(
+  workspaceId: string,
+  version: number,
+  state: SessionGroupServerState | null,
+): void {
+  const status = syncStatus(workspaceId);
+  status.pendingMutations = Math.max(0, status.pendingMutations - 1);
+  if (state && version > (status.latestMutationSuccess?.version ?? 0)) {
+    status.latestMutationSuccess = { version, state };
+  }
+  if (status.pendingMutations > 0) return;
+
+  const success = status.latestMutationSuccess;
+  if (!success || success.version <= status.lastAppliedMutationVersion) return;
+  status.lastAppliedMutationVersion = success.version;
+  useSessionManagementStore.getState().replaceWorkspaceGroups(workspaceId, success.state);
 }
 
 function reportSyncError(error: unknown): void {
@@ -86,10 +125,13 @@ function reportSyncError(error: unknown): void {
 
 function syncServerState(request: Promise<SessionGroupServerState | null> | undefined, workspaceId: string): void {
   if (!request) return;
-  const version = nextSessionGroupSyncVersion(workspaceId);
+  const version = beginSessionGroupMutation(workspaceId);
   void request
-    .then((state) => applySessionGroupServerState(workspaceId, state, version))
-    .catch(reportSyncError);
+    .then((state) => completeSessionGroupMutation(workspaceId, version, state))
+    .catch((error) => {
+      completeSessionGroupMutation(workspaceId, version, null);
+      reportSyncError(error);
+    });
 }
 
 export const useSessionManagementStore = create<SessionManagementStore>()(

--- a/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
@@ -142,7 +142,7 @@ function completeSessionGroupMutation(
   }
 
   const deferred = status.deferredServerSync;
-  if (!deferred || deferred.version !== status.nextServerSyncVersion) return;
+  if (!deferred) return;
   status.deferredServerSync = undefined;
   useSessionManagementStore.getState().replaceWorkspaceGroups(workspaceId, deferred.state);
 }

--- a/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
@@ -58,13 +58,25 @@ type SessionManagementStore = SessionManagementState & SessionManagementActions;
 const EMPTY_GROUP_STATE: WorkspaceGroupState = { groups: [], assignments: {} };
 
 let sessionGroupSyncHandler: SessionGroupSyncHandler | null = null;
+const sessionGroupSyncVersionByWorkspace: Record<string, number> = {};
 
 export function setSessionGroupSyncHandler(handler: SessionGroupSyncHandler | null): void {
   sessionGroupSyncHandler = handler;
 }
 
-function applyServerState(workspaceId: string, state: SessionGroupServerState | null): void {
+export function nextSessionGroupSyncVersion(workspaceId: string): number {
+  const next = (sessionGroupSyncVersionByWorkspace[workspaceId] ?? 0) + 1;
+  sessionGroupSyncVersionByWorkspace[workspaceId] = next;
+  return next;
+}
+
+export function applySessionGroupServerState(
+  workspaceId: string,
+  state: SessionGroupServerState | null,
+  version?: number,
+): void {
   if (!state) return;
+  if (typeof version === "number" && sessionGroupSyncVersionByWorkspace[workspaceId] !== version) return;
   useSessionManagementStore.getState().replaceWorkspaceGroups(workspaceId, state);
 }
 
@@ -74,8 +86,9 @@ function reportSyncError(error: unknown): void {
 
 function syncServerState(request: Promise<SessionGroupServerState | null> | undefined, workspaceId: string): void {
   if (!request) return;
+  const version = nextSessionGroupSyncVersion(workspaceId);
   void request
-    .then((state) => applyServerState(workspaceId, state))
+    .then((state) => applySessionGroupServerState(workspaceId, state, version))
     .catch(reportSyncError);
 }
 

--- a/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
@@ -1,10 +1,12 @@
 /**
  * Zustand store for session management primitives (pin, manual order, custom
- * groups). Persisted to localStorage via zustand/middleware/persist.
+ * group mirror + expanded state). Persisted to localStorage via
+ * zustand/middleware/persist.
  *
- * Archive is server-side (OpenCode session.time.archived); this store is
- * purely client-side view state. Components import it directly with selectors,
- * avoiding context/prop drilling.
+ * Archive is server-side (OpenCode session.time.archived). Session groups are
+ * synced server-side; this store keeps a local optimistic mirror plus UI-only
+ * collapsed state. Components import it directly with selectors, avoiding
+ * context/prop drilling.
  */
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
@@ -14,10 +16,22 @@ export type SessionGroupDefinition = {
   label: string;
 };
 
-type WorkspaceGroupState = {
+export type WorkspaceGroupState = {
   groups: SessionGroupDefinition[];
   assignments: Record<string, string>;
   collapsedGroupIds?: string[];
+};
+
+export type SessionGroupServerState = {
+  groups: SessionGroupDefinition[];
+  assignments: Record<string, string>;
+};
+
+type SessionGroupSyncHandler = {
+  createGroup: (workspaceId: string, group: SessionGroupDefinition) => Promise<SessionGroupServerState | null>;
+  assignGroup: (workspaceId: string, sessionId: string, groupId: string | null) => Promise<SessionGroupServerState | null>;
+  reorderGroups: (workspaceId: string, groupIds: string[]) => Promise<SessionGroupServerState | null>;
+  removeGroup: (workspaceId: string, groupId: string) => Promise<SessionGroupServerState | null>;
 };
 
 type SessionManagementState = {
@@ -33,6 +47,7 @@ type SessionManagementActions = {
   createGroup: (workspaceId: string, label: string) => void;
   reorderGroups: (workspaceId: string, groupIds: string[]) => void;
   toggleGroupExpanded: (workspaceId: string, groupId: string) => void;
+  replaceWorkspaceGroups: (workspaceId: string, state: SessionGroupServerState) => void;
   /** Remove a group definition. Sessions assigned to it become ungrouped. */
   removeGroup: (workspaceId: string, groupId: string) => void;
   forgetWorkspace: (workspaceId: string) => void;
@@ -41,6 +56,28 @@ type SessionManagementActions = {
 type SessionManagementStore = SessionManagementState & SessionManagementActions;
 
 const EMPTY_GROUP_STATE: WorkspaceGroupState = { groups: [], assignments: {} };
+
+let sessionGroupSyncHandler: SessionGroupSyncHandler | null = null;
+
+export function setSessionGroupSyncHandler(handler: SessionGroupSyncHandler | null): void {
+  sessionGroupSyncHandler = handler;
+}
+
+function applyServerState(workspaceId: string, state: SessionGroupServerState | null): void {
+  if (!state) return;
+  useSessionManagementStore.getState().replaceWorkspaceGroups(workspaceId, state);
+}
+
+function reportSyncError(error: unknown): void {
+  console.warn("[session-groups] server sync failed", error);
+}
+
+function syncServerState(request: Promise<SessionGroupServerState | null> | undefined, workspaceId: string): void {
+  if (!request) return;
+  void request
+    .then((state) => applyServerState(workspaceId, state))
+    .catch(reportSyncError);
+}
 
 export const useSessionManagementStore = create<SessionManagementStore>()(
   persist(
@@ -65,7 +102,7 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
           orderByWorkspace: { ...state.orderByWorkspace, [workspaceId]: sessionIds },
         })),
 
-      assignGroup: (workspaceId, sessionId, groupId) =>
+      assignGroup: (workspaceId, sessionId, groupId) => {
         set((state) => {
           const ws = state.groupsByWorkspace[workspaceId] ?? EMPTY_GROUP_STATE;
           const assignments = { ...ws.assignments };
@@ -80,21 +117,29 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
               [workspaceId]: { ...ws, assignments },
             },
           };
-        }),
+        });
+        syncServerState(
+          sessionGroupSyncHandler?.assignGroup(workspaceId, sessionId, groupId),
+          workspaceId,
+        );
+      },
 
-      createGroup: (workspaceId, label) =>
+      createGroup: (workspaceId, label) => {
+        const id = `grp_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+        const group = { id, label };
         set((state) => {
           const ws = state.groupsByWorkspace[workspaceId] ?? EMPTY_GROUP_STATE;
-          const id = `grp_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
           return {
             groupsByWorkspace: {
               ...state.groupsByWorkspace,
-              [workspaceId]: { ...ws, groups: [...ws.groups, { id, label }] },
+              [workspaceId]: { ...ws, groups: [...ws.groups, group] },
             },
           };
-        }),
+        });
+        syncServerState(sessionGroupSyncHandler?.createGroup(workspaceId, group), workspaceId);
+      },
 
-      reorderGroups: (workspaceId, groupIds) =>
+      reorderGroups: (workspaceId, groupIds) => {
         set((state) => {
           const ws = state.groupsByWorkspace[workspaceId] ?? EMPTY_GROUP_STATE;
           const byId = new Map(ws.groups.map((group) => [group.id, group]));
@@ -115,7 +160,9 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
               [workspaceId]: { ...ws, groups },
             },
           };
-        }),
+        });
+        syncServerState(sessionGroupSyncHandler?.reorderGroups(workspaceId, groupIds), workspaceId);
+      },
 
       toggleGroupExpanded: (workspaceId, groupId) =>
         set((state) => {
@@ -134,7 +181,26 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
           };
         }),
 
-      removeGroup: (workspaceId, groupId) =>
+      replaceWorkspaceGroups: (workspaceId, serverState) =>
+        set((state) => {
+          const ws = state.groupsByWorkspace[workspaceId] ?? EMPTY_GROUP_STATE;
+          const knownGroupIds = new Set(serverState.groups.map((group) => group.id));
+          const collapsedGroupIds = (ws.collapsedGroupIds ?? []).filter(
+            (id) => id === "__openwork_ungrouped" || knownGroupIds.has(id),
+          );
+          return {
+            groupsByWorkspace: {
+              ...state.groupsByWorkspace,
+              [workspaceId]: {
+                groups: serverState.groups,
+                assignments: serverState.assignments,
+                collapsedGroupIds,
+              },
+            },
+          };
+        }),
+
+      removeGroup: (workspaceId, groupId) => {
         set((state) => {
           const ws = state.groupsByWorkspace[workspaceId] ?? EMPTY_GROUP_STATE;
           const groups = ws.groups.filter((g) => g.id !== groupId);
@@ -150,7 +216,9 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
               [workspaceId]: { groups, assignments, collapsedGroupIds },
             },
           };
-        }),
+        });
+        syncServerState(sessionGroupSyncHandler?.removeGroup(workspaceId, groupId), workspaceId);
+      },
 
       forgetWorkspace: (workspaceId) =>
         set((state) => {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -154,6 +154,7 @@ import { useReloadCoordinator } from "./reload-coordinator";
 import { useShellConfig } from "./shell-config";
 import { useShellShortcuts } from "./use-shell-shortcuts";
 import { useEngineReload } from "./use-engine-reload";
+import { useSessionGroupSync } from "./use-session-group-sync";
 import { useWorkspaceRouteState } from "./use-workspace-route-state";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
 import { useSessionControlActions } from "@/react-app/domains/session/control/session-control-actions";
@@ -481,6 +482,7 @@ export function SessionRoute() {
     () => toSessionGroups(workspaces, sessionsByWorkspaceId, errorsByWorkspaceId, new Set(retryingWorkspaceIds)),
     [errorsByWorkspaceId, retryingWorkspaceIds, sessionsByWorkspaceId, workspaces],
   );
+  useSessionGroupSync({ workspaces, endpointForWorkspace });
   const seedWorkspaceActivitySessions = useSessionActivityStore((state) => state.seedWorkspaceSessions);
   const sessionActivityByWorkspaceId = useSessionActivityStore((state) => state.statusesByWorkspaceId);
 

--- a/apps/app/src/react-app/shell/use-session-group-sync.ts
+++ b/apps/app/src/react-app/shell/use-session-group-sync.ts
@@ -4,7 +4,6 @@ import type { OpenworkSessionGroupState } from "@/app/lib/openwork-server";
 import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
 import {
   applySessionGroupServerState,
-  nextSessionGroupSyncVersion,
   setSessionGroupSyncHandler,
   useSessionManagementStore,
   type SessionGroupDefinition,
@@ -110,7 +109,6 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
     const syncWorkspace = async (workspace: RouteWorkspace, migrateLocal: boolean) => {
       const endpoint = endpointForWorkspace(workspace);
       if (!endpoint) return;
-      const version = nextSessionGroupSyncVersion(workspace.id);
 
       const response = await endpoint.client.getSessionGroups(endpoint.workspaceId);
       if (cancelled) return;
@@ -132,7 +130,7 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
       }
 
       writeMigrationComplete(endpoint);
-      applySessionGroupServerState(workspace.id, nextState, version);
+      applySessionGroupServerState(workspace.id, nextState);
     };
 
     for (const workspace of workspaces) {

--- a/apps/app/src/react-app/shell/use-session-group-sync.ts
+++ b/apps/app/src/react-app/shell/use-session-group-sync.ts
@@ -4,6 +4,7 @@ import type { OpenworkSessionGroupState } from "@/app/lib/openwork-server";
 import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
 import {
   applySessionGroupServerState,
+  beginSessionGroupServerSync,
   setSessionGroupSyncHandler,
   useSessionManagementStore,
   type SessionGroupDefinition,
@@ -109,6 +110,7 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
     const syncWorkspace = async (workspace: RouteWorkspace, migrateLocal: boolean) => {
       const endpoint = endpointForWorkspace(workspace);
       if (!endpoint) return;
+      const version = beginSessionGroupServerSync(workspace.id);
 
       const response = await endpoint.client.getSessionGroups(endpoint.workspaceId);
       if (cancelled) return;
@@ -130,7 +132,7 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
       }
 
       writeMigrationComplete(endpoint);
-      applySessionGroupServerState(workspace.id, nextState);
+      applySessionGroupServerState(workspace.id, nextState, version);
     };
 
     for (const workspace of workspaces) {

--- a/apps/app/src/react-app/shell/use-session-group-sync.ts
+++ b/apps/app/src/react-app/shell/use-session-group-sync.ts
@@ -1,0 +1,172 @@
+import { useEffect, useRef } from "react";
+
+import type { OpenworkSessionGroupState } from "@/app/lib/openwork-server";
+import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
+import {
+  setSessionGroupSyncHandler,
+  useSessionManagementStore,
+  type SessionGroupDefinition,
+  type SessionGroupServerState,
+  type WorkspaceGroupState,
+} from "@/react-app/domains/session/sidebar/session-management-store";
+import type { RouteWorkspace } from "./route-workspaces";
+
+const MIGRATION_PREFIX = "openwork.sessionGroups.migrated.v1";
+
+type UseSessionGroupSyncInput = {
+  workspaces: RouteWorkspace[];
+  endpointForWorkspace: (workspace: RouteWorkspace | null | undefined) => ResolvedWorkspaceEndpoint | null;
+};
+
+function hasGroupData(state: SessionGroupServerState | WorkspaceGroupState | undefined): boolean {
+  return Boolean(state && (state.groups.length > 0 || Object.keys(state.assignments).length > 0));
+}
+
+function serverStateFromWorkspaceState(state: WorkspaceGroupState): OpenworkSessionGroupState {
+  return {
+    groups: state.groups.map((group) => ({ id: group.id, label: group.label })),
+    assignments: { ...state.assignments },
+  };
+}
+
+function migrationKey(endpoint: ResolvedWorkspaceEndpoint): string {
+  return `${MIGRATION_PREFIX}:${endpoint.baseUrl}:${endpoint.workspaceId}`;
+}
+
+function readMigrationComplete(endpoint: ResolvedWorkspaceEndpoint): boolean {
+  try {
+    return window.localStorage.getItem(migrationKey(endpoint)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeMigrationComplete(endpoint: ResolvedWorkspaceEndpoint): void {
+  try {
+    window.localStorage.setItem(migrationKey(endpoint), "1");
+  } catch {
+    // ignore storage failures; the next launch can retry safely.
+  }
+}
+
+export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
+  const { workspaces, endpointForWorkspace } = input;
+  const workspacesRef = useRef(workspaces);
+  const endpointForWorkspaceRef = useRef(endpointForWorkspace);
+  const eventCursorByWorkspaceRef = useRef<Record<string, number | null>>({});
+
+  useEffect(() => {
+    workspacesRef.current = workspaces;
+  }, [workspaces]);
+
+  useEffect(() => {
+    endpointForWorkspaceRef.current = endpointForWorkspace;
+  }, [endpointForWorkspace]);
+
+  useEffect(() => {
+    setSessionGroupSyncHandler({
+      createGroup: async (workspaceId: string, group: SessionGroupDefinition) => {
+        const workspace = workspacesRef.current.find((item) => item.id === workspaceId);
+        const endpoint = endpointForWorkspaceRef.current(workspace);
+        if (!endpoint) return null;
+        const response = await endpoint.client.createSessionGroup(endpoint.workspaceId, group);
+        writeMigrationComplete(endpoint);
+        return response.state;
+      },
+      assignGroup: async (workspaceId: string, sessionId: string, groupId: string | null) => {
+        const workspace = workspacesRef.current.find((item) => item.id === workspaceId);
+        const endpoint = endpointForWorkspaceRef.current(workspace);
+        if (!endpoint) return null;
+        const response = await endpoint.client.assignSessionGroup(endpoint.workspaceId, sessionId, groupId);
+        writeMigrationComplete(endpoint);
+        return response.state;
+      },
+      reorderGroups: async (workspaceId: string, groupIds: string[]) => {
+        const workspace = workspacesRef.current.find((item) => item.id === workspaceId);
+        const endpoint = endpointForWorkspaceRef.current(workspace);
+        if (!endpoint) return null;
+        const response = await endpoint.client.reorderSessionGroups(endpoint.workspaceId, groupIds);
+        writeMigrationComplete(endpoint);
+        return response.state;
+      },
+      removeGroup: async (workspaceId: string, groupId: string) => {
+        const workspace = workspacesRef.current.find((item) => item.id === workspaceId);
+        const endpoint = endpointForWorkspaceRef.current(workspace);
+        if (!endpoint) return null;
+        const response = await endpoint.client.removeSessionGroup(endpoint.workspaceId, groupId);
+        writeMigrationComplete(endpoint);
+        return response.state;
+      },
+    });
+    return () => setSessionGroupSyncHandler(null);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const syncWorkspace = async (workspace: RouteWorkspace, migrateLocal: boolean) => {
+      const endpoint = endpointForWorkspace(workspace);
+      if (!endpoint) return;
+
+      const response = await endpoint.client.getSessionGroups(endpoint.workspaceId);
+      if (cancelled) return;
+
+      let nextState = response.state;
+      const localState = useSessionManagementStore.getState().groupsByWorkspace[workspace.id];
+      if (
+        migrateLocal &&
+        !readMigrationComplete(endpoint) &&
+        !hasGroupData(response.state) &&
+        hasGroupData(localState)
+      ) {
+        const migrated = await endpoint.client.putSessionGroups(
+          endpoint.workspaceId,
+          serverStateFromWorkspaceState(localState),
+        );
+        if (cancelled) return;
+        nextState = migrated.state;
+      }
+
+      writeMigrationComplete(endpoint);
+      useSessionManagementStore.getState().replaceWorkspaceGroups(workspace.id, nextState);
+    };
+
+    for (const workspace of workspaces) {
+      void syncWorkspace(workspace, true).catch((error) => {
+        console.warn("[session-groups] initial sync failed", error);
+      });
+    }
+
+    const pollEvents = async () => {
+      for (const workspace of workspacesRef.current) {
+        const endpoint = endpointForWorkspaceRef.current(workspace);
+        if (!endpoint) continue;
+        const key = `${endpoint.baseUrl}:${endpoint.workspaceId}`;
+        const currentCursor = eventCursorByWorkspaceRef.current[key];
+        try {
+          const response = await endpoint.client.listSessionGroupEvents(
+            endpoint.workspaceId,
+            typeof currentCursor === "number" ? { since: currentCursor } : undefined,
+          );
+          if (cancelled) return;
+          eventCursorByWorkspaceRef.current[key] =
+            typeof response.cursor === "number"
+              ? response.cursor
+              : Math.max(currentCursor ?? 0, ...((response.items ?? []).map((item) => Number(item.seq) || 0)));
+          if (currentCursor === undefined || currentCursor === null) continue;
+          if ((response.items ?? []).length === 0) continue;
+          await syncWorkspace(workspace, false);
+        } catch {
+          // Best effort: normal workspace/session loading still surfaces connection issues.
+        }
+      }
+    };
+
+    void pollEvents();
+    const interval = window.setInterval(() => void pollEvents(), 3000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [endpointForWorkspace, workspaces]);
+}

--- a/apps/app/src/react-app/shell/use-session-group-sync.ts
+++ b/apps/app/src/react-app/shell/use-session-group-sync.ts
@@ -3,6 +3,8 @@ import { useEffect, useRef } from "react";
 import type { OpenworkSessionGroupState } from "@/app/lib/openwork-server";
 import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
 import {
+  applySessionGroupServerState,
+  nextSessionGroupSyncVersion,
   setSessionGroupSyncHandler,
   useSessionManagementStore,
   type SessionGroupDefinition,
@@ -54,6 +56,7 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
   const workspacesRef = useRef(workspaces);
   const endpointForWorkspaceRef = useRef(endpointForWorkspace);
   const eventCursorByWorkspaceRef = useRef<Record<string, number | null>>({});
+  const pollInFlightRef = useRef(false);
 
   useEffect(() => {
     workspacesRef.current = workspaces;
@@ -107,6 +110,7 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
     const syncWorkspace = async (workspace: RouteWorkspace, migrateLocal: boolean) => {
       const endpoint = endpointForWorkspace(workspace);
       if (!endpoint) return;
+      const version = nextSessionGroupSyncVersion(workspace.id);
 
       const response = await endpoint.client.getSessionGroups(endpoint.workspaceId);
       if (cancelled) return;
@@ -128,7 +132,7 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
       }
 
       writeMigrationComplete(endpoint);
-      useSessionManagementStore.getState().replaceWorkspaceGroups(workspace.id, nextState);
+      applySessionGroupServerState(workspace.id, nextState, version);
     };
 
     for (const workspace of workspaces) {
@@ -138,27 +142,33 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
     }
 
     const pollEvents = async () => {
-      for (const workspace of workspacesRef.current) {
-        const endpoint = endpointForWorkspaceRef.current(workspace);
-        if (!endpoint) continue;
-        const key = `${endpoint.baseUrl}:${endpoint.workspaceId}`;
-        const currentCursor = eventCursorByWorkspaceRef.current[key];
-        try {
-          const response = await endpoint.client.listSessionGroupEvents(
-            endpoint.workspaceId,
-            typeof currentCursor === "number" ? { since: currentCursor } : undefined,
-          );
-          if (cancelled) return;
-          eventCursorByWorkspaceRef.current[key] =
-            typeof response.cursor === "number"
-              ? response.cursor
-              : Math.max(currentCursor ?? 0, ...((response.items ?? []).map((item) => Number(item.seq) || 0)));
-          if (currentCursor === undefined || currentCursor === null) continue;
-          if ((response.items ?? []).length === 0) continue;
-          await syncWorkspace(workspace, false);
-        } catch {
-          // Best effort: normal workspace/session loading still surfaces connection issues.
+      if (pollInFlightRef.current) return;
+      pollInFlightRef.current = true;
+      try {
+        for (const workspace of workspacesRef.current) {
+          const endpoint = endpointForWorkspaceRef.current(workspace);
+          if (!endpoint) continue;
+          const key = `${endpoint.baseUrl}:${endpoint.workspaceId}`;
+          const currentCursor = eventCursorByWorkspaceRef.current[key];
+          try {
+            const response = await endpoint.client.listSessionGroupEvents(
+              endpoint.workspaceId,
+              typeof currentCursor === "number" ? { since: currentCursor } : undefined,
+            );
+            if (cancelled) return;
+            eventCursorByWorkspaceRef.current[key] =
+              typeof response.cursor === "number"
+                ? response.cursor
+                : Math.max(currentCursor ?? 0, ...((response.items ?? []).map((item) => Number(item.seq) || 0)));
+            if (currentCursor === undefined || currentCursor === null) continue;
+            if ((response.items ?? []).length === 0) continue;
+            await syncWorkspace(workspace, false);
+          } catch {
+            // Best effort: normal workspace/session loading still surfaces connection issues.
+          }
         }
+      } finally {
+        pollInFlightRef.current = false;
       }
     };
 

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -1,6 +1,15 @@
 import type { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { ApiError } from "../errors.js";
 import { buildSession, buildSessionList, buildSessionMessages, buildSessionSnapshot } from "../session-read-model.js";
+import {
+  createSessionGroupId,
+  normalizeSessionGroupState,
+  readSessionGroupState,
+  SessionGroupEventStore,
+  writeSessionGroupState,
+  type SessionGroupDefinition,
+  type SessionGroupState,
+} from "../session-groups.js";
 import type { ServerConfig, TokenScope, WorkspaceInfo } from "../types.js";
 import { addRoute, type RequestContext, type Route } from "./registry.js";
 
@@ -8,6 +17,7 @@ type JsonResponse = (data: unknown, status?: number) => Response;
 type ParseOptionalBoolean = (value: string | null, name: string) => boolean | undefined;
 type ParseOptionalPositiveInteger = (value: string | null, name: string) => number | undefined;
 type ParseOptionalNonNegativeInteger = (value: string | null, name: string) => number | undefined;
+type ReadJsonBody = (request: Request) => Promise<Record<string, unknown>>;
 type WorkspaceOpencodeClient = ReturnType<typeof createOpencodeClient>;
 type OpencodeClientResult<T, E> =
   | { data: T | undefined; error: undefined; response: Response }
@@ -21,6 +31,7 @@ interface RegisterSessionRoutesOptions {
   parseOptionalBoolean: ParseOptionalBoolean;
   parseOptionalPositiveInteger: ParseOptionalPositiveInteger;
   parseOptionalNonNegativeInteger: ParseOptionalNonNegativeInteger;
+  readJsonBody: ReadJsonBody;
   ensureWritable: (config: ServerConfig) => void;
   requireClientScope: (ctx: RequestContext, required: TokenScope) => void;
   resolveWorkspace: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
@@ -40,12 +51,14 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
     parseOptionalBoolean,
     parseOptionalPositiveInteger,
     parseOptionalNonNegativeInteger,
+    readJsonBody,
     ensureWritable,
     requireClientScope,
     resolveWorkspace,
     createWorkspaceOpencodeClient,
     unwrapOpencodeResult,
   } = options;
+  const sessionGroupEvents = new SessionGroupEventStore();
 
   function remapSessionReadError(error: unknown): never {
     if (error instanceof ApiError && error.code === "opencode_request_failed") {
@@ -141,6 +154,22 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
     }
   }
 
+  async function updateWorkspaceSessionGroups(
+    workspaceId: string,
+    updater: (current: SessionGroupState) => SessionGroupState,
+  ) {
+    const current = await readSessionGroupState(config, workspaceId);
+    return writeSessionGroupState(config, workspaceId, updater(current.state));
+  }
+
+  function requireStringField(body: Record<string, unknown>, field: string): string {
+    const value = body[field];
+    if (typeof value !== "string" || !value.trim()) {
+      throw new ApiError(400, "invalid_payload", `${field} is required`);
+    }
+    return value.trim();
+  }
+
   addRoute(routes, "GET", "/workspace/:id/sessions", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const items = await listWorkspaceSessions(workspace, {
@@ -150,6 +179,132 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
       limit: parseOptionalPositiveInteger(ctx.url.searchParams.get("limit"), "limit"),
     });
     return jsonResponse({ items });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/session-groups", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const result = await readSessionGroupState(config, workspace.id);
+    return jsonResponse({ state: result.state, updatedAt: result.updatedAt });
+  });
+
+  addRoute(routes, "PUT", "/workspace/:id/session-groups", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const state = normalizeSessionGroupState(body.state);
+    const result = await writeSessionGroupState(config, workspace.id, state);
+    sessionGroupEvents.record(workspace.id, "imported");
+    return jsonResponse({ state: result.state, updatedAt: result.updatedAt });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/session-groups", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const label = requireStringField(body, "label").slice(0, 120);
+    const requestedId = typeof body.id === "string" ? body.id.trim().slice(0, 128) : "";
+    const result = await updateWorkspaceSessionGroups(workspace.id, (current) => {
+      const existingIds = new Set(current.groups.map((group) => group.id));
+      const id = requestedId && !existingIds.has(requestedId) ? requestedId : createSessionGroupId();
+      return { ...current, groups: [...current.groups, { id, label }] };
+    });
+    const groupId = result.state.groups[result.state.groups.length - 1]?.id;
+    sessionGroupEvents.record(workspace.id, "created", groupId ? { groupId } : undefined);
+    return jsonResponse({ state: result.state, updatedAt: result.updatedAt });
+  });
+
+  addRoute(routes, "PATCH", "/workspace/:id/session-groups/reorder", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const requestedIds = Array.isArray(body.groupIds)
+      ? body.groupIds.filter((item) => typeof item === "string").map((item) => item.trim()).filter(Boolean)
+      : [];
+    const result = await updateWorkspaceSessionGroups(workspace.id, (current) => {
+      const byId = new Map(current.groups.map((group) => [group.id, group]));
+      const used = new Set<string>();
+      const groups: SessionGroupDefinition[] = [];
+      for (const id of requestedIds) {
+        const group = byId.get(id);
+        if (!group || used.has(id)) continue;
+        groups.push(group);
+        used.add(id);
+      }
+      for (const group of current.groups) {
+        if (!used.has(group.id)) groups.push(group);
+      }
+      return { ...current, groups };
+    });
+    sessionGroupEvents.record(workspace.id, "reordered");
+    return jsonResponse({ state: result.state, updatedAt: result.updatedAt });
+  });
+
+  addRoute(routes, "PATCH", "/workspace/:id/session-groups/assignments/:sessionId", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const sessionId = (ctx.params.sessionId ?? "").trim();
+    if (!sessionId) throw new ApiError(400, "invalid_payload", "sessionId is required");
+    const body = await readJsonBody(ctx.request);
+    const groupId = typeof body.groupId === "string" && body.groupId.trim() ? body.groupId.trim() : null;
+    const result = await updateWorkspaceSessionGroups(workspace.id, (current) => {
+      const assignments = { ...current.assignments };
+      if (groupId && current.groups.some((group) => group.id === groupId)) {
+        assignments[sessionId] = groupId;
+      } else {
+        delete assignments[sessionId];
+      }
+      return { ...current, assignments };
+    });
+    sessionGroupEvents.record(workspace.id, "assigned", { sessionId, ...(groupId ? { groupId } : {}) });
+    return jsonResponse({ state: result.state, updatedAt: result.updatedAt });
+  });
+
+  addRoute(routes, "PATCH", "/workspace/:id/session-groups/:groupId", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const groupId = (ctx.params.groupId ?? "").trim();
+    if (!groupId) throw new ApiError(400, "invalid_payload", "groupId is required");
+    const body = await readJsonBody(ctx.request);
+    const label = requireStringField(body, "label").slice(0, 120);
+    const result = await updateWorkspaceSessionGroups(workspace.id, (current) => ({
+      ...current,
+      groups: current.groups.map((group) => group.id === groupId ? { ...group, label } : group),
+    }));
+    sessionGroupEvents.record(workspace.id, "updated", { groupId });
+    return jsonResponse({ state: result.state, updatedAt: result.updatedAt });
+  });
+
+  addRoute(routes, "DELETE", "/workspace/:id/session-groups/:groupId", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const groupId = (ctx.params.groupId ?? "").trim();
+    if (!groupId) throw new ApiError(400, "invalid_payload", "groupId is required");
+    const result = await updateWorkspaceSessionGroups(workspace.id, (current) => {
+      const assignments: Record<string, string> = {};
+      for (const [sessionId, assignedGroupId] of Object.entries(current.assignments)) {
+        if (assignedGroupId !== groupId) assignments[sessionId] = assignedGroupId;
+      }
+      return {
+        groups: current.groups.filter((group) => group.id !== groupId),
+        assignments,
+      };
+    });
+    sessionGroupEvents.record(workspace.id, "deleted", { groupId });
+    return jsonResponse({ state: result.state, updatedAt: result.updatedAt });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/session-groups/events", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const sinceRaw = ctx.url.searchParams.get("since");
+    const since = sinceRaw ? Number(sinceRaw) : undefined;
+    const items = sessionGroupEvents.list(workspace.id, since);
+    return jsonResponse({ items, cursor: sessionGroupEvents.cursor(), workspaceId: workspace.id });
   });
 
   addRoute(routes, "GET", "/workspace/:id/sessions/:sessionId", "client", async (ctx) => {

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -6,7 +6,7 @@ import {
   normalizeSessionGroupState,
   readSessionGroupState,
   SessionGroupEventStore,
-  writeSessionGroupState,
+  updateSessionGroupState,
   type SessionGroupDefinition,
   type SessionGroupState,
 } from "../session-groups.js";
@@ -158,8 +158,7 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
     workspaceId: string,
     updater: (current: SessionGroupState) => SessionGroupState,
   ) {
-    const current = await readSessionGroupState(config, workspaceId);
-    return writeSessionGroupState(config, workspaceId, updater(current.state));
+    return updateSessionGroupState(config, workspaceId, updater);
   }
 
   function requireStringField(body: Record<string, unknown>, field: string): string {
@@ -193,7 +192,7 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const state = normalizeSessionGroupState(body.state);
-    const result = await writeSessionGroupState(config, workspace.id, state);
+    const result = await updateWorkspaceSessionGroups(workspace.id, () => state);
     sessionGroupEvents.record(workspace.id, "imported");
     return jsonResponse({ state: result.state, updatedAt: result.updatedAt });
   });
@@ -304,7 +303,7 @@ export function registerSessionRoutes(options: RegisterSessionRoutesOptions): vo
     const sinceRaw = ctx.url.searchParams.get("since");
     const since = sinceRaw ? Number(sinceRaw) : undefined;
     const items = sessionGroupEvents.list(workspace.id, since);
-    return jsonResponse({ items, cursor: sessionGroupEvents.cursor(), workspaceId: workspace.id });
+    return jsonResponse({ items, cursor: sessionGroupEvents.cursor(workspace.id), workspaceId: workspace.id });
   });
 
   addRoute(routes, "GET", "/workspace/:id/sessions/:sessionId", "client", async (ctx) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1727,6 +1727,7 @@ function createRoutes(
     parseOptionalBoolean,
     parseOptionalPositiveInteger,
     parseOptionalNonNegativeInteger,
+    readJsonBody,
     ensureWritable,
     requireClientScope,
     resolveWorkspace,

--- a/apps/server/src/session-groups.e2e.test.ts
+++ b/apps/server/src/session-groups.e2e.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { startServer } from "./server.js";
+import { SessionGroupEventStore } from "./session-groups.js";
 import type { ServerConfig } from "./types.js";
 
 const stops: Array<() => void | Promise<void>> = [];
@@ -106,5 +107,45 @@ describe("session group API", () => {
 
     const persisted = await json(await fetch(`${base}/workspace/ws_1/session-groups`, { headers: auth(token) }));
     expect(persisted).toMatchObject(assigned);
+  });
+
+  test("serializes concurrent read-modify-write group updates", async () => {
+    const root = await createWorkspaceRoot();
+    const { base, token } = await startOpenworkServer(root);
+
+    const responses = await Promise.all([
+      fetch(`${base}/workspace/ws_1/session-groups`, {
+        method: "POST",
+        headers: auth(token),
+        body: JSON.stringify({ id: "grp_first", label: "First" }),
+      }),
+      fetch(`${base}/workspace/ws_1/session-groups`, {
+        method: "POST",
+        headers: auth(token),
+        body: JSON.stringify({ id: "grp_second", label: "Second" }),
+      }),
+    ]);
+    for (const response of responses) {
+      expect(response.status).toBe(200);
+    }
+
+    const persisted = await json(await fetch(`${base}/workspace/ws_1/session-groups`, { headers: auth(token) }));
+    expect(persisted.state.groups.map((group: { id: string }) => group.id).sort()).toEqual([
+      "grp_first",
+      "grp_second",
+    ]);
+  });
+
+  test("keeps session group events buffered per workspace", () => {
+    const store = new SessionGroupEventStore(2);
+    const first = store.record("quiet", "created", { groupId: "grp_quiet" });
+    store.record("busy", "created", { groupId: "grp_1" });
+    store.record("busy", "created", { groupId: "grp_2" });
+    store.record("busy", "created", { groupId: "grp_3" });
+
+    expect(store.list("quiet", first.seq - 1).map((event) => event.groupId)).toEqual(["grp_quiet"]);
+    expect(store.list("busy").map((event) => event.groupId)).toEqual(["grp_2", "grp_3"]);
+    expect(store.cursor("quiet")).toBe(1);
+    expect(store.cursor("busy")).toBe(3);
   });
 });

--- a/apps/server/src/session-groups.e2e.test.ts
+++ b/apps/server/src/session-groups.e2e.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+  if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+  else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+});
+
+async function createWorkspaceRoot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-session-groups-"));
+  roots.push(root);
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  return root;
+}
+
+async function startOpenworkServer(workspaceRoot: string) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config);
+  stops.push(() => server.stop());
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+}
+
+function auth(token: string) {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+async function json(response: Response) {
+  expect(response.status).toBe(200);
+  return response.json();
+}
+
+describe("session group API", () => {
+  test("persists groups, assignments, and update events in the runtime db", async () => {
+    const root = await createWorkspaceRoot();
+    const { base, token } = await startOpenworkServer(root);
+
+    const empty = await json(await fetch(`${base}/workspace/ws_1/session-groups`, { headers: auth(token) }));
+    expect(empty).toMatchObject({ state: { groups: [], assignments: {} } });
+
+    const imported = await json(await fetch(`${base}/workspace/ws_1/session-groups`, {
+      method: "PUT",
+      headers: auth(token),
+      body: JSON.stringify({
+        state: {
+          groups: [{ id: "grp_imported", label: "Imported" }],
+          assignments: { ses_1: "grp_imported" },
+        },
+      }),
+    }));
+    expect(imported).toMatchObject({
+      state: {
+        groups: [{ id: "grp_imported", label: "Imported" }],
+        assignments: { ses_1: "grp_imported" },
+      },
+    });
+
+    const created = await json(await fetch(`${base}/workspace/ws_1/session-groups`, {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({ id: "grp_next", label: "Next" }),
+    }));
+    expect(created).toMatchObject({
+      state: {
+        groups: [
+          { id: "grp_imported", label: "Imported" },
+          { id: "grp_next", label: "Next" },
+        ],
+      },
+    });
+
+    const assigned = await json(await fetch(`${base}/workspace/ws_1/session-groups/assignments/ses_2`, {
+      method: "PATCH",
+      headers: auth(token),
+      body: JSON.stringify({ groupId: "grp_next" }),
+    }));
+    expect(assigned).toMatchObject({ state: { assignments: { ses_1: "grp_imported", ses_2: "grp_next" } } });
+
+    const events = await json(await fetch(`${base}/workspace/ws_1/session-groups/events`, { headers: auth(token) }));
+    expect(events.items.map((event: { action: string }) => event.action)).toEqual(["imported", "created", "assigned"]);
+
+    const persisted = await json(await fetch(`${base}/workspace/ws_1/session-groups`, { headers: auth(token) }));
+    expect(persisted).toMatchObject(assigned);
+  });
+});

--- a/apps/server/src/session-groups.ts
+++ b/apps/server/src/session-groups.ts
@@ -42,6 +42,11 @@ type SessionGroupDb = {
   upsert: (value: { workspaceId: string; stateJson: string; updatedAt: number }) => void;
 };
 
+type SessionGroupEventState = {
+  seq: number;
+  events: SessionGroupEvent[];
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -144,6 +149,7 @@ async function openSessionGroupDb(path: string): Promise<SessionGroupDb> {
 }
 
 const dbByPath = new Map<string, Promise<SessionGroupDb>>();
+const updateQueueByWorkspace = new Map<string, Promise<void>>();
 
 async function sessionGroupDb(config: ServerConfig): Promise<SessionGroupDb> {
   const path = runtimeDbPath(config);
@@ -180,9 +186,34 @@ export async function writeSessionGroupState(
   return { state: next, updatedAt };
 }
 
+export async function updateSessionGroupState(
+  config: ServerConfig,
+  workspaceId: string,
+  updater: (current: SessionGroupState) => SessionGroupState,
+): Promise<{ state: SessionGroupState; updatedAt: number }> {
+  const key = `${runtimeDbPath(config)}:${workspaceId}`;
+  const previous = updateQueueByWorkspace.get(key) ?? Promise.resolve();
+  let release = () => {};
+  const queued = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const currentQueue = previous.then(() => queued, () => queued);
+  updateQueueByWorkspace.set(key, currentQueue);
+
+  await previous.catch(() => undefined);
+  try {
+    const current = await readSessionGroupState(config, workspaceId);
+    return await writeSessionGroupState(config, workspaceId, updater(current.state));
+  } finally {
+    release();
+    if (updateQueueByWorkspace.get(key) === currentQueue) {
+      updateQueueByWorkspace.delete(key);
+    }
+  }
+}
+
 export class SessionGroupEventStore {
-  private events: SessionGroupEvent[] = [];
-  private seq = 0;
+  private eventsByWorkspace = new Map<string, SessionGroupEventState>();
   private maxSize: number;
 
   constructor(maxSize = 500) {
@@ -194,9 +225,10 @@ export class SessionGroupEventStore {
     action: SessionGroupEventAction,
     details?: { groupId?: string; sessionId?: string },
   ): SessionGroupEvent {
+    const state = this.eventsByWorkspace.get(workspaceId) ?? { seq: 0, events: [] };
     const event: SessionGroupEvent = {
       id: shortId(),
-      seq: ++this.seq,
+      seq: ++state.seq,
       workspaceId,
       type: "session_groups.updated",
       action,
@@ -205,19 +237,21 @@ export class SessionGroupEventStore {
       timestamp: Date.now(),
     };
 
-    this.events.push(event);
-    if (this.events.length > this.maxSize) {
-      this.events.splice(0, this.events.length - this.maxSize);
+    state.events.push(event);
+    if (state.events.length > this.maxSize) {
+      state.events.splice(0, state.events.length - this.maxSize);
     }
+    this.eventsByWorkspace.set(workspaceId, state);
     return event;
   }
 
   list(workspaceId: string, since?: number): SessionGroupEvent[] {
     const cursor = typeof since === "number" && Number.isFinite(since) ? since : 0;
-    return this.events.filter((event) => event.workspaceId === workspaceId && event.seq > cursor);
+    const state = this.eventsByWorkspace.get(workspaceId);
+    return state ? state.events.filter((event) => event.seq > cursor) : [];
   }
 
-  cursor(): number {
-    return this.seq;
+  cursor(workspaceId: string): number {
+    return this.eventsByWorkspace.get(workspaceId)?.seq ?? 0;
   }
 }

--- a/apps/server/src/session-groups.ts
+++ b/apps/server/src/session-groups.ts
@@ -1,0 +1,223 @@
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { eq } from "drizzle-orm";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import type { ServerConfig } from "./types.js";
+import { ensureDir, shortId } from "./utils.js";
+
+export type SessionGroupDefinition = {
+  id: string;
+  label: string;
+};
+
+export type SessionGroupState = {
+  groups: SessionGroupDefinition[];
+  assignments: Record<string, string>;
+};
+
+export type SessionGroupEventAction = "created" | "updated" | "deleted" | "assigned" | "reordered" | "imported";
+
+export type SessionGroupEvent = {
+  id: string;
+  seq: number;
+  workspaceId: string;
+  type: "session_groups.updated";
+  action: SessionGroupEventAction;
+  groupId?: string;
+  sessionId?: string;
+  timestamp: number;
+};
+
+const EMPTY_SESSION_GROUP_STATE: SessionGroupState = { groups: [], assignments: {} };
+
+const sessionGroupStates = sqliteTable("session_group_states", {
+  workspaceId: text("workspace_id").primaryKey(),
+  stateJson: text("state_json").notNull(),
+  schemaVersion: integer("schema_version").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});
+
+type SessionGroupDb = {
+  get: (workspaceId: string) => { stateJson: string; updatedAt: number } | undefined;
+  upsert: (value: { workspaceId: string; stateJson: string; updatedAt: number }) => void;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeGroupId(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return trimmed.slice(0, 128);
+}
+
+function normalizeLabel(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, 120);
+}
+
+export function createSessionGroupId(): string {
+  return `grp_${Date.now().toString(36)}_${shortId()}`;
+}
+
+export function normalizeSessionGroupState(value: unknown): SessionGroupState {
+  if (!isRecord(value)) return EMPTY_SESSION_GROUP_STATE;
+
+  const groups: SessionGroupDefinition[] = [];
+  const seenGroupIds = new Set<string>();
+  if (Array.isArray(value.groups)) {
+    for (const item of value.groups) {
+      if (!isRecord(item)) continue;
+      const id = normalizeGroupId(item.id);
+      const label = normalizeLabel(item.label);
+      if (!id || !label || seenGroupIds.has(id)) continue;
+      groups.push({ id, label });
+      seenGroupIds.add(id);
+    }
+  }
+
+  const assignments: Record<string, string> = {};
+  if (isRecord(value.assignments)) {
+    for (const [sessionId, rawGroupId] of Object.entries(value.assignments)) {
+      const normalizedSessionId = sessionId.trim().slice(0, 256);
+      const groupId = normalizeGroupId(rawGroupId);
+      if (!normalizedSessionId || !groupId || !seenGroupIds.has(groupId)) continue;
+      assignments[normalizedSessionId] = groupId;
+    }
+  }
+
+  return { groups, assignments };
+}
+
+function runtimeDbPath(config: ServerConfig): string {
+  const override = process.env.OPENWORK_RUNTIME_DB?.trim();
+  if (override) return resolve(override);
+  const configPath = config.configPath?.trim();
+  const configDir = configPath ? dirname(configPath) : join(homedir(), ".config", "openwork");
+  return join(configDir, "runtime.sqlite");
+}
+
+async function openSessionGroupDb(path: string): Promise<SessionGroupDb> {
+  await ensureDir(dirname(path));
+  if (typeof process.versions.bun === "string") {
+    const { Database } = await import("bun:sqlite");
+    const { drizzle } = await import("drizzle-orm/bun-sqlite");
+    const sqlite = new Database(path, { create: true });
+    sqlite.run("CREATE TABLE IF NOT EXISTS session_group_states (workspace_id TEXT PRIMARY KEY NOT NULL, state_json TEXT NOT NULL, schema_version INTEGER NOT NULL DEFAULT 1, updated_at INTEGER NOT NULL)");
+    const db = drizzle(sqlite);
+    return {
+      get: (workspaceId) => db
+        .select()
+        .from(sessionGroupStates)
+        .where(eq(sessionGroupStates.workspaceId, workspaceId))
+        .get(),
+      upsert: ({ workspaceId, stateJson, updatedAt }) => {
+        db
+          .insert(sessionGroupStates)
+          .values({ workspaceId, stateJson, schemaVersion: 1, updatedAt })
+          .onConflictDoUpdate({
+            target: sessionGroupStates.workspaceId,
+            set: { stateJson, schemaVersion: 1, updatedAt },
+          })
+          .run();
+      },
+    };
+  }
+
+  const { DatabaseSync } = await import("node:sqlite");
+  const sqlite = new DatabaseSync(path);
+  sqlite.exec("CREATE TABLE IF NOT EXISTS session_group_states (workspace_id TEXT PRIMARY KEY NOT NULL, state_json TEXT NOT NULL, schema_version INTEGER NOT NULL DEFAULT 1, updated_at INTEGER NOT NULL)");
+  const get = sqlite.prepare("SELECT state_json AS stateJson, updated_at AS updatedAt FROM session_group_states WHERE workspace_id = ?");
+  const upsert = sqlite.prepare("INSERT INTO session_group_states (workspace_id, state_json, schema_version, updated_at) VALUES (?, ?, 1, ?) ON CONFLICT(workspace_id) DO UPDATE SET state_json = excluded.state_json, schema_version = excluded.schema_version, updated_at = excluded.updated_at");
+  return {
+    get: (workspaceId) => {
+      const row = get.get(workspaceId);
+      if (!isRecord(row) || typeof row.stateJson !== "string" || typeof row.updatedAt !== "number") return undefined;
+      return { stateJson: row.stateJson, updatedAt: row.updatedAt };
+    },
+    upsert: ({ workspaceId, stateJson, updatedAt }) => {
+      upsert.run(workspaceId, stateJson, updatedAt);
+    },
+  };
+}
+
+const dbByPath = new Map<string, Promise<SessionGroupDb>>();
+
+async function sessionGroupDb(config: ServerConfig): Promise<SessionGroupDb> {
+  const path = runtimeDbPath(config);
+  const existing = dbByPath.get(path);
+  if (existing) return existing;
+  const db = openSessionGroupDb(path);
+  dbByPath.set(path, db);
+  return db;
+}
+
+export async function readSessionGroupState(
+  config: ServerConfig,
+  workspaceId: string,
+): Promise<{ state: SessionGroupState; updatedAt: number | null }> {
+  const db = await sessionGroupDb(config);
+  const row = db.get(workspaceId);
+  if (!row) return { state: EMPTY_SESSION_GROUP_STATE, updatedAt: null };
+  try {
+    return { state: normalizeSessionGroupState(JSON.parse(row.stateJson)), updatedAt: row.updatedAt };
+  } catch {
+    return { state: EMPTY_SESSION_GROUP_STATE, updatedAt: row.updatedAt };
+  }
+}
+
+export async function writeSessionGroupState(
+  config: ServerConfig,
+  workspaceId: string,
+  state: SessionGroupState,
+): Promise<{ state: SessionGroupState; updatedAt: number }> {
+  const db = await sessionGroupDb(config);
+  const next = normalizeSessionGroupState(state);
+  const updatedAt = Date.now();
+  db.upsert({ workspaceId, stateJson: JSON.stringify(next), updatedAt });
+  return { state: next, updatedAt };
+}
+
+export class SessionGroupEventStore {
+  private events: SessionGroupEvent[] = [];
+  private seq = 0;
+  private maxSize: number;
+
+  constructor(maxSize = 500) {
+    this.maxSize = maxSize;
+  }
+
+  record(
+    workspaceId: string,
+    action: SessionGroupEventAction,
+    details?: { groupId?: string; sessionId?: string },
+  ): SessionGroupEvent {
+    const event: SessionGroupEvent = {
+      id: shortId(),
+      seq: ++this.seq,
+      workspaceId,
+      type: "session_groups.updated",
+      action,
+      ...(details?.groupId ? { groupId: details.groupId } : {}),
+      ...(details?.sessionId ? { sessionId: details.sessionId } : {}),
+      timestamp: Date.now(),
+    };
+
+    this.events.push(event);
+    if (this.events.length > this.maxSize) {
+      this.events.splice(0, this.events.length - this.maxSize);
+    }
+    return event;
+  }
+
+  list(workspaceId: string, since?: number): SessionGroupEvent[] {
+    const cursor = typeof since === "number" && Number.isFinite(since) ? since : 0;
+    return this.events.filter((event) => event.workspaceId === workspaceId && event.seq > cursor);
+  }
+
+  cursor(): number {
+    return this.seq;
+  }
+}


### PR DESCRIPTION
## Summary
- Store session groups and assignments server-side in the runtime SQLite DB
- Add session group APIs plus update events so clients can sync group state
- Add client-side migration from existing local group state and show "Create a Group" next to "Show x more" when no groups exist

## Tests
- pnpm --filter openwork-server test src/session-groups.e2e.test.ts
- pnpm --filter openwork-server typecheck
- pnpm --filter @openwork/app typecheck
- Manual desktop smoke: ran pnpm dev from the worktree with Electron CDP on http://127.0.0.1:9830; verified migration PUT, session-groups/events polling, "Show 2 more ⋅ Create a Group", creating a Test Group, and server persistence/events in the UI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

