### PR TITLE
fix(bootstrap): copy macOS app with ditto so it isn't reported as damaged

### DIFF
--- a/packages/openwork-bootstrap/bin/openwork.mjs
+++ b/packages/openwork-bootstrap/bin/openwork.mjs
@@ -261,12 +261,36 @@ function findInstallCandidate(root, expectedName) {
   throw new Error(`app_not_found_in_archive: ${expectedName}`)
 }
 
+// Copy an installed artifact into place. macOS .app bundles contain internal
+// framework symlinks (e.g. Versions/Current, the framework binary/Resources
+// links) that a naive recursive copy can break — leaving dangling links into a
+// now-unmounted DMG, which makes Gatekeeper report the app as "damaged". Use
+// `ditto` on macOS, which is the Apple-supported way to copy bundles while
+// preserving relative symlinks and the code signature.
+function copyArtifact(source, target) {
+  if (process.platform === "darwin") {
+    try {
+      execFileSync("ditto", [source, target], { stdio: "pipe" })
+    } catch {
+      // Fall back to cp -R (also preserves bundle symlinks) before giving up.
+      execFileSync("cp", ["-R", source, target], { stdio: "pipe" })
+    }
+    // Remove the quarantine flag so Gatekeeper does not block the freshly
+    // installed (already-notarized) app on first launch. Best-effort.
+    try {
+      execFileSync("xattr", ["-dr", "com.apple.quarantine", target], { stdio: "pipe" })
+    } catch {}
+    return
+  }
+  cpSync(source, target, { recursive: true })
+}
+
 function installFromDirectory(input) {
   const source = findInstallCandidate(input.sourceDir, input.appName)
   mkdirSync(input.appDir, { recursive: true })
   const target = join(input.appDir, input.appName)
   rmSync(target, { recursive: true, force: true })
-  cpSync(source, target, { recursive: true })
+  copyArtifact(source, target)
   if (input.executable) chmodSync(target, 0o755)
   return target
 }
@@ -290,7 +314,7 @@ function installDmg(input) {
     mkdirSync(input.appDir, { recursive: true })
     const targetApp = join(input.appDir, appName)
     rmSync(targetApp, { recursive: true, force: true })
-    cpSync(sourceApp, targetApp, { recursive: true })
+    copyArtifact(sourceApp, targetApp)
     return targetApp
   } finally {
     if (mounted) {


### PR DESCRIPTION
## Symptom

After `openwork-bootstrap install app`, launching the app showed:

> "OpenWork" is damaged and can't be opened. You should move it to the Trash.

## Root cause

It wasn't signing or quarantine. The DMG asset the manifest resolves **is** correctly signed + notarized (Developer ID: Different AI inc.). The install **copy** corrupted the bundle.

`installDmg` / `installFromDirectory` used `cpSync(..., { recursive: true })` to copy `OpenWork.app` out of the mounted DMG. Node's recursive copy preserved framework symlinks but pointed them at the **temporary DMG mount path**, which is unmounted right after install:

```
Squirrel.framework/Versions/Current -> /private/var/folders/.../T/openwork-app-install-.../mount/OpenWork.app/.../Versions/A   (dangling)
```

Dangling framework links break the code signature, so Gatekeeper reports the app as "damaged."

## Fix

- Copy `.app` bundles with `ditto` on macOS (Apple-supported; preserves relative framework symlinks + signature), with a `cp -R` fallback.
- Strip `com.apple.quarantine` on the freshly installed (already-notarized) app so first launch isn't blocked.
- Applies to both the DMG and zip/tar.gz install paths (they shared the same `cpSync`).

## Verification

Fresh install via the prod manifest:

- framework symlinks are now relative: `Squirrel -> Versions/Current/Squirrel`, `Current -> A`
- `codesign --verify --deep --strict` → `valid on disk`, `satisfies its Designated Requirement` (exit 0)
- `spctl --assess --type execute` → `accepted`, `source=Notarized Developer ID`, `Different AI inc. (F5DJWB4CCV)`
- no quarantine attribute

`pnpm --filter openwork-bootstrap check` and `test` pass.

Note: the landing serves `bin/openwork.mjs` at `/openwork-bootstrap.mjs` via a prebuild copy, so this reaches the installer on the next landing deploy.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

