### PR TITLE
fix(cloud-providers): diff/update model list on re-import (#2346)

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
@@ -66,6 +66,17 @@ export const getCloudManagedProviderId = (
   provider: Pick<DenOrgLlmProvider, "id" | "providerId" | "source">,
 ) => (provider.source === "openwork" ? "openwork" : provider.id.trim());
 
+/**
+ * A provider key in `opencode.jsonc` that is owned by the cloud-import system:
+ * `lpr_*` keys (org-managed providers) and the `openwork` hosted provider.
+ * These keys are never hand-authored, so re-importing over an existing block
+ * with one of these ids is a safe reconcile (recovers a lost import baseline)
+ * rather than a clobber of a user's manual provider (#2346).
+ */
+export const isCloudManagedProviderKey = (providerId: string) =>
+  /^lpr_/i.test(providerId) || providerId.trim() === "openwork";
+
+
 export const getProviderModelIds = (
   provider: Pick<DenOrgLlmProvider, "models">,
 ) =>

--- a/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
@@ -1,0 +1,230 @@
+import { applyEdits, modify } from "jsonc-parser";
+import type { ProviderConfig } from "@opencode-ai/sdk/v2/client";
+
+import type {
+  DenOrgLlmProvider,
+  DenOrgLlmProviderConnection,
+} from "../../../../app/lib/den";
+import type { CloudImportedProvider } from "../../../../app/cloud/import-state";
+
+/**
+ * Pure helpers that build and reconcile the cloud-managed ("lpr_*") provider
+ * block inside a workspace `opencode.jsonc`. Extracted from the provider-auth
+ * store so the diff/update behaviour can be unit tested directly (#2346).
+ */
+
+const getStringList = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter(
+        (entry): entry is string =>
+          typeof entry === "string" && entry.trim().length > 0,
+      )
+    : [];
+
+const sortStrings = (values: string[]) => values.toSorted();
+
+const sameStringList = (a: string[], b: string[]) =>
+  a.length === b.length && a.every((value, index) => value === b[index]);
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const cloudProviderComment = (provider: Pick<DenOrgLlmProvider, "id" | "name">) =>
+  `// OpenWork Cloud import: ${provider.name
+    .replace(/\s+/g, " ")
+    .trim()} (${provider.id}). Manage this entry from Cloud settings.`;
+
+const removeCloudProviderComment = (raw: string, providerId: string) =>
+  raw.replace(
+    new RegExp(
+      `(^[ \t]*)// OpenWork Cloud import:.*\\n\\1(?="${escapeRegExp(providerId)}":)`,
+      "m",
+    ),
+    "$1",
+  );
+
+const addCloudProviderComment = (
+  raw: string,
+  provider: Pick<DenOrgLlmProvider, "id" | "name">,
+  localProviderId: string,
+) => {
+  const withoutExisting = removeCloudProviderComment(raw, localProviderId);
+  const propertyPattern = new RegExp(
+    `^([ \t]*)"${escapeRegExp(localProviderId)}":`,
+    "m",
+  );
+  return withoutExisting.replace(
+    propertyPattern,
+    `$1${cloudProviderComment(provider)}\n$1"${localProviderId}":`,
+  );
+};
+
+export const getCloudProviderEnv = (config: Record<string, unknown>) =>
+  getStringList(config.env);
+
+export const getCloudManagedProviderId = (
+  provider: Pick<DenOrgLlmProvider, "id" | "providerId" | "source">,
+) => (provider.source === "openwork" ? "openwork" : provider.id.trim());
+
+export const getProviderModelIds = (
+  provider: Pick<DenOrgLlmProvider, "models">,
+) =>
+  provider.models
+    .flatMap((model) => {
+      const id = model.id.trim();
+      return id ? [id] : [];
+    })
+    .sort();
+
+export const isCloudProviderOutOfSync = (
+  provider: DenOrgLlmProvider,
+  importedProvider: CloudImportedProvider,
+) =>
+  importedProvider.providerId !== getCloudManagedProviderId(provider) ||
+  importedProvider.sourceProviderId !== provider.providerId ||
+  (importedProvider.source ?? null) !== provider.source ||
+  (importedProvider.updatedAt ?? null) !== (provider.updatedAt ?? null) ||
+  !sameStringList(
+    importedProvider.modelIds,
+    sortStrings(provider.models.map((model) => model.id)),
+  );
+
+export const buildCloudProviderConfig = (
+  provider: DenOrgLlmProviderConnection,
+): ProviderConfig => {
+  const models = Object.fromEntries(
+    provider.models.map((model) => {
+      const next: NonNullable<ProviderConfig["models"]>[string] = {
+        id: model.id,
+        name: model.name,
+      };
+      const raw = model.config;
+      for (const key of [
+        "family",
+        "release_date",
+        "attachment",
+        "reasoning",
+        "temperature",
+        "tool_call",
+        "interleaved",
+        "cost",
+        "limit",
+        "modalities",
+        "status",
+        "options",
+        "headers",
+        "provider",
+        "variants",
+      ] as const) {
+        const value = raw[key];
+        if (value !== undefined) {
+          (next as Record<string, unknown>)[key] = value;
+        }
+      }
+      return [model.id, next];
+    }),
+  );
+
+  const next: ProviderConfig = {
+    id: provider.providerId,
+    name: provider.name,
+    env: getCloudProviderEnv(provider.providerConfig),
+    models,
+  };
+
+  if (
+    typeof provider.providerConfig.npm === "string" &&
+    provider.providerConfig.npm.trim()
+  ) {
+    next.npm = provider.providerConfig.npm;
+  }
+  if (
+    typeof provider.providerConfig.api === "string" &&
+    provider.providerConfig.api.trim()
+  ) {
+    next.api = provider.providerConfig.api;
+  }
+  if (
+    provider.providerConfig.options &&
+    typeof provider.providerConfig.options === "object"
+  ) {
+    next.options = provider.providerConfig.options as Record<string, unknown>;
+  }
+  if (Array.isArray(provider.providerConfig.whitelist)) {
+    next.whitelist = getStringList(provider.providerConfig.whitelist);
+  }
+  if (Array.isArray(provider.providerConfig.blacklist)) {
+    next.blacklist = getStringList(provider.providerConfig.blacklist);
+  }
+
+  return next;
+};
+
+/**
+ * Rewrite the cloud-managed provider block in `opencode.jsonc`. This fully
+ * replaces the block via jsonc `modify()`, so an updated Den model list (added,
+ * changed, or removed models) is reconciled into the file rather than keeping
+ * the first-import snapshot.
+ */
+export const formatConfigWithCloudProvider = (
+  raw: string,
+  provider: DenOrgLlmProviderConnection,
+  localProviderId: string,
+  options: { previousProviderId?: string | null; disabledProviders: string[] },
+) => {
+  const previousProviderId = options.previousProviderId ?? null;
+  const nextProviderConfig = buildCloudProviderConfig(
+    provider,
+  ) as unknown as Record<string, unknown>;
+  let updated = raw.trim()
+    ? raw
+    : '{\n  "$schema": "https://opencode.ai/config.json"\n}\n';
+
+  if (previousProviderId && previousProviderId !== localProviderId) {
+    updated = removeCloudProviderComment(updated, previousProviderId);
+    const previousEdits = modify(updated, ["provider", previousProviderId], undefined, {
+      formattingOptions: { insertSpaces: true, tabSize: 2 },
+    });
+    updated = applyEdits(updated, previousEdits);
+  }
+
+  const providerEdits = modify(updated, ["provider", localProviderId], nextProviderConfig, {
+    formattingOptions: { insertSpaces: true, tabSize: 2 },
+  });
+  updated = applyEdits(updated, providerEdits);
+  updated = addCloudProviderComment(updated, provider, localProviderId);
+
+  const disabledToRemove = new Set([localProviderId, previousProviderId ?? ""]);
+  const currentDisabled = options.disabledProviders;
+  if (currentDisabled.some((id) => disabledToRemove.has(id))) {
+    const nextDisabled = currentDisabled.filter((id) => !disabledToRemove.has(id));
+    const disabledEdits = modify(updated, ["disabled_providers"], nextDisabled, {
+      formattingOptions: { insertSpaces: true, tabSize: 2 },
+    });
+    updated = applyEdits(updated, disabledEdits);
+  }
+
+  return updated.endsWith("\n") ? updated : `${updated}\n`;
+};
+
+export const formatConfigWithoutCloudProvider = (
+  raw: string,
+  providerId: string,
+  disabledProviders: string[],
+) => {
+  let updated = raw.trim()
+    ? raw
+    : '{\n  "$schema": "https://opencode.ai/config.json"\n}\n';
+  updated = removeCloudProviderComment(updated, providerId);
+  const providerEdits = modify(updated, ["provider", providerId], undefined, {
+    formattingOptions: { insertSpaces: true, tabSize: 2 },
+  });
+  updated = applyEdits(updated, providerEdits);
+
+  const nextDisabled = disabledProviders.filter((id) => id !== providerId);
+  const disabledEdits = modify(updated, ["disabled_providers"], nextDisabled, {
+    formattingOptions: { insertSpaces: true, tabSize: 2 },
+  });
+  updated = applyEdits(updated, disabledEdits);
+  return updated.endsWith("\n") ? updated : `${updated}\n`;
+};

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -62,6 +62,7 @@ import {
   getCloudManagedProviderId,
   getCloudProviderEnv,
   getProviderModelIds,
+  isCloudManagedProviderKey,
   isCloudProviderOutOfSync,
 } from "./cloud-provider-config";
 import { refreshDesktopCloudSync } from "../../../../app/cloud/desktop-cloud-sync";
@@ -605,6 +606,12 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   ) => {
     const localProviderId = getCloudManagedProviderId(provider);
     const existingImported = state.importedCloudProviders[provider.id] ?? null;
+    // `lpr_*` / `openwork` keys are owned by the cloud-import system. When the
+    // import baseline was lost or diverged (e.g. it lives in a different file
+    // than the provider block, or a prior reconcile failed mid-flight), an
+    // existing cloud-managed block must be treated as a re-import to reconcile,
+    // not blocked. Only guard against clobbering a user's manual provider.
+    const cloudManagedKey = isCloudManagedProviderKey(localProviderId);
     if (
       existingImported &&
       existingImported.providerId !== localProviderId &&
@@ -617,14 +624,18 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       );
     }
 
