### PR TITLE
fix(settings): align authorized folders empty state

### DIFF
--- a/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
+++ b/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
@@ -154,10 +154,11 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
   const canPickAuthorizedFolder =
     isDesktopRuntime() && canWriteConfig && props.activeWorkspaceType === "local";
   const workspaceRootFolder = serverWorkspaceRoot || props.selectedWorkspaceRoot.trim();
-  const visibleAuthorizedFolders = useMemo(() => {
+  const externalAuthorizedFolders = useMemo(() => {
     const root = workspaceRootFolder;
-    return root ? [root, ...authorizedFolders.filter((folder) => folder !== root)] : authorizedFolders;
+    return root ? authorizedFolders.filter((folder) => folder !== root) : authorizedFolders;
   }, [authorizedFolders, workspaceRootFolder]);
+  const hasVisibleFolderRows = Boolean(workspaceRootFolder) || externalAuthorizedFolders.length > 0;
 
   useEffect(() => {
     const openworkClient = props.openworkServerClient;
@@ -292,10 +293,20 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
         </SettingsNotice>
       ) : (
         <>
-          {/* Folder list */}
-          {visibleAuthorizedFolders.length > 0 ? (
+          {hasVisibleFolderRows ? (
             <ul className="flex flex-col gap-2">
-              {visibleAuthorizedFolders.map((folder) => (
+              {workspaceRootFolder ? (
+                <AuthorizedFolderItem
+                  key={workspaceRootFolder}
+                  folder={workspaceRootFolder}
+                  workspaceRootFolder={workspaceRootFolder}
+                  authorizedFoldersLoading={authorizedFoldersLoading}
+                  authorizedFoldersSaving={authorizedFoldersSaving}
+                  canWriteConfig={canWriteConfig}
+                  onRemove={removeAuthorizedFolder}
+                />
+              ) : null}
+              {externalAuthorizedFolders.map((folder) => (
                 <AuthorizedFolderItem
                   key={folder}
                   folder={folder}
@@ -307,7 +318,9 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
                 />
               ))}
             </ul>
-          ) : (
+          ) : null}
+
+          {externalAuthorizedFolders.length === 0 ? (
             <Empty
               variant="ghost"
               className="rounded-2xl border border-dashed border-dls-border bg-dls-surface px-5 py-8 text-dls-text"
@@ -333,7 +346,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
                 </Button>
               </EmptyContent>
             </Empty>
-          )}
+          ) : null}
 
           {/* Status / error */}
           {authorizedFoldersStatus ? (

--- a/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
+++ b/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
@@ -308,27 +308,30 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
               ))}
             </ul>
           ) : (
-            <Empty>
+            <Empty
+              variant="ghost"
+              className="rounded-2xl border border-dashed border-dls-border bg-dls-surface px-5 py-8 text-dls-text"
+            >
               <EmptyHeader>
-                <EmptyMedia>
-                  <Folder className="text-muted-foreground" />
+                <EmptyMedia className="mb-1 flex size-10 rounded-xl border border-dls-border bg-dls-hover text-dls-secondary">
+                  <Folder className="size-5" />
                 </EmptyMedia>
-                <EmptyTitle>
+                <EmptyTitle className="text-sm text-dls-text">
                   {t("context_panel.no_external_folders")}
                 </EmptyTitle>
-                <EmptyDescription>
+                <EmptyDescription className="text-xs text-dls-secondary">
                   {t("context_panel.add_folder_hint")}
                 </EmptyDescription>
               </EmptyHeader>
-            <EmptyContent>
-              <Button
-                onClick={() => void pickAuthorizedFolder()}
-                disabled={authorizedFoldersLoading || authorizedFoldersSaving || !canPickAuthorizedFolder}
-              >
-                <Plus className="size-4" />
-                Add folder
-              </Button>
-            </EmptyContent>
+              <EmptyContent>
+                <Button
+                  onClick={() => void pickAuthorizedFolder()}
+                  disabled={authorizedFoldersLoading || authorizedFoldersSaving || !canPickAuthorizedFolder}
+                >
+                  <Plus className="size-4" />
+                  Add folder
+                </Button>
+              </EmptyContent>
             </Empty>
           )}
 


### PR DESCRIPTION
## Summary
- Fixes #1101
- Restyles the Authorized folders empty state to match the Settings dark theme
- Uses OpenWork settings DLS surface, border, and text tokens instead of the generic Empty defaults

## Verification
- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/app test
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

