### PR TITLE
docs(fraimz): extract the fraimz loop into a dedicated skill

### DIFF
--- a/.opencode/commands/fraimz.md
+++ b/.opencode/commands/fraimz.md
@@ -43,5 +43,6 @@ Run the full loop, in order, and stop on any failure:
    dead engine, no CDP), say so explicitly and give the exact commands to
    reproduce.
 
-The mechanics live in `evals/README.md` and the `run-evals` /
+The loop and its pitfalls live in the **`fraimz` skill** (load it first); the
+deeper mechanics live in `evals/README.md` and the `run-evals` /
 `daytona-flow-validator` skills — use them as the source of truth.

--- a/.opencode/skills/fraimz/SKILL.md
+++ b/.opencode/skills/fraimz/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: fraimz
+description: create a fraimz, make fraimz, prove it works, frame proof, PR proof, validate experience, e2e evidence, fraimz.html. The full fraimz loop — frame the claim, drive the real app via CDP, validate/repair, output fraimz.html. Use whenever a task ends with "please create a fraimz" or any change needs end-to-end proof.
+---
+
+# Skill: fraimz
+
+**fraimz** is the canonical proof artifact: a single `fraimz.html`
+(`evals/results/<run-id>/fraimz.html`) with one frame per step. Each frame binds
+a **claim**, the **action** the end user took, the **assertion** that witnesses
+the side effect, and a validated **screenshot**. It is the atomic thing a human
+looks at to understand, at a glance, that an experience works.
+
+This skill owns the whole loop. Trigger phrases: "create a fraimz", "make
+fraimz", "prove it works", "frame proof", "PR proof". The `/fraimz` command runs
+the same loop.
+
+## When this applies
+
+Make fraimz whenever a change can alter behavior observable outside the process:
+filesystem, SQLite/runtime DB, server endpoints, sessions, config, provisioning,
+cloud sync, or network. **This also applies to changes you expect to be inert** —
+refactors, storage swaps, renames, dead-code removal: the fraimz job is then to
+prove the canonical core flow is unchanged. Pure docs/comments and types-only
+changes with no runtime path may skip — but say so explicitly.
+
+## The loop (never report success from a click or a return value alone)
+
+1. **Frame the experience** as a one-line claim ("user can do X and sees Y").
+   State it back before proceeding.
+2. **Express it as a flow.** Reuse or add a coded flow in
+   `evals/flows/<id>.flow.mjs`. The end user is the protagonist (driven via CDP).
+   REST/DB/filesystem checks are *only* how you witness the expected side
+   effects — never the thing being tested. Every meaningful step must use
+   `ctx.prove("claim", { action, assert, screenshot })`.
+3. **Drive it for real.** Launch the app (Daytona preferred, local Electron
+   fallback) and run `pnpm fraimz --flow <id> --cdp-url <electron-cdp-url>`.
+   Observe → act → observe → assert.
+4. **Validate, repair, repeat.** If a frame does not support its claim (wrong
+   route, error state, missing text, stale dialog, duplicate image), fix the
+   visible state or the code and rerun until every claim has a passing assertion
+   and a valid screenshot.
+5. **Output fraimz + verdict.** The run writes `fraimz.html` plus
+   `report.md` / `report.json` to `evals/results/<run-id>/`. Report the path to
+   `fraimz.html` as the headline deliverable. Report `Passed` only when fraimz
+   exists and every claim is backed by an observable assertion; otherwise
+   `Incomplete` / `Failed`, stated honestly with repro steps.
+
+## The canonical core flow
+
+When a change is expected to be inert, re-run the core flow —
+**open the app → write a message → get a response → close → reopen and confirm
+the session survived** (`evals/flows/core-flow.flow.mjs`). If it stays green, the
+inertness claim is backed by evidence.
+
+## Driving the real app
+
+Preferred (Daytona): `bash .devcontainer/test-on-daytona.sh <branch>` then use
+the printed Electron CDP URL. See the `run-evals` and `daytona-electron-test`
+skills.
+
+Local Electron fallback:
+
+```bash
+# from the worktree you changed
+OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9826 pnpm dev   # & in background
+
+# wait for the renderer, then run the flow against it
+pnpm fraimz --flow <id> --cdp-url http://127.0.0.1:9826
+```
+
+The runner default-probes `:9825` (Daytona) then `:9823` (local `pnpm dev`).
+Pass `--cdp-url` for any other port.
+
+## Practical pitfalls (learned the hard way)
+
+- **Target the right CDP frame.** A sandbox can expose multiple page targets
+  (e.g. a `Google` page plus `OpenWork`). The runner uses `pickAppTarget`, but
+  ad-hoc `browser_eval` defaults to the first target — pass the OpenWork
+  `target_id` explicitly when probing manually.
+- **`__openworkControl` readiness.** It attaches in the renderer after boot and
+  resets on config reload. Always `ctx.waitFor("Boolean(window.__openworkControl)")`
+  before driving; re-wait after any "Reloading OpenCode config".
+- **Panels that auto-mount a browser tab** can steal focus from the artifact
+  view. Re-select the artifact tab inside a `waitFor` and assert geometry in the
+  same poll so the browser sync can't race you mid-measurement.
+- **Reflow timing.** When you change layout/width to force a state, split it:
+  first a `waitFor` that returns true only once the DOM has actually reflowed
+  (e.g. `row.getBoundingClientRect().width <= 380`), then a separate
+  `ctx.eval(MEASURE)` for the measurement.
+- **Assert the regression, not nice-to-haves.** Prove what the change
+  guarantees (e.g. "title truncates and does not overlap the buttons"); don't
+  fail the run on a cosmetic extra the fix never promised.
+- **Eval-only seed affordances are fine.** Adding a dev-only
+  (`import.meta.env.DEV`) arg to an existing `eval.*` control action to make a
+  state reproducible is acceptable; keep it out of production paths and say so.
+- **`screenshot` validation takes arrays.** `requireText: ["foo"]`,
+  `rejectText: [...]`, `hashIncludes: "/route"`. A screenshot with no validation
+  metadata is a checkpoint, not proof.
+
+## ctx.* helpers (the flow API)
+
+`ctx.eval`, `ctx.waitFor`, `ctx.waitForText`, `ctx.clickText`, `ctx.fill`,
+`ctx.navigateHash`, `ctx.control(actionId, args)`, `ctx.expectText`,
+`ctx.expectNoText`, `ctx.expectHashIncludes`, `ctx.assert`,
+`ctx.screenshot(name, { claim, requireText, rejectText, hashIncludes })`, and
+the headline `ctx.prove("claim", { action, assert, screenshot })`.
+
+## Source of truth
+
+Keep this skill as the loop. The deeper mechanics live in:
+
+- `evals/README.md` — runner, flags, conventions, full `ctx.*` reference.
+- `evals/flows/` — existing coded flows to reuse or pattern-match.
+- Skills: `run-evals` (launch + run), `daytona-flow-validator` (observe → act →
+  assert → repair → verdict), `daytona-electron-test`,
+  `daytona-recording-artifacts` (optional video).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,62 +41,22 @@ flow, then drive it as the end user and validate it against reality until
 it actually holds.**
 
 A change is an *experience*: it might be a persistent feature, a single new
