### PR TITLE
[codex] restrict MCP OAuth redirect URIs

### DIFF
--- a/ee/apps/den-api/src/mcp/oauth-client-policy.ts
+++ b/ee/apps/den-api/src/mcp/oauth-client-policy.ts
@@ -1,0 +1,65 @@
+const BLOCKED_CUSTOM_REDIRECT_PROTOCOLS = new Set([
+  "data:",
+  "file:",
+  "javascript:",
+  "vbscript:",
+])
+
+function isIpv4Loopback(hostname: string) {
+  const parts = hostname.split(".")
+  if (parts.length !== 4 || parts[0] !== "127") {
+    return false
+  }
+
+  return parts.every((part) => {
+    if (!/^\d+$/.test(part)) {
+      return false
+    }
+
+    const octet = Number(part)
+    return octet >= 0 && octet <= 255
+  })
+}
+
+function isLoopbackHostname(hostname: string) {
+  const normalized = hostname.trim().toLowerCase()
+  return normalized === "localhost"
+    || normalized.endsWith(".localhost")
+    || normalized === "::1"
+    || normalized === "[::1]"
+    || isIpv4Loopback(normalized)
+}
+
+function isPrivateUseCustomScheme(protocol: string) {
+  const scheme = protocol.endsWith(":") ? protocol.slice(0, -1) : protocol
+  return /^[a-z][a-z0-9+.-]*$/.test(scheme) && scheme.includes(".")
+}
+
+export function isAllowedMcpOAuthRedirectUri(uri: string) {
+  let parsed: URL
+  try {
+    parsed = new URL(uri)
+  } catch {
+    return false
+  }
+
+  if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+    return isLoopbackHostname(parsed.hostname)
+  }
+
+  if (BLOCKED_CUSTOM_REDIRECT_PROTOCOLS.has(parsed.protocol)) {
+    return false
+  }
+
+  return isPrivateUseCustomScheme(parsed.protocol)
+}
+
+export function getInvalidMcpOAuthRedirectUris(value: unknown) {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((entry): entry is string => typeof entry === "string")
+    .filter((entry) => !isAllowedMcpOAuthRedirectUri(entry))
+}

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -6,6 +6,7 @@ import { describeRoute } from "hono-openapi"
 import { auth } from "../../auth.js"
 import { db } from "../../db.js"
 import { env } from "../../env.js"
+import { getInvalidMcpOAuthRedirectUris } from "../../mcp/oauth-client-policy.js"
 import { emptyResponse } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 import { registerDesktopAuthRoutes } from "./desktop-handoff.js"
