### PR TITLE
[codex] fix Daytona validation runbooks

### DIFF
--- a/.opencode/skills/daytona-cloud-instance/SKILL.md
+++ b/.opencode/skills/daytona-cloud-instance/SKILL.md
@@ -13,10 +13,10 @@ Start the Den cloud stack in Daytona, confirm it is reachable, and return the UR
 
 ## Fast Path
 
-From the repo root, prefer the existing Daytona helper when available:
+From the repo root, prefer the existing Daytona server helper when available:
 
 ```bash
-bash .devcontainer/test-on-daytona.sh $(git rev-parse --abbrev-ref HEAD) --server-only --artifacts-volume
+bash .devcontainer/test-server-on-daytona.sh $(git rev-parse --abbrev-ref HEAD)
 ```
 
 If the branch is local-only, push it first or apply the local diff manually in the sandbox before validating.

--- a/.opencode/skills/daytona-dev/SKILL.md
+++ b/.opencode/skills/daytona-dev/SKILL.md
@@ -13,7 +13,7 @@ browser.
 
 - Daytona CLI installed: `brew install daytonaio/cli/daytona` or download from [GitHub releases](https://github.com/daytonaio/daytona/releases)
 - Logged in: `daytona login`
-- Using the "Different AI" org: `daytona organization use "Different AI"`
+- Using the right Daytona organization for your workspace: `daytona organization use "<org-name>"`
 
 ## Quick Start
 

--- a/.opencode/skills/daytona-seeded-cloud-demo/SKILL.md
+++ b/.opencode/skills/daytona-seeded-cloud-demo/SKILL.md
@@ -148,7 +148,9 @@ Daytona cloud demo is running and seeded.
 
 ## Troubleshooting
 
-If `.devcontainer/test-on-daytona.sh --server-only` appears in older docs, do not use it unless this checkout supports that flag. Use `.devcontainer/test-server-on-daytona.sh` for server-only cloud demos.
+If older docs suggest running the Electron helper in a server-only mode, do not
+use that path unless this checkout supports it. Use
+`.devcontainer/test-server-on-daytona.sh` for server-only cloud demos.
 
 If sign-in returns `403` for email verification, Den API is not running with `OPENWORK_DEV_MODE=1` or did not restart after env changes. Restart the Den stack and rerun the seed.
 

--- a/.opencode/skills/run-evals/SKILL.md
+++ b/.opencode/skills/run-evals/SKILL.md
@@ -16,7 +16,7 @@ Run the OpenWork UI evaluation flows against a real Electron app. Prefer a fresh
 ## Prerequisites
 
 - `daytona` CLI installed and logged in (`daytona login`)
-- Using the "Different AI" org (`daytona organization use "Different AI"`)
+- Using the right Daytona organization for your workspace (`daytona organization use "<org-name>"`)
 - The `.devcontainer/` files exist in the repo
 - Optional provider coverage: reusable Daytona volume `openwork-eval-secrets`
   populated with `.env` files using `bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken`
@@ -38,7 +38,7 @@ Use these Daytona skills when an eval touches a specific area:
 Use the repo helper unless you need to debug a specific Daytona step manually:
 
 ```bash
-daytona organization use "Different AI"
+daytona organization use "<org-name>"
 bash .devcontainer/test-on-daytona.sh <branch-or-commit>
 ```
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -61,7 +61,7 @@ display needed. See [`daytona-flows.md`](./daytona-flows.md) for full details.
 Quick start:
 
 ```bash
-daytona organization use "Different AI"
+daytona organization use "<org-name>"
 bash .devcontainer/test-on-daytona.sh [branch-or-commit]
 # Use the printed Electron CDP URL with browser_* tools.
 ```

--- a/evals/daytona-flows.md
+++ b/evals/daytona-flows.md
@@ -10,7 +10,7 @@ Daytona proxy.
 ### 1. Create/start the sandbox
 
 ```bash
-daytona organization use "Different AI"
+daytona organization use "<org-name>"
 bash .devcontainer/test-on-daytona.sh [branch-or-commit]
 ```
 


### PR DESCRIPTION
## Summary

- Fix the Daytona cloud-instance fast path so it uses the maintained server helper instead of an unsupported Electron-helper server-only mode.
- Replace hard-coded Daytona organization examples with `<org-name>` placeholders in Daytona eval/runbook docs.
- Reword the seeded cloud demo troubleshooting note so the obsolete flag is not copyable.

## Validation

Local/static checks:
- `pnpm install --frozen-lockfile` passed.
- Bash syntax checks passed for the Daytona helper scripts and related Docker helper.
- `docker compose -f packaging/docker/docker-compose.den-dev.yml config` passed.
- Daytona skill frontmatter check passed for 10 Daytona skills.
- Targeted stale-command/private-org scan passed after the docs cleanup.
- `git diff --check` and `git diff --cached --check` passed.

Build/type/test checks:
- `pnpm --filter @openwork-ee/den-api build` passed.
- `pnpm --filter @openwork-ee/den-db build` passed.
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` passed.
- `pnpm --dir ee/apps/den-worker-proxy exec tsc -p tsconfig.json --noEmit` passed.
- `pnpm --filter @openwork-ee/den-web build` passed.
- `bun test ee/apps/den-api/test` passed: 142 pass / 0 fail.
- `pnpm --filter @openwork/app typecheck` passed.
- `pnpm --filter @openwork/app build` passed.
- `pnpm --filter @openwork/app test` passed: 65 pass / 0 fail.
- `pnpm --filter @openwork/app test:desktop-cloud-sync` passed: 8 pass / 0 fail.
- `pnpm --filter @openwork/desktop check:electron` passed.
- `pnpm --filter @openwork/desktop test` passed: 18 pass / 1 skip / 0 fail.
- `pnpm --filter @openwork/desktop typecheck:electron` passed.
- `pnpm --filter @openwork/desktop build` passed.
- `pnpm --filter openwork-server typecheck` passed.
- `pnpm --filter openwork-server build` passed.
- `pnpm --filter openwork-server test:artifacts` passed: 20 pass / 0 fail.
- Isolated-home `pnpm --filter openwork-server test` passed: 226 pass / 6 skip / 0 fail.
- `node --check` passed for the eval runner scripts, mock OAuth MCP server, and Daytona runtime installer script.

Live Daytona checks:
- Verified Daytona CLI access. The reusable Electron/VNC snapshot and secrets/artifacts volumes were present and ready. The reusable server snapshot was missing, so the server helper exercised its Dockerfile fallback.
- Electron helper completed for commit `f89fd8fed24c4a9b4483a73c1c7d9966c57bd8b2` with artifacts enabled.
- CDP showed an `OpenWork` Electron target at the welcome route; user agent included `Electron/35.7.5`.
- Created `/workspace/hello` through the visible Daytona folder-path flow; app reached a workspace/session route, showed `Ready for new tasks`, showed `Run task`, and the opencode sidecar was running.
- Captured and locally inspected clean Daytona screenshots for the welcome and ready-workspace states.
- Server helper completed from Dockerfile fallback; Den API, Den Web, and worker proxy started and passed public health/proxy checks.
- Launched a second Electron sandbox pointed at the Daytona Den Web/API URLs with required sign-in; bootstrap JSON contained the Daytona Den URLs, CDP landed on `#/signin`, and the UI rendered the sign-in screen.
- Seeded the server demo org and verified sign-in through both public Den Web and direct Den API auth routes without printing tokens.
- Deleted the temporary Daytona sandboxes after validation.

## Notes

- Daytona CLI warned that the local CLI version is behind the API version. The warning did not block any helper, health check, CDP check, screenshot capture, or cleanup.
- Because the server snapshot is missing, server startup currently falls back to building from the Dockerfile and takes longer than the snapshot path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

