### PR TITLE
[codex] audit organization API key changes

### DIFF
--- a/ee/apps/den-api/src/audit-events.ts
+++ b/ee/apps/den-api/src/audit-events.ts
@@ -1,0 +1,32 @@
+import { AuditEventTable } from "@openwork-ee/den-db/schema"
+import type { DenTypeId } from "@openwork-ee/utils/typeid"
+import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+
+export const ORGANIZATION_AUDIT_ACTIONS = {
+  apiKeyCreated: "organization.api_key.created",
+  apiKeyDeleted: "organization.api_key.deleted",
+}
+
+type OrganizationAuditAction = typeof ORGANIZATION_AUDIT_ACTIONS[keyof typeof ORGANIZATION_AUDIT_ACTIONS]
+type OrganizationAuditPayload = Record<string, string | number | boolean | null>
+
+export function buildOrganizationAuditEvent(input: {
+  organizationId: DenTypeId<"organization">
+  actorUserId: typeof AuditEventTable.$inferInsert.actor_user_id
+  action: OrganizationAuditAction
+  payload?: OrganizationAuditPayload
+}) {
+  return {
+    id: createDenTypeId("auditEvent"),
+    org_id: normalizeDenTypeId("org", input.organizationId),
+    worker_id: null,
+    actor_user_id: input.actorUserId,
+    action: input.action,
+    payload: input.payload ?? null,
+  }
+}
+
+export async function recordOrganizationAuditEvent(input: Parameters<typeof buildOrganizationAuditEvent>[0]) {
+  const { db } = await import("./db.js")
+  await db.insert(AuditEventTable).values(buildOrganizationAuditEvent(input))
+}

--- a/ee/apps/den-api/src/routes/org/api-keys.ts
+++ b/ee/apps/den-api/src/routes/org/api-keys.ts
@@ -8,6 +8,7 @@ import {
   DEN_API_KEY_RATE_LIMIT_TIME_WINDOW_MS,
   listOrganizationApiKeys,
 } from "../../api-keys.js"
+import { ORGANIZATION_AUDIT_ACTIONS, recordOrganizationAuditEvent } from "../../audit-events.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema } from "../../openapi.js"
 import { auth } from "../../auth.js"
@@ -239,6 +240,18 @@ export function registerOrgApiKeyRoutes<T extends { Variables: OrgRouteVariables
         },
       })
 
+      await recordOrganizationAuditEvent({
+        organizationId: payload.organization.id,
+        actorUserId: payload.currentMember.userId,
+        action: ORGANIZATION_AUDIT_ACTIONS.apiKeyCreated,
+        payload: {
+          apiKeyId: created.id,
+          orgMembershipId: payload.currentMember.id,
+          name: created.name,
+          prefix: created.prefix,
+        },
+      })
+
       return c.json({
         apiKey: {
           id: created.id,
@@ -323,6 +336,19 @@ export function registerOrgApiKeyRoutes<T extends { Variables: OrgRouteVariables
       if (!deleted) {
         return c.json({ error: "api_key_not_found" }, 404)
       }
+
+      await recordOrganizationAuditEvent({
+        organizationId: payload.organization.id,
+        actorUserId: payload.currentMember.userId,
+        action: ORGANIZATION_AUDIT_ACTIONS.apiKeyDeleted,
+        payload: {
+          apiKeyId: deleted.id,
+          ownerUserId: deleted.owner.userId,
+          ownerOrgMembershipId: deleted.owner.memberId,
+          name: deleted.name,
+          prefix: deleted.prefix,
+        },
+      })
 
       return c.body(null, 204)
     },

--- a/ee/apps/den-api/test/audit-events.test.ts
+++ b/ee/apps/den-api/test/audit-events.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { buildOrganizationAuditEvent, ORGANIZATION_AUDIT_ACTIONS } from "../src/audit-events.js"
+
+test("organization audit events normalize org ids and keep actor context", () => {
+  const organizationId = createDenTypeId("organization")
+  const actorUserId = createDenTypeId("user")
+
+  const event = buildOrganizationAuditEvent({
+    organizationId,
+    actorUserId,
+    action: ORGANIZATION_AUDIT_ACTIONS.apiKeyCreated,
+    payload: {
+      apiKeyId: "api-key-id",
+      orgMembershipId: "member-id",
+      name: "CI key",
+      prefix: "den_",
+    },
+  })
+
+  expect(event.id.startsWith("aev_")).toBe(true)
+  expect(event.org_id).toBe(organizationId)
+  expect(event.actor_user_id).toBe(actorUserId)
+  expect(event.worker_id).toBe(null)
+  expect(event.action).toBe("organization.api_key.created")
+  expect(event.payload).toEqual({
+    apiKeyId: "api-key-id",
+    orgMembershipId: "member-id",
+    name: "CI key",
+    prefix: "den_",
+  })
+})
+
+test("organization audit events allow empty payloads", () => {
+  const event = buildOrganizationAuditEvent({
+    organizationId: createDenTypeId("organization"),
+    actorUserId: createDenTypeId("user"),
+    action: ORGANIZATION_AUDIT_ACTIONS.apiKeyDeleted,
+  })
+
+  expect(event.action).toBe("organization.api_key.deleted")
+  expect(event.payload).toBe(null)
+})


### PR DESCRIPTION
## Summary
- Add a reusable organization audit event helper backed by the existing `audit_event` table.
- Record audit events when organization API keys are created or deleted.
- Keep audit payloads non-secret: key identifiers, membership/owner references, name, and prefix only.
- Add focused tests for audit row construction.

## Security Impact
- Starts privileged-action audit coverage for organization API key lifecycle events without storing returned API key secrets in the audit payload.

## Validation
- `pnpm install --frozen-lockfile` - passed
- Initial `bun test ee/apps/den-api/test/audit-events.test.ts` failed before package build, then failed once because the helper eagerly loaded DB/env config; fixed with a lazy DB import.
- `bun test ee/apps/den-api/test/audit-events.test.ts` - passed, 2 pass / 0 fail
- `pnpm --filter @openwork-ee/den-api build` - passed
- `bun test ee/apps/den-api/test` - passed, 111 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Live Smoke
- Not applicable for this server-only audit instrumentation change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

