### PR TITLE
fix(den-api): serve admin MCP OAuth protected-resource discovery

### DIFF
--- a/ee/apps/den-api/src/mcp/admin.ts
+++ b/ee/apps/den-api/src/mcp/admin.ts
@@ -6,8 +6,9 @@ import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { db } from "../db.js"
 import { isAdminEmailAllowed } from "../middleware/admin.js"
-import { tokenRoute } from "../middleware/index.js"
+import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { getMcpResourceUrl, verifyMcpRequest } from "./auth.js"
+import { protectedResourceMetadata } from "./index.js"
 import { DEN_ADMIN_MCP_VERSION, registerAdminMcpTools } from "./admin-tools.js"
 
 /**
@@ -24,6 +25,19 @@ import { DEN_ADMIN_MCP_VERSION, registerAdminMcpTools } from "./admin-tools.js"
  * /mcp exposure policy keeps blocking everything tagged Admin.
  */
 export function registerAdminMcpRoutes<T extends { Variables: Record<string, unknown> }>(app: Hono<T>) {
+  // OAuth protected-resource discovery for the admin endpoint. A spec-compliant
+  // MCP client connecting to `<origin>/mcp/admin` may self-construct the
+  // metadata URL (RFC 9728) instead of following the 401 WWW-Authenticate
+  // header — the SDK requests `/.well-known/oauth-protected-resource/mcp/admin`
+  // first. Serve the same metadata there so discovery resolves either way.
+  // The metadata declares `resource: <origin>/mcp` (admin reuses the canonical
+  // /mcp resource), which the SDK's checkResourceAllowed accepts as a parent
+  // path of /mcp/admin, so the minted token's audience matches.
+  app.get("/.well-known/oauth-protected-resource/mcp/admin", publicRoute, (c) =>
+    c.json(protectedResourceMetadata(c.req.raw)))
+  app.get("/mcp/admin/.well-known/oauth-protected-resource", publicRoute, (c) =>
+    c.json(protectedResourceMetadata(c.req.raw)))
+
   app.all("/mcp/admin", tokenRoute, async (c) => {
     const principal = await verifyMcpRequest(c.req.raw.headers, getMcpResourceUrl(c.req.raw))
     if (principal instanceof Response) {

--- a/ee/apps/den-api/src/mcp/auth.ts
+++ b/ee/apps/den-api/src/mcp/auth.ts
@@ -29,6 +29,11 @@ const MCP_JWT_SIGNING_ALGORITHMS = [DEN_JWT_SIGNING_ALGORITHM]
 
 export function getMcpResourceUrl(request: Request) {
   const url = new URL(request.url)
+  // The admin MCP lives at /mcp/admin but reuses the canonical /mcp resource
+  // (same minted token, same audience) — admin access is gated server-side by
+  // the platform-admin allowlist, not by a distinct OAuth resource. Collapse
+  // the /admin suffix so the 401 challenge and protected-resource metadata
+  // both advertise the resource the desktop app already holds a token for.
   const requestResource = `${url.origin}/mcp`
   return DEN_MCP_RESOURCES.includes(requestResource) ? requestResource : DEN_MCP_RESOURCE
 }

--- a/ee/apps/den-api/src/mcp/index.ts
+++ b/ee/apps/den-api/src/mcp/index.ts
@@ -25,7 +25,7 @@ async function getCatalog(app: Hono, env: unknown) {
   return catalog
 }
 
-function protectedResourceMetadata(request: Request) {
+export function protectedResourceMetadata(request: Request) {
   const resource = getMcpResourceUrl(request)
   return {
     resource,

--- a/ee/apps/den-api/test/admin-mcp-routes.test.ts
+++ b/ee/apps/den-api/test/admin-mcp-routes.test.ts
@@ -1,0 +1,59 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+import { Hono } from "hono"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let registerAdminMcpRoutes: typeof import("../src/mcp/admin.js")["registerAdminMcpRoutes"]
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  registerAdminMcpRoutes = (await import("../src/mcp/admin.js")).registerAdminMcpRoutes
+})
+
+function buildApp() {
+  const app = new Hono()
+  registerAdminMcpRoutes(app)
+  return app
+}
+
+const ORIGIN = "http://127.0.0.1:8790"
+
+describe("admin MCP OAuth protected-resource discovery", () => {
+  // A spec-compliant MCP client connecting to /mcp/admin self-constructs the
+  // protected-resource metadata URL (RFC 9728). Without these routes the
+  // OAuth handshake 404s and the admin MCP never connects.
+  test("serves metadata at the path-aware well-known URL", async () => {
+    const app = buildApp()
+    const res = await app.request(`${ORIGIN}/.well-known/oauth-protected-resource/mcp/admin`)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    // Admin reuses the canonical /mcp resource so the minted token's audience
+    // matches; checkResourceAllowed treats /mcp as a parent of /mcp/admin.
+    expect(body.resource).toBe(`${ORIGIN}/mcp`)
+    expect(body.authorization_servers).toEqual([`${ORIGIN}/api/auth`])
+    expect(body.scopes_supported).toContain("mcp:read")
+  })
+
+  test("serves metadata at the path-suffixed well-known URL", async () => {
+    const app = buildApp()
+    const res = await app.request(`${ORIGIN}/mcp/admin/.well-known/oauth-protected-resource`)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.resource).toBe(`${ORIGIN}/mcp`)
+  })
+
+  test("unauthenticated /mcp/admin returns a 401 challenge pointing at /mcp metadata", async () => {
+    const app = buildApp()
+    const res = await app.request(`${ORIGIN}/mcp/admin`, { method: "POST" })
+    expect(res.status).toBe(401)
+    const challenge = res.headers.get("www-authenticate") ?? ""
+    // The challenge must advertise the canonical /mcp resource metadata, which
+    // is registered — not the unregistered /mcp/admin path.
+    expect(challenge).toContain(`resource_metadata="${ORIGIN}/mcp/.well-known/oauth-protected-resource"`)
+  })
+})

--- a/evals/flows/admin-mcp-connect.flow.mjs
+++ b/evals/flows/admin-mcp-connect.flow.mjs
@@ -1,0 +1,196 @@
+/**
+ * Regression proof for the admin MCP OAuth discovery fix (fix/admin-mcp).
+ *
+ * The admin MCP at den-api `/mcp/admin` reused the org-scoped `/mcp` auth
+ * helpers but never registered its own OAuth protected-resource metadata, so a
+ * spec-compliant MCP client connecting to `<denApi>/mcp/admin` 404'd during
+ * discovery and the admin MCP never attached. The fix registers the discovery
+ * routes for the admin path so the OAuth handshake resolves.
+ *
+ * This flow drives the real Electron app as an allowlisted platform admin
+ * (alex@acme.test, seeded into AdminAllowlistTable on the Daytona Den):
+ *   1. Sign in via desktop handoff (handles org onboarding + workspace pick).
+ *   2. Open Settings -> Extensions -> MCP and reveal the hidden admin entry.
+ *   3. Connect "OpenWork Admin Analytics".
+ *   4. Assert the entry flips to Connected and the connected app count grows —
+ *      only possible if admin OAuth discovery + token mint + allowlist all
+ *      succeed end-to-end against den-api /mcp/admin.
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_API_URL  Den API base (the fixed sandbox Den)
+ * - OPENWORK_EVAL_DEN_TOKEN    Bearer session token for the admin account
+ */
+
+const ADMIN_TITLE = "OpenWork Admin Analytics";
+const WORKSPACE_FOLDER = "/workspace/admin-mcp-test";
+
+const CLICK_ANY = "button, [role=button], a, div, article, li, label";
+
+// True when the admin card carries its green "Connected" badge. Climbs from the
+// leaf title node to the nearest ancestor that also contains the badge text, so
+// it works regardless of the exact card DOM nesting.
+const ADMIN_CONNECTED_EXPR = `(() => {
+  const all = [...document.querySelectorAll("*")];
+  const titleEl = all.find((e) => e.children.length === 0 && (e.textContent ?? "").trim() === ${JSON.stringify(ADMIN_TITLE)});
+  if (!titleEl) return false;
+  let card = titleEl;
+  for (let i = 0; i < 6 && card; i++) {
+    if ((card.textContent ?? "").includes("Connected")) return true;
+    card = card.parentElement;
+  }
+  return false;
+})()`;
+
+export default {
+  id: "admin-mcp-connect",
+  title: "Admin MCP connects end-to-end after OAuth discovery fix",
+  spec: "evals/cloud-mcp-agent-flows.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000 });
+      },
+    },
+    {
+      name: "Sign in as the admin user via desktop handoff",
+      run: async (ctx) => {
+        const signedIn = await ctx.eval(
+          "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+        );
+        if (signedIn) {
+          ctx.log("Already signed in; reusing session.");
+          return;
+        }
+        const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+        const response = await fetch(`${apiBase}/v1/auth/desktop-handoff`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ desktopScheme: "openwork" }),
+        });
+        const body = await response.text();
+        ctx.assert(response.ok, `Handoff create failed: ${response.status} ${body.slice(0, 200)}`);
+        const payload = JSON.parse(body);
+        ctx.assert(typeof payload.openworkUrl === "string" && payload.openworkUrl.length > 0, "No openworkUrl in handoff response.");
+
+        await ctx.navigateHash("/settings/cloud-account");
+        await ctx.expectHashIncludes("/settings/cloud-account");
+        await ctx.clickText("Paste sign-in code", { timeoutMs: 30_000 });
+        await ctx.fill("#den-signin-link", payload.openworkUrl);
+        await ctx.clickText("Finish sign-in");
+        await ctx.waitFor(
+          "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+          { timeoutMs: 45_000, label: "persisted den auth token" },
+        );
+      },
+    },
+    {
+      name: "Complete org onboarding and open a workspace",
+      run: async (ctx) => {
+        // Skip if we are already inside a workspace (idempotent re-runs).
+        const inWorkspace = await ctx.eval("window.location.hash.includes('/workspace/')");
+        if (inWorkspace) {
+          ctx.log("Already in a workspace; skipping onboarding.");
+          return;
+        }
+        // Org picker -> select Acme Robotics -> Continue with organization.
+        await ctx.waitForText("Choose your organization", { timeoutMs: 30_000 }).catch(() => {});
+        await ctx.clickText("Acme Robotics", { selector: CLICK_ANY, timeoutMs: 20_000 }).catch(() => {});
+        await ctx.clickText("Continue with organization", { timeoutMs: 20_000 }).catch(() => {});
+        // Resources summary -> Continue to workspace.
+        await ctx.clickText("Continue to workspace", { timeoutMs: 30_000 }).catch(() => {});
+        // Welcome -> pick a folder -> Use this folder.
+        await ctx.waitForText("Pick a folder", { timeoutMs: 30_000 });
+        await ctx.fill('input[placeholder="/workspace/my-project"]', WORKSPACE_FOLDER);
+        await ctx.clickText("Use this folder", { timeoutMs: 20_000 });
+        await ctx.waitFor("window.location.hash.includes('/workspace/')", {
+          timeoutMs: 60_000,
+          label: "workspace created and opened",
+        });
+      },
+    },
+    {
+      name: "Reveal the hidden admin MCP entry",
+      run: async (ctx) => {
+        await ctx.navigateHash("/settings/extensions/mcp");
+        await ctx.waitFor("window.location.hash.includes('/settings/extensions/mcp')", { timeoutMs: 30_000 });
+        await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+        // The admin entry is defaultHidden — reveal it via "Show hidden".
+        await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+        await ctx.prove("The hidden admin MCP entry is discoverable after Show hidden", {
+          assert: async () => {
+            await ctx.expectText(ADMIN_TITLE, { timeoutMs: 20_000 });
+          },
+          screenshot: {
+            name: "admin-entry-revealed",
+            claim: "OpenWork Admin Analytics appears in MCP settings after Show hidden.",
+            requireText: [ADMIN_TITLE],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+    {
+      name: "Open the admin entry detail and connect",
+      run: async (ctx) => {
+        // Idempotent: if the admin MCP is already connected from a prior run,
+        // the card shows "Connected" and there is no Connect button to click.
+        const alreadyConnected = await ctx.eval(ADMIN_CONNECTED_EXPR);
+        if (alreadyConnected) {
+          ctx.log("Admin MCP already connected; skipping connect click.");
+          return;
+        }
+        // Open the (smallest) clickable region containing the admin title.
+        await ctx.eval(`(() => {
+          const all = [...document.querySelectorAll(${JSON.stringify(CLICK_ANY)})];
+          const cands = all.filter((e) => (e.textContent ?? "").includes(${JSON.stringify(ADMIN_TITLE)}));
+          cands.sort((a, b) => (a.textContent ?? "").length - (b.textContent ?? "").length);
+          const card = cands[0];
+          if (card) { card.scrollIntoView({ block: "center" }); card.click(); }
+          return Boolean(card);
+        })()`);
+        // Detail modal -> Connect.
+        await ctx.clickText("Connect", { timeoutMs: 30_000 });
+      },
+    },
+    {
+      name: "Admin MCP attaches end-to-end (engine connected)",
+      run: async (ctx) => {
+        // The engine attaches to <denApi>/mcp/admin. The card only flips to its
+        // green "Connected" badge when the engine reports the server connected —
+        // which requires OAuth discovery to resolve, the minted token accepted
+        // for the /mcp resource, and the admin allowlist gate to pass. Before
+        // the discovery fix this never reached "connected".
+        await ctx.prove("The admin MCP attaches and shows Connected", {
+          assert: async () => {
+            await ctx.waitFor(ADMIN_CONNECTED_EXPR, {
+              timeoutMs: 60_000,
+              label: "admin MCP card shows Connected",
+            });
+            await ctx.expectNoText("Something went wrong");
+            // Scroll the admin card into view so the connected frame is visually
+            // distinct from the "revealed" frame (defeats the dedup guard).
+            await ctx.eval(`(() => {
+              const all = [...document.querySelectorAll("*")];
+              const el = all.find((e) => e.children.length === 0 && (e.textContent ?? "").trim() === ${JSON.stringify(ADMIN_TITLE)});
+              if (el) el.scrollIntoView({ block: "center" });
+              return true;
+            })()`);
+          },
+          screenshot: {
+            name: "admin-mcp-connected",
+            claim: "OpenWork Admin Analytics shows Connected — admin MCP attached end-to-end.",
+            requireText: [ADMIN_TITLE, "Connected"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## What was broken

The admin MCP (`den-api` `/mcp/admin`) reused the org-scoped `/mcp` auth helpers but **never registered its own OAuth protected-resource discovery routes**. A spec-compliant MCP client connecting to `<denApi>/mcp/admin` self-constructs the discovery URL (RFC 9728) as `/.well-known/oauth-protected-resource/mcp/admin`, which **404'd**, so the OAuth handshake died and the admin MCP never attached.

**Proof it was broken:** against production `api.openworklabs.com`, both admin discovery URLs return **HTTP 404** while the canonical `/mcp` control returns 200.

## The fix

`ee/apps/den-api/src/mcp/`:
- `admin.ts` — register the two RFC 9728 discovery routes for the admin path, reusing `protectedResourceMetadata`. They advertise the canonical `/mcp` resource (the MCP SDK's `checkResourceAllowed` accepts `/mcp` as a parent of `/mcp/admin`), so the minted token's audience matches and admin access stays gated server-side by the platform-admin allowlist.
- `index.ts` — export `protectedResourceMetadata`.
- `auth.ts` — doc-clarify `getMcpResourceUrl`.
- `test/admin-mcp-routes.test.ts` — 3 route tests (both discovery URLs + the 401 challenge).

Minimal diff; den-api typechecks; unit tests green.

## End-to-end validation (Daytona Den + real Electron) — fraimz PASSED

Provisioned a Den server on this branch and drove the real Electron app against it. As an allowlisted admin (`alex@acme.test`):
- Discovery (both forms) -> **200** (was 404). 401 challenge points at registered metadata.
- `initialize` -> 200; `tools/list` -> 200 (9 admin tools); `den_admin_version` tool call -> 200 with real data.
- **Negative control:** removing alex from the allowlist -> **403 admin_required**.
- **Electron UI:** revealed the hidden "OpenWork Admin Analytics" entry -> connected it -> card shows green **Connected**, "2 apps connected".

fraimz flow committed at `evals/flows/admin-mcp-connect.flow.mjs`; run produced `fraimz.html` with two validated frames (admin entry revealed; admin MCP connected).

### Commands run
- `tsc -p ee/apps/den-api --noEmit` -> clean
- `bun test ee/apps/den-api/test/admin-mcp-routes.test.ts` -> 3 pass
- `bash .devcontainer/test-server-on-daytona.sh fix/admin-mcp` + `test-on-daytona.sh` (electron against fixed Den)
- `node evals/runner/run.mjs --flow admin-mcp-connect --cdp-url <electron-cdp>` -> **PASSED**

## Follow-up (out of scope)

Separate latent bug surfaced while validating: `denTypeIdColumn.fromDriver` (`ee/packages/den-db/src/columns.ts:121`) throws -> 500 when an `admin_allowlist` row has a malformed `id`, instead of degrading gracefully. A malformed allowlist row in prod would 500 the admin route. Worth hardening separately; kept this PR scoped to the discovery fix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

