### PR TITLE
Add model switcher to command palette

### DIFF
--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -24,7 +24,7 @@ import {
   CommandShortcut,
 } from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
-import { Check, ChevronLeftIcon, FileText, Globe, Zap } from "lucide-react";
+import { BrainCircuit, Check, ChevronLeftIcon, FileText, Globe, Zap } from "lucide-react";
 
 export type PaletteItem = {
   id: string;
@@ -84,6 +84,9 @@ export type CommandPaletteProps = {
   onCreateNewSession: () => void;
   /** Called when "Open settings" is chosen. Accepts an optional route to jump straight to a tab. */
   onOpenSettings: (route?: string) => void;
+  /** Optional: open the full default-model picker. */
+  onOpenModelPicker?: () => void;
+  selectedModelLabel?: string;
   /** Optional — open a URL in the user's browser. Falls back to window.open. */
   onOpenUrl?: (url: string) => void;
   /** Optional: current session servers/artifacts exposed through Cmd/Ctrl+K. */
@@ -164,6 +167,20 @@ export function CommandPalette(props: CommandPaletteProps) {
         setMode("sessions");
       },
     },
+    ...(props.onOpenModelPicker
+      ? [{
+          id: "models",
+          title: "Switch model",
+          detail: "Choose the LLM that runs your next prompts",
+          meta: props.selectedModelLabel ?? t("session.default_model"),
+          icon: <BrainCircuit className="size-4 text-primary" />,
+          searchText: "model models llm provider openai anthropic claude gpt gemini switch pick select default",
+          action: () => {
+            props.onClose();
+            props.onOpenModelPicker?.();
+          },
+        }]
+      : []),
     ...(props.listAgents
       ? [{
           id: "agents",

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1847,6 +1847,12 @@ export function SessionRoute() {
       }}
       onOpenSession={(workspaceId, sessionId) => navigateToWorkspaceSession(workspaceId, sessionId)}
       onOpenSettings={(route) => handleOpenSettings(route ?? "/settings/general")}
+      onOpenModelPicker={() => {
+        modelPicker.setQuery("");
+        modelPicker.setRecentProviderIds(new Set());
+        window.requestAnimationFrame(() => modelPicker.setOpen(true));
+      }}
+      selectedModelLabel={modelLabel}
       accessibleTargets={paletteAccessibleTargets}
       onOpenAccessibleTarget={(target) => {
         try {


### PR DESCRIPTION
## Summary
- Add a root-level `Switch model` action to Cmd/Ctrl+K.
- Show the current model as command metadata for quick confirmation.
- Reuse the existing default model picker so provider filtering and model selection stay consistent.

## Verification
- `pnpm --filter @openwork/app typecheck` passed.
- `pnpm --filter @openwork/app build` passed with existing bundle-size warnings.
- Daytona Electron validation passed on sandbox `openwork-test-20260619-182944`.

## Daytona Proof Frames
- https://8090-pftgnmalbr7c425e.daytonaproxy01.net/validation/command-palette-model-switcher/index.html

Flow verified: workspace ready -> Ctrl+K shows `Switch model` with current `Big Pickle` model -> selecting it opens the existing model picker.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

