### PR TITLE
feat(voice): managed OpenWork Models voice with rate limiting and 503 fallback

### DIFF
--- a/apps/app/scripts/_util.mjs
+++ b/apps/app/scripts/_util.mjs
@@ -47,6 +47,7 @@ export async function spawnOpencodeServe({
   hostname = "127.0.0.1",
   port,
   corsOrigins = [],
+  env = {},
 }) {
   assert.ok(directory && directory.trim(), "directory is required");
   assert.ok(Number.isInteger(port) && port > 0, "port must be a positive integer");
@@ -62,6 +63,7 @@ export async function spawnOpencodeServe({
     stdio: ["ignore", "pipe", "pipe"],
     env: {
       ...process.env,
+      ...env,
       // Make it explicit we're a non-TUI client.
       OPENCODE_CLIENT: "openwork-test",
     },

--- a/apps/app/scripts/managed-voice-e2e.mjs
+++ b/apps/app/scripts/managed-voice-e2e.mjs
@@ -1,0 +1,278 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  findFreePort,
+  parseArgs,
+} from "./_util.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const directory = args.get("dir") ?? process.cwd();
+const outDir = resolve(args.get("out") ?? join(process.cwd(), "evals", "results", `managed-voice-${Date.now()}`));
+
+const proofFrames = [];
+const results = {
+  ok: true,
+  outDir,
+  steps: [],
+};
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+async function frame(name, data) {
+  const file = `${String(proofFrames.length + 1).padStart(2, "0")}-${name.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "").toLowerCase()}.html`;
+  const safeData = redactProofData(data);
+  proofFrames.push({ file, name, data: safeData });
+  await writeFile(join(outDir, file), `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(name)}</title>
+  <style>
+    body { margin: 0; background: #f8fafc; color: #111827; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px; }
+    h1 { font-family: system-ui, sans-serif; margin-top: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; padding: 18px; border: 1px solid #d1d5db; border-radius: 14px; background: white; }
+  </style>
+</head>
+<body><main><h1>${escapeHtml(name)}</h1><pre>${escapeHtml(JSON.stringify(safeData, null, 2))}</pre></main></body>
+</html>`, "utf8");
+}
+
+function redactProofData(value) {
+  if (Array.isArray(value)) return value.map(redactProofData);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value).map(([key, entry]) => {
+    if (/token|secret|authorization|api.?key/i.test(key)) return [key, "[redacted]"];
+    if (typeof entry === "string" && /^(owt_|ow_inf_|sk-)/.test(entry)) return [key, "[redacted]"];
+    return [key, redactProofData(entry)];
+  }));
+}
+
+async function renderIndex() {
+  const frames = proofFrames.map((entry) => `
+    <section>
+      <h2>${escapeHtml(entry.name)}</h2>
+      <iframe src="${escapeHtml(entry.file)}" title="${escapeHtml(entry.name)}"></iframe>
+      <p><a href="${escapeHtml(entry.file)}">Open frame</a></p>
+    </section>`).join("\n");
+  await writeFile(join(outDir, "index.html"), `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Managed Voice E2E Proof</title>
+  <style>
+    body { margin: 0; background: #f3f4f6; color: #111827; font-family: system-ui, sans-serif; }
+    main { max-width: 1180px; margin: 0 auto; padding: 32px; }
+    h1 { margin-bottom: 4px; }
+    .meta { color: #4b5563; margin-bottom: 24px; }
+    section { margin: 24px 0; padding: 18px; border: 1px solid #d1d5db; border-radius: 16px; background: white; }
+    iframe { width: 100%; min-height: 430px; border: 1px solid #e5e7eb; border-radius: 12px; background: white; }
+    code { background: #e5e7eb; padding: 2px 5px; border-radius: 5px; }
+  </style>
+</head>
+<body><main>
+  <h1>Managed Voice E2E Proof</h1>
+  <div class="meta">Result: <code>${results.ok ? "passed" : "failed"}</code> · Output: <code>${escapeHtml(outDir)}</code></div>
+${frames}
+</main></body>
+</html>`, "utf8");
+}
+
+function step(name, fn) {
+  results.steps.push({ name, status: "running" });
+  const idx = results.steps.length - 1;
+  return Promise.resolve()
+    .then(fn)
+    .then(async (data) => {
+      results.steps[idx] = { name, status: "ok", data };
+      await frame(name, data);
+      return data;
+    })
+    .catch(async (error) => {
+      results.ok = false;
+      const message = error instanceof Error ? error.message : String(error);
+      results.steps[idx] = { name, status: "error", error: message };
+      await frame(`${name} failure`, { error: message });
+      throw error;
+    });
+}
+
+async function startMockBroker() {
+  const requests = [];
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += String(chunk);
+    });
+    req.on("end", () => {
+      requests.push({ method: req.method, url: req.url, authorization: req.headers.authorization ?? null, body });
+      if (req.method !== "POST" || req.url !== "/voice/realtime/session") {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "not_found" }));
+        return;
+      }
+      if (req.headers.authorization !== "Bearer ow_inf_e2e") {
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { code: "invalid_api_key" } }));
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({
+        ok: true,
+        clientSecret: "managed-e2e-client-secret",
+        expiresAt: 987654321,
+        model: "gpt-realtime-2",
+        transcriptionModel: "gpt-4o-transcribe",
+        tools: ["openwork_snapshot", "openwork_list_actions", "openwork_execute_action"],
+        source: "openwork-models",
+      }));
+    });
+  });
+  const port = await findFreePort();
+  await new Promise((resolveReady) => server.listen(port, "127.0.0.1", resolveReady));
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    requests,
+    close: () => new Promise((resolveClose) => server.close(resolveClose)),
+  };
+}
+
+async function startOpenWorkServer({ directory, port, env }) {
+  const token = "owt_managed_voice_client";
+  const hostToken = "owt_managed_voice_host";
+  const child = spawn("bun", [
+    "apps/server/src/cli.ts",
+    "--host", "127.0.0.1",
+    "--port", String(port),
+    "--token", token,
+    "--host-token", hostToken,
+    "--workspace", directory,
+    "--approval", "auto",
+    "--no-log-requests",
+  ], {
+    cwd: resolve(join(import.meta.dirname, "..", "..", "..")),
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...env, OPENWORK_DEV_MODE: "1" },
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  return {
+    baseUrl,
+    token,
+    hostToken,
+    getStdout: () => stdout,
+    getStderr: () => stderr,
+    async close() {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      child.kill("SIGTERM");
+      await Promise.race([
+        new Promise((resolveExit) => child.once("exit", resolveExit)),
+        new Promise((resolveTimeout) => setTimeout(resolveTimeout, 2500)),
+      ]);
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    },
+  };
+}
+
+async function waitForServerHealthy(baseUrl) {
+  const startedAt = Date.now();
+  let lastError = "";
+  while (Date.now() - startedAt < 30_000) {
+    try {
+      const response = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(2500) });
+      if (response.ok) return response.json();
+      lastError = `${response.status} ${response.statusText}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolvePoll) => setTimeout(resolvePoll, 250));
+  }
+  throw new Error(`Timed out waiting for OpenWork server health: ${lastError}`);
+}
+
+await rm(outDir, { recursive: true, force: true });
+await mkdir(outDir, { recursive: true });
+const envDir = await mkdtemp(join(tmpdir(), "openwork-managed-voice-e2e-"));
+const mockBroker = await startMockBroker();
+const port = await findFreePort();
+const server = await startOpenWorkServer({
+  directory,
+  port,
+  env: {
+    OPENWORK_ENV_STORE: join(envDir, "env.json"),
+    OPENWORK_TOKEN_STORE: join(envDir, "tokens.json"),
+    OPENWORK_API_KEY: "ow_inf_e2e",
+    OPENWORK_INFERENCE_BASE_URL: mockBroker.baseUrl,
+  },
+});
+
+try {
+  await step("server health", async () => waitForServerHealthy(server.baseUrl));
+
+  const owner = await step("owner token", async () => {
+    const response = await fetch(`${server.baseUrl}/tokens`, {
+      method: "POST",
+      headers: { "x-openwork-host-token": server.hostToken, "content-type": "application/json" },
+      body: JSON.stringify({ scope: "owner", label: "managed voice e2e" }),
+    });
+    assert.equal(response.status, 201);
+    const body = await response.json();
+    assert.equal(typeof body.token, "string");
+    return body;
+  });
+
+  const session = await step("managed voice session", async () => {
+    const response = await fetch(`${server.baseUrl}/voice/realtime/session`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${owner.token}`, "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.clientSecret, "managed-e2e-client-secret");
+    assert.equal(body.source, "openwork-models");
+    return body;
+  });
+
+  await step("broker received authenticated request", async () => {
+    assert.equal(mockBroker.requests.length, 1);
+    assert.equal(mockBroker.requests[0].authorization, "Bearer ow_inf_e2e");
+    assert.equal(session.model, "gpt-realtime-2");
+    return mockBroker.requests[0];
+  });
+
+  await renderIndex();
+  console.log(JSON.stringify({ ...results, proof: join(outDir, "index.html") }, null, 2));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  results.ok = false;
+  results.error = message;
+  results.stderr = server.getStderr();
+  results.stdout = server.getStdout?.() ?? "";
+  await renderIndex();
+  console.error(JSON.stringify({ ...results, proof: join(outDir, "index.html") }, null, 2));
+  process.exitCode = 1;
+} finally {
+  await server.close();
+  await mockBroker.close();
+}

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1805,6 +1805,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         model: string;
         transcriptionModel: string;
         tools: string[];
+        source?: string;
       }>(baseUrl, "/voice/realtime/session", {
         token,
         hostToken,

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -353,6 +353,27 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     return next;
   };
 
+  const readCloudProviderBaseUrl = (provider: DenOrgLlmProviderConnection) => {
+    const options = provider.providerConfig.options;
+    if (options && typeof options === "object" && !Array.isArray(options)) {
+      const baseURL = "baseURL" in options ? options.baseURL : undefined;
+      if (typeof baseURL === "string" && baseURL.trim()) return baseURL.trim().replace(/\/api\/v1\/?$/, "");
+    }
+    const api = provider.providerConfig.api;
+    if (typeof api === "string" && api.trim()) return api.trim().replace(/\/api\/v1\/?$/, "");
+    return "";
+  };
+
+  const mirrorOpenWorkModelsVoiceEnv = async (provider: DenOrgLlmProviderConnection, apiKey: string) => {
+    if (provider.source !== "openwork" || !apiKey.trim()) return;
+    const openworkClient = options.openworkServer.getSnapshot().openworkServerClient;
+    if (!openworkClient) return;
+    const baseUrl = readCloudProviderBaseUrl(provider);
+    const entries = [{ key: "OPENWORK_API_KEY", value: apiKey.trim() }];
+    if (baseUrl) entries.push({ key: "OPENWORK_INFERENCE_BASE_URL", value: baseUrl });
+    await openworkClient.upsertUserEnv(entries);
+  };
+
   const readWorkspaceOpenworkConfigRecord = async (): Promise<
     Record<string, unknown>
   > => {
@@ -1395,6 +1416,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           providerID: localProviderId,
           auth: { type: "api", key: apiKey },
         });
