### PR TITLE
fix(server): isolate managed OpenCode config

### DIFF
--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -8,6 +8,7 @@
 import { mkdir } from "node:fs/promises";
 import { resolveServerConfig, type CliArgs } from "./config.js";
 import { createManagedOpencodeServer, type ManagedOpencodeServer, type OpencodeExecutionSnapshot } from "./managed-opencode.js";
+import { prepareManagedOpencodeEnvironment } from "./managed-opencode-env.js";
 import { startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
 import { ensureLocalWorkspaceFiles } from "./workspace-init.js";
 import { findManagedEngineWorkspace } from "./workspaces.js";
@@ -63,12 +64,14 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
         || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
         || workspace.path;
       await mkdir(cwd, { recursive: true });
+      const opencodeEnv = await prepareManagedOpencodeEnvironment(config);
 
       managedOpencode = await createManagedOpencodeServer({
         bin: options.opencodeBin || process.env.OPENWORK_OPENCODE_BIN,
         cwd,
         excludedPorts: [config.port],
         env: {
+          ...opencodeEnv,
           ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
           ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
           OPENWORK_SERVER_URL: serverUrl,

--- a/apps/server/src/managed-opencode-env.test.ts
+++ b/apps/server/src/managed-opencode-env.test.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { prepareManagedOpencodeEnvironment } from "./managed-opencode-env.js";
+import type { ServerConfig } from "./types.js";
+
+function testConfig(configPath: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "client-token",
+    hostToken: "host-token",
+    configPath,
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [],
+    authorizedRoots: [],
+    readOnly: false,
+    startedAt: 0,
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+describe("prepareManagedOpencodeEnvironment", () => {
+  test("isolates OpenCode home and global config paths under OpenWork runtime storage", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openwork-managed-opencode-env-"));
+    const env = await prepareManagedOpencodeEnvironment(testConfig(join(root, "config", "server.json")));
+
+    expect(env.HOME).toBe(join(root, "config", "managed-opencode", "home"));
+    expect(env.USERPROFILE).toBe(env.HOME);
+    expect(env.XDG_CONFIG_HOME).toBe(join(root, "config", "managed-opencode", "xdg", "config"));
+    expect(env.OPENCODE_CONFIG_DIR).toBe(join(env.XDG_CONFIG_HOME, "opencode"));
+    expect(env.APPDATA).toBe(join(root, "config", "managed-opencode", "appdata", "roaming"));
+    expect(env.LOCALAPPDATA).toBe(join(root, "config", "managed-opencode", "appdata", "local"));
+
+    await expect(stat(env.OPENCODE_CONFIG_DIR)).resolves.toMatchObject({});
+  });
+});

--- a/apps/server/src/managed-opencode-env.ts
+++ b/apps/server/src/managed-opencode-env.ts
@@ -1,0 +1,41 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { runtimeStorageDir } from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+
+export async function prepareManagedOpencodeEnvironment(config: ServerConfig): Promise<Record<string, string>> {
+  const root = join(runtimeStorageDir(config), "managed-opencode");
+  const home = join(root, "home");
+  const xdgConfigHome = join(root, "xdg", "config");
+  const xdgDataHome = join(root, "xdg", "data");
+  const xdgCacheHome = join(root, "xdg", "cache");
+  const xdgStateHome = join(root, "xdg", "state");
+  const appData = join(root, "appdata", "roaming");
+  const localAppData = join(root, "appdata", "local");
+  const opencodeConfigDir = join(xdgConfigHome, "opencode");
+
+  for (const dir of [
+    home,
+    xdgConfigHome,
+    xdgDataHome,
+    xdgCacheHome,
+    xdgStateHome,
+    appData,
+    localAppData,
+    opencodeConfigDir,
+  ]) {
+    await mkdir(dir, { recursive: true });
+  }
+
+  return {
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: xdgConfigHome,
+    XDG_DATA_HOME: xdgDataHome,
+    XDG_CACHE_HOME: xdgCacheHome,
+    XDG_STATE_HOME: xdgStateHome,
+    APPDATA: appData,
+    LOCALAPPDATA: localAppData,
+    OPENCODE_CONFIG_DIR: opencodeConfigDir,
+  };
+}


### PR DESCRIPTION
## Summary
- isolate the managed OpenCode child from user-global OpenCode config paths
- keep OpenWork's generated runtime config as the managed engine config source
- add a focused test for the isolated managed OpenCode environment

Fixes #2386.

## Verification
- Local: `pnpm --filter openwork-server test src/managed-opencode-env.test.ts` passed
- Local: `pnpm --filter openwork-server typecheck` passed
- Local repro: OpenCode 1.17.11 fails with inherited invalid global `opencode.jsonc` containing `instruction`, then starts successfully when launched with the isolated managed env shape
- Daytona sandbox: `bash .devcontainer/test-on-daytona.sh fix/2386-opencode-invalid-config --artifacts-volume` passed and launched Electron
- Daytona e2e: injected invalid `~/.config/opencode/opencode.jsonc` and `~/.opencode/opencode.jsonc`, created workspace `/workspace/issue-2386` in the real Electron app, observed `Ready for new tasks`, verified managed `opencode serve` process was running, and checked logs for no `ConfigInvalidError`, `Unrecognized key: instruction`, or `OpenCode unavailable`
- Daytona: `pnpm --filter openwork-server test src/managed-opencode-env.test.ts` passed inside sandbox `openwork-test-20260627-074614`

Screenshot evidence: https://8090-udgunpi18bbvp5q8.daytonaproxy01.net/screenshots/daytona-screenshot-20260627-145029.png

No video captured; screenshot plus DOM/process/log assertions were used for this config-startup regression.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

