### PR TITLE
feat(den-api): unverified accounts can self-serve but cannot join others' orgs

### DIFF
--- a/ee/apps/den-api/evals/agent-fraimz-unverified-signup.mjs
+++ b/ee/apps/den-api/evals/agent-fraimz-unverified-signup.mjs
@@ -1,114 +1,188 @@
-// Agent-fraimz for the "unverified, but usable" onboarding boundary.
+// Live e2e agent-fraimz for the "unverified, but usable" onboarding boundary.
 //
-// This is an AGENT-driven frame proof (no screenshots): the protagonist is an
-// agent driving the real Den REST handlers. Each frame binds a claim, the
-// action the agent took, the assertion that witnesses the side effect, and the
-// captured evidence (the actual JSON response / value).
+// This is intentionally NOT a handler test. It drives a real Den API server over
+// HTTP and writes a frame proof with captured JSON evidence. The only direct DB
+// operation simulates the email-verification side effect before retrying the
+// invitation accept call.
 //
-// Run from ee/apps/den-api:  bun evals/agent-fraimz-unverified-signup.mjs
+// Required:
+//   DEN_API_E2E_BASE_URL=http://127.0.0.1:18990
+//   DATABASE_URL=mysql://root:password@127.0.0.1:33307/openwork_agent_signup
+//
+// Run from ee/apps/den-api:
+//   DEN_API_E2E_BASE_URL=... DATABASE_URL=... bun evals/agent-fraimz-unverified-signup.mjs
 
+import { eq } from "@openwork-ee/den-db/drizzle"
+import { AuthUserTable } from "@openwork-ee/den-db/schema"
 import { mkdirSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { db } from "../src/db.js"
 
-process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_test"
-process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32)
-process.env.BETTER_AUTH_SECRET ??= "y".repeat(32)
-process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:8790"
-process.env.CORS_ORIGINS ??= "http://127.0.0.1:8790"
-
-const { Hono } = await import("hono")
-const { registerOrgRoutes } = await import("../src/routes/org/index.js")
-const { validateInvitationAcceptVerification } = await import("../src/organization-join-verification.js")
+const baseUrl = process.env.DEN_API_E2E_BASE_URL?.replace(/\/$/, "")
+if (!baseUrl) {
+  throw new Error("DEN_API_E2E_BASE_URL is required for live e2e fraimz")
+}
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is required so the e2e can simulate email verification")
+}
 
 const here = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(here, "..", "..", "..", "..")
 const outDir = join(repoRoot, "evals", "results", "unverified-agent-signup")
 mkdirSync(outDir, { recursive: true })
 
-function appWithUser(user) {
-  const app = new Hono()
-  app.use("*", async (c, next) => {
-    c.set("user", user)
-    c.set("session", {
-      id: "session_agent",
-      token: "session_agent",
-      userId: user.id,
-      activeOrganizationId: null,
-      activeTeamId: null,
-      expiresAt: new Date(Date.now() + 60_000),
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      ipAddress: null,
-      userAgent: null,
-    })
-    c.set("apiKey", null)
-    await next()
-  })
-  registerOrgRoutes(app)
-  return app
-}
-
 const frames = []
+const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
 function prove(claim, { action, assert, evidence }, ok) {
   frames.push({ claim, action, assert, evidence, ok })
   if (!ok) throw new Error(`Frame failed: ${claim}`)
 }
 
-// Frame 1 — an anonymous agent cannot accept an invitation.
-{
-  const app = new Hono()
-  registerOrgRoutes(app)
-  const res = await app.request("http://den.local/v1/orgs/invitations/accept", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ id: "invitation_1" }),
+async function request(path, options = {}) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      origin: baseUrl,
+      ...(options.headers ?? {}),
+    },
   })
-  const body = await res.json()
-  prove("An unauthenticated agent cannot join an org", {
-    action: "POST /v1/orgs/invitations/accept with no session",
-    assert: "HTTP 401 unauthorized",
-    evidence: { status: res.status, body },
-  }, res.status === 401 && body.error === "unauthorized")
+  const text = await response.text()
+  let body = null
+  if (text) {
+    try {
+      body = JSON.parse(text)
+    } catch {
+      body = text
+    }
+  }
+  return { status: response.status, headers: Object.fromEntries(response.headers), body }
 }
 
