### PR TITLE
docs: clarify Slack MCP scopes

### DIFF
--- a/packages/docs/start-here/connect-your-stack/connect-slack-mcp.mdx
+++ b/packages/docs/start-here/connect-your-stack/connect-slack-mcp.mdx
@@ -12,10 +12,53 @@ You do not need the old Slack bot tokens (`xoxb-...` or `xapp-...`) for this flo
 You need:
 
 - A Slack workspace where you can install or request approval for Slack apps.
-- A Slack OAuth client ID and client secret for the Slack MCP app.
+- A Slack app that is published in the Slack Marketplace or marked as an internal app.
+- A Slack OAuth client ID and client secret from that app.
 - The Slack MCP server URL: `https://mcp.slack.com/mcp`.
 
 Keep the client secret out of chats and source control. Treat it like any other workspace secret.
+
+## Create or approve the Slack app
+
+In Slack, an admin should create or approve an app for OpenWork's MCP access.
+
+1. Open [Slack API apps](https://api.slack.com/apps) and create a new app, or open the existing internal app you want to use.
+2. Go to `OAuth & Permissions`.
+3. Add this redirect URL: `http://127.0.0.1:19876/mcp/oauth/callback`.
+4. Add the `User Token Scopes` for the Slack MCP tools your team wants OpenWork to use.
+5. Save the app and install or approve it for the workspace.
+6. Go to `Basic Information` > `App Credentials` and copy the `Client ID` and `Client Secret`.
+
+Slack MCP uses user token scopes. Choose the smallest set that matches what your team wants agents to do.
+
+For a useful read-first setup, start with:
+
+```text
+search:read.public search:read.private search:read.mpim search:read.im search:read.files search:read.users channels:history groups:history mpim:history im:history users:read users:read.email channels:read groups:read mpim:read
+```
+
+Add write scopes only if you want agents to take action in Slack:
+
+```text
+chat:write reactions:write channels:write groups:write im:write mpim:write canvases:read canvases:write
+```
+
+Use this table to pick scopes by capability:
+
+| Slack MCP capability | User token scopes |
+| --- | --- |
+| Search public and private messages/channels | `search:read.public`, `search:read.private`, `search:read.mpim`, `search:read.im` |
+| Search files | `search:read.files` |
+| Read files | `files:read` |
+| Search emoji | `emoji:read` |
+| Search users | `search:read.users` |
+| Send messages | `chat:write` |
+| Read channels and threads | `channels:history`, `groups:history`, `mpim:history`, `im:history` |
+| Create conversations/channels | `channels:write`, `groups:write`, `im:write`, `mpim:write` |
+| Add reactions | `reactions:write` |
+| Read and write canvases | `canvases:read`, `canvases:write` |
+| Read user profiles and email | `users:read`, `users:read.email` |
+| List channel members | `channels:read`, `groups:read`, `mpim:read` |
 
 ## Open Extensions
 
@@ -35,7 +78,7 @@ In the Add Custom App dialog:
 4. Open `Advanced OAuth`.
 5. Paste the Slack OAuth client ID.
 6. Paste the Slack OAuth client secret.
-7. Add scopes only if your Slack admin gave you explicit scopes to use.
+7. Paste the same user token scopes you added in Slack, separated by spaces.
 8. Click `Add App`.
 
 <Frame>
@@ -60,16 +103,20 @@ OpenWork writes the MCP entry with the OAuth client credentials, similar to this
 }
 ```
 
-If you entered scopes, OpenWork also saves them as `oauth.scope`.
+If you entered scopes, OpenWork also saves them as `oauth.scope`. This is the scope list Slack sees during OAuth consent.
 
 ## Sign in to Slack
 
 After the MCP app is added, reload the engine if OpenWork asks you to. Then start Slack MCP sign-in from the Slack app card or the MCP auth prompt.
 
-Slack opens in your browser. Approve the Slack app for the workspace you want OpenWork to use, then return to OpenWork when authorization finishes.
+Slack opens in your browser and shows the scopes you configured. Approve the Slack app for the workspace you want OpenWork to use, then return to OpenWork when authorization finishes.
 
 ## Troubleshooting
 
 If you see an error like `Incompatible auth server: does not support dynamic client registration`, the Slack MCP entry is missing a pre-registered OAuth client ID and client secret. Reopen the Slack MCP setup, add those values under `Advanced OAuth`, reload the engine, and try sign-in again.
+
+If Slack says the redirect URL is invalid, add `http://127.0.0.1:19876/mcp/oauth/callback` to the Slack app's `OAuth & Permissions` redirect URLs.
+
+If Slack says a scope is invalid or unavailable, remove that scope from both the Slack app and OpenWork's `OAuth scopes` field, then retry. Slack workspace policies and plan settings can limit which scopes an app may request.
 
 If your Slack workspace blocks app installation, ask a Slack admin to approve the app first. OpenWork cannot bypass Slack workspace approval policies.


### PR DESCRIPTION
## Summary
- explain that Slack MCP uses user token scopes selected by capability
- add Slack app setup steps, including the OpenWork MCP callback redirect URL
- add recommended read-first scopes, optional write scopes, and a capability-to-scope table
- add troubleshooting for invalid redirect URLs and unavailable scopes

## Validation
- git diff --check: passed

## Notes
This is a follow-up to #2272 after reviewing the Slack MCP tutorial text for missing scope guidance.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

