### PR TITLE
Render env var request tools in chat

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -25,6 +25,7 @@ import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types"
 import { ApplyPatchTool } from "@/components/tools/apply-patch"
 import { BashTool } from "@/components/tools/bash"
 import { EditTool } from "@/components/tools/edit"
+import { EnvVarRequestTool } from "@/components/tools/env-var-request"
 import { ReadFileTool, WriteFileTool } from "@/components/tools/file"
 import { GlobTool } from "@/components/tools/glob"
 import { GrepTool } from "@/components/tools/grep"
@@ -62,6 +63,7 @@ import {
   isApplyPatchToolPart,
   isBashToolPart,
   isEditToolPart,
+  isEnvVarRequestToolPart,
   isGlobToolPart,
   isGrepToolPart,
   isLspToolPart,
@@ -181,6 +183,10 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
 
   if (isQuestionToolPart(part)) {
     return <QuestionTool part={part} />
+  }
+
+  if (isEnvVarRequestToolPart(part)) {
+    return <EnvVarRequestTool part={part} />
   }
 
   return <Tool toolPart={part} />

--- a/apps/app/src/components/tools/env-var-request.tsx
+++ b/apps/app/src/components/tools/env-var-request.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import { Check, ExternalLink, KeyRound, LoaderCircle, RefreshCw } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Tool } from "@/components/ui/tool"
+import { useMessageList } from "@/components/chat/message-list-provider"
+import type { EnvVarRequestToolPart } from "@/lib/build-in-tools"
+import { cn } from "@/lib/utils"
+import { EnvironmentEditorFields } from "@/react-app/domains/settings/pages/environment-view"
+import {
+  useEnvironmentVariableApplyChanges,
+  useEnvironmentVariableAvailability,
+  useEnvironmentVariableModify,
+  useIsEnvironmentVariableChangesPending,
+  type EnvironmentEditorDraft,
+} from "@/react-app/domains/settings/pages/environment-variable-provider"
+
+interface EnvVarRequestToolProps {
+  part: EnvVarRequestToolPart
+}
+
+function clean(value: string | undefined) {
+  return value?.trim() ?? ""
+}
+
+export function EnvVarRequestTool({ part }: EnvVarRequestToolProps) {
+  const key = clean(part.input?.key)
+  const label = clean(part.input?.label) || key || "environment variable"
+  const description = clean(part.input?.description)
+  const placeholder = clean(part.input?.placeholder)
+  const helpUrl = clean(part.input?.helpUrl)
+  const followUpPrompt = clean(part.input?.followUpPrompt)
+  const [editor, setEditor] = React.useState<EnvironmentEditorDraft>(() => ({
+    mode: "edit",
+    key,
+    value: "",
+  }))
+  const [saved, setSaved] = React.useState(false)
+  const { canModify, canApplyChanges } = useEnvironmentVariableAvailability()
+  const { modifyAsync, isModifying, error: modifyError } = useEnvironmentVariableModify()
+  const { applyAsync, isApplying, error: applyError } = useEnvironmentVariableApplyChanges()
+  const pendingChanges = useIsEnvironmentVariableChangesPending()
+  const { setPrompt } = useMessageList()
+
+  React.useEffect(() => {
+    setEditor({ mode: "edit", key, value: "" })
+    setSaved(false)
+  }, [key])
+
+  if (!key) {
+    return <Tool toolPart={part} title="Requested environment variable" />
+  }
+
+  const save = () => {
+    if (isModifying) return
+    void modifyAsync(editor, {
+      onSuccess: () => setSaved(true),
+    })
+  }
+
+  const apply = () => {
+    if (isApplying) return
+    void applyAsync(undefined)
+  }
+
+  return (
+    <div className="not-prose w-full max-w-xl rounded-2xl border border-dls-border bg-dls-surface/95 p-4 shadow-sm">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full border border-violet-6/35 bg-violet-3/30 text-violet-11">
+          <KeyRound className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-sm font-semibold text-dls-primary">Add {label}</h3>
+              {saved ? (
+                <span className="inline-flex items-center gap-1 rounded-full border border-green-6/40 bg-green-3/30 px-2 py-0.5 text-[11px] font-medium text-green-11">
+                  <Check className="size-3" />
+                  Saved
+                </span>
+              ) : null}
+            </div>
+            <p className="text-xs leading-5 text-dls-secondary">
+              {description || "Paste the token here. OpenWork stores it locally and does not send the secret back into chat."}
+            </p>
+          </div>
+
+          <EnvironmentEditorFields
+            editor={editor}
+            onChange={setEditor}
+            disabled={!canModify || isModifying}
+            error={modifyError}
+            keyPlaceholder="NOTION_TOKEN"
+            valuePlaceholder={placeholder || "secret_..."}
+          />
+
+          {!canModify ? (
+            <p className="rounded-lg border border-amber-6/40 bg-amber-3/20 px-3 py-2 text-xs text-amber-11">
+              Environment variables can only be edited from a local desktop workspace.
+            </p>
+          ) : null}
+          {applyError ? (
+            <p className="rounded-lg border border-red-6/40 bg-red-3/20 px-3 py-2 text-xs text-red-11">
+              {applyError.message}
+            </p>
+          ) : null}
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button size="sm" onClick={save} disabled={!canModify || isModifying || !editor.value}>
+              {isModifying ? <LoaderCircle className="size-4 animate-spin" /> : null}
+              {saved ? "Update token" : "Save token"}
+            </Button>
+            {canApplyChanges && pendingChanges ? (
+              <Button size="sm" variant="outline" onClick={apply} disabled={isApplying}>
+                {isApplying ? <LoaderCircle className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
+                Apply changes
+              </Button>
+            ) : null}
+            {helpUrl ? (
+              <Button size="sm" variant="ghost" render={<a href={helpUrl} target="_blank" rel="noreferrer" />}>
+                Open setup guide
+                <ExternalLink className="size-3.5" />
+              </Button>
+            ) : null}
+            {followUpPrompt && saved ? (
+              <Button size="sm" variant="ghost" onClick={() => setPrompt(followUpPrompt)}>
+                Continue setup
+              </Button>
+            ) : null}
+          </div>
+
+          <p className={cn("text-[11px] leading-4 text-dls-tertiary", saved && pendingChanges ? "text-amber-11" : "")}>
+            {saved && pendingChanges
+              ? "Saved locally. Apply changes so local agents can read the latest value."
+              : "The token is written through the same local Environment Variables store used by Settings."}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/app/src/components/tools/env-var-request.tsx
+++ b/apps/app/src/components/tools/env-var-request.tsx
@@ -56,7 +56,10 @@ export function EnvVarRequestTool({ part }: EnvVarRequestToolProps) {
   const save = () => {
     if (isModifying) return
     void modifyAsync(editor, {
-      onSuccess: () => setSaved(true),
+      onSuccess: () => {
+        setSaved(true)
+        setEditor((current) => ({ ...current, value: "" }))
+      },
     })
   }
 

--- a/apps/app/src/components/ui/tool.tsx
+++ b/apps/app/src/components/ui/tool.tsx
@@ -12,6 +12,7 @@ import {
   ChevronDown,
   CircleAlert,
   FilePen,
+  KeyRound,
   ListTodo,
   LoaderCircle,
   MessageCircleQuestion,
@@ -40,6 +41,9 @@ function toolIcon(part: ToolPart) {
       return ListTodo
     case "question":
       return MessageCircleQuestion
+    case "request_env_var":
+    case "env_var_request":
+      return KeyRound
     case "task":
       return Bot
     default:

--- a/apps/app/src/lib/build-in-tools.ts
+++ b/apps/app/src/lib/build-in-tools.ts
@@ -32,6 +32,15 @@ export interface QuestionMetadata extends ToolMetadata {
   answers: string[][];
 }
 
+export interface EnvVarRequestInput {
+  key: string;
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  helpUrl?: string;
+  followUpPrompt?: string;
+}
+
 export interface BashInput {
   command: string;
   timeout?: number;
@@ -367,6 +376,12 @@ export type QuestionToolPart = BuiltInDynamicToolPart<"question", QuestionInput>
 
 export function isQuestionToolPart(part: ToolUIPart | DynamicToolUIPart): part is QuestionToolPart {
   return part.type === "dynamic-tool" && part.toolName === "question";
+}
+
+export type EnvVarRequestToolPart = BuiltInDynamicToolPart<"request_env_var" | "env_var_request", EnvVarRequestInput, unknown>;
+
+export function isEnvVarRequestToolPart(part: ToolUIPart | DynamicToolUIPart): part is EnvVarRequestToolPart {
+  return part.type === "dynamic-tool" && (part.toolName === "request_env_var" || part.toolName === "env_var_request");
 }
 
 export type TaskToolPart = BuiltInDynamicToolPart<"task", TaskInput>;

--- a/apps/app/src/lib/tool-activity.ts
+++ b/apps/app/src/lib/tool-activity.ts
@@ -3,6 +3,7 @@ import {
   isApplyPatchToolPart,
   isBashToolPart,
   isEditToolPart,
+  isEnvVarRequestToolPart,
   isGlobToolPart,
   isGrepToolPart,
   isLspToolPart,
@@ -92,6 +93,10 @@ export function getToolActivityLabel(part: AnyToolPart): string {
   if (isQuestionToolPart(part)) {
     return "Asking a question"
   }
+  if (isEnvVarRequestToolPart(part)) {
+    const key = part.input?.key?.trim()
+    return key ? `Requesting ${key}` : "Requesting an environment variable"
+  }
   if (isTaskToolPart(part)) {
     const description = part.input?.description?.trim()
     return description
@@ -114,5 +119,4 @@ export function getActiveToolLabel(parts: DynamicToolUIPart[]): string | null {
   }
   return null
 }
-
 

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -146,6 +146,7 @@ export type SessionPageProps = {
   clientConnected: boolean;
   openworkServerStatus: OpenworkServerStatus;
   openworkServerClient: OpenworkServerClient | null;
+  environmentClient?: OpenworkServerClient | null;
   openworkServerToken?: string | null;
   developerMode: boolean;
   headerStatus: string;
@@ -986,6 +987,7 @@ export function SessionPage(props: SessionPageProps) {
                         // SessionRoute, not from anything in `surface`.
                         {...props.surface!}
                         client={props.openworkServerClient!}
+                        environmentClient={props.environmentClient}
                         workspaceId={props.runtimeWorkspaceId!}
                         sessionId={props.selectedSessionId!}
                         opencodeBaseUrl={reactSessionBaseUrl}
@@ -1006,6 +1008,7 @@ export function SessionPage(props: SessionPageProps) {
                         <SessionSurface
                           {...props.surface!}
                           client={props.openworkServerClient!}
+                          environmentClient={props.environmentClient}
                           workspaceId={props.runtimeWorkspaceId!}
                           sessionId={splitSessionId!}
                           opencodeBaseUrl={reactSessionBaseUrl}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -93,6 +93,7 @@ type SessionError = {
 
 export type SessionSurfaceProps = {
   client: OpenworkServerClient;
+  environmentClient?: OpenworkServerClient | null;
   workspaceId: string;
   workspaceRoot: string;
   sessionId: string;
@@ -1281,7 +1282,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                   onOpenTarget={props.onOpenTarget}
                 >
                   <EnvironmentVariableProvider
-                    client={props.isRemoteWorkspace ? null : props.client}
+                    client={props.isRemoteWorkspace ? null : props.environmentClient ?? props.client}
                     runtimeKey={props.environmentRuntimeKey}
                     onApplyChanges={props.onApplyEnvironmentChanges}
                   >

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -73,6 +73,10 @@ import { MessageList } from "@/components/chat/message-list";
 import { MessageListProvider, type DispatchAction } from "@/components/chat/message-list-provider";
 import { OpenTargetProvider } from "@/lib/target-provider";
 import type { ThreadStatus } from "@/lib/messages";
+import {
+  EnvironmentVariableProvider,
+  type ApplyEnvironmentChangesResult,
+} from "@/react-app/domains/settings/pages/environment-variable-provider";
 
 const EMPTY_TRANSCRIPT: UIMessage[] = [];
 const IDLE_STATUS: SessionStatus = { type: "idle" };
@@ -134,6 +138,8 @@ export type SessionSurfaceProps = {
   onRevertToMessage?: (messageId: string, sessionId: string) => Promise<boolean>;
   onForkAtMessage?: (messageId: string | null, sessionId: string) => void;
   onOpenTarget?: (target: OpenTarget, options?: { auto?: boolean }, sessionId?: string) => void;
+  environmentRuntimeKey?: string | null;
+  onApplyEnvironmentChanges?: () => Promise<ApplyEnvironmentChangesResult>;
 };
 
 function messageToReadableText(message: UIMessage) {
@@ -1274,25 +1280,31 @@ export function SessionSurface(props: SessionSurfaceProps) {
                   openTargets={verifiedOpenTargets}
                   onOpenTarget={props.onOpenTarget}
                 >
-                  <MessageListProvider
-                    workspaceId={props.workspaceId}
-                    sessionId={props.sessionId}
-                    showThinking={showThinking}
-                    developerMode={props.developerMode}
-                    displaySuggestions={shellConfig.starterCards}
-                    providerConnectedCount={props.providerConnectedCount ?? 0}
-                    dispatchAction={handleMessageListDispatchAction}
-                    setPrompt={handleMessageListSetPrompt}
-                    onRevertToUserMessage={handleRevertToUserMessage}
-                    onForkAtMessage={handleForkAtMessage}
-                    onEditUserMessage={handleEditUserMessage}
+                  <EnvironmentVariableProvider
+                    client={props.isRemoteWorkspace ? null : props.client}
+                    runtimeKey={props.environmentRuntimeKey}
+                    onApplyChanges={props.onApplyEnvironmentChanges}
                   >
-                    <MessageList
-                      messages={renderedMessages}
-                      status={status}
-                      retryStatus={liveStatus.type === "retry" ? liveStatus : null}
-                    />
-                  </MessageListProvider>
+                    <MessageListProvider
+                      workspaceId={props.workspaceId}
+                      sessionId={props.sessionId}
+                      showThinking={showThinking}
+                      developerMode={props.developerMode}
+                      displaySuggestions={shellConfig.starterCards}
+                      providerConnectedCount={props.providerConnectedCount ?? 0}
+                      dispatchAction={handleMessageListDispatchAction}
+                      setPrompt={handleMessageListSetPrompt}
+                      onRevertToUserMessage={handleRevertToUserMessage}
+                      onForkAtMessage={handleForkAtMessage}
+                      onEditUserMessage={handleEditUserMessage}
+                    >
+                      <MessageList
+                        messages={renderedMessages}
+                        status={status}
+                        retryStatus={liveStatus.type === "retry" ? liveStatus : null}
+                      />
+                    </MessageListProvider>
+                  </EnvironmentVariableProvider>
                 </OpenTargetProvider>
               </DevProfiler>
             )}

--- a/apps/app/src/react-app/domains/settings/pages/environment-variable-provider.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/environment-variable-provider.tsx
@@ -70,6 +70,8 @@ export interface RemoveAsyncOptions {
 }
 
 interface EnvironmentVariableContextValue {
+  canModify: boolean;
+  canApplyChanges: boolean;
   isPendingChanges: boolean;
   applyAsync: UseMutateFunction<ApplyEnvironmentChangesResult | undefined, Error, void, unknown>;
   modifyAsync: UseMutateFunction<unknown, Error, EnvironmentEditorDraft, unknown>;
@@ -180,6 +182,8 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
     },
   });
   const value = useMemo<EnvironmentVariableContextValue>(() => ({
+    canModify: client !== null,
+    canApplyChanges: onApplyChanges !== undefined,
     isPendingChanges: data === true,
     applyAsync,
     modifyAsync,
@@ -191,6 +195,8 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
     modifyError,
     removeError,
   }), [
+    client,
+    onApplyChanges,
     applyAsync,
     modifyAsync,
     removeAsync,
@@ -256,4 +262,10 @@ export function useIsEnvironmentVariableChangesPending() {
   const { isPendingChanges } = useEnvironmentVariableContext();
 
   return isPendingChanges;
+}
+
+export function useEnvironmentVariableAvailability() {
+  const { canModify, canApplyChanges } = useEnvironmentVariableContext();
+
+  return { canModify, canApplyChanges };
 }

--- a/apps/app/src/react-app/domains/settings/pages/environment-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/environment-view.tsx
@@ -384,11 +384,62 @@ type EnvironmentEditorModalProps = {
   onChange: (value: SetStateAction<EnvironmentEditorState>) => void;
 };
 
+type EnvironmentEditorFieldsProps = {
+  editor: EnvironmentEditorDraft;
+  onChange: (value: SetStateAction<EnvironmentEditorDraft>) => void;
+  disabled?: boolean;
+  error?: Error | null;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+};
+
+export function EnvironmentEditorFields(props: EnvironmentEditorFieldsProps) {
+  const keyFieldId = useId();
+  const valueFieldId = useId();
+
+  return (
+    <FieldGroup>
+      <Field data-invalid={props.error ? true : undefined}>
+        <FieldLabel htmlFor={keyFieldId}>{t("settings.environment.key_label")}</FieldLabel>
+        <Input
+          id={keyFieldId}
+          value={props.editor.key}
+          onChange={(event) =>
+            props.onChange((current) => ({ ...current, key: event.target.value }))
+          }
+          disabled={props.editor.mode === "edit" || props.disabled}
+          placeholder={props.keyPlaceholder ?? "ANTHROPIC_API_KEY"}
+          spellCheck={false}
+          autoComplete="off"
+          aria-invalid={props.error ? true : undefined}
+        />
+        <FieldDescription>{t("settings.environment.key_hint")}</FieldDescription>
+      </Field>
+      <Field data-invalid={props.error ? true : undefined}>
+        <FieldLabel htmlFor={valueFieldId}>{t("settings.environment.value_label")}</FieldLabel>
+        <Textarea
+          id={valueFieldId}
+          value={props.editor.value}
+          onChange={(event) =>
+            props.onChange((current) => ({ ...current, value: event.target.value }))
+          }
+          disabled={props.disabled}
+          rows={3}
+          spellCheck={false}
+          autoComplete="off"
+          placeholder={props.valuePlaceholder}
+          className="font-mono"
+          aria-invalid={props.error ? true : undefined}
+        />
+        {props.error ? <FieldError>{props.error.message}</FieldError> : null}
+      </Field>
+    </FieldGroup>
+  );
+}
+
 function EnvironmentEditorModal(props: EnvironmentEditorModalProps) {
   const { modifyAsync, isModifying, error } = useEnvironmentVariableModify();
   const titleId = useId();
-  const keyFieldId = useId();
-  const valueFieldId = useId();
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -424,41 +475,17 @@ function EnvironmentEditorModal(props: EnvironmentEditorModalProps) {
           </DialogTitle>
         </DialogHeader>
 
-        <FieldGroup>
-          <Field data-invalid={error ? true : undefined}>
-            <FieldLabel htmlFor={keyFieldId}>{t("settings.environment.key_label")}</FieldLabel>
-            <Input
-              id={keyFieldId}
-              value={props.editor.key}
-              onChange={(event) =>
-                props.onChange((current) => (current ? { ...current, key: event.target.value } : current))
-              }
-              disabled={props.editor.mode === "edit" || isModifying}
-              placeholder="ANTHROPIC_API_KEY"
-              spellCheck={false}
-              autoComplete="off"
-              aria-invalid={error ? true : undefined}
-            />
-            <FieldDescription>{t("settings.environment.key_hint")}</FieldDescription>
-          </Field>
-          <Field data-invalid={error ? true : undefined}>
-            <FieldLabel htmlFor={valueFieldId}>{t("settings.environment.value_label")}</FieldLabel>
-            <Textarea
-              id={valueFieldId}
-              value={props.editor.value}
-              onChange={(event) =>
-                props.onChange((current) => (current ? { ...current, value: event.target.value } : current))
-              }
-              disabled={isModifying}
-              rows={3}
-              spellCheck={false}
-              autoComplete="off"
-              className="font-mono"
-              aria-invalid={error ? true : undefined}
-            />
-            {error ? <FieldError>{error.message}</FieldError> : null}
-          </Field>
-        </FieldGroup>
+        <EnvironmentEditorFields
+          editor={props.editor}
+          onChange={(value) => {
+            props.onChange((current) => {
+              if (!current) return current;
+              return typeof value === "function" ? value(current) : value;
+            });
+          }}
+          disabled={isModifying}
+          error={error}
+        />
 
         <DialogFooter>
           <DialogClose

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1537,6 +1537,7 @@ export function SessionRoute() {
       clientConnected={canCreateTask}
       openworkServerStatus={client ? "connected" : "disconnected"}
       openworkServerClient={selectedWorkspaceEndpoint?.client ?? client}
+      environmentClient={client}
       openworkServerToken={selectedWorkspaceServerToken}
       developerMode={developerMode}
       headerStatus={canCreateTask ? t("status.connected") : t("session.loading_detail")}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -455,7 +455,7 @@ export function SessionRoute() {
     onSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
   });
 
-  const { engineReloadVersion, routeEngineInfo } = useEngineReload({
+  const { engineReloadVersion, routeEngineInfo, reloadWorkspaceEngineFromUi } = useEngineReload({
     client,
     workspaceId: selectedWorkspaceId,
     workspace: selectedWorkspace,
@@ -464,6 +464,31 @@ export function SessionRoute() {
     onError: setRouteError,
     refreshRouteState,
   });
+
+  const environmentRuntimeKey = useMemo(
+    () => buildOpenworkEnvRuntimeKey({
+      baseUrl: client?.baseUrl ?? null,
+      pid: openworkServerHostInfoState?.pid ?? null,
+      port: openworkServerHostInfoState?.port ?? null,
+    }),
+    [client?.baseUrl, openworkServerHostInfoState?.pid, openworkServerHostInfoState?.port],
+  );
+
+  const handleApplyEnvironmentChanges = useCallback(async () => {
+    if (!isDesktopRuntime()) {
+      throw new Error(t("settings.environment.apply_unavailable"));
+    }
+    if (activeReloadBlockingSessions.length > 0) {
+      throw new Error(t("settings.environment.apply_blocked_active_tasks"));
+    }
+    if (!selectedWorkspaceRoot) {
+      throw new Error(t("settings.environment.apply_no_local_workspace"));
+    }
+    const reloaded = await reloadWorkspaceEngineFromUi();
+    if (!reloaded) {
+      throw new Error(t("app.error_connect_first"));
+    }
+  }, [activeReloadBlockingSessions.length, reloadWorkspaceEngineFromUi, selectedWorkspaceRoot]);
 
   const shareWorkspaceState = useShareWorkspaceState({
     workspaces,
@@ -823,14 +848,9 @@ export function SessionRoute() {
         }
 
         const parts = await draftToParts(draft, selectedWorkspaceRoot);
-        const envRuntimeKey = buildOpenworkEnvRuntimeKey({
-          baseUrl: client?.baseUrl ?? null,
-          pid: openworkServerHostInfoState?.pid ?? null,
-          port: openworkServerHostInfoState?.port ?? null,
-        });
         const envSystemContext = await buildOpenworkEnvSystemContext(client, {
           cacheKey: targetSessionId,
-          runtimeKey: envRuntimeKey,
+          runtimeKey: environmentRuntimeKey,
         });
         const result = await opencodeClient.session.promptAsync({
           sessionID: targetSessionId,
@@ -922,12 +942,18 @@ export function SessionRoute() {
             : null,
         }));
       },
+      environmentRuntimeKey,
+      onApplyEnvironmentChanges: isDesktopRuntime() && selectedWorkspace?.workspaceType !== "remote"
+        ? handleApplyEnvironmentChanges
+        : undefined,
     };
   }, [
     client,
     modelPicker.compactOpen,
     handleOpenSettings,
     hasUsableModel,
+    handleApplyEnvironmentChanges,
+    environmentRuntimeKey,
     local,
     listAgents,
     listSlashCommands,

--- a/apps/app/src/react-app/shell/use-engine-reload.ts
+++ b/apps/app/src/react-app/shell/use-engine-reload.ts
@@ -149,5 +149,5 @@ export function useEngineReload(input: UseEngineReloadInput) {
     };
   }, []);
 
-  return { engineReloadVersion, routeEngineInfo };
+  return { engineReloadVersion, routeEngineInfo, reloadWorkspaceEngineFromUi };
 }

--- a/apps/app/tests/session-sync-tool-parts.test.ts
+++ b/apps/app/tests/session-sync-tool-parts.test.ts
@@ -111,6 +111,15 @@ describe("tool part mapper", () => {
     });
   });
 
+  test("maps env var request tools for rich chat rendering", () => {
+    const part = writeToolPart("running", { key: "NOTION_TOKEN" }, { tool: "request_env_var" });
+    expect(parseDynamicToolUIPart(part)).toMatchObject({
+      type: "dynamic-tool",
+      toolName: "request_env_var",
+      input: { key: "NOTION_TOKEN" },
+    });
+  });
+
   test("skips empty structured output while streaming", () => {
     const part = writeToolPart("running", {}, { tool: "StructuredOutput" });
     expect(parseStructuredOutputUIPart(part)).toBeNull();


### PR DESCRIPTION
## Summary
- Adds a first-party chat card for trusted env-var request tool calls (`request_env_var` / `env_var_request`).
- Reuses the existing Settings environment variable provider and extracted editor fields instead of adding a separate secret-writing path.
- Wires chat env writes through the host-authenticated OpenWork client, preserves the existing pending/apply flow, and clears the value field after save so tokens are not left visible in chat.

## Validation
- `pnpm --filter @openwork/app typecheck` passed.
- `pnpm --filter @openwork/app test` passed: 71 tests, 0 failures.
- Daytona Electron validation on sandbox `openwork-test-20260618-113235`:
  - Created local workspace `/workspace/rich-chat-env-ui`.
  - Verified Settings -> Environment still saves `NOTION_TOKEN` and shows pending apply state using the shared editor fields.
  - Injected a synthetic `request_env_var` tool part through the dev React Query session snapshot to validate the real chat renderer.
  - Verified chat card rendered `Add Notion token`, saved through host env APIs, showed `Saved`, `Apply changes`, and `Continue setup`.
  - Verified no `Invalid host token` error after the host-client fix.
  - Verified the fake token text was not present in page text after save and the textarea value was cleared.

## Evidence
- Frame-by-frame Daytona proof: https://8090-i2ewatuotyftpgpr.daytonaproxy01.net/index.html
- Individual frames:
  - Settings env saved: https://8090-i2ewatuotyftpgpr.daytonaproxy01.net/01-settings-env-saved.png
  - Chat env request card saved: https://8090-i2ewatuotyftpgpr.daytonaproxy01.net/02-chat-env-card-saved.png
- Note: the standard `/daytona-artifacts` helper path was not writable in this sandbox, so these frames are served from `/workspace/proof-frames` on port 8090 instead.