-// Frame 2 — THE boundary: an unverified agent is blocked from joining.
-{
-  const app = appWithUser({ id: "user_unverified", email: "ada@example.com", emailVerified: false })
-  const res = await app.request("http://den.local/v1/orgs/invitations/accept", {
+function randomPassword() {
+  return `A${crypto.randomUUID()}!9zZ`
+}
+
+async function signupAndSignin(label, email) {
+  const password = randomPassword()
+  const signup = await request("/api/auth/sign-up/email", {
     method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ id: "invitation_1" }),
+    body: JSON.stringify({ name: label, email, password }),
   })
-  const body = await res.json()
-  prove("An unverified agent is blocked from JOINING someone else's org", {
-    action: "POST /v1/orgs/invitations/accept as an authenticated but unverified account",
-    assert: "HTTP 403 email_verification_required (returned before any DB access)",
-    evidence: { status: res.status, body },
-  }, res.status === 403 && body.error === "email_verification_required")
+  if (signup.status !== 200) {
+    throw new Error(`signup failed for ${email}: ${signup.status} ${JSON.stringify(signup.body)}`)
+  }
+
+  const signin = await request("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  })
+  if (signin.status !== 200 || !signin.body?.token) {
+    throw new Error(`signin failed for ${email}: ${signin.status} ${JSON.stringify(signin.body)}`)
+  }
+
+  return { email, password, signup, signin, token: signin.body.token, user: signin.body.user }
 }
 
-// Frame 3 — the allow path: a verified account may join.
+function authHeaders(token) {
+  return { authorization: `Bearer ${token}` }
+}
+
+// Frame 1 — live server health.
 {
-  const result = validateInvitationAcceptVerification({ emailVerified: true })
-  prove("A verified account is permitted to join an org", {
-    action: "validateInvitationAcceptVerification({ emailVerified: true })",
-    assert: "guard returns { ok: true }",
-    evidence: result,
-  }, result.ok === true)
+  const health = await request("/health", { method: "GET" })
+  prove("Den API is running as a live e2e target", {
+    action: `GET ${baseUrl}/health`,
+    assert: "HTTP 200 { ok: true, service: den-api }",
+    evidence: health,
+  }, health.status === 200 && health.body?.ok === true && health.body?.service === "den-api")
 }
 
-// Frame 4 — the agent onboarding contract is published.
+// Frame 2 — an agent can create an unverified account and receive a token.
+const ownerEmail = `owner-${runId}@example.com`
+const owner = await signupAndSignin("Owner Agent", ownerEmail)
+prove("An agent can sign up and sign in headlessly", {
+  action: "POST /api/auth/sign-up/email, then POST /api/auth/sign-in/email",
+  assert: "signup returns an unverified user; signin returns a bearer token",
+  evidence: {
+    signupStatus: owner.signup.status,
+    signinStatus: owner.signin.status,
+    userId: owner.user.id,
+    email: owner.user.email,
+    emailVerified: owner.user.emailVerified,
+    hasToken: Boolean(owner.token),
+  },
+}, owner.signup.status === 200 && owner.signin.status === 200 && owner.user.emailVerified === false && Boolean(owner.token))
+
+// Frame 3 — that unverified account can create its own organization.
+const org = await request("/v1/org", {
+  method: "POST",
+  headers: authHeaders(owner.token),
+  body: JSON.stringify({ name: `Agent E2E Org ${runId}` }),
+})
+prove("An unverified agent can create its own organization", {
+  action: "POST /v1/org with the owner's bearer token",
+  assert: "HTTP 201 and organization id returned",
+  evidence: { status: org.status, organization: org.body?.organization },
+}, org.status === 201 && typeof org.body?.organization?.id === "string")
+
+// Frame 4 — the unverified owner can invite a teammate.
+const joinerEmail = `joiner-${runId}@example.com`
+const invite = await request("/v1/invitations", {
+  method: "POST",
+  headers: authHeaders(owner.token),
+  body: JSON.stringify({ email: joinerEmail, role: "member" }),
+})
+prove("An unverified organization owner can invite a teammate", {
+  action: "POST /v1/invitations with the owner's bearer token",
+  assert: "HTTP 201 invitation is created in dev email mode",
+  evidence: { status: invite.status, body: invite.body },
+}, invite.status === 201 && typeof invite.body?.invitationId === "string" && invite.body?.email === joinerEmail)
+
+// Frame 5 — an unverified invited user is blocked from joining.
+const joiner = await signupAndSignin("Joiner Agent", joinerEmail)
+const blockedAccept = await request("/v1/orgs/invitations/accept", {
+  method: "POST",
+  headers: authHeaders(joiner.token),
+  body: JSON.stringify({ id: invite.body.invitationId }),
+})
+prove("An unverified invitee cannot join another organization", {
+  action: "POST /v1/orgs/invitations/accept as the unverified invited user",
+  assert: "HTTP 403 email_verification_required",
+  evidence: { status: blockedAccept.status, body: blockedAccept.body },
+}, blockedAccept.status === 403 && blockedAccept.body?.error === "email_verification_required")
+
+// Frame 6 — after verification, the same user can accept the same invite.
+await db
+  .update(AuthUserTable)
+  .set({ emailVerified: true })
+  .where(eq(AuthUserTable.id, joiner.user.id))
+
+const accepted = await request("/v1/orgs/invitations/accept", {
+  method: "POST",
+  headers: authHeaders(joiner.token),
+  body: JSON.stringify({ id: invite.body.invitationId }),
+})
+prove("After email verification, the invited user can join", {
+  action: "Simulate email verification in the DB, then retry POST /v1/orgs/invitations/accept",
+  assert: "HTTP 200 { accepted: true } for the same invitation id",
+  evidence: { status: accepted.status, body: accepted.body },
+}, accepted.status === 200 && accepted.body?.accepted === true && accepted.body?.invitationId === invite.body.invitationId)
+
+// Frame 7 — the published start.md matches the live flow.
 {
   const startPath = join(here, "..", "start.md")
   const text = await Bun.file(startPath).text()
-  const mentionsBoundary = text.includes("email_verification_required")
   const mentionsSignup = text.includes("/api/auth/sign-up/email")
-  prove("The cold-start contract (start.md) documents the headless flow + boundary", {
+  const mentionsCreateOrg = text.includes("/v1/org")
+  const mentionsBoundary = text.includes("email_verification_required")
+  prove("The cold-start contract documents the live headless flow", {
     action: "read ee/apps/den-api/start.md",
-    assert: "documents POST /api/auth/sign-up/email and the email_verification_required boundary",
-    evidence: { path: "ee/apps/den-api/start.md", mentionsSignup, mentionsBoundary, bytes: text.length },
-  }, mentionsBoundary && mentionsSignup)
+    assert: "documents signup, org creation, and email_verification_required boundary",
+    evidence: { path: "ee/apps/den-api/start.md", mentionsSignup, mentionsCreateOrg, mentionsBoundary, bytes: text.length },
+  }, mentionsSignup && mentionsCreateOrg && mentionsBoundary)
 }
 
 // ---- emit fraimz ----
@@ -133,11 +207,11 @@ const frameFiles = frames.map((f, i) => {
 
 const allOk = frames.every((f) => f.ok)
 const index = `<!doctype html><html lang="en"><head><meta charset="utf-8" />
-<title>Unverified Agent Signup — fraimz</title>
+<title>Unverified Agent Signup — live e2e fraimz</title>
 <style>body{margin:0;background:#f3f4f6;color:#111827;font-family:system-ui,sans-serif}main{max-width:1180px;margin:0 auto;padding:32px}h1{margin-bottom:4px}.meta{color:#4b5563;margin-bottom:24px}section{margin:20px 0;padding:16px;border:1px solid #d1d5db;border-radius:16px;background:white}iframe{width:100%;min-height:360px;border:1px solid #e5e7eb;border-radius:12px;background:white}code{background:#e5e7eb;padding:2px 5px;border-radius:5px}</style>
 </head><body><main>
-<h1>Unverified Agent Signup — fraimz</h1>
-<div class="meta">Result: <code>${allOk ? "passed" : "failed"}</code> · Agent-driven REST proof (no screenshots) · Frames: ${frames.length}</div>
+<h1>Unverified Agent Signup — live e2e fraimz</h1>
+<div class="meta">Result: <code>${allOk ? "passed" : "failed"}</code> · Live Den API: <code>${esc(baseUrl)}</code> · Agent-driven REST proof (no screenshots) · Frames: ${frames.length}</div>
 ${frameFiles.map((ff) => `<section><h2>${esc(ff.frame.claim)}</h2><iframe src="${ff.name}" title="${esc(ff.frame.claim)}"></iframe><p><a href="${ff.name}">Open frame</a></p></section>`).join("\n")}
 </main></body></html>`
 writeFileSync(join(outDir, "fraimz.html"), index)
@@ -145,8 +219,10 @@ writeFileSync(join(outDir, "fraimz.html"), index)
 writeFileSync(join(outDir, "report.json"), JSON.stringify({
   flow: "unverified-agent-signup",
   result: allOk ? "passed" : "failed",
+  liveBaseUrl: baseUrl,
   frames: frames.map((f) => ({ claim: f.claim, action: f.action, assert: f.assert, ok: f.ok })),
 }, null, 2))
 
 console.log(`fraimz: ${join(outDir, "fraimz.html")}`)
 console.log(`result: ${allOk ? "passed" : "failed"} (${frames.length} frames)`)
+process.exit(allOk ? 0 : 1)

--- a/ee/apps/den-api/evals/agent-fraimz-unverified-signup.mjs
+++ b/ee/apps/den-api/evals/agent-fraimz-unverified-signup.mjs
@@ -1,0 +1,152 @@
+// Agent-fraimz for the "unverified, but usable" onboarding boundary.
+//
+// This is an AGENT-driven frame proof (no screenshots): the protagonist is an
+// agent driving the real Den REST handlers. Each frame binds a claim, the
+// action the agent took, the assertion that witnesses the side effect, and the
+// captured evidence (the actual JSON response / value).
+//
+// Run from ee/apps/den-api:  bun evals/agent-fraimz-unverified-signup.mjs
+
+import { mkdirSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_test"
+process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32)
+process.env.BETTER_AUTH_SECRET ??= "y".repeat(32)
+process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:8790"
+process.env.CORS_ORIGINS ??= "http://127.0.0.1:8790"
+
+const { Hono } = await import("hono")
+const { registerOrgRoutes } = await import("../src/routes/org/index.js")
+const { validateInvitationAcceptVerification } = await import("../src/organization-join-verification.js")
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(here, "..", "..", "..", "..")
+const outDir = join(repoRoot, "evals", "results", "unverified-agent-signup")
+mkdirSync(outDir, { recursive: true })
+
+function appWithUser(user) {
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("user", user)
+    c.set("session", {
+      id: "session_agent",
+      token: "session_agent",
+      userId: user.id,
+      activeOrganizationId: null,
+      activeTeamId: null,
+      expiresAt: new Date(Date.now() + 60_000),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ipAddress: null,
+      userAgent: null,
+    })
+    c.set("apiKey", null)
+    await next()
+  })
+  registerOrgRoutes(app)
+  return app
+}
+
+const frames = []
+function prove(claim, { action, assert, evidence }, ok) {
+  frames.push({ claim, action, assert, evidence, ok })
+  if (!ok) throw new Error(`Frame failed: ${claim}`)
+}
+
+// Frame 1 — an anonymous agent cannot accept an invitation.
+{
+  const app = new Hono()
+  registerOrgRoutes(app)
+  const res = await app.request("http://den.local/v1/orgs/invitations/accept", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ id: "invitation_1" }),
+  })
+  const body = await res.json()
+  prove("An unauthenticated agent cannot join an org", {
+    action: "POST /v1/orgs/invitations/accept with no session",
+    assert: "HTTP 401 unauthorized",
+    evidence: { status: res.status, body },
+  }, res.status === 401 && body.error === "unauthorized")
+}
+
+// Frame 2 — THE boundary: an unverified agent is blocked from joining.
+{
+  const app = appWithUser({ id: "user_unverified", email: "ada@example.com", emailVerified: false })
+  const res = await app.request("http://den.local/v1/orgs/invitations/accept", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ id: "invitation_1" }),
+  })
+  const body = await res.json()
+  prove("An unverified agent is blocked from JOINING someone else's org", {
+    action: "POST /v1/orgs/invitations/accept as an authenticated but unverified account",
+    assert: "HTTP 403 email_verification_required (returned before any DB access)",
+    evidence: { status: res.status, body },
+  }, res.status === 403 && body.error === "email_verification_required")
+}
+
+// Frame 3 — the allow path: a verified account may join.
+{
+  const result = validateInvitationAcceptVerification({ emailVerified: true })
+  prove("A verified account is permitted to join an org", {
+    action: "validateInvitationAcceptVerification({ emailVerified: true })",
+    assert: "guard returns { ok: true }",
+    evidence: result,
+  }, result.ok === true)
+}
+
+// Frame 4 — the agent onboarding contract is published.
+{
+  const startPath = join(here, "..", "start.md")
+  const text = await Bun.file(startPath).text()
+  const mentionsBoundary = text.includes("email_verification_required")
+  const mentionsSignup = text.includes("/api/auth/sign-up/email")
+  prove("The cold-start contract (start.md) documents the headless flow + boundary", {
+    action: "read ee/apps/den-api/start.md",
+    assert: "documents POST /api/auth/sign-up/email and the email_verification_required boundary",
+    evidence: { path: "ee/apps/den-api/start.md", mentionsSignup, mentionsBoundary, bytes: text.length },
+  }, mentionsBoundary && mentionsSignup)
+}
+
+// ---- emit fraimz ----
+const esc = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+const slug = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 60)
+
+const frameFiles = frames.map((f, i) => {
+  const name = `${String(i + 1).padStart(2, "0")}-${slug(f.claim)}.html`
+  const html = `<!doctype html><html lang="en"><head><meta charset="utf-8" />
+<title>${esc(f.claim)}</title>
+<style>body{margin:0;background:#f8fafc;color:#111827;font-family:ui-monospace,Menlo,Consolas,monospace}main{max-width:980px;margin:0 auto;padding:32px}h1{font-family:system-ui,sans-serif;margin-top:0;font-size:18px}.k{color:#6b7280;font-family:system-ui,sans-serif}.ok{color:#047857;font-weight:600}pre{white-space:pre-wrap;word-break:break-word;padding:16px;border:1px solid #d1d5db;border-radius:14px;background:white}</style>
+</head><body><main>
+<h1>${esc(f.claim)} — <span class="ok">${f.ok ? "PASS" : "FAIL"}</span></h1>
+<p><span class="k">action:</span> ${esc(f.action)}</p>
+<p><span class="k">assert:</span> ${esc(f.assert)}</p>
+<p class="k">evidence:</p>
+<pre>${esc(JSON.stringify(f.evidence, null, 2))}</pre>
+</main></body></html>`
+  writeFileSync(join(outDir, name), html)
+  return { name, frame: f }
+})
+
+const allOk = frames.every((f) => f.ok)
+const index = `<!doctype html><html lang="en"><head><meta charset="utf-8" />
+<title>Unverified Agent Signup — fraimz</title>
+<style>body{margin:0;background:#f3f4f6;color:#111827;font-family:system-ui,sans-serif}main{max-width:1180px;margin:0 auto;padding:32px}h1{margin-bottom:4px}.meta{color:#4b5563;margin-bottom:24px}section{margin:20px 0;padding:16px;border:1px solid #d1d5db;border-radius:16px;background:white}iframe{width:100%;min-height:360px;border:1px solid #e5e7eb;border-radius:12px;background:white}code{background:#e5e7eb;padding:2px 5px;border-radius:5px}</style>
+</head><body><main>
+<h1>Unverified Agent Signup — fraimz</h1>
+<div class="meta">Result: <code>${allOk ? "passed" : "failed"}</code> · Agent-driven REST proof (no screenshots) · Frames: ${frames.length}</div>
+${frameFiles.map((ff) => `<section><h2>${esc(ff.frame.claim)}</h2><iframe src="${ff.name}" title="${esc(ff.frame.claim)}"></iframe><p><a href="${ff.name}">Open frame</a></p></section>`).join("\n")}
+</main></body></html>`
+writeFileSync(join(outDir, "fraimz.html"), index)
+
+writeFileSync(join(outDir, "report.json"), JSON.stringify({
+  flow: "unverified-agent-signup",
+  result: allOk ? "passed" : "failed",
+  frames: frames.map((f) => ({ claim: f.claim, action: f.action, assert: f.assert, ok: f.ok })),
+}, null, 2))
+
+console.log(`fraimz: ${join(outDir, "fraimz.html")}`)
+console.log(`result: ${allOk ? "passed" : "failed"} (${frames.length} frames)`)

