### PR TITLE
fix(settings): keep theme previews independent of active theme

### DIFF
--- a/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
+++ b/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
@@ -14,6 +14,11 @@ import {
 
 type ThemeMode = AppearanceViewProps["themeMode"];
 
+export const THEME_PREVIEW_CLASSES: Record<"light" | "dark", string> = {
+  light: "bg-white",
+  dark: "bg-black",
+};
+
 interface ThemeSectionProps
   extends Pick<AppearanceViewProps, "busy" | "themeMode" | "setThemeMode"> {}
 
@@ -69,14 +74,14 @@ function ThemePicker(props: ThemePickerProps) {
         value="light"
         label={t("settings.theme_light")}
       >
-        <ThemePreview value="light" className="bg-white" />
+        <ThemePreview value="light" className={THEME_PREVIEW_CLASSES.light} />
         <ThemePickerLabel>{t("settings.theme_light")}</ThemePickerLabel>
       </ThemePickerItem>
       <ThemePickerItem
         value="dark"
         label={t("settings.theme_dark")}
       >
-        <ThemePreview value="dark" className="bg-zinc-950" />
+        <ThemePreview value="dark" className={THEME_PREVIEW_CLASSES.dark} />
         <ThemePickerLabel>{t("settings.theme_dark")}</ThemePickerLabel>
       </ThemePickerItem>
     </ToggleGroup>
@@ -116,8 +121,8 @@ function ThemePreview(props: ThemePreviewProps) {
     >
       {props.value === "system" && (
         <div className="flex h-full">
-          <div className="w-1/2 bg-white" />
-          <div className="w-1/2 bg-zinc-950" />
+          <div className={cn("w-1/2", THEME_PREVIEW_CLASSES.light)} />
+          <div className={cn("w-1/2", THEME_PREVIEW_CLASSES.dark)} />
         </div>
       )}
     </div>

--- a/apps/app/tests/theme-preview.test.ts
+++ b/apps/app/tests/theme-preview.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+
+import { THEME_PREVIEW_CLASSES } from "../src/react-app/domains/settings/appearance/theme-section";
+
+describe("theme picker previews", () => {
+  test("uses fixed light and dark preview colors", () => {
+    expect(THEME_PREVIEW_CLASSES.light).toBe("bg-white");
+    expect(THEME_PREVIEW_CLASSES.dark).toBe("bg-black");
+  });
+});

--- a/apps/app/tests/theme-preview.test.ts
+++ b/apps/app/tests/theme-preview.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, test } from "bun:test";
 
+import tailwindConfig from "../tailwind.config";
 import { THEME_PREVIEW_CLASSES } from "../src/react-app/domains/settings/appearance/theme-section";
 
 describe("theme picker previews", () => {
   test("uses fixed light and dark preview colors", () => {
     expect(THEME_PREVIEW_CLASSES.light).toBe("bg-white");
     expect(THEME_PREVIEW_CLASSES.dark).toBe("bg-black");
+  });
+
+  test("uses colors defined by the Tailwind palette", () => {
+    for (const className of Object.values(THEME_PREVIEW_CLASSES)) {
+      const colorName = className.replace("bg-", "");
+
+      expect(Object.hasOwn(tailwindConfig.theme.colors, colorName)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Replaces unsupported `bg-zinc-950` utilities with configured `bg-black` utilities in the Appearance theme picker.
- Keeps the Light, Dark, and System preview swatches visually stable, regardless of the active app theme.
- Uses fixed pure white and black preview examples by design; the swatches show the available modes rather than tracking a custom active-theme surface.
- Adds regression coverage for both the intended preview colors and their configured Tailwind palette entries.

## Why
The app overrides Tailwind colors and does not define the Zinc palette. The old `bg-zinc-950` class therefore produced no background rule, letting the preview inherit its parent theme.

## Issue
- Closes #2328

## Scope
- `apps/app/src/react-app/domains/settings/appearance/theme-section.tsx`
- `apps/app/tests/theme-preview.test.ts`

## Out of scope
- Changing the selected theme behavior or application theme tokens.

## Testing
### Ran
- `pnpm --filter @openwork/app test`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app build`
- `git diff --check`

### Result
- pass: 73 tests, typecheck, production build, and whitespace check.
- build emitted existing `use memo` and chunk-size warnings only.

## CI status
- pass: local verification above.
- code-related failures: none.
- external/env/auth blockers: none.

## Manual verification
1. Open Settings > Appearance.
2. Select Light, Dark, and System in turn.
3. Confirm the previews remain: Light = white, Dark = black, System = white/black split.

## Evidence
- [Original reproduction recording and report](https://github.com/different-ai/openwork/issues/2328)

## Risk
- Low. This changes only fixed preview swatch classes.

## Rollback
- Revert commits `fac8b55b` and `b6d5995`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->