### PR TITLE
fix(app): restart dead engine from settings reload paths

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -17,9 +17,11 @@ import { unwrap, waitForHealthy } from "../../../../app/lib/opencode";
 import {
   readOpencodeConfig,
   writeOpencodeConfig,
+  engineRestart,
   workspaceOpenworkRead,
   workspaceOpenworkWrite,
 } from "../../../../app/lib/desktop";
+import { OpenworkServerError } from "../../../../app/lib/openwork-server";
 import type {
   Client,
   ProviderListItem,
@@ -1058,7 +1060,16 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             (await options.ensureRuntimeWorkspaceId?.())?.trim() ||
             "";
           if (workspaceId) {
-            await openworkClient.reloadEngine(workspaceId);
+            try {
+              await openworkClient.reloadEngine(workspaceId);
+            } catch (error) {
+              const unreachable =
+                error instanceof OpenworkServerError && error.code === "opencode_engine_unreachable";
+              if (!unreachable || !isDesktopRuntime()) {
+                throw error;
+              }
+              await engineRestart({});
+            }
             reloaded = true;
           }
         }

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -10,6 +10,7 @@ import {
   createOpenworkServerClient,
   isLoopbackOpenworkServerUrl,
   readOpenworkServerSettings,
+  OpenworkServerError,
   type OpenworkServerCapabilities,
   type OpenworkServerClient,
   type OpenworkWorkspaceInfo,
@@ -99,6 +100,7 @@ import {
   openworkServerInfo,
   openworkServerRestart,
   engineStart,
+  engineRestart,
   pickDirectory,
   resolveWorkspaceListSelectedId,
   workspaceBootstrap,
@@ -168,6 +170,24 @@ const ROUTE_OPENWORK_CAPABILITIES: OpenworkServerCapabilities = {
   commands: { read: true, write: true },
   config: { read: true, write: true },
 };
+
+async function reloadEngineOrRestartDesktop(
+  client: Pick<OpenworkServerClient, "reloadEngine">,
+  workspaceId: string,
+  afterRestart?: () => Promise<void>,
+): Promise<void> {
+  try {
+    await client.reloadEngine(workspaceId);
+  } catch (error) {
+    const unreachable =
+      error instanceof OpenworkServerError && error.code === "opencode_engine_unreachable";
+    if (!unreachable || !isDesktopRuntime()) {
+      throw error;
+    }
+    await engineRestart({});
+    await afterRestart?.();
+  }
+}
 
 function isOpenWorkCloudProvider(provider: {
   providerId?: string | null;
@@ -513,49 +533,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         }),
     [sessionsByWorkspaceId],
   );
-
-  const reloadWorkspaceEngineFromUi = useCallback(async () => {
-    const workspaceId = routeStateRef.current.runtimeWorkspaceId?.trim() || selectedWorkspaceId.trim();
-    if (!openworkClient || !workspaceId) {
-      toast.error(t("app.error_connect_first"));
-      return false;
-    }
-
-    await openworkClient.reloadEngine(workspaceId);
-    await refreshProviderListQueries(getReactQueryClient());
-
-    try {
-      window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
-    } catch {
-      // ignore browser event dispatch failures
-    }
-
-    // OpenCode reconnects MCPs async after dispose — the store polls until
-    // statuses settle so users don't have to collapse/expand the card.
-    void pollMcpServersAfterReloadRef.current?.();
-
-    return true;
-  }, [openworkClient, selectedWorkspaceId]);
-
-  useEffect(() => {
-    return reloadCoordinator.registerWorkspaceReloadControls({
-      canReloadWorkspaceEngine: () => Boolean(openworkClient && (selectedWorkspace?.id || selectedWorkspaceId)),
-      reloadWorkspaceEngine: reloadWorkspaceEngineFromUi,
-      activeSessions: () => activeReloadBlockingSessions,
-      stopSession: async (sessionId) => {
-        if (!activeClient) return;
-        await abortSessionSafe(activeClient, sessionId);
-      },
-    });
-  }, [
-    activeClient,
-    activeReloadBlockingSessions,
-    openworkClient,
-    reloadCoordinator,
-    reloadWorkspaceEngineFromUi,
-    selectedWorkspace?.id,
-    selectedWorkspaceId,
-  ]);
 
   const openworkServerStore = useMemo(
     () =>
@@ -1057,7 +1034,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       }
       reloadCoordinator.markReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
       try {
-        await client.reloadEngine(workspaceId);
+        await reloadEngineOrRestartDesktop(client, workspaceId);
       } catch {
         // The reload toast still lets the user retry if the immediate reload fails.
       }
@@ -1240,6 +1217,49 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       markBootRouteReady();
     }
   }, [markBootRouteReady, navigationSessionId, navigationWorkspaceId, routeWorkspaceId]);