@@ -15,6 +16,17 @@ function rewriteAuthRequest(request: Request, path: string) {
   const url = new URL(request.url)
   url.pathname = path
   return new Request(url, request)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function oauthRegistrationError(status: number, error: string, errorDescription: string) {
+  return new Response(JSON.stringify({ error, error_description: errorDescription }), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 async function rewriteMcpClientRegistrationRequest(request: Request, path: string) {
@@ -27,7 +39,30 @@ async function rewriteMcpClientRegistrationRequest(request: Request, path: strin
     return new Request(url, request)
   }
 
-  const body = await request.json() as Record<string, unknown>
+  let parsedBody: unknown
+  try {
+    parsedBody = await request.json()
+  } catch {
+    return oauthRegistrationError(400, "invalid_client_metadata", "Registration request body must be valid JSON.")
+  }
+
+  if (!isRecord(parsedBody)) {
+    return oauthRegistrationError(400, "invalid_client_metadata", "Registration request body must be a JSON object.")
+  }
+
+  const body = parsedBody
+  const invalidRedirectUris = [
+    ...getInvalidMcpOAuthRedirectUris(body.redirect_uris),
+    ...getInvalidMcpOAuthRedirectUris(body.post_logout_redirect_uris),
+  ]
+  if (invalidRedirectUris.length > 0) {
+    return oauthRegistrationError(
+      400,
+      "invalid_redirect_uri",
+      "MCP OAuth redirect URIs must use loopback HTTP(S) or a private-use custom scheme.",
+    )
+  }
+
   const scope = typeof body.scope === "string" ? body.scope : ""
   const scopes = new Set(scope.split(/\s+/).filter(Boolean))
   if (scopes.has("mcp:read") || scopes.has("mcp:write")) {
@@ -44,6 +79,11 @@ async function rewriteMcpClientRegistrationRequest(request: Request, path: strin
     headers,
     body: JSON.stringify(body),
   })
+}
+
+async function handleMcpClientRegistrationRequest(request: Request, path: string) {
+  const rewritten = await rewriteMcpClientRegistrationRequest(request, path)
+  return rewritten instanceof Response ? rewritten : auth.handler(rewritten)
 }
 
 async function rewriteMetadataOrigin(response: Response, origin: string) {
@@ -128,8 +168,8 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
   app.get("/.well-known/openid-configuration/api/auth", async (c) => rewriteMetadataOrigin(await oauthProviderOpenIdConfigMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
   app.get("/.well-known/oauth-authorization-server", async (c) => rewriteMetadataOrigin(await oauthProviderAuthServerMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/oauth-authorization-server")), requestOrigin(c.req.raw)))
   app.get("/.well-known/openid-configuration", async (c) => rewriteMetadataOrigin(await oauthProviderOpenIdConfigMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/openid-configuration")), requestOrigin(c.req.raw)))
-  app.post("/register", async (c) => auth.handler(await rewriteMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register")))
-  app.post("/api/auth/oauth2/register", async (c) => auth.handler(await rewriteMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register")))
+  app.post("/register", async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
+  app.post("/api/auth/oauth2/register", async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
   app.get("/api/auth/oauth2/authorize", async (c) => {
     await ensureMcpClientScopes(c.req.raw)
     return auth.handler(c.req.raw)

--- a/ee/apps/den-api/test/mcp-oauth-client-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-oauth-client-policy.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import {
+  getInvalidMcpOAuthRedirectUris,
+  isAllowedMcpOAuthRedirectUri,
+} from "../src/mcp/oauth-client-policy.js"
+
+test("MCP OAuth redirect policy allows loopback redirects", () => {
+  expect(isAllowedMcpOAuthRedirectUri("http://127.0.0.1:49321/callback")).toBe(true)
+  expect(isAllowedMcpOAuthRedirectUri("http://localhost:49321/callback")).toBe(true)
+  expect(isAllowedMcpOAuthRedirectUri("https://dev.localhost/callback")).toBe(true)
+  expect(isAllowedMcpOAuthRedirectUri("http://[::1]:49321/callback")).toBe(true)
+})
+
+test("MCP OAuth redirect policy allows private-use custom schemes", () => {
+  expect(isAllowedMcpOAuthRedirectUri("com.openwork.desktop:/oauth/callback")).toBe(true)
+  expect(isAllowedMcpOAuthRedirectUri("software.openwork.app://oauth/callback")).toBe(true)
+})
+
+test("MCP OAuth redirect policy rejects public web and dangerous redirects", () => {
+  expect(isAllowedMcpOAuthRedirectUri("https://example.com/oauth/callback")).toBe(false)
+  expect(isAllowedMcpOAuthRedirectUri("http://example.com/oauth/callback")).toBe(false)
+  expect(isAllowedMcpOAuthRedirectUri("javascript:alert(1)")).toBe(false)
+  expect(isAllowedMcpOAuthRedirectUri("file:///tmp/callback")).toBe(false)
+  expect(isAllowedMcpOAuthRedirectUri("openwork:/oauth/callback")).toBe(false)
+})
+
+test("MCP OAuth redirect policy lists invalid registration redirect URIs", () => {
+  expect(getInvalidMcpOAuthRedirectUris([
+    "http://127.0.0.1:49321/callback",
+    "https://example.com/oauth/callback",
+    "com.openwork.desktop:/oauth/callback",
+    "data:text/plain,callback",
+  ])).toEqual([
+    "https://example.com/oauth/callback",
+    "data:text/plain,callback",
+  ])
+})


### PR DESCRIPTION
## Summary
- add a focused MCP OAuth redirect URI policy for dynamic client registration
- allow loopback HTTP(S) redirects and reverse-domain private-use custom schemes
- reject public web redirects and dangerous schemes before forwarding registration to Better Auth
- keep Better Auth's existing MCP scope and PKCE enforcement in place

## Security Impact
Unauthenticated MCP OAuth client registration can no longer register arbitrary public HTTPS redirect URIs through the public registration path. This narrows registration to native-client redirect patterns appropriate for local MCP clients.

## Validation
- `pnpm install --frozen-lockfile` - passed
- `bun test ee/apps/den-api/test/mcp-oauth-client-policy.test.ts` - passed, 4 pass / 0 fail
- `pnpm --filter @openwork-ee/den-api build` - passed
- `bun test ee/apps/den-api/test` - passed, 105 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Live Smoke
Not applicable for this server-only MCP/OAuth registration policy change; covered by focused policy test, full den-api test suite, build, typecheck, and PR CI.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

