### PR TITLE
feat(voice): add managed OpenWork Models sessions

### DIFF
--- a/apps/app/scripts/_util.mjs
+++ b/apps/app/scripts/_util.mjs
@@ -47,6 +47,7 @@ export async function spawnOpencodeServe({
   hostname = "127.0.0.1",
   port,
   corsOrigins = [],
+  env = {},
 }) {
   assert.ok(directory && directory.trim(), "directory is required");
   assert.ok(Number.isInteger(port) && port > 0, "port must be a positive integer");
@@ -62,6 +63,7 @@ export async function spawnOpencodeServe({
     stdio: ["ignore", "pipe", "pipe"],
     env: {
       ...process.env,
+      ...env,
       // Make it explicit we're a non-TUI client.
       OPENCODE_CLIENT: "openwork-test",
     },

--- a/apps/app/scripts/managed-voice-e2e.mjs
+++ b/apps/app/scripts/managed-voice-e2e.mjs
@@ -1,0 +1,278 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  findFreePort,
+  parseArgs,
+} from "./_util.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const directory = args.get("dir") ?? process.cwd();
+const outDir = resolve(args.get("out") ?? join(process.cwd(), "evals", "results", `managed-voice-${Date.now()}`));
+
+const proofFrames = [];
+const results = {
+  ok: true,
+  outDir,
+  steps: [],
+};
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+async function frame(name, data) {
+  const file = `${String(proofFrames.length + 1).padStart(2, "0")}-${name.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "").toLowerCase()}.html`;
+  const safeData = redactProofData(data);
+  proofFrames.push({ file, name, data: safeData });
+  await writeFile(join(outDir, file), `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(name)}</title>
+  <style>
+    body { margin: 0; background: #f8fafc; color: #111827; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px; }
+    h1 { font-family: system-ui, sans-serif; margin-top: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; padding: 18px; border: 1px solid #d1d5db; border-radius: 14px; background: white; }
+  </style>
+</head>
+<body><main><h1>${escapeHtml(name)}</h1><pre>${escapeHtml(JSON.stringify(safeData, null, 2))}</pre></main></body>
+</html>`, "utf8");
+}
+
+function redactProofData(value) {
+  if (Array.isArray(value)) return value.map(redactProofData);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value).map(([key, entry]) => {
+    if (/token|secret|authorization|api.?key/i.test(key)) return [key, "[redacted]"];
+    if (typeof entry === "string" && /^(owt_|ow_inf_|sk-)/.test(entry)) return [key, "[redacted]"];
+    return [key, redactProofData(entry)];
+  }));
+}
+
+async function renderIndex() {
+  const frames = proofFrames.map((entry) => `
+    <section>
+      <h2>${escapeHtml(entry.name)}</h2>
+      <iframe src="${escapeHtml(entry.file)}" title="${escapeHtml(entry.name)}"></iframe>
+      <p><a href="${escapeHtml(entry.file)}">Open frame</a></p>
+    </section>`).join("\n");
+  await writeFile(join(outDir, "index.html"), `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Managed Voice E2E Proof</title>
+  <style>
+    body { margin: 0; background: #f3f4f6; color: #111827; font-family: system-ui, sans-serif; }
+    main { max-width: 1180px; margin: 0 auto; padding: 32px; }
+    h1 { margin-bottom: 4px; }
+    .meta { color: #4b5563; margin-bottom: 24px; }
+    section { margin: 24px 0; padding: 18px; border: 1px solid #d1d5db; border-radius: 16px; background: white; }
+    iframe { width: 100%; min-height: 430px; border: 1px solid #e5e7eb; border-radius: 12px; background: white; }
+    code { background: #e5e7eb; padding: 2px 5px; border-radius: 5px; }
+  </style>
+</head>
+<body><main>
+  <h1>Managed Voice E2E Proof</h1>
+  <div class="meta">Result: <code>${results.ok ? "passed" : "failed"}</code> · Output: <code>${escapeHtml(outDir)}</code></div>
+${frames}
+</main></body>
+</html>`, "utf8");
+}
+
+function step(name, fn) {
+  results.steps.push({ name, status: "running" });
+  const idx = results.steps.length - 1;
+  return Promise.resolve()
+    .then(fn)
+    .then(async (data) => {
+      results.steps[idx] = { name, status: "ok", data };
+      await frame(name, data);
+      return data;
+    })
+    .catch(async (error) => {
+      results.ok = false;
+      const message = error instanceof Error ? error.message : String(error);
+      results.steps[idx] = { name, status: "error", error: message };
+      await frame(`${name} failure`, { error: message });
+      throw error;
+    });
+}
+
+async function startMockBroker() {
+  const requests = [];
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += String(chunk);
+    });
+    req.on("end", () => {
+      requests.push({ method: req.method, url: req.url, authorization: req.headers.authorization ?? null, body });
+      if (req.method !== "POST" || req.url !== "/voice/realtime/session") {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "not_found" }));
+        return;
+      }
+      if (req.headers.authorization !== "Bearer ow_inf_e2e") {
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { code: "invalid_api_key" } }));
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({
+        ok: true,
+        clientSecret: "managed-e2e-client-secret",
+        expiresAt: 987654321,
+        model: "gpt-realtime-2",
+        transcriptionModel: "gpt-4o-transcribe",
+        tools: ["openwork_snapshot", "openwork_list_actions", "openwork_execute_action"],
+        source: "openwork-models",
+      }));
+    });
+  });
+  const port = await findFreePort();
+  await new Promise((resolveReady) => server.listen(port, "127.0.0.1", resolveReady));
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    requests,
+    close: () => new Promise((resolveClose) => server.close(resolveClose)),
+  };
+}
+
+async function startOpenWorkServer({ directory, port, env }) {
+  const token = "owt_managed_voice_client";
+  const hostToken = "owt_managed_voice_host";
+  const child = spawn("bun", [
+    "apps/server/src/cli.ts",
+    "--host", "127.0.0.1",
+    "--port", String(port),
+    "--token", token,
+    "--host-token", hostToken,
+    "--workspace", directory,
+    "--approval", "auto",
+    "--no-log-requests",
+  ], {
+    cwd: resolve(join(import.meta.dirname, "..", "..", "..")),
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...env, OPENWORK_DEV_MODE: "1" },
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  return {
+    baseUrl,
+    token,
+    hostToken,
+    getStdout: () => stdout,
+    getStderr: () => stderr,
+    async close() {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      child.kill("SIGTERM");
+      await Promise.race([
+        new Promise((resolveExit) => child.once("exit", resolveExit)),
+        new Promise((resolveTimeout) => setTimeout(resolveTimeout, 2500)),
+      ]);
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    },
+  };
+}
+
+async function waitForServerHealthy(baseUrl) {
+  const startedAt = Date.now();
+  let lastError = "";
+  while (Date.now() - startedAt < 30_000) {
+    try {
+      const response = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(2500) });
+      if (response.ok) return response.json();
+      lastError = `${response.status} ${response.statusText}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolvePoll) => setTimeout(resolvePoll, 250));
+  }
+  throw new Error(`Timed out waiting for OpenWork server health: ${lastError}`);
+}
+
+await rm(outDir, { recursive: true, force: true });
+await mkdir(outDir, { recursive: true });
+const envDir = await mkdtemp(join(tmpdir(), "openwork-managed-voice-e2e-"));
+const mockBroker = await startMockBroker();
+const port = await findFreePort();
+const server = await startOpenWorkServer({
+  directory,
+  port,
+  env: {
+    OPENWORK_ENV_STORE: join(envDir, "env.json"),
+    OPENWORK_TOKEN_STORE: join(envDir, "tokens.json"),
+    OPENWORK_API_KEY: "ow_inf_e2e",
+    OPENWORK_INFERENCE_BASE_URL: mockBroker.baseUrl,
+  },
+});
+
+try {
+  await step("server health", async () => waitForServerHealthy(server.baseUrl));
+
+  const owner = await step("owner token", async () => {
+    const response = await fetch(`${server.baseUrl}/tokens`, {
+      method: "POST",
+      headers: { "x-openwork-host-token": server.hostToken, "content-type": "application/json" },
+      body: JSON.stringify({ scope: "owner", label: "managed voice e2e" }),
+    });
+    assert.equal(response.status, 201);
+    const body = await response.json();
+    assert.equal(typeof body.token, "string");
+    return body;
+  });
+
+  const session = await step("managed voice session", async () => {
+    const response = await fetch(`${server.baseUrl}/voice/realtime/session`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${owner.token}`, "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.clientSecret, "managed-e2e-client-secret");
+    assert.equal(body.source, "openwork-models");
+    return body;
+  });
+
+  await step("broker received authenticated request", async () => {
+    assert.equal(mockBroker.requests.length, 1);
+    assert.equal(mockBroker.requests[0].authorization, "Bearer ow_inf_e2e");
+    assert.equal(session.model, "gpt-realtime-2");
+    return mockBroker.requests[0];
+  });
+
+  await renderIndex();
+  console.log(JSON.stringify({ ...results, proof: join(outDir, "index.html") }, null, 2));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  results.ok = false;
+  results.error = message;
+  results.stderr = server.getStderr();
+  results.stdout = server.getStdout?.() ?? "";
+  await renderIndex();
+  console.error(JSON.stringify({ ...results, proof: join(outDir, "index.html") }, null, 2));
+  process.exitCode = 1;
+} finally {
+  await server.close();
+  await mockBroker.close();
+}

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1805,6 +1805,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         model: string;
         transcriptionModel: string;
         tools: string[];
