### PR TITLE
fix(landing): serve bootstrap assets

### DIFF
--- a/ee/apps/landing/app/install.sh/route.ts
+++ b/ee/apps/landing/app/install.sh/route.ts
@@ -12,6 +12,7 @@
 //   curl -fsSLo /tmp/openwork-install.sh https://openworklabs.com/install.sh
 //   less /tmp/openwork-install.sh
 //   sh /tmp/openwork-install.sh
+export const dynamic = "force-static";
 
 const installScript = `#!/usr/bin/env sh
 # OpenWork bootstrap installer.
@@ -59,18 +60,12 @@ if [ ! -s "$TMP_CLI" ]; then
 fi
 chmod 0755 "$TMP_CLI"
 
-# Use the CLI's own installer to copy itself into place and write the wrapper +
-# install manifest so the layout matches \`openwork-bootstrap doctor\`.
-node "$TMP_CLI" install \\
-  --source "$TMP_CLI" \\
-  --install-dir "$INSTALL_DIR" \\
-  --bin-dir "$BIN_DIR" \\
-  --json
+node "$TMP_CLI" install --source "$TMP_CLI" --install-dir "$INSTALL_DIR" --bin-dir "$BIN_DIR" --json
 
 echo
 echo "Installed openwork-bootstrap into $BIN_DIR."
 echo "If 'openwork-bootstrap' is not found, add $BIN_DIR to your PATH:"
-echo "  export PATH=\\"$BIN_DIR:\\$PATH\\""
+echo "  export PATH=$BIN_DIR"':$PATH'
 echo
 echo "Verify with:"
 echo "  openwork-bootstrap doctor --json"

--- a/ee/apps/landing/app/openwork-bootstrap.mjs/route.ts
+++ b/ee/apps/landing/app/openwork-bootstrap.mjs/route.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const dynamic = "force-static";
+
+function readBootstrapCli() {
+  return readFileSync(join(process.cwd(), "..", "..", "..", "packages", "openwork-bootstrap", "bin", "openwork.mjs"), "utf8");
+}
+
+export function GET() {
+  return new Response(readBootstrapCli(), {
+    headers: {
+      "content-type": "application/javascript; charset=utf-8",
+      "cache-control": "public, max-age=300, stale-while-revalidate=3600",
+    },
+  });
+}

--- a/ee/apps/landing/app/start.md/route.ts
+++ b/ee/apps/landing/app/start.md/route.ts
@@ -1,120 +1,17 @@
-const startMarkdown = `# OpenWork Start
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
-You are an agent helping a user install and set up OpenWork.
+export const dynamic = "force-static";
 
