### PR TITLE
[codex] Revoke credentials when role permissions change

### DIFF
--- a/ee/apps/den-api/src/organization-role-credential-revocation.ts
+++ b/ee/apps/den-api/src/organization-role-credential-revocation.ts
@@ -1,0 +1,67 @@
+import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
+import { MemberTable } from "@openwork-ee/den-db/schema"
+import { revokeOrganizationApiKeysForMember } from "./api-keys.js"
+import { revokeMembershipSessionCredentials } from "./credential-revocation.js"
+import { db } from "./db.js"
+
+type OrganizationId = typeof MemberTable.$inferSelect.organizationId
+
+export type OrganizationRoleCredentialRevocationCounts = {
+  members: number
+  apiKeys: number
+  sessions: number
+  oauthAccessTokens: number
+  oauthRefreshTokens: number
+}
+
+function splitRoleValue(value: string) {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+export async function revokeCredentialsForOrganizationRoleMembers(input: {
+  organizationId: OrganizationId
+  role: string
+}): Promise<OrganizationRoleCredentialRevocationCounts> {
+  const members = await db
+    .select({
+      id: MemberTable.id,
+      role: MemberTable.role,
+      userId: MemberTable.userId,
+    })
+    .from(MemberTable)
+    .where(and(eq(MemberTable.organizationId, input.organizationId), isNull(MemberTable.removedAt)))
+
+  const counts: OrganizationRoleCredentialRevocationCounts = {
+    members: 0,
+    apiKeys: 0,
+    sessions: 0,
+    oauthAccessTokens: 0,
+    oauthRefreshTokens: 0,
+  }
+
+  for (const member of members) {
+    if (!splitRoleValue(member.role).includes(input.role)) {
+      continue
+    }
+
+    counts.members += 1
+    counts.apiKeys += await revokeOrganizationApiKeysForMember({
+      organizationId: input.organizationId,
+      orgMembershipId: member.id,
+      userId: member.userId,
+    })
+
+    const credentials = await revokeMembershipSessionCredentials({
+      organizationId: input.organizationId,
+      userId: member.userId,
+    })
+    counts.sessions += credentials.sessions
+    counts.oauthAccessTokens += credentials.oauthAccessTokens
+    counts.oauthRefreshTokens += credentials.oauthRefreshTokens
+  }
+
+  return counts
+}

--- a/ee/apps/den-api/src/routes/org/roles.ts
+++ b/ee/apps/den-api/src/routes/org/roles.ts
@@ -9,6 +9,7 @@ import { db } from "../../db.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
 import { validateAssignableOrganizationPermissionRecord } from "../../organization-access.js"
+import { revokeCredentialsForOrganizationRoleMembers } from "../../organization-role-credential-revocation.js"
 import { serializePermissionRecord } from "../../orgs.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { createRoleId, ensureOwner, idParamSchema, normalizeRoleName, replaceRoleValue, splitRoles } from "./shared.js"
@@ -175,6 +176,7 @@ export function registerOrgRoleRoutes<T extends { Variables: OrgRouteVariables }
       }
       nextPermission = serializePermissionRecord(input.permission)
     }
+    const permissionChanged = nextPermission !== roleRow.permission
 
     await db
       .update(OrganizationRoleTable)
@@ -215,6 +217,13 @@ export function registerOrgRoleRoutes<T extends { Variables: OrgRouteVariables }
       }
     }
 
+    if (permissionChanged) {
+      await revokeCredentialsForOrganizationRoleMembers({
+        organizationId: payload.organization.id,
+        role: nextRoleName,
+      })
+    }
+
     await recordOrganizationAuditEvent({
       organizationId: payload.organization.id,
       actorUserId: payload.currentMember.userId,
@@ -224,7 +233,7 @@ export function registerOrgRoleRoutes<T extends { Variables: OrgRouteVariables }
         previousRole: roleRow.role,
         nextRole: nextRoleName,
         roleRenamed: nextRoleName !== roleRow.role,
-        permissionChanged: nextPermission !== roleRow.permission,
+        permissionChanged,
       },
     })
 

