### PR TITLE
fix(den-api): parse YAML frontmatter in deriveProjection to prevent SKILL.md name/description mangling

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -245,17 +245,24 @@ function deriveProjection(input: { objectType: ConfigObjectRow["objectType"]; va
   const metadata = input.value.metadata ?? {}
   const payload = input.value.normalizedPayloadJson ?? {}
   const rawSourceText = normalizeOptionalString(input.value.rawSourceText)
+
+  const frontmatter = rawSourceText ? parseMarkdownFrontmatter(rawSourceText).data : {}
+  const frontmatterName: string | undefined = frontmatter.name ?? frontmatter.title
+  const frontmatterDescription: string | undefined = frontmatter.description ?? frontmatter.summary
+
   const titleCandidate = [
     typeof metadata.title === "string" ? metadata.title : null,
     typeof metadata.name === "string" ? metadata.name : null,
     typeof payload.title === "string" ? payload.title : null,
     typeof payload.name === "string" ? payload.name : null,
+    typeof frontmatterName === "string" ? frontmatterName : null,
     rawSourceText ? stripLineDecorators(firstTextLine(rawSourceText)) : null,
   ].find((value) => Boolean(normalizeOptionalString(value ?? undefined)))
 
   const descriptionCandidate = [
     typeof metadata.description === "string" ? metadata.description : null,
     typeof payload.description === "string" ? payload.description : null,
+    typeof frontmatterDescription === "string" ? frontmatterDescription : null,
     rawSourceText
       ? rawSourceText
         .split(/\r?\n/g)


### PR DESCRIPTION
- fixes : #2350

## Problem

When a member installs a shared skill from the org Marketplace, the materialized `SKILL.md` frontmatter is wrong:

- `name` becomes the **config-object id** (`cob_...`) instead of the real skill name
- The original `name:` line is nested into `description`

```yaml
# Owner-created:
name: laptop-refresh
description: 4-step laptop refresh / ServiceNow request policy for the Sales team

# Member-installed (broken):
name: "cob-01kvshfchxfqc94qnmvanzsv4c"
description: "name: laptop-refresh"
```

## Root Cause

`deriveProjection()` in `ee/apps/den-api/src/routes/org/plugin-system/store.ts` extracts `title` and `description` when creating config objects, but **never parsed YAML frontmatter** from `rawSourceText` for markdown-based types (skill, agent, command).

- **Title** fell through to `firstTextLine()` → returned `"---"` → stored as title
- **Description** scanned non-decorated lines after stripping `---` → `"name: laptop-refresh"` was the first hit

## Fix

Parse YAML frontmatter using the existing `parseMarkdownFrontmatter()` helper and insert `name`/`title` and `description`/`summary` as high-priority candidates before the raw-text heuristics.

## Reproduction Evidence

**Before (broken) — config-object create response:**
```json
{
  "title": "---",
  "description": "name: laptop-refresh"
}
```

**After (fixed) — config-object create response:**
```json
{
  "title": "laptop-refresh",
  "description": "4-step laptop refresh / ServiceNow request policy for the Sales team"
}
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

