### PR TITLE
fix(server): boot managed engine in first local workspace, not workspaces[0]

### DIFF
--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -6,6 +6,7 @@ import { parseCliArgs, printHelp, resolveServerConfig } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
 import { createServerLogger, startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
 import { ensureLocalWorkspaceFiles } from "./workspace-init.js";
+import { findManagedEngineWorkspace } from "./workspaces.js";
 import { keepOpenworkRuntimeConfigFileFresh, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import pkg from "../package.json" with { type: "json" };
 
@@ -31,8 +32,8 @@ if (!config.readOnly) {
 }
 
 if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
-  const workspace = config.workspaces[0];
-  if (workspace?.path) {
+  const workspace = findManagedEngineWorkspace(config.workspaces);
+  if (workspace) {
     // Server-managed config file: the engine re-reads it from disk on every
     // instance rebuild, and keepOpenworkRuntimeConfigFileFresh rewrites it
     // on every runtime-DB write — so disposes always pick up current state.

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -10,6 +10,7 @@ import { resolveServerConfig, type CliArgs } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer, type OpencodeExecutionSnapshot } from "./managed-opencode.js";
 import { startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
 import { ensureLocalWorkspaceFiles } from "./workspace-init.js";
+import { findManagedEngineWorkspace } from "./workspaces.js";
 import { keepOpenworkRuntimeConfigFileFresh, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import type { ServeResult } from "./serve-node.js";
 import type { ServerConfig } from "./types.js";
@@ -51,8 +52,8 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
   }
 
   if (!config.opencodeBaseUrl && options.manageOpencode) {
-    const workspace = config.workspaces[0];
-    if (workspace?.path) {
+    const workspace = findManagedEngineWorkspace(config.workspaces);
+    if (workspace) {
       // Server-managed config file: the engine re-reads it from disk on every
       // instance rebuild, and keepOpenworkRuntimeConfigFileFresh rewrites it
       // on every runtime-DB write — so disposes always pick up current state.

--- a/apps/server/src/workspaces.test.ts
+++ b/apps/server/src/workspaces.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { findManagedEngineWorkspace } from "./workspaces.js";
+import type { WorkspaceInfo } from "./types.js";
+
+function ws(fields: {
+  id?: string;
+  name?: string;
+  path: string;
+  preset?: string;
+  workspaceType: WorkspaceInfo["workspaceType"];
+}): WorkspaceInfo {
+  return {
+    id: fields.id ?? "ws_test",
+    name: fields.name ?? "Workspace",
+    path: fields.path,
+    preset: fields.preset ?? (fields.workspaceType === "remote" ? "remote" : "starter"),
+    workspaceType: fields.workspaceType,
+  };
+}
+
+describe("findManagedEngineWorkspace", () => {
+  test("selects the local workspace in a typical local + remote config", () => {
+    // Mirrors the real desktop config: a local workspace followed by an OpenWork
+    // remote worker that has no local path.
+    const workspaces = [
+      ws({ id: "ws_local", path: "/home/user/cloud/work", workspaceType: "local" }),
+      ws({ id: "rem_ws", path: "", workspaceType: "remote" }),
+    ];
+    expect(findManagedEngineWorkspace(workspaces)?.id).toBe("ws_local");
+  });
+
+  test("selects the local workspace even when a path-less remote is first", () => {
+    // A freshly added remote worker is prepended, putting it at index 0. The
+    // engine must still boot in the local workspace instead of skipping startup.
+    const workspaces = [
+      ws({ id: "rem_ws", path: "", workspaceType: "remote" }),
+      ws({ id: "ws_local", path: "/home/user/cloud/work", workspaceType: "local" }),
+    ];
+    expect(findManagedEngineWorkspace(workspaces)?.id).toBe("ws_local");
+  });
+
+  test("returns undefined for a remote-only config", () => {
+    const workspaces = [ws({ id: "rem_ws", path: "", workspaceType: "remote" })];
+    expect(findManagedEngineWorkspace(workspaces)).toBeUndefined();
+  });
+
+  test("ignores a remote workspace that carries a non-empty directory path", () => {
+    // OpenCode remotes can store a `directory`, giving the remote a non-empty
+    // path; it still runs on its host, so it must not be chosen as the local cwd.
+    const workspaces = [ws({ id: "rem_dir", path: "/remote/dir", workspaceType: "remote" })];
+    expect(findManagedEngineWorkspace(workspaces)).toBeUndefined();
+  });
+
+  test("skips path-less entries and returns the first local workspace with a path", () => {
+    const workspaces = [
+      ws({ id: "rem_ws", path: "", workspaceType: "remote" }),
+      ws({ id: "ws_blank", path: "  ", workspaceType: "local" }),
+      ws({ id: "ws_local", path: "/home/user/work", workspaceType: "local" }),
+    ];
+    expect(findManagedEngineWorkspace(workspaces)?.id).toBe("ws_local");
+  });
+
+  test("returns undefined for an empty workspace list", () => {
+    expect(findManagedEngineWorkspace([])).toBeUndefined();
+  });
+});

--- a/apps/server/src/workspaces.ts
+++ b/apps/server/src/workspaces.ts
@@ -70,3 +70,18 @@ export function buildWorkspaceInfos(
     };
   });
 }
+
+/**
+ * Pick the workspace the server-managed OpenCode engine should boot in.
+ *
+ * The engine serves every workspace but needs one local directory to start in.
+ * `config.workspaces[0]` is not reliably that: a freshly added remote worker is
+ * prepended to the list, so index 0 can be a remote workspace (no local path)
+ * even when local workspaces exist — which would leave the engine unstarted.
+ * Select the first non-remote workspace with a resolved local path so the engine
+ * starts regardless of ordering; returns undefined for remote-only setups (which
+ * need no local engine).
+ */
+export function findManagedEngineWorkspace(workspaces: WorkspaceInfo[]): WorkspaceInfo | undefined {
+  return workspaces.find((workspace) => workspace.workspaceType !== "remote" && workspace.path.trim() !== "");
+}


### PR DESCRIPTION
## Summary
- The server-managed OpenCode engine boots in `config.workspaces[0]`. When index 0 is a remote workspace with no local path, the engine **skips startup entirely**, leaving local workspaces with nothing to connect to. Select the first non-remote workspace with a local path instead.

## Why
- A remote worker added via "Add a worker → Connect remote" is **prepended** to `config.workspaces` (`routes/workspaces.ts`), so index 0 can be a remote workspace whose `path` is `""`. The managed-engine block guards on `workspaces[0]?.path`, so it silently doesn't spawn the engine — and every local workspace then has no engine to reach. The engine serves all workspaces but only needs one local directory to start in; that should be a real local workspace, not whatever happens to sit at index 0.

## Issue
- Companion to #2359 (the remote-workspace boot crash). Surfaced while fixing that; independently correct, since index 0 is not reliably the local/active workspace. With #2359 alone a path-less remote at index 0 no longer crashes provisioning, but the engine could still skip startup — this closes that gap.

## Scope
- `apps/server/src/workspaces.ts`: new `findManagedEngineWorkspace()` — first non-remote workspace with a resolved local path, else `undefined`.
- `apps/server/src/embedded.ts`, `apps/server/src/cli.ts`: use it for the managed-engine cwd / runtime-config selection instead of `config.workspaces[0]`.
- `apps/server/src/workspaces.test.ts`: unit tests.

## Out of scope
- Other `config.workspaces[0]` uses (active-workspace fallbacks, proxy default, image generation) — those are "default/active workspace" selection, a separate concern; left untouched.

## Testing
### Ran (in `apps/server`)
- `pnpm install --filter "openwork-server..."`
- `pnpm run typecheck`
- `bun test src/workspaces.test.ts`
- `bun test` over the workspace-related non-e2e files (`workspace-init`, `workspace-import-preview`, `workspace-export-safety`, `reload-watcher`, `validators`)

### Result
- pass/fail: **pass**. `typecheck` exits 0; new selection tests **6/6**; **61/61** across the workspace-related suite — no regressions.
- Full `pnpm test:e2e` not run here (needs the OpenCode runtime + a display).

## CI status
- pass: pending CI
- code-related failures: none expected
- external/env/auth blockers: n/a

## Manual verification
1. Config with a path-less remote worker at index 0 and a local workspace after it.
2. **Before:** managed engine doesn't spawn (`workspaces[0]?.path` is empty); the local workspace has no engine.
3. **After:** the engine boots in the local workspace; remote-only configs still (correctly) spawn no local engine.

## Evidence
No video — this is boot-path/selection logic, deterministically covered by unit tests. The tests assert selection against real config shapes: local+remote in both orders (incl. a path-less remote at index 0), remote-only, a remote that carries a non-empty `directory`, and blank entries.

## Risk
- Low. For the common case (a local workspace at index 0) selection is identical to before. Behavior only changes when index 0 has no local path — where the engine previously failed to start at all.

## Rollback
- Revert this commit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

