### PR TITLE
[codex] audit organization invitations

### DIFF
--- a/ee/apps/den-api/src/audit-events.ts
+++ b/ee/apps/den-api/src/audit-events.ts
@@ -5,6 +5,9 @@ import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 export const ORGANIZATION_AUDIT_ACTIONS = {
   apiKeyCreated: "organization.api_key.created",
   apiKeyDeleted: "organization.api_key.deleted",
+  invitationCreated: "organization.invitation.created",
+  invitationRefreshed: "organization.invitation.refreshed",
+  invitationCanceled: "organization.invitation.canceled",
   memberRoleUpdated: "organization.member.role_updated",
   memberRemoved: "organization.member.removed",
   scimTokenRotated: "organization.scim.token_rotated",

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -4,6 +4,7 @@ import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
+import { ORGANIZATION_AUDIT_ACTIONS, recordOrganizationAuditEvent } from "../../audit-events.js"
 import { db } from "../../db.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
@@ -151,6 +152,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     const invitationId = existingInvitation[0]?.id ?? createInvitationId()
     const inviteToken = createInvitationToken()
     let createdOrgMemberId: typeof MemberTable.$inferSelect.id | null = null
+    let invitationOrgMemberId: typeof MemberTable.$inferSelect.id | null = null
 
     if (existingInvitation[0]) {
       await db
@@ -169,6 +171,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
           .update(MemberTable)
           .set({ role, invitedByOrgMember: payload.currentMember.id })
           .where(eq(MemberTable.id, invitedMemberRows[0].id))
+        invitationOrgMemberId = invitedMemberRows[0].id
       } else {
         const memberId = createDenTypeId("member")
         await db.insert(MemberTable).values({
@@ -181,6 +184,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
           joinedAt: null,
         })
         createdOrgMemberId = memberId
+        invitationOrgMemberId = memberId
       }
     } else {
       await db.insert(InvitationTable).values({
@@ -206,11 +210,27 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         joinedAt: null,
       })
       createdOrgMemberId = memberId
+      invitationOrgMemberId = memberId
     }
 
     if (createdOrgMemberId) {
       await runPostOrganizationMemberChangeHooks({ organizationId: payload.organization.id, memberId: createdOrgMemberId, change: "added" })
     }
+
+    await recordOrganizationAuditEvent({
+      organizationId: payload.organization.id,
+      actorUserId: payload.currentMember.userId,
+      action: existingInvitation[0]
+        ? ORGANIZATION_AUDIT_ACTIONS.invitationRefreshed
+        : ORGANIZATION_AUDIT_ACTIONS.invitationCreated,
+      payload: {
+        invitationId,
+        targetOrgMembershipId: invitationOrgMemberId,
+        targetEmail: email,
+        role,
+        expiresAt: expiresAt.toISOString(),
+      },
+    })
 
     try {
       await sendEmail({
@@ -287,7 +307,12 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     }
 
     const invitationRows = await db
-      .select({ id: InvitationTable.id })
+      .select({
+        id: InvitationTable.id,
+        email: InvitationTable.email,
+        role: InvitationTable.role,
+        status: InvitationTable.status,
+      })
       .from(InvitationTable)
       .where(and(eq(InvitationTable.id, invitationId), eq(InvitationTable.organizationId, payload.organization.id)))
       .limit(1)
@@ -315,6 +340,19 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         return c.json({ error: removed.error, message: removed.message }, 400)
       }
     }
+
+    await recordOrganizationAuditEvent({
+      organizationId: payload.organization.id,
+      actorUserId: payload.currentMember.userId,
+      action: ORGANIZATION_AUDIT_ACTIONS.invitationCanceled,
+      payload: {
+        invitationId: invitationRows[0].id,
+        targetOrgMembershipId: invitedMember?.id ?? null,
+        targetEmail: invitationRows[0].email,
+        role: invitationRows[0].role,
+        previousStatus: invitationRows[0].status,
+      },
+    })
 
     return c.json({ success: true })
     },

--- a/ee/apps/den-api/test/audit-events.test.ts
+++ b/ee/apps/den-api/test/audit-events.test.ts
@@ -67,6 +67,36 @@ test("organization audit events support member lifecycle actions", () => {
   })
 })
 
+test("organization audit events support invitation lifecycle actions", () => {
+  const invitationId = createDenTypeId("invitation")
+  const targetOrgMembershipId = createDenTypeId("member")
+
+  expect(ORGANIZATION_AUDIT_ACTIONS.invitationRefreshed).toBe("organization.invitation.refreshed")
+  expect(ORGANIZATION_AUDIT_ACTIONS.invitationCanceled).toBe("organization.invitation.canceled")
+
+  const event = buildOrganizationAuditEvent({
+    organizationId: createDenTypeId("organization"),
+    actorUserId: createDenTypeId("user"),
+    action: ORGANIZATION_AUDIT_ACTIONS.invitationCreated,
+    payload: {
+      invitationId,
+      targetOrgMembershipId,
+      targetEmail: "new-member@example.com",
+      role: "member",
+      expiresAt: "2026-06-20T00:00:00.000Z",
+    },
+  })
+
+  expect(event.action).toBe("organization.invitation.created")
+  expect(event.payload).toEqual({
+    invitationId,
+    targetOrgMembershipId,
+    targetEmail: "new-member@example.com",
+    role: "member",
+    expiresAt: "2026-06-20T00:00:00.000Z",
+  })
+})
+
 test("organization audit events support SCIM management actions", () => {
   const scimProviderId = createDenTypeId("scimProvider")
 


### PR DESCRIPTION
## Summary
- Add organization audit actions for invitation creation, refresh, and cancellation.
- Record non-secret audit events after invitation rows are persisted or canceled.
- Keep invite tokens out of audit payloads while preserving useful target member, email, role, and status context.
- Extend focused audit helper coverage for invitation lifecycle actions.

## Security Impact
- Expands privileged-action audit coverage for member-add invitation workflows without storing invitation bearer tokens in audit payloads.

## Validation
- `pnpm install --frozen-lockfile` - passed
- `pnpm --filter @openwork-ee/den-api build` - passed
- `bun test ee/apps/den-api/test/audit-events.test.ts` - passed, 6 pass / 0 fail
- `bun test ee/apps/den-api/test/org-invitations.test.ts` - passed, 5 pass / 0 fail
- `bun test ee/apps/den-api/test` - passed, 116 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Rebase Validation
After refreshing onto current `origin/dev`:
- `bun test ee/apps/den-api/test/audit-events.test.ts` - passed, 6 pass / 0 fail
- `bun test ee/apps/den-api/test/org-invitations.test.ts` - passed, 5 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `git diff --check` - passed

## Live Smoke
- Not applicable for this server-only invitation audit instrumentation change.