### PR TITLE
fix(app): restart engine when config reload endpoint is stale

### DIFF
--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1134,6 +1134,7 @@ export function SessionRoute() {
         workspace_type: workspace.workspaceType ?? "unknown",
       });
       toast.dismiss(taskCreateUnavailableToastId(workspaceId));
+      toast.dismiss();
       setLegacySelectedWorkspaceId(workspaceId);
       writeActiveWorkspaceId(workspaceId || null);
       writeLastSessionFor(workspaceId, session.id);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -207,6 +207,10 @@ function describeTaskCreateError(error: unknown) {
   return message;
 }
 
+function taskCreateUnavailableToastId(workspaceId: string) {
+  return `opencode-unavailable:${workspaceId}`;
+}
+
 function focusPromptSoon() {
   if (typeof window === "undefined") return;
   const focus = () => window.dispatchEvent(new Event("openwork:focusPrompt"));
@@ -1129,6 +1133,7 @@ export function SessionRoute() {
         source: "new_task",
         workspace_type: workspace.workspaceType ?? "unknown",
       });
+      toast.dismiss(taskCreateUnavailableToastId(workspaceId));
       setLegacySelectedWorkspaceId(workspaceId);
       writeActiveWorkspaceId(workspaceId || null);
       writeLastSessionFor(workspaceId, session.id);
@@ -1149,6 +1154,7 @@ export function SessionRoute() {
       setRouteError(message);
       setErrorsByWorkspaceId((current) => ({ ...current, [workspaceId]: message }));
       toast.error("OpenCode unavailable", {
+        id: taskCreateUnavailableToastId(workspaceId),
         description: message,
         action: {
           label: "Retry",

--- a/apps/app/src/react-app/shell/use-engine-reload.ts
+++ b/apps/app/src/react-app/shell/use-engine-reload.ts
@@ -15,8 +15,13 @@ import { useReloadCoordinator } from "./reload-coordinator";
 import { refreshProviderListQueries } from "@/react-app/infra/provider-list-query";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
 import type { RouteWorkspace } from "./route-workspaces";
+import { toast } from "@/components/ui/sonner";
 
 const reloadAfterOrgOnboardingKey = "openwork.reloadAfterOrgOnboarding";
+
+function taskCreateUnavailableToastId(workspaceId: string) {
+  return `opencode-unavailable:${workspaceId}`;
+}
 
 export type UseEngineReloadInput = {
   client: OpenworkServerClient | null;
@@ -82,6 +87,7 @@ export function useEngineReload(input: UseEngineReloadInput) {
     if (!restartedEngine) {
       await refreshRouteState();
     }
+    toast.dismiss(taskCreateUnavailableToastId(workspaceId));
     return true;
   }, [client, endpointForWorkspace, onError, refreshRouteState, workspace, workspaceId]);
 

--- a/apps/app/src/react-app/shell/use-engine-reload.ts
+++ b/apps/app/src/react-app/shell/use-engine-reload.ts
@@ -5,10 +5,10 @@
 // instead of `any`.
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { engineInfo } from "@/app/lib/desktop";
+import { engineInfo, engineRestart } from "@/app/lib/desktop";
 import type { EngineInfo } from "@/app/lib/desktop-types";
 import { isDesktopRuntime } from "@/app/lib/runtime-env";
-import type { OpenworkServerClient } from "@/app/lib/openwork-server";
+import { OpenworkServerError, type OpenworkServerClient } from "@/app/lib/openwork-server";
 import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
 import { t } from "@/i18n";
 import { useReloadCoordinator } from "./reload-coordinator";
@@ -55,15 +55,33 @@ export function useEngineReload(input: UseEngineReloadInput) {
       onError(t("app.error_connect_first"));
       return false;
     }
-    await endpoint.client.reloadEngine(endpoint.workspaceId);
-    await refreshProviderListQueries(getReactQueryClient());
+    let restartedEngine = false;
+    try {
+      await endpoint.client.reloadEngine(endpoint.workspaceId);
+    } catch (error) {
+      const unreachable =
+        error instanceof OpenworkServerError && error.code === "opencode_engine_unreachable";
+      if (!unreachable || !isDesktopRuntime()) {
+        throw error;
+      }
+      await engineRestart({});
+      restartedEngine = true;
+    }
+    if (restartedEngine) {
+      await refreshRouteState();
+      await refreshProviderListQueries(getReactQueryClient()).catch(() => undefined);
+    } else {
+      await refreshProviderListQueries(getReactQueryClient());
+    }
     setEngineReloadVersion((v) => v + 1);
     try {
       window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
     } catch {
       // ignore browser event dispatch failures
     }
-    await refreshRouteState();
+    if (!restartedEngine) {
+      await refreshRouteState();
+    }
     return true;
   }, [client, endpointForWorkspace, onError, refreshRouteState, workspace, workspaceId]);
 

--- a/apps/app/src/react-app/shell/use-engine-reload.ts
+++ b/apps/app/src/react-app/shell/use-engine-reload.ts
@@ -88,6 +88,7 @@ export function useEngineReload(input: UseEngineReloadInput) {
       await refreshRouteState();
     }
     toast.dismiss(taskCreateUnavailableToastId(workspaceId));
+    toast.dismiss();
     return true;
   }, [client, endpointForWorkspace, onError, refreshRouteState, workspace, workspaceId]);
 

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -1393,6 +1393,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     // EADDRINUSE and leaving the runtime in error -> boot screen.
     const requestedRemoteAccess = options.openworkRemoteAccess === true;
     if (
+      options.forceRestart !== true &&
       openworkServerState.inProcess &&
       lifecycleState === "healthy" &&
       normalizeWorkspaceKey(engineState.projectDir) === normalizeWorkspaceKey(safeProjectDir) &&
@@ -1448,11 +1449,15 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     if (!projectDir) {
       throw new Error("OpenCode is not configured for a local workspace");
     }
+    const openworkRemoteAccess = typeof options.openworkRemoteAccess === "boolean"
+      ? options.openworkRemoteAccess
+      : openworkServerState.remoteAccessEnabled;
     return engineStart(projectDir, {
       runtime: engineState.runtime,
       workspacePaths: [projectDir],
       opencodeEnableExa: options.opencodeEnableExa,
-      openworkRemoteAccess: options.openworkRemoteAccess,
+      openworkRemoteAccess,
+      forceRestart: true,
     });
   }
 

