### PR TITLE
docs(cloud): document hosted HA topology

### DIFF
--- a/packages/docs/cloud/security-and-operations.mdx
+++ b/packages/docs/cloud/security-and-operations.mdx
@@ -113,13 +113,21 @@ Audit payloads avoid bearer tokens, API key secrets, SCIM tokens, SAML certifica
 
 ## Availability and failover
 
-Production deployments should avoid a single-node control plane:
+OpenWork Cloud treats Den API as the logical control plane for identity, RBAC, hosted workers, shared providers, and organization policy. The hosted deployment avoids making that logical control plane a single physical chokepoint:
+
+- Render runs the Cloud app and Den API as scaled services with a minimum of two instances for production traffic.
+- Render load balances requests across healthy instances, stops routing to instances that fail health checks, and restarts failed instances.
+- Den API instances are stateless application replicas; shared state lives in PlanetScale and external managed services.
+- PlanetScale production clusters provide one primary and at least two replicas across three availability zones, with automated failover managed by PlanetScale.
+- PlanetScale automated backups run at least every 12 hours on the Base plan; operators should also define retention, restore testing, and point-in-time recovery expectations for their plan.
+
+Production and private deployments should avoid a single-node control plane:
 
 - Run the Cloud app and Den API behind health checks.
 - Run more than one API instance where the platform supports it.
-- Use a managed database with automated backups and failover.
+- Use a managed database with automated backups and failover, such as PlanetScale production branches or an equivalent MySQL-compatible HA service.
 - Monitor API health, worker provisioning, queue depth, webhook failures, sign-in failures, and database connectivity.
 - Define recovery objectives for the database, object storage, and worker state.
 - Test restore and failover procedures before an incident.
 
-For self-hosted deployments, document the exact topology: ingress, app, API, worker provisioning, database, backups, and the person or team responsible for each part.
+For self-hosted deployments, document the exact topology: ingress, app, API, worker provisioning, database, backups, failover owner, restore owner, and the person or team responsible for each part.

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -22,6 +22,8 @@ If you only need one private remote workspace, deploy the worker runtime. If you
 
 Our hosted deployment uses Render for long-running services and worker provisioning. Render gives us service deploys, env vars, health checks, logs, and worker builds without asking us to operate raw AWS services directly. If you want to run closer to AWS yourself, use the same service boundaries on ECS/Fargate, EC2, Kubernetes, or another container platform.
 
+In production, hosted OpenWork runs the Cloud app and Den controller as scaled Render services with at least two instances. Render load balances traffic across healthy instances, removes failing instances from routing, and restarts failed instances. Den controller application instances are stateless replicas; shared control-plane state is stored in PlanetScale.
+
 The production shape is straightforward:
 
 - Put HTTPS in front of every public service.
@@ -36,6 +38,7 @@ For a containerized worker runtime, start from the [Docker packaging](https://gi
 
 - Worker runtimes use filesystem state and opencode SQLite data inside the mounted workspace/data paths.
 - The Den control plane uses a MySQL-compatible database. Local Docker uses MySQL 8.4; production can use standard MySQL or PlanetScale-compatible credentials.
+- Hosted OpenWork uses PlanetScale for Den control-plane state. PlanetScale production clusters provide one primary and at least two replicas across three availability zones, managed failover, and automated backups.
 - Postgres is not required by the current Den deployment path.
 
 For production, configure encryption explicitly:
@@ -44,6 +47,8 @@ For production, configure encryption explicitly:
 - Require TLS for application-to-database traffic. PlanetScale connections require TLS. For standard MySQL, include a certificate-verifying SSL mode in `DATABASE_URL`, such as `?sslmode=require`, `?sslmode=verify-ca`, or `?sslmode=verify-full`.
 - Keep the local Docker MySQL URL (`mysql://root:password@127.0.0.1:3306/openwork_den`) for development only; it is not a production security posture.
 - Set a unique `DEN_DB_ENCRYPTION_KEY` of at least 32 characters. OpenWork uses it to encrypt selected sensitive database columns, but it does not replace infrastructure-level encryption at rest.
+
+For a self-hosted production deployment, use a managed MySQL-compatible database with automated failover and backups, or provide equivalent redundancy yourself. Document the restore process, backup retention, recovery time objective, recovery point objective, and the person or team responsible for failover and restore.
 
 ## Auth and SSO
 


### PR DESCRIPTION
## Summary
- Document hosted OpenWork Cloud HA topology with Render multi-instance services and health-check recovery.
- Document PlanetScale redundancy, managed failover, and backups for Den control-plane state.
- Clarify self-hosted HA, backup, RTO/RPO, and ownership expectations.

## Validation
- `git diff --check`
- Docs-only change; no app tests or video/screenshot captured.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

