### PR TITLE
[codex] pin MCP JWT validation algorithm

### DIFF
--- a/ee/apps/den-api/src/mcp/auth.ts
+++ b/ee/apps/den-api/src/mcp/auth.ts
@@ -21,10 +21,22 @@ export type McpPrincipal = {
   payload: Record<string, unknown>
 }
 
+type McpJwtVerifyOptions = Parameters<typeof verifyJwsAccessToken>[1]["verifyOptions"]
+
+const MCP_JWT_SIGNING_ALGORITHMS = ["EdDSA"]
+
 export function getMcpResourceUrl(request: Request) {
   const url = new URL(request.url)
   const requestResource = `${url.origin}/mcp`
   return DEN_MCP_RESOURCES.includes(requestResource) ? requestResource : DEN_MCP_RESOURCE
+}
+
+export function getMcpJwtVerifyOptions(): McpJwtVerifyOptions {
+  return {
+    issuer: `${env.betterAuthUrl}/api/auth`,
+    audience: DEN_MCP_RESOURCES,
+    algorithms: MCP_JWT_SIGNING_ALGORITHMS,
+  }
 }
 
 function readBearerToken(headers: Headers) {
@@ -77,10 +89,7 @@ async function getJwks() {
 async function verifyJwtMcpToken(token: string) {
   const payload = await verifyJwsAccessToken(token, {
     jwksFetch: getJwks,
-    verifyOptions: {
-      issuer: `${env.betterAuthUrl}/api/auth`,
-      audience: DEN_MCP_RESOURCES,
-    },
+    verifyOptions: getMcpJwtVerifyOptions(),
   })
   return payload as Record<string, unknown>
 }

--- a/ee/apps/den-api/test/mcp-auth.test.ts
+++ b/ee/apps/den-api/test/mcp-auth.test.ts
@@ -1,0 +1,23 @@
+import { beforeAll, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let mcpAuth: typeof import("../src/mcp/auth.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mcpAuth = await import("../src/mcp/auth.js")
+})
+
+test("MCP JWT verification pins issuer, audience, and signing algorithm", () => {
+  expect(mcpAuth.getMcpJwtVerifyOptions()).toEqual({
+    issuer: "http://127.0.0.1:8790/api/auth",
+    audience: ["http://127.0.0.1:8790/mcp"],
+    algorithms: ["EdDSA"],
+  })
+})


### PR DESCRIPTION
## Summary
- Pin MCP JWT access-token verification to Better Auth's `EdDSA` signing algorithm.
- Keep the existing issuer and audience checks in one named verifier-options helper.
- Add focused coverage for the MCP JWT verifier options.

## Security Impact
- Closes the MCP JWT validation gap around algorithm pinning and blocks algorithm-confusion-style acceptance at the MCP verifier boundary.

## Validation
- `pnpm install --frozen-lockfile` - passed
- `pnpm --filter @openwork-ee/den-api build` - passed
- `bun test ee/apps/den-api/test/mcp-auth.test.ts` - passed, 1 pass / 0 fail
- `bun test ee/apps/den-api/test` - passed, 115 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Live Smoke
- Not applicable for this server-only MCP JWT verifier change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