+        source?: string;
       }>(baseUrl, "/voice/realtime/session", {
         token,
         hostToken,

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -353,6 +353,27 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     return next;
   };
 
+  const readCloudProviderBaseUrl = (provider: DenOrgLlmProviderConnection) => {
+    const options = provider.providerConfig.options;
+    if (options && typeof options === "object" && !Array.isArray(options)) {
+      const baseURL = "baseURL" in options ? options.baseURL : undefined;
+      if (typeof baseURL === "string" && baseURL.trim()) return baseURL.trim().replace(/\/api\/v1\/?$/, "");
+    }
+    const api = provider.providerConfig.api;
+    if (typeof api === "string" && api.trim()) return api.trim().replace(/\/api\/v1\/?$/, "");
+    return "";
+  };
+
+  const mirrorOpenWorkModelsVoiceEnv = async (provider: DenOrgLlmProviderConnection, apiKey: string) => {
+    if (provider.source !== "openwork" || !apiKey.trim()) return;
+    const openworkClient = options.openworkServer.getSnapshot().openworkServerClient;
+    if (!openworkClient) return;
+    const baseUrl = readCloudProviderBaseUrl(provider);
+    const entries = [{ key: "OPENWORK_API_KEY", value: apiKey.trim() }];
+    if (baseUrl) entries.push({ key: "OPENWORK_INFERENCE_BASE_URL", value: baseUrl });
+    await openworkClient.upsertUserEnv(entries);
+  };
+
   const readWorkspaceOpenworkConfigRecord = async (): Promise<
     Record<string, unknown>
   > => {
@@ -1395,6 +1416,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           providerID: localProviderId,
           auth: { type: "api", key: apiKey },
         });
