### PR TITLE
Fix queued messages leaking across sessions

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-import type { ComposerAttachment } from "../../../../app/types";
+import type { ComposerAttachment, ComposerDraft } from "../../../../app/types";
 import type { ComposerMentionKind } from "./composer/mention-encoding";
 
 export type ComposerPastePart = {
@@ -19,6 +19,7 @@ export type ComposerSessionState = {
 
 export type ComposerStateStore = {
   sessions: Record<string, ComposerSessionState>;
+  queuedDrafts: Record<string, ComposerDraft[]>;
   /**
    * Sent-prompt history per session, oldest first. Kept outside
    * `sessions` because `clearSession` resets the composer after every
@@ -30,6 +31,10 @@ export type ComposerStateStore = {
   setMentions: (sessionId: string, mentions: Record<string, ComposerMentionKind>) => void;
   setPasteParts: (sessionId: string, pasteParts: ComposerPastePart[]) => void;
   appendHistory: (sessionId: string, text: string) => void;
+  appendQueuedDraft: (sessionId: string, draft: ComposerDraft) => void;
+  removeQueuedDraft: (sessionId: string, index: number) => void;
+  clearQueuedDrafts: (sessionId: string) => void;
+  prependQueuedDrafts: (sessionId: string, drafts: ComposerDraft[]) => void;
   clearSession: (sessionId: string) => void;
 };
 
@@ -37,6 +42,7 @@ const EMPTY_ATTACHMENTS: ComposerAttachment[] = [];
 const EMPTY_MENTIONS: Record<string, ComposerMentionKind> = {};
 const EMPTY_PASTE_PARTS: ComposerPastePart[] = [];
 const EMPTY_HISTORY: string[] = [];
+const EMPTY_QUEUED_DRAFTS: ComposerDraft[] = [];
 const HISTORY_LIMIT = 50;
 
 function createEmptyComposerSession(): ComposerSessionState {
@@ -54,6 +60,7 @@ function getWritableSession(state: ComposerStateStore, sessionId: string): Compo
 
 export const useComposerStateStore = create<ComposerStateStore>((set) => ({
   sessions: {},
+  queuedDrafts: {},
   history: {},
   setDraft: (sessionId, draft) => set((state) => {
     const current = getWritableSession(state, sessionId);
@@ -85,6 +92,31 @@ export const useComposerStateStore = create<ComposerStateStore>((set) => ({
     const next = [...current, trimmed].slice(-HISTORY_LIMIT);
     return { history: { ...state.history, [sessionId]: next } };
   }),
+  appendQueuedDraft: (sessionId, draft) => set((state) => {
+    const current = state.queuedDrafts[sessionId] ?? EMPTY_QUEUED_DRAFTS;
+    return { queuedDrafts: { ...state.queuedDrafts, [sessionId]: [...current, draft] } };
+  }),
+  removeQueuedDraft: (sessionId, index) => set((state) => {
+    const current = state.queuedDrafts[sessionId];
+    if (!current) return state;
+    const next = current.filter((_, itemIndex) => itemIndex !== index);
+    if (next.length === current.length) return state;
+    if (next.length > 0) return { queuedDrafts: { ...state.queuedDrafts, [sessionId]: next } };
+    const queuedDrafts = { ...state.queuedDrafts };
+    delete queuedDrafts[sessionId];
+    return { queuedDrafts };
+  }),
+  clearQueuedDrafts: (sessionId) => set((state) => {
+    if (!state.queuedDrafts[sessionId]) return state;
+    const queuedDrafts = { ...state.queuedDrafts };
+    delete queuedDrafts[sessionId];
+    return { queuedDrafts };
+  }),
+  prependQueuedDrafts: (sessionId, drafts) => set((state) => {
+    if (drafts.length === 0) return state;
+    const current = state.queuedDrafts[sessionId] ?? EMPTY_QUEUED_DRAFTS;
+    return { queuedDrafts: { ...state.queuedDrafts, [sessionId]: [...drafts, ...current] } };
+  }),
   clearSession: (sessionId) => set((state) => {
     if (!state.sessions[sessionId]) return state;
     const sessions = { ...state.sessions };
@@ -111,4 +143,8 @@ export function getComposerPasteParts(state: ComposerStateStore, sessionId: stri
 
 export function getComposerHistory(state: ComposerStateStore, sessionId: string): string[] {
   return state.history[sessionId] ?? EMPTY_HISTORY;
+}
+
+export function getComposerQueuedDrafts(state: ComposerStateStore, sessionId: string): ComposerDraft[] {
+  return state.queuedDrafts[sessionId] ?? EMPTY_QUEUED_DRAFTS;
 }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -66,6 +66,7 @@ import {
   getComposerHistory,
   getComposerMentions,
   getComposerPasteParts,
+  getComposerQueuedDrafts,
   useComposerStateStore,
 } from "./composer-state-store";
 import { MessageList } from "@/components/chat/message-list";
@@ -407,12 +408,17 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const clearComposerSession = useComposerStateStore((state) => state.clearSession);
   const inputHistory = useComposerStateStore((state) => getComposerHistory(state, props.sessionId));
   const appendComposerHistory = useComposerStateStore((state) => state.appendHistory);
+  // Queued follow-up drafts live in the shared composer store keyed by session
+  // id. That keeps a queued message in session A from being drained into
+  // session B when the route swaps the same surface component to another
+  // session.
+  const queuedDrafts = useComposerStateStore((state) => getComposerQueuedDrafts(state, props.sessionId));
+  const appendQueuedDraft = useComposerStateStore((state) => state.appendQueuedDraft);
+  const removeQueuedDraftFromStore = useComposerStateStore((state) => state.removeQueuedDraft);
+  const clearQueuedDrafts = useComposerStateStore((state) => state.clearQueuedDrafts);
+  const prependQueuedDrafts = useComposerStateStore((state) => state.prependQueuedDrafts);
   const [error, setError] = useState<SessionError | null>(null);
   const [sending, setSending] = useState(false);
-  // Locally queued follow-up drafts. OpenCode has no server-side queue, so we
-  // hold these client-side and auto-send the first one once the session goes
-  // idle (see the drain effect below).
-  const [queuedDrafts, setQueuedDrafts] = useState<ComposerDraft[]>([]);
   const [showDelayedLoading, setShowDelayedLoading] = useState(false);
   const [awaitingAssistantBaseline, setAwaitingAssistantBaseline] = useState<number | null>(null);
   const [rendered, setRendered] = useState<{ sessionId: string; snapshot: OpenworkSessionSnapshot } | null>(null);
@@ -769,13 +775,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const handleQueue = useCallback(() => {
     const text = draft.trim();
     if (!text && attachments.length === 0) return;
-    setQueuedDrafts((current) => [...current, buildDraft(text, attachments)]);
+    appendQueuedDraft(props.sessionId, buildDraft(text, attachments));
     clearComposer();
-  }, [attachments, buildDraft, clearComposer, draft]);
+  }, [appendQueuedDraft, attachments, buildDraft, clearComposer, draft, props.sessionId]);
 
   const removeQueuedDraft = useCallback((index: number) => {
-    setQueuedDrafts((current) => current.filter((_, itemIndex) => itemIndex !== index));
-  }, []);
+    removeQueuedDraftFromStore(props.sessionId, index);
+  }, [props.sessionId, removeQueuedDraftFromStore]);
 
   // One label per queued draft, kept index-aligned with `queuedDrafts` so the
   // panel's remove action targets the correct entry. Attachment-only drafts
@@ -796,7 +802,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     // Stop means stop: drop queued follow-ups before aborting, otherwise the
     // queue-drain effect below re-prompts the agent the moment the abort
     // lands and the session reports idle (#2014).
-    setQueuedDrafts([]);
+    clearQueuedDrafts(props.sessionId);
     // The prompt was sent through a directory-scoped client (session-route
     // passes the workspace root), so the abort must target the same scope —
     // without it the server resolves the default project, finds no live run,
@@ -812,7 +818,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
     captureAnalyticsEvent("task_run_stopped", {});
     await snapshotQuery.refetch();
-  }, [chatStreaming, opencodeClient, props.sessionId, props.workspaceRoot, snapshotQuery.refetch]);
+  }, [chatStreaming, clearQueuedDrafts, opencodeClient, props.sessionId, props.workspaceRoot, snapshotQuery.refetch]);
 
   const handleDismissError = useCallback(() => {
     setError(null);
@@ -837,18 +843,18 @@ export function SessionSurface(props: SessionSurfaceProps) {
     if (!merged) return;
     const drained = queuedDrafts;
     drainingQueueRef.current = true;
-    setQueuedDrafts([]);
+    clearQueuedDrafts(props.sessionId);
     void (async () => {
       try {
         await sendDraft(merged, merged.attachments);
       } catch {
         // Restore the queue so the user can retry / edit on failure.
-        setQueuedDrafts((current) => [...drained, ...current]);
+        prependQueuedDrafts(props.sessionId, drained);
       } finally {
         drainingQueueRef.current = false;
       }
     })();
-  }, [queuedDrafts, chatStreaming, liveStatus.type, sendDraft]);
+  }, [chatStreaming, clearQueuedDrafts, liveStatus.type, prependQueuedDrafts, props.sessionId, queuedDrafts, sendDraft]);
 
   useEffect(() => {
     props.onDraftChange(buildDraft(draft, attachments));

--- a/apps/app/tests/composer-state-store.test.ts
+++ b/apps/app/tests/composer-state-store.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { ComposerDraft } from "../src/app/types";
+import {
+  getComposerQueuedDrafts,
+  useComposerStateStore,
+} from "../src/react-app/domains/session/surface/composer-state-store";
+
+function reset() {
+  useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {} });
+}
+
+function draft(text: string): ComposerDraft {
+  return {
+    mode: "prompt",
+    parts: [{ type: "text", text }],
+    attachments: [],
+    text,
+    resolvedText: text,
+    command: undefined,
+  };
+}
+
+describe("composer state store", () => {
+  beforeEach(reset);
+
+  test("scopes queued drafts by session", () => {
+    const { appendQueuedDraft } = useComposerStateStore.getState();
+    appendQueuedDraft("session-a", draft("queued in A"));
+    appendQueuedDraft("session-b", draft("queued in B"));
+
+    const state = useComposerStateStore.getState();
+    expect(getComposerQueuedDrafts(state, "session-a").map((item) => item.text)).toEqual(["queued in A"]);
+    expect(getComposerQueuedDrafts(state, "session-b").map((item) => item.text)).toEqual(["queued in B"]);
+  });
+
+  test("clearing composer input does not clear queued drafts", () => {
+    const { appendQueuedDraft, clearSession, setDraft } = useComposerStateStore.getState();
+    setDraft("session-a", "in-progress draft");
+    appendQueuedDraft("session-a", draft("queued follow-up"));
+
+    clearSession("session-a");
+
+    expect(getComposerQueuedDrafts(useComposerStateStore.getState(), "session-a").map((item) => item.text)).toEqual([
+      "queued follow-up",
+    ]);
+  });
+
+  test("remove and clear only affect the target session", () => {
+    const { appendQueuedDraft, clearQueuedDrafts, removeQueuedDraft } = useComposerStateStore.getState();
+    appendQueuedDraft("session-a", draft("first A"));
+    appendQueuedDraft("session-a", draft("second A"));
+    appendQueuedDraft("session-b", draft("only B"));
+
+    removeQueuedDraft("session-a", 0);
+    expect(getComposerQueuedDrafts(useComposerStateStore.getState(), "session-a").map((item) => item.text)).toEqual([
+      "second A",
+    ]);
+    expect(getComposerQueuedDrafts(useComposerStateStore.getState(), "session-b").map((item) => item.text)).toEqual([
+      "only B",
+    ]);
+
+    clearQueuedDrafts("session-a");
+    expect(getComposerQueuedDrafts(useComposerStateStore.getState(), "session-a")).toEqual([]);
+    expect(getComposerQueuedDrafts(useComposerStateStore.getState(), "session-b").map((item) => item.text)).toEqual([
+      "only B",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Move queued composer drafts into the shared composer Zustand store keyed by session id
- Update queue, remove, abort, and drain paths to operate on the active session id
- Add store tests covering per-session queued draft isolation

## Tests
- bun test tests/composer-state-store.test.ts
- pnpm --filter @openwork/app typecheck

## Evidence
- No video captured; this is covered by focused store tests and typecheck.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

