### PR TITLE
feat(app): add in-chat search with match navigation

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,7 +2,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { Columns2, FileText, Globe, Mic2, Settings2, X, Zap } from "lucide-react";
+import { Columns2, FileText, Globe, Mic2, SearchIcon, Settings2, X, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { OPENWORK_EXTENSION_CATALOG } from "../../../../app/constants";
@@ -317,6 +317,7 @@ export function SessionPage(props: SessionPageProps) {
   const [sessionActionId, setSessionActionId] = useState<string | null>(null);
   const [sessionTabs, setSessionTabs] = useState<OpenSessionTab[]>([]);
   const [splitSessionId, setSplitSessionId] = useState<string | null>(null);
+  const [chatSearchOpen, setChatSearchOpen] = useState(false);
   const [createGroupOpen, setCreateGroupOpen] = useState(false);
   const [createGroupLabel, setCreateGroupLabel] = useState("");
   const [createGroupWorkspaceId, setCreateGroupWorkspaceId] = useState<string | null>(null);
@@ -667,6 +668,10 @@ export function SessionPage(props: SessionPageProps) {
   );
   const canRenderSplitSurface = Boolean(canRenderReactSurface && splitSessionId && splitSessionId !== props.selectedSessionId);
 
+  useEffect(() => {
+    setChatSearchOpen(false);
+  }, [props.selectedSessionId]);
+
   const openSessionTab = useCallback((workspaceId: string, sessionId: string) => {
     setSessionTabs((current) => {
       const next = current.filter((tab) => tab.workspaceId === workspaceId);
@@ -825,7 +830,17 @@ export function SessionPage(props: SessionPageProps) {
             </div>
 
             <div className="flex items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
-              {/* Revert/redo moved to per-message actions */}
+              {canRenderReactSurface ? (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => setChatSearchOpen(true)}
+                  title="Search this chat (⌘F)"
+                  aria-label="Search this chat"
+                >
+                  <SearchIcon />
+                </Button>
+              ) : null}
               <NotificationBell />
               {props.developerMode ? (
                 <Button
@@ -966,6 +981,9 @@ export function SessionPage(props: SessionPageProps) {
                         respondQuestion={props.respondQuestion}
                         safeStringify={props.safeStringify}
                         onOpenTarget={openTarget}
+                        chatSearchOpen={chatSearchOpen}
+                        onChatSearchOpenChange={setChatSearchOpen}
+                        enableChatSearchShortcuts
                       />
                     </div>
                     {canRenderSplitSurface ? (
@@ -979,6 +997,7 @@ export function SessionPage(props: SessionPageProps) {
                           openworkToken={reactSessionToken}
                           todos={[]}
                           onOpenTarget={openTarget}
+                          enableChatSearchShortcuts={false}
                         />
                       </div>
                     ) : null}

--- a/apps/app/src/react-app/domains/session/search/session-chat-search-bar.tsx
+++ b/apps/app/src/react-app/domains/session/search/session-chat-search-bar.tsx
@@ -1,0 +1,74 @@
+/** @jsxImportSource react */
+import { ChevronDownIcon, ChevronUpIcon, SearchIcon, XIcon } from "lucide-react";
+
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+
+export type SessionChatSearchBarProps = {
+  query: string;
+  onQueryChange: (value: string) => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  statusLabel: string;
+  canNavigate: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  onClose: () => void;
+};
+
+export function SessionChatSearchBar(props: SessionChatSearchBarProps) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b border-border bg-background/95 px-3 py-1.5 mac:backdrop-blur-xl">
+      <InputGroup className="h-8 flex-1">
+        <InputGroupAddon align="inline-start" className="ps-2.5">
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput
+          ref={props.inputRef}
+          value={props.query}
+          onChange={(event) => props.onQueryChange(event.target.value)}
+          placeholder="Search this chat…"
+          aria-label="Search this chat"
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <InputGroupAddon align="inline-end" className="pe-1.5">
+          {props.statusLabel ? (
+            <span className="px-1 text-xs tabular-nums text-muted-foreground">
+              {props.statusLabel}
+            </span>
+          ) : null}
+          <InputGroupButton
+            size="icon-xs"
+            onClick={props.onPrev}
+            disabled={!props.canNavigate}
+            aria-label="Previous match"
+            title="Previous match"
+          >
+            <ChevronUpIcon />
+          </InputGroupButton>
+          <InputGroupButton
+            size="icon-xs"
+            onClick={props.onNext}
+            disabled={!props.canNavigate}
+            aria-label="Next match"
+            title="Next match"
+          >
+            <ChevronDownIcon />
+          </InputGroupButton>
+          <InputGroupButton
+            size="icon-xs"
+            onClick={props.onClose}
+            aria-label="Close search"
+            title="Close"
+          >
+            <XIcon />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/session/search/session-chat-search.ts
+++ b/apps/app/src/react-app/domains/session/search/session-chat-search.ts
@@ -1,0 +1,30 @@
+import type { UIMessage } from "ai";
+
+function messageSearchText(message: UIMessage): string {
+  return message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
+
+export function countChatSearchMatches(messages: UIMessage[], query: string): number {
+  const needle = query.trim().toLowerCase();
+  if (!needle) {
+    return 0;
+  }
+
+  let count = 0;
+  for (const message of messages) {
+    const text = messageSearchText(message).toLowerCase();
+    let start = 0;
+    while (true) {
+      const index = text.indexOf(needle, start);
+      if (index < 0) {
+        break;
+      }
+      count += 1;
+      start = index + needle.length;
+    }
+  }
+  return count;
+}

--- a/apps/app/src/react-app/domains/session/search/use-session-chat-search.ts
+++ b/apps/app/src/react-app/domains/session/search/use-session-chat-search.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { UIMessage } from "ai";
+
+import {
+  applyTextHighlights,
+  clearTextHighlights,
+  scrollActiveMatchIntoView,
+} from "@/react-app/domains/session/surface/text-highlights";
+import { countChatSearchMatches } from "./session-chat-search";
+
+const DEBOUNCE_MS = 200;
+
+function useDebouncedValue(value: string, delayMs: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    if (!value) {
+      setDebounced("");
+      return;
+    }
+    const timer = window.setTimeout(() => setDebounced(value), delayMs);
+    return () => window.clearTimeout(timer);
+  }, [value, delayMs]);
+  return debounced;
+}
+
+export type UseSessionChatSearchInput = {
+  messages: UIMessage[];
+  contentRef: React.RefObject<HTMLDivElement | null>;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  enableShortcuts?: boolean;
+};
+
+export function useSessionChatSearch(input: UseSessionChatSearchInput) {
+  const { messages, contentRef, open, onOpenChange, enableShortcuts = true } = input;
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debouncedQuery = useDebouncedValue(query.trim(), DEBOUNCE_MS);
+
+  const matchCount = useMemo(
+    () => countChatSearchMatches(messages, debouncedQuery),
+    [messages, debouncedQuery],
+  );
+
+  const safeActiveIndex = matchCount > 0 ? activeIndex % matchCount : 0;
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [debouncedQuery]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setActiveIndex(0);
+      const root = contentRef.current;
+      if (root) {
+        clearTextHighlights(root);
+      }
+      return;
+    }
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [open, contentRef]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const root = contentRef.current;
+    if (!root) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      applyTextHighlights(root, debouncedQuery, safeActiveIndex);
+      scrollActiveMatchIntoView(root);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [open, debouncedQuery, safeActiveIndex, messages, contentRef]);
+
+  const goNext = useCallback(() => {
+    if (matchCount === 0) {
+      return;
+    }
+    setActiveIndex((current) => (current + 1) % matchCount);
+  }, [matchCount]);
+
+  const goPrev = useCallback(() => {
+    if (matchCount === 0) {
+      return;
+    }
+    setActiveIndex((current) => (current - 1 + matchCount) % matchCount);
+  }, [matchCount]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onOpenChange(false);
+        return;
+      }
+      if (event.key === "Enter") {
+        event.preventDefault();
+        if (event.shiftKey) {
+          goPrev();
+        } else {
+          goNext();
+        }
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onOpenChange, goNext, goPrev]);
+
+  useEffect(() => {
+    if (!enableShortcuts) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isMac = /Mac/i.test(navigator.platform);
+      const mod = isMac ? event.metaKey : event.ctrlKey;
+      if (!mod || event.shiftKey || event.altKey || event.key?.toLowerCase() !== "f") {
+        return;
+      }
+      event.preventDefault();
+      onOpenChange(true);
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [enableShortcuts, onOpenChange]);
+
+  const statusLabel = !query.trim()
+    ? ""
+    : matchCount > 0
+      ? `${safeActiveIndex + 1} of ${matchCount}`
+      : "No matches";
+
+  return {
+    query,
+    setQuery,
+    inputRef,
+    matchCount,
+    statusLabel,
+    goNext,
+    goPrev,
+    close: () => onOpenChange(false),
+  };
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -73,6 +73,8 @@ import { MessageList } from "@/components/chat/message-list";
 import { MessageListProvider, type DispatchAction } from "@/components/chat/message-list-provider";
 import { OpenTargetProvider } from "@/lib/target-provider";
 import type { ThreadStatus } from "@/lib/messages";
+import { SessionChatSearchBar } from "@/react-app/domains/session/search/session-chat-search-bar";
+import { useSessionChatSearch } from "@/react-app/domains/session/search/use-session-chat-search";
 
 const EMPTY_TRANSCRIPT: UIMessage[] = [];
 const IDLE_STATUS: SessionStatus = { type: "idle" };
@@ -134,6 +136,9 @@ export type SessionSurfaceProps = {
   onRevertToMessage?: (messageId: string, sessionId: string) => Promise<boolean>;
   onForkAtMessage?: (messageId: string | null, sessionId: string) => void;
   onOpenTarget?: (target: OpenTarget, options?: { auto?: boolean }, sessionId?: string) => void;
+  chatSearchOpen?: boolean;
+  onChatSearchOpenChange?: (open: boolean) => void;
+  enableChatSearchShortcuts?: boolean;
 };
 
 function messageToReadableText(message: UIMessage) {
@@ -1093,6 +1098,16 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const [internalChatSearchOpen, setInternalChatSearchOpen] = useState(false);
+  const chatSearchOpen = props.chatSearchOpen ?? internalChatSearchOpen;
+  const setChatSearchOpen = props.onChatSearchOpenChange ?? setInternalChatSearchOpen;
+  const chatSearch = useSessionChatSearch({
+    messages: renderedMessages,
+    contentRef,
+    open: chatSearchOpen,
+    onOpenChange: setChatSearchOpen,
+    enableShortcuts: props.enableChatSearchShortcuts ?? true,
+  });
   const sessionScroll = useSessionScrollController({
     selectedSessionId: props.sessionId,
     renderedMessages,
@@ -1206,6 +1221,18 @@ export function SessionSurface(props: SessionSurfaceProps) {
   return (
     <DevProfiler id="SessionSurface">
     <div className="flex h-full min-h-0 flex-col">
+      {chatSearchOpen ? (
+        <SessionChatSearchBar
+          query={chatSearch.query}
+          onQueryChange={chatSearch.setQuery}
+          inputRef={chatSearch.inputRef}
+          statusLabel={chatSearch.statusLabel}
+          canNavigate={chatSearch.matchCount > 0}
+          onPrev={chatSearch.goPrev}
+          onNext={chatSearch.goNext}
+          onClose={chatSearch.close}
+        />
+      ) : null}
       {model.transitionState === "switching" && showDelayedLoading ? (
         <div className="flex justify-center px-6 pt-4">
           <div className="rounded-full border border-dls-border bg-dls-hover/80 px-3 py-1 text-xs text-dls-secondary">

--- a/apps/app/src/react-app/domains/session/surface/text-highlights.ts
+++ b/apps/app/src/react-app/domains/session/surface/text-highlights.ts
@@ -1,4 +1,5 @@
 const SEARCH_HIGHLIGHT_MARK_ATTR = "data-search-highlight";
+const SEARCH_HIGHLIGHT_ACTIVE_ATTR = "data-search-active";
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 export function clearTextHighlights(root: HTMLElement) {
@@ -11,7 +12,13 @@ export function clearTextHighlights(root: HTMLElement) {
   root.normalize();
 }
 
-export function applyTextHighlights(root: HTMLElement, query: string) {
+export function scrollActiveMatchIntoView(root: HTMLElement) {
+  const active = root.querySelector(`mark[${SEARCH_HIGHLIGHT_ACTIVE_ATTR}="true"]`);
+  const target = active ?? root.querySelector(`mark[${SEARCH_HIGHLIGHT_MARK_ATTR}="true"]`);
+  target?.scrollIntoView({ block: "center", behavior: "smooth" });
+}
+
+export function applyTextHighlights(root: HTMLElement, query: string, activeIndex = 0) {
   const needle = query.trim().toLowerCase();
   // Fast path: if search is inactive, avoid walking large message DOM trees.
   // We only need to clear existing marks if a previous search actually added
@@ -47,6 +54,8 @@ export function applyTextHighlights(root: HTMLElement, query: string) {
     current = walker.nextNode();
   }
 
+  let matchCounter = 0;
+
   nodes.forEach((node) => {
     const text = node.nodeValue ?? "";
     const lower = text.toLowerCase();
@@ -62,7 +71,13 @@ export function applyTextHighlights(root: HTMLElement, query: string) {
 
       const mark = document.createElement("mark");
       mark.setAttribute(SEARCH_HIGHLIGHT_MARK_ATTR, "true");
-      mark.className = "rounded px-0.5 bg-amber-4/70 text-current";
+      if (matchCounter === activeIndex) {
+        mark.setAttribute(SEARCH_HIGHLIGHT_ACTIVE_ATTR, "true");
+        mark.className = "rounded px-0.5 bg-primary/35 ring-1 ring-primary/50 text-current";
+      } else {
+        mark.className = "rounded px-0.5 bg-amber-4/70 text-current";
+      }
+      matchCounter += 1;
       mark.textContent = text.slice(matchIndex, matchIndex + needle.length);
       fragment.appendChild(mark);
       searchIndex = matchIndex + needle.length;

--- a/apps/app/tests/session-chat-search.test.ts
+++ b/apps/app/tests/session-chat-search.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+
+import { countChatSearchMatches } from "../src/react-app/domains/session/search/session-chat-search";
+
+function textMessage(id: string, text: string): UIMessage {
+  return {
+    id,
+    role: "user",
+    parts: [{ type: "text", text }],
+  };
+}
+
+describe("countChatSearchMatches", () => {
+  test("counts every occurrence across messages", () => {
+    const messages = [
+      textMessage("a", "hello world"),
+      textMessage("b", "hello again hello"),
+    ];
+
+    expect(countChatSearchMatches(messages, "hello")).toBe(3);
+  });
+
+  test("is case-insensitive", () => {
+    expect(countChatSearchMatches([textMessage("a", "Hello HELLO")], "hello")).toBe(2);
+  });
+
+  test("returns zero for empty query", () => {
+    expect(countChatSearchMatches([textMessage("a", "hello")], "   ")).toBe(0);
+  });
+});


### PR DESCRIPTION
#### Summary
- Add in-chat search for the current session with a header search button and find bar
- Highlight matches and move between them with prev/next controls

#### Why
- Chat search was hard to find (Cmd+Shift+F only) and felt global, not session-scoped

#### Issue
Closes #2230

#### Scope
- Current-chat search UI, Cmd/Ctrl+F, match highlighting, next/previous navigation, debounced search

#### Out of scope
- Changes to global session search (Cmd/Ctrl+Shift+F)

#### Testing
- Ran
pnpm typecheck in apps/app
- Result
pass/fail: pass
if fail, exact files/errors: N/A

#### CI status
- pass: not run here
- code-related failures: none known
- external/env/auth blockers: bun not available locally for unit tests

#### Manual verification
- Open a chat and click the search icon in the header
- Type a term and confirm matches are highlighted
- Use ↑↓ or Enter to move between matches; Escape to close