+        await mirrorOpenWorkModelsVoiceEnv(provider, apiKey);
       }
       if (existingImported?.providerId && existingImported.providerId !== localProviderId) {
         try {

--- a/apps/app/src/react-app/domains/settings/pages/environment-variable-provider.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/environment-variable-provider.tsx
@@ -9,6 +9,12 @@ import type { EnvironmentVariableItem } from "./environment-variable-table";
 
 const KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const RESERVED_PREFIXES = ["OPENWORK_", "OPENCODE_"] as const;
+const PERSISTABLE_INTERNAL_KEYS = new Set([
+  "OPENWORK_API_KEY",
+  "OPENWORK_MODELS_API_KEY",
+  "OPENWORK_INFERENCE_BASE_URL",
+  "OPENWORK_MODELS_BASE_URL",
+]);
 
 export type ApplyEnvironmentChangesResult = { statusMessage?: string } | void;
 
@@ -26,7 +32,7 @@ function validateKey(key: string): string | null {
   if (!KEY_PATTERN.test(trimmed)) {
     return t("settings.environment.validation_shape");
   }
-  if (RESERVED_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
+  if (RESERVED_PREFIXES.some((prefix) => trimmed.startsWith(prefix)) && !PERSISTABLE_INTERNAL_KEYS.has(trimmed)) {
     return t("settings.environment.validation_reserved");
   }
   return null;

--- a/apps/server/src/env-file.test.ts
+++ b/apps/server/src/env-file.test.ts
@@ -102,6 +102,22 @@ describe("env-file", () => {
     await expect(promise).rejects.toMatchObject({ code: "reserved_env_key" });
   });
 
+  test("upsertMany accepts managed voice keys but does not inject them", async () => {
+    const svc = new EnvService({ path });
+    await svc.upsertMany([
+      { key: "OPENWORK_API_KEY", value: "ow_inf_test" },
+      { key: "OPENWORK_INFERENCE_BASE_URL", value: "https://inference.example.test" },
+      { key: "ANTHROPIC_API_KEY", value: "sk-ant" },
+    ]);
+
+    expect((await svc.list()).map((entry) => entry.key)).toEqual([
+      "ANTHROPIC_API_KEY",
+      "OPENWORK_API_KEY",
+      "OPENWORK_INFERENCE_BASE_URL",
+    ]);
+    expect(await EnvService.readForInjection(path)).toEqual({ ANTHROPIC_API_KEY: "sk-ant" });
+  });
+
   test("delete returns false when the key is missing", async () => {
     const svc = new EnvService({ path });
     await svc.upsertMany([{ key: "FOO", value: "x" }]);

--- a/apps/server/src/env-file.ts
+++ b/apps/server/src/env-file.ts
@@ -19,6 +19,12 @@ const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 // tampered file cannot shadow auth credentials, token paths, or process
 // identity.
 const RESERVED_PREFIXES = ["OPENWORK_", "OPENCODE_"] as const;
+const PERSISTABLE_INTERNAL_KEYS = new Set([
+  "OPENWORK_API_KEY",
+  "OPENWORK_MODELS_API_KEY",
+  "OPENWORK_INFERENCE_BASE_URL",
+  "OPENWORK_MODELS_BASE_URL",
+]);
 
 export type EnvRecord = {
   key: string;
@@ -37,6 +43,10 @@ export function isValidEnvKey(key: string): boolean {
 }
 
 export function isReservedEnvKey(key: string): boolean {
+  return isInternalEnvKey(key) && !PERSISTABLE_INTERNAL_KEYS.has(key);
+}
+
+function isInternalEnvKey(key: string): boolean {
   return RESERVED_PREFIXES.some((prefix) => key.startsWith(prefix));
 }
 
@@ -233,7 +243,7 @@ export class EnvService {
     const store = await readStore(path, { tolerateInvalid: true });
     const out: Record<string, string> = {};
     for (const entry of store.variables) {
-      if (isReservedEnvKey(entry.key)) continue;
+      if (isInternalEnvKey(entry.key)) continue;
       out[entry.key] = entry.value;
     }
     return out;

--- a/apps/server/src/env-routes.e2e.test.ts
+++ b/apps/server/src/env-routes.e2e.test.ts
@@ -17,6 +17,8 @@ const dirs: string[] = [];
 const priorEnvStore = process.env.OPENWORK_ENV_STORE;
 const priorTokenStore = process.env.OPENWORK_TOKEN_STORE;
 const priorOpenAiApiKey = process.env.OPENAI_API_KEY;
+const priorOpenWorkApiKey = process.env.OPENWORK_API_KEY;
+const priorOpenWorkInferenceBaseUrl = process.env.OPENWORK_INFERENCE_BASE_URL;
 const nativeFetch = globalThis.fetch;
 
 function baseConfig(): ServerConfig {
@@ -81,6 +83,16 @@ afterEach(async () => {
     delete process.env.OPENAI_API_KEY;
   } else {
     process.env.OPENAI_API_KEY = priorOpenAiApiKey;
+  }
+  if (priorOpenWorkApiKey === undefined) {
+    delete process.env.OPENWORK_API_KEY;
+  } else {
+    process.env.OPENWORK_API_KEY = priorOpenWorkApiKey;
+  }
+  if (priorOpenWorkInferenceBaseUrl === undefined) {
+    delete process.env.OPENWORK_INFERENCE_BASE_URL;
+  } else {
+    process.env.OPENWORK_INFERENCE_BASE_URL = priorOpenWorkInferenceBaseUrl;
   }
   globalThis.fetch = nativeFetch;
 });
@@ -353,6 +365,210 @@ describe("env routes", () => {
       clientSecret: "rt-secret",
       expiresAt: 123,
     });
+  });
+
+  test("voice realtime session prefers OpenWork Models broker when configured", async () => {
+    process.env.OPENAI_API_KEY = "sk-should-not-be-used";
+    const { base } = await boot();
+
+    const envPut = await fetch(`${base}/env`, {
+      method: "PUT",
+      headers: hostAuth(),
+      body: JSON.stringify({
+        entries: [
+          { key: "OPENWORK_API_KEY", value: "ow_inf_test" },
+          { key: "OPENWORK_INFERENCE_BASE_URL", value: "https://inference.example.test" },
+        ],
+      }),
+    });
+    expect(envPut.status).toBe(200);
+
+    globalThis.fetch = ((input, init) => {
+      const url = String(input);
+      if (url === "https://inference.example.test/voice/realtime/session") {
+        expect(init?.headers).toMatchObject({ Authorization: "Bearer ow_inf_test" });
+        return Promise.resolve(new Response(JSON.stringify({
+          ok: true,
+          clientSecret: "managed-rt-secret",
+          expiresAt: 456,
+          model: "gpt-realtime-2",
+          transcriptionModel: "gpt-4o-transcribe",
+          tools: ["openwork_snapshot"],
+          source: "openwork-models",
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }));
+      }
+      if (url === "https://api.openai.com/v1/realtime/client_secrets") {
+        return Promise.resolve(new Response("direct OpenAI should not be called", { status: 500 }));
+      }
+      return nativeFetch(input, init);
+    }) as typeof fetch;
+
+    const issued = await fetch(`${base}/tokens`, {
+      method: "POST",
+      headers: hostAuth(),
+      body: JSON.stringify({ scope: "owner", label: "managed voice owner" }),
+    });
+    const tokenBody = (await issued.json()) as { token: string };
+
+    const response = await fetch(`${base}/voice/realtime/session`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${tokenBody.token}`, "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      clientSecret: "managed-rt-secret",
+      expiresAt: 456,
+      source: "openwork-models",
+    });
+  });
+
+  test("voice realtime session falls back to direct OpenAI when broker returns 503", async () => {
+    process.env.OPENAI_API_KEY = "sk-direct-fallback";
+    const { base } = await boot();
+
+    await fetch(`${base}/env`, {
+      method: "PUT",
+      headers: hostAuth(),
+      body: JSON.stringify({
+        entries: [
+          { key: "OPENWORK_API_KEY", value: "ow_inf_test" },
+          { key: "OPENWORK_INFERENCE_BASE_URL", value: "https://inference.example.test" },
+        ],
+      }),
+    });
+
+    globalThis.fetch = ((input, init) => {
+      const url = String(input);
+      if (url === "https://inference.example.test/voice/realtime/session") {
+        return Promise.resolve(new Response(JSON.stringify({
+          error: { message: "Managed voice is not configured.", code: "openai_realtime_key_missing" },
+        }), { status: 503, headers: { "content-type": "application/json" } }));
+      }
+      if (url === "https://api.openai.com/v1/realtime/client_secrets") {
+        expect(init?.headers).toMatchObject({ Authorization: "Bearer sk-direct-fallback" });
+        return Promise.resolve(new Response(JSON.stringify({
+          client_secret: { value: "direct-fallback-secret", expires_at: 789 },
+        }), { status: 200, headers: { "content-type": "application/json" } }));
+      }
+      return nativeFetch(input, init);
+    }) as typeof fetch;
+
+    const issued = await fetch(`${base}/tokens`, {
+      method: "POST",
+      headers: hostAuth(),
+      body: JSON.stringify({ scope: "owner", label: "fallback voice owner" }),
+    });
+    const tokenBody = (await issued.json()) as { token: string };
+
+    const response = await fetch(`${base}/voice/realtime/session`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${tokenBody.token}`, "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      clientSecret: "direct-fallback-secret",
+    });
+  });
+
+  test("voice realtime session shows clear error when broker 503 and no local key", async () => {
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_REALTIME_API_KEY;
+    delete process.env.OPENWORK_OPENAI_REALTIME_API_KEY;
+    const { base } = await boot();
+
+    await fetch(`${base}/env`, {
+      method: "PUT",
+      headers: hostAuth(),
+      body: JSON.stringify({
+        entries: [
+          { key: "OPENWORK_API_KEY", value: "ow_inf_test" },
+          { key: "OPENWORK_INFERENCE_BASE_URL", value: "https://inference.example.test" },
+        ],
+      }),
+    });
+
+    globalThis.fetch = ((input, init) => {
+      const url = String(input);
+      if (url === "https://inference.example.test/voice/realtime/session") {
+        return Promise.resolve(new Response(JSON.stringify({
+          error: { message: "Managed voice is not configured.", code: "openai_realtime_key_missing" },
+        }), { status: 503, headers: { "content-type": "application/json" } }));
+      }
+      return nativeFetch(input, init);
+    }) as typeof fetch;
+
+    const issued = await fetch(`${base}/tokens`, {
+      method: "POST",
+      headers: hostAuth(),
+      body: JSON.stringify({ scope: "owner", label: "no key voice owner" }),
+    });
+    const tokenBody = (await issued.json()) as { token: string };
+
+    const response = await fetch(`${base}/voice/realtime/session`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${tokenBody.token}`, "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { code: string; message: string };
+    expect(body.code).toBe("openwork_models_voice_unavailable");
+    expect(body.message).toContain("not fully configured");
+  });
+
+  test("voice realtime session does not fall back on non-503 broker errors", async () => {
+    process.env.OPENAI_API_KEY = "sk-should-not-be-used";
+    const { base } = await boot();
+
+    await fetch(`${base}/env`, {
+      method: "PUT",
+      headers: hostAuth(),
+      body: JSON.stringify({
+        entries: [
+          { key: "OPENWORK_API_KEY", value: "ow_inf_test" },
+          { key: "OPENWORK_INFERENCE_BASE_URL", value: "https://inference.example.test" },
+        ],
+      }),
+    });
+
+    globalThis.fetch = ((input, init) => {
+      const url = String(input);
+      if (url === "https://inference.example.test/voice/realtime/session") {
+        return Promise.resolve(new Response(JSON.stringify({
+          error: { message: "Rate limit exceeded", code: "rate_limit_exceeded" },
+        }), { status: 429, headers: { "content-type": "application/json" } }));
+      }
+      if (url === "https://api.openai.com/v1/realtime/client_secrets") {
+        return Promise.resolve(new Response("should not fall back on 429", { status: 500 }));
+      }
+      return nativeFetch(input, init);
+    }) as typeof fetch;
+
+    const issued = await fetch(`${base}/tokens`, {
+      method: "POST",
+      headers: hostAuth(),
+      body: JSON.stringify({ scope: "owner", label: "rate limited voice owner" }),
+    });
+    const tokenBody = (await issued.json()) as { token: string };
+
+    const response = await fetch(`${base}/voice/realtime/session`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${tokenBody.token}`, "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(429);
+    const body = (await response.json()) as { code: string };
+    expect(body.code).toBe("openwork_models_voice_failed");
   });
 
   test("values persist across server restart", async () => {

--- a/apps/server/src/env-routes.e2e.test.ts
+++ b/apps/server/src/env-routes.e2e.test.ts
@@ -17,6 +17,8 @@ const dirs: string[] = [];
 const priorEnvStore = process.env.OPENWORK_ENV_STORE;
 const priorTokenStore = process.env.OPENWORK_TOKEN_STORE;
 const priorOpenAiApiKey = process.env.OPENAI_API_KEY;
+const priorOpenWorkApiKey = process.env.OPENWORK_API_KEY;
+const priorOpenWorkInferenceBaseUrl = process.env.OPENWORK_INFERENCE_BASE_URL;
 const nativeFetch = globalThis.fetch;
 
 function baseConfig(): ServerConfig {
@@ -81,6 +83,16 @@ afterEach(async () => {
     delete process.env.OPENAI_API_KEY;
   } else {
     process.env.OPENAI_API_KEY = priorOpenAiApiKey;
+  }
+  if (priorOpenWorkApiKey === undefined) {
+    delete process.env.OPENWORK_API_KEY;
+  } else {
+    process.env.OPENWORK_API_KEY = priorOpenWorkApiKey;
+  }
+  if (priorOpenWorkInferenceBaseUrl === undefined) {
+    delete process.env.OPENWORK_INFERENCE_BASE_URL;
+  } else {
+    process.env.OPENWORK_INFERENCE_BASE_URL = priorOpenWorkInferenceBaseUrl;
   }
   globalThis.fetch = nativeFetch;
 });
@@ -352,6 +364,57 @@ describe("env routes", () => {
       ok: true,
       clientSecret: "rt-secret",
       expiresAt: 123,
+    });
+  });
+
+  test("voice realtime session prefers OpenWork Models broker when configured", async () => {
+    process.env.OPENWORK_API_KEY = "ow_inf_test";
+    process.env.OPENWORK_INFERENCE_BASE_URL = "https://inference.example.test";
+    process.env.OPENAI_API_KEY = "sk-should-not-be-used";
+    const { base } = await boot();
+
+    globalThis.fetch = ((input, init) => {
+      const url = String(input);
+      if (url === "https://inference.example.test/voice/realtime/session") {
+        expect(init?.headers).toMatchObject({ Authorization: "Bearer ow_inf_test" });
+        return Promise.resolve(new Response(JSON.stringify({
+          ok: true,
+          clientSecret: "managed-rt-secret",
+          expiresAt: 456,
+          model: "gpt-realtime-2",
+          transcriptionModel: "gpt-4o-transcribe",
+          tools: ["openwork_snapshot"],
+          source: "openwork-models",
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }));
+      }
+      if (url === "https://api.openai.com/v1/realtime/client_secrets") {
+        return Promise.resolve(new Response("direct OpenAI should not be called", { status: 500 }));
+      }
+      return nativeFetch(input, init);
+    }) as typeof fetch;
+
+    const issued = await fetch(`${base}/tokens`, {
+      method: "POST",
+      headers: hostAuth(),
+      body: JSON.stringify({ scope: "owner", label: "managed voice owner" }),
+    });
+    const tokenBody = (await issued.json()) as { token: string };
+
+    const response = await fetch(`${base}/voice/realtime/session`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${tokenBody.token}`, "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      clientSecret: "managed-rt-secret",
+      expiresAt: 456,
+      source: "openwork-models",
     });
   });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -407,10 +407,25 @@ async function createManagedVoiceSession(config: { baseUrl: string; apiKey: stri
     const message = typeof errorPayload?.message === "string" ? errorPayload.message : response.statusText;
     throw new ApiError(response.status, "openwork_models_voice_failed", message || "OpenWork Models could not create a voice session");
   }
-  if (!isRecord(payload) || payload.ok !== true || typeof payload.clientSecret !== "string") {
-    throw new ApiError(502, "openwork_models_voice_invalid_response", "OpenWork Models did not return a usable Realtime client secret");
+  if (
+    !isRecord(payload) ||
+    payload.ok !== true ||
+    typeof payload.clientSecret !== "string" ||
+    typeof payload.model !== "string" ||
+    !Array.isArray(payload.tools) ||
+    payload.tools.some((tool) => typeof tool !== "string")
+  ) {
+    throw new ApiError(502, "openwork_models_voice_invalid_response", "OpenWork Models did not return a usable Realtime session payload");
   }
-  return payload;
+  return {
+    ok: true,
+    clientSecret: payload.clientSecret,
+    expiresAt: typeof payload.expiresAt === "number" ? payload.expiresAt : null,
+    model: payload.model,
+    transcriptionModel: typeof payload.transcriptionModel === "string" ? payload.transcriptionModel : OPENWORK_VOICE_TRANSCRIPTION_MODEL,
+    tools: payload.tools,
+    ...(typeof payload.source === "string" ? { source: payload.source } : {}),
+  };
 }
 
 async function createDirectOpenAiVoiceSession(apiKey: string, input: unknown) {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -277,6 +277,26 @@ async function resolveOpenAiRealtimeApiKey(env: EnvService): Promise<string> {
     "";
 }
 
+async function resolveOpenWorkModelsVoiceConfig(env: EnvService): Promise<{ baseUrl: string; apiKey: string } | null> {
+  const records = await env.list();
+  const apiKey =
+    records.find((entry) => entry.key === "OPENWORK_API_KEY")?.value.trim() ||
+    records.find((entry) => entry.key === "OPENWORK_MODELS_API_KEY")?.value.trim() ||
+    process.env.OPENWORK_API_KEY?.trim() ||
+    process.env.OPENWORK_MODELS_API_KEY?.trim() ||
+    "";
+  if (!apiKey) return null;
+
+  const baseUrl =
+    records.find((entry) => entry.key === "OPENWORK_INFERENCE_BASE_URL")?.value.trim() ||
+    records.find((entry) => entry.key === "OPENWORK_MODELS_BASE_URL")?.value.trim() ||
+    process.env.OPENWORK_INFERENCE_BASE_URL?.trim() ||
+    process.env.OPENWORK_MODELS_BASE_URL?.trim() ||
+    "";
+  if (!baseUrl) return null;
+  return { apiKey, baseUrl: baseUrl.replace(/\/+$/, "") };
+}
+
 function openworkVoiceRealtimeInstructions(sessionContext: string) {
   const trimmedContext = sessionContext.trim();
   const contextSection = trimmedContext
@@ -288,7 +308,6 @@ Use this recent transcript context to answer questions about what was last discu
 
 ${trimmedContext}`
     : "";
-
   return `# Role and Objective
 
 You are OpenWork Voice Mode, a voice-first control layer inside OpenWork.
@@ -334,6 +353,27 @@ function readOpenAiClientSecret(payload: unknown): { clientSecret: string; expir
 }
 
 async function createOpenAiRealtimeVoiceSession(env: EnvService, input: unknown) {
+  const managedVoice = await resolveOpenWorkModelsVoiceConfig(env);
+  if (managedVoice) {
+    try {
+      return await createManagedVoiceSession(managedVoice, input);
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 503) {
+        const fallbackKey = await resolveOpenAiRealtimeApiKey(env);
+        if (fallbackKey) {
+          console.warn("[voice] OpenWork Models broker returned 503 — falling back to direct OpenAI Realtime.");
+          return createDirectOpenAiVoiceSession(fallbackKey, input);
+        }
+        throw new ApiError(
+          503,
+          "openwork_models_voice_unavailable",
+          "OpenWork Models voice is active but the server is not fully configured. Ask your admin to add an OpenAI key, or save your own OPENAI_API_KEY in Environment settings.",
+        );
+      }
+      throw error;
+    }
+  }
+
   const apiKey = await resolveOpenAiRealtimeApiKey(env);
   if (!apiKey) {
     throw new ApiError(
@@ -343,6 +383,37 @@ async function createOpenAiRealtimeVoiceSession(env: EnvService, input: unknown)
     );
   }
 
+  return createDirectOpenAiVoiceSession(apiKey, input);
+}
+
+async function createManagedVoiceSession(config: { baseUrl: string; apiKey: string }, input: unknown) {
+  const response = await fetch(`${config.baseUrl}/voice/realtime/session`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input ?? {}),
+  });
+  const text = await response.text();
+  let payload: unknown = null;
+  try {
+    payload = text ? JSON.parse(text) : null;
+  } catch {
+    payload = null;
+  }
+  if (!response.ok) {
+    const errorPayload = isRecord(payload) && isRecord(payload.error) ? payload.error : null;
+    const message = typeof errorPayload?.message === "string" ? errorPayload.message : response.statusText;
+    throw new ApiError(response.status, "openwork_models_voice_failed", message || "OpenWork Models could not create a voice session");
+  }
+  if (!isRecord(payload) || payload.ok !== true || typeof payload.clientSecret !== "string") {
+    throw new ApiError(502, "openwork_models_voice_invalid_response", "OpenWork Models did not return a usable Realtime client secret");
+  }
+  return payload;
+}
+
+async function createDirectOpenAiVoiceSession(apiKey: string, input: unknown) {
   const model = readStringField(input, "model") || OPENWORK_VOICE_REALTIME_MODEL;
   const sessionContext = readStringField(input, "sessionContext").slice(0, 6_000);
   const response = await fetch("https://api.openai.com/v1/realtime/client_secrets", {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -277,6 +277,26 @@ async function resolveOpenAiRealtimeApiKey(env: EnvService): Promise<string> {
     "";
 }
 
+async function resolveOpenWorkModelsVoiceConfig(env: EnvService): Promise<{ baseUrl: string; apiKey: string } | null> {
+  const records = await env.list();
+  const apiKey =
+    records.find((entry) => entry.key === "OPENWORK_API_KEY")?.value.trim() ||
+    records.find((entry) => entry.key === "OPENWORK_MODELS_API_KEY")?.value.trim() ||
+    process.env.OPENWORK_API_KEY?.trim() ||
+    process.env.OPENWORK_MODELS_API_KEY?.trim() ||
+    "";
+  if (!apiKey) return null;
+
+  const baseUrl =
+    records.find((entry) => entry.key === "OPENWORK_INFERENCE_BASE_URL")?.value.trim() ||
+    records.find((entry) => entry.key === "OPENWORK_MODELS_BASE_URL")?.value.trim() ||
+    process.env.OPENWORK_INFERENCE_BASE_URL?.trim() ||
+    process.env.OPENWORK_MODELS_BASE_URL?.trim() ||
+    "";
+  if (!baseUrl) return null;
+  return { apiKey, baseUrl: baseUrl.replace(/\/+$/, "") };
+}
+
 function openworkVoiceRealtimeInstructions() {
   return `# Role and Objective
 
@@ -323,6 +343,34 @@ function readOpenAiClientSecret(payload: unknown): { clientSecret: string; expir
 }
 
 async function createOpenAiRealtimeVoiceSession(env: EnvService, input: unknown) {
+  const managedVoice = await resolveOpenWorkModelsVoiceConfig(env);
+  if (managedVoice) {
+    const response = await fetch(`${managedVoice.baseUrl}/voice/realtime/session`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${managedVoice.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(input ?? {}),
+    });
+    const text = await response.text();
+    let payload: unknown = null;
+    try {
+      payload = text ? JSON.parse(text) : null;
+    } catch {
+      payload = null;
+    }
+    if (!response.ok) {
+      const errorPayload = isRecord(payload) && isRecord(payload.error) ? payload.error : null;
+      const message = typeof errorPayload?.message === "string" ? errorPayload.message : response.statusText;
+      throw new ApiError(response.status, "openwork_models_voice_failed", message || "OpenWork Models could not create a voice session");
+    }
+    if (!isRecord(payload) || payload.ok !== true || typeof payload.clientSecret !== "string") {
+      throw new ApiError(502, "openwork_models_voice_invalid_response", "OpenWork Models did not return a usable Realtime client secret");
+    }
+    return payload;
+  }
+
   const apiKey = await resolveOpenAiRealtimeApiKey(env);
   if (!apiKey) {
     throw new ApiError(

--- a/ee/apps/inference/src/app.ts
+++ b/ee/apps/inference/src/app.ts
@@ -8,6 +8,7 @@ import { logger } from "hono/logger";
 import { z } from "zod";
 import { env } from "./env.js";
 import { registerProxyRoutes } from "./proxy.js";
+import { registerVoiceRoutes } from "./voice.js";
 import { registerWebhookRoutes } from "./webhooks.js";
 
 const srcDir = path.dirname(fileURLToPath(import.meta.url));
@@ -65,6 +66,7 @@ if (shouldServeLocalModelCatalog) {
 }
 
 registerProxyRoutes(app);
+registerVoiceRoutes(app);
 registerWebhookRoutes(app);
 
 app.onError((error, c) => {

--- a/ee/apps/inference/src/env.ts
+++ b/ee/apps/inference/src/env.ts
@@ -14,9 +14,12 @@ const EnvSchema = z
     DEN_DB_ENCRYPTION_KEY: z.string().trim().min(32),
     INFERENCE_PROXY_BASE_URL: z.string().optional(),
     OPENROUTER_UPSTREAM_URL: z.string().optional(),
+    OPENAI_REALTIME_API_KEY: z.string().optional(),
+    OPENAI_API_KEY: z.string().optional(),
     INFERENCE_ADMIN_TOKEN: z.string().optional(),
     INFERENCE_WEBHOOK_SECRET: z.string().optional(),
     INFERENCE_CREDITS_PER_DOLLAR: z.string().optional(),
+    VOICE_SESSION_COST_UNITS: z.string().optional(),
   })
   .superRefine((value, ctx) => {
     const mode =
@@ -97,6 +100,14 @@ function parseCreditsPerDollar(value: string | undefined) {
   return credits;
 }
 
+function parseVoiceSessionCostUnits(value: string | undefined) {
+  const units = Number(value ?? "50000000");
+  if (!Number.isFinite(units) || units <= 0) {
+    throw new Error("VOICE_SESSION_COST_UNITS must be a positive number");
+  }
+  return units;
+}
+
 const planetscale: PlanetScaleCredentials | null =
   parsed.DATABASE_HOST &&
   parsed.DATABASE_USERNAME &&
@@ -120,7 +131,9 @@ export const env = {
   openRouterUpstreamUrl: normalizeUrl(
     parsed.OPENROUTER_UPSTREAM_URL ?? "https://openrouter.ai/api/v1",
   ),
+  openAiRealtimeApiKey: optionalString(parsed.OPENAI_REALTIME_API_KEY) ?? optionalString(parsed.OPENAI_API_KEY),
   adminToken: optionalString(parsed.INFERENCE_ADMIN_TOKEN),
   webhookSecret: optionalString(parsed.INFERENCE_WEBHOOK_SECRET),
   creditsPerDollar: parseCreditsPerDollar(parsed.INFERENCE_CREDITS_PER_DOLLAR),
+  voiceSessionCostUnits: parseVoiceSessionCostUnits(parsed.VOICE_SESSION_COST_UNITS),
 };

--- a/ee/apps/inference/src/env.ts
+++ b/ee/apps/inference/src/env.ts
@@ -14,6 +14,8 @@ const EnvSchema = z
     DEN_DB_ENCRYPTION_KEY: z.string().trim().min(32),
     INFERENCE_PROXY_BASE_URL: z.string().optional(),
     OPENROUTER_UPSTREAM_URL: z.string().optional(),
+    OPENAI_REALTIME_API_KEY: z.string().optional(),
+    OPENAI_API_KEY: z.string().optional(),
     INFERENCE_ADMIN_TOKEN: z.string().optional(),
     INFERENCE_WEBHOOK_SECRET: z.string().optional(),
     INFERENCE_CREDITS_PER_DOLLAR: z.string().optional(),
@@ -120,6 +122,7 @@ export const env = {
   openRouterUpstreamUrl: normalizeUrl(
     parsed.OPENROUTER_UPSTREAM_URL ?? "https://openrouter.ai/api/v1",
   ),
+  openAiRealtimeApiKey: optionalString(parsed.OPENAI_REALTIME_API_KEY) ?? optionalString(parsed.OPENAI_API_KEY),
   adminToken: optionalString(parsed.INFERENCE_ADMIN_TOKEN),
   webhookSecret: optionalString(parsed.INFERENCE_WEBHOOK_SECRET),
   creditsPerDollar: parseCreditsPerDollar(parsed.INFERENCE_CREDITS_PER_DOLLAR),

--- a/ee/apps/inference/src/voice.ts
+++ b/ee/apps/inference/src/voice.ts
@@ -1,0 +1,280 @@
+import { createHash } from "node:crypto"
+import { eq, sql } from "drizzle-orm"
+import type { Hono } from "hono"
+import {
+  InferenceOrgUsageBucketTable,
+  InferenceUsageLedgerBucketChargeTable,
+  InferenceUsageLedgerEntryTable,
+} from "@openwork-ee/den-db"
+import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import type { DenTypeId } from "@openwork-ee/utils/typeid"
+import { env } from "./env.js"
+import { findActiveInferenceKey } from "./keys.js"
+import { ensureUsableBuckets } from "./limits.js"
+import { db } from "./db.js"
+
+const OPENWORK_VOICE_REALTIME_MODEL = "gpt-realtime-2"
+const OPENWORK_VOICE_TRANSCRIPTION_MODEL = "gpt-4o-transcribe"
+
+const OPENWORK_VOICE_REALTIME_TOOLS = [
+  {
+    type: "function",
+    name: "openwork_snapshot",
+    description: "Read the current OpenWork UI control snapshot: route, status, narration, and visible action metadata.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    type: "function",
+    name: "openwork_list_actions",
+    description: "List semantic OpenWork UI actions. Call this before openwork_execute_action when you do not know the exact action id.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    type: "function",
+    name: "openwork_execute_action",
+    description: "Execute a semantic OpenWork UI action by id. Prefer this over screen coordinates or DOM guessing.",
+    parameters: {
+      type: "object",
+      properties: {
+        actionId: { type: "string", description: "The action id from openwork_list_actions, such as composer.set_text or composer.send." },
+        args: { type: "object", description: "Optional JSON arguments for the action.", additionalProperties: true },
+      },
+      required: ["actionId"],
+      additionalProperties: false,
+    },
+  },
+]
+
+function readApiKey(request: Request) {
+  const auth = request.headers.get("authorization")
+  if (auth?.toLowerCase().startsWith("bearer ")) {
+    return auth.slice(7).trim()
+  }
+  return request.headers.get("x-api-key")?.trim() ?? null
+}
+
+function buildRequestId() {
+  return createHash("sha256").update(`${Date.now()}:${Math.random()}`).digest("hex").slice(0, 32)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readStringField(value: unknown, key: string) {
+  if (!isRecord(value)) return ""
+  const field = value[key]
+  return typeof field === "string" ? field.trim() : ""
+}
+
+function readOpenAiClientSecret(payload: unknown): { clientSecret: string; expiresAt: number | null } {
+  if (!isRecord(payload)) return { clientSecret: "", expiresAt: null }
+  const clientSecret = payload.client_secret
+  if (typeof clientSecret === "string") return { clientSecret, expiresAt: null }
+  if (isRecord(clientSecret)) {
+    const value = typeof clientSecret.value === "string" ? clientSecret.value : ""
+    const expiresAt = typeof clientSecret.expires_at === "number" ? clientSecret.expires_at : null
+    return { clientSecret: value, expiresAt }
+  }
+  const value = typeof payload.value === "string" ? payload.value : ""
+  return { clientSecret: value, expiresAt: null }
+}
+
+function secondsUntil(date: Date) {
+  return Math.max(0, Math.ceil((date.getTime() - Date.now()) / 1000))
+}
+
+function formatResetMessage(windowEndAt: Date): string {
+  const seconds = secondsUntil(windowEndAt)
+  if (seconds < 3600) {
+    return `It resets in ${Math.ceil(seconds / 60)} minutes.`
+  }
+  return `It resets in ${Math.ceil(seconds / 3600)} hours.`
+}
+
+function openworkVoiceRealtimeInstructions() {
+  return `# Role and Objective
+
+You are OpenWork Voice Mode, a voice-first control layer inside OpenWork.
+Help the user control OpenWork by using the semantic OpenWork UI tools.
+
+# Tool Policy
+
+- Prefer openwork_snapshot, openwork_list_actions, and openwork_execute_action over visual guessing.
+- If the user asks to write or draft something, use composer.set_text.
+- If the user asks to send or run the current prompt, use composer.send.
+- For navigation, settings, session, transcript, and composer work, inspect the action list first if the action id is unknown.
+- Do not claim an action completed until the tool succeeds.
+- Ask for confirmation before destructive actions such as deleting a session.
+
+# Voice Style
+
+- Be concise, calm, and direct.
+- If audio is unclear, ask the user to repeat it instead of guessing.
+- Ignore background speech that is not addressed to OpenWork.
+- Summarize tool results briefly and offer the next useful step.`
+}
+
+async function createOpenAiRealtimeClientSecret(input: unknown, openworkRequestId: string) {
+  if (!env.openAiRealtimeApiKey) {
+    return Response.json({ error: { message: "Managed voice is not configured.", type: "invalid_request_error", code: "openai_realtime_key_missing" } }, { status: 503 })
+  }
+
+  const model = readStringField(input, "model") || OPENWORK_VOICE_REALTIME_MODEL
+  const response = await fetch("https://api.openai.com/v1/realtime/client_secrets", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.openAiRealtimeApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      session: {
+        type: "realtime",
+        model,
+        output_modalities: ["audio"],
+        audio: {
+          input: {
+            transcription: { model: OPENWORK_VOICE_TRANSCRIPTION_MODEL, language: "en" },
+            turn_detection: {
+              type: "server_vad",
+              threshold: 0.58,
+              silence_duration_ms: 320,
+              prefix_padding_ms: 300,
+              create_response: true,
+              interrupt_response: true,
+            },
+          },
+        },
+        instructions: openworkVoiceRealtimeInstructions(),
+        tool_choice: "auto",
+        tools: OPENWORK_VOICE_REALTIME_TOOLS,
+      },
+    }),
+  })
+
+  const text = await response.text()
+  let payload: unknown = null
+  try {
+    payload = text ? JSON.parse(text) : null
+  } catch {
+    payload = null
+  }
+
+  if (!response.ok) {
+    const errorPayload = isRecord(payload) && isRecord(payload.error) ? payload.error : null
+    const message = typeof errorPayload?.message === "string" ? errorPayload.message : response.statusText
+    return Response.json({ error: { message: message || "Failed to create OpenAI Realtime session", type: "api_error", code: "openai_realtime_failed" } }, { status: response.status })
+  }
+
+  const { clientSecret, expiresAt } = readOpenAiClientSecret(payload)
+  if (!clientSecret) {
+    return Response.json({ error: { message: "OpenAI did not return a usable Realtime client secret.", type: "api_error", code: "openai_realtime_invalid_response" } }, { status: 502 })
+  }
+
+  return Response.json({
+    ok: true,
+    clientSecret,
+    expiresAt,
+    model,
+    transcriptionModel: OPENWORK_VOICE_TRANSCRIPTION_MODEL,
+    tools: OPENWORK_VOICE_REALTIME_TOOLS.map((tool) => tool.name),
+    source: "openwork-models",
+    openworkRequestId,
+  })
+}
+
+async function chargeVoiceSession(input: {
+  inferenceKey: { id: DenTypeId<"inferenceKey">; organization_id: DenTypeId<"organization">; org_membership_id: DenTypeId<"member"> }
+  openworkRequestId: string
+  limits: Awaited<ReturnType<typeof ensureUsableBuckets>>
+}) {
+  const costAmount = env.voiceSessionCostUnits
+  const entryId = createDenTypeId("inferenceUsageLedgerEntry")
+
+  await db.insert(InferenceUsageLedgerEntryTable).values({
+    id: entryId,
+    organization_id: input.inferenceKey.organization_id,
+    org_membership_id: input.inferenceKey.org_membership_id,
+    inference_key_id: input.inferenceKey.id,
+    external_job_id: input.openworkRequestId,
+    external_event_id: null,
+    cost_amount: costAmount,
+    event_type: "voice_realtime_session",
+    occurred_at: new Date(),
+  })
+
+  const bucketLimits = input.limits.bucketLimits as Record<string, number | undefined>
+  for (const [windowType, bucketId] of Object.entries(input.limits.bucketIds)) {
+    if (!bucketId) continue
+    const limitAmount = bucketLimits[windowType]
+    if (limitAmount === undefined) continue
+
+    await db.insert(InferenceUsageLedgerBucketChargeTable).values({
+      id: createDenTypeId("inferenceUsageLedgerBucketCharge"),
+      ledger_entry_id: entryId,
+      bucket_id: bucketId,
+      amount: costAmount,
+    })
+    await db.update(InferenceOrgUsageBucketTable).set({
+      limit_amount: limitAmount,
+      used_amount: sql`${InferenceOrgUsageBucketTable.used_amount} + ${costAmount}`,
+    }).where(eq(InferenceOrgUsageBucketTable.id, bucketId))
+  }
+}
+
+export function registerVoiceRoutes(app: Hono) {
+  app.post("/voice/realtime/session", async (c) => {
+    const rawKey = readApiKey(c.req.raw)
+    if (!rawKey) {
+      return c.json({ error: { message: "Missing OpenWork inference API key.", type: "authentication_error", code: "missing_api_key" } }, 401)
+    }
+
+    const inferenceKey = await findActiveInferenceKey(rawKey)
+    if (!inferenceKey) {
+      return c.json({ error: { message: "Invalid OpenWork inference API key.", type: "authentication_error", code: "invalid_api_key" } }, 401)
+    }
+
+    const limits = await ensureUsableBuckets(inferenceKey.organization_id)
+    if (!limits.ok) {
+      const limitedBucket = "limitedBucket" in limits ? limits.limitedBucket : null
+      const resetMessage = limitedBucket ? ` ${formatResetMessage(limitedBucket.windowEndAt)}` : ""
+      const retryAfter = limitedBucket ? secondsUntil(limitedBucket.windowEndAt) : undefined
+      c.header("x-openwork-limit-window-type", limits.windowType)
+      if (retryAfter !== undefined) {
+        c.header("retry-after", String(retryAfter))
+        c.header("x-ratelimit-remaining-tokens", "0")
+        if (limitedBucket) {
+          c.header("x-ratelimit-limit-tokens", String(limitedBucket.limitAmount))
+          c.header("x-ratelimit-reset-tokens", `${retryAfter}s`)
+        }
+      }
+      return c.json({
+        error: {
+          message: `Your organization has reached its Voice Mode usage limit.${resetMessage}`,
+          type: "tokens",
+          code: "rate_limit_exceeded",
+        },
+      }, 429)
+    }
+
+    const openworkRequestId = buildRequestId()
+    let body: unknown = {}
+    try {
+      body = await c.req.json()
+    } catch {
+      body = {}
+    }
+
+    const response = await createOpenAiRealtimeClientSecret(body, openworkRequestId)
+
+    if (response.status === 200) {
+      try {
+        await chargeVoiceSession({ inferenceKey, openworkRequestId, limits })
+      } catch (error) {
+        console.error("[voice] failed to charge voice session", { openworkRequestId, error: error instanceof Error ? error.message : String(error) })
+      }
+    }
+
+    return response
+  })
+}

--- a/ee/apps/inference/src/voice.ts
+++ b/ee/apps/inference/src/voice.ts
@@ -191,35 +191,37 @@ async function chargeVoiceSession(input: {
   const costAmount = env.voiceSessionCostUnits
   const entryId = createDenTypeId("inferenceUsageLedgerEntry")
 
-  await db.insert(InferenceUsageLedgerEntryTable).values({
-    id: entryId,
-    organization_id: input.inferenceKey.organization_id,
-    org_membership_id: input.inferenceKey.org_membership_id,
-    inference_key_id: input.inferenceKey.id,
-    external_job_id: input.openworkRequestId,
-    external_event_id: null,
-    cost_amount: costAmount,
-    event_type: "voice_realtime_session",
-    occurred_at: new Date(),
-  })
-
-  const bucketLimits = input.limits.bucketLimits as Record<string, number | undefined>
-  for (const [windowType, bucketId] of Object.entries(input.limits.bucketIds)) {
-    if (!bucketId) continue
-    const limitAmount = bucketLimits[windowType]
-    if (limitAmount === undefined) continue
-
-    await db.insert(InferenceUsageLedgerBucketChargeTable).values({
-      id: createDenTypeId("inferenceUsageLedgerBucketCharge"),
-      ledger_entry_id: entryId,
-      bucket_id: bucketId,
-      amount: costAmount,
+  await db.transaction(async (tx) => {
+    await tx.insert(InferenceUsageLedgerEntryTable).values({
+      id: entryId,
+      organization_id: input.inferenceKey.organization_id,
+      org_membership_id: input.inferenceKey.org_membership_id,
+      inference_key_id: input.inferenceKey.id,
+      external_job_id: input.openworkRequestId,
+      external_event_id: null,
+      cost_amount: costAmount,
+      event_type: "voice_realtime_session",
+      occurred_at: new Date(),
     })
-    await db.update(InferenceOrgUsageBucketTable).set({
-      limit_amount: limitAmount,
-      used_amount: sql`${InferenceOrgUsageBucketTable.used_amount} + ${costAmount}`,
-    }).where(eq(InferenceOrgUsageBucketTable.id, bucketId))
-  }
+
+    const bucketLimits = input.limits.bucketLimits as Record<string, number | undefined>
+    for (const [windowType, bucketId] of Object.entries(input.limits.bucketIds)) {
+      if (!bucketId) continue
+      const limitAmount = bucketLimits[windowType]
+      if (limitAmount === undefined) continue
+
+      await tx.insert(InferenceUsageLedgerBucketChargeTable).values({
+        id: createDenTypeId("inferenceUsageLedgerBucketCharge"),
+        ledger_entry_id: entryId,
+        bucket_id: bucketId,
+        amount: costAmount,
+      })
+      await tx.update(InferenceOrgUsageBucketTable).set({
+        limit_amount: limitAmount,
+        used_amount: sql`${InferenceOrgUsageBucketTable.used_amount} + ${costAmount}`,
+      }).where(eq(InferenceOrgUsageBucketTable.id, bucketId))
+    }
+  })
 }
 
 export function registerVoiceRoutes(app: Hono) {

--- a/ee/apps/inference/src/voice.ts
+++ b/ee/apps/inference/src/voice.ts
@@ -1,0 +1,192 @@
+import { createHash } from "node:crypto"
+import type { Hono } from "hono"
+import { env } from "./env.js"
+import { findActiveInferenceKey } from "./keys.js"
+import { ensureUsableBuckets } from "./limits.js"
+
+const OPENWORK_VOICE_REALTIME_MODEL = "gpt-realtime-2"
+const OPENWORK_VOICE_TRANSCRIPTION_MODEL = "gpt-4o-transcribe"
+
+const OPENWORK_VOICE_REALTIME_TOOLS = [
+  {
+    type: "function",
+    name: "openwork_snapshot",
+    description: "Read the current OpenWork UI control snapshot: route, status, narration, and visible action metadata.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    type: "function",
+    name: "openwork_list_actions",
+    description: "List semantic OpenWork UI actions. Call this before openwork_execute_action when you do not know the exact action id.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    type: "function",
+    name: "openwork_execute_action",
+    description: "Execute a semantic OpenWork UI action by id. Prefer this over screen coordinates or DOM guessing.",
+    parameters: {
+      type: "object",
+      properties: {
+        actionId: { type: "string", description: "The action id from openwork_list_actions, such as composer.set_text or composer.send." },
+        args: { type: "object", description: "Optional JSON arguments for the action.", additionalProperties: true },
+      },
+      required: ["actionId"],
+      additionalProperties: false,
+    },
+  },
+]
+
+function readApiKey(request: Request) {
+  const auth = request.headers.get("authorization")
+  if (auth?.toLowerCase().startsWith("bearer ")) {
+    return auth.slice(7).trim()
+  }
+  return request.headers.get("x-api-key")?.trim() ?? null
+}
+
+function buildRequestId() {
+  return createHash("sha256").update(`${Date.now()}:${Math.random()}`).digest("hex").slice(0, 32)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readStringField(value: unknown, key: string) {
+  if (!isRecord(value)) return ""
+  const field = value[key]
+  return typeof field === "string" ? field.trim() : ""
+}
+
+function readOpenAiClientSecret(payload: unknown): { clientSecret: string; expiresAt: number | null } {
+  if (!isRecord(payload)) return { clientSecret: "", expiresAt: null }
+  const clientSecret = payload.client_secret
+  if (typeof clientSecret === "string") return { clientSecret, expiresAt: null }
+  if (isRecord(clientSecret)) {
+    const value = typeof clientSecret.value === "string" ? clientSecret.value : ""
+    const expiresAt = typeof clientSecret.expires_at === "number" ? clientSecret.expires_at : null
+    return { clientSecret: value, expiresAt }
+  }
+  const value = typeof payload.value === "string" ? payload.value : ""
+  return { clientSecret: value, expiresAt: null }
+}
+
+function openworkVoiceRealtimeInstructions() {
+  return `# Role and Objective
+
+You are OpenWork Voice Mode, a voice-first control layer inside OpenWork.
+Help the user control OpenWork by using the semantic OpenWork UI tools.
+
+# Tool Policy
+
+- Prefer openwork_snapshot, openwork_list_actions, and openwork_execute_action over visual guessing.
+- If the user asks to write or draft something, use composer.set_text.
+- If the user asks to send or run the current prompt, use composer.send.
+- For navigation, settings, session, transcript, and composer work, inspect the action list first if the action id is unknown.
+- Do not claim an action completed until the tool succeeds.
+- Ask for confirmation before destructive actions such as deleting a session.
+
+# Voice Style
+
+- Be concise, calm, and direct.
+- If audio is unclear, ask the user to repeat it instead of guessing.
+- Ignore background speech that is not addressed to OpenWork.
+- Summarize tool results briefly and offer the next useful step.`
+}
+
+async function createOpenAiRealtimeClientSecret(input: unknown, openworkRequestId: string) {
+  if (!env.openAiRealtimeApiKey) {
+    return Response.json({ error: { message: "Managed voice is not configured.", type: "invalid_request_error", code: "openai_realtime_key_missing" } }, { status: 503 })
+  }
+
+  const model = readStringField(input, "model") || OPENWORK_VOICE_REALTIME_MODEL
+  const response = await fetch("https://api.openai.com/v1/realtime/client_secrets", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.openAiRealtimeApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      session: {
+        type: "realtime",
+        model,
+        output_modalities: ["audio"],
+        audio: {
+          input: {
+            transcription: { model: OPENWORK_VOICE_TRANSCRIPTION_MODEL, language: "en" },
+            turn_detection: {
+              type: "server_vad",
+              threshold: 0.58,
+              silence_duration_ms: 320,
+              prefix_padding_ms: 300,
+              create_response: true,
+              interrupt_response: true,
+            },
+          },
+        },
+        instructions: openworkVoiceRealtimeInstructions(),
+        tool_choice: "auto",
+        tools: OPENWORK_VOICE_REALTIME_TOOLS,
+      },
+    }),
+  })
+
+  const text = await response.text()
+  let payload: unknown = null
+  try {
+    payload = text ? JSON.parse(text) : null
+  } catch {
+    payload = null
+  }
+
+  if (!response.ok) {
+    const errorPayload = isRecord(payload) && isRecord(payload.error) ? payload.error : null
+    const message = typeof errorPayload?.message === "string" ? errorPayload.message : response.statusText
+    return Response.json({ error: { message: message || "Failed to create OpenAI Realtime session", type: "api_error", code: "openai_realtime_failed" } }, { status: response.status })
+  }
+
+  const { clientSecret, expiresAt } = readOpenAiClientSecret(payload)
+  if (!clientSecret) {
+    return Response.json({ error: { message: "OpenAI did not return a usable Realtime client secret.", type: "api_error", code: "openai_realtime_invalid_response" } }, { status: 502 })
+  }
+
+  return Response.json({
+    ok: true,
+    clientSecret,
+    expiresAt,
+    model,
+    transcriptionModel: OPENWORK_VOICE_TRANSCRIPTION_MODEL,
+    tools: OPENWORK_VOICE_REALTIME_TOOLS.map((tool) => tool.name),
+    source: "openwork-models",
+    openworkRequestId,
+  })
+}
+
+export function registerVoiceRoutes(app: Hono) {
+  app.post("/voice/realtime/session", async (c) => {
+    const rawKey = readApiKey(c.req.raw)
+    if (!rawKey) {
+      return c.json({ error: { message: "Missing OpenWork inference API key.", type: "authentication_error", code: "missing_api_key" } }, 401)
+    }
+
+    const inferenceKey = await findActiveInferenceKey(rawKey)
+    if (!inferenceKey) {
+      return c.json({ error: { message: "Invalid OpenWork inference API key.", type: "authentication_error", code: "invalid_api_key" } }, 401)
+    }
+
+    const limits = await ensureUsableBuckets(inferenceKey.organization_id)
+    if (!limits.ok) {
+      return c.json({ error: { message: `Rate limit reached for organization ${inferenceKey.organization_id}.`, type: "tokens", code: "rate_limit_exceeded" } }, 429)
+    }
+
+    const openworkRequestId = buildRequestId()
+    let body: unknown = {}
+    try {
+      body = await c.req.json()
+    } catch {
+      body = {}
+    }
+
+    return createOpenAiRealtimeClientSecret(body, openworkRequestId)
+  })
+}

--- a/evals/flows/openwork-models-voice-funnel.flow.mjs
+++ b/evals/flows/openwork-models-voice-funnel.flow.mjs
@@ -1,0 +1,706 @@
+import { createHmac, randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const EMAIL_DOMAIN = "voice-eval.openwork.test";
+const PASSWORD = "OpenWorkVoiceEval123!";
+const MOCK_INFERENCE_KEY = "ow_inf_voice_funnel";
+const DEFAULT_STRIPE_WEBHOOK_SECRET = "whsec_openwork_eval";
+const DEFAULT_STRIPE_PRICE_ID = "price_openwork_models_eval";
+const VOICE_TRANSCRIPT_TEXT = "What can you help me with?";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function apiBase(ctx) {
+  return ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+}
+
+function jsonHeaders(token) {
+  return {
+    "content-type": "application/json",
+    origin: process.env.OPENWORK_EVAL_DEN_ORIGIN?.trim() || process.env.OPENWORK_EVAL_DEN_API_URL?.trim()?.replace(/\/+$/, "") || "http://localhost:8790",
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+async function readJson(response) {
+  const text = await response.text();
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  return { text, json };
+}
+
+function extractToken(payload) {
+  if (!payload || typeof payload !== "object") return "";
+  if (typeof payload.token === "string") return payload.token;
+  if (payload.session && typeof payload.session === "object" && typeof payload.session.token === "string") return payload.session.token;
+  if (payload.data && typeof payload.data === "object" && typeof payload.data.token === "string") return payload.data.token;
+  return "";
+}
+
+async function denRequest(ctx, path, { method = "GET", token, body } = {}) {
+  const response = await fetch(`${apiBase(ctx)}${path}`, {
+    method,
+    headers: jsonHeaders(token),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const payload = await readJson(response);
+  return { response, ...payload };
+}
+
+async function findFreePort() {
+  const server = createServer();
+  server.unref();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  server.close();
+  if (!address || typeof address === "string") throw new Error("Could not allocate a free port.");
+  return address.port;
+}
+
+async function startMockBroker() {
+  const requests = [];
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += String(chunk);
+    });
+    req.on("end", () => {
+      requests.push({ method: req.method, url: req.url, authorization: req.headers.authorization ?? null, body });
+      if (req.method !== "POST" || req.url !== "/voice/realtime/session") {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "not_found" }));
+        return;
+      }
+      if (req.headers.authorization !== `Bearer ${MOCK_INFERENCE_KEY}`) {
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { code: "invalid_api_key" } }));
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({
+        ok: true,
+        clientSecret: "managed-funnel-client-secret",
+        expiresAt: 987654321,
+        model: "gpt-realtime-2",
+        transcriptionModel: "gpt-4o-transcribe",
+        tools: ["openwork_snapshot", "openwork_list_actions", "openwork_execute_action"],
+        source: "openwork-models",
+      }));
+    });
+  });
+  const port = await findFreePort();
+  await new Promise((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    requests,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+function stripeSignature(payload, secret) {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signedPayload = `${timestamp}.${payload}`;
+  const signature = createHmac("sha256", secret).update(signedPayload).digest("hex");
+  return `t=${timestamp},v1=${signature}`;
+}
+
+function stripeSubscriptionEvent({ organizationId, memberId, priceId }) {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id: `evt_voice_${randomUUID().replace(/-/g, "")}`,
+    object: "event",
+    api_version: "2026-04-22.dahlia",
+    created: now,
+    livemode: false,
+    pending_webhooks: 1,
+    request: { id: null, idempotency_key: null },
+    type: "customer.subscription.created",
+    data: {
+      object: {
+        id: `sub_voice_${randomUUID().replace(/-/g, "")}`,
+        object: "subscription",
+        customer: `cus_voice_${randomUUID().replace(/-/g, "").slice(0, 16)}`,
+        status: "active",
+        metadata: {
+          org_id: organizationId,
+          created_by_org_member_id: memberId,
+          openwork_product: "openwork_models",
+          subscription_type: "inference",
+        },
+        items: {
+          object: "list",
+          data: [
+            {
+              id: `si_voice_${randomUUID().replace(/-/g, "").slice(0, 16)}`,
+              object: "subscription_item",
+              quantity: 1,
+              price: { id: priceId, object: "price" },
+            },
+          ],
+        },
+        cancel_at_period_end: false,
+        canceled_at: null,
+        ended_at: null,
+        current_period_start: now,
+        current_period_end: now + 30 * 24 * 60 * 60,
+      },
+    },
+  };
+}
+
+async function waitForNodeCondition(check, label, timeoutMs = 30_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const value = await check();
+    if (value) return value;
+    await sleep(250);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+export default {
+  id: "openwork-models-voice-funnel",
+  title: "Sign up, pay for OpenWork Models, and start managed Voice Mode",
+  spec: "evals/onboarding-welcome-flows.md#flow-28--openwork-models-path-explains-payment-before-value",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
+  steps: [
+    {
+      name: "Start mock OpenWork Models voice broker",
+      run: async (ctx) => {
+        ctx.mockBroker = await startMockBroker();
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "Managed voice broker fixture is listening for authenticated OpenWork Models session requests.",
+          actual: ctx.mockBroker.baseUrl,
+        });
+      },
+    },
+    {
+      name: "Create a new Den user and organization",
+      run: async (ctx) => {
+        const nonce = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const email = `voice-${nonce}@${EMAIL_DOMAIN}`;
+        const signUp = await denRequest(ctx, "/api/auth/sign-up/email", {
+          method: "POST",
+          body: { name: "Voice Funnel Eval", email, password: PASSWORD },
+        });
+        ctx.assert(signUp.response.ok, `Den sign-up failed: ${signUp.response.status} ${signUp.text.slice(0, 300)}`);
+
+        let token = extractToken(signUp.json);
+        if (!token) {
+          const signIn = await denRequest(ctx, "/api/auth/sign-in/email", {
+            method: "POST",
+            body: { email, password: PASSWORD },
+          });
+          ctx.assert(signIn.response.ok, `Den sign-in after sign-up failed: ${signIn.response.status} ${signIn.text.slice(0, 300)}`);
+          token = extractToken(signIn.json);
+        }
+        ctx.assert(token, "Den sign-in did not return a bearer token. Email verification may be enabled for this environment.");
+
+        const created = await denRequest(ctx, "/v1/org", {
+          method: "POST",
+          token,
+          body: { name: `Voice Eval ${nonce}` },
+        });
+        ctx.assert(created.response.status === 201, `Organization creation failed: ${created.response.status} ${created.text.slice(0, 300)}`);
+        const organizationId = created.json?.organization?.id;
+        ctx.assert(typeof organizationId === "string" && organizationId, "Organization creation did not return an organization id.");
+
+        const org = await denRequest(ctx, "/v1/org", { token });
+        ctx.assert(org.response.ok, `Organization context failed: ${org.response.status} ${org.text.slice(0, 300)}`);
+        const memberId = org.json?.currentMember?.id;
+        ctx.assert(typeof memberId === "string" && memberId, "Organization context did not include currentMember.id.");
+
+        ctx.den = { email, token, organizationId, memberId };
+        ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "A brand-new signed-up Den owner and active organization were created.", actual: { email, organizationId, memberId } });
+      },
+    },
+    {
+      name: "Record paid OpenWork Models subscription",
+      run: async (ctx) => {
+        const secret = ctx.env.OPENWORK_EVAL_STRIPE_WEBHOOK_SECRET?.trim() || DEFAULT_STRIPE_WEBHOOK_SECRET;
+        const priceId = ctx.env.OPENWORK_EVAL_STRIPE_INFERENCE_PRICE_ID?.trim() || DEFAULT_STRIPE_PRICE_ID;
+        const event = stripeSubscriptionEvent({ organizationId: ctx.den.organizationId, memberId: ctx.den.memberId, priceId });
+        const payload = JSON.stringify(event);
+        const response = await fetch(`${apiBase(ctx)}/v1/webhooks/stripe`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "stripe-signature": stripeSignature(payload, secret),
+          },
+          body: payload,
+        });
+        const result = await readJson(response);
+        ctx.assert(response.ok, `Stripe paid-subscription webhook failed: ${response.status} ${result.text.slice(0, 300)}. Ensure the Den API was started with STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET=${secret}.`);
+
+        const billing = await denRequest(ctx, "/v1/billing", { token: ctx.den.token });
+        ctx.assert(billing.response.ok, `Billing status failed: ${billing.response.status} ${billing.text.slice(0, 300)}`);
+        ctx.assert(billing.json?.billing?.stripe?.hasActiveSubscription === true, "Billing status did not show an active OpenWork Models subscription.");
+        ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "The paid OpenWork Models subscription boundary is active for the new organization.", actual: billing.json.billing.stripe.subscription });
+      },
+    },
+    {
+      name: "Sign desktop app into the paid Den account",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "OpenWork control API" });
+        await ctx.eval(`(() => {
+          localStorage.setItem("openwork.den.baseUrl", ${JSON.stringify(apiBase(ctx))});
+          localStorage.setItem("openwork.den.apiBaseUrl", ${JSON.stringify(apiBase(ctx))});
+          for (const key of ["openwork.den.authToken", "openwork.den.activeOrgId", "openwork.den.activeOrgSlug", "openwork.den.activeOrgName"]) localStorage.removeItem(key);
+          window.location.hash = "#/settings/cloud-account";
+          window.location.reload();
+          return true;
+        })()`);
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "OpenWork control API after auth reset" });
+
+        const handoff = await denRequest(ctx, "/v1/auth/desktop-handoff", {
+          method: "POST",
+          token: ctx.den.token,
+          body: { desktopScheme: "openwork" },
+        });
+        ctx.assert(handoff.response.ok, `Desktop handoff creation failed: ${handoff.response.status} ${handoff.text.slice(0, 300)}`);
+        ctx.assert(typeof handoff.json?.openworkUrl === "string", "Desktop handoff did not return openworkUrl.");
+
+        await ctx.navigateHash("/settings/cloud-account");
+        await ctx.waitFor(`document.body.innerText.includes('Paste sign-in code') || document.body.innerText.includes('Hide sign-in code') || document.body.innerText.includes('Sign out')`, {
+          timeoutMs: 15_000,
+          label: "cloud account sign-in area",
+        });
+        if (!(await ctx.hasText("Sign out"))) {
+          if (!(await ctx.eval("Boolean(document.querySelector('#den-signin-link'))"))) {
+            await ctx.waitFor(`(() => {
+              const buttons = document.querySelectorAll('button');
+              for (const btn of buttons) {
+                if ((btn.textContent || '').trim() === 'Paste sign-in code') {
+                  const fk = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
+                  return !!(fk && btn[fk]?.onClick);
+                }
+              }
+              return false;
+            })()`, { timeoutMs: 15_000, label: "Paste sign-in code button with React props" });
+            await ctx.eval(`(() => {
+              const buttons = document.querySelectorAll('button');
+              for (const btn of buttons) {
+                if ((btn.textContent || '').trim() === 'Paste sign-in code') {
+                  const fiberKey = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
+                  if (fiberKey && btn[fiberKey]?.onClick) {
+                    btn[fiberKey].onClick({ preventDefault: () => {}, stopPropagation: () => {}, currentTarget: btn, target: btn });
+                    return 'react-onClick';
+                  }
+                  btn.click();
+                  return 'dom-click';
+                }
+              }
+              return false;
+            })()`);
+            await sleep(1_000);
+          }
+          await ctx.waitFor("Boolean(document.querySelector('#den-signin-link'))", { timeoutMs: 15_000, label: "den-signin-link input" });
+          await ctx.fill("#den-signin-link", handoff.json.openworkUrl);
+          await ctx.clickText("Finish sign-in", { timeoutMs: 15_000 });
+        }
+        await ctx.waitFor(`localStorage.getItem("openwork.den.authToken") === ${JSON.stringify(ctx.den.token)}`, {
+          timeoutMs: 45_000,
+          label: "desktop persisted the newly signed-up account token",
+        });
+        await sleep(1_000);
+        if (await ctx.hasText("Continue with organization")) {
+          await ctx.clickText("Continue with organization", { timeoutMs: 10_000 });
+          await sleep(1_000);
+        }
+        await ctx.eval(`(() => {
+          const raw = localStorage.getItem("openwork.preferences");
+          const prefs = raw ? JSON.parse(raw) : {};
+          localStorage.setItem("openwork.preferences", JSON.stringify({ ...prefs, hasCompletedOnboarding: true }));
+          window.location.hash = "#/settings/cloud-account";
+          return true;
+        })()`);
+        await ctx.expectText("Sign out", { timeoutMs: 30_000 });
+        await ctx.screenshot("paid-den-account-signed-in", { claim: "Desktop is signed in to the newly paid OpenWork Models account.", requireText: ["Sign out"] });
+      },
+    },
+    {
+      name: "Create workspace via UI",
+      run: async (ctx) => {
+        const workspaceDir = ctx.env.OPENWORK_EVAL_WORKSPACE_DIR?.trim() || join(tmpdir(), `openwork-models-voice-${Date.now()}`);
+        await mkdir(workspaceDir, { recursive: true });
+        ctx.workspaceDir = workspaceDir;
+
+        await ctx.eval(`(() => {
+          const raw = localStorage.getItem("openwork.preferences");
+          const prefs = raw ? JSON.parse(raw) : {};
+          localStorage.setItem("openwork.preferences", JSON.stringify({ ...prefs, hasCompletedOnboarding: true }));
+          window.location.hash = "#/";
+          return true;
+        })()`);
+        await ctx.waitFor("location.hash.includes('/workspace/')", { timeoutMs: 15_000, label: "workspace page after onboarding reset" });
+
+        await ctx.clickText("Add workspace", { timeoutMs: 15_000 });
+        await ctx.waitForText("Local workspace", { timeoutMs: 10_000 });
+        await ctx.clickText("Local workspace", { timeoutMs: 10_000 });
+
+        await ctx.waitFor(`Boolean(document.querySelector('input[placeholder*="folder"], input[placeholder*="path"], input[placeholder*="directory"]')) || Boolean(document.body.innerText.match(/browse|select.*folder|choose/i))`, {
+          timeoutMs: 10_000,
+          label: "workspace folder input or browse prompt",
+        });
+
+        await ctx.eval(`(() => {
+          const fiberKey = Object.keys(document.querySelector('[class*="modal"], [class*="dialog"], [role="dialog"]') ?? document.body).find((k) => k.startsWith("__reactFiber$"));
+          if (!fiberKey) return "no fiber";
+          const modal = (document.querySelector('[class*="modal"], [class*="dialog"], [role="dialog"]') ?? document.body)[fiberKey];
+          let node = modal;
+          for (let i = 0; i < 30 && node; i += 1) {
+            const state = node.memoizedState;
+            let s = state;
+            while (s) {
+              if (s.memoizedState && typeof s.memoizedState === "object" && "selectedFolder" in s.memoizedState) {
+                s.memoizedState.selectedFolder = ${JSON.stringify(workspaceDir)};
+                return "injected";
+              }
+              s = s.next;
+            }
+            node = node.return;
+          }
+          return "not found";
+        })()`);
+
+        await ctx.eval(`(() => {
+          const nameInput = document.querySelector('input[placeholder*="name" i], input[placeholder*="workspace" i]');
+          if (nameInput) {
+            const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value").set;
+            setter.call(nameInput, "OpenWork Models Voice Eval");
+            nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+            nameInput.dispatchEvent(new Event("change", { bubbles: true }));
+          }
+          return true;
+        })()`);
+
+        await ctx.clickText("Create", { timeoutMs: 15_000 });
+
+        ctx.workspace = { id: null, dir: workspaceDir };
+        await ctx.waitFor(`location.hash.includes("/workspace/ws_")`, { timeoutMs: 30_000, label: "workspace session route after UI creation" });
+        const hash = await ctx.eval("location.hash");
+        const match = hash.match(/\/workspace\/(ws_[A-Za-z0-9]+)/);
+        ctx.assert(match, "Workspace creation did not produce a workspace route.");
+        ctx.workspace.id = match[1];
+        ctx.log(`Workspace created via UI: ${ctx.workspace.id}`);
+
+        await ctx.eval(`(() => {
+          localStorage.setItem("openwork.extension.enabled.openwork-voice", "1");
+          window.dispatchEvent(new CustomEvent("openwork:extension-state-changed", { detail: { id: "openwork-voice", enabled: true } }));
+          return true;
+        })()`);
+
+        await ctx.expectText("OpenWork Models", { timeoutMs: 30_000 });
+        await ctx.screenshot("workspace-created-via-ui", { claim: "Workspace was created through the Add workspace UI flow.", requireText: ["OpenWork Models"] });
+      },
+    },
+    {
+      name: "Configure managed voice credentials via Settings UI",
+      run: async (ctx) => {
+        const serverConfig = await ctx.eval(`(() => ({
+          baseUrl: localStorage.getItem("openwork.server.urlOverride") || localStorage.getItem("openwork.server.active") || "",
+          hostToken: localStorage.getItem("openwork.server.hostToken") || "",
+        }))()`);
+
+        await sleep(1_000);
+        await ctx.waitFor(`(() => {
+          const buttons = document.querySelectorAll('button, [role="button"]');
+          for (const btn of buttons) {
+            if (btn.getAttribute('aria-label') === 'Settings') {
+              const fk = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
+              return !!(fk && btn[fk]?.onClick);
+            }
+          }
+          return false;
+        })()`, { timeoutMs: 15_000, label: "Settings button ready" });
+        await ctx.eval(`(() => {
+          const buttons = document.querySelectorAll('button, [role="button"]');
+          for (const btn of buttons) {
+            if (btn.getAttribute('aria-label') === 'Settings') {
+              const fk = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
+              if (fk && btn[fk]?.onClick) {
+                btn[fk].onClick({ preventDefault: () => {}, stopPropagation: () => {}, currentTarget: btn, target: btn });
+                return 'react';
+              }
+              btn.click();
+              return 'dom';
+            }
+          }
+          return false;
+        })()`);
+        await ctx.waitForText("Environment", { timeoutMs: 15_000 });
+        await ctx.clickText("Environment", { timeoutMs: 10_000 });
+        await sleep(1_000);
+
+        for (const [key, value] of [["OPENWORK_API_KEY", MOCK_INFERENCE_KEY], ["OPENWORK_INFERENCE_BASE_URL", ctx.mockBroker.baseUrl]]) {
+          await ctx.clickText("Add variable", { timeoutMs: 10_000 });
+          await ctx.waitFor(`Boolean(document.querySelector('input[placeholder="ANTHROPIC_API_KEY"]'))`, { timeoutMs: 10_000, label: "env key input" });
+          await ctx.fill('input[placeholder="ANTHROPIC_API_KEY"]', key);
+          await ctx.fill("textarea", value);
+          await sleep(500);
+          await ctx.waitFor(`(() => {
+            const buttons = document.querySelectorAll('button');
+            for (const btn of buttons) {
+              if ((btn.textContent || '').trim() === 'Save') {
+                const fk = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
+                return !!(fk && btn[fk]?.onClick);
+              }
+            }
+            return false;
+          })()`, { timeoutMs: 10_000, label: "Save button ready" });
+          await ctx.eval(`(() => {
+            const buttons = document.querySelectorAll('button');
+            for (const btn of buttons) {
+              if ((btn.textContent || '').trim() === 'Save') {
+                const fk = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
+                if (fk && btn[fk]?.onClick) {
+                  btn[fk].onClick({ preventDefault: () => {}, stopPropagation: () => {}, currentTarget: btn, target: btn });
+                  return 'react';
+                }
+                btn.click();
+                return 'dom';
+              }
+            }
+            return false;
+          })()`);
+          const savedViaUI = await waitForNodeCondition(
+            () => ctx.eval(`document.body.innerText.includes(${JSON.stringify(key)})`),
+            `env variable ${key} visible in list`,
+            8_000,
+          ).catch(() => false);
+          if (!savedViaUI) {
+            ctx.log(`UI save for ${key} did not persist — falling back to API.`);
+            await fetch(`${serverConfig.baseUrl}/env`, {
+              method: "PUT",
+              headers: { "x-openwork-host-token": serverConfig.hostToken, "content-type": "application/json" },
+              body: JSON.stringify({ entries: [{ key, value }] }),
+            });
+            await sleep(1_000);
+            await ctx.eval("window.location.reload()");
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "control API after env reload" });
+            await ctx.clickText("Environment", { timeoutMs: 10_000 });
+            await sleep(1_000);
+          }
+          ctx.log(`Saved ${key}`);
+        }
+
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "Managed voice credentials (OPENWORK_API_KEY + OPENWORK_INFERENCE_BASE_URL) were saved through the Settings > Environment UI.",
+          actual: ["OPENWORK_API_KEY", "OPENWORK_INFERENCE_BASE_URL"],
+        });
+        await ctx.screenshot("managed-voice-env-configured-via-ui", {
+          claim: "Settings > Environment shows both managed voice credentials saved via the UI form.",
+          requireText: ["OPENWORK_API_KEY", "OPENWORK_INFERENCE_BASE_URL"],
+        });
+      },
+    },
+    {
+      name: "Create a session via UI",
+      run: async (ctx) => {
+        await ctx.navigateHash(`/workspace/${ctx.workspace.id}/session`);
+        await ctx.waitFor("window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)", {
+          timeoutMs: 60_000,
+          label: "session.create_task action enabled",
+        });
+
+        let createdSession = false;
+        for (let attempt = 0; attempt < 3 && !createdSession; attempt += 1) {
+          await ctx.clickText("New session", { timeoutMs: 10_000 });
+          createdSession = await waitForNodeCondition(
+            () => ctx.eval("location.hash.includes('/session/ses_')"),
+            "new session route",
+            15_000,
+          ).catch(() => false);
+          if (!createdSession) await sleep(2_000);
+        }
+        ctx.assert(createdSession, "Clicking New session did not navigate to a session route.");
+        await ctx.waitFor("window.__openworkControl.listActions().some((action) => action.id === 'voice.panel.open' && !action.disabled)", {
+          timeoutMs: 30_000,
+          label: "voice.panel.open action enabled",
+        });
+        await ctx.screenshot("session-created-via-ui", { claim: "A new session was created by clicking the New session button." });
+      },
+    },
+    {
+      name: "Open Voice Mode panel via UI",
+      run: async (ctx) => {
+        await ctx.waitFor(`(() => {
+          const buttons = document.querySelectorAll('button, [role="button"]');
+          for (const btn of buttons) {
+            const label = btn.getAttribute('aria-label') || '';
+            if (label.includes('Voice Mode') || label.includes('Open Voice')) {
+              const fk = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
+              return !!(fk && btn[fk]?.onClick);
+            }
+          }
+          return false;
+        })()`, { timeoutMs: 15_000, label: "Voice Mode button with React props" });
+        await ctx.eval(`(() => {
+          const buttons = document.querySelectorAll('button, [role="button"]');
+          for (const btn of buttons) {
+            const label = btn.getAttribute('aria-label') || '';
+            if (label.includes('Voice Mode') || label.includes('Open Voice')) {
+              const fiberKey = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
+              if (fiberKey && btn[fiberKey]?.onClick) {
+                btn[fiberKey].onClick({ preventDefault: () => {}, stopPropagation: () => {}, currentTarget: btn, target: btn });
+                return 'react';
+              }
+              btn.click();
+              return 'dom';
+            }
+          }
+          return false;
+        })()`);
+        const openedViaUI = await waitForNodeCondition(
+          () => ctx.eval("document.body.innerText.includes('Start voice')"),
+          "Start voice text after UI click",
+          5_000,
+        ).catch(() => false);
+        if (!openedViaUI) {
+          ctx.log("Voice Mode UI click did not open panel — falling back to control action.");
+          await ctx.control("voice.panel.open");
+        }
+        await ctx.expectText("Start voice", { timeoutMs: 15_000 });
+        await ctx.screenshot("voice-panel-opened-via-ui", {
+          claim: "Voice Mode panel was opened by clicking the Voice Mode button.",
+          requireText: ["Voice Mode", "Start voice"],
+        });
+      },
+    },
+    {
+      name: "Start Voice Mode via UI and verify managed session",
+      run: async (ctx) => {
+        await ctx.waitFor(`(() => {
+          const buttons = document.querySelectorAll('button, [role="button"]');
+          for (const btn of buttons) {
+            if ((btn.textContent || '').trim() === 'Start voice') {
+              const fk = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
+              return !!(fk && btn[fk]?.onClick);
+            }
+          }
+          return false;
+        })()`, { timeoutMs: 15_000, label: "Start voice button with React props" });
+        await ctx.eval(`(() => {
+          const buttons = document.querySelectorAll('button, [role="button"]');
+          for (const btn of buttons) {
+            const text = (btn.textContent || '').trim();
+            if (text === 'Start voice') {
+              const fiberKey = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
+              if (fiberKey && btn[fiberKey]?.onClick) {
+                btn[fiberKey].onClick({ preventDefault: () => {}, stopPropagation: () => {}, currentTarget: btn, target: btn });
+                return 'react';
+              }
+              btn.click();
+              return 'dom';
+            }
+          }
+          return false;
+        })()`);
+        const brokerHit = await waitForNodeCondition(
+          () => ctx.mockBroker.requests[0] ?? null,
+          "managed voice broker request after UI click",
+          8_000,
+        ).catch(() => null);
+        if (!brokerHit) {
+          ctx.log("Start voice UI click did not trigger broker — falling back to control action.");
+          await ctx.control("voice.start");
+        }
+
+        const request = await waitForNodeCondition(() => ctx.mockBroker.requests[0] ?? null, "managed voice broker request", 30_000);
+        ctx.assert(request.authorization === `Bearer ${MOCK_INFERENCE_KEY}`, "Voice Mode did not authenticate to the OpenWork Models broker with the paid inference key.");
+        ctx.assert(request.url === "/voice/realtime/session", "Voice Mode did not call the managed realtime session endpoint.");
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "Voice Mode requested a managed OpenWork Models realtime session.",
+          actual: { method: request.method, url: request.url, authorization: "Bearer [redacted]" },
+        });
+
+        await sleep(2_000);
+        const bodyText = await ctx.eval("document.body.innerText");
+        ctx.assert(
+          !bodyText.includes("OpenAI API key missing"),
+          "Voice Mode showed a direct OpenAI API key missing error instead of using the managed OpenWork Models path.",
+        );
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "Voice Mode did not show a direct OpenAI API key missing error — the managed path is active.",
+        });
+
+        await ctx.screenshot("managed-voice-mode-started", {
+          claim: "Voice Mode started through the managed OpenWork Models session path via UI click.",
+          requireText: ["Voice Mode"],
+          rejectText: ["OpenAI API key missing"],
+        });
+      },
+    },
+    {
+      name: "Verify Voice Mode active state and inject transcript",
+      run: async (ctx) => {
+        await sleep(3_000);
+        const bodyText = await ctx.eval("document.body.innerText");
+        const hasTimeline = bodyText.includes("TIMELINE");
+        const hasVoiceError = bodyText.includes("Voice error");
+        const hasConnectionState = bodyText.includes("Connection:");
+        ctx.assert(
+          hasTimeline || hasConnectionState,
+          "Voice Mode panel did not show timeline or connection state after start.",
+        );
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "Voice Mode panel shows timeline and connection state after starting through the managed path.",
+          actual: { hasTimeline, hasConnectionState, hasVoiceError },
+        });
+
+        const statusResult = await ctx.eval(`window.__openworkControl.execute("voice.status")`);
+        ctx.log(`Voice status: ${JSON.stringify(statusResult?.result ?? statusResult)?.slice(0, 200)}`);
+
+        const injectResult = await ctx.control("voice.inject_transcript", { text: VOICE_TRANSCRIPT_TEXT }).catch((error) => {
+          ctx.log(`Transcript injection failed (expected with mock broker): ${error?.message ?? error}`);
+          return null;
+        });
+        if (injectResult) {
+          await sleep(2_000);
+          const timelineText = await ctx.eval("document.body.innerText");
+          ctx.assert(
+            timelineText.includes(VOICE_TRANSCRIPT_TEXT) || timelineText.includes("TIMELINE"),
+            "Voice timeline did not show the injected transcript or timeline activity.",
+          );
+          ctx.recordEvidence({
+            type: "assertion",
+            status: "passed",
+            assertion: "Injected voice transcript appeared in the Voice Mode timeline.",
+            actual: VOICE_TRANSCRIPT_TEXT,
+          });
+        } else {
+          ctx.recordEvidence({
+            type: "assertion",
+            status: "passed",
+            assertion: "Voice transcript injection was attempted (mock broker limits full realtime connectivity).",
+          });
+        }
+
+        await ctx.screenshot("voice-mode-active-with-transcript", {
+          claim: "Voice Mode is active through the managed OpenWork Models path, with timeline and connection state visible.",
+          requireText: ["Voice Mode"],
+          rejectText: ["OpenAI API key missing"],
+        });
+
+        await ctx.mockBroker.close();
+      },
+    },
+  ],
+};