-Goal: install OpenWork, create or sign in to an OpenWork Cloud account, create a workspace organization, invite a teammate, create a first skill, prepare the desktop app with that account/org/skill, and verify the running app opens already signed in.
-
-> The bootstrap command is \`openwork-bootstrap\` (NOT \`openwork\`). The bare
-> \`openwork\` command belongs to the separate \`openwork-orchestrator\` package and
-> may already be on the user's PATH — do not use it for these steps.
-
-## 1. Install CLI
-
-Install the \`openwork-bootstrap\` CLI into a user-writable bin dir.
-
-Production path: download the script, inspect it, then run it. Do not pipe remote
-scripts directly into a shell.
-
-\`\`\`bash
-curl -fsSLo /tmp/openwork-install.sh https://openworklabs.com/install.sh
-less /tmp/openwork-install.sh
-sh /tmp/openwork-install.sh
-\`\`\`
-
-This installs \`openwork-bootstrap\` into \`$HOME/.local/bin\`. If that dir is not on
-your PATH, either add it or call the binary by its full path.
-
-If working from the OpenWork repository locally:
-
-\`\`\`bash
-node packages/openwork-bootstrap/bin/openwork.mjs install \\
-  --install-dir "$HOME/.openwork/bootstrap" \\
-  --bin-dir "$HOME/.local/bin" \\
-  --json
-\`\`\`
-
-Verify:
-
-\`\`\`bash
-openwork-bootstrap doctor --json
-\`\`\`
-
-## 2. Install App
-
-Install the desktop app for this OS from the manifest:
-
-\`\`\`bash
-openwork-bootstrap install app \\
-  --manifest https://openworklabs.com/install-manifest.json \\
-  --json
-\`\`\`
-
-Verify:
-
-\`\`\`bash
-openwork-bootstrap doctor --app --json
-\`\`\`
-
-## 3. Create Cloud Workspace
-
-Ask the user for the owner email, workspace name, and teammate email to invite. Generate a strong password locally unless the user provides one. Do not print the password or token in the final response.
-
-\`\`\`bash
-OPENWORK_OWNER_PASSWORD="<generated-password>" \\
-openwork-bootstrap cloud onboard \\
-  --base-url https://app.openworklabs.com \\
-  --owner-email "<owner-email>" \\
-  --org-name "<workspace-name>" \\
-  --invite-email "<teammate-email>" \\
-  --skill-name "First OpenWork Skill" \\
-  --prepare-desktop \\
-  --json
-\`\`\`
-
-## 4. Success Criteria
-
-You are done only when all are true:
-
-- \`openwork-bootstrap doctor --json\` returns \`ok: true\`
-- \`openwork-bootstrap doctor --app --json\` returns \`ok: true\`
-- \`openwork-bootstrap cloud onboard ... --json\` returns:
-  - \`ok: true\`
-  - \`organization.id\` is present
-  - \`invitation.invitationId\` is present
-  - \`skill.id\` is present
-  - \`skillRun.triggered\` is \`true\`
-  - \`skillRun.output\` is \`OPENWORK_BOOTSTRAP_SKILL_TRIGGERED\`
-  - \`desktop.prepared\` is \`true\`
-  - \`desktop.bootstrapPath\` is present
-  - \`desktop.skillPath\` is present
-- \`openwork-bootstrap doctor --desktop-bootstrap --json\` returns \`ok: true\`
-- When the desktop app is launched, it opens already signed in and lands on the
-  onboarding screen showing a green "Setup complete" banner, the organization
-  name, and a "First skill ready" tile with the skill created by the CLI.
-
-## 5. If Something Fails
-
-- If CLI install fails: report OS, shell, command, and stderr.
-- If the \`openwork-bootstrap\` command is not found after install: ensure
-  \`$HOME/.local/bin\` is on PATH, or call the binary by its full path
-  (\`$HOME/.local/bin/openwork-bootstrap\`).
-- If app install fails: run \`openwork-bootstrap doctor --app --json\` and report failed checks.
-- If signup says the email already exists: ask the user whether to sign in instead.
-- If invite accept returns \`email_verification_required\`: tell the invited user to verify email before joining.
-
-## 6. Constraints
-
-- Do not require admin privileges.
-- Prefer user-local install paths.
-- Do not print passwords or tokens in final output.
-- Report exactly what was installed and where.
-`;
+function readBootstrapFile(...segments: string[]) {
+  return readFileSync(join(process.cwd(), "..", "..", "..", "packages", "openwork-bootstrap", ...segments), "utf8");
+}
 
 export function GET() {
-  return new Response(startMarkdown, {
+  return new Response(readBootstrapFile("start.md"), {
     headers: {
       "content-type": "text/markdown; charset=utf-8",
-      "cache-control": "public, max-age=300, stale-while-revalidate=3600"
-    }
+      "cache-control": "public, max-age=300, stale-while-revalidate=3600",
+    },
   });
 }

--- a/packages/openwork-bootstrap/start.md
+++ b/packages/openwork-bootstrap/start.md
@@ -2,14 +2,13 @@
 
 You are an agent helping a user install and set up OpenWork.
 
-Goal: install OpenWork, create or sign in to an OpenWork Cloud account, create a
-workspace organization, invite a teammate, create a first skill, prepare the
-desktop app with that account/org/skill, and verify the running app opens already
-signed in.
+Goal: install OpenWork, create a provisional workspace without requiring email
+identity first, create a first skill, prepare the desktop app with that
+workspace/skill, and verify the running app opens to the setup-complete state.
 
 > The bootstrap command is `openwork-bootstrap` (NOT `openwork`). The bare
 > `openwork` command belongs to the separate `openwork-orchestrator` package and
-> may already be on the user's PATH — do not use it for these steps.
+> may already be on the user's PATH - do not use it for these steps.
 
 ## 1. Install CLI
 
@@ -27,7 +26,7 @@ node packages/openwork-bootstrap/bin/openwork.mjs install \
 In production, download the bootstrap script, inspect it, then run it. Do not
 pipe remote scripts directly into a shell. The script downloads the
 `openwork-bootstrap` CLI (a single dependency-free Node file) and installs it
-into `$HOME/.local/bin` — no npm or npx required.
+into `$HOME/.local/bin` - no npm or npx required.
 
 ```bash
 curl -fsSLo /tmp/openwork-install.sh https://openworklabs.com/install.sh
@@ -65,7 +64,7 @@ account. It writes claim links to the local desktop bootstrap file so a human ca
 claim ownership later.
 
 ```bash
-openwork cloud bootstrap-workspace \
+openwork-bootstrap cloud bootstrap-workspace \
   --base-url https://api.openworklabs.com \
   --workspace-name "<workspace-name>" \
   --skill-name "First OpenWork Skill" \
@@ -104,20 +103,21 @@ You are done only when all are true:
 
 - `openwork-bootstrap doctor --json` returns `ok: true`
 - `openwork-bootstrap doctor --app --json` returns `ok: true`
-- `openwork-bootstrap cloud onboard ... --json` returns:
+- `openwork-bootstrap cloud bootstrap-workspace ... --json` returns:
   - `ok: true`
   - `organization.id` is present
-  - `invitation.invitationId` is present
+  - `setup.id` is present
   - `skill.id` is present
   - `skillRun.triggered` is `true`
   - `skillRun.output` is `OPENWORK_BOOTSTRAP_SKILL_TRIGGERED`
+  - `claimLinks[0].id` is present
   - `desktop.prepared` is `true`
   - `desktop.bootstrapPath` is present
   - `desktop.skillPath` is present
 - `openwork-bootstrap doctor --desktop-bootstrap --json` returns `ok: true`
-- When the desktop app is launched, it opens already signed in and lands on the
-  onboarding screen showing a green "Setup complete" banner, the organization
-  name, and a "First skill ready" tile with the skill created by the CLI.
+- When the desktop app is launched, it lands on the onboarding screen showing a
+  green "Setup complete" banner, the organization name, a "First skill ready"
+  tile, and a "Claim this workspace" action.
 
 ## 5. If Something Fails
 
@@ -138,8 +138,8 @@ You are done only when all are true:
 
 ## 7. Security note: desktop preparation
 
-`--prepare-desktop` writes a one-time, short-lived (~5 minute) desktop sign-in
-grant to a machine-local `desktop-bootstrap.json`. The grant is never printed.
-On first launch the desktop app exchanges it once and rewrites the file without
-the grant, so it cannot be reused. This file is local-only; do not copy it
-between machines or commit it.
+`--prepare-desktop` writes machine-local setup state to
+`desktop-bootstrap.json`. For passwordless workspace bootstrap, this includes
+short-lived claim links so a human can attach an owner later. The links are not
+printed in final output. This file is local-only; do not copy it between
+machines or commit it.


### PR DESCRIPTION
## Summary
- serve /openwork-bootstrap.mjs from the canonical bootstrap CLI source
- serve /start.md from packages/openwork-bootstrap/start.md instead of duplicating stale instructions
- update start.md for passwordless workspace bootstrap and setup-complete claim flow
- make /install.sh static and fix its PATH help quoting

## Verification
- pnpm --filter openwork-bootstrap check
- pnpm --filter @openwork-ee/landing build
- sh -n ee/apps/landing/.next/server/app/install.sh.body
- node --check --input-type=module < ee/apps/landing/.next/server/app/openwork-bootstrap.mjs.body
- local installer smoke test with OPENWORK_BOOTSTRAP_CLI_URL=file://.../openwork-bootstrap.mjs.body, temporary OPENWORK_BIN_DIR/OPENWORK_INSTALL_DIR, then openwork-bootstrap doctor --install-dir ... --bin-dir ... --json => ok: true

Fraimz: not run for this landing asset/docs route change; validation was via generated static artifacts and installer smoke test.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

