### PR TITLE
Generate frame proof index for UI evals

### DIFF
--- a/.opencode/skills/daytona-electron-test/SKILL.md
+++ b/.opencode/skills/daytona-electron-test/SKILL.md
@@ -23,10 +23,23 @@ the ref, conditionally installs deps, starts XFCE/noVNC, Vite, Electron, and
 waits for CDP:
 
 ```bash
-bash .devcontainer/test-on-daytona.sh [branch-or-commit]
+bash .devcontainer/test-on-daytona.sh [branch-or-commit] --artifacts-volume
 ```
 
-It prints the CDP and noVNC URLs at the end. Then use `browser_list` to connect.
+It prints the CDP and noVNC URLs at the end. For UI validation, keep
+`--artifacts-volume` on by default so `/daytona-artifacts` is mounted and the
+artifact server on port 8090 is available for frame proof. Then run the coded
+eval runner when a flow exists:
+
+```bash
+pnpm evals --flow <flow-id> --cdp-url <printed-electron-cdp-url>
+```
+
+Use direct browser tools for exploration/debugging or for UI paths that are not
+codified yet. If the behavior is PR evidence and repeatable, add a flow under
+`evals/flows/*.flow.mjs` and rerun it through `pnpm evals`.
+
+Use `browser_list` to connect when manual inspection is needed.
 Refresh the snapshot with `bash .devcontainer/create-daytona-openwork-snapshot.sh`
 when dependencies or base setup change. The snapshot excludes `node_modules`;
 dependency installs reuse the `openwork-eval-pnpm-store` volume.
@@ -62,6 +75,8 @@ source every `/daytona-secrets/*.env` file before Electron starts.
 
 Validation standard: use `daytona-flow-validator`. Default proof format is
 frame-by-frame HTML — named PNGs in a browseable index served on port 8090.
+The eval runner writes `evals/results/<run-id>/index.html`; serve that result
+directory or copy it into `/daytona-artifacts/validation/<flow>/` for PR proof.
 Use video only for interactions that need motion (streaming, animations,
 loading states). See `daytona-recording-artifacts` for the frame workflow.
 

--- a/.opencode/skills/daytona-recording-artifacts/SKILL.md
+++ b/.opencode/skills/daytona-recording-artifacts/SKILL.md
@@ -19,6 +19,15 @@ spinners, animations, drag-and-drop, or real-time interactions that a static
 frame cannot capture. When video is used, embed it inside the frame-by-frame
 HTML page alongside the static frames.
 
+When a coded eval exists, prefer the eval runner frame output first:
+
+```bash
+pnpm evals --flow <flow-id> --cdp-url <printed-electron-cdp-url>
+```
+
+The runner writes `evals/results/<run-id>/index.html` plus PNG screenshots from
+`ctx.screenshot(...)`. Serve or copy that result directory for PR evidence.
+
 ### How to produce frame proof
 
 1. Serve a directory from the sandbox on port 8090:
@@ -43,6 +52,27 @@ echo "${FRAMES_URL}/index.html"
 
 5. Post the index URL in the PR body. Individual frame PNGs are also directly
    linkable: `${FRAMES_URL}/01-auth-landing.png`.
+
+### Fallback when `/daytona-artifacts` is unavailable
+
+The preferred path is `test-on-daytona.sh --artifacts-volume`, which mounts and
+serves `/daytona-artifacts`. If that path is unavailable or not writable, do not
+stop at local screenshots. Use `/workspace/proof-frames` as a fallback:
+
+```bash
+daytona exec "$SANDBOX" -- 'bash -lc "mkdir -p /workspace/proof-frames; nohup python3 -m http.server 8090 --bind 0.0.0.0 --directory /workspace/proof-frames >/tmp/proof-frames-http.log 2>&1 &"'
+```
+
+Upload the generated `index.html` and PNG frames there, then verify every file is
+non-zero before sharing:
+
+```bash
+daytona exec "$SANDBOX" -- 'bash -lc "ls -lh /workspace/proof-frames && curl -s -I http://127.0.0.1:8090/index.html | sed -n \"1,8p\""'
+daytona preview-url "$SANDBOX" -p 8090
+```
+
+If you use this fallback, say so in the PR/eval report because the files are not
+on the persistent artifacts volume.
 
 ### When to include video clips
 

--- a/.opencode/skills/run-evals/SKILL.md
+++ b/.opencode/skills/run-evals/SKILL.md
@@ -33,13 +33,13 @@ Use these Daytona skills when an eval touches a specific area:
 - `daytona-secrets-volume` for adding or checking provider keys and eval secrets.
 - `daytona-recording-artifacts` for screenshots, recordings, before/after videos, and PR evidence.
 
