### PR TITLE
fix(release): publish Electron updater manifests even when one platform fails

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -524,12 +524,16 @@ jobs:
   publish-electron-assets:
     name: Publish Electron Assets
     needs: [resolve-release, verify-release, publish-electron]
+    # Run even when a single Electron platform (e.g. Windows) fails. The merge
+    # script only publishes manifests that were actually produced and validates
+    # that latest-mac.yml contains both mac arches, so a missing mac arch still
+    # fails this job correctly instead of silently skipping the updater feed.
     if: |
       always() &&
       needs.resolve-release.outputs.build_electron == 'true' &&
       needs.resolve-release.result == 'success' &&
       needs.verify-release.result == 'success' &&
-      needs.publish-electron.result == 'success'
+      (needs.publish-electron.result == 'success' || needs.publish-electron.result == 'failure')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
@@ -885,12 +889,16 @@ jobs:
       - release-orchestrator-sidecars
       - publish-npm
       - publish-daytona-snapshot
+    # Allow a partial Electron build (e.g. Windows failed) to still publish as
+    # latest, but ONLY when the updater manifests were actually published -- a
+    # release must never become "latest" without its latest-mac.yml/latest-linux
+    # feeds, which is what left v0.17.2 mac users hitting a 404 on auto-update.
     if: |
       always() &&
       needs.resolve-release.result == 'success' &&
       needs.verify-release.result == 'success' &&
-      (needs.publish-electron.result == 'success' || needs.publish-electron.result == 'skipped') &&
-      (needs.publish-electron-assets.result == 'success' || needs.publish-electron-assets.result == 'skipped') &&
+      (needs.publish-electron.result == 'success' || needs.publish-electron.result == 'skipped' || needs.publish-electron.result == 'failure') &&
+      (needs.publish-electron-assets.result == 'success' || (needs.resolve-release.outputs.build_electron != 'true' && needs.publish-electron-assets.result == 'skipped')) &&
       (needs.release-orchestrator-sidecars.result == 'success' || needs.release-orchestrator-sidecars.result == 'skipped') &&
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
       (needs.publish-daytona-snapshot.result == 'success' || needs.publish-daytona-snapshot.result == 'skipped')


### PR DESCRIPTION
## Problem

macOS users on `v0.17.2` get a 404 on auto-update:

```
Cannot find channel "latest-mac.yml" update info: HttpError: 404
url: https://github.com/different-ai/openwork/releases/download/v0.17.2/latest-mac.yml
```

The `v0.17.2` GitHub release has the mac/linux installers and `.blockmap` files but **no `latest-mac.yml` / `latest-linux*.yml`** updater feeds, even though the release notes say they should be attached.

## Root cause

