### PR TITLE
fix(settings): restore skills tab navigation

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/general-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/general-view.tsx
@@ -31,7 +31,8 @@ export type GeneralSettingsViewProps = {
 const workspaceCards: { tab: SettingsTab; icon: typeof Sparkles; title: string; desc: string }[] = [
   { tab: "preferences", icon: Cog, title: "Preferences", desc: "Default model, reasoning, and compaction." },
   { tab: "permissions", icon: FolderLock, title: "Permissions", desc: "Authorized folders and file access." },
-  { tab: "extensions", icon: Puzzle, title: "Extensions", desc: "MCPs, skills, plugins, and integrations." },
+  { tab: "skills", icon: Sparkles, title: "Skills", desc: "Browse, edit, install, and share worker skills." },
+  { tab: "extensions", icon: Puzzle, title: "Extensions", desc: "MCP apps, plugins, and integrations." },
   { tab: "advanced", icon: Wrench, title: "Advanced", desc: "Runtime, engine, and developer options." },
 ];
 

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -177,7 +177,7 @@ export function getSettingsTabDescription(tab: SettingsTab) {
 }
 
 export function getWorkspaceSettingsTabs(): SettingsTab[] {
-  return ["preferences", "permissions", "extensions", "advanced"];
+  return ["preferences", "permissions", "skills", "extensions", "advanced"];
 }
 
 export function getGlobalSettingsTabs(developerMode: boolean): SettingsTab[] {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -238,6 +238,7 @@ function parseSettingsPath(pathname: string): {
     case "ai":
     case "preferences":
     case "permissions":
+    case "skills":
     case "shell":
     case "advanced":
     case "appearance":


### PR DESCRIPTION
Fixes #1141

Summary
- Restores Skills as a first-class Workspace settings tab
- Makes /settings/skills route to the Skills settings view instead of falling back to General
- Adds a Skills card to the Settings overview
- Keeps Extensions copy focused on MCP apps/plugins instead of skills

Verification
- Verified locally that /settings/skills opens the Skills page instead of redirecting to General
- Verified the Workspace settings rail shows Skills
- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/app test
- git diff --check
<img width="2762" height="1502" alt="image" src="https://github.com/user-attachments/assets/7de8bde8-1920-4842-9e79-3c0f651d798a" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