-### Preferred path: helper script
+### Preferred path: helper script + coded eval runner
 
 Use the repo helper unless you need to debug a specific Daytona step manually:
 
 ```bash
 daytona organization use "<org-name>"
-bash .devcontainer/test-on-daytona.sh <branch-or-commit>
+bash .devcontainer/test-on-daytona.sh <branch-or-commit> --artifacts-volume
 ```
 
 The helper creates a fresh VNC-capable Daytona sandbox from the reusable
@@ -47,7 +47,9 @@ The helper creates a fresh VNC-capable Daytona sandbox from the reusable
 `openwork-eval-secrets:/daytona-secrets` volume, mounts the reusable
 `openwork-eval-pnpm-store` pnpm cache volume, starts XFCE/noVNC, Vite, and
 Electron with Daytona-safe graphics flags, waits for CDP, then prints the CDP
-and noVNC URLs. If the snapshot is missing, create it before rerunning.
+and noVNC URLs. `--artifacts-volume` mounts `/daytona-artifacts` and serves it
+on port 8090 so UI validation can publish frame proof. If the snapshot is
+missing, create it before rerunning.
 
 Refresh the snapshot when dependencies or base setup change:
 
@@ -99,7 +101,34 @@ If the app shows the Welcome page, create a workspace:
 
 ### Step 6: Run the requested eval
 
-Read the eval file from `evals/` and execute each step using the browser tools.
+Prefer coded flows under `evals/flows/` and run them through the eval runner:
+
+```bash
+pnpm evals --list
+pnpm evals --flow <flow-id> --cdp-url <printed-electron-cdp-url>
+```
+
+The runner uses CDP directly, produces machine-checkable assertions, and writes
+`report.json`, `report.md`, screenshots, and a browseable `index.html` frame
+proof under `evals/results/<run-id>/`.
+
+If no coded flow exists yet for the UI behavior under test, add or adapt a
+`evals/flows/*.flow.mjs` file and use the runner helpers:
+
+- `ctx.clickText("Button label")`
+- `ctx.fill("input-or-textarea-selector", "value")`
+- `ctx.waitFor("JavaScript condition")`
+- `ctx.waitForText("Visible text")`
+- `ctx.control("action.id", args)`
+- `ctx.screenshot("checkpoint-name")`
+
+Use manual browser tools only to debug/prototype a flow or when product UI
+cannot expose the needed state yet. Do not report ad hoc browser calls as the
+preferred PR evidence when a coded flow can be created.
+
+When manually replaying a markdown-only eval, execute each step using the
+browser tools and convert the flow to `evals/flows/` if it becomes repeated PR
+coverage.
 
 For each step:
 1. Observe the current state with `browser_snapshot` or `browser_eval`.
@@ -111,7 +140,10 @@ For each step:
 Use the `daytona-flow-validator` skill for pass/fail decisions. If there is no
 post-action assertion, report `Incomplete`, not `Passed`.
 
-### Key techniques
+### Manual browser-tool fallback techniques
+
+Use these only when debugging, prototyping a flow, or bridging a product gap.
+For repeatable UI proof, prefer `pnpm evals` and `ctx.*` helpers above.
 
 **Clicking buttons:**
 ```

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,12 +1,13 @@
 # OpenWork UI evals
 
-Human-readable scenarios that an LLM (or a person) can replay against a live
-OpenWork instance to verify end-to-end behavior of the UI.
+Human-readable scenarios and coded flows that verify end-to-end OpenWork UI
+behavior against a live app.
 
-Each eval is:
-- A short list of steps written in plain English.
+Each eval should have:
+- A short narrative spec written in plain English.
 - An **expected outcome** with observable signals.
-- The CDP browser tool calls to drive it.
+- A coded flow under [`flows/`](./flows) when it is used for PR evidence or
+  repeated regression coverage.
 
 They are not unit tests. They intentionally exercise the running stack
 (OpenCode + OpenWork server + React UI) so regressions in wiring — not just
@@ -17,7 +18,8 @@ types — get caught.
 A growing subset of flows is codified under [`flows/`](./flows) and executed by
 the zero-dependency runner in [`runner/`](./runner) with machine-checkable
 assertions, poll-until-condition waits (no fixed sleeps), and JSON + markdown
-reports with screenshots.
+reports with screenshots. The runner also writes a browseable frame-by-frame
+`index.html` in each result directory.
 
 ```bash
 pnpm evals --list                 # show available coded flows
