### PR TITLE
docs(auth): document login protections

### DIFF
--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -168,7 +168,7 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
       responses: {
         200: emptyResponse("Better Auth handled the request successfully."),
         302: emptyResponse("Better Auth redirected the user to continue the auth flow."),
-        400: emptyResponse("Better Auth rejected the request as invalid. Password creation or reset is also rejected when the proposed password is known to be compromised."),
+        400: emptyResponse("Better Auth rejected the request as invalid. Password creation, password change, or reset is also rejected when the proposed password is known to be compromised."),
         401: emptyResponse("Better Auth rejected the request because authentication failed."),
         429: jsonResponse("Email/password sign-in is temporarily locked after too many failed attempts. The response includes a Retry-After header.", authLoginLockedSchema),
         503: jsonResponse("Password breach screening is temporarily unavailable, so password creation or reset should be retried later.", authPasswordScreeningUnavailableSchema),

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -1,6 +1,7 @@
 import { oauthProviderAuthServerMetadata, oauthProviderOpenIdConfigMetadata } from "@better-auth/oauth-provider"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
+import { z } from "zod"
 import { auth } from "../../auth.js"
 import {
   getBreachedPasswordResponse,
@@ -12,7 +13,7 @@ import { env } from "../../env.js"
 import { getInvalidMcpOAuthRedirectUris } from "../../mcp/oauth-client-policy.js"
 import { normalizeMcpOAuthClientScope } from "../../mcp/scopes.js"
 import { publicRoute, tokenRoute } from "../../middleware/index.js"
-import { emptyResponse } from "../../openapi.js"
+import { emptyResponse, jsonResponse } from "../../openapi.js"
 import { samlResponsePolicyMiddleware } from "../../sso-saml-response-middleware.js"
 import type { AuthContextVariables } from "../../session.js"
 import { registerDesktopAuthRoutes } from "./desktop-handoff.js"
@@ -111,6 +112,16 @@ function requestOrigin(request: Request) {
   return new URL(request.url).origin
 }
 
+const authLoginLockedSchema = z.object({
+  error: z.literal("login_locked"),
+  message: z.string(),
+}).meta({ ref: "AuthLoginLockedError" })
+
+const authPasswordScreeningUnavailableSchema = z.object({
+  error: z.literal("password_screening_unavailable"),
+  message: z.string(),
+}).meta({ ref: "AuthPasswordScreeningUnavailableError" })
+
 async function handleAuthRequest(request: Request) {
   const emailPasswordAttempt = await readEmailPasswordSignInAttempt(request)
   if (emailPasswordAttempt) {
@@ -157,8 +168,10 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
       responses: {
         200: emptyResponse("Better Auth handled the request successfully."),
         302: emptyResponse("Better Auth redirected the user to continue the auth flow."),
-        400: emptyResponse("Better Auth rejected the request as invalid."),
+        400: emptyResponse("Better Auth rejected the request as invalid. Password creation or reset is also rejected when the proposed password is known to be compromised."),
         401: emptyResponse("Better Auth rejected the request because authentication failed."),
+        429: jsonResponse("Email/password sign-in is temporarily locked after too many failed attempts. The response includes a Retry-After header.", authLoginLockedSchema),
+        503: jsonResponse("Password breach screening is temporarily unavailable, so password creation or reset should be retried later.", authPasswordScreeningUnavailableSchema),
       },
     }),
     publicRoute,

--- a/packages/docs/cloud/security-and-operations.mdx
+++ b/packages/docs/cloud/security-and-operations.mdx
@@ -58,6 +58,17 @@ For production organizations, use SSO with identity-provider MFA as the primary 
 
 Native factor enrollment and in-product reauthentication should be treated as product work before replacing SSO-enforced MFA as the production control.
 
+## Standard email/password protections
+
+The standard OpenWork Cloud email/password path is protected server-side against high-volume guessing and known-compromised passwords:
+
+- Email/password sign-in is rate limited. The default sign-in rule allows 5 attempts in a 5-minute window, in addition to the global Better Auth rate limit.
+- Failed email/password sign-ins are tracked by a hashed account identifier. After 5 recent failures, the account enters progressive lockout: 5 minutes first, then longer lockouts for continued failures, capped at 1 hour. Successful sign-in clears the failure counter.
+- Password creation and password reset requests screen the proposed password against the Have I Been Pwned Pwned Passwords range API. OpenWork sends only the first 5 characters of the SHA-1 password hash, uses the k-anonymity response to compare suffixes locally, and rejects known-compromised passwords.
+- If password screening is temporarily unavailable, password creation or reset fails closed and asks the user to try again later.
+
+OpenWork does not call the breached-password service during normal sign-in. Existing-password sign-in should be protected by rate limiting, lockout, identity-provider controls, monitoring, and a forced reset process if a credential is later suspected to be compromised.
+
 For mover and leaver handling:
 
 - Change roles when responsibilities change.


### PR DESCRIPTION
## Summary
- Document standard email/password rate limiting, progressive lockout, and breached-password screening in Cloud security docs
- Add OpenAPI response documentation for login lockout (429) and password screening outage (503)
- Clarify compromised password rejection behavior on auth 400 responses

## Validation
- `pnpm --filter @openwork-ee/den-db build`
- `pnpm exec bun test ee/apps/den-api/test/auth-protection.test.ts` — 6 pass, 0 fail
- `pnpm --filter @openwork-ee/den-api build`

## Evidence
- No video/screenshot attached because this is docs/OpenAPI metadata only; reviewer can verify via the changed docs page and generated API metadata.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