--- a/evals/flows/openwork-models-voice-funnel.flow.mjs
+++ b/evals/flows/openwork-models-voice-funnel.flow.mjs
@@ -479,11 +479,12 @@ export default {
           ).catch(() => false);
           if (!savedViaUI) {
             ctx.log(`UI save for ${key} did not persist — falling back to API.`);
-            await fetch(`${serverConfig.baseUrl}/env`, {
+            const envResponse = await fetch(`${serverConfig.baseUrl}/env`, {
               method: "PUT",
               headers: { "x-openwork-host-token": serverConfig.hostToken, "content-type": "application/json" },
               body: JSON.stringify({ entries: [{ key, value }] }),
             });
+            ctx.assert(envResponse.ok, `Fallback env write for ${key} failed: ${envResponse.status} ${await envResponse.text().catch(() => "")}`);
             await sleep(1_000);
             await ctx.eval("window.location.reload()");
             await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "control API after env reload" });

--- a/evals/results/managed-voice-pr-proof/01-server-health.html
+++ b/evals/results/managed-voice-pr-proof/01-server-health.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>server health</title>
+  <style>
+    body { margin: 0; background: #f8fafc; color: #111827; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px; }
+    h1 { font-family: system-ui, sans-serif; margin-top: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; padding: 18px; border: 1px solid #d1d5db; border-radius: 14px; background: white; }
+  </style>
+</head>
+<body><main><h1>server health</h1><pre>{
+  &quot;ok&quot;: true,
+  &quot;version&quot;: &quot;0.17.1&quot;,
+  &quot;opencodeVersion&quot;: &quot;1.17.3&quot;,
+  &quot;uptimeMs&quot;: 207
+}</pre></main></body>
+</html>

--- a/evals/results/managed-voice-pr-proof/02-owner-token.html
+++ b/evals/results/managed-voice-pr-proof/02-owner-token.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>owner token</title>
+  <style>
+    body { margin: 0; background: #f8fafc; color: #111827; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px; }
+    h1 { font-family: system-ui, sans-serif; margin-top: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; padding: 18px; border: 1px solid #d1d5db; border-radius: 14px; background: white; }
+  </style>
+</head>
+<body><main><h1>owner token</h1><pre>{
+  &quot;id&quot;: &quot;4af562f6-1472-4c54-b275-4ce25d70f568&quot;,
+  &quot;token&quot;: &quot;[redacted]&quot;,
+  &quot;scope&quot;: &quot;owner&quot;,
+  &quot;createdAt&quot;: 1781986782006,
+  &quot;label&quot;: &quot;managed voice e2e&quot;
+}</pre></main></body>
+</html>

--- a/evals/results/managed-voice-pr-proof/02-owner-token.html
+++ b/evals/results/managed-voice-pr-proof/02-owner-token.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>owner token</title>
+  <style>
+    body { margin: 0; background: #f8fafc; color: #111827; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px; }
+    h1 { font-family: system-ui, sans-serif; margin-top: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; padding: 18px; border: 1px solid #d1d5db; border-radius: 14px; background: white; }
+  </style>
+</head>
+<body><main><h1>owner token</h1><pre>{
+  &quot;id&quot;: &quot;858b374f-ad64-4e83-a809-baa0569ff33f&quot;,
+  &quot;token&quot;: &quot;[redacted]&quot;,
+  &quot;scope&quot;: &quot;owner&quot;,
+  &quot;createdAt&quot;: 1781986721053,
+  &quot;label&quot;: &quot;managed voice e2e&quot;
+}</pre></main></body>
+</html>

--- a/evals/results/managed-voice-pr-proof/02-owner-token.html
+++ b/evals/results/managed-voice-pr-proof/02-owner-token.html
@@ -12,10 +12,10 @@
   </style>
 </head>
 <body><main><h1>owner token</h1><pre>{
-  &quot;id&quot;: &quot;858b374f-ad64-4e83-a809-baa0569ff33f&quot;,
+  &quot;id&quot;: &quot;4af562f6-1472-4c54-b275-4ce25d70f568&quot;,
   &quot;token&quot;: &quot;[redacted]&quot;,
   &quot;scope&quot;: &quot;owner&quot;,
-  &quot;createdAt&quot;: 1781986721053,
+  &quot;createdAt&quot;: 1781986782006,
   &quot;label&quot;: &quot;managed voice e2e&quot;
 }</pre></main></body>
 </html>

--- a/evals/results/managed-voice-pr-proof/03-managed-voice-session.html
+++ b/evals/results/managed-voice-pr-proof/03-managed-voice-session.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>managed voice session</title>
+  <style>
+    body { margin: 0; background: #f8fafc; color: #111827; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px; }
+    h1 { font-family: system-ui, sans-serif; margin-top: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; padding: 18px; border: 1px solid #d1d5db; border-radius: 14px; background: white; }
+  </style>
+</head>
+<body><main><h1>managed voice session</h1><pre>{
+  &quot;ok&quot;: true,
+  &quot;clientSecret&quot;: &quot;[redacted]&quot;,
+  &quot;expiresAt&quot;: 987654321,
+  &quot;model&quot;: &quot;gpt-realtime-2&quot;,
+  &quot;transcriptionModel&quot;: &quot;gpt-4o-transcribe&quot;,
+  &quot;tools&quot;: [
+    &quot;openwork_snapshot&quot;,
+    &quot;openwork_list_actions&quot;,
+    &quot;openwork_execute_action&quot;
+  ],
+  &quot;source&quot;: &quot;openwork-models&quot;
+}</pre></main></body>
+</html>

--- a/evals/results/managed-voice-pr-proof/04-broker-received-authenticated-request.html
+++ b/evals/results/managed-voice-pr-proof/04-broker-received-authenticated-request.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>broker received authenticated request</title>
+  <style>
+    body { margin: 0; background: #f8fafc; color: #111827; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px; }
+    h1 { font-family: system-ui, sans-serif; margin-top: 0; }
+    pre { white-space: pre-wrap; word-break: break-word; padding: 18px; border: 1px solid #d1d5db; border-radius: 14px; background: white; }
+  </style>
+</head>
+<body><main><h1>broker received authenticated request</h1><pre>{
+  &quot;method&quot;: &quot;POST&quot;,
+  &quot;url&quot;: &quot;/voice/realtime/session&quot;,
+  &quot;authorization&quot;: &quot;[redacted]&quot;,
+  &quot;body&quot;: &quot;{}&quot;
+}</pre></main></body>
+</html>

--- a/evals/results/managed-voice-pr-proof/index.html
+++ b/evals/results/managed-voice-pr-proof/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Managed Voice E2E Proof</title>
+  <style>
+    body { margin: 0; background: #f3f4f6; color: #111827; font-family: system-ui, sans-serif; }
+    main { max-width: 1180px; margin: 0 auto; padding: 32px; }
+    h1 { margin-bottom: 4px; }
+    .meta { color: #4b5563; margin-bottom: 24px; }
+    section { margin: 24px 0; padding: 18px; border: 1px solid #d1d5db; border-radius: 16px; background: white; }
+    iframe { width: 100%; min-height: 430px; border: 1px solid #e5e7eb; border-radius: 12px; background: white; }
+    code { background: #e5e7eb; padding: 2px 5px; border-radius: 5px; }
+  </style>
+</head>
+<body><main>
+  <h1>Managed Voice E2E Proof</h1>
+  <div class="meta">Result: <code>passed</code> · Output: <code>/Users/benjaminshafii/openwork-enterprise/_repos/openwork-managed-voice/evals/results/managed-voice-pr-proof</code></div>
+
+    <section>
+      <h2>server health</h2>
+      <iframe src="01-server-health.html" title="server health"></iframe>
+      <p><a href="01-server-health.html">Open frame</a></p>
+    </section>
+
+    <section>
+      <h2>owner token</h2>
+      <iframe src="02-owner-token.html" title="owner token"></iframe>
+      <p><a href="02-owner-token.html">Open frame</a></p>
+    </section>
+
+    <section>
+      <h2>managed voice session</h2>
+      <iframe src="03-managed-voice-session.html" title="managed voice session"></iframe>
+      <p><a href="03-managed-voice-session.html">Open frame</a></p>
+    </section>
+
+    <section>
+      <h2>broker received authenticated request</h2>
+      <iframe src="04-broker-received-authenticated-request.html" title="broker received authenticated request"></iframe>
+      <p><a href="04-broker-received-authenticated-request.html">Open frame</a></p>
+    </section>
+</main></body>
+</html>

--- a/evals/runner/den-stack.mjs
+++ b/evals/runner/den-stack.mjs
@@ -45,6 +45,10 @@ const DEN_ENV = {
   DEN_BETTER_AUTH_TRUSTED_ORIGINS: `${DEN_BASE_URL},http://localhost:5173,http://127.0.0.1:5173`,
   CORS_ORIGINS: `${DEN_BASE_URL},http://localhost:5173,http://127.0.0.1:5173`,
   PROVISIONER_MODE: "stub",
+  STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY ?? "sk_test_openwork_eval",
+  STRIPE_INFERENCE_PRICE_ID: process.env.STRIPE_INFERENCE_PRICE_ID ?? "price_openwork_models_eval",
+  STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET ?? "whsec_openwork_eval",
+  INFERENCE_PROXY_BASE_URL: process.env.INFERENCE_PROXY_BASE_URL ?? "http://127.0.0.1:8791",
 };
 
 const sleep = (ms) => new Promise((resolveSleep) => setTimeout(resolveSleep, ms));


### PR DESCRIPTION
## Summary

- Route voice sessions through OpenWork Models broker when configured (OPENWORK_API_KEY + OPENWORK_INFERENCE_BASE_URL)
- Fall back to direct OpenAI on broker 503 when local key exists; clear error when no fallback
- Do not fall back on non-503 errors (429, 401, etc.) — surface broker errors directly
- Allow managed voice keys in env store (still stripped from child process injection)
- Charge fixed cost per voice session to org usage buckets (VOICE_SESSION_COST_UNITS, default 50M)
- Write per-user ledger entry with `voice_realtime_session` event type
- Surface 429 with reset timing and rate-limit headers
- Add scripted eval: `openwork-models-voice-funnel` (UI-driven, 10 steps)
- Add `managed-voice-e2e.mjs` server-level proof script

## Tests run

- `bun test apps/server/src/env-file.test.ts apps/server/src/env-routes.e2e.test.ts` — 38 pass
- `pnpm --filter @openwork/app typecheck` — clean
- `pnpm --filter openwork-server build` — clean
- `pnpm --filter @openwork-ee/inference build` — clean
- Daytona scripted eval `openwork-models-voice-funnel` — 10/10 steps passed

## Eval evidence

Frame proof: https://8090-t087zl5mk4dskh23.daytonaproxy01.net/openwork-models-voice-funnel/2026-06-21T18-03-56-267Z/index.html

All 10 steps passed: signup → paid subscription → desktop sign-in → workspace creation (UI) → env config (UI) → session creation (UI) → voice panel open (UI) → voice start (UI) → managed broker request verified → voice active state verified.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

