### PR TITLE
fix(den): protect org ownership lifecycle

### DIFF
--- a/ee/apps/den-api/src/audit-events.ts
+++ b/ee/apps/den-api/src/audit-events.ts
@@ -12,6 +12,7 @@ export const ORGANIZATION_AUDIT_ACTIONS = {
   roleUpdated: "organization.role.updated",
   roleDeleted: "organization.role.deleted",
   memberRoleUpdated: "organization.member.role_updated",
+  memberOwnershipTransferred: "organization.member.ownership_transferred",
   memberRemoved: "organization.member.removed",
   scimTokenRotated: "organization.scim.token_rotated",
   scimConnectionDeleted: "organization.scim.connection_deleted",

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -41,7 +41,12 @@ import {
   ORGANIZATION_SAML_DEPRECATED_ALGORITHM_BEHAVIOR,
   ORGANIZATION_SAML_REQUIRE_TIMESTAMPS,
 } from "./sso-saml-policy.js";
-import { getOrganizationContextForUser, seedDefaultOrganizationRoles } from "./orgs.js";
+import {
+  getOrganizationContextForUser,
+  seedDefaultOrganizationRoles,
+  validateOrganizationMemberRemovalForHook,
+  validateOrganizationMemberRoleUpdate,
+} from "./orgs.js";
 import {
   findEnterpriseAuthRequirementForEmail,
   findEnterpriseAuthRequirementForUserId,
@@ -92,6 +97,8 @@ export const DEN_MCP_ORG_ID_CLAIM = "https://openworklabs.com/org_id";
 export const DEN_MCP_RESOURCE_CLAIM = "https://openworklabs.com/resource";
 export const DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX = "ow_mcp_at_";
 export { DEN_MCP_SCOPES } from "./mcp/scopes.js";
+
+type AuthMemberHookRow = typeof schema.MemberTable.$inferSelect;
 
 const socialProviders = {
   ...(env.github.clientId && env.github.clientSecret
@@ -172,6 +179,10 @@ async function revokeOrganizationMemberCredentials(input: {
   });
 }
 
+function throwMemberLifecycleError(message: string): never {
+  throw new APIError("BAD_REQUEST", { message });
+}
+
 function getBodyEmail(body: unknown) {
   if (!body || typeof body !== "object") {
     return null;
@@ -213,6 +224,25 @@ export const auth = betterAuth({
     freshAge: 15 * 60,
   },
   databaseHooks: {
+    member: {
+      delete: {
+        before: async (member: AuthMemberHookRow) => {
+          const validation = await validateOrganizationMemberRemovalForHook({
+            organizationId: normalizeDenTypeId("organization", member.organizationId),
+            memberId: normalizeDenTypeId("member", member.id),
+          });
+          if (!validation.ok) {
+            throwMemberLifecycleError(validation.message);
+          }
+
+          await revokeOrganizationMemberCredentials({
+            organizationId: member.organizationId,
+            orgMembershipId: member.id,
+            userId: member.userId,
+          });
+        },
+      },
+    },
     session: {
       create: {
         before: async (session) => {
@@ -427,10 +457,12 @@ export const auth = betterAuth({
           );
         },
         beforeRemoveMember: async ({ member }) => {
-          if (hasRole(member.role, "owner")) {
-            throw new APIError("BAD_REQUEST", {
-              message: "The organization owner cannot be removed.",
-            });
+          const validation = await validateOrganizationMemberRemovalForHook({
+            organizationId: normalizeDenTypeId("organization", member.organizationId),
+            memberId: normalizeDenTypeId("member", member.id),
+          });
+          if (!validation.ok) {
+            throwMemberLifecycleError(validation.message);
           }
 
           await revokeOrganizationMemberCredentials({
@@ -451,6 +483,15 @@ export const auth = betterAuth({
               message:
                 "Owner can only be assigned during organization creation.",
             });
+          }
+
+          const validation = await validateOrganizationMemberRoleUpdate({
+            organizationId: normalizeDenTypeId("organization", member.organizationId),
+            memberId: normalizeDenTypeId("member", member.id),
+            nextRole: newRole,
+          });
+          if (!validation.ok) {
+            throwMemberLifecycleError(validation.message);
           }
 
           if (member.role !== newRole) {

--- a/ee/apps/den-api/src/organization-member-guards.ts
+++ b/ee/apps/den-api/src/organization-member-guards.ts
@@ -19,6 +19,33 @@ function splitRoles(value: string) {
     .filter(Boolean)
 }
 
+function addRole(roleValue: string, roleName: string) {
+  const roles = splitRoles(roleValue).filter((role) => role !== roleName)
+  return [roleName, ...roles].join(",")
+}
+
+function removeRole(roleValue: string, roleName: string) {
+  return splitRoles(roleValue).filter((role) => role !== roleName)
+}
+
+export function getRoleValueAfterOwnershipTransfer(input: {
+  currentRole: string
+  targetRole: string
+}) {
+  const currentRoles = removeRole(input.currentRole, "owner")
+  const previousOwnerRole = currentRoles.includes("admin")
+    ? currentRoles.join(",")
+    : addRole(currentRoles.join(","), "admin")
+  const targetRoles = removeRole(input.targetRole, "owner")
+    .filter((role) => role !== "admin" && role !== "member")
+  const newOwnerRole = addRole(targetRoles.join(","), "owner")
+
+  return {
+    previousOwnerRole,
+    newOwnerRole,
+  }
+}
+
 export function roleIncludesOwner(roleValue: string) {
   return splitRoles(roleValue).includes("owner")
 }

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -14,6 +14,8 @@ import { revokeOrganizationApiKeysForMember } from "./api-keys.js"
 import { revokeMembershipSessionCredentials } from "./credential-revocation.js"
 import { db } from "./db.js"
 import {
+  getRoleValueAfterOwnershipTransfer,
+  roleIncludesPrivileged,
   roleIncludesOwner as guardRoleIncludesOwner,
   validateOrganizationMemberRemoval,
   validateOrganizationMemberRoleChange,
@@ -49,6 +51,27 @@ type MemberMutationResult = {
   ok: true
   member: MemberRow
 } | MemberMutationFailure
+
+type OwnershipTransferFailure = {
+  ok: false
+  error: "owner_not_found" | "target_member_not_found" | "owner_transfer_invalid"
+  message: string
+}
+
+type OwnershipTransferResult = {
+  ok: true
+  previousOwner: MemberRow
+  newOwner: MemberRow
+  previousOwnerRole: string
+  newOwnerRole: string
+} | OwnershipTransferFailure
+
+type OwnershipRecoveryResult = {
+  ok: true
+  previousOwnerCount: number
+  newOwner: MemberRow
+  newOwnerRole: string
+} | OwnershipTransferFailure
 
 export type InvitationStatus = "pending" | "accepted" | "canceled" | "expired"
 
@@ -1065,10 +1088,16 @@ async function listActiveOrganizationMemberGuardRows(organizationId: OrgId) {
     .select({
       id: MemberTable.id,
       role: MemberTable.role,
-      userId: MemberTable.userId,
+      userId: AuthUserTable.id,
     })
     .from(MemberTable)
+    .leftJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
     .where(and(eq(MemberTable.organizationId, organizationId), isNull(MemberTable.removedAt)))
+}
+
+export async function organizationHasActiveOwner(organizationId: OrgId) {
+  const activeMembers = await listActiveOrganizationMemberGuardRows(organizationId)
+  return activeMembers.some((member) => member.userId && roleIncludesOwner(member.role))
 }
 
 function memberNotFound(): MemberMutationFailure {
@@ -1106,6 +1135,192 @@ export async function validateOrganizationMemberRoleUpdate(input: {
   }
 
   return { ok: true, member }
+}
+
+export async function validateOrganizationMemberRemovalForHook(input: {
+  organizationId: OrgId
+  memberId: MemberRow["id"]
+}): Promise<MemberMutationResult> {
+  const memberRows = await db
+    .select()
+    .from(MemberTable)
+    .where(and(eq(MemberTable.id, input.memberId), eq(MemberTable.organizationId, input.organizationId), isNull(MemberTable.removedAt)))
+    .limit(1)
+
+  const member = memberRows[0] ?? null
+  if (!member) {
+    return memberNotFound()
+  }
+
+  const activeMembers = await listActiveOrganizationMemberGuardRows(input.organizationId)
+  const validation = validateOrganizationMemberRemoval({ member, activeMembers })
+  if (!validation.ok) {
+    return validation
+  }
+
+  return { ok: true, member }
+}
+
+export async function transferOrganizationOwnership(input: {
+  organizationId: OrgId
+  currentOwnerMemberId: MemberRow["id"]
+  targetMemberId: MemberRow["id"]
+}): Promise<OwnershipTransferResult> {
+  if (input.currentOwnerMemberId === input.targetMemberId) {
+    return {
+      ok: false,
+      error: "owner_transfer_invalid",
+      message: "Choose a different active member to become workspace owner.",
+    }
+  }
+
+  const memberRows = await db
+    .select({ member: MemberTable, userId: AuthUserTable.id })
+    .from(MemberTable)
+    .leftJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
+    .where(and(
+      eq(MemberTable.organizationId, input.organizationId),
+      inArray(MemberTable.id, [input.currentOwnerMemberId, input.targetMemberId]),
+      isNull(MemberTable.removedAt),
+    ))
+
+  const currentOwnerRow = memberRows.find((row) => row.member.id === input.currentOwnerMemberId) ?? null
+  if (!currentOwnerRow || !currentOwnerRow.userId || !roleIncludesOwner(currentOwnerRow.member.role)) {
+    return {
+      ok: false,
+      error: "owner_not_found",
+      message: "The current workspace owner could not be found.",
+    }
+  }
+
+  const targetRow = memberRows.find((row) => row.member.id === input.targetMemberId) ?? null
+  if (!targetRow || !targetRow.userId) {
+    return {
+      ok: false,
+      error: "target_member_not_found",
+      message: "Choose an active member to become workspace owner.",
+    }
+  }
+
+  if (roleIncludesOwner(targetRow.member.role)) {
+    return {
+      ok: false,
+      error: "owner_transfer_invalid",
+      message: "This member is already a workspace owner.",
+    }
+  }
+
+  const roles = getRoleValueAfterOwnershipTransfer({
+    currentRole: currentOwnerRow.member.role,
+    targetRole: targetRow.member.role,
+  })
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(MemberTable)
+      .set({ role: roles.previousOwnerRole })
+      .where(eq(MemberTable.id, currentOwnerRow.member.id))
+    await tx
+      .update(MemberTable)
+      .set({ role: roles.newOwnerRole })
+      .where(eq(MemberTable.id, targetRow.member.id))
+  })
+
+  await revokeOrganizationApiKeysForMember({
+    organizationId: input.organizationId,
+    orgMembershipId: currentOwnerRow.member.id,
+    userId: currentOwnerRow.member.userId,
+  })
+  await revokeOrganizationApiKeysForMember({
+    organizationId: input.organizationId,
+    orgMembershipId: targetRow.member.id,
+    userId: targetRow.member.userId,
+  })
+  await revokeMembershipSessionCredentials({
+    organizationId: input.organizationId,
+    userId: currentOwnerRow.member.userId,
+  })
+  await revokeMembershipSessionCredentials({
+    organizationId: input.organizationId,
+    userId: targetRow.member.userId,
+  })
+
+  return {
+    ok: true,
+    previousOwner: currentOwnerRow.member,
+    newOwner: targetRow.member,
+    previousOwnerRole: roles.previousOwnerRole,
+    newOwnerRole: roles.newOwnerRole,
+  }
+}
+
+export async function recoverOrganizationOwnership(input: {
+  organizationId: OrgId
+  targetMemberId: MemberRow["id"]
+}): Promise<OwnershipRecoveryResult> {
+  if (await organizationHasActiveOwner(input.organizationId)) {
+    return {
+      ok: false,
+      error: "owner_transfer_invalid",
+      message: "Only the current workspace owner can transfer ownership while an active owner exists.",
+    }
+  }
+
+  const memberRows = await db
+    .select({ member: MemberTable, userId: AuthUserTable.id })
+    .from(MemberTable)
+    .leftJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
+    .where(and(eq(MemberTable.organizationId, input.organizationId), isNull(MemberTable.removedAt)))
+
+  const targetRow = memberRows.find((row) => row.member.id === input.targetMemberId) ?? null
+  if (!targetRow || !targetRow.userId || !roleIncludesPrivileged(targetRow.member.role)) {
+    return {
+      ok: false,
+      error: "target_member_not_found",
+      message: "Choose an active workspace admin to become owner.",
+    }
+  }
+
+  const previousOwnerRows = memberRows.filter((row) => roleIncludesOwner(row.member.role))
+  const roles = getRoleValueAfterOwnershipTransfer({
+    currentRole: "owner",
+    targetRole: targetRow.member.role,
+  })
+
+  await db.transaction(async (tx) => {
+    for (const ownerRow of previousOwnerRows) {
+      const ownerRoles = getRoleValueAfterOwnershipTransfer({
+        currentRole: ownerRow.member.role,
+        targetRole: targetRow.member.role,
+      })
+      await tx
+        .update(MemberTable)
+        .set({ role: ownerRoles.previousOwnerRole })
+        .where(eq(MemberTable.id, ownerRow.member.id))
+    }
+
+    await tx
+      .update(MemberTable)
+      .set({ role: roles.newOwnerRole })
+      .where(eq(MemberTable.id, targetRow.member.id))
+  })
+
+  await revokeOrganizationApiKeysForMember({
+    organizationId: input.organizationId,
+    orgMembershipId: targetRow.member.id,
+    userId: targetRow.member.userId,
+  })
+  await revokeMembershipSessionCredentials({
+    organizationId: input.organizationId,
+    userId: targetRow.member.userId,
+  })
+
+  return {
+    ok: true,
+    previousOwnerCount: previousOwnerRows.length,
+    newOwner: targetRow.member,
+    newOwnerRole: roles.newOwnerRole,
+  }
 }
 
 export async function removeOrganizationMember(input: {

--- a/ee/apps/den-api/src/routes/org/members.ts
+++ b/ee/apps/den-api/src/routes/org/members.ts
@@ -10,9 +10,9 @@ import { revokeMembershipSessionCredentials } from "../../credential-revocation.
 import { db } from "../../db.js"
 import { jsonValidator, orgRoleRoute, paramValidator } from "../../middleware/index.js"
 import { emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
-import { listAssignableRoles, removeOrganizationMember, validateOrganizationMemberRoleUpdate } from "../../orgs.js"
+import { listAssignableRoles, recoverOrganizationOwnership, removeOrganizationMember, transferOrganizationOwnership, validateOrganizationMemberRoleUpdate } from "../../orgs.js"
 import type { OrgRouteVariables } from "./shared.js"
-import { ensureMemberRemover, ensureOwner, idParamSchema, normalizeRoleName, orgAccessFailureStatus } from "./shared.js"
+import { ensureMemberRemover, ensureOrganizationAdmin, ensureOwner, idParamSchema, normalizeRoleName, orgAccessFailureStatus } from "./shared.js"
 
 const updateMemberRoleSchema = z.object({
   role: z.string().trim().min(1).max(64),
@@ -97,6 +97,81 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
         },
       })
     }
+
+    return c.json({ success: true })
+    },
+  )
+
+  app.post(
+    "/v1/members/:memberId/transfer-ownership",
+    describeRoute({
+      tags: ["Members"],
+      summary: "Transfer workspace ownership",
+      description: "Transfers the protected workspace owner role to another active organization member. Workspace admins may use this endpoint only to recover an organization that has no active owner.",
+      responses: {
+        200: jsonResponse("Workspace ownership transferred successfully.", successSchema),
+        400: jsonResponse("The ownership transfer request was invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to transfer ownership.", unauthorizedSchema),
+        403: jsonResponse("Only workspace owners can transfer ownership.", forbiddenSchema),
+        404: jsonResponse("The target member or organization could not be found.", notFoundSchema),
+      },
+    }),
+    orgRoleRoute(["admin"]),
+    paramValidator(orgMemberParamsSchema),
+    async (c) => {
+    const permission = ensureOrganizationAdmin(c, "Only workspace owners and admins can transfer ownership.")
+    if (!permission.ok) {
+      return c.json(permission.response, orgAccessFailureStatus(permission.response))
+    }
+
+    const payload = c.get("organizationContext")
+    const params = c.req.valid("param")
+    let memberId: MemberId
+    try {
+      memberId = normalizeDenTypeId("member", params.memberId)
+    } catch {
+      return c.json({ error: "target_member_not_found", message: "Choose an active member to become workspace owner." }, 404)
+    }
+
+    const transfer = payload.currentMember.isOwner
+      ? await transferOrganizationOwnership({
+        organizationId: payload.organization.id,
+        currentOwnerMemberId: payload.currentMember.id,
+        targetMemberId: memberId,
+      })
+      : await recoverOrganizationOwnership({
+        organizationId: payload.organization.id,
+        targetMemberId: memberId,
+      })
+    if (!transfer.ok) {
+      if (transfer.error === "target_member_not_found" || transfer.error === "owner_not_found") {
+        return c.json({ error: transfer.error, message: transfer.message }, 404)
+      }
+      if (!payload.currentMember.isOwner) {
+        return c.json({ error: transfer.error, message: transfer.message }, 403)
+      }
+      return c.json({ error: transfer.error, message: transfer.message }, 400)
+    }
+
+    const previousOwner = "previousOwner" in transfer ? transfer.previousOwner : null
+    const previousOwnerRole = "previousOwnerRole" in transfer ? transfer.previousOwnerRole : null
+
+    await recordOrganizationAuditEvent({
+      organizationId: payload.organization.id,
+      actorUserId: payload.currentMember.userId,
+      action: ORGANIZATION_AUDIT_ACTIONS.memberOwnershipTransferred,
+      payload: {
+        previousOwnerOrgMembershipId: previousOwner?.id ?? null,
+        previousOwnerUserId: previousOwner?.userId ?? null,
+        previousOwnerRole: previousOwner?.role ?? null,
+        previousOwnerNextRole: previousOwnerRole,
+        previousOwnerCount: "previousOwnerCount" in transfer ? transfer.previousOwnerCount : 1,
+        newOwnerOrgMembershipId: transfer.newOwner.id,
+        newOwnerUserId: transfer.newOwner.userId,
+        newOwnerPreviousRole: transfer.newOwner.role,
+        newOwnerRole: transfer.newOwnerRole,
+      },
+    })
 
     return c.json({ success: true })
     },

--- a/ee/apps/den-api/test/org-member-guards.test.ts
+++ b/ee/apps/den-api/test/org-member-guards.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import {
+  getRoleValueAfterOwnershipTransfer,
   validateOrganizationMemberRemoval,
   validateOrganizationMemberRoleChange,
   type MemberLifecycleGuardRow,
@@ -69,4 +70,24 @@ test("member role changes allow privileged downgrades when another active privil
     activeMembers: [owner, admin],
     nextRole: "member",
   })).toEqual({ ok: true })
+})
+
+test("ownership transfer makes the old owner an admin and preserves custom target roles", () => {
+  expect(getRoleValueAfterOwnershipTransfer({
+    currentRole: "owner,security-admin",
+    targetRole: "admin,billing-admin",
+  })).toEqual({
+    previousOwnerRole: "admin,security-admin",
+    newOwnerRole: "owner,billing-admin",
+  })
+})
+
+test("ownership transfer promotes a basic member to owner", () => {
+  expect(getRoleValueAfterOwnershipTransfer({
+    currentRole: "owner",
+    targetRole: "member",
+  })).toEqual({
+    previousOwnerRole: "admin",
+    newOwnerRole: "owner",
+  })
 })


### PR DESCRIPTION
## Summary
- enforce last active privileged member checks through Den and Better Auth member lifecycle paths
- count only active memberships with real user rows for privileged-user/owner checks
- add ownership transfer and admin recovery path for owner-orphaned orgs, with audit logging

## Tests
- pnpm exec bun test ee/apps/den-api/test/org-member-guards.test.ts
- pnpm --filter @openwork-ee/den-api build

## Evidence
- Backend/API security fix; no UI recording captured.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

