### PR TITLE
feat(server): add Routines/Cron primitive and scheduler (#2284)

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -289,6 +289,15 @@ export type OpenworkCommandItem = {
   scope: "workspace" | "global";
 };
 
+export type OpenworkRoutineItem = {
+  name: string;
+  description?: string;
+  schedule: string;
+  command: string;
+  enabled: boolean;
+  scope: "workspace" | "global";
+};
+
 export type OpenworkMcpItem = {
   name: string;
   config: Record<string, unknown>;
@@ -1534,6 +1543,28 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
       }),
     deleteCommand: (workspaceId: string, name: string) =>
       requestJson<{ ok: boolean }>(baseUrl, `/workspace/${workspaceId}/commands/${encodeURIComponent(name)}`, {
+        token,
+        hostToken,
+        method: "DELETE",
+      }),
+    listRoutines: (workspaceId: string, scope: "workspace" | "global" = "workspace") =>
+      requestJson<{ items: OpenworkRoutineItem[] }>(
+        baseUrl,
+        `/workspace/${workspaceId}/routines?scope=${scope}`,
+        { token, hostToken },
+      ),
+    upsertRoutine: (
+      workspaceId: string,
+      payload: { name: string; description?: string; schedule: string; command: string; enabled: boolean },
+    ) =>
+      requestJson<{ items: OpenworkRoutineItem[] }>(baseUrl, `/workspace/${workspaceId}/routines`, {
+        token,
+        hostToken,
+        method: "POST",
+        body: payload,
+      }),
+    deleteRoutine: (workspaceId: string, name: string) =>
+      requestJson<{ ok: boolean }>(baseUrl, `/workspace/${workspaceId}/routines/${encodeURIComponent(name)}`, {
         token,
         hostToken,
         method: "DELETE",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@opencode-ai/sdk": "^1.17.3",
     "better-sqlite3": "^11.10.0",
+    "cron-parser": "^5.5.0",
     "drizzle-orm": "^0.45.1",
     "jsonc-parser": "^3.2.1",
     "minimatch": "^10.0.1",

--- a/apps/server/src/routines.ts
+++ b/apps/server/src/routines.ts
@@ -35,11 +35,11 @@ async function listRoutinesInDir(dir: string, scope: "workspace" | "global"): Pr
       }
 
       const schedule = typeof data.schedule === "string" ? data.schedule : "";
+      if (schedule.trim().length === 0) continue;
+
       try {
         // Validate cron expression
-        if (schedule) {
-          CronExpressionParser.parse(schedule);
-        }
+        CronExpressionParser.parse(schedule);
       } catch {
         // Skip invalid crons
         continue;

--- a/apps/server/src/routines.ts
+++ b/apps/server/src/routines.ts
@@ -23,35 +23,39 @@ async function listRoutinesInDir(dir: string, scope: "workspace" | "global"): Pr
     if (!entry.isFile()) continue;
     if (!entry.name.endsWith(".md")) continue;
     const filePath = join(dir, entry.name);
-    const content = await readFile(filePath, "utf8");
-    const { data, body } = parseFrontmatter(content);
-    
-    const name = typeof data.name === "string" ? data.name : entry.name.replace(/\.md$/, "");
     try {
-      validateRoutineName(name);
-    } catch {
-      continue;
-    }
-
-    const schedule = typeof data.schedule === "string" ? data.schedule : "";
-    try {
-      // Validate cron expression
-      if (schedule) {
-        CronExpressionParser.parse(schedule);
+      const content = await readFile(filePath, "utf8");
+      const { data, body } = parseFrontmatter(content);
+      
+      const name = typeof data.name === "string" ? data.name : entry.name.replace(/\.md$/, "");
+      try {
+        validateRoutineName(name);
+      } catch {
+        continue;
       }
-    } catch {
-      // Skip invalid crons
-      continue;
-    }
 
-    items.push({
-      name,
-      description: typeof data.description === "string" ? data.description : undefined,
-      schedule,
-      enabled: typeof data.enabled === "boolean" ? data.enabled : true,
-      command: body.trim(),
-      scope,
-    });
+      const schedule = typeof data.schedule === "string" ? data.schedule : "";
+      try {
+        // Validate cron expression
+        if (schedule) {
+          CronExpressionParser.parse(schedule);
+        }
+      } catch {
+        // Skip invalid crons
+        continue;
+      }
+
+      items.push({
+        name,
+        description: typeof data.description === "string" ? data.description : undefined,
+        schedule,
+        enabled: typeof data.enabled === "boolean" ? data.enabled : true,
+        command: body.trim(),
+        scope,
+      });
+    } catch (err) {
+      console.warn(`Failed to read/parse routine file ${filePath}`, err);
+    }
   }
   return items;
 }

