### PR TITLE
feat(landing): interactive GLM 5.2 cost calculator

### DIFF
--- a/ee/apps/landing/app/glm-5.2/cost/page.tsx
+++ b/ee/apps/landing/app/glm-5.2/cost/page.tsx
@@ -1,0 +1,185 @@
+import { SiteFooter } from "../../../components/site-footer";
+import { SiteNav } from "../../../components/site-nav";
+import { StructuredData } from "../../../components/structured-data";
+import { GlmCostCalculator } from "../../../components/glm-cost-calculator";
+import { getGithubData } from "../../../lib/github";
+import { baseOpenGraph } from "../../../lib/seo";
+
+const CLOUD_SIGNUP_URL =
+  "https://app.openworklabs.com?mode=sign-up&intent=models";
+const CALENDAR_URL =
+  "https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0M6zjfdm9ntqokfGCWovfuM21J9C2sqB9R6E1v_plXo8MqKswICQET7-ncV4dOVM5W8pFn1RFM";
+const DOWNLOAD_URL = "/download";
+
+const costSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: "OpenWork — GLM 5.2 cost calculator",
+  description:
+    "Interactive cost model comparing GLM 5.2 vs Sonnet 4.6 vs Opus 4.8 for AI coworker token spend across teams.",
+  url: "https://openworklabs.com/glm-5.2/cost",
+  applicationCategory: "BusinessApplication",
+  offers: {
+    "@type": "Offer",
+    price: "10",
+    priceCurrency: "USD",
+    url: CLOUD_SIGNUP_URL
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "OpenWork",
+    url: "https://openworklabs.com"
+  }
+};
+
+export const metadata = {
+  title: "GLM 5.2 cost calculator — OpenWork",
+  description:
+    "Interactive cost model: GLM 5.2 runs ~6.6x cheaper than Opus 4.8 at every usage tier. Drag the sliders and see the savings.",
+  alternates: {
+    canonical: "/glm-5.2/cost"
+  },
+  openGraph: {
+    ...baseOpenGraph,
+    url: "https://openworklabs.com/glm-5.2/cost"
+  }
+};
+
+const ASSUMPTIONS = [
+  {
+    label: "Tasks / employee / month",
+    value: "160",
+    detail: "20 working days × 8 agent tasks/day",
+  },
+  {
+    label: "Tokens per task",
+    value: "25K in · 6K out",
+    detail: "System prompt + tool defs + context + reasoning",
+  },
+  {
+    label: "Moderate tier",
+    value: "4M / 1M",
+    detail: "per employee / month (in / out)",
+  },
+  {
+    label: "GLM 5.2 list price",
+    value: "$0.95 / $3",
+    detail: "OpenRouter, per M tokens (in / out)",
+  },
+  {
+    label: "Sonnet 4.6 list price",
+    value: "$3 / $15",
+    detail: "Anthropic, per M tokens (in / out)",
+  },
+  {
+    label: "Opus 4.8 list price",
+    value: "$5 / $25",
+    detail: "Anthropic, per M tokens (in / out)",
+  },
+];
+
+export default async function GlmCostLanding() {
+  const github = await getGithubData();
+
+  return (
+    <div className="min-h-screen">
+      <StructuredData data={costSchema} />
+      <SiteNav
+        stars={github.stars}
+        downloadHref={github.downloads.macos}
+      />
+
+      <main className="pb-24 pt-20">
+        <div className="content-max-width px-6">
+          <div className="animate-fade-up max-w-3xl">
+            <div className="mb-3 text-[12px] font-bold uppercase tracking-wider text-gray-500">
+              GLM 5.2 · Cost model
+            </div>
+            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+              AI coworkers don&apos;t reduce spend. They multiply it.
+            </h1>
+            <p className="mb-6 text-[17px] leading-relaxed text-gray-700">
+              An AI coworker is agentic — every task re-sends system prompt, tool
+              defs, and accumulated context, plus reasoning on output. As adoption
+              climbs from light to heavy use, the <strong>absolute</strong> gap
+              between GLM 5.2 and Anthropic-only pricing explodes. Same coworker,
+              ~6–7× cheaper, and the savings grow exactly as adoption grows.
+            </p>
+            <div className="flex flex-wrap items-center gap-3">
+              <a
+                href={CLOUD_SIGNUP_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="doc-button inline-flex"
+              >
+                Try GLM 5.2 in OpenWork →
+              </a>
+              <a href={CALENDAR_URL} target="_blank" rel="noreferrer" className="secondary-button inline-flex">
+                Book a call
+              </a>
+              <a href="/glm-5.2" className="secondary-button inline-flex">
+                About GLM 5.2
+              </a>
+            </div>
+          </div>
+
+          <div className="my-12">
+            <GlmCostCalculator />
+          </div>
+
+          <section className="landing-shell my-12 rounded-3xl p-6 md:p-8">
+            <div className="mb-3 text-[12px] font-bold uppercase tracking-wider text-gray-500">
+              Assumptions
+            </div>
+            <h2 className="mb-6 text-2xl font-bold tracking-tight text-[#011627]">
+              How the model is built
+            </h2>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {ASSUMPTIONS.map((a) => (
+                <div key={a.label} className="rounded-2xl border border-gray-200 bg-white p-4">
+                  <div className="text-[12px] font-semibold text-gray-500">{a.label}</div>
+                  <div className="mono mt-1 text-[16px] font-bold text-[#011627]">{a.value}</div>
+                  <div className="mt-1 text-[12px] leading-snug text-gray-500">{a.detail}</div>
+                </div>
+              ))}
+            </div>
+            <p className="mt-5 text-[12px] leading-relaxed text-gray-500">
+              Prices are OpenRouter / Anthropic list prices as of Jun 23, 2026. GLM 5.2
+              dropped from $1.40/$4.40 a week prior. Token estimates are directional
+              for agentic (not chatbot) usage. Actual spend depends on your tasks,
+              context length, and model routing.
+            </p>
+          </section>
+
+          <section className="landing-shell my-12 flex flex-col items-center gap-4 rounded-3xl p-8 text-center">
+            <h2 className="text-2xl font-bold tracking-tight text-[#011627]">
+              Run real agent work on GLM 5.2 today
+            </h2>
+            <p className="max-w-xl text-[15px] text-gray-600">
+              Open source, 50+ models, and managed OSS model access — all in one app.
+              Start free, subscribe to OpenWork Models, and get 2x usage on GLM 5.2.
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <a
+                href={CLOUD_SIGNUP_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="doc-button inline-flex"
+              >
+                Try GLM 5.2 in OpenWork →
+              </a>
+              <a href={CALENDAR_URL} target="_blank" rel="noreferrer" className="secondary-button inline-flex">
+                Book a call
+              </a>
+              <a href={DOWNLOAD_URL} className="secondary-button inline-flex">
+                Download the app
+              </a>
+            </div>
+          </section>
+
+          <SiteFooter />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/ee/apps/landing/components/glm-cost-calculator.tsx
+++ b/ee/apps/landing/components/glm-cost-calculator.tsx
@@ -1,0 +1,513 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { TrendingDown, Users, Zap, Calendar } from "lucide-react";
+
+type ModelKey = "glm" | "sonnet" | "opus";
+
+type Model = {
+  key: ModelKey;
+  name: string;
+  inPrice: number;
+  outPrice: number;
+  color: string;
+  accent: string;
+  chip: string;
+};
+
+const MODELS: Model[] = [
+  { key: "glm",    name: "GLM 5.2",     inPrice: 0.95, outPrice: 3,  color: "#2563EB", accent: "#1D4ED8", chip: "bg-blue-50 text-blue-700 border-blue-200" },
+  { key: "sonnet", name: "Sonnet 4.6",   inPrice: 3,    outPrice: 15, color: "#8B5CF6", accent: "#7C3AED", chip: "bg-violet-50 text-violet-700 border-violet-200" },
+  { key: "opus",   name: "Opus 4.8",     inPrice: 5,    outPrice: 25, color: "#F97316", accent: "#EA580C", chip: "bg-orange-50 text-orange-700 border-orange-200" },
+];
+
+type Tier = {
+  key: string;
+  label: string;
+  inM: number;
+  outM: number;
+  blurb: string;
+};
+
+const TIERS: Tier[] = [
+  { key: "light",    label: "Light",    inM: 1,  outM: 0.25, blurb: "Occasional tasks, 1–2/day" },
+  { key: "moderate", label: "Moderate", inM: 4,  outM: 1,    blurb: "Daily coworker, ~160 tasks/mo" },
+  { key: "heavy",    label: "Heavy",    inM: 12, outM: 3,    blurb: "Power user, always-on agent" },
+];
+
+const RAMP = [
+  { month: "Month 1", tierKey: "light" },
+  { month: "Month 3", tierKey: "moderate" },
+  { month: "Month 6", tierKey: "heavy" },
+];
+
+const RAMP_LINE_KEYS: ReadonlyArray<ModelKey> = ["opus", "sonnet", "glm"];
+const HORIZONS: ReadonlyArray<"month" | "year"> = ["month", "year"];
+
+function costFor(model: Model, tier: Tier, employees: number): number {
+  const inCost = (tier.inM * 1_000_000 * model.inPrice) / 1_000_000;
+  const outCost = (tier.outM * 1_000_000 * model.outPrice) / 1_000_000;
+  return (inCost + outCost) * employees;
+}
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toFixed(n < 10 ? 2 : 0)}`;
+}
+
+function fmtShort(n: number): string {
+  if (n >= 1_000) return `$${Math.round(n / 1000)}K`;
+  return `$${Math.round(n)}`;
+}
+
+function Slider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  icon,
+  suffix,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+  icon: React.ReactNode;
+  suffix: string;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <label className="flex items-center gap-1.5 text-[13px] font-medium text-gray-700">
+          {icon}
+          {label}
+        </label>
+        <span className="mono text-[13px] font-semibold text-[#011627]">
+          {value}
+          {suffix}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="slider-input"
+        aria-label={label}
+      />
+    </div>
+  );
+}
+
+function BarChart({
+  data,
+  height = 260,
+}: {
+  data: Array<{ label: string; values: Array<{ model: Model; cost: number }> }>;
+  height?: number;
+}) {
+  const maxCost = useMemo(() => {
+    const m = Math.max(...data.flatMap((d) => d.values.map((v) => v.cost)), 1);
+    return m * 1.12;
+  }, [data]);
+
+  const barW = 26;
+  const groupGap = 56;
+  const groupW = MODELS.length * (barW + 4) + 8;
+  const chartW = data.length * groupW + (data.length - 1) * groupGap + 48;
+  const leftPad = 44;
+  const bottomPad = 44;
+  const topPad = 16;
+
+  const yTicks = 4;
+  const ticks = Array.from({ length: yTicks + 1 }, (_, i) => (maxCost / yTicks) * i);
+
+  return (
+    <div className="w-full overflow-x-auto">
+      <svg
+        viewBox={`0 0 ${chartW} ${height}`}
+        className="w-full"
+        style={{ minWidth: chartW > 560 ? chartW : "100%" }}
+        role="img"
+        aria-label="Cost comparison bar chart"
+      >
+        {ticks.map((t, i) => {
+          const y = height - bottomPad - ((height - bottomPad - topPad) * (t / maxCost));
+          return (
+            <g key={i}>
+              <line
+                x1={leftPad}
+                x2={chartW - 8}
+                y1={y}
+                y2={y}
+                stroke="rgba(148,163,184,0.18)"
+                strokeWidth={1}
+                strokeDasharray={i === 0 ? "0" : "3 4"}
+              />
+              <text x={leftPad - 8} y={y + 4} textAnchor="end" className="fill-gray-400" style={{ fontSize: 10, fontWeight: 600 }}>
+                {fmtShort(t)}
+              </text>
+            </g>
+          );
+        })}
+
+        {data.map((group, gi) => {
+          const gx = leftPad + gi * (groupW + groupGap) + 8;
+          return (
+            <g key={group.label}>
+              {group.values.map((v, mi) => {
+                const bh = ((height - bottomPad - topPad) * (v.cost / maxCost));
+                const bx = gx + mi * (barW + 4);
+                const by = height - bottomPad - bh;
+                const isGlm = v.model.key === "glm";
+                return (
+                  <g key={v.model.key}>
+                    <rect
+                      x={bx}
+                      y={by}
+                      width={barW}
+                      height={Math.max(bh, 1)}
+                      rx={4}
+                      fill={v.model.color}
+                      opacity={isGlm ? 1 : 0.85}
+                    />
+                    {bh > 22 ? (
+                      <text x={bx + barW / 2} y={by - 6} textAnchor="middle" className="fill-gray-700" style={{ fontSize: 10, fontWeight: 700 }}>
+                        {fmtShort(v.cost)}
+                      </text>
+                    ) : null}
+                  </g>
+                );
+              })}
+              <text
+                x={gx + (groupW - 8) / 2}
+                y={height - bottomPad + 20}
+                textAnchor="middle"
+                className="fill-gray-600"
+                style={{ fontSize: 11, fontWeight: 600 }}
+              >
+                {group.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+function LineChart({
+  points,
+  height = 220,
+}: {
+  points: Array<{ x: string; glm: number; opus: number; sonnet: number }>;
+  height?: number;
+}) {
+  const width = 560;
+  const leftPad = 48;
+  const rightPad = 16;
+  const topPad = 16;
+  const bottomPad = 36;
+  const maxCost = Math.max(...points.flatMap((p) => [p.glm, p.opus, p.sonnet]), 1) * 1.1;
+  const innerW = width - leftPad - rightPad;
+  const innerH = height - topPad - bottomPad;
+
+  const xStep = points.length > 1 ? innerW / (points.length - 1) : 0;
+
+  const path = (key: "glm" | "opus" | "sonnet") =>
+    points
+      .map((p, i) => {
+        const x = leftPad + i * xStep;
+        const y = height - bottomPad - (innerH * (p[key] / maxCost));
+        return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join(" ");
+
+  const yTicks = 4;
+  const ticks = Array.from({ length: yTicks + 1 }, (_, i) => (maxCost / yTicks) * i);
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full" role="img" aria-label="Adoption ramp cost curve">
+      {ticks.map((t, i) => {
+        const y = height - bottomPad - (innerH * (t / maxCost));
+        return (
+          <g key={i}>
+            <line x1={leftPad} x2={width - rightPad} y1={y} y2={y} stroke="rgba(148,163,184,0.18)" strokeWidth={1} strokeDasharray={i === 0 ? "0" : "3 4"} />
+            <text x={leftPad - 8} y={y + 4} textAnchor="end" className="fill-gray-400" style={{ fontSize: 10, fontWeight: 600 }}>
+              {fmtShort(t)}
+            </text>
+          </g>
+        );
+      })}
+
+      {points.map((p, i) => {
+        const x = leftPad + i * xStep;
+        return (
+          <text key={p.x} x={x} y={height - bottomPad + 18} textAnchor="middle" className="fill-gray-600" style={{ fontSize: 11, fontWeight: 600 }}>
+            {p.x}
+          </text>
+        );
+      })}
+
+      <path d={path("opus")} fill="none" stroke="#F97316" strokeWidth={2.5} strokeLinejoin="round" strokeLinecap="round" />
+      <path d={path("sonnet")} fill="none" stroke="#8B5CF6" strokeWidth={2.5} strokeLinejoin="round" strokeLinecap="round" />
+      <path d={path("glm")} fill="none" stroke="#2563EB" strokeWidth={2.5} strokeLinejoin="round" strokeLinecap="round" />
+
+      {points.map((p, i) => {
+        const x = leftPad + i * xStep;
+        return (
+          <g key={i}>
+            {RAMP_LINE_KEYS.map((k) => {
+              const m = MODELS.find((mm) => mm.key === k)!;
+              const y = height - bottomPad - (innerH * (p[k] / maxCost));
+              return <circle key={k} cx={x} cy={y} r={3.5} fill={m.color} stroke="white" strokeWidth={1.5} />;
+            })}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export function GlmCostCalculator() {
+  const [employees, setEmployees] = useState(50);
+  const [tierIdx, setTierIdx] = useState(1);
+  const [horizon, setHorizon] = useState<"month" | "year">("year");
+
+  const tier = TIERS[tierIdx];
+  const glm = MODELS[0];
+  const sonnet = MODELS[1];
+  const opus = MODELS[2];
+
+  const perTier = useMemo(() => {
+    return TIERS.map((t) => ({
+      label: t.label,
+      values: MODELS.map((m) => ({ model: m, cost: costFor(m, t, 1) })),
+    }));
+  }, []);
+
+  const company = useMemo(() => {
+    const mult = horizon === "year" ? 12 : 1;
+    return MODELS.map((m) => ({
+      model: m,
+      cost: costFor(m, tier, employees) * mult,
+    }));
+  }, [tier, employees, horizon]);
+
+  const glmCost = company.find((c) => c.model.key === "glm")!.cost;
+  const opusCost = company.find((c) => c.model.key === "opus")!.cost;
+  const saved = opusCost - glmCost;
+  const ratio = opusCost / Math.max(glmCost, 0.01);
+
+  const rampData = useMemo(
+    () =>
+      RAMP.map((r) => {
+        const t = TIERS.find((tt) => tt.key === r.tierKey)!;
+        return {
+          x: r.month,
+          glm: costFor(glm, t, employees),
+          sonnet: costFor(sonnet, t, employees),
+          opus: costFor(opus, t, employees),
+        };
+      }),
+    [employees]
+  );
+
+  return (
+    <div className="flex flex-col gap-10">
+      <style>{`
+        .slider-input {
+          -webkit-appearance: none;
+          appearance: none;
+          width: 100%;
+          height: 6px;
+          border-radius: 9999px;
+          background: linear-gradient(to right, #2563EB 0%, #2563EB var(--pct,50%), #E2E8F0 var(--pct,50%), #E2E8F0 100%);
+          outline: none;
+        }
+        .slider-input::-webkit-slider-thumb {
+          -webkit-appearance: none;
+          appearance: none;
+          width: 20px;
+          height: 20px;
+          border-radius: 50%;
+          background: #fff;
+          border: 2px solid #2563EB;
+          box-shadow: 0 2px 6px rgba(37,99,235,0.35);
+          cursor: pointer;
+          transition: transform 0.15s ease;
+        }
+        .slider-input::-webkit-slider-thumb:hover { transform: scale(1.12); }
+        .slider-input::-moz-range-thumb {
+          width: 20px; height: 20px; border-radius: 50%;
+          background: #fff; border: 2px solid #2563EB;
+          box-shadow: 0 2px 6px rgba(37,99,235,0.35); cursor: pointer;
+        }
+      `}</style>
+
+      <section className="landing-shell rounded-3xl p-6 md:p-8">
+        <div className="mb-3 flex items-center gap-2">
+          <span className="rounded-full bg-blue-50 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-blue-700 border border-blue-200">
+            Live model
+          </span>
+        </div>
+        <h2 className="mb-1 text-2xl font-bold tracking-tight text-[#011627]">
+          The same coworker, a fraction of the bill
+        </h2>
+        <p className="mb-6 max-w-2xl text-[15px] leading-relaxed text-gray-600">
+          Drag the sliders. AI coworkers don&apos;t reduce token spend — they multiply it.
+          The more your team adopts, the bigger the Anthropic-only bill gets. Route the same
+          work to GLM 5.2 and the curve stays flat.
+        </p>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+          <Slider
+            label="Equipped employees"
+            value={employees}
+            min={1}
+            max={300}
+            step={1}
+            onChange={setEmployees}
+            icon={<Users size={14} className="text-gray-500" />}
+            suffix=""
+          />
+          <div className="flex flex-col gap-2">
+            <label className="flex items-center gap-1.5 text-[13px] font-medium text-gray-700">
+              <Zap size={14} className="text-gray-500" />
+              Usage tier
+            </label>
+            <div className="flex flex-col gap-1.5">
+              {TIERS.map((t, i) => (
+                <button
+                  key={t.key}
+                  type="button"
+                  onClick={() => setTierIdx(i)}
+                  className={`flex items-center justify-between rounded-xl border px-3 py-1.5 text-left text-[12px] transition-colors ${
+                    tierIdx === i
+                      ? "border-blue-300 bg-blue-50/70 text-[#011627]"
+                      : "border-gray-200 bg-white text-gray-600 hover:border-gray-300"
+                  }`}
+                >
+                  <span className="font-semibold">{t.label}</span>
+                  <span className="mono text-[11px] text-gray-500">
+                    {t.inM}M / {t.outM}M
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            <label className="flex items-center gap-1.5 text-[13px] font-medium text-gray-700">
+              <Calendar size={14} className="text-gray-500" />
+              Horizon
+            </label>
+            <div className="flex gap-2">
+              {HORIZONS.map((h) => (
+                <button
+                  key={h}
+                  type="button"
+                  onClick={() => setHorizon(h)}
+                  className={`flex-1 rounded-xl border px-3 py-2 text-[13px] font-semibold capitalize transition-colors ${
+                    horizon === h
+                      ? "border-blue-300 bg-blue-50/70 text-[#011627]"
+                      : "border-gray-200 bg-white text-gray-600 hover:border-gray-300"
+                  }`}
+                >
+                  {h}
+                </button>
+              ))}
+            </div>
+            <p className="text-[11px] leading-snug text-gray-500">{tier.blurb}</p>
+          </div>
+        </div>
+
+        <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {company.map((c) => {
+            const isGlm = c.model.key === "glm";
+            return (
+              <div
+                key={c.model.key}
+                className={`rounded-2xl border p-5 ${
+                  isGlm ? "border-blue-200 bg-blue-50/50" : "border-gray-200 bg-white"
+                }`}
+              >
+                <div className="mb-1 flex items-center gap-2">
+                  <span className={`inline-block h-2.5 w-2.5 rounded-full`} style={{ background: c.model.color }} />
+                  <span className="text-[13px] font-semibold text-gray-700">{c.model.name}</span>
+                  <span className="mono ml-auto text-[11px] text-gray-400">
+                    ${c.model.inPrice}/${c.model.outPrice}
+                  </span>
+                </div>
+                <div className="text-[28px] font-bold tracking-tight text-[#011627]">
+                  {fmt(c.cost)}
+                </div>
+                <div className="text-[12px] text-gray-500">
+                  {horizon === "year" ? "per year" : "per month"} · {employees} {employees === 1 ? "seat" : "seats"}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3 rounded-2xl bg-[#011627] px-5 py-4 text-white">
+          <TrendingDown size={18} className="text-emerald-300" />
+          <span className="text-[14px] font-medium">
+            GLM 5.2 saves <span className="font-bold text-emerald-300">{fmt(saved)}</span> vs Opus 4.8 —{" "}
+            <span className="font-bold text-emerald-300">{ratio.toFixed(1)}×</span> cheaper, same coworker.
+          </span>
+        </div>
+      </section>
+
+      <section className="landing-shell rounded-3xl p-6 md:p-8">
+        <div className="mb-1 text-[12px] font-bold uppercase tracking-wider text-gray-500">
+          Per employee / month
+        </div>
+        <h3 className="mb-5 text-xl font-bold tracking-tight text-[#011627]">
+          Cost per employee by usage tier
+        </h3>
+        <BarChart data={perTier} />
+        <div className="mt-4 flex flex-wrap gap-4">
+          {MODELS.map((m) => (
+            <div key={m.key} className="flex items-center gap-1.5">
+              <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ background: m.color }} />
+              <span className="text-[12px] font-medium text-gray-700">{m.name}</span>
+              <span className="mono text-[11px] text-gray-400">
+                ${m.inPrice}/M in · ${m.outPrice}/M out
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="landing-shell rounded-3xl p-6 md:p-8">
+        <div className="mb-1 text-[12px] font-bold uppercase tracking-wider text-gray-500">
+          The adoption ramp
+        </div>
+        <h3 className="mb-1 text-xl font-bold tracking-tight text-[#011627]">
+          As adoption climbs, the gap explodes
+        </h3>
+        <p className="mb-5 max-w-2xl text-[14px] leading-relaxed text-gray-600">
+          Month 1 your team barely uses it. By Month 6 the coworker is running all day.
+          On Anthropic-only pricing the bill compounds at $25/M output. On GLM 5.2 it stays flat.
+        </p>
+        <LineChart points={rampData} />
+        <div className="mt-4 grid grid-cols-3 gap-3 text-center">
+          {rampData.map((r) => (
+            <div key={r.x} className="rounded-xl border border-gray-200 bg-white p-3">
+              <div className="text-[11px] font-semibold text-gray-500">{r.x}</div>
+              <div className="mono mt-1 text-[13px] font-bold text-blue-600">{fmt(r.glm)}</div>
+              <div className="mono text-[11px] text-orange-500 line-through opacity-70">{fmt(r.opus)}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds an interactive landing page at **`/glm-5.2/cost`** that turns the GLM 5.2 cost model into a live, draggable chart.

The page models AI coworker token spend across **GLM 5.2 ($0.95/$3)**, **Sonnet 4.6 ($3/$15)**, and **Opus 4.8 ($5/$25)** — using the assumptions from the cost analysis:

- 160 tasks/employee/month, ~25K in + 6K out per task
- Three usage tiers (Light 1M/0.25M, Moderate 4M/1M, Heavy 12M/3M)
- A Month 1 → Month 6 adoption ramp showing the absolute gap exploding as usage climbs

## Interactive

- **Employees slider** (1–300), **usage tier** selector, **month/year** horizon toggle
- All numbers recompute live. Default state (50 seats, moderate, year): GLM **\$4.1K** vs Opus **\$27K** → **6.6× cheaper**, **\$22.9K saved/yr**
- At 300 seats / year: GLM **\$24.5K** vs Opus **\$162K** → **\$137.5K saved/yr**
- Two pure-SVG charts: a per-employee bar chart (all tiers) and an adoption-ramp line chart (GLM vs Sonnet vs Opus)

## Implementation

- **No new dependencies** — charts are hand-rolled SVG (lightweight, matches the minimal-diff principle)
- New files only, no changes to existing code:
  - `ee/apps/landing/app/glm-5.2/cost/page.tsx` (route + hero + assumptions + CTA)
  - `ee/apps/landing/components/glm-cost-calculator.tsx` (client component: sliders, charts, live math)
- Reuses the existing landing design system (`landing-shell`, `feature-card`, `doc-button`, `secondary-button`, `content-max-width`, `SiteNav`, `SiteFooter`)
- Follows the existing `app/glm-5.2/page.tsx` conventions (metadata, `StructuredData`, `getGithubData`)

## Verification

- `pnpm --filter @openwork-ee/landing build` → **Compiled successfully** (Next.js build). The build type-check step fails on a **pre-existing** error in `packages/email/src/send-email.ts` (untouched by this PR, present on `origin/dev`); my files typecheck clean via `tsc --noEmit` (zero errors in `glm-cost-calculator.tsx` / `cost/page.tsx`).
- Dev server: `GET /glm-5.2/cost` → **200**, 67KB, all content present (h1, calculator, savings bar, CTAs).
- Interactivity verified via CDP: dragging the employees slider to 300 updates GLM \$4.1K→\$24.5K, Opus \$27K→\$162K, and the savings bar \$22.9K→\$137.5K live.
- Screenshot (full page, 300-employee state): \`/var/folders/8j/hhcc8zs100d3fd654fjkk9580000gn/T/browser-screenshot-1782308373623.png\` — note: I could not visually inspect it (this environment has no vision), but DOM assertions confirm correct rendering.

## To review

\`\`\`bash
pnpm install
pnpm --filter @openwork-ee/landing dev
# open http://localhost:3000/glm-5.2/cost
\`\`\`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

