### PR TITLE
fix(den): harden MCP JWT policy

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -2,6 +2,7 @@ import { getInitialActiveOrganizationIdForUser } from "./active-organization.js"
 import { db } from "./db.js";
 import { env } from "./env.js";
 import { deriveDenMcpResource } from "./mcp/resource.js";
+import { getDenAuthIssuer, getDenJwtOptions } from "./mcp/jwt-policy.js";
 import {
   DEN_MCP_DEFAULT_CLIENT_SCOPES,
   DEN_MCP_SCOPES,
@@ -378,7 +379,7 @@ export const auth = betterAuth({
     },
   },
   plugins: [
-    jwt(),
+    jwt(getDenJwtOptions({ issuer: getDenAuthIssuer(env.betterAuthUrl) })),
     emailOTP({
       overrideDefaultEmailVerification: true,
       otpLength: 6,

--- a/ee/apps/den-api/src/mcp/auth.ts
+++ b/ee/apps/den-api/src/mcp/auth.ts
@@ -14,6 +14,7 @@ import {
 } from "../auth.js"
 import { db } from "../db.js"
 import { env } from "../env.js"
+import { DEN_JWT_SIGNING_ALGORITHM, getDenAuthIssuer } from "./jwt-policy.js"
 
 export type McpPrincipal = {
   userId: string
@@ -24,7 +25,7 @@ export type McpPrincipal = {
 
 type McpJwtVerifyOptions = Parameters<typeof verifyJwsAccessToken>[1]["verifyOptions"]
 
-const MCP_JWT_SIGNING_ALGORITHMS = ["EdDSA"]
+const MCP_JWT_SIGNING_ALGORITHMS = [DEN_JWT_SIGNING_ALGORITHM]
 
 export function getMcpResourceUrl(request: Request) {
   const url = new URL(request.url)
@@ -34,7 +35,7 @@ export function getMcpResourceUrl(request: Request) {
 
 export function getMcpJwtVerifyOptions(): McpJwtVerifyOptions {
   return {
-    issuer: `${env.betterAuthUrl}/api/auth`,
+    issuer: getDenAuthIssuer(env.betterAuthUrl),
     audience: DEN_MCP_RESOURCES,
     algorithms: MCP_JWT_SIGNING_ALGORITHMS,
   }

--- a/ee/apps/den-api/src/mcp/jwt-policy.ts
+++ b/ee/apps/den-api/src/mcp/jwt-policy.ts
@@ -1,0 +1,26 @@
+import type { JwtOptions } from "better-auth/plugins"
+
+export const DEN_JWT_SIGNING_ALGORITHM = "EdDSA"
+export const DEN_JWT_KEY_CURVE = "Ed25519"
+export const DEN_JWKS_ROTATION_INTERVAL_SECONDS = 24 * 60 * 60
+export const DEN_JWKS_GRACE_PERIOD_SECONDS = 60 * 60
+
+export function getDenAuthIssuer(baseUrl: string) {
+  return `${baseUrl.replace(/\/+$/, "")}/api/auth`
+}
+
+export function getDenJwtOptions(input: { issuer: string }) {
+  return {
+    jwt: {
+      issuer: input.issuer,
+    },
+    jwks: {
+      keyPairConfig: {
+        alg: DEN_JWT_SIGNING_ALGORITHM,
+        crv: DEN_JWT_KEY_CURVE,
+      },
+      rotationInterval: DEN_JWKS_ROTATION_INTERVAL_SECONDS,
+      gracePeriod: DEN_JWKS_GRACE_PERIOD_SECONDS,
+    },
+  } satisfies JwtOptions
+}

--- a/ee/apps/den-api/src/middleware/route-access.ts
+++ b/ee/apps/den-api/src/middleware/route-access.ts
@@ -12,6 +12,13 @@ type OrgRoleContext = {
 
 type RouteAccessVariables = AuthContextVariables & Partial<OrganizationContextVariables> & Partial<UserOrganizationsContext>
 
+const explicitAuthGuardHandlers = new WeakSet<object>([
+  requireAdminMiddleware,
+  requireUserMiddleware,
+  resolveOrganizationContextMiddleware,
+  resolveUserOrganizationsMiddleware,
+])
+
 /**
  * Den API routes are deny-by-default: every `app.get/post/patch/delete/all/on`
  * registration must include one explicit access policy marker from this file.
@@ -62,6 +69,10 @@ export function adminRoute(): MiddlewareHandler<{ Variables: AuthContextVariable
   return requireAdminMiddleware
 }
 
+export function hasExplicitAuthGuardHandler(handler: unknown) {
+  return typeof handler === "function" && explicitAuthGuardHandlers.has(handler)
+}
+
 export function orgMemberRoute(options: { useUserOrganizations: true }): typeof resolveUserOrganizationsMiddleware
 export function orgMemberRoute(): typeof resolveOrganizationContextMiddleware
 export function orgMemberRoute(options?: { useUserOrganizations: true }) {
@@ -73,7 +84,7 @@ export function orgMemberRoute(options?: { useUserOrganizations: true }) {
 }
 
 export function orgRoleRoute(roles: readonly string[]): MiddlewareHandler<{ Variables: RouteAccessVariables }> {
-  return async (c, next) => {
+  const handler: MiddlewareHandler<{ Variables: RouteAccessVariables }> = async (c, next) => {
     let roleResponse: Response | undefined
     const contextResponse = await resolveOrganizationContextMiddleware(c, async () => {
       const payload = c.get("organizationContext")
@@ -93,4 +104,6 @@ export function orgRoleRoute(roles: readonly string[]): MiddlewareHandler<{ Vari
 
     return contextResponse ?? roleResponse
   }
+  explicitAuthGuardHandlers.add(handler)
+  return handler
 }

--- a/ee/apps/den-api/test/mcp-auth.test.ts
+++ b/ee/apps/den-api/test/mcp-auth.test.ts
@@ -1,4 +1,13 @@
 import { beforeAll, expect, test } from "bun:test"
+import { DEN_MCP_ACCESS_TOKEN_EXPIRES_IN_SECONDS } from "../src/mcp/token-lifetime.js"
+import {
+  DEN_JWKS_GRACE_PERIOD_SECONDS,
+  DEN_JWKS_ROTATION_INTERVAL_SECONDS,
+  DEN_JWT_KEY_CURVE,
+  DEN_JWT_SIGNING_ALGORITHM,
+  getDenAuthIssuer,
+  getDenJwtOptions,
+} from "../src/mcp/jwt-policy.js"
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -16,8 +25,26 @@ beforeAll(async () => {
 
 test("MCP JWT verification pins issuer, audience, and signing algorithm", () => {
   expect(mcpAuth.getMcpJwtVerifyOptions()).toEqual({
-    issuer: "http://127.0.0.1:8790/api/auth",
+    issuer: getDenAuthIssuer("http://127.0.0.1:8790"),
     audience: ["http://127.0.0.1:8790/mcp"],
-    algorithms: ["EdDSA"],
+    algorithms: [DEN_JWT_SIGNING_ALGORITHM],
   })
+})
+
+test("Den JWT keys pin EdDSA and retain rotated keys during the MCP token lifetime", () => {
+  expect(getDenJwtOptions({ issuer: "https://api.openworklabs.com/api/auth" })).toEqual({
+    jwt: {
+      issuer: "https://api.openworklabs.com/api/auth",
+    },
+    jwks: {
+      keyPairConfig: {
+        alg: DEN_JWT_SIGNING_ALGORITHM,
+        crv: DEN_JWT_KEY_CURVE,
+      },
+      rotationInterval: DEN_JWKS_ROTATION_INTERVAL_SECONDS,
+      gracePeriod: DEN_JWKS_GRACE_PERIOD_SECONDS,
+    },
+  })
+  expect(DEN_JWKS_ROTATION_INTERVAL_SECONDS).toBe(24 * 60 * 60)
+  expect(DEN_JWKS_GRACE_PERIOD_SECONDS).toBeGreaterThan(DEN_MCP_ACCESS_TOKEN_EXPIRES_IN_SECONDS)
 })

--- a/ee/apps/den-api/test/route-guard-policy.test.ts
+++ b/ee/apps/den-api/test/route-guard-policy.test.ts
@@ -4,6 +4,7 @@ type DenApiApp = typeof import("../src/app.js").default
 
 let app: DenApiApp | null = null
 let explicitAuthGuards = new Set<unknown>()
+let hasExplicitAuthGuardHandler: (handler: unknown) => boolean = () => false
 
 const routeGuardExceptions = new Map<string, string>([
   ["GET /", "public marketing redirect"],
@@ -20,6 +21,8 @@ const routeGuardExceptions = new Map<string, string>([
   ["POST /register", "MCP OAuth dynamic client registration policy validates the request"],
   ["POST /api/auth/oauth2/register", "MCP OAuth dynamic client registration policy validates the request"],
   ["GET /api/auth/oauth2/authorize", "Better Auth OAuth authorization endpoint"],
+  ["ALL /api/auth/sso/saml2/callback/*", "SAML response policy validates callback responses before Better Auth"],
+  ["ALL /api/auth/sso/saml2/sp/acs/*", "SAML response policy validates ACS responses before Better Auth"],
   ["GET /api/auth/*", "Better Auth route mount"],
   ["POST /api/auth/*", "Better Auth route mount"],
   ["PUT /api/auth/*", "Better Auth route mount"],
@@ -75,6 +78,7 @@ beforeAll(async () => {
     middlewareModule.resolveOrganizationContextMiddleware,
     middlewareModule.resolveUserOrganizationsMiddleware,
   ])
+  hasExplicitAuthGuardHandler = middlewareModule.hasExplicitAuthGuardHandler
 })
 
 function routeChains() {
@@ -106,7 +110,7 @@ test("registered den-api routes require an auth guard or explicit exception", ()
         return false
       }
 
-      return !handlers.some((handler) => explicitAuthGuards.has(handler))
+      return !handlers.some((handler) => explicitAuthGuards.has(handler) || hasExplicitAuthGuardHandler(handler))
     })
     .map(([key]) => key)
     .sort()

--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -93,6 +93,13 @@ OpenWork Cloud's MCP OAuth flow is hardened for public MCP clients:
   redirects and dangerous schemes such as `javascript:`, `file:`, and `data:`
   are rejected.
 - MCP OAuth access tokens expire after 15 minutes.
+- JWT access tokens are signed with EdDSA only. The MCP verifier pins that
+  signing algorithm, validates the issuer as the OpenWork Cloud auth server,
+  and validates the audience against the MCP resource URLs advertised by the
+  protected-resource metadata.
+- JWKS signing keys rotate every 24 hours. Previous public keys remain in the
+  JWKS for a 1-hour overlap, which is longer than the MCP access-token
+  lifetime, so in-flight tokens can expire naturally during rotation.
 - MCP OAuth refresh tokens expire after 7 days, rotate on refresh, and are
   revocable. Reusing a revoked refresh token invalidates the token family.
 - Access is rechecked against the user's active OpenWork Cloud session and


### PR DESCRIPTION
## Summary
- pin Den JWT signing to EdDSA/Ed25519 and configure 24h JWKS rotation with 1h overlap
- reuse the shared issuer/signing policy for MCP token verification
- document MCP JWT issuer/audience/algorithm and JWKS rotation controls
- fix route guard policy coverage for dynamic org role guards and SAML policy routes

## Validation
- bun test ee/apps/den-api/test/mcp-auth.test.ts ee/apps/den-api/test/mcp-token-lifetime.test.ts
- bun test ee/apps/den-api/test/route-guard-policy.test.ts
- bun test ee/apps/den-api/test
- pnpm --filter @openwork-ee/den-api build
- git diff --check

No video attached because this is a backend security/configuration change with no visual UI flow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

