### PR TITLE
Fix regression audit findings

### DIFF
--- a/apps/app/src/react-app/domains/session/panel/side-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/side-panel.tsx
@@ -393,8 +393,13 @@ export function SidePanel({
   const { createTab, closeTab, selectTab, reorderTabs } = useSidePanelTabs(sessionId);
 
   React.useEffect(() => {
+    const isEditableTarget = (target: EventTarget | null) => {
+      if (!(target instanceof HTMLElement)) return false;
+      return Boolean(target.closest("input, textarea, select, [contenteditable='true'], [role='dialog']"));
+    };
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (!event.ctrlKey || event.altKey || event.metaKey || event.key !== "Tab" || tabs.length < 2) {
+      if (event.defaultPrevented || isEditableTarget(event.target) || !event.ctrlKey || event.altKey || event.metaKey || event.key !== "Tab" || tabs.length < 2) {
         return;
       }
 

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -755,7 +755,7 @@ export function SessionRoute() {
     // local server with the local `rem_*` id.
     return {
       workspaceRoot: selectedWorkspaceRoot,
-      developerMode: false,
+      developerMode,
       modelLabel,
       onModelClick: () => {
         modelPicker.setQuery("");
@@ -922,6 +922,7 @@ export function SessionRoute() {
     };
   }, [
     client,
+    developerMode,
     modelPicker.compactOpen,
     handleOpenSettings,
     hasUsableModel,
@@ -1581,7 +1582,7 @@ export function SessionRoute() {
         workspaceSessionGroups,
         selectedWorkspaceId,
         selectedSessionId,
-        developerMode: false,
+        developerMode,
         sessionStatusById: sidebarSessionStatusById,
         connectingWorkspaceId: null,
         workspaceConnectionStateById,

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -510,7 +510,7 @@ export const auth = betterAuth({
         defaultExpiresIn: DEN_API_KEY_EXPIRES_IN_SECONDS,
         disableCustomExpiresTime: true,
         minExpiresIn: 1,
-        maxExpiresIn: DEN_API_KEY_EXPIRES_IN_DAYS,
+        maxExpiresIn: DEN_API_KEY_EXPIRES_IN_SECONDS,
       },
       rateLimit: {
         enabled: true,

--- a/ee/apps/den-api/src/mcp/admin-tools.ts
+++ b/ee/apps/den-api/src/mcp/admin-tools.ts
@@ -31,6 +31,15 @@ const SERVER_STARTED_AT = new Date().toISOString()
 
 type Row = Record<string, unknown>
 type OrganizationId = typeof OrganizationTable.$inferSelect.id
+type AdminMcpToolOptions = {
+  canWrite?: boolean
+}
+
+export function assertAdminWriteAllowed(canWrite: boolean) {
+  if (!canWrite) {
+    throw new Error("mcp_write_scope_required")
+  }
+}
 
 /**
  * `db` is drizzle over either mysql2 (returns `[rows, fields]`) or
@@ -308,7 +317,7 @@ export function buildAdminMcpVersionInfo() {
 
 // --- tool registration ---
 
-export function registerAdminMcpTools(server: McpServer) {
+export function registerAdminMcpTools(server: McpServer, options: AdminMcpToolOptions = {}) {
   server.registerTool(
     "den_admin_version",
     {
@@ -376,6 +385,8 @@ export function registerAdminMcpTools(server: McpServer) {
     },
     async ({ organizationId, tier, seatLimit }) =>
       run(async () => {
+        assertAdminWriteAllowed(options.canWrite === true)
+
         if (!isOrganizationId(organizationId)) {
           throw new Error("Invalid organization id")
         }

--- a/ee/apps/den-api/src/mcp/admin.ts
+++ b/ee/apps/den-api/src/mcp/admin.ts
@@ -19,7 +19,7 @@ import { DEN_ADMIN_MCP_VERSION, registerAdminMcpTools } from "./admin-tools.js"
  *    token's user — the same gate as /v1/admin/overview. Non-admins get 403.
  *
  * This intentionally does NOT reuse the /mcp OpenAPI tool catalog: admin
- * tools are hand-written read-only analytics (see ./admin-tools.ts), and the
+ * tools are hand-written for platform operations (see ./admin-tools.ts), and the
  * /mcp exposure policy keeps blocking everything tagged Admin.
  */
 export function registerAdminMcpRoutes<T extends { Variables: Record<string, unknown> }>(app: Hono<T>) {
@@ -55,7 +55,7 @@ export function registerAdminMcpRoutes<T extends { Variables: Record<string, unk
       name: "den-admin",
       version: DEN_ADMIN_MCP_VERSION,
     })
-    registerAdminMcpTools(server)
+    registerAdminMcpTools(server, { canWrite: principal.scopes.has("mcp:write") })
 
     const transport = new StreamableHTTPTransport()
     await server.connect(transport)

--- a/ee/apps/den-api/src/organization-access.ts
+++ b/ee/apps/den-api/src/organization-access.ts
@@ -90,13 +90,14 @@ export function cloneOrganizationPermissionCatalog() {
 
 export function filterOrganizationPermissionRecord(permission: OrganizationPermissionRecord) {
   const filtered: OrganizationPermissionRecord = {}
-  for (const [resource, actions] of Object.entries(permission)) {
-    const allowedActions = getAllowedPermissionActions(resource)
-    if (!allowedActions) {
+  for (const [resource, allowedActions] of denOrganizationPermissionCatalogEntries) {
+    const actions = permission[resource]
+    if (!actions) {
       continue
     }
 
-    const validActions = actions.filter((action) => allowedActions.includes(action))
+    const actionSet = new Set(actions)
+    const validActions = allowedActions.filter((action) => actionSet.has(action))
     if (validActions.length > 0) {
       filtered[resource] = validActions
     }

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -295,7 +295,7 @@ export function parsePermissionRecord(value: string | null) {
 }
 
 export function serializePermissionRecord(value: OrganizationPermissionRecord) {
-  return JSON.stringify(value)
+  return JSON.stringify(filterOrganizationPermissionRecord(value))
 }
 
 export class OrganizationEmailDomainRestrictionError extends Error {

--- a/ee/apps/den-api/src/routes/org/shared.ts
+++ b/ee/apps/den-api/src/routes/org/shared.ts
@@ -19,10 +19,17 @@ export type OrgRouteVariables =
 export const PRIVILEGED_SESSION_MAX_AGE_MS = 15 * 60 * 1000
 
 type PrivilegedOrgRouteContext = {
-  get: <K extends "organizationContext" | "session">(key: K) => OrgRouteVariables[K]
+  get: <K extends "organizationContext" | "session" | "apiKey">(key: K) => OrgRouteVariables[K]
 }
 
-export function hasFreshPrivilegedSession(payload: { session: { createdAt?: Date | string | null } | null | undefined }, now = new Date()) {
+export function hasFreshPrivilegedSession(payload: {
+  session: { id?: string | null; createdAt?: Date | string | null } | null | undefined
+  apiKey?: unknown | null
+}, now = new Date()) {
+  if (payload.apiKey || payload.session?.id === "mcp_internal") {
+    return false
+  }
+
   const createdAt = payload.session?.createdAt
   const createdAtMs = createdAt instanceof Date
     ? createdAt.getTime()
@@ -38,8 +45,8 @@ export function hasFreshPrivilegedSession(payload: { session: { createdAt?: Date
   return ageMs >= 0 && ageMs <= PRIVILEGED_SESSION_MAX_AGE_MS
 }
 
-function ensureFreshPrivilegedSession(c: { get: (key: "session") => OrgRouteVariables["session"] }) {
-  if (hasFreshPrivilegedSession({ session: c.get("session") })) {
+function ensureFreshPrivilegedSession(c: { get: <K extends "session" | "apiKey">(key: K) => OrgRouteVariables[K] }) {
+  if (hasFreshPrivilegedSession({ session: c.get("session"), apiKey: c.get("apiKey") })) {
     return { ok: true as const }
   }
 

--- a/ee/apps/den-api/src/scim-token-storage.ts
+++ b/ee/apps/den-api/src/scim-token-storage.ts
@@ -7,12 +7,29 @@ export function hashScimToken(scimToken: string) {
   return createHash("sha256").update(scimToken).digest("base64url")
 }
 
-export function verifyStoredScimToken(input: {
+function timingSafeStringEqual(left: string, right: string) {
+  const leftBytes = Uint8Array.from(Buffer.from(left))
+  const rightBytes = Uint8Array.from(Buffer.from(right))
+  return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes)
+}
+
+export function getStoredScimTokenVerification(input: {
   storedToken: string
   rawToken: string
 }) {
   const expectedToken = hashScimToken(input.rawToken)
-  const storedBytes = Uint8Array.from(Buffer.from(input.storedToken))
-  const expectedBytes = Uint8Array.from(Buffer.from(expectedToken))
-  return storedBytes.length === expectedBytes.length && timingSafeEqual(storedBytes, expectedBytes)
+  if (timingSafeStringEqual(input.storedToken, expectedToken)) {
+    return { ok: true, needsRehash: false }
+  }
+  if (timingSafeStringEqual(input.storedToken, input.rawToken)) {
+    return { ok: true, needsRehash: true }
+  }
+  return { ok: false, needsRehash: false }
+}
+
+export function verifyStoredScimToken(input: {
+  storedToken: string
+  rawToken: string
+}) {
+  return getStoredScimTokenVerification(input).ok
 }

--- a/ee/apps/den-api/src/scim.ts
+++ b/ee/apps/den-api/src/scim.ts
@@ -6,7 +6,7 @@ import { auth } from "./auth.js"
 import { db } from "./db.js"
 import { env } from "./env.js"
 import { removeOrganizationMember } from "./orgs.js"
-import { verifyStoredScimToken } from "./scim-token-storage.js"
+import { getStoredScimTokenVerification, hashScimToken } from "./scim-token-storage.js"
 
 type OrganizationId = typeof MemberTable.$inferSelect.organizationId
 type UserId = typeof AuthUserTable.$inferSelect.id
@@ -64,8 +64,24 @@ async function resolveScimProviderFromBearerToken(bearerToken: string) {
     .limit(1)
 
   const provider = providerRows[0] ?? null
-  if (!provider || !verifyStoredScimToken({ storedToken: provider.scimToken, rawToken })) {
+  if (!provider) {
     return null
+  }
+
+  const verification = getStoredScimTokenVerification({ storedToken: provider.scimToken, rawToken })
+  if (!verification.ok) {
+    return null
+  }
+
+  if (verification.needsRehash) {
+    try {
+      await db
+        .update(ScimProviderTable)
+        .set({ scimToken: hashScimToken(rawToken) })
+        .where(eq(ScimProviderTable.id, provider.id))
+    } catch {
+      // Keep legacy SCIM integrations working even if the opportunistic upgrade fails.
+    }
   }
 
   return provider

--- a/ee/apps/den-api/test/admin-mcp.test.ts
+++ b/ee/apps/den-api/test/admin-mcp.test.ts
@@ -101,3 +101,10 @@ describe("buildAdminMcpVersionInfo", () => {
     expect(Date.parse(info.serverStartedAt)).not.toBeNaN()
   })
 })
+
+describe("admin write tool scope", () => {
+  test("requires mcp:write for mutating admin tools", () => {
+    expect(() => adminTools.assertAdminWriteAllowed(false)).toThrow("mcp_write_scope_required")
+    expect(() => adminTools.assertAdminWriteAllowed(true)).not.toThrow()
+  })
+})

--- a/ee/apps/den-api/test/org-identity-access.test.ts
+++ b/ee/apps/den-api/test/org-identity-access.test.ts
@@ -82,6 +82,15 @@ test("privileged actions require a fresh session", () => {
   }, now)).toBe(false)
 
   expect(sharedModule.hasFreshPrivilegedSession({ session: null }, now)).toBe(false)
+
+  expect(sharedModule.hasFreshPrivilegedSession({
+    session: { id: "mcp_internal", createdAt: now },
+  }, now)).toBe(false)
+
+  expect(sharedModule.hasFreshPrivilegedSession({
+    session: { id: "api_key_session", createdAt: now },
+    apiKey: { id: "api_key_session" },
+  }, now)).toBe(false)
 })
 
 test("fresh auth failures remain forbidden responses", () => {

--- a/ee/apps/den-api/test/org-role-permissions.test.ts
+++ b/ee/apps/den-api/test/org-role-permissions.test.ts
@@ -121,3 +121,13 @@ test("legacy stored permissions are filtered to the catalog when read", () => {
     [SECURITY_CONFIGURATION_PERMISSION_RESOURCE]: [SECURITY_CONFIGURATION_PERMISSION_ACTION],
   })
 })
+
+test("permission records are canonicalized to avoid false-positive revocations", () => {
+  expect(filterOrganizationPermissionRecord({
+    [SECURITY_CONFIGURATION_PERMISSION_RESOURCE]: [SECURITY_CONFIGURATION_PERMISSION_ACTION],
+    ac: ["delete", "read", "delete"],
+  })).toEqual({
+    ac: ["read", "delete"],
+    [SECURITY_CONFIGURATION_PERMISSION_RESOURCE]: [SECURITY_CONFIGURATION_PERMISSION_ACTION],
+  })
+})

--- a/ee/apps/den-api/test/scim-token-storage.test.ts
+++ b/ee/apps/den-api/test/scim-token-storage.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import {
+  getStoredScimTokenVerification,
   hashScimToken,
   SCIM_TOKEN_STORAGE_STRATEGY,
   verifyStoredScimToken,
@@ -14,4 +15,11 @@ test("SCIM token verification compares the stored hash in constant time", () => 
   const storedToken = hashScimToken("scim-test-token")
   expect(verifyStoredScimToken({ storedToken, rawToken: "scim-test-token" })).toBe(true)
   expect(verifyStoredScimToken({ storedToken, rawToken: "wrong-token" })).toBe(false)
+})
+
+test("SCIM token verification accepts legacy plaintext tokens for migration", () => {
+  expect(getStoredScimTokenVerification({
+    storedToken: "legacy-scim-token",
+    rawToken: "legacy-scim-token",
+  })).toEqual({ ok: true, needsRehash: true })
 })


### PR DESCRIPTION
## Summary
- harden privileged session freshness checks, API key expiration units, admin MCP write scope, SCIM token migration, and permission canonicalization
- propagate Developer Mode state into the session shell
- guard browser-panel Ctrl+Tab handling around prevented events, editable targets, dialogs, and modifier shape

## Verification
- pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit
- pnpm --filter @openwork-ee/den-api exec bun test test
- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/app test
- pnpm --filter @openwork/app test:e2e
- pnpm --filter @openwork/app build
- pnpm --filter openwork-server typecheck
- pnpm --filter openwork-server test
- pnpm --filter @openwork/desktop test
- pnpm --filter @openwork-ee/den-api build
- pnpm --filter @openwork-ee/den-web build
- pnpm --filter @openwork-ee/den-admin-mcp check
- bash -n Daytona helper scripts

## Daytona Evidence
- Server sandbox: openwork-server-20260614-134647
- Electron sandbox: openwork-test-20260614-134949
- Full coded suite passed: evals/results/2026-06-14T20-54-21-325Z/report.md
- Cloud handoff passed: evals/results/2026-06-14T20-54-56-506Z/report.md
- Cloud MCP standalone passed: evals/results/2026-06-14T21-07-26-404Z/report.md
- Final signed-in suite passed: evals/results/2026-06-14T21-08-01-253Z/report.md
- Manual CDP validation passed for Developer Mode command-palette toggle and browser-panel Ctrl+Tab guards

## Visual Evidence
- Daytona proof index: https://8090-ftimtsoiriv6o9et.daytonaproxy01.net/validation/bc5ed-regression-hardening/index.html
- No video attached; static frame proof plus coded Daytona evals cover the validated states.