### PR TITLE
chore(evals): validate frame proof evidence

### DIFF
--- a/.opencode/skills/daytona-cloud-instance/SKILL.md
+++ b/.opencode/skills/daytona-cloud-instance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daytona-cloud-instance
-description: Daytona cloud instance, Den server, OpenWork Cloud, Marketplace onboarding. Use when the user asks to run, launch, start, validate, or record a Daytona cloud/Den instance for OpenWork Cloud flows.
+description: Daytona cloud instance, Den server, OpenWork Cloud, Marketplace onboarding, desktop plus cloud e2e, frame proof. Use when launching, validating, or recording Daytona cloud/Den flows.
 ---
 
 # Daytona Cloud Instance

--- a/.opencode/skills/daytona-cloud-server/SKILL.md
+++ b/.opencode/skills/daytona-cloud-server/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daytona-cloud-server
-description: Daytona cloud server and Den sandbox setup. Use when the user says Daytona server, cloud server, Den server, marketplace server, worker proxy, cloud auth, org policies, or connect Electron to a Daytona server.
+description: Daytona cloud server, Den sandbox, desktop plus cloud e2e, marketplace server, worker proxy, cloud auth, org policies, connect Electron to Den. Use for server-side setup in validated flows.
 ---
 
 # Daytona Cloud Server

--- a/.opencode/skills/daytona-electron-den/SKILL.md
+++ b/.opencode/skills/daytona-electron-den/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daytona-electron-den
-description: Validate Electron against a Daytona Den server. Use for two-sandbox cloud auth, marketplace, org policy, worker proxy, provider sync, or desktop handoff flows.
+description: Electron and Den, desktop plus cloud, two-sandbox e2e, cloud auth, marketplace, org policy, worker proxy, provider sync, desktop handoff. Validate Electron against a Daytona Den server with unified proof.
 ---
 
 # Daytona Electron Against Den

--- a/.opencode/skills/daytona-electron-test/SKILL.md
+++ b/.opencode/skills/daytona-electron-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daytona-electron-test
-description: "Daytona Electron sandbox testing with CDP/noVNC. Use when the user says test on Daytona, run Electron on Daytona, Daytona dry run, test Electron remotely, reproduce on Daytona, or validate a real desktop flow."
+description: "do e2e tests, run e2e, test on Daytona, run Electron on Daytona, validate feature, real desktop flow, CDP/noVNC, PR proof. Launch and drive OpenWork Electron in Daytona with validated frame evidence."
 ---
 
 # Skill: Daytona Electron Test

--- a/.opencode/skills/daytona-flow-validator/SKILL.md
+++ b/.opencode/skills/daytona-flow-validator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daytona-flow-validator
-description: Daytona UI flow validation loop. Use when validating real app behavior, checking a Daytona flow, proving a bug is fixed, or deciding pass/fail from CDP snapshots, screenshots, and assertions.
+description: do e2e tests, validate feature, prove it works, pass/fail, frame proof, screenshots, CDP assertions. Daytona validation loop for real app behavior with repair before declaring success.
 ---
 
 # Daytona Flow Validator
@@ -22,6 +22,10 @@ action must follow this loop:
 5. Capture a screenshot checkpoint when the visible state matters.
 
 If any assertion is missing, the flow is not validated yet.
+
+When a coded eval exists, prefer `pnpm evals --flow <flow-id>` because the runner
+binds assertions, screenshots, and validation metadata into one HTML proof. Use
+manual CDP only to debug or to create a new coded flow.
 
 Use `browser_eval`, direct API calls, localStorage writes, filesystem edits, or
 database changes only when a human-visible path is impossible, unavailable in the
@@ -179,6 +183,20 @@ If any check fails, mark the evidence as failed, fix the visible state, capture 
 new screenshot, inspect the new image, and only then share it. If bad evidence
 was already posted, post a superseding correction that clearly says the earlier
 screenshot was invalid.
+
+## Repair Loop
+
+If a frame does not support the claim, repair before reporting a verdict:
+
+1. Diagnose why the frame is invalid: wrong route, hidden target, duplicate
+   screenshot, error state, native dialog, stale modal, or unreadable content.
+2. Repair the visible state: close blockers, activate the intended window, wait
+   for text/route stability, scroll the target into view, or rerun the visible
+   action.
+3. Reassert the expected state with CDP.
+4. Capture a new frame with a new name.
+5. Include repair attempts in the final report. If repair fails, report
+   `Incomplete` or `Failed`, not `Passed`.
 
 Before every Daytona display screenshot, run a native-window check and fail fast
 if a picker is present:

