### PR TITLE
fix(desktop): include mac x64 node-pty package

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -326,7 +326,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-electron-pnpm-
 
+      - name: Install dependencies (macOS dual arch)
+        if: matrix.os_type == 'macos'
+        run: |
+          set -euo pipefail
+          # The x64 macOS app is built on an arm64 runner, but node-pty
+          # resolves its CPU-specific optional package at runtime.
+          {
+            echo "supportedArchitectures.cpu[]=x64"
+            echo "supportedArchitectures.cpu[]=arm64"
+          } >> .npmrc
+          pnpm install --frozen-lockfile
+
       - name: Install dependencies
+        if: matrix.os_type != 'macos'
         run: pnpm install --frozen-lockfile
 
       - name: Write Electron notary API key (macOS)

--- a/apps/desktop/electron/packaging.test.mjs
+++ b/apps/desktop/electron/packaging.test.mjs
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+
+const repoRoot = resolve(import.meta.dirname, "..", "..", "..");
+
+describe("desktop packaging dependencies", () => {
+  it("installs both CPU variants of native packages for Electron release builds", () => {
+    const workflow = parse(
+      readFileSync(resolve(repoRoot, ".github/workflows/release-macos-aarch64.yml"), "utf8"),
+    );
+    const steps = workflow.jobs["publish-electron"].steps;
+    const installStep = steps.find((step) => step.name === "Install dependencies (macOS dual arch)");
+
+    assert.ok(installStep);
+    assert.equal(installStep.if, "matrix.os_type == 'macos'");
+    assert.match(installStep.run, /supportedArchitectures\.cpu\[\]=x64/);
+    assert.match(installStep.run, /supportedArchitectures\.cpu\[\]=arm64/);
+    assert.match(installStep.run, /pnpm install --frozen-lockfile/);
+  });
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/runtime.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/runtime.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs electron/packaging.test.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.17.3",


### PR DESCRIPTION
Fixes #2190

## Summary
- Adds pnpm supportedArchitectures so macOS Electron release installs include both arm64 and x64 native optional packages
- Ensures the Intel macOS app can resolve @lydell/node-pty-darwin-x64 at runtime
- Adds a desktop packaging regression test for the architecture config

## Verification
- Verified with a clean temp install that both @lydell/node-pty-darwin-arm64 and @lydell/node-pty-darwin-x64 are installed and resolvable
- pnpm install --frozen-lockfile
- pnpm --filter @openwork/desktop test
- pnpm --filter @openwork/desktop typecheck:electron
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

