### PR TITLE
feat(den): enforce enterprise auth sign-in

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -159,7 +159,7 @@ function getEnterpriseAuthRedirectUrl(input: {
   email: string;
   callbackUrl: string | null;
 }) {
-  const url = new URL(input.signInPath, env.betterAuthTrustedOrigins[0] ?? env.betterAuthUrl);
+  const url = new URL(input.signInPath, getInvitationOrigin());
   url.searchParams.set("loginHint", input.email);
   if (input.callbackUrl) {
     url.searchParams.set("callbackURL", input.callbackUrl);

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -35,15 +35,20 @@ import {
   ORGANIZATION_SAML_REQUIRE_TIMESTAMPS,
 } from "./sso-saml-policy.js";
 import { getOrganizationContextForUser, seedDefaultOrganizationRoles } from "./orgs.js";
+import {
+  findEnterpriseAuthRequirementForEmail,
+  findEnterpriseAuthRequirementForUserId,
+} from "./enterprise-auth-requirement.js";
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid";
 import * as schema from "@openwork-ee/den-db/schema";
 import { apiKey } from "@better-auth/api-key";
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { scim } from "@better-auth/scim";
 import { sso } from "@better-auth/sso";
-import { APIError } from "better-call";
 import { betterAuth } from "better-auth";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { deleteSessionCookie } from "better-auth/cookies";
 import { sql } from "@openwork-ee/den-db/drizzle";
 import { emailOTP, jwt, organization } from "better-auth/plugins";
 
@@ -140,6 +145,28 @@ function hasMcpScope(scopes: readonly string[]) {
   return scopes.some((scope) => scope.startsWith("mcp:"));
 }
 
+function getBodyEmail(body: unknown) {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  const value = Object.getOwnPropertyDescriptor(body, "email")?.value;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function getEnterpriseAuthRedirectUrl(input: {
+  signInPath: string;
+  email: string;
+  callbackUrl: string | null;
+}) {
+  const url = new URL(input.signInPath, env.betterAuthTrustedOrigins[0] ?? env.betterAuthUrl);
+  url.searchParams.set("loginHint", input.email);
+  if (input.callbackUrl) {
+    url.searchParams.set("callbackURL", input.callbackUrl);
+  }
+  return url.toString();
+}
+
 export const auth = betterAuth({
   baseURL: env.betterAuthUrl,
   secret: env.betterAuthSecret,
@@ -172,6 +199,50 @@ export const auth = betterAuth({
         },
       },
     },
+  },
+  hooks: {
+    before: createAuthMiddleware(async (ctx) => {
+      if (ctx.path !== "/sign-in/email" && ctx.path !== "/sign-up/email") {
+        return;
+      }
+
+      const email = getBodyEmail(ctx.body);
+      if (!email) {
+        return;
+      }
+
+      const requirement = await findEnterpriseAuthRequirementForEmail(email);
+      if (!requirement) {
+        return;
+      }
+
+      throw new APIError("FORBIDDEN", {
+        message: "This account is managed by an organization. Use SSO to sign in.",
+      });
+    }),
+    after: createAuthMiddleware(async (ctx) => {
+      if (ctx.path !== "/callback/:id") {
+        return;
+      }
+
+      const newSession = ctx.context.newSession;
+      if (!newSession) {
+        return;
+      }
+
+      const requirement = await findEnterpriseAuthRequirementForUserId(newSession.user.id);
+      if (!requirement) {
+        return;
+      }
+
+      await ctx.context.internalAdapter.deleteSession(newSession.session.token);
+      deleteSessionCookie(ctx);
+      throw ctx.redirect(getEnterpriseAuthRedirectUrl({
+        signInPath: requirement.signInPath,
+        email: newSession.user.email,
+        callbackUrl: ctx.context.responseHeaders?.get("location") ?? null,
+      }));
+    }),
   },
   advanced: {
     ipAddress: {

--- a/ee/apps/den-api/src/enterprise-auth-requirement.ts
+++ b/ee/apps/den-api/src/enterprise-auth-requirement.ts
@@ -1,0 +1,90 @@
+import { and, eq, isNotNull, isNull, or, sql } from "@openwork-ee/den-db/drizzle"
+import {
+  AuthUserTable,
+  MemberTable,
+  OrganizationTable,
+  ScimProviderTable,
+  SsoConnectionTable,
+} from "@openwork-ee/den-db/schema"
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { db } from "./db.js"
+
+type EnterpriseAuthRequirementRow = {
+  organizationId: string
+  organizationSlug: string
+  signInPath: string | null
+  ssoProviderId: string | null
+  scimProviderId: string | null
+}
+
+export type EnterpriseAuthRequirement = {
+  organizationId: string
+  organizationSlug: string
+  signInPath: string
+  ssoProviderId: string | null
+  scimProviderId: string | null
+  hasSso: boolean
+  hasScim: boolean
+}
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase()
+}
+
+function getOrganizationSsoSignInPath(organizationSlug: string) {
+  return `/sso/${encodeURIComponent(organizationSlug)}`
+}
+
+function toRequirement(row: EnterpriseAuthRequirementRow): EnterpriseAuthRequirement {
+  return {
+    organizationId: row.organizationId,
+    organizationSlug: row.organizationSlug,
+    signInPath: row.signInPath ?? getOrganizationSsoSignInPath(row.organizationSlug),
+    ssoProviderId: row.ssoProviderId,
+    scimProviderId: row.scimProviderId,
+    hasSso: Boolean(row.ssoProviderId),
+    hasScim: Boolean(row.scimProviderId),
+  }
+}
+
+function pickRequirement(rows: EnterpriseAuthRequirementRow[]) {
+  const ssoRow = rows.find((row) => row.ssoProviderId)
+  return ssoRow ?? rows[0] ?? null
+}
+
+async function findEnterpriseAuthRequirement(where: ReturnType<typeof and>) {
+  const rows = await db
+    .select({
+      organizationId: OrganizationTable.id,
+      organizationSlug: OrganizationTable.slug,
+      signInPath: SsoConnectionTable.signInPath,
+      ssoProviderId: SsoConnectionTable.providerId,
+      scimProviderId: ScimProviderTable.providerId,
+    })
+    .from(AuthUserTable)
+    .innerJoin(MemberTable, eq(AuthUserTable.id, MemberTable.userId))
+    .innerJoin(OrganizationTable, eq(MemberTable.organizationId, OrganizationTable.id))
+    .leftJoin(SsoConnectionTable, eq(OrganizationTable.id, SsoConnectionTable.organizationId))
+    .leftJoin(ScimProviderTable, eq(OrganizationTable.id, ScimProviderTable.organizationId))
+    .where(and(
+      where,
+      isNull(MemberTable.removedAt),
+      or(isNotNull(SsoConnectionTable.id), isNotNull(ScimProviderTable.id)),
+    ))
+
+  const requirement = pickRequirement(rows)
+  return requirement ? toRequirement(requirement) : null
+}
+
+export async function findEnterpriseAuthRequirementForEmail(email: string) {
+  const normalizedEmail = normalizeEmail(email)
+  if (!normalizedEmail) {
+    return null
+  }
+
+  return findEnterpriseAuthRequirement(sql`lower(${AuthUserTable.email}) = ${normalizedEmail}`)
+}
+
+export async function findEnterpriseAuthRequirementForUserId(userId: string) {
+  return findEnterpriseAuthRequirement(eq(AuthUserTable.id, normalizeDenTypeId("user", userId)))
+}

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -1,5 +1,5 @@
 import { eq } from "@openwork-ee/den-db/drizzle"
-import { OrganizationTable, SsoConnectionTable } from "@openwork-ee/den-db/schema"
+import { OrganizationTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
@@ -8,6 +8,7 @@ import { auth } from "../../auth.js"
 import { db } from "../../db.js"
 import { checkEntitlement, getOrganizationEntitlements, parseOrganizationPlan } from "../../entitlements.js"
 import { env } from "../../env.js"
+import { findEnterpriseAuthRequirementForEmail } from "../../enterprise-auth-requirement.js"
 import { jsonValidator, queryValidator, requireUserMiddleware, resolveMemberTeamsMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, enterprisePlanRequiredSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { normalizeOrganizationMetadata } from "../../organization-limits.js"
@@ -348,43 +349,27 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
     describeRoute({
       tags: ["Organizations"],
       hide: true,
-      summary: "Resolve organization SSO by email",
-      description: "Returns the org SSO entry URL for an email address when the matching organization requires SSO.",
+      summary: "Resolve required organization SSO by email",
+      description: "Returns the org SSO entry URL when the email belongs to a member of any organization with SSO or SCIM configured.",
       responses: {
         200: jsonResponse("Organization SSO resolution returned successfully.", resolveSsoByEmailResponseSchema),
-        204: { description: "No enforced organization SSO route matched this email." },
+        204: { description: "No organization SSO or SCIM requirement matched this email." },
         400: jsonResponse("The SSO resolution query parameters were invalid.", invalidRequestSchema),
       },
     }),
     queryValidator(resolveSsoByEmailQuerySchema),
     async (c) => {
       const query = c.req.valid("query")
-      const domain = query.email.slice(query.email.lastIndexOf("@") + 1).toLowerCase()
-      const matches = await db
-        .select({
-          slug: OrganizationTable.slug,
-          metadata: OrganizationTable.metadata,
-          signInPath: SsoConnectionTable.signInPath,
-          domain: SsoConnectionTable.domain,
-        })
-        .from(OrganizationTable)
-        .innerJoin(SsoConnectionTable, eq(OrganizationTable.id, SsoConnectionTable.organizationId))
-        .where(eq(SsoConnectionTable.domain, domain))
-
-      const match = matches.find((row) => {
-        const metadata = row.metadata && typeof row.metadata === "object" ? row.metadata as Record<string, unknown> : {}
-        return metadata.requireSso === true
-      })
-
-      if (!match) {
+      const requirement = await findEnterpriseAuthRequirementForEmail(query.email)
+      if (!requirement) {
         return c.body(null, 204)
       }
 
       return c.json({
         requireSso: true,
-        organizationSlug: match.slug,
-        signInPath: match.signInPath,
-        signInUrl: new URL(match.signInPath, env.betterAuthTrustedOrigins[0] ?? env.betterAuthUrl).toString(),
+        organizationSlug: requirement.organizationSlug,
+        signInPath: requirement.signInPath,
+        signInUrl: new URL(requirement.signInPath, env.betterAuthTrustedOrigins[0] ?? env.betterAuthUrl).toString(),
       })
     },
   )

--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -118,6 +118,7 @@ export function AuthPanel({
     desktopRedirectUrl,
     desktopRedirectBusy,
     showAuthFeedback,
+    continueSignInWithEmail,
     submitAuth,
     submitVerificationCode,
     resendVerificationCode,
@@ -125,6 +126,7 @@ export function AuthPanel({
     beginSocialAuth,
     resolveUserLandingRoute,
   } = useDenFlow();
+  const [signInEmailConfirmed, setSignInEmailConfirmed] = useState(false);
 
   const resolvedSignUpContent: PanelContent = {
     title: "Get started.",
@@ -159,11 +161,19 @@ export function AuthPanel({
 
   const desktopGrant = getDesktopGrant(desktopRedirectUrl);
   const isPasswordResetRequest = authMode === "sign-in" && passwordResetRequested && !verificationRequired;
+  const isEmailFirstSignIn = authMode === "sign-in" && !verificationRequired && !isPasswordResetRequest && !hideEmailField;
+  const isSignInEmailStep = isEmailFirstSignIn && !signInEmailConfirmed;
   const formBusy = isPasswordResetRequest ? passwordResetBusy : authBusy || desktopRedirectBusy;
   const activeContent = verificationRequired
     ? resolvedVerificationContent
     : isPasswordResetRequest
       ? passwordResetContent
+      : isSignInEmailStep
+      ? {
+          ...resolvedSignInContent,
+          copy: "Enter your email and we’ll send you to the right sign-in method.",
+          submitLabel: "Next",
+        }
       : authMode === "sign-in"
       ? resolvedSignInContent
       : resolvedSignUpContent;
@@ -180,6 +190,7 @@ export function AuthPanel({
     setEmail(prefilledEmail?.trim() ?? "");
     setPassword("");
     setVerificationCode("");
+    setSignInEmailConfirmed(false);
   }, [initialMode, prefillKey, prefilledEmail, setAuthMode, setEmail, setPassword, setVerificationCode]);
 
   const copyDesktopValue = async (field: "link" | "code", value: string | null) => {
@@ -323,6 +334,15 @@ export function AuthPanel({
             return;
           }
 
+          if (isSignInEmailStep) {
+            event.preventDefault();
+            const shouldContinue = await continueSignInWithEmail();
+            if (shouldContinue) {
+              setSignInEmailConfirmed(true);
+            }
+            return;
+          }
+
           const next = verificationRequired
             ? await submitVerificationCode(event)
             : await submitAuth(event);
@@ -341,13 +361,15 @@ export function AuthPanel({
       >
         {!verificationRequired && !isPasswordResetRequest && !hideSocialAuth ? (
           <>
-            <SocialButton
-              onClick={() => void beginSocialAuth("github")}
-              disabled={authBusy || desktopRedirectBusy}
-            >
-              <GitHubLogo />
-              <span>Continue with GitHub</span>
-            </SocialButton>
+            {authMode !== "sign-in" ? (
+              <SocialButton
+                onClick={() => void beginSocialAuth("github")}
+                disabled={authBusy || desktopRedirectBusy}
+              >
+                <GitHubLogo />
+                <span>Continue with GitHub</span>
+              </SocialButton>
+            ) : null}
 
             <SocialButton
               onClick={() => void beginSocialAuth("google")}
@@ -377,7 +399,12 @@ export function AuthPanel({
               className="den-input disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500"
               type="email"
               value={email}
-              onChange={(event) => setEmail(event.target.value)}
+              onChange={(event) => {
+                setEmail(event.target.value);
+                if (authMode === "sign-in") {
+                  setSignInEmailConfirmed(false);
+                }
+              }}
               autoComplete="email"
               readOnly={lockEmail}
               disabled={lockEmail}
@@ -386,7 +413,7 @@ export function AuthPanel({
           </label>
         ) : null}
 
-        {!verificationRequired && !isPasswordResetRequest ? (
+        {!verificationRequired && !isPasswordResetRequest && !isSignInEmailStep ? (
           <label className="grid gap-2">
             <span className="den-label">Password</span>
             <input
@@ -416,7 +443,7 @@ export function AuthPanel({
           </label>
         )}
 
-        {authMode === "sign-in" && !verificationRequired && !isPasswordResetRequest && !hideEmailField ? (
+        {authMode === "sign-in" && !verificationRequired && !isPasswordResetRequest && !isSignInEmailStep && !hideEmailField ? (
           <div className="-mt-2 flex justify-end">
             <button
               type="button"
@@ -455,7 +482,10 @@ export function AuthPanel({
             <button
               type="button"
               className="den-button-secondary w-full"
-              onClick={() => cancelVerification()}
+              onClick={() => {
+                setSignInEmailConfirmed(false);
+                cancelVerification();
+              }}
               disabled={authBusy || desktopRedirectBusy}
             >
               Change email
@@ -474,6 +504,7 @@ export function AuthPanel({
               setPasswordResetRequested(false);
               setPasswordResetInfo("");
               setPasswordResetError(null);
+              setSignInEmailConfirmed(false);
               setAuthMode("sign-in");
             }}
           >
@@ -494,6 +525,7 @@ export function AuthPanel({
               setPasswordResetRequested(false);
               setPasswordResetInfo("");
               setPasswordResetError(null);
+              setSignInEmailConfirmed(false);
               setAuthMode(authMode === "sign-in" ? "sign-up" : "sign-in");
             }}
           >

--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -425,7 +425,7 @@ export function AuthPanel({
               required
             />
           </label>
-        ) : isPasswordResetRequest ? null : (
+        ) : verificationRequired ? (
           <label className="grid gap-2">
             <span className="den-label">Verification code</span>
             <input
@@ -441,7 +441,7 @@ export function AuthPanel({
               required
             />
           </label>
-        )}
+        ) : null}
 
         {authMode === "sign-in" && !verificationRequired && !isPasswordResetRequest && !isSignInEmailStep && !hideEmailField ? (
           <div className="-mt-2 flex justify-end">

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -84,6 +84,7 @@ type DenFlowContextValue = {
   desktopRedirectUrl: string | null;
   desktopRedirectBusy: boolean;
   showAuthFeedback: boolean;
+  continueSignInWithEmail: () => Promise<boolean>;
   submitAuth: (event: FormEvent<HTMLFormElement>) => Promise<AuthNavigationResult>;
   submitVerificationCode: (event: FormEvent<HTMLFormElement>) => Promise<AuthNavigationResult>;
   resendVerificationCode: () => Promise<void>;
@@ -365,6 +366,38 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     nextUrl.searchParams.set("loginHint", trimmedEmail);
     window.location.assign(nextUrl.toString());
     return true;
+  }
+
+  async function continueSignInWithEmail() {
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      setAuthError("Enter your email to continue.");
+      return false;
+    }
+
+    setAuthBusy(true);
+    setAuthError(null);
+    setAuthInfo("Checking your workspace sign-in settings...");
+    trackPosthogEvent("den_auth_submitted", {
+      mode: "sign-in",
+      method: "email_next",
+      email_domain: getEmailDomain(trimmedEmail),
+    });
+
+    try {
+      if (await redirectToRequiredSso(trimmedEmail)) {
+        return false;
+      }
+
+      setAuthInfo("Enter your password to finish signing in.");
+      return true;
+    } catch (error) {
+      setAuthError(error instanceof Error ? error.message : "Could not check workspace sign-in settings.");
+      setAuthInfo(getAuthInfoForMode("sign-in"));
+      return false;
+    } finally {
+      setAuthBusy(false);
+    }
   }
 
   async function finalizeEmailPasswordSignIn(
@@ -1986,6 +2019,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     desktopRedirectUrl,
     desktopRedirectBusy,
     showAuthFeedback,
+    continueSignInWithEmail,
     submitAuth,
     submitVerificationCode,
     resendVerificationCode,


### PR DESCRIPTION
## Summary
- Make Den sign-in email-first and resolve whether the address belongs to any org with SSO or SCIM configured before showing password entry.
- Add shared Den API lookup for enterprise auth requirements based on actual org membership.
- Enforce SSO-only access in Better Auth hooks by blocking email/password auth and redirecting social OAuth sessions for SSO/SCIM org members.

## Verification
- pnpm --filter @openwork-ee/den-api build
- pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json
- pnpm --filter @openwork-ee/den-web build

## Evidence
No video/screenshot captured; validation was build/typecheck only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