--- a/.opencode/skills/daytona-recording-artifacts/SKILL.md
+++ b/.opencode/skills/daytona-recording-artifacts/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: daytona-recording-artifacts
-description: Daytona recording volume, screenshots, artifacts, and validation evidence. Use when the user says record Daytona, recording volume, artifacts volume, screenshots, proof, PR evidence, before/after video, or validate behavior visually.
+description: frame proof, HTML frames, screenshots, recording, PR proof, e2e evidence, validate visually. Daytona artifacts workflow for validated screenshots and optional videos.
 ---
 
 # Daytona Recording Artifacts
 
 Use this skill to collect proof that a Daytona UI flow works.
-Use `daytona-flow-validator` before declaring the flow passed.
+Use `daytona-flow-validator` before declaring the flow passed. If the user asks
+to do e2e tests for a feature, frame proof is required unless they explicitly
+ask for non-UI or mock-only validation.
 
 ## Default: Frame-by-Frame HTML Proof
 
@@ -25,8 +27,9 @@ When a coded eval exists, prefer the eval runner frame output first:
 pnpm evals --flow <flow-id> --cdp-url <printed-electron-cdp-url>
 ```
 
-The runner writes `evals/results/<run-id>/index.html` plus PNG screenshots from
-`ctx.screenshot(...)`. Serve or copy that result directory for PR evidence.
+The runner writes `evals/results/<run-id>/index.html` plus validated PNG evidence
+from `ctx.prove(...)` and `ctx.screenshot(...)`. Serve or copy that result
+directory for PR evidence.
 
 ### How to produce frame proof
 

--- a/.opencode/skills/daytona-secrets-volume/SKILL.md
+++ b/.opencode/skills/daytona-secrets-volume/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daytona-secrets-volume
-description: Daytona secrets volume setup. Use when the user says Daytona secrets, add provider key, OpenAI key, Anthropic key, eval secrets, /daytona-secrets, or openwork-eval-secrets.
+description: Daytona secrets, provider key, OpenAI key, Anthropic key, real model e2e, voice e2e, eval secrets, /daytona-secrets, openwork-eval-secrets. Use for real provider tests in Daytona.
 ---
 
 # Daytona Secrets Volume

--- a/.opencode/skills/run-evals/SKILL.md
+++ b/.opencode/skills/run-evals/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-evals
-description: Run OpenWork UI evals on a Daytona sandbox or local Electron instance. Handles sandbox creation, service startup, and eval execution via CDP browser tools.
+description: do e2e tests, run e2e, validate feature, prove it works, PR proof, frame proof, pnpm evals. Runs OpenWork UI evals on Daytona or local Electron with CDP and validated HTML frame evidence.
 ---
 
 # Skill: Run Evals
@@ -9,9 +9,9 @@ Run the OpenWork UI evaluation flows against a real Electron app. Prefer a fresh
 
 ## When to use
 
-- User says "run evals on Daytona" or "run this flow on Daytona"
-- User wants to verify a UI change end-to-end
-- User wants to test the onboarding, session, or settings flows
+- User says "do e2e tests for <feature>", "run e2e", "validate feature", "prove it works", "PR proof", "frame proof", or "run evals on Daytona".
+- User wants to verify a UI change end-to-end against the real Electron app.
+- User wants to test onboarding, session, settings, cloud, Marketplace, provider, or voice flows.
 
 ## Prerequisites
 
@@ -108,9 +108,9 @@ pnpm evals --list
 pnpm evals --flow <flow-id> --cdp-url <printed-electron-cdp-url>
 ```
 
-The runner uses CDP directly, produces machine-checkable assertions, and writes
-`report.json`, `report.md`, screenshots, and a browseable `index.html` frame
-proof under `evals/results/<run-id>/`.
+The runner uses CDP directly, produces machine-checkable assertions, validates
+proof screenshots, and writes `report.json`, `report.md`, screenshots, and a
+browseable `index.html` frame proof under `evals/results/<run-id>/`.
 
 If no coded flow exists yet for the UI behavior under test, add or adapt a
 `evals/flows/*.flow.mjs` file and use the runner helpers:
@@ -118,9 +118,16 @@ If no coded flow exists yet for the UI behavior under test, add or adapt a
 - `ctx.clickText("Button label")`
 - `ctx.fill("input-or-textarea-selector", "value")`
 - `ctx.waitFor("JavaScript condition")`
-- `ctx.waitForText("Visible text")`
+- `ctx.expectText("Visible text")`
+- `ctx.expectNoText("Error text")`
+- `ctx.expectHashIncludes("/route")`
 - `ctx.control("action.id", args)`