-    if (!existingImported && options.providerConnectedIds().includes(localProviderId)) {
+    if (
+      !existingImported &&
+      !cloudManagedKey &&
+      options.providerConnectedIds().includes(localProviderId)
+    ) {
       throw new Error(
         `${localProviderId} is already connected in this workspace. Disconnect it before importing the cloud-managed version.`,
       );
     }
 
     const configFile = await readProjectConfigFile() as { content?: string } | null;
-    if (!configFile?.content?.trim() || existingImported) {
+    if (!configFile?.content?.trim() || existingImported || cloudManagedKey) {
       return;
     }
 

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -3,7 +3,6 @@ import { useSyncExternalStore } from "react";
 import { applyEdits, modify, parse } from "jsonc-parser";
 import type {
   ProviderAuthAuthorization,
-  ProviderConfig,
   ProviderListResponse,
 } from "@opencode-ai/sdk/v2/client";
 
@@ -57,6 +56,14 @@ import {
   withWorkspaceCloudImports,
   type CloudImportedProvider,
 } from "../../../../app/cloud/import-state";
+import {
+  formatConfigWithCloudProvider,
+  formatConfigWithoutCloudProvider,
+  getCloudManagedProviderId,
+  getCloudProviderEnv,
+  getProviderModelIds,
+  isCloudProviderOutOfSync,
+} from "./cloud-provider-config";
 import { refreshDesktopCloudSync } from "../../../../app/cloud/desktop-cloud-sync";
 import { dispatchNewProviders } from "../../../../app/lib/provider-events";
 import {
@@ -162,25 +169,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
   const emitChange = () => {
     for (const listener of listeners) listener();
-  };
-
-  const getStringList = (value: unknown) =>
-    Array.isArray(value)
-      ? value.filter(
-          (entry): entry is string =>
-            typeof entry === "string" && entry.trim().length > 0,
-        )
-      : [];
-
-  const getCloudProviderEnv = (config: Record<string, unknown>) =>
-    getStringList(config.env);
-  const sortStrings = (values: string[]) => values.toSorted();
-  const sameStringList = (a: string[], b: string[]) =>
-    a.length === b.length && a.every((value, index) => value === b[index]);
-
-  const getCloudManagedProviderId = (
-    provider: Pick<DenOrgLlmProvider, "id" | "providerId" | "source">,
-  ) => provider.source === "openwork" ? "openwork" : provider.id.trim();
+   };
 
   const getProviderAuthWorkerType = (): "local" | "remote" =>
     options.selectedWorkspaceDisplay().workspaceType === "remote" ? "remote" : "local";
@@ -281,77 +270,6 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     env: getCloudProviderEnv(provider.providerConfig),
     modelCount: provider.models.length,
   });
