### PR TITLE
[codex] Restrict organization API key management to owners

### DIFF
--- a/ee/apps/den-api/src/routes/org/api-keys.ts
+++ b/ee/apps/den-api/src/routes/org/api-keys.ts
@@ -131,7 +131,7 @@ export function registerOrgApiKeyRoutes<T extends { Variables: OrgRouteVariables
           },
         },
         403: {
-          description: "Only workspace owners and admins can list API keys.",
+          description: "Only workspace owners can list API keys.",
           content: {
             "application/json": {
               schema: resolver(forbiddenApiKeyManagerSchema),
@@ -196,7 +196,7 @@ export function registerOrgApiKeyRoutes<T extends { Variables: OrgRouteVariables
           },
         },
         403: {
-          description: "Only workspace owners and admins can create API keys.",
+          description: "Only workspace owners can create API keys.",
           content: {
             "application/json": {
               schema: resolver(forbiddenApiKeyManagerSchema),
@@ -300,7 +300,7 @@ export function registerOrgApiKeyRoutes<T extends { Variables: OrgRouteVariables
           },
         },
         403: {
-          description: "Only workspace owners and admins can delete API keys.",
+          description: "Only workspace owners can delete API keys.",
           content: {
             "application/json": {
               schema: resolver(forbiddenApiKeyManagerSchema),

--- a/ee/apps/den-api/src/routes/org/shared.ts
+++ b/ee/apps/den-api/src/routes/org/shared.ts
@@ -161,7 +161,7 @@ export function ensureApiKeyManager(c: { get: (key: "organizationContext") => Or
     }
   }
 
-  if (payload.currentMember.isOwner || memberHasRole(payload.currentMember.role, "admin")) {
+  if (canManageApiKeys(payload)) {
     return { ok: true as const }
   }
 
@@ -169,9 +169,13 @@ export function ensureApiKeyManager(c: { get: (key: "organizationContext") => Or
     ok: false as const,
     response: {
       error: "forbidden",
-      message: "Only workspace owners and admins can manage API keys.",
+      message: "Only workspace owners can manage API keys.",
     },
   }
+}
+
+export function canManageApiKeys(payload: { currentMember: { isOwner: boolean; role?: string } } | null | undefined) {
+  return payload?.currentMember.isOwner === true
 }
 
 export function canManageIdentityConfiguration(payload: { currentMember: { isOwner: boolean; role?: string } } | null | undefined) {

--- a/ee/apps/den-api/test/org-identity-access.test.ts
+++ b/ee/apps/den-api/test/org-identity-access.test.ts
@@ -29,3 +29,19 @@ test("identity configuration management is owner-only", () => {
 
   expect(sharedModule.canManageIdentityConfiguration(null)).toBe(false)
 })
+
+test("api key management is owner-only", () => {
+  expect(sharedModule.canManageApiKeys({
+    currentMember: { isOwner: true, role: "owner" },
+  })).toBe(true)
+
+  expect(sharedModule.canManageApiKeys({
+    currentMember: { isOwner: false, role: "admin" },
+  })).toBe(false)
+
+  expect(sharedModule.canManageApiKeys({
+    currentMember: { isOwner: false, role: "member" },
+  })).toBe(false)
+
+  expect(sharedModule.canManageApiKeys(null)).toBe(false)
+})

--- a/packages/docs/cloud/security-and-operations.mdx
+++ b/packages/docs/cloud/security-and-operations.mdx
@@ -49,7 +49,7 @@ For production organizations, use SSO with identity-provider MFA as the primary 
 
 - Enable enforced SSO for organizations that have owners, admins, SCIM, SSO, API keys, or shared production providers.
 - Require MFA, phishing-resistant factors where available, and conditional-access policy in the identity provider before users reach OpenWork Cloud.
-- Keep SSO and SCIM configuration owner-only. Treat owner-only changes, custom-role changes, member role changes, API-key creation, and emergency access as privileged actions that require a fresh IdP-authenticated session.
+- Keep SSO, SCIM, and API-key management owner-only. Treat owner-only changes, custom-role changes, member role changes, API-key creation, and emergency access as privileged actions that require a fresh IdP-authenticated session.
 - Do not rely on standalone email/password accounts for production owner access unless the deployment has an equivalent MFA and recovery control outside OpenWork.
 
 Native factor enrollment and in-product reauthentication should be treated as product work before replacing SSO-enforced MFA as the production control.


### PR DESCRIPTION
## Summary
- Restrict organization API-key management to workspace owners only.
- Update the API response descriptions and security operations docs to match the owner-only policy.
- Add regression coverage for the API-key management access gate alongside the existing identity-configuration gate.

## Validation
- `pnpm install --frozen-lockfile` - passed.
- `pnpm --filter @openwork-ee/den-api build` - passed.
- `bun test ee/apps/den-api/test/org-identity-access.test.ts` - passed, 2 pass / 0 fail.
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed.
- `node -e "JSON.parse(require('fs').readFileSync('packages/docs/docs.json','utf8')); console.log('docs.json parse ok')"` - passed.
- `git diff --check` - passed.
- `bun test ee/apps/den-api/test` - passed, 139 pass / 0 fail.
- `git diff --cached --check` - passed before commit.

## Live Smoke
Not applicable: this is a server-side authorization and documentation change with no UI/runtime boundary change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

