### PR TITLE
fix(app): surface v2 permission requests

### DIFF
--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -2,6 +2,7 @@ import type {
   Message,
   Part,
   PermissionRequest as ApiPermissionRequest,
+  PermissionV2Request,
   QuestionRequest,
   ProviderListResponse,
   Session,
@@ -382,8 +383,11 @@ export type ReloadTrigger = {
   path?: string;
 };
 
-export type PendingPermission = ApiPermissionRequest & {
+export type PendingPermission = Omit<ApiPermissionRequest, "always"> & {
+  always: unknown;
   receivedAt: number;
+  protocol: "legacy" | "v2";
+  v2?: Pick<PermissionV2Request, "action" | "resources" | "save">;
 };
 
 export type PendingQuestion = QuestionRequest & {

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -1,5 +1,5 @@
 import type { UIMessage } from "ai";
-import type { FilePart, Part, PermissionRequest, QuestionRequest, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
+import type { FilePart, Part, PermissionRequest, PermissionV2Request, QuestionRequest, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
 import { getReactQueryClient } from "../../../infra/query-client";
 import { captureAnalyticsEvent, takeTaskRunStart } from "@/app/lib/analytics";
@@ -208,8 +208,52 @@ function releaseRetainedSessionSoon(input: SyncOptions, entry: SyncEntry, sessio
   retainSession(input, entry, sessionId, idleRetainedSessionTtlMs);
 }
 
-function withReceivedAt(permission: PermissionRequest, receivedAt: number): PendingPermission {
-  return { ...permission, receivedAt };
+type PermissionSeed = PermissionRequest | PermissionV2Request;
+
+function isV2PermissionRequest(permission: PermissionSeed): permission is PermissionV2Request {
+  return "action" in permission;
+}
+
+function legacyPermissionWithReceivedAt(permission: PermissionRequest, receivedAt: number): PendingPermission {
+  return { ...permission, receivedAt, protocol: "legacy" };
+}
+
+function v2PermissionKind(action: string): string {
+  if (action === "external_directory") return "external_directory";
+  if (action.endsWith(".external_directory")) return "external_directory";
+  if (action === "file.read") return "read";
+  if (action === "file.edit" || action === "file.write") return "edit";
+  return action;
+}
+
+function v2PermissionWithReceivedAt(permission: PermissionV2Request, receivedAt: number): PendingPermission {
+  const metadata: Record<string, unknown> = {
+    ...(permission.metadata ?? {}),
+    action: permission.action,
+  };
+  if (permission.save?.length) metadata.save = permission.save.join(", ");
+  return {
+    id: permission.id,
+    sessionID: permission.sessionID,
+    permission: v2PermissionKind(permission.action),
+    patterns: permission.resources,
+    metadata,
+    always: permission.save ?? [],
+    ...(permission.source ? { tool: { messageID: permission.source.messageID, callID: permission.source.callID } } : {}),
+    receivedAt,
+    protocol: "v2",
+    v2: {
+      action: permission.action,
+      resources: permission.resources,
+      ...(permission.save ? { save: permission.save } : {}),
+    },
+  };
+}
+
+function permissionWithReceivedAt(permission: PermissionSeed, receivedAt: number): PendingPermission {
+  return isV2PermissionRequest(permission)
+    ? v2PermissionWithReceivedAt(permission, receivedAt)
+    : legacyPermissionWithReceivedAt(permission, receivedAt);
 }
 
 function questionWithReceivedAt(question: QuestionRequest, receivedAt: number): PendingQuestion {
@@ -227,7 +271,7 @@ function sortQuestions(a: PendingQuestion, b: PendingQuestion) {
 export function seedPermissionState(
   workspaceId: string,
   sessionId: string,
-  permissions: PermissionRequest[],
+  permissions: PermissionSeed[],
   options: { snapshotStartedAt?: number } = {},
 ) {
   useSessionActivityStore.getState().replaceWaitingRequests(
@@ -241,7 +285,7 @@ export function seedPermissionState(
   queryClient.setQueryData<PendingPermission[]>(permissionKey(workspaceId, sessionId), (current = []) => {
     const receivedAtById = new Map(current.map((permission) => [permission.id, permission.receivedAt]));
     const seeded = permissions.flatMap((permission) =>
-      permission.sessionID === sessionId ? [withReceivedAt(permission, receivedAtById.get(permission.id) ?? now)] : [],
+      permission.sessionID === sessionId ? [permissionWithReceivedAt(permission, receivedAtById.get(permission.id) ?? now)] : [],
     );
     const seededIds = new Set(seeded.map((permission) => permission.id));
     const snapshotStartedAt = options.snapshotStartedAt;
@@ -644,7 +688,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     const receivedAt = Date.now();
     queryClient.setQueryData<PendingPermission[]>(permissionKey(workspaceId, permission.sessionID), (current = []) => {
       const existing = current.find((item) => item.id === permission.id);
-      const next = withReceivedAt(permission, existing?.receivedAt ?? receivedAt);
+      const next = permissionWithReceivedAt(permission, existing?.receivedAt ?? receivedAt);
       if (existing) {
         return current.map((item) => (item.id === permission.id ? next : item)).sort(sortPermissions);
       }
@@ -653,7 +697,24 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     return;
   }
 
-  if (event.type === "permission.replied") {
+  if (event.type === "permission.v2.asked") {
+    const permission = event.properties as PermissionV2Request;
+    if (!permission?.id || !permission.sessionID) return;
+    useSessionActivityStore.getState().setWaitingRequest(workspaceId, permission.sessionID, "permission", permission.id, true);
+    if (!isTrackedSession(entry, permission.sessionID)) return;
+    const receivedAt = Date.now();
+    queryClient.setQueryData<PendingPermission[]>(permissionKey(workspaceId, permission.sessionID), (current = []) => {
+      const existing = current.find((item) => item.id === permission.id);
+      const next = permissionWithReceivedAt(permission, existing?.receivedAt ?? receivedAt);
+      if (existing) {
+        return current.map((item) => (item.id === permission.id ? next : item)).sort(sortPermissions);
+      }
+      return [...current, next].sort(sortPermissions);
+    });
+    return;
+  }
+
+  if (event.type === "permission.replied" || event.type === "permission.v2.replied") {
     const props = (event.properties ?? {}) as { sessionID?: string; requestID?: string };
     if (!props.sessionID || !props.requestID) return;
     useSessionActivityStore.getState().setWaitingRequest(workspaceId, props.sessionID, "permission", props.requestID, false);

--- a/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
+++ b/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
@@ -67,7 +67,21 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
     void (async () => {
       const snapshotStartedAt = Date.now();
       try {
-        const list = unwrap(await client.permission.list({ directory }));
+        const list: Parameters<typeof seedPermissionState>[2] = [];
+        let readSucceeded = false;
+        try {
+          list.push(...unwrap(await client.permission.list({ directory })));
+          readSucceeded = true;
+        } catch {
+          // Older/newer OpenCode permission APIs can fail independently.
+        }
+        try {
+          list.push(...unwrap(await client.v2.session.permission.list({ sessionID: sessionId })).data);
+          readSucceeded = true;
+        } catch {
+          // Keep the legacy snapshot if the v2 endpoint is unavailable.
+        }
+        if (!readSucceeded) return;
         if (!cancelled) {
           seedPermissionState(workspaceId, sessionId, list, { snapshotStartedAt });
         }
@@ -110,13 +124,23 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
       permissionReplyBusyRef.current = true;
       setPermissionReplyBusy(true);
       try {
-        unwrap(
-          await client.permission.reply({
+        const pendingPermission = pendingPermissions.find((permission) => permission.id === requestID);
+        if (pendingPermission?.protocol === "v2") {
+          const result = await client.v2.session.permission.reply({
+            sessionID: pendingPermission.sessionID,
             requestID,
             reply,
-            directory: workspaceRoot || undefined,
-          }),
-        );
+          });
+          if (result.error !== undefined) unwrap(result);
+        } else {
+          unwrap(
+            await client.permission.reply({
+              requestID,
+              reply,
+              directory: workspaceRoot || undefined,
+            }),
+          );
+        }
         getReactQueryClient().setQueryData<PendingPermission[]>(
           permissionKey(workspaceId, sessionId),
           (current = []) => current.filter((permission) => permission.id !== requestID),
@@ -130,7 +154,7 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
         setPermissionReplyBusy(false);
       }
     },
-    [client, sessionId, workspaceId, workspaceRoot],
+    [client, pendingPermissions, sessionId, workspaceId, workspaceRoot],
   );
 
   const activeQuestion = pendingQuestions[0] ?? null;

--- a/apps/app/tests/permission-approval-modal.test.ts
+++ b/apps/app/tests/permission-approval-modal.test.ts
@@ -20,6 +20,7 @@ function pendingPermission(overrides: Partial<PendingPermission> = {}): PendingP
       project: false,
     },
     receivedAt: 1,
+    protocol: "legacy",
     ...overrides,
   };
 }

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { UIMessage } from "ai";
-import type { PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2/client";
+import type { PermissionRequest, PermissionV2Request, QuestionRequest } from "@opencode-ai/sdk/v2/client";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
@@ -27,10 +27,18 @@ function permission(id: string, sessionID: string): PermissionRequest {
     permission: "bash",
     patterns: ["echo ok"],
     metadata: {},
-    always: {
-      session: false,
-      project: false,
-    },
+    always: [],
+  };
+}
+
+function v2Permission(id: string, sessionID: string): PermissionV2Request {
+  return {
+    id,
+    sessionID,
+    action: "file.read",
+    resources: ["/outside/project/secrets.txt"],
+    metadata: { path: "/outside/project/secrets.txt" },
+    save: ["/outside/project/*"],
   };
 }
 
@@ -147,6 +155,50 @@ describe("session permission sync", () => {
     seedPermissionState("workspace-a", "session-a", [], { snapshotStartedAt: 200 });
 
     expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-a"))).toEqual([]);
+  });
+
+  test("seeds v2 permissions for the selected session", () => {
+    seedPermissionState("workspace-a", "session-a", [
+      v2Permission("perm-v2-a", "session-a"),
+      v2Permission("perm-v2-b", "session-b"),
+    ]);
+
+    expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-a"))).toMatchObject([
+      {
+        id: "perm-v2-a",
+        sessionID: "session-a",
+        permission: "read",
+        patterns: ["/outside/project/secrets.txt"],
+        protocol: "v2",
+      },
+    ]);
+  });
+
+  test("adds and removes live v2 permission events", () => {
+    const syncInput = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
+    const releaseSession = trackWorkspaceSessionSync(syncInput, "session-a");
+
+    try {
+      __applySessionSyncEventForTest(syncInput, {
+        type: "permission.v2.asked",
+        properties: v2Permission("perm-v2-live", "session-a"),
+      });
+
+      expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-a"))).toMatchObject([
+        { id: "perm-v2-live", sessionID: "session-a", permission: "read", protocol: "v2" },
+      ]);
+
+      __applySessionSyncEventForTest(syncInput, {
+        type: "permission.v2.replied",
+        properties: { sessionID: "session-a", requestID: "perm-v2-live", reply: "once" },
+      });
+
+      expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-a"))).toEqual([]);
+    } finally {
+      releaseSession();
+      cleanup();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- normalize OpenCode v2 permission requests into the existing pending permission UI state
- listen for permission.v2 asked/replied events so external file access prompts appear in the session
- reply through the v2 session permission endpoint for v2 requests
- add coverage for seeded and live v2 permission requests

## Validation
- pnpm --filter @openwork/app test apps/app/tests/session-sync-permissions.test.ts apps/app/tests/permission-approval-modal.test.ts — passed
- pnpm --filter @openwork/app typecheck — passed

## Visual evidence
No screenshot/video captured; this is a session-sync/event handling fix validated with focused tests and typecheck.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

