### PR TITLE
fix(white-label): gate brand appearance behind enterprise entitlement

### DIFF
--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -330,6 +330,14 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
         }
       }
 
+      const enablesBranding = (typeof input.brandLogoUrl === "string") || (typeof input.brandAccentColor === "string")
+      if (enablesBranding) {
+        const entitlement = checkEntitlement(payload.organization.metadata, "desktopPolicies")
+        if (!entitlement.ok) {
+          return c.json(entitlement.response, entitlement.status)
+        }
+      }
+
       const updated = await updateOrganizationSettings({
         organizationId: payload.organization.id,
         name: input.name,

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
@@ -678,6 +678,9 @@ export function OrgSettingsScreen() {
             </p>
           </div>
 
+          {orgContext && !orgContext.entitlements.desktopPolicies ? (
+            <EnterprisePlanNotice feature="White-label brand appearance" />
+          ) : (
           <div className="grid gap-5 lg:grid-cols-2">
             <label className="grid gap-3">
               <span className="text-[14px] font-medium text-gray-700">
@@ -732,6 +735,7 @@ export function OrgSettingsScreen() {
               </span>
             </label>
           </div>
+          )}
         </DenCard>
 
         <div className="flex flex-wrap items-center justify-between gap-3">


### PR DESCRIPTION
## Summary

Gates the white-label brand appearance feature (logo URL + accent color) behind the `desktopPolicies` enterprise entitlement — same tier as desktop policy management, SSO, and version pinning.

### Changes

**Server** (`ee/apps/den-api/src/routes/org/core.ts`):
- `PATCH /v1/org` with `brandLogoUrl` or `brandAccentColor` now checks `checkEntitlement(metadata, "desktopPolicies")` before proceeding. Non-enterprise orgs get HTTP 402 `enterprise_plan_required`.

**Den web** (`org-settings-screen.tsx`):
- The Brand Appearance card shows `EnterprisePlanNotice` when `orgContext.entitlements.desktopPolicies` is false, hiding the logo/accent inputs behind the upgrade prompt.

### Testing

```
ee/den-api:  tsc --noEmit  ✓
ee/den-web:  tsc --noEmit  ✓
```

Clearing brand (`null`) is always allowed so admins can revert even if they downgrade.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