-button, or an entirely new screen. Every experience gets validated with the
-same loop.
+button, or an entirely new screen. Every experience gets validated the same
+way — by producing **fraimz**, the frame-by-frame proof
+(`evals/results/<run-id>/fraimz.html`) where each frame binds a claim, the user
+action, an observable assertion, and a validated screenshot.
 
-### When this applies
+The deliverable and the full loop (frame → coded flow → drive the real app via
+CDP → validate/repair → verdict) live in the **`fraimz` skill** — load it
+whenever a task asks you to "create a fraimz" / "prove it works", or whenever a
+change touches anything observable outside the process. Run it via the
+`/fraimz` command or `pnpm fraimz --flow <id>`.
 
-Run a user-driven eval whenever a change can alter behavior observable
-outside the process: filesystem, SQLite/runtime DB, server endpoints,
-sessions, config, provisioning, cloud sync, or network. **This also applies
-to changes you expect to be inert** — refactors, storage swaps, renames,
-dead-code removal. In that case the eval's job is to prove the core flow is
-unchanged. Pure docs/comments and types-only changes with no runtime path
-may skip — but say so explicitly.
-
-### The loop (do not report success from a click or a return value alone)
-
-1. **Frame the experience** as a one-line claim ("user can do X and sees Y").
-2. **Express it as a flow** — reuse or add a coded flow in
-   `evals/flows/*.flow.mjs`. The end user is the protagonist (driven via
-   CDP). REST/DB/filesystem checks are *only* how you witness the expected
-   side effects, never the thing being tested.
-3. **Drive it for real** with `pnpm fraimz --flow <id>` (Daytona preferred,
-   local Electron fallback). Observe → act → observe → assert.
-4. **Validate, repair, repeat.** If a frame does not support the claim, fix
-   the visible state or the code and rerun. Every claim needs an observable
-   assertion via `ctx.prove("claim", { action, assert, screenshot })`.
-5. **Output fraimz and give a verdict.** The deliverable is
-   **fraimz** — `evals/results/<run-id>/fraimz.html`, the frame-by-frame proof
-   where each frame binds a claim, the user action, the assertion, and a
-   validated screenshot. It is the atomic artifact a human looks at to
-   understand the experience at a glance. Report `Passed` only when fraimz
-   exists and every claim is backed by an observable assertion; otherwise
-   `Incomplete` / `Failed`, stated honestly with repro steps.
-
-### Make fraimz
-
-"Make fraimz for this flow" is the trigger for the whole loop: it creates or
-picks the eval, drives it as the end user, validates and repairs, and outputs
-`fraimz.html`. Run it via the `/fraimz` command or `pnpm fraimz --flow <id>`.
-fraimz is what we look at; we can fine-tune what each frame captures over time.
-
-### The core flow
-
-When a change is expected to be inert, re-run the canonical core flow —
-**open the app → write a message → get a response → close → reopen and
-confirm the session survived** (`evals/flows/core-flow.flow.mjs`). If that
-stays green, the inertness claim is backed by evidence.
-
-### Where the mechanics live
-
-Keep this section short on purpose. The rails are documented elsewhere and
-are the source of truth:
-
-- `evals/README.md` — runner, flags, conventions, `ctx.*` helpers.
-- `evals/flows/` — existing coded flows to reuse or pattern-match.
-- Skills: `run-evals` (launch + run) and `daytona-flow-validator` (the
-  observe → act → assert → repair → verdict loop).
+Report `Passed` only when `fraimz.html` exists and every claim is backed by an
+observable assertion; otherwise `Incomplete` / `Failed`, stated honestly with
+repro steps. Pure docs/comments and types-only changes with no runtime path may
+skip — but say so explicitly. For changes you expect to be inert, the `fraimz`
+skill's canonical core flow proves the core experience is unchanged.
 
 ## Coding Guidelines
 


### PR DESCRIPTION
## What

Extracts the **Validate Every Experience** / fraimz procedure out of `AGENTS.md` into a dedicated, keyword-triggered **`fraimz` skill** so you can just say:

> do <task>, please create a fraimz

and the loop loads on demand.

### Changes
- **New** `.opencode/skills/fraimz/SKILL.md` — the single source of truth for the fraimz loop: when it applies, the 5-step loop (frame → coded flow → drive via CDP → validate/repair → verdict), the canonical core flow, how to drive the app (Daytona + local Electron fallback commands), the `ctx.*` helper list, and the practical CDP/flow pitfalls learned while producing the artifact-header fraimz (right CDP frame, `__openworkControl` readiness, browser-tab focus stealing, reflow timing, asserting the regression not nice-to-haves, dev-only seed affordances, array-shaped screenshot validation).
- **`AGENTS.md`** — replaced ~55 lines of inline procedure with a short pointer to the skill (−57/+18).
- **`.opencode/commands/fraimz.md`** — now references the `fraimz` skill as the source of truth.

## Why

Keep AGENTS.md lean and make the loop reusable/auto-loading rather than copy-pasted across docs.

## Validation

Docs/skill-only change with no runtime path — per the process itself, this may skip fraimz. No code paths touched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

