### PR TITLE
[codex] audit organization member changes

### DIFF
--- a/ee/apps/den-api/src/audit-events.ts
+++ b/ee/apps/den-api/src/audit-events.ts
@@ -5,6 +5,8 @@ import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 export const ORGANIZATION_AUDIT_ACTIONS = {
   apiKeyCreated: "organization.api_key.created",
   apiKeyDeleted: "organization.api_key.deleted",
+  memberRoleUpdated: "organization.member.role_updated",
+  memberRemoved: "organization.member.removed",
 }
 
 type OrganizationAuditAction = typeof ORGANIZATION_AUDIT_ACTIONS[keyof typeof ORGANIZATION_AUDIT_ACTIONS]

--- a/ee/apps/den-api/src/routes/org/members.ts
+++ b/ee/apps/den-api/src/routes/org/members.ts
@@ -5,6 +5,7 @@ import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { revokeOrganizationApiKeysForMember } from "../../api-keys.js"
+import { ORGANIZATION_AUDIT_ACTIONS, recordOrganizationAuditEvent } from "../../audit-events.js"
 import { db } from "../../db.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
@@ -80,6 +81,17 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
         orgMembershipId: validation.member.id,
         userId: validation.member.userId,
       })
+      await recordOrganizationAuditEvent({
+        organizationId: payload.organization.id,
+        actorUserId: payload.currentMember.userId,
+        action: ORGANIZATION_AUDIT_ACTIONS.memberRoleUpdated,
+        payload: {
+          targetOrgMembershipId: validation.member.id,
+          targetUserId: validation.member.userId,
+          previousRole: validation.member.role,
+          nextRole: role,
+        },
+      })
     }
 
     return c.json({ success: true })
@@ -129,6 +141,17 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
       }
       return c.json({ error: removed.error, message: removed.message }, 400)
     }
+
+    await recordOrganizationAuditEvent({
+      organizationId: payload.organization.id,
+      actorUserId: payload.currentMember.userId,
+      action: ORGANIZATION_AUDIT_ACTIONS.memberRemoved,
+      payload: {
+        targetOrgMembershipId: removed.member.id,
+        targetUserId: removed.member.userId,
+        previousRole: removed.member.role,
+      },
+    })
 
     return c.body(null, 204)
     },

--- a/ee/apps/den-api/test/audit-events.test.ts
+++ b/ee/apps/den-api/test/audit-events.test.ts
@@ -41,3 +41,28 @@ test("organization audit events allow empty payloads", () => {
   expect(event.action).toBe("organization.api_key.deleted")
   expect(event.payload).toBe(null)
 })
+
+test("organization audit events support member lifecycle actions", () => {
+  const targetOrgMembershipId = createDenTypeId("member")
+  const targetUserId = createDenTypeId("user")
+
+  const event = buildOrganizationAuditEvent({
+    organizationId: createDenTypeId("organization"),
+    actorUserId: createDenTypeId("user"),
+    action: ORGANIZATION_AUDIT_ACTIONS.memberRoleUpdated,
+    payload: {
+      targetOrgMembershipId,
+      targetUserId,
+      previousRole: "member",
+      nextRole: "admin",
+    },
+  })
+
+  expect(event.action).toBe("organization.member.role_updated")
+  expect(event.payload).toEqual({
+    targetOrgMembershipId,
+    targetUserId,
+    previousRole: "member",
+    nextRole: "admin",
+  })
+})


### PR DESCRIPTION
## Summary
- Add organization audit actions for member role updates and member removals.
- Record non-secret audit events after successful member role changes.
- Record non-secret audit events after successful member removals.
- Extend focused audit helper coverage for member lifecycle actions.

## Security Impact
- Expands privileged-action audit coverage from API keys to organization member lifecycle operations.

## Validation
- `pnpm install --frozen-lockfile` - passed
- `pnpm --filter @openwork-ee/den-api build` - passed
- `bun test ee/apps/den-api/test/audit-events.test.ts` - passed, 3 pass / 0 fail
- `bun test ee/apps/den-api/test` - passed, 112 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Live Smoke
- Not applicable for this server-only audit instrumentation change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

