### PR TITLE
fix(server): migrate project opencode.jsonc MCPs into runtime store

### DIFF
--- a/apps/server/src/runtime-config-migrate.e2e.test.ts
+++ b/apps/server/src/runtime-config-migrate.e2e.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+import { readRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+
+type Served = {
+  port: number;
+  stop: (closeActiveConnections?: boolean) => void | Promise<void>;
+};
+
+const CLIENT_TOKEN = "owt_runtime_migrate_client";
+const HOST_TOKEN = "owt_runtime_migrate_host";
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+const priorDataDir = process.env.OPENWORK_DATA_DIR;
+const priorTokenStore = process.env.OPENWORK_TOKEN_STORE;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function clientAuth() {
+  return { authorization: `Bearer ${CLIENT_TOKEN}`, "content-type": "application/json" };
+}
+
+async function createTempRoot(prefix: string) {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function startOpenworkServer(workspaceRoot: string) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    configPath: join(workspaceRoot, "server.json"),
+    token: CLIENT_TOKEN,
+    hostToken: HOST_TOKEN,
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { base: `http://127.0.0.1:${server.port}`, config };
+}
+
+beforeEach(async () => {
+  const envRoot = await createTempRoot("openwork-runtime-migrate-env-");
+  process.env.OPENWORK_DATA_DIR = join(envRoot, "data");
+  process.env.OPENWORK_TOKEN_STORE = join(envRoot, "tokens.json");
+});
+
+afterEach(async () => {
+  while (stops.length) {
+    await stops.pop()?.();
+  }
+  while (roots.length) {
+    await rm(roots.pop()!, { recursive: true, force: true });
+  }
+  if (priorDataDir === undefined) {
+    delete process.env.OPENWORK_DATA_DIR;
+  } else {
+    process.env.OPENWORK_DATA_DIR = priorDataDir;
+  }
+  if (priorTokenStore === undefined) {
+    delete process.env.OPENWORK_TOKEN_STORE;
+  } else {
+    process.env.OPENWORK_TOKEN_STORE = priorTokenStore;
+  }
+});
+
+describe("runtime-config migrate route", () => {
+  test("lifts MCP entries from project opencode.jsonc into the runtime store", async () => {
+    const workspaceRoot = await createTempRoot("openwork-runtime-migrate-");
+    await writeFile(
+      join(workspaceRoot, "opencode.jsonc"),
+      JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        mcp: {
+          "nova-mail": { type: "remote", url: "https://example.com/mcp/mail", enabled: true },
+        },
+      }, null, 2) + "\n",
+      "utf8",
+    );
+
+    const { base, config } = await startOpenworkServer(workspaceRoot);
+
+    const response = await fetch(`${base}/workspace/ws_1/runtime-config/migrate`, {
+      method: "POST",
+      headers: clientAuth(),
+    });
+    expect(response.status).toBe(200);
+
+    const body = asRecord(await response.json());
+    expect(body.migrated).toBe(true);
+    expect(Array.isArray(body.userOpencodeKeys) && body.userOpencodeKeys.includes("mcp")).toBe(true);
+
+    const runtime = await readRuntimeOpencodeConfig(config, "ws_1");
+    expect(runtime.mcp?.["nova-mail"]?.url).toBe("https://example.com/mcp/mail");
+
+    const parsed = asRecord(JSON.parse(await readFile(join(workspaceRoot, "opencode.jsonc"), "utf8")));
+    expect(parsed.mcp).toBeUndefined();
+  });
+});

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -129,7 +129,7 @@ function readStringField(value: unknown, key: string): string {
 }
 
 const LEGACY_RUNTIME_CONFIG_KEYS = ["plugin", "mcp", "permission", "provider"] as const;
-const USER_OPENCODE_RUNTIME_CONFIG_KEYS = ["default_agent", "plugin", "disabled_providers", "provider"] as const;
+const USER_OPENCODE_RUNTIME_CONFIG_KEYS = ["default_agent", "plugin", "mcp", "disabled_providers", "provider"] as const;
 
 type LegacyRuntimeConfigKey = typeof LEGACY_RUNTIME_CONFIG_KEYS[number];
 type UserOpencodeRuntimeConfigKey = typeof USER_OPENCODE_RUNTIME_CONFIG_KEYS[number];
