### PR TITLE
fix(den): split security configuration access

### DIFF
--- a/ee/apps/den-api/src/audit-events.ts
+++ b/ee/apps/den-api/src/audit-events.ts
@@ -39,7 +39,45 @@ export function buildOrganizationAuditEvent(input: {
   }
 }
 
+type OrganizationAuditEvent = ReturnType<typeof buildOrganizationAuditEvent>
+
+export function isOrganizationAuditAlertAction(action: OrganizationAuditAction) {
+  switch (action) {
+    case ORGANIZATION_AUDIT_ACTIONS.apiKeyCreated:
+    case ORGANIZATION_AUDIT_ACTIONS.apiKeyDeleted:
+    case ORGANIZATION_AUDIT_ACTIONS.invitationCreated:
+    case ORGANIZATION_AUDIT_ACTIONS.invitationRefreshed:
+    case ORGANIZATION_AUDIT_ACTIONS.invitationCanceled:
+    case ORGANIZATION_AUDIT_ACTIONS.roleCreated:
+    case ORGANIZATION_AUDIT_ACTIONS.roleUpdated:
+    case ORGANIZATION_AUDIT_ACTIONS.roleDeleted:
+    case ORGANIZATION_AUDIT_ACTIONS.memberRoleUpdated:
+    case ORGANIZATION_AUDIT_ACTIONS.memberRemoved:
+    case ORGANIZATION_AUDIT_ACTIONS.scimTokenRotated:
+    case ORGANIZATION_AUDIT_ACTIONS.scimConnectionDeleted:
+    case ORGANIZATION_AUDIT_ACTIONS.ssoConnectionRegistered:
+    case ORGANIZATION_AUDIT_ACTIONS.ssoConnectionDeleted:
+      return true
+    case ORGANIZATION_AUDIT_ACTIONS.scimReconciliationRun:
+      return false
+  }
+}
+
+export function buildOrganizationAuditAlertLogLine(event: OrganizationAuditEvent) {
+  return `[audit-alert] ${JSON.stringify({
+    auditEventId: event.id,
+    organizationId: event.org_id,
+    actorUserId: event.actor_user_id,
+    action: event.action,
+    payload: event.payload,
+  })}`
+}
+
 export async function recordOrganizationAuditEvent(input: Parameters<typeof buildOrganizationAuditEvent>[0]) {
   const { db } = await import("./db.js")
-  await db.insert(AuditEventTable).values(buildOrganizationAuditEvent(input))
+  const event = buildOrganizationAuditEvent(input)
+  await db.insert(AuditEventTable).values(event)
+  if (isOrganizationAuditAlertAction(event.action)) {
+    console.warn(buildOrganizationAuditAlertLogLine(event))
+  }
 }

--- a/ee/apps/den-api/test/audit-events.test.ts
+++ b/ee/apps/den-api/test/audit-events.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "bun:test"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
-import { buildOrganizationAuditEvent, ORGANIZATION_AUDIT_ACTIONS } from "../src/audit-events.js"
+import {
+  buildOrganizationAuditAlertLogLine,
+  buildOrganizationAuditEvent,
+  isOrganizationAuditAlertAction,
+  ORGANIZATION_AUDIT_ACTIONS,
+} from "../src/audit-events.js"
 
 test("organization audit events normalize org ids and keep actor context", () => {
   const organizationId = createDenTypeId("organization")
@@ -188,4 +193,34 @@ test("organization audit events support SSO management actions", () => {
     issuer: "https://idp.example.com",
     domain: "example.com",
   })
+})
+
+test("organization audit alerting covers sensitive access changes", () => {
+  expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.apiKeyCreated)).toBe(true)
+  expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.invitationCreated)).toBe(true)
+  expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.memberRoleUpdated)).toBe(true)
+  expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.roleUpdated)).toBe(true)
+  expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.scimTokenRotated)).toBe(true)
+  expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.ssoConnectionRegistered)).toBe(true)
+  expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.scimReconciliationRun)).toBe(false)
+})
+
+test("organization audit alert log line is structured and secret-free", () => {
+  const event = buildOrganizationAuditEvent({
+    organizationId: createDenTypeId("organization"),
+    actorUserId: createDenTypeId("user"),
+    action: ORGANIZATION_AUDIT_ACTIONS.ssoConnectionDeleted,
+    payload: {
+      ssoConnectionId: createDenTypeId("ssoConnection"),
+      providerId: "openwork-sso-org_id",
+      domain: "example.com",
+    },
+  })
+
+  const logLine = buildOrganizationAuditAlertLogLine(event)
+  expect(logLine.startsWith("[audit-alert] ")).toBe(true)
+  expect(logLine).toContain("organization.sso.connection_deleted")
+  expect(logLine).toContain(event.org_id)
+  expect(logLine).not.toContain("secret")
+  expect(logLine).not.toContain("token")
 })