-- `ctx.screenshot("checkpoint-name")`
+- `ctx.prove("claim", { action, assert, screenshot })`
+- `ctx.screenshot("checkpoint-name", { claim, requireText, rejectText, hashIncludes })`
+
+For PR evidence, do not leave screenshots as a loose gallery. Each important
+frame should have a claim and validation checks. If screenshot validation fails,
+repair the visible state and recapture before reporting `Passed`.
 
 Use manual browser tools only to debug/prototype a flow or when product UI
 cannot expose the needed state yet. Do not report ad hoc browser calls as the
@@ -138,7 +145,8 @@ For each step:
 5. Capture screenshot/recording evidence when the visible state matters.
 
 Use the `daytona-flow-validator` skill for pass/fail decisions. If there is no
-post-action assertion, report `Incomplete`, not `Passed`.
+post-action assertion or the frame evidence does not visibly support the claim,
+report `Incomplete`, not `Passed`.
 
 ### Manual browser-tool fallback techniques
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -105,7 +105,14 @@ plugin (configured in `.opencode/opencode.json`). Every tool takes
 
 - Prefer coded flows in `evals/flows/*.flow.mjs` over ad hoc browser tool calls.
 - Use runner helpers such as `ctx.clickText`, `ctx.fill`, `ctx.waitFor`,
-  `ctx.waitForText`, `ctx.control`, and `ctx.screenshot`.
+  `ctx.expectText`, `ctx.expectNoText`, `ctx.expectHashIncludes`,
+  `ctx.control`, `ctx.prove`, and validated `ctx.screenshot` calls.
+- Prefer `ctx.prove("claim", { action, assert, screenshot })` for PR evidence.
+  It records the claim, assertions, screenshot, and validation results together
+  so the HTML frame proof explains why each image proves the step.
+- Screenshots should include `claim`, `requireText`, `rejectText`, or
+  `hashIncludes` whenever possible. A screenshot without an assertion is only a
+  visual checkpoint, not proof that the workflow passed.
 - Use direct `browser_eval` only for debugging/prototyping or when a flow has
   not yet been codified. If the behavior matters for a PR, codify it before
   calling the UI validation complete.
@@ -115,6 +122,24 @@ plugin (configured in `.opencode/opencode.json`). Every tool takes
   `__reactFiber$` → reducer dispatch pattern documented in `daytona-flows.md`.
 - Prefer poll-until-condition waits (`ctx.waitFor`, `ctx.waitForText`) over
   fixed sleeps.
+
+## Evidence and repair standard
+
+Frame proof is the default for UI evals. The generated `index.html` should show
+each step, the claim being proven, assertions, screenshot validation checks, and
+supporting images. Treat recordings as supplementary evidence for motion, not as
+the primary pass/fail source.
+
+Before reporting a flow as passed:
+- Confirm every important user-visible claim has an assertion.
+- Confirm every important screenshot has validation metadata and is not just a
+  loose gallery image.
+- Re-capture or repair evidence if the screenshot is duplicated, missing required
+  text, showing an error state, or taken on the wrong route.
+- For Daytona display screenshots, also verify no native picker, modal, stale
+  dialog, or unrelated desktop window is covering the claimed state.
+- If the test used API/localStorage/setup shortcuts, label that evidence as setup
+  and resume visible proof at the next user-facing step.
 
 ## Files
 

--- a/evals/flows/analytics-task-events.flow.mjs
+++ b/evals/flows/analytics-task-events.flow.mjs
@@ -72,7 +72,10 @@ export default {
           "window.__openwork.events(200).filter((e) => e.name.startsWith('analytics.')).map((e) => e.name)",
         );
         ctx.log(`analytics events: ${JSON.stringify(events)}`);
-        await ctx.screenshot("task-created");
+        await ctx.screenshot("task-created", {
+          claim: "The app remains visibly usable after task creation analytics are captured.",
+          rejectText: ["Something went wrong"],
+        });
       },
     },
   ],

--- a/evals/flows/app-smoke.flow.mjs
+++ b/evals/flows/app-smoke.flow.mjs
@@ -40,7 +40,9 @@ export default {
         await ctx.waitFor("document.body.innerText.trim().length > 40", {
           label: "rendered body text",
         });
-        await ctx.screenshot("booted");
+        await ctx.screenshot("booted", {
+          claim: "The app rendered meaningful visible content after boot.",
+        });
       },
     },
   ],

