### PR TITLE
Insert composer skills at cursor

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -14,7 +14,7 @@ import { isOpenWorkExtensionEnabled, isOpenWorkExtensionHidden, OPENWORK_EXTENSI
 import { useDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
 import { ModelBehaviorSelect } from "@/components/model-behavior-select";
 import { ModelSelect } from "@/components/model-select";
-import { LexicalPromptEditor } from "./editor";
+import { LexicalPromptEditor, type LexicalPromptEditorHandle } from "./editor";
 import { listRunningAppsForMention } from "./app-mentions";
 import type { ComposerMentionKind } from "./mention-encoding";
 import { getSlashCommandQuery } from "./slash-command";
@@ -315,6 +315,7 @@ export function ReactSessionComposer(props: ComposerProps) {
   const agentItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const [dropzoneActive, setDropzoneActive] = useState(false);
   const toolMenuRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<LexicalPromptEditorHandle | null>(null);
   const agentMenuRef = useRef<HTMLDivElement | null>(null);
   // IME composition guard: while an IME composition is active, we must not
   // treat Enter as a submit. Three signals keep this reliable across WebKit,
@@ -750,9 +751,9 @@ export function ReactSessionComposer(props: ComposerProps) {
     target?.scrollIntoView({ block: "nearest" });
   }, [menuIndex, activeItems.length]);
 
-  const applyCommandSelection = (command: SlashCommandOption) => {
+  const applyCommandSelection = (command: SlashCommandOption, options?: { replaceSkillDraft?: boolean }) => {
     if (command.source === "skill") {
-      applySkillSelection(command.name);
+      applySkillSelection(command.name, options);
       return;
     }
     props.onDraftChange(`/${command.name} `);
@@ -760,8 +761,18 @@ export function ReactSessionComposer(props: ComposerProps) {
     setToolMenuOpen(false);
   };
 
-  const applySkillSelection = (name: string) => {
-    props.onDraftChange(`[skill ${name}] `);
+  const applySkillSelection = (name: string, options?: { replaceSkillDraft?: boolean }) => {
+    if (options?.replaceSkillDraft) {
+      props.onDraftChange(`[skill ${name}] `);
+    } else {
+      const editor = editorRef.current;
+      if (editor) {
+        editor.insertSkillAtSelection(name);
+      } else {
+        const separator = props.draft.length > 0 && !/\s$/.test(props.draft) ? " " : "";
+        props.onDraftChange(`${props.draft}${separator}[skill ${name}] `);
+      }
+    }
     setSlashOpen(false);
     setToolMenuOpen(false);
   };
@@ -804,7 +815,7 @@ export function ReactSessionComposer(props: ComposerProps) {
     if (activeMenu === "slash") {
       const command = slashFiltered[menuIndex];
       if (!command) return false;
-      applyCommandSelection(command);
+      applyCommandSelection(command, { replaceSkillDraft: true });
       return true;
     }
     if (activeMenu === "mention") {
@@ -1036,10 +1047,10 @@ export function ReactSessionComposer(props: ComposerProps) {
                     onMouseDown={(event) => {
                       event.preventDefault();
                       event.stopPropagation();
-                      applyCommandSelection(command);
+                      applyCommandSelection(command, { replaceSkillDraft: true });
                     }}
                     onClick={(event) => {
-                      if (event.detail === 0) applyCommandSelection(command);
+                      if (event.detail === 0) applyCommandSelection(command, { replaceSkillDraft: true });
                     }}
                   >
                     <Terminal size={14} className="mt-0.5 shrink-0 text-gray-9" />
@@ -1194,6 +1205,7 @@ export function ReactSessionComposer(props: ComposerProps) {
           <div className="px-4 pt-3 pb-2">
             {/* Editor */}
             <LexicalPromptEditor
+              ref={editorRef}
               value={props.draft}
               mentions={props.mentions}
               pastedText={pastedTextTokens}
@@ -1306,7 +1318,14 @@ export function ReactSessionComposer(props: ComposerProps) {
                 >
                   <Paperclip size={16} />
                 </button>
-                <div ref={toolMenuRef} className="relative">
+                <div
+                  ref={toolMenuRef}
+                  className="relative"
+                  onMouseDown={(event) => {
+                    const target = event.target;
+                    if (target instanceof Element && target.closest("button")) event.preventDefault();
+                  }}
+                >
                   <button
                     type="button"
                     className={`inline-flex h-9 max-h-9 w-9 items-center justify-center rounded-md transition-colors ${toolMenuOpen ? "bg-gray-3 text-gray-12" : "text-gray-10 hover:bg-gray-3"}`}

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, type ForwardedRef } from "react";
 import { LexicalComposer } from "@lexical/react/LexicalComposer.js";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin.js";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable.js";
@@ -48,6 +48,10 @@ type EditorProps = {
   onDrop?: React.DragEventHandler<HTMLDivElement>;
   onDragOver?: React.DragEventHandler<HTMLDivElement>;
   onDragLeave?: React.DragEventHandler<HTMLDivElement>;
+};
+
+export type LexicalPromptEditorHandle = {
+  insertSkillAtSelection: (skillName: string) => void;
 };
 
 type SerializedComposerMentionNode = Spread<
@@ -416,7 +420,7 @@ function $createComposerPastedTextNode(label: string, lines: number) {
 
 type ComposerInlineTokenNode = ComposerMentionNode | ComposerSlashCommandNode | ComposerSkillNode | ComposerPastedTextNode;
 
-function setSelectionAfterNode(node: ComposerInlineTokenNode) {
+function setSelectionAfterNode(node: TextNode) {
   const parent = node.getParent();
   if (!parent || !$isElementNode(parent)) return;
   const selection = $createRangeSelection();
@@ -503,6 +507,29 @@ function setPrompt(value: string, mentions: Record<string, ComposerMentionKind>,
     }
     paragraph = appendSegmentWithNewlines(paragraph, segment);
   }
+}
+
+function appendSkillAtEnd(skillName: string) {
+  const root = $getRoot();
+  const lastChild = root.getLastChild();
+  const paragraph = $isElementNode(lastChild) ? lastChild : $createParagraphNode();
+  if (!$isElementNode(lastChild)) root.append(paragraph);
+  const skillNode = $createComposerSkillNode(skillName);
+  const spaceNode = $createTextNode(" ");
+  paragraph.append(skillNode, spaceNode);
+  setSelectionAfterNode(spaceNode);
+}
+
+function insertSkillAtSelection(skillName: string) {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection)) {
+    appendSkillAtEnd(skillName);
+    return;
+  }
+  const skillNode = $createComposerSkillNode(skillName);
+  const spaceNode = $createTextNode(" ");
+  selection.insertNodes([skillNode, spaceNode]);
+  setSelectionAfterNode(spaceNode);
 }
 
 // Serialize the current editor state to the external draft string. Lexical's
@@ -760,7 +787,20 @@ function MentionChipNavigationPlugin() {
   return null;
 }
 
-export function LexicalPromptEditor(props: EditorProps) {
+function ImperativeHandlePlugin(props: { editorRef: ForwardedRef<LexicalPromptEditorHandle> }) {
+  const [editor] = useLexicalComposerContext();
+
+  useImperativeHandle(props.editorRef, () => ({
+    insertSkillAtSelection(skillName: string) {
+      editor.update(() => insertSkillAtSelection(skillName));
+      editor.focus();
+    },
+  }), [editor]);
+
+  return null;
+}
+
+export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorProps>(function LexicalPromptEditor(props, ref) {
   const valueRef = useRef(props.value);
   const onChangeRef = useRef(props.onChange);
 
@@ -853,7 +893,8 @@ export function LexicalPromptEditor(props: EditorProps) {
         <SubmitPlugin onSubmit={props.onSubmit} disabled={props.disabled} />
         <PasteChipPlugin onPasteText={props.onPasteText} />
         <MentionChipNavigationPlugin />
+        <ImperativeHandlePlugin editorRef={ref} />
       </div>
     </LexicalComposer>
   );
-}
+});


### PR DESCRIPTION
## Summary
- Insert skill quick actions at the current composer cursor instead of replacing the whole draft
- Preserve the existing slash-command behavior for `/skill` selection
- Allow multiple skill chips in the same composer message

## Verification
- `pnpm --filter @openwork/app typecheck` ✅
- `pnpm --filter @openwork/app test` ✅ (68 pass, 0 fail)
- Ran desktop app with `OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9824 pnpm dev` and verified through Electron CDP that skill quick actions insert at the cursor and multiple `composer-skill` nodes can exist in one draft.

## Evidence
- Local screenshot captured: `/var/folders/6w/z6896bkn5w7fmyy8f_ryk8h40000gn/T/browser-screenshot-1781695851487.png`
- No video captured; verification was done locally through CDP automation and screenshot evidence.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

