### PR TITLE
fix(den): revoke credentials on membership changes

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -19,7 +19,9 @@ import {
   DEN_API_KEY_EXPIRES_IN_SECONDS,
   DEN_API_KEY_RATE_LIMIT_MAX,
   DEN_API_KEY_RATE_LIMIT_TIME_WINDOW_MS,
+  revokeOrganizationApiKeysForMember,
 } from "./api-keys.js";
+import { revokeMembershipSessionCredentials } from "./credential-revocation.js";
 import {
   canManageSecurityConfiguration,
   denOrganizationAccess,
@@ -143,6 +145,26 @@ function buildInvitationLink(invitationId: string) {
 
 function hasMcpScope(scopes: readonly string[]) {
   return scopes.some((scope) => scope.startsWith("mcp:"));
+}
+
+async function revokeOrganizationMemberCredentials(input: {
+  organizationId: string;
+  orgMembershipId: string;
+  userId: string | null;
+}) {
+  const organizationId = normalizeDenTypeId("organization", input.organizationId);
+  const orgMembershipId = normalizeDenTypeId("member", input.orgMembershipId);
+  const userId = input.userId ? normalizeDenTypeId("user", input.userId) : null;
+
+  await revokeOrganizationApiKeysForMember({
+    organizationId,
+    orgMembershipId,
+    userId,
+  });
+  await revokeMembershipSessionCredentials({
+    organizationId,
+    userId,
+  });
 }
 
 function getBodyEmail(body: unknown) {
@@ -404,6 +426,12 @@ export const auth = betterAuth({
               message: "The organization owner cannot be removed.",
             });
           }
+
+          await revokeOrganizationMemberCredentials({
+            organizationId: member.organizationId,
+            orgMembershipId: member.id,
+            userId: member.userId,
+          });
         },
         beforeUpdateMemberRole: async ({ member, newRole }) => {
           if (hasRole(member.role, "owner")) {
@@ -416,6 +444,14 @@ export const auth = betterAuth({
             throw new APIError("BAD_REQUEST", {
               message:
                 "Owner can only be assigned during organization creation.",
+            });
+          }
+
+          if (member.role !== newRole) {
+            await revokeOrganizationMemberCredentials({
+              organizationId: member.organizationId,
+              orgMembershipId: member.id,
+              userId: member.userId,
             });
           }
         },

--- a/ee/apps/den-api/src/mcp/auth.ts
+++ b/ee/apps/den-api/src/mcp/auth.ts
@@ -1,6 +1,7 @@
 import * as crypto from "node:crypto"
-import { eq } from "@openwork-ee/den-db/drizzle"
-import { OAuthAccessTokenTable } from "@openwork-ee/den-db/schema"
+import { and, eq, gt, isNull } from "@openwork-ee/den-db/drizzle"
+import { AuthSessionTable, MemberTable, OAuthAccessTokenTable } from "@openwork-ee/den-db/schema"
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { verifyJwsAccessToken } from "better-auth/oauth2"
 import {
   auth,
@@ -78,6 +79,55 @@ function readStringClaim(payload: Record<string, unknown>, claim: string) {
   return typeof value === "string" && value.trim() ? value.trim() : null
 }
 
+function normalizeMcpPrincipal(input: { userId: string; organizationId: string }) {
+  try {
+    return {
+      userId: normalizeDenTypeId("user", input.userId),
+      organizationId: normalizeDenTypeId("organization", input.organizationId),
+    }
+  } catch {
+    return null
+  }
+}
+
+export async function hasActiveMcpMembership(input: { userId: string; organizationId: string }) {
+  const principal = normalizeMcpPrincipal(input)
+  if (!principal) {
+    return false
+  }
+
+  const rows = await db
+    .select({ id: MemberTable.id })
+    .from(MemberTable)
+    .where(and(
+      eq(MemberTable.userId, principal.userId),
+      eq(MemberTable.organizationId, principal.organizationId),
+      isNull(MemberTable.removedAt),
+    ))
+    .limit(1)
+
+  return rows.length > 0
+}
+
+export async function hasActiveMcpSession(sessionId: string) {
+  try {
+    const normalizedSessionId = normalizeDenTypeId("session", sessionId)
+
+    const rows = await db
+      .select({ id: AuthSessionTable.id })
+      .from(AuthSessionTable)
+      .where(and(
+        eq(AuthSessionTable.id, normalizedSessionId),
+        gt(AuthSessionTable.expiresAt, new Date()),
+      ))
+      .limit(1)
+
+    return rows.length > 0
+  } catch {
+    return false
+  }
+}
+
 async function getJwks() {
   const response = await auth.handler(new Request(`${env.betterAuthUrl}/api/auth/jwks`))
   if (!response.ok) {
@@ -119,6 +169,7 @@ async function verifyOpaqueMcpToken(token: string) {
     iat: Math.floor(accessToken.createdAt.getTime() / 1000),
     [DEN_MCP_TOKEN_USE_CLAIM]: "mcp",
     [DEN_MCP_RESOURCE_CLAIM]: DEN_MCP_RESOURCE,
+    ...(accessToken.sessionId ? { sid: accessToken.sessionId } : {}),
     ...(accessToken.referenceId ? { [DEN_MCP_ORG_ID_CLAIM]: accessToken.referenceId } : {}),
   }
 }
@@ -172,6 +223,21 @@ export async function verifyMcpRequest(headers: Headers, resourceUrl = DEN_MCP_R
   const organizationId = readStringClaim(payload, DEN_MCP_ORG_ID_CLAIM)
   if (!userId || !organizationId) {
     return new Response(JSON.stringify({ error: "missing_mcp_principal" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    })
+  }
+
+  const sessionId = readStringClaim(payload, "sid")
+  if (sessionId && !(await hasActiveMcpSession(sessionId))) {
+    return new Response(JSON.stringify({ error: "mcp_session_revoked" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    })
+  }
+
+  if (!(await hasActiveMcpMembership({ userId, organizationId }))) {
+    return new Response(JSON.stringify({ error: "mcp_membership_revoked" }), {
       status: 403,
       headers: { "content-type": "application/json" },
     })

--- a/ee/apps/den-api/src/mcp/auth.ts
+++ b/ee/apps/den-api/src/mcp/auth.ts
@@ -229,7 +229,14 @@ export async function verifyMcpRequest(headers: Headers, resourceUrl = DEN_MCP_R
   }
 
   const sessionId = readStringClaim(payload, "sid")
-  if (sessionId && !(await hasActiveMcpSession(sessionId))) {
+  if (!sessionId) {
+    return new Response(JSON.stringify({ error: "mcp_session_required" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    })
+  }
+
+  if (!(await hasActiveMcpSession(sessionId))) {
     return new Response(JSON.stringify({ error: "mcp_session_revoked" }), {
       status: 403,
       headers: { "content-type": "application/json" },

--- a/ee/apps/den-api/test/mcp-membership-revocation.test.ts
+++ b/ee/apps/den-api/test/mcp-membership-revocation.test.ts
@@ -1,0 +1,78 @@
+import { beforeAll, expect, mock, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let selectedRows: Array<{ id: string }> = []
+let mcpAuth: typeof import("../src/mcp/auth.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+
+  mock.module("../src/auth.js", () => ({
+    auth: {
+      handler: () => Promise.resolve(new Response(JSON.stringify({ keys: [] }), { status: 200 })),
+    },
+    DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX: "ow_mcp_at_",
+    DEN_MCP_ORG_ID_CLAIM: "https://openworklabs.com/org_id",
+    DEN_MCP_RESOURCE: "http://127.0.0.1:8790/mcp",
+    DEN_MCP_RESOURCE_CLAIM: "https://openworklabs.com/resource",
+    DEN_MCP_RESOURCES: ["http://127.0.0.1:8790/mcp"],
+    DEN_MCP_TOKEN_USE_CLAIM: "https://openworklabs.com/token_use",
+  }))
+
+  mock.module("../src/db.js", () => ({
+    db: {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: () => Promise.resolve(selectedRows),
+          }),
+        }),
+      }),
+    },
+  }))
+
+  mcpAuth = await import("../src/mcp/auth.js")
+})
+
+test("MCP principals require an active organization membership", async () => {
+  const userId = createDenTypeId("user")
+  const organizationId = createDenTypeId("organization")
+
+  selectedRows = [{ id: createDenTypeId("member") }]
+  await expect(mcpAuth.hasActiveMcpMembership({
+    userId,
+    organizationId,
+  })).resolves.toBe(true)
+
+  selectedRows = []
+  await expect(mcpAuth.hasActiveMcpMembership({
+    userId,
+    organizationId,
+  })).resolves.toBe(false)
+})
+
+test("MCP membership check rejects malformed principals", async () => {
+  selectedRows = [{ id: "member_active" }]
+  await expect(mcpAuth.hasActiveMcpMembership({
+    userId: "not-a-user-id",
+    organizationId: createDenTypeId("organization"),
+  })).resolves.toBe(false)
+})
+
+test("MCP bearer tokens tied to deleted sessions are rejected", async () => {
+  const sessionId = createDenTypeId("session")
+
+  selectedRows = [{ id: sessionId }]
+  await expect(mcpAuth.hasActiveMcpSession(sessionId)).resolves.toBe(true)
+
+  selectedRows = []
+  await expect(mcpAuth.hasActiveMcpSession(sessionId)).resolves.toBe(false)
+  await expect(mcpAuth.hasActiveMcpSession("not-a-session-id")).resolves.toBe(false)
+})

--- a/ee/apps/den-api/test/mcp-membership-revocation.test.ts
+++ b/ee/apps/den-api/test/mcp-membership-revocation.test.ts
@@ -9,6 +9,7 @@ function seedRequiredEnv() {
 }
 
 let selectedRows: Array<{ id: string }> = []
+let jwtPayload: Record<string, unknown> = {}
 let mcpAuth: typeof import("../src/mcp/auth.js")
 
 beforeAll(async () => {
@@ -36,6 +37,10 @@ beforeAll(async () => {
         }),
       }),
     },
+  }))
+
+  mock.module("better-auth/oauth2", () => ({
+    verifyJwsAccessToken: () => Promise.resolve(jwtPayload),
   }))
 
   mcpAuth = await import("../src/mcp/auth.js")
@@ -75,4 +80,23 @@ test("MCP bearer tokens tied to deleted sessions are rejected", async () => {
   selectedRows = []
   await expect(mcpAuth.hasActiveMcpSession(sessionId)).resolves.toBe(false)
   await expect(mcpAuth.hasActiveMcpSession("not-a-session-id")).resolves.toBe(false)
+})
+
+test("MCP JWTs without session claims are rejected", async () => {
+  jwtPayload = {
+    sub: createDenTypeId("user"),
+    scope: "mcp:read mcp:write",
+    "https://openworklabs.com/token_use": "mcp",
+    "https://openworklabs.com/resource": "http://127.0.0.1:8790/mcp",
+    "https://openworklabs.com/org_id": createDenTypeId("organization"),
+  }
+
+  const response = await mcpAuth.verifyMcpRequest(new Headers({
+    authorization: "Bearer header.payload.signature",
+  }))
+
+  expect(response).toBeInstanceOf(Response)
+  if (response instanceof Response) {
+    await expect(response.json()).resolves.toEqual({ error: "mcp_session_required" })
+  }
 })


### PR DESCRIPTION
## Summary
- revoke org-scoped API keys, sessions, and OAuth tokens from Better Auth member removal/role hooks
- reject MCP tokens when the backing membership or session is no longer active
- add focused MCP revocation coverage

## Tests
- `bun test ee/apps/den-api/test/mcp-membership-revocation.test.ts` ✅
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json` ✅
- `bun test ee/apps/den-api/test/mcp-auth.test.ts` ✅
- `bun test ee/apps/den-api/test/session-lifetime.test.ts ee/apps/den-api/test/mcp-token-lifetime.test.ts ee/apps/den-api/test/api-keys.test.ts ee/apps/den-api/test/credential-revocation.test.ts ee/apps/den-api/test/org-member-guards.test.ts` ✅
- `bun test ee/apps/den-api/test/organization-role-credential-revocation.test.ts` ✅

## Evidence
No video/screenshot captured because this is a backend credential lifecycle change validated with focused tests and typecheck.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

