### PR TITLE
fix(server): don't let remote workspaces block engine startup

### DIFF
--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -5,7 +5,7 @@ import { mkdir } from "node:fs/promises";
 import { parseCliArgs, printHelp, resolveServerConfig } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
 import { createServerLogger, startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
-import { ensureWorkspaceFiles } from "./workspace-init.js";
+import { ensureLocalWorkspaceFiles } from "./workspace-init.js";
 import { keepOpenworkRuntimeConfigFileFresh, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import pkg from "../package.json" with { type: "json" };
 
@@ -27,9 +27,7 @@ const serverUrl = `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.hos
 let managedOpencode: ManagedOpencodeServer | null = null;
 
 if (!config.readOnly) {
-  for (const workspace of config.workspaces) {
-    await ensureWorkspaceFiles(workspace.path, workspace.preset ?? "starter");
-  }
+  await ensureLocalWorkspaceFiles(config.workspaces);
 }
 
 if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -9,7 +9,7 @@ import { mkdir } from "node:fs/promises";
 import { resolveServerConfig, type CliArgs } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer, type OpencodeExecutionSnapshot } from "./managed-opencode.js";
 import { startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
-import { ensureWorkspaceFiles } from "./workspace-init.js";
+import { ensureLocalWorkspaceFiles } from "./workspace-init.js";
 import { keepOpenworkRuntimeConfigFileFresh, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import type { ServeResult } from "./serve-node.js";
 import type { ServerConfig } from "./types.js";
@@ -47,9 +47,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
   let managedOpencode: ManagedOpencodeServer | null = null;
 
   if (!config.readOnly) {
-    for (const workspace of config.workspaces) {
-      await ensureWorkspaceFiles(workspace.path, workspace.preset ?? "starter");
-    }
+    await ensureLocalWorkspaceFiles(config.workspaces);
   }
 
   if (!config.opencodeBaseUrl && options.manageOpencode) {

--- a/apps/server/src/workspace-init.test.ts
+++ b/apps/server/src/workspace-init.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, writeFile, mkdir, stat } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { ensureWorkspaceFiles } from "./workspace-init.js";
+import { ensureWorkspaceFiles, ensureLocalWorkspaceFiles } from "./workspace-init.js";
 import { openworkExtensionsPreviewPluginPath, openworkPluginPath } from "./openwork-extensions-plugin-path.js";
 
 async function withWorkspace(fn: (root: string) => Promise<void>) {
@@ -130,5 +130,35 @@ describe("ensureWorkspaceFiles", () => {
 `);
       expect(result.reloadReasons).not.toContain("config");
     });
