### PR TITLE
[codex] Add email password login protection

### DIFF
--- a/ee/apps/den-api/src/auth-protection.ts
+++ b/ee/apps/den-api/src/auth-protection.ts
@@ -1,0 +1,254 @@
+import { createHash } from "node:crypto"
+import { eq } from "@openwork-ee/den-db/drizzle"
+import { RateLimitTable } from "@openwork-ee/den-db/schema"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { db } from "./db.js"
+
+export const EMAIL_PASSWORD_SIGN_IN_PATH = "/api/auth/sign-in/email"
+export const EMAIL_PASSWORD_SIGN_UP_PATH = "/api/auth/sign-up/email"
+export const CHANGE_PASSWORD_PATH = "/api/auth/change-password"
+export const RESET_PASSWORD_PATH = "/api/auth/reset-password"
+export const LOGIN_LOCKOUT_FAILURE_THRESHOLD = 5
+export const LOGIN_LOCKOUT_FAILURE_WINDOW_MS = 60 * 60 * 1000
+export const LOGIN_LOCKOUT_BASE_MS = 5 * 60 * 1000
+export const LOGIN_LOCKOUT_MAX_MS = 60 * 60 * 1000
+
+type LoginAttempt = {
+  email: string
+}
+
+type LoginFailureState = {
+  count: number
+  lastRequest: number
+}
+
+type LockoutStatus = {
+  locked: boolean
+  retryAfterSeconds: number
+}
+
+type PwnedPasswordsFetch = (input: string, init?: RequestInit) => Promise<Response>
+
+function normalizedPath(request: Request) {
+  const path = new URL(request.url).pathname
+  return path !== "/" ? path.replace(/\/+$/, "") : path
+}
+
+function normalizeEmail(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim().toLowerCase() : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+async function readJsonObject(request: Request) {
+  const contentType = request.headers.get("content-type")?.toLowerCase() ?? ""
+  if (!contentType.includes("application/json")) {
+    return null
+  }
+
+  try {
+    const parsed: unknown = await request.clone().json()
+    return isRecord(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function jsonError(status: number, body: { error: string; message: string }, headers?: HeadersInit) {
+  const responseHeaders = new Headers(headers)
+  responseHeaders.set("content-type", "application/json")
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: responseHeaders,
+  })
+}
+
+function lockoutKey(email: string) {
+  const digest = createHash("sha256").update(email).digest("base64url")
+  return `auth:email-password-lockout:${digest}`
+}
+
+function hashPasswordForRangeLookup(password: string) {
+  return createHash("sha1").update(password).digest("hex").toUpperCase()
+}
+
+export function getLoginLockoutDurationMs(failureCount: number) {
+  if (failureCount < LOGIN_LOCKOUT_FAILURE_THRESHOLD) {
+    return 0
+  }
+
+  const exponent = Math.min(failureCount - LOGIN_LOCKOUT_FAILURE_THRESHOLD, 4)
+  return Math.min(LOGIN_LOCKOUT_BASE_MS * (2 ** exponent), LOGIN_LOCKOUT_MAX_MS)
+}
+
+export function getLoginLockoutStatus(state: LoginFailureState | null, now = Date.now()): LockoutStatus {
+  if (!state || now - state.lastRequest > LOGIN_LOCKOUT_FAILURE_WINDOW_MS) {
+    return { locked: false, retryAfterSeconds: 0 }
+  }
+
+  const durationMs = getLoginLockoutDurationMs(state.count)
+  const retryAfterMs = state.lastRequest + durationMs - now
+  if (retryAfterMs <= 0) {
+    return { locked: false, retryAfterSeconds: 0 }
+  }
+
+  return {
+    locked: true,
+    retryAfterSeconds: Math.ceil(retryAfterMs / 1000),
+  }
+}
+
+export async function readEmailPasswordSignInAttempt(request: Request): Promise<LoginAttempt | null> {
+  if (request.method !== "POST" || normalizedPath(request) !== EMAIL_PASSWORD_SIGN_IN_PATH) {
+    return null
+  }
+
+  const body = await readJsonObject(request)
+  const email = normalizeEmail(body?.email)
+  return email ? { email } : null
+}
+
+async function readLoginFailureState(email: string): Promise<LoginFailureState | null> {
+  const [row] = await db
+    .select({
+      count: RateLimitTable.count,
+      lastRequest: RateLimitTable.lastRequest,
+    })
+    .from(RateLimitTable)
+    .where(eq(RateLimitTable.key, lockoutKey(email)))
+    .limit(1)
+
+  return row ?? null
+}
+
+export async function getEmailPasswordLockoutResponse(attempt: LoginAttempt, now = Date.now()) {
+  const status = getLoginLockoutStatus(await readLoginFailureState(attempt.email), now)
+  if (!status.locked) {
+    return null
+  }
+
+  return jsonError(429, {
+    error: "login_locked",
+    message: "Too many failed sign-in attempts. Try again later.",
+  }, {
+    "retry-after": String(status.retryAfterSeconds),
+  })
+}
+
+export async function recordEmailPasswordSignInFailure(attempt: LoginAttempt, now = Date.now()) {
+  const key = lockoutKey(attempt.email)
+  const [row] = await db
+    .select({
+      id: RateLimitTable.id,
+      count: RateLimitTable.count,
+      lastRequest: RateLimitTable.lastRequest,
+    })
+    .from(RateLimitTable)
+    .where(eq(RateLimitTable.key, key))
+    .limit(1)
+
+  if (!row) {
+    await db.insert(RateLimitTable).values({
+      id: createDenTypeId("rateLimit"),
+      key,
+      count: 1,
+      lastRequest: now,
+    })
+    return
+  }
+
+  const nextCount = now - row.lastRequest > LOGIN_LOCKOUT_FAILURE_WINDOW_MS ? 1 : row.count + 1
+  await db
+    .update(RateLimitTable)
+    .set({ count: nextCount, lastRequest: now })
+    .where(eq(RateLimitTable.id, row.id))
+}
+
+export async function clearEmailPasswordSignInFailures(attempt: LoginAttempt) {
+  await db
+    .delete(RateLimitTable)
+    .where(eq(RateLimitTable.key, lockoutKey(attempt.email)))
+}
+
+export async function recordEmailPasswordSignInResult(attempt: LoginAttempt, response: Response, now = Date.now()) {
+  if (response.status === 401) {
+    await recordEmailPasswordSignInFailure(attempt, now)
+    return
+  }
+
+  if (response.status >= 200 && response.status < 400) {
+    await clearEmailPasswordSignInFailures(attempt)
+  }
+}
+
+export async function readPasswordForBreachCheck(request: Request) {
+  if (request.method !== "POST") {
+    return null
+  }
+
+  const path = normalizedPath(request)
+  const body = await readJsonObject(request)
+  if (!body) {
+    return null
+  }
+
+  const password = path === EMAIL_PASSWORD_SIGN_UP_PATH
+    ? body.password
+    : path === CHANGE_PASSWORD_PATH || path === RESET_PASSWORD_PATH
+      ? body.newPassword
+      : null
+
+  return typeof password === "string" && password ? password : null
+}
+
+export async function isPasswordCompromised(password: string, fetchPasswordRange: PwnedPasswordsFetch = fetch) {
+  const hash = hashPasswordForRangeLookup(password)
+  const prefix = hash.slice(0, 5)
+  const suffix = hash.slice(5)
+  const response = await fetchPasswordRange(`https://api.pwnedpasswords.com/range/${prefix}`, {
+    headers: {
+      "add-padding": "true",
+      "user-agent": "OpenWork den-api password screening",
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error("password_screening_unavailable")
+  }
+
+  const body = await response.text()
+  return body
+    .split(/\r?\n/g)
+    .some((line) => {
+      const [entry] = line.trim().split(":")
+      return entry === suffix
+    })
+}
+
+export async function getBreachedPasswordResponse(request: Request, fetchPasswordRange?: PwnedPasswordsFetch) {
+  const password = await readPasswordForBreachCheck(request)
+  if (!password) {
+    return null
+  }
+
+  let compromised: boolean
+  try {
+    compromised = await isPasswordCompromised(password, fetchPasswordRange)
+  } catch {
+    return jsonError(503, {
+      error: "password_screening_unavailable",
+      message: "Password screening is temporarily unavailable. Try again later.",
+    })
+  }
+
+  if (!compromised) {
+    return null
+  }
+
+  return jsonError(400, {
+    error: "password_compromised",
+    message: "Choose a different password.",
+  })
+}

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -4,6 +4,12 @@ import { oauthProviderAuthServerMetadata, oauthProviderOpenIdConfigMetadata } fr
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { auth } from "../../auth.js"
+import {
+  getBreachedPasswordResponse,
+  getEmailPasswordLockoutResponse,
+  readEmailPasswordSignInAttempt,
+  recordEmailPasswordSignInResult,
+} from "../../auth-protection.js"
 import { db } from "../../db.js"
 import { env } from "../../env.js"
 import { getInvalidMcpOAuthRedirectUris } from "../../mcp/oauth-client-policy.js"
@@ -160,6 +166,27 @@ async function ensureMcpClientScopes(request: Request) {
     .where(eq(OAuthClientTable.clientId, clientId))
 }
 
+async function handleAuthRequest(request: Request) {
+  const emailPasswordAttempt = await readEmailPasswordSignInAttempt(request)
+  if (emailPasswordAttempt) {
+    const lockoutResponse = await getEmailPasswordLockoutResponse(emailPasswordAttempt)
+    if (lockoutResponse) {
+      return lockoutResponse
+    }
+  }
+
+  const breachedPasswordResponse = await getBreachedPasswordResponse(request)
+  if (breachedPasswordResponse) {
+    return breachedPasswordResponse
+  }
+
+  const response = await auth.handler(request)
+  if (emailPasswordAttempt) {
+    await recordEmailPasswordSignInResult(emailPasswordAttempt, response)
+  }
+  return response
+}
+
 export function registerAuthRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
   registerScimAuthRoutes(app)
   app.get("/api/auth/.well-known/oauth-authorization-server", async (c) => rewriteMetadataOrigin(await oauthProviderAuthServerMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
@@ -190,7 +217,7 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
         401: emptyResponse("Better Auth rejected the request because authentication failed."),
       },
     }),
-    (c) => auth.handler(c.req.raw),
+    (c) => handleAuthRequest(c.req.raw),
   )
   registerDesktopAuthRoutes(app)
 }

--- a/ee/apps/den-api/test/auth-protection.test.ts
+++ b/ee/apps/den-api/test/auth-protection.test.ts
@@ -1,0 +1,123 @@
+import { beforeAll, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let authProtection: typeof import("../src/auth-protection.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  authProtection = await import("../src/auth-protection.js")
+})
+
+test("email password lockout starts at threshold and resets after the failure window", () => {
+  const now = 1_700_000_000_000
+  expect(authProtection.getLoginLockoutStatus({
+    count: authProtection.LOGIN_LOCKOUT_FAILURE_THRESHOLD - 1,
+    lastRequest: now,
+  }, now)).toEqual({ locked: false, retryAfterSeconds: 0 })
+
+  expect(authProtection.getLoginLockoutStatus({
+    count: authProtection.LOGIN_LOCKOUT_FAILURE_THRESHOLD,
+    lastRequest: now,
+  }, now)).toEqual({
+    locked: true,
+    retryAfterSeconds: authProtection.LOGIN_LOCKOUT_BASE_MS / 1000,
+  })
+
+  expect(authProtection.getLoginLockoutStatus({
+    count: authProtection.LOGIN_LOCKOUT_FAILURE_THRESHOLD,
+    lastRequest: now - authProtection.LOGIN_LOCKOUT_FAILURE_WINDOW_MS - 1,
+  }, now)).toEqual({ locked: false, retryAfterSeconds: 0 })
+})
+
+test("email password lockout duration progresses but is capped", () => {
+  expect(authProtection.getLoginLockoutDurationMs(authProtection.LOGIN_LOCKOUT_FAILURE_THRESHOLD)).toBe(authProtection.LOGIN_LOCKOUT_BASE_MS)
+  expect(authProtection.getLoginLockoutDurationMs(authProtection.LOGIN_LOCKOUT_FAILURE_THRESHOLD + 1)).toBe(authProtection.LOGIN_LOCKOUT_BASE_MS * 2)
+  expect(authProtection.getLoginLockoutDurationMs(authProtection.LOGIN_LOCKOUT_FAILURE_THRESHOLD + 10)).toBe(authProtection.LOGIN_LOCKOUT_MAX_MS)
+})
+
+test("email password sign-in parsing normalizes the account identifier", async () => {
+  const request = new Request("http://den.local/api/auth/sign-in/email", {
+    body: JSON.stringify({ email: " User@Example.COM ", password: "secret" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+
+  await expect(authProtection.readEmailPasswordSignInAttempt(request)).resolves.toEqual({
+    email: "user@example.com",
+  })
+
+  const ignored = new Request("http://den.local/api/auth/sign-in/social", {
+    method: "POST",
+  })
+  await expect(authProtection.readEmailPasswordSignInAttempt(ignored)).resolves.toBeNull()
+})
+
+test("breached password screening reads password fields only on password creation routes", async () => {
+  const signUp = new Request("http://den.local/api/auth/sign-up/email", {
+    body: JSON.stringify({ email: "user@example.com", password: "created-password" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+  await expect(authProtection.readPasswordForBreachCheck(signUp)).resolves.toBe("created-password")
+
+  const reset = new Request("http://den.local/api/auth/reset-password", {
+    body: JSON.stringify({ newPassword: "reset-password" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+  await expect(authProtection.readPasswordForBreachCheck(reset)).resolves.toBe("reset-password")
+
+  const signIn = new Request("http://den.local/api/auth/sign-in/email", {
+    body: JSON.stringify({ email: "user@example.com", password: "existing-password" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+  await expect(authProtection.readPasswordForBreachCheck(signIn)).resolves.toBeNull()
+})
+
+test("breached password screening uses k-anonymity range responses", async () => {
+  let requestedUrl = ""
+  const compromised = await authProtection.isPasswordCompromised("password", async (input) => {
+    requestedUrl = input
+    return new Response("1E4C9B93F3F0682250B6CF8331B7EE68FD8:3303003\n", { status: 200 })
+  })
+
+  expect(requestedUrl).toBe("https://api.pwnedpasswords.com/range/5BAA6")
+  expect(compromised).toBe(true)
+
+  await expect(authProtection.isPasswordCompromised("password", async () => new Response("00000000000000000000000000000000000:1\n", { status: 200 }))).resolves.toBe(false)
+})
+
+test("breached password response blocks compromised passwords and fails closed on screening errors", async () => {
+  const request = new Request("http://den.local/api/auth/sign-up/email", {
+    body: JSON.stringify({ email: "user@example.com", password: "password" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+
+  const blocked = await authProtection.getBreachedPasswordResponse(
+    request,
+    async () => new Response("1E4C9B93F3F0682250B6CF8331B7EE68FD8:3303003\n", { status: 200 }),
+  )
+  expect(blocked?.status).toBe(400)
+  await expect(blocked?.json()).resolves.toEqual({
+    error: "password_compromised",
+    message: "Choose a different password.",
+  })
+
+  const unavailable = await authProtection.getBreachedPasswordResponse(
+    request,
+    async () => new Response("", { status: 503 }),
+  )
+  expect(unavailable?.status).toBe(503)
+  await expect(unavailable?.json()).resolves.toEqual({
+    error: "password_screening_unavailable",
+    message: "Password screening is temporarily unavailable. Try again later.",
+  })
+})


### PR DESCRIPTION
## Summary
- Add an email/password auth protection wrapper around the existing Better Auth handler.
- Store progressive lockout state in the existing `rate_limit` table using a SHA-256-derived account key rather than raw email.
- Record only invalid-credential `401` responses as failed sign-in attempts and clear the failure state after successful sign-in.
- Screen new/reset/change passwords with a k-anonymity breached-password range lookup before Better Auth persists the password.

## Root Cause
The email/password path already had Better Auth request rate limiting, but it did not keep account-specific progressive lockout state after repeated invalid credentials, and password creation/reset/change did not screen for known compromised passwords.

## Validation
- `pnpm install --frozen-lockfile` - passed.
- `pnpm --filter @openwork-ee/den-api build` - passed.
- `bun test ee/apps/den-api/test/auth-protection.test.ts` - passed, 6 pass / 0 fail.
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed.
- `git diff --check` - passed.
- `bun test ee/apps/den-api/test` - passed, 129 pass / 0 fail.
- `git diff --cached --check` - passed before commit.

## Live Smoke
- Not applicable for this server-only auth proxy/data-layer protection change; screenshots or video are not relevant.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

