### PR TITLE
docs(cloud): document MCP OAuth hardening

### DIFF
--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -82,6 +82,23 @@ If your client expects the server map directly, use just the server entry:
 
 The token is scoped to the organization you select during OAuth. If you need to switch organizations, remove the stored MCP auth token in your client and run the auth flow again.
 
+## OAuth security controls
+
+OpenWork Cloud's MCP OAuth flow is hardened for public MCP clients:
+
+- PKCE is required for dynamically registered/public clients. Only the `S256`
+  code challenge method is supported.
+- Redirect URIs are restricted to loopback HTTP(S) callbacks, such as
+  `http://127.0.0.1:<port>/callback`, or private-use custom schemes. Public web
+  redirects and dangerous schemes such as `javascript:`, `file:`, and `data:`
+  are rejected.
+- MCP OAuth access tokens expire after 15 minutes.
+- MCP OAuth refresh tokens expire after 7 days, rotate on refresh, and are
+  revocable. Reusing a revoked refresh token invalidates the token family.
+- Access is rechecked against the user's active OpenWork Cloud session and
+  organization membership, so removing a member or revoking their session also
+  cuts off MCP access.
+
 ## What the server exposes
 
 The hosted MCP server exposes OpenWork Cloud API tools for normal product resources, including config objects, connectors, plugins, marketplaces, skills, workers, members, roles, teams, and LLM providers.


### PR DESCRIPTION
## Summary\n- document Cloud MCP OAuth security controls for PKCE, redirect URI restrictions, token TTLs, refresh token rotation/revocation, and session/membership revocation checks\n- clarifies that the reported MCP-02 hardening requirements are implemented for the hosted MCP OAuth flow\n\n## Validation\n- pnpm --filter @openwork-ee/den-api exec bun test test/mcp-auth.test.ts test/mcp-oauth-client-policy.test.ts test/mcp-token-lifetime.test.ts test/credential-revocation.test.ts — 9 pass, 0 fail\n\n## Notes\n- No video/screenshot captured; this is a docs-only clarification backed by targeted security tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

