### PR TITLE
Refine session header and status bar UI

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -801,7 +801,7 @@ export function SessionPage(props: SessionPageProps) {
           >
             <ResizablePanel minSize="360px" className="min-w-0">
               <main className="flex h-full min-w-0 flex-col overflow-hidden border-r border-border">
-          <header className="z-10 flex h-10 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
+          <header className="z-10 flex shrink-0 items-center justify-between border-b border-border py-1.5 pl-3 pr-1 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
             <div className="flex min-w-0 items-center gap-3">
               {shellConfig.sidebar ? <SidebarTrigger className="mac:hidden" /> : null}
               <h1 className="truncate text-[15px] font-semibold text-dls-text">
@@ -894,7 +894,7 @@ export function SessionPage(props: SessionPageProps) {
               {!showDelayedSessionLoadingState && canRenderReactSurface ? (
                 <div className="flex h-full min-h-0 flex-col">
                   {sessionTabs.length > 0 ? (
-                    <div className="flex h-10 shrink-0 items-center gap-1 overflow-x-auto border-b border-border bg-background/80 px-2 mac:backdrop-blur-xl">
+                    <div className="flex py-2 shrink-0 items-center gap-1 overflow-x-auto border-b border-border bg-background/80 px-2 mac:backdrop-blur-xl">
                       {sessionTabs.map((tab) => {
                         const title = sessionTitleForId(props.sidebar.workspaceSessionGroups, tab.sessionId) || t("session.default_title");
                         const active = tab.sessionId === props.selectedSessionId;

--- a/apps/app/src/react-app/domains/session/chat/status-bar.tsx
+++ b/apps/app/src/react-app/domains/session/chat/status-bar.tsx
@@ -68,7 +68,7 @@ type StatusIndicatorProps = {
 function StatusIndicator(props: StatusIndicatorProps) {
   if (props.loading || (props.openworkServerStatus === "disconnected" && props.initializing)) {
     return (
-      <div className="flex min-w-0 items-center gap-2.5">
+      <div className="flex min-w-0 items-center gap-2.5 px-1">
         <StatusDot variant="loading" />
         <span className="shrink-0 font-medium text-foreground text-xs">
           {t("session.preparing_workspace")}
@@ -82,7 +82,7 @@ function StatusIndicator(props: StatusIndicatorProps) {
 
   if (props.clientConnected) {
     return (
-      <div className="flex min-w-0 items-center gap-2.5">
+      <div className="flex min-w-0 items-center gap-2.5 px-1">
         <Tooltip>
           <TooltipTrigger render={<span className="inline-flex" />}>
             <StatusDot variant="connected" />
@@ -105,7 +105,7 @@ function StatusIndicator(props: StatusIndicatorProps) {
 
   if (props.openworkServerStatus === "limited") {
     return (
-      <div className="flex min-w-0 items-center gap-2.5">
+      <div className="flex min-w-0 items-center gap-2.5 px-1">
         <StatusDot variant="partial" />
         <span className="shrink-0 font-medium text-foreground text-xs">
           {t("status.limited_mode")}
@@ -120,7 +120,7 @@ function StatusIndicator(props: StatusIndicatorProps) {
   }
 
   return (
-    <div className="flex min-w-0 items-center gap-2.5">
+    <div className="flex min-w-0 items-center gap-2.5 px-1">
       <StatusDot variant="disconnected" />
       <span className="shrink-0 font-medium text-foreground text-xs">
         {t("status.disconnected_label")}
@@ -266,7 +266,7 @@ export function StatusBar(props: StatusBarProps) {
 
   return (
     <div className="border-t border-border bg-background">
-      <div className="flex h-8 items-center justify-between gap-3 px-4 md:px-6">
+      <div className="flex h-8 items-center justify-between gap-3 px-2 md:px-2">
         <StatusIndicator
           clientConnected={props.clientConnected}
           openworkServerStatus={props.openworkServerStatus}

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -55,7 +55,7 @@ export function SettingsShell(props: SettingsShellProps) {
   if (props.compact) {
     return (
       <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background">
-        <header className="flex h-11 shrink-0 items-center justify-between gap-2 border-b border-dls-border px-3 mac:titlebar-drag">
+        <header className="flex py-1.5 px-1.5 shrink-0 items-center justify-between gap-2 border-b border-dls-border mac:titlebar-drag">
           <div className="flex min-w-0 items-center gap-2 mac:titlebar-no-drag">
             <SettingsSectionMenu
               activeTab={props.activeTab}


### PR DESCRIPTION
## Summary

Refined the session header and status bar UI to improve spacing, alignment, and visual consistency across surfaces.

## Changes

* Reduced excessive padding in the session header
* Improved spacing and alignment in the status bar
* Aligned settings and session headers for a more consistent layout
* No functional changes

## Comparison

https://github.com/user-attachments/assets/16b8fca4-db87-4cce-a08a-7f173fe884bc

## Before
<img width="702" height="864" alt="Screenshot 2026-06-17 at 12 10 22 AM 2" src="https://github.com/user-attachments/assets/8451dfbf-78bd-450a-9c51-6a3f582d559d" />

## After

<img width="702" height="864" alt="Screenshot 2026-06-17 at 12 10 22 AM 1" src="https://github.com/user-attachments/assets/6e23a25a-5528-4e70-aedc-3452c99b1925" />

## Aligned Settings with Session screen

<img width="992" height="228" alt="Screenshot 2026-06-17 at 12 54 52 AM" src="https://github.com/user-attachments/assets/93883242-41eb-481a-ab8d-f5727158d0ae" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