+
+  const reloadWorkspaceEngineFromUi = useCallback(async () => {
+    const workspaceId = routeStateRef.current.runtimeWorkspaceId?.trim() || selectedWorkspaceId.trim();
+    if (!openworkClient || !workspaceId) {
+      toast.error(t("app.error_connect_first"));
+      return false;
+    }
+
+    await reloadEngineOrRestartDesktop(openworkClient, workspaceId, refreshRouteState);
+    await refreshProviderListQueries(getReactQueryClient());
+
+    try {
+      window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
+    } catch {
+      // ignore browser event dispatch failures
+    }
+
+    // OpenCode reconnects MCPs async after dispose — the store polls until
+    // statuses settle so users don't have to collapse/expand the card.
+    void pollMcpServersAfterReloadRef.current?.();
+
+    return true;
+  }, [openworkClient, refreshRouteState, selectedWorkspaceId]);
+
+  useEffect(() => {
+    return reloadCoordinator.registerWorkspaceReloadControls({
+      canReloadWorkspaceEngine: () => Boolean(openworkClient && (selectedWorkspace?.id || selectedWorkspaceId)),
+      reloadWorkspaceEngine: reloadWorkspaceEngineFromUi,
+      activeSessions: () => activeReloadBlockingSessions,
+      stopSession: async (sessionId) => {
+        if (!activeClient) return;
+        await abortSessionSafe(activeClient, sessionId);
+      },
+    });
+  }, [
+    activeClient,
+    activeReloadBlockingSessions,
+    openworkClient,
+    reloadCoordinator,
+    reloadWorkspaceEngineFromUi,
+    selectedWorkspace?.id,
+    selectedWorkspaceId,
+  ]);
 
   useEffect(() => {
     workspacesRef.current = workspaces;


### PR DESCRIPTION
## Summary
- Fixes a follow-up bypass from #2375: Settings registered its own engine reload control and still called /engine/reload directly.
- Adds the same opencode_engine_unreachable handling in Settings: desktop reload now escalates to engineRestart().
- Applies the same restart fallback to provider-auth refresh/dispose flows so a dead OpenCode process does not fall back to direct instance.dispose().

## Why
#2375 fixed the session-route command path, but Settings and provider-auth had independent reload paths. If the user was in Settings/Advanced/provider auth when the engine process was dead, those paths could still fail or silently avoid a desktop restart.

## Validation
- apps/app: pnpm typecheck — pass
- apps/server: bun test src/mcp.engine-sync.e2e.test.ts src/workspace-activate.e2e.test.ts — 14 pass / 0 fail
- Daytona sandbox updated to cc6072aa; apps/app pnpm typecheck — pass
- Daytona observation: reproduced stale runtime shape in Settings (engine running:false, pid:null, lifecycleState:healthy). This confirmed why Settings could show misleading connected state while the engine was dead.

## Follow-up
Settings > Advanced still labels OpenCode as Connected based on client construction, not live /health. That is a separate status-reporting issue from the reload recovery path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