-
-  const buildCloudProviderConfig = (
-    provider: DenOrgLlmProviderConnection,
-  ): ProviderConfig => {
-    const models = Object.fromEntries(
-      provider.models.map((model) => {
-        const next: NonNullable<ProviderConfig["models"]>[string] = {
-          id: model.id,
-          name: model.name,
-        };
-        const raw = model.config;
-        for (const key of [
-          "family",
-          "release_date",
-          "attachment",
-          "reasoning",
-          "temperature",
-          "tool_call",
-          "interleaved",
-          "cost",
-          "limit",
-          "modalities",
-          "status",
-          "options",
-          "headers",
-          "provider",
-          "variants",
-        ] as const) {
-          const value = raw[key];
-          if (value !== undefined) {
-            (next as Record<string, unknown>)[key] = value;
-          }
-        }
-        return [model.id, next];
-      }),
-    );
-
-    const next: ProviderConfig = {
-      id: provider.providerId,
-      name: provider.name,
-      env: getCloudProviderEnv(provider.providerConfig),
-      models,
-    };
-
-    if (
-      typeof provider.providerConfig.npm === "string" &&
-      provider.providerConfig.npm.trim()
-    ) {
-      next.npm = provider.providerConfig.npm;
-    }
-    if (
-      typeof provider.providerConfig.api === "string" &&
-      provider.providerConfig.api.trim()
-    ) {
-      next.api = provider.providerConfig.api;
-    }
-    if (
-      provider.providerConfig.options &&
-      typeof provider.providerConfig.options === "object"
-    ) {
-      next.options = provider.providerConfig.options as Record<string, unknown>;
-    }
-    if (Array.isArray(provider.providerConfig.whitelist)) {
-      next.whitelist = getStringList(provider.providerConfig.whitelist);
-    }
-    if (Array.isArray(provider.providerConfig.blacklist)) {
-      next.blacklist = getStringList(provider.providerConfig.blacklist);
-    }
-
-    return next;
-  };
 
   const readCloudProviderBaseUrl = (provider: DenOrgLlmProviderConnection) => {
     const options = provider.providerConfig.options;
@@ -650,103 +568,6 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
   };
 
