### PR TITLE
feat(den): support additional free seats

### DIFF
--- a/ee/apps/den-api/scripts/seed-demo-org.ts
+++ b/ee/apps/den-api/scripts/seed-demo-org.ts
@@ -23,6 +23,7 @@ import { db } from "../src/db.js"
 import { ensureDefaultDesktopPolicyForOrganization } from "../src/desktop-policies.js"
 import { env } from "../src/env.js"
 import { seedDefaultOrganizationRoles } from "../src/orgs.js"
+import { calculateOrganizationSeatBillingCounts } from "../src/stripe-billing.js"
 
 const RESET_MODE = process.argv.includes("--reset")
 
@@ -415,6 +416,7 @@ async function ensureTeamMember(teamId: TeamId, orgMembershipId: MemberId) {
 async function ensureDemoSeatSubscription(input: { createdByOrgMembershipId: MemberId; memberCount: number; organizationId: OrganizationId }) {
   const now = new Date()
   const currentPeriodEnd = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 30)
+  const quantity = calculateOrganizationSeatBillingCounts({ memberCount: input.memberCount }).chargeable
   await db.insert(OrgSubscriptionTable).values({
     cancel_at_period_end: false,
     canceled_at: null,
@@ -426,7 +428,7 @@ async function ensureDemoSeatSubscription(input: { createdByOrgMembershipId: Mem
     id: createDenTypeId("orgSubscription"),
     last_event_id: "demo-seed-seat-subscription",
     organization_id: input.organizationId,
-    quantity: Math.max(0, input.memberCount - 5),
+    quantity,
     status: "active",
     stripe_customer_id: `cus_demo_${input.organizationId}`,
     stripe_price_id: "price_demo_seats",
@@ -443,7 +445,7 @@ async function ensureDemoSeatSubscription(input: { createdByOrgMembershipId: Mem
       current_period_start: now,
       ended_at: null,
       last_event_id: "demo-seed-seat-subscription",
-      quantity: Math.max(0, input.memberCount - 5),
+      quantity,
       status: "active",
       stripe_customer_id: `cus_demo_${input.organizationId}`,
       stripe_price_id: "price_demo_seats",

--- a/ee/apps/den-api/src/organization-limits.ts
+++ b/ee/apps/den-api/src/organization-limits.ts
@@ -18,6 +18,7 @@ type OrganizationId = typeof OrganizationTable.$inferSelect.id
 
 export type OrganizationMetadata = {
   limits: OrganizationLimits
+  seatsFreeAdditional?: number
   allowedDesktopVersions?: string[]
   requireSso?: boolean
 } & Record<string, unknown>

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -20,9 +20,12 @@ import { queryValidator, requireAdminMiddleware } from "../../middleware/index.j
 import { denTypeIdSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import { DEFAULT_ORGANIZATION_LIMITS, normalizeOrganizationMetadata } from "../../organization-limits.js"
 import type { AuthContextVariables } from "../../session.js"
+import { calculateOrganizationSeatBillingCounts, getOrganizationSeatBillingCounts, syncSeatSubscriptionQuantityAfterMemberChange } from "../../stripe-billing.js"
 
 type UserId = typeof AuthUserTable.$inferSelect.id
 type OrganizationId = typeof OrganizationTable.$inferSelect.id
+
+const DEFAULT_ORGANIZATION_FREE_SEAT_COUNT = calculateOrganizationSeatBillingCounts({ memberCount: 0 }).includedFree
 
 const overviewQuerySchema = z.object({
   includeBilling: z.string().optional(),
@@ -31,6 +34,10 @@ const overviewQuerySchema = z.object({
 const updateOrganizationPlanSchema = z.object({
   tier: z.enum(["free", "team", "enterprise"]),
   seatLimit: z.number().int().min(1).max(100000),
+})
+
+const updateOrganizationFreeSeatsSchema = z.object({
+  totalFreeSeats: z.number().int().min(DEFAULT_ORGANIZATION_FREE_SEAT_COUNT).max(100000),
 })
 
 const adminOverviewResponseSchema = z.object({
@@ -42,6 +49,7 @@ const adminOverviewResponseSchema = z.object({
   admins: z.array(z.object({}).passthrough()),
   summary: z.object({}).passthrough(),
   users: z.array(z.object({}).passthrough()),
+  organizations: z.array(z.object({}).passthrough()),
   generatedAt: z.string().datetime(),
 }).meta({ ref: "AdminOverviewResponse" })
 
@@ -225,6 +233,58 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
     },
   )
 
+  app.patch(
+    "/v1/admin/organizations/:organizationId/free-seats",
+    requireAdminMiddleware,
+    async (c) => {
+      const body = updateOrganizationFreeSeatsSchema.safeParse(await c.req.json().catch(() => null))
+      if (!body.success) {
+        return c.json({ error: "invalid_request", message: body.error.issues[0]?.message ?? "Invalid organization free seats request." }, 400)
+      }
+
+      const organizationId = c.req.param("organizationId")
+      if (!isOrganizationId(organizationId)) {
+        return c.json({ error: "invalid_request", message: "Invalid organization id." }, 400)
+      }
+
+      const rows = await db
+        .select({ id: OrganizationTable.id, metadata: OrganizationTable.metadata })
+        .from(OrganizationTable)
+        .where(eq(OrganizationTable.id, organizationId))
+        .limit(1)
+
+      const organization = rows[0]
+      if (!organization) {
+        return c.json({ error: "not_found", message: "Organization not found." }, 404)
+      }
+
+      const seatsFreeAdditional = body.data.totalFreeSeats - DEFAULT_ORGANIZATION_FREE_SEAT_COUNT
+      const metadata = {
+        ...normalizeOrganizationMetadata(organization.metadata).metadata,
+        seatsFreeAdditional,
+      }
+
+      await db
+        .update(OrganizationTable)
+        .set({ metadata })
+        .where(eq(OrganizationTable.id, organizationId))
+
+      const seatCounts = await getOrganizationSeatBillingCounts({ organizationId })
+      await syncSeatSubscriptionQuantityAfterMemberChange({ organizationId, memberCount: seatCounts.total })
+
+      return c.json({
+        ok: true,
+        organization: {
+          id: organizationId,
+          memberCount: seatCounts.total,
+          freeSeatCount: seatCounts.free,
+          seatsFreeAdditional: seatCounts.additionalFree,
+          billableSeatCount: seatCounts.chargeable,
+        },
+      })
+    },
+  )
+
   app.get(
     "/v1/admin/overview",
     describeRoute({
@@ -370,6 +430,10 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
       const metadata = normalizeOrganizationMetadata(entry.metadata).metadata
       const plan = parseOrganizationPlan(metadata)
       const seatLimit = metadata.limits.members ?? DEFAULT_ORGANIZATION_LIMITS.members
+      const seatCounts = calculateOrganizationSeatBillingCounts({
+        memberCount: memberCountByOrg.get(entry.id) ?? 0,
+        metadata,
+      })
 
       return {
         id: entry.id,
@@ -377,9 +441,12 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         slug: entry.slug,
         createdAt: entry.createdAt,
         updatedAt: entry.updatedAt,
-        memberCount: memberCountByOrg.get(entry.id) ?? 0,
+        memberCount: seatCounts.total,
         plan,
         seatLimit,
+        freeSeatCount: seatCounts.free,
+        seatsFreeAdditional: seatCounts.additionalFree,
+        billableSeatCount: seatCounts.chargeable,
       }
     })
 

--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -136,8 +136,51 @@ async function activeMemberCount(organizationId: OrgId) {
   return Math.max(0, Number(row?.count ?? 0))
 }
 
-export async function getActiveMemberCountForBilling(organizationId: OrgId) {
-  return activeMemberCount(organizationId)
+function normalizeSeatCount(value: number) {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
+}
+
+function normalizeAdditionalFreeSeats(value: unknown) {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : 0
+}
+
+export function additionalFreeSeatCountFromMetadata(metadata: Record<string, unknown> | null | undefined) {
+  return normalizeAdditionalFreeSeats(metadata?.seatsFreeAdditional)
+}
+
+export function calculateOrganizationSeatBillingCounts(input: {
+  memberCount: number
+  metadata?: Record<string, unknown> | null
+  additionalFreeSeats?: number
+}) {
+  const total = normalizeSeatCount(input.memberCount)
+  const additionalFree = input.additionalFreeSeats === undefined
+    ? additionalFreeSeatCountFromMetadata(input.metadata)
+    : normalizeAdditionalFreeSeats(input.additionalFreeSeats)
+  const free = FREE_ORG_SEAT_COUNT + additionalFree
+  const chargeable = Math.max(0, total - free)
+
+  return {
+    total,
+    chargeable,
+    free,
+    includedFree: FREE_ORG_SEAT_COUNT,
+    additionalFree,
+  }
+}
+
+export async function getOrganizationSeatBillingCounts(input: { organizationId: OrgId; memberCount?: number }) {
+  const memberCountPromise = typeof input.memberCount === "number"
+    ? Promise.resolve(input.memberCount)
+    : activeMemberCount(input.organizationId)
+  const metadataPromise = db
+    .select({ metadata: OrganizationTable.metadata })
+    .from(OrganizationTable)
+    .where(eq(OrganizationTable.id, input.organizationId))
+    .limit(1)
+
+  const [memberCount, rows] = await Promise.all([memberCountPromise, metadataPromise])
+  return calculateOrganizationSeatBillingCounts({ memberCount, metadata: rows[0]?.metadata })
 }
 
 async function findOrgSubscriptionByType(organizationId: OrgId, subscriptionType: OrgSubscriptionTypeValue) {
@@ -210,17 +253,14 @@ export async function organizationHasActiveSeatSubscription(organizationId: OrgI
   return Boolean(row && ACTIVE_STATUSES.has(row.status))
 }
 
-export function billableSeatQuantity(memberCount: number) {
-  return Math.max(0, memberCount - FREE_ORG_SEAT_COUNT)
-}
-
 export async function getOrganizationSeatAddEligibility(organizationId: OrgId) {
-  const currentCount = await activeMemberCount(organizationId)
-  if (currentCount < FREE_ORG_SEAT_COUNT) {
+  const seatCounts = await getOrganizationSeatBillingCounts({ organizationId })
+  if (seatCounts.total < seatCounts.free) {
     return {
       allowed: true,
-      currentCount,
-      freeSeatCount: FREE_ORG_SEAT_COUNT,
+      currentCount: seatCounts.total,
+      freeSeatCount: seatCounts.free,
+      billableSeatCount: seatCounts.chargeable,
       hasActiveSeatSubscription: false,
     }
   }
@@ -228,8 +268,9 @@ export async function getOrganizationSeatAddEligibility(organizationId: OrgId) {
   const hasActiveSeatSubscription = await organizationHasActiveSeatSubscription(organizationId)
   return {
     allowed: hasActiveSeatSubscription,
-    currentCount,
-    freeSeatCount: FREE_ORG_SEAT_COUNT,
+    currentCount: seatCounts.total,
+    freeSeatCount: seatCounts.free,
+    billableSeatCount: seatCounts.chargeable,
     hasActiveSeatSubscription,
   }
 }
@@ -436,7 +477,7 @@ function serializeSubscription(row: Awaited<ReturnType<typeof findOrgSubscriptio
 export async function getOrgBillingSummary(input: { organizationId: OrgId; includePortalUrl?: boolean; returnUrl: string }) {
   const row = await findInferenceSubscriptionByOrg(input.organizationId)
   const seatRow = await findSeatSubscriptionByOrg(input.organizationId)
-  const memberCount = await activeMemberCount(input.organizationId)
+  const seatCounts = await getOrganizationSeatBillingCounts({ organizationId: input.organizationId })
   const hasActiveSubscription = Boolean(row && ACTIVE_STATUSES.has(row.status))
   const hasActiveSeatSubscription = Boolean(seatRow && ACTIVE_STATUSES.has(seatRow.status))
   let portalUrl: string | null = null
@@ -455,7 +496,7 @@ export async function getOrgBillingSummary(input: { organizationId: OrgId; inclu
       unitAmount: 1000,
       currency: "usd",
       interval: "month",
-      memberCount,
+      memberCount: seatCounts.total,
       hasActiveSubscription,
       portalUrl,
       subscription: serializeSubscription(row),
@@ -465,8 +506,9 @@ export async function getOrgBillingSummary(input: { organizationId: OrgId; inclu
         unitAmount: 1000,
         currency: "usd",
         interval: "month",
-        freeSeatCount: FREE_ORG_SEAT_COUNT,
-        billableSeatCount: billableSeatQuantity(memberCount),
+        freeSeatCount: seatCounts.free,
+        seatsFreeAdditional: seatCounts.additionalFree,
+        billableSeatCount: seatCounts.chargeable,
         hasActiveSubscription: hasActiveSeatSubscription,
         subscription: serializeSubscription(seatRow),
       },
@@ -501,8 +543,9 @@ export async function syncSeatSubscriptionQuantityAfterMemberChange(input: { org
     return
   }
 
+  const seatCounts = await getOrganizationSeatBillingCounts(input)
   await stripe().subscriptionItems.update(row.stripe_subscription_item_id, {
-    quantity: billableSeatQuantity(input.memberCount),
+    quantity: seatCounts.chargeable,
     proration_behavior: "always_invoice",
   })
 }

--- a/ee/apps/den-api/test/stripe-billing-seats.test.ts
+++ b/ee/apps/den-api/test/stripe-billing-seats.test.ts
@@ -1,0 +1,33 @@
+import { beforeAll, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+let stripeBillingModule: typeof import("../src/stripe-billing.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  stripeBillingModule = await import("../src/stripe-billing.js")
+})
+
+test("organization seat billing counts include organization metadata additional free seats", () => {
+  expect(stripeBillingModule.calculateOrganizationSeatBillingCounts({ memberCount: 5 })).toMatchObject({
+    total: 5,
+    free: 5,
+    chargeable: 0,
+    additionalFree: 0,
+  })
+  expect(stripeBillingModule.calculateOrganizationSeatBillingCounts({ memberCount: 6 })).toMatchObject({ chargeable: 1 })
+  expect(stripeBillingModule.calculateOrganizationSeatBillingCounts({ memberCount: 7, metadata: { seatsFreeAdditional: 2 } })).toMatchObject({
+    total: 7,
+    free: 7,
+    chargeable: 0,
+    additionalFree: 2,
+  })
+  expect(stripeBillingModule.calculateOrganizationSeatBillingCounts({ memberCount: 8, additionalFreeSeats: 2 })).toMatchObject({ chargeable: 1 })
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
@@ -84,7 +84,7 @@ function parseStripeBilling(payload: unknown): StripeBilling | null {
       unitAmount: typeof seats?.unitAmount === "number" ? seats.unitAmount : 1000,
       currency: typeof seats?.currency === "string" ? seats.currency : "usd",
       interval: typeof seats?.interval === "string" ? seats.interval : "month",
-      freeSeatCount: typeof seats?.freeSeatCount === "number" ? seats.freeSeatCount : 5,
+      freeSeatCount: typeof seats?.freeSeatCount === "number" ? seats.freeSeatCount : DEFAULT_FREE_SEAT_COUNT,
       billableSeatCount: typeof seats?.billableSeatCount === "number" ? seats.billableSeatCount : 0,
       hasActiveSubscription: seats?.hasActiveSubscription === true,
       subscription: seats?.subscription && typeof seats.subscription === "object"
@@ -101,6 +101,7 @@ function parseStripeBilling(payload: unknown): StripeBilling | null {
 
 const STRIPE_RETURN_POLL_ATTEMPTS = 20;
 const STRIPE_RETURN_POLL_INTERVAL_MS = 3000;
+const DEFAULT_FREE_SEAT_COUNT = 5;
 
 function parsePolarBilling(payload: unknown): PolarBilling | null {
   if (!payload || typeof payload !== "object" || !("billing" in payload)) return null;
@@ -298,7 +299,7 @@ export function BillingDashboardScreen() {
             <p className="mb-2 text-[12px] font-semibold uppercase tracking-[0.12em] text-blue-500">Stripe</p>
             <h2 className="text-[20px] font-medium text-gray-950">OpenWork Users</h2>
             <p className="mt-2 max-w-[620px] text-[14px] leading-6 text-gray-500">
-              The first {seatBilling?.freeSeatCount ?? 5} users in your organization are free. Additional users are billed at {seatPrice}/user/month.
+              The first {seatBilling?.freeSeatCount ?? DEFAULT_FREE_SEAT_COUNT} users in your organization are free. Additional users are billed at {seatPrice}/user/month.
             </p>
           </div>
           <DenButton variant="secondary" loading={stripeBusy} onClick={() => void refreshStripeBilling(false)}>
@@ -309,7 +310,7 @@ export function BillingDashboardScreen() {
         <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-4">
           <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
             <p className="text-[12px] text-gray-500">Included users</p>
-            <p className="mt-1 text-[20px] font-semibold text-gray-950">{seatBilling?.freeSeatCount ?? 5}</p>
+            <p className="mt-1 text-[20px] font-semibold text-gray-950">{seatBilling?.freeSeatCount ?? DEFAULT_FREE_SEAT_COUNT}</p>
           </div>
           <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
             <p className="text-[12px] text-gray-500">Active users</p>
@@ -317,7 +318,7 @@ export function BillingDashboardScreen() {
           </div>
           <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
             <p className="text-[12px] text-gray-500">Billable users</p>
-            <p className="mt-1 text-[20px] font-semibold text-gray-950">{seatBilling?.billableSeatCount ?? Math.max(0, activeMemberCount - 5)}</p>
+            <p className="mt-1 text-[20px] font-semibold text-gray-950">{seatBilling?.billableSeatCount ?? Math.max(0, activeMemberCount - DEFAULT_FREE_SEAT_COUNT)}</p>
           </div>
           <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
             <p className="text-[12px] text-gray-500">Status</p>
@@ -341,7 +342,7 @@ export function BillingDashboardScreen() {
         ) : (
           <div className="flex flex-col gap-4 rounded-[16px] border border-blue-100 bg-blue-50 p-5 md:flex-row md:items-center md:justify-between">
             <div>
-              <p className="text-[15px] font-medium text-blue-950">Subscribe when your workspace grows beyond {seatBilling?.freeSeatCount ?? 5} users</p>
+              <p className="text-[15px] font-medium text-blue-950">Subscribe when your workspace grows beyond {seatBilling?.freeSeatCount ?? DEFAULT_FREE_SEAT_COUNT} users</p>
               <p className="mt-1 text-[13px] leading-5 text-blue-900/70">You will only be charged for users above the free included seats.</p>
             </div>
             <DenButton disabled={!isOwner || seatBilling?.configured === false} loading={stripeActionBusy === "seat-checkout"} onClick={startSeatCheckout}>

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Pencil } from "lucide-react";
 
 type AccessState = "loading" | "ready" | "signed-out" | "forbidden" | "error";
 type WorkerFilter = "all" | "with-workers" | "without-workers";
@@ -8,6 +9,8 @@ type BillingFilter = "all" | "paid" | "unpaid" | "unavailable";
 type ViewMode = "users" | "companies" | "organizations";
 type ActivityFilter = "all" | "active-7d" | "active-30d" | "recurring" | "inactive-30d";
 type SortMode = "newest" | "recently-active" | "most-sign-ins" | "most-active-days" | "fastest-invite";
+
+const DEFAULT_FREE_SEAT_COUNT = 5;
 
 type AdminBillingStatus = {
   status: "paid" | "unpaid" | "unavailable";
@@ -93,6 +96,9 @@ type AdminOrganization = {
     source: string;
   };
   seatLimit: number;
+  freeSeatCount: number;
+  seatsFreeAdditional: number;
+  billableSeatCount: number;
 };
 
 type AdminPayload = {
@@ -251,7 +257,10 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
             tier,
             source: toStringValue(plan.source) ?? "default"
           },
-          seatLimit: toNumberValue(value.seatLimit)
+          seatLimit: toNumberValue(value.seatLimit),
+          freeSeatCount: toNumberValue(value.freeSeatCount) || DEFAULT_FREE_SEAT_COUNT,
+          seatsFreeAdditional: toNumberValue(value.seatsFreeAdditional),
+          billableSeatCount: toNumberValue(value.billableSeatCount)
         };
       })
       .filter((value): value is AdminOrganization => value !== null)
@@ -733,6 +742,8 @@ export function DenAdminPanel() {
   const [includeBilling, setIncludeBilling] = useState(false);
   const [orgDrafts, setOrgDrafts] = useState<Record<string, { tier: AdminOrganization["plan"]["tier"]; seatLimit: string }>>({});
   const [savingOrgId, setSavingOrgId] = useState<string | null>(null);
+  const [freeSeatsDialog, setFreeSeatsDialog] = useState<{ org: AdminOrganization; totalFreeSeats: string } | null>(null);
+  const [savingFreeSeatsOrgId, setSavingFreeSeatsOrgId] = useState<string | null>(null);
 
   const loadOverview = useCallback(async (loadBilling: boolean) => {
     setRefreshing(true);
@@ -941,12 +952,45 @@ export function DenAdminPanel() {
     }
   }, [includeBilling, loadOverview, orgDrafts]);
 
+  const saveOrganizationFreeSeats = useCallback(async () => {
+    if (!freeSeatsDialog) {
+      return;
+    }
+
+    const totalFreeSeats = Number(freeSeatsDialog.totalFreeSeats);
+    if (!Number.isInteger(totalFreeSeats) || totalFreeSeats < DEFAULT_FREE_SEAT_COUNT) {
+      setError(`Free seats must be a whole number at least ${DEFAULT_FREE_SEAT_COUNT}.`);
+      return;
+    }
+
+    setSavingFreeSeatsOrgId(freeSeatsDialog.org.id);
+    setError(null);
+
+    try {
+      const { response, payload: nextPayload } = await patchJson(`/v1/admin/organizations/${freeSeatsDialog.org.id}/free-seats`, {
+        totalFreeSeats
+      });
+
+      if (!response.ok) {
+        setError(getErrorMessage(nextPayload, `Could not update free seats for ${freeSeatsDialog.org.name}.`));
+        return;
+      }
+
+      setFreeSeatsDialog(null);
+      await loadOverview(includeBilling);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Unknown network error");
+    } finally {
+      setSavingFreeSeatsOrgId(null);
+    }
+  }, [freeSeatsDialog, includeBilling, loadOverview]);
+
   const exportCsv = useCallback(() => {
     const date = new Date().toISOString().slice(0, 10);
 
     if (viewMode === "organizations") {
       downloadCsv(`den-organizations-${date}.csv`, [
-        ["id", "name", "slug", "plan", "plan_source", "seat_limit", "members", "created_at"],
+        ["id", "name", "slug", "plan", "plan_source", "seat_limit", "free_seats", "additional_free_seats", "chargeable_seats", "members", "created_at"],
         ...filteredOrganizations.map((org) => [
           org.id,
           org.name,
@@ -954,6 +998,9 @@ export function DenAdminPanel() {
           org.plan.tier,
           org.plan.source,
           String(org.seatLimit),
+          String(org.freeSeatCount),
+          String(org.seatsFreeAdditional),
+          String(org.billableSeatCount),
           String(org.memberCount),
           org.createdAt ?? ""
         ])
@@ -1310,6 +1357,12 @@ export function DenAdminPanel() {
                       <span className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-600">
                         {org.memberCount} / {org.seatLimit} seats
                       </span>
+                      <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-emerald-700">
+                        {org.freeSeatCount} free
+                      </span>
+                      <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-amber-700">
+                        {org.billableSeatCount} chargeable
+                      </span>
                     </div>
                   </div>
 
@@ -1317,7 +1370,23 @@ export function DenAdminPanel() {
                     <MetaCell label="Created" value={formatDateTime(org.createdAt)} />
                     <MetaCell label="Plan source" value={formatProvider(org.plan.source)} />
                     <MetaCell label="Members" value={String(org.memberCount)} />
-                    <MetaCell label="Seat limit" value={String(org.seatLimit)} />
+                    <div>
+                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Free seats</p>
+                      <div className="mt-1 flex items-center gap-2">
+                        <p className="text-sm text-slate-700">{org.freeSeatCount}</p>
+                        <button
+                          type="button"
+                          aria-label={`Edit free seats for ${org.name}`}
+                          onClick={() => setFreeSeatsDialog({ org, totalFreeSeats: String(org.freeSeatCount) })}
+                          className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-900"
+                        >
+                          <Pencil size={13} aria-hidden="true" />
+                        </button>
+                      </div>
+                      <p className="mt-1 text-xs text-slate-400">
+                        {org.seatsFreeAdditional > 0 ? `${org.seatsFreeAdditional} additional` : "Default included"}
+                      </p>
+                    </div>
                   </div>
 
                   <div className="mt-4 grid gap-3 border-t border-slate-200 pt-4 lg:grid-cols-[12rem_10rem_auto] lg:items-end">
@@ -1507,6 +1576,61 @@ export function DenAdminPanel() {
 
         <p className="mt-6 text-xs leading-6 text-slate-500">Snapshot generated {formatDateTime(payload.generatedAt)}.</p>
       </div>
+
+      {freeSeatsDialog ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="free-seats-dialog-title"
+          onClick={() => setFreeSeatsDialog(null)}
+        >
+          <div className="w-full max-w-md rounded-3xl border border-slate-200 bg-white p-6 shadow-xl" onClick={(event) => event.stopPropagation()}>
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-500">Organization billing</p>
+            <h2 id="free-seats-dialog-title" className="mt-2 text-2xl font-semibold tracking-[-0.04em] text-slate-950">
+              Edit free seats
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Set the total number of free seats for {freeSeatsDialog.org.name}. The default {DEFAULT_FREE_SEAT_COUNT} seats stay included; OpenWork saves only the additional seats in organization metadata.
+            </p>
+
+            <label className="mt-5 grid gap-2">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Total free seats</span>
+              <input
+                type="number"
+                min={DEFAULT_FREE_SEAT_COUNT}
+                value={freeSeatsDialog.totalFreeSeats}
+                onChange={(event) => setFreeSeatsDialog({ ...freeSeatsDialog, totalFreeSeats: event.target.value })}
+                className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-slate-400"
+              />
+            </label>
+
+            <p className="mt-3 rounded-2xl bg-slate-50 px-4 py-3 text-xs leading-5 text-slate-500">
+              Additional metadata value to save: {Math.max(0, Number(freeSeatsDialog.totalFreeSeats) - DEFAULT_FREE_SEAT_COUNT) || 0}
+            </p>
+
+            <div className="mt-6 flex flex-wrap justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setFreeSeatsDialog(null)}
+                className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  void saveOrganizationFreeSeats();
+                }}
+                disabled={savingFreeSeatsOrgId === freeSeatsDialog.org.id}
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {savingFreeSeatsOrgId === freeSeatsDialog.org.id ? "Saving..." : "Save"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add shared Den seat billing count helpers for total/free/chargeable seats
- support organization metadata `seatsFreeAdditional` in invite eligibility, billing summaries, Stripe seat sync, and demo seeding
- add Den admin UI/API to view and edit total free seats per organization

## Verification
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json` ✅
- `pnpm --filter @openwork-ee/den-web exec tsc --noEmit -p tsconfig.json` ✅
- `bun test "ee/apps/den-api/test/stripe-billing-seats.test.ts"` ✅

## Evidence
- Automated typechecks and focused unit test passed.
- No video/screenshot captured; this was validated with code-level checks rather than a running admin UI session.