+        await mirrorOpenWorkModelsVoiceEnv(provider, apiKey);
       }
       if (existingImported?.providerId && existingImported.providerId !== localProviderId) {
         try {

--- a/apps/server/src/env-routes.e2e.test.ts
+++ b/apps/server/src/env-routes.e2e.test.ts
@@ -17,6 +17,8 @@ const dirs: string[] = [];
 const priorEnvStore = process.env.OPENWORK_ENV_STORE;
 const priorTokenStore = process.env.OPENWORK_TOKEN_STORE;
 const priorOpenAiApiKey = process.env.OPENAI_API_KEY;
+const priorOpenWorkApiKey = process.env.OPENWORK_API_KEY;
+const priorOpenWorkInferenceBaseUrl = process.env.OPENWORK_INFERENCE_BASE_URL;
 const nativeFetch = globalThis.fetch;
 
 function baseConfig(): ServerConfig {
@@ -81,6 +83,16 @@ afterEach(async () => {
     delete process.env.OPENAI_API_KEY;
   } else {
     process.env.OPENAI_API_KEY = priorOpenAiApiKey;
+  }
+  if (priorOpenWorkApiKey === undefined) {
+    delete process.env.OPENWORK_API_KEY;
+  } else {
+    process.env.OPENWORK_API_KEY = priorOpenWorkApiKey;
+  }
+  if (priorOpenWorkInferenceBaseUrl === undefined) {
+    delete process.env.OPENWORK_INFERENCE_BASE_URL;
+  } else {
+    process.env.OPENWORK_INFERENCE_BASE_URL = priorOpenWorkInferenceBaseUrl;
   }
   globalThis.fetch = nativeFetch;
 });
@@ -352,6 +364,57 @@ describe("env routes", () => {
       ok: true,
       clientSecret: "rt-secret",
       expiresAt: 123,
+    });
+  });
+
+  test("voice realtime session prefers OpenWork Models broker when configured", async () => {
+    process.env.OPENWORK_API_KEY = "ow_inf_test";
+    process.env.OPENWORK_INFERENCE_BASE_URL = "https://inference.example.test";
+    process.env.OPENAI_API_KEY = "sk-should-not-be-used";
+    const { base } = await boot();
+
+    globalThis.fetch = ((input, init) => {
+      const url = String(input);
+      if (url === "https://inference.example.test/voice/realtime/session") {
+        expect(init?.headers).toMatchObject({ Authorization: "Bearer ow_inf_test" });
+        return Promise.resolve(new Response(JSON.stringify({
+          ok: true,
+          clientSecret: "managed-rt-secret",
+          expiresAt: 456,
+          model: "gpt-realtime-2",
+          transcriptionModel: "gpt-4o-transcribe",
+          tools: ["openwork_snapshot"],
+          source: "openwork-models",
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }));
+      }
+      if (url === "https://api.openai.com/v1/realtime/client_secrets") {
+        return Promise.resolve(new Response("direct OpenAI should not be called", { status: 500 }));
+      }
+      return nativeFetch(input, init);
+    }) as typeof fetch;
+
+    const issued = await fetch(`${base}/tokens`, {
+      method: "POST",
+      headers: hostAuth(),
+      body: JSON.stringify({ scope: "owner", label: "managed voice owner" }),
+    });
+    const tokenBody = (await issued.json()) as { token: string };
+
+    const response = await fetch(`${base}/voice/realtime/session`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${tokenBody.token}`, "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      clientSecret: "managed-rt-secret",
+      expiresAt: 456,
+      source: "openwork-models",
     });
   });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -277,6 +277,26 @@ async function resolveOpenAiRealtimeApiKey(env: EnvService): Promise<string> {
     "";
 }
 
+async function resolveOpenWorkModelsVoiceConfig(env: EnvService): Promise<{ baseUrl: string; apiKey: string } | null> {
+  const records = await env.list();
+  const apiKey =
+    records.find((entry) => entry.key === "OPENWORK_API_KEY")?.value.trim() ||
+    records.find((entry) => entry.key === "OPENWORK_MODELS_API_KEY")?.value.trim() ||
+    process.env.OPENWORK_API_KEY?.trim() ||
+    process.env.OPENWORK_MODELS_API_KEY?.trim() ||
+    "";
+  if (!apiKey) return null;
+
+  const baseUrl =
+    records.find((entry) => entry.key === "OPENWORK_INFERENCE_BASE_URL")?.value.trim() ||
+    records.find((entry) => entry.key === "OPENWORK_MODELS_BASE_URL")?.value.trim() ||
+    process.env.OPENWORK_INFERENCE_BASE_URL?.trim() ||
+    process.env.OPENWORK_MODELS_BASE_URL?.trim() ||
+    "";
+  if (!baseUrl) return null;
+  return { apiKey, baseUrl: baseUrl.replace(/\/+$/, "") };
+}
+
 function openworkVoiceRealtimeInstructions() {
   return `# Role and Objective
 
@@ -323,6 +343,34 @@ function readOpenAiClientSecret(payload: unknown): { clientSecret: string; expir
 }
 
 async function createOpenAiRealtimeVoiceSession(env: EnvService, input: unknown) {
+  const managedVoice = await resolveOpenWorkModelsVoiceConfig(env);
+  if (managedVoice) {
+    const response = await fetch(`${managedVoice.baseUrl}/voice/realtime/session`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${managedVoice.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(input ?? {}),
+    });
+    const text = await response.text();
+    let payload: unknown = null;
+    try {
+      payload = text ? JSON.parse(text) : null;
+    } catch {
+      payload = null;
+    }
+    if (!response.ok) {
+      const errorPayload = isRecord(payload) && isRecord(payload.error) ? payload.error : null;
+      const message = typeof errorPayload?.message === "string" ? errorPayload.message : response.statusText;
+      throw new ApiError(response.status, "openwork_models_voice_failed", message || "OpenWork Models could not create a voice session");
+    }
+    if (!isRecord(payload) || payload.ok !== true || typeof payload.clientSecret !== "string") {
+      throw new ApiError(502, "openwork_models_voice_invalid_response", "OpenWork Models did not return a usable Realtime client secret");
+    }
+    return payload;
+  }
+
   const apiKey = await resolveOpenAiRealtimeApiKey(env);
   if (!apiKey) {
     throw new ApiError(

--- a/ee/apps/inference/src/app.ts
+++ b/ee/apps/inference/src/app.ts
@@ -8,6 +8,7 @@ import { logger } from "hono/logger";
 import { z } from "zod";
 import { env } from "./env.js";
 import { registerProxyRoutes } from "./proxy.js";
+import { registerVoiceRoutes } from "./voice.js";
 import { registerWebhookRoutes } from "./webhooks.js";
 
 const srcDir = path.dirname(fileURLToPath(import.meta.url));
@@ -65,6 +66,7 @@ if (shouldServeLocalModelCatalog) {
 }
 
 registerProxyRoutes(app);
+registerVoiceRoutes(app);
 registerWebhookRoutes(app);
 
 app.onError((error, c) => {

--- a/ee/apps/inference/src/env.ts
+++ b/ee/apps/inference/src/env.ts
@@ -14,6 +14,8 @@ const EnvSchema = z
     DEN_DB_ENCRYPTION_KEY: z.string().trim().min(32),
     INFERENCE_PROXY_BASE_URL: z.string().optional(),
     OPENROUTER_UPSTREAM_URL: z.string().optional(),
+    OPENAI_REALTIME_API_KEY: z.string().optional(),
+    OPENAI_API_KEY: z.string().optional(),
     INFERENCE_ADMIN_TOKEN: z.string().optional(),
     INFERENCE_WEBHOOK_SECRET: z.string().optional(),
     INFERENCE_CREDITS_PER_DOLLAR: z.string().optional(),
@@ -120,6 +122,7 @@ export const env = {
   openRouterUpstreamUrl: normalizeUrl(
     parsed.OPENROUTER_UPSTREAM_URL ?? "https://openrouter.ai/api/v1",
   ),
+  openAiRealtimeApiKey: optionalString(parsed.OPENAI_REALTIME_API_KEY) ?? optionalString(parsed.OPENAI_API_KEY),
   adminToken: optionalString(parsed.INFERENCE_ADMIN_TOKEN),
   webhookSecret: optionalString(parsed.INFERENCE_WEBHOOK_SECRET),
   creditsPerDollar: parseCreditsPerDollar(parsed.INFERENCE_CREDITS_PER_DOLLAR),

--- a/ee/apps/inference/src/voice.ts
+++ b/ee/apps/inference/src/voice.ts
@@ -1,0 +1,192 @@
+import { createHash } from "node:crypto"
+import type { Hono } from "hono"
+import { env } from "./env.js"
+import { findActiveInferenceKey } from "./keys.js"
+import { ensureUsableBuckets } from "./limits.js"
+
+const OPENWORK_VOICE_REALTIME_MODEL = "gpt-realtime-2"
+const OPENWORK_VOICE_TRANSCRIPTION_MODEL = "gpt-4o-transcribe"
+
+const OPENWORK_VOICE_REALTIME_TOOLS = [
+  {
+    type: "function",
+    name: "openwork_snapshot",
+    description: "Read the current OpenWork UI control snapshot: route, status, narration, and visible action metadata.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    type: "function",
+    name: "openwork_list_actions",
+    description: "List semantic OpenWork UI actions. Call this before openwork_execute_action when you do not know the exact action id.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    type: "function",
+    name: "openwork_execute_action",
+    description: "Execute a semantic OpenWork UI action by id. Prefer this over screen coordinates or DOM guessing.",
+    parameters: {
+      type: "object",
+      properties: {
+        actionId: { type: "string", description: "The action id from openwork_list_actions, such as composer.set_text or composer.send." },
+        args: { type: "object", description: "Optional JSON arguments for the action.", additionalProperties: true },
+      },
+      required: ["actionId"],
+      additionalProperties: false,
+    },
+  },
+]
+
+function readApiKey(request: Request) {
+  const auth = request.headers.get("authorization")
+  if (auth?.toLowerCase().startsWith("bearer ")) {
+    return auth.slice(7).trim()
+  }
+  return request.headers.get("x-api-key")?.trim() ?? null
+}
+
+function buildRequestId() {
+  return createHash("sha256").update(`${Date.now()}:${Math.random()}`).digest("hex").slice(0, 32)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readStringField(value: unknown, key: string) {
+  if (!isRecord(value)) return ""
+  const field = value[key]
+  return typeof field === "string" ? field.trim() : ""
+}
+
+function readOpenAiClientSecret(payload: unknown): { clientSecret: string; expiresAt: number | null } {
+  if (!isRecord(payload)) return { clientSecret: "", expiresAt: null }
+  const clientSecret = payload.client_secret
+  if (typeof clientSecret === "string") return { clientSecret, expiresAt: null }
+  if (isRecord(clientSecret)) {
+    const value = typeof clientSecret.value === "string" ? clientSecret.value : ""
+    const expiresAt = typeof clientSecret.expires_at === "number" ? clientSecret.expires_at : null
+    return { clientSecret: value, expiresAt }
+  }
+  const value = typeof payload.value === "string" ? payload.value : ""
+  return { clientSecret: value, expiresAt: null }
+}
+
+function openworkVoiceRealtimeInstructions() {
+  return `# Role and Objective
+
+You are OpenWork Voice Mode, a voice-first control layer inside OpenWork.
+Help the user control OpenWork by using the semantic OpenWork UI tools.
+
+# Tool Policy
+
+- Prefer openwork_snapshot, openwork_list_actions, and openwork_execute_action over visual guessing.
+- If the user asks to write or draft something, use composer.set_text.
+- If the user asks to send or run the current prompt, use composer.send.
+- For navigation, settings, session, transcript, and composer work, inspect the action list first if the action id is unknown.
+- Do not claim an action completed until the tool succeeds.
+- Ask for confirmation before destructive actions such as deleting a session.
+
+# Voice Style
+
+- Be concise, calm, and direct.
+- If audio is unclear, ask the user to repeat it instead of guessing.
+- Ignore background speech that is not addressed to OpenWork.
+- Summarize tool results briefly and offer the next useful step.`
+}
+
+async function createOpenAiRealtimeClientSecret(input: unknown, openworkRequestId: string) {
+  if (!env.openAiRealtimeApiKey) {
+    return Response.json({ error: { message: "Managed voice is not configured.", type: "invalid_request_error", code: "openai_realtime_key_missing" } }, { status: 503 })
+  }
+
+  const model = readStringField(input, "model") || OPENWORK_VOICE_REALTIME_MODEL
+  const response = await fetch("https://api.openai.com/v1/realtime/client_secrets", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.openAiRealtimeApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      session: {
+        type: "realtime",
+        model,
+        output_modalities: ["audio"],
+        audio: {
+          input: {
+            transcription: { model: OPENWORK_VOICE_TRANSCRIPTION_MODEL, language: "en" },
+            turn_detection: {
+              type: "server_vad",
+              threshold: 0.58,
+              silence_duration_ms: 320,
+              prefix_padding_ms: 300,
+              create_response: true,
+              interrupt_response: true,
+            },
+          },
+        },
+        instructions: openworkVoiceRealtimeInstructions(),
+        tool_choice: "auto",
+        tools: OPENWORK_VOICE_REALTIME_TOOLS,
+      },
+    }),
+  })
+
+  const text = await response.text()
+  let payload: unknown = null
+  try {
+    payload = text ? JSON.parse(text) : null
+  } catch {
+    payload = null
+  }
+
+  if (!response.ok) {
+    const errorPayload = isRecord(payload) && isRecord(payload.error) ? payload.error : null
+    const message = typeof errorPayload?.message === "string" ? errorPayload.message : response.statusText
+    return Response.json({ error: { message: message || "Failed to create OpenAI Realtime session", type: "api_error", code: "openai_realtime_failed" } }, { status: response.status })
+  }
+
+  const { clientSecret, expiresAt } = readOpenAiClientSecret(payload)
+  if (!clientSecret) {
+    return Response.json({ error: { message: "OpenAI did not return a usable Realtime client secret.", type: "api_error", code: "openai_realtime_invalid_response" } }, { status: 502 })
+  }
+
+  return Response.json({
+    ok: true,
+    clientSecret,
+    expiresAt,
+    model,
+    transcriptionModel: OPENWORK_VOICE_TRANSCRIPTION_MODEL,
+    tools: OPENWORK_VOICE_REALTIME_TOOLS.map((tool) => tool.name),
+    source: "openwork-models",
+    openworkRequestId,
+  })
+}
+
+export function registerVoiceRoutes(app: Hono) {
+  app.post("/voice/realtime/session", async (c) => {
+    const rawKey = readApiKey(c.req.raw)
+    if (!rawKey) {
+      return c.json({ error: { message: "Missing OpenWork inference API key.", type: "authentication_error", code: "missing_api_key" } }, 401)
+    }
+
+    const inferenceKey = await findActiveInferenceKey(rawKey)
+    if (!inferenceKey) {
+      return c.json({ error: { message: "Invalid OpenWork inference API key.", type: "authentication_error", code: "invalid_api_key" } }, 401)
+    }
+
+    const limits = await ensureUsableBuckets(inferenceKey.organization_id)
+    if (!limits.ok) {
+      return c.json({ error: { message: `Rate limit reached for organization ${inferenceKey.organization_id}.`, type: "tokens", code: "rate_limit_exceeded" } }, 429)
+    }
+
+    const openworkRequestId = buildRequestId()
+    let body: unknown = {}
+    try {
+      body = await c.req.json()
+    } catch {
+      body = {}
+    }
+
+    return createOpenAiRealtimeClientSecret(body, openworkRequestId)
+  })
+}

--- a/evals/results/managed-voice-pr-proof/01-server-health.html
+++ b/evals/results/managed-voice-pr-proof/01-server-health.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>server health</title>
+  <style>
+    body { margin: 0; background: #f8fafc; color: #111827; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px; }
+    h1 { font-family: system-ui, sans-serif; margin-top: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; padding: 18px; border: 1px solid #d1d5db; border-radius: 14px; background: white; }
+  </style>
+</head>
+<body><main><h1>server health</h1><pre>{
+  &quot;ok&quot;: true,
+  &quot;version&quot;: &quot;0.17.1&quot;,
+  &quot;opencodeVersion&quot;: &quot;1.17.3&quot;,
+  &quot;uptimeMs&quot;: 207
+}</pre></main></body>
+</html>

--- a/evals/results/managed-voice-pr-proof/02-owner-token.html
+++ b/evals/results/managed-voice-pr-proof/02-owner-token.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>owner token</title>
+  <style>
+    body { margin: 0; background: #f8fafc; color: #111827; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px; }
+    h1 { font-family: system-ui, sans-serif; margin-top: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; padding: 18px; border: 1px solid #d1d5db; border-radius: 14px; background: white; }
+  </style>
+</head>
+<body><main><h1>owner token</h1><pre>{
+  &quot;id&quot;: &quot;858b374f-ad64-4e83-a809-baa0569ff33f&quot;,
+  &quot;token&quot;: &quot;[redacted]&quot;,
+  &quot;scope&quot;: &quot;owner&quot;,
+  &quot;createdAt&quot;: 1781986721053,
+  &quot;label&quot;: &quot;managed voice e2e&quot;
+}</pre></main></body>
+</html>

--- a/evals/results/managed-voice-pr-proof/02-owner-token.html
+++ b/evals/results/managed-voice-pr-proof/02-owner-token.html
@@ -12,10 +12,10 @@
   </style>
 </head>
 <body><main><h1>owner token</h1><pre>{
-  &quot;id&quot;: &quot;858b374f-ad64-4e83-a809-baa0569ff33f&quot;,
+  &quot;id&quot;: &quot;4af562f6-1472-4c54-b275-4ce25d70f568&quot;,
   &quot;token&quot;: &quot;[redacted]&quot;,
   &quot;scope&quot;: &quot;owner&quot;,
-  &quot;createdAt&quot;: 1781986721053,
+  &quot;createdAt&quot;: 1781986782006,
   &quot;label&quot;: &quot;managed voice e2e&quot;
 }</pre></main></body>
 </html>

--- a/evals/results/managed-voice-pr-proof/03-managed-voice-session.html
+++ b/evals/results/managed-voice-pr-proof/03-managed-voice-session.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>managed voice session</title>
+  <style>
+    body { margin: 0; background: #f8fafc; color: #111827; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px; }
+    h1 { font-family: system-ui, sans-serif; margin-top: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; padding: 18px; border: 1px solid #d1d5db; border-radius: 14px; background: white; }
+  </style>
+</head>
+<body><main><h1>managed voice session</h1><pre>{
+  &quot;ok&quot;: true,
+  &quot;clientSecret&quot;: &quot;[redacted]&quot;,
+  &quot;expiresAt&quot;: 987654321,
+  &quot;model&quot;: &quot;gpt-realtime-2&quot;,
+  &quot;transcriptionModel&quot;: &quot;gpt-4o-transcribe&quot;,
+  &quot;tools&quot;: [
+    &quot;openwork_snapshot&quot;,
+    &quot;openwork_list_actions&quot;,
+    &quot;openwork_execute_action&quot;
+  ],
+  &quot;source&quot;: &quot;openwork-models&quot;
+}</pre></main></body>
+</html>

--- a/evals/results/managed-voice-pr-proof/04-broker-received-authenticated-request.html
+++ b/evals/results/managed-voice-pr-proof/04-broker-received-authenticated-request.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>broker received authenticated request</title>
+  <style>
+    body { margin: 0; background: #f8fafc; color: #111827; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px; }
+    h1 { font-family: system-ui, sans-serif; margin-top: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; padding: 18px; border: 1px solid #d1d5db; border-radius: 14px; background: white; }
+  </style>
+</head>
+<body><main><h1>broker received authenticated request</h1><pre>{
+  &quot;method&quot;: &quot;POST&quot;,
+  &quot;url&quot;: &quot;/voice/realtime/session&quot;,
+  &quot;authorization&quot;: &quot;[redacted]&quot;,
+  &quot;body&quot;: &quot;{}&quot;
+}</pre></main></body>
+</html>

--- a/evals/results/managed-voice-pr-proof/index.html
+++ b/evals/results/managed-voice-pr-proof/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Managed Voice E2E Proof</title>
+  <style>
+    body { margin: 0; background: #f3f4f6; color: #111827; font-family: system-ui, sans-serif; }
+    main { max-width: 1180px; margin: 0 auto; padding: 32px; }
+    h1 { margin-bottom: 4px; }
+    .meta { color: #4b5563; margin-bottom: 24px; }
+    section { margin: 24px 0; padding: 18px; border: 1px solid #d1d5db; border-radius: 16px; background: white; }
+    iframe { width: 100%; min-height: 430px; border: 1px solid #e5e7eb; border-radius: 12px; background: white; }
+    code { background: #e5e7eb; padding: 2px 5px; border-radius: 5px; }
+  </style>
+</head>
+<body><main>
+  <h1>Managed Voice E2E Proof</h1>
+  <div class="meta">Result: <code>passed</code> · Output: <code>/Users/benjaminshafii/openwork-enterprise/_repos/openwork-managed-voice/evals/results/managed-voice-pr-proof</code></div>
+
+    <section>
+      <h2>server health</h2>
+      <iframe src="01-server-health.html" title="server health"></iframe>
+      <p><a href="01-server-health.html">Open frame</a></p>
+    </section>
+
+    <section>
+      <h2>owner token</h2>
+      <iframe src="02-owner-token.html" title="owner token"></iframe>
+      <p><a href="02-owner-token.html">Open frame</a></p>
+    </section>
+
+    <section>
+      <h2>managed voice session</h2>
+      <iframe src="03-managed-voice-session.html" title="managed voice session"></iframe>
+      <p><a href="03-managed-voice-session.html">Open frame</a></p>
+    </section>
+
+    <section>
+      <h2>broker received authenticated request</h2>
+      <iframe src="04-broker-received-authenticated-request.html" title="broker received authenticated request"></iframe>
+      <p><a href="04-broker-received-authenticated-request.html">Open frame</a></p>
+    </section>
+</main></body>
+</html>


### PR DESCRIPTION
## Summary
- Add an OpenWork Models voice broker endpoint to the inference service that authenticates inference keys, checks org buckets, and mints OpenAI Realtime client secrets server-side.
- Make the local OpenWork server prefer the managed broker when an OpenWork Models key/base URL is configured, while keeping BYO OpenAI fallback.
- Mirror imported OpenWork Models credentials into the local OpenWork env store so voice is included after provider import.
- Add script-first managed voice e2e proof with committed redacted HTML frames.

## Proof
- HTML frame proof: `evals/results/managed-voice-pr-proof/index.html`
- Frames: server health, owner token creation, managed voice session response, authenticated broker request.
- Proof files were regenerated by `node apps/app/scripts/managed-voice-e2e.mjs --out evals/results/managed-voice-pr-proof`.
- Proof HTML was checked for token/client-secret patterns with no matches for `owt_|ow_inf_|Bearer|managed-e2e-client-secret`.

## Tests
- `pnpm --filter openwork-server test src/env-routes.e2e.test.ts` passed: 18 pass, 0 fail.
- `pnpm --filter openwork-server typecheck` passed.
- `pnpm --filter @openwork/app typecheck` passed.
- `pnpm --filter @openwork-ee/inference build` passed.
- `node apps/app/scripts/managed-voice-e2e.mjs --out evals/results/managed-voice-pr-proof` passed.
