### PR TITLE
fix(den): default MCP tokens to read scope

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -1850,7 +1850,7 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
         method: "POST",
         token,
         organizationId: orgId,
-        body: {},
+        body: { scopes: ["mcp:read", "mcp:write"] },
       });
       const minted = getMcpToken(payload);
       if (!minted) {

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -3,6 +3,10 @@ import { db } from "./db.js";
 import { env } from "./env.js";
 import { deriveDenMcpResource } from "./mcp/resource.js";
 import {
+  DEN_MCP_DEFAULT_CLIENT_SCOPES,
+  DEN_MCP_SCOPES,
+} from "./mcp/scopes.js";
+import {
   DEN_MCP_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
   DEN_MCP_REFRESH_TOKEN_EXPIRES_IN_SECONDS,
 } from "./mcp/token-lifetime.js";
@@ -82,11 +86,11 @@ export const DEN_MCP_RESOURCES = Array.from(new Set([
   `${env.betterAuthUrl}/mcp`,
   ...localMcpResourceAliases(DEN_MCP_RESOURCE),
 ]));
-export const DEN_MCP_SCOPES = ["openid", "profile", "email", "offline_access", "mcp:read", "mcp:write"];
 export const DEN_MCP_TOKEN_USE_CLAIM = "https://openworklabs.com/token_use";
 export const DEN_MCP_ORG_ID_CLAIM = "https://openworklabs.com/org_id";
 export const DEN_MCP_RESOURCE_CLAIM = "https://openworklabs.com/resource";
 export const DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX = "ow_mcp_at_";
+export { DEN_MCP_SCOPES } from "./mcp/scopes.js";
 
 const socialProviders = {
   ...(env.github.clientId && env.github.clientSecret
@@ -469,7 +473,7 @@ export const auth = betterAuth({
       accessTokenExpiresIn: DEN_MCP_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
       m2mAccessTokenExpiresIn: DEN_MCP_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
       refreshTokenExpiresIn: DEN_MCP_REFRESH_TOKEN_EXPIRES_IN_SECONDS,
-      clientRegistrationDefaultScopes: ["openid", "profile", "email", "mcp:read", "mcp:write"],
+      clientRegistrationDefaultScopes: [...DEN_MCP_DEFAULT_CLIENT_SCOPES],
       clientRegistrationAllowedScopes: [...DEN_MCP_SCOPES],
       advertisedMetadata: {
         scopes_supported: [...DEN_MCP_SCOPES],

--- a/ee/apps/den-api/src/mcp/scopes.ts
+++ b/ee/apps/den-api/src/mcp/scopes.ts
@@ -1,0 +1,35 @@
+export const DEN_MCP_READ_SCOPE = "mcp:read"
+export const DEN_MCP_WRITE_SCOPE = "mcp:write"
+
+export type DenMcpTokenScope = typeof DEN_MCP_READ_SCOPE | typeof DEN_MCP_WRITE_SCOPE
+
+export const DEN_MCP_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "offline_access",
+  DEN_MCP_READ_SCOPE,
+  DEN_MCP_WRITE_SCOPE,
+]
+
+export const DEN_MCP_DEFAULT_CLIENT_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  DEN_MCP_READ_SCOPE,
+]
+
+export const DEN_MCP_DEFAULT_TOKEN_SCOPES: readonly DenMcpTokenScope[] = [DEN_MCP_READ_SCOPE]
+
+export function resolveMcpTokenScopes(scopes: readonly DenMcpTokenScope[] | undefined) {
+  return [...(scopes ?? DEN_MCP_DEFAULT_TOKEN_SCOPES)]
+}
+
+export function normalizeMcpOAuthClientScope(scope: unknown) {
+  if (typeof scope !== "string") {
+    return null
+  }
+
+  const normalized = scope.split(/\s+/).filter(Boolean).join(" ")
+  return normalized || null
+}

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -1,5 +1,3 @@
-import { eq } from "@openwork-ee/den-db/drizzle"
-import { OAuthClientTable } from "@openwork-ee/den-db/schema"
 import { oauthProviderAuthServerMetadata, oauthProviderOpenIdConfigMetadata } from "@better-auth/oauth-provider"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
@@ -10,9 +8,9 @@ import {
   readEmailPasswordSignInAttempt,
   recordEmailPasswordSignInResult,
 } from "../../auth-protection.js"
-import { db } from "../../db.js"
 import { env } from "../../env.js"
 import { getInvalidMcpOAuthRedirectUris } from "../../mcp/oauth-client-policy.js"
+import { normalizeMcpOAuthClientScope } from "../../mcp/scopes.js"
 import { emptyResponse } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 import { registerDesktopAuthRoutes } from "./desktop-handoff.js"
@@ -69,12 +67,9 @@ async function rewriteMcpClientRegistrationRequest(request: Request, path: strin
     )
   }
 
-  const scope = typeof body.scope === "string" ? body.scope : ""
-  const scopes = new Set(scope.split(/\s+/).filter(Boolean))
-  if (scopes.has("mcp:read") || scopes.has("mcp:write")) {
-    scopes.add("mcp:read")
-    scopes.add("mcp:write")
-    body.scope = Array.from(scopes).join(" ")
+  const normalizedScope = normalizeMcpOAuthClientScope(body.scope)
+  if (normalizedScope) {
+    body.scope = normalizedScope
   }
 
   headers.set("content-type", "application/json")
@@ -114,58 +109,6 @@ function requestOrigin(request: Request) {
   return new URL(request.url).origin
 }
 
-function readStoredClientScopes(scopes: string | null) {
-  if (!scopes) {
-    return []
-  }
-
-  try {
-    const parsed = JSON.parse(scopes) as unknown
-    if (Array.isArray(parsed)) return parsed.filter((entry): entry is string => typeof entry === "string")
-  } catch {}
-
-  return scopes.split(/\s+/).filter(Boolean)
-}
-
-async function ensureMcpClientScopes(request: Request) {
-  const url = new URL(request.url)
-  const requestedScopes = new Set((url.searchParams.get("scope") ?? "").split(/\s+/).filter(Boolean))
-  if (!requestedScopes.has("mcp:read") && !requestedScopes.has("mcp:write")) {
-    return
-  }
-
-  const clientId = url.searchParams.get("client_id")
-  if (!clientId) {
-    return
-  }
-
-  const [client] = await db
-    .select({ scopes: OAuthClientTable.scopes })
-    .from(OAuthClientTable)
-    .where(eq(OAuthClientTable.clientId, clientId))
-    .limit(1)
-  if (!client) {
-    return
-  }
-
-  const scopes = new Set(readStoredClientScopes(client.scopes))
-  const hasMcpRead = scopes.has("mcp:read")
-  const hasMcpWrite = scopes.has("mcp:write")
-  if (!hasMcpRead && !hasMcpWrite) {
-    return
-  }
-  if (hasMcpRead && hasMcpWrite) {
-    return
-  }
-
-  scopes.add("mcp:read")
-  scopes.add("mcp:write")
-  await db
-    .update(OAuthClientTable)
-    .set({ scopes: JSON.stringify(Array.from(scopes)) })
-    .where(eq(OAuthClientTable.clientId, clientId))
-}
-
 async function handleAuthRequest(request: Request) {
   const emailPasswordAttempt = await readEmailPasswordSignInAttempt(request)
   if (emailPasswordAttempt) {
@@ -197,10 +140,7 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
   app.get("/.well-known/openid-configuration", async (c) => rewriteMetadataOrigin(await oauthProviderOpenIdConfigMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/openid-configuration")), requestOrigin(c.req.raw)))
   app.post("/register", async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
   app.post("/api/auth/oauth2/register", async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
-  app.get("/api/auth/oauth2/authorize", async (c) => {
-    await ensureMcpClientScopes(c.req.raw)
-    return auth.handler(c.req.raw)
-  })
+  app.get("/api/auth/oauth2/authorize", (c) => auth.handler(c.req.raw))
 
   app.on(
     ["GET", "POST", "PUT", "PATCH", "DELETE"],

--- a/ee/apps/den-api/src/routes/mcp/index.ts
+++ b/ee/apps/den-api/src/routes/mcp/index.ts
@@ -7,6 +7,7 @@ import { z } from "zod"
 import { DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX, DEN_MCP_RESOURCE } from "../../auth.js"
 import { db } from "../../db.js"
 import { hashOpaqueMcpSecret } from "../../mcp/auth.js"
+import { resolveMcpTokenScopes } from "../../mcp/scopes.js"
 import { DEN_FIRST_PARTY_MCP_TOKEN_TTL_MS } from "../../mcp/token-lifetime.js"
 import {
   jsonValidator,
@@ -87,7 +88,7 @@ export function registerMcpTokenRoutes<T extends { Variables: McpRouteVariables 
         }, 403)
       }
 
-      const scopes = input.scopes ?? ["mcp:read", "mcp:write"]
+      const scopes = resolveMcpTokenScopes(input.scopes)
       const secret = crypto.randomBytes(32).toString("base64url")
       const expiresAt = new Date(Date.now() + DEN_FIRST_PARTY_MCP_TOKEN_TTL_MS)
 

--- a/ee/apps/den-api/test/mcp-scopes.test.ts
+++ b/ee/apps/den-api/test/mcp-scopes.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import {
+  DEN_MCP_DEFAULT_CLIENT_SCOPES,
+  DEN_MCP_DEFAULT_TOKEN_SCOPES,
+  normalizeMcpOAuthClientScope,
+  resolveMcpTokenScopes,
+} from "../src/mcp/scopes.js"
+
+test("MCP OAuth client defaults are read-only", () => {
+  expect(DEN_MCP_DEFAULT_CLIENT_SCOPES).toEqual(["openid", "profile", "email", "mcp:read"])
+})
+
+test("first-party MCP token mint defaults to read-only", () => {
+  expect(DEN_MCP_DEFAULT_TOKEN_SCOPES).toEqual(["mcp:read"])
+  expect(resolveMcpTokenScopes(undefined)).toEqual(["mcp:read"])
+})
+
+test("explicit MCP token scopes are preserved", () => {
+  expect(resolveMcpTokenScopes(["mcp:write"])).toEqual(["mcp:write"])
+  expect(resolveMcpTokenScopes(["mcp:read", "mcp:write"])).toEqual(["mcp:read", "mcp:write"])
+})
+
+test("OAuth client registration scope normalization does not upgrade MCP scopes", () => {
+  expect(normalizeMcpOAuthClientScope("mcp:read")).toBe("mcp:read")
+  expect(normalizeMcpOAuthClientScope("mcp:write")).toBe("mcp:write")
+  expect(normalizeMcpOAuthClientScope(" openid   profile  mcp:read ")).toBe("openid profile mcp:read")
+  expect(normalizeMcpOAuthClientScope(undefined)).toBeNull()
+})


### PR DESCRIPTION
## Summary
- centralize Den MCP scope constants and defaults
- default dynamic MCP clients and first-party MCP token minting to read-only scope
- stop auto-upgrading MCP OAuth clients to both read/write scopes while preserving explicit desktop read/write requests
- add regression coverage for MCP scope defaults and no-upgrade behavior

## Validation
- `pnpm --filter @openwork-ee/den-api exec bun test test/mcp-scopes.test.ts test/mcp-auth.test.ts test/mcp-invoke-body.test.ts test/mcp-oauth-client-policy.test.ts test/mcp-token-lifetime.test.ts test/mcp-membership-revocation.test.ts` → 23 pass, 0 fail
- `pnpm --filter @openwork-ee/den-api build` → passed
- `pnpm --filter @openwork/app typecheck` → passed
- `pnpm dev:web-local` live validation after restoring local MySQL health:
  - protected-resource metadata advertises `mcp:read` and `mcp:write`
  - dynamic client registration defaults to `openid profile email mcp:read`
  - explicit `mcp:read` remains read-only; explicit `mcp:write` remains write-only
  - invalid public redirect URI is rejected
  - first-party MCP token mint defaults to `["mcp:read"]`
  - explicit desktop MCP token mint returns `["mcp:read", "mcp:write"]`
  - read-only MCP token can initialize MCP but write tool calls return `insufficient_mcp_scope`

## Note
Live third-party OAuth code exchange exposed a separate existing Better Auth MySQL adapter issue where the authorization code row is consumed but `/oauth2/token` returns `invalid_grant`. The scope behavior up through registration, consent/code issuance, and first-party MCP enforcement is validated in this PR; that token-exchange bug is separate from this least-privilege change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

