### PR TITLE
fix(den-api): shorten cloud MCP tool names for Bedrock

### DIFF
--- a/ee/apps/den-api/src/mcp/catalog.ts
+++ b/ee/apps/den-api/src/mcp/catalog.ts
@@ -4,6 +4,65 @@ import { isMcpOperationAllowed, type OpenApiOperation } from "./policy.js"
 
 const METHODS = new Set(["get", "post", "put", "patch", "delete"])
 
+// AWS Bedrock's Converse API rejects any `toolConfig.tools.*.member.toolSpec.name`
+// longer than 64 characters. MCP clients namespace our tools as
+// `<serverName>_<name>` (e.g. `openwork-cloud_` adds 15 chars), so the raw
+// operationId budget is even tighter. We keep the registered tool name well
+// under 64 so the prefixed name still validates on Bedrock.
+export const BEDROCK_MAX_TOOL_NAME_LENGTH = 64
+export const MAX_CLIENT_PREFIX = "openwork-cloud_".length // 15
+export const MAX_TOOL_NAME_LENGTH = BEDROCK_MAX_TOOL_NAME_LENGTH - MAX_CLIENT_PREFIX // 49
+
+// Generated operationIds are verbose and structured: `<verb>V1<Resource>By<Param>Id<Sub>...`.
+// The `V1` version marker and the `By<Param>Id` path-param restatements carry no
+// meaning for a model choosing a tool; it reasons about verb + resource nouns.
+// Stripping them yields short, unique, human-readable names (e.g.
+// `deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId` ->
+// `deleteConnectorInstancesAccess`) that an LLM recognizes far more reliably
+// than a truncated+hashed name.
+function structuralShorten(name: string): string {
+  return name
+    .replace(/^(get|post|put|patch|delete)V1/, "$1") // version marker is irrelevant to tool selection
+    .replace(/By[A-Z][a-zA-Z]*?Id/g, "") // drop "ByConfigObjectId" path-param markers
+}
+
+// Deterministic, stable short hash (FNV-1a, base36) used only as a last-resort
+// fallback when two structurally-shortened names collide. Stable across runs so
+// tool identities don't churn between deploys.
+function shortHash(value: string): string {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+// Produce the registered MCP tool name. Structurally shortens every name for a
+// clean, consistent catalog, then disambiguates against `taken` with a short
+// deterministic hash suffix only if two operationIds collapse to the same name.
+//
+// Note: this does NOT silently truncate over-length names. If structural
+// shortening cannot fit the budget, buildMcpCatalog's guard throws so the
+// regression is fixed in structuralShorten() rather than shipped as a
+// hard-to-read hashed name. See the guard in buildMcpCatalog.
+export function shortenToolName(operationId: string, taken?: ReadonlySet<string>): string {
+  const base = structuralShorten(operationId)
+  if (!taken?.has(base)) {
+    return base
+  }
+  // Deterministic disambiguation: append a stable hash of the full operationId.
+  const suffix = `_${shortHash(operationId)}`
+  let name = `${base.slice(0, Math.max(1, MAX_TOOL_NAME_LENGTH - suffix.length))}${suffix}`
+  let salt = 1
+  while (taken.has(name)) {
+    const salted = `_${shortHash(`${operationId}#${salt}`)}`
+    name = `${base.slice(0, Math.max(1, MAX_TOOL_NAME_LENGTH - salted.length))}${salted}`
+    salt += 1
+  }
+  return name
+}
+
 type OpenApiDocument = {
   paths?: Record<string, Record<string, OpenApiOperation>>
 }
@@ -196,13 +255,26 @@ export function buildMcpCatalog(document: OpenApiDocument): McpToolOperation[] {
         continue
       }
 
-      const name = operation.operationId
-      if (!name) {
+      const operationId = operation.operationId
+      if (!operationId) {
         continue
       }
 
+      const name = shortenToolName(operationId, names)
       if (names.has(name)) {
-        throw new Error(`Duplicate MCP tool operationId: ${name}`)
+        throw new Error(`Duplicate MCP tool name after shortening: ${name} (operationId: ${operationId})`)
+      }
+
+      // Guard against future regressions: a tool name that overflows the client
+      // prefix budget (e.g. `openwork-cloud_` + name > 64) is rejected by AWS
+      // Bedrock's Converse API and breaks every Bedrock model. Surface it here,
+      // at catalog-build time (covered by tests/CI), instead of in production.
+      const prefixedLength = MAX_CLIENT_PREFIX + name.length
+      if (name.length > MAX_TOOL_NAME_LENGTH) {
+        throw new Error(
+          `MCP tool name too long for Bedrock: "${name}" (${prefixedLength} chars prefixed, max 64; operationId: ${operationId}). ` +
+            `Adjust structuralShorten() in catalog.ts.`,
+        )
       }
       names.add(name)
 

--- a/ee/apps/den-api/test/mcp-tool-name-length.test.ts
+++ b/ee/apps/den-api/test/mcp-tool-name-length.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "bun:test"
+import {
+  BEDROCK_MAX_TOOL_NAME_LENGTH,
+  buildMcpCatalog,
+  MAX_CLIENT_PREFIX,
+  MAX_TOOL_NAME_LENGTH,
+  shortenToolName,
+} from "../src/mcp/catalog.js"
+
+// AWS Bedrock's Converse API rejects toolConfig.tools.*.member.toolSpec.name
+// longer than 64 chars. MCP clients namespace tools as `<serverName>_<name>`;
+// the OpenWork Cloud client uses the `openwork-cloud_` prefix (15 chars), so
+// the registered name must stay <= 49 so the prefixed name validates.
+const CLIENT_PREFIX = "openwork-cloud_"
+
+test("budget constants leave room for the client prefix", () => {
+  expect(CLIENT_PREFIX.length).toBe(MAX_CLIENT_PREFIX)
+  expect(MAX_CLIENT_PREFIX + MAX_TOOL_NAME_LENGTH).toBe(BEDROCK_MAX_TOOL_NAME_LENGTH)
+})
+
+test("structural shortening drops V1 and path-param markers", () => {
+  expect(shortenToolName("getV1Organization")).toBe("getOrganization")
+  expect(shortenToolName("deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId")).toBe(
+    "deleteConnectorInstancesAccess",
+  )
+})
+
+test("shortened names stay within the Bedrock budget once prefixed", () => {
+  const short = shortenToolName("deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId")
+  expect(short.length).toBeLessThanOrEqual(MAX_TOOL_NAME_LENGTH)
+  expect((CLIENT_PREFIX + short).length).toBeLessThanOrEqual(BEDROCK_MAX_TOOL_NAME_LENGTH)
+})
+
+test("near-duplicate operationIds resolve to distinct, readable names", () => {
+  const a = shortenToolName("getV1ConnectorInstancesByConnectorInstanceIdAccess")
+  const b = shortenToolName("getV1ConnectorInstancesByConnectorInstanceIdConfiguration")
+  expect(a).toBe("getConnectorInstancesAccess")
+  expect(b).toBe("getConnectorInstancesConfiguration")
+  expect(a).not.toBe(b)
+})
+
+test("shortening is deterministic", () => {
+  const id = "deleteV1MarketplacesByMarketplaceIdPluginsByPluginId"
+  expect(shortenToolName(id)).toBe(shortenToolName(id))
+})
+
+test("collisions against taken names fall back to a unique suffix", () => {
+  const taken = new Set(["getOrganization"])
+  const name = shortenToolName("getV1Organization", taken)
+  expect(name).not.toBe("getOrganization")
+  expect(taken.has(name)).toBe(false)
+})
+
+test("every catalog tool name fits Bedrock once client-prefixed", () => {
+  // Reproduces the exact paths from Felix's Praxis Medicines Bedrock 400.
+  const op = (operationId: string) => ({ operationId, "x-mcp": true })
+  const document = {
+    paths: {
+      "/v1/config-objects/:configObjectId/access/:grantId": {
+        delete: op("deleteV1ConfigObjectsByConfigObjectIdAccessByGrantId"),
+      },
+      "/v1/config-objects/:configObjectId/plugins/:pluginId": {
+        delete: op("deleteV1ConfigObjectsByConfigObjectIdPluginsByPluginId"),
+      },
+      "/v1/connector-instances/:connectorInstanceId/access/:grantId": {
+        delete: op("deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId"),
+      },
+      "/v1/llm-providers/:llmProviderId/access/:accessId": {
+        delete: op("deleteV1LlmProvidersByLlmProviderIdAccessByAccessId"),
+      },
+      "/v1/marketplaces/:marketplaceId/access/:grantId": {
+        delete: op("deleteV1MarketplacesByMarketplaceIdAccessByGrantId"),
+      },
+      "/v1/marketplaces/:marketplaceId/plugins/:pluginId": {
+        delete: op("deleteV1MarketplacesByMarketplaceIdPluginsByPluginId"),
+      },
+      "/v1/plugins/:pluginId/config-objects/:configObjectId": {
+        delete: op("deleteV1PluginsByPluginIdConfigObjectsByConfigObjectId"),
+      },
+      "/v1/config-objects/:configObjectId/versions/:versionId": {
+        get: op("getV1ConfigObjectsByConfigObjectIdVersionsByVersionId"),
+      },
+      "/v1/connector-instances/:connectorInstanceId/access": {
+        get: op("getV1ConnectorInstancesByConnectorInstanceIdAccess"),
+      },
+      "/v1/connector-instances/:connectorInstanceId/configuration": {
+        get: op("getV1ConnectorInstancesByConnectorInstanceIdConfiguration"),
+      },
+    },
+  }
+
+  const catalog = buildMcpCatalog(document)
+  expect(catalog.length).toBe(10)
+
+  const names = new Set<string>()
+  for (const tool of catalog) {
+    const prefixed = CLIENT_PREFIX + tool.name
+    expect(prefixed.length).toBeLessThanOrEqual(BEDROCK_MAX_TOOL_NAME_LENGTH)
+    expect(names.has(tool.name)).toBe(false)
+    names.add(tool.name)
+  }
+})
+
+test("buildMcpCatalog guard throws if a name overflows the Bedrock budget", () => {
+  // A pathological operationId that survives structural shortening yet is still
+  // far too long must be caught at build time, not in production.
+  const tooLong = `getV2${"X".repeat(80)}` // no V1 / ByXId markers to strip
+  const document = {
+    paths: { "/v2/x": { get: { operationId: tooLong, "x-mcp": true } } },
+  }
+  expect(() => buildMcpCatalog(document)).toThrow(/too long for Bedrock/)
+})


### PR DESCRIPTION
## Summary
- structurally shorten Den API MCP tool names for the OpenWork Cloud catalog (drop V1 and By<Param>Id noise)
- keep names model-readable while fitting Bedrock's 64-char `toolSpec.name` limit after the `openwork-cloud_` client prefix
- add a catalog-build guard so future over-length names fail in tests/CI instead of as Bedrock 400s in production
- add focused regression coverage using the exact Praxis/Bedrock failing operationIds

## Validation
- `bun test test/mcp-tool-name-length.test.ts` - pass (8 tests)
- `bun test test/mcp-invoke-body.test.ts test/mcp-scopes.test.ts test/route-access-policy.test.ts test/mcp-resource.test.ts` - pass (19 tests)
- `pnpm exec tsc --noEmit -p tsconfig.json` - pass
- `git diff --check -- ee/apps/den-api/src/mcp/catalog.ts ee/apps/den-api/test/mcp-tool-name-length.test.ts` - pass

## E2E proof
- No real Bedrock Converse e2e/fraimz run was captured in this workspace because no Bedrock credentials/provider were available. The unit regression reproduces the exact over-limit operationIds and asserts the prefixed names stay within Bedrock's 64-char limit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

