### PR TITLE
[codex] audit SCIM management

### DIFF
--- a/ee/apps/den-api/src/audit-events.ts
+++ b/ee/apps/den-api/src/audit-events.ts
@@ -7,6 +7,8 @@ export const ORGANIZATION_AUDIT_ACTIONS = {
   apiKeyDeleted: "organization.api_key.deleted",
   memberRoleUpdated: "organization.member.role_updated",
   memberRemoved: "organization.member.removed",
+  scimTokenRotated: "organization.scim.token_rotated",
+  scimConnectionDeleted: "organization.scim.connection_deleted",
 }
 
 type OrganizationAuditAction = typeof ORGANIZATION_AUDIT_ACTIONS[keyof typeof ORGANIZATION_AUDIT_ACTIONS]

--- a/ee/apps/den-api/src/routes/org/scim.ts
+++ b/ee/apps/den-api/src/routes/org/scim.ts
@@ -2,6 +2,7 @@ import type { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
 import { deleteOrganizationScimConnection, getOrganizationScimConnection, getScimBaseUrl, rotateOrganizationScimToken } from "../../scim.js"
+import { ORGANIZATION_AUDIT_ACTIONS, recordOrganizationAuditEvent } from "../../audit-events.js"
 import { requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureScimManager } from "./shared.js"
@@ -190,6 +191,16 @@ export function registerOrgScimRoutes<T extends { Variables: OrgRouteVariables }
         headers: c.req.raw.headers,
       })
 
+      await recordOrganizationAuditEvent({
+        organizationId: payload.organization.id,
+        actorUserId: payload.currentMember.userId,
+        action: ORGANIZATION_AUDIT_ACTIONS.scimTokenRotated,
+        payload: {
+          scimProviderId: rotated.connection.id,
+          providerId: rotated.connection.providerId,
+        },
+      })
+
       return c.json({
         baseUrl: getScimBaseUrl(),
         connection: serializeConnection(rotated.connection),
@@ -252,7 +263,14 @@ export function registerOrgScimRoutes<T extends { Variables: OrgRouteVariables }
       }
 
       const payload = c.get("organizationContext")
-      await deleteOrganizationScimConnection(payload.organization.id)
+      const deleted = await deleteOrganizationScimConnection(payload.organization.id)
+      if (deleted) {
+        await recordOrganizationAuditEvent({
+          organizationId: payload.organization.id,
+          actorUserId: payload.currentMember.userId,
+          action: ORGANIZATION_AUDIT_ACTIONS.scimConnectionDeleted,
+        })
+      }
       return c.body(null, 204)
     },
   )

--- a/ee/apps/den-api/test/audit-events.test.ts
+++ b/ee/apps/den-api/test/audit-events.test.ts
@@ -66,3 +66,23 @@ test("organization audit events support member lifecycle actions", () => {
     nextRole: "admin",
   })
 })
+
+test("organization audit events support SCIM management actions", () => {
+  const scimProviderId = createDenTypeId("scimProvider")
+
+  const event = buildOrganizationAuditEvent({
+    organizationId: createDenTypeId("organization"),
+    actorUserId: createDenTypeId("user"),
+    action: ORGANIZATION_AUDIT_ACTIONS.scimTokenRotated,
+    payload: {
+      scimProviderId,
+      providerId: "openwork-scim-org_id",
+    },
+  })
+
+  expect(event.action).toBe("organization.scim.token_rotated")
+  expect(event.payload).toEqual({
+    scimProviderId,
+    providerId: "openwork-scim-org_id",
+  })
+})


### PR DESCRIPTION
## Summary
- Add organization audit actions for SCIM token rotation and connection deletion.
- Record non-secret audit events after successful SCIM token rotation.
- Record connection deletion audit events only when an existing SCIM connection was removed.
- Extend focused audit helper coverage for SCIM management actions.

## Security Impact
- Expands privileged-action audit coverage to SCIM management without storing SCIM bearer tokens in audit payloads.

## Validation
- `pnpm install --frozen-lockfile` - passed
- `pnpm --filter @openwork-ee/den-api build` - passed
- `bun test ee/apps/den-api/test/audit-events.test.ts` - passed, 4 pass / 0 fail
- `bun test ee/apps/den-api/test` - passed, 113 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Live Smoke
- Not applicable for this server-only SCIM audit instrumentation change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