--- a/evals/flows/cloud-account-renders.flow.mjs
+++ b/evals/flows/cloud-account-renders.flow.mjs
@@ -18,10 +18,7 @@ export default {
       name: "Navigate to Settings -> Cloud -> Account",
       run: async (ctx) => {
         await ctx.navigateHash("/settings/cloud-account");
-        await ctx.waitFor(
-          "window.location.hash.includes('/settings/cloud-account')",
-          { label: "cloud account route" },
-        );
+        await ctx.expectHashIncludes("/settings/cloud-account");
       },
     },
     {
@@ -38,7 +35,12 @@ export default {
         );
         const signedIn = await ctx.hasText("Sign out");
         ctx.log(`cloud account state: ${signedIn ? "signed in" : "signed out"}`);
-        await ctx.screenshot("cloud-account");
+        await ctx.screenshot("cloud-account", {
+          claim: "Cloud Account renders either signed-in controls or the signed-out paste-code entry point.",
+          requireText: [signedIn ? "Sign out" : "Paste sign-in code"],
+          rejectText: ["Something went wrong"],
+          hashIncludes: "/settings/cloud-account",
+        });
       },
     },
   ],

--- a/evals/flows/cloud-mcp-auto-config.flow.mjs
+++ b/evals/flows/cloud-mcp-auto-config.flow.mjs
@@ -79,8 +79,14 @@ export default {
       name: "OpenWork Cloud Control appears as a configured app",
       run: async (ctx) => {
         await ctx.navigateHash("/settings/extensions/mcp");
-        await ctx.waitForText("OpenWork Cloud Control", { timeoutMs: 30_000 });
-        await ctx.screenshot("cloud-mcp-configured");
+        await ctx.expectHashIncludes("/settings/extensions/mcp");
+        await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 30_000 });
+        await ctx.screenshot("cloud-mcp-configured", {
+          claim: "OpenWork Cloud Control appears in MCP settings after cloud sign-in sync.",
+          requireText: ["OpenWork Cloud Control"],
+          rejectText: ["Something went wrong"],
+          hashIncludes: "/settings/extensions/mcp",
+        });
       },
     },
   ],