-  const escapeRegExp = (value: string) =>
-    value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-  const cloudProviderComment = (provider: Pick<DenOrgLlmProvider, "id" | "name">) =>
-    `// OpenWork Cloud import: ${provider.name
-      .replace(/\s+/g, " ")
-      .trim()} (${provider.id}). Manage this entry from Cloud settings.`;
-
-  const removeCloudProviderComment = (raw: string, providerId: string) =>
-    raw.replace(
-      new RegExp(
-        `(^[ \t]*)// OpenWork Cloud import:.*\\n\\1(?="${escapeRegExp(providerId)}":)`,
-        "m",
-      ),
-      "$1",
-    );
-
-  const addCloudProviderComment = (
-    raw: string,
-    provider: Pick<DenOrgLlmProvider, "id" | "name">,
-    localProviderId: string,
-  ) => {
-    const withoutExisting = removeCloudProviderComment(raw, localProviderId);
-    const propertyPattern = new RegExp(
-      `^([ \t]*)"${escapeRegExp(localProviderId)}":`,
-      "m",
-    );
-    return withoutExisting.replace(
-      propertyPattern,
-      `$1${cloudProviderComment(provider)}\n$1"${localProviderId}":`,
-    );
-  };
-
-  const getProviderModelIds = (provider: Pick<DenOrgLlmProvider, "models">) =>
-    provider.models.flatMap((model) => {
-      const id = model.id.trim();
-      return id ? [id] : [];
-    }).sort();
-
-  const formatConfigWithCloudProvider = (
-    raw: string,
-    provider: DenOrgLlmProviderConnection,
-    localProviderId: string,
-    previousProviderId?: string | null,
-  ) => {
-    const nextProviderConfig = buildCloudProviderConfig(
-      provider,
-    ) as unknown as Record<string, unknown>;
-    let updated = raw.trim()
-      ? raw
-      : '{\n  "$schema": "https://opencode.ai/config.json"\n}\n';
-
-    if (previousProviderId && previousProviderId !== localProviderId) {
-      updated = removeCloudProviderComment(updated, previousProviderId);
-      const previousEdits = modify(updated, ["provider", previousProviderId], undefined, {
-        formattingOptions: { insertSpaces: true, tabSize: 2 },
-      });
-      updated = applyEdits(updated, previousEdits);
-    }
-
-    const providerEdits = modify(updated, ["provider", localProviderId], nextProviderConfig, {
-      formattingOptions: { insertSpaces: true, tabSize: 2 },
-    });
-    updated = applyEdits(updated, providerEdits);
-    updated = addCloudProviderComment(updated, provider, localProviderId);
-
-    const disabledToRemove = new Set([localProviderId, previousProviderId ?? ""]);
-    const currentDisabled = options.disabledProviders();
-    if (currentDisabled.some((id) => disabledToRemove.has(id))) {
-      const nextDisabled = currentDisabled.filter((id) => !disabledToRemove.has(id));
-      const disabledEdits = modify(updated, ["disabled_providers"], nextDisabled, {
-        formattingOptions: { insertSpaces: true, tabSize: 2 },
-      });
-      updated = applyEdits(updated, disabledEdits);
-    }
-
-    return updated.endsWith("\n") ? updated : `${updated}\n`;
-  };
-
-  const formatConfigWithoutCloudProvider = (raw: string, providerId: string) => {
-    let updated = raw.trim()
-      ? raw
-      : '{\n  "$schema": "https://opencode.ai/config.json"\n}\n';
-    updated = removeCloudProviderComment(updated, providerId);
-    const providerEdits = modify(updated, ["provider", providerId], undefined, {
-      formattingOptions: { insertSpaces: true, tabSize: 2 },
-    });
-    updated = applyEdits(updated, providerEdits);
-
-    const nextDisabled = options.disabledProviders().filter((id) => id !== providerId);
-    const disabledEdits = modify(updated, ["disabled_providers"], nextDisabled, {
-      formattingOptions: { insertSpaces: true, tabSize: 2 },
-    });
-    updated = applyEdits(updated, disabledEdits);
-    return updated.endsWith("\n") ? updated : `${updated}\n`;
-  };
-
   // Sweep all cloud-managed provider entries (keys matching /^lpr_/) from
   // opencode.jsonc regardless of importedCloudProviders state. Returns the
   // list of provider IDs that were removed so callers can also clear their