@@ -181,6 +181,12 @@ function userRuntimeConfigFromOpencodeConfig(opencode: Record<string, unknown>):
   const keys: UserOpencodeRuntimeConfigKey[] = [];
   const defaultAgent = opencode.default_agent === "openwork" ? "openwork" : undefined;
   const plugin = Array.isArray(opencode.plugin) ? opencode.plugin.filter((item) => typeof item === "string") : undefined;
+  const mcp: Record<string, Record<string, unknown>> = {};
+  if (isRecord(opencode.mcp)) {
+    for (const [name, value] of Object.entries(opencode.mcp)) {
+      if (isRecord(value)) mcp[name] = value;
+    }
+  }
   const disabledProviders = Array.isArray(opencode.disabled_providers)
     ? opencode.disabled_providers.filter((item) => typeof item === "string")
     : undefined;
@@ -188,6 +194,7 @@ function userRuntimeConfigFromOpencodeConfig(opencode: Record<string, unknown>):
 
   if (defaultAgent) keys.push("default_agent");
   if (Array.isArray(opencode.plugin)) keys.push("plugin");
+  if (Object.keys(mcp).length) keys.push("mcp");
   if (Array.isArray(opencode.disabled_providers)) keys.push("disabled_providers");
   if (isRecord(opencode.provider)) keys.push("provider");
 
@@ -196,6 +203,7 @@ function userRuntimeConfigFromOpencodeConfig(opencode: Record<string, unknown>):
     config: {
       ...(defaultAgent ? { default_agent: defaultAgent } : {}),
       ...(plugin?.length ? { plugin } : {}),
+      ...(Object.keys(mcp).length ? { mcp } : {}),
       ...(disabledProviders?.length ? { disabled_providers: disabledProviders } : {}),
       ...(provider && Object.keys(provider).length ? { provider } : {}),
     },


### PR DESCRIPTION
## Summary
- the runtime-config migrate route now lifts `mcp` entries out of a project `opencode.jsonc` into the runtime config store, the same way it already does for plugins, providers and default_agent
- add an e2e test for the migrate route that asserts a project-file mcp lands in the runtime store and is stripped from the file

## Why
MCPs written into a project `opencode.jsonc` (e.g. by the add flow before MCP storage moved to the runtime store in #2066) can't be removed from the UI. Delete only touches the runtime store, but `listMcp` unions the project file back in, so the entry returns 200 on delete and reappears on reload. The migrate route is the intended fix-up path, but `userRuntimeConfigFromOpencodeConfig` read default_agent/plugin/disabled_providers/provider and skipped `mcp`, while `legacyRuntimeConfigFromOpenworkConfig` already handled `mcp`. The merge and the opencode.jsonc strip both key off the returned key list, so adding `mcp` to the extraction and the key tuple makes both the copy-into-store and the remove-from-file work.

## Issue
- Closes #2342

## Scope
- `apps/server/src/server.ts`: `userRuntimeConfigFromOpencodeConfig` + `USER_OPENCODE_RUNTIME_CONFIG_KEYS`
- new `apps/server/src/runtime-config-migrate.e2e.test.ts`

## Out of scope
- the `DELETE /mcp` route itself
- the global `~/.config/opencode` case (delete still can't touch a global entry; that's a separate limitation)

## Testing
### Ran
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit` (in `apps/server`)

### Result
- pass: typecheck clean
- I could not run the new e2e locally. Every `startServer`-based e2e (including the existing `authorized-folders.e2e`) fails on this machine because `better-sqlite3`'s native binary won't build on my Node (v26; repo pins 24, no prebuild). The new test copies the `authorized-folders.e2e` harness, so it should run under CI. To run it: `bun test src/runtime-config-migrate.e2e.test.ts` from `apps/server`.

## CI status
- pass: relying on CI for the e2e
- code-related failures: none expected
- external/env/auth blockers: local `better-sqlite3` build (Node version), not the change

## Manual verification
1. Hit this on a real workspace whose `opencode.jsonc` had mcp entries that wouldn't delete from the UI (200, then reappear on reload). Confirmed they live in the project file and `listMcp` tags them `config.project`.
2. Traced the migrate route and confirmed `userRuntimeConfigFromOpencodeConfig` never reads `mcp`.
3. After the change, typecheck passes and the new e2e encodes the expected before/after (entry in runtime store, gone from `opencode.jsonc`).

## Evidence
- N/A (server-side fix, no UI change)

## Risk
- Low. It only adds `mcp` to a migration path that already moves the other keys the same way, and it matches how the openwork-legacy source already migrates `mcp`.

## Rollback
- Revert this commit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

