### PR TITLE
fix(cloud-providers): refresh imported state after import; don't reset on transient failure (#2352)

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -440,11 +440,19 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     try {
       const config = await readWorkspaceOpenworkConfigRecord();
       const cloudImports = readWorkspaceCloudImports(config);
-      setStateField("importedCloudProviders", cloudImports.providers);
-      return cloudImports.providers;
+      const next = cloudImports.providers;
+      // Guard: don't overwrite non-empty import state with an empty read.
+      // This prevents a transient server unavailability (e.g. during engine
+      // restart) from clearing a just-completed import from the badge.
+      const hasNext = Object.keys(next).length > 0;
+      const hasCurrent = Object.keys(state.importedCloudProviders).length > 0;
+      if (hasNext || !hasCurrent) {
+        setStateField("importedCloudProviders", next);
+      }
+      return next;
     } catch {
-      setStateField("importedCloudProviders", {});
-      return {};
+      // Preserve existing state on read failure to avoid losing import state.
+      return state.importedCloudProviders;
     }
   };
 
@@ -1931,6 +1939,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     dispose,
     syncFromOptions,
     refreshCloudOrgProviders,
+    refreshImportedCloudProviders,
     runCloudProviderSync,
     startProviderAuth,
     refreshProviders,

--- a/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
@@ -25,6 +25,7 @@ export type CloudProvidersViewProps = {
   importedCloudProviders: Record<string, CloudImportedProvider>;
   onOpenAccount: () => void;
   refreshCloudOrgProviders: (options?: { force?: boolean }) => Promise<DenOrgLlmProvider[]>;
+  refreshImportedCloudProviders: () => Promise<Record<string, CloudImportedProvider>>;
   removeCloudProvider: (cloudProviderId: string) => Promise<string | void>;
   session: CloudProvidersSession;
 };
@@ -41,6 +42,7 @@ export function CloudProvidersView({
   importedCloudProviders,
   onOpenAccount,
   refreshCloudOrgProviders,
+  refreshImportedCloudProviders,
   removeCloudProvider,
   session,
 }: CloudProvidersViewProps) {
@@ -97,7 +99,10 @@ export function CloudProvidersView({
 
       try {
         session.syncCurrentDenSettings();
-        const items = await refreshCloudOrgProviders({ force: !quiet });
+        const [items] = await Promise.all([
+          refreshCloudOrgProviders({ force: !quiet }),
+          refreshImportedCloudProviders(),
+        ]);
         if (!quiet) {
           toast.info(
             items.length > 0
@@ -115,6 +120,7 @@ export function CloudProvidersView({
     },
     [
       refreshCloudOrgProviders,
+      refreshImportedCloudProviders,
       activeOrg,
       activeOrgId,
       authToken,

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1977,6 +1977,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 importedCloudProviders={providerAuthSnapshot.importedCloudProviders}
                 onOpenAccount={openCloudAccountSettings}
                 refreshCloudOrgProviders={providerAuthStore.refreshCloudOrgProviders}
+                refreshImportedCloudProviders={providerAuthStore.refreshImportedCloudProviders}
                 removeCloudProvider={providerAuthStore.removeCloudProvider}
                 session={denSession}
               />
@@ -2141,6 +2142,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             importedCloudProviders={providerAuthSnapshot.importedCloudProviders}
             onOpenAccount={openCloudAccountSettings}
             refreshCloudOrgProviders={providerAuthStore.refreshCloudOrgProviders}
+            refreshImportedCloudProviders={providerAuthStore.refreshImportedCloudProviders}
             removeCloudProvider={providerAuthStore.removeCloudProvider}
             session={denSession}
           />


### PR DESCRIPTION
## Summary

Fixes #2352 — Cloud Providers UI still shows 'Import' after a successful import (badge not updating).

## Root Cause

After a successful import, `connectCloudProviderInternal` calls `refreshProviders({ dispose: true })` to reload the opencode engine. During this restart, the server connection is briefly unavailable. `syncFromOptions` fires due to the context-key change, triggering `runCloudProviderSync` → `performCloudProviderSync` → `refreshImportedCloudProviders()`. Since the OpenWork server is temporarily unavailable, `readWorkspaceOpenworkConfigRecord()` fails. The previous `catch` block reset `importedCloudProviders` to `{}`, losing the just-completed import from the badge.

Additionally, the Refresh button only called `refreshCloudOrgProviders` (live provider list from Den) but never re-read `importedCloudProviders` from disk, so manually refreshing after a stale badge could not recover the import state.

## Changes

**`apps/app/src/react-app/domains/connections/provider-auth/store.ts`**
- `refreshImportedCloudProviders`: on failure, preserve existing state instead of resetting to `{}`
- `refreshImportedCloudProviders`: guard against overwriting non-empty state with an empty read (handles transient empty responses during engine restart)
- Export `refreshImportedCloudProviders` from the store

**`apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx`**
- Add `refreshImportedCloudProviders` prop
- Call it alongside `refreshCloudOrgProviders` in the Refresh handler so the badge always reflects the latest persisted import state after a manual refresh

**`apps/app/src/react-app/shell/settings-route.tsx`**
- Pass `providerAuthStore.refreshImportedCloudProviders` to both `CloudProvidersView` usages

## Tests

```
pnpm --filter @openwork/app test -- --run
```

Result: **71 pass, 0 fail** ✓

TypeScript: **no errors** ✓

## Daytona Eval

- Branch deployed to Daytona sandbox `openwork-test-20260623-070045`
- App launched and Cloud Providers settings page verified to render correctly
- Screenshot: https://8090-mu3mtmhmidtpvoj2.daytonaproxy01.net/screenshots/daytona-screenshot-20260623-140712.png

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

