### PR TITLE
docs(cloud): clarify SSO JIT role default

### DIFF
--- a/packages/docs/cloud/members-and-rbac.mdx
+++ b/packages/docs/cloud/members-and-rbac.mdx
@@ -29,6 +29,12 @@ Only `Owner` can change member roles, remove members, or create, edit, and delet
 
 Invites are tied to the invited email address.
 
+## SSO just-in-time provisioning
+
+When SSO just-in-time provisioning adds someone to an organization on first sign-in, OpenWork assigns the baseline `Member` role. IdP attributes such as `role`, `groups`, or `admin` are not used to grant OpenWork organization roles.
+
+Treat `Admin`, `Owner`, and custom-role elevation as explicit access changes made inside OpenWork. Review those changes in the member list and audit trail instead of relying on unvalidated IdP attributes for authorization.
+
 ## Restrict who can join
 
 If you only want teammates from specific companies or domains to join:

--- a/packages/docs/cloud/security-and-operations.mdx
+++ b/packages/docs/cloud/security-and-operations.mdx
@@ -41,6 +41,8 @@ Use the Cloud member model as the source of truth for organization access:
 - Use custom roles only when the built-in roles are too broad.
 - Use teams for resource access to marketplaces and providers.
 
+SSO just-in-time provisioning uses `Member` as the safe default for first-login users. OpenWork does not convert IdP attributes such as `role`, `groups`, or `admin` into organization roles during SSO sign-in. Elevation to `Admin`, `Owner`, or a custom role should be an explicit, reviewed, and audited change in OpenWork.
+
 For access reviews, export the current member list, roles, teams, pending invitations, API keys, SSO configuration, and SCIM configuration on a regular cadence. Reconfirm that each member still needs their current role and team access.
 
 ## MFA and step-up controls


### PR DESCRIPTION
## Summary
- Document that SSO JIT provisioning assigns first-login users the baseline Member role
- Clarify that IdP role/group/admin attributes do not grant OpenWork org roles
- Reinforce that Admin/Owner/custom-role elevation is explicit and audited in OpenWork

## Tests
- pnpm exec bun test ee/apps/den-api/test/sso-jit.test.ts — 2 pass, 0 fail

## Evidence
- Docs-only change; no video or screenshot captured.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