--- a/evals/flows/cloud-signin-handoff.flow.mjs
+++ b/evals/flows/cloud-signin-handoff.flow.mjs
@@ -43,6 +43,7 @@ export default {
       name: "Open Settings -> Cloud -> Account",
       run: async (ctx) => {
         await ctx.navigateHash("/settings/cloud-account");
+        await ctx.expectHashIncludes("/settings/cloud-account");
         await ctx.waitFor(
           `(() => {
             const text = document.body.innerText;
@@ -66,12 +67,17 @@ export default {
     {
       name: "Session is connected",
       run: async (ctx) => {
-        await ctx.waitForText("Sign out", { timeoutMs: 45_000 });
+        await ctx.expectText("Sign out", { timeoutMs: 45_000 });
         const token = await ctx.eval(
           "localStorage.getItem('openwork.den.authToken') ?? ''",
         );
         ctx.assert(typeof token === "string" && token.trim().length > 0, "No persisted den auth token.");
-        await ctx.screenshot("signed-in");
+        await ctx.screenshot("signed-in", {
+          claim: "Cloud Account shows a connected session after desktop handoff.",
+          requireText: ["Sign out"],
+          rejectText: ["Something went wrong"],
+          hashIncludes: "/settings/cloud-account",
+        });
       },
     },
   ],

--- a/evals/flows/extensions-marketplace-updates.flow.mjs
+++ b/evals/flows/extensions-marketplace-updates.flow.mjs
@@ -25,18 +25,15 @@ export default {
       name: "Navigate to Settings -> Marketplace",
       run: async (ctx) => {
         await ctx.navigateHash("/settings/cloud-marketplaces");
-        await ctx.waitFor(
-          "window.location.hash.includes('/settings/cloud-marketplaces')",
-          { label: "cloud marketplaces route" },
-        );
+        await ctx.expectHashIncludes("/settings/cloud-marketplaces");
       },
     },
     {
       name: "Marketplace header and status filters render",
       run: async (ctx) => {
-        await ctx.waitForText("Extension Marketplace", { timeoutMs: 30_000 });
-        await ctx.waitForText("Installed");
-        await ctx.waitForText("Updates");
+        await ctx.expectText("Extension Marketplace", { timeoutMs: 30_000 });
+        await ctx.expectText("Installed");
+        await ctx.expectText("Updates");
       },
     },
     {
@@ -52,17 +49,26 @@ export default {
           signedOutNotice || hasRows,
           "Expected either the signed-out notice or marketplace rows to render",
         );
-        await ctx.screenshot("marketplace-view");
+        await ctx.screenshot("marketplace-view", {
+          claim: "Marketplace view renders a coherent signed-out notice or marketplace rows.",
+          requireText: ["Extension Marketplace"],
+          rejectText: ["Something went wrong"],
+          hashIncludes: "/settings/cloud-marketplaces",
+        });
       },
     },
     {
       name: "Updates filter is interactive and view stays stable",
       run: async (ctx) => {
         await ctx.clickText("Updates");
-        await ctx.waitForText("Extension Marketplace");
-        const crashed = await ctx.hasText("Something went wrong");
-        ctx.assert(!crashed, "Marketplace view crashed after selecting Updates filter");
-        await ctx.screenshot("updates-filter");
+        await ctx.expectText("Extension Marketplace");
+        await ctx.expectNoText("Something went wrong");
+        await ctx.screenshot("updates-filter", {
+          claim: "Selecting Updates keeps the Marketplace view stable.",
+          requireText: ["Extension Marketplace", "Updates"],
+          rejectText: ["Something went wrong"],
+          hashIncludes: "/settings/cloud-marketplaces",
+        });
       },
     },
   ],

--- a/evals/flows/settings-extensions-mcp.flow.mjs
+++ b/evals/flows/settings-extensions-mcp.flow.mjs
@@ -19,18 +19,15 @@ export default {
       name: "Navigate to Settings -> Extensions -> MCP",
       run: async (ctx) => {
         await ctx.navigateHash("/settings/extensions/mcp");
-        await ctx.waitFor(
-          "window.location.hash.includes('/settings/extensions/mcp')",
-          { label: "settings MCP route" },
-        );
+        await ctx.expectHashIncludes("/settings/extensions/mcp");
       },
     },
     {
       name: "Extensions surface renders tabs and custom app entry",
       run: async (ctx) => {
-        await ctx.waitForText("My Extensions", { timeoutMs: 30_000 });
-        await ctx.waitForText("Marketplace");
-        await ctx.waitForText("Add Custom App");
+        await ctx.expectText("My Extensions", { timeoutMs: 30_000 });
+        await ctx.expectText("Marketplace");
+        await ctx.expectText("Add Custom App");
       },
     },
     {
@@ -46,10 +43,15 @@ export default {
     {
       name: "Unconfigured directory entries are discoverable",
       run: async (ctx) => {
-        await ctx.waitForText("OpenWork Cloud Control", { timeoutMs: 15_000 });
+        await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 15_000 });
         const hasDirectoryEntry = (await ctx.hasText("Notion")) || (await ctx.hasText("Linear"));
         ctx.assert(hasDirectoryEntry, "Expected at least one MCP directory entry (Notion/Linear) in quick connect.");
-        await ctx.screenshot("mcp-view");
+        await ctx.screenshot("mcp-view", {
+          claim: "MCP settings shows the built-in cloud control app and directory entries.",
+          requireText: ["OpenWork Cloud Control"],
+          rejectText: ["Something went wrong"],
+          hashIncludes: "/settings/extensions/mcp",
+        });
       },
     },
   ],

--- a/evals/runner/context.mjs
+++ b/evals/runner/context.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { captureScreenshot, evaluate } from "./cdp.mjs";
@@ -8,6 +9,20 @@ const POLL_INTERVAL_MS = 250;
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export class EvalError extends Error {}
+
+function pngDimensions(buffer) {
+  const signature = buffer.subarray(0, 8).toString("hex");
+  if (signature !== "89504e470d0a1a0a" || buffer.length < 24) return null;
+  return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+}
+
+function slug(value) {
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "") || "frame";
+}
 
 /**
  * Per-flow execution context handed to every step's `run(ctx)`.
@@ -22,8 +37,24 @@ export class EvalContext {
     this.flowId = flowId;
     this.env = env;
     this.screenshots = [];
+    this.evidenceFrames = [];
     this.logs = [];
     this.screenshotIndex = 0;
+    this.currentStepName = null;
+    this.currentStepEvidence = [];
+    this.lastScreenshotHash = null;
+  }
+
+  beginStep(name) {
+    this.currentStepName = name;
+    this.currentStepEvidence = [];
+  }
+
+  endStep() {
+    const evidence = this.currentStepEvidence;
+    this.currentStepName = null;
+    this.currentStepEvidence = [];
+    return evidence;
   }
 
   log(message) {
@@ -36,6 +67,56 @@ export class EvalContext {
 
   assert(condition, message) {
     if (!condition) throw new EvalError(message);
+  }
+
+  recordEvidence(entry) {
+    const next = {
+      step: this.currentStepName,
+      at: new Date().toISOString(),
+      ...entry,
+    };
+    this.currentStepEvidence.push(next);
+    return next;
+  }
+
+  async expectText(text, options = {}) {
+    await this.waitForText(text, options);
+    return this.recordEvidence({ type: "assertion", status: "passed", assertion: `Visible text includes ${JSON.stringify(text)}` });
+  }
+
+  async expectNoText(text) {
+    const present = await this.hasText(text);
+    if (present) {
+      this.recordEvidence({ type: "assertion", status: "failed", assertion: `Visible text does not include ${JSON.stringify(text)}` });
+      throw new EvalError(`Unexpected visible text: ${text}`);
+    }
+    return this.recordEvidence({ type: "assertion", status: "passed", assertion: `Visible text does not include ${JSON.stringify(text)}` });
+  }
+
+  async expectHashIncludes(fragment) {
+    const hash = await this.eval("window.location.hash");
+    const passed = typeof hash === "string" && hash.includes(fragment);
+    this.recordEvidence({
+      type: "assertion",
+      status: passed ? "passed" : "failed",
+      assertion: `URL hash includes ${JSON.stringify(fragment)}`,
+      actual: hash,
+    });
+    if (!passed) throw new EvalError(`Expected URL hash to include ${fragment}, got ${hash}`);
+  }
+
+  async prove(name, options) {
+    const claim = options?.claim ?? name;
+    this.recordEvidence({ type: "claim", status: "running", name, claim });
+    if (typeof options?.action === "function") await options.action();
+    if (typeof options?.assert === "function") await options.assert();
+    if (options?.screenshot) {
+      const screenshot = typeof options.screenshot === "string"
+        ? { name: options.screenshot }
+        : options.screenshot;
+      await this.screenshot(screenshot.name ?? slug(name), { claim, ...screenshot });
+    }
+    this.recordEvidence({ type: "claim", status: "passed", name, claim });
   }
 
   /**
@@ -149,13 +230,48 @@ export class EvalContext {
     return result.result;
   }
 
-  async screenshot(name) {
+  async screenshot(name, options = {}) {
     this.screenshotIndex += 1;
-    const fileName = `${this.flowId}-${String(this.screenshotIndex).padStart(2, "0")}-${name}.png`;
+    const fileName = `${this.flowId}-${String(this.screenshotIndex).padStart(2, "0")}-${slug(name)}.png`;
     const buffer = await captureScreenshot(this.client);
     await writeFile(join(this.outDir, fileName), buffer);
     this.screenshots.push(fileName);
+    const bodyText = await this.eval("document.body.innerText").catch(() => "");
+    const url = await this.eval("location.href").catch(() => "");
+    const hash = createHash("sha256").update(buffer).digest("hex");
+    const dimensions = pngDimensions(buffer);
+    const validations = [
+      { label: "PNG exists and is non-empty", passed: buffer.length > 0, detail: `${buffer.length} bytes` },
+      { label: "PNG dimensions are sane", passed: Boolean(dimensions?.width && dimensions?.height), detail: dimensions ? `${dimensions.width}x${dimensions.height}` : "unknown" },
+      { label: "Frame is not a duplicate of the previous capture", passed: this.lastScreenshotHash !== hash, detail: hash.slice(0, 12) },
+    ];
+    for (const text of options.requireText ?? []) {
+      validations.push({ label: `Required visible text: ${text}`, passed: typeof bodyText === "string" && bodyText.includes(text) });
+    }
+    for (const text of options.rejectText ?? []) {
+      validations.push({ label: `Rejected visible text: ${text}`, passed: !(typeof bodyText === "string" && bodyText.includes(text)) });
+    }
+    if (options.hashIncludes) {
+      validations.push({ label: `URL hash includes ${options.hashIncludes}`, passed: typeof url === "string" && url.includes(options.hashIncludes), detail: url });
+    }
+    const passed = validations.every((item) => item.passed);
+    this.lastScreenshotHash = hash;
+    const frame = {
+      type: "frame",
+      status: passed ? "passed" : "failed",
+      file: fileName,
+      name,
+      claim: options.claim ?? null,
+      url,
+      validations,
+    };
+    this.evidenceFrames.push(frame);
+    this.recordEvidence(frame);
     this.log(`Screenshot: ${fileName}`);
+    if (!passed && options.allowInvalid !== true) {
+      const failed = validations.filter((item) => !item.passed).map((item) => item.label).join(", ");
+      throw new EvalError(`Screenshot evidence failed validation: ${failed}`);
+    }
     return fileName;
   }
 }

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -111,14 +111,17 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
       }
     }
     for (const step of flow.steps) {
-      const stepResult = { name: step.name, status: "passed", durationMs: 0, error: null };
+      const stepResult = { name: step.name, status: "passed", durationMs: 0, error: null, evidence: [] };
       const startedAt = Date.now();
+      ctx.beginStep(step.name);
       try {
         await step.run(ctx);
       } catch (error) {
         stepResult.status = "failed";
         stepResult.error = error instanceof Error ? error.message : String(error);
         result.status = "failed";
+      } finally {
+        stepResult.evidence = ctx.endStep();
       }
       stepResult.durationMs = Date.now() - startedAt;
       result.steps.push(stepResult);
@@ -129,6 +132,7 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
     }
   } finally {
     result.screenshots = ctx.screenshots;
+    result.evidenceFrames = ctx.evidenceFrames;
     result.logs = ctx.logs;
     client.close();
   }
@@ -155,6 +159,10 @@ function renderMarkdown(report) {
     for (const step of flow.steps ?? []) {
       const stepIcon = step.status === "passed" ? "✅" : "❌";
       lines.push(`- ${stepIcon} ${step.name} (${step.durationMs}ms)${step.error ? ` — ${step.error}` : ""}`);
+      for (const evidence of step.evidence ?? []) {
+        if (evidence.type === "frame") lines.push(`  - Frame: ${evidence.file} (${evidence.status})`);
+        if (evidence.type === "assertion") lines.push(`  - Assertion: ${evidence.assertion} (${evidence.status})`);
+      }
     }
     if (flow.screenshots?.length) {
       lines.push("", `Screenshots: ${flow.screenshots.join(", ")}`);
@@ -174,27 +182,21 @@ function escapeHtml(value) {
 
 function renderFrameIndex(report) {
   const flowSections = report.flows.map((flow) => {
-    const screenshots = flow.screenshots ?? [];
-    const frames = screenshots.length > 0
-      ? screenshots.map((screenshot) => `
-          <figure>
-            <a href="${escapeHtml(screenshot)}"><img src="${escapeHtml(screenshot)}" alt="${escapeHtml(screenshot)}" /></a>
-            <figcaption>${escapeHtml(screenshot)}</figcaption>
-          </figure>`).join("\n")
-      : `<p class="muted">No screenshots captured for this flow.</p>`;
     const steps = (flow.steps ?? []).map((step) => `
-        <li class="${step.status === "passed" ? "passed" : "failed"}">
-          <strong>${escapeHtml(step.status.toUpperCase())}</strong>
-          ${escapeHtml(step.name)} (${Number(step.durationMs) || 0}ms)
-          ${step.error ? `<div class="error">${escapeHtml(step.error)}</div>` : ""}
-        </li>`).join("\n");
+        <article class="step ${step.status === "passed" ? "passed" : "failed"}">
+          <header>
+            <div class="eyebrow">${escapeHtml(step.status.toUpperCase())} · ${Number(step.durationMs) || 0}ms</div>
+            <h3>${escapeHtml(step.name)}</h3>
+            ${step.error ? `<div class="error">${escapeHtml(step.error)}</div>` : ""}
+          </header>
+          ${renderEvidence(step.evidence ?? [])}
+        </article>`).join("\n");
     return `
       <section>
         <h2>${escapeHtml(flow.id)} - ${escapeHtml(flow.title)}</h2>
         ${flow.spec ? `<p class="muted">Spec: ${escapeHtml(flow.spec)}</p>` : ""}
         ${flow.skipReason ? `<p class="skipped">Skipped: ${escapeHtml(flow.skipReason)}</p>` : ""}
-        <ol>${steps}</ol>
-        <div class="grid">${frames}</div>
+        <div class="steps">${steps}</div>
       </section>`;
   }).join("\n");
 
