### PR TITLE
fix(app): open generated file links natively

### DIFF
--- a/apps/app/scripts/open-target.test.ts
+++ b/apps/app/scripts/open-target.test.ts
@@ -86,6 +86,22 @@ describe("deriveOpenTargets", () => {
     expect(target ? isCollectibleArtifactTarget({ ...target, exists: true }) : true).toBe(false);
   });
 
+  it("uses markdown link href once when the label is the href basename", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "I generated the file [native-link.txt](reports/native-link.txt)."),
+    ]);
+
+    expect(targets.map((target) => target.value)).toEqual(["reports/native-link.txt"]);
+  });
+
+  it("keeps distinct markdown link labels as normal file mentions", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "I generated the file [summary.md](reports/native-link.txt)."),
+    ]);
+
+    expect(targets.map((target) => target.value).sort()).toEqual(["reports/native-link.txt", "summary.md"]);
+  });
+
   it("extracts PowerPoint decks from assistant artifact summaries", () => {
     const targets = deriveOpenTargets([
       message("msg_1", "assistant", "Updated file: decks/openwork-vertebrae-deck.pptx"),

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -352,6 +352,10 @@ export async function revealDesktopItemInDir(target: string): Promise<void> {
   await invokeElectronHelper("__revealItemInDir", target);
 }
 
+export async function getDesktopFileIcon(target: string, size?: "small" | "normal" | "large"): Promise<string | null> {
+  return invokeElectronHelper("__getFileIcon", target, size);
+}
+
 export async function relaunchDesktopApp(): Promise<void> {
   await window.__OPENWORK_ELECTRON__?.shell?.relaunch?.();
 }

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -356,6 +356,23 @@ export async function getDesktopFileIcon(target: string, size?: "small" | "norma
   return invokeElectronHelper("__getFileIcon", target, size);
 }
 
+export type DesktopApplication = {
+  name: string;
+  appPath: string;
+  icon: string | null;
+};
+
+export async function getDesktopApplicationsForFile(target: string): Promise<DesktopApplication[]> {
+  return invokeElectronHelper("__getApplicationsForFile", target);
+}
+
+export async function openDesktopWithApp(target: string, appPath: string): Promise<void> {
+  const result = await invokeElectronHelper("__openWithApp", target, appPath);
+  if (typeof result === "string" && result.trim()) {
+    throw new Error(result);
+  }
+}
+
 export async function relaunchDesktopApp(): Promise<void> {
   await window.__OPENWORK_ELECTRON__?.shell?.relaunch?.();
 }

--- a/apps/app/src/components/markdown/link-action-menu.tsx
+++ b/apps/app/src/components/markdown/link-action-menu.tsx
@@ -1,0 +1,157 @@
+/** @jsxImportSource react */
+import { useEffect, useRef, useState } from "react";
+import { ExternalLink, Eye, FolderOpen, Loader2 } from "lucide-react";
+
+import type { DesktopApplication } from "@/app/lib/desktop";
+import { getDesktopApplicationsForFile, openDesktopWithApp } from "@/app/lib/desktop";
+import { isElectronRuntime } from "@/app/utils";
+import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
+import type { OpenTargetOptions } from "@/lib/target-provider";
+
+const SUPPORTED_PANEL_PREVIEWS = new Set(["markdown", "sheet", "slides", "image", "pdf", "html", "text"]);
+
+type LinkActionMenuProps = {
+  target: OpenTarget;
+  anchorRect: DOMRect;
+  onOpenTarget: (target: OpenTarget, options?: OpenTargetOptions) => void;
+  onClose: () => void;
+};
+
+export function LinkActionMenu({ target, anchorRect, onOpenTarget, onClose }: LinkActionMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [apps, setApps] = useState<DesktopApplication[] | null>(null);
+  const [appsLoading, setAppsLoading] = useState(false);
+  const canOpenInPanel = target.kind === "file" && SUPPORTED_PANEL_PREVIEWS.has(target.preview);
+  const canOpenExternally = isElectronRuntime() && target.kind === "file";
+
+  useEffect(() => {
+    function handleOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("mousedown", handleOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!canOpenExternally) return;
+    setAppsLoading(true);
+    let cancelled = false;
+    void (async () => {
+      try {
+        const result = await getDesktopApplicationsForFile(target.value);
+        if (!cancelled) {
+          setApps(result.slice(0, 12));
+        }
+      } catch {
+        if (!cancelled) setApps([]);
+      } finally {
+        if (!cancelled) setAppsLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [canOpenExternally, target.value]);
+
+  const handleOpenDefault = () => {
+    onOpenTarget(target, { external: true });
+    onClose();
+  };
+
+  const handleOpenInPanel = () => {
+    onOpenTarget(target);
+    onClose();
+  };
+
+  const handleReveal = () => {
+    onOpenTarget(target, { external: true, reveal: true });
+    onClose();
+  };
+
+  const handleOpenWithApp = async (app: DesktopApplication) => {
+    try {
+      await openDesktopWithApp(target.value, app.appPath);
+    } catch {
+      // fall back to default open
+      onOpenTarget(target, { external: true });
+    }
+    onClose();
+  };
+
+  const top = anchorRect.bottom + 4;
+  const left = anchorRect.left;
+
+  return (
+    <div
+      ref={menuRef}
+      className="fixed z-50 min-w-52 rounded-lg border border-border bg-popover/95 p-1 shadow-lg backdrop-blur-xl"
+      style={{ top, left }}
+    >
+      <button
+        type="button"
+        onClick={handleOpenDefault}
+        disabled={!canOpenExternally}
+        className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-foreground/10 disabled:opacity-50"
+      >
+        <ExternalLink className="size-4 shrink-0" />
+        Open with default app
+      </button>
+      {canOpenInPanel ? (
+        <button
+          type="button"
+          onClick={handleOpenInPanel}
+          className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-foreground/10"
+        >
+          <Eye className="size-4 shrink-0" />
+          Open in panel
+        </button>
+      ) : null}
+      <button
+        type="button"
+        onClick={handleReveal}
+        disabled={!canOpenExternally}
+        className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-foreground/10 disabled:opacity-50"
+      >
+        <FolderOpen className="size-4 shrink-0" />
+        Show in folder
+      </button>
+      {canOpenExternally && apps && apps.length > 0 ? (
+        <>
+          <div className="my-1 h-px bg-foreground/5" />
+          <div className="max-h-48 overflow-y-auto">
+            {apps.map((app) => (
+              <button
+                key={app.appPath}
+                type="button"
+                onClick={() => void handleOpenWithApp(app)}
+                className="flex w-full items-center gap-2.5 rounded-md px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+              >
+                {app.icon ? (
+                  <img src={app.icon} alt="" className="size-4 shrink-0 object-contain" />
+                ) : (
+                  <span className="size-4 shrink-0" />
+                )}
+                <span className="truncate">{app.name}</span>
+              </button>
+            ))}
+          </div>
+        </>
+      ) : appsLoading ? (
+        <>
+          <div className="my-1 h-px bg-foreground/5" />
+          <div className="flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground">
+            <Loader2 className="size-3.5 shrink-0 animate-spin" />
+            Loading apps…
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -22,6 +22,7 @@ import { useOpenTargets } from "@/lib/target-provider";
 import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 
 import { applyTextHighlights } from "./text-highlights";
+import { LinkActionMenu } from "./link-action-menu";
 
 function escapeHtml(value: string) {
   return value
@@ -238,6 +239,7 @@ function sanitizeMarkdownHtml(value: string) {
       "data-openwork-image-toggle",
       "data-openwork-image-toggle-label",
       "data-openwork-link-href",
+      "data-openwork-link-chevron",
       "data-openwork-shiki",
       "decoding",
       "disabled",
@@ -313,14 +315,15 @@ const baseMarkedOptions = {
       const originalHref = escapeAttribute(href);
       const titleAttr = title ? ` title="${escapeAttribute(title)}"` : "";
       const isFilePath = !/^(https?|wss?|ftp|mailto|tel|file):/i.test(href);
-      const linkClass = isFilePath
-        ? "inline-flex items-center gap-1 rounded-md border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs font-medium text-foreground no-underline transition-colors hover:bg-muted hover:border-border"
-        : "text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8";
-      const icon = isFilePath
-        ? `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 text-muted-foreground"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v5h5"/></svg>`
-        : "";
 
-      return `<a href="${safe}" data-openwork-link-href="${originalHref}"${titleAttr} target="_blank" rel="noreferrer noopener" class="${linkClass}">${icon}${this.parser.parseInline(tokens)}</a>`;
+      if (isFilePath) {
+        const fileIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 text-muted-foreground"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v5h5"/></svg>`;
+        const chevron = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 text-muted-foreground"><path d="m6 9 6 6 6-6"/></svg>`;
+
+        return `<span class="inline-flex items-stretch overflow-hidden rounded-md border border-border/60 bg-muted/40 text-xs font-medium text-foreground align-middle"><a href="${safe}" data-openwork-link-href="${originalHref}"${titleAttr} target="_blank" rel="noreferrer noopener" class="inline-flex items-center gap-1 px-1.5 py-0.5 no-underline transition-colors hover:bg-muted">${fileIcon}${this.parser.parseInline(tokens)}</a><button type="button" data-openwork-link-chevron="${originalHref}" class="inline-flex items-center border-l border-border/60 px-1 transition-colors hover:bg-muted" aria-label="Open with">${chevron}</button></span>`;
+      }
+
+      return `<a href="${safe}" data-openwork-link-href="${originalHref}"${titleAttr} target="_blank" rel="noreferrer noopener" class="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8">${this.parser.parseInline(tokens)}</a>`;
     },
     image({ href, title, text }) {
       const safe = escapeAttribute(safeHref(href));
@@ -412,6 +415,7 @@ function MarkdownBlockInner({
 }: MarkdownBlockInnerProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const { openTargets, onOpenTarget } = useOpenTargets();
+  const [linkMenu, setLinkMenu] = useState<{ target: OpenTarget; rect: DOMRect } | null>(null);
   const syncHtml = useMemo(() => {
     if (!text.trim()) {
       return "";
@@ -476,12 +480,26 @@ function MarkdownBlockInner({
     const handleClick = (event: MouseEvent) => {
       if (!(event.target instanceof Element)) return;
 
-      const anchor = event.target.closest("a[data-openwork-link-href]");
-      if (anchor instanceof HTMLAnchorElement) {
-        const target = openTargetForHref(anchor.dataset.openworkLinkHref ?? "", openTargets);
+      const chevron = event.target.closest("[data-openwork-link-chevron]");
+      if (chevron instanceof HTMLElement) {
+        event.preventDefault();
+        event.stopPropagation();
+        const href = chevron.dataset.openworkLinkChevron ?? "";
+        const target = openTargetForHref(href, openTargets);
+        if (target) {
+          setLinkMenu({ target, rect: chevron.getBoundingClientRect() });
+        }
+        return;
+      }
+
+      const link = event.target.closest("a[data-openwork-link-href]");
+      if (link instanceof HTMLAnchorElement) {
+        const href = link.dataset.openworkLinkHref ?? link.getAttribute("href") ?? "";
+        const target = openTargetForHref(href, openTargets);
+
         if (target && onOpenTarget) {
           event.preventDefault();
-          onOpenTarget(target);
+          onOpenTarget(target, { external: true });
           return;
         }
       }
@@ -523,12 +541,22 @@ function MarkdownBlockInner({
   }
 
   return (
-    <motion.div
-      ref={rootRef}
-      className={cn("markdown-content max-w-none text-foreground", className)}
-      dangerouslySetInnerHTML={{ __html: html }}
-      {...props}
-    />
+    <>
+      <motion.div
+        ref={rootRef}
+        className={cn("markdown-content max-w-none text-foreground", className)}
+        dangerouslySetInnerHTML={{ __html: html }}
+        {...props}
+      />
+      {linkMenu && onOpenTarget ? (
+        <LinkActionMenu
+          target={linkMenu.target}
+          anchorRect={linkMenu.rect}
+          onOpenTarget={onOpenTarget}
+          onClose={() => setLinkMenu(null)}
+        />
+      ) : null}
+    </>
   );
 }
 

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -312,8 +312,15 @@ const baseMarkedOptions = {
       const safe = escapeAttribute(safeHref(href));
       const originalHref = escapeAttribute(href);
       const titleAttr = title ? ` title="${escapeAttribute(title)}"` : "";
+      const isFilePath = !/^(https?|wss?|ftp|mailto|tel|file):/i.test(href);
+      const linkClass = isFilePath
+        ? "inline-flex items-center gap-1 rounded-md border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs font-medium text-foreground no-underline transition-colors hover:bg-muted hover:border-border"
+        : "text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8";
+      const icon = isFilePath
+        ? `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 text-muted-foreground"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v5h5"/></svg>`
+        : "";
 
-      return `<a href="${safe}" data-openwork-link-href="${originalHref}"${titleAttr} target="_blank" rel="noreferrer noopener" class="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8">${this.parser.parseInline(tokens)}</a>`;
+      return `<a href="${safe}" data-openwork-link-href="${originalHref}"${titleAttr} target="_blank" rel="noreferrer noopener" class="${linkClass}">${icon}${this.parser.parseInline(tokens)}</a>`;
     },
     image({ href, title, text }) {
       const safe = escapeAttribute(safeHref(href));
@@ -475,7 +482,6 @@ function MarkdownBlockInner({
         if (target && onOpenTarget) {
           event.preventDefault();
           onOpenTarget(target);
-
           return;
         }
       }

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -24,6 +24,9 @@ import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-targ
 import { applyTextHighlights } from "./text-highlights";
 import { LinkActionMenu } from "./link-action-menu";
 
+const WORKSPACES_PREFIX_PATTERN = /^workspaces\/[^/]+\//i;
+const WORKSPACE_ID_PREFIX_PATTERN = /^workspace\/(?:ws_[^/]+|\d+|[0-9a-f-]{6,})\//i;
+
 function escapeHtml(value: string) {
   return value
     .replace(/&/g, "&amp;")
@@ -93,6 +96,8 @@ function normalizeFilePathForMatch(path: string) {
     .trim()
     .replace(/[\\]+/g, "/")
     .replace(/^\.\//, "")
+    .replace(WORKSPACES_PREFIX_PATTERN, "")
+    .replace(WORKSPACE_ID_PREFIX_PATTERN, "")
     .replace(/[/]+$/, "")
     .toLowerCase();
 }
@@ -148,51 +153,6 @@ function parseShikiLanguage(lang: string) {
 
 function hasFencedCodeBlock(text: string) {
   return /(^|\n)```/.test(text);
-}
-
-function normalizeOpenTargetLink(value: string) {
-  const trimmed = value.trim();
-  if (/^(https?|wss?):\/\//i.test(trimmed)) {
-    return trimmed;
-  }
-  const withoutHash = trimmed.split("#")[0] ?? "";
-  const withoutQuery = withoutHash.split("?")[0] ?? "";
-  let decoded = withoutQuery;
-
-  try {
-    decoded = decodeURIComponent(withoutQuery);
-  } catch {
-    decoded = withoutQuery;
-  }
-
-  if (/^file:\/\//i.test(decoded)) {
-    try {
-      const pathname = new URL(decoded).pathname;
-      decoded = /^\/[a-zA-Z]:/.test(pathname) ? pathname.slice(1) : pathname;
-    } catch {
-      decoded = decoded.replace(/^file:\/\//i, "");
-    }
-  }
-
-  return decoded
-    .replace(/[\\]+/g, "/")
-    .replace(/^\.\//, "")
-    .replace(WORKSPACES_PREFIX_PATTERN, "")
-    .replace(WORKSPACE_ID_PREFIX_PATTERN, "")
-    .replace(/\/$/, "");
-}
-
-function linkMatchesTarget(href: string, target: OpenTarget) {
-  const normalizedHref = normalizeOpenTargetLink(href).toLowerCase();
-  const normalizedTarget = normalizeOpenTargetLink(target.value).toLowerCase();
-
-  if (!normalizedHref || !normalizedTarget) return false;
-  if (target.kind === "url") return normalizedHref === normalizedTarget;
-  return normalizedHref === normalizedTarget || normalizedHref.endsWith(`/${normalizedTarget}`) || normalizedTarget.endsWith(`/${normalizedHref}`);
-}
-
-function openTargetForHref(href: string, targets: OpenTarget[]) {
-  return targets.find((target) => linkMatchesTarget(href, target)) ?? null;
 }
 
 function estimatedRenderedImageHeight(image: HTMLImageElement) {

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -149,6 +149,51 @@ function hasFencedCodeBlock(text: string) {
   return /(^|\n)```/.test(text);
 }
 
+function normalizeOpenTargetLink(value: string) {
+  const trimmed = value.trim();
+  if (/^(https?|wss?):\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  const withoutHash = trimmed.split("#")[0] ?? "";
+  const withoutQuery = withoutHash.split("?")[0] ?? "";
+  let decoded = withoutQuery;
+
+  try {
+    decoded = decodeURIComponent(withoutQuery);
+  } catch {
+    decoded = withoutQuery;
+  }
+
+  if (/^file:\/\//i.test(decoded)) {
+    try {
+      const pathname = new URL(decoded).pathname;
+      decoded = /^\/[a-zA-Z]:/.test(pathname) ? pathname.slice(1) : pathname;
+    } catch {
+      decoded = decoded.replace(/^file:\/\//i, "");
+    }
+  }
+
+  return decoded
+    .replace(/[\\]+/g, "/")
+    .replace(/^\.\//, "")
+    .replace(WORKSPACES_PREFIX_PATTERN, "")
+    .replace(WORKSPACE_ID_PREFIX_PATTERN, "")
+    .replace(/\/$/, "");
+}
+
+function linkMatchesTarget(href: string, target: OpenTarget) {
+  const normalizedHref = normalizeOpenTargetLink(href).toLowerCase();
+  const normalizedTarget = normalizeOpenTargetLink(target.value).toLowerCase();
+
+  if (!normalizedHref || !normalizedTarget) return false;
+  if (target.kind === "url") return normalizedHref === normalizedTarget;
+  return normalizedHref === normalizedTarget || normalizedHref.endsWith(`/${normalizedTarget}`) || normalizedTarget.endsWith(`/${normalizedHref}`);
+}
+
+function openTargetForHref(href: string, targets: OpenTarget[]) {
+  return targets.find((target) => linkMatchesTarget(href, target)) ?? null;
+}
+
 function estimatedRenderedImageHeight(image: HTMLImageElement) {
   if (!image.naturalWidth || !image.naturalHeight) return 0;
 

--- a/apps/app/src/lib/target-provider.ts
+++ b/apps/app/src/lib/target-provider.ts
@@ -2,7 +2,13 @@ import * as React from "react";
 
 import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 
-type OpenTargetHandler = (target: OpenTarget, options?: { auto?: boolean }) => void;
+export type OpenTargetOptions = {
+  auto?: boolean;
+  external?: boolean;
+  reveal?: boolean;
+};
+
+type OpenTargetHandler = (target: OpenTarget, options?: OpenTargetOptions) => void;
 
 type OpenTargetContextValue = {
   openTargets: OpenTarget[];

--- a/apps/app/src/lib/target-provider.ts
+++ b/apps/app/src/lib/target-provider.ts
@@ -2,13 +2,7 @@ import * as React from "react";
 
 import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 
-export type OpenTargetOptions = {
-  auto?: boolean;
-  external?: boolean;
-  reveal?: boolean;
-};
-
-type OpenTargetHandler = (target: OpenTarget, options?: OpenTargetOptions) => void;
+type OpenTargetHandler = (target: OpenTarget, options?: { auto?: boolean }) => void;
 
 type OpenTargetContextValue = {
   openTargets: OpenTarget[];

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -4,7 +4,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Download, ExternalLink, FolderOpen, X } from "lucide-react";
 
 import type { OpenworkServerClient } from "@/app/lib/openwork-server";
-import { openDesktopPath, revealDesktopItemInDir } from "@/app/lib/desktop";
+import { getDesktopFileIcon, openDesktopPath, revealDesktopItemInDir } from "@/app/lib/desktop";
+import { isElectronRuntime } from "@/app/utils";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatFileSize } from "@/lib/utils";
@@ -84,6 +85,14 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
   const [draft, setDraft] = useState("");
   const isDirectTextEdit = isTextContent(target) && target.preview === "markdown";
   const externalPath = useMemo(() => target.kind === "file" ? absoluteWorkspacePath(workspaceRoot, target.value) : target.value, [target.kind, target.value, workspaceRoot]);
+
+  const { data: fileIcon } = useQuery<string | null>({
+    queryKey: ["desktop-file-icon", externalPath] as const,
+    queryFn: async () => getDesktopFileIcon(externalPath, "small"),
+    enabled: target.kind === "file" && !isRemoteWorkspace && isElectronRuntime(),
+    staleTime: Infinity,
+    gcTime: 5 * 60 * 1000,
+  });
 
   const { data, error, isError, isLoading } = useQuery<ArtifactQueryState>({
     queryKey: ["artifact-panel", workspaceId, target.id] as const,
@@ -230,6 +239,9 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
       <div className="shrink-0 border-b border-border bg-background mac:bg-background/80 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
         <div className="flex h-10 items-center gap-2 pe-2 ps-4">
           <div className="min-w-0 flex-1 flex items-center gap-1.5">
+            {fileIcon ? (
+              <img src={fileIcon} alt="" className="h-4 w-4 shrink-0 object-contain" />
+            ) : null}
             <h3 className="text-sm font-medium text-foreground">
               <span className="truncate">{target.name}</span>
             </h3>

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -1,10 +1,10 @@
 /** @jsxImportSource react */
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Download, ExternalLink, X } from "lucide-react";
+import { Download, ExternalLink, FolderOpen, X } from "lucide-react";
 
 import type { OpenworkServerClient } from "@/app/lib/openwork-server";
-import { openDesktopPath } from "@/app/lib/desktop";
+import { openDesktopPath, revealDesktopItemInDir } from "@/app/lib/desktop";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatFileSize } from "@/lib/utils";
@@ -194,6 +194,11 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
     await download();
   };
 
+  const revealExternal = async () => {
+    if (target.kind !== "file" || isRemoteWorkspace) return;
+    await revealDesktopItemInDir(externalPath);
+  };
+
   const save = () => {
     if (target.kind !== "file" || !isTextContent(target) || data?.kind !== "text") {
       return;
@@ -287,6 +292,18 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
               <TooltipContent>Download artifact</TooltipContent>
             </Tooltip>
           ) : null}
+          {target.kind === "file" && !isRemoteWorkspace ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={(
+                  <Button variant="ghost" size="icon-sm" onClick={() => void revealExternal()} aria-label="Show in folder">
+                    <FolderOpen />
+                  </Button>
+                )}
+              />
+              <TooltipContent>Show in folder</TooltipContent>
+            </Tooltip>
+          ) : null}
           <Tooltip>
             <TooltipTrigger
               render={(
@@ -369,4 +386,3 @@ function SheetEditor({ className, ...props }: SheetEditorProps) {
     </Suspense>
   );
 }
-

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -35,6 +35,7 @@ const FILE_PATTERN = /(?:^|[\s"'`([{])((?:\.{1,2}[/\\]|~[/\\]|[/\\])?[\w.\-]+(?:
 const URL_PATTERN = /https?:\/\/[^\s)\]}>"'`]+/gi;
 const SOCKET_PATTERN = /(?:ws|wss):\/\/[^\s)\]}>"'`]+/gi;
 const SIDEBAR_ARTIFACT_FILE_PREVIEWS = new Set<OpenTargetPreview>(["markdown", "sheet", "slides", "image", "pdf", "html"]);
+const MARKDOWN_LINK_PATTERN = /\[([^\]\n]+)\]\(([^)\s]+)\)/g;
 const ASSISTANT_ARTIFACT_MENTION_PATTERN = /\b(?:artifact|created|deck|deliverable|exported|file|generated|opened|presentation|saved|slides?|updated|wrote)\b/i;
 const DISCOVERY_TOOL_NAMES = new Set(["glob", "grep", "search", "find"]);
 const ARTIFACT_METADATA_TOOL_NAMES = new Set(["openwork_extension_call"]);
@@ -93,6 +94,14 @@ function classifyOpenTarget(value: string, kind: OpenTargetKind): OpenTargetPrev
 
 function shouldScanAssistantFileMentions(text: string) {
   return ASSISTANT_ARTIFACT_MENTION_PATTERN.test(text);
+}
+
+function textWithoutRedundantMarkdownLinkLabels(text: string) {
+  return text.replace(MARKDOWN_LINK_PATTERN, (match, label: string, href: string) => {
+    const cleanLabel = label.trim();
+    const cleanHref = href.trim();
+    return cleanLabel === basename(cleanHref) ? `[](${cleanHref})` : match;
+  });
 }
 
 function targetFromFile(path: string, confidence: number, reason: string): OpenTarget | null {
@@ -169,22 +178,39 @@ function scanText(
     return;
   }
 
+  let scanValue = text;
+
+  MARKDOWN_LINK_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(MARKDOWN_LINK_PATTERN)) {
+    const href = match[2];
+    if (!href) continue;
+    if (/^(?:https?|wss?):\/\//i.test(href)) {
+      addTarget(map, targetFromUrl(href, confidence, reason));
+    } else if (options.includeFiles) {
+      addTarget(map, targetFromFile(href, confidence, reason));
+    }
+  }
+
+  if (options.includeFiles) {
+    scanValue = textWithoutRedundantMarkdownLinkLabels(text);
+  }
+
   URL_PATTERN.lastIndex = 0;
 
-  for (const match of text.matchAll(URL_PATTERN)) {
+  for (const match of scanValue.matchAll(URL_PATTERN)) {
     if (match[0]) addTarget(map, targetFromUrl(match[0], confidence, reason));
   }
 
   SOCKET_PATTERN.lastIndex = 0;
 
-  for (const match of text.matchAll(SOCKET_PATTERN)) {
+  for (const match of scanValue.matchAll(SOCKET_PATTERN)) {
     if (match[0]) addTarget(map, targetFromUrl(match[0], confidence, reason));
   }
 
   if (!options.includeFiles) return;
 
   FILE_PATTERN.lastIndex = 0;
-  for (const match of text.matchAll(FILE_PATTERN)) {
+  for (const match of scanValue.matchAll(FILE_PATTERN)) {
     if (match[1]) addTarget(map, targetFromFile(match[1], confidence, reason));
   }
 }

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -9,7 +9,7 @@ import { OPENWORK_EXTENSION_CATALOG } from "../../../../app/constants";
 import { type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
-import { openDesktopPath, type WorkspaceInfo } from "../../../../app/lib/desktop";
+import { openDesktopPath, revealDesktopItemInDir, type WorkspaceInfo } from "../../../../app/lib/desktop";
 import type {
   PendingPermission,
   PendingQuestion,
@@ -55,6 +55,7 @@ import { type SidePanelItem, useUiStateStore } from "../../../shell/ui-state-sto
 
 import { isElectronRuntime } from "../../../../app/utils";
 import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTarget, type OpenTarget } from "../artifacts/open-target";
+import type { OpenTargetOptions } from "@/lib/target-provider";
 import { VoicePanel } from "../voice/voice-panel";
 import { SidePanel } from "../panel/side-panel";
 import { TerminalDock } from "../terminal/terminal-dock";
@@ -218,6 +219,23 @@ function sessionExistsInWorkspace(groups: WorkspaceSessionGroup[], workspaceId: 
 
 function isTrackableAccessibleTarget(target: OpenTarget) {
   return isOpenableFileTarget(target) || isLocalhostBrowserTarget(target);
+}
+
+function absoluteWorkspacePath(root: string | null | undefined, value: string) {
+  const target = value.trim();
+  if (!target) return "";
+  if (/^file:\/\//i.test(target)) {
+    try {
+      const pathname = new URL(target).pathname;
+      return /^\/[a-zA-Z]:/.test(pathname) ? pathname.slice(1) : pathname;
+    } catch {
+      return target.replace(/^file:\/\//i, "");
+    }
+  }
+  if (target.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(target)) return target;
+  const cleanRoot = root?.trim().replace(/[/\\]+$/, "") ?? "";
+  const cleanTarget = target.replace(/^[.][\\/]/, "");
+  return cleanRoot ? `${cleanRoot}/${cleanTarget}` : cleanTarget;
 }
 
 function hiddenAccessibleTargetsStorageKey(workspaceId: string | null | undefined, sessionId: string | null | undefined) {
@@ -401,7 +419,7 @@ export function SessionPage(props: SessionPageProps) {
 
     window.setTimeout(() => URL.revokeObjectURL(url), 1000);
   }, [props.openworkServerClient, props.runtimeWorkspaceId]);
-  const openTarget = useCallback((target: OpenTarget, options?: { auto?: boolean }, sourceSessionId?: string) => {
+  const openTarget = useCallback((target: OpenTarget, options?: OpenTargetOptions, sourceSessionId?: string) => {
     if (target.kind === "url" || target.preview === "browser") {
       const url = browserUrlForTarget(target);
       if (isElectronRuntime()) {
@@ -412,6 +430,24 @@ export function SessionPage(props: SessionPageProps) {
       }
       return;
     }
+    if (options?.external && target.kind === "file" && props.selectedWorkspaceDisplay.workspaceType !== "remote") {
+      const path = absoluteWorkspacePath(props.selectedWorkspaceRoot, target.value);
+      if (path && isElectronRuntime()) {
+        void (async () => {
+          try {
+            if (options.reveal) {
+              await revealDesktopItemInDir(path);
+            } else {
+              await openDesktopPath(path);
+            }
+          } catch {
+            await revealDesktopItemInDir(path).catch(() => undefined);
+          }
+        })();
+      }
+      return;
+    }
+
     if (!isCollectibleArtifactTarget(target)) {
       if (isOpenableFileTarget(target)) {
         if (props.selectedWorkspaceDisplay.workspaceType === "remote") {
@@ -434,7 +470,6 @@ export function SessionPage(props: SessionPageProps) {
     });
     preserveSidePanelOnPanelOpenRef.current = true;
     setCurrentSidePanel("panel");
-  }, [activePanelTab?.id, browserUrlForTarget, downloadOpenTarget, openTab, props.selectedSessionId, props.selectedWorkspaceDisplay.workspaceType, props.selectedWorkspaceRoot, setCurrentSidePanel]);
   }, [activePanelTab?.id, browserUrlForTarget, downloadOpenTarget, openTab, props.selectedSessionId, props.selectedWorkspaceDisplay.workspaceType, props.selectedWorkspaceRoot, setCurrentSidePanel]);
   const closeRightPane = useCallback(() => {
     setCurrentSidePanel(null);

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -220,23 +220,6 @@ function isTrackableAccessibleTarget(target: OpenTarget) {
   return isOpenableFileTarget(target) || isLocalhostBrowserTarget(target);
 }
 
-function absoluteWorkspacePath(root: string | null | undefined, value: string) {
-  const target = value.trim();
-  if (!target) return "";
-  if (/^file:\/\//i.test(target)) {
-    try {
-      const pathname = new URL(target).pathname;
-      return /^\/[a-zA-Z]:/.test(pathname) ? pathname.slice(1) : pathname;
-    } catch {
-      return target.replace(/^file:\/\//i, "");
-    }
-  }
-  if (target.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(target)) return target;
-  const cleanRoot = root?.trim().replace(/[/\\]+$/, "") ?? "";
-  const cleanTarget = target.replace(/^[.][\\/]/, "");
-  return cleanRoot ? `${cleanRoot}/${cleanTarget}` : cleanTarget;
-}
-
 function hiddenAccessibleTargetsStorageKey(workspaceId: string | null | undefined, sessionId: string | null | undefined) {
   if (!workspaceId || !sessionId) return null;
   return `openwork.session.hiddenAccessibleTargets.v1:${workspaceId}:${sessionId}`;
@@ -451,6 +434,7 @@ export function SessionPage(props: SessionPageProps) {
     });
     preserveSidePanelOnPanelOpenRef.current = true;
     setCurrentSidePanel("panel");
+  }, [activePanelTab?.id, browserUrlForTarget, downloadOpenTarget, openTab, props.selectedSessionId, props.selectedWorkspaceDisplay.workspaceType, props.selectedWorkspaceRoot, setCurrentSidePanel]);
   }, [activePanelTab?.id, browserUrlForTarget, downloadOpenTarget, openTab, props.selectedSessionId, props.selectedWorkspaceDisplay.workspaceType, props.selectedWorkspaceRoot, setCurrentSidePanel]);
   const closeRightPane = useCallback(() => {
     setCurrentSidePanel(null);

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -225,7 +225,8 @@ function absoluteWorkspacePath(root: string | null | undefined, value: string) {
   if (!target) return "";
   if (/^file:\/\//i.test(target)) {
     try {
-      return new URL(target).pathname;
+      const pathname = new URL(target).pathname;
+      return /^\/[a-zA-Z]:/.test(pathname) ? pathname.slice(1) : pathname;
     } catch {
       return target.replace(/^file:\/\//i, "");
     }

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -220,11 +220,20 @@ function isTrackableAccessibleTarget(target: OpenTarget) {
   return isOpenableFileTarget(target) || isLocalhostBrowserTarget(target);
 }
 
-function absoluteWorkspacePath(root: string, path: string) {
-  const cleanRoot = root.trim().replace(/[/\\]+$/, "");
-  const cleanPath = path.trim().replace(/^\.\//, "");
-
-  return cleanRoot ? `${cleanRoot}/${cleanPath}` : cleanPath;
+function absoluteWorkspacePath(root: string | null | undefined, value: string) {
+  const target = value.trim();
+  if (!target) return "";
+  if (/^file:\/\//i.test(target)) {
+    try {
+      return new URL(target).pathname;
+    } catch {
+      return target.replace(/^file:\/\//i, "");
+    }
+  }
+  if (target.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(target)) return target;
+  const cleanRoot = root?.trim().replace(/[/\\]+$/, "") ?? "";
+  const cleanTarget = target.replace(/^[.][\\/]/, "");
+  return cleanRoot ? `${cleanRoot}/${cleanTarget}` : cleanTarget;
 }
 
 function hiddenAccessibleTargetsStorageKey(workspaceId: string | null | undefined, sessionId: string | null | undefined) {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -71,7 +71,7 @@ import {
 } from "./composer-state-store";
 import { MessageList } from "@/components/chat/message-list";
 import { MessageListProvider, type DispatchAction } from "@/components/chat/message-list-provider";
-import { OpenTargetProvider } from "@/lib/target-provider";
+import { OpenTargetProvider, type OpenTargetOptions } from "@/lib/target-provider";
 import type { ThreadStatus } from "@/lib/messages";
 import {
   EnvironmentVariableProvider,
@@ -138,7 +138,7 @@ export type SessionSurfaceProps = {
   onOpenSettingsSection?: ((section: "commands" | "skills" | "mcps" | "plugins" | "providers") => void) | undefined;
   onRevertToMessage?: (messageId: string, sessionId: string) => Promise<boolean>;
   onForkAtMessage?: (messageId: string | null, sessionId: string) => void;
-  onOpenTarget?: (target: OpenTarget, options?: { auto?: boolean }, sessionId?: string) => void;
+  onOpenTarget?: (target: OpenTarget, options?: OpenTargetOptions, sessionId?: string) => void;
   environmentRuntimeKey?: string | null;
   onApplyEnvironmentChanges?: () => Promise<ApplyEnvironmentChangesResult>;
 };

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -71,7 +71,7 @@ import {
 } from "./composer-state-store";
 import { MessageList } from "@/components/chat/message-list";
 import { MessageListProvider, type DispatchAction } from "@/components/chat/message-list-provider";
-import { OpenTargetProvider, type OpenTargetOptions } from "@/lib/target-provider";
+import { OpenTargetProvider } from "@/lib/target-provider";
 import type { ThreadStatus } from "@/lib/messages";
 import {
   EnvironmentVariableProvider,

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -71,7 +71,7 @@ import {
 } from "./composer-state-store";
 import { MessageList } from "@/components/chat/message-list";
 import { MessageListProvider, type DispatchAction } from "@/components/chat/message-list-provider";
-import { OpenTargetProvider } from "@/lib/target-provider";
+import { OpenTargetProvider, type OpenTargetOptions } from "@/lib/target-provider";
 import type { ThreadStatus } from "@/lib/messages";
 import {
   EnvironmentVariableProvider,

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1279,6 +1279,85 @@ const desktopCommandHandlers = {
         return null;
       }
   },
+  "__getApplicationsForFile": async (event, ...args) => {
+      const target = String(args[0] ?? "").trim();
+      if (!target) return [];
+      const platform = process.platform;
+      const results = [];
+
+      try {
+        if (platform === "darwin") {
+          // Scan /Applications and /System/Applications for .app bundles
+          const appDirs = ["/Applications", "/System/Applications", "/Applications/Utilities", `${os.homedir()}/Applications`];
+          const seen = new Set();
+          for (const dir of appDirs) {
+            let entries;
+            try { entries = await readdir(dir); } catch { continue; }
+            for (const entry of entries) {
+              if (!entry.endsWith(".app")) continue;
+              const appPath = path.join(dir, entry);
+              if (seen.has(appPath)) continue;
+              seen.add(appPath);
+              const name = entry.replace(/\.app$/i, "");
+              let icon = null;
+              try {
+                const img = await app.getFileIcon(appPath, { size: "small" });
+                icon = img.isEmpty() ? null : img.toDataURL();
+              } catch {}
+              results.push({ name, appPath, icon });
+            }
+          }
+        } else if (platform === "linux") {
+          // Parse .desktop files in standard directories
+          const desktopDirs = ["/usr/share/applications", "/usr/local/share/applications", `${os.homedir()}/.local/share/applications`];
+          const seen = new Set();
+          for (const dir of desktopDirs) {
+            let entries;
+            try { entries = await readdir(dir); } catch { continue; }
+            for (const entry of entries) {
+              if (!entry.endsWith(".desktop")) continue;
+              const filePath = path.join(dir, entry);
+              if (seen.has(filePath)) continue;
+              seen.add(filePath);
+              try {
+                const content = await readFile(filePath, "utf-8");
+                const nameMatch = content.match(/^Name=(.+)$/m);
+                const execMatch = content.match(/^Exec=(.+)$/m);
+                if (!nameMatch || !execMatch) continue;
+                const name = nameMatch[1].trim();
+                const appPath = execMatch[1].trim().replace(/%[fFuU]/g, "").trim();
+                if (!appPath) continue;
+                let icon = null;
+                try {
+                  const img = await app.getFileIcon(filePath, { size: "small" });
+                  icon = img.isEmpty() ? null : img.toDataURL();
+                } catch {}
+                results.push({ name, appPath, icon });
+              } catch {}
+            }
+          }
+        }
+      } catch {}
+
+      return results;
+  },
+  "__openWithApp": async (event, ...args) => {
+      const target = String(args[0] ?? "").trim();
+      const appPath = String(args[1] ?? "").trim();
+      if (!target || !appPath) return "Target and app path are required.";
+      const platform = process.platform;
+      try {
+        if (platform === "darwin") {
+          execFileSync("open", ["-a", appPath, target]);
+        } else if (platform === "linux") {
+          execFileSync(appPath, [target], { detached: true, stdio: "ignore" });
+        } else {
+          return `Open with app is not supported on ${platform}`;
+        }
+      } catch (err) {
+        return String(err?.message ?? err);
+      }
+  },
   "__fetch": async (event, ...args) => {
       const url = String(args[0] ?? "").trim();
       const init = args[1] ?? {};

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1270,8 +1270,12 @@ const desktopCommandHandlers = {
   "__getFileIcon": async (event, ...args) => {
       const target = String(args[0] ?? "").trim();
       if (!target) return null;
-      const size = String(args[1] ?? "normal");
-      const validSize = ["small", "normal", "large"].includes(size) ? size : "normal";
+      const requestedSize = args[1];
+      /** @type {"small" | "normal" | "large"} */
+      let validSize = "normal";
+      if (requestedSize === "small" || requestedSize === "normal" || requestedSize === "large") {
+        validSize = requestedSize;
+      }
       try {
         const image = await app.getFileIcon(target, { size: validSize });
         return image.isEmpty() ? null : image.toDataURL();
@@ -1350,7 +1354,8 @@ const desktopCommandHandlers = {
         if (platform === "darwin") {
           execFileSync("open", ["-a", appPath, target]);
         } else if (platform === "linux") {
-          execFileSync(appPath, [target], { detached: true, stdio: "ignore" });
+          const child = spawn(appPath, [target], { detached: true, stdio: "ignore" });
+          child.unref();
         } else {
           return `Open with app is not supported on ${platform}`;
         }

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1267,6 +1267,18 @@ const desktopCommandHandlers = {
       shell.showItemInFolder(target);
       return undefined;
   },
+  "__getFileIcon": async (event, ...args) => {
+      const target = String(args[0] ?? "").trim();
+      if (!target) return null;
+      const size = String(args[1] ?? "normal");
+      const validSize = ["small", "normal", "large"].includes(size) ? size : "normal";
+      try {
+        const image = await app.getFileIcon(target, { size: validSize });
+        return image.isEmpty() ? null : image.toDataURL();
+      } catch {
+        return null;
+      }
+  },
   "__fetch": async (event, ...args) => {
       const url = String(args[0] ?? "").trim();
       const init = args[1] ?? {};

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -466,6 +466,7 @@ export type DesktopCommandMap = {
   // Window / OS utilities (dunder commands)
   __openPath: { args: [target: string]; result: unknown };
   __revealItemInDir: { args: [target: string]; result: unknown };
+  __getFileIcon: { args: [target: string, size?: "small" | "normal" | "large"]; result: string | null };
   __fetch: { args: [url: string, init?: DesktopFetchInit]; result: DesktopFetchResult };
   __homeDir: { args: []; result: string };
   __joinPath: { args: [...segments: string[]]; result: string };

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -467,6 +467,8 @@ export type DesktopCommandMap = {
   __openPath: { args: [target: string]; result: unknown };
   __revealItemInDir: { args: [target: string]; result: unknown };
   __getFileIcon: { args: [target: string, size?: "small" | "normal" | "large"]; result: string | null };
+  __getApplicationsForFile: { args: [target: string]; result: { name: string; appPath: string; icon: string | null }[] };
+  __openWithApp: { args: [target: string, appPath: string]; result: unknown };
   __fetch: { args: [url: string, init?: DesktopFetchInit]; result: DesktopFetchResult };
   __homeDir: { args: []; result: string };
   __joinPath: { args: [...segments: string[]]; result: string };


### PR DESCRIPTION
## Summary

Generated file links in assistant markdown now have a **split-button dropdown** that defaults to opening with the OS default program, with options to open in-panel, reveal in folder, or open with a specific OS application.

### New behavior

- **Click the filename** → opens with OS default program (e.g., default text editor, browser, etc.)
- **Click the chevron** → opens a dropdown menu with:
  - **Open with default app** — same as clicking the filename
  - **Open in panel** — opens the in-app artifact panel (only if file type supports preview: markdown, text, sheet, slides, image, pdf, html)
  - **Show in folder** — reveals the file in Finder/Explorer/Thunar
  - **Open with...** — lists available OS applications (scanned from /Applications on macOS, .desktop files on Linux) with native icons

### Visual design

File links render as a split-button chip: file icon + filename (clickable for OS default) + chevron button (clickable for dropdown). This gives users a clear visual affordance that the link is a file, not a web link.

### Changes

- `markdown.tsx`: Split-button chip renderer with `data-openwork-link-chevron` attribute; click handler delegates to chevron (dropdown) vs link (OS default)
- `link-action-menu.tsx`: New React dropdown component with all action options + lazy-loaded app list
- `desktop-ipc.ts` + `main.mjs` + `desktop.ts`: New `__getApplicationsForFile` and `__openWithApp` IPC handlers
- `session-page.tsx`: Re-added `external`/`reveal` open-target options for native OS open
- `target-provider.ts`: Re-added `OpenTargetOptions` type with `external`/`reveal` flags
- `daytona-flow-validator/SKILL.md`: Updated to require before/after frame comparison when validating changes to existing behavior

## Test plan

- [x] `pnpm -r typecheck` — all packages pass
- [x] `pnpm --dir apps/app test:open-target` — 19/19 pass
- [x] Daytona Electron validation — before/after frames captured

### Evidence (before/after comparison)

**HTML evidence:** https://8090-uvzec2uiny9jzybb.daytonaproxy01.net/validation/native-file-links-v3.html

**noVNC (live):** https://6080-x1rjhj2l6sewchmn.daytonaproxy01.net

**Frames:**
- Before (plain underlined link): https://8090-uvzec2uiny9jzybb.daytonaproxy01.net/screenshots/native-file-links-v2/01-before-click.png
- After (split-button chip): https://8090-uvzec2uiny9jzybb.daytonaproxy01.net/screenshots/native-file-links-v3/01-chip-with-chevron.png
- Dropdown open: https://8090-uvzec2uiny9jzybb.daytonaproxy01.net/screenshots/native-file-links-v3/02-dropdown-open.png
- Native app opened: https://8090-uvzec2uiny9jzybb.daytonaproxy01.net/screenshots/native-file-links-v3/03-native-app-opened.png