### PR TITLE
fix(server): seed default openwork config for existing workspaces

### DIFF
--- a/apps/server/src/openwork-config-db-migration.e2e.test.ts
+++ b/apps/server/src/openwork-config-db-migration.e2e.test.ts
@@ -158,4 +158,40 @@ describe("openwork config DB migration", () => {
       }
     });
   });
+
+  test("existing local workspace without legacy file gets default DB config on read", async () => {
+    await withSandbox(async ({ root, config }) => {
+      const workspacePath = join(root, "ws-existing-no-file");
+      const workspaceId = "ws_existing_no_file";
+      await mkdir(workspacePath, { recursive: true });
+
+      const existingConfig: ServerConfig = {
+        ...config,
+        workspaces: [
+          { id: workspaceId, name: "Existing", path: workspacePath, preset: "starter", workspaceType: "local" },
+        ],
+        authorizedRoots: [workspacePath],
+      };
+
+      const server = (await startServer(existingConfig)) as Served;
+      try {
+        expect(await fileExists(join(workspacePath, ".opencode", "openwork.json"))).toBe(false);
+        expect(Object.keys(await readOpenworkWorkspaceConfig(existingConfig, workspaceId)).length).toBe(0);
+
+        const configRes = await fetch(`http://127.0.0.1:${server.port}/workspace/${workspaceId}/config`, {
+          headers: { authorization: `Bearer ${existingConfig.token}` },
+        });
+        expect(configRes.status).toBe(200);
+        const body = (await configRes.json()) as { openwork: Record<string, unknown> };
+        expect(body.openwork.version).toBe(1);
+        expect(body.openwork.authorizedRoots).toEqual([workspacePath]);
+        expect((body.openwork.workspace as { preset?: string } | undefined)?.preset).toBe("starter");
+
+        const stored = await readOpenworkWorkspaceConfig(existingConfig, workspaceId);
+        expect(stored.authorizedRoots).toEqual([workspacePath]);
+      } finally {
+        await server.stop(true);
+      }
+    });
+  });
 });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -19,7 +19,7 @@ import { computeReloadFingerprint } from "./reload-fingerprint.js";
 import { startReloadWatchers } from "./reload-watcher.js";
 import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
-import { ensureWorkspaceFiles, readRawOpencodeConfig } from "./workspace-init.js";
+import { defaultWorkspaceOpenworkConfig, ensureWorkspaceFiles, readRawOpencodeConfig } from "./workspace-init.js";
 import { sanitizeCommandName, validateMcpName } from "./validators.js";
 import { TokenService } from "./tokens.js";
 import { EnvService } from "./env-file.js";
@@ -2709,7 +2709,16 @@ async function readOpenworkConfigForWorkspace(
     return stored;
   }
   const legacy = await readOpenworkConfigForStatus(workspace.path);
-  if (Object.keys(legacy.data).length === 0) return {};
+  if (Object.keys(legacy.data).length === 0) {
+    if (workspace.workspaceType !== "remote" && workspace.path.trim()) {
+      return seedOpenworkWorkspaceConfigIfEmpty(
+        config,
+        workspace.id,
+        defaultWorkspaceOpenworkConfig(workspace.path, workspace.preset ?? "starter"),
+      );
+    }
+    return {};
+  }
   // Migrate-on-read: copy the legacy file contents into the DB once.
   await seedOpenworkWorkspaceConfigIfEmpty(config, workspace.id, legacy.data);
   return mergeOpenworkWorkspaceConfigs(legacy.data, await readOpenworkWorkspaceConfig(config, workspace.id));


### PR DESCRIPTION
## Summary
- Fixes a migration hole introduced by f607914e (#2365): existing local workspaces loaded from server.json could have neither a runtime DB row nor legacy .opencode/openwork.json.
- On first OpenWork config read, local workspaces now seed the same default DB config used for new workspace creation.
- Leaves remote workspaces untouched.

## Why
The original DB migration covered new workspace creation and legacy-file migrate-on-read, but not existing local workspaces with no legacy file. Those returned openwork: {} and lost defaults like version, workspace metadata, reload metadata, and authorizedRoots.

## Validation
- apps/server: pnpm typecheck — pass
- apps/server: bun test src/openwork-config-db-migration.e2e.test.ts — 3 pass / 0 fail
- apps/server: bun test src/workspace-init.test.ts src/workspace-activate.e2e.test.ts src/runtime-opencode-config-store.test.ts src/authorized-folders.e2e.test.ts — 28 pass / 0 fail
- apps/server: bun test src/ — 252 pass / 2 skip / 0 fail


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