@@ -209,15 +211,23 @@ function renderFrameIndex(report) {
     main { max-width: 1180px; margin: 0 auto; padding: 32px; }
     h1 { margin: 0 0 8px; font-size: 28px; }
     h2 { margin-top: 32px; }
+    h3 { margin: 2px 0 10px; font-size: 18px; }
     .meta, .muted { color: #5f6368; }
     .summary { display: inline-flex; gap: 12px; margin: 16px 0 8px; padding: 10px 12px; border: 1px solid #ddd; border-radius: 10px; background: white; }
-    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 18px; margin-top: 16px; }
+    .steps { display: grid; gap: 18px; margin-top: 16px; }
+    .step { padding: 16px; border: 1px solid #ddd; border-radius: 14px; background: white; box-shadow: 0 1px 4px rgba(0,0,0,.04); }
+    .step.failed { border-color: #f4b4ae; background: #fff8f7; }
+    .eyebrow { color: #5f6368; font-size: 12px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
+    .evidence { display: grid; gap: 12px; }
+    .claim { padding: 10px 12px; border-left: 4px solid #7c3aed; background: #f5f3ff; border-radius: 8px; }
+    .assertions, .validations { margin: 8px 0 0; padding-left: 20px; }
+    .assertions li, .validations li { margin: 5px 0; }
     figure { margin: 0; overflow: hidden; border: 1px solid #ddd; border-radius: 12px; background: white; box-shadow: 0 1px 4px rgba(0,0,0,.06); }
     img { display: block; width: 100%; height: auto; }
     figcaption { padding: 10px 12px; border-top: 1px solid #eee; font-size: 13px; color: #444; }
     li { margin: 8px 0; }
-    .passed strong { color: #0a7f35; }
-    .failed strong, .error { color: #b42318; }
+    .passed-text { color: #0a7f35; font-weight: 700; }
+    .failed-text, .error { color: #b42318; font-weight: 700; }
     .skipped { color: #8a5a00; }
     code { background: #ededf0; padding: 2px 5px; border-radius: 5px; }
   </style>
@@ -240,6 +250,34 @@ function renderFrameIndex(report) {
   </main>
 </body>
 </html>`;
+}
+
+function renderEvidence(evidence) {
+  if (evidence.length === 0) return `<p class="muted">No structured evidence recorded for this step.</p>`;
+  return `<div class="evidence">${evidence.map((item) => {
+    if (item.type === "claim") {
+      return `<div class="claim"><strong>${escapeHtml(item.name ?? "Claim")}</strong><br />${escapeHtml(item.claim ?? "")}</div>`;
+    }
+    if (item.type === "assertion") {
+      const cls = item.status === "passed" ? "passed-text" : "failed-text";
+      return `<div><span class="${cls}">${escapeHtml(item.status ?? "unknown")}</span> ${escapeHtml(item.assertion ?? "Assertion")}${item.actual ? `<br /><span class="muted">Actual: ${escapeHtml(item.actual)}</span>` : ""}</div>`;
+    }
+    if (item.type === "frame") {
+      const validations = (item.validations ?? []).map((validation) => {
+        const cls = validation.passed ? "passed-text" : "failed-text";
+        return `<li><span class="${cls}">${validation.passed ? "PASS" : "FAIL"}</span> ${escapeHtml(validation.label)}${validation.detail ? ` <span class="muted">${escapeHtml(validation.detail)}</span>` : ""}</li>`;
+      }).join("\n");
+      return `<figure>
+        <a href="${escapeHtml(item.file)}"><img src="${escapeHtml(item.file)}" alt="${escapeHtml(item.claim ?? item.name ?? item.file)}" /></a>
+        <figcaption>
+          <strong>${escapeHtml(item.name ?? item.file)}</strong>${item.claim ? `<br />Claim: ${escapeHtml(item.claim)}` : ""}
+          ${item.url ? `<br /><span class="muted">URL: ${escapeHtml(item.url)}</span>` : ""}
+          <ul class="validations">${validations}</ul>
+        </figcaption>
+      </figure>`;
+    }
+    return `<pre>${escapeHtml(JSON.stringify(item, null, 2))}</pre>`;
+  }).join("\n")}</div>`;
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- Add structured eval evidence: assertions, claims, screenshot validation, duplicate-frame detection, and per-step evidence records.
- Upgrade the eval HTML report from a screenshot gallery into step-by-step proof cards with claims, assertions, validation checks, and supporting frames.
- Convert existing screenshot-based flows to the new validated proof API.
- Update Daytona/eval skills so phrases like "do e2e tests for <feature>", "run e2e", "prove it works", and "PR proof" trigger the Daytona + validated frame proof workflow.

## Converted flows
- `app-smoke`
- `cloud-account-renders`
- `settings-extensions-mcp`
- `extensions-marketplace-updates`
- `cloud-signin-handoff`
- `cloud-mcp-auto-config`
- `analytics-task-events`

## Tests
- `pnpm evals --list` passed and imported all flows.
- `git diff --check` passed.
- `node --check evals/runner/context.mjs && node --check evals/runner/run.mjs && node --check evals/flows/app-smoke.flow.mjs && node --check evals/flows/cloud-account-renders.flow.mjs && node --check evals/flows/settings-extensions-mcp.flow.mjs && node --check evals/flows/extensions-marketplace-updates.flow.mjs && node --check evals/flows/cloud-signin-handoff.flow.mjs && node --check evals/flows/cloud-mcp-auto-config.flow.mjs && node --check evals/flows/analytics-task-events.flow.mjs` passed.

## E2E note
- I attempted to run converted flows locally against the existing CDP endpoint with `pnpm evals --flow app-smoke --flow cloud-account-renders --flow settings-extensions-mcp --flow extensions-marketplace-updates --cdp-url http://127.0.0.1:9823 --out evals/results/proof-ux-local`.
- The run could not complete because the available local OpenWork target timed out on basic `Runtime.evaluate` calls, and direct browser-tool `Runtime.evaluate` calls against that target also timed out.
- No pass is claimed from that hung target. The branch improves the runner/skills and validates imports/syntax; a fresh Daytona sandbox should be used for real PR proof.

## Operational note
- Because this changes project skills under `.opencode/skills`, running opencode sessions need a restart before the new skill trigger descriptions are loaded.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

