### PR TITLE
fix(plugins): update path handling to support both POSIX and Windows …

### DIFF
--- a/apps/server/src/plugins.test.ts
+++ b/apps/server/src/plugins.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizePluginSpec } from "./plugins.js";
+
+describe("normalizePluginSpec", () => {
+  test("Windows absolute path with @ in directory is returned unchanged", () => {
+    expect(normalizePluginSpec("C:\\Users\\me@work\\my-plugin")).toBe("C:\\Users\\me@work\\my-plugin");
+  });
+
+  test("POSIX absolute path is returned unchanged", () => {
+    expect(normalizePluginSpec("/abs/path/plugin")).toBe("/abs/path/plugin");
+  });
+
+  test("normal package spec with version is truncated to package name", () => {
+    expect(normalizePluginSpec("some-plugin@1.2.0")).toBe("some-plugin");
+  });
+
+  test("scoped package spec keeps scope, strips version", () => {
+    expect(normalizePluginSpec("@my-org/plugin@2.0.0")).toBe("@my-org/plugin");
+  });
+
+  test("file: url is returned unchanged", () => {
+    expect(normalizePluginSpec("file:///some/plugin")).toBe("file:///some/plugin");
+  });
+
+  test("https: url is returned unchanged", () => {
+    expect(normalizePluginSpec("https://example.com/plugin")).toBe("https://example.com/plugin");
+  });
+});

--- a/apps/server/src/plugins.ts
+++ b/apps/server/src/plugins.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join, relative } from "node:path";
+import { join, posix, relative, win32 } from "node:path";
 import { readdir } from "node:fs/promises";
 import type { PluginItem, ServerConfig } from "./types.js";
 import { readJsoncFile } from "./jsonc.js";
@@ -13,7 +13,7 @@ export function normalizePluginSpec(spec: string): string {
   if (trimmed.startsWith("file:") || trimmed.startsWith("http:") || trimmed.startsWith("https:") || trimmed.startsWith("git:")) {
     return trimmed;
   }
-  if (trimmed.startsWith("/")) {
+  if (posix.isAbsolute(trimmed) || win32.isAbsolute(trimmed)) {
     return trimmed;
   }
   if (trimmed.startsWith("@")) {


### PR DESCRIPTION
## Summary
Fix `normalizePluginSpec` so Windows absolute paths are recognized as local plugin specs instead of being parsed as package names.

## Why
`normalizePluginSpec` only treated `/`-prefixed strings as absolute paths. On Windows, an absolute path like `C:\Users\me\my-plugin` doesn't start with `/`, so it fell through to package-name logic that splits on `@`. A local plugin path containing `@` (e.g. `C:\Users\me@work\my-plugin`) was truncated to `C:\Users\me`, silently pointing at the wrong location.

## Issue
- N/A (no existing issue; bug found while testing plugin specs on Windows)

## Scope
- `apps/server/src/plugins.ts`: recognize both posix and win32 absolute paths via `node:path` (`posix.isAbsolute` / `win32.isAbsolute`), so the check is correct regardless of host OS.
- `apps/server/src/plugins.test.ts`: new unit tests for `normalizePluginSpec`.

## Out of scope
- No changes to plugin loading, validation, or any other normalization branch (file:/http:/https:/git:/scoped packages preserved as-is).

## Testing
### Ran
- `bun test src/plugins.test.ts`
- `tsc --noEmit`

### Result
- pass/fail: pass (6/6 new tests, typecheck clean)
- if fail, exact files/errors: N/A

## CI status
- pass: 6/6 new tests, tsc clean
- code-related failures: none
- external/env/auth blockers: pre-existing Windows suite failures (incl. `cloud-plugins.test.ts` EBUSY temp-dir flakes) are present on `dev` before this change. This PR introduces 0 new failures and touches only the two files above.

## Manual verification
1. On `dev`, `normalizePluginSpec("C:\\Users\\me@work\\my-plugin")` returns `C:\Users\me` (truncated at `@`).
2. After this change, the same input returns `C:\Users\me@work\my-plugin` unchanged.
3. POSIX absolute paths and package/scope/url specs behave exactly as before (covered by tests).

## Evidence
<img width="912" height="332" alt="Screenshot 2026-06-17 023824" src="https://github.com/user-attachments/assets/44c37a7f-f954-4bba-b97a-0dde2c090891" />

## Risk
- Low. Single normalization branch widened; all other branches untouched. `win32.isAbsolute` won't false-positive on package names (they contain no drive letters or backslashes).

## Rollback
- Revert this PR. No migrations, no state, no config changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

