### PR TITLE
feat(admin): allow deleting users

### DIFF
--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -15,7 +15,6 @@ import {
   OrganizationTable,
   OrgSubscriptionTable,
   ScimSyncEventTable,
-  SsoProviderTable,
   TelemetryEventTable,
   WorkerTable,
   AdminAllowlistTable,
@@ -280,7 +279,6 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         await tx.delete(DesktopHandoffGrantTable).where(eq(DesktopHandoffGrantTable.user_id, userId))
         await tx.delete(ExternalIdentityTable).where(eq(ExternalIdentityTable.userId, userId))
         await tx.delete(ScimSyncEventTable).where(eq(ScimSyncEventTable.userId, userId))
-        await tx.delete(SsoProviderTable).where(eq(SsoProviderTable.userId, userId))
         await tx.update(MemberTable).set({ removedAt }).where(eq(MemberTable.userId, userId))
         await tx.update(WorkerTable).set({ created_by_user_id: null }).where(eq(WorkerTable.created_by_user_id, userId))
         await tx.delete(AuthUserTable).where(eq(AuthUserTable.id, userId))

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -1,12 +1,21 @@
 import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import {
   AuthAccountTable,
+  AuthApiKeyTable,
   AuthSessionTable,
   AuthUserTable,
+  DesktopHandoffGrantTable,
+  ExternalIdentityTable,
   InvitationTable,
   MemberTable,
+  OAuthAccessTokenTable,
+  OAuthClientTable,
+  OAuthConsentTable,
+  OAuthRefreshTokenTable,
   OrganizationTable,
   OrgSubscriptionTable,
+  ScimSyncEventTable,
+  SsoProviderTable,
   TelemetryEventTable,
   WorkerTable,
   AdminAllowlistTable,
@@ -178,6 +187,10 @@ function isOrganizationId(value: string): value is OrganizationId {
   return value.startsWith("org_")
 }
 
+function isUserId(value: string): value is UserId {
+  return value.startsWith("user_")
+}
+
 async function mapWithConcurrency<T, R>(items: T[], limit: number, mapper: (item: T) => Promise<R>) {
   if (items.length === 0) {
     return [] as R[]
@@ -224,6 +237,65 @@ function shouldReplaceBillingStatus(current: AdminBillingStatus, candidate: Admi
 }
 
 export function registerAdminRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
+  app.delete(
+    "/v1/admin/users/:userId",
+    adminRoute(),
+    async (c) => {
+      const currentUser = c.get("user")
+      const userId = c.req.param("userId")
+      if (!isUserId(userId)) {
+        return c.json({ error: "invalid_request", message: "Invalid user id." }, 400)
+      }
+
+      if (userId === currentUser.id) {
+        return c.json({ error: "invalid_request", message: "You cannot delete your own admin user." }, 400)
+      }
+
+      const rows = await db
+        .select({ id: AuthUserTable.id, email: AuthUserTable.email })
+        .from(AuthUserTable)
+        .where(eq(AuthUserTable.id, userId))
+        .limit(1)
+
+      const targetUser = rows[0]
+      if (!targetUser) {
+        return c.json({ error: "not_found", message: "User not found." }, 404)
+      }
+
+      const activeMembershipRows = await db
+        .select({ organizationId: MemberTable.organizationId })
+        .from(MemberTable)
+        .where(and(eq(MemberTable.userId, userId), isNull(MemberTable.removedAt)))
+
+      await db.transaction(async (tx) => {
+        const removedAt = new Date()
+
+        await tx.delete(OAuthAccessTokenTable).where(eq(OAuthAccessTokenTable.userId, userId))
+        await tx.delete(OAuthRefreshTokenTable).where(eq(OAuthRefreshTokenTable.userId, userId))
+        await tx.delete(OAuthConsentTable).where(eq(OAuthConsentTable.userId, userId))
+        await tx.update(OAuthClientTable).set({ userId: null }).where(eq(OAuthClientTable.userId, userId))
+        await tx.delete(AuthApiKeyTable).where(eq(AuthApiKeyTable.referenceId, userId))
+        await tx.delete(AuthSessionTable).where(eq(AuthSessionTable.userId, userId))
+        await tx.delete(AuthAccountTable).where(eq(AuthAccountTable.userId, userId))
+        await tx.delete(DesktopHandoffGrantTable).where(eq(DesktopHandoffGrantTable.user_id, userId))
+        await tx.delete(ExternalIdentityTable).where(eq(ExternalIdentityTable.userId, userId))
+        await tx.delete(ScimSyncEventTable).where(eq(ScimSyncEventTable.userId, userId))
+        await tx.delete(SsoProviderTable).where(eq(SsoProviderTable.userId, userId))
+        await tx.update(MemberTable).set({ removedAt }).where(eq(MemberTable.userId, userId))
+        await tx.update(WorkerTable).set({ created_by_user_id: null }).where(eq(WorkerTable.created_by_user_id, userId))
+        await tx.delete(AuthUserTable).where(eq(AuthUserTable.id, userId))
+      })
+
+      const organizationIds = Array.from(new Set(activeMembershipRows.map((row) => row.organizationId).filter(isOrganizationId)))
+      for (const organizationId of organizationIds) {
+        const seatCounts = await getOrganizationSeatBillingCounts({ organizationId })
+        await syncSeatSubscriptionQuantityAfterMemberChange({ organizationId, memberCount: seatCounts.total })
+      }
+
+      return c.json({ ok: true, user: { id: targetUser.id, email: targetUser.email } })
+    },
+  )
+
   app.patch(
     "/v1/admin/organizations/:organizationId/plan",
     adminRoute(),

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Copy, Pencil } from "lucide-react";
+import { Copy, Pencil, Trash2 } from "lucide-react";
 
 type AccessState = "loading" | "ready" | "signed-out" | "forbidden" | "error";
 type WorkerFilter = "all" | "with-workers" | "without-workers";
@@ -428,6 +428,29 @@ async function patchJson(path: string, body: unknown) {
   return { response, payload };
 }
 
+async function deleteJson(path: string) {
+  const response = await fetch(`/api/den${path}`, {
+    method: "DELETE",
+    credentials: "include",
+    headers: {
+      Accept: "application/json"
+    }
+  });
+
+  const text = await response.text();
+  let payload: unknown = null;
+
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
+
+  return { response, payload };
+}
+
 function formatDateTime(value: string | null): string {
   if (!value) {
     return "-";
@@ -773,6 +796,8 @@ export function DenAdminPanel() {
   const [savingOrgId, setSavingOrgId] = useState<string | null>(null);
   const [freeSeatsDialog, setFreeSeatsDialog] = useState<{ org: AdminOrganization; totalFreeSeats: string } | null>(null);
   const [savingFreeSeatsOrgId, setSavingFreeSeatsOrgId] = useState<string | null>(null);
+  const [deleteUserDialog, setDeleteUserDialog] = useState<AdminUser | null>(null);
+  const [deletingUserId, setDeletingUserId] = useState<string | null>(null);
 
   const loadOverview = useCallback(async (loadBilling: boolean) => {
     setRefreshing(true);
@@ -1037,6 +1062,32 @@ export function DenAdminPanel() {
       setSavingFreeSeatsOrgId(null);
     }
   }, [freeSeatsDialog, includeBilling, loadOverview]);
+
+  const deleteUser = useCallback(async () => {
+    if (!deleteUserDialog) {
+      return;
+    }
+
+    setDeletingUserId(deleteUserDialog.id);
+    setError(null);
+
+    try {
+      const { response, payload: nextPayload } = await deleteJson(`/v1/admin/users/${deleteUserDialog.id}`);
+
+      if (!response.ok) {
+        setError(getErrorMessage(nextPayload, `Could not delete ${deleteUserDialog.email}.`));
+        return;
+      }
+
+      setDeleteUserDialog(null);
+      setSelectedUserId(null);
+      await loadOverview(includeBilling);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Unknown network error");
+    } finally {
+      setDeletingUserId(null);
+    }
+  }, [deleteUserDialog, includeBilling, loadOverview]);
 
   const exportCsv = useCallback(() => {
     const date = new Date().toISOString().slice(0, 10);
@@ -1637,6 +1688,24 @@ export function DenAdminPanel() {
                         ) : null}
                       </div>
 
+                      <div className="mt-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-4">
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                          <div>
+                            <p className="text-sm font-semibold text-red-950">Delete user</p>
+                            <p className="mt-1 text-sm leading-6 text-red-700">Removes this user account, active sessions, auth records, and org memberships.</p>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => setDeleteUserDialog(user)}
+                            disabled={deletingUserId === user.id}
+                            className="inline-flex items-center justify-center gap-2 rounded-full border border-red-200 bg-white px-4 py-2 text-sm font-semibold text-red-700 transition hover:border-red-300 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            <Trash2 size={15} aria-hidden="true" />
+                            {deletingUserId === user.id ? "Deleting..." : "Delete user"}
+                          </button>
+                        </div>
+                      </div>
+
                       {user.organizations.length > 0 ? (
                         <div className="mt-3 grid gap-2">
                           {user.organizations.map((org) => (
@@ -1745,6 +1814,46 @@ export function DenAdminPanel() {
                 className="inline-flex items-center justify-center rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {savingFreeSeatsOrgId === freeSeatsDialog.org.id ? "Saving..." : "Save"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {deleteUserDialog ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-user-dialog-title"
+          onClick={() => setDeleteUserDialog(null)}
+        >
+          <div className="w-full max-w-md rounded-3xl border border-red-100 bg-white p-6 shadow-xl" onClick={(event) => event.stopPropagation()}>
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-red-500">Danger zone</p>
+            <h2 id="delete-user-dialog-title" className="mt-2 text-2xl font-semibold tracking-[-0.04em] text-slate-950">
+              Delete {deleteUserDialog.email}?
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-slate-600">
+              This permanently removes the user account and revokes their sessions. Organization memberships are marked removed.
+            </p>
+            <div className="mt-6 flex flex-wrap justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setDeleteUserDialog(null)}
+                disabled={deletingUserId === deleteUserDialog.id}
+                className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  void deleteUser();
+                }}
+                disabled={deletingUserId === deleteUserDialog.id}
+                className="inline-flex items-center justify-center rounded-full bg-red-600 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {deletingUserId === deleteUserDialog.id ? "Deleting..." : "Delete user"}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Add a protected admin DELETE endpoint for user accounts
- Revoke sessions/auth/OAuth records, remove identity records, detach workers, mark memberships removed, and resync org seat billing
- Add a confirmation flow in /admin user details

## Tests
- pnpm --filter @openwork-ee/den-api build
- pnpm --filter @openwork-ee/den-web build

Note: an initial parallel build attempt caused a pnpm install ENOTEMPTY race while both commands tried to populate node_modules; rerunning sequentially passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

