### PR TITLE
fix(den-api): harden SAML response validation

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -33,6 +33,7 @@
     "better-auth": "1.6.11",
     "better-call": "1.3.5",
     "dotenv": "^16.4.5",
+    "fast-xml-parser": "5.8.0",
     "hono": "^4.7.2",
     "hono-openapi": "^1.3.0",
     "jsonc-parser": "^3.2.1",

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -14,6 +14,7 @@ import { db } from "../../db.js"
 import { env } from "../../env.js"
 import { getInvalidMcpOAuthRedirectUris } from "../../mcp/oauth-client-policy.js"
 import { emptyResponse } from "../../openapi.js"
+import { samlResponsePolicyMiddleware } from "../../sso-saml-response-middleware.js"
 import type { AuthContextVariables } from "../../session.js"
 import { registerDesktopAuthRoutes } from "./desktop-handoff.js"
 import { registerScimAuthRoutes } from "./scim.js"
@@ -189,6 +190,8 @@ async function handleAuthRequest(request: Request) {
 
 export function registerAuthRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
   registerScimAuthRoutes(app)
+  app.use("/api/auth/sso/saml2/callback/*", samlResponsePolicyMiddleware)
+  app.use("/api/auth/sso/saml2/sp/acs/*", samlResponsePolicyMiddleware)
   app.get("/api/auth/.well-known/oauth-authorization-server", async (c) => rewriteMetadataOrigin(await oauthProviderAuthServerMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
   app.get("/api/auth/.well-known/openid-configuration", async (c) => rewriteMetadataOrigin(await oauthProviderOpenIdConfigMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
   app.get("/.well-known/oauth-authorization-server/api/auth", async (c) => rewriteMetadataOrigin(await oauthProviderAuthServerMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))

--- a/ee/apps/den-api/src/sso-saml-response-middleware.ts
+++ b/ee/apps/den-api/src/sso-saml-response-middleware.ts
@@ -81,7 +81,7 @@ function providerIdFromPath(pathname: string) {
 }
 
 async function readSamlResponse(request: Request) {
-  const contentType = request.headers.get("content-type") ?? ""
+  const contentType = request.headers.get("content-type")?.toLowerCase() ?? ""
   if (contentType.includes("application/json")) {
     const body: unknown = await request.clone().json().catch(() => null)
     if (!isRecord(body)) {

--- a/ee/apps/den-api/src/sso-saml-response-middleware.ts
+++ b/ee/apps/den-api/src/sso-saml-response-middleware.ts
@@ -1,0 +1,101 @@
+import { eq } from "@openwork-ee/den-db/drizzle"
+import { SsoProviderTable } from "@openwork-ee/den-db/schema"
+import type { MiddlewareHandler } from "hono"
+import { z } from "zod"
+import { db } from "./db.js"
+import { validateSamlResponsePolicy } from "./sso-saml-response-policy.js"
+
+const samlProviderConfigSchema = z.object({
+  audience: z.string().min(1),
+  callbackUrl: z.string().url(),
+})
+
+export const samlResponsePolicyMiddleware: MiddlewareHandler = async (c, next) => {
+  if (c.req.method !== "POST") {
+    await next()
+    return
+  }
+
+  const providerId = providerIdFromPath(new URL(c.req.url).pathname)
+  if (!providerId) {
+    await next()
+    return
+  }
+
+  const samlResponse = await readSamlResponse(c.req.raw)
+  if (!samlResponse) {
+    await next()
+    return
+  }
+
+  const rows = await db
+    .select({ samlConfig: SsoProviderTable.samlConfig })
+    .from(SsoProviderTable)
+    .where(eq(SsoProviderTable.providerId, providerId))
+    .limit(1)
+  const provider = rows[0]
+  if (!provider?.samlConfig) {
+    await next()
+    return
+  }
+
+  const config = parseProviderConfig(provider.samlConfig)
+  if (!config) {
+    return c.json({ error: "invalid_saml_configuration" }, 400)
+  }
+
+  const result = validateSamlResponsePolicy({
+    samlResponse,
+    expectedAudience: config.audience,
+    expectedRecipient: config.callbackUrl,
+    expectedDestination: config.callbackUrl,
+  })
+  if (!result.ok) {
+    return c.json({ error: result.code, message: result.message }, 400)
+  }
+
+  await next()
+}
+
+function parseProviderConfig(value: string) {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    const result = samlProviderConfigSchema.safeParse(parsed)
+    return result.success ? result.data : null
+  } catch {
+    return null
+  }
+}
+
+function providerIdFromPath(pathname: string) {
+  const segment = pathname.split("/").filter(Boolean).at(-1)
+  if (!segment) {
+    return null
+  }
+
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return null
+  }
+}
+
+async function readSamlResponse(request: Request) {
+  const contentType = request.headers.get("content-type") ?? ""
+  if (contentType.includes("application/json")) {
+    const body: unknown = await request.clone().json().catch(() => null)
+    if (!isRecord(body)) {
+      return null
+    }
+    const value = body.SAMLResponse
+    return typeof value === "string" && value.length > 0 ? value : null
+  }
+
+  const formData = await request.clone().formData().catch(() => null)
+  const value = formData?.get("SAMLResponse")
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/ee/apps/den-api/src/sso-saml-response-policy.ts
+++ b/ee/apps/den-api/src/sso-saml-response-policy.ts
@@ -1,0 +1,159 @@
+import { XMLParser } from "fast-xml-parser"
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  removeNSPrefix: true,
+  textNodeName: "#text",
+  trimValues: true,
+})
+
+export type SamlResponsePolicyInput = {
+  samlResponse: string
+  expectedAudience: string
+  expectedRecipient: string
+  expectedDestination: string
+}
+
+type SamlResponsePolicyFailure = { ok: false; code: string; message: string }
+
+export type SamlResponsePolicyResult = { ok: true } | SamlResponsePolicyFailure
+
+export function validateSamlResponsePolicy(input: SamlResponsePolicyInput): SamlResponsePolicyResult {
+  const parsed = parseSamlResponse(input.samlResponse)
+  if (!parsed.ok) {
+    return parsed
+  }
+
+  const response = firstRecordChild(parsed.document, "Response")
+  if (!response) {
+    return invalid("missing_response", "SAML response XML is missing a Response element.")
+  }
+
+  const destination = stringAttribute(response, "Destination")
+  if (!sameUrl(destination, input.expectedDestination)) {
+    return invalid("invalid_destination", "SAML response Destination does not match the configured ACS URL.")
+  }
+
+  const assertions = recordChildren(response, "Assertion")
+  if (assertions.length !== 1) {
+    return invalid("invalid_assertion_count", "SAML response must contain exactly one plaintext Assertion.")
+  }
+
+  const assertion = assertions[0]
+  const assertionId = stringAttribute(assertion, "ID")
+  if (!assertionId) {
+    return invalid("missing_assertion_id", "SAML assertion is missing an ID required for replay protection.")
+  }
+
+  const audiences = audienceValues(assertion)
+  if (!audiences.some((audience) => audience === input.expectedAudience)) {
+    return invalid("invalid_audience", "SAML assertion AudienceRestriction does not include the configured SP audience.")
+  }
+
+  const recipients = recipientValues(assertion)
+  if (recipients.length === 0) {
+    return invalid("missing_recipient", "SAML assertion is missing SubjectConfirmationData Recipient.")
+  }
+
+  if (!recipients.every((recipient) => sameUrl(recipient, input.expectedRecipient))) {
+    return invalid("invalid_recipient", "SAML assertion Recipient does not match the configured ACS URL.")
+  }
+
+  return { ok: true }
+}
+
+function parseSamlResponse(samlResponse: string): { ok: true; document: Record<string, unknown> } | { ok: false; code: string; message: string } {
+  const xml = Buffer.from(samlResponse.replace(/\s+/g, ""), "base64").toString("utf8")
+  if (!xml.includes("<")) {
+    return invalid("invalid_encoding", "SAMLResponse is not valid base64-encoded XML.")
+  }
+
+  try {
+    const parsed: unknown = parser.parse(xml)
+    if (!isRecord(parsed)) {
+      return invalid("invalid_xml", "SAMLResponse XML did not parse to an object.")
+    }
+    return { ok: true, document: parsed }
+  } catch {
+    return invalid("invalid_xml", "SAMLResponse XML could not be parsed.")
+  }
+}
+
+function audienceValues(assertion: Record<string, unknown>) {
+  return recordChildren(assertion, "Conditions")
+    .flatMap((conditions) => recordChildren(conditions, "AudienceRestriction"))
+    .flatMap((restriction) => valuesForKey(restriction, "Audience"))
+    .map(textValue)
+    .filter(isNonEmptyString)
+}
+
+function recipientValues(assertion: Record<string, unknown>) {
+  return recordChildren(assertion, "Subject")
+    .flatMap((subject) => recordChildren(subject, "SubjectConfirmation"))
+    .flatMap((confirmation) => recordChildren(confirmation, "SubjectConfirmationData"))
+    .map((data) => stringAttribute(data, "Recipient"))
+    .filter(isNonEmptyString)
+}
+
+function firstRecordChild(record: Record<string, unknown>, key: string) {
+  return recordChildren(record, key)[0] ?? null
+}
+
+function recordChildren(record: Record<string, unknown>, key: string) {
+  return valuesForKey(record, key).filter(isRecord)
+}
+
+function valuesForKey(record: Record<string, unknown>, key: string) {
+  const value = record[key]
+  if (Array.isArray(value)) {
+    return value
+  }
+  return value === undefined ? [] : [value]
+}
+
+function stringAttribute(record: Record<string, unknown>, name: string) {
+  const value = record[`@_${name}`]
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function textValue(value: unknown) {
+  if (typeof value === "string") {
+    return value
+  }
+  if (!isRecord(value)) {
+    return null
+  }
+  const text = value["#text"]
+  return typeof text === "string" && text.length > 0 ? text : null
+}
+
+function sameUrl(value: string | null, expected: string) {
+  const normalizedValue = normalizeUrl(value)
+  const normalizedExpected = normalizeUrl(expected)
+  return normalizedValue !== null && normalizedExpected !== null && normalizedValue === normalizedExpected
+}
+
+function normalizeUrl(value: string | null) {
+  if (!value) {
+    return null
+  }
+
+  try {
+    return new URL(value).href
+  } catch {
+    return null
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isNonEmptyString(value: string | null): value is string {
+  return typeof value === "string" && value.length > 0
+}
+
+function invalid(code: string, message: string): SamlResponsePolicyFailure {
+  return { ok: false, code, message }
+}

--- a/ee/apps/den-api/test/sso-saml-response-policy.test.ts
+++ b/ee/apps/den-api/test/sso-saml-response-policy.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test"
+import { validateSamlResponsePolicy } from "../src/sso-saml-response-policy.js"
+
+const expectedAudience = "https://openwork.example.com/saml/metadata"
+const expectedAcsUrl = "https://openwork.example.com/api/auth/sso/saml2/sp/acs/openwork-sso-org_123"
+
+describe("SAML response policy", () => {
+  test("accepts matching audience, destination, recipient, and assertion ID", () => {
+    expect(validateSamlResponsePolicy({
+      samlResponse: samlResponse(),
+      expectedAudience,
+      expectedRecipient: expectedAcsUrl,
+      expectedDestination: expectedAcsUrl,
+    })).toEqual({ ok: true })
+  })
+
+  test("rejects missing assertion IDs so replay protection can fail closed", () => {
+    const result = validateSamlResponsePolicy({
+      samlResponse: samlResponse({ assertionId: null }),
+      expectedAudience,
+      expectedRecipient: expectedAcsUrl,
+      expectedDestination: expectedAcsUrl,
+    })
+
+    expect(result).toMatchObject({ ok: false, code: "missing_assertion_id" })
+  })
+
+  test("rejects responses for another audience", () => {
+    const result = validateSamlResponsePolicy({
+      samlResponse: samlResponse({ audience: "https://other-sp.example.com/saml/metadata" }),
+      expectedAudience,
+      expectedRecipient: expectedAcsUrl,
+      expectedDestination: expectedAcsUrl,
+    })
+
+    expect(result).toMatchObject({ ok: false, code: "invalid_audience" })
+  })
+
+  test("rejects responses posted to another destination", () => {
+    const result = validateSamlResponsePolicy({
+      samlResponse: samlResponse({ destination: "https://evil.example.com/acs" }),
+      expectedAudience,
+      expectedRecipient: expectedAcsUrl,
+      expectedDestination: expectedAcsUrl,
+    })
+
+    expect(result).toMatchObject({ ok: false, code: "invalid_destination" })
+  })
+
+  test("rejects assertions with another recipient", () => {
+    const result = validateSamlResponsePolicy({
+      samlResponse: samlResponse({ recipient: "https://evil.example.com/acs" }),
+      expectedAudience,
+      expectedRecipient: expectedAcsUrl,
+      expectedDestination: expectedAcsUrl,
+    })
+
+    expect(result).toMatchObject({ ok: false, code: "invalid_recipient" })
+  })
+})
+
+function samlResponse(overrides: {
+  assertionId?: string | null
+  audience?: string
+  destination?: string
+  recipient?: string
+} = {}) {
+  const assertionId = overrides.assertionId === undefined ? "assertion-123" : overrides.assertionId
+  const assertionIdAttribute = assertionId ? `ID="${assertionId}"` : ""
+  const audience = overrides.audience ?? expectedAudience
+  const destination = overrides.destination ?? expectedAcsUrl
+  const recipient = overrides.recipient ?? expectedAcsUrl
+  const xml = `
+    <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="response-123" Version="2.0" IssueInstant="2026-06-15T00:00:00Z" Destination="${destination}">
+      <saml:Issuer>https://idp.example.com</saml:Issuer>
+      <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+      </samlp:Status>
+      <saml:Assertion ${assertionIdAttribute} Version="2.0" IssueInstant="2026-06-15T00:00:00Z">
+        <saml:Issuer>https://idp.example.com</saml:Issuer>
+        <saml:Subject>
+          <saml:NameID>user@example.com</saml:NameID>
+          <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml:SubjectConfirmationData Recipient="${recipient}" NotOnOrAfter="2026-06-15T00:05:00Z" />
+          </saml:SubjectConfirmation>
+        </saml:Subject>
+        <saml:Conditions NotBefore="2026-06-14T23:55:00Z" NotOnOrAfter="2026-06-15T00:05:00Z">
+          <saml:AudienceRestriction>
+            <saml:Audience>${audience}</saml:Audience>
+          </saml:AudienceRestriction>
+        </saml:Conditions>
+      </saml:Assertion>
+    </samlp:Response>
+  `
+
+  return Buffer.from(xml, "utf8").toString("base64")
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,6 +471,9 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
+      fast-xml-parser:
+        specifier: 5.8.0
+        version: 5.8.0
       hono:
         specifier: ^4.7.2
         version: 4.12.8


### PR DESCRIPTION
## Summary
- add pre-Better Auth SAML response policy checks for ACS callback routes
- enforce matching Response Destination, SubjectConfirmationData Recipient, and AudienceRestriction
- fail closed when assertions are missing IDs needed for replay protection
- add focused regression coverage for audience, destination, recipient, and assertion ID validation

## Tests
- bun test ee/apps/den-api/test/sso-saml-policy.test.ts ee/apps/den-api/test/sso-saml-response-policy.test.ts — passed (7 pass, 0 fail)
- DEN_API_LATEST_APP_VERSION=0.13.8 pnpm --filter @openwork-ee/den-api build — passed

## Evidence
- No video/screenshot captured; this is server-side SAML validation covered by focused tests and Den API build.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

