### PR TITLE
Stabilize Daytona eval flows

### DIFF
--- a/evals/flows/cloud-mcp-auto-config.flow.mjs
+++ b/evals/flows/cloud-mcp-auto-config.flow.mjs
@@ -68,6 +68,9 @@ export default {
     {
       name: "Cloud MCP auto-config marker is written",
       run: async (ctx) => {
+        await ctx.navigateHash("/settings/extensions/mcp");
+        await ctx.waitForText("OpenWork Cloud Control", { timeoutMs: 30_000 });
+        await ctx.eval(`window.dispatchEvent(new CustomEvent("openwork-den-settings-changed"))`);
         await ctx.waitFor(
           "Boolean(localStorage.getItem('openwork.den.mcp.sync'))",
           { timeoutMs: 120_000, label: "openwork.den.mcp.sync marker" },

--- a/evals/flows/extensions-marketplace-updates.flow.mjs
+++ b/evals/flows/extensions-marketplace-updates.flow.mjs
@@ -58,7 +58,18 @@ export default {
     {
       name: "Updates filter is interactive and view stays stable",
       run: async (ctx) => {
-        await ctx.clickText("Updates");
+        const clicked = await ctx.eval(`(() => {
+          const buttons = Array.from(document.querySelectorAll("button"));
+          const filter = buttons.find((button) => {
+            const label = (button.textContent ?? "").trim();
+            return label === "Updates" && button.getBoundingClientRect().left > 250;
+          });
+          if (!filter) return false;
+          filter.scrollIntoView({ block: "center" });
+          filter.click();
+          return true;
+        })()`);
+        ctx.assert(clicked, "Expected to click the Marketplace Updates filter");
         await ctx.waitForText("Extension Marketplace");
         const crashed = await ctx.hasText("Something went wrong");
         ctx.assert(!crashed, "Marketplace view crashed after selecting Updates filter");


### PR DESCRIPTION
## Summary
- target the Marketplace Updates filter instead of the Settings sidebar item with the same label
- navigate to the MCP settings surface and trigger the Den settings change event before waiting for the Cloud MCP sync marker

## Verification
- node --check evals/flows/cloud-mcp-auto-config.flow.mjs
- node --check evals/flows/extensions-marketplace-updates.flow.mjs
- Daytona full coded suite passed with these local eval-flow changes: evals/results/2026-06-14T20-54-21-325Z/report.md
- Daytona Cloud MCP standalone passed with these local eval-flow changes: evals/results/2026-06-14T21-07-26-404Z/report.md
- Daytona final signed-in suite passed with these local eval-flow changes: evals/results/2026-06-14T21-08-01-253Z/report.md

## Visual Evidence
- Daytona proof index: https://8090-ftimtsoiriv6o9et.daytonaproxy01.net/validation/bc5ed-regression-hardening/index.html
- No video attached; static frame proof plus coded Daytona evals cover the validated states.

## Note
This PR is stacked on #2264 so reviewers can see only the eval-flow cleanup diff.