--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -340,11 +340,13 @@ describe("runtime MCP engine sync", () => {
     }
   });
 
-  // Repro for "Failed to reload the engine": when the OpenCode engine process
-  // is not running (engine.running === false in runtime diagnostics), the reload
-  // POST to /instance/dispose throws ECONNREFUSED. The reload endpoint must not
-  // 5xx on a connection error — a down engine is reloadable, not a server fault.
-  test("engine reload succeeds when the engine is unreachable", async () => {
+  // When the OpenCode engine endpoint on record is unreachable (process down or
+  // moved to a new port), a lightweight /instance/dispose cannot revive it.
+  // The reload endpoint must report a distinct, actionable error
+  // (opencode_engine_unreachable) instead of either a generic 502 or a fake
+  // 200 — the latter would tell the user "reloaded" while chat stays broken.
+  // The desktop client uses this code to escalate to a full engine restart.
+  test("engine reload reports engine-unreachable when the engine is down", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const previousDb = process.env.OPENWORK_RUNTIME_DB;
     process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
@@ -355,9 +357,9 @@ describe("runtime MCP engine sync", () => {
         method: "POST",
         headers: auth(openwork.token),
       });
-      expect(response.status).toBe(200);
-      const body = await response.json() as { ok: boolean };
-      expect(body.ok).toBe(true);
+      expect(response.status).toBe(503);
+      const body = await response.json() as { code?: string };
+      expect(body.code).toBe("opencode_engine_unreachable");
     } finally {
       if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
       else process.env.OPENWORK_RUNTIME_DB = previousDb;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2788,13 +2788,13 @@ async function reloadOpencodeEngine(config: ServerConfig, workspace: WorkspaceIn
   let response: Response;
   try {
     response = await fetch(targetUrl, { method: "POST", headers });
-  } catch {
-    // The engine process isn't running (e.g. it crashed or was never started),
-    // so the dispose POST throws ECONNREFUSED. There's no live instance to
-    // dispose — the engine rebuilds from the on-disk config on the next request
-    // — so a reload is a no-op success here, not a server fault. Surfacing this
-    // as a 5xx is what produces the user-facing "Failed to reload the engine".
-    return;
+  } catch (error) {
+    throw new ApiError(
+      503,
+      "opencode_engine_unreachable",
+      "OpenCode engine is not reachable; a full engine restart is required",
+      { baseUrl, cause: error instanceof Error ? error.message : String(error) },
+    );
   }
   if (!response.ok) {
     const body = parseOpencodeErrorBody(await response.text());


### PR DESCRIPTION
## Summary
- Return a typed 503 when the bound OpenCode engine reload endpoint is unreachable instead of masking it as success.
- Escalate the desktop UI reload action to a full engine restart for that error.
- Force engine restart to avoid reusing stale runtime state.
- Clear stale OpenCode-unavailable toasts after successful recovery/task creation.

## Validation
- Local: apps/app pnpm typecheck — pass
- Local: apps/server pnpm typecheck — pass
- Local: apps/server bun test src/mcp.engine-sync.e2e.test.ts src/workspace-activate.e2e.test.ts — 14 pass / 0 fail
- Daytona: apps/app pnpm typecheck — pass
- Daytona Electron e2e: killed opencode serve, triggered OpenCode unavailable, clicked Reload OpenCode config, verified health 200, fresh POST /opencode/session 200, Ready for new tasks visible, and OpenCode unavailable absent.

Fraimz: https://8090-bwpewcbsipobjeet.daytonaproxy01.net/validation/reload-engine-restart/fraimz.html