### PR TITLE
[codex] Delegate security configuration access with fresh-session checks

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -21,6 +21,7 @@ import {
   DEN_API_KEY_RATE_LIMIT_TIME_WINDOW_MS,
 } from "./api-keys.js";
 import {
+  canManageSecurityConfiguration,
   denOrganizationAccess,
   denOrganizationStaticRoles,
 } from "./organization-access.js";
@@ -33,7 +34,7 @@ import {
   ORGANIZATION_SAML_DEPRECATED_ALGORITHM_BEHAVIOR,
   ORGANIZATION_SAML_REQUIRE_TIMESTAMPS,
 } from "./sso-saml-policy.js";
-import { seedDefaultOrganizationRoles } from "./orgs.js";
+import { getOrganizationContextForUser, seedDefaultOrganizationRoles } from "./orgs.js";
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid";
 import * as schema from "@openwork-ee/den-db/schema";
 import { apiKey } from "@better-auth/api-key";
@@ -416,15 +417,20 @@ export const auth = betterAuth({
     scim({
       storeSCIMToken: SCIM_TOKEN_STORAGE_STRATEGY,
       beforeSCIMTokenGenerated: async ({ member }) => {
-        if (!member?.organizationId) {
+        if (!member?.organizationId || !member.userId) {
           throw new APIError("FORBIDDEN", {
             message: "SCIM connections must belong to an organization.",
           });
         }
 
-        if (!hasRole(member.role, "owner")) {
+        const organizationContext = await getOrganizationContextForUser({
+          organizationId: normalizeDenTypeId("organization", member.organizationId),
+          userId: normalizeDenTypeId("user", member.userId),
+        });
+
+        if (!canManageSecurityConfiguration(organizationContext)) {
           throw new APIError("FORBIDDEN", {
-            message: "Only workspace owners can manage SCIM.",
+            message: "Only workspace owners or members with security configuration permission can manage SCIM.",
           });
         }
       },

--- a/ee/apps/den-api/src/openapi.ts
+++ b/ee/apps/den-api/src/openapi.ts
@@ -61,7 +61,7 @@ export const unauthorizedSchema = z.object({
 }).meta({ ref: "UnauthorizedError" })
 
 export const forbiddenSchema = z.object({
-  error: z.literal("forbidden"),
+  error: z.enum(["forbidden", "fresh_auth_required"]),
   message: z.string().optional(),
 }).meta({ ref: "ForbiddenError" })
 

--- a/ee/apps/den-api/src/organization-access.ts
+++ b/ee/apps/den-api/src/organization-access.ts
@@ -1,13 +1,29 @@
 import { createAccessControl } from "better-auth/plugins/access"
 import { defaultRoles, defaultStatements } from "better-auth/plugins/organization/access"
 
-export const denOrganizationAccess = createAccessControl(defaultStatements)
+export const SECURITY_CONFIGURATION_PERMISSION_RESOURCE = "security_configuration"
+export const SECURITY_CONFIGURATION_PERMISSION_ACTION = "manage"
+
+const denOrganizationStatements = {
+  ...defaultStatements,
+  [SECURITY_CONFIGURATION_PERMISSION_RESOURCE]: [SECURITY_CONFIGURATION_PERMISSION_ACTION],
+} as const
+
+export const denOrganizationAccess = createAccessControl(denOrganizationStatements)
 
 export type OrganizationPermissionRecord = Record<string, string[]>
 
 export type OrganizationRolePermission = {
   role: string
   permission: OrganizationPermissionRecord
+}
+
+export type SecurityConfigurationPermissionPayload = {
+  currentMember: {
+    isOwner: boolean
+    role: string
+  }
+  roles: readonly OrganizationRolePermission[]
 }
 
 type PermissionValidationResult = {
@@ -18,12 +34,19 @@ type PermissionValidationResult = {
   message: string
 }
 
-const denOrganizationPermissionCatalogEntries = Object.entries(defaultStatements)
+const denOwnerRole = denOrganizationAccess.newRole({
+  ...defaultRoles.owner.statements,
+  [SECURITY_CONFIGURATION_PERMISSION_RESOURCE]: [SECURITY_CONFIGURATION_PERMISSION_ACTION],
+})
+const denAdminRole = denOrganizationAccess.newRole(defaultRoles.admin.statements)
+const denMemberRole = denOrganizationAccess.newRole(defaultRoles.member.statements)
+
+const denOrganizationPermissionCatalogEntries = Object.entries(denOrganizationStatements)
 
 export const denOrganizationStaticRoles = {
-  owner: defaultRoles.owner,
-  admin: defaultRoles.admin,
-  member: defaultRoles.member,
+  owner: denOwnerRole,
+  admin: denAdminRole,
+  member: denMemberRole,
 } as const
 
 export const denDefaultDynamicOrganizationRoles = {
@@ -144,4 +167,17 @@ export function validateAssignableOrganizationPermissionRecord(input: {
   }
 
   return { ok: true }
+}
+
+export function canManageSecurityConfiguration(payload: SecurityConfigurationPermissionPayload | null | undefined) {
+  if (!payload) {
+    return false
+  }
+
+  if (payload.currentMember.isOwner) {
+    return true
+  }
+
+  const permissions = resolveOrganizationPermissionRecord(payload.currentMember.role, payload.roles)
+  return permissions[SECURITY_CONFIGURATION_PERMISSION_RESOURCE]?.includes(SECURITY_CONFIGURATION_PERMISSION_ACTION) ?? false
 }

--- a/ee/apps/den-api/src/routes/org/api-keys.ts
+++ b/ee/apps/den-api/src/routes/org/api-keys.ts
@@ -13,7 +13,7 @@ import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizati
 import { denTypeIdSchema } from "../../openapi.js"
 import { auth } from "../../auth.js"
 import type { OrgRouteVariables } from "./shared.js"
-import { ensureApiKeyManager, idParamSchema } from "./shared.js"
+import { ensureApiKeyManager, idParamSchema, orgAccessFailureStatus } from "./shared.js"
 
 const createOrganizationApiKeySchema = z.object({
   name: z.string().trim().min(2).max(64),
@@ -38,7 +38,7 @@ const organizationNotFoundSchema = z.object({
 }).meta({ ref: "OrganizationNotFoundError" })
 
 const forbiddenApiKeyManagerSchema = z.object({
-  error: z.literal("forbidden"),
+  error: z.enum(["forbidden", "fresh_auth_required"]),
   message: z.string(),
 }).meta({ ref: "OrganizationApiKeyForbiddenError" })
 
@@ -131,7 +131,7 @@ export function registerOrgApiKeyRoutes<T extends { Variables: OrgRouteVariables
           },
         },
         403: {
-          description: "Only workspace owners can list API keys.",
+          description: "Only workspace owners or members with security configuration permission can list API keys.",
           content: {
             "application/json": {
               schema: resolver(forbiddenApiKeyManagerSchema),
@@ -153,7 +153,7 @@ export function registerOrgApiKeyRoutes<T extends { Variables: OrgRouteVariables
     async (c) => {
       const access = ensureApiKeyManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const payload = c.get("organizationContext")
@@ -196,7 +196,7 @@ export function registerOrgApiKeyRoutes<T extends { Variables: OrgRouteVariables
           },
         },
         403: {
-          description: "Only workspace owners can create API keys.",
+          description: "Only workspace owners or members with security configuration permission can create API keys.",
           content: {
             "application/json": {
               schema: resolver(forbiddenApiKeyManagerSchema),
@@ -219,7 +219,7 @@ export function registerOrgApiKeyRoutes<T extends { Variables: OrgRouteVariables
     async (c) => {
       const access = ensureApiKeyManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const payload = c.get("organizationContext")
@@ -300,7 +300,7 @@ export function registerOrgApiKeyRoutes<T extends { Variables: OrgRouteVariables
           },
         },
         403: {
-          description: "Only workspace owners can delete API keys.",
+          description: "Only workspace owners or members with security configuration permission can delete API keys.",
           content: {
             "application/json": {
               schema: resolver(forbiddenApiKeyManagerSchema),
@@ -323,7 +323,7 @@ export function registerOrgApiKeyRoutes<T extends { Variables: OrgRouteVariables
     async (c) => {
       const access = ensureApiKeyManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const payload = c.get("organizationContext")

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -9,6 +9,7 @@ import { db } from "../../db.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
 import { runPostOrganizationMemberChangeHooks } from "../../organization-member-hooks.js"
+import { resolveOrganizationPermissionRecord, validateAssignableOrganizationPermissionRecord } from "../../organization-access.js"
 import { isEmailAllowedForOrganization, listAssignableRoles, removeOrganizationMember } from "../../orgs.js"
 import { getOrganizationSeatAddEligibility } from "../../stripe-billing.js"
 import { DenEmailSendError, sendEmail } from "../../utils/email/send-email.js"
@@ -68,7 +69,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         400: jsonResponse("The invitation request body or path parameters were invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to invite organization members.", unauthorizedSchema),
         402: jsonResponse("A seat subscription is required before inviting more members.", invitePaymentRequiredSchema),
-        403: jsonResponse("Only workspace owners and admins can create or resend invitations.", forbiddenSchema),
+        403: jsonResponse("Only workspace owners and admins can create invitations, and invitees can only receive roles whose permissions the inviter already has.", forbiddenSchema),
         404: jsonResponse("The organization could not be found.", notFoundSchema),
         409: jsonResponse("The email address is outside this workspace's allowed domains.", inviteEmailDomainNotAllowedSchema),
         502: jsonResponse("The invitation was saved but the email provider rejected or failed to deliver it. Retry by submitting the same email again.", invitationEmailFailedSchema),
@@ -105,6 +106,18 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     const role = normalizeRoleName(input.role)
     if (!availableRoles.has(role)) {
       return c.json({ error: "invalid_role", message: "Choose one of the existing organization roles." }, 400)
+    }
+
+    const assignableRole = validateAssignableOrganizationPermissionRecord({
+      permission: resolveOrganizationPermissionRecord(role, payload.roles),
+      roleValue: payload.currentMember.role,
+      roles: payload.roles,
+    })
+    if (!assignableRole.ok) {
+      return c.json({
+        error: "forbidden",
+        message: "You can only invite members into roles with permissions you already have.",
+      }, 403)
     }
 
     const existingMembers = await db

--- a/ee/apps/den-api/src/routes/org/scim.ts
+++ b/ee/apps/den-api/src/routes/org/scim.ts
@@ -5,7 +5,7 @@ import { deleteOrganizationScimConnection, getOrganizationScimConnection, getSci
 import { ORGANIZATION_AUDIT_ACTIONS, recordOrganizationAuditEvent } from "../../audit-events.js"
 import { requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import type { OrgRouteVariables } from "./shared.js"
-import { ensureScimManager } from "./shared.js"
+import { ensureScimManager, orgAccessFailureStatus } from "./shared.js"
 
 const invalidRequestSchema = z.object({
   error: z.literal("invalid_request"),
@@ -24,7 +24,7 @@ const organizationNotFoundSchema = z.object({
 }).meta({ ref: "ScimOrganizationNotFoundError" })
 
 const forbiddenSchema = z.object({
-  error: z.literal("forbidden"),
+  error: z.enum(["forbidden", "fresh_auth_required"]),
   message: z.string(),
 }).meta({ ref: "ScimForbiddenError" })
 
@@ -91,7 +91,7 @@ export function registerOrgScimRoutes<T extends { Variables: OrgRouteVariables }
           },
         },
         403: {
-          description: "Only workspace owners can manage SCIM.",
+          description: "Only workspace owners or members with security configuration permission can manage SCIM.",
           content: {
             "application/json": {
               schema: resolver(forbiddenSchema),
@@ -113,7 +113,7 @@ export function registerOrgScimRoutes<T extends { Variables: OrgRouteVariables }
     async (c) => {
       const access = ensureScimManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const payload = c.get("organizationContext")
@@ -160,7 +160,7 @@ export function registerOrgScimRoutes<T extends { Variables: OrgRouteVariables }
           },
         },
         403: {
-          description: "Only workspace owners can manage SCIM.",
+          description: "Only workspace owners or members with security configuration permission can manage SCIM.",
           content: {
             "application/json": {
               schema: resolver(forbiddenSchema),
@@ -182,7 +182,7 @@ export function registerOrgScimRoutes<T extends { Variables: OrgRouteVariables }
     async (c) => {
       const access = ensureScimManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const payload = c.get("organizationContext")
@@ -237,7 +237,7 @@ export function registerOrgScimRoutes<T extends { Variables: OrgRouteVariables }
           },
         },
         403: {
-          description: "Only workspace owners can manage SCIM.",
+          description: "Only workspace owners or members with security configuration permission can manage SCIM.",
           content: {
             "application/json": {
               schema: resolver(forbiddenSchema),
@@ -259,7 +259,7 @@ export function registerOrgScimRoutes<T extends { Variables: OrgRouteVariables }
     async (c) => {
       const access = ensureScimManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const payload = c.get("organizationContext")

--- a/ee/apps/den-api/src/routes/org/shared.ts
+++ b/ee/apps/den-api/src/routes/org/shared.ts
@@ -4,6 +4,10 @@ import { z } from "zod"
 import type { MemberTeamsContext, OrganizationContextVariables, UserOrganizationsContext } from "../../middleware/index.js"
 import { env } from "../../env.js"
 import { denTypeIdSchema } from "../../openapi.js"
+import {
+  canManageSecurityConfiguration as canManageOrganizationSecurityConfiguration,
+  type SecurityConfigurationPermissionPayload,
+} from "../../organization-access.js"
 import type { AuthContextVariables } from "../../session.js"
 
 export type OrgRouteVariables =
@@ -11,6 +15,46 @@ export type OrgRouteVariables =
   & Partial<UserOrganizationsContext>
   & Partial<OrganizationContextVariables>
   & Partial<MemberTeamsContext>
+
+export const PRIVILEGED_SESSION_MAX_AGE_MS = 15 * 60 * 1000
+
+type PrivilegedOrgRouteContext = {
+  get: <K extends "organizationContext" | "session">(key: K) => OrgRouteVariables[K]
+}
+
+export function hasFreshPrivilegedSession(payload: { session: { createdAt?: Date | string | null } | null | undefined }, now = new Date()) {
+  const createdAt = payload.session?.createdAt
+  const createdAtMs = createdAt instanceof Date
+    ? createdAt.getTime()
+    : typeof createdAt === "string"
+      ? new Date(createdAt).getTime()
+      : Number.NaN
+
+  if (!Number.isFinite(createdAtMs)) {
+    return false
+  }
+
+  const ageMs = now.getTime() - createdAtMs
+  return ageMs >= 0 && ageMs <= PRIVILEGED_SESSION_MAX_AGE_MS
+}
+
+function ensureFreshPrivilegedSession(c: { get: (key: "session") => OrgRouteVariables["session"] }) {
+  if (hasFreshPrivilegedSession({ session: c.get("session") })) {
+    return { ok: true as const }
+  }
+
+  return {
+    ok: false as const,
+    response: {
+      error: "fresh_auth_required",
+      message: "Sign in again before performing this privileged action.",
+    },
+  }
+}
+
+export function orgAccessFailureStatus(response: { error: string }) {
+  return response.error === "organization_not_found" ? 404 : 403
+}
 
 export function idParamSchema<K extends string>(key: K, typeName?: DenTypeIdName) {
   if (!typeName) {
@@ -63,7 +107,7 @@ export function buildInvitationLink(inviteToken: string) {
   return new URL(`/join-org?invite=${encodeURIComponent(inviteToken)}`, getInvitationOrigin()).toString()
 }
 
-export function ensureOwner(c: { get: (key: "organizationContext") => OrgRouteVariables["organizationContext"] }) {
+export function ensureOwner(c: PrivilegedOrgRouteContext) {
   const payload = c.get("organizationContext")
   if (!payload?.currentMember.isOwner) {
     return {
@@ -75,7 +119,7 @@ export function ensureOwner(c: { get: (key: "organizationContext") => OrgRouteVa
     }
   }
 
-  return { ok: true as const }
+  return ensureFreshPrivilegedSession(c)
 }
 
 export function ensureInviteManager(c: { get: (key: "organizationContext") => OrgRouteVariables["organizationContext"] }) {
@@ -150,7 +194,7 @@ export function ensureTeamManager(c: { get: (key: "organizationContext") => OrgR
   }
 }
 
-export function ensureApiKeyManager(c: { get: (key: "organizationContext") => OrgRouteVariables["organizationContext"] }) {
+export function ensureApiKeyManager(c: PrivilegedOrgRouteContext) {
   const payload = c.get("organizationContext")
   if (!payload) {
     return {
@@ -162,27 +206,31 @@ export function ensureApiKeyManager(c: { get: (key: "organizationContext") => Or
   }
 
   if (canManageApiKeys(payload)) {
-    return { ok: true as const }
+    return ensureFreshPrivilegedSession(c)
   }
 
   return {
     ok: false as const,
     response: {
       error: "forbidden",
-      message: "Only workspace owners can manage API keys.",
+      message: "Only workspace owners or members with security configuration permission can manage API keys.",
     },
   }
 }
 
-export function canManageApiKeys(payload: { currentMember: { isOwner: boolean; role?: string } } | null | undefined) {
-  return payload?.currentMember.isOwner === true
+export function canManageSecurityConfiguration(payload: SecurityConfigurationPermissionPayload | null | undefined) {
+  return canManageOrganizationSecurityConfiguration(payload)
 }
 
-export function canManageIdentityConfiguration(payload: { currentMember: { isOwner: boolean; role?: string } } | null | undefined) {
-  return payload?.currentMember.isOwner === true
+export function canManageApiKeys(payload: SecurityConfigurationPermissionPayload | null | undefined) {
+  return canManageSecurityConfiguration(payload)
 }
 
-export function ensureScimManager(c: { get: (key: "organizationContext") => OrgRouteVariables["organizationContext"] }) {
+export function canManageIdentityConfiguration(payload: SecurityConfigurationPermissionPayload | null | undefined) {
+  return canManageSecurityConfiguration(payload)
+}
+
+export function ensureScimManager(c: PrivilegedOrgRouteContext) {
   const payload = c.get("organizationContext")
   if (!payload) {
     return {
@@ -194,19 +242,19 @@ export function ensureScimManager(c: { get: (key: "organizationContext") => OrgR
   }
 
   if (canManageIdentityConfiguration(payload)) {
-    return { ok: true as const }
+    return ensureFreshPrivilegedSession(c)
   }
 
   return {
     ok: false as const,
     response: {
       error: "forbidden",
-      message: "Only workspace owners can manage SCIM.",
+      message: "Only workspace owners or members with security configuration permission can manage SCIM.",
     },
   }
 }
 
-export function ensureSsoManager(c: { get: (key: "organizationContext") => OrgRouteVariables["organizationContext"] }) {
+export function ensureSsoManager(c: PrivilegedOrgRouteContext) {
   const payload = c.get("organizationContext")
   if (!payload) {
     return {
@@ -218,14 +266,14 @@ export function ensureSsoManager(c: { get: (key: "organizationContext") => OrgRo
   }
 
   if (canManageIdentityConfiguration(payload)) {
-    return { ok: true as const }
+    return ensureFreshPrivilegedSession(c)
   }
 
   return {
     ok: false as const,
     response: {
       error: "forbidden",
-      message: "Only workspace owners can manage SSO.",
+      message: "Only workspace owners or members with security configuration permission can manage SSO.",
     },
   }
 }

--- a/ee/apps/den-api/src/routes/org/sso.ts
+++ b/ee/apps/den-api/src/routes/org/sso.ts
@@ -18,7 +18,7 @@ import {
 } from "../../sso.js"
 import { requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import type { OrgRouteVariables } from "./shared.js"
-import { ensureSsoManager } from "./shared.js"
+import { ensureSsoManager, orgAccessFailureStatus } from "./shared.js"
 
 const invalidRequestSchema = z.object({
   error: z.literal("invalid_request"),
@@ -37,7 +37,7 @@ const organizationNotFoundSchema = z.object({
 }).meta({ ref: "SsoOrganizationNotFoundError" })
 
 const forbiddenSchema = z.object({
-  error: z.literal("forbidden"),
+  error: z.enum(["forbidden", "fresh_auth_required"]),
   message: z.string(),
 }).meta({ ref: "SsoForbiddenError" })
 
@@ -235,7 +235,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
         200: { description: "Organization SSO configuration", content: { "application/json": { schema: resolver(ssoConnectionResponseSchema) } } },
         400: { description: "Invalid request", content: { "application/json": { schema: resolver(invalidRequestSchema) } } },
         401: { description: "Unauthorized", content: { "application/json": { schema: resolver(unauthorizedSchema) } } },
-        403: { description: "Only workspace owners can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
+        403: { description: "Only workspace owners or members with security configuration permission can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
         404: { description: "Organization not found", content: { "application/json": { schema: resolver(organizationNotFoundSchema) } } },
       },
     }),
@@ -244,7 +244,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
     async (c) => {
       const access = ensureSsoManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const payload = c.get("organizationContext")
@@ -271,7 +271,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
         400: { description: "Invalid request", content: { "application/json": { schema: resolver(invalidRequestSchema) } } },
         401: { description: "Unauthorized", content: { "application/json": { schema: resolver(unauthorizedSchema) } } },
         402: { description: "SSO management requires an Enterprise plan.", content: { "application/json": { schema: resolver(enterprisePlanRequiredSchema) } } },
-        403: { description: "Only workspace owners can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
+        403: { description: "Only workspace owners or members with security configuration permission can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
         404: { description: "Organization not found", content: { "application/json": { schema: resolver(organizationNotFoundSchema) } } },
       },
     }),
@@ -280,7 +280,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
     async (c) => {
       const access = ensureSsoManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const entitlement = checkEntitlement(c.get("organizationContext").organization.metadata, "sso")
@@ -335,7 +335,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
         400: { description: "Invalid request", content: { "application/json": { schema: resolver(invalidRequestSchema) } } },
         401: { description: "Unauthorized", content: { "application/json": { schema: resolver(unauthorizedSchema) } } },
         402: { description: "SSO management requires an Enterprise plan.", content: { "application/json": { schema: resolver(enterprisePlanRequiredSchema) } } },
-        403: { description: "Only workspace owners can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
+        403: { description: "Only workspace owners or members with security configuration permission can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
         404: { description: "Organization not found", content: { "application/json": { schema: resolver(organizationNotFoundSchema) } } },
       },
     }),
@@ -344,7 +344,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
     async (c) => {
       const access = ensureSsoManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const entitlement = checkEntitlement(c.get("organizationContext").organization.metadata, "sso")
@@ -398,7 +398,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
         204: { description: "Organization SSO connection deleted" },
         400: { description: "Invalid request", content: { "application/json": { schema: resolver(invalidRequestSchema) } } },
         401: { description: "Unauthorized", content: { "application/json": { schema: resolver(unauthorizedSchema) } } },
-        403: { description: "Only workspace owners can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
+        403: { description: "Only workspace owners or members with security configuration permission can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
         404: { description: "Organization not found", content: { "application/json": { schema: resolver(organizationNotFoundSchema) } } },
       },
     }),
@@ -407,7 +407,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
     async (c) => {
       const access = ensureSsoManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const payload = c.get("organizationContext")
@@ -442,7 +442,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
         200: { description: "SAML metadata document" },
         400: { description: "Invalid request", content: { "application/json": { schema: resolver(invalidRequestSchema) } } },
         401: { description: "Unauthorized", content: { "application/json": { schema: resolver(unauthorizedSchema) } } },
-        403: { description: "Only workspace owners can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
+        403: { description: "Only workspace owners or members with security configuration permission can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
         404: { description: "Organization not found", content: { "application/json": { schema: resolver(organizationNotFoundSchema) } } },
       },
     }),
@@ -451,7 +451,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
     async (c) => {
       const access = ensureSsoManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const parsed = metadataQuerySchema.safeParse(c.req.query())
@@ -491,7 +491,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
         400: { description: "Invalid request", content: { "application/json": { schema: resolver(invalidRequestSchema) } } },
         401: { description: "Unauthorized", content: { "application/json": { schema: resolver(unauthorizedSchema) } } },
         402: { description: "SSO management requires an Enterprise plan.", content: { "application/json": { schema: resolver(enterprisePlanRequiredSchema) } } },
-        403: { description: "Only workspace owners can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
+        403: { description: "Only workspace owners or members with security configuration permission can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
         404: { description: "Organization not found", content: { "application/json": { schema: resolver(organizationNotFoundSchema) } } },
       },
     }),
@@ -500,7 +500,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
     async (c) => {
       const access = ensureSsoManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const payload = c.get("organizationContext")
@@ -550,7 +550,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
         400: { description: "Invalid request", content: { "application/json": { schema: resolver(invalidRequestSchema) } } },
         401: { description: "Unauthorized", content: { "application/json": { schema: resolver(unauthorizedSchema) } } },
         402: { description: "SSO management requires an Enterprise plan.", content: { "application/json": { schema: resolver(enterprisePlanRequiredSchema) } } },
-        403: { description: "Only workspace owners can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
+        403: { description: "Only workspace owners or members with security configuration permission can manage SSO.", content: { "application/json": { schema: resolver(forbiddenSchema) } } },
         404: { description: "Organization not found", content: { "application/json": { schema: resolver(organizationNotFoundSchema) } } },
       },
     }),
@@ -559,7 +559,7 @@ export function registerOrgSsoRoutes<T extends { Variables: OrgRouteVariables }>
     async (c) => {
       const access = ensureSsoManager(c)
       if (!access.ok) {
-        return c.json(access.response, access.response.error === "forbidden" ? 403 : 404)
+        return c.json(access.response, orgAccessFailureStatus(access.response))
       }
 
       const payload = c.get("organizationContext")

--- a/ee/apps/den-api/test/org-identity-access.test.ts
+++ b/ee/apps/den-api/test/org-identity-access.test.ts
@@ -14,34 +14,78 @@ beforeAll(async () => {
   sharedModule = await import("../src/routes/org/shared.js")
 })
 
-test("identity configuration management is owner-only", () => {
+test("identity configuration management requires owner or delegated security permission", () => {
   expect(sharedModule.canManageIdentityConfiguration({
     currentMember: { isOwner: true, role: "owner" },
+    roles: [],
   })).toBe(true)
 
   expect(sharedModule.canManageIdentityConfiguration({
     currentMember: { isOwner: false, role: "admin" },
+    roles: [],
   })).toBe(false)
 
   expect(sharedModule.canManageIdentityConfiguration({
     currentMember: { isOwner: false, role: "member" },
+    roles: [],
   })).toBe(false)
+
+  expect(sharedModule.canManageIdentityConfiguration({
+    currentMember: { isOwner: false, role: "security-admin" },
+    roles: [
+      { role: "security-admin", permission: { security_configuration: ["manage"] } },
+    ],
+  })).toBe(true)
 
   expect(sharedModule.canManageIdentityConfiguration(null)).toBe(false)
 })
 
-test("api key management is owner-only", () => {
+test("api key management requires owner or delegated security permission", () => {
   expect(sharedModule.canManageApiKeys({
     currentMember: { isOwner: true, role: "owner" },
+    roles: [],
   })).toBe(true)
 
   expect(sharedModule.canManageApiKeys({
     currentMember: { isOwner: false, role: "admin" },
+    roles: [],
   })).toBe(false)
 
   expect(sharedModule.canManageApiKeys({
     currentMember: { isOwner: false, role: "member" },
+    roles: [],
   })).toBe(false)
 
+  expect(sharedModule.canManageApiKeys({
+    currentMember: { isOwner: false, role: "security-admin" },
+    roles: [
+      { role: "security-admin", permission: { security_configuration: ["manage"] } },
+    ],
+  })).toBe(true)
+
   expect(sharedModule.canManageApiKeys(null)).toBe(false)
+})
+
+test("privileged actions require a fresh session", () => {
+  const now = new Date("2026-06-13T12:00:00.000Z")
+
+  expect(sharedModule.hasFreshPrivilegedSession({
+    session: { createdAt: new Date(now.getTime() - sharedModule.PRIVILEGED_SESSION_MAX_AGE_MS) },
+  }, now)).toBe(true)
+
+  expect(sharedModule.hasFreshPrivilegedSession({
+    session: { createdAt: new Date(now.getTime() - sharedModule.PRIVILEGED_SESSION_MAX_AGE_MS - 1) },
+  }, now)).toBe(false)
+
+  expect(sharedModule.hasFreshPrivilegedSession({
+    session: { createdAt: new Date(now.getTime() + 1) },
+  }, now)).toBe(false)
+
+  expect(sharedModule.hasFreshPrivilegedSession({ session: null }, now)).toBe(false)
+})
+
+test("fresh auth failures remain forbidden responses", () => {
+  expect(sharedModule.orgAccessFailureStatus({ error: "fresh_auth_required" })).toBe(403)
+  expect(sharedModule.orgAccessFailureStatus({ error: "forbidden" })).toBe(403)
+  expect(sharedModule.orgAccessFailureStatus({ error: "organization_not_found" })).toBe(404)
 })

--- a/ee/apps/den-api/test/org-role-permissions.test.ts
+++ b/ee/apps/den-api/test/org-role-permissions.test.ts
@@ -2,6 +2,9 @@ import { expect, test } from "bun:test"
 import {
   cloneOrganizationPermissionCatalog,
   filterOrganizationPermissionRecord,
+  resolveOrganizationPermissionRecord,
+  SECURITY_CONFIGURATION_PERMISSION_ACTION,
+  SECURITY_CONFIGURATION_PERMISSION_RESOURCE,
   validateAssignableOrganizationPermissionRecord,
   validateOrganizationPermissionRecord,
   type OrganizationPermissionRecord,
@@ -39,6 +42,7 @@ test("organization role permissions allow catalog permissions", () => {
   expect(validateOrganizationPermissionRecord({
     ac: ["read"],
     invitation: ["create", "cancel"],
+    [SECURITY_CONFIGURATION_PERMISSION_RESOURCE]: [SECURITY_CONFIGURATION_PERMISSION_ACTION],
   })).toEqual({ ok: true })
 })
 
@@ -57,6 +61,16 @@ test("organization role permissions cannot exceed the assigner permission set", 
     error: "invalid_permission",
     message: 'Cannot assign permission "ac.delete".',
   })
+
+  expect(validateAssignableOrganizationPermissionRecord({
+    permission: { [SECURITY_CONFIGURATION_PERMISSION_RESOURCE]: [SECURITY_CONFIGURATION_PERMISSION_ACTION] },
+    roleValue: "limited",
+    roles,
+  })).toEqual({
+    ok: false,
+    error: "invalid_permission",
+    message: `Cannot assign permission "${SECURITY_CONFIGURATION_PERMISSION_RESOURCE}.${SECURITY_CONFIGURATION_PERMISSION_ACTION}".`,
+  })
 })
 
 test("organization owners can assign permissions from the fixed catalog", () => {
@@ -72,11 +86,38 @@ test("organization owners can assign permissions from the fixed catalog", () => 
   })).toEqual({ ok: true })
 })
 
+test("default admins cannot assign delegated security configuration roles", () => {
+  const roles = [
+    role("admin", {
+      organization: ["update"],
+      invitation: ["create", "cancel"],
+      member: ["create", "update", "delete"],
+      team: ["create", "update", "delete"],
+      ac: ["create", "read", "update", "delete"],
+    }),
+    role("security-admin", {
+      [SECURITY_CONFIGURATION_PERMISSION_RESOURCE]: [SECURITY_CONFIGURATION_PERMISSION_ACTION],
+    }),
+  ]
+
+  expect(validateAssignableOrganizationPermissionRecord({
+    permission: resolveOrganizationPermissionRecord("security-admin", roles),
+    roleValue: "admin",
+    roles,
+  })).toEqual({
+    ok: false,
+    error: "invalid_permission",
+    message: `Cannot assign permission "${SECURITY_CONFIGURATION_PERMISSION_RESOURCE}.${SECURITY_CONFIGURATION_PERMISSION_ACTION}".`,
+  })
+})
+
 test("legacy stored permissions are filtered to the catalog when read", () => {
   expect(filterOrganizationPermissionRecord({
     ac: ["read", "delete", "unknown"],
     billing: ["delete"],
+    [SECURITY_CONFIGURATION_PERMISSION_RESOURCE]: [SECURITY_CONFIGURATION_PERMISSION_ACTION],
   })).toEqual({
     ac: ["read", "delete"],
+    [SECURITY_CONFIGURATION_PERMISSION_RESOURCE]: [SECURITY_CONFIGURATION_PERMISSION_ACTION],
   })
 })

--- a/packages/docs/cloud/security-and-operations.mdx
+++ b/packages/docs/cloud/security-and-operations.mdx
@@ -49,7 +49,9 @@ For production organizations, use SSO with identity-provider MFA as the primary 
 
 - Enable enforced SSO for organizations that have owners, admins, SCIM, SSO, API keys, or shared production providers.
 - Require MFA, phishing-resistant factors where available, and conditional-access policy in the identity provider before users reach OpenWork Cloud.
-- Keep SSO, SCIM, and API-key management owner-only. Treat owner-only changes, custom-role changes, member role changes, API-key creation, and emergency access as privileged actions that require a fresh IdP-authenticated session.
+- Keep SSO, SCIM, and API-key management behind the `security_configuration.manage` permission. Owners receive that permission by default and can delegate it through a custom role; default admins do not receive it automatically.
+- Invitation role assignment is bounded by the inviter's own permissions, so default admins can invite standard admins or members but cannot grant delegated security-configuration access unless they already hold that permission.
+- The server requires a session created in the last 15 minutes before privileged routes can change SSO, SCIM, API keys, organization settings, custom roles, member roles, billing, or inference settings.
 - Do not rely on standalone email/password accounts for production owner access unless the deployment has an equivalent MFA and recovery control outside OpenWork.
 
 Native factor enrollment and in-product reauthentication should be treated as product work before replacing SSO-enforced MFA as the production control.


### PR DESCRIPTION
## Summary
- Add a bounded `security_configuration.manage` organization permission for SSO, SCIM, and organization API-key management.
- Let owners delegate that permission through custom roles while default admins do not receive it automatically.
- Require a session created in the last 15 minutes before privileged owner/security-configuration routes can proceed.
- Bound invitation role assignment by the inviter's own permissions so default admins cannot invite another account into a delegated security-configuration role they do not hold.
- Update route response schemas/descriptions and security operations docs to match the delegated model.

## Validation
- `pnpm install --frozen-lockfile` - passed.
- `pnpm --filter @openwork-ee/den-api build` - passed.
- `bun test ee/apps/den-api/test/org-identity-access.test.ts ee/apps/den-api/test/org-role-permissions.test.ts` - passed, 11 pass / 0 fail.
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` - passed.
- `node -e "JSON.parse(require('fs').readFileSync('packages/docs/docs.json','utf8')); console.log('docs.json parse ok')"` - passed.
- `git diff --check` - passed.
- `bun test ee/apps/den-api/test` - passed, 142 pass / 0 fail.
- `git diff --cached --check` - passed before commit.

## Live Smoke
Not applicable: this is a server-side authorization and documentation change with no UI/runtime boundary change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

