### PR TITLE
fix(artifacts): render PDFs inline and harden reveal-in-finder

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -349,7 +349,10 @@ export async function openDesktopPath(target: string): Promise<void> {
 }
 
 export async function revealDesktopItemInDir(target: string): Promise<void> {
-  await invokeElectronHelper("__revealItemInDir", target);
+  const result = await invokeElectronHelper("__revealItemInDir", target);
+  if (typeof result === "string" && result.trim()) {
+    throw new Error(result);
+  }
 }
 
 export async function getDesktopFileIcon(target: string, size?: "small" | "normal" | "large"): Promise<string | null> {

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -7,11 +7,12 @@ import type { OpenworkServerClient } from "@/app/lib/openwork-server";
 import { getDesktopFileIcon, openDesktopPath, revealDesktopItemInDir } from "@/app/lib/desktop";
 import { isElectronRuntime } from "@/app/utils";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatFileSize } from "@/lib/utils";
 import { type ArtifactPanelTab, usePanelTabStore } from "../panel/panel-tab-store";
 import { isCollectibleArtifactTarget, type BinaryData, type Data, type OpenTarget, type TextData } from "./open-target";
-import { HTMLPreview, ImagePreview, MarkdownPreview, PlainText, PreviewError, PreviewLoading, PreviewUnavailable } from "./preview";
+import { HTMLPreview, ImagePreview, MarkdownPreview, PdfPreview, PlainText, PreviewError, PreviewLoading, PreviewUnavailable } from "./preview";
 
 const ArtifactTextEditor = lazy(() =>
   import("./artifact-text-editor").then((module) => ({ default: module.ArtifactTextEditor })),
@@ -128,12 +129,13 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
       return;
     }
 
-    const url = URL.createObjectURL(new Blob([data.data], { type: data.contentType ?? "application/octet-stream" }));
+    const fallbackType = target.preview === "pdf" ? "application/pdf" : "application/octet-stream";
+    const url = URL.createObjectURL(new Blob([data.data], { type: data.contentType ?? fallbackType }));
 
     setBinaryObjectUrl(url);
 
     return () => URL.revokeObjectURL(url);
