### PR TITLE
[codex] audit SSO management

### DIFF
--- a/ee/apps/den-api/src/audit-events.ts
+++ b/ee/apps/den-api/src/audit-events.ts
@@ -9,6 +9,8 @@ export const ORGANIZATION_AUDIT_ACTIONS = {
   memberRemoved: "organization.member.removed",
   scimTokenRotated: "organization.scim.token_rotated",
   scimConnectionDeleted: "organization.scim.connection_deleted",
+  ssoConnectionRegistered: "organization.sso.connection_registered",
+  ssoConnectionDeleted: "organization.sso.connection_deleted",
 }
 
 type OrganizationAuditAction = typeof ORGANIZATION_AUDIT_ACTIONS[keyof typeof ORGANIZATION_AUDIT_ACTIONS]

--- a/ee/apps/den-api/src/routes/org/sso.ts
+++ b/ee/apps/den-api/src/routes/org/sso.ts
@@ -2,6 +2,7 @@ import type { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
 import { auth } from "../../auth.js"
+import { ORGANIZATION_AUDIT_ACTIONS, recordOrganizationAuditEvent } from "../../audit-events.js"
 import { checkEntitlement } from "../../entitlements.js"
 import { env } from "../../env.js"
 import { enterprisePlanRequiredSchema } from "../../openapi.js"
@@ -305,6 +306,19 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
       })
       const domainVerificationToken = await requestDomainVerificationToken(connection.providerId, c.req.raw.headers).catch(() => null)
 
+      await recordOrganizationAuditEvent({
+        organizationId: payload.organization.id,
+        actorUserId: payload.currentMember.userId,
+        action: ORGANIZATION_AUDIT_ACTIONS.ssoConnectionRegistered,
+        payload: {
+          ssoConnectionId: connection.id,
+          providerId: connection.providerId,
+          kind: connection.kind,
+          issuer: connection.issuer,
+          domain: connection.domain,
+        },
+      })
+
       return c.json({ connection: await buildConnectionPayload(connection, c.req.url), domainVerificationToken }, 201)
     },
   )
@@ -356,6 +370,19 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
       })
       const domainVerificationToken = await requestDomainVerificationToken(connection.providerId, c.req.raw.headers).catch(() => null)
 
+      await recordOrganizationAuditEvent({
+        organizationId: payload.organization.id,
+        actorUserId: payload.currentMember.userId,
+        action: ORGANIZATION_AUDIT_ACTIONS.ssoConnectionRegistered,
+        payload: {
+          ssoConnectionId: connection.id,
+          providerId: connection.providerId,
+          kind: connection.kind,
+          issuer: connection.issuer,
+          domain: connection.domain,
+        },
+      })
+
       return c.json({ connection: await buildConnectionPayload(connection, c.req.url), domainVerificationToken }, 201)
     },
   )
@@ -384,7 +411,22 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
       }
 
       const payload = c.get("organizationContext")
-      await deleteOrganizationSsoConnection(payload.organization.id)
+      const connection = await getOrganizationSsoConnection(payload.organization.id)
+      const deleted = await deleteOrganizationSsoConnection(payload.organization.id)
+      if (deleted && connection) {
+        await recordOrganizationAuditEvent({
+          organizationId: payload.organization.id,
+          actorUserId: payload.currentMember.userId,
+          action: ORGANIZATION_AUDIT_ACTIONS.ssoConnectionDeleted,
+          payload: {
+            ssoConnectionId: connection.id,
+            providerId: connection.providerId,
+            kind: connection.kind,
+            issuer: connection.issuer,
+            domain: connection.domain,
+          },
+        })
+      }
       return c.body(null, 204)
     },
   )

--- a/ee/apps/den-api/test/audit-events.test.ts
+++ b/ee/apps/den-api/test/audit-events.test.ts
@@ -86,3 +86,29 @@ test("organization audit events support SCIM management actions", () => {
     providerId: "openwork-scim-org_id",
   })
 })
+
+test("organization audit events support SSO management actions", () => {
+  const ssoConnectionId = createDenTypeId("ssoConnection")
+
+  const event = buildOrganizationAuditEvent({
+    organizationId: createDenTypeId("organization"),
+    actorUserId: createDenTypeId("user"),
+    action: ORGANIZATION_AUDIT_ACTIONS.ssoConnectionRegistered,
+    payload: {
+      ssoConnectionId,
+      providerId: "openwork-sso-org_id",
+      kind: "saml",
+      issuer: "https://idp.example.com",
+      domain: "example.com",
+    },
+  })
+
+  expect(event.action).toBe("organization.sso.connection_registered")
+  expect(event.payload).toEqual({
+    ssoConnectionId,
+    providerId: "openwork-sso-org_id",
+    kind: "saml",
+    issuer: "https://idp.example.com",
+    domain: "example.com",
+  })
+})


### PR DESCRIPTION
## Summary
- Add organization audit actions for SSO registration and deletion.
- Record non-secret audit events after successful SAML and OIDC SSO registration/replacement.
- Record SSO deletion audit events only when an existing SSO connection was removed.
- Extend focused audit helper coverage for SSO management actions.

## Security Impact
- Expands privileged-action audit coverage to SSO management without storing SAML certificates or OIDC client secrets in audit payloads.

## Validation
- `pnpm install --frozen-lockfile` - passed
- `pnpm --filter @openwork-ee/den-api build` - passed
- `bun test ee/apps/den-api/test/audit-events.test.ts` - passed, 5 pass / 0 fail
- `bun test ee/apps/den-api/test` - passed, 114 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Live Smoke
- Not applicable for this server-only SSO audit instrumentation change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

