### PR TITLE
[codex] Bound organization role permissions

### DIFF
--- a/ee/apps/den-api/src/organization-access.ts
+++ b/ee/apps/den-api/src/organization-access.ts
@@ -3,6 +3,23 @@ import { defaultRoles, defaultStatements } from "better-auth/plugins/organizatio
 
 export const denOrganizationAccess = createAccessControl(defaultStatements)
 
+export type OrganizationPermissionRecord = Record<string, string[]>
+
+export type OrganizationRolePermission = {
+  role: string
+  permission: OrganizationPermissionRecord
+}
+
+type PermissionValidationResult = {
+  ok: true
+} | {
+  ok: false
+  error: "invalid_permission"
+  message: string
+}
+
+const denOrganizationPermissionCatalogEntries = Object.entries(defaultStatements)
+
 export const denOrganizationStaticRoles = {
   owner: defaultRoles.owner,
   admin: defaultRoles.admin,
@@ -13,3 +30,118 @@ export const denDefaultDynamicOrganizationRoles = {
   admin: defaultRoles.admin.statements,
   member: defaultRoles.member.statements,
 } as const
+
+function getAllowedPermissionActions(resource: string): readonly string[] | null {
+  const entry = denOrganizationPermissionCatalogEntries.find(([knownResource]) => knownResource === resource)
+  return entry?.[1] ?? null
+}
+
+function splitRoleValue(value: string) {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+function addPermissions(target: OrganizationPermissionRecord, source: OrganizationPermissionRecord) {
+  for (const [resource, actions] of Object.entries(source)) {
+    const merged = new Set(target[resource] ?? [])
+    for (const action of actions) {
+      merged.add(action)
+    }
+    target[resource] = [...merged]
+  }
+}
+
+function hasPermission(permission: OrganizationPermissionRecord, resource: string, action: string) {
+  return permission[resource]?.includes(action) ?? false
+}
+
+export function cloneOrganizationPermissionCatalog() {
+  const permission: OrganizationPermissionRecord = {}
+  for (const [resource, actions] of denOrganizationPermissionCatalogEntries) {
+    permission[resource] = [...actions]
+  }
+  return permission
+}
+
+export function filterOrganizationPermissionRecord(permission: OrganizationPermissionRecord) {
+  const filtered: OrganizationPermissionRecord = {}
+  for (const [resource, actions] of Object.entries(permission)) {
+    const allowedActions = getAllowedPermissionActions(resource)
+    if (!allowedActions) {
+      continue
+    }
+
+    const validActions = actions.filter((action) => allowedActions.includes(action))
+    if (validActions.length > 0) {
+      filtered[resource] = validActions
+    }
+  }
+  return filtered
+}
+
+export function validateOrganizationPermissionRecord(permission: OrganizationPermissionRecord): PermissionValidationResult {
+  for (const [resource, actions] of Object.entries(permission)) {
+    const allowedActions = getAllowedPermissionActions(resource)
+    if (!allowedActions) {
+      return {
+        ok: false,
+        error: "invalid_permission",
+        message: `Unsupported permission resource "${resource}".`,
+      }
+    }
+
+    for (const action of actions) {
+      if (!allowedActions.includes(action)) {
+        return {
+          ok: false,
+          error: "invalid_permission",
+          message: `Unsupported permission action "${resource}.${action}".`,
+        }
+      }
+    }
+  }
+
+  return { ok: true }
+}
+
+export function resolveOrganizationPermissionRecord(roleValue: string, roles: readonly OrganizationRolePermission[]) {
+  const roleNames = splitRoleValue(roleValue)
+  const permission: OrganizationPermissionRecord = {}
+
+  for (const role of roles) {
+    if (!roleNames.includes(role.role)) {
+      continue
+    }
+    addPermissions(permission, role.permission)
+  }
+
+  return filterOrganizationPermissionRecord(permission)
+}
+
+export function validateAssignableOrganizationPermissionRecord(input: {
+  permission: OrganizationPermissionRecord
+  roleValue: string
+  roles: readonly OrganizationRolePermission[]
+}): PermissionValidationResult {
+  const validPermission = validateOrganizationPermissionRecord(input.permission)
+  if (!validPermission.ok) {
+    return validPermission
+  }
+
+  const assignablePermission = resolveOrganizationPermissionRecord(input.roleValue, input.roles)
+  for (const [resource, actions] of Object.entries(input.permission)) {
+    for (const action of actions) {
+      if (!hasPermission(assignablePermission, resource, action)) {
+        return {
+          ok: false,
+          error: "invalid_permission",
+          message: `Cannot assign permission "${resource}.${action}".`,
+        }
+      }
+    }
+  }
+
+  return { ok: true }
+}

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -13,7 +13,12 @@ import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "./db.js"
 import { runPostOrganizationMemberChangeHooks } from "./organization-member-hooks.js"
 import { DEFAULT_ORGANIZATION_LIMITS, normalizeOrganizationMetadata, serializeOrganizationMetadata } from "./organization-limits.js"
-import { denDefaultDynamicOrganizationRoles, denOrganizationStaticRoles } from "./organization-access.js"
+import {
+  denDefaultDynamicOrganizationRoles,
+  denOrganizationStaticRoles,
+  filterOrganizationPermissionRecord,
+  type OrganizationPermissionRecord,
+} from "./organization-access.js"
 import { ensureDefaultDesktopPolicyForOrganization } from "./desktop-policies.js"
 
 type UserId = typeof AuthUserTable.$inferSelect.id
@@ -103,7 +108,7 @@ export type OrganizationContext = {
   roles: Array<{
     id: string
     role: string
-    permission: Record<string, string[]>
+    permission: OrganizationPermissionRecord
     builtIn: boolean
     protected: boolean
     createdAt: Date | null
@@ -253,21 +258,26 @@ export function parsePermissionRecord(value: string | null) {
   }
 
   try {
-    const parsed = JSON.parse(value) as Record<string, unknown>
-    return Object.fromEntries(
-      Object.entries(parsed)
-        .filter((entry): entry is [string, unknown[]] => Array.isArray(entry[1]))
-        .map(([resource, actions]) => [
-          resource,
-          actions.filter((entry: unknown): entry is string => typeof entry === "string"),
-        ]),
-    )
+    const parsed: unknown = JSON.parse(value)
+    const permission: OrganizationPermissionRecord = {}
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return permission
+    }
+
+    for (const [resource, actions] of Object.entries(parsed)) {
+      if (!Array.isArray(actions)) {
+        continue
+      }
+      permission[resource] = actions.filter((entry): entry is string => typeof entry === "string")
+    }
+
+    return filterOrganizationPermissionRecord(permission)
   } catch {
     return {}
   }
 }
 
-export function serializePermissionRecord(value: Record<string, string[]>) {
+export function serializePermissionRecord(value: OrganizationPermissionRecord) {
   return JSON.stringify(value)
 }
 
@@ -289,9 +299,11 @@ export class OrganizationEmailDomainRestrictionError extends Error {
 }
 
 function clonePermissionRecord(value: Record<string, readonly string[]>) {
-  return Object.fromEntries(
-    Object.entries(value).map(([resource, actions]) => [resource, [...actions]]),
-  ) as Record<string, string[]>
+  const permission: OrganizationPermissionRecord = {}
+  for (const [resource, actions] of Object.entries(value)) {
+    permission[resource] = [...actions]
+  }
+  return permission
 }
 
 async function listMembershipRows(userId: UserId) {

--- a/ee/apps/den-api/src/routes/org/roles.ts
+++ b/ee/apps/den-api/src/routes/org/roles.ts
@@ -7,6 +7,7 @@ import { z } from "zod"
 import { db } from "../../db.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
+import { validateAssignableOrganizationPermissionRecord } from "../../organization-access.js"
 import { serializePermissionRecord } from "../../orgs.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { createRoleId, ensureOwner, idParamSchema, normalizeRoleName, replaceRoleValue, splitRoles } from "./shared.js"
@@ -52,6 +53,15 @@ export function registerOrgRoleRoutes<T extends { Variables: OrgRouteVariables }
 
     const payload = c.get("organizationContext")
     const input = c.req.valid("json")
+
+    const validPermission = validateAssignableOrganizationPermissionRecord({
+      permission: input.permission,
+      roleValue: payload.currentMember.role,
+      roles: payload.roles,
+    })
+    if (!validPermission.ok) {
+      return c.json({ error: validPermission.error, message: validPermission.message }, 400)
+    }
 
     const roleName = normalizeRoleName(input.roleName)
     if (roleName === "owner") {
@@ -141,7 +151,18 @@ export function registerOrgRoleRoutes<T extends { Variables: OrgRouteVariables }
       }
     }
 
-    const nextPermission = input.permission ? serializePermissionRecord(input.permission) : roleRow.permission
+    let nextPermission = roleRow.permission
+    if (input.permission !== undefined) {
+      const validPermission = validateAssignableOrganizationPermissionRecord({
+        permission: input.permission,
+        roleValue: payload.currentMember.role,
+        roles: payload.roles,
+      })
+      if (!validPermission.ok) {
+        return c.json({ error: validPermission.error, message: validPermission.message }, 400)
+      }
+      nextPermission = serializePermissionRecord(input.permission)
+    }
 
     await db
       .update(OrganizationRoleTable)

--- a/ee/apps/den-api/test/org-role-permissions.test.ts
+++ b/ee/apps/den-api/test/org-role-permissions.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test"
+import {
+  cloneOrganizationPermissionCatalog,
+  filterOrganizationPermissionRecord,
+  validateAssignableOrganizationPermissionRecord,
+  validateOrganizationPermissionRecord,
+  type OrganizationPermissionRecord,
+  type OrganizationRolePermission,
+} from "../src/organization-access.js"
+
+function role(roleName: string, permission: OrganizationPermissionRecord): OrganizationRolePermission {
+  return {
+    role: roleName,
+    permission,
+  }
+}
+
+test("organization role permissions reject unknown resources", () => {
+  expect(validateOrganizationPermissionRecord({
+    billing: ["delete"],
+  })).toEqual({
+    ok: false,
+    error: "invalid_permission",
+    message: 'Unsupported permission resource "billing".',
+  })
+})
+
+test("organization role permissions reject unknown actions", () => {
+  expect(validateOrganizationPermissionRecord({
+    organization: ["create"],
+  })).toEqual({
+    ok: false,
+    error: "invalid_permission",
+    message: 'Unsupported permission action "organization.create".',
+  })
+})
+
+test("organization role permissions allow catalog permissions", () => {
+  expect(validateOrganizationPermissionRecord({
+    ac: ["read"],
+    invitation: ["create", "cancel"],
+  })).toEqual({ ok: true })
+})
+
+test("organization role permissions cannot exceed the assigner permission set", () => {
+  const limitedPermission = { ac: ["read"] }
+  const roles = [
+    role("limited", limitedPermission),
+  ]
+
+  expect(validateAssignableOrganizationPermissionRecord({
+    permission: { ac: ["delete"] },
+    roleValue: "limited",
+    roles,
+  })).toEqual({
+    ok: false,
+    error: "invalid_permission",
+    message: 'Cannot assign permission "ac.delete".',
+  })
+})
+
+test("organization owners can assign permissions from the fixed catalog", () => {
+  const ownerPermission = cloneOrganizationPermissionCatalog()
+  const roles = [
+    role("owner", ownerPermission),
+  ]
+
+  expect(validateAssignableOrganizationPermissionRecord({
+    permission: ownerPermission,
+    roleValue: "owner",
+    roles,
+  })).toEqual({ ok: true })
+})
+
+test("legacy stored permissions are filtered to the catalog when read", () => {
+  expect(filterOrganizationPermissionRecord({
+    ac: ["read", "delete", "unknown"],
+    billing: ["delete"],
+  })).toEqual({
+    ac: ["read", "delete"],
+  })
+})


### PR DESCRIPTION
## Summary
- Validate custom organization role permissions against the fixed Better Auth organization permission catalog.
- Enforce that role updates cannot assign permissions outside the caller's resolved role permission set.
- Filter legacy stored role permission maps to known catalog entries when read back.

## Verification
- `pnpm install --frozen-lockfile` - passed
- `bun test ee/apps/den-api/test/org-role-permissions.test.ts` - 6 passed, 0 failed
- `pnpm --filter @openwork-ee/den-api build` - passed
- `bun test ee/apps/den-api/test` - 89 passed, 0 failed
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed before commit

## Live Smoke Evidence
Server-only role-permission validation change; video is not relevant. The focused and full den-api test runs above cover the request validation and permission-bounding behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

