### PR TITLE
[codex] harden SAML SSO policy

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -19,6 +19,11 @@ import {
   getOrganizationSsoJitRole,
   ORGANIZATION_SSO_JIT_ROLE,
 } from "./sso-jit.js";
+import {
+  ORGANIZATION_SAML_ALLOW_IDP_INITIATED,
+  ORGANIZATION_SAML_DEPRECATED_ALGORITHM_BEHAVIOR,
+  ORGANIZATION_SAML_REQUIRE_TIMESTAMPS,
+} from "./sso-saml-policy.js";
 import { seedDefaultOrganizationRoles } from "./orgs.js";
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid";
 import * as schema from "@openwork-ee/den-db/schema";
@@ -420,9 +425,10 @@ export const auth = betterAuth({
       },
       saml: {
         enableInResponseToValidation: true,
-        allowIdpInitiated: true,
+        allowIdpInitiated: ORGANIZATION_SAML_ALLOW_IDP_INITIATED,
+        requireTimestamps: ORGANIZATION_SAML_REQUIRE_TIMESTAMPS,
         algorithms: {
-          onDeprecated: "warn",
+          onDeprecated: ORGANIZATION_SAML_DEPRECATED_ALGORITHM_BEHAVIOR,
         },
       },
       provisionUser: async ({ user, userInfo, provider }) => {

--- a/ee/apps/den-api/src/routes/org/sso.ts
+++ b/ee/apps/den-api/src/routes/org/sso.ts
@@ -49,7 +49,6 @@ const samlRegistrationSchema = baseRegistrationSchema.extend({
   entryPoint: z.string().url(),
   cert: z.string().min(1),
   audience: z.string().url().optional(),
-  wantAssertionsSigned: z.boolean().optional(),
 }).meta({ ref: "RegisterOrganizationSamlSsoBody" })
 
 const oidcRegistrationSchema = baseRegistrationSchema.extend({

--- a/ee/apps/den-api/src/sso-saml-policy.ts
+++ b/ee/apps/den-api/src/sso-saml-policy.ts
@@ -1,0 +1,4 @@
+export const ORGANIZATION_SAML_WANT_ASSERTIONS_SIGNED: true = true
+export const ORGANIZATION_SAML_ALLOW_IDP_INITIATED: false = false
+export const ORGANIZATION_SAML_REQUIRE_TIMESTAMPS: true = true
+export const ORGANIZATION_SAML_DEPRECATED_ALGORITHM_BEHAVIOR: "reject" = "reject"

--- a/ee/apps/den-api/src/sso.ts
+++ b/ee/apps/den-api/src/sso.ts
@@ -6,6 +6,7 @@ import { auth } from "./auth.js"
 import { db } from "./db.js"
 import { env } from "./env.js"
 import { SSO_IDENTITY_EXTRA_FIELDS } from "./sso-jit.js"
+import { ORGANIZATION_SAML_WANT_ASSERTIONS_SIGNED } from "./sso-saml-policy.js"
 
 type SsoConnection = typeof SsoConnectionTable.$inferSelect
 type OrganizationId = SsoConnection["organizationId"]
@@ -17,7 +18,6 @@ type SamlRegistrationInput = {
   entryPoint: string
   cert: string
   audience?: string | null
-  wantAssertionsSigned?: boolean | null
 }
 
 type OidcRegistrationInput = {
@@ -146,7 +146,7 @@ async function registerBetterAuthSsoProvider(input: OrganizationSsoRegistrationI
           cert: input.cert,
           callbackUrl: getSsoAcsUrl(providerId),
           audience: input.audience || env.betterAuthUrl,
-          wantAssertionsSigned: input.wantAssertionsSigned ?? true,
+          wantAssertionsSigned: ORGANIZATION_SAML_WANT_ASSERTIONS_SIGNED,
           spMetadata: {},
           mapping: {
             id: "nameID",

--- a/ee/apps/den-api/test/sso-saml-policy.test.ts
+++ b/ee/apps/den-api/test/sso-saml-policy.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import {
+  ORGANIZATION_SAML_ALLOW_IDP_INITIATED,
+  ORGANIZATION_SAML_DEPRECATED_ALGORITHM_BEHAVIOR,
+  ORGANIZATION_SAML_REQUIRE_TIMESTAMPS,
+  ORGANIZATION_SAML_WANT_ASSERTIONS_SIGNED,
+} from "../src/sso-saml-policy.js"
+
+test("organization SAML registrations require signed assertions", () => {
+  expect(ORGANIZATION_SAML_WANT_ASSERTIONS_SIGNED).toBe(true)
+})
+
+test("organization SAML runtime rejects unsolicited or weak responses", () => {
+  expect(ORGANIZATION_SAML_ALLOW_IDP_INITIATED).toBe(false)
+  expect(ORGANIZATION_SAML_REQUIRE_TIMESTAMPS).toBe(true)
+  expect(ORGANIZATION_SAML_DEPRECATED_ALGORITHM_BEHAVIOR).toBe("reject")
+})


### PR DESCRIPTION
## Summary
- require SP-initiated SAML by rejecting IdP-initiated responses without `InResponseTo`
- require timestamp conditions and reject deprecated SAML algorithms instead of warning
- remove the organization SAML registration option that could disable signed assertions
- force new or replaced organization SAML provider configs to store `wantAssertionsSigned: true`

## Security Impact
SAML SSO now has stricter runtime checks for unsolicited responses, assertion timestamps, and weak algorithms. New or replaced SAML provider configs can no longer opt out of signed assertions through the organization SSO API.

## Validation
- `pnpm install --frozen-lockfile` - passed
- `bun test ee/apps/den-api/test/sso-saml-policy.test.ts` - passed, 2 pass / 0 fail
- `pnpm --filter @openwork-ee/den-api build` - passed
- `bun test ee/apps/den-api/test` - passed, 101 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Live Smoke
Not applicable for this server-only SAML policy change; covered by focused policy test, full den-api test suite, build, typecheck, and PR CI.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

