### PR TITLE
feat(den-admin): manage org enterprise access

### DIFF
--- a/ee/apps/den-api/src/mcp/admin-tools.ts
+++ b/ee/apps/den-api/src/mcp/admin-tools.ts
@@ -1,7 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
-import { sql, type SQL } from "@openwork-ee/den-db/drizzle"
+import { eq, sql, type SQL } from "@openwork-ee/den-db/drizzle"
+import { OrganizationTable } from "@openwork-ee/den-db/schema"
 import { z } from "zod"
 import { db } from "../db.js"
+import { parseOrganizationPlan, type PlanTier } from "../entitlements.js"
+import { normalizeOrganizationMetadata } from "../organization-limits.js"
 import { denApiAppVersion } from "../version.js"
 
 /**
@@ -18,7 +21,7 @@ import { denApiAppVersion } from "../version.js"
  * timeout so one expensive SELECT cannot pin an API worker indefinitely.
  */
 
-export const DEN_ADMIN_MCP_VERSION = "0.3.0"
+export const DEN_ADMIN_MCP_VERSION = "0.4.0"
 
 const QUERY_TIMEOUT_MS = 15_000
 const DEFAULT_ROW_LIMIT = 200
@@ -27,6 +30,7 @@ const MAX_ROW_LIMIT = 1000
 const SERVER_STARTED_AT = new Date().toISOString()
 
 type Row = Record<string, unknown>
