### PR TITLE
ci: sign Windows releases with SignPath

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -55,6 +55,7 @@ on:
         default: true
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
 
@@ -65,7 +66,9 @@ concurrency:
 jobs:
   resolve-release:
     name: Resolve Release Metadata
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # SignPath trusted builds require every job leading to the Windows signing
+    # request to use GitHub-hosted runners.
+    runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.resolve.outputs.release_tag }}
       release_name: ${{ steps.resolve.outputs.release_name }}
@@ -224,7 +227,9 @@ jobs:
   verify-release:
     name: Verify Release Versions
     needs: resolve-release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # SignPath trusted builds require every job leading to the Windows signing
+    # request to use GitHub-hosted runners.
+    runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
     steps:
@@ -410,6 +415,89 @@ jobs:
             --config electron-builder.yml \
             ${{ matrix.electron_args }} \
             --publish never
+
+      - name: Validate SignPath configuration (Windows)
+        if: matrix.os_type == 'windows'
+        shell: bash
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+          SIGNPATH_ORGANIZATION_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          SIGNPATH_PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          SIGNPATH_SIGNING_POLICY_SLUG: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for name in \
+            SIGNPATH_API_TOKEN \
+            SIGNPATH_ORGANIZATION_ID \
+            SIGNPATH_PROJECT_SLUG \
+            SIGNPATH_SIGNING_POLICY_SLUG; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing Windows SignPath configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Stage unsigned Windows installer for SignPath
+        if: matrix.os_type == 'windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p "$RUNNER_TEMP/signpath-unsigned"
+          shopt -s nullglob
+          installers=(apps/desktop/dist-electron/openwork-win-x64-*.exe)
+          if [ "${#installers[@]}" -ne 1 ]; then
+            printf 'Expected exactly one unsigned Windows installer, found %s.\n' "${#installers[@]}" >&2
+            printf '%s\n' "${installers[@]}" >&2
+            exit 1
+          fi
+          cp "${installers[0]}" "$RUNNER_TEMP/signpath-unsigned/"
+
+      - name: Upload unsigned Windows installer for SignPath
+        if: matrix.os_type == 'windows'
+        id: upload-unsigned-windows-installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-openwork-windows-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/signpath-unsigned/*.exe
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Submit Windows signing request to SignPath
+        if: matrix.os_type == 'windows' && vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG == ''
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned-windows-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: ${{ runner.temp }}/signpath-signed
+
+      - name: Submit Windows signing request to SignPath (artifact configuration)
+        if: matrix.os_type == 'windows' && vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG != ''
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned-windows-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: ${{ runner.temp }}/signpath-signed
+
+      - name: Apply signed Windows installer
+        if: matrix.os_type == 'windows'
+        shell: bash
+        run: node scripts/release/apply-signpath-windows-artifact.mjs "$RUNNER_TEMP/signpath-signed" apps/desktop/dist-electron
 
       - name: Upload Electron release assets
         env:

--- a/scripts/release/apply-signpath-windows-artifact.mjs
+++ b/scripts/release/apply-signpath-windows-artifact.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const [signedArtifactDirArg, distDirArg] = process.argv.slice(2);
+
+if (!signedArtifactDirArg || !distDirArg) {
+  console.error("Usage: node scripts/release/apply-signpath-windows-artifact.mjs <signed-artifact-dir> <dist-dir>");
+  process.exit(2);
+}
+
+const signedArtifactDir = resolve(signedArtifactDirArg);
+const distDir = resolve(distDirArg);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const desktopRequire = createRequire(new URL("../../apps/desktop/package.json", import.meta.url));
+const YAML = desktopRequire("yaml");
+
+function walk(dir) {
+  const entries = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) entries.push(...walk(path));
+    else if (stat.isFile()) entries.push(path);
+  }
+  return entries;
+}
+
+function findOne(paths, description) {
+  if (paths.length !== 1) {
+    console.error(`Expected exactly one ${description}, found ${paths.length}.`);
+    for (const path of paths) console.error(`- ${path}`);
+    process.exit(1);
+  }
+  return paths[0];
+}
+
+function sha512(file) {
+  return createHash("sha512").update(readFileSync(file)).digest("base64");
+}
+
+function findAppBuilderPath() {
+  const pnpmDir = join(repoRoot, "node_modules", ".pnpm");
+  if (!existsSync(pnpmDir)) {
+    throw new Error(`Cannot find pnpm store directory: ${pnpmDir}`);
+  }
+
+  for (const entry of readdirSync(pnpmDir)) {
+    if (!entry.startsWith("app-builder-bin@")) continue;
+    const appBuilderPackage = join(pnpmDir, entry, "node_modules", "app-builder-bin", "index.js");
+    if (!existsSync(appBuilderPackage)) continue;
+    const appBuilderRequire = createRequire(appBuilderPackage);
+    const { appBuilderPath } = appBuilderRequire(appBuilderPackage);
+    return appBuilderPath;
+  }
+
+  throw new Error("Cannot find app-builder-bin. Run pnpm install before applying the signed Windows artifact.");
+}
+
+function regenerateBlockmap(installerPath) {
+  const blockmapPath = `${installerPath}.blockmap`;
+  mkdirSync(dirname(blockmapPath), { recursive: true });
+
+  const result = spawnSync(findAppBuilderPath(), ["blockmap", "--input", installerPath, "--output", blockmapPath], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`app-builder blockmap failed with status ${result.status}`);
+  }
+  if (!existsSync(blockmapPath)) {
+    throw new Error(`app-builder did not create ${blockmapPath}`);
+  }
+}
+
+function updateLatestYml(installerPath) {
+  const latestPath = join(distDir, "latest.yml");
+  if (!existsSync(latestPath)) {
+    throw new Error(`Missing Windows updater manifest: ${latestPath}`);
+  }
+
+  const installerName = basename(installerPath);
+  const installerSha512 = sha512(installerPath);
+  const installerSize = statSync(installerPath).size;
+  const manifest = YAML.parse(readFileSync(latestPath, "utf8"));
+
+  if (!manifest || !Array.isArray(manifest.files)) {
+    throw new Error(`Invalid Windows updater manifest: ${latestPath}`);
+  }
+
+  let matchedFile = false;
+  manifest.files = manifest.files.map((file) => {
+    if (!file || file.url !== installerName) return file;
+    matchedFile = true;
+    return {
+      ...file,
+      sha512: installerSha512,
+      size: installerSize,
+    };
+  });
+
+  if (!matchedFile) {
+    throw new Error(`Manifest ${latestPath} does not reference signed installer ${installerName}`);
+  }
+
+  manifest.path = installerName;
+  manifest.sha512 = installerSha512;
+  writeFileSync(latestPath, YAML.stringify(manifest), "utf8");
+}
+
+if (!existsSync(signedArtifactDir)) {
+  console.error(`Signed artifact directory does not exist: ${signedArtifactDir}`);
+  process.exit(1);
+}
+if (!existsSync(distDir)) {
+  console.error(`Electron dist directory does not exist: ${distDir}`);
+  process.exit(1);
+}
+
+const signedInstaller = findOne(
+  walk(signedArtifactDir).filter((file) => /^openwork-win-x64-.+\.exe$/i.test(basename(file))),
+  "signed Windows installer from SignPath",
+);
+const distInstaller = findOne(
+  walk(distDir).filter((file) => basename(file) === basename(signedInstaller)),
+  "matching unsigned Windows installer in dist-electron",
+);
+
+copyFileSync(signedInstaller, distInstaller);
+regenerateBlockmap(distInstaller);
+updateLatestYml(distInstaller);
+
+console.log(`Applied signed Windows installer: ${distInstaller}`);


### PR DESCRIPTION
## Summary
- wire Windows Electron release packaging through SignPath trusted-build signing
- replace the unsigned Windows installer with the signed artifact before publishing
- regenerate the Windows blockmap and update latest.yml hashes after signing
- move prerequisite release jobs to GitHub-hosted runners for SignPath trusted-build compatibility

## Validation
- node --check scripts/release/apply-signpath-windows-artifact.mjs
- parsed .github/workflows/release-macos-aarch64.yml with yaml
- local functional test of scripts/release/apply-signpath-windows-artifact.mjs against a temp signed installer fixture

## Notes
- This only affects the Windows Electron release path.
- SignPath must be configured with SIGNPATH_API_TOKEN plus SIGNPATH_ORGANIZATION_ID, SIGNPATH_PROJECT_SLUG, and SIGNPATH_SIGNING_POLICY_SLUG. SIGNPATH_ARTIFACT_CONFIGURATION_SLUG is optional.
- No video/screenshot captured because this is CI/release workflow automation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

