### PR TITLE
[codex] document Cloud security operations posture

### DIFF
--- a/packages/docs/cloud/security-and-operations.mdx
+++ b/packages/docs/cloud/security-and-operations.mdx
@@ -1,0 +1,93 @@
+---
+title: "Security and operations"
+description: "Review OpenWork Cloud security posture, access governance, and availability expectations"
+---
+
+This page summarizes the security and operational controls that matter when a team runs OpenWork Cloud or a private OpenWork deployment.
+
+OpenWork is local-first, but Cloud adds shared identity, members, RBAC, hosted workers, shared providers, and organization policy. Treat Cloud as the control plane for team access and shared runtime state.
+
+## Encryption and transport
+
+Production deployments should enforce encrypted transport and encrypted storage:
+
+- Use HTTPS for the Cloud app, Den API, OAuth callbacks, webhook ingress, and worker-control traffic.
+- Terminate TLS at the edge or load balancer and forward only through trusted private networking.
+- Enable encryption at rest for the production database, object storage, backups, and logs that may contain operational metadata.
+- Keep local development defaults local-only. Example development database URLs and local secrets in repository scripts are not production settings.
+
+For private or self-hosted deployments, the operator is responsible for enabling TLS certificates, database storage encryption, backup encryption, and private network policy in the target environment.
+
+## Secrets and keys
+
+Production secrets should live in a managed secrets system or KMS-backed environment, not in committed files or shared shell history.
+
+Use separate secrets per environment for:
+
+- Better Auth signing and session secrets
+- database encryption material
+- OAuth, SSO, SCIM, and webhook secrets
+- provider API keys and worker provisioning tokens
+
+OpenWork stores organization API keys and SCIM bearer tokens as hashes. SSO provider configuration is stored encrypted. Rotate production secrets on a defined schedule and immediately after suspected exposure or emergency access use.
+
+## Identity and access governance
+
+Use the Cloud member model as the source of truth for organization access:
+
+- Keep at least two `Owner` members.
+- Use `Admin` for day-to-day operators.
+- Keep most people as `Member`.
+- Use custom roles only when the built-in roles are too broad.
+- Use teams for resource access to marketplaces and providers.
+
+For access reviews, export the current member list, roles, teams, pending invitations, API keys, SSO configuration, and SCIM configuration on a regular cadence. Reconfirm that each member still needs their current role and team access.
+
+For mover and leaver handling:
+
+- Change roles when responsibilities change.
+- Remove members when access is no longer needed.
+- Cancel stale invitations.
+- Rotate or revoke organization API keys that were issued for the affected member.
+- Prefer SCIM deprovisioning where an identity provider is the system of record.
+
+## Emergency access
+
+Plan emergency access before it is needed.
+
+Recommended pattern:
+
+- Maintain a break-glass `Owner` account or equivalent recovery path.
+- Protect it with the strongest authentication available in the deployment.
+- Store credentials in a controlled emergency vault.
+- Alert on any use.
+- Review the audit trail after use.
+- Rotate credentials or signing material if emergency access exposed them.
+
+Do not use break-glass accounts for routine administration.
+
+## Audit events
+
+OpenWork records structured organization audit events for privileged Cloud actions, including:
+
+- API key creation and deletion
+- member role changes and removals
+- invitation creation, refresh, and cancellation
+- custom role creation, updates, and deletion
+- SCIM token rotation and connection deletion
+- SSO registration and deletion
+
+Audit payloads avoid bearer tokens, API key secrets, SCIM tokens, SAML certificates, and OIDC client secrets. For private deployments, export audit data through the deployment's database or logging pipeline into the organization's retention and SIEM process.
+
+## Availability and failover
+
+Production deployments should avoid a single-node control plane:
+
+- Run the Cloud app and Den API behind health checks.
+- Run more than one API instance where the platform supports it.
+- Use a managed database with automated backups and failover.
+- Monitor API health, worker provisioning, queue depth, webhook failures, sign-in failures, and database connectivity.
+- Define recovery objectives for the database, object storage, and worker state.
+- Test restore and failover procedures before an incident.
+
+For self-hosted deployments, document the exact topology: ingress, app, API, worker provisioning, database, backups, and the person or team responsible for each part.

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -78,6 +78,7 @@
             ]
           },
           "cloud/members-and-rbac",
+          "cloud/security-and-operations",
           "cloud/enterprise"
         ]
       },


### PR DESCRIPTION
## Summary
- Add a Cloud security and operations page covering encryption, TLS, secrets, access governance, emergency access, audit events, and availability expectations.
- Add the page to the Cloud docs navigation.
- Keep the guidance public and deployment-oriented, without referencing any private review context.

## Security Impact
- Documents operational controls for encryption/TLS, access review, mover/leaver handling, break-glass access, audit export, and HA/failover expectations.

## Validation
- `node -e 'JSON.parse(require("fs").readFileSync("packages/docs/docs.json", "utf8")); console.log("docs.json ok")'` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Live Smoke
- Not applicable for this docs-only change; screenshots or video are not relevant.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