The `v0.17.2` tag run ([run 28069104797](https://github.com/different-ai/openwork/actions/runs/28069104797)) had this job graph:

| Job | Result |
| --- | --- |
| Build + publish Electron (electron-macos-arm64) | success |
| Build + publish Electron (electron-macos-x64) | success |
| Build + publish Electron (electron-linux-x64) | success |
| Build + publish Electron (electron-linux-arm64) | success |
| Build + publish Electron (electron-windows-x64) | **failure** |
| **Publish Electron Assets** | **skipped** |
| Publish GitHub Release | skipped |

Each Electron build uploads its installers to the release and its `latest*.yml` as a **workflow artifact**. `Publish Electron Assets` is the job that downloads those artifacts, merges them per-arch, validates, and uploads the merged `latest-mac.yml` / `latest-linux*.yml` to the release.

That job was gated on `needs.publish-electron.result == 'success'`. Because the **Windows** leg failed, the whole `publish-electron` matrix is `failure`, so `Publish Electron Assets` was **skipped** — the mac/linux updater manifests were never attached. The draft release was then published as `latest` without its updater feeds, so every mac install now 404s on `latest-mac.yml`.

A failure in one unrelated platform (Windows) held the macOS updater feed hostage.

## Fix

Two `if:` changes in `release-macos-aarch64.yml`:

1. **`publish-electron-assets`** now runs as long as `resolve-release`/`verify-release` succeeded and `build_electron == 'true'`, even when `publish-electron` partially failed (`success || failure`). The merge script (`publish-electron-assets.mjs`) already only publishes manifests that were actually produced, and `validateManifest()` requires `latest-mac.yml` to contain **both** `mac-arm64` and `mac-x64` entries — so a genuinely missing mac arch still fails the job correctly rather than silently shipping a broken feed. A Windows-only failure no longer suppresses the mac/linux feeds.

2. **`publish-release`** no longer accepts `publish-electron-assets` being `skipped` when `build_electron == 'true'`: a release can only be flipped to `--latest` once the updater manifests were actually published (`result == 'success'`, or `skipped` only when electron builds are off). This prevents a "latest" release from ever existing without its updater feeds.

No change to the merge script was needed — it already handles missing manifests gracefully and validates the merged feeds.

## Validation

Reproduced the merge locally using the actual `electron-macos-arm64` / `electron-macos-x64` artifacts from the failed run. With the fix, `Publish Electron Assets` would have succeeded and produced this valid merged feed:

<details><summary>merged <code>latest-mac.yml</code> (ready to attach to v0.17.2)</summary>

```yaml
version: 0.17.2
files:
  - url: openwork-mac-arm64-0.17.2.zip
    sha512: /+qUMv8o6eqUMoBs6nHPGi3XhR6eEjS8mmNaOS/PClInb3/B35LIDkV++D59ObRWhkOPK9u7OIWOnxAw8GHb9g==
    size: 237542865
  - url: openwork-mac-arm64-0.17.2.dmg
    sha512: TIt/Xm8FNjUUCXogqqYyMsXs8nwym5qA5DRnNZN/6iTXZNqkFNKW6R/OAjqQ8wK6dztQFI+ujzZCnI8bBfg1fw==
    size: 246847262
  - url: openwork-mac-x64-0.17.2.zip
    sha512: AP9mvo6HBFF/S28cmdv8PY2SFd6Axis41W7DdrArJX6BxAChHTAjEIWPuI6w6HyjVK4vR10BiHJYKzyGTWkFAg==
    size: 253271290
  - url: openwork-mac-x64-0.17.2.dmg
    sha512: VU8HQ0hDgzPQ8KXfsKyoRgi29iNx0uSnH6ELjjpqqWm3hcjBM2BBQ9xLHEZX26jSxqdQLS5ImBX6CFVMpI86kw==
    size: 262911667
releaseDate: '2026-06-24T01:43:00.413Z'
```

</details>

YAML validated (`YAML.load_file` OK). Behavior matrix:

- All platforms succeed → identical to today (manifests published, release goes latest).
- Windows fails, mac/linux succeed → manifests published, release goes latest with mac/linux feeds (no Windows installer/feed). Previously: manifests skipped, broken latest release.
- A mac arch fails → `validateManifest` fails `publish-electron-assets` → `publish-release` skipped → release stays draft. Safe.
- `build_electron == false` → unchanged (publish-release proceeds as today).

## Retro-fixing v0.17.2

This PR prevents recurrence for future releases. For the already-shipped `v0.17.2`, a maintainer with release write access can attach the missing feed right now:

```bash
gh run download 28069104797 -R different-ai/openwork -n electron-macos-arm64 -D dist/arm64
gh run download 28069104797 -R different-ai/openwork -n electron-macos-x64  -D dist/x64
GITHUB_REPOSITORY=different-ai/openwork RUNNER_TEMP=/tmp/ow \
  node scripts/release/publish-electron-assets.mjs --manifests-only dist v0.17.2
# (same for the linux artifacts → latest-linux.yml / latest-linux-arm64.yml)
```

Or cut a new release once this is merged.

## Out of scope (possible follow-ups)

- `aur-publish` still requires `publish-electron.result == 'success'`, so a Windows failure would still skip the AUR publish. Same class of coupling; left untouched here to keep this fix surgical.
- The Windows Electron build itself failing on `v0.17.2` is a separate issue.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

