### PR TITLE
docs: document database encryption posture

### DIFF
--- a/packages/docs/cloud/security-and-operations.mdx
+++ b/packages/docs/cloud/security-and-operations.mdx
@@ -16,6 +16,10 @@ Production deployments should enforce encrypted transport and encrypted storage:
 - Enable encryption at rest for the production database, object storage, backups, and logs that may contain operational metadata.
 - Keep local development defaults local-only. Example development database URLs and local secrets in repository scripts are not production settings.
 
+OpenWork Cloud's hosted Den database runs on PlanetScale. PlanetScale encrypts database storage and backups at rest, and PlanetScale database connection strings require TLS before SQL commands can be issued. OpenWork's production migration workflow also configures strict TLS verification for PlanetScale MySQL-protocol connections.
+
+OpenWork also encrypts selected sensitive database columns, such as provider secrets and SSO configuration, with application-level AES-256-GCM encryption using `DEN_DB_ENCRYPTION_KEY`. This is an additional control and does not replace provider-managed storage encryption at rest.
+
 For private or self-hosted deployments, the operator is responsible for enabling TLS certificates, database storage encryption, backup encryption, and private network policy in the target environment.
 
 ## Secrets and keys

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -41,7 +41,7 @@ For a containerized worker runtime, start from the [Docker packaging](https://gi
 For production, configure encryption explicitly:
 
 - Enable encryption at rest for the MySQL-compatible database, database backups, object storage, worker volumes, and logs that may contain operational metadata.
-- Require TLS for application-to-database traffic. PlanetScale connections require TLS. For standard MySQL, include an SSL mode in `DATABASE_URL`, such as `?sslmode=require` or, when you can validate the server certificate chain, `?sslmode=verify-full`.
+- Require TLS for application-to-database traffic. PlanetScale connections require TLS. For standard MySQL, include a certificate-verifying SSL mode in `DATABASE_URL`, such as `?sslmode=require`, `?sslmode=verify-ca`, or `?sslmode=verify-full`.
 - Keep the local Docker MySQL URL (`mysql://root:password@127.0.0.1:3306/openwork_den`) for development only; it is not a production security posture.
 - Set a unique `DEN_DB_ENCRYPTION_KEY` of at least 32 characters. OpenWork uses it to encrypt selected sensitive database columns, but it does not replace infrastructure-level encryption at rest.
 

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -38,6 +38,13 @@ For a containerized worker runtime, start from the [Docker packaging](https://gi
 - The Den control plane uses a MySQL-compatible database. Local Docker uses MySQL 8.4; production can use standard MySQL or PlanetScale-compatible credentials.
 - Postgres is not required by the current Den deployment path.
 
+For production, configure encryption explicitly:
+
+- Enable encryption at rest for the MySQL-compatible database, database backups, object storage, worker volumes, and logs that may contain operational metadata.
+- Require TLS for application-to-database traffic. PlanetScale connections require TLS. For standard MySQL, include an SSL mode in `DATABASE_URL`, such as `?sslmode=require` or, when you can validate the server certificate chain, `?sslmode=verify-full`.
+- Keep the local Docker MySQL URL (`mysql://root:password@127.0.0.1:3306/openwork_den`) for development only; it is not a production security posture.
+- Set a unique `DEN_DB_ENCRYPTION_KEY` of at least 32 characters. OpenWork uses it to encrypt selected sensitive database columns, but it does not replace infrastructure-level encryption at rest.
+
 ## Auth and SSO
 
 Den uses Better Auth. It runs in your deployment, uses your database, and is configured with your `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, trusted origins, and optional GitHub/Google OAuth credentials.


### PR DESCRIPTION
## Summary
- document hosted OpenWork Cloud database encryption-at-rest and TLS posture
- clarify app-level encrypted columns are an additional control
- add self-host production guidance for MySQL/PlanetScale TLS, storage encryption, and DEN_DB_ENCRYPTION_KEY

## Validation
- git diff --check -- packages/docs/cloud/security-and-operations.mdx packages/docs/start-here/self-host.mdx

## Evidence
- Docs-only change; no screenshot or video captured.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

