### PR TITLE
feat(artifacts): live-preview markdown view in artifact panel

### DIFF
--- a/apps/app/src/react-app/domains/session/artifacts/artifact-text-editor.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-text-editor.tsx
@@ -5,6 +5,7 @@ import { markdown } from "@codemirror/lang-markdown";
 import { EditorState } from "@codemirror/state";
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
 import { cn } from "@/lib/utils";
+import { markdownLivePreview } from "./markdown-live-preview";
 
 type ArtifactTextEditorProps = {
   className?: string;
@@ -34,34 +35,49 @@ export function ArtifactTextEditor(props: ArtifactTextEditorProps) {
       state: EditorState.create({
         doc: props.value,
         extensions: [
-          lineNumbers(),
+          props.language === "markdown" ? [] : lineNumbers(),
           history(),
           keymap.of([...defaultKeymap, ...historyKeymap]),
-          props.language === "markdown" ? markdown() : [],
+          props.language === "markdown" ? [markdown(), markdownLivePreview()] : [],
           EditorView.lineWrapping,
           EditorView.updateListener.of((update) => {
             if (update.docChanged) {
               onChangeRef.current(update.state.doc.toString());
             }
           }),
-          EditorView.theme({
-            "&": { height: "100%", background: "transparent" },
-            ".cm-scroller": { fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" },
-            ".cm-content": { minHeight: "100%", padding: "12px 0", fontSize: "12px", lineHeight: "20px" },
-            ".cm-gutters": { background: "transparent", borderRight: "1px solid hsl(var(--border))" },
-            ".cm-lineNumbers .cm-gutterElement": { padding: "0 8px", color: "hsl(var(--muted-foreground))" },
-            ".cm-activeLine": { backgroundColor: "hsl(var(--muted) / 0.35)" },
-            ".cm-activeLineGutter": { backgroundColor: "hsl(var(--muted) / 0.35)" },
-          }),
+          props.language === "markdown"
+            ? EditorView.theme({
+                "&": { height: "100%", background: "transparent" },
+                ".cm-scroller": { fontFamily: "inherit" },
+                ".cm-content": { minHeight: "100%", padding: "16px", maxWidth: "768px", margin: "0 auto", fontSize: "14px", lineHeight: "1.7" },
+                ".cm-activeLine": { backgroundColor: "transparent" },
+              })
+            : EditorView.theme({
+                "&": { height: "100%", background: "transparent" },
+                ".cm-scroller": { fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" },
+                ".cm-content": { minHeight: "100%", padding: "12px 0", fontSize: "12px", lineHeight: "20px" },
+                ".cm-gutters": { background: "transparent", borderRight: "1px solid hsl(var(--border))" },
+                ".cm-lineNumbers .cm-gutterElement": { padding: "0 8px", color: "hsl(var(--muted-foreground))" },
+                ".cm-activeLine": { backgroundColor: "hsl(var(--muted) / 0.35)" },
+                ".cm-activeLineGutter": { backgroundColor: "hsl(var(--muted) / 0.35)" },
+              }),
         ],
       }),
     });
 
     viewRef.current = view;
 
+    // Dev-only handle so e2e flows can drive the editor selection.
+    if (import.meta.env.DEV) {
+      (window as unknown as { __artifactEditorView?: EditorView }).__artifactEditorView = view;
+    }
+
     return () => {
       view.destroy();
       viewRef.current = null;
+      if (import.meta.env.DEV) {
+        delete (window as unknown as { __artifactEditorView?: EditorView }).__artifactEditorView;
+      }
     };
   }, [props.language]);
 