--- a/ee/apps/den-api/test/organization-role-credential-revocation.test.ts
+++ b/ee/apps/den-api/test/organization-role-credential-revocation.test.ts
@@ -1,0 +1,101 @@
+import { beforeAll, expect, mock, test } from "bun:test"
+import { MemberTable } from "@openwork-ee/den-db/schema"
+
+const members = [
+  { id: "member_one", role: "member,security-admin", userId: "user_one" },
+  { id: "member_two", role: "security-admin", userId: null },
+  { id: "member_three", role: "admin", userId: "user_three" },
+]
+
+const apiKeyRevocations: unknown[] = []
+const credentialRevocations: unknown[] = []
+let selectCalls = 0
+
+function resetCalls() {
+  apiKeyRevocations.length = 0
+  credentialRevocations.length = 0
+  selectCalls = 0
+}
+
+let roleCredentialRevocationModule: typeof import("../src/organization-role-credential-revocation.js")
+
+beforeAll(async () => {
+  mock.module("../src/db.js", () => ({
+    db: {
+      select: () => ({
+        from: (table: unknown) => ({
+          where: () => {
+            selectCalls += 1
+            return Promise.resolve(table === MemberTable ? members : [])
+          },
+        }),
+      }),
+    },
+  }))
+
+  mock.module("../src/api-keys.js", () => ({
+    revokeOrganizationApiKeysForMember: (input: unknown) => {
+      apiKeyRevocations.push(input)
+      return Promise.resolve(1)
+    },
+  }))
+
+  mock.module("../src/credential-revocation.js", () => ({
+    revokeMembershipSessionCredentials: (input: unknown) => {
+      credentialRevocations.push(input)
+      return Promise.resolve({
+        sessions: input && typeof input === "object" && "userId" in input && input.userId ? 2 : 0,
+        oauthAccessTokens: input && typeof input === "object" && "userId" in input && input.userId ? 1 : 0,
+        oauthRefreshTokens: input && typeof input === "object" && "userId" in input && input.userId ? 1 : 0,
+      })
+    },
+  }))
+
+  roleCredentialRevocationModule = await import("../src/organization-role-credential-revocation.js")
+})
+
+test("role credential revocation touches active members using the changed role", async () => {
+  resetCalls()
+
+  const counts = await roleCredentialRevocationModule.revokeCredentialsForOrganizationRoleMembers({
+    organizationId: "org_123",
+    role: "security-admin",
+  })
+
+  expect(counts).toEqual({
+    members: 2,
+    apiKeys: 2,
+    sessions: 2,
+    oauthAccessTokens: 1,
+    oauthRefreshTokens: 1,
+  })
+  expect(selectCalls).toBe(1)
+  expect(apiKeyRevocations).toEqual([
+    { organizationId: "org_123", orgMembershipId: "member_one", userId: "user_one" },
+    { organizationId: "org_123", orgMembershipId: "member_two", userId: null },
+  ])
+  expect(credentialRevocations).toEqual([
+    { organizationId: "org_123", userId: "user_one" },
+    { organizationId: "org_123", userId: null },
+  ])
+})
+
+test("role credential revocation skips members without the changed role", async () => {
+  resetCalls()
+
+  const counts = await roleCredentialRevocationModule.revokeCredentialsForOrganizationRoleMembers({
+    organizationId: "org_123",
+    role: "billing-admin",
+  })
+
+  expect(counts).toEqual({
+    members: 0,
+    apiKeys: 0,
+    sessions: 0,
+    oauthAccessTokens: 0,
+    oauthRefreshTokens: 0,
+  })
+  expect(selectCalls).toBe(1)
+  expect(apiKeyRevocations).toEqual([])
+  expect(credentialRevocations).toEqual([])
+})


### PR DESCRIPTION
## Summary
- Revokes sessions, organization API keys, and org-scoped OAuth credentials for active members holding a custom role when that role's permission map changes.
- Wires the revocation into organization role updates without changing role creation, deletion, or permission validation behavior.
- Adds focused regression coverage for role-member credential revocation.

## Why
Changing a custom role permission map can grant or remove sensitive delegated security capabilities for every current member with that role. Direct member role changes already revoke credentials; role permission-map changes now get the same treatment.

## Validation
- `pnpm install --frozen-lockfile` passed.
- `pnpm --filter @openwork-ee/den-db build` passed.
- `pnpm --filter @openwork-ee/utils build` passed.
- `pnpm --filter @openwork-ee/den-api build` passed.
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit` passed.
- `bun test ee/apps/den-api/test/organization-role-credential-revocation.test.ts ee/apps/den-api/test/org-role-permissions.test.ts ee/apps/den-api/test/org-identity-access.test.ts` passed, 13 pass / 0 fail.
- `bun test ee/apps/den-api/test` passed, 144 pass / 0 fail.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.

## Daytona Evidence
- Reviewed the Daytona opencode server skill and used `.devcontainer/test-server-on-daytona.sh` for this server-only validation.
- Daytona sandbox `openwork-security-role-revoke-20260613-202528` checked out commit `c1429c3`.
- Den API health passed: `GET /health` returned `{"ok":true,"service":"den-api"}`.
- Den Web proxy health passed: `GET /api/den/health` returned `{"ok":true,"service":"den-api"}`.
- Worker proxy unknown-worker smoke returned HTTP 404 with `worker_not_found`, as expected.
- Focused Daytona test run passed: 13 pass / 0 fail.
- Temporary Daytona sandbox was deleted after validation.

## Live Smoke
Video is not relevant for this server-only authorization/credential lifecycle hardening; the focused Daytona server smoke and tests are the relevant runtime evidence.

## Merge Note
Draft PR only. Do not merge until reviewed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

