### PR TITLE
fix(app): cycle Ctrl+T through open tabs only, not all sessions

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -73,7 +73,7 @@ const STARTUP_SKELETON_ROWS = [
 const GLOBAL_VOICE_SIDE_PANEL_KEY = "__openwork_voice__";
 const EMPTY_TRANSCRIPT_TARGETS: OpenTarget[] = [];
 
-type OpenSessionTab = {
+export type OpenSessionTab = {
   workspaceId: string;
   sessionId: string;
 };
@@ -184,6 +184,7 @@ export type SessionPageProps = {
   settingsSlot?: React.ReactNode;
   terminalOpen?: boolean;
   onTerminalOpenChange?: (open: boolean) => void;
+  onSessionTabsChange?: (tabs: OpenSessionTab[]) => void;
 };
 
 function getSidebarInitialLoading(props: SessionPageSidebarProps) {
@@ -658,6 +659,9 @@ export function SessionPage(props: SessionPageProps) {
       ));
     });
   }, [props.selectedSessionId, props.selectedWorkspaceId, props.sidebar.workspaceSessionGroups]);
+  useEffect(() => {
+    props.onSessionTabsChange?.(sessionTabs);
+  }, [sessionTabs, props.onSessionTabsChange]);
   useEffect(() => {
     if (!splitSessionId) return;
     if (splitSessionId === props.selectedSessionId) {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -89,7 +89,7 @@ import {
 } from "@/react-app/shell/route-workspaces";
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { usePlatform } from "@/react-app/kernel/platform";
-import { SessionPage } from "@/react-app/domains/session/chat/session-page";
+import { SessionPage, type OpenSessionTab } from "@/react-app/domains/session/chat/session-page";
 import { isDesktopProviderBlocked, DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID } from "@/app/cloud/desktop-app-restrictions";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
 import { useRestrictionNotice } from "@/react-app/domains/cloud/restriction-notice-provider";
@@ -1169,12 +1169,12 @@ export function SessionRoute() {
     }
   }, [baseUrl, loading, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, token, workspaces]);
 
-  // Latest session-list state for prev/next session tab navigation. Updated
-  // during render (see below, after `paletteSessionOptions` is computed) so the
-  // stable callbacks below always read fresh data without re-subscribing the
-  // global keydown listener.
+  // Latest session-list state for prev/next session tab navigation. The
+  // `options` field is updated by `onSessionTabsChange` from SessionPage so we
+  // only cycle through tabs the user actually opened (not artifact sessions).
+  // The remaining fields are refreshed during render.
   const sessionTabNavRef = useRef<{
-    options: PaletteSessionOption[];
+    options: OpenSessionTab[];
     workspaceId: string;
     sessionId: string | null;
     navigate: (workspaceId: string, sessionId?: string | null) => void;
@@ -1326,11 +1326,10 @@ export function SessionRoute() {
     return out;
   }, [sessionsByWorkspaceId, selectedWorkspaceId, workspaces]);
 
-  // Keep the prev/next session tab navigation ref in sync with the latest
-  // session list, current selection, and navigator. Read by the stable
-  // callbacks above so the global keydown handler never goes stale.
+  // Refresh the non-tab fields of the nav ref during render. The `options`
+  // field is maintained by the `onSessionTabsChange` callback from SessionPage.
   sessionTabNavRef.current = {
-    options: paletteSessionOptions,
+    options: sessionTabNavRef.current.options,
     workspaceId: selectedWorkspaceId,
     sessionId: selectedSessionId,
     navigate: navigateToWorkspaceSession,
@@ -1697,6 +1696,9 @@ export function SessionRoute() {
       }
       terminalOpen={terminalOpen}
       onTerminalOpenChange={setTerminalOpen}
+      onSessionTabsChange={(tabs) => {
+        sessionTabNavRef.current = { ...sessionTabNavRef.current, options: tabs };
+      }}
       sidebar={{
         workspaceSessionGroups,
         selectedWorkspaceId,


### PR DESCRIPTION
## Problem

PR #2336 added Ctrl+T / Ctrl+Shift+T session tab navigation, but it cycled through **all sessions** in the workspace (via `paletteSessionOptions`), including artifact sessions. This is terrible UX — pressing Ctrl+T would land on artifact/spreadsheet sessions the user never opened as a tab.

## Fix

Cycle only through sessions that are actually **open as tabs**. The open-tab list (`sessionTabs`) lives in `SessionPage`, but the keyboard shortcuts are in `SessionRoute`. Added an `onSessionTabsChange` callback prop (same pattern as the existing `terminalOpen`/`onTerminalOpenChange` bridge) so `SessionPage` reports its open tabs upward. The nav ref now uses those tabs instead of `paletteSessionOptions`.

## Changes (2 files, +17/-11 lines)

- `session-page.tsx`: Export `OpenSessionTab` type, add `onSessionTabsChange?` prop, fire it in an effect when `sessionTabs` changes.
- `session-route.tsx`: Import `OpenSessionTab`, change nav ref to use `OpenSessionTab[]` instead of `PaletteSessionOption[]`, update ref from `onSessionTabsChange` callback instead of `paletteSessionOptions`.

## E2e eval results (Daytona)

```
▶ session-tab-navigation — Cmd/Ctrl+T and Cmd/Ctrl+Shift+T switch session tabs
  ✓ Electron app and control API are ready (470ms)
  ✓ Create two sessions in the current workspace (2314ms)
  ✓ Ctrl+Shift+T navigates to the previous session (1317ms)
  ✓ Ctrl+T navigates to the next session (1309ms)
  ✓ Command palette shows tab items and Previous navigates back (3262ms)

Result: PASSED — 1 passed, 0 failed, 0 skipped
```

## Typecheck

```
pnpm --filter @openwork/app typecheck
```
Passed cleanly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