--- a/ee/apps/den-api/src/organization-join-verification.ts
+++ b/ee/apps/den-api/src/organization-join-verification.ts
@@ -1,0 +1,27 @@
+export type JoinVerificationResult =
+  | { ok: true }
+  | { ok: false; error: string; message: string }
+
+/**
+ * Verification boundary for organization membership.
+ *
+ * Unverified accounts are intentionally allowed to sign up, create their OWN
+ * organization, and invite teammates so that an agent can bootstrap a workspace
+ * end-to-end with no human in the loop. The one hard boundary is JOINING an
+ * organization owned by someone else: that requires a verified email. This keeps
+ * the open self-serve signup path agent-friendly while ensuring an unverified
+ * actor can only ever affect their own sandbox org.
+ */
+export function validateInvitationAcceptVerification(input: {
+  emailVerified: boolean | null | undefined
+}): JoinVerificationResult {
+  if (input.emailVerified === true) {
+    return { ok: true }
+  }
+
+  return {
+    ok: false,
+    error: "email_verification_required",
+    message: "Verify your email address before joining an organization.",
+  }
+}

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -11,6 +11,7 @@ import { env } from "../../env.js"
 import { findEnterpriseAuthRequirementForEmail } from "../../enterprise-auth-requirement.js"
 import { authenticatedRoute, jsonValidator, orgMemberRoute, orgRoleRoute, publicRoute, queryValidator, resolveMemberTeamsMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, enterprisePlanRequiredSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
+import { validateInvitationAcceptVerification } from "../../organization-join-verification.js"
 import { normalizeOrganizationMetadata } from "../../organization-limits.js"
 import {
   acceptInvitationForUser,
@@ -219,7 +220,7 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
         200: jsonResponse("Invitation accepted successfully.", invitationAcceptedResponseSchema),
         400: jsonResponse("The invitation acceptance request body was invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to accept an invitation.", unauthorizedSchema),
-        403: jsonResponse("API keys cannot accept organization invitations.", forbiddenSchema),
+        403: jsonResponse("API keys cannot accept invitations, or the account email is unverified.", forbiddenSchema),
         409: jsonResponse("The current account email is not allowed to join this organization.", accountEmailDomainNotAllowedSchema),
         404: jsonResponse("The invitation could not be found.", notFoundSchema),
       },
@@ -240,6 +241,11 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
 
     if (!email) {
       return c.json({ error: "user_email_required" }, 400)
+    }
+
+    const verification = validateInvitationAcceptVerification({ emailVerified: user.emailVerified })
+    if (!verification.ok) {
+      return c.json({ error: verification.error, message: verification.message }, 403)
     }
 
     let accepted

--- a/ee/apps/den-api/start.md
+++ b/ee/apps/den-api/start.md
@@ -1,0 +1,85 @@
+# OpenWork — Agent Onboarding (start.md)
+
+This is the cold-start contract for an **agent** onboarding a user into OpenWork
+Cloud (Den) with no human in the loop. Every step below is a plain REST call
+against the Den API. Read this file, then drive the calls in order.
+
+> Base URL: the Den API origin (self-hosted or hosted), e.g. `https://den.example.com`.
+> All request/response bodies are JSON.
+
+## The model: unverified, but usable
+
+An **unverified** account is a first-class citizen. It can:
+
+- sign up,
+- create its **own** organization,
+- invite teammates,
+- install the desktop app and add marketplace skills.
+
+The single hard boundary: an unverified account **cannot JOIN an organization
+owned by someone else**. Accepting an invitation requires a verified email. This
+keeps signup open and agent-friendly while ensuring an unverified actor can only
+ever affect its own sandbox org.
+
+## Flow
+
+### 1. Sign up (headless, no browser)
+
+```
+POST /api/auth/sign-up/email
+{ "name": "Ada Agent", "email": "ada@example.com", "password": "<generated>" }
+```
+
+Creates an unverified account. Keep the returned session token (or sign in next).
+
+### 2. Sign in
+
+```
+POST /api/auth/sign-in/email
+{ "email": "ada@example.com", "password": "<same>" }
+```
+
+Use the returned bearer token as `Authorization: Bearer <token>` for all `/v1/*`
+calls below.
+
+### 3. Create your own organization (allowed while unverified)
+
+```
+POST /v1/org
+{ "name": "Ada's Workspace" }
+-> 201 { "organization": { "id": "...", "slug": "...", ... } }
+```
+
+### 4. Invite teammates (allowed while unverified)
+
+```
+POST /v1/invitations
+{ "email": "teammate@example.com", "role": "admin" }
+```
+
+### 5. Join an existing org — requires a VERIFIED email
+
+```
+POST /v1/orgs/invitations/accept
+{ "id": "<invitationId>" }
+```
+
+- Verified account -> `200 { "accepted": true, ... }`
+- Unverified account -> `403 { "error": "email_verification_required",
+  "message": "Verify your email address before joining an organization." }`
+
+If you receive `email_verification_required`, guide the user to verify their
+email (or complete email-OTP), then retry the accept call.
+
+### 6. Continue setup
+
+With an org in place, the agent can install the desktop app, connect a
+workspace, and add skills from the marketplace — the user is fully set up.
+
+## Notes for agents
+
+- Treat `403 email_verification_required` as a *pause-and-guide* signal, never a
+  hard failure: creating an org and inviting people do not require verification,
+  only joining someone else's org does.
+- All steps are idempotent-friendly: re-running signup with an existing email
+  returns an error you can fall back to sign-in for.

--- a/ee/apps/den-api/test/organization-join-verification.test.ts
+++ b/ee/apps/den-api/test/organization-join-verification.test.ts
@@ -1,0 +1,100 @@
+import { beforeAll, expect, test } from "bun:test"
+import { Hono } from "hono"
+import { validateInvitationAcceptVerification } from "../src/organization-join-verification.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+let orgRoutesModule: typeof import("../src/routes/org/index.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  orgRoutesModule = await import("../src/routes/org/index.js")
+})
+
+// Builds an org app with a fake authenticated session so we can exercise the
+// route guard without the session middleware or a live database. The handler
+// rejects unverified users before any database access, so no MySQL is required.
+function createOrgAppWithUser(user: { id: string; email: string; emailVerified: boolean }) {
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("user", user)
+    c.set("session", {
+      id: "session_test",
+      token: "session_test",
+      userId: user.id,
+      activeOrganizationId: null,
+      activeTeamId: null,
+      expiresAt: new Date(Date.now() + 60_000),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ipAddress: null,
+      userAgent: null,
+    })
+    c.set("apiKey", null)
+    await next()
+  })
+  orgRoutesModule.registerOrgRoutes(app)
+  return app
+}
+
+test("unverified accounts may create their own org and invite, but not join one", () => {
+  // Unverified is the only blocked transition: joining someone else's org.
+  expect(validateInvitationAcceptVerification({ emailVerified: false })).toEqual({
+    ok: false,
+    error: "email_verification_required",
+    message: "Verify your email address before joining an organization.",
+  })
+  expect(validateInvitationAcceptVerification({ emailVerified: null })).toEqual({
+    ok: false,
+    error: "email_verification_required",
+    message: "Verify your email address before joining an organization.",
+  })
+  expect(validateInvitationAcceptVerification({ emailVerified: undefined })).toEqual({
+    ok: false,
+    error: "email_verification_required",
+    message: "Verify your email address before joining an organization.",
+  })
+})
+
+test("verified accounts are allowed to join an organization", () => {
+  expect(validateInvitationAcceptVerification({ emailVerified: true })).toEqual({ ok: true })
+})
+
+test("accept-invitation route blocks an unverified user with 403 before touching the database", async () => {
+  const app = createOrgAppWithUser({
+    id: "user_unverified",
+    email: "agent@example.com",
+    emailVerified: false,
+  })
+
+  const response = await app.request("http://den.local/v1/orgs/invitations/accept", {
+    body: JSON.stringify({ id: "invitation_123" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+
+  expect(response.status).toBe(403)
+  await expect(response.json()).resolves.toEqual({
+    error: "email_verification_required",
+    message: "Verify your email address before joining an organization.",
+  })
+})
+
+test("accept-invitation route still requires authentication", async () => {
+  const app = new Hono()
+  orgRoutesModule.registerOrgRoutes(app)
+  const response = await app.request("http://den.local/v1/orgs/invitations/accept", {
+    body: JSON.stringify({ id: "invitation_123" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+
+  expect(response.status).toBe(401)
+  await expect(response.json()).resolves.toEqual({ error: "unauthorized" })
+})


### PR DESCRIPTION
## What & why

Makes OpenWork onboarding **agent-native**: an agent can sign a user up and
bootstrap a workspace fully headlessly, with one safe boundary.

An **unverified** account is now a first-class citizen — it can sign up, create
its **own** organization, and invite teammates. The single hard boundary: an
unverified account **cannot JOIN an organization owned by someone else** until
its email is verified. This keeps signup open and agent-friendly while ensuring
an unverified actor can only ever affect its own sandbox org.

This is the smallest vertical that proves the thesis: `signup → own org → invite`
works with no human, while `join someone else's org` stays gated.

## Changes

- `src/organization-join-verification.ts` — `validateInvitationAcceptVerification()`
  pure guard (mirrors the existing `organization-member-guards` style).
- `src/routes/org/core.ts` — enforce the guard in `POST /v1/orgs/invitations/accept`;
  unverified callers get `403 email_verification_required` **before any DB access**.
  Create-org (`POST /v1/org`) and invite (`POST /v1/invitations`) stay ungated.
- `start.md` — cold-start contract describing the headless REST onboarding flow
  for agents (the "read start.md then onboard" entry point).
- `test/organization-join-verification.test.ts` — bun tests (pure guard + route
  403/401).
- `evals/agent-fraimz-unverified-signup.mjs` — agent-fraimz generator (frame
  proof, no screenshots) that drives the real REST handlers.

## Tests run

`bun test test/organization-join-verification.test.ts` (from `ee/apps/den-api`):

```
(pass) unverified accounts may create their own org and invite, but not join one
(pass) verified accounts are allowed to join an organization
(pass) accept-invitation route blocks an unverified user with 403 before touching the database
(pass) accept-invitation route still requires authentication
 4 pass / 0 fail / 8 expect() calls
```

Related suites still green: `org-invitations`, `org-member-guards`,
`route-access-policy`. (`route-guard-policy` has a **pre-existing** failure on
`origin/dev` unrelated to this change — verified by stashing this diff and
re-running.)

## Agent-fraimz (frame proof, no screenshots)

`bun evals/agent-fraimz-unverified-signup.mjs` → `result: passed (4 frames)`.
The agent drives the real Den REST handlers; each frame binds claim → action →
assertion → captured JSON evidence. `fraimz.html` is written to
`evals/results/unverified-agent-signup/` (gitignored, per repo convention).

| # | Claim | Assertion |
|---|-------|-----------|
| 1 | Unauthenticated agent cannot join | HTTP 401 unauthorized |
| 2 | Unverified agent blocked from joining | HTTP 403 `email_verification_required` (before DB) |
| 3 | Verified account permitted to join | guard returns `{ ok: true }` |
| 4 | start.md documents the headless flow + boundary | contract published |

## Follow-ups (out of scope)

- The better-auth plugin path `/api/auth/organization/accept-invitation` already
  has its own gate (`requireEmailVerificationOnInvitation`, tied to
  `env.requireEmailVerification`). Aligning it to always block unverified joins
  independent of the global flag is a separate change.
- Abuse limits on the open unverified-signup path (rate limit / provider-key gate)
  and the precise definition of "verified" (email vs payment).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

