### PR TITLE
[codex] hash SCIM tokens

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -6,6 +6,7 @@ import {
   DEN_MCP_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
   DEN_MCP_REFRESH_TOKEN_EXPIRES_IN_SECONDS,
 } from "./mcp/token-lifetime.js";
+import { SCIM_TOKEN_STORAGE_STRATEGY } from "./scim-token-storage.js";
 import { syncDenSignupContact } from "./loops.js";
 import { sendEmail } from "./utils/email/send-email.js";
 import {
@@ -405,6 +406,7 @@ export const auth = betterAuth({
       },
     }),
     scim({
+      storeSCIMToken: SCIM_TOKEN_STORAGE_STRATEGY,
       beforeSCIMTokenGenerated: async ({ member }) => {
         if (!member?.organizationId) {
           throw new APIError("FORBIDDEN", {

--- a/ee/apps/den-api/src/scim-token-storage.ts
+++ b/ee/apps/den-api/src/scim-token-storage.ts
@@ -1,0 +1,18 @@
+import { Buffer } from "node:buffer"
+import { createHash, timingSafeEqual } from "node:crypto"
+
+export const SCIM_TOKEN_STORAGE_STRATEGY = "hashed"
+
+export function hashScimToken(scimToken: string) {
+  return createHash("sha256").update(scimToken).digest("base64url")
+}
+
+export function verifyStoredScimToken(input: {
+  storedToken: string
+  rawToken: string
+}) {
+  const expectedToken = hashScimToken(input.rawToken)
+  const storedBytes = Uint8Array.from(Buffer.from(input.storedToken))
+  const expectedBytes = Uint8Array.from(Buffer.from(expectedToken))
+  return storedBytes.length === expectedBytes.length && timingSafeEqual(storedBytes, expectedBytes)
+}

--- a/ee/apps/den-api/src/scim.ts
+++ b/ee/apps/den-api/src/scim.ts
@@ -1,5 +1,4 @@
 import { Buffer } from "node:buffer"
-import { timingSafeEqual } from "node:crypto"
 import { and, eq, isNotNull, isNull } from "@openwork-ee/den-db/drizzle"
 import { AuthAccountTable, AuthUserTable, ExternalIdentityTable, MemberTable, ScimProviderTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
@@ -7,6 +6,7 @@ import { auth } from "./auth.js"
 import { db } from "./db.js"
 import { env } from "./env.js"
 import { removeOrganizationMember } from "./orgs.js"
+import { verifyStoredScimToken } from "./scim-token-storage.js"
 
 type OrganizationId = typeof MemberTable.$inferSelect.organizationId
 type UserId = typeof AuthUserTable.$inferSelect.id
@@ -43,12 +43,6 @@ function asArray(value: unknown): unknown[] | null {
   return Array.isArray(value) ? value : null
 }
 
-function safeEqualSecret(left: string, right: string) {
-  const leftBytes = Uint8Array.from(Buffer.from(left))
-  const rightBytes = Uint8Array.from(Buffer.from(right))
-  return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes)
-}
-
 async function resolveScimProviderFromBearerToken(bearerToken: string) {
   let decoded: string
   try {
@@ -70,7 +64,7 @@ async function resolveScimProviderFromBearerToken(bearerToken: string) {
     .limit(1)
 
   const provider = providerRows[0] ?? null
-  if (!provider || !safeEqualSecret(provider.scimToken, rawToken)) {
+  if (!provider || !verifyStoredScimToken({ storedToken: provider.scimToken, rawToken })) {
     return null
   }
 

--- a/ee/apps/den-api/test/scim-token-storage.test.ts
+++ b/ee/apps/den-api/test/scim-token-storage.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import {
+  hashScimToken,
+  SCIM_TOKEN_STORAGE_STRATEGY,
+  verifyStoredScimToken,
+} from "../src/scim-token-storage.js"
+
+test("SCIM token storage uses Better Auth compatible hashed storage", () => {
+  expect(SCIM_TOKEN_STORAGE_STRATEGY).toBe("hashed")
+  expect(hashScimToken("scim-test-token")).toBe("ai6yKWtx5P0IDcrGT0DoX6GiKMx85Q42b0UVBmL8usE")
+})
+
+test("SCIM token verification compares the stored hash in constant time", () => {
+  const storedToken = hashScimToken("scim-test-token")
+  expect(verifyStoredScimToken({ storedToken, rawToken: "scim-test-token" })).toBe(true)
+  expect(verifyStoredScimToken({ storedToken, rawToken: "wrong-token" })).toBe(false)
+})


### PR DESCRIPTION
## Summary
- Configure the SCIM plugin to store generated SCIM tokens as hashes.
- Add a shared SCIM token-storage helper using the same SHA-256/base64url format expected by the plugin.
- Update Den SCIM sync/deprovision token checks to verify the stored hash.
- Add focused coverage for SCIM token hashing and verification.

## Security Impact
- Removes recoverable SCIM bearer tokens from application reads while preserving the existing one-time token return and rotation path.

## Operational Note
- SCIM tokens generated before this storage-mode change should be rotated through the existing organization SCIM endpoint.

## Validation
- `pnpm install --frozen-lockfile` - passed
- `bun test ee/apps/den-api/test/scim-token-storage.test.ts` - passed, 2 pass / 0 fail
- `pnpm --filter @openwork-ee/den-api build` - passed after fixing a TypeScript comparison input type
- `bun test ee/apps/den-api/test` - passed, 109 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Live Smoke
- Not applicable for this server-only SCIM token storage change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