+  });
+});
+
+describe("ensureLocalWorkspaceFiles", () => {
+  test("provisions local workspaces and skips remote ones", async () => {
+    await withWorkspace(async (root) => {
+      await ensureLocalWorkspaceFiles([
+        { path: root, preset: "starter", workspaceType: "local" },
+        { path: "", preset: "remote", workspaceType: "remote" },
+      ]);
+      const openwork = await readFile(join(root, ".opencode", "openwork.json"), "utf8");
+      expect(openwork).toContain('"authorizedRoots"');
+    });
+  });
+
+  test("does not throw when a remote workspace has an empty path", async () => {
+    // Regression: a remote workspace is persisted with an empty path, which used
+    // to reach ensureWorkspaceFiles() and throw invalid_workspace_path, aborting
+    // server startup so local workspaces could never connect to the engine.
+    await expect(
+      ensureLocalWorkspaceFiles([{ path: "", preset: "remote", workspaceType: "remote" }]),
+    ).resolves.toBeUndefined();
+  });
+
+  test("skips a non-remote workspace that has no local path", async () => {
+    // A legacy/migrated entry can default to workspaceType "local" with an empty
+    // path; it has no local files to provision and must be skipped, not crash.
+    await expect(
+      ensureLocalWorkspaceFiles([{ path: "", preset: "starter", workspaceType: "local" }]),
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -5,7 +5,7 @@ import { ensureDir, exists } from "./utils.js";
 import { ApiError } from "./errors.js";
 import { openworkConfigPath, opencodeConfigPath } from "./workspace-files.js";
 import { readJsoncFile } from "./jsonc.js";
-import type { ReloadReason } from "./types.js";
+import type { ReloadReason, WorkspaceInfo } from "./types.js";
 
 type WorkspaceOpenworkConfig = {
   version: number;
@@ -72,6 +72,25 @@ export async function ensureWorkspaceFiles(workspaceRoot: string, presetInput: s
     changed: openworkConfigChanged || reloadReasons.size > 0,
     reloadReasons: Array.from(reloadReasons),
   };
+}
+
+/**
+ * Provision workspace files for every workspace that has local files to set up.
+ *
+ * Skips remote workspaces (which live on a host and may even carry a non-empty
+ * remote `directory`) and any workspace without a resolved local path. Either
+ * would otherwise reach ensureWorkspaceFiles() — which throws
+ * `invalid_workspace_path` on a blank path — and abort server startup. Local
+ * workspaces are always created with a validated path, so they are unaffected.
+ * Shared by the embedded-server and CLI boot paths.
+ */
+export async function ensureLocalWorkspaceFiles(
+  workspaces: ReadonlyArray<Pick<WorkspaceInfo, "path" | "preset" | "workspaceType">>,
+): Promise<void> {
+  for (const workspace of workspaces) {
+    if (workspace.workspaceType === "remote" || !workspace.path.trim()) continue;
+    await ensureWorkspaceFiles(workspace.path, workspace.preset);
+  }
 }
 
 export async function readRawOpencodeConfig(path: string): Promise<{ exists: boolean; content: string | null }> {


### PR DESCRIPTION
## Summary
- A configured **remote** workspace stops the local managed OpenCode engine from starting, so **local** workspaces can no longer connect (while the remote keeps working). Fixed by only provisioning workspace files for workspaces that actually have local files to set up.

## Why
- Remote workspaces are persisted with an empty `path`. Both `startEmbeddedServer` (desktop) and the CLI ran `for (const workspace of config.workspaces) await ensureWorkspaceFiles(workspace.path, ...)`.
- `ensureWorkspaceFiles()` throws `ApiError(400, "invalid_workspace_path", "workspace path is required")` on a blank path, which aborts startup. The managed engine never binds, so every local workspace fails to connect.
- Remote workspaces are unaffected (they reach their host directly), producing the confusing **"remote works, local is broken"** symptom whenever both are configured. `embedded.ts` already special-cases `workspaceType === "remote"` a few lines below the offending loop — the provisioning loop just didn't.

## Scope
- `apps/server/src/workspace-init.ts`: new `ensureLocalWorkspaceFiles()` helper. It skips workspaces that have no local files to provision — **remote** workspaces (which live on a host and may even carry a non-empty remote `directory`) **and** any workspace **without a resolved local path** (e.g. a legacy entry that defaults to `workspaceType: "local"` with an empty path, per `buildWorkspaceInfos`). Both conditions are needed: a `path`-only guard would wrongly provision local files into a remote's `directory`, and a `workspaceType`-only guard would miss a pathless local entry.
- `apps/server/src/embedded.ts`, `apps/server/src/cli.ts`: call the helper instead of the duplicated inline loop.
- `apps/server/src/workspace-init.test.ts`: regression tests.

## Out of scope
- `ensureWorkspaceFiles()` still throws on a blank path — that validation is correct for the single-path callers (`routes/workspaces.ts`, `server.ts`) which pass a resolved local path.
- `reload-watcher.ts` also iterates workspaces, but already wraps per-workspace startup in try/catch (degrades gracefully, doesn't abort), so it's left as-is.

## Testing
### Ran (in `apps/server`)
- `pnpm install --filter "openwork-server..."`
- `pnpm run typecheck`
- `bun test src/workspace-init.test.ts`

### Result
- pass/fail: **pass**
- `typecheck` exits 0; **11 tests pass** (3 new, covering: local provisioned + remote skipped, remote with empty path doesn't throw, pathless non-remote skipped).
- Full `pnpm test:e2e` not run here (needs the OpenCode runtime + a display); the change is covered by the new server-level tests + typecheck.

## CI status
- pass: pending CI
- code-related failures: none expected
- external/env/auth blockers: n/a

## Manual verification
1. Configure one local + one remote workspace (the remote is stored with an empty `path` in `server.json`).
2. **Before:** desktop boot fails; managed OpenCode never binds; the local workspace cannot connect to the engine. The remote still works.
3. **After:** boot succeeds, the engine binds, the local workspace connects, and the remote is unchanged.

## Evidence
No video/screenshot attached (the repro uses a private remote worker, and this is a server-side boot crash best shown via logs). Before the fix (OpenWork desktop v0.17.1):
```
ApiError: workspace path is required
    at ensureWorkspaceFiles (resources/app.asar/server/dist/workspace-init.js:42:15)
    at async engineStart (resources/app.asar/electron/runtime.mjs)
  code: 'invalid_workspace_path'
```
After (local-patched build, blank remote path present), the managed engine binds and serves the local workspace:
```
opencode-x86_64 ... serve --hostname 127.0.0.1 --port 41169
GET /workspace/<local-id>/events 200
```
Exact repro for a reviewer: add a local workspace and an OpenWork remote worker, restart the app.

## Risk
- Low. Skipped workspaces have no local files to provision, so this only avoids a guaranteed throw. Validation for real local paths is unchanged, and the duplicated loop is now a single tested helper.

## Rollback
- Revert this commit.