-  }, [data]);
+  }, [data, target.preview]);
 
   useEffect(() => {
     setEditing(false);
@@ -195,7 +197,11 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
       return;
     }
     else if (!isRemoteWorkspace) {
-      void openDesktopPath(externalPath);
+      try {
+        await openDesktopPath(externalPath);
+      } catch (cause) {
+        toast.error(cause instanceof Error ? cause.message : "Could not open this file.");
+      }
 
       return;
     }
@@ -205,7 +211,11 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
 
   const revealExternal = async () => {
     if (target.kind !== "file" || isRemoteWorkspace) return;
-    await revealDesktopItemInDir(externalPath);
+    try {
+      await revealDesktopItemInDir(externalPath);
+    } catch (cause) {
+      toast.error(cause instanceof Error ? cause.message : "Could not show this file in your file manager.");
+    }
   };
 
   const save = () => {
@@ -358,7 +368,9 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
           <HTMLPreview type="text" title={target.name} content={data.data} />
         ) : target.preview === "image" && data?.kind === "binary" && binaryObjectUrl ? (
           <ImagePreview src={binaryObjectUrl} alt={target.name} />
-        ) : data?.kind === "binary" && binaryObjectUrl && (target.preview === "pdf" || target.preview === "html") ? (
+        ) : target.preview === "pdf" && data?.kind === "binary" && binaryObjectUrl ? (
+          <PdfPreview url={binaryObjectUrl} title={target.name} />
+        ) : data?.kind === "binary" && binaryObjectUrl && target.preview === "html" ? (
           <HTMLPreview type="binary" title={target.name} url={binaryObjectUrl} />
         ) : data?.kind === "text" ? (
           <PlainText content={data.data} />

--- a/apps/app/src/react-app/domains/session/artifacts/preview.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/preview.tsx
@@ -65,6 +65,19 @@ export function HTMLPreview({ className, ...props }: HTMLPreviewProps) {
   return <iframe src={props.url} title={props.title} className={cn("h-full w-full border-0", className)} sandbox="allow-scripts allow-same-origin" />;
 }
 
+interface PdfPreviewProps {
+  url: string;
+  title: string;
+  className?: string;
+}
+
+export function PdfPreview({ url, title, className }: PdfPreviewProps) {
+  // Chromium's built-in PDF viewer (enabled via webPreferences.plugins) renders
+  // reliably through <embed>; <object>/sandboxed <iframe> show a blank frame.
+  // The blob URL comes from a trusted workspace file.
+  return <embed src={url} type="application/pdf" title={title} className={cn("h-full w-full border-0", className)} />;
+}
+
 interface ImagePreviewProps extends React.ComponentProps<"div"> {
   src: string;
   alt: string;

--- a/apps/app/src/react-app/domains/session/panel/side-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/side-panel.tsx
@@ -461,6 +461,51 @@ export function SidePanel({
   }, [client, sessionId, workspaceId]);
   useControlAction(seedArtifactOverflowControlAction);
 
+  const seedPdfArtifactControlAction = React.useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+
+    return {
+      id: "eval.artifact_tabs.seed_pdf",
+      label: "Seed a PDF artifact",
+      description: "Write a small valid PDF and open it as an artifact tab to verify inline PDF rendering.",
+      sideEffect: "mutation",
+      disabled: !client || !workspaceId,
+      execute: async () => {
+        if (!client || !workspaceId) return { ok: false, error: "Workspace client is not ready." };
+
+        // Minimal single-page PDF that draws "OpenWork PDF" — base64 encoded.
+        const pdfBase64 =
+          "JVBERi0xLjQKMSAwIG9iago8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiAwIFI+PgplbmRvYmoKMiAwIG9iago8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PgplbmRvYmoKMyAwIG9iago8PC9UeXBlL1BhZ2UvUGFyZW50IDIgMCBSL01lZGlhQm94WzAgMCAzMDAgMTQ0XS9SZXNvdXJjZXM8PC9Gb250PDwvRjEgNCAwIFI+Pj4+L0NvbnRlbnRzIDUgMCBSPj4KZW5kb2JqCjQgMCBvYmoKPDwvVHlwZS9Gb250L1N1YnR5cGUvVHlwZTEvQmFzZUZvbnQvSGVsdmV0aWNhPj4KZW5kb2JqCjUgMCBvYmoKPDwvTGVuZ3RoIDQ0Pj4Kc3RyZWFtCkJUCi9GMSAyNCBUZgo3MiA3MCBUZAooT3BlbldvcmsgUERGKSBUagpFVAplbmRzdHJlYW0KZW5kb2JqCnhyZWYKMCA2CjAwMDAwMDAwMDAgNjU1MzUgZiAKMDAwMDAwMDAwOSAwMDAwMCBuIAowMDAwMDAwMDU4IDAwMDAwIG4gCjAwMDAwMDAxMTUgMDAwMDAgbiAKMDAwMDAwMDI0MSAwMDAwMCBuIAowMDAwMDAwMzEyIDAwMDAwIG4gCnRyYWlsZXIKPDwvU2l6ZSA2L1Jvb3QgMSAwIFI+PgpzdGFydHhyZWYKNDA2CiUlRU9G";
+        const binary = atob(pdfBase64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+
+        const value = "artifacts/sample-document.pdf";
+        await client.writeWorkspaceBinaryFile(workspaceId, { path: value, data: bytes.buffer, baseUpdatedAt: null });
+
+        const target: OpenTarget = {
+          id: `file:${value}`,
+          kind: "file",
+          value,
+          name: "sample-document.pdf",
+          preview: "pdf",
+          confidence: 100,
+          reason: "eval",
+          exists: true,
+          size: bytes.length,
+        };
+
+        const store = usePanelTabStore.getState();
+        store.syncTranscriptArtifacts(sessionId, [target]);
+        store.openTab(sessionId, { id: target.id, type: "artifact", label: target.name, preview: target.preview });
+        store.selectTab(sessionId, target.id);
+
+        return { ok: true, activeTabId: target.id };
+      },
+    };
+  }, [client, sessionId, workspaceId]);
+  useControlAction(seedPdfArtifactControlAction);
+
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!event.ctrlKey || event.altKey || event.metaKey || event.key !== "Tab" || tabs.length < 2) {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1268,9 +1268,19 @@ const desktopCommandHandlers = {
   },
   "__revealItemInDir": async (event, ...args) => {
       const target = String(args[0] ?? "").trim();
-      if (!target) return undefined;
-      shell.showItemInFolder(target);
-      return undefined;
+      if (!target) return "Path is required.";
+      if (existsSync(target)) {
+        shell.showItemInFolder(target);
+        return undefined;
+      }
+      // The exact file may not exist yet (or path is slightly off); fall back to
+      // opening the containing directory so the user still lands in the right place.
+      const parent = path.dirname(target);
+      if (parent && parent !== target && existsSync(parent)) {
+        const error = await shell.openPath(parent);
+        return error && error.trim() ? error : undefined;
+      }
+      return `Could not find "${target}" on disk.`;
   },
   "__getFileIcon": async (event, ...args) => {
       const target = String(args[0] ?? "").trim();
@@ -1447,6 +1457,9 @@ async function createMainWindow() {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
+      // Enable Chromium's built-in PDF viewer so PDFs render inside the
+      // artifact panel (<embed> pointed at a blob URL).
+      plugins: true,
     },
   });
   applicationMenu.applyVisibility(mainWindow);

--- a/evals/flows/artifact-pdf-render-reveal.flow.mjs
+++ b/evals/flows/artifact-pdf-render-reveal.flow.mjs
@@ -1,0 +1,160 @@
+/**
+ * PDF artifacts render inline and "Show in folder" works.
+ *
+ * 1. Seed a real one-page PDF into the workspace and open it as an artifact tab.
+ * 2. Confirm the PDF actually renders inline (Chromium's built-in viewer inside
+ *    an <object>/<iframe> pointed at a blob URL — not a blank frame).
+ * 3. Click "Show in folder" and confirm the reveal completes without surfacing
+ *    an error toast (the file exists on disk, so the reveal resolves cleanly).
+ */
+export default {
+  id: "artifact-pdf-render-reveal",
+  title: "PDF artifacts render inline and Show in folder works",
+  spec: "evals/react-session-flows.md",
+  steps: [
+    {
+      name: "App is ready and Electron-backed",
+      run: async (ctx) => {
+        await ctx.prove("App boots to a session surface with the control API", {
+          action: async () => {
+            await ctx.waitFor("Boolean(window.__openworkControl)", {
+              timeoutMs: 60_000,
+              label: "control API",
+            });
+          },
+          assert: async () => {
+            const userAgent = await ctx.eval("navigator.userAgent");
+            ctx.assert(userAgent.includes("Electron/"), `Expected Electron userAgent, got ${userAgent}`);
+          },
+          screenshot: { name: "booted" },
+        });
+      },
+    },
+    {
+      name: "Open a session and mount the artifact side panel",
+      run: async (ctx) => {
+        await ctx.prove("A session is active and the PDF seed action is available", {
+          action: async () => {
+            const hasSelectedSession = await ctx.eval(`window.__openworkControl.snapshot().route.includes("/session/")`);
+            if (!hasSelectedSession) {
+              await ctx.control("session.create_task");
+              await ctx.waitFor(
+                `window.__openworkControl.snapshot().route.includes("/session/")`,
+                { timeoutMs: 60_000, label: "session route after task creation" },
+              );
+            }
+            // Mount the side panel (registers the seed action) only if not open.
+            await ctx.eval(`(() => {
+              const seedReady = window.__openworkControl.listActions()
+                .some((a) => a.id === "eval.artifact_tabs.seed_pdf" && !a.disabled);
+              if (seedReady) return "already-open";
+              const button = Array.from(document.querySelectorAll("button"))
+                .find((item) => item.getAttribute("aria-label") === "Browser" && !item.disabled);
+              button?.click();
+              return button ? "clicked" : "no-button";
+            })()`);
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `window.__openworkControl.listActions().some((a) => a.id === "eval.artifact_tabs.seed_pdf" && !a.disabled)`,
+              { timeoutMs: 30_000, label: "PDF seed action enabled" },
+            );
+          },
+        });
+      },
+    },
+    {
+      name: "Open a PDF artifact and confirm it renders inline",
+      run: async (ctx) => {
+        await ctx.prove("A PDF artifact renders inline via an embedded PDF viewer (not a blank frame)", {
+          action: async () => {
+            await ctx.control("eval.artifact_tabs.seed_pdf");
+            await ctx.waitFor(
+              `document.querySelectorAll('button[aria-label^="Select tab: sample-document.pdf"]').length >= 1`,
+              { timeoutMs: 30_000, label: "seeded PDF artifact tab present" },
+            );
+            // Wait for the <embed> PDF viewer to mount with a blob URL.
+            await ctx.waitFor(
+              `(() => {
+                const embed = document.querySelector('embed[type="application/pdf"]');
+                const src = embed ? embed.getAttribute("src") || "" : "";
+                return Boolean(embed) && src.startsWith("blob:");
+              })()`,
+              { timeoutMs: 30_000, label: "PDF embed mounted with blob URL" },
+            );
+          },
+          assert: async () => {
+            const result = await ctx.eval(`(() => {
+              const embed = document.querySelector('embed[type="application/pdf"]');
+              if (!embed) return { ok: false, reason: "no <embed> PDF viewer" };
+              const rect = embed.getBoundingClientRect();
+              const src = embed.getAttribute("src") || "";
+              // The embed must be a real, sized region pointed at the blob URL.
+              return {
+                ok: true,
+                hasBlob: src.startsWith("blob:"),
+                width: Math.round(rect.width),
+                height: Math.round(rect.height),
+                visible: rect.width > 100 && rect.height > 100,
+              };
+            })()`);
+            ctx.assert(result.ok, result.reason || "PDF embed not found.");
+            ctx.assert(result.hasBlob, "PDF embed is not pointed at a blob URL.");
+            ctx.assert(
+              result.visible,
+              `PDF embed is not visibly sized (width=${result.width}px, height=${result.height}px).`,
+            );
+            ctx.log(`PDF embed sized ${result.width}x${result.height}px with blob URL`);
+          },
+          screenshot: { name: "pdf-rendered-inline" },
+        });
+      },
+    },
+    {
+      name: "Show in folder completes without an error toast",
+      run: async (ctx) => {
+        await ctx.prove("Clicking Show in folder reveals the file without surfacing an error", {
+          action: async () => {
+            // Dismiss any pre-existing toasts so we measure only this action.
+            await ctx.eval(`(() => {
+              document.querySelectorAll('[data-sonner-toast]').forEach((node) => node.remove());
+              return true;
+            })()`);
+            const clicked = await ctx.eval(`(() => {
+              const button = Array.from(document.querySelectorAll("button"))
+                .find((item) => item.getAttribute("aria-label") === "Show in folder" && !item.disabled);
+              if (!button) return "no-button";
+              button.click();
+              return "clicked";
+            })()`);
+            ctx.assert(clicked === "clicked", `Show in folder button not found: ${clicked}`);
+            // Give the IPC round-trip a moment to surface a toast on failure.
+            await ctx.waitFor("true", { timeoutMs: 1_500, label: "reveal settle" }).catch(() => undefined);
+          },
+          assert: async () => {
+            const result = await ctx.eval(`(() => {
+              const toasts = Array.from(document.querySelectorAll('[data-sonner-toast]'));
+              const errorToast = toasts.find((node) =>
+                node.getAttribute("data-type") === "error" ||
+                /could not|unavailable|error|not found/i.test(node.textContent || ""),
+              );
+              return {
+                hadErrorToast: Boolean(errorToast),
+                errorText: errorToast ? (errorToast.textContent || "").slice(0, 120) : "",
+              };
+            })()`);
+            ctx.assert(
+              !result.hadErrorToast,
+              `Show in folder surfaced an error toast: "${result.errorText}".`,
+            );
+            ctx.log("Show in folder completed without an error toast");
+          },
+          // Reveal opens the OS file manager (outside the app window), so the
+          // app's own frame is intentionally unchanged. The assertion above
+          // (no error toast) is the real proof; this is a visual checkpoint.
+          screenshot: { name: "show-in-folder-no-error", allowInvalid: true },
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## What

Two artifact-panel bug fixes:

1. **PDFs now render inline in the artifact view.** They previously showed a blank frame.
2. **"Show in folder" (reveal in Finder) is hardened** and now reports failures instead of silently no-op'ing.

## Why / root cause

**PDF rendering (two parts):**
- The Electron main window had Chromium's built-in PDF viewer disabled (`webPreferences.plugins` defaults to `false`).
- PDFs were rendered through a sandboxed `<iframe>`, which blocks the PDF viewer even with plugins enabled.

**Reveal in Finder:**
- `__revealItemInDir` called `shell.showItemInFolder` and always returned `undefined`, so a non-existent/slightly-off path silently no-op'd with zero feedback.

## Changes

- `apps/desktop/electron/main.mjs` — enable `plugins: true` on the main window; `__revealItemInDir` verifies the path, falls back to opening the parent directory, and returns an error string on failure.
- `apps/app/.../artifacts/preview.tsx` — add a dedicated `PdfPreview` using `<embed>` (renders reliably; `<object>`/sandboxed iframe stay blank).
- `apps/app/.../artifacts/artifact-panel.tsx` — route PDF artifacts to `PdfPreview`; default blob MIME to `application/pdf`; surface reveal/open failures via toast.
- `apps/app/src/app/lib/desktop.ts` — `revealDesktopItemInDir` throws on error.
- `evals/flows/artifact-pdf-render-reveal.flow.mjs` — new e2e flow + dev-only seed action.

## Validation (Validate Every Experience)

Ran the new user-driven flow against the live local Electron app:

\`\`\`
▶ artifact-pdf-render-reveal — PDF artifacts render inline and Show in folder works
  ✓ App is ready and Electron-backed
  ✓ Open a session and mount the artifact side panel
  ✓ Open a PDF artifact and confirm it renders inline
  ✓ Show in folder completes without an error toast
Result: PASSED — 1 passed, 0 failed, 0 skipped
\`\`\`

fraimz screenshot confirms the PDF ("OpenWork PDF") rendering inline with the Chromium PDF toolbar. `pnpm typecheck` passes.

Commands run:
- `pnpm typecheck` — pass
- `pnpm fraimz --flow artifact-pdf-render-reveal --cdp-url http://127.0.0.1:9823` — PASSED

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

