### PR TITLE
fix(den-api): surface SCIM sync failures

### DIFF
--- a/ee/apps/den-api/src/routes/auth/scim.ts
+++ b/ee/apps/den-api/src/routes/auth/scim.ts
@@ -27,40 +27,83 @@ function logScimSyncWarning(action: string, error: unknown) {
   console.warn(`[scim][external_identity_sync_failed] action=${action} reason=${message}`)
 }
 
-async function syncScimMutationFromResponse(input: {
+export type ScimSyncAction = "sync_resource" | "sync_user_id"
+export type ScimSyncResult =
+  | { ok: true; required: boolean }
+  | { ok: false; action: ScimSyncAction; message: string }
+
+function failedScimSync(action: ScimSyncAction, error: unknown): ScimSyncResult {
+  const message = error instanceof Error ? error.message : String(error)
+  logScimSyncWarning(action, error)
+  return { ok: false, action, message }
+}
+
+function isScimResource(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export function createScimSyncFailureResponse(result: Extract<ScimSyncResult, { ok: false }>) {
+  return new Response(JSON.stringify({
+    schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+    detail: "SCIM user mutation completed, but external identity sync failed; retry later.",
+    status: "503",
+    action: result.action,
+  }), {
+    status: 503,
+    headers: {
+      "content-type": "application/scim+json",
+      "retry-after": "60",
+    },
+  })
+}
+
+export async function syncScimMutationFromResponse(input: {
   bearerToken: string
   response: Response
   fallbackUserId?: string
-}) {
+  syncResource?: typeof syncExternalIdentityFromScimResource
+  syncUserId?: typeof syncExternalIdentityFromScimUserId
+}): Promise<ScimSyncResult> {
   if (!input.response.ok) {
-    return
+    return { ok: true, required: false }
   }
+
+  const syncResource = input.syncResource ?? syncExternalIdentityFromScimResource
+  const syncUserId = input.syncUserId ?? syncExternalIdentityFromScimUserId
 
   if (input.response.status === 204 && input.fallbackUserId) {
     try {
-      await syncExternalIdentityFromScimUserId({
+      const synced = await syncUserId({
         bearerToken: input.bearerToken,
         userId: normalizeDenTypeId("user", input.fallbackUserId),
       })
+      if (!synced) {
+        return failedScimSync("sync_user_id", "external identity sync returned false")
+      }
     } catch (error) {
-      logScimSyncWarning("sync_user_id", error)
+      return failedScimSync("sync_user_id", error)
     }
-    return
+    return { ok: true, required: true }
   }
 
-  const payload = await input.response.clone().json().catch(() => null) as Record<string, unknown> | null
-  if (!payload) {
-    return
+  const payload: unknown = await input.response.clone().json().catch(() => null)
+  if (!isScimResource(payload)) {
+    return failedScimSync("sync_resource", "SCIM response body was not a JSON object")
   }
 
   try {
-    await syncExternalIdentityFromScimResource({
+    const synced = await syncResource({
       bearerToken: input.bearerToken,
       resource: payload,
     })
+    if (!synced) {
+      return failedScimSync("sync_resource", "external identity sync returned false")
+    }
   } catch (error) {
-    logScimSyncWarning("sync_resource", error)
+    return failedScimSync("sync_resource", error)
   }
+
+  return { ok: true, required: true }
 }
 
 export function registerScimAuthRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
@@ -240,11 +283,14 @@ export function registerScimAuthRoutes<T extends { Variables: AuthContextVariabl
       return response
     }
 
-    await syncScimMutationFromResponse({
+    const syncResult = await syncScimMutationFromResponse({
       bearerToken,
       response,
       fallbackUserId: c.req.param("userId") || undefined,
     })
+    if (!syncResult.ok) {
+      return createScimSyncFailureResponse(syncResult)
+    }
     return response
   }
 

--- a/ee/apps/den-api/test/scim-auth-sync.test.ts
+++ b/ee/apps/den-api/test/scim-auth-sync.test.ts
@@ -1,0 +1,108 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let scimAuthModule: typeof import("../src/routes/auth/scim.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  scimAuthModule = await import("../src/routes/auth/scim.js")
+})
+
+test("SCIM mutation sync is skipped when the upstream SCIM mutation fails", async () => {
+  let syncWasCalled = false
+
+  const result = await scimAuthModule.syncScimMutationFromResponse({
+    bearerToken: "scim-token",
+    response: new Response(JSON.stringify({ detail: "Invalid SCIM token" }), { status: 401 }),
+    syncResource: async () => {
+      syncWasCalled = true
+      return true
+    },
+  })
+
+  expect(result).toEqual({ ok: true, required: false })
+  expect(syncWasCalled).toBe(false)
+})
+
+test("SCIM mutation sync mirrors successful JSON user resources", async () => {
+  const userId = createDenTypeId("user")
+  let syncedResource: unknown = null
+
+  const result = await scimAuthModule.syncScimMutationFromResponse({
+    bearerToken: "scim-token",
+    response: Response.json({ id: userId, userName: "member@example.com", active: true }, { status: 201 }),
+    syncResource: async (input) => {
+      syncedResource = input.resource
+      return true
+    },
+  })
+
+  expect(result).toEqual({ ok: true, required: true })
+  expect(syncedResource).toEqual({ id: userId, userName: "member@example.com", active: true })
+})
+
+test("SCIM mutation sync mirrors 204 responses by fallback user id", async () => {
+  const userId = createDenTypeId("user")
+  let syncedUserId: string | null = null
+
+  const result = await scimAuthModule.syncScimMutationFromResponse({
+    bearerToken: "scim-token",
+    response: new Response(null, { status: 204 }),
+    fallbackUserId: userId,
+    syncUserId: async (input) => {
+      syncedUserId = input.userId
+      return true
+    },
+  })
+
+  expect(result).toEqual({ ok: true, required: true })
+  expect(syncedUserId).toBe(userId)
+})
+
+test("SCIM mutation sync reports a retryable failure when the mirror cannot update", async () => {
+  const result = await scimAuthModule.syncScimMutationFromResponse({
+    bearerToken: "scim-token",
+    response: Response.json({ id: createDenTypeId("user"), userName: "member@example.com" }, { status: 200 }),
+    syncResource: async () => false,
+  })
+
+  expect(result).toEqual({
+    ok: false,
+    action: "sync_resource",
+    message: "external identity sync returned false",
+  })
+})
+
+test("SCIM mutation sync reports thrown mirror failures without exposing internals to clients", async () => {
+  const result = await scimAuthModule.syncScimMutationFromResponse({
+    bearerToken: "scim-token",
+    response: Response.json({ id: createDenTypeId("user"), userName: "member@example.com" }, { status: 200 }),
+    syncResource: async () => {
+      throw new Error("database unavailable")
+    },
+  })
+
+  expect(result).toEqual({
+    ok: false,
+    action: "sync_resource",
+    message: "database unavailable",
+  })
+
+  const response = scimAuthModule.createScimSyncFailureResponse(result)
+  expect(response.status).toBe(503)
+  expect(response.headers.get("retry-after")).toBe("60")
+  expect(response.headers.get("content-type")).toBe("application/scim+json")
+  await expect(response.json()).resolves.toEqual({
+    schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+    detail: "SCIM user mutation completed, but external identity sync failed; retry later.",
+    status: "503",
+    action: "sync_resource",
+  })
+})


### PR DESCRIPTION
## Summary
- Stops silently accepting successful SCIM User mutations when the local external-identity mirror cannot sync.
- Returns a retryable SCIM 503 response with `Retry-After: 60` when post-mutation sync fails.
- Adds focused coverage for upstream failure passthrough, successful resource/user-id sync, retryable false returns, and thrown sync failures.

## Validation
- `pnpm install --frozen-lockfile` - passed.
- `pnpm --filter @openwork-ee/den-api build` - passed.
- `bun test ee/apps/den-api/test/scim-auth-sync.test.ts` - passed, 5 pass / 0 fail.
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed.
- `git diff --check` - passed.
- `bun test ee/apps/den-api/test` - passed, 137 pass / 0 fail.
- `git diff --cached --check` - passed before commit.

## Live Smoke
- Not applicable for this server-only SCIM error-handling change; screenshots or video are not relevant.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

