### PR TITLE
fix(app): sync cloud providers when the app window regains focus

### DIFF
--- a/apps/app/src/app/cloud/sync/constants.ts
+++ b/apps/app/src/app/cloud/sync/constants.ts
@@ -1,1 +1,9 @@
 export const CLOUD_SYNC_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Minimum spacing between window-focus / visibility cloud-provider syncs so
+ * rapid blur/focus cycles don't refetch the Den provider list repeatedly.
+ * The in-flight guard and the provider-auth store's sync queue dedup
+ * concurrent runs on top of this.
+ */
+export const CLOUD_FOCUS_SYNC_MIN_INTERVAL_MS = 15 * 1000;

--- a/apps/app/src/react-app/domains/cloud/use-cloud-provider-auto-sync.ts
+++ b/apps/app/src/react-app/domains/cloud/use-cloud-provider-auto-sync.ts
@@ -1,28 +1,39 @@
 /** @jsxImportSource react */
 import { useEffect, useRef } from "react";
 
-import { CLOUD_SYNC_INTERVAL_MS } from "../../../app/cloud/sync/constants";
+import {
+  CLOUD_FOCUS_SYNC_MIN_INTERVAL_MS,
+  CLOUD_SYNC_INTERVAL_MS,
+} from "../../../app/cloud/sync/constants";
 import { denSettingsChangedEvent } from "../../../app/lib/den-session-events";
 import { useDenAuth } from "./den-auth-provider";
 
-type CloudProviderSyncReason = "sign_in" | "app_launch" | "interval" | "settings_cloud_opened";
+type CloudProviderSyncReason =
+  | "sign_in"
+  | "app_launch"
+  | "interval"
+  | "settings_cloud_opened"
+  | "window_focus";
 type SyncFn = (reason: CloudProviderSyncReason) => Promise<unknown>;
 
 /**
   * Periodic cloud-provider reconciliation, ported from dev #1509 "auto-sync
   * cloud providers". Runs the provided sync function immediately, whenever Den
-  * settings change (for example active-org selection), and every
-  * `CLOUD_SYNC_INTERVAL_MS` while the Den session is signed-in; suspends while
-  * signed-out and lets the provider-auth store own user-visible errors.
- *
- * Mount once (e.g. from the settings route) — the hook is idempotent
- * within a single mount, and avoids overlapping ticks using an in-flight
- * ref guard.
- */
+  * settings change (for example active-org selection), every
+  * `CLOUD_SYNC_INTERVAL_MS` while the Den session is signed-in, and when the
+  * window regains focus/visibility so models added in the web admin appear
+  * without waiting for the next interval; suspends while signed-out and lets
+  * the provider-auth store own user-visible errors.
+  *
+  * Mount once (e.g. from the settings route) — the hook is idempotent
+  * within a single mount, and avoids overlapping ticks using an in-flight
+  * ref guard.
+  */
 export function useCloudProviderAutoSync(sync: SyncFn) {
   const denAuth = useDenAuth();
   const syncRef = useRef(sync);
   const inFlightRef = useRef(false);
+  const lastFocusSyncAtRef = useRef(0);
 
   // Keep the ref current so we always call the latest closure (store
   // identity can change between mounts and we don't want to restart the
@@ -58,6 +69,21 @@ export function useCloudProviderAutoSync(sync: SyncFn) {
     };
     window.addEventListener(denSettingsChangedEvent, handleDenSettingsChanged);
 
+    // When the user returns to the app (window focused or made visible again),
+    // reconcile cloud providers so models added in the web admin appear
+    // without waiting up to the full interval. Throttled so rapid blur/focus
+    // cycles don't hammer the Den API; the in-flight guard and the store's
+    // sync queue dedup concurrent runs on top of this.
+    const handleReturnToApp = () => {
+      if (document.visibilityState !== "visible") return;
+      const now = Date.now();
+      if (now - lastFocusSyncAtRef.current < CLOUD_FOCUS_SYNC_MIN_INTERVAL_MS) return;
+      lastFocusSyncAtRef.current = now;
+      void tick("window_focus");
+    };
+    window.addEventListener("focus", handleReturnToApp);
+    document.addEventListener("visibilitychange", handleReturnToApp);
+
     const interval = window.setInterval(() => {
       void tick();
     }, CLOUD_SYNC_INTERVAL_MS);
@@ -65,6 +91,8 @@ export function useCloudProviderAutoSync(sync: SyncFn) {
     return () => {
       cancelled = true;
       window.removeEventListener(denSettingsChangedEvent, handleDenSettingsChanged);
+      window.removeEventListener("focus", handleReturnToApp);
+      document.removeEventListener("visibilitychange", handleReturnToApp);
       window.clearInterval(interval);
     };
   }, [denAuth.isSignedIn]);

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -65,7 +65,12 @@ import {
 } from "../../../../app/cloud/desktop-app-restrictions";
 
 type ProviderReturnFocusTarget = "none" | "composer";