--- a/apps/app/src/react-app/domains/session/artifacts/markdown-live-preview.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/markdown-live-preview.ts
@@ -1,0 +1,255 @@
+import { ensureSyntaxTree, syntaxTree } from "@codemirror/language";
+import { type Extension, type Range, RangeSetBuilder } from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+  WidgetType,
+} from "@codemirror/view";
+
+/**
+ * Obsidian-style "merged" markdown view for CodeMirror 6: the document stays
+ * fully editable as plain markdown, but headings, emphasis, lists, quotes and
+ * links are rendered inline. Syntax markers (`#`, `*`, `` ` ``, `>`, link
+ * brackets) are hidden unless the selection touches the line they belong to,
+ * so editing the raw markup is always one click away.
+ */
+
+const HIDE = Decoration.replace({});
+
+const HEADING_MARK = [
+  Decoration.mark({ class: "cm-md-h1" }),
+  Decoration.mark({ class: "cm-md-h2" }),
+  Decoration.mark({ class: "cm-md-h3" }),
+  Decoration.mark({ class: "cm-md-h4" }),
+  Decoration.mark({ class: "cm-md-h5" }),
+  Decoration.mark({ class: "cm-md-h6" }),
+];
+
+const STRONG = Decoration.mark({ class: "cm-md-strong" });
+const EMPHASIS = Decoration.mark({ class: "cm-md-emphasis" });
+const STRIKE = Decoration.mark({ class: "cm-md-strike" });
+const INLINE_CODE = Decoration.mark({ class: "cm-md-code" });
+const LINK_TEXT = Decoration.mark({ class: "cm-md-link" });
+const QUOTE = Decoration.line({ class: "cm-md-quote" });
+const CODE_BLOCK = Decoration.line({ class: "cm-md-codeblock" });
+
+class BulletWidget extends WidgetType {
+  eq() {
+    return true;
+  }
+  toDOM() {
+    const span = document.createElement("span");
+    span.className = "cm-md-bullet";
+    span.textContent = "\u2022";
+    return span;
+  }
+  ignoreEvent() {
+    return false;
+  }
+}
+
+const BULLET = Decoration.replace({ widget: new BulletWidget() });
+
+function selectionTouchesRange(view: EditorView, from: number, to: number) {
+  for (const range of view.state.selection.ranges) {
+    if (range.from <= to && range.to >= from) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function lineHasSelection(view: EditorView, pos: number) {
+  const line = view.state.doc.lineAt(pos);
+  return selectionTouchesRange(view, line.from, line.to);
+}
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const widgets: Range<Decoration>[] = [];
+  // Force the markdown tree to be parsed across the whole document so headings
+  // and inline marks are decorated immediately, even before incremental parsing
+  // would otherwise reach them.
+  const tree =
+    ensureSyntaxTree(view.state, view.state.doc.length, 200) ?? syntaxTree(view.state);
+
+  for (const { from, to } of view.visibleRanges) {
+    tree.iterate({
+      from,
+      to,
+      enter: (node) => {
+        const name = node.name;
+
+        if (/^ATXHeading[1-6]$/.test(name)) {
+          const level = Number(name.slice(-1)) - 1;
+          widgets.push(HEADING_MARK[level].range(node.from, node.to));
+          return;
+        }
+
+        if (name === "HeaderMark") {
+          // `#` markers and the trailing space; hide unless editing the line.
+          if (!lineHasSelection(view, node.from)) {
+            const after = view.state.doc.sliceString(node.to, node.to + 1) === " " ? node.to + 1 : node.to;
+            widgets.push(HIDE.range(node.from, after));
+          }
+          return;
+        }
+
+        if (name === "StrongEmphasis") {
+          widgets.push(STRONG.range(node.from, node.to));
+          return;
+        }
+        if (name === "Emphasis") {
+          widgets.push(EMPHASIS.range(node.from, node.to));
+          return;
+        }
+        if (name === "Strikethrough") {
+          widgets.push(STRIKE.range(node.from, node.to));
+          return;
+        }
+        if (name === "InlineCode") {
+          widgets.push(INLINE_CODE.range(node.from, node.to));
+          return;
+        }
+
+        if (name === "EmphasisMark" || name === "CodeMark" || name === "StrikethroughMark") {
+          if (!lineHasSelection(view, node.from)) {
+            widgets.push(HIDE.range(node.from, node.to));
+          }
+          return;
+        }
+
+        if (name === "QuoteMark") {
+          if (!lineHasSelection(view, node.from)) {
+            const after = view.state.doc.sliceString(node.to, node.to + 1) === " " ? node.to + 1 : node.to;
+            widgets.push(HIDE.range(node.from, after));
+          }
+          return;
+        }
+
+        if (name === "ListMark") {
+          const lineText = view.state.doc.lineAt(node.from).text;
+          const isBullet = /^\s*[-*+]\s/.test(lineText);
+          if (isBullet && !lineHasSelection(view, node.from)) {
+            widgets.push(BULLET.range(node.from, node.to));
+          }
+          return;
+        }
+
+        if (name === "LinkMark") {
+          if (!lineHasSelection(view, node.from)) {
+            widgets.push(HIDE.range(node.from, node.to));
+          }
+          return;
+        }
+        if (name === "URL") {
+          // Hide the (target) part of a link unless editing it.
+          if (!lineHasSelection(view, node.from)) {
+            widgets.push(HIDE.range(node.from, node.to));
+          }
+          return;
+        }
+      },
+    });
+  }
+
+  // Line decorations must be applied in document order; collect them separately.
+  for (const { from, to } of view.visibleRanges) {
+    tree.iterate({
+      from,
+      to,
+      enter: (node) => {
+        if (node.name === "Blockquote") {
+          let pos = node.from;
+          while (pos <= node.to) {
+            const line = view.state.doc.lineAt(pos);
+            widgets.push(QUOTE.range(line.from));
+            if (line.to + 1 > node.to) break;
+            pos = line.to + 1;
+          }
+        }
+        if (node.name === "FencedCode" || node.name === "CodeBlock") {
+          let pos = node.from;
+          while (pos <= node.to) {
+            const line = view.state.doc.lineAt(pos);
+            widgets.push(CODE_BLOCK.range(line.from));
+            if (line.to + 1 > node.to) break;
+            pos = line.to + 1;
+          }
+        }
+      },
+    });
+  }
+
+  widgets.sort((a, b) => a.from - b.from || a.value.startSide - b.value.startSide);
+
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const w of widgets) {
+    builder.add(w.from, w.to, w.value);
+  }
+  return builder.finish();
+}
+
+const livePreviewPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      // Rebuild when the document, viewport or selection changes. Also rebuild
+      // when the language parser advances (the syntax tree may not be ready in
+      // the constructor for large documents), detected via any transaction that
+      // touched the language state.
+      if (
+        update.docChanged ||
+        update.viewportChanged ||
+        update.selectionSet ||
+        syntaxTree(update.startState) !== syntaxTree(update.state)
+      ) {
+        this.decorations = buildDecorations(update.view);
+      }
+    }
+  },
+  {
+    decorations: (plugin) => plugin.decorations,
+  },
+);
+
+const livePreviewTheme = EditorView.baseTheme({
+  ".cm-md-h1": { fontSize: "1.6em", fontWeight: "700", lineHeight: "1.3" },
+  ".cm-md-h2": { fontSize: "1.4em", fontWeight: "700", lineHeight: "1.3" },
+  ".cm-md-h3": { fontSize: "1.2em", fontWeight: "600", lineHeight: "1.3" },
+  ".cm-md-h4": { fontSize: "1.1em", fontWeight: "600" },
+  ".cm-md-h5": { fontSize: "1.05em", fontWeight: "600" },
+  ".cm-md-h6": { fontSize: "1em", fontWeight: "600" },
+  ".cm-md-strong": { fontWeight: "700" },
+  ".cm-md-emphasis": { fontStyle: "italic" },
+  ".cm-md-strike": { textDecoration: "line-through" },
+  ".cm-md-code": {
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+    backgroundColor: "hsl(var(--muted) / 0.6)",
+    borderRadius: "4px",
+    padding: "0.1em 0.3em",
+  },
+  ".cm-md-link": { color: "hsl(var(--primary))", textDecoration: "underline" },
+  ".cm-md-quote": {
+    borderLeft: "3px solid hsl(var(--border))",
+    paddingLeft: "0.75em",
+    color: "hsl(var(--muted-foreground))",
+    fontStyle: "italic",
+  },
+  ".cm-md-codeblock": {
+    backgroundColor: "hsl(var(--muted) / 0.4)",
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+  },
+  ".cm-md-bullet": { paddingRight: "0.4em", color: "hsl(var(--muted-foreground))" },
+});
+
+export function markdownLivePreview(): Extension {
+  return [livePreviewPlugin, livePreviewTheme];
+}