@@ -772,7 +593,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     await updateProjectConfigFile((raw) => {
       let next = raw;
       for (const id of orphanIds) {
-        next = formatConfigWithoutCloudProvider(next, id);
+        next = formatConfigWithoutCloudProvider(next, id, options.disabledProviders());
       }
       return next;
     });
@@ -1429,7 +1250,10 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         }
       }
       const updatedConfig = await updateProjectConfigFile((raw) =>
-        formatConfigWithCloudProvider(raw, provider, localProviderId, existingImported?.providerId ?? null),
+        formatConfigWithCloudProvider(raw, provider, localProviderId, {
+          previousProviderId: existingImported?.providerId ?? null,
+          disabledProviders: options.disabledProviders(),
+        }),
       );
       if (!updatedConfig) {
         throw new Error("Could not update opencode.jsonc for this workspace.");
@@ -1497,7 +1321,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         }
       }
       const updatedConfig = await updateProjectConfigFile((raw) =>
-        formatConfigWithoutCloudProvider(raw, imported.providerId),
+        formatConfigWithoutCloudProvider(raw, imported.providerId, options.disabledProviders()),
       );
       if (!updatedConfig) {
         throw new Error("Could not update opencode.jsonc for this workspace.");
@@ -1559,16 +1383,6 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     );
   };
 
