### PR TITLE
fix(app): retry session group migration for aliases

### DIFF
--- a/apps/app/src/react-app/shell/use-session-group-sync.ts
+++ b/apps/app/src/react-app/shell/use-session-group-sync.ts
@@ -13,7 +13,7 @@ import {
 } from "@/react-app/domains/session/sidebar/session-management-store";
 import type { RouteWorkspace } from "./route-workspaces";
 
-const MIGRATION_PREFIX = "openwork.sessionGroups.migrated.v1";
+const MIGRATION_PREFIX = "openwork.sessionGroups.migrated.v2";
 
 type UseSessionGroupSyncInput = {
   workspaces: RouteWorkspace[];
@@ -29,6 +29,19 @@ function serverStateFromWorkspaceState(state: WorkspaceGroupState): OpenworkSess
     groups: state.groups.map((group) => ({ id: group.id, label: group.label })),
     assignments: { ...state.assignments },
   };
+}
+
+function localGroupStateForWorkspace(
+  workspace: RouteWorkspace,
+  endpoint: ResolvedWorkspaceEndpoint,
+): WorkspaceGroupState | undefined {
+  const byWorkspace = useSessionManagementStore.getState().groupsByWorkspace;
+  const ids = [workspace.id, endpoint.workspaceId, `rem_${endpoint.workspaceId}`];
+  for (const id of ids) {
+    const state = byWorkspace[id];
+    if (hasGroupData(state)) return state;
+  }
+  return undefined;
 }
 
 function migrationKey(endpoint: ResolvedWorkspaceEndpoint): string {
@@ -116,12 +129,12 @@ export function useSessionGroupSync(input: UseSessionGroupSyncInput): void {
       if (cancelled) return;
 
       let nextState = response.state;
-      const localState = useSessionManagementStore.getState().groupsByWorkspace[workspace.id];
+      const localState = localGroupStateForWorkspace(workspace, endpoint);
       if (
         migrateLocal &&
         !readMigrationComplete(endpoint) &&
         !hasGroupData(response.state) &&
-        hasGroupData(localState)
+        localState !== undefined
       ) {
         const migrated = await endpoint.client.putSessionGroups(
           endpoint.workspaceId,


### PR DESCRIPTION
## Summary
- Retry session-group migration with a v2 marker so hosts that already marked the old migration complete can migrate again
- Look for existing local group data under the current workspace id, the server workspace id, and the rem_ alias before deciding there is nothing to migrate
- This should cover host/client workspace id mismatches where the host UI had legacy local groups but the server DB stayed empty, so remote clients saw no groups

## Tests
- pnpm --filter @openwork/app typecheck
- pnpm --filter openwork-server test src/session-groups.e2e.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