--- a/apps/server/src/routines.ts
+++ b/apps/server/src/routines.ts
@@ -1,0 +1,118 @@
+import { readdir, readFile, writeFile, rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { RoutineItem } from "./types.js";
+import { parseFrontmatter, buildFrontmatter } from "./frontmatter.js";
+import { exists } from "./utils.js";
+import { projectRoutinesDir } from "./workspace-files.js";
+import { validateRoutineName, sanitizeRoutineName } from "./validators.js";
+import { ApiError } from "./errors.js";
+import { CronExpressionParser } from "cron-parser";
+
+function normalizeRoutineFrontmatter(data: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(data).filter(([, value]) => value !== null && value !== undefined),
+  );
+}
+
+async function listRoutinesInDir(dir: string, scope: "workspace" | "global"): Promise<RoutineItem[]> {
+  if (!(await exists(dir))) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  const items: RoutineItem[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith(".md")) continue;
+    const filePath = join(dir, entry.name);
+    const content = await readFile(filePath, "utf8");
+    const { data, body } = parseFrontmatter(content);
+    
+    const name = typeof data.name === "string" ? data.name : entry.name.replace(/\.md$/, "");
+    try {
+      validateRoutineName(name);
+    } catch {
+      continue;
+    }
+
+    const schedule = typeof data.schedule === "string" ? data.schedule : "";
+    try {
+      // Validate cron expression
+      if (schedule) {
+        CronExpressionParser.parse(schedule);
+      }
+    } catch {
+      // Skip invalid crons
+      continue;
+    }
+
+    items.push({
+      name,
+      description: typeof data.description === "string" ? data.description : undefined,
+      schedule,
+      enabled: typeof data.enabled === "boolean" ? data.enabled : true,
+      command: body.trim(),
+      scope,
+    });
+  }
+  return items;
+}
+
+export async function listRoutines(workspaceRoot: string, scope: "workspace" | "global"): Promise<RoutineItem[]> {
+  if (scope === "global") {
+    const dir = join(homedir(), ".config", "opencode", "routines");
+    return listRoutinesInDir(dir, "global");
+  }
+  return listRoutinesInDir(projectRoutinesDir(workspaceRoot), "workspace");
+}
+
+export type UpsertRoutinePayload = {
+  name: string;
+  description?: string;
+  schedule: string;
+  command: string;
+  enabled: boolean;
+};
+
+export function buildRoutineContent(payload: UpsertRoutinePayload): { name: string; content: string } {
+  if (!payload.command || payload.command.trim().length === 0) {
+    throw new ApiError(400, "invalid_routine_command", "Routine command is required");
+  }
+  if (!payload.schedule || payload.schedule.trim().length === 0) {
+    throw new ApiError(400, "invalid_routine_schedule", "Routine schedule is required");
+  }
+  try {
+    CronExpressionParser.parse(payload.schedule);
+  } catch (err) {
+    throw new ApiError(400, "invalid_routine_schedule", "Invalid cron expression");
+  }
+
+  const sanitized = sanitizeRoutineName(payload.name);
+  validateRoutineName(sanitized);
+
+  const frontmatter = buildFrontmatter(normalizeRoutineFrontmatter({
+    name: sanitized,
+    description: payload.description,
+    schedule: payload.schedule,
+    enabled: payload.enabled,
+  }));
+  const content = frontmatter + "\n" + payload.command.trim() + "\n";
+  return { name: sanitized, content };
+}
+
+export async function upsertRoutine(
+  workspaceRoot: string,
+  payload: UpsertRoutinePayload,
+): Promise<string> {
+  const routine = buildRoutineContent(payload);
+  const dir = projectRoutinesDir(workspaceRoot);
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, `${routine.name}.md`);
+  await writeFile(path, routine.content, "utf8");
+  return path;
+}
+
+export async function deleteRoutine(workspaceRoot: string, name: string): Promise<void> {
+  const sanitized = sanitizeRoutineName(name);
+  validateRoutineName(sanitized);
+  const path = join(projectRoutinesDir(workspaceRoot), `${sanitized}.md`);
+  await rm(path, { force: true });
+}

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -1,16 +1,17 @@
 import { listRoutines } from "./routines.js";
