### PR TITLE
fix(ee): enforce tenant ownership checks

### DIFF
--- a/ee/apps/den-api/src/routes/mcp/index.ts
+++ b/ee/apps/den-api/src/routes/mcp/index.ts
@@ -14,7 +14,7 @@ import {
   resolveOrganizationContextMiddleware,
   type OrganizationContextVariables,
 } from "../../middleware/index.js"
-import { invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
+import { forbiddenSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 
 /**
@@ -66,6 +66,7 @@ export function registerMcpTokenRoutes<T extends { Variables: McpRouteVariables 
         200: jsonResponse("MCP access token minted successfully.", mcpTokenResponseSchema),
         400: jsonResponse("The token request was invalid or no active organization is selected.", z.union([invalidRequestSchema, organizationRequiredSchema])),
         401: jsonResponse("The caller must be signed in to mint an MCP token.", unauthorizedSchema),
+        403: jsonResponse("API keys cannot mint MCP tokens.", forbiddenSchema),
       },
     }),
     requireUserMiddleware,

--- a/ee/apps/den-api/src/routes/mcp/index.ts
+++ b/ee/apps/den-api/src/routes/mcp/index.ts
@@ -11,8 +11,8 @@ import { DEN_FIRST_PARTY_MCP_TOKEN_TTL_MS } from "../../mcp/token-lifetime.js"
 import {
   jsonValidator,
   requireUserMiddleware,
-  resolveUserOrganizationsMiddleware,
-  type UserOrganizationsContext,
+  resolveOrganizationContextMiddleware,
+  type OrganizationContextVariables,
 } from "../../middleware/index.js"
 import { invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
@@ -24,8 +24,8 @@ import type { AuthContextVariables } from "../../session.js"
  * without the browser OAuth dance. This is not a privilege escalation: the
  * caller already holds a full session token for the same user, which can do
  * strictly more than the resulting `mcp:*`-scoped token. The org is the
- * session's active organization, validated for membership by
- * `resolveUserOrganizationsMiddleware`.
+ * session's active organization, validated for membership and API-key scope by
+ * `resolveOrganizationContextMiddleware`.
  *
  * Tokens are stored exactly like oauthProvider-issued opaque tokens
  * (sha256 of the secret in OAuthAccessTokenTable, org in referenceId), so
@@ -51,7 +51,7 @@ const organizationRequiredSchema = z.object({
   message: z.string(),
 }).meta({ ref: "McpTokenOrganizationRequiredError" })
 
-type McpRouteVariables = AuthContextVariables & Partial<UserOrganizationsContext>
+type McpRouteVariables = AuthContextVariables & Partial<OrganizationContextVariables>
 
 export function registerMcpTokenRoutes<T extends { Variables: McpRouteVariables }>(app: Hono<T>) {
   app.post(
@@ -69,19 +69,21 @@ export function registerMcpTokenRoutes<T extends { Variables: McpRouteVariables 
       },
     }),
     requireUserMiddleware,
-    resolveUserOrganizationsMiddleware,
+    resolveOrganizationContextMiddleware,
     jsonValidator(mintMcpTokenSchema),
     async (c) => {
       const user = c.get("user")
       const session = c.get("session")
-      const orgId = c.get("activeOrganizationId")
+      const apiKey = c.get("apiKey")
+      const organizationContext = c.get("organizationContext")
+      const orgId = organizationContext.organization.id
       const input = c.req.valid("json")
 
-      if (!orgId) {
+      if (apiKey) {
         return c.json({
-          error: "organization_required",
-          message: "Select an active organization before minting an MCP token.",
-        }, 400)
+          error: "forbidden",
+          message: "Use a signed-in user session to mint MCP tokens.",
+        }, 403)
       }
 
       const scopes = input.scopes ?? ["mcp:read", "mcp:write"]

--- a/ee/apps/den-api/src/routes/org/plugin-system/access.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/access.ts
@@ -26,6 +26,7 @@ export type PluginArchActorContext = {
 
 type MemberId = OrganizationContext["currentMember"]["id"]
 type TeamId = MemberTeamSummary["id"]
+type OrganizationId = OrganizationContext["organization"]["id"]
 type ConfigObjectId = typeof ConfigObjectTable.$inferSelect.id
 type MarketplaceId = typeof MarketplaceTable.$inferSelect.id
 type PluginId = typeof PluginTable.$inferSelect.id
@@ -104,6 +105,70 @@ function roleSatisfies(role: PluginArchRole | null, required: PluginArchRole) {
   return rolePriority[role] >= rolePriority[required]
 }
 
+async function filterPluginIdsInOrganization(organizationId: OrganizationId, pluginIds: PluginId[]) {
+  if (pluginIds.length === 0) {
+    return []
+  }
+
+  const rows = await db
+    .select({ id: PluginTable.id })
+    .from(PluginTable)
+    .where(and(eq(PluginTable.organizationId, organizationId), inArray(PluginTable.id, pluginIds)))
+
+  return rows.map((row) => row.id)
+}
+
+async function filterMarketplaceIdsInOrganization(organizationId: OrganizationId, marketplaceIds: MarketplaceId[]) {
+  if (marketplaceIds.length === 0) {
+    return []
+  }
+
+  const rows = await db
+    .select({ id: MarketplaceTable.id })
+    .from(MarketplaceTable)
+    .where(and(eq(MarketplaceTable.organizationId, organizationId), inArray(MarketplaceTable.id, marketplaceIds)))
+
+  return rows.map((row) => row.id)
+}
+
+async function resourceExistsInOrganization(input: ResourceLookupInput) {
+  const organizationId = input.context.organizationContext.organization.id
+
+  if (input.resourceKind === "marketplace") {
+    const rows = await db
+      .select({ id: MarketplaceTable.id })
+      .from(MarketplaceTable)
+      .where(and(eq(MarketplaceTable.organizationId, organizationId), eq(MarketplaceTable.id, input.resourceId)))
+      .limit(1)
+    return Boolean(rows[0])
+  }
+
+  if (input.resourceKind === "plugin") {
+    const rows = await db
+      .select({ id: PluginTable.id })
+      .from(PluginTable)
+      .where(and(eq(PluginTable.organizationId, organizationId), eq(PluginTable.id, input.resourceId)))
+      .limit(1)
+    return Boolean(rows[0])
+  }
+
+  if (input.resourceKind === "connector_instance") {
+    const rows = await db
+      .select({ id: ConnectorInstanceTable.id })
+      .from(ConnectorInstanceTable)
+      .where(and(eq(ConnectorInstanceTable.organizationId, organizationId), eq(ConnectorInstanceTable.id, input.resourceId)))
+      .limit(1)
+    return Boolean(rows[0])
+  }
+
+  const rows = await db
+    .select({ id: ConfigObjectTable.id })
+    .from(ConfigObjectTable)
+    .where(and(eq(ConfigObjectTable.organizationId, organizationId), eq(ConfigObjectTable.id, input.resourceId)))
+    .limit(1)
+  return Boolean(rows[0])
+}
+
 export function resolvePluginArchGrantRole(input: {
   grants: GrantRow[]
   memberId: MemberId
@@ -134,7 +199,8 @@ async function resolveGrantRole(input: {
 }
 
 async function resolvePluginRoleForIds(context: PluginArchActorContext, pluginIds: PluginId[]) {
-  if (pluginIds.length === 0) {
+  const organizationPluginIds = await filterPluginIdsInOrganization(context.organizationContext.organization.id, pluginIds)
+  if (organizationPluginIds.length === 0) {
     return null
   }
 
@@ -151,13 +217,17 @@ async function resolvePluginRoleForIds(context: PluginArchActorContext, pluginId
       teamId: PluginAccessGrantTable.teamId,
     })
     .from(PluginAccessGrantTable)
-    .where(inArray(PluginAccessGrantTable.pluginId, pluginIds))
+    .where(and(
+      inArray(PluginAccessGrantTable.pluginId, organizationPluginIds),
+      eq(PluginAccessGrantTable.organizationId, context.organizationContext.organization.id),
+    ))
 
   return resolveGrantRole({ context, grants })
 }
 
 async function resolveMarketplaceRoleForIds(context: PluginArchActorContext, marketplaceIds: MarketplaceId[]) {
-  if (marketplaceIds.length === 0) {
+  const organizationMarketplaceIds = await filterMarketplaceIdsInOrganization(context.organizationContext.organization.id, marketplaceIds)
+  if (organizationMarketplaceIds.length === 0) {
     return null
   }
 
@@ -174,12 +244,19 @@ async function resolveMarketplaceRoleForIds(context: PluginArchActorContext, mar
       teamId: MarketplaceAccessGrantTable.teamId,
     })
     .from(MarketplaceAccessGrantTable)
-    .where(inArray(MarketplaceAccessGrantTable.marketplaceId, marketplaceIds))
+    .where(and(
+      inArray(MarketplaceAccessGrantTable.marketplaceId, organizationMarketplaceIds),
+      eq(MarketplaceAccessGrantTable.organizationId, context.organizationContext.organization.id),
+    ))
 
   return resolveGrantRole({ context, grants })
 }
 
 export async function resolvePluginArchResourceRole(input: ResourceLookupInput) {
+  if (!(await resourceExistsInOrganization(input))) {
+    return null
+  }
+
   if (isPluginArchOrgAdmin(input.context)) {
     return "manager" satisfies PluginArchRole
   }
@@ -194,7 +271,10 @@ export async function resolvePluginArchResourceRole(input: ResourceLookupInput) 
         teamId: MarketplaceAccessGrantTable.teamId,
       })
       .from(MarketplaceAccessGrantTable)
-      .where(eq(MarketplaceAccessGrantTable.marketplaceId, input.resourceId))
+      .where(and(
+        eq(MarketplaceAccessGrantTable.marketplaceId, input.resourceId),
+        eq(MarketplaceAccessGrantTable.organizationId, input.context.organizationContext.organization.id),
+      ))
     return resolveGrantRole({ context: input.context, grants })
   }
 
@@ -208,7 +288,10 @@ export async function resolvePluginArchResourceRole(input: ResourceLookupInput) 
         teamId: PluginAccessGrantTable.teamId,
       })
       .from(PluginAccessGrantTable)
-      .where(eq(PluginAccessGrantTable.pluginId, input.resourceId))
+      .where(and(
+        eq(PluginAccessGrantTable.pluginId, input.resourceId),
+        eq(PluginAccessGrantTable.organizationId, input.context.organizationContext.organization.id),
+      ))
     const resolved = await resolveGrantRole({ context: input.context, grants })
     if (resolved) {
       return resolved
@@ -233,7 +316,10 @@ export async function resolvePluginArchResourceRole(input: ResourceLookupInput) 
         teamId: ConnectorInstanceAccessGrantTable.teamId,
       })
       .from(ConnectorInstanceAccessGrantTable)
-      .where(eq(ConnectorInstanceAccessGrantTable.connectorInstanceId, input.resourceId))
+      .where(and(
+        eq(ConnectorInstanceAccessGrantTable.connectorInstanceId, input.resourceId),
+        eq(ConnectorInstanceAccessGrantTable.organizationId, input.context.organizationContext.organization.id),
+      ))
     return resolveGrantRole({ context: input.context, grants })
   }
 
@@ -246,7 +332,10 @@ export async function resolvePluginArchResourceRole(input: ResourceLookupInput) 
       teamId: ConfigObjectAccessGrantTable.teamId,
     })
     .from(ConfigObjectAccessGrantTable)
-    .where(eq(ConfigObjectAccessGrantTable.configObjectId, input.resourceId))
+    .where(and(
+      eq(ConfigObjectAccessGrantTable.configObjectId, input.resourceId),
+      eq(ConfigObjectAccessGrantTable.organizationId, input.context.organizationContext.organization.id),
+    ))
 
   let resolved = await resolveGrantRole({ context: input.context, grants: directGrants })
   if (resolved) {

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -1149,6 +1149,13 @@ export async function listConfigObjects(input: {
   type?: ConfigObjectRow["objectType"]
 }) {
   const organizationId = input.context.organizationContext.organization.id
+  if (input.connectorInstanceId) {
+    await ensureVisibleConnectorInstance(input.context, input.connectorInstanceId)
+  }
+  if (input.pluginId) {
+    await ensureVisiblePlugin(input.context, input.pluginId)
+  }
+
   const rows = await db
     .select()
     .from(ConfigObjectTable)
@@ -1174,7 +1181,12 @@ export async function listConfigObjects(input: {
       const memberships = await db
         .select({ id: PluginConfigObjectTable.id })
         .from(PluginConfigObjectTable)
-        .where(and(eq(PluginConfigObjectTable.pluginId, input.pluginId), eq(PluginConfigObjectTable.configObjectId, row.id), isNull(PluginConfigObjectTable.removedAt)))
+        .where(and(
+          eq(PluginConfigObjectTable.organizationId, organizationId),
+          eq(PluginConfigObjectTable.pluginId, input.pluginId),
+          eq(PluginConfigObjectTable.configObjectId, row.id),
+          isNull(PluginConfigObjectTable.removedAt),
+        ))
         .limit(1)
       if (!memberships[0]) continue
     }
@@ -2202,7 +2214,7 @@ export async function disconnectConnectorAccount(input: { connectorAccountId: Co
 
   // Resolve every imported marketplace/plugin id to delete up front so the
   // transaction below is a single pass of pure writes (no reads on the tx).
-  const importedResourceCleanupPlan = await planConnectorImportedResourceCleanupIds(connectorPluginIds)
+  const importedResourceCleanupPlan = await planConnectorImportedResourceCleanupIds({ organizationId, seedPluginIds: connectorPluginIds })
 
   await db.transaction(async (tx) => {
     if (instanceIds.length > 0) {
@@ -2229,7 +2241,7 @@ export async function disconnectConnectorAccount(input: { connectorAccountId: Co
       await tx.delete(ConnectorInstanceTable).where(inArray(ConnectorInstanceTable.id, instanceIds))
     }
 
-    await deleteConnectorImportedResources({ plan: importedResourceCleanupPlan, tx })
+    await deleteConnectorImportedResources({ organizationId, plan: importedResourceCleanupPlan, tx })
 
     await tx.delete(ConnectorAccountTable).where(eq(ConnectorAccountTable.id, row.id))
   })
@@ -2372,8 +2384,8 @@ type ConnectorImportedResourceCleanupPlan = {
 
 // Read-only planning pass. Runs outside of any transaction so that the
 // subsequent delete pass can execute as a single transaction of pure writes.
-async function planConnectorImportedResourceCleanupIds(seedPluginIds: PluginId[]): Promise<ConnectorImportedResourceCleanupPlan> {
-  const uniqueSeedPluginIds = uniqueIds(seedPluginIds)
+async function planConnectorImportedResourceCleanupIds(input: { organizationId: OrganizationId; seedPluginIds: PluginId[] }): Promise<ConnectorImportedResourceCleanupPlan> {
+  const uniqueSeedPluginIds = uniqueIds(input.seedPluginIds)
   if (uniqueSeedPluginIds.length === 0) {
     return { marketplaceIdsToDelete: [], pluginIdsToDelete: [] }
   }
@@ -2381,8 +2393,11 @@ async function planConnectorImportedResourceCleanupIds(seedPluginIds: PluginId[]
   const connectorMarketplaceRows = await db
     .select({ marketplaceId: MarketplacePluginTable.marketplaceId })
     .from(MarketplacePluginTable)
+    .innerJoin(MarketplaceTable, eq(MarketplacePluginTable.marketplaceId, MarketplaceTable.id))
     .where(and(
       inArray(MarketplacePluginTable.pluginId, uniqueSeedPluginIds),
+      eq(MarketplacePluginTable.organizationId, input.organizationId),
+      eq(MarketplaceTable.organizationId, input.organizationId),
       eq(MarketplacePluginTable.membershipSource, "connector"),
       isNull(MarketplacePluginTable.removedAt),
     ))
@@ -2399,6 +2414,7 @@ async function planConnectorImportedResourceCleanupIds(seedPluginIds: PluginId[]
       .from(MarketplacePluginTable)
       .where(and(
         inArray(MarketplacePluginTable.marketplaceId, candidateMarketplaceIds),
+        eq(MarketplacePluginTable.organizationId, input.organizationId),
         isNull(MarketplacePluginTable.removedAt),
       ))
 
@@ -2416,6 +2432,7 @@ async function planConnectorImportedResourceCleanupIds(seedPluginIds: PluginId[]
       .from(PluginConfigObjectTable)
       .where(and(
         inArray(PluginConfigObjectTable.pluginId, candidatePluginIds),
+        eq(PluginConfigObjectTable.organizationId, input.organizationId),
         isNull(PluginConfigObjectTable.removedAt),
       ))
 
@@ -2424,7 +2441,10 @@ async function planConnectorImportedResourceCleanupIds(seedPluginIds: PluginId[]
     : await db
       .select({ pluginId: ConnectorMappingTable.pluginId })
       .from(ConnectorMappingTable)
-      .where(inArray(ConnectorMappingTable.pluginId, candidatePluginIds))
+      .where(and(
+        inArray(ConnectorMappingTable.pluginId, candidatePluginIds),
+        eq(ConnectorMappingTable.organizationId, input.organizationId),
+      ))
 
   return planConnectorImportedResourceCleanup({
     activeMarketplaceMemberships,
@@ -2440,22 +2460,23 @@ async function planConnectorImportedResourceCleanupIds(seedPluginIds: PluginId[]
 // Write-only delete pass. Must run inside a transaction. Contains no reads so it
 // is safe to run alongside the other deletes on the same Vitess connection.
 async function deleteConnectorImportedResources(input: {
+  organizationId: OrganizationId
   plan: ConnectorImportedResourceCleanupPlan
   tx: DbTransaction
 }) {
   const { marketplaceIdsToDelete, pluginIdsToDelete } = input.plan
 
   if (pluginIdsToDelete.length > 0) {
-    await input.tx.delete(PluginConfigObjectTable).where(inArray(PluginConfigObjectTable.pluginId, pluginIdsToDelete))
-    await input.tx.delete(MarketplacePluginTable).where(inArray(MarketplacePluginTable.pluginId, pluginIdsToDelete))
-    await input.tx.delete(PluginAccessGrantTable).where(inArray(PluginAccessGrantTable.pluginId, pluginIdsToDelete))
-    await input.tx.delete(PluginTable).where(inArray(PluginTable.id, pluginIdsToDelete))
+    await input.tx.delete(PluginConfigObjectTable).where(and(inArray(PluginConfigObjectTable.pluginId, pluginIdsToDelete), eq(PluginConfigObjectTable.organizationId, input.organizationId)))
+    await input.tx.delete(MarketplacePluginTable).where(and(inArray(MarketplacePluginTable.pluginId, pluginIdsToDelete), eq(MarketplacePluginTable.organizationId, input.organizationId)))
+    await input.tx.delete(PluginAccessGrantTable).where(and(inArray(PluginAccessGrantTable.pluginId, pluginIdsToDelete), eq(PluginAccessGrantTable.organizationId, input.organizationId)))
+    await input.tx.delete(PluginTable).where(and(inArray(PluginTable.id, pluginIdsToDelete), eq(PluginTable.organizationId, input.organizationId)))
   }
 
   if (marketplaceIdsToDelete.length > 0) {
-    await input.tx.delete(MarketplacePluginTable).where(inArray(MarketplacePluginTable.marketplaceId, marketplaceIdsToDelete))
-    await input.tx.delete(MarketplaceAccessGrantTable).where(inArray(MarketplaceAccessGrantTable.marketplaceId, marketplaceIdsToDelete))
-    await input.tx.delete(MarketplaceTable).where(inArray(MarketplaceTable.id, marketplaceIdsToDelete))
+    await input.tx.delete(MarketplacePluginTable).where(and(inArray(MarketplacePluginTable.marketplaceId, marketplaceIdsToDelete), eq(MarketplacePluginTable.organizationId, input.organizationId)))
+    await input.tx.delete(MarketplaceAccessGrantTable).where(and(inArray(MarketplaceAccessGrantTable.marketplaceId, marketplaceIdsToDelete), eq(MarketplaceAccessGrantTable.organizationId, input.organizationId)))
+    await input.tx.delete(MarketplaceTable).where(and(inArray(MarketplaceTable.id, marketplaceIdsToDelete), eq(MarketplaceTable.organizationId, input.organizationId)))
   }
 }
 
@@ -2571,7 +2592,7 @@ export async function removeConnectorInstance(input: { connectorInstanceId: Conn
 
   // Resolve every imported marketplace/plugin id to delete up front so the
   // transaction below is a single pass of pure writes (no reads on the tx).
-  const importedResourceCleanupPlan = await planConnectorImportedResourceCleanupIds(pluginIds)
+  const importedResourceCleanupPlan = await planConnectorImportedResourceCleanupIds({ organizationId: instance.organizationId, seedPluginIds: pluginIds })
 
   await db.transaction(async (tx) => {
     await tx.delete(ConnectorSourceTombstoneTable).where(eq(ConnectorSourceTombstoneTable.connectorInstanceId, instance.id))
@@ -2594,7 +2615,7 @@ export async function removeConnectorInstance(input: { connectorInstanceId: Conn
     await tx.delete(ConnectorInstanceAccessGrantTable).where(eq(ConnectorInstanceAccessGrantTable.connectorInstanceId, instance.id))
     await tx.delete(ConnectorInstanceTable).where(eq(ConnectorInstanceTable.id, instance.id))
 
-    await deleteConnectorImportedResources({ plan: importedResourceCleanupPlan, tx })
+    await deleteConnectorImportedResources({ organizationId: instance.organizationId, plan: importedResourceCleanupPlan, tx })
   })
 
   return {
@@ -4271,7 +4292,17 @@ export async function enqueueGithubWebhookSync(input: {
     .select({ instance: ConnectorInstanceTable, target: ConnectorTargetTable })
     .from(ConnectorTargetTable)
     .innerJoin(ConnectorInstanceTable, eq(ConnectorTargetTable.connectorInstanceId, ConnectorInstanceTable.id))
-    .where(and(eq(ConnectorTargetTable.connectorType, "github"), eq(ConnectorTargetTable.remoteId, input.repositoryFullName)))
+    .innerJoin(ConnectorAccountTable, eq(ConnectorInstanceTable.connectorAccountId, ConnectorAccountTable.id))
+    .where(and(
+      eq(ConnectorTargetTable.connectorType, "github"),
+      eq(ConnectorTargetTable.remoteId, input.repositoryFullName),
+      eq(ConnectorTargetTable.organizationId, ConnectorInstanceTable.organizationId),
+      eq(ConnectorAccountTable.organizationId, ConnectorInstanceTable.organizationId),
+      eq(ConnectorAccountTable.connectorType, "github"),
+      eq(ConnectorAccountTable.remoteId, String(input.installationId)),
+      eq(ConnectorAccountTable.status, "active"),
+      eq(ConnectorInstanceTable.status, "active"),
+    ))
 
   const queuedIds: string[] = []
   for (const row of instances) {

--- a/ee/apps/den-api/src/routes/org/skills.ts
+++ b/ee/apps/den-api/src/routes/org/skills.ts
@@ -966,6 +966,16 @@ export function registerOrgSkillRoutes<T extends { Variables: OrgRouteVariables 
         return c.json({ error: "forbidden", message: "Only the hub creator or a workspace admin can manage hub skills." }, 403)
       }
 
+      const skillRows = await db
+        .select({ id: SkillTable.id })
+        .from(SkillTable)
+        .where(and(eq(SkillTable.id, skillId), eq(SkillTable.organizationId, payload.organization.id)))
+        .limit(1)
+
+      if (!skillRows[0]) {
+        return c.json({ error: "skill_not_found" }, 404)
+      }
+
       const existing = await db
         .select({ id: SkillHubSkillTable.id })
         .from(SkillHubSkillTable)

--- a/ee/apps/den-api/test/github-webhook-tenant-scope.test.ts
+++ b/ee/apps/den-api/test/github-webhook-tenant-scope.test.ts
@@ -22,6 +22,7 @@ type QueryChain = {
 }
 
 let insertCalls = 0
+let maxInnerJoinCalls = 0
 
 const vulnerableCrossInstallationMatch = {
   instance: {
@@ -48,6 +49,7 @@ function queryChain(): QueryChain {
     from: () => chain,
     innerJoin: () => {
       innerJoinCalls += 1
+      maxInnerJoinCalls = Math.max(maxInnerJoinCalls, innerJoinCalls)
       return chain
     },
     limit: () => Promise.resolve(resolveRows(innerJoinCalls)),
@@ -59,7 +61,7 @@ function queryChain(): QueryChain {
 }
 
 function resolveRows(innerJoinCalls: number): QueryResult {
-  if (innerJoinCalls === 1) {
+  if (innerJoinCalls < 2) {
     return [vulnerableCrossInstallationMatch]
   }
 
@@ -86,6 +88,7 @@ beforeAll(async () => {
 
 test("GitHub push webhooks only match targets for the payload installation", async () => {
   insertCalls = 0
+  maxInnerJoinCalls = 0
 
   const result = await storeModule.enqueueGithubWebhookSync({
     deliveryId: "delivery-tenant-scope",
@@ -99,5 +102,6 @@ test("GitHub push webhooks only match targets for the payload installation", asy
   })
 
   expect(result).toEqual({ accepted: false, reason: "event ignored" })
+  expect(maxInnerJoinCalls).toBeGreaterThanOrEqual(2)
   expect(insertCalls).toBe(0)
 })

--- a/ee/apps/den-api/test/github-webhook-tenant-scope.test.ts
+++ b/ee/apps/den-api/test/github-webhook-tenant-scope.test.ts
@@ -1,0 +1,103 @@
+import { beforeAll, expect, mock, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+type QueryResult = Array<Record<string, unknown>>
+
+type QueryChain = {
+  from: () => QueryChain
+  innerJoin: () => QueryChain
+  limit: () => Promise<QueryResult>
+  orderBy: () => QueryChain
+  then: <TResult1 = QueryResult, TResult2 = never>(
+    onfulfilled?: ((value: QueryResult) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ) => Promise<TResult1 | TResult2>
+  where: () => QueryChain
+}
+
+let insertCalls = 0
+
+const vulnerableCrossInstallationMatch = {
+  instance: {
+    id: "connectorInstance_foreign",
+    organizationId: "organization_foreign",
+    connectorAccountId: "connectorAccount_foreign",
+    connectorType: "github",
+    instanceConfigJson: { autoImportNewPlugins: false },
+    status: "active",
+  },
+  target: {
+    id: "connectorTarget_foreign",
+    organizationId: "organization_foreign",
+    connectorInstanceId: "connectorInstance_foreign",
+    connectorType: "github",
+    remoteId: "different-ai/openwork",
+    targetConfigJson: {},
+  },
+}
+
+function queryChain(): QueryChain {
+  let innerJoinCalls = 0
+  const chain: QueryChain = {
+    from: () => chain,
+    innerJoin: () => {
+      innerJoinCalls += 1
+      return chain
+    },
+    limit: () => Promise.resolve(resolveRows(innerJoinCalls)),
+    orderBy: () => chain,
+    then: (onfulfilled, onrejected) => Promise.resolve(resolveRows(innerJoinCalls)).then(onfulfilled, onrejected),
+    where: () => chain,
+  }
+  return chain
+}
+
+function resolveRows(innerJoinCalls: number): QueryResult {
+  if (innerJoinCalls === 1) {
+    return [vulnerableCrossInstallationMatch]
+  }
+
+  return []
+}
+
+let storeModule: typeof import("../src/routes/org/plugin-system/store.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.module("../src/db.js", () => ({
+    db: {
+      insert: () => {
+        insertCalls += 1
+        return { values: () => Promise.resolve(undefined) }
+      },
+      select: queryChain,
+      update: () => ({ set: () => ({ where: () => Promise.resolve(undefined) }) }),
+    },
+  }))
+
+  storeModule = await import("../src/routes/org/plugin-system/store.js")
+})
+
+test("GitHub push webhooks only match targets for the payload installation", async () => {
+  insertCalls = 0
+
+  const result = await storeModule.enqueueGithubWebhookSync({
+    deliveryId: "delivery-tenant-scope",
+    event: "push",
+    headSha: "abc123",
+    installationId: 12345,
+    payload: {},
+    ref: "refs/heads/main",
+    repositoryFullName: "different-ai/openwork",
+    repositoryId: 42,
+  })
+
+  expect(result).toEqual({ accepted: false, reason: "event ignored" })
+  expect(insertCalls).toBe(0)
+})

--- a/ee/apps/den-worker-proxy/src/app.ts
+++ b/ee/apps/den-worker-proxy/src/app.ts
@@ -186,6 +186,22 @@ async function resolveWorkerTokenScope(workerId: WorkerId, request: Request): Pr
   return "invalid"
 }
 
+function isProxyReadMethod(method: string) {
+  return method.toUpperCase() === "GET" || method.toUpperCase() === "HEAD"
+}
+
+export function isProxyTokenAuthorized(method: string, tokenScope: WorkerTokenScope | "invalid" | null): tokenScope is WorkerTokenScope {
+  if (!tokenScope || tokenScope === "invalid") {
+    return false
+  }
+
+  if (isProxyReadMethod(method)) {
+    return tokenScope === "client" || tokenScope === "host"
+  }
+
+  return tokenScope === "host"
+}
+
 async function enforceProxyRateLimit(input: {
   workerId: WorkerId
   request: Request
@@ -353,9 +369,8 @@ app.all("*", async (c) => {
   try {
     const normalizedWorkerId = normalizeDenTypeId("worker", workerId)
     const tokenScope = await resolveWorkerTokenScope(normalizedWorkerId, c.req.raw)
-    const isWriteMethod = !["GET", "HEAD", "OPTIONS"].includes(c.req.method.toUpperCase())
 
-    if (tokenScope === "invalid" || (isWriteMethod && !tokenScope)) {
+    if (!isProxyTokenAuthorized(c.req.method, tokenScope)) {
       const headers = new Headers({ "Content-Type": "application/json" })
       noCacheHeaders(headers)
       applyPublicCorsHeaders(headers, c.req.raw)

--- a/ee/apps/den-worker-proxy/test/proxy-authorization.test.ts
+++ b/ee/apps/den-worker-proxy/test/proxy-authorization.test.ts
@@ -1,0 +1,27 @@
+import { beforeAll, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+}
+
+let appModule: typeof import("../src/app.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  appModule = await import("../src/app.js")
+})
+
+test("worker proxy reads require a client or host token", () => {
+  expect(appModule.isProxyTokenAuthorized("GET", null)).toBe(false)
+  expect(appModule.isProxyTokenAuthorized("GET", "invalid")).toBe(false)
+  expect(appModule.isProxyTokenAuthorized("GET", "activity")).toBe(false)
+  expect(appModule.isProxyTokenAuthorized("GET", "client")).toBe(true)
+  expect(appModule.isProxyTokenAuthorized("HEAD", "host")).toBe(true)
+})
+
+test("worker proxy writes require a host token", () => {
+  expect(appModule.isProxyTokenAuthorized("POST", null)).toBe(false)
+  expect(appModule.isProxyTokenAuthorized("POST", "client")).toBe(false)
+  expect(appModule.isProxyTokenAuthorized("POST", "activity")).toBe(false)
+  expect(appModule.isProxyTokenAuthorized("POST", "host")).toBe(true)
+})

--- a/ee/apps/inference/src/keys.ts
+++ b/ee/apps/inference/src/keys.ts
@@ -1,6 +1,6 @@
 import { createHash, timingSafeEqual } from "node:crypto"
-import { and, eq } from "drizzle-orm"
-import { InferenceKeyTable, InferenceOrgUpstreamProviderKeyTable } from "@openwork-ee/den-db"
+import { and, eq, isNull } from "drizzle-orm"
+import { InferenceKeyTable, InferenceOrgUpstreamProviderKeyTable, MemberTable } from "@openwork-ee/den-db"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "./db.js"
 
@@ -15,11 +15,21 @@ export function constantTimeEquals(a: string, b: string) {
 }
 
 export async function findActiveInferenceKey(rawKey: string) {
-  const [row] = await db.select().from(InferenceKeyTable).where(eq(InferenceKeyTable.key_hash, sha256(rawKey))).limit(1)
-  if (!row || row.status !== "active") {
+  const [row] = await db
+    .select({ inferenceKey: InferenceKeyTable })
+    .from(InferenceKeyTable)
+    .innerJoin(MemberTable, eq(InferenceKeyTable.org_membership_id, MemberTable.id))
+    .where(and(
+      eq(InferenceKeyTable.key_hash, sha256(rawKey)),
+      eq(InferenceKeyTable.status, "active"),
+      eq(MemberTable.organizationId, InferenceKeyTable.organization_id),
+      isNull(MemberTable.removedAt),
+    ))
+    .limit(1)
+  if (!row) {
     return null
   }
-  return row
+  return row.inferenceKey
 }
 
 export async function getOpenRouterProviderKey(organizationId: string) {

--- a/ee/apps/inference/src/limits.ts
+++ b/ee/apps/inference/src/limits.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm"
+import { and, eq, isNull, sql } from "drizzle-orm"
 import { InferenceOrgLimitPolicyTable, InferenceOrgUsageBucketTable, MemberTable, OrganizationTable } from "@openwork-ee/den-db"
 import { createDenTypeId, normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { INFERENCE_TIER_LIMITS, INFERENCE_WINDOW_DURATIONS_MS } from "@openwork/types/den/inference"
@@ -44,7 +44,7 @@ async function getEffectiveLimits(organizationId: DenTypeId<"organization">) {
   const [memberCountRow] = await db
     .select({ count: sql<number>`count(*)` })
     .from(MemberTable)
-    .where(eq(MemberTable.organizationId, organizationId))
+    .where(and(eq(MemberTable.organizationId, organizationId), isNull(MemberTable.removedAt)))
   const memberCount = Math.max(0, Number(memberCountRow?.count ?? 0))
 
   return Object.fromEntries(


### PR DESCRIPTION
## Summary
- Require worker proxy read/write requests to use an appropriate worker token
- Bind plugin-system resource role checks, connector cleanup, and GitHub webhook sync to the caller/payload organization
- Harden MCP token minting, skill hub removal, and inference key validation against stale or cross-tenant resources
- Add regression coverage for GitHub webhook tenant scoping and worker proxy token authorization

## Verification
- `pnpm --filter @openwork-ee/den-api build` ✅
- `pnpm --filter @openwork-ee/den-worker-proxy build` ✅
- `pnpm --filter @openwork-ee/inference build` ✅
- `DATABASE_URL=... DEN_DB_ENCRYPTION_KEY=... BETTER_AUTH_SECRET=... BETTER_AUTH_URL=... bun test test/plugin-system-cross-org-idor.test.ts test/plugin-system-config-object-ownership.test.ts test/github-webhook.test.ts test/github-webhook-tenant-scope.test.ts test/route-guard-policy.test.ts` ✅
- `DATABASE_URL=... bun test test/proxy-authorization.test.ts` ✅
- `DATABASE_URL=... DEN_DB_ENCRYPTION_KEY=... BETTER_AUTH_SECRET=... BETTER_AUTH_URL=... bun test test/api-keys.test.ts test/mcp-auth.test.ts test/mcp-resource.test.ts test/plugin-system-access.test.ts test/org-member-guards.test.ts` ✅
- `git diff --check` ✅

No video attached: this is backend/API security hardening validated with targeted builds and automated tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

