### PR TITLE
fix(opencode): bump runtime for session schema compatibility

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -48,7 +48,7 @@
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@heroicons/react": "^2.2.0",
     "@lexical/react": "^0.35.0",
-    "@opencode-ai/sdk": "^1.17.3",
+    "@opencode-ai/sdk": "^1.17.11",
     "@openwork/types": "workspace:*",
     "@openwork/ui": "workspace:*",
     "@paper-design/shaders-react": "0.0.72",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,7 +23,7 @@
     "test": "node --test electron/runtime.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.17.3",
+    "@opencode-ai/sdk": "^1.17.11",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
     "electron-updater": "^6.3.9",

--- a/apps/opencode-router/package.json
+++ b/apps/opencode-router/package.json
@@ -44,7 +44,7 @@
     "test:npx": "bun scripts/test-npx.mjs"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.17.3",
+    "@opencode-ai/sdk": "^1.17.11",
     "@slack/socket-mode": "^2.0.5",
     "@slack/web-api": "^7.13.0",
     "commander": "^12.1.0",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.17.3",
+    "@opencode-ai/sdk": "^1.17.11",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
     "opencode-router": "0.17.2",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -46,7 +46,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.17.3",
+    "@opencode-ai/sdk": "^1.17.11",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
     "jsonc-parser": "^3.2.1",

--- a/constants.json
+++ b/constants.json
@@ -1,3 +1,3 @@
 {
-  "opencodeVersion": "v1.17.3"
+  "opencodeVersion": "v1.17.11"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^0.35.0
         version: 0.35.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.30)
       '@opencode-ai/sdk':
-        specifier: ^1.17.3
-        version: 1.17.3
+        specifier: ^1.17.11
+        version: 1.17.11
       '@openwork/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -218,8 +218,8 @@ importers:
   apps/desktop:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.17.3
-        version: 1.17.3
+        specifier: ^1.17.11
+        version: 1.17.11
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -261,8 +261,8 @@ importers:
   apps/opencode-router:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.17.3
-        version: 1.17.3
+        specifier: ^1.17.11
+        version: 1.17.11
       '@slack/socket-mode':
         specifier: ^2.0.5
         version: 2.0.5
@@ -295,8 +295,8 @@ importers:
   apps/orchestrator:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.17.3
-        version: 1.17.3
+        specifier: ^1.17.11
+        version: 1.17.11
       '@opentui/core':
         specifier: 0.1.77
         version: 0.1.77(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
@@ -341,8 +341,8 @@ importers:
   apps/server:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.17.3
-        version: 1.17.3
+        specifier: ^1.17.11
+        version: 1.17.11
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -2870,8 +2870,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opencode-ai/sdk@1.17.3':
-    resolution: {integrity: sha512-oXrEjOuP3+J9pPNw3cmOnRma/xiVQ4WIIvGd6YkhPQgqqi2PnD/b1qfNY0AMead3QfNhKwKdDM4QFJdN2LpByg==}
+  '@opencode-ai/sdk@1.17.11':
+    resolution: {integrity: sha512-UdSwnNM4/cD5rHnI8O7VaHuiwYnsEOglpRPVeeYE2S5Nm1K34ijCyZGDvBecb0ShdBQgn49XvyQWJH6cREsIPw==}
 
   '@opentelemetry/api-logs@0.207.0':
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
@@ -11546,7 +11546,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opencode-ai/sdk@1.17.3':
+  '@opencode-ai/sdk@1.17.11':
     dependencies:
       cross-spawn: 7.0.6
 


### PR DESCRIPTION
## Summary
- Bump the bundled OpenCode sidecar from `v1.17.3` to `v1.17.11`.
- Bump all direct `@opencode-ai/sdk` consumers to `^1.17.11` and update the lockfile.

## Why
- Closes #2370.
- Users can hit `SQLiteError: no such column: replacement_seq` when OpenWork's pinned OpenCode runtime handles a session prompt against a DB schema where upstream OpenCode has already removed that column.
- Upstream OpenCode v1.17.11 contains the migration/schema compatibility fix path noted in anomalyco/opencode#33898.

## Issue
- Closes #2370

## Scope
- OpenCode sidecar version pin in `constants.json`.
- Direct SDK dependency pins in app, desktop, server, orchestrator, and opencode-router packages.
- Minimal lockfile update for `@opencode-ai/sdk@1.17.11`.

## Out of scope
- No OpenWork session UI or server route behavior changes.
- No OpenCode DB repair/migration code in OpenWork.

## Testing
### Ran
- `pnpm install --frozen-lockfile --ignore-scripts --store-dir ../pnpm-store`
- `git diff --check`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/desktop typecheck:electron`
- `pnpm --filter opencode-router typecheck`
- `pnpm --filter openwork-orchestrator typecheck`
- `PATH=$PWD/../opencode-bin/extract:$PATH HOME=$PWD/../opencode-e2e-home XDG_DATA_HOME=$PWD/../opencode-e2e-data XDG_CONFIG_HOME=$PWD/../opencode-e2e-config OPENCODE_DISABLE_AUTOUPDATE=1 OPENCODE_CHANNEL=local OPENCODE_CLIENT=openwork-e2e node apps/app/scripts/e2e.mjs --dir "$PWD"`
- `sqlite3 ../opencode-e2e-data/opencode/opencode.db "pragma table_info('session_context_epoch');"`

### Result
- pass: frozen lockfile install reported lockfile up to date and supply-chain policy passed.
- pass: all five SDK consumers typechecked.
- pass: real OpenCode v1.17.11 smoke returned `healthy: true`, created a session, ran `session.prompt noReply`, and wrote 1 message.
- pass: the smoke DB's `session_context_epoch` columns were `session_id`, `baseline`, `snapshot`, `baseline_seq`; `replacement_seq` was absent while prompt write still succeeded.

## CI status
- pass: not run remotely yet; local gates above passed.
- code-related failures: none observed.
- external/env/auth blockers: full AI model call skipped because the regression is in prompt/session DB setup and the local smoke intentionally used `noReply` to avoid requiring provider credentials.

## Manual verification
1. Downloaded the v1.17.11 darwin-arm64 OpenCode release asset used by `constants.json`.
2. Started `opencode serve` from that binary with isolated HOME/XDG dirs.
3. Verified `session.prompt noReply` succeeds on a DB schema without `replacement_seq`.

## Evidence
- Runtime smoke output: `health.version = 1.17.11`, `session.prompt noReply` status `ok`, message count `1`.
- Schema check: `session_context_epoch` has no `replacement_seq` column.
- Video/screenshot: N/A; this is a backend/runtime DB compatibility path validated by scripted smoke output.

## Risk
- Low-to-medium: this updates the embedded OpenCode runtime across OpenWork consumers. Typechecks passed and the release asset exists for supported sidecar platforms.

## Rollback
- Revert this PR to restore OpenCode/SDK `1.17.3` pins.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

