### PR TITLE
fix(desktop): recover empty workspace state

### DIFF
--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -511,7 +511,7 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
 
   async function readWorkspaceState() {
     const state = await readJsonFile(workspaceStatePath(), EMPTY_WORKSPACE_LIST);
-    const selectedId =
+    let selectedId =
       typeof state?.selectedId === "string"
         ? state.selectedId
         : typeof state?.selectedWorkspaceId === "string"
@@ -519,14 +519,14 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
           : typeof state?.activeId === "string"
             ? state.activeId
             : "";
-    const watchedId =
+    let watchedId =
       typeof state?.watchedId === "string"
         ? state.watchedId
         : typeof state?.watchedWorkspaceId === "string"
           ? state.watchedWorkspaceId
           : null;
-    const activeId = typeof state?.activeId === "string" ? state.activeId : null;
-    const workspaces = Array.isArray(state?.workspaces) ? state.workspaces : [];
+    let activeId = typeof state?.activeId === "string" ? state.activeId : null;
+    let workspaces = Array.isArray(state?.workspaces) ? state.workspaces : [];
     let changed = false;
     if (workspaces.length === 0) {
       const recoveredWorkspaces = await recoverWorkspacesFromKnownState();
@@ -536,12 +536,11 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
           count: recoveredWorkspaces.length,
           selectedWorkspaceId: selectedWorkspace.id,
         });
-        return writeWorkspaceState({
-          selectedId: selectedWorkspace.id,
-          watchedId: selectedWorkspace.id,
-          activeId: selectedWorkspace.id,
-          workspaces: recoveredWorkspaces,
-        });
+        selectedId = selectedWorkspace.id;
+        watchedId = selectedWorkspace.id;
+        activeId = selectedWorkspace.id;
+        workspaces = recoveredWorkspaces;
+        changed = true;
       }
     }
     const idMap = new Map();

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -127,6 +127,16 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     return path.join(app.getPath("userData"), "openwork-workspaces.json");
   }
 
