### PR TITLE
[codex] harden SSO JIT role provisioning

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -15,6 +15,10 @@ import {
   denOrganizationAccess,
   denOrganizationStaticRoles,
 } from "./organization-access.js";
+import {
+  getOrganizationSsoJitRole,
+  ORGANIZATION_SSO_JIT_ROLE,
+} from "./sso-jit.js";
 import { seedDefaultOrganizationRoles } from "./orgs.js";
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid";
 import * as schema from "@openwork-ee/den-db/schema";
@@ -411,7 +415,8 @@ export const auth = betterAuth({
       },
       organizationProvisioning: {
         disabled: false,
-        defaultRole: "member",
+        defaultRole: ORGANIZATION_SSO_JIT_ROLE,
+        getRole: getOrganizationSsoJitRole,
       },
       saml: {
         enableInResponseToValidation: true,

--- a/ee/apps/den-api/src/sso-jit.ts
+++ b/ee/apps/den-api/src/sso-jit.ts
@@ -1,0 +1,13 @@
+export const ORGANIZATION_SSO_JIT_ROLE: "member" = "member"
+
+export const SSO_IDENTITY_EXTRA_FIELDS = {
+  department: "department",
+} satisfies Record<string, string>
+
+type OrganizationSsoJitRoleInput = {
+  userInfo: Record<string, unknown>
+}
+
+export async function getOrganizationSsoJitRole(_input: OrganizationSsoJitRoleInput): Promise<typeof ORGANIZATION_SSO_JIT_ROLE> {
+  return ORGANIZATION_SSO_JIT_ROLE
+}

--- a/ee/apps/den-api/src/sso.ts
+++ b/ee/apps/den-api/src/sso.ts
@@ -5,6 +5,7 @@ import { z } from "zod"
 import { auth } from "./auth.js"
 import { db } from "./db.js"
 import { env } from "./env.js"
+import { SSO_IDENTITY_EXTRA_FIELDS } from "./sso-jit.js"
 
 type SsoConnection = typeof SsoConnectionTable.$inferSelect
 type OrganizationId = SsoConnection["organizationId"]
@@ -151,11 +152,7 @@ async function registerBetterAuthSsoProvider(input: OrganizationSsoRegistrationI
             id: "nameID",
             email: "email",
             name: "displayName",
-            extraFields: {
-              department: "department",
-              role: "role",
-              groups: "groups",
-            },
+            extraFields: SSO_IDENTITY_EXTRA_FIELDS,
           },
         },
       },
@@ -179,11 +176,7 @@ async function registerBetterAuthSsoProvider(input: OrganizationSsoRegistrationI
           emailVerified: "email_verified",
           name: "name",
           image: "picture",
-          extraFields: {
-            department: "department",
-            role: "role",
-            groups: "groups",
-          },
+          extraFields: SSO_IDENTITY_EXTRA_FIELDS,
         },
       },
     },

--- a/ee/apps/den-api/test/sso-jit.test.ts
+++ b/ee/apps/den-api/test/sso-jit.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import {
+  getOrganizationSsoJitRole,
+  ORGANIZATION_SSO_JIT_ROLE,
+  SSO_IDENTITY_EXTRA_FIELDS,
+} from "../src/sso-jit.js"
+
+test("SSO JIT provisioning always assigns the baseline member role", async () => {
+  const role = await getOrganizationSsoJitRole({
+    userInfo: {
+      role: "admin",
+      groups: ["owners"],
+    },
+  })
+
+  expect(role).toBe(ORGANIZATION_SSO_JIT_ROLE)
+})
+
+test("SSO identity mapping excludes authorization attributes", () => {
+  expect(SSO_IDENTITY_EXTRA_FIELDS).toEqual({
+    department: "department",
+  })
+  expect("role" in SSO_IDENTITY_EXTRA_FIELDS).toBe(false)
+  expect("groups" in SSO_IDENTITY_EXTRA_FIELDS).toBe(false)
+})


### PR DESCRIPTION
## Summary
- make SSO JIT org membership role selection explicit through a shared `member` role policy
- remove upstream `role` and `groups` attributes from the SAML/OIDC identity extra-field mapping
- add focused tests proving privileged IdP attributes are ignored for JIT role selection and excluded from identity mapping

## Security Impact
SSO/JIT provisioning now has an explicit deny-by-default role policy: newly provisioned organization members are created as baseline members, while privileged workspace roles must be granted through OpenWork organization controls.

## Validation
- `pnpm install --frozen-lockfile` - passed
- `bun test ee/apps/den-api/test/sso-jit.test.ts` - passed, 2 pass / 0 fail
- initial `pnpm --filter @openwork-ee/den-api build` caught a too-wide helper return type; fixed and reran
- `pnpm --filter @openwork-ee/den-api build` - passed
- `bun test ee/apps/den-api/test` - passed, 99 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Live Smoke
Not applicable for this server-only SSO/JIT provisioning policy change; covered by focused unit test, full den-api test suite, build, and typecheck.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

