### PR TITLE
fix(landing): align mobile demo content

### DIFF
--- a/ee/apps/landing/components/landing-app-demo-panel.tsx
+++ b/ee/apps/landing/components/landing-app-demo-panel.tsx
@@ -69,7 +69,7 @@ export function LandingAppDemoPanel(props: Props) {
               return (
                 <div
                   key={`${message.role}-${index}`}
-                  className="mt-2 max-w-[85%] self-center rounded-3xl bg-gray-100/80 px-5 py-3 text-center text-gray-800"
+                  className="mt-2 max-w-[85%] self-center break-words rounded-3xl bg-gray-100/80 px-5 py-3 text-center text-gray-800 [overflow-wrap:anywhere]"
                 >
                   {message.content}
                 </div>

--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -162,7 +162,7 @@ export function LandingHome(props: Props) {
               </div>
 
               <div className="relative z-10 mb-4 flex w-full flex-col items-start justify-between gap-4 px-2 md:flex-row md:items-center">
-                <div className="landing-chip flex w-full flex-wrap gap-2 overflow-x-auto rounded-full p-1.5 md:w-[600px]">
+                <div className="landing-chip flex w-full flex-wrap justify-center gap-2 overflow-x-auto rounded-full p-1.5 md:w-[600px] md:justify-start">
                   {landingDemoFlows.map((flow) => {
                     const isActive = flow.id === activeDemo.id;
 


### PR DESCRIPTION
Fixes #2321

Summary
- Centers the landing demo category pills on mobile so Browser Automation, Data Analysis, and Outreach Creation align cleanly.
- Allows long chat-bubble text, including URLs, to wrap instead of overflowing at narrow viewport widths.

Verification
- Verified locally on the landing page in mobile viewport.
- `git diff --check`
- `pnpm --dir ee/apps/landing exec tsc --noEmit`
- `pnpm --dir ee/apps/landing build`
<img width="382" height="260" alt="Screenshot 2026-06-19 at 5 04 11 PM" src="https://github.com/user-attachments/assets/c7a1949f-d82d-40c6-b906-044a772b6554" />
<img width="273" height="286" alt="Screenshot 2026-06-19 at 5 03 46 PM" src="https://github.com/user-attachments/assets/060bea1f-b9c1-4611-b349-159b9d3c33c3" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