-  const isCloudProviderOutOfSync = (
-    provider: DenOrgLlmProvider,
-    importedProvider: CloudImportedProvider,
-  ) =>
-    importedProvider.providerId !== getCloudManagedProviderId(provider) ||
-    importedProvider.sourceProviderId !== provider.providerId ||
-    (importedProvider.source ?? null) !== provider.source ||
-    (importedProvider.updatedAt ?? null) !== (provider.updatedAt ?? null) ||
-    !sameStringList(importedProvider.modelIds, sortStrings(provider.models.map((model) => model.id)));
-
   async function performCloudProviderSync(reason: CloudProviderSyncReason) {
     if (!hasCloudProviderSyncPrerequisites()) {
       return;
@@ -1602,7 +1416,13 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       }
 
       try {
-        await removeCloudProviderInternal(importedProvider.cloudProviderId, { silent: true });
+        // Reconcile in place with a single idempotent rewrite. Re-importing
+        // via connectCloudProviderInternal fetches the fresh Den model list
+        // and fully replaces the `lpr_*` provider block (added/changed/removed
+        // models) while keeping the import baseline. The previous
+        // remove-then-reconnect dance could leave the block deleted if the
+        // reconnect aborted on a stale in-memory connected-providers guard,
+        // so the workspace kept the first-import snapshot forever (#2346).
         await connectCloudProviderInternal(liveProvider.id, { silent: true });
         configChanged = true;
       } catch (error) {

--- a/apps/app/tests/cloud-provider-reimport.test.ts
+++ b/apps/app/tests/cloud-provider-reimport.test.ts
@@ -10,6 +10,7 @@ import {
   formatConfigWithCloudProvider,
   getCloudManagedProviderId,
   getProviderModelIds,
+  isCloudManagedProviderKey,
   isCloudProviderOutOfSync,
 } from "../src/react-app/domains/connections/provider-auth/cloud-provider-config";
 
@@ -138,6 +139,14 @@ describe("cloud provider re-import diff (#2346)", () => {
       LPR_ID,
     ]);
     expect(providerModelKeys(result)).toEqual(["model-x", "model-y"]);
+  });
+
+  test("cloud-managed key predicate guards re-import vs manual clobber", () => {
+    expect(isCloudManagedProviderKey(LPR_ID)).toBe(true);
+    expect(isCloudManagedProviderKey("lpr_anything")).toBe(true);
+    expect(isCloudManagedProviderKey("openwork")).toBe(true);
+    expect(isCloudManagedProviderKey("openai")).toBe(false);
+    expect(isCloudManagedProviderKey("anthropic")).toBe(false);
   });
 
   test("out-of-sync detection flags a changed Den model list", () => {

--- a/apps/app/tests/cloud-provider-reimport.test.ts
+++ b/apps/app/tests/cloud-provider-reimport.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import { parse } from "jsonc-parser";
+
+import type {
+  DenOrgLlmProviderConnection,
+  DenOrgLlmProviderModel,
+} from "../src/app/lib/den";
+import type { CloudImportedProvider } from "../src/app/cloud/import-state";
+import {
+  formatConfigWithCloudProvider,
+  getCloudManagedProviderId,
+  getProviderModelIds,
+  isCloudProviderOutOfSync,
+} from "../src/react-app/domains/connections/provider-auth/cloud-provider-config";
+
+const LPR_ID = "lpr_openrouter";
+
+const makeModel = (id: string, name = id): DenOrgLlmProviderModel => ({
+  id,
+  name,
+  config: {},
+  createdAt: null,
+});
+
+const makeProvider = (
+  models: DenOrgLlmProviderModel[],
+  updatedAt: string,
+): DenOrgLlmProviderConnection => ({
+  id: LPR_ID,
+  source: "custom",
+  providerId: "openrouter",
+  name: "OpenRouter",
+  providerConfig: {
+    id: "openrouter",
+    name: "OpenRouter",
+    npm: "@ai-sdk/openai-compatible",
+    env: ["OPENROUTER_API_KEY"],
+    api: "https://openrouter.ai/api/v1",
+    models: {},
+  },
+  hasApiKey: true,
+  models,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt,
+  apiKey: "sk-test",
+});
+
+const importedFrom = (
+  provider: DenOrgLlmProviderConnection,
+): CloudImportedProvider => ({
+  cloudProviderId: provider.id,
+  providerId: getCloudManagedProviderId(provider),
+  sourceProviderId: provider.providerId,
+  name: provider.name,
+  source: provider.source,
+  updatedAt: provider.updatedAt,
+  modelIds: getProviderModelIds(provider),
+  importedAt: Date.now(),
+});
+
+const providerModelKeys = (raw: string): string[] => {
+  const parsed = parse(raw) as
+    | { provider?: Record<string, { models?: Record<string, unknown> }> }
+    | undefined;
+  const block = parsed?.provider?.[LPR_ID];
+  return block?.models ? Object.keys(block.models).sort() : [];
+};
+
+describe("cloud provider re-import diff (#2346)", () => {
+  test("first import writes the lpr_* block with the initial model", () => {
+    const provider = makeProvider([makeModel("model-x")], "2024-02-01T00:00:00.000Z");
+    const config = formatConfigWithCloudProvider("", provider, LPR_ID, {
+      disabledProviders: [],
+    });
+    expect(providerModelKeys(config)).toEqual(["model-x"]);
+  });
+
+  test("re-import adds a newly added model (X then X + Y)", () => {
+    const first = makeProvider([makeModel("model-x")], "2024-02-01T00:00:00.000Z");
+    const initial = formatConfigWithCloudProvider("", first, LPR_ID, {
+      disabledProviders: [],
+    });
+    expect(providerModelKeys(initial)).toEqual(["model-x"]);
+
+    const updated = makeProvider(
+      [makeModel("model-x"), makeModel("model-y")],
+      "2024-03-01T00:00:00.000Z",
+    );
+    const reimported = formatConfigWithCloudProvider(initial, updated, LPR_ID, {
+      previousProviderId: LPR_ID,
+      disabledProviders: [],
+    });
+    expect(providerModelKeys(reimported)).toEqual(["model-x", "model-y"]);
+  });
+
+  test("re-import drops a removed model (X + Y then only Y)", () => {
+    const both = makeProvider(
+      [makeModel("model-x"), makeModel("model-y")],
+      "2024-03-01T00:00:00.000Z",
+    );
+    const initial = formatConfigWithCloudProvider("", both, LPR_ID, {
+      disabledProviders: [],
+    });
+    expect(providerModelKeys(initial)).toEqual(["model-x", "model-y"]);
+
+    const onlyY = makeProvider([makeModel("model-y")], "2024-04-01T00:00:00.000Z");
+    const reimported = formatConfigWithCloudProvider(initial, onlyY, LPR_ID, {
+      previousProviderId: LPR_ID,
+      disabledProviders: [],
+    });
+    expect(providerModelKeys(reimported)).toEqual(["model-y"]);
+  });
+
+  test("re-import preserves unrelated provider blocks and config keys", () => {
+    const base = [
+      "{",
+      '  "$schema": "https://opencode.ai/config.json",',
+      '  "provider": {',
+      '    "anthropic": { "models": { "claude": { "id": "claude", "name": "Claude" } } }',
+      "  }",
+      "}",
+      "",
+    ].join("\n");
+    const provider = makeProvider(
+      [makeModel("model-x"), makeModel("model-y")],
+      "2024-03-01T00:00:00.000Z",
+    );
+    const result = formatConfigWithCloudProvider(base, provider, LPR_ID, {
+      disabledProviders: [],
+    });
+    const parsed = parse(result) as {
+      provider?: Record<string, unknown>;
+      $schema?: string;
+    };
+    expect(parsed.$schema).toBe("https://opencode.ai/config.json");
+    expect(Object.keys(parsed.provider ?? {}).sort()).toEqual([
+      "anthropic",
+      LPR_ID,
+    ]);
+    expect(providerModelKeys(result)).toEqual(["model-x", "model-y"]);
+  });
+
+  test("out-of-sync detection flags a changed Den model list", () => {
+    const first = makeProvider([makeModel("model-x")], "2024-02-01T00:00:00.000Z");
+    const baseline = importedFrom(first);
+
+    // Same payload -> in sync.
+    expect(isCloudProviderOutOfSync(first, baseline)).toBe(false);
+
+    // Den adds a model -> out of sync (drives the Sync/Import action).
+    const updated = makeProvider(
+      [makeModel("model-x"), makeModel("model-y")],
+      "2024-03-01T00:00:00.000Z",
+    );
+    expect(isCloudProviderOutOfSync(updated, baseline)).toBe(true);
+
+    // After re-import the baseline advances -> in sync again.
+    expect(isCloudProviderOutOfSync(updated, importedFrom(updated))).toBe(false);
+  });
+});

--- a/evals/cloud-provider-sync-flows.md
+++ b/evals/cloud-provider-sync-flows.md
@@ -65,7 +65,15 @@ curl -H "authorization: Bearer $TOKEN" \
 
 - The changed provider metadata is visible in the desktop UI.
 - `opencode.jsonc` reflects the new model list after sync.
+- The `lpr_*` provider block's `models` map is rewritten to match Den exactly:
+  newly added models appear and removed models are dropped (not the
+  first-import snapshot — see #2346).
+- The newly added model is selectable in the composer model picker.
 - Removed models are not left as stale selectable models.
+
+> Regression coverage: `apps/app/tests/cloud-provider-reimport.test.ts`
+> asserts the `lpr_*` `models` map is rewritten (adds new, drops removed) on
+> re-import, and that out-of-sync detection flags a changed Den model list.
 
 ## Flow 3: Provider delete sync
 


### PR DESCRIPTION
## Summary

Fixes #2346 — re-importing an org-managed cloud LLM provider did **not** update the workspace `opencode.jsonc` model list; it kept the first-import snapshot.

Closes #2346.

## Root cause (what was actually failing)

The JSONC writer was **not** the bug — `formatConfigWithCloudProvider` uses `jsonc-parser` `modify()` which fully replaces the `lpr_*` provider block. The bug was in the **reconcile orchestration / safety guard**:

1. **`assertCloudProviderImportSafe` blocked re-import when the import baseline diverged.** The out-of-sync / imported state is tracked in a baseline (`cloudImports.providers`, keyed by cloud id with `modelIds` + `updatedAt`) that lives in a **different place** than the actual `lpr_*` block in `opencode.jsonc`. When that baseline was missing/diverged but the `lpr_*` block still existed (very reproducible: the desktop persists the baseline via the OpenWork server runtime, not the local `.opencode/openwork.json`), the provider shows as **"available"** and any Import/auto-sync attempt threw:
   > `lpr_… is already connected in this workspace. Disconnect it before importing the cloud-managed version.`
   …or `…already has a provider block in opencode.jsonc.` The error was swallowed during auto-sync, so the block was **never updated** and the app silently kept model X forever.

2. **`performCloudProviderSync` used a fragile remove-then-reconnect dance.** For an out-of-sync provider it called `removeCloudProviderInternal` (which removes the block + baseline but does **not** refresh `providerConnectedIds`) and then `connectCloudProviderInternal`, whose `assertCloudProviderImportSafe` could then throw against the now-stale in-memory connected list — aborting the rewrite **after** the block was already removed.

## Fix

- **Relax `assertCloudProviderImportSafe` for cloud-managed keys.** `lpr_*` keys and the `openwork` hosted provider are owned by the cloud-import system and are never hand-authored, so re-importing over an existing cloud-managed block is a safe **reconcile** (recovers a lost/diverged baseline), not a clobber of a user's manual provider. New `isCloudManagedProviderKey()` predicate gates the two guards.
- **Replace remove-then-reconnect in `performCloudProviderSync` with a single idempotent rewrite** (`connectCloudProviderInternal` directly), which fetches the fresh Den model list and fully replaces the block while keeping the baseline — no window where the block is deleted.
- Extracted the pure config/diff logic into `cloud-provider-config.ts` so it is unit-testable (and shrinks `store.ts`).

## Before / after `opencode.jsonc`

Scenario: import provider with model X (`openai/gpt-4o-mini`); update Den to add Y (`anthropic/claude-3.5-sonnet`); re-import.

**Before (bug):** block keeps only X.
```jsonc
"lpr_01kvsfe0h3feyt2cbx50rgfzcr": {
  "models": { "openai/gpt-4o-mini": { "id": "openai/gpt-4o-mini", "name": "GPT-4o mini" } }
}
```

**After (fixed):** block has X **and** Y.
```jsonc
"lpr_01kvsfe0h3feyt2cbx50rgfzcr": {
  "models": {
    "anthropic/claude-3.5-sonnet": { "id": "anthropic/claude-3.5-sonnet", "name": "Claude 3.5 Sonnet" },
    "openai/gpt-4o-mini": { "id": "openai/gpt-4o-mini", "name": "GPT-4o mini" }
  }
}
```

**Removal also works** — Den updated to drop X → desktop shows "Out of sync" → Sync → block drops X, keeps only Y.

## Tests

New unit suite `apps/app/tests/cloud-provider-reimport.test.ts` asserts the `lpr_*` `models` map is rewritten on re-import (adds new, drops removed), preserves unrelated provider blocks, the cloud-managed-key predicate, and out-of-sync detection.

Commands run (from the worktree root):
```
pnpm --filter @openwork/app typecheck        # EXIT 0
pnpm --filter @openwork/app exec bun test tests/   # 77 pass / 0 fail
pnpm --filter @openwork/app exec bun test tests/cloud-provider-reimport.test.ts  # 6 pass / 0 fail
```

## Daytona e2e (two-sandbox: Den server + Electron)

- Den server sandbox `openwork-server-20260622-222458`; Electron sandbox `openwork-test-20260622-223543` (bootstrap confirmed pointing at the Daytona Den URLs, not prod).
- Seeded demo org (Acme Robotics), created an OpenRouter org provider with model X, signed the desktop in via desktop-handoff.
- Reproduced the bug on this branch's pre-fix code: clicking **Import** errored "lpr_… is already connected…", `opencode.jsonc` kept only X.
- Applied fix (HMR), re-ran: `opencode.jsonc` reconciled to **X + Y**; then Den-removed X → Sync → block drops X; the new model **Claude 3.5 Sonnet (OpenRouter, LP/cloud badge)** is selectable in the composer picker and shows as the active model.

**Frame-proof / artifacts** (Daytona artifacts volume, port 8090):
- Index: https://8090-6osbo0nofesyvtwo.daytonaproxy01.net/validation/2346/index.html
- before/after configs: `opencode-before-fix.jsonc`, `opencode-after-fix.jsonc`, `opencode-after-remove.jsonc` in the same folder.

> Note: Daytona preview URLs are not permanent; sandboxes will be torn down after review. Reproduce with `.devcontainer/test-server-on-daytona.sh` + `.devcontainer/test-on-daytona.sh --den-base-url … --den-api-base-url …` per the steps above.

## Files changed
- `apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts` (new, extracted pure helpers + `isCloudManagedProviderKey`)
- `apps/app/src/react-app/domains/connections/provider-auth/store.ts` (use helpers; relax guard; idempotent sync)
- `apps/app/tests/cloud-provider-reimport.test.ts` (new tests)
- `evals/cloud-provider-sync-flows.md` (Flow 2 expected outcome + regression coverage note)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