@@ -31,7 +33,8 @@ The runner probes `http://127.0.0.1:9825` (Daytona) then `:9823` (local
 `requiredEnv` and are skipped (not failed) when the env is missing — e.g.
 `cloud-signin-handoff` needs `OPENWORK_EVAL_DEN_API_URL` and
 `OPENWORK_EVAL_DEN_TOKEN`. Reports land in `evals/results/<run-id>/`
-(gitignored). A non-zero exit code means at least one flow failed.
+(gitignored). Open `evals/results/<run-id>/index.html` for the frame proof.
+A non-zero exit code means at least one flow failed.
 
 ### One-command cloud stack
 
@@ -62,8 +65,8 @@ Quick start:
 
 ```bash
 daytona organization use "<org-name>"
-bash .devcontainer/test-on-daytona.sh [branch-or-commit]
-# Use the printed Electron CDP URL with browser_* tools.
+bash .devcontainer/test-on-daytona.sh [branch-or-commit] --artifacts-volume
+pnpm evals --flow app-smoke --cdp-url <printed-electron-cdp-url>
 ```
 
 ### Option B: Local Electron
@@ -76,9 +79,11 @@ pnpm dev
 
 Wait ~15s, then use the browser tools against `http://127.0.0.1:9825`.
 
-### Option C: Manual browser
+### Option C: Manual browser/debugging
 
-Open the app and follow the step lists by hand.
+Open the app and follow the step lists by hand. Use this for exploration or
+debugging only; PR evidence for UI changes should use a coded flow when
+possible.
 
 ## Tool reference
 
@@ -98,13 +103,18 @@ plugin (configured in `.opencode/opencode.json`). Every tool takes
 
 ## Conventions
 
-- Use `browser_eval` for button clicks and text input — it's more reliable
-  than snapshot UIDs for dynamic React UIs.
-- For Lexical editors, use `document.execCommand('insertText', false, text)`
-  after focusing. Direct DOM manipulation doesn't trigger Lexical state updates.
+- Prefer coded flows in `evals/flows/*.flow.mjs` over ad hoc browser tool calls.
+- Use runner helpers such as `ctx.clickText`, `ctx.fill`, `ctx.waitFor`,
+  `ctx.waitForText`, `ctx.control`, and `ctx.screenshot`.
+- Use direct `browser_eval` only for debugging/prototyping or when a flow has
+  not yet been codified. If the behavior matters for a PR, codify it before
+  calling the UI validation complete.
+- For Lexical editors in coded flows, use a synthetic paste/event helper; direct
+  DOM manipulation doesn't trigger Lexical state updates.
 - For React state injection (e.g., folder picker bypass), use the
   `__reactFiber$` → reducer dispatch pattern documented in `daytona-flows.md`.
-- When asked to "wait for X", use `sleep` then `browser_eval` to check.
+- Prefer poll-until-condition waits (`ctx.waitFor`, `ctx.waitForText`) over
+  fixed sleeps.
 
 ## Files
 

--- a/evals/daytona-flows.md
+++ b/evals/daytona-flows.md
@@ -11,13 +11,14 @@ Daytona proxy.
 
 ```bash
 daytona organization use "<org-name>"
-bash .devcontainer/test-on-daytona.sh [branch-or-commit]
+bash .devcontainer/test-on-daytona.sh [branch-or-commit] --artifacts-volume
 ```
 
 Use the helper. It creates from the reusable `openwork-eval-vnc` snapshot,
 mounts secrets, mounts the reusable pnpm store volume, checks out the requested
 ref, conditionally installs deps, starts services, waits for CDP, and prints the
-CDP/noVNC URLs. If the snapshot is missing, create it with
+CDP/noVNC URLs. Keep `--artifacts-volume` on for UI validation so frame proof can
+be served from port 8090. If the snapshot is missing, create it with
 `bash .devcontainer/create-daytona-openwork-snapshot.sh`.
 
 The reusable `openwork-eval-secrets` volume is mounted at `/daytona-secrets`.
@@ -30,6 +31,17 @@ To persist downloadable artifacts, pass `--artifacts-volume`. The helper mounts
 the reusable `openwork-eval-artifacts` volume at `/daytona-artifacts`, starts a
 static download server, and prints its Daytona preview URL. Capture screenshot
 checkpoints with `daytona exec <sandbox> -- 'bash .devcontainer/capture-daytona-screenshot.sh'`.
+
+For repeatable PR evidence, prefer coded flows under `evals/flows/`:
+
+```bash
+pnpm evals --list
+pnpm evals --flow <flow-id> --cdp-url <printed-electron-cdp-url>
+```
+
+The runner writes `evals/results/<run-id>/report.md` and a frame-by-frame
+`index.html` with screenshots captured by `ctx.screenshot(...)`. Use the manual
+CDP snippets below for debugging or for flows that have not been codified yet.
 
 To record the Electron display, pass `--record-video`:
 

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -143,6 +143,7 @@ function renderMarkdown(report) {
     `- Started: ${report.startedAt}`,
     `- CDP: ${report.cdpUrl}`,
     `- Result: ${report.summary.failed > 0 ? "FAILED" : "PASSED"} (${report.summary.passed} passed, ${report.summary.failed} failed, ${report.summary.skipped} skipped)`,
+    `- Frame index: index.html`,
     "",
   ];
   for (const flow of report.flows) {
@@ -161,6 +162,84 @@ function renderMarkdown(report) {
     lines.push("");
   }
   return lines.join("\n");
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function renderFrameIndex(report) {
+  const flowSections = report.flows.map((flow) => {
+    const screenshots = flow.screenshots ?? [];
+    const frames = screenshots.length > 0
+      ? screenshots.map((screenshot) => `
+          <figure>
+            <a href="${escapeHtml(screenshot)}"><img src="${escapeHtml(screenshot)}" alt="${escapeHtml(screenshot)}" /></a>
+            <figcaption>${escapeHtml(screenshot)}</figcaption>
+          </figure>`).join("\n")
+      : `<p class="muted">No screenshots captured for this flow.</p>`;
+    const steps = (flow.steps ?? []).map((step) => `
+        <li class="${step.status === "passed" ? "passed" : "failed"}">
+          <strong>${escapeHtml(step.status.toUpperCase())}</strong>
+          ${escapeHtml(step.name)} (${Number(step.durationMs) || 0}ms)
+          ${step.error ? `<div class="error">${escapeHtml(step.error)}</div>` : ""}
+        </li>`).join("\n");
+    return `
+      <section>
+        <h2>${escapeHtml(flow.id)} - ${escapeHtml(flow.title)}</h2>
+        ${flow.spec ? `<p class="muted">Spec: ${escapeHtml(flow.spec)}</p>` : ""}
+        ${flow.skipReason ? `<p class="skipped">Skipped: ${escapeHtml(flow.skipReason)}</p>` : ""}
+        <ol>${steps}</ol>
+        <div class="grid">${frames}</div>
+      </section>`;
+  }).join("\n");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenWork Eval Run ${escapeHtml(report.runId)}</title>
+  <style>
+    body { margin: 0; background: #f7f7f8; color: #171717; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    main { max-width: 1180px; margin: 0 auto; padding: 32px; }
+    h1 { margin: 0 0 8px; font-size: 28px; }
+    h2 { margin-top: 32px; }
+    .meta, .muted { color: #5f6368; }
+    .summary { display: inline-flex; gap: 12px; margin: 16px 0 8px; padding: 10px 12px; border: 1px solid #ddd; border-radius: 10px; background: white; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 18px; margin-top: 16px; }
+    figure { margin: 0; overflow: hidden; border: 1px solid #ddd; border-radius: 12px; background: white; box-shadow: 0 1px 4px rgba(0,0,0,.06); }
+    img { display: block; width: 100%; height: auto; }
+    figcaption { padding: 10px 12px; border-top: 1px solid #eee; font-size: 13px; color: #444; }
+    li { margin: 8px 0; }
+    .passed strong { color: #0a7f35; }
+    .failed strong, .error { color: #b42318; }
+    .skipped { color: #8a5a00; }
+    code { background: #ededf0; padding: 2px 5px; border-radius: 5px; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>OpenWork Eval Run</h1>
+    <div class="meta">
+      Run ID: <code>${escapeHtml(report.runId)}</code><br />
+      Started: ${escapeHtml(report.startedAt)}<br />
+      Finished: ${escapeHtml(report.finishedAt ?? "") }<br />
+      CDP: <code>${escapeHtml(report.cdpUrl)}</code>
+    </div>
+    <div class="summary">
+      <span>Passed: ${report.summary.passed}</span>
+      <span>Failed: ${report.summary.failed}</span>
+      <span>Skipped: ${report.summary.skipped}</span>
+    </div>
+    ${flowSections}
+  </main>
+</body>
+</html>`;
 }
 
 async function main() {
@@ -235,12 +314,14 @@ async function main() {
   report.finishedAt = new Date().toISOString();
   await writeFile(join(outDir, "report.json"), JSON.stringify(report, null, 2));
   await writeFile(join(outDir, "report.md"), renderMarkdown(report));
+  await writeFile(join(outDir, "index.html"), renderFrameIndex(report));
 
   console.log("");
   console.log(
     `Result: ${report.summary.failed > 0 ? "FAILED" : "PASSED"} — ${report.summary.passed} passed, ${report.summary.failed} failed, ${report.summary.skipped} skipped`,
   );
   console.log(`Report: ${join(outDir, "report.md")}`);
+  console.log(`Frames: ${join(outDir, "index.html")}`);
 
   if (report.summary.failed > 0) process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Teach the eval runner to emit a browsable `index.html` frame proof alongside `report.md` and screenshots.
- Update eval docs and Daytona skills so UI validation defaults to coded eval flows plus `--artifacts-volume` frame evidence.
- Reframe manual `browser_eval` usage as debugging/prototyping rather than the preferred PR evidence path.

## Validation
- `pnpm evals --list` passed.
- `git diff --check` passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