--- a/evals/flows/artifact-markdown-render.flow.mjs
+++ b/evals/flows/artifact-markdown-render.flow.mjs
@@ -1,0 +1,181 @@
+/**
+ * Markdown artifacts render inline (merged view): opening a `.md` artifact shows
+ * a live-preview CodeMirror editor where the markdown is *rendered* (headings
+ * styled, `#` markers hidden) while still being fully editable as source.
+ */
+export default {
+  id: "artifact-markdown-render",
+  title: "Markdown artifacts render inline in an editable merged view",
+  spec: "evals/react-session-flows.md",
+  steps: [
+    {
+      name: "App is ready and Electron-backed",
+      run: async (ctx) => {
+        await ctx.prove("App boots to a session surface with the control API", {
+          action: async () => {
+            await ctx.waitFor("Boolean(window.__openworkControl)", {
+              timeoutMs: 60_000,
+              label: "control API",
+            });
+          },
+          assert: async () => {
+            const userAgent = await ctx.eval("navigator.userAgent");
+            ctx.assert(userAgent.includes("Electron/"), `Expected Electron userAgent, got ${userAgent}`);
+          },
+          screenshot: { name: "booted" },
+        });
+      },
+    },
+    {
+      name: "Open a session and mount the artifact side panel",
+      run: async (ctx) => {
+        await ctx.prove("A session is active and the artifact seed action is available", {
+          action: async () => {
+            const hasSelectedSession = await ctx.eval(`window.__openworkControl.snapshot().route.includes("/session/")`);
+            if (!hasSelectedSession) {
+              await ctx.control("session.create_task");
+              await ctx.waitFor(
+                `window.__openworkControl.snapshot().route.includes("/session/")`,
+                { timeoutMs: 60_000, label: "session route after task creation" },
+              );
+            }
+            // Mount the side panel (which registers the seed action) only if it
+            // is not already open — clicking "Browser" toggles the panel.
+            await ctx.eval(`(() => {
+              const seedReady = window.__openworkControl.listActions()
+                .some((a) => a.id === "eval.artifact_tabs.seed_overflow" && !a.disabled);
+              if (seedReady) return "already-open";
+              const button = Array.from(document.querySelectorAll("button"))
+                .find((item) => item.getAttribute("aria-label") === "Browser" && !item.disabled);
+              button?.click();
+              return button ? "clicked" : "no-button";
+            })()`);
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `window.__openworkControl.listActions().some((a) => a.id === "eval.artifact_tabs.seed_overflow" && !a.disabled)`,
+              { timeoutMs: 30_000, label: "artifact seed action enabled" },
+            );
+          },
+        });
+      },
+    },
+    {
+      name: "Open a markdown artifact and confirm it renders inline",
+      run: async (ctx) => {
+        await ctx.prove("A markdown artifact opens in an editable, rendered merged view", {
+          action: async () => {
+            // Seed writes real markdown files ("# Overflow tab NN") and opens them
+            // as artifact tabs with preview: "markdown".
+            await ctx.control("eval.artifact_tabs.seed_overflow", { count: 12 });
+            // Make sure an artifact tab is the *active* panel view (the panel may
+            // still be showing a browser tab), then wait for the editor.
+            await ctx.waitFor(
+              `document.querySelectorAll('button[aria-label^="Select tab: overflow-tab"]').length >= 12`,
+              { timeoutMs: 30_000, label: "seeded artifact tabs present" },
+            );
+            await ctx.eval(`(() => {
+              const tabs = Array.from(document.querySelectorAll('button[aria-label^="Select tab: overflow-tab"]'));
+              const last = tabs[tabs.length - 1];
+              last?.click();
+              return Boolean(last);
+            })()`);
+            await ctx.waitFor(
+              `(() => {
+                const cm = document.querySelector(".cm-editor .cm-content");
+                return Boolean(cm) && /Overflow tab/.test(cm.textContent || "");
+              })()`,
+              { timeoutMs: 30_000, label: "markdown CodeMirror editor mounted with content" },
+            );
+          },
+          assert: async () => {
+            const result = await ctx.eval(`(() => {
+              const content = document.querySelector(".cm-editor .cm-content");
+              if (!content) return { ok: false, reason: "no cm-content" };
+              // Live-preview heading decoration must be applied to the heading text.
+              const h1 = content.querySelector(".cm-md-h1");
+              const headingFontSize = h1 ? parseFloat(getComputedStyle(h1).fontSize) : 0;
+              const bodyFontSize = parseFloat(getComputedStyle(content).fontSize) || 14;
+              // The literal "#" HeaderMark should be hidden (not visible as text)
+              // on the rendered heading line when it is not being edited.
+              const text = content.textContent || "";
+              const hasRenderedHeadingNode = Boolean(h1) && /Overflow tab/.test(h1.textContent || "");
+              return {
+                ok: true,
+                hasRenderedHeadingNode,
+                headingFontSize,
+                bodyFontSize,
+                headingLargerThanBody: headingFontSize > bodyFontSize,
+                rawText: text.slice(0, 80),
+              };
+            })()`);
+            ctx.assert(result.ok, result.reason || "Markdown editor not found.");
+            ctx.assert(
+              result.hasRenderedHeadingNode,
+              "Heading text was not wrapped in a live-preview heading decoration (.cm-md-h1).",
+            );
+            ctx.assert(
+              result.headingLargerThanBody,
+              `Rendered heading not visually larger than body (heading=${result.headingFontSize}px, body=${result.bodyFontSize}px).`,
+            );
+            ctx.log(`heading=${result.headingFontSize}px body=${result.bodyFontSize}px`);
+          },
+          screenshot: { name: "markdown-rendered-inline" },
+        });
+      },
+    },
+    {
+      name: "Markdown source markers hide off the active line",
+      run: async (ctx) => {
+        await ctx.prove("The literal '#' marker is hidden on heading lines that are not being edited", {
+          action: async () => {
+            // Move the editor selection off the heading line (line 1) to the end
+            // of the document via the CodeMirror view API so the `#` HeaderMark on
+            // line 1 is replaced/hidden. A raw DOM selection would not update CM's
+            // internal selection model, so we reach the EditorView on the node.
+            const moved = await ctx.eval(`(() => {
+              const view = window.__artifactEditorView;
+              if (!view || !view.dispatch) return "no-view";
+              const end = view.state.doc.length;
+              view.dispatch({ selection: { anchor: end, head: end } });
+              view.focus();
+              return "ok";
+            })()`);
+            ctx.assert(moved === "ok", `Could not move selection off the heading line: ${moved}`);
+            await ctx.waitFor(
+              `(() => {
+                const firstLine = document.querySelector(".cm-editor .cm-content .cm-line");
+                const text = firstLine ? (firstLine.textContent || "").trim() : "";
+                return text.length > 0 && !text.startsWith("#");
+              })()`,
+              { timeoutMs: 5_000, label: "heading line marker hidden" },
+            );
+          },
+          assert: async () => {
+            const result = await ctx.eval(`(() => {
+              const content = document.querySelector(".cm-editor .cm-content");
+              if (!content) return { ok: false, reason: "no cm-content" };
+              const firstLine = content.querySelector(".cm-line");
+              const lineText = firstLine ? (firstLine.textContent || "").trim() : "";
+              const h1 = content.querySelector(".cm-md-h1");
+              return {
+                ok: true,
+                lineText,
+                markerHidden: !lineText.startsWith("#") && lineText.includes("Overflow tab"),
+                stillRendered: Boolean(h1),
+              };
+            })()`);
+            ctx.assert(result.ok, result.reason || "Markdown editor not found.");
+            ctx.assert(
+              result.markerHidden,
+              `Heading line still shows the literal '#' marker: "${result.lineText}".`,
+            );
+            ctx.assert(result.stillRendered, "Heading lost its rendered styling after moving selection.");
+            ctx.log(`heading line now reads: "${result.lineText}"`);
+          },
+          screenshot: { name: "markdown-markers-hidden" },
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## What

Render markdown **inline while keeping it fully editable** (a merged view) in the artifact panel. Previously, opening a `.md`/`.markdown`/`.mdx` artifact always dropped you into a raw CodeMirror source editor — the rendered preview path was effectively unreachable, so you could only ever see source.

Now markdown artifacts read like a document: headings, bold/italic/strikethrough, inline code, bullets, blockquotes, and code blocks render in place, and syntax markers (`#`, `*`, `` ` ``, `>`, link brackets) hide off the active line — so editing the raw markup is one click away.

## How

- **New** `markdown-live-preview.ts` — an Obsidian-style CodeMirror 6 decoration plugin (uses already-installed `@codemirror/lang-markdown` + `@codemirror/language`; `ensureSyntaxTree` so decorations apply immediately).
- `artifact-text-editor.tsx` — enable the extension for `language === "markdown"`, drop line numbers, and use a document-style theme (larger font, centered max-width). Adds a dev-only `window.__artifactEditorView` handle for e2e.
- **New** eval flow `artifact-markdown-render.flow.mjs`.

## Validation

- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm fraimz --flow artifact-markdown-render --cdp-url http://127.0.0.1:9823` — **PASSED (4/4 claims)**

Frame proof (open a markdown artifact → heading renders large/bold; move cursor off the heading line → `#` marker hides while styling stays):

- Frame 02 (cursor on heading): `# Overflow tab 12` rendered, marker visible for editing
- Frame 03 (cursor off heading): `Overflow tab 12` rendered, marker hidden

> Note: the only live Electron app on the dev machine ran from a separate `openwork-white-label` checkout, and a fresh dev server from this repo couldn't be kept alive in the agent environment. The same edits were mirrored there to validate against the live app on CDP `:9823`. Reviewers can reproduce with the app running and the `pnpm fraimz` command above.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