+  function openworkServerTokenStorePath() {
+    return path.join(app.getPath("userData"), "openwork-server-tokens.json");
+  }
+
+  function openworkServerConfigPath() {
+    if (process.env.OPENWORK_SERVER_CONFIG?.trim()) return path.resolve(process.env.OPENWORK_SERVER_CONFIG.trim());
+    if (process.platform === "win32") return path.join(process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"), "openwork", "server.json");
+    return path.join(process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config"), "openwork", "server.json");
+  }
+
   // Earlier Electron alpha builds copied Tauri's openwork-workspaces.json into
   // an Electron-only workspace-state.json. Keep importing that file when the
   // shared canonical file is missing, but write openwork-workspaces.json going
@@ -250,6 +260,106 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
   function normalizeWorkspacePathKey(value) {
     const trimmed = String(value ?? "").trim();
     return trimmed ? path.resolve(trimmed).replace(/\\/g, "/").toLowerCase() : "";
+  }
+
+  function normalizeRecoveredWorkspacePath(value) {
+    const trimmed = String(value ?? "").trim();
+    if (!trimmed) return "";
+    if (process.platform !== "win32") return trimmed;
+    return trimmed
+      .replace(/^\\\\\?\\UNC\\/i, "\\\\")
+      .replace(/^\\\\\?\\/i, "")
+      .replace(/^\/\/\?\/UNC\//i, "//")
+      .replace(/^\/\/\?\//i, "")
+      .replace(/\//g, "\\");
+  }
+
+  function isRecord(value) {
+    return typeof value === "object" && value !== null;
+  }
+
+  async function recoverWorkspacesFromTokenStore() {
+    const store = await readJsonFile(openworkServerTokenStorePath(), null);
+    if (!isRecord(store) || !isRecord(store.workspaces)) return [];
+
+    const candidates = [];
+    for (const [rawPath, entry] of Object.entries(store.workspaces)) {
+      const normalizedInput = normalizeRecoveredWorkspacePath(rawPath);
+      if (!normalizedInput) continue;
+      const workspacePath = await normalizeLocalWorkspacePath(normalizedInput);
+      if (!(await pathExists(workspacePath))) continue;
+      candidates.push({
+        path: workspacePath,
+        updatedAt: isRecord(entry) && typeof entry.updatedAt === "number" ? entry.updatedAt : 0,
+      });
+    }
+
+    candidates.sort((left, right) => right.updatedAt - left.updatedAt);
+    const seen = new Set();
+    return candidates.flatMap((candidate) => {
+      const key = normalizeWorkspacePathKey(candidate.path);
+      if (!key || seen.has(key)) return [];
+      seen.add(key);
+      return [normalizeWorkspaceEntry({
+        id: localWorkspaceId(candidate.path),
+        name: path.basename(candidate.path) || "Workspace",
+        displayName: path.basename(candidate.path) || "Workspace",
+        path: candidate.path,
+        preset: "starter",
+        workspaceType: "local",
+      })];
+    });
+  }
+
+  async function recoverWorkspacesFromServerConfig() {
+    const config = await readJsonFile(openworkServerConfigPath(), null);
+    if (!isRecord(config) || !Array.isArray(config.workspaces)) return [];
+
+    const seen = new Set();
+    const workspaces = [];
+    for (const entry of config.workspaces) {
+      if (!isRecord(entry)) continue;
+      const workspaceType = entry.workspaceType === "remote" ? "remote" : "local";
+      const rawPath = typeof entry.path === "string" ? entry.path.trim() : "";
+      const normalizedPath = workspaceType === "local"
+        ? await normalizeLocalWorkspacePath(normalizeRecoveredWorkspacePath(rawPath))
+        : rawPath;
+      if (workspaceType === "local" && (!normalizedPath || !(await pathExists(normalizedPath)))) continue;
+
+      const baseUrl = typeof entry.baseUrl === "string" ? entry.baseUrl.trim() : "";
+      const directory = typeof entry.directory === "string" && entry.directory.trim() ? entry.directory.trim() : null;
+      const remoteType = entry.remoteType === "opencode" ? "opencode" : "openwork";
+      const openworkWorkspaceId = typeof entry.openworkWorkspaceId === "string" ? entry.openworkWorkspaceId.trim() : "";
+      const id = typeof entry.id === "string" && entry.id.trim()
+        ? entry.id.trim()
+        : workspaceType === "remote"
+          ? remoteType === "openwork"
+            ? openworkRemoteWorkspaceId(baseUrl, openworkWorkspaceId)
+            : remoteWorkspaceId(baseUrl, directory)
+          : localWorkspaceId(normalizedPath);
+      const key = workspaceType === "remote" ? id : normalizeWorkspacePathKey(normalizedPath);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      workspaces.push(normalizeWorkspaceEntry({
+        ...entry,
+        id,
+        path: normalizedPath,
+        name: typeof entry.name === "string" && entry.name.trim()
+          ? entry.name.trim()
+          : path.basename(normalizedPath) || "Workspace",
+        displayName: typeof entry.displayName === "string" ? entry.displayName : undefined,
+        preset: typeof entry.preset === "string" && entry.preset.trim() ? entry.preset.trim() : "starter",
+        workspaceType,
+        ...(workspaceType === "remote" ? { remoteType, baseUrl, directory } : {}),
+      }));
+    }
+    return workspaces;
+  }
+
+  async function recoverWorkspacesFromKnownState() {
+    const fromServerConfig = await recoverWorkspacesFromServerConfig();
+    if (fromServerConfig.length > 0) return fromServerConfig;
+    return recoverWorkspacesFromTokenStore();
   }
 
   function stableWorkspaceId(value) {
@@ -418,6 +528,22 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     const activeId = typeof state?.activeId === "string" ? state.activeId : null;
     const workspaces = Array.isArray(state?.workspaces) ? state.workspaces : [];
     let changed = false;
+    if (workspaces.length === 0) {
+      const recoveredWorkspaces = await recoverWorkspacesFromKnownState();
+      if (recoveredWorkspaces.length > 0) {
+        const selectedWorkspace = recoveredWorkspaces[0];
+        console.info("[migration] recovered desktop workspaces from persisted OpenWork state", {
+          count: recoveredWorkspaces.length,
+          selectedWorkspaceId: selectedWorkspace.id,
+        });
+        return writeWorkspaceState({
+          selectedId: selectedWorkspace.id,
+          watchedId: selectedWorkspace.id,
+          activeId: selectedWorkspace.id,
+          workspaces: recoveredWorkspaces,
+        });
+      }
+    }
     const idMap = new Map();
     const migratedWorkspaces = workspaces.map((entry) => {
       const workspace = entry && typeof entry === "object" ? entry : normalizeWorkspaceEntry(entry ?? {});

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -101,3 +101,59 @@ test("prefers server config workspaces when desktop state is empty", async () =>
     else process.env.OPENWORK_SERVER_CONFIG = previous;
   }
 });
+
+test("normalizes recovered remote OpenWork entries before persisting", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "openwork-workspace-store-"));
+  const userData = path.join(root, "userData");
+  const serverConfig = path.join(root, "server.json");
+  await mkdir(userData, { recursive: true });
+
+  await writeFile(
+    path.join(userData, "openwork-workspaces.json"),
+    JSON.stringify({ selectedId: "", activeId: null, watchedId: null, workspaces: [] }),
+    "utf8",
+  );
+  await writeFile(
+    serverConfig,
+    JSON.stringify({
+      workspaces: [
+        {
+          id: "legacy_one",
+          path: "/workspace",
+          workspaceType: "remote",
+          remoteType: "openwork",
+          baseUrl: "https://worker.example.com/workspace/ws_remote",
+        },
+        {
+          id: "legacy_two",
+          path: "/workspace",
+          workspaceType: "remote",
+          remoteType: "openwork",
+          baseUrl: "https://worker.example.com/w/ws_remote",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  const previous = process.env.OPENWORK_SERVER_CONFIG;
+  process.env.OPENWORK_SERVER_CONFIG = serverConfig;
+  try {
+    const store = createWorkspaceStore({
+      app: { getPath: (name) => name === "userData" ? userData : root },
+      defaultDenBaseUrl: "https://example.test",
+      defaultRequireSignin: false,
+      forceRequireSignin: false,
+    });
+
+    const state = await store.readWorkspaceState();
+    assert.equal(state.workspaces.length, 1);
+    assert.equal(state.workspaces[0].id, "rem_ws_remote");
+    assert.equal(state.workspaces[0].baseUrl, "https://worker.example.com");
+    assert.equal(state.workspaces[0].openworkWorkspaceId, "ws_remote");
+    assert.equal(state.selectedId, "rem_ws_remote");
+  } finally {
+    if (previous === undefined) delete process.env.OPENWORK_SERVER_CONFIG;
+    else process.env.OPENWORK_SERVER_CONFIG = previous;
+  }
+});

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { createWorkspaceStore } from "./workspace-store.mjs";
+
+test("recovers empty desktop workspace state from token store paths", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "openwork-workspace-store-"));
+  const userData = path.join(root, "userData");
+  const oldWorkspace = path.join(root, "old-workspace");
+  await mkdir(oldWorkspace, { recursive: true });
+  const oldWorkspaceReal = await realpath(oldWorkspace);
+  await mkdir(userData, { recursive: true });
+
+  await writeFile(
+    path.join(userData, "openwork-workspaces.json"),
+    JSON.stringify({ selectedId: "ws_missing", activeId: "ws_missing", watchedId: null, workspaces: [] }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(userData, "openwork-server-tokens.json"),
+    JSON.stringify({
+      version: 1,
+      workspaces: {
+        "": { updatedAt: 3 },
+        [oldWorkspace]: { updatedAt: 2 },
+        [path.join(root, "missing")]: { updatedAt: 4 },
+      },
+    }),
+    "utf8",
+  );
+
+  const previous = process.env.OPENWORK_SERVER_CONFIG;
+  process.env.OPENWORK_SERVER_CONFIG = path.join(root, "missing-server.json");
+  try {
+    const store = createWorkspaceStore({
+      app: { getPath: (name) => name === "userData" ? userData : root },
+      defaultDenBaseUrl: "https://example.test",
+      defaultRequireSignin: false,
+      forceRequireSignin: false,
+    });
+
+    const state = await store.readWorkspaceState();
+    assert.equal(state.workspaces.length, 1);
+    assert.equal(state.workspaces[0].path, oldWorkspaceReal);
+    assert.equal(state.selectedId, state.workspaces[0].id);
+    assert.equal(state.watchedId, state.workspaces[0].id);
+
+    const persisted = JSON.parse(await readFile(path.join(userData, "openwork-workspaces.json"), "utf8"));
+    assert.equal(persisted.workspaces.length, 1);
+    assert.equal(persisted.selectedWorkspaceId, state.workspaces[0].id);
+  } finally {
+    if (previous === undefined) delete process.env.OPENWORK_SERVER_CONFIG;
+    else process.env.OPENWORK_SERVER_CONFIG = previous;
+  }
+});
+
+test("prefers server config workspaces when desktop state is empty", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "openwork-workspace-store-"));
+  const userData = path.join(root, "userData");
+  const oldWorkspace = path.join(root, "server-workspace");
+  const serverConfig = path.join(root, "server.json");
+  await mkdir(oldWorkspace, { recursive: true });
+  await mkdir(userData, { recursive: true });
+  const oldWorkspaceReal = await realpath(oldWorkspace);
+
+  await writeFile(
+    path.join(userData, "openwork-workspaces.json"),
+    JSON.stringify({ selectedId: "", activeId: null, watchedId: null, workspaces: [] }),
+    "utf8",
+  );
+  await writeFile(
+    serverConfig,
+    JSON.stringify({ workspaces: [{ path: oldWorkspace, name: "From Server" }] }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(userData, "openwork-server-tokens.json"),
+    JSON.stringify({ version: 1, workspaces: { [path.join(root, "other")]: { updatedAt: 9 } } }),
+    "utf8",
+  );
+
+  const previous = process.env.OPENWORK_SERVER_CONFIG;
+  process.env.OPENWORK_SERVER_CONFIG = serverConfig;
+  try {
+    const store = createWorkspaceStore({
+      app: { getPath: (name) => name === "userData" ? userData : root },
+      defaultDenBaseUrl: "https://example.test",
+      defaultRequireSignin: false,
+      forceRequireSignin: false,
+    });
+
+    const state = await store.readWorkspaceState();
+    assert.equal(state.workspaces.length, 1);
+    assert.equal(state.workspaces[0].path, oldWorkspaceReal);
+    assert.equal(state.workspaces[0].name, "From Server");
+  } finally {
+    if (previous === undefined) delete process.env.OPENWORK_SERVER_CONFIG;
+    else process.env.OPENWORK_SERVER_CONFIG = previous;
+  }
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/runtime.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs"
+    "test": "node --test electron/runtime.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.17.3",


### PR DESCRIPTION
## Summary
- recover desktop workspace state at startup when openwork-workspaces.json has an empty workspaces array
- prefer persisted OpenWork server config, then fall back to openwork-server-tokens.json path recovery
- add Electron workspace-store coverage for both recovery paths

## Tests
- pnpm --filter @openwork/desktop test ✅
- pnpm --filter @openwork/desktop typecheck:electron ✅

## Evidence
- No video captured; this is a startup migration/state recovery path verified with focused Electron tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

