### PR TITLE
[codex] Guard organization member lifecycle

### DIFF
--- a/ee/apps/den-api/src/organization-member-guards.ts
+++ b/ee/apps/den-api/src/organization-member-guards.ts
@@ -1,0 +1,94 @@
+export type MemberLifecycleGuardRow = {
+  id: string
+  role: string
+  userId: string | null
+}
+
+export type MemberLifecycleValidation = {
+  ok: true
+} | {
+  ok: false
+  error: "owner_role_locked" | "last_privileged_member"
+  message: string
+}
+
+function splitRoles(value: string) {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+export function roleIncludesOwner(roleValue: string) {
+  return splitRoles(roleValue).includes("owner")
+}
+
+export function roleIncludesPrivileged(roleValue: string) {
+  const roles = splitRoles(roleValue)
+  return roles.includes("owner") || roles.includes("admin")
+}
+
+function hasOtherActivePrivilegedMember(input: {
+  memberId: string
+  members: readonly MemberLifecycleGuardRow[]
+}) {
+  return input.members.some((member) => (
+    member.id !== input.memberId
+    && member.userId !== null
+    && roleIncludesPrivileged(member.role)
+  ))
+}
+
+export function validateOrganizationMemberRemoval(input: {
+  member: MemberLifecycleGuardRow
+  activeMembers: readonly MemberLifecycleGuardRow[]
+}): MemberLifecycleValidation {
+  if (roleIncludesOwner(input.member.role)) {
+    return {
+      ok: false,
+      error: "owner_role_locked",
+      message: "The organization owner cannot be removed.",
+    }
+  }
+
+  if (
+    roleIncludesPrivileged(input.member.role)
+    && !hasOtherActivePrivilegedMember({ memberId: input.member.id, members: input.activeMembers })
+  ) {
+    return {
+      ok: false,
+      error: "last_privileged_member",
+      message: "Add another workspace owner or admin before removing this member.",
+    }
+  }
+
+  return { ok: true }
+}
+
+export function validateOrganizationMemberRoleChange(input: {
+  member: MemberLifecycleGuardRow
+  activeMembers: readonly MemberLifecycleGuardRow[]
+  nextRole: string
+}): MemberLifecycleValidation {
+  if (roleIncludesOwner(input.member.role)) {
+    return {
+      ok: false,
+      error: "owner_role_locked",
+      message: "The organization owner role cannot be changed.",
+    }
+  }
+
+  if (
+    roleIncludesPrivileged(input.member.role)
+    && !roleIncludesPrivileged(input.nextRole)
+    && !hasOtherActivePrivilegedMember({ memberId: input.member.id, members: input.activeMembers })
+  ) {
+    return {
+      ok: false,
+      error: "last_privileged_member",
+      message: "Add another workspace owner or admin before changing this member's role.",
+    }
+  }
+
+  return { ok: true }
+}

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -11,6 +11,12 @@ import {
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "./db.js"
+import {
+  roleIncludesOwner as guardRoleIncludesOwner,
+  validateOrganizationMemberRemoval,
+  validateOrganizationMemberRoleChange,
+  type MemberLifecycleValidation,
+} from "./organization-member-guards.js"
 import { runPostOrganizationMemberChangeHooks } from "./organization-member-hooks.js"
 import { DEFAULT_ORGANIZATION_LIMITS, normalizeOrganizationMetadata, serializeOrganizationMetadata } from "./organization-limits.js"
 import {
@@ -28,6 +34,19 @@ type MemberRow = typeof MemberTable.$inferSelect
 type MemberId = MemberRow["id"]
 type InvitationRow = typeof InvitationTable.$inferSelect
 export type AllowedEmailDomains = string[] | null
+
+type MemberLifecycleValidationFailure = Extract<MemberLifecycleValidation, { ok: false }>
+
+type MemberMutationFailure = {
+  ok: false
+  error: "member_not_found" | MemberLifecycleValidationFailure["error"]
+  message: string
+}
+
+type MemberMutationResult = {
+  ok: true
+  member: MemberRow
+} | MemberMutationFailure
 
 export type InvitationStatus = "pending" | "accepted" | "canceled" | "expired"
 
@@ -138,12 +157,8 @@ function splitRoles(value: string) {
     .filter(Boolean)
 }
 
-function hasRole(roleValue: string, roleName: string) {
-  return splitRoles(roleValue).includes(roleName)
-}
-
 export function roleIncludesOwner(roleValue: string) {
-  return hasRole(roleValue, "owner")
+  return guardRoleIncludesOwner(roleValue)
 }
 
 function titleCase(value: string) {
@@ -1043,11 +1058,30 @@ export async function listTeamsForMember(input: {
     .orderBy(asc(TeamTable.createdAt))
 }
 
-export async function removeOrganizationMember(input: {
+async function listActiveOrganizationMemberGuardRows(organizationId: OrgId) {
+  return db
+    .select({
+      id: MemberTable.id,
+      role: MemberTable.role,
+      userId: MemberTable.userId,
+    })
+    .from(MemberTable)
+    .where(and(eq(MemberTable.organizationId, organizationId), isNull(MemberTable.removedAt)))
+}
+
+function memberNotFound(): MemberMutationFailure {
+  return {
+    ok: false,
+    error: "member_not_found",
+    message: "The organization member could not be found.",
+  }
+}
+
+export async function validateOrganizationMemberRoleUpdate(input: {
   organizationId: OrgId
   memberId: MemberRow["id"]
-  removedByOrgMemberId?: MemberRow["id"]
-}) {
+  nextRole: string
+}): Promise<MemberMutationResult> {
   const memberRows = await db
     .select()
     .from(MemberTable)
@@ -1056,7 +1090,42 @@ export async function removeOrganizationMember(input: {
 
   const member = memberRows[0] ?? null
   if (!member) {
-    return null
+    return memberNotFound()
+  }
+
+  const activeMembers = await listActiveOrganizationMemberGuardRows(input.organizationId)
+  const validation = validateOrganizationMemberRoleChange({
+    member,
+    activeMembers,
+    nextRole: input.nextRole,
+  })
+  if (!validation.ok) {
+    return validation
+  }
+
+  return { ok: true, member }
+}
+
+export async function removeOrganizationMember(input: {
+  organizationId: OrgId
+  memberId: MemberRow["id"]
+  removedByOrgMemberId?: MemberRow["id"]
+}): Promise<MemberMutationResult> {
+  const memberRows = await db
+    .select()
+    .from(MemberTable)
+    .where(and(eq(MemberTable.id, input.memberId), eq(MemberTable.organizationId, input.organizationId), isNull(MemberTable.removedAt)))
+    .limit(1)
+
+  const member = memberRows[0] ?? null
+  if (!member) {
+    return memberNotFound()
+  }
+
+  const activeMembers = await listActiveOrganizationMemberGuardRows(input.organizationId)
+  const validation = validateOrganizationMemberRemoval({ member, activeMembers })
+  if (!validation.ok) {
+    return validation
   }
 
   await db.transaction(async (tx) => {
@@ -1072,5 +1141,5 @@ export async function removeOrganizationMember(input: {
 
   await runPostOrganizationMemberChangeHooks({ organizationId: input.organizationId, memberId: member.id, change: "removed" })
 
-  return member
+  return { ok: true, member }
 }

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -304,12 +304,16 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
 
     await db.update(InvitationTable).set({ status: "canceled" }).where(eq(InvitationTable.id, invitationId))
 
-    if (invitedMemberRows[0]) {
-      await removeOrganizationMember({
+    const invitedMember = invitedMemberRows[0]
+    if (invitedMember) {
+      const removed = await removeOrganizationMember({
         organizationId: payload.organization.id,
-        memberId: invitedMemberRows[0].id,
+        memberId: invitedMember.id,
         removedByOrgMemberId: payload.currentMember.id,
       })
+      if (!removed.ok && removed.error !== "member_not_found") {
+        return c.json({ error: removed.error, message: removed.message }, 400)
+      }
     }
 
     return c.json({ success: true })

--- a/ee/apps/den-api/src/routes/org/members.ts
+++ b/ee/apps/den-api/src/routes/org/members.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
+import { eq } from "@openwork-ee/den-db/drizzle"
 import { MemberTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
@@ -7,7 +7,7 @@ import { z } from "zod"
 import { db } from "../../db.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
-import { listAssignableRoles, removeOrganizationMember, roleIncludesOwner } from "../../orgs.js"
+import { listAssignableRoles, removeOrganizationMember, validateOrganizationMemberRoleUpdate } from "../../orgs.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureMemberRemover, ensureOwner, idParamSchema, normalizeRoleName } from "./shared.js"
 
@@ -54,28 +54,25 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
       return c.json({ error: "member_not_found" }, 404)
     }
 
-    const memberRows = await db
-      .select()
-      .from(MemberTable)
-      .where(and(eq(MemberTable.id, memberId), eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.removedAt)))
-      .limit(1)
-
-    const member = memberRows[0]
-    if (!member) {
-      return c.json({ error: "member_not_found" }, 404)
-    }
-
-    if (roleIncludesOwner(member.role)) {
-      return c.json({ error: "owner_role_locked", message: "The organization owner role cannot be changed." }, 400)
-    }
-
     const role = normalizeRoleName(input.role)
     const availableRoles = await listAssignableRoles(payload.organization.id)
     if (!availableRoles.has(role)) {
       return c.json({ error: "invalid_role", message: "Choose one of the existing organization roles." }, 400)
     }
 
-    await db.update(MemberTable).set({ role }).where(eq(MemberTable.id, member.id))
+    const validation = await validateOrganizationMemberRoleUpdate({
+      organizationId: payload.organization.id,
+      memberId,
+      nextRole: role,
+    })
+    if (!validation.ok) {
+      if (validation.error === "member_not_found") {
+        return c.json({ error: validation.error, message: validation.message }, 404)
+      }
+      return c.json({ error: validation.error, message: validation.message }, 400)
+    }
+
+    await db.update(MemberTable).set({ role }).where(eq(MemberTable.id, validation.member.id))
     return c.json({ success: true })
     },
   )
@@ -112,26 +109,18 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
       return c.json({ error: "member_not_found" }, 404)
     }
 
-    const memberRows = await db
-      .select()
-      .from(MemberTable)
-      .where(and(eq(MemberTable.id, memberId), eq(MemberTable.organizationId, payload.organization.id), isNull(MemberTable.removedAt)))
-      .limit(1)
-
-    const member = memberRows[0]
-    if (!member) {
-      return c.json({ error: "member_not_found" }, 404)
-    }
-
-    if (roleIncludesOwner(member.role)) {
-      return c.json({ error: "owner_role_locked", message: "The organization owner cannot be removed." }, 400)
-    }
-
-    await removeOrganizationMember({
+    const removed = await removeOrganizationMember({
       organizationId: payload.organization.id,
-      memberId: member.id,
+      memberId,
       removedByOrgMemberId: payload.currentMember.id,
     })
+    if (!removed.ok) {
+      if (removed.error === "member_not_found") {
+        return c.json({ error: removed.error, message: removed.message }, 404)
+      }
+      return c.json({ error: removed.error, message: removed.message }, 400)
+    }
+
     return c.body(null, 204)
     },
   )

--- a/ee/apps/den-api/src/scim.ts
+++ b/ee/apps/den-api/src/scim.ts
@@ -331,10 +331,13 @@ export async function deleteScimProvisionedAccess(input: {
     return { ok: false as const, status: 404, body: { detail: "User not found" } }
   }
 
-  await removeOrganizationMember({
+  const removed = await removeOrganizationMember({
     organizationId: provider.organizationId,
     memberId: member.id,
   })
+  if (!removed.ok) {
+    return { ok: false as const, status: 409, body: { detail: removed.message } }
+  }
 
   await db.delete(AuthAccountTable).where(eq(AuthAccountTable.id, account.id))
   await deactivateExternalIdentityForScimUser({ bearerToken: input.bearerToken, userId: input.userId })

--- a/ee/apps/den-api/test/org-member-guards.test.ts
+++ b/ee/apps/den-api/test/org-member-guards.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import {
+  validateOrganizationMemberRemoval,
+  validateOrganizationMemberRoleChange,
+  type MemberLifecycleGuardRow,
+} from "../src/organization-member-guards.js"
+
+function member(id: string, role: string, userId: string | null): MemberLifecycleGuardRow {
+  return { id, role, userId }
+}
+
+test("member removal rejects organization owners", () => {
+  const owner = member("member_owner", "owner", "user_owner")
+
+  expect(validateOrganizationMemberRemoval({
+    member: owner,
+    activeMembers: [owner],
+  })).toEqual({
+    ok: false,
+    error: "owner_role_locked",
+    message: "The organization owner cannot be removed.",
+  })
+})
+
+test("member removal rejects the last active privileged member", () => {
+  const admin = member("member_admin", "admin", "user_admin")
+  const inactiveOwner = member("member_owner", "owner", null)
+
+  expect(validateOrganizationMemberRemoval({
+    member: admin,
+    activeMembers: [admin, inactiveOwner],
+  })).toEqual({
+    ok: false,
+    error: "last_privileged_member",
+    message: "Add another workspace owner or admin before removing this member.",
+  })
+})
+
+test("member removal allows admins when another active privileged member remains", () => {
+  const owner = member("member_owner", "owner", "user_owner")
+  const admin = member("member_admin", "admin", "user_admin")
+
+  expect(validateOrganizationMemberRemoval({
+    member: admin,
+    activeMembers: [owner, admin],
+  })).toEqual({ ok: true })
+})
+
+test("member role changes reject the last active privileged downgrade", () => {
+  const admin = member("member_admin", "admin", "user_admin")
+
+  expect(validateOrganizationMemberRoleChange({
+    member: admin,
+    activeMembers: [admin],
+    nextRole: "member",
+  })).toEqual({
+    ok: false,
+    error: "last_privileged_member",
+    message: "Add another workspace owner or admin before changing this member's role.",
+  })
+})
+
+test("member role changes allow privileged downgrades when another active privileged member remains", () => {
+  const owner = member("member_owner", "owner", "user_owner")
+  const admin = member("member_admin", "admin", "user_admin")
+
+  expect(validateOrganizationMemberRoleChange({
+    member: admin,
+    activeMembers: [owner, admin],
+    nextRole: "member",
+  })).toEqual({ ok: true })
+})


### PR DESCRIPTION
## Summary
- Add shared lifecycle guards for organization member owner protection and last active privileged member protection.
- Route member role changes, member removals, invitation cancellation cleanup, and SCIM deprovisioning through guarded removal behavior.
- Stop SCIM deprovisioning before account cleanup when the organization member cannot safely be removed.

## Verification
- `pnpm install --frozen-lockfile` - passed
- `pnpm --filter @openwork-ee/den-api build` - passed after fixing a TypeScript union issue
- `bun test ee/apps/den-api/test/org-member-guards.test.ts` - 5 passed, 0 failed
- `bun test ee/apps/den-api/test` - 94 passed, 0 failed
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check HEAD~1..HEAD` - passed

Note: an initial full den-api test run failed before package build because workspace package entrypoints were unavailable in the fresh worktree; the same command passed after running the den-api build.

## Live Smoke Evidence
Server-only lifecycle guard change; video is not relevant. The focused guard tests and full den-api suite cover the affected behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

