### PR TITLE
feat(composer): use a friendlier label for the built-in build agent

### DIFF
--- a/apps/app/src/i18n/locales/ca.ts
+++ b/apps/app/src/i18n/locales/ca.ts
@@ -75,6 +75,7 @@ export default {
   "common.something_went_wrong": "Hi ha hagut un problema",
   "common.submit": "Envia",
   "common.unknown": "Desconegut",
+  "composer.agent_general_purpose": "Agent de propòsit general",
   "composer.agent_label": "Agent",
   "composer.any_file_type_supported": "S'admet qualsevol tipus de fitxer.",
   "composer.attach_files": "Adjuntar fitxers",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -77,6 +77,7 @@ export default {
   "common.something_went_wrong": "Something went wrong",
   "common.submit": "Submit",
   "common.unknown": "Unknown",
+  "composer.agent_general_purpose": "General purpose agent",
   "composer.agent_label": "Agent",
   "composer.agent_selected": "Agent set to {agent}.",
   "composer.agent_selected_default": "Agent reset to default.",

--- a/apps/app/src/i18n/locales/es.ts
+++ b/apps/app/src/i18n/locales/es.ts
@@ -75,6 +75,7 @@ export default {
   "common.something_went_wrong": "Algo salió mal",
   "common.submit": "Enviar",
   "common.unknown": "Desconocido",
+  "composer.agent_general_purpose": "Agente de propósito general",
   "composer.agent_label": "Agente",
   "composer.any_file_type_supported": "Se admite cualquier tipo de archivo.",
   "composer.attach_files": "Adjuntar archivos",

--- a/apps/app/src/i18n/locales/fr.ts
+++ b/apps/app/src/i18n/locales/fr.ts
@@ -75,6 +75,7 @@ export default {
   "common.something_went_wrong": "Un problème est survenu",
   "common.submit": "Envoyer",
   "common.unknown": "Inconnu",
+  "composer.agent_general_purpose": "Agent polyvalent",
   "composer.agent_label": "Agent",
   "composer.any_file_type_supported": "Tous les types de fichiers sont pris en charge.",
   "composer.attach_files": "Joindre des fichiers",

--- a/apps/app/src/i18n/locales/ja.ts
+++ b/apps/app/src/i18n/locales/ja.ts
@@ -74,6 +74,7 @@ export default {
   "common.something_went_wrong": "エラーが発生しました",
   "common.submit": "送信",
   "common.unknown": "不明",
+  "composer.agent_general_purpose": "汎用エージェント",
   "composer.agent_label": "エージェント",
   "composer.any_file_type_supported": "すべてのファイル形式に対応しています。",
   "composer.attach_files": "ファイルを添付",

--- a/apps/app/src/i18n/locales/pt-BR.ts
+++ b/apps/app/src/i18n/locales/pt-BR.ts
@@ -75,6 +75,7 @@ export default {
   "common.something_went_wrong": "Algo deu errado",
   "common.submit": "Enviar",
   "common.unknown": "Desconhecido",
+  "composer.agent_general_purpose": "Agente de uso geral",
   "composer.agent_label": "Agente",
   "composer.any_file_type_supported": "Qualquer tipo de arquivo é aceito.",
   "composer.attach_files": "Anexar arquivos",

--- a/apps/app/src/i18n/locales/ru.ts
+++ b/apps/app/src/i18n/locales/ru.ts
@@ -76,6 +76,7 @@ export default {
   "common.something_went_wrong": "Что-то пошло не так",
   "common.submit": "Отправить",
   "common.unknown": "Неизвестно",
+  "composer.agent_general_purpose": "Универсальный агент",
   "composer.agent_label": "Агент",
   "composer.any_file_type_supported": "Поддерживаются файлы любого типа.",
   "composer.attach_files": "Прикрепить файлы",

--- a/apps/app/src/i18n/locales/th.ts
+++ b/apps/app/src/i18n/locales/th.ts
@@ -75,6 +75,7 @@ export default {
   "common.something_went_wrong": "เกิดข้อผิดพลาด",
   "common.submit": "ส่ง",
   "common.unknown": "ไม่ทราบ",
+  "composer.agent_general_purpose": "Agent อเนกประสงค์",
   "composer.agent_label": "Agent",
   "composer.any_file_type_supported": "รองรับไฟล์ทุกประเภท",
   "composer.attach_files": "แนบไฟล์",

--- a/apps/app/src/i18n/locales/vi.ts
+++ b/apps/app/src/i18n/locales/vi.ts
@@ -75,6 +75,7 @@ export default {
   "common.something_went_wrong": "Đã xảy ra lỗi",
   "common.submit": "Gửi",
   "common.unknown": "Không rõ",
+  "composer.agent_general_purpose": "Agent đa năng",
   "composer.agent_label": "Agent",
   "composer.any_file_type_supported": "Hỗ trợ mọi loại tệp.",
   "composer.attach_files": "Đính kèm tệp",

--- a/apps/app/src/i18n/locales/zh.ts
+++ b/apps/app/src/i18n/locales/zh.ts
@@ -78,6 +78,7 @@ export default {
   "common.something_went_wrong": "出了点问题",
   "common.submit": "提交",
   "common.unknown": "未知",
+  "composer.agent_general_purpose": "通用智能体",
   "composer.agent_label": "智能体",
   "composer.any_file_type_supported": "支持任何文件类型。",
   "composer.attach_files": "附加文件",

--- a/apps/app/src/react-app/domains/session/surface/composer/agent-label.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/agent-label.ts
@@ -1,0 +1,17 @@
+import { t } from "@/i18n";
+
+/**
+ * OpenCode ships built-in agents whose raw names (e.g. "build") read as
+ * developer jargon in the composer. Map the known ones to friendly,
+ * self-explanatory labels so non-technical users can pick them without needing
+ * agent vocabulary. Custom agents keep their capitalized name.
+ */
+const FRIENDLY_AGENT_LABEL_KEYS: Record<string, string> = {
+  build: "composer.agent_general_purpose",
+};
+
+export function formatComposerAgentLabel(name: string): string {
+  const friendlyKey = FRIENDLY_AGENT_LABEL_KEYS[name];
+  if (friendlyKey) return t(friendlyKey);
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -10,6 +10,7 @@ import type { CloudImportedPlugin, CloudImportedPluginFile } from "@/app/cloud/i
 import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
 import { formatBytes, isMacPlatform } from "@/app/utils";
 import { t } from "@/i18n";
+import { formatComposerAgentLabel } from "./agent-label";
 import { isOpenWorkExtensionEnabled, isOpenWorkExtensionHidden, OPENWORK_EXTENSION_STATE_CHANGED } from "@/react-app/domains/settings/extension-state";
 import { useDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
 import { ModelBehaviorSelect } from "@/components/model-behavior-select";
@@ -1392,7 +1393,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                                   >
                                     <Zap size={14} className="mt-0.5 shrink-0 text-gray-9" />
                                     <div className="min-w-0 flex-1">
-                                      <div className="truncate text-xs font-semibold">{agent.name.charAt(0).toUpperCase() + agent.name.slice(1)}</div>
+                                      <div className="truncate text-xs font-semibold">{formatComposerAgentLabel(agent.name)}</div>
                                       {agent.description ? <div className="truncate text-xs text-gray-10">{agent.description}</div> : null}
                                     </div>
                                     {active ? <Check size={14} className="mt-0.5 shrink-0 text-gray-10" /> : null}
@@ -1595,7 +1596,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                                 applyAgentSelection(agent.name);
                               }}
                             >
-                              <span className="truncate">{agent.name.charAt(0).toUpperCase() + agent.name.slice(1)}</span>
+                              <span className="truncate">{formatComposerAgentLabel(agent.name)}</span>
                               {active ? <Check size={14} className="text-gray-10" /> : null}
                             </button>
                           );

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -102,6 +102,7 @@ import {
 import { firstLineLocalFileParts } from "@/react-app/domains/session/sync/prompt-file-parts";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
+import { formatComposerAgentLabel } from "@/react-app/domains/session/surface/composer/agent-label";
 import { useModelPicker } from "@/react-app/domains/session/modals/use-model-picker";
 import { appMentionInstruction } from "@/react-app/domains/session/surface/composer/app-mentions";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
@@ -855,7 +856,7 @@ export function SessionRoute() {
       onModelVariantChange: (value: string | null) => {
         local.setPrefs((previous) => ({ ...previous, modelVariant: value }));
       },
-      agentLabel: selectedAgent ? selectedAgent.charAt(0).toUpperCase() + selectedAgent.slice(1) : t("session.default_agent"),
+      agentLabel: selectedAgent ? formatComposerAgentLabel(selectedAgent) : t("session.default_agent"),
       selectedAgent,
       listAgents,
       onSelectAgent: (agent: string | null) => setSelectedAgent(agent),

--- a/apps/app/tests/agent-label.test.ts
+++ b/apps/app/tests/agent-label.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatComposerAgentLabel } from "../src/react-app/domains/session/surface/composer/agent-label";
+
+describe("formatComposerAgentLabel", () => {
+  test("relabels the built-in build agent to a friendly name", () => {
+    expect(formatComposerAgentLabel("build")).toBe("General purpose agent");
+  });
+
+  test("capitalizes custom / non-mapped agent names", () => {
+    expect(formatComposerAgentLabel("plan")).toBe("Plan");
+    expect(formatComposerAgentLabel("reviewer")).toBe("Reviewer");
+  });
+});


### PR DESCRIPTION
## Problem

Closes #1065.

The composer agent picker rendered each agent's **raw name**, so OpenCode's built-in `build` agent showed up as **"Build"** in the picker and in the selected-agent pill. As called out in the issue, that's developer jargon — a non-technical user can't tell that "Build" is the general-purpose option.

## Change

- Add `formatComposerAgentLabel(name)` (`.../composer/agent-label.ts`): maps known built-in agents to friendly, **translatable** labels and falls back to the existing capitalized name for every other (custom) agent. Today the only mapping is `build → "General purpose agent"`, matching the issue's explicit direction.
- Add the `composer.agent_general_purpose` key to `en.ts`. Other locales resolve it through the existing locale → English fallback, so no other locale files need to change.
- Wire the helper into both agent-picker menus (`composer.tsx`) and the selected-agent pill (`session-route.tsx`), replacing the inline `name.charAt(0).toUpperCase() + name.slice(1)`.

The `@`-mention list is intentionally left alone — its label doubles as the value the engine matches on, so it must stay the raw agent name.

## Scope

Minimal and behavior-preserving for every agent except `build`: custom agents and `plan` still render exactly as before.

## Testing

- `bun test tests/agent-label.test.ts` — added unit test for the helper (built-in relabel + capitalization fallback). **2 pass.**
- I did **not** run the full `pnpm typecheck`/build or capture a UI video: this is a fresh clone without the monorepo `node_modules` installed, and a full install was avoided as too heavy for a one-line-helper change. The edits are type-preserving (`string → string`) substitutions.

### Reviewer repro (UI)
1. Connect any provider and open a session.
2. Open the agent picker in the composer.
3. The `build` entry now reads **"General purpose agent"** instead of "Build"; selecting it shows the same friendly label in the agent pill. Other agents are unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

