### PR TITLE
fix(den-api): require fresh auth for membership changes

### DIFF
--- a/docs/security-architecture-review-tracker.md
+++ b/docs/security-architecture-review-tracker.md
@@ -1,0 +1,22 @@
+# Security Architecture Review Tracker
+
+Current PR scope: require fresh auth for organization invitation and member-removal actions.
+
+## This PR
+
+- Requires a session created in the last 15 minutes before owners/admins can invite members or remove members.
+- Keeps the change small by reusing the existing `fresh_auth_required` helper instead of adding a new MFA or reauth system.
+- Adds tests for fresh-auth coverage on invitation and member-removal authorization helpers.
+
+## Remaining Follow-Ups
+
+- Native MFA or a clear product decision that enforced SSO with IdP MFA is the supported production control.
+- SCIM drift reconciliation and alerting beyond retryable mutation failures.
+- Tamper-evident audit logging and SIEM export path.
+- KMS-backed signing/encryption key storage and rotation plan.
+- Explicit MCP dynamic-client PKCE and refresh-token rotation validation.
+
+## Validation Log
+
+- Passed: `pnpm exec bun test test` from `ee/apps/den-api` (145 tests, 0 failures)
+- Passed: `pnpm test:e2e`

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -14,7 +14,7 @@ import { isEmailAllowedForOrganization, listAssignableRoles, removeOrganizationM
 import { getOrganizationSeatAddEligibility } from "../../stripe-billing.js"
 import { DenEmailSendError, sendEmail } from "../../utils/email/send-email.js"
 import type { OrgRouteVariables } from "./shared.js"
-import { buildInvitationLink, createInvitationId, createInvitationToken, ensureInviteManager, idParamSchema, normalizeRoleName } from "./shared.js"
+import { buildInvitationLink, createInvitationId, createInvitationToken, ensureInviteManager, idParamSchema, normalizeRoleName, orgAccessFailureStatus } from "./shared.js"
 
 const inviteMemberSchema = z.object({
   email: z.string().email(),
@@ -81,7 +81,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     async (c) => {
     const permission = ensureInviteManager(c)
     if (!permission.ok) {
-      return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
+      return c.json(permission.response, orgAccessFailureStatus(permission.response))
     }
 
     const payload = c.get("organizationContext")
@@ -307,7 +307,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     async (c) => {
     const permission = ensureInviteManager(c)
     if (!permission.ok) {
-      return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
+      return c.json(permission.response, orgAccessFailureStatus(permission.response))
     }
 
     const payload = c.get("organizationContext")

--- a/ee/apps/den-api/src/routes/org/members.ts
+++ b/ee/apps/den-api/src/routes/org/members.ts
@@ -12,7 +12,7 @@ import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizati
 import { emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
 import { listAssignableRoles, removeOrganizationMember, validateOrganizationMemberRoleUpdate } from "../../orgs.js"
 import type { OrgRouteVariables } from "./shared.js"
-import { ensureMemberRemover, ensureOwner, idParamSchema, normalizeRoleName } from "./shared.js"
+import { ensureMemberRemover, ensureOwner, idParamSchema, normalizeRoleName, orgAccessFailureStatus } from "./shared.js"
 
 const updateMemberRoleSchema = z.object({
   role: z.string().trim().min(1).max(64),
@@ -123,7 +123,7 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
     async (c) => {
     const permission = ensureMemberRemover(c)
     if (!permission.ok) {
-      return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
+      return c.json(permission.response, orgAccessFailureStatus(permission.response))
     }
 
     const payload = c.get("organizationContext")

--- a/ee/apps/den-api/src/routes/org/shared.ts
+++ b/ee/apps/den-api/src/routes/org/shared.ts
@@ -122,7 +122,7 @@ export function ensureOwner(c: PrivilegedOrgRouteContext) {
   return ensureFreshPrivilegedSession(c)
 }
 
-export function ensureInviteManager(c: { get: (key: "organizationContext") => OrgRouteVariables["organizationContext"] }) {
+export function ensureInviteManager(c: PrivilegedOrgRouteContext) {
   const payload = c.get("organizationContext")
   if (!payload) {
     return {
@@ -134,7 +134,7 @@ export function ensureInviteManager(c: { get: (key: "organizationContext") => Or
   }
 
   if (payload.currentMember.isOwner || memberHasRole(payload.currentMember.role, "admin")) {
-    return { ok: true as const }
+    return ensureFreshPrivilegedSession(c)
   }
 
   return {
@@ -146,7 +146,7 @@ export function ensureInviteManager(c: { get: (key: "organizationContext") => Or
   }
 }
 
-export function ensureMemberRemover(c: { get: (key: "organizationContext") => OrgRouteVariables["organizationContext"] }) {
+export function ensureMemberRemover(c: PrivilegedOrgRouteContext) {
   const payload = c.get("organizationContext")
   if (!payload) {
     return {
@@ -158,7 +158,7 @@ export function ensureMemberRemover(c: { get: (key: "organizationContext") => Or
   }
 
   if (payload.currentMember.isOwner || memberHasRole(payload.currentMember.role, "admin")) {
-    return { ok: true as const }
+    return ensureFreshPrivilegedSession(c)
   }
 
   return {

--- a/ee/apps/den-api/test/org-identity-access.test.ts
+++ b/ee/apps/den-api/test/org-identity-access.test.ts
@@ -9,6 +9,18 @@ function seedRequiredEnv() {
 
 let sharedModule: typeof import("../src/routes/org/shared.js")
 
+function privilegedContext(input: {
+  createdAt: Date
+  isOwner: boolean
+  role: string
+}) {
+  return {
+    get: (key: "organizationContext" | "session") => key === "organizationContext"
+      ? { currentMember: { isOwner: input.isOwner, role: input.role } }
+      : { createdAt: input.createdAt },
+  } as Parameters<typeof sharedModule.ensureInviteManager>[0]
+}
+
 beforeAll(async () => {
   seedRequiredEnv()
   sharedModule = await import("../src/routes/org/shared.js")
@@ -88,4 +100,35 @@ test("fresh auth failures remain forbidden responses", () => {
   expect(sharedModule.orgAccessFailureStatus({ error: "fresh_auth_required" })).toBe(403)
   expect(sharedModule.orgAccessFailureStatus({ error: "forbidden" })).toBe(403)
   expect(sharedModule.orgAccessFailureStatus({ error: "organization_not_found" })).toBe(404)
+})
+
+test("member invitations and removals require a fresh privileged session", () => {
+  const now = new Date()
+  const freshContext = privilegedContext({
+    createdAt: new Date(now.getTime() - 1000),
+    isOwner: false,
+    role: "admin",
+  })
+  const staleContext = privilegedContext({
+    createdAt: new Date(now.getTime() - sharedModule.PRIVILEGED_SESSION_MAX_AGE_MS - 1),
+    isOwner: false,
+    role: "admin",
+  })
+
+  expect(sharedModule.ensureInviteManager(freshContext)).toEqual({ ok: true })
+  expect(sharedModule.ensureMemberRemover(freshContext)).toEqual({ ok: true })
+  expect(sharedModule.ensureInviteManager(staleContext)).toEqual({
+    ok: false,
+    response: {
+      error: "fresh_auth_required",
+      message: "Sign in again before performing this privileged action.",
+    },
+  })
+  expect(sharedModule.ensureMemberRemover(staleContext)).toEqual({
+    ok: false,
+    response: {
+      error: "fresh_auth_required",
+      message: "Sign in again before performing this privileged action.",
+    },
+  })
 })


### PR DESCRIPTION
Summary
- Require fresh privileged sessions for organization invitations and member removals.
- Reuse existing fresh_auth_required handling and status mapping.
- Add a security review tracker with remaining follow-ups and validation log.

Tests
- Passed: pnpm exec bun test test from ee/apps/den-api (145 tests, 0 failures).
- Passed: pnpm test:e2e.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