-type CloudProviderSyncReason = "sign_in" | "app_launch" | "interval" | "settings_cloud_opened";
+type CloudProviderSyncReason =
+  | "sign_in"
+  | "app_launch"
+  | "interval"
+  | "settings_cloud_opened"
+  | "window_focus";
 
 export type ProviderAuthMethod = {
   type: "oauth" | "api" | "cloud";


### PR DESCRIPTION
## Problem

Cloud-managed provider/model changes made in the Den web admin (port 3005) only reached the desktop app on sign-in, app launch, a 5-minute interval, or by manually opening Settings → Cloud providers. **Returning to the app window after editing a model in the web admin left the new model invisible for up to five minutes** — there was no window-focus / visibility trigger.

## Fix

Add `focus` and `visibilitychange` triggers to `useCloudProviderAutoSync` so reconciliation runs when the user comes back to the app. The tick is:
- Throttled (15s minimum spacing) so rapid blur/focus cycles don't hammer the Den API.
- Deduped by the existing in-flight ref guard in the hook.
- Serialized by the provider-auth store's sync queue (`runCloudProviderSync`).

Files:
- `apps/app/src/app/cloud/sync/constants.ts` — new `CLOUD_FOCUS_SYNC_MIN_INTERVAL_MS`.
- `apps/app/src/react-app/domains/cloud/use-cloud-provider-auto-sync.ts` — `window_focus` reason + listeners.
- `apps/app/src/react-app/domains/connections/provider-auth/store.ts` — extend `CloudProviderSyncReason` union.

The reconciliation path itself (`performCloudProviderSync` in `store.ts`) is unchanged and already correct — it force-refreshes Den providers, detects out-of-sync imports via `updatedAt` + `modelIds`, and removes + re-imports. The only gap was the missing trigger.

## Verification

### Typecheck
\`\`\`
pnpm --filter @openwork/app typecheck   # PASS (tsc --noEmit, no errors)
\`\`\`

### Daytona e2e (BEFORE / dev branch — bug reproduced)
Two-sandbox flow: Den server sandbox (`openwork-server-...`) + Electron sandbox (`openwork-test-...`) pointed at Den via `--den-base-url`/`--den-api-base-url` with `--require-signin`.

1. Seeded Acme Robotics demo org; created a cloud OpenAI provider (`lpr_01kv9rrbbbfzvsegx77t9jt274`) with one model `gpt-4o-mini` + credential via `POST /v1/llm-providers`.
2. Desktop handoff sign-in as `alex@acme.test`; selected Acme Robotics; onboarding showed "AI Providers — 1 MODEL".
3. Created workspace `/workspace/hello`. Cloud sync on sign-in imported the provider:
   \`\`\`
   opencode.jsonc -> provider.lpr_01kv9rrbbbfzvsegx77t9jt274.models = ["gpt-4o-mini"]  ✅
   \`\`\`
4. Added a 2nd model `gpt-4.1-mini` via `PATCH /v1/llm-providers/:id` (same payload the Den Web editor sends). Den list now returned 2 models; `updatedAt` bumped.
5. Simulated "come back to the app" — dispatched `blur` + `focus` + `visibilitychange` (visible) on the window.
6. **BEFORE result (bug):** `opencode.jsonc` still showed only `["gpt-4o-mini"]` after focus. The new model did NOT sync. Confirmed `useCloudProviderAutoSync` had no focus/visibility listener on `dev`.

### Daytona e2e (AFTER / fix branch)
Switched the same Electron sandbox to `fix/cloud-provider-window-focus-sync`; Vite HMR picked up the change. The sandbox auto-stopped (60min `--auto-stop`) before the full AFTER flow could be re-run end-to-end, so the AFTER assertion is not yet captured as a recording.

**What is verified:** the fix compiles clean, and the missing trigger is the only gap — `performCloudProviderSync` is the exact same reconciliation path the Settings → Cloud providers tab uses (`settings_cloud_opened` reason), which was verified working in the BEFORE run (it correctly detected the provider as out-of-sync and offered Import).

### Commands to reproduce
\`\`\`bash
# Server sandbox
bash .devcontainer/test-server-on-daytona.sh dev
# Seed
daytona exec <server> -- 'cd /workspace && pnpm --filter @openwork/email build && cd ee/apps/den-api && OPENWORK_DEV_MODE=1 ... pnpm exec tsx scripts/seed-demo-org.ts --reset'
# Electron sandbox
bash .devcontainer/test-on-daytona.sh <branch> --den-base-url <DEN_WEB_URL> --den-api-base-url <DEN_API_URL> --require-signin --artifacts-volume
\`\`\`

## Notes / honesty
- I could not capture a video recording of the AFTER flow; the Daytona sandbox auto-stopped mid-test. The fix is a small, surgical trigger addition; the reconciliation logic it invokes is unchanged and already proven by the BEFORE run.
- I did not test the OpenWork UI-control MCP server path in this pass; the focus is the model-sync bug as requested.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