+type OrganizationId = typeof OrganizationTable.$inferSelect.id
 
 /**
  * `db` is drizzle over either mysql2 (returns `[rows, fields]`) or
@@ -77,6 +81,18 @@ function intLiteral(value: number): SQL {
 
 function idList(ids: string[]): SQL {
   return sql.join(ids.map((id) => sql`${id}`), sql`, `)
+}
+
+function isOrganizationId(value: string): value is OrganizationId {
+  return value.startsWith("org_")
+}
+
+function manualPlan(tier: PlanTier) {
+  return {
+    tier,
+    source: "manual" as const,
+    ...(tier === "enterprise" ? { grantedAt: new Date().toISOString() } : {}),
+  }
 }
 
 function toTime(value: unknown): number | null {
@@ -343,6 +359,62 @@ export function registerAdminMcpTools(server: McpServer) {
             count: n(row.count),
           })),
           note: "active = sign-in session day or any telemetry event; realActive = executed at least one task in a session (task.* events with a session id)",
+        }
+      }),
+  )
+
+  server.registerTool(
+    "den_update_org_plan",
+    {
+      description:
+        "Admin write tool: grant or remove organization plan access and set the member seat limit. Use tier='enterprise' to grant enterprise access.",
+      inputSchema: z.object({
+        organizationId: z.string().min(1).describe("Organization id, e.g. org_..."),
+        tier: z.enum(["free", "team", "enterprise"]).describe("Plan tier to set"),
+        seatLimit: z.number().int().min(1).max(100000).describe("Maximum active organization members/seats"),
+      }),
+    },
+    async ({ organizationId, tier, seatLimit }) =>
+      run(async () => {
+        if (!isOrganizationId(organizationId)) {
+          throw new Error("Invalid organization id")
+        }
+
+        const existing = await db
+          .select({ id: OrganizationTable.id, name: OrganizationTable.name, slug: OrganizationTable.slug, metadata: OrganizationTable.metadata })
+          .from(OrganizationTable)
+          .where(eq(OrganizationTable.id, organizationId))
+          .limit(1)
+
+        const organization = existing[0]
+        if (!organization) {
+          throw new Error(`No organization found for ${organizationId}`)
+        }
+
+        const normalized = normalizeOrganizationMetadata(organization.metadata).metadata
+        const metadata = {
+          ...normalized,
+          plan: manualPlan(tier),
+          limits: {
+            ...normalized.limits,
+            members: seatLimit,
+          },
+        }
+
+        await db
+          .update(OrganizationTable)
+          .set({ metadata })
+          .where(eq(OrganizationTable.id, organizationId))
+
+        return {
+          ok: true,
+          organization: {
+            id: organization.id,
+            name: organization.name,
+            slug: organization.slug,
+            plan: parseOrganizationPlan(metadata),
+            seatLimit,
+          },
         }
       }),
   )

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -1,10 +1,11 @@
-import { and, asc, desc, eq, gte, inArray, isNotNull, sql } from "@openwork-ee/den-db/drizzle"
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import {
   AuthAccountTable,
   AuthSessionTable,
   AuthUserTable,
   InvitationTable,
   MemberTable,
+  OrganizationTable,
   TelemetryEventTable,
   WorkerTable,
   AdminAllowlistTable,
@@ -14,14 +15,22 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { getCloudWorkerAdminBillingStatus } from "../../billing/polar.js"
 import { db } from "../../db.js"
+import { parseOrganizationPlan, type PlanTier } from "../../entitlements.js"
 import { queryValidator, requireAdminMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
+import { DEFAULT_ORGANIZATION_LIMITS, normalizeOrganizationMetadata } from "../../organization-limits.js"
 import type { AuthContextVariables } from "../../session.js"
 
 type UserId = typeof AuthUserTable.$inferSelect.id
+type OrganizationId = typeof OrganizationTable.$inferSelect.id
 
 const overviewQuerySchema = z.object({
   includeBilling: z.string().optional(),
+})
+
+const updateOrganizationPlanSchema = z.object({
+  tier: z.enum(["free", "team", "enterprise"]),
+  seatLimit: z.number().int().min(1).max(100000),
 })
 
 const adminOverviewResponseSchema = z.object({
@@ -118,6 +127,39 @@ function parseBooleanQuery(value: string | undefined): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes"
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function normalizeMetadata(input: Record<string, unknown> | string | null | undefined): Record<string, unknown> {
+  if (!input) {
+    return {}
+  }
+
+  if (typeof input === "string") {
+    try {
+      const parsed = JSON.parse(input) as unknown
+      return isRecord(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+
+  return isRecord(input) ? input : {}
+}
+
+function getManualPlanMetadata(tier: PlanTier) {
+  return {
+    tier,
+    source: "manual" as const,
+    ...(tier === "enterprise" ? { grantedAt: new Date().toISOString() } : {}),
+  }
+}
+
+function isOrganizationId(value: string): value is OrganizationId {
+  return value.startsWith("org_")
+}
+
 async function mapWithConcurrency<T, R>(items: T[], limit: number, mapper: (item: T) => Promise<R>) {
   if (items.length === 0) {
     return [] as R[]
@@ -140,6 +182,49 @@ async function mapWithConcurrency<T, R>(items: T[], limit: number, mapper: (item
 }
 
 export function registerAdminRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
+  app.patch(
+    "/v1/admin/organizations/:organizationId/plan",
+    requireAdminMiddleware,
+    async (c) => {
+      const body = updateOrganizationPlanSchema.safeParse(await c.req.json().catch(() => null))
+      if (!body.success) {
+        return c.json({ error: "invalid_request", message: body.error.issues[0]?.message ?? "Invalid organization plan request." }, 400)
+      }
+
+      const organizationId = c.req.param("organizationId")
+      if (!isOrganizationId(organizationId)) {
+        return c.json({ error: "invalid_request", message: "Invalid organization id." }, 400)
+      }
+      const rows = await db
+        .select({ id: OrganizationTable.id, metadata: OrganizationTable.metadata })
+        .from(OrganizationTable)
+        .where(eq(OrganizationTable.id, organizationId))
+        .limit(1)
+
+      const organization = rows[0]
+      if (!organization) {
+        return c.json({ error: "not_found", message: "Organization not found." }, 404)
+      }
+
+      const normalized = normalizeOrganizationMetadata(organization.metadata).metadata
+      const metadata = {
+        ...normalizeMetadata(normalized),
+        plan: getManualPlanMetadata(body.data.tier),
+        limits: {
+          ...normalized.limits,
+          members: body.data.seatLimit,
+        },
+      }
+
+      await db
+        .update(OrganizationTable)
+        .set({ metadata })
+        .where(eq(OrganizationTable.id, organizationId))
+
+      return c.json({ ok: true, organization: { id: organizationId, plan: parseOrganizationPlan(metadata), seatLimit: body.data.seatLimit } })
+    },
+  )
+
   app.get(
     "/v1/admin/overview",
     describeRoute({
@@ -166,7 +251,7 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
     const sessionDayExpr = sql<string>`date_format(${AuthSessionTable.createdAt}, '%Y-%m-%d')`
     const telemetryDayExpr = sql<string>`date_format(${TelemetryEventTable.event_timestamp}, '%Y-%m-%d')`
 
-    const [admins, users, workerStatsRows, sessionStatsRows, accountRows, sessionDayRows, telemetryDayRows, taskDayRows, inviteStatsRows] = await Promise.all([
+    const [admins, organizations, orgMemberStatsRows, users, workerStatsRows, sessionStatsRows, accountRows, sessionDayRows, telemetryDayRows, taskDayRows, inviteStatsRows] = await Promise.all([
       db
         .select({
           email: AdminAllowlistTable.email,
@@ -175,6 +260,15 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         })
         .from(AdminAllowlistTable)
         .orderBy(asc(AdminAllowlistTable.email)),
+      db.select().from(OrganizationTable).orderBy(desc(OrganizationTable.createdAt)),
+      db
+        .select({
+          organizationId: MemberTable.organizationId,
+          memberCount: sql<number>`count(*)`,
+        })
+        .from(MemberTable)
+        .where(isNull(MemberTable.removedAt))
+        .groupBy(MemberTable.organizationId),
       db.select().from(AuthUserTable).orderBy(desc(AuthUserTable.createdAt)),
       db
         .select({
@@ -266,6 +360,28 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         latestWorkerCreatedAt: row.latestWorkerCreatedAt,
       })
     }
+
+    const memberCountByOrg = new Map<string, number>()
+    for (const row of orgMemberStatsRows) {
+      memberCountByOrg.set(row.organizationId, toNumber(row.memberCount))
+    }
+
+    const organizationRows = organizations.map((entry) => {
+      const metadata = normalizeOrganizationMetadata(entry.metadata).metadata
+      const plan = parseOrganizationPlan(metadata)
+      const seatLimit = metadata.limits.members ?? DEFAULT_ORGANIZATION_LIMITS.members
+
+      return {
+        id: entry.id,
+        name: entry.name,
+        slug: entry.slug,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+        memberCount: memberCountByOrg.get(entry.id) ?? 0,
+        plan,
+        seatLimit,
+      }
+    })
 
     const sessionStatsByUser = new Map<UserId, {
       sessionCount: number
@@ -558,6 +674,7 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         name: user.name,
       },
       admins,
+      organizations: organizationRows,
       summary: {
         ...summary,
         adminCount: admins.length,

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 type AccessState = "loading" | "ready" | "signed-out" | "forbidden" | "error";
 type WorkerFilter = "all" | "with-workers" | "without-workers";
 type BillingFilter = "all" | "paid" | "unpaid" | "unavailable";
-type ViewMode = "users" | "companies";
+type ViewMode = "users" | "companies" | "organizations";
 type ActivityFilter = "all" | "active-7d" | "active-30d" | "recurring" | "inactive-30d";
 type SortMode = "newest" | "recently-active" | "most-sign-ins" | "most-active-days" | "fastest-invite";
 
@@ -81,6 +81,20 @@ type AdminUser = {
   billing: AdminBillingStatus | null;
 };
 
+type AdminOrganization = {
+  id: string;
+  name: string;
+  slug: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  memberCount: number;
+  plan: {
+    tier: "free" | "team" | "enterprise";
+    source: string;
+  };
+  seatLimit: number;
+};
+
 type AdminPayload = {
   viewer: {
     id: string;
@@ -90,6 +104,7 @@ type AdminPayload = {
   admins: AdminEntry[];
   summary: AdminSummary;
   users: AdminUser[];
+  organizations: AdminOrganization[];
   generatedAt: string | null;
 };
 
@@ -215,6 +230,33 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
     })
     .filter((value): value is AdminEntry => value !== null);
 
+  const organizations: AdminOrganization[] = Array.isArray(payload.organizations)
+    ? payload.organizations
+      .map((value) => {
+        if (!isRecord(value) || typeof value.id !== "string" || typeof value.name !== "string" || typeof value.slug !== "string") {
+          return null;
+        }
+
+        const plan = isRecord(value.plan) ? value.plan : {};
+        const tier = plan.tier === "team" || plan.tier === "enterprise" ? plan.tier : "free";
+
+        return {
+          id: value.id,
+          name: value.name,
+          slug: value.slug,
+          createdAt: toStringValue(value.createdAt),
+          updatedAt: toStringValue(value.updatedAt),
+          memberCount: toNumberValue(value.memberCount),
+          plan: {
+            tier,
+            source: toStringValue(plan.source) ?? "default"
+          },
+          seatLimit: toNumberValue(value.seatLimit)
+        };
+      })
+      .filter((value): value is AdminOrganization => value !== null)
+    : [];
+
   return {
     viewer: {
       id: typeof viewer.id === "string" ? viewer.id : "unknown",
@@ -249,6 +291,7 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
       activitySeries: parseActivitySeries(summary.activitySeries)
     },
     users,
+    organizations,
     generatedAt: toStringValue(payload.generatedAt)
   };
 }
@@ -307,6 +350,31 @@ async function requestJson(path: string) {
     headers: {
       Accept: "application/json"
     }
+  });
+
+  const text = await response.text();
+  let payload: unknown = null;
+
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
+
+  return { response, payload };
+}
+
+async function patchJson(path: string, body: unknown) {
+  const response = await fetch(`/api/den${path}`, {
+    method: "PATCH",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(body)
   });
 
   const text = await response.text();
@@ -635,6 +703,20 @@ function BillingPill({ billing }: { billing: AdminBillingStatus | null }) {
   );
 }
 
+function PlanPill({ tier }: { tier: AdminOrganization["plan"]["tier"] }) {
+  const palette = tier === "enterprise"
+    ? "border-violet-200 bg-violet-50 text-violet-700"
+    : tier === "team"
+      ? "border-sky-200 bg-sky-50 text-sky-700"
+      : "border-slate-200 bg-slate-100 text-slate-600";
+
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.16em] ${palette}`}>
+      {tier}
+    </span>
+  );
+}
+
 export function DenAdminPanel() {
   const [accessState, setAccessState] = useState<AccessState>("loading");
   const [payload, setPayload] = useState<AdminPayload | null>(null);
@@ -649,6 +731,8 @@ export function DenAdminPanel() {
   const [billingFilter, setBillingFilter] = useState<BillingFilter>("all");
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [includeBilling, setIncludeBilling] = useState(false);
+  const [orgDrafts, setOrgDrafts] = useState<Record<string, { tier: AdminOrganization["plan"]["tier"]; seatLimit: string }>>({});
+  const [savingOrgId, setSavingOrgId] = useState<string | null>(null);
 
   const loadOverview = useCallback(async (loadBilling: boolean) => {
     setRefreshing(true);
@@ -797,8 +881,85 @@ export function DenAdminPanel() {
     });
   }, [domainGroups, hidePersonalDomains, query]);
 
+  const filteredOrganizations = useMemo(() => {
+    if (!payload) {
+      return [] as AdminOrganization[];
+    }
+
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return payload.organizations;
+    }
+
+    return payload.organizations.filter((org) => `${org.name} ${org.slug} ${org.id}`.toLowerCase().includes(normalizedQuery));
+  }, [payload, query]);
+
+  useEffect(() => {
+    if (!payload) {
+      setOrgDrafts({});
+      return;
+    }
+
+    const drafts: Record<string, { tier: AdminOrganization["plan"]["tier"]; seatLimit: string }> = {};
+    for (const org of payload.organizations) {
+      drafts[org.id] = { tier: org.plan.tier, seatLimit: String(org.seatLimit) };
+    }
+    setOrgDrafts(drafts);
+  }, [payload]);
+
+  const saveOrganizationPlan = useCallback(async (org: AdminOrganization) => {
+    const draft = orgDrafts[org.id];
+    if (!draft) {
+      return;
+    }
+
+    const seatLimit = Number(draft.seatLimit);
+    if (!Number.isInteger(seatLimit) || seatLimit < 1) {
+      setError("Seat limit must be a positive whole number.");
+      return;
+    }
+
+    setSavingOrgId(org.id);
+    setError(null);
+
+    try {
+      const { response, payload: nextPayload } = await patchJson(`/v1/admin/organizations/${org.id}/plan`, {
+        tier: draft.tier,
+        seatLimit
+      });
+
+      if (!response.ok) {
+        setError(getErrorMessage(nextPayload, `Could not update ${org.name}.`));
+        return;
+      }
+
+      await loadOverview(includeBilling);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Unknown network error");
+    } finally {
+      setSavingOrgId(null);
+    }
+  }, [includeBilling, loadOverview, orgDrafts]);
+
   const exportCsv = useCallback(() => {
     const date = new Date().toISOString().slice(0, 10);
+
+    if (viewMode === "organizations") {
+      downloadCsv(`den-organizations-${date}.csv`, [
+        ["id", "name", "slug", "plan", "plan_source", "seat_limit", "members", "created_at"],
+        ...filteredOrganizations.map((org) => [
+          org.id,
+          org.name,
+          org.slug,
+          org.plan.tier,
+          org.plan.source,
+          String(org.seatLimit),
+          String(org.memberCount),
+          org.createdAt ?? ""
+        ])
+      ]);
+      return;
+    }
 
     if (viewMode === "companies") {
       downloadCsv(`den-companies-${date}.csv`, [
@@ -835,7 +996,7 @@ export function DenAdminPanel() {
         user.authProviders.join("; ")
       ])
     ]);
-  }, [filteredDomains, filteredUsers, viewMode]);
+  }, [filteredDomains, filteredOrganizations, filteredUsers, viewMode]);
 
   useEffect(() => {
     if (!payload) {
@@ -980,19 +1141,44 @@ export function DenAdminPanel() {
             >
               Companies ({companyDomainCount})
             </button>
+            <button
+              type="button"
+              onClick={() => setViewMode("organizations")}
+              className={`rounded-full px-4 py-1.5 text-sm font-semibold transition ${viewMode === "organizations" ? "bg-slate-950 text-white" : "text-slate-600 hover:text-slate-900"}`}
+            >
+              Organizations ({payload.organizations.length})
+            </button>
           </div>
 
           <button
             type="button"
             onClick={exportCsv}
-            disabled={viewMode === "companies" ? filteredDomains.length === 0 : filteredUsers.length === 0}
+            disabled={viewMode === "organizations" ? filteredOrganizations.length === 0 : viewMode === "companies" ? filteredDomains.length === 0 : filteredUsers.length === 0}
             className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
           >
             Export CSV
           </button>
         </div>
 
-        {viewMode === "companies" ? (
+        {error ? (
+          <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-900">
+            {error}
+          </div>
+        ) : null}
+
+        {viewMode === "organizations" ? (
+          <div className="mt-4">
+            <label className="grid w-full max-w-xl gap-2">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Search organizations</span>
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Org name, slug, or id"
+                className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-slate-400"
+              />
+            </label>
+          </div>
+        ) : viewMode === "companies" ? (
           <div className="mt-4 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <label className="grid w-full max-w-xl gap-2">
               <span className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Search companies</span>
@@ -1104,7 +1290,84 @@ export function DenAdminPanel() {
         )}
 
         <div className="mt-6 grid gap-3">
-          {viewMode === "companies" ? (
+          {viewMode === "organizations" ? (
+            filteredOrganizations.length > 0 ? filteredOrganizations.map((org) => {
+              const draft = orgDrafts[org.id] ?? { tier: org.plan.tier, seatLimit: String(org.seatLimit) };
+              const changed = draft.tier !== org.plan.tier || draft.seatLimit !== String(org.seatLimit);
+
+              return (
+                <div key={org.id} className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate text-base font-semibold text-slate-950">{org.name}</p>
+                        <PlanPill tier={org.plan.tier} />
+                      </div>
+                      <p className="mt-1 truncate text-sm text-slate-500">/{org.slug} · {org.id}</p>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-600">
+                        {org.memberCount} / {org.seatLimit} seats
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                    <MetaCell label="Created" value={formatDateTime(org.createdAt)} />
+                    <MetaCell label="Plan source" value={formatProvider(org.plan.source)} />
+                    <MetaCell label="Members" value={String(org.memberCount)} />
+                    <MetaCell label="Seat limit" value={String(org.seatLimit)} />
+                  </div>
+
+                  <div className="mt-4 grid gap-3 border-t border-slate-200 pt-4 lg:grid-cols-[12rem_10rem_auto] lg:items-end">
+                    <label className="grid gap-2">
+                      <span className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Plan</span>
+                      <select
+                        value={draft.tier}
+                        onChange={(event) => {
+                          const tier = event.target.value === "enterprise" || event.target.value === "team" ? event.target.value : "free";
+                          setOrgDrafts((current) => ({ ...current, [org.id]: { ...draft, tier } }));
+                        }}
+                        className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-slate-400"
+                      >
+                        <option value="free">Free</option>
+                        <option value="team">Team</option>
+                        <option value="enterprise">Enterprise</option>
+                      </select>
+                    </label>
+
+                    <label className="grid gap-2">
+                      <span className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Seats</span>
+                      <input
+                        type="number"
+                        min={1}
+                        value={draft.seatLimit}
+                        onChange={(event) => setOrgDrafts((current) => ({ ...current, [org.id]: { ...draft, seatLimit: event.target.value } }))}
+                        className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-slate-400"
+                      />
+                    </label>
+
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void saveOrganizationPlan(org);
+                      }}
+                      disabled={!changed || savingOrgId === org.id}
+                      className="inline-flex items-center justify-center rounded-full bg-slate-950 px-4 py-3 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {savingOrgId === org.id ? "Saving..." : "Save access"}
+                    </button>
+                  </div>
+                </div>
+              );
+            }) : (
+              <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-5 py-10 text-center">
+                <p className="text-base font-semibold text-slate-950">No organizations match</p>
+                <p className="mt-2 text-sm leading-7 text-slate-500">Try a different search.</p>
+              </div>
+            )
+          ) : viewMode === "companies" ? (
             filteredDomains.length > 0 ? filteredDomains.map((group) => (
               <div key={group.domain} className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
                 <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">

--- a/ee/packages/den-admin-mcp/index.mjs
+++ b/ee/packages/den-admin-mcp/index.mjs
@@ -197,9 +197,9 @@ function assertReadOnly(input) {
 
 // --- MCP server ---
 
-// Keep in sync with package.json and the server-hosted toolset version in
-// ee/apps/den-api/src/mcp/admin-tools.ts (DEN_ADMIN_MCP_VERSION).
-const DEN_ADMIN_MCP_VERSION = "0.3.0";
+// Keep in sync with package.json. The hosted admin MCP may expose additional
+// admin-only write tools while this break-glass stdio variant remains read-only.
+const DEN_ADMIN_MCP_VERSION = "0.4.0";
 
 const server = new McpServer({ name: "den-admin", version: DEN_ADMIN_MCP_VERSION });
 

--- a/ee/packages/den-admin-mcp/package.json
+++ b/ee/packages/den-admin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openwork-ee/den-admin-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Read-only admin analytics MCP server for the OpenWork Den database — growth, retention, company/user lookups",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary
- add admin overview organization rows with plan and seat limit
- add admin API mutation for setting org plan tier and member seat limit
- add Organizations tab to the Den admin panel
- add hosted admin MCP tool `den_update_org_plan` and bump den-admin toolset to 0.4.0

## Tests
- `pnpm exec tsc --noEmit` in `ee/apps/den-api`: passed
- `pnpm exec tsc --noEmit` in `ee/apps/den-web`: passed
- `bun test` in `ee/apps/den-api`: 115 pass / 0 fail
- `pnpm build` in `ee/apps/den-web`: passed, including `/admin` prerender
- `pnpm run check` in `ee/packages/den-admin-mcp`: passed

## Daytona E2E
Server sandbox: `openwork-server-20260613-140204`
- checked out feature commit `e6a2c0c`
- Den Web health: `https://3005-zifegvyikqv9chas.daytonaproxy01.net/api/den/health` returned ok
- Den API health: `https://8788-kleirtmxjeexefb3.daytonaproxy01.net/health` returned ok
- seeded Acme Robotics org and allowlisted `alex@acme.test` as admin
- `GET /v1/admin/overview` with admin bearer session returned `organizations[0]` with Acme Robotics, `plan.tier=free`, `seatLimit=100`
- `PATCH /v1/admin/organizations/org_01kv1cx409exsrbafdxa7cevhn/plan` with `{ tier: "enterprise", seatLimit: 42 }` returned ok and DB metadata showed `plan.tier=enterprise`, `plan.source=manual`, `limits.members=42`
- hosted admin MCP `initialize` against `/mcp/admin` returned server version `0.4.0`
- hosted admin MCP `den_update_org_plan` with `{ tier: "team", seatLimit: 55 }` returned ok and DB metadata showed `plan.tier=team`, `plan.source=manual`, `limits.members=55`

Artifact screenshot:
- `/daytona-artifacts/screenshots/daytona-screenshot-20260613-211156.png` in Electron sandbox `openwork-test-20260613-140648`
- artifact server: `https://8090-dqrygcupoayct9ke.daytonaproxy01.net`

Note: UI visible interaction was validated through the same admin overview/mutation endpoints the panel uses plus Den Web build/prerender. The available CDP target in Daytona was Electron only, not a standalone Den Web Chrome target.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

