### PR TITLE
[codex] revoke sessions on membership changes

### DIFF
--- a/ee/apps/den-api/src/credential-revocation.ts
+++ b/ee/apps/den-api/src/credential-revocation.ts
@@ -1,0 +1,75 @@
+import { and, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
+import {
+  AuthSessionTable,
+  MemberTable,
+  OAuthAccessTokenTable,
+  OAuthRefreshTokenTable,
+} from "@openwork-ee/den-db/schema"
+import { db } from "./db.js"
+
+type OrganizationId = typeof MemberTable.$inferSelect.organizationId
+type UserId = typeof AuthSessionTable.$inferSelect.userId
+
+export type MembershipCredentialRevocationCounts = {
+  sessions: number
+  oauthAccessTokens: number
+  oauthRefreshTokens: number
+}
+
+export async function revokeMembershipSessionCredentials(input: {
+  organizationId: OrganizationId
+  userId: UserId | null
+}): Promise<MembershipCredentialRevocationCounts> {
+  if (!input.userId) {
+    return { sessions: 0, oauthAccessTokens: 0, oauthRefreshTokens: 0 }
+  }
+
+  const sessions = await db
+    .select({ id: AuthSessionTable.id })
+    .from(AuthSessionTable)
+    .where(eq(AuthSessionTable.userId, input.userId))
+
+  if (sessions.length > 0) {
+    // Auth sessions are user-scoped credentials. Revoke them all so a live
+    // session cannot re-select the changed organization and mint new tokens.
+    await db
+      .delete(AuthSessionTable)
+      .where(inArray(AuthSessionTable.id, sessions.map((session) => session.id)))
+  }
+
+  const oauthAccessTokens = await db
+    .select({ id: OAuthAccessTokenTable.id })
+    .from(OAuthAccessTokenTable)
+    .where(and(
+      eq(OAuthAccessTokenTable.userId, input.userId),
+      eq(OAuthAccessTokenTable.referenceId, input.organizationId),
+    ))
+
+  if (oauthAccessTokens.length > 0) {
+    await db
+      .delete(OAuthAccessTokenTable)
+      .where(inArray(OAuthAccessTokenTable.id, oauthAccessTokens.map((token) => token.id)))
+  }
+
+  const oauthRefreshTokens = await db
+    .select({ id: OAuthRefreshTokenTable.id })
+    .from(OAuthRefreshTokenTable)
+    .where(and(
+      eq(OAuthRefreshTokenTable.userId, input.userId),
+      eq(OAuthRefreshTokenTable.referenceId, input.organizationId),
+      isNull(OAuthRefreshTokenTable.revoked),
+    ))
+
+  if (oauthRefreshTokens.length > 0) {
+    await db
+      .update(OAuthRefreshTokenTable)
+      .set({ revoked: new Date() })
+      .where(inArray(OAuthRefreshTokenTable.id, oauthRefreshTokens.map((token) => token.id)))
+  }
+
+  return {
+    sessions: sessions.length,
+    oauthAccessTokens: oauthAccessTokens.length,
+    oauthRefreshTokens: oauthRefreshTokens.length,
+  }
+}

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -11,6 +11,7 @@ import {
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { revokeOrganizationApiKeysForMember } from "./api-keys.js"
+import { revokeMembershipSessionCredentials } from "./credential-revocation.js"
 import { db } from "./db.js"
 import {
   roleIncludesOwner as guardRoleIncludesOwner,
@@ -1132,6 +1133,10 @@ export async function removeOrganizationMember(input: {
   await revokeOrganizationApiKeysForMember({
     organizationId: input.organizationId,
     orgMembershipId: member.id,
+    userId: member.userId,
+  })
+  await revokeMembershipSessionCredentials({
+    organizationId: input.organizationId,
     userId: member.userId,
   })
 

--- a/ee/apps/den-api/src/routes/org/members.ts
+++ b/ee/apps/den-api/src/routes/org/members.ts
@@ -6,6 +6,7 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { revokeOrganizationApiKeysForMember } from "../../api-keys.js"
 import { ORGANIZATION_AUDIT_ACTIONS, recordOrganizationAuditEvent } from "../../audit-events.js"
+import { revokeMembershipSessionCredentials } from "../../credential-revocation.js"
 import { db } from "../../db.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
@@ -79,6 +80,10 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
       await revokeOrganizationApiKeysForMember({
         organizationId: payload.organization.id,
         orgMembershipId: validation.member.id,
+        userId: validation.member.userId,
+      })
+      await revokeMembershipSessionCredentials({
+        organizationId: payload.organization.id,
         userId: validation.member.userId,
       })
       await recordOrganizationAuditEvent({

--- a/ee/apps/den-api/test/credential-revocation.test.ts
+++ b/ee/apps/den-api/test/credential-revocation.test.ts
@@ -1,0 +1,109 @@
+import { beforeAll, expect, mock, test } from "bun:test"
+import {
+  AuthSessionTable,
+  OAuthAccessTokenTable,
+  OAuthRefreshTokenTable,
+} from "@openwork-ee/den-db/schema"
+
+const selectedRows = {
+  sessions: [{ id: "session_one" }, { id: "session_two" }],
+  oauthAccessTokens: [{ id: "oauth_access_one" }],
+  oauthRefreshTokens: [{ id: "oauth_refresh_one" }],
+}
+
+const deleteCalls: unknown[] = []
+const updateCalls: { table: unknown; value: unknown }[] = []
+let selectCalls = 0
+
+function rowsForTable(table: unknown) {
+  if (table === AuthSessionTable) {
+    return selectedRows.sessions
+  }
+  if (table === OAuthAccessTokenTable) {
+    return selectedRows.oauthAccessTokens
+  }
+  if (table === OAuthRefreshTokenTable) {
+    return selectedRows.oauthRefreshTokens
+  }
+  return []
+}
+
+function resetCalls() {
+  deleteCalls.length = 0
+  updateCalls.length = 0
+  selectCalls = 0
+}
+
+let credentialRevocationModule: typeof import("../src/credential-revocation.js")
+
+beforeAll(async () => {
+  mock.module("../src/db.js", () => ({
+    db: {
+      select: () => ({
+        from: (table: unknown) => ({
+          where: () => {
+            selectCalls += 1
+            return Promise.resolve(rowsForTable(table))
+          },
+        }),
+      }),
+      delete: (table: unknown) => ({
+        where: () => {
+          deleteCalls.push(table)
+          return Promise.resolve()
+        },
+      }),
+      update: (table: unknown) => ({
+        set: (value: unknown) => ({
+          where: () => {
+            updateCalls.push({ table, value })
+            return Promise.resolve()
+          },
+        }),
+      }),
+    },
+  }))
+
+  credentialRevocationModule = await import("../src/credential-revocation.js")
+})
+
+test("membership credential revocation deletes sessions and org-scoped OAuth access tokens", async () => {
+  resetCalls()
+
+  const counts = await credentialRevocationModule.revokeMembershipSessionCredentials({
+    organizationId: "org_123",
+    userId: "user_123",
+  })
+
+  expect(counts).toEqual({
+    sessions: 2,
+    oauthAccessTokens: 1,
+    oauthRefreshTokens: 1,
+  })
+  expect(selectCalls).toBe(3)
+  expect(deleteCalls).toEqual([
+    AuthSessionTable,
+    OAuthAccessTokenTable,
+  ])
+  expect(updateCalls).toHaveLength(1)
+  expect(updateCalls[0]?.table).toBe(OAuthRefreshTokenTable)
+  expect(updateCalls[0]?.value).toEqual({ revoked: expect.any(Date) })
+})
+
+test("membership credential revocation skips anonymous pending members", async () => {
+  resetCalls()
+
+  const counts = await credentialRevocationModule.revokeMembershipSessionCredentials({
+    organizationId: "org_123",
+    userId: null,
+  })
+
+  expect(counts).toEqual({
+    sessions: 0,
+    oauthAccessTokens: 0,
+    oauthRefreshTokens: 0,
+  })
+  expect(selectCalls).toBe(0)
+  expect(deleteCalls).toEqual([])
+  expect(updateCalls).toEqual([])
+})


### PR DESCRIPTION
## Summary
- Add a shared membership credential revocation helper for den-api.
- Revoke user auth sessions and org-scoped MCP OAuth access/refresh tokens when a member is removed or their role changes.
- Keep existing organization API-key revocation in place and add focused unit coverage.

## Security Impact
- Reduces stale-token exposure after deprovisioning or role changes.
- Session tokens are user-scoped, so membership changes revoke all user sessions to prevent re-selecting the changed organization and minting fresh org-scoped tokens.
- Org-scoped MCP OAuth access tokens are deleted and refresh tokens are marked revoked for the affected organization.

## Validation
- `pnpm install --frozen-lockfile` - passed
- `pnpm --filter @openwork-ee/den-api build` - passed
- `bun test ee/apps/den-api/test/credential-revocation.test.ts` - passed, 2 pass / 0 fail
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed
- `bun test ee/apps/den-api/test` - passed, 121 pass / 0 fail
- `git diff --check` - passed
- `git diff --cached --check` - passed before commit

## Live Smoke
- Not applicable for this server-only credential lifecycle change; screenshots or video are not relevant.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

