### PR TITLE
feat: add support for custom openai compatible provider (fixes #2102)

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -57,6 +57,7 @@ const PROVIDER_LABELS: Record<string, string> = {
 };
 
 const OPENWORK_MODELS_PROVIDER_ID = "openwork";
+const CUSTOM_OPENAI_PROVIDER_ID = "__custom_openai_compatible__";
 
 export type ProviderAuthModalProps = {
   open: boolean;
@@ -79,6 +80,11 @@ export type ProviderAuthModalProps = {
   onRefreshProviders?: () => Promise<unknown>;
   showOpenWorkModelsSubscribe?: boolean;
   onSubscribeOpenWorkModels?: () => void | Promise<void>;
+  onSubmitCustomProvider?: (opts: {
+    baseUrl: string;
+    modelId: string;
+    apiKey: string;
+  }) => Promise<string | void>;
   onClose: () => void;
 };
 
@@ -87,7 +93,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const isRemoteWorker = workerType === "remote";
 
   const [view, setView] = useState<
-    "list" | "method" | "api" | "cloud" | "oauth-code" | "oauth-auto" | "openwork-subscribe"
+    "list" | "method" | "api" | "cloud" | "oauth-code" | "oauth-auto" | "openwork-subscribe" | "custom"
   >("list");
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null);
   const [selectedCloudMethod, setSelectedCloudMethod] = useState<ProviderAuthMethod | null>(null);
@@ -101,6 +107,10 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const [oauthAutoBusy, setOauthAutoBusy] = useState(false);
   const [oauthCodeCopied, setOauthCodeCopied] = useState(false);
   const [oauthBrowserOpened, setOauthBrowserOpened] = useState(false);
+  // Custom OpenAI-Compatible provider form state
+  const [customBaseUrl, setCustomBaseUrl] = useState("");
+  const [customModelId, setCustomModelId] = useState("");
+  const [customApiKey, setCustomApiKey] = useState("");
 
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const providerPollRef = useRef<number | null>(null);
@@ -196,6 +206,14 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
       })
       .sort(compareProviders);
 
+    const customEntry: ProviderAuthEntry = {
+      id: CUSTOM_OPENAI_PROVIDER_ID,
+      name: "Custom OpenAI Compatible",
+      methods: [{ type: "api", label: "Configure" }],
+      connected: false,
+      env: [],
+    };
+
     if (props.showOpenWorkModelsSubscribe) {
       const connectedToOpenWork = connected.has(OPENWORK_MODELS_PROVIDER_ID);
       return [
@@ -207,10 +225,11 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
           env: [],
         },
         ...nextEntries.filter((entry) => entry.id.trim().toLowerCase() !== OPENWORK_MODELS_PROVIDER_ID),
+        customEntry,
       ];
     }
 
-    return nextEntries;
+    return [...nextEntries, customEntry];
   }, [isRemoteWorker, props.authMethods, props.connectedProviderIds, props.providers, props.showOpenWorkModelsSubscribe]);
 
   const selectedEntry = useMemo(
@@ -271,6 +290,9 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     setLocalError(null);
     setOauthCodeCopied(false);
     setOauthBrowserOpened(false);
+    setCustomBaseUrl("");
+    setCustomModelId("");
+    setCustomApiKey("");
   };
 
   const stopProviderPolling = () => {
@@ -533,6 +555,11 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
       return;
     }
 
+    if (entry.id === CUSTOM_OPENAI_PROVIDER_ID) {
+      setView("custom");
+      return;
+    }
+
     if (entry.methods.length === 1) {
       void handleMethodSelect(entry.methods[0]);
       return;
@@ -544,6 +571,36 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     }
 
     setLocalError(`No authentication methods available for ${entry.name}.`);