-import type { ServerConfig } from "./types.js";
+import type { ServerConfig, WorkspaceInfo, RoutineItem } from "./types.js";
 import { createWorkspaceOpencodeClient } from "./server.js"; // We need to export this or pass a callback
 import { CronExpressionParser } from "cron-parser";
 
 export class CronScheduler {
   private config: ServerConfig;
   private intervalId: ReturnType<typeof setInterval> | null = null;
-  private createClient: (workspace: ServerConfig["workspaces"][number]) => any;
+  private createClient: (workspace: WorkspaceInfo) => any;
   private isTicking = false;
   private lastTickMinute: number | null = null;
+  private runningRoutines = new Set<string>();
 
-  constructor(config: ServerConfig, createClient: (workspace: ServerConfig["workspaces"][number]) => any) {
+  constructor(config: ServerConfig, createClient: (workspace: WorkspaceInfo) => any) {
     this.config = config;
     this.createClient = createClient;
   }
@@ -45,33 +46,42 @@ export class CronScheduler {
         startMinute = targetMinute - 5 * 60000;
       }
 
-      if (startMinute > targetMinute) return;
+      if (startMinute > targetMinute) {
+        this.lastTickMinute = targetMinute;
+        return;
+      }
       this.lastTickMinute = targetMinute;
+
+      // Pre-fetch all routines for all workspaces outside the catch-up loop to avoid redundant disk I/O
+      const workspacesRoutines = new Map<WorkspaceInfo, RoutineItem[]>();
+      for (const workspace of this.config.workspaces) {
+        try {
+          const routines = await listRoutines(workspace.path, "workspace");
+          workspacesRoutines.set(workspace, routines);
+        } catch (err) {
+          console.error(`Error listing routines for workspace ${workspace.id}:`, err);
+        }
+      }
 
       for (let time = startMinute; time <= targetMinute; time += 60000) {
         const checkTime = new Date(time);
-        for (const workspace of this.config.workspaces) {
-          try {
-            const routines = await listRoutines(workspace.path, "workspace");
-            for (const routine of routines) {
-              if (!routine.enabled) continue;
+        for (const [workspace, routines] of workspacesRoutines.entries()) {
+          for (const routine of routines) {
+            if (!routine.enabled) continue;
 
-              try {
-                const interval = CronExpressionParser.parse(routine.schedule, { currentDate: new Date(checkTime.getTime() - 60000) });
-                const nextDate = interval.next().toDate();
-                
-                // If the next scheduled time matches our check minute exactly
-                if (nextDate.getTime() === checkTime.getTime()) {
-                  this.triggerRoutine(workspace, routine).catch((err) => {
-                    console.error(`Failed to execute routine ${routine.name}:`, err);
-                  });
-                }
-              } catch (err) {
-                console.error(`Error parsing schedule for routine ${routine.name}:`, err);
+            try {
+              const interval = CronExpressionParser.parse(routine.schedule, { currentDate: new Date(checkTime.getTime() - 60000) });
+              const nextDate = interval.next().toDate();
+              
+              // If the next scheduled time matches our check minute exactly
+              if (nextDate.getTime() === checkTime.getTime()) {
+                this.executeRoutineInBackground(workspace, routine).catch((err) => {
+                  console.error(`Failed to execute routine ${routine.name}:`, err);
+                });
               }
+            } catch (err) {
+              console.error(`Error parsing schedule for routine ${routine.name}:`, err);
             }
-          } catch (err) {
-            console.error(`Error listing routines for workspace ${workspace.id}:`, err);
           }
         }
       }
@@ -80,7 +90,21 @@ export class CronScheduler {
     }
   }
 
-  private async triggerRoutine(workspace: ServerConfig["workspaces"][number], routine: any) {
+  private async executeRoutineInBackground(workspace: WorkspaceInfo, routine: RoutineItem) {
+    const key = `${workspace.id}:${routine.name}`;
+    if (this.runningRoutines.has(key)) {
+      console.warn(`Skipping overlapping routine trigger for ${routine.name}`);
+      return;
+    }
+    this.runningRoutines.add(key);
+    try {
+      await this.triggerRoutine(workspace, routine);
+    } finally {
+      this.runningRoutines.delete(key);
+    }
+  }
+
+  private async triggerRoutine(workspace: WorkspaceInfo, routine: RoutineItem) {
     try {
       const opencode = this.createClient(workspace);
       
@@ -101,9 +125,8 @@ export class CronScheduler {
 
       // 2. Prompt the agent
       await opencode.session.prompt({
-        sessionID: sessionId,
-        text: routine.command,
-        mode: "prompt",
+        path: { id: sessionId },
+        body: { parts: [{ text: routine.command }] },
       });
 
     } catch (err) {

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -1,0 +1,90 @@
+import { listRoutines } from "./routines.js";
+import type { ServerConfig } from "./types.js";
+import { createWorkspaceOpencodeClient } from "./server.js"; // We need to export this or pass a callback
+import { CronExpressionParser } from "cron-parser";
+
+export class CronScheduler {
+  private config: ServerConfig;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private createClient: (workspace: ServerConfig["workspaces"][number]) => any;
+
+  constructor(config: ServerConfig, createClient: (workspace: ServerConfig["workspaces"][number]) => any) {
+    this.config = config;
+    this.createClient = createClient;
+  }
+
+  public start() {
+    if (this.intervalId) return;
+    // Check every minute
+    this.intervalId = setInterval(() => this.tick(), 60000);
+    // Initial check on start
+    setTimeout(() => this.tick(), 5000);
+  }
+
+  public stop() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  private async tick() {
+    const now = new Date();
+    // Round down to the current minute to avoid missing/double triggers
+    now.setSeconds(0, 0);
+
+    for (const workspace of this.config.workspaces) {
+      try {
+        const routines = await listRoutines(workspace.path, "workspace");
+        for (const routine of routines) {
+          if (!routine.enabled) continue;
+
+          try {
+            const interval = CronExpressionParser.parse(routine.schedule, { currentDate: new Date(now.getTime() - 60000) });
+            const nextDate = interval.next().toDate();
+            
+            // If the next scheduled time matches our current minute exactly
+            if (nextDate.getTime() === now.getTime()) {
+              await this.triggerRoutine(workspace, routine);
+            }
+          } catch (err) {
+            console.error(`Error parsing schedule for routine ${routine.name}:`, err);
+          }
+        }
+      } catch (err) {
+        console.error(`Error listing routines for workspace ${workspace.id}:`, err);
+      }
+    }
+  }
+
+  private async triggerRoutine(workspace: ServerConfig["workspaces"][number], routine: any) {
+    try {
+      const opencode = this.createClient(workspace);
+      
+      // 1. Create a background session
+      const result = await opencode.session.create({ title: `Routine: ${routine.name}` });
+      // Depending on sdk version, result might be wrapped
+      let sessionId = "";
+      if (result && typeof result === "object" && "id" in result) {
+        sessionId = String(result.id);
+      } else if (result && typeof result === "object" && "data" in result && result.data && "id" in result.data) {
+        sessionId = String(result.data.id);
+      }
+
+      if (!sessionId) {
+        console.error(`Failed to create session for routine ${routine.name}`);
+        return;
+      }
+
+      // 2. Prompt the agent
+      await opencode.session.prompt({
+        sessionID: sessionId,
+        text: routine.command,
+        mode: "prompt",
+      });
+
+    } catch (err) {
+      console.error(`Failed to execute routine ${routine.name}:`, err);
+    }
+  }
+}

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -7,6 +7,8 @@ export class CronScheduler {
   private config: ServerConfig;
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private createClient: (workspace: ServerConfig["workspaces"][number]) => any;
+  private isTicking = false;
+  private lastTickMinute: number | null = null;
 
   constructor(config: ServerConfig, createClient: (workspace: ServerConfig["workspaces"][number]) => any) {
     this.config = config;
@@ -29,11 +31,17 @@ export class CronScheduler {
   }
 
   private async tick() {
-    const now = new Date();
-    // Round down to the current minute to avoid missing/double triggers
-    now.setSeconds(0, 0);
+    if (this.isTicking) return;
+    this.isTicking = true;
+    try {
+      const now = new Date();
+      // Round down to the current minute to avoid missing/double triggers
+      now.setSeconds(0, 0);
 
-    for (const workspace of this.config.workspaces) {
+      if (this.lastTickMinute === now.getTime()) return;
+      this.lastTickMinute = now.getTime();
+
+      for (const workspace of this.config.workspaces) {
       try {
         const routines = await listRoutines(workspace.path, "workspace");
         for (const routine of routines) {
@@ -54,6 +62,9 @@ export class CronScheduler {
       } catch (err) {
         console.error(`Error listing routines for workspace ${workspace.id}:`, err);
       }
+    }
+    } finally {
+      this.isTicking = false;
     }
   }
 

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -34,35 +34,47 @@ export class CronScheduler {
     if (this.isTicking) return;
     this.isTicking = true;
     try {
-      const now = new Date();
-      // Round down to the current minute to avoid missing/double triggers
-      now.setSeconds(0, 0);
+      const nowMinute = new Date();
+      nowMinute.setSeconds(0, 0);
+      const targetMinute = nowMinute.getTime();
 
-      if (this.lastTickMinute === now.getTime()) return;
-      this.lastTickMinute = now.getTime();
+      let startMinute = this.lastTickMinute !== null ? this.lastTickMinute + 60000 : targetMinute;
+      
+      // Cap catch-up to the last 5 minutes to prevent spam after system sleep
+      if (targetMinute - startMinute > 5 * 60000) {
+        startMinute = targetMinute - 5 * 60000;
+      }
 
-      for (const workspace of this.config.workspaces) {
-      try {
-        const routines = await listRoutines(workspace.path, "workspace");
-        for (const routine of routines) {
-          if (!routine.enabled) continue;
+      if (startMinute > targetMinute) return;
+      this.lastTickMinute = targetMinute;
 
+      for (let time = startMinute; time <= targetMinute; time += 60000) {
+        const checkTime = new Date(time);
+        for (const workspace of this.config.workspaces) {
           try {
-            const interval = CronExpressionParser.parse(routine.schedule, { currentDate: new Date(now.getTime() - 60000) });
-            const nextDate = interval.next().toDate();
-            
-            // If the next scheduled time matches our current minute exactly
-            if (nextDate.getTime() === now.getTime()) {
-              await this.triggerRoutine(workspace, routine);
+            const routines = await listRoutines(workspace.path, "workspace");
+            for (const routine of routines) {
+              if (!routine.enabled) continue;
+
+              try {
+                const interval = CronExpressionParser.parse(routine.schedule, { currentDate: new Date(checkTime.getTime() - 60000) });
+                const nextDate = interval.next().toDate();
+                
+                // If the next scheduled time matches our check minute exactly
+                if (nextDate.getTime() === checkTime.getTime()) {
+                  this.triggerRoutine(workspace, routine).catch((err) => {
+                    console.error(`Failed to execute routine ${routine.name}:`, err);
+                  });
+                }
+              } catch (err) {
+                console.error(`Error parsing schedule for routine ${routine.name}:`, err);
+              }
             }
           } catch (err) {
-            console.error(`Error parsing schedule for routine ${routine.name}:`, err);
+            console.error(`Error listing routines for workspace ${workspace.id}:`, err);
           }
         }
-      } catch (err) {
-        console.error(`Error listing routines for workspace ${workspace.id}:`, err);
       }
-    }
     } finally {
       this.isTicking = false;
     }

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -9,7 +9,7 @@ export class CronScheduler {
   private createClient: (workspace: WorkspaceInfo) => any;
   private isTicking = false;
   private lastTickMinute: number | null = null;
-  private runningRoutines = new Set<string>();
+  private routineQueues = new Map<string, Promise<void>>();
 
   constructor(config: ServerConfig, createClient: (workspace: WorkspaceInfo) => any) {
     this.config = config;
@@ -90,18 +90,29 @@ export class CronScheduler {
     }
   }
 
-  private async executeRoutineInBackground(workspace: WorkspaceInfo, routine: RoutineItem) {
+  private executeRoutineInBackground(workspace: WorkspaceInfo, routine: RoutineItem) {
     const key = `${workspace.id}:${routine.name}`;
-    if (this.runningRoutines.has(key)) {
-      console.warn(`Skipping overlapping routine trigger for ${routine.name}`);
-      return;
-    }
-    this.runningRoutines.add(key);
-    try {
-      await this.triggerRoutine(workspace, routine);
-    } finally {
-      this.runningRoutines.delete(key);
-    }
+    const previous = this.routineQueues.get(key) || Promise.resolve();
+    
+    // Chain the next execution to ensure sequential processing without overlap
+    const next = previous.then(async () => {
+      try {
+        await this.triggerRoutine(workspace, routine);
+      } catch (err) {
+        console.error(`Error in background routine ${routine.name}:`, err);
+      }
+    });
+
+    this.routineQueues.set(key, next);
+
+    // Clean up the queue entry once it finishes, if no new tasks were queued
+    next.finally(() => {
+      if (this.routineQueues.get(key) === next) {
+        this.routineQueues.delete(key);
+      }
+    });
+
+    return next;
   }
 
   private async triggerRoutine(workspace: WorkspaceInfo, routine: RoutineItem) {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -12,6 +12,7 @@ import { deleteSkill, listSkills, upsertSkill } from "./skills.js";
 import { installHubSkill, listHubSkills } from "./skill-hub.js";
 import { deleteCommand, listCommands, repairCommands, upsertCommand } from "./commands.js";
 import { deleteRoutine, listRoutines, upsertRoutine } from "./routines.js";
+import { sanitizeRoutineName } from "./validators.js";
 import { CronScheduler } from "./scheduler.js";
 import { ApiError, formatError } from "./errors.js";
 import { readJsoncFile, updateJsoncTopLevel, writeJsoncFile } from "./jsonc.js";
@@ -2271,13 +2272,14 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const name = String(body.name ?? "");
+    const sanitizedName = sanitizeRoutineName(name);
     const schedule = String(body.schedule ?? "");
     const command = String(body.command ?? "");
     await requireApproval(ctx, {
       workspaceId: workspace.id,
       action: "routines.upsert",
       summary: `Upsert routine ${name}`,
-      paths: [join(workspace.path, ".opencode", "routines", `${name}.md`)],
+      paths: [join(workspace.path, ".opencode", "routines", `${sanitizedName}.md`)],
     });
     const path = await upsertRoutine(workspace.path, {
       name,
@@ -2305,11 +2307,12 @@ function createRoutes(
     requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const name = String(ctx.params.name ?? "").trim();
+    const sanitizedName = sanitizeRoutineName(name);
     await requireApproval(ctx, {
       workspaceId: workspace.id,
       action: "routines.delete",
       summary: `Delete routine ${name}`,
-      paths: [join(workspace.path, ".opencode", "routines", `${name}.md`)],
+      paths: [join(workspace.path, ".opencode", "routines", `${sanitizedName}.md`)],
     });
     await deleteRoutine(workspace.path, name);
     await recordAudit(workspace.path, {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -20,7 +20,12 @@ import { recordAudit, readAuditEntries, readLastAudit } from "./audit.js";
 import { ReloadEventStore } from "./events.js";
 import { computeReloadFingerprint } from "./reload-fingerprint.js";
 import { startReloadWatchers } from "./reload-watcher.js";
-import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
+import { opencodeConfigPath,  openworkConfigPath,
+  projectCommandsDir,
+  projectPluginsDir,
+  projectSkillsDir,
+  projectRoutinesDir,
+} from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
 import { ensureWorkspaceFiles, readRawOpencodeConfig } from "./workspace-init.js";
 import { sanitizeCommandName, validateMcpName } from "./validators.js";
@@ -2919,6 +2924,7 @@ async function exportWorkspace(
   const openwork = sanitizeOpenworkTemplateConfig(await readOpenworkConfig(workspace.path));
   const skills = await listSkills(workspace.path, false);
   const commands = await listCommands(workspace.path, "workspace");
+  const routines = await listRoutines(workspace.path, "workspace");
   let files = await listPortableFiles(workspace.path);
   const warnings = collectWorkspaceExportWarnings({ opencode: rawOpencode, files });
   if (warnings.length && sensitiveMode === "auto") {
@@ -2948,6 +2954,13 @@ async function exportWorkspace(
       template: command.template,
     })),
   );
+  const routineContents = routines.map((routine) => ({
+    name: routine.name,
+    description: routine.description,
+    schedule: routine.schedule,
+    enabled: routine.enabled,
+    command: routine.command,
+  }));
 
   return {
     workspaceId: workspace.id,
@@ -2956,6 +2969,7 @@ async function exportWorkspace(
     openwork,
     skills: skillContents,
     commands: commandContents,
+    routines: routineContents,
     ...(files.length ? { files } : {}),
   };
 }
@@ -3041,6 +3055,21 @@ async function importWorkspace(workspace: WorkspaceInfo, payload: Record<string,
     if (input.modes.commands === "replace") {
       for (const change of preview.changes) {
         if (change.kind === "command" && change.action === "delete") {
+          await rm(change.absolutePath, { force: true });
+        }
+      }
+    }
+  }
+
+  if (input.sections.routines) {
+    for (const routine of input.routines) {
+      const path = workspaceImportRelativePath(workspace, join(projectRoutinesDir(workspace.path), `${routine.name}.md`));
+      if (!changedPath("routine", path)) continue;
+      await upsertRoutine(workspace.path, routine);
+    }
+    if (input.modes.routines === "replace") {
+      for (const change of preview.changes) {
+        if (change.kind === "routine" && change.action === "delete") {
           await rm(change.absolutePath, { force: true });
         }
       }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -11,6 +11,8 @@ import { addMcp, listMcp, removeMcp, setMcpEnabled } from "./mcp.js";
 import { deleteSkill, listSkills, upsertSkill } from "./skills.js";
 import { installHubSkill, listHubSkills } from "./skill-hub.js";
 import { deleteCommand, listCommands, repairCommands, upsertCommand } from "./commands.js";
+import { deleteRoutine, listRoutines, upsertRoutine } from "./routines.js";
+import { CronScheduler } from "./scheduler.js";
 import { ApiError, formatError } from "./errors.js";
 import { readJsoncFile, updateJsoncTopLevel, writeJsoncFile } from "./jsonc.js";
 import { recordAudit, readAuditEntries, readLastAudit } from "./audit.js";
@@ -562,6 +564,9 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     watcherHandle = startReloadWatchers({ config, reloadEvents, logger });
   };
   const routes = createRoutes(config, approvals, tokens, env, restartReloadWatchers);
+  
+  const scheduler = new CronScheduler(config, (workspace) => createWorkspaceOpencodeClient(config, workspace));
+  scheduler.start();
 
   const serverOptions: {
     hostname: string;
@@ -746,7 +751,7 @@ type OpencodeClientResult<T, E> =
   | { data: T | undefined; error: undefined; response: Response }
   | { data: undefined; error: E; response: Response };
 
-function createWorkspaceOpencodeClient(config: ServerConfig, workspace: WorkspaceInfo) {
+export function createWorkspaceOpencodeClient(config: ServerConfig, workspace: WorkspaceInfo) {
   const connection = resolveWorkspaceOpencodeConnection(config, workspace);
   const directory = resolveOpencodeDirectory(workspace);
   const directoryFetch = directory ? createOpencodeDirectoryFetch(directory) : undefined;
@@ -2247,6 +2252,77 @@ function createRoutes(
       path,
     });
     const items = await listCommands(workspace.path, "workspace");
+    return jsonResponse({ items });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/routines", "client", async (ctx) => {
+    const scope = ctx.url.searchParams.get("scope") === "global" ? "global" : "workspace";
+    if (scope === "global") {
+      await requireHost(ctx.request, config, tokens);
+    }
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const items = await listRoutines(workspace.path, scope);
+    return jsonResponse({ items });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/routines", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const name = String(body.name ?? "");
+    const schedule = String(body.schedule ?? "");
+    const command = String(body.command ?? "");
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "routines.upsert",
+      summary: `Upsert routine ${name}`,
+      paths: [join(workspace.path, ".opencode", "routines", `${name}.md`)],
+    });
+    const path = await upsertRoutine(workspace.path, {
+      name,
+      description: body.description ? String(body.description) : undefined,
+      schedule,
+      command,
+      enabled: typeof body.enabled === "boolean" ? body.enabled : true,
+    });
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "routines.upsert",
+      target: path,
+      summary: `Upserted routine ${name}`,
+      timestamp: Date.now(),
+    });
+
+    const items = await listRoutines(workspace.path, "workspace");
+    return jsonResponse({ items });
+  });
+
+  addRoute(routes, "DELETE", "/workspace/:id/routines/:name", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const name = String(ctx.params.name ?? "").trim();
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "routines.delete",
+      summary: `Delete routine ${name}`,
+      paths: [join(workspace.path, ".opencode", "routines", `${name}.md`)],
+    });
+    await deleteRoutine(workspace.path, name);
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "routines.delete",
+      target: name,
+      summary: `Deleted routine ${name}`,
+      timestamp: Date.now(),
+    });
+
+    const items = await listRoutines(workspace.path, "workspace");
     return jsonResponse({ items });
   });
 

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -211,6 +211,15 @@ export interface CommandItem {
   scope: "workspace" | "global";
 }
 
+export interface RoutineItem {
+  name: string;
+  description?: string;
+  schedule: string;
+  command: string;
+  enabled: boolean;
+  scope: "workspace" | "global";
+}
+
 export interface Actor {
   type: "remote" | "host";
   clientId?: string;

--- a/apps/server/src/validators.ts
+++ b/apps/server/src/validators.ts
@@ -33,6 +33,17 @@ export function validateCommandName(name: string): void {
   }
 }
 
+export function sanitizeRoutineName(name: string): string {
+  const trimmed = name.trim().replace(/^\/+/, "");
+  return trimmed;
+}
+
+export function validateRoutineName(name: string): void {
+  if (!name || !COMMAND_NAME_REGEX.test(name)) {
+    throw new ApiError(400, "invalid_routine_name", "Routine name must be alphanumeric with _ or -");
+  }
+}
+
 export function validateMcpName(name: string): void {
   if (!name || name.startsWith("-") || !MCP_NAME_REGEX.test(name)) {
     throw new ApiError(400, "invalid_mcp_name", "MCP name must be alphanumeric and not start with -");

--- a/apps/server/src/workspace-files.ts
+++ b/apps/server/src/workspace-files.ts
@@ -25,6 +25,10 @@ export function projectCommandsDir(workspaceRoot: string): string {
   return join(workspaceRoot, ".opencode", "commands");
 }
 
+export function projectRoutinesDir(workspaceRoot: string): string {
+  return join(workspaceRoot, ".opencode", "routines");
+}
+
 export function projectPluginsDir(workspaceRoot: string): string {
   return join(workspaceRoot, ".opencode", "plugins");
 }

--- a/apps/server/src/workspace-import-preview.ts
+++ b/apps/server/src/workspace-import-preview.ts
@@ -11,16 +11,18 @@ import { planPortableFiles, listPortableFilePaths, type PortableFile } from "./p
 import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
 import { buildSkillContent } from "./skills.js";
 import { exists } from "./utils.js";
-import { sanitizeCommandName, validateCommandName, validateSkillName } from "./validators.js";
+import { sanitizeCommandName, validateCommandName, validateSkillName, sanitizeRoutineName, validateRoutineName } from "./validators.js";
 import {
   opencodeConfigPath,
   openworkConfigPath,
   projectCommandsDir,
   projectSkillsDir,
+  projectRoutinesDir,
 } from "./workspace-files.js";
+import { buildRoutineContent } from "./routines.js";
 
 export type WorkspaceImportMode = "merge" | "replace";
-export type WorkspaceImportChangeKind = "opencode" | "openwork" | "skill" | "command" | "file";
+export type WorkspaceImportChangeKind = "opencode" | "openwork" | "skill" | "command" | "routine" | "file";
 export type WorkspaceImportChangeAction = "create" | "update" | "replace" | "delete" | "unchanged";
 
 export type WorkspaceImportChange = {
@@ -53,7 +55,7 @@ export type WorkspaceImportPlan = Omit<WorkspaceImportPreview, "changes"> & {
   changes: WorkspaceImportPlannedChange[];
 };
 
-type WorkspaceImportSection = "opencode" | "openwork" | "skills" | "commands" | "files";
+type WorkspaceImportSection = "opencode" | "openwork" | "skills" | "commands" | "routines" | "files";
 
 export type NormalizedWorkspaceImport = {
   modes: Record<string, WorkspaceImportMode>;
@@ -68,6 +70,13 @@ export type NormalizedWorkspaceImport = {
     agent?: string;
     model?: string | null;
     subtask?: boolean;
+  }>;
+  routines: Array<{
+    name: string;
+    command: string;
+    schedule: string;
+    enabled: boolean;
+    description?: string;
   }>;
   files: PortableFile[];
 };
@@ -89,6 +98,7 @@ function normalizeModes(value: unknown): Record<string, WorkspaceImportMode> {
     openwork: readMode(record.openwork),
     skills: readMode(record.skills),
     commands: readMode(record.commands),
+    routines: readMode(record.routines),
     files: readMode(record.files),
   };
 }
@@ -167,6 +177,43 @@ function normalizeCommands(value: unknown): NormalizedWorkspaceImport["commands"
   });
 }
 
+function normalizeRoutines(value: unknown): NormalizedWorkspaceImport["routines"] {
+  return readArray(value, "routines").map((routine) => {
+    if (typeof routine.content === "string" && routine.content.trim()) {
+      const parsed = parseFrontmatter(routine.content);
+      const name = sanitizeRoutineName(
+        String(routine.name || (typeof parsed.data.name === "string" ? parsed.data.name : "")),
+      );
+      validateRoutineName(name);
+      const command = parsed.body.trim();
+      if (!command) {
+        throw new ApiError(400, "invalid_routine_command", "Routine command is required");
+      }
+      return {
+        name,
+        command,
+        schedule: typeof parsed.data.schedule === "string" ? parsed.data.schedule : "",
+        enabled: typeof parsed.data.enabled === "boolean" ? parsed.data.enabled : true,
+        description: typeof parsed.data.description === "string" ? parsed.data.description : undefined,
+      };
+    }
+
+    const name = sanitizeRoutineName(String(routine.name ?? ""));
+    validateRoutineName(name);
+    const command = typeof routine.command === "string" ? routine.command : "";
+    if (!command.trim()) {
+      throw new ApiError(400, "invalid_routine_command", "Routine command is required");
+    }
+    return {
+      name,
+      command,
+      schedule: typeof routine.schedule === "string" ? routine.schedule : "",
+      enabled: typeof routine.enabled === "boolean" ? routine.enabled : true,
+      description: typeof routine.description === "string" ? routine.description : undefined,
+    };
+  });
+}
+
 export function normalizeWorkspaceImportPayload(
   workspaceRoot: string,
   payload: Record<string, unknown>,
@@ -178,6 +225,7 @@ export function normalizeWorkspaceImportPayload(
       openwork: payload.openwork !== undefined,
       skills: payload.skills !== undefined,
       commands: payload.commands !== undefined,
+      routines: payload.routines !== undefined,
       files: payload.files !== undefined,
     },
     ...(payload.opencode !== undefined
@@ -188,6 +236,7 @@ export function normalizeWorkspaceImportPayload(
       : {}),
     skills: normalizeSkills(payload.skills),
     commands: normalizeCommands(payload.commands),
+    routines: normalizeRoutines(payload.routines),
     files: planPortableFiles(workspaceRoot, payload.files).map((file) => ({
       path: file.path,
       content: file.content,
@@ -308,6 +357,16 @@ async function listProjectCommandNames(workspaceRoot: string): Promise<string[]>
     .sort();
 }
 
+async function listProjectRoutineNames(workspaceRoot: string): Promise<string[]> {
+  const dir = projectRoutinesDir(workspaceRoot);
+  if (!(await exists(dir))) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => entry.name.replace(/\.md$/, ""))
+    .sort();
+}
+
 export async function buildWorkspaceImportPreview(
   workspaceRoot: string,
   payload: Record<string, unknown>,
@@ -412,6 +471,44 @@ export async function buildWorkspaceImportPreview(
         if (before === null) continue;
         changes.push({
           kind: "command",
+          action: "delete",
+          label: name,
+          path: rel(workspaceRoot, path),
+          absolutePath: path,
+          beforeDigest: textDigest(before),
+          afterDigest: textDigest(null),
+        });
+      }
+    }
+  }
+
+  if (input.sections.routines) {
+    const existing = new Set(await listProjectRoutineNames(workspaceRoot));
+    const incoming = new Set<string>();
+    for (const routine of input.routines) {
+      incoming.add(routine.name);
+      const path = join(projectRoutinesDir(workspaceRoot), `${routine.name}.md`);
+      const existsBefore = existing.has(routine.name);
+      const before = existsBefore ? await readTextIfPresent(path) : null;
+      const next = buildRoutineContent(routine);
+      changes.push({
+        kind: "routine",
+        action: actionForTarget(before !== null, before !== next.content, "merge"),
+        label: routine.name,
+        path: rel(workspaceRoot, path),
+        absolutePath: path,
+        beforeDigest: before !== null ? textDigest(before) : textDigest(null),
+        afterDigest: textDigest(next.content),
+      });
+    }
+    if (input.modes.routines === "replace") {
+      for (const name of existing) {
+        if (incoming.has(name)) continue;
+        const path = join(projectRoutinesDir(workspaceRoot), `${name}.md`);
+        const before = await readTextIfPresent(path);
+        if (before === null) continue;
+        changes.push({
+          kind: "routine",
           action: "delete",
           label: name,
           path: rel(workspaceRoot, path),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,9 @@ importers:
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
+      cron-parser:
+        specifier: ^5.5.0
+        version: 5.5.0
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.17)(mysql2@3.17.4)
@@ -5190,6 +5193,10 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cron-parser@5.5.0:
+    resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -13936,6 +13943,10 @@ snapshots:
     optional: true
 
   crelt@1.0.6: {}
+
+  cron-parser@5.5.0:
+    dependencies:
+      luxon: 3.7.2
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
## Summary
- Added support for backend "Routines" (cron jobs). This introduces a new primitive and a background `CronScheduler` service to automatically trigger open-ended tasks (like Claude co-work) on a recurring schedule.

## Why
- To allow power users and non-technical users alike to define recurring agents/tasks (e.g., "fetch this info and send that in slack every hour") without needing an external job orchestrator.

## Issue
- Closes #2284

## Scope
- Added `RoutineItem` primitive in `types.ts`.
- Built robust file-based CRUD in `routines.ts` and `server.ts` API endpoints (storing in `.opencode/routines/<name>.md`).
- Built `CronScheduler` (`scheduler.ts`) using `cron-parser` to evaluate schedules every minute.
- Automated creation of background agent sessions (`opencode.session.create()`) upon cron trigger.

## Out of scope
- Full UI components/settings page for visual routine management (laying the backend foundation first).

## Testing
### Ran
- `pnpm run typecheck` across all server packages
- Automated linting pipelines

### Result
- pass/fail: pass
- if fail, exact files/errors: N/A

## CI status
- pass: Not run yet (waiting on CI hook)
- code-related failures: N/A
- external/env/auth blockers: N/A

## Manual verification
1. Verified API accepts cron parameters and persists them correctly with `.md` frontmatter.
2. Verified `cron-parser` evaluates valid schedules and handles malformed strings without crashing the background thread.
3. Verified the scheduler isolates execution strictly to the matched minute boundary avoiding duplicated triggers.

## Evidence
- N/A (Backend logic/primitive addition)

## Risk
- Low. The `CronScheduler` isolates exceptions per routine. If a schedule fails to parse, it skips it and logs an error, preventing the server from crashing. Time validation acts upon isolated boundaries.

## Rollback
- Revert this PR. There are no breaking database migrations; the primitive relies on standard `.md` file deletion if needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

