### PR TITLE
ci: enforce signed commits

### DIFF
--- a/.github/workflows/aur-validate.yml
+++ b/.github/workflows/aur-validate.yml
@@ -134,6 +134,8 @@ jobs:
       INPUT_ARTIFACT_NAME: ${{ inputs.artifact_name || 'openwork-electron-linux-x64' }}
       PUSH_TO_AUR: ${{ inputs.push_to_aur && 'true' || 'false' }}
       AUR_REPO: ${{ inputs.aur_repo || 'openwork' }}
+      OPENWORK_GH_AGENT_NAME: ${{ secrets.OPENWORK_GH_AGENT_NAME }}
+      OPENWORK_GH_AGENT_EMAIL: ${{ secrets.OPENWORK_GH_AGENT_EMAIL }}
     steps:
       - name: Validate workflow inputs
         shell: bash
@@ -173,6 +175,7 @@ jobs:
             base-devel \
             curl \
             git \
+            gnupg \
             jq \
             namcap \
             openssh \
@@ -408,6 +411,18 @@ jobs:
             echo "No runnable desktop binary found; install sanity check passed." 
           fi
 
+      - name: Import OpenWork GH Agent GPG key
+        if: env.PUSH_TO_AUR == 'true'
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.OPENWORK_GH_AGENT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.OPENWORK_GH_AGENT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_committer_name: ${{ env.OPENWORK_GH_AGENT_NAME }}
+          git_committer_email: ${{ env.OPENWORK_GH_AGENT_EMAIL }}
+
       - name: Publish to AUR
         if: env.PUSH_TO_AUR == 'true'
         env:
@@ -449,9 +464,9 @@ jobs:
           fi
 
           git add PKGBUILD .SRCINFO
-          git -c user.name="OpenWork Release Bot" \
-              -c user.email="release-bot@users.noreply.github.com" \
-              commit -m "chore(aur): update PKGBUILD for ${RELEASE_TAG#v}"
+          git config --local user.email "$OPENWORK_GH_AGENT_EMAIL"
+          git config --local user.name "$OPENWORK_GH_AGENT_NAME"
+          git commit -S -m "chore(aur): update PKGBUILD for ${RELEASE_TAG#v}"
 
           current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
           if [ -z "$current_branch" ]; then

--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -13,10 +13,25 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write
+    env:
+      OPENWORK_GH_AGENT_NAME: ${{ secrets.OPENWORK_GH_AGENT_NAME }}
+      OPENWORK_GH_AGENT_EMAIL: ${{ secrets.OPENWORK_GH_AGENT_EMAIL }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.OPENWORK_GH_AGENT_TOKEN }}
+
+      - name: Import OpenWork GH Agent GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.OPENWORK_GH_AGENT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.OPENWORK_GH_AGENT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_committer_name: ${{ env.OPENWORK_GH_AGENT_NAME }}
+          git_committer_email: ${{ env.OPENWORK_GH_AGENT_EMAIL }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -36,8 +51,8 @@ jobs:
 
       - name: Commit stats
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "$OPENWORK_GH_AGENT_EMAIL"
+          git config --local user.name "$OPENWORK_GH_AGENT_NAME"
           git add STATS.md STATS_V2.md
-          git diff --staged --quiet || git commit -m "ignore: update download stats $(date -I)"
+          git diff --staged --quiet || git commit -S -m "ignore: update download stats $(date -I)"
           git push

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -834,12 +834,25 @@ jobs:
       contents: write
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+      OPENWORK_GH_AGENT_NAME: ${{ secrets.OPENWORK_GH_AGENT_NAME }}
+      OPENWORK_GH_AGENT_EMAIL: ${{ secrets.OPENWORK_GH_AGENT_EMAIL }}
     steps:
       - name: Checkout dev
         uses: actions/checkout@v6
         with:
           ref: dev
           fetch-depth: 0
+          token: ${{ secrets.OPENWORK_GH_AGENT_TOKEN }}
+
+      - name: Import OpenWork GH Agent GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.OPENWORK_GH_AGENT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.OPENWORK_GH_AGENT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_committer_name: ${{ env.OPENWORK_GH_AGENT_NAME }}
+          git_committer_email: ${{ env.OPENWORK_GH_AGENT_EMAIL }}
 
       - name: Update AUR packaging files
         run: scripts/aur/update-aur.sh "$RELEASE_TAG"
@@ -855,10 +868,10 @@ jobs:
           fi
 
           version="${RELEASE_TAG#v}"
+          git config --local user.email "$OPENWORK_GH_AGENT_EMAIL"
+          git config --local user.name "$OPENWORK_GH_AGENT_NAME"
           git add packaging/aur/PKGBUILD packaging/aur/.SRCINFO
-          git -c user.name="OpenWork Release Bot" \
-              -c user.email="release-bot@users.noreply.github.com" \
-              commit -m "chore(aur): update PKGBUILD for ${version}"
+          git commit -S -m "chore(aur): update PKGBUILD for ${version}"
           git push origin HEAD:dev
 
       - name: Publish to AUR

--- a/.github/workflows/require-signed-pr-commits.yml
+++ b/.github/workflows/require-signed-pr-commits.yml
@@ -1,0 +1,66 @@
+name: Close PRs With Unsigned Commits
+
+on:
+  pull_request_target:
+    branches:
+      - dev
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-signed-commits:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Close PRs with unsigned commits
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const unsigned = commits.filter((commit) => {
+              return commit.commit.verification?.verified !== true;
+            });
+
+            if (unsigned.length === 0) {
+              core.info("All PR commits are verified.");
+              return;
+            }
+
+            const body = [
+              "This PR has been automatically closed due to unsigned commits.",
+              "OpenWork only accepts signed commits for all and any contributions. Please recommit your changes after enabling signing for your account, and reopen the PR.",
+              "Thanks for helping us keep OpenSource software safe and secure",
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: "closed",
+            });
+
+            core.setFailed("PR contains unsigned or unverified commits.");


### PR DESCRIPTION
## Summary
- sign automated repository/AUR commits with the OPENWORK_GH_AGENT GPG key
- add a pull_request_target workflow that closes PRs with unsigned commits
- use OPENWORK_GH_AGENT secrets for bot identity, token, and GPG material

## Required secrets
- OPENWORK_GH_AGENT_NAME
- OPENWORK_GH_AGENT_EMAIL
- OPENWORK_GH_AGENT_TOKEN
- OPENWORK_GH_AGENT_GPG_PRIVATE_KEY
- OPENWORK_GH_AGENT_GPG_PASSPHRASE

## Tests
- git diff --check
- ruby YAML parse for modified workflow files
- actionlint on modified workflows, if installed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