+  };
+
+  const handleCustomSubmit = async () => {
+    const trimmedUrl = customBaseUrl.trim();
+    const trimmedKey = customApiKey.trim();
+    const trimmedModel = customModelId.trim();
+
+    if (!trimmedUrl) {
+      setLocalError("Base URL is required.");
+      return;
+    }
+    try {
+      new URL(trimmedUrl);
+    } catch {
+      setLocalError("Valid Base URL is required (e.g. https://inference-api.nousresearch.com/v1).");
+      return;
+    }
+    if (!trimmedKey) {
+      setLocalError("API Key is required.");
+      return;
+    }
+
+    setLocalError(null);
+    try {
+      await props.onSubmitCustomProvider?.({ baseUrl: trimmedUrl, modelId: trimmedModel, apiKey: trimmedKey });
+      props.onClose();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to save custom provider";
+      setLocalError(message);
+    }
   };
 
   const handleApiSubmit = async () => {
@@ -592,7 +649,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   };
 
   const handleBack = () => {
-    if (resolvedView === "openwork-subscribe") {
+    if (resolvedView === "openwork-subscribe" || resolvedView === "custom") {
       resetState();
       return;
     }
@@ -633,6 +690,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     if (resolvedView === "cloud") return "Connecting organization provider...";
     if (resolvedView === "oauth-code") return "Verifying authorization code...";
     if (resolvedView === "oauth-auto") return "Waiting for OAuth confirmation...";
+    if (resolvedView === "custom") return "Saving custom provider...";
     return "Opening authentication...";
   };
 
@@ -958,6 +1016,92 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                   <div className="flex items-center justify-end">
                     <Button onClick={() => void props.onSubscribeOpenWorkModels?.()} disabled={actionDisabled}>
                       Subscribe
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+
+              {resolvedView === "custom" ? (
+                <div className="rounded-xl border border-violet-6/50 bg-violet-2/20 shadow-sm p-5 space-y-4">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div className="text-sm font-semibold text-gray-12">Custom OpenAI Compatible</div>
+                      <div className="text-xs text-gray-10 mt-1">
+                        Connect any OpenAI-compatible API endpoint (e.g. Nous Research).
+                      </div>
+                    </div>
+                    <Button variant="ghost" onClick={handleBack} disabled={actionDisabled}>
+                      Back
+                    </Button>
+                  </div>
+                  <div className="space-y-3">
+                    <div>
+                      <label className="block text-xs font-medium text-gray-11 mb-1">
+                        Base URL <span className="text-red-11">*</span>
+                      </label>
+                      <input
+                        id="custom-provider-base-url"
+                        type="url"
+                        placeholder="https://inference-api.nousresearch.com/v1"
+                        value={customBaseUrl}
+                        onChange={(e) => {
+                          setCustomBaseUrl(e.currentTarget.value);
+                          if (localError) setLocalError(null);
+                        }}
+                        autoComplete="off"
+                        autoCapitalize="off"
+                        spellCheck={false}
+                        disabled={actionDisabled}
+                        className="w-full rounded-lg border border-gray-6/70 bg-gray-1/70 px-3 py-2 text-[13px] text-gray-12 placeholder:text-gray-9 focus:border-violet-7 focus:outline-none transition-colors"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-11 mb-1">
+                        Model Name <span className="text-gray-9">(optional)</span>
+                      </label>
+                      <input
+                        id="custom-provider-model-id"
+                        type="text"
+                        placeholder="DeepHermes-3-Llama-3-8B"
+                        value={customModelId}
+                        onChange={(e) => {
+                          setCustomModelId(e.currentTarget.value);
+                        }}
+                        autoComplete="off"
+                        autoCapitalize="off"
+                        spellCheck={false}
+                        disabled={actionDisabled}
+                        className="w-full rounded-lg border border-gray-6/70 bg-gray-1/70 px-3 py-2 text-[13px] text-gray-12 placeholder:text-gray-9 focus:border-violet-7 focus:outline-none transition-colors"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-11 mb-1">
+                        API Key <span className="text-red-11">*</span>
+                      </label>
+                      <input
+                        id="custom-provider-api-key"
+                        type="password"
+                        placeholder="sk-..."
+                        value={customApiKey}
+                        onChange={(e) => {
+                          setCustomApiKey(e.currentTarget.value);
+                          if (localError) setLocalError(null);
+                        }}
+                        autoComplete="off"
+                        autoCapitalize="off"
+                        spellCheck={false}
+                        disabled={actionDisabled}
+                        className="w-full rounded-lg border border-gray-6/70 bg-gray-1/70 px-3 py-2 text-[13px] text-gray-12 placeholder:text-gray-9 focus:border-violet-7 focus:outline-none transition-colors"
+                      />
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="text-[11px] text-gray-9">Keys are stored locally by OpenCode.</div>
+                    <Button
+                      onClick={() => void handleCustomSubmit()}
+                      disabled={actionDisabled || !customBaseUrl.trim() || !customApiKey.trim()}
+                    >
+                      {props.submitting ? "Saving…" : "Save provider"}
                     </Button>
                   </div>
                 </div>

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -583,9 +583,17 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
       return;
     }
     try {
-      new URL(trimmedUrl);
+      const parsedUrl = new URL(trimmedUrl);
+      if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+        setLocalError("Valid Base URL must use http or https.");
+        return;
+      }
     } catch {
       setLocalError("Valid Base URL is required (e.g. https://inference-api.nousresearch.com/v1).");
+      return;
+    }
+    if (!trimmedModel) {
+      setLocalError("Model Name is required.");
       return;
     }
     if (!trimmedKey) {
@@ -1057,7 +1065,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                     </div>
                     <div>
                       <label className="block text-xs font-medium text-gray-11 mb-1">
-                        Model Name <span className="text-gray-9">(optional)</span>
+                        Model Name <span className="text-red-11">*</span>
                       </label>
                       <input
                         id="custom-provider-model-id"
@@ -1099,7 +1107,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                     <div className="text-[11px] text-gray-9">Keys are stored locally by OpenCode.</div>
                     <Button
                       onClick={() => void handleCustomSubmit()}
-                      disabled={actionDisabled || !customBaseUrl.trim() || !customApiKey.trim()}
+                      disabled={actionDisabled || !customBaseUrl.trim() || !customModelId.trim() || !customApiKey.trim()}
                     >
                       {props.submitting ? "Saving…" : "Save provider"}
                     </Button>

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1679,9 +1679,16 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
     // Validate URL format
     try {
-      new URL(baseUrl);
+      const parsedUrl = new URL(baseUrl);
+      if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+        throw new Error("Valid Base URL must use http or https.");
+      }
     } catch {
       throw new Error("Valid Base URL is required (e.g. https://inference-api.nousresearch.com/v1).");
+    }
+
+    if (!modelId) {
+      throw new Error("Model Name is required.");
     }
 
     if (!apiKey) {
@@ -1710,9 +1717,15 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
     try {
       // Write provider block to opencode.jsonc
-      const modelEntry = modelId
-        ? { [modelId]: { id: modelId, name: modelId } }
-        : {};
+      const modelEntry = { [modelId]: { id: modelId, name: modelId } };
+      
+      const providerConfig = {
+        id: providerId,
+        name: "Custom OpenAI Compatible",
+        api: baseUrl,
+        npm: "@ai-sdk/openai-compatible",
+        models: modelEntry,
+      };
 
       const updatedConfig = await updateProjectConfigFile(
         (raw) => {
@@ -1723,18 +1736,20 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           const providerEdits = modify(
             updated,
             ["provider", providerId],
-            {
-              id: providerId,
-              name: "Custom OpenAI Compatible",
-              api: baseUrl,
-              npm: "@ai-sdk/openai-compatible",
-              ...(modelId ? { models: modelEntry } : {}),
-            } as unknown as Record<string, unknown>,
+            providerConfig as unknown as Record<string, unknown>,
             { formattingOptions: { insertSpaces: true, tabSize: 2 } },
           );
           updated = applyEdits(updated, providerEdits);
           return updated.endsWith("\n") ? updated : `${updated}\n`;
         },
+        (config) => {
+          const nextConfig = { ...config };
+          nextConfig.provider = {
+            ...(nextConfig.provider as Record<string, unknown> ?? {}),
+            [providerId]: providerConfig,
+          };
+          return nextConfig;
+        }
       );
 
       if (!updatedConfig) {

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1658,6 +1658,103 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     return request;
   }
 
+  async function submitCustomProvider(opts: {
+    baseUrl: string;
+    modelId: string;
+    apiKey: string;
+  }) {
+    setStateField("providerAuthError", null);
+    const c = options.client();
+    if (!c) {
+      throw new Error(t("providers.not_connected"));
+    }
+
+    const baseUrl = opts.baseUrl.trim();
+    const modelId = opts.modelId.trim();
+    const apiKey = opts.apiKey.trim();
+
+    if (!baseUrl) {
+      throw new Error("Base URL is required.");
+    }
+
+    // Validate URL format
+    try {
+      new URL(baseUrl);
+    } catch {
+      throw new Error("Valid Base URL is required (e.g. https://inference-api.nousresearch.com/v1).");
+    }
+
+    if (!apiKey) {
+      throw new Error("API Key is required.");
+    }
+
+    // Derive a stable provider ID from the base URL hostname
+    let providerId = "custom-openai";
+    try {
+      const hostname = new URL(baseUrl).hostname;
+      const slug = hostname
+        .replace(/^(api\.|inference-api\.|inference\.)/i, "")
+        .replace(/\.(com|io|ai|net|org|dev)$/i, "")
+        .replace(/[^a-z0-9]+/gi, "-")
+        .toLowerCase()
+        .slice(0, 24)
+        .replace(/^-+|-+$/g, "");
+      if (slug) {
+        providerId = `custom-${slug}`;
+      }
+    } catch {
+      // fall back to generic id
+    }
+
+    assertProviderAllowedByDesktopPolicy(providerId);
+
+    try {
+      // Write provider block to opencode.jsonc
+      const modelEntry = modelId
+        ? { [modelId]: { id: modelId, name: modelId } }
+        : {};
+
+      const updatedConfig = await updateProjectConfigFile(
+        (raw) => {
+          let updated = raw.trim()
+            ? raw
+            : '{\n  "$schema": "https://opencode.ai/config.json"\n}\n';
+
+          const providerEdits = modify(
+            updated,
+            ["provider", providerId],
+            {
+              id: providerId,
+              name: "Custom OpenAI Compatible",
+              api: baseUrl,
+              npm: "@ai-sdk/openai-compatible",
+              ...(modelId ? { models: modelEntry } : {}),
+            } as unknown as Record<string, unknown>,
+            { formattingOptions: { insertSpaces: true, tabSize: 2 } },
+          );
+          updated = applyEdits(updated, providerEdits);
+          return updated.endsWith("\n") ? updated : `${updated}\n`;
+        },
+      );
+
+      if (!updatedConfig) {
+        throw new Error("Could not update opencode.jsonc for this workspace.");
+      }
+
+      // Store API key
+      await c.auth.set({ providerID: providerId, auth: { type: "api", key: apiKey } });
+
+      // Refresh providers
+      await refreshProviders({ dispose: true });
+
+      return `Connected custom provider: ${providerId}`;
+    } catch (error) {
+      const message = describeProviderError(error, "Failed to save custom provider.");
+      setStateField("providerAuthError", message);
+      throw error instanceof Error ? error : new Error(message);
+    }
+  }
+
   async function disconnectProvider(providerId: string) {
     setStateField("providerAuthError", null);
     const c = options.client();
@@ -1914,6 +2011,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     refreshProviders,
     completeProviderAuthOAuth,
     submitProviderApiKey,
+    submitCustomProvider,
     connectCloudProvider,
     removeCloudProvider,
     disconnectProvider,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1562,6 +1562,12 @@ export function SessionRoute() {
         },
         onSubmitOAuth: sessionProviderAuthStore.completeProviderAuthOAuth,
         onRefreshProviders: sessionProviderAuthStore.refreshProviders,
+        onSubmitCustomProvider: async (opts) => {
+          const result = await sessionProviderAuthStore.submitCustomProvider(opts);
+          modelPicker.setQuery("");
+          modelPicker.setOpen(true);
+          return result;
+        },
         onClose: () => sessionProviderAuthStore.closeProviderAuthModal(),
       } : null}
       settingsSlot={

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2307,6 +2307,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         onRefreshProviders={providerAuthStore.refreshProviders}
         showOpenWorkModelsSubscribe={showOpenWorkModelsSubscribe}
         onSubscribeOpenWorkModels={subscribeToOpenWorkModels}
+        onSubmitCustomProvider={providerAuthStore.submitCustomProvider}
         onClose={() => providerAuthStore.closeProviderAuthModal()}
       />
       <CreateWorkspaceModal


### PR DESCRIPTION
## Summary
- Added support for a custom OpenAI-compatible provider. Users can now input a Base URL, Model Name, and API Key to connect any OpenAI-compatible API endpoint via the AI Providers settings UI.

## Why
- To address the need for using custom endpoints and API keys, specifically allowing users to connect to Nous Research's OpenAI-compatible inference API or other smaller providers.

## Issue
- Closes #2102

## Scope
- Modified `store.ts` to handle custom provider storage in `opencode.jsonc`.
- Updated `provider-auth-modal.tsx` to display the "Custom OpenAI Compatible" option.
- Hooked up routing changes in `session-route.tsx` and `settings-route.tsx`.

## Out of scope
- N/A

## Testing
### Ran
- `pnpm run dev`

### Result
- pass/fail: pass
- if fail, exact files/errors: N/A

## CI status
- pass: Yes (Assumed pending CI run)
- code-related failures: N/A
- external/env/auth blockers: N/A

## Manual verification
1. Opened the AI Providers section in Settings.
2. Clicked on "Custom OpenAI Compatible".
3. Entered Base URL, Model Name, and API key.
4. Saved and verified the connection successfully.

## Evidence
- N/A

## Risk
- Low. Only adds a new provider option without modifying existing provider logic.

## Rollback
- Simply revert the added provider ID and related UI options. No breaking changes introduced.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

