### PR TITLE
[codex] Remove customer-specific docs examples

### DIFF
--- a/docs/mcp-ui-control-profile.md
+++ b/docs/mcp-ui-control-profile.md
@@ -38,7 +38,7 @@ That's it. HandsFree can now list your sessions, read transcripts, type into the
 
 OpenWork's cross-session memory currently comes from saved session history exposed through the UI control surface. It is not a separate long-term memory database.
 
-For requests like `What did I say in the Blue Yonder session?` or `Remind me what we decided in session ses_abc123`, an MCP client can:
+For requests like `What did I say in the customer migration session?` or `Remind me what we decided in session ses_abc123`, an MCP client can:
 
 1. Run `session.list_sessions` to find a matching session by ID, title, workspace, or topic words.
 2. Run `session.open` with the selected `sessionId`.

--- a/packages/docs/start-here/do-work-with-it/cross-chat-memory.mdx
+++ b/packages/docs/start-here/do-work-with-it/cross-chat-memory.mdx
@@ -14,7 +14,7 @@ When an agent is running inside the OpenWork app, it can use OpenWork's semantic
 
 That means you can ask things like:
 
-- `What did I say in the Blue Yonder session?`
+- `What did I say in the customer migration session?`
 - `Find the session about Ramki and remind me what we decided.`
 - `Open the onboarding bug chat and summarize the next steps.`
 - `What did I ask you to do in session ses_abc123?`
@@ -37,4 +37,4 @@ Because this uses the OpenWork UI, the agent may briefly navigate away from your
 
 ## How to ask
 
-Give the agent whatever clue you have: a session ID, title, person name, project name, workspace, or rough topic. For example: `Use the OpenWork app UI to find the Blue Yonder chat and tell me what I said about customer references.`
+Give the agent whatever clue you have: a session ID, title, person name, project name, workspace, or rough topic. For example: `Use the OpenWork app UI to find the customer migration chat and tell me what I said about customer references.`


### PR DESCRIPTION
## Summary
- Replace customer-specific examples in cross-session memory documentation with generic session wording.
- Keep the examples useful without naming a real customer or project.

## Verification
- Customer-name repository scan - no matches
- `git diff --check` - passed
- `git diff --cached --check` - passed before commit

## Live Smoke Evidence
Docs-only text change; video is not relevant. No runtime behavior changed.