### PR TITLE
docs: document MFA step-up posture

### DIFF
--- a/packages/docs/cloud/security-and-operations.mdx
+++ b/packages/docs/cloud/security-and-operations.mdx
@@ -43,6 +43,17 @@ Use the Cloud member model as the source of truth for organization access:
 
 For access reviews, export the current member list, roles, teams, pending invitations, API keys, SSO configuration, and SCIM configuration on a regular cadence. Reconfirm that each member still needs their current role and team access.
 
+## MFA and step-up controls
+
+For production organizations, use SSO with identity-provider MFA as the primary step-up control:
+
+- Enable enforced SSO for organizations that have owners, admins, SCIM, SSO, API keys, or shared production providers.
+- Require MFA, phishing-resistant factors where available, and conditional-access policy in the identity provider before users reach OpenWork Cloud.
+- Keep SSO and SCIM configuration owner-only. Treat owner-only changes, custom-role changes, member role changes, API-key creation, and emergency access as privileged actions that require a fresh IdP-authenticated session.
+- Do not rely on standalone email/password accounts for production owner access unless the deployment has an equivalent MFA and recovery control outside OpenWork.
+
+Native factor enrollment and in-product reauthentication should be treated as product work before replacing SSO-enforced MFA as the production control.
+
 For mover and leaver handling:
 
 - Change roles when responsibilities change.


### PR DESCRIPTION
## Summary
- Documents production MFA and step-up expectations for Cloud/private deployments.
- Ties the current control to enforced SSO with identity-provider MFA and owner-only privileged configuration.
- Explicitly notes native factor enrollment and in-product reauthentication as product work before replacing SSO-enforced MFA.

## Validation
- `node -e 'JSON.parse(require("fs").readFileSync("packages/docs/docs.json", "utf8")); console.log("docs.json ok")'` - passed.
- `git diff --check` - passed.
- `git diff --cached --check` - passed before commit.

## Live Smoke
- Not applicable for this docs-only change; screenshots or video are not relevant.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

