### PR TITLE
fix(app): open unsupported file artifacts externally

### DIFF
--- a/apps/app/scripts/artifacts.test.ts
+++ b/apps/app/scripts/artifacts.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { UIMessage } from "ai";
 
 import type { OpenTarget } from "../src/react-app/domains/session/artifacts/open-target";
-import { canPreviewArtifact, getArtifactsFromMessages } from "../src/lib/artifacts";
+import { canOpenArtifact, canPreviewArtifact, getArtifactsFromMessages } from "../src/lib/artifacts";
 
 describe("getArtifactsFromMessages", () => {
   it("includes verified slide deck targets mentioned in assistant summaries", () => {
@@ -109,5 +109,29 @@ describe("getArtifactsFromMessages", () => {
     expect(artifacts.map((artifact) => artifact.path)).toEqual(["reports/new.md", "reports/old.md", "src/widget.tsx"]);
     expect(canPreviewArtifact(artifacts[0])).toBe(true);
     expect(canPreviewArtifact(artifacts[2])).toBe(false);
+  });
+
+  it("lets verified unsupported file artifacts open outside the sidebar", () => {
+    const messages: UIMessage[] = [{
+      id: "msg_unsupported",
+      role: "assistant",
+      parts: [{ type: "text", text: "Created src/widget.tsx", state: "done" }],
+    }];
+    const targets: OpenTarget[] = [{
+      id: "file:src/widget.tsx",
+      kind: "file",
+      value: "src/widget.tsx",
+      name: "widget.tsx",
+      preview: "text",
+      confidence: 65,
+      reason: "message",
+      exists: true,
+    }];
+
+    const artifact = getArtifactsFromMessages(messages, targets, { includeTargetFallbacks: false })[0];
+
+    expect(artifact).toMatchObject({ path: "src/widget.tsx", legacy_target: { exists: true, preview: "text" } });
+    expect(artifact ? canPreviewArtifact(artifact) : true).toBe(false);
+    expect(artifact ? canOpenArtifact(artifact) : false).toBe(true);
   });
 });

--- a/apps/app/scripts/open-target.test.ts
+++ b/apps/app/scripts/open-target.test.ts
@@ -75,6 +75,17 @@ describe("deriveOpenTargets", () => {
     expect(targets[0]).toMatchObject({ value: "reports/summary.md", preview: "markdown", confidence: 95 });
   });
 
+  it("keeps written unsupported files available for opening externally", () => {
+    const targets = deriveOpenTargets([
+      toolMessage("msg_tool", "write", { filePath: "src/widget.tsx" }, { filePath: "src/widget.tsx" }),
+    ]);
+
+    const target = targets[0];
+
+    expect(target).toMatchObject({ value: "src/widget.tsx", preview: "text", confidence: 95 });
+    expect(target ? isCollectibleArtifactTarget({ ...target, exists: true }) : true).toBe(false);
+  });
+
   it("extracts PowerPoint decks from assistant artifact summaries", () => {
     const targets = deriveOpenTargets([
       message("msg_1", "assistant", "Updated file: decks/openwork-vertebrae-deck.pptx"),

--- a/apps/app/src/components/chat/artifact.tsx
+++ b/apps/app/src/components/chat/artifact.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/descriptive-button";
 import {
   type ArtifactItem,
+  canOpenArtifact,
   canPreviewArtifact,
   useArtifacts,
   usePreviewArtifact,
@@ -31,7 +32,8 @@ function compactArtifactTitle(name: string) {
 
 function ArtifactButton({ artifact }: ArtifactButtonProps) {
   const previewArtifact = usePreviewArtifact();
-  const canOpen = canPreviewArtifact(artifact);
+  const canOpen = canOpenArtifact(artifact);
+  const canPreview = canPreviewArtifact(artifact);
   const title = compactArtifactTitle(artifact.name);
 
   const content = (
@@ -58,7 +60,7 @@ function ArtifactButton({ artifact }: ArtifactButtonProps) {
     <DescriptiveButton
       className="w-fit max-w-full flex-none items-center gap-1.5 rounded-xl px-2 py-1.5 whitespace-nowrap"
       onClick={() => previewArtifact(artifact)}
-      title={`Open ${artifact.name}`}
+      title={canPreview ? `Preview ${artifact.name}` : `Open ${artifact.name}`}
     >
       {content}
     </DescriptiveButton>

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -18,6 +18,8 @@ import {
 import { bundledLanguages, codeToHtml } from "shiki";
 
 import { cn } from "@/lib/utils";
+import { useOpenTargets } from "@/lib/target-provider";
+import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 
 import { applyTextHighlights } from "./text-highlights";
 
@@ -56,6 +58,52 @@ function safeHref(href: string) {
   }
 
   return "#";
+}
+
+function localPathFromHref(href: string) {
+  const trimmed = href.trim();
+
+  if (!trimmed || trimmed.startsWith("#") || /^(?:https?|mailto):/i.test(trimmed)) {
+    return "";
+  }
+
+  if (/^file:/i.test(trimmed)) {
+    try {
+      const pathname = decodeURIComponent(new URL(trimmed).pathname);
+
+      return /^\/[A-Za-z]:\//.test(pathname) ? pathname.slice(1) : pathname;
+    } catch {
+      return "";
+    }
+  }
+
+  return trimmed.split(/[?#]/)[0] ?? trimmed;
+}
+
+function normalizeFilePathForMatch(path: string) {
+  return path
+    .trim()
+    .replace(/[\\]+/g, "/")
+    .replace(/^\.\//, "")
+    .replace(/[/]+$/, "")
+    .toLowerCase();
+}
+
+function filePathMatchesTarget(path: string, targetValue: string) {
+  const normalizedPath = normalizeFilePathForMatch(path);
+  const normalizedTarget = normalizeFilePathForMatch(targetValue);
+
+  return normalizedPath === normalizedTarget || normalizedPath.endsWith(`/${normalizedTarget}`);
+}
+
+function openTargetForHref(href: string, openTargets: OpenTarget[]) {
+  const path = localPathFromHref(href);
+
+  if (!path) {
+    return null;
+  }
+
+  return openTargets.find((target) => target.kind === "file" && filePathMatchesTarget(path, target.value)) ?? null;
 }
 
 function alignAttribute(align: Tokens.TableCell["align"]) {
@@ -137,6 +185,7 @@ function sanitizeMarkdownHtml(value: string) {
       "data-openwork-image-preview",
       "data-openwork-image-toggle",
       "data-openwork-image-toggle-label",
+      "data-openwork-link-href",
       "data-openwork-shiki",
       "decoding",
       "disabled",
@@ -209,9 +258,10 @@ const baseMarkedOptions = {
     },
     link({ href, title, tokens }) {
       const safe = escapeAttribute(safeHref(href));
+      const originalHref = escapeAttribute(href);
       const titleAttr = title ? ` title="${escapeAttribute(title)}"` : "";
 
-      return `<a href="${safe}"${titleAttr} target="_blank" rel="noreferrer noopener" class="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8">${this.parser.parseInline(tokens)}</a>`;
+      return `<a href="${safe}" data-openwork-link-href="${originalHref}"${titleAttr} target="_blank" rel="noreferrer noopener" class="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8">${this.parser.parseInline(tokens)}</a>`;
     },
     image({ href, title, text }) {
       const safe = escapeAttribute(safeHref(href));
@@ -302,6 +352,7 @@ function MarkdownBlockInner({
   ...props
 }: MarkdownBlockInnerProps) {
   const rootRef = useRef<HTMLDivElement>(null);
+  const { openTargets, onOpenTarget } = useOpenTargets();
   const syncHtml = useMemo(() => {
     if (!text.trim()) {
       return "";
@@ -366,6 +417,17 @@ function MarkdownBlockInner({
     const handleClick = (event: MouseEvent) => {
       if (!(event.target instanceof Element)) return;
 
+      const anchor = event.target.closest("a[data-openwork-link-href]");
+      if (anchor instanceof HTMLAnchorElement) {
+        const target = openTargetForHref(anchor.dataset.openworkLinkHref ?? "", openTargets);
+        if (target && onOpenTarget) {
+          event.preventDefault();
+          onOpenTarget(target);
+
+          return;
+        }
+      }
+
       const button = event.target.closest("[data-openwork-image-toggle]");
       if (!(button instanceof HTMLButtonElement)) return;
 
@@ -396,7 +458,7 @@ function MarkdownBlockInner({
       root.removeEventListener("load", handleLoad, true);
       root.removeEventListener("click", handleClick);
     };
-  }, [html]);
+  }, [html, onOpenTarget, openTargets]);
 
   if (!html) {
     return null;

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -69,9 +69,16 @@ function localPathFromHref(href: string) {
 
   if (/^file:/i.test(trimmed)) {
     try {
-      const pathname = decodeURIComponent(new URL(trimmed).pathname);
+      const parsed = new URL(trimmed);
+      const host = decodeURIComponent(parsed.hostname);
+      const pathname = decodeURIComponent(parsed.pathname);
+      const localPath = /^\/[A-Za-z]:\//.test(pathname) ? pathname.slice(1) : pathname;
 
-      return /^\/[A-Za-z]:\//.test(pathname) ? pathname.slice(1) : pathname;
+      if (host && host !== "localhost") {
+        return `//${host}${localPath.startsWith("/") ? localPath : `/${localPath}`}`;
+      }
+
+      return localPath;
     } catch {
       return "";
     }

--- a/apps/app/src/lib/artifacts.ts
+++ b/apps/app/src/lib/artifacts.ts
@@ -7,7 +7,7 @@ import {
   isWriteToolPart,
 } from "@/lib/build-in-tools";
 import { useOpenTargets } from "@/lib/target-provider";
-import { isCollectibleArtifactTarget, type OpenTarget, type OpenTargetPreview } from "@/react-app/domains/session/artifacts/open-target";
+import { isCollectibleArtifactTarget, isOpenableFileTarget, type OpenTarget, type OpenTargetPreview } from "@/react-app/domains/session/artifacts/open-target";
 
 export type ArtifactType = "website" | "markdown" | "sheet" | "slides" | "document" | "image" | "video" | "audio" | "pdf" | "html" | "text" | "unknown";
 
@@ -136,6 +136,10 @@ export function getArtifactTypeLabel(type: ArtifactType) {
 
 export function canPreviewArtifact(artifact: ArtifactItem) {
   return isCollectibleArtifactTarget(artifact.legacy_target);
+}
+
+export function canOpenArtifact(artifact: ArtifactItem) {
+  return canPreviewArtifact(artifact) || isOpenableFileTarget(artifact.legacy_target);
 }
 
 function getArtifactName(path: string) {
@@ -317,7 +321,7 @@ export function getArtifactsFromMessages(messages: UIMessage[], openTargets: Ope
   if (options.includeTargetFallbacks ?? true) {
     const fallbackMessageId = messages[messages.length - 1]?.id ?? "open-target";
     for (const target of openTargets) {
-      if (isCollectibleArtifactTarget(target)) {
+      if (isOpenableFileTarget(target)) {
         addArtifact(artifacts, target.value, fallbackMessageId, messages.length, sequence, openTargets, target);
         sequence += 1;
       }

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -34,7 +34,7 @@ const WORKSPACE_ID_PREFIX_PATTERN = /^workspace\/(?:ws_[^/]+|\d+|[0-9a-f-]{6,})\
 const FILE_PATTERN = /(?:^|[\s"'`([{])((?:\.{1,2}[/\\]|~[/\\]|[/\\])?[\w.\-]+(?:[/\\][\w.\-]+)+\.[a-z][a-z0-9]{0,9}|[\w.\-]+\.[a-z][a-z0-9]{0,9})/gi;
 const URL_PATTERN = /https?:\/\/[^\s)\]}>"'`]+/gi;
 const SOCKET_PATTERN = /(?:ws|wss):\/\/[^\s)\]}>"'`]+/gi;
-const ARTIFACT_FILE_PREVIEWS = new Set<OpenTargetPreview>(["markdown", "sheet", "slides", "image", "pdf", "html"]);
+const SIDEBAR_ARTIFACT_FILE_PREVIEWS = new Set<OpenTargetPreview>(["markdown", "sheet", "slides", "image", "pdf", "html"]);
 const ASSISTANT_ARTIFACT_MENTION_PATTERN = /\b(?:artifact|created|deck|deliverable|exported|file|generated|opened|presentation|saved|slides?|updated|wrote)\b/i;
 const DISCOVERY_TOOL_NAMES = new Set(["glob", "grep", "search", "find"]);
 const ARTIFACT_METADATA_TOOL_NAMES = new Set(["openwork_extension_call"]);
@@ -139,11 +139,15 @@ function addTarget(map: Map<string, OpenTarget>, target: OpenTarget | null) {
 }
 
 function isArtifactTarget(target: OpenTarget) {
-  return target.kind === "url" || ARTIFACT_FILE_PREVIEWS.has(target.preview);
+  return target.kind === "url" || target.kind === "file";
 }
 
 export function isCollectibleArtifactTarget(target: OpenTarget) {
-  return target.kind === "file" && target.exists === true && ARTIFACT_FILE_PREVIEWS.has(target.preview);
+  return target.kind === "file" && target.exists === true && SIDEBAR_ARTIFACT_FILE_PREVIEWS.has(target.preview);
+}
+
+export function isOpenableFileTarget(target: OpenTarget) {
+  return target.kind === "file" && target.exists === true;
 }
 
 export function isLocalhostBrowserTarget(target: OpenTarget) {

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -9,7 +9,7 @@ import { OPENWORK_EXTENSION_CATALOG } from "../../../../app/constants";
 import { type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
-import type { WorkspaceInfo } from "../../../../app/lib/desktop";
+import { openDesktopPath, type WorkspaceInfo } from "../../../../app/lib/desktop";
 import type {
   PendingPermission,
   PendingQuestion,
@@ -54,7 +54,7 @@ import { useShellConfig } from "../../../shell/shell-config";
 import { type SidePanelItem, useUiStateStore } from "../../../shell/ui-state-store";
 
 import { isElectronRuntime } from "../../../../app/utils";
-import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, type OpenTarget } from "../artifacts/open-target";
+import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTarget, type OpenTarget } from "../artifacts/open-target";
 import { VoicePanel } from "../voice/voice-panel";
 import { SidePanel } from "../panel/side-panel";
 import { TerminalDock } from "../terminal/terminal-dock";
@@ -216,7 +216,14 @@ function sessionExistsInWorkspace(groups: WorkspaceSessionGroup[], workspaceId: 
 }
 
 function isTrackableAccessibleTarget(target: OpenTarget) {
-  return isCollectibleArtifactTarget(target) || isLocalhostBrowserTarget(target);
+  return isOpenableFileTarget(target) || isLocalhostBrowserTarget(target);
+}
+
+function absoluteWorkspacePath(root: string, path: string) {
+  const cleanRoot = root.trim().replace(/[/\\]+$/, "");
+  const cleanPath = path.trim().replace(/^\.\//, "");
+
+  return cleanRoot ? `${cleanRoot}/${cleanPath}` : cleanPath;
 }
 
 function hiddenAccessibleTargetsStorageKey(workspaceId: string | null | undefined, sessionId: string | null | undefined) {
@@ -385,6 +392,21 @@ export function SessionPage(props: SessionPageProps) {
     if (/^wss?:\/\//i.test(target.value)) return target.value.replace(/^ws:/i, "http:").replace(/^wss:/i, "https:");
     return target.value;
   }, []);
+  const downloadOpenTarget = useCallback(async (target: OpenTarget) => {
+    if (target.kind !== "file" || !props.openworkServerClient || !props.runtimeWorkspaceId) {
+      return;
+    }
+
+    const result = await props.openworkServerClient.downloadWorkspaceFile(props.runtimeWorkspaceId, target.value);
+    const url = URL.createObjectURL(new Blob([result.data], { type: result.contentType ?? "application/octet-stream" }));
+    const anchor = document.createElement("a");
+
+    anchor.href = url;
+    anchor.download = target.name;
+    anchor.click();
+
+    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }, [props.openworkServerClient, props.runtimeWorkspaceId]);
   const openTarget = useCallback((target: OpenTarget, options?: { auto?: boolean }, sourceSessionId?: string) => {
     if (target.kind === "url" || target.preview === "browser") {
       const url = browserUrlForTarget(target);
@@ -396,8 +418,19 @@ export function SessionPage(props: SessionPageProps) {
       }
       return;
     }
+    if (!isCollectibleArtifactTarget(target)) {
+      if (isOpenableFileTarget(target)) {
+        if (props.selectedWorkspaceDisplay.workspaceType === "remote") {
+          void downloadOpenTarget(target).catch(() => undefined);
+        } else if (isElectronRuntime()) {
+          void openDesktopPath(absoluteWorkspacePath(props.selectedWorkspaceRoot, target.value)).catch(() => undefined);
+        }
+      }
+      return;
+    }
+
     const sessionId = sourceSessionId ?? props.selectedSessionId;
-    if (!sessionId || !isCollectibleArtifactTarget(target)) return;
+    if (!sessionId) return;
     if (options?.auto && activePanelTab?.id === target.id) return;
     openTab(sessionId, {
       id: target.id,
@@ -407,7 +440,7 @@ export function SessionPage(props: SessionPageProps) {
     });
     preserveSidePanelOnPanelOpenRef.current = true;
     setCurrentSidePanel("panel");
-  }, [activePanelTab?.id, browserUrlForTarget, openTab, props.selectedSessionId, setCurrentSidePanel]);
+  }, [activePanelTab?.id, browserUrlForTarget, downloadOpenTarget, openTab, props.selectedSessionId, props.selectedWorkspaceDisplay.workspaceType, props.selectedWorkspaceRoot, setCurrentSidePanel]);
   const closeRightPane = useCallback(() => {
     setCurrentSidePanel(null);
   }, [setCurrentSidePanel]);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1372,8 +1372,17 @@ async function createMainWindow() {
   });
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith("file://")) {
+      try {
+        void shell.openPath(fileURLToPath(url));
+      } catch {
+        void shell.openExternal(url);
+      }
+
+      return { action: "deny" };
+    }
+
     const local =
-      url.startsWith("file://") ||
       url.startsWith("http://127.0.0.1") ||
       url.startsWith("http://localhost");
     if (!local) {


### PR DESCRIPTION
## Summary
- route markdown file links through verified OpenWork targets before default browser handling
- keep sidebar previews limited to supported artifact types, while opening unsupported local files in the desktop default app
- prevent Electron file:// links from spawning a blank OpenWork window by opening them through the OS instead

## Tests
- ✅ pnpm --filter @openwork/app test:open-target
- ✅ bun test apps/app/scripts/artifacts.test.ts
- ✅ pnpm --filter @openwork/app typecheck
- ✅ pnpm --filter @openwork/desktop check:electron
- ✅ pnpm --filter @openwork/desktop typecheck:electron
- ✅ git diff --check

## Evidence
- No video/screenshot captured; verification was via focused automated tests and type checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