--- a/ee/apps/den-api/test/den-web-org-access.test.ts
+++ b/ee/apps/den-api/test/den-web-org-access.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { DEN_ROLE_PERMISSION_OPTIONS, getOrgAccessFlags, type DenOrgRole } from "../../den-web/app/(den)/_lib/den-org.ts"
+
+function role(roleName: string, permission: Record<string, string[]>): DenOrgRole {
+  return {
+    id: `role_${roleName}`,
+    role: roleName,
+    permission,
+    builtIn: roleName === "admin" || roleName === "member",
+    protected: roleName === "admin" || roleName === "member",
+    createdAt: null,
+    updatedAt: null,
+  }
+}
+
+test("default admin access does not include security configuration", () => {
+  const access = getOrgAccessFlags("admin", false, [
+    role("admin", { member: ["create", "update", "delete"] }),
+  ])
+
+  expect(access.isAdmin).toBe(true)
+  expect(access.canInviteMembers).toBe(true)
+  expect(access.canManageApiKeys).toBe(false)
+  expect(access.canManageScim).toBe(false)
+  expect(access.canManageSso).toBe(false)
+})
+
+test("delegated security configuration role can manage identity settings", () => {
+  const access = getOrgAccessFlags("security-admin", false, [
+    role("security-admin", { security_configuration: ["manage"] }),
+  ])
+
+  expect(access.isAdmin).toBe(false)
+  expect(access.canInviteMembers).toBe(false)
+  expect(access.canManageSecurityConfiguration).toBe(true)
+  expect(access.canManageApiKeys).toBe(true)
+  expect(access.canManageScim).toBe(true)
+  expect(access.canManageSso).toBe(true)
+})
+
+test("role editor exposes security configuration delegation", () => {
+  expect(DEN_ROLE_PERMISSION_OPTIONS.security_configuration).toEqual(["manage"])
+})

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -213,6 +213,7 @@ export const DEN_ROLE_PERMISSION_OPTIONS = {
   invitation: ["create", "cancel"],
   team: ["create", "update", "delete"],
   ac: ["create", "read", "update", "delete"],
+  security_configuration: ["manage"],
 } as const;
 
 export const PENDING_ORG_INVITATION_STORAGE_KEY = "openwork:web:pending-org-invitation";
@@ -299,22 +300,32 @@ export function splitRoleString(value: string): string[] {
     .filter(Boolean);
 }
 
-export function getOrgAccessFlags(roleValue: string, isOwner: boolean) {
-  const roles = new Set(splitRoleString(roleValue));
-  const isAdmin = isOwner || roles.has("admin");
+function roleHasSecurityConfigurationPermission(roleValue: string, roles: readonly DenOrgRole[]) {
+  const roleNames = new Set(splitRoleString(roleValue));
+  return roles.some((role) => (
+    roleNames.has(role.role)
+    && (role.permission.security_configuration?.includes("manage") ?? false)
+  ));
+}
+
+export function getOrgAccessFlags(roleValue: string, isOwner: boolean, roleDefinitions: readonly DenOrgRole[] = []) {
+  const roleNames = new Set(splitRoleString(roleValue));
+  const isAdmin = isOwner || roleNames.has("admin");
+  const canManageSecurityConfiguration = isOwner || roleHasSecurityConfigurationPermission(roleValue, roleDefinitions);
 
   return {
     isOwner,
     isAdmin,
+    canManageSecurityConfiguration,
     canInviteMembers: isAdmin,
     canCancelInvitations: isAdmin,
     canManageMembers: isOwner,
     canRemoveMembers: isAdmin,
     canManageRoles: isOwner,
     canManageTeams: isAdmin,
-    canManageApiKeys: isAdmin,
-    canManageScim: isAdmin,
-    canManageSso: isAdmin,
+    canManageApiKeys: canManageSecurityConfiguration,
+    canManageScim: canManageSecurityConfiguration,
+    canManageSso: canManageSecurityConfiguration,
   };
 }
 

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/layout.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/layout.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { getOrgAccessFlags } from "../../_lib/den-org";
+import { usePathname, useRouter } from "next/navigation";
+import { getApiKeysRoute, getOrgAccessFlags } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 
 export default function AdminDashboardLayout({
@@ -11,17 +11,20 @@ export default function AdminDashboardLayout({
   children: React.ReactNode;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
   const { orgContext, orgBusy } = useOrgDashboard();
   const access = getOrgAccessFlags(
     orgContext?.currentMember.role ?? "member",
     orgContext?.currentMember.isOwner ?? false,
+    orgContext?.roles,
   );
+  const canUseAdminRoute = access.isAdmin || (pathname === getApiKeysRoute() && access.canManageApiKeys);
 
   useEffect(() => {
-    if (orgContext && !access.isAdmin) {
+    if (orgContext && !canUseAdminRoute) {
       router.replace("/dashboard");
     }
-  }, [access.isAdmin, orgContext, router]);
+  }, [canUseAdminRoute, orgContext, router]);
 
   if (orgBusy || !orgContext) {
     return (
@@ -31,7 +34,7 @@ export default function AdminDashboardLayout({
     );
   }
 
-  if (!access.isAdmin) {
+  if (!canUseAdminRoute) {
     return (
       <div className="flex min-h-[320px] items-center justify-center px-6 text-[14px] text-gray-500">
         Redirecting to your dashboard...

--- a/ee/apps/den-web/app/(den)/dashboard/_components/api-keys-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/api-keys-screen.tsx
@@ -69,8 +69,9 @@ export function ApiKeysScreen() {
             getOrgAccessFlags(
                 orgContext?.currentMember.role ?? "member",
                 orgContext?.currentMember.isOwner ?? false,
+                orgContext?.roles,
             ),
-        [orgContext?.currentMember.isOwner, orgContext?.currentMember.role],
+        [orgContext?.currentMember.isOwner, orgContext?.currentMember.role, orgContext?.roles],
     );
 
     async function loadApiKeys() {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-home-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-home-screen.tsx
@@ -10,6 +10,7 @@ export function DashboardHomeScreen() {
   const access = getOrgAccessFlags(
     orgContext?.currentMember.role ?? "member",
     orgContext?.currentMember.isOwner ?? false,
+    orgContext?.roles,
   );
 
   if (orgBusy || !orgContext) {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
@@ -169,8 +169,9 @@ export function ManageMembersScreen() {
       getOrgAccessFlags(
         orgContext?.currentMember.role ?? "member",
         orgContext?.currentMember.isOwner ?? false,
+        orgContext?.roles,
       ),
-    [orgContext?.currentMember.isOwner, orgContext?.currentMember.role],
+    [orgContext?.currentMember.isOwner, orgContext?.currentMember.role, orgContext?.roles],
   );
   const canStartSeatCheckout = orgContext?.currentMember.isOwner === true;
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -21,6 +21,7 @@ import {
   SlidersHorizontal,
   Sparkles,
   Store,
+  type LucideIcon,
   Users,
   X,
 } from "lucide-react";
@@ -48,6 +49,13 @@ import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { buildDenFeedbackUrl } from "../../_lib/feedback";
 
 const OPENWORK_DOCS_URL = "https://openworklabs.com/docs";
+
+type DashboardNavItem = {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  badge?: string;
+};
 
 function OrgMark({ name }: { name: string }) {
   const initials = useMemo(() => {
@@ -171,6 +179,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   const access = getOrgAccessFlags(
     orgContext?.currentMember.role ?? "member",
     orgContext?.currentMember.isOwner ?? false,
+    orgContext?.roles,
   );
 
   const pageTitle = getDashboardPageTitle(pathname, activeOrg?.slug ?? null);
@@ -179,99 +188,109 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
     orgSlug: activeOrg?.slug,
   });
 
-  const navItems = [
+  const adminNavItems: DashboardNavItem[] = access.isAdmin
+    ? [
+        {
+          href: activeOrg ? getAnalyticsRoute(activeOrg.slug) : "#",
+          label: "Analytics",
+          icon: BarChart3,
+          badge: "New",
+        },
+        // NOTE: Shared Workspace soft-disabled — uncomment to re-enable
+        // {
+        //   href: activeOrg ? getBackgroundAgentsRoute(activeOrg.slug) : "#",
+        //   label: "Shared Workspace",
+        //   icon: Bot,
+        //   badge: "Alpha",
+        // },
+        {
+          href: activeOrg ? getInferenceRoute(activeOrg.slug) : "#",
+          label: "OpenWork Models",
+          icon: Sparkles,
+          badge: "Beta",
+        },
+        {
+          href: activeOrg ? getCustomLlmProvidersRoute(activeOrg.slug) : "#",
+          label: "LLM Providers",
+          icon: Cpu,
+        },
+        {
+          href: activeOrg ? getDesktopPoliciesRoute(activeOrg.slug) : "#",
+          label: "Desktop Policies",
+          icon: Laptop,
+        },
+        {
+          href: activeOrg ? getIntegrationsRoute(activeOrg.slug) : "#",
+          label: "Integrations",
+          icon: Cable,
+          badge: "New",
+        },
+        {
+          href: activeOrg ? getMarketplacesRoute(activeOrg.slug) : "#",
+          label: "Marketplaces",
+          icon: Store,
+          badge: "New",
+        },
+        {
+          href: activeOrg ? getPluginsRoute(activeOrg.slug) : "#",
+          label: "Plugins",
+          icon: Puzzle,
+          badge: "New",
+        },
+        {
+          href: activeOrg ? getMembersRoute(activeOrg.slug) : "#",
+          label: "Members",
+          icon: Users,
+        },
+      ]
+    : [];
+  const securityNavItems: DashboardNavItem[] = [
+    ...(access.canManageApiKeys
+      ? [{
+          href: activeOrg ? getApiKeysRoute(activeOrg.slug) : "#",
+          label: "API Keys",
+          icon: KeyRound,
+        }]
+      : []),
+    ...(access.canManageScim
+      ? [{
+          href: activeOrg ? getScimRoute(activeOrg.slug) : "#",
+          label: "SCIM",
+          icon: Shield,
+        }]
+      : []),
+    ...(access.canManageSso
+      ? [{
+          href: activeOrg ? getSsoRoute(activeOrg.slug) : "#",
+          label: "SSO",
+          icon: Shield,
+        }]
+      : []),
+  ];
+  const ownerAdminNavItems: DashboardNavItem[] = access.isAdmin
+    ? [
+        {
+          href: getBillingRoute(activeOrg?.slug),
+          label: "Billing",
+          icon: CreditCard,
+        },
+        {
+          href: activeOrg ? getOrgSettingsRoute(activeOrg.slug) : "#",
+          label: "Org Settings",
+          icon: SlidersHorizontal,
+        },
+      ]
+    : [];
+
+  const navItems: DashboardNavItem[] = [
     {
       href: activeOrg ? getOrgDashboardRoute(activeOrg.slug) : "#",
       label: "Dashboard",
       icon: Home,
     },
-    ...(access.isAdmin
-      ? [
-          {
-            href: activeOrg ? getAnalyticsRoute(activeOrg.slug) : "#",
-            label: "Analytics",
-            icon: BarChart3,
-            badge: "New",
-          },
-          // NOTE: Shared Workspace soft-disabled — uncomment to re-enable
-          // {
-          //   href: activeOrg ? getBackgroundAgentsRoute(activeOrg.slug) : "#",
-          //   label: "Shared Workspace",
-          //   icon: Bot,
-          //   badge: "Alpha",
-          // },
-          {
-            href: activeOrg ? getInferenceRoute(activeOrg.slug) : "#",
-            label: "OpenWork Models",
-            icon: Sparkles,
-            badge: "Beta",
-          },
-          {
-            href: activeOrg ? getCustomLlmProvidersRoute(activeOrg.slug) : "#",
-            label: "LLM Providers",
-            icon: Cpu,
-          },
-          {
-            href: activeOrg ? getDesktopPoliciesRoute(activeOrg.slug) : "#",
-            label: "Desktop Policies",
-            icon: Laptop,
-          },
-          {
-            href: activeOrg ? getIntegrationsRoute(activeOrg.slug) : "#",
-            label: "Integrations",
-            icon: Cable,
-            badge: "New",
-          },
-          {
-            href: activeOrg ? getMarketplacesRoute(activeOrg.slug) : "#",
-            label: "Marketplaces",
-            icon: Store,
-            badge: "New",
-          },
-          {
-            href: activeOrg ? getPluginsRoute(activeOrg.slug) : "#",
-            label: "Plugins",
-            icon: Puzzle,
-            badge: "New",
-          },
-          {
-            href: activeOrg ? getMembersRoute(activeOrg.slug) : "#",
-            label: "Members",
-            icon: Users,
-          },
-          ...(access.canManageApiKeys
-            ? [{
-                href: activeOrg ? getApiKeysRoute(activeOrg.slug) : "#",
-                label: "API Keys",
-                icon: KeyRound,
-              }]
-            : []),
-          ...(access.canManageScim
-            ? [{
-                href: activeOrg ? getScimRoute(activeOrg.slug) : "#",
-                label: "SCIM",
-                icon: Shield,
-              }]
-            : []),
-          ...(access.canManageSso
-            ? [{
-                href: activeOrg ? getSsoRoute(activeOrg.slug) : "#",
-                label: "SSO",
-                icon: Shield,
-              }]
-            : []),
-          {
-            href: getBillingRoute(activeOrg?.slug),
-            label: "Billing",
-            icon: CreditCard,
-          },
-          {
-            href: activeOrg ? getOrgSettingsRoute(activeOrg.slug) : "#",
-            label: "Org Settings",
-            icon: SlidersHorizontal,
-          },
-        ]
-      : []),
+    ...adminNavItems,
+    ...securityNavItems,
+    ...ownerAdminNavItems,
   ];
 
   const orgSwitcher = (

--- a/ee/apps/den-web/app/(den)/dashboard/_components/scim-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/scim-screen.tsx
@@ -51,8 +51,9 @@ export function ScimScreen() {
       getOrgAccessFlags(
         orgContext?.currentMember.role ?? "member",
         orgContext?.currentMember.isOwner ?? false,
+        orgContext?.roles,
       ),
-    [orgContext?.currentMember.isOwner, orgContext?.currentMember.role],
+    [orgContext?.currentMember.isOwner, orgContext?.currentMember.role, orgContext?.roles],
   );
 
   async function loadScimConfig(isCurrent = () => true) {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
@@ -47,8 +47,8 @@ export function SsoScreen() {
   const [tokenEndpointAuthentication, setTokenEndpointAuthentication] = useState<"" | "client_secret_basic" | "client_secret_post">("");
 
   const access = useMemo(
-    () => getOrgAccessFlags(orgContext?.currentMember.role ?? "member", orgContext?.currentMember.isOwner ?? false),
-    [orgContext?.currentMember.isOwner, orgContext?.currentMember.role],
+    () => getOrgAccessFlags(orgContext?.currentMember.role ?? "member", orgContext?.currentMember.isOwner ?? false, orgContext?.roles),
+    [orgContext?.currentMember.isOwner, orgContext?.currentMember.role, orgContext?.roles],
   );
 
   async function loadSsoConfig() {

--- a/packages/docs/cloud/members-and-rbac.mdx
+++ b/packages/docs/cloud/members-and-rbac.mdx
@@ -64,6 +64,8 @@ You can use teams to control access to marketplaces and LLM providers without as
 4. Choose the permissions that role should have.
 5. Click `Create role`.
 
+Use `security_configuration.manage` for the identity/security operator role that manages SSO, SCIM, and organization API keys. Keep it separate from day-to-day `Admin` membership operations when your organization needs separation of duties.
+
 ## Practical access pattern
 
 A simple setup that works well for most orgs:

--- a/packages/docs/cloud/security-and-operations.mdx
+++ b/packages/docs/cloud/security-and-operations.mdx
@@ -105,7 +105,7 @@ OpenWork records structured organization audit events for privileged Cloud actio
 - SCIM token rotation and connection deletion
 - SSO registration and deletion
 
-Audit payloads avoid bearer tokens, API key secrets, SCIM tokens, SAML certificates, and OIDC client secrets. For private deployments, export audit data through the deployment's database or logging pipeline into the organization's retention and SIEM process.
+Audit payloads avoid bearer tokens, API key secrets, SCIM tokens, SAML certificates, and OIDC client secrets. Sensitive access changes also emit structured `[audit-alert]` log lines so operators can route SSO, SCIM, API-key, role, invitation, and member-change events into alerting. For private deployments, export audit data and audit-alert logs through the deployment's database or logging pipeline into the organization's retention and SIEM process.
 
 ## Availability and failover
 


### PR DESCRIPTION
## Summary\n- keep default Admin membership capabilities separate from security-configuration management in Den web\n- show SSO, SCIM, and API-key controls only to Owners or roles with security_configuration.manage\n- emit structured [audit-alert] log lines for sensitive org access changes\n- document the delegated security role pattern and audit-alert routing\n\n## Tests\n- pnpm exec bun test "ee/apps/den-api/test/org-identity-access.test.ts" "ee/apps/den-api/test/org-role-permissions.test.ts" "ee/apps/den-api/test/audit-events.test.ts" "ee/apps/den-api/test/den-web-org-access.test.ts" — 23 pass\n- pnpm --filter @openwork-ee/den-web exec tsc --noEmit — pass\n- pnpm --filter @openwork-ee/den-api build — pass\n- git diff --check — pass\n- pnpm dev:web-local — stack started on 3005/8788/8789/8791; smoke-tested /, /dashboard, /dashboard/api-keys, /dashboard/scim, /dashboard/sso as 200 and unauthenticated /v1/me as 401\n\n## Evidence\n- Browser smoke tested API Keys, SCIM, and SSO pages with no Next error overlay.\n- No video captured.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

