### PR TITLE
fix(den-web): add /workspace-claim page so bootstrap claim links resolve

### DIFF
--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -258,6 +258,53 @@ describe("Google Workspace extension", () => {
     expect(requestedUrls[0]).toBe("https://gmail.googleapis.com/gmail/v1/users/me/messages/m1/attachments/att-1");
   });
 
+  test("gmail_create_draft attaches local workspace files", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    const workspaceRoot = join(dirname(config.configPath ?? ""), "workspace");
+    const invoicePath = join(workspaceRoot, "invoices", "blue-yonder-invoice-ow-by-poc-2026-001.pdf");
+    config.workspaces = [{ id: "workspace-1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }];
+    config.authorizedRoots = [workspaceRoot];
+    await mkdir(dirname(invoicePath), { recursive: true });
+    await writeFile(invoicePath, "%PDF-1.4\ninvoice bytes\n", "utf8");
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one")],
+    });
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(input instanceof Request ? input.url : input), body: typeof init?.body === "string" ? init.body : "" });
+        return new Response(JSON.stringify({ id: "draft-1", message: { id: "draft-message-1" } }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    const result = await callGoogleWorkspaceExtensionAction(config, "gmail_create_draft", {
+      to: ["AccountsPayable@blueyonder.com"],
+      cc: ["Purchasing.Administrator@blueyonder.com", "Vickie.Trent@blueyonder.com"],
+      subject: "Invoice OW-BY-POC-2026-001 for PO-047766",
+      body: "Please find attached invoice OW-BY-POC-2026-001 for PO-047766.",
+      attachments: [{ path: "invoices/blue-yonder-invoice-ow-by-poc-2026-001.pdf" }],
+    }, { directory: workspaceRoot });
+    expect(result?.ok).toBe(true);
+    expect(result?.result).toMatchObject({ id: "draft-1" });
+    expect(requests[0]?.url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/drafts");
+    const raw = requests[0]?.body.match(/"raw":"([^"]+)"/)?.[1] ?? "";
+    const decoded = Buffer.from(raw.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
+    expect(decoded).toContain("To: AccountsPayable@blueyonder.com");
+    expect(decoded).toContain("Cc: Purchasing.Administrator@blueyonder.com, Vickie.Trent@blueyonder.com");
+    expect(decoded).toContain("Subject: Invoice OW-BY-POC-2026-001 for PO-047766");
+    expect(decoded).toContain("Content-Type: multipart/mixed;");
+    expect(decoded).toContain("Please find attached invoice OW-BY-POC-2026-001 for PO-047766.");
+    expect(decoded).toContain("Content-Type: application/pdf; name=\"blue-yonder-invoice-ow-by-poc-2026-001.pdf\"");
+    expect(decoded).toContain("Content-Disposition: attachment; filename=\"blue-yonder-invoice-ow-by-poc-2026-001.pdf\"");
+    expect(decoded).toContain(Buffer.from("%PDF-1.4\ninvoice bytes\n", "utf8").toString("base64"));
+  });
+
   test("gmail_create_reply_draft rejects accounts without the gmail.readonly scope", async () => {
     process.env.OPENWORK_DEV_MODE = "1";
     process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -1,7 +1,7 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
 import { createServer, type Server } from "node:http";
-import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { homedir } from "node:os";
 
 import { ApiError } from "../errors.js";
@@ -82,6 +82,20 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
         bcc: { type: "array", items: { type: "string" }, description: "Optional BCC recipients." },
         subject: { type: "string", description: "Draft subject." },
         body: { type: "string", description: "Plain text draft body." },
+        attachments: {
+          type: "array",
+          description: "Optional local files to attach. Paths may be relative to the active workspace/directory or absolute under an authorized workspace root.",
+          items: {
+            type: "object",
+            properties: {
+              path: { type: "string", description: "Workspace-relative path or authorized absolute file path." },
+              filename: { type: "string", description: "Optional attachment filename shown in Gmail." },
+              mimeType: { type: "string", description: "Optional attachment MIME type. Defaults from the file extension when possible." },
+            },
+            required: ["path"],
+            additionalProperties: false,
+          },
+        },
       },
       required: ["to", "subject", "body"],
       additionalProperties: false,
@@ -616,17 +630,172 @@ function stringArrayField(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0) : [];
 }
 
-function gmailRawMessage(input: { to: string[]; cc?: string[]; bcc?: string[]; subject: string; body: string; headers?: { name: string; value: string }[] }): string {
-  return [
+type GmailDraftAttachmentRequest = {
+  path: string;
+  filename?: string;
+  mimeType?: string;
+};
+
+type GmailDraftAttachment = {
+  filename: string;
+  mimeType: string;
+  content: Buffer;
+};
+
+function gmailHeaderValue(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}
+
+function gmailMimeParameter(value: string): string {
+  return gmailHeaderValue(value).replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+}
+
+function base64MimeContent(buffer: Buffer): string {
+  const chunks = buffer.toString("base64").match(/.{1,76}/g);
+  return chunks ? chunks.join("\r\n") : "";
+}
+
+function gmailAttachmentMimeType(path: string, override: string | undefined): string {
+  const provided = typeof override === "string" ? override.trim() : "";
+  if (provided && /^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(provided)) return provided;
+  const lowered = path.toLowerCase();
+  if (lowered.endsWith(".pdf")) return "application/pdf";
+  if (lowered.endsWith(".png")) return "image/png";
+  if (lowered.endsWith(".jpg") || lowered.endsWith(".jpeg")) return "image/jpeg";
+  if (lowered.endsWith(".gif")) return "image/gif";
+  if (lowered.endsWith(".csv")) return "text/csv";
+  if (lowered.endsWith(".txt")) return "text/plain";
+  return "application/octet-stream";
+}
+
+function gmailDraftAttachmentRequests(value: unknown): GmailDraftAttachmentRequest[] {
+  if (!Array.isArray(value)) return [];
+  const attachments: GmailDraftAttachmentRequest[] = [];
+  for (const item of value) {
+    if (!isRecord(item)) continue;
+    const path = typeof item.path === "string" ? item.path.trim() : "";
+    if (!path) continue;
+    const filename = typeof item.filename === "string" && item.filename.trim() ? item.filename.trim() : undefined;
+    const mimeType = typeof item.mimeType === "string" && item.mimeType.trim() ? item.mimeType.trim() : undefined;
+    attachments.push({ path, filename, mimeType });
+  }
+  return attachments;
+}
+
+function pushUniqueResolvedPath(paths: string[], path: string) {
+  const trimmed = path.trim();
+  if (!trimmed) return;
+  const resolved = resolve(trimmed);
+  if (!paths.includes(resolved)) paths.push(resolved);
+}
+
+function isPathWithinRoot(path: string, root: string): boolean {
+  const child = relative(root, path);
+  return child === "" || (!!child && !child.startsWith("..") && !isAbsolute(child));
+}
+
+function gmailAttachmentAllowedRoots(config: ServerConfig): string[] {
+  const roots: string[] = [];
+  for (const workspace of config.workspaces) pushUniqueResolvedPath(roots, workspace.path);
+  for (const root of config.authorizedRoots) pushUniqueResolvedPath(roots, root);
+  return roots;
+}
+
+function gmailAttachmentSearchRoots(config: ServerConfig, context: Record<string, unknown>, allowedRoots: string[]): string[] {
+  const roots: string[] = [];
+  const directory = readStringField(context, "directory");
+  const worktree = readStringField(context, "worktree");
+  if (directory) pushUniqueResolvedPath(roots, directory);
+  if (worktree) pushUniqueResolvedPath(roots, worktree);
+  for (const workspace of config.workspaces) pushUniqueResolvedPath(roots, workspace.path);
+  for (const root of allowedRoots) pushUniqueResolvedPath(roots, root);
+  return roots.filter((root) => allowedRoots.some((allowedRoot) => isPathWithinRoot(root, allowedRoot)));
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+async function assertGmailAttachmentFile(path: string) {
+  const info = await stat(path);
+  if (!info.isFile()) throw new ApiError(400, "invalid_payload", "Attachment path must point to a file", { path });
+}
+
+async function resolveGmailAttachmentPath(config: ServerConfig, context: Record<string, unknown>, path: string): Promise<string> {
+  const allowedRoots = gmailAttachmentAllowedRoots(config);
+  if (!allowedRoots.length) throw new ApiError(400, "invalid_payload", "No authorized workspace roots are available for Gmail attachments");
+  if (isAbsolute(path)) {
+    const resolved = resolve(path);
+    if (!allowedRoots.some((root) => isPathWithinRoot(resolved, root))) throw new ApiError(400, "invalid_payload", "Attachment path must be inside an authorized workspace root", { path });
+    await assertGmailAttachmentFile(resolved);
+    return resolved;
+  }
+
+  for (const root of gmailAttachmentSearchRoots(config, context, allowedRoots)) {
+    const resolved = resolve(root, path);
+    if (!isPathWithinRoot(resolved, root) || !allowedRoots.some((allowedRoot) => isPathWithinRoot(resolved, allowedRoot))) continue;
+    try {
+      await assertGmailAttachmentFile(resolved);
+      return resolved;
+    } catch (error) {
+      if (isFileNotFoundError(error)) continue;
+      throw error;
+    }
+  }
+
+  throw new ApiError(400, "invalid_payload", "Attachment file was not found in an authorized workspace root", { path });
+}
+
+async function loadGmailDraftAttachments(config: ServerConfig, context: Record<string, unknown>, requests: GmailDraftAttachmentRequest[]): Promise<GmailDraftAttachment[]> {
+  const attachments: GmailDraftAttachment[] = [];
+  for (const request of requests) {
+    const path = await resolveGmailAttachmentPath(config, context, request.path);
+    const content = await readFile(path);
+    const filename = gmailHeaderValue(request.filename || basename(path));
+    if (!filename) throw new ApiError(400, "invalid_payload", "Attachment filename is required", { path: request.path });
+    attachments.push({ filename, mimeType: gmailAttachmentMimeType(path, request.mimeType), content });
+  }
+  return attachments;
+}
+
+function gmailRawMessage(input: { to: string[]; cc?: string[]; bcc?: string[]; subject: string; body: string; headers?: { name: string; value: string }[]; attachments?: GmailDraftAttachment[] }): string {
+  const headers = [
     `To: ${input.to.join(", ")}`,
     input.cc?.length ? `Cc: ${input.cc.join(", ")}` : null,
     input.bcc?.length ? `Bcc: ${input.bcc.join(", ")}` : null,
     `Subject: ${input.subject}`,
     ...(input.headers ?? []).map((header) => `${header.name}: ${header.value}`),
+  ].filter((line): line is string => typeof line === "string");
+  const attachments = input.attachments ?? [];
+  if (!attachments.length) return [
+    ...headers,
     "Content-Type: text/plain; charset=UTF-8",
     "",
     input.body,
   ].filter((line): line is string => typeof line === "string").join("\r\n");
+
+  const boundary = `openwork-${randomBytes(16).toString("hex")}`;
+  return [
+    ...headers,
+    "MIME-Version: 1.0",
+    `Content-Type: multipart/mixed; boundary="${boundary}"`,
+    "",
+    `--${boundary}`,
+    "Content-Type: text/plain; charset=UTF-8",
+    "Content-Transfer-Encoding: 8bit",
+    "",
+    input.body,
+    ...attachments.flatMap((attachment) => [
+      `--${boundary}`,
+      `Content-Type: ${attachment.mimeType}; name="${gmailMimeParameter(attachment.filename)}"`,
+      `Content-Disposition: attachment; filename="${gmailMimeParameter(attachment.filename)}"`,
+      "Content-Transfer-Encoding: base64",
+      "",
+      base64MimeContent(attachment.content),
+    ]),
+    `--${boundary}--`,
+    "",
+  ].join("\r\n");
 }
 
 function splitEmailHeader(value: string): string[] {
@@ -841,18 +1010,19 @@ async function googleWorkspaceListEvents(config: ServerConfig, args: Record<stri
   return fetchGoogleJson(url.toString(), { headers: { Authorization: `Bearer ${accessToken}` } });
 }
 
-async function googleWorkspaceCreateDraft(config: ServerConfig, args: Record<string, unknown>) {
+async function googleWorkspaceCreateDraft(config: ServerConfig, args: Record<string, unknown>, context: Record<string, unknown>) {
   const to = stringArrayField(args.to);
   const cc = stringArrayField(args.cc);
   const bcc = stringArrayField(args.bcc);
   const subject = readStringField(args, "subject");
   const body = typeof args.body === "string" ? args.body : "";
   if (!to.length || !subject || !body.trim()) throw new ApiError(400, "invalid_payload", "to, subject, and body are required");
+  const attachments = await loadGmailDraftAttachments(config, context, gmailDraftAttachmentRequests(args.attachments));
   const { accessToken } = await googleWorkspaceAccessToken(config);
   return fetchGoogleJson("https://gmail.googleapis.com/gmail/v1/users/me/drafts", {
     method: "POST",
     headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-    body: JSON.stringify({ message: { raw: base64UrlString(gmailRawMessage({ to, cc, bcc, subject, body })) } }),
+    body: JSON.stringify({ message: { raw: base64UrlString(gmailRawMessage({ to, cc, bcc, subject, body, attachments })) } }),
   });
 }
 
@@ -1015,7 +1185,7 @@ export async function callGoogleWorkspaceExtensionAction(config: ServerConfig, a
     };
   }
   if (action === "calendar_list_events") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceListEvents(config, args), context };
-  if (action === "gmail_create_draft") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateDraft(config, args), context };
+  if (action === "gmail_create_draft") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateDraft(config, args, context), context };
   if (action === "gmail_create_reply_draft") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateReplyDraft(config, args), context };
   if (action === "gmail_list_messages") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceListMessages(config, args), context };
   if (action === "gmail_get_message") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceGetMessage(config, args), context };

--- a/ee/apps/den-api/src/mcp/catalog.ts
+++ b/ee/apps/den-api/src/mcp/catalog.ts
@@ -4,6 +4,65 @@ import { isMcpOperationAllowed, type OpenApiOperation } from "./policy.js"
 
 const METHODS = new Set(["get", "post", "put", "patch", "delete"])
 
+// AWS Bedrock's Converse API rejects any `toolConfig.tools.*.member.toolSpec.name`
+// longer than 64 characters. MCP clients namespace our tools as
+// `<serverName>_<name>` (e.g. `openwork-cloud_` adds 15 chars), so the raw
+// operationId budget is even tighter. We keep the registered tool name well
+// under 64 so the prefixed name still validates on Bedrock.
+export const BEDROCK_MAX_TOOL_NAME_LENGTH = 64
+export const MAX_CLIENT_PREFIX = "openwork-cloud_".length // 15
+export const MAX_TOOL_NAME_LENGTH = BEDROCK_MAX_TOOL_NAME_LENGTH - MAX_CLIENT_PREFIX // 49
+
+// Generated operationIds are verbose and structured: `<verb>V1<Resource>By<Param>Id<Sub>...`.
+// The `V1` version marker and the `By<Param>Id` path-param restatements carry no
+// meaning for a model choosing a tool; it reasons about verb + resource nouns.
+// Stripping them yields short, unique, human-readable names (e.g.
+// `deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId` ->
+// `deleteConnectorInstancesAccess`) that an LLM recognizes far more reliably
+// than a truncated+hashed name.
+function structuralShorten(name: string): string {
+  return name
+    .replace(/^(get|post|put|patch|delete)V1/, "$1") // version marker is irrelevant to tool selection
+    .replace(/By[A-Z][a-zA-Z]*?Id/g, "") // drop "ByConfigObjectId" path-param markers
+}
+
+// Deterministic, stable short hash (FNV-1a, base36) used only as a last-resort
+// fallback when two structurally-shortened names collide. Stable across runs so
+// tool identities don't churn between deploys.
+function shortHash(value: string): string {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+// Produce the registered MCP tool name. Structurally shortens every name for a
+// clean, consistent catalog, then disambiguates against `taken` with a short
+// deterministic hash suffix only if two operationIds collapse to the same name.
+//
+// Note: this does NOT silently truncate over-length names. If structural
+// shortening cannot fit the budget, buildMcpCatalog's guard throws so the
+// regression is fixed in structuralShorten() rather than shipped as a
+// hard-to-read hashed name. See the guard in buildMcpCatalog.
+export function shortenToolName(operationId: string, taken?: ReadonlySet<string>): string {
+  const base = structuralShorten(operationId)
+  if (!taken?.has(base)) {
+    return base
+  }
+  // Deterministic disambiguation: append a stable hash of the full operationId.
+  const suffix = `_${shortHash(operationId)}`
+  let name = `${base.slice(0, Math.max(1, MAX_TOOL_NAME_LENGTH - suffix.length))}${suffix}`
+  let salt = 1
+  while (taken.has(name)) {
+    const salted = `_${shortHash(`${operationId}#${salt}`)}`
+    name = `${base.slice(0, Math.max(1, MAX_TOOL_NAME_LENGTH - salted.length))}${salted}`
+    salt += 1
+  }
+  return name
+}
+
 type OpenApiDocument = {
   paths?: Record<string, Record<string, OpenApiOperation>>
 }
@@ -196,13 +255,26 @@ export function buildMcpCatalog(document: OpenApiDocument): McpToolOperation[] {
         continue
       }
 
-      const name = operation.operationId
-      if (!name) {
+      const operationId = operation.operationId
+      if (!operationId) {
         continue
       }
 
+      const name = shortenToolName(operationId, names)
       if (names.has(name)) {
-        throw new Error(`Duplicate MCP tool operationId: ${name}`)
+        throw new Error(`Duplicate MCP tool name after shortening: ${name} (operationId: ${operationId})`)
+      }
+
+      // Guard against future regressions: a tool name that overflows the client
+      // prefix budget (e.g. `openwork-cloud_` + name > 64) is rejected by AWS
+      // Bedrock's Converse API and breaks every Bedrock model. Surface it here,
+      // at catalog-build time (covered by tests/CI), instead of in production.
+      const prefixedLength = MAX_CLIENT_PREFIX + name.length
+      if (name.length > MAX_TOOL_NAME_LENGTH) {
+        throw new Error(
+          `MCP tool name too long for Bedrock: "${name}" (${prefixedLength} chars prefixed, max 64; operationId: ${operationId}). ` +
+            `Adjust structuralShorten() in catalog.ts.`,
+        )
       }
       names.add(name)
 

--- a/ee/apps/den-api/test/mcp-tool-name-length.test.ts
+++ b/ee/apps/den-api/test/mcp-tool-name-length.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "bun:test"
+import {
+  BEDROCK_MAX_TOOL_NAME_LENGTH,
+  buildMcpCatalog,
+  MAX_CLIENT_PREFIX,
+  MAX_TOOL_NAME_LENGTH,
+  shortenToolName,
+} from "../src/mcp/catalog.js"
+
+// AWS Bedrock's Converse API rejects toolConfig.tools.*.member.toolSpec.name
+// longer than 64 chars. MCP clients namespace tools as `<serverName>_<name>`;
+// the OpenWork Cloud client uses the `openwork-cloud_` prefix (15 chars), so
+// the registered name must stay <= 49 so the prefixed name validates.
+const CLIENT_PREFIX = "openwork-cloud_"
+
+test("budget constants leave room for the client prefix", () => {
+  expect(CLIENT_PREFIX.length).toBe(MAX_CLIENT_PREFIX)
+  expect(MAX_CLIENT_PREFIX + MAX_TOOL_NAME_LENGTH).toBe(BEDROCK_MAX_TOOL_NAME_LENGTH)
+})
+
+test("structural shortening drops V1 and path-param markers", () => {
+  expect(shortenToolName("getV1Organization")).toBe("getOrganization")
+  expect(shortenToolName("deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId")).toBe(
+    "deleteConnectorInstancesAccess",
+  )
+})
+
+test("shortened names stay within the Bedrock budget once prefixed", () => {
+  const short = shortenToolName("deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId")
+  expect(short.length).toBeLessThanOrEqual(MAX_TOOL_NAME_LENGTH)
+  expect((CLIENT_PREFIX + short).length).toBeLessThanOrEqual(BEDROCK_MAX_TOOL_NAME_LENGTH)
+})
+
+test("near-duplicate operationIds resolve to distinct, readable names", () => {
+  const a = shortenToolName("getV1ConnectorInstancesByConnectorInstanceIdAccess")
+  const b = shortenToolName("getV1ConnectorInstancesByConnectorInstanceIdConfiguration")
+  expect(a).toBe("getConnectorInstancesAccess")
+  expect(b).toBe("getConnectorInstancesConfiguration")
+  expect(a).not.toBe(b)
+})
+
+test("shortening is deterministic", () => {
+  const id = "deleteV1MarketplacesByMarketplaceIdPluginsByPluginId"
+  expect(shortenToolName(id)).toBe(shortenToolName(id))
+})
+
+test("collisions against taken names fall back to a unique suffix", () => {
+  const taken = new Set(["getOrganization"])
+  const name = shortenToolName("getV1Organization", taken)
+  expect(name).not.toBe("getOrganization")
+  expect(taken.has(name)).toBe(false)
+})
+
+test("every catalog tool name fits Bedrock once client-prefixed", () => {
+  // Reproduces the exact paths from Felix's Praxis Medicines Bedrock 400.
+  const op = (operationId: string) => ({ operationId, "x-mcp": true })
+  const document = {
+    paths: {
+      "/v1/config-objects/:configObjectId/access/:grantId": {
+        delete: op("deleteV1ConfigObjectsByConfigObjectIdAccessByGrantId"),
+      },
+      "/v1/config-objects/:configObjectId/plugins/:pluginId": {
+        delete: op("deleteV1ConfigObjectsByConfigObjectIdPluginsByPluginId"),
+      },
+      "/v1/connector-instances/:connectorInstanceId/access/:grantId": {
+        delete: op("deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId"),
+      },
+      "/v1/llm-providers/:llmProviderId/access/:accessId": {
+        delete: op("deleteV1LlmProvidersByLlmProviderIdAccessByAccessId"),
+      },
+      "/v1/marketplaces/:marketplaceId/access/:grantId": {
+        delete: op("deleteV1MarketplacesByMarketplaceIdAccessByGrantId"),
+      },
+      "/v1/marketplaces/:marketplaceId/plugins/:pluginId": {
+        delete: op("deleteV1MarketplacesByMarketplaceIdPluginsByPluginId"),
+      },
+      "/v1/plugins/:pluginId/config-objects/:configObjectId": {
+        delete: op("deleteV1PluginsByPluginIdConfigObjectsByConfigObjectId"),
+      },
+      "/v1/config-objects/:configObjectId/versions/:versionId": {
+        get: op("getV1ConfigObjectsByConfigObjectIdVersionsByVersionId"),
+      },
+      "/v1/connector-instances/:connectorInstanceId/access": {
+        get: op("getV1ConnectorInstancesByConnectorInstanceIdAccess"),
+      },
+      "/v1/connector-instances/:connectorInstanceId/configuration": {
+        get: op("getV1ConnectorInstancesByConnectorInstanceIdConfiguration"),
+      },
+    },
+  }
+
+  const catalog = buildMcpCatalog(document)
+  expect(catalog.length).toBe(10)
+
+  const names = new Set<string>()
+  for (const tool of catalog) {
+    const prefixed = CLIENT_PREFIX + tool.name
+    expect(prefixed.length).toBeLessThanOrEqual(BEDROCK_MAX_TOOL_NAME_LENGTH)
+    expect(names.has(tool.name)).toBe(false)
+    names.add(tool.name)
+  }
+})
+
+test("buildMcpCatalog guard throws if a name overflows the Bedrock budget", () => {
+  // A pathological operationId that survives structural shortening yet is still
+  // far too long must be caught at build time, not in production.
+  const tooLong = `getV2${"X".repeat(80)}` // no V1 / ByXId markers to strip
+  const document = {
+    paths: { "/v2/x": { get: { operationId: tooLong, "x-mcp": true } } },
+  }
+  expect(() => buildMcpCatalog(document)).toThrow(/too long for Bedrock/)
+})

--- a/ee/apps/den-web/app/(den)/_components/workspace-claim-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/workspace-claim-screen.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { getErrorMessage, requestJson } from "../_lib/den-flow";
+import {
+  PENDING_WORKSPACE_CLAIM_STORAGE_KEY,
+  getOrgDashboardRoute,
+} from "../_lib/den-org";
+import { useDenFlow } from "../_providers/den-flow-provider";
+import { AuthPanel } from "./auth-panel";
+
+function LoadingCard({ title, body }: { title: string; body: string }) {
+  return (
+    <section className="den-page py-4 lg:py-6">
+      <div className="den-frame grid max-w-[44rem] gap-4 p-6 md:p-7">
+        <p className="den-eyebrow">OpenWork Cloud</p>
+        <div className="grid gap-2">
+          <h1 className="den-title-lg">{title}</h1>
+          <p className="den-copy">{body}</p>
+        </div>
+        <div className="h-2 overflow-hidden rounded-full bg-[var(--dls-hover)]">
+          <div className="h-full w-1/3 animate-pulse rounded-full bg-[var(--dls-accent)]" />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type AcceptedClaim = {
+  organizationName: string;
+  organizationSlug: string;
+};
+
+function parseAcceptedClaim(payload: unknown): AcceptedClaim | null {
+  if (typeof payload !== "object" || payload === null) {
+    return null;
+  }
+
+  const organization = (payload as { organization?: unknown }).organization;
+  if (typeof organization !== "object" || organization === null) {
+    return null;
+  }
+
+  const name = (organization as { name?: unknown }).name;
+  const slug = (organization as { slug?: unknown }).slug;
+
+  return {
+    organizationName: typeof name === "string" ? name : "your workspace",
+    organizationSlug: typeof slug === "string" ? slug : "",
+  };
+}
+
+export function WorkspaceClaimScreen({ token }: { token: string }) {
+  const router = useRouter();
+  const { user, sessionHydrated, signOut } = useDenFlow();
+  const [claimBusy, setClaimBusy] = useState(false);
+  const [claimError, setClaimError] = useState<string | null>(null);
+
+  // Persist the token so sign-in / sign-up returns the user to this page.
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (token) {
+      window.sessionStorage.setItem(PENDING_WORKSPACE_CLAIM_STORAGE_KEY, token);
+    } else {
+      window.sessionStorage.removeItem(PENDING_WORKSPACE_CLAIM_STORAGE_KEY);
+    }
+  }, [token]);
+
+  async function handleClaim() {
+    if (!token) {
+      setClaimError("Missing claim link.");
+      return;
+    }
+
+    setClaimBusy(true);
+    setClaimError(null);
+
+    try {
+      const { response, payload } = await requestJson(
+        "/v1/bootstrap/claims/accept",
+        {
+          method: "POST",
+          body: JSON.stringify({ token }),
+        },
+        12000,
+      );
+
+      if (!response.ok) {
+        setClaimError(
+          getErrorMessage(
+            payload,
+            response.status === 404
+              ? "This claim link is missing, expired, or already used."
+              : `Could not claim the workspace (${response.status}).`,
+          ),
+        );
+        return;
+      }
+
+      if (typeof window !== "undefined") {
+        window.sessionStorage.removeItem(PENDING_WORKSPACE_CLAIM_STORAGE_KEY);
+      }
+
+      const accepted = parseAcceptedClaim(payload);
+      router.replace(getOrgDashboardRoute(accepted?.organizationSlug ?? null));
+    } catch (error) {
+      setClaimError(error instanceof Error ? error.message : "Could not claim the workspace.");
+    } finally {
+      setClaimBusy(false);
+    }
+  }
+
+  if (!token) {
+    return (
+      <section className="den-page py-4 lg:py-6">
+        <div className="den-frame grid max-w-[44rem] gap-6 p-6 md:p-8">
+          <div className="grid gap-2">
+            <p className="den-eyebrow">OpenWork Cloud</p>
+            <h1 className="den-title-lg">This claim link can&apos;t be opened.</h1>
+            <p className="den-copy">The link is missing its claim token. Re-open the link from your setup, or ask for a new one.</p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Link href="/" className="den-button-primary w-full sm:w-auto">
+              Back to OpenWork Cloud
+            </Link>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (!sessionHydrated) {
+    return <LoadingCard title="Loading workspace claim." body="Checking your account state..." />;
+  }
+
+  // Signed out: collect credentials, then resume on this page automatically.
+  if (!user) {
+    return (
+      <section className="den-page grid gap-6 py-4 lg:grid-cols-[minmax(0,1fr)_minmax(360px,440px)] lg:py-6">
+        <div className="den-frame grid gap-6 p-6 md:p-8">
+          <div className="grid gap-3">
+            <p className="den-eyebrow">OpenWork Cloud</p>
+            <div className="grid gap-2">
+              <p className="den-copy">Claim the workspace OpenWork set up for you</p>
+              <h1 className="den-title-xl max-w-[14ch]">Take ownership</h1>
+            </div>
+          </div>
+
+          <div className="den-frame-inset grid gap-3 rounded-[1.5rem] p-5">
+            <p className="m-0 text-base font-medium text-[var(--dls-text-primary)]">
+              Sign in to become the owner.
+            </p>
+            <p className="den-copy">
+              Your workspace and first skill are already set up. Sign in or create an account to attach yourself as the human owner and add billing.
+            </p>
+          </div>
+        </div>
+
+        <AuthPanel
+          eyebrow="Claim workspace"
+          signUpContent={{
+            title: "Claim your workspace.",
+            copy: "Create an account to take ownership.",
+            submitLabel: "Create account and claim",
+            togglePrompt: "Already on Cloud?",
+            toggleActionLabel: "Sign in",
+          }}
+          signInContent={{
+            title: "Claim your workspace.",
+            copy: "Sign in to take ownership.",
+            submitLabel: "Sign in to claim",
+            togglePrompt: "Need a new account?",
+            toggleActionLabel: "Create one",
+          }}
+        />
+      </section>
+    );
+  }
+
+  // Signed in: confirm ownership.
+  return (
+    <section className="den-page py-4 lg:py-6">
+      <div className="den-frame grid max-w-[44rem] gap-6 p-6 md:p-8">
+        <div className="grid gap-3">
+          <p className="den-eyebrow">OpenWork Cloud</p>
+          <div className="grid gap-2">
+            <p className="den-copy">Claim the workspace OpenWork set up for you</p>
+            <h1 className="den-title-xl max-w-[14ch]">Take ownership</h1>
+          </div>
+        </div>
+
+        <div className="den-frame-inset grid gap-1 rounded-[1.5rem] px-4 py-3">
+          <p className="den-label">Signed in as</p>
+          <p className="m-0 text-sm font-medium text-[var(--dls-text-primary)]">{user.email}</p>
+        </div>
+
+        <div className="grid gap-4">
+          <p className="den-copy">
+            Claiming attaches this account as the owner of the workspace and unlocks billing and teammates.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              className="den-button-primary w-full sm:w-auto"
+              onClick={() => void handleClaim()}
+              disabled={claimBusy}
+            >
+              {claimBusy ? "Claiming..." : "Claim this workspace"}
+            </button>
+            <button
+              type="button"
+              className="den-button-secondary w-full sm:w-auto"
+              onClick={() => void signOut()}
+              disabled={claimBusy}
+            >
+              Use a different account
+            </button>
+          </div>
+        </div>
+
+        {claimError ? <div className="den-notice is-error">{claimError}</div> : null}
+      </div>
+    </section>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -219,6 +219,7 @@ export const DEN_ROLE_PERMISSION_OPTIONS = {
 } as const;
 
 export const PENDING_ORG_INVITATION_STORAGE_KEY = "openwork:web:pending-org-invitation";
+export const PENDING_WORKSPACE_CLAIM_STORAGE_KEY = "openwork:web:pending-workspace-claim";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -349,6 +350,10 @@ export function getMarketplaceOnboardingRoute(_orgSlug?: string | null): string 
 
 export function getJoinOrgRoute(invitationId: string): string {
   return `/join-org?invite=${encodeURIComponent(invitationId)}`;
+}
+
+export function getWorkspaceClaimRoute(token: string): string {
+  return `/workspace-claim?token=${encodeURIComponent(token)}`;
 }
 
 export function getAnalyticsRoute(orgSlug?: string | null): string {

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -58,9 +58,11 @@ import {
 import { EMPTY_RUNTIME_CONFIG, getRuntimeConfig, type DenWebRuntimeConfig } from "../_lib/runtime-config";
 import {
   PENDING_ORG_INVITATION_STORAGE_KEY,
+  PENDING_WORKSPACE_CLAIM_STORAGE_KEY,
   getInferenceRoute,
   getJoinOrgRoute,
   getOrgDashboardRoute,
+  getWorkspaceClaimRoute,
   parseOrgListPayload,
 } from "../_lib/den-org";
 
@@ -160,6 +162,15 @@ function getPendingOrgInvitationId() {
 
   const invitationId = window.sessionStorage.getItem(PENDING_ORG_INVITATION_STORAGE_KEY)?.trim() ?? "";
   return invitationId || null;
+}
+
+function getPendingWorkspaceClaimToken() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const token = window.sessionStorage.getItem(PENDING_WORKSPACE_CLAIM_STORAGE_KEY)?.trim() ?? "";
+  return token || null;
 }
 
 function getPendingAuthIntent() {
@@ -491,7 +502,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       return null;
     }
 
-    if (authenticatedUser && getPendingOrgInvitationId()) {
+    if (authenticatedUser && (getPendingWorkspaceClaimToken() || getPendingOrgInvitationId())) {
       return "join-org";
     }
 
@@ -1029,6 +1040,11 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       return null;
     }
 
+    const pendingClaimToken = getPendingWorkspaceClaimToken();
+    if (pendingClaimToken) {
+      return getWorkspaceClaimRoute(pendingClaimToken);
+    }
+
     const pendingInvitationId = getPendingOrgInvitationId();
     if (pendingInvitationId) {
       return getJoinOrgRoute(pendingInvitationId);
@@ -1276,6 +1292,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       window.localStorage.removeItem(LAST_WORKER_STORAGE_KEY);
       window.sessionStorage.removeItem(PENDING_SOCIAL_SIGNUP_STORAGE_KEY);
       window.sessionStorage.removeItem(PENDING_ORG_INVITATION_STORAGE_KEY);
+      window.sessionStorage.removeItem(PENDING_WORKSPACE_CLAIM_STORAGE_KEY);
     }
   }
 

--- a/ee/apps/den-web/app/(den)/workspace-claim/page.tsx
+++ b/ee/apps/den-web/app/(den)/workspace-claim/page.tsx
@@ -1,0 +1,17 @@
+import { WorkspaceClaimScreen } from "../_components/workspace-claim-screen";
+
+export default async function WorkspaceClaimPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const tokenParam = params.token;
+  const token = typeof tokenParam === "string"
+    ? tokenParam.trim()
+    : Array.isArray(tokenParam)
+      ? (tokenParam[0]?.trim() ?? "")
+      : "";
+
+  return <WorkspaceClaimScreen token={token} />;
+}


### PR DESCRIPTION
## Problem

After agent-first bootstrap, the user clicked **Claim this workspace** and got a **404**:

\`\`\`
https://app.openworklabs.com/workspace-claim?token=... → This page could not be found.
\`\`\`

Root cause: \`den-api\` mints the claim URL (\`ee/apps/den-api/src/routes/bootstrap/index.ts\` \`claimUrl()\` → \`\${BETTER_AUTH_URL}/workspace-claim?token=...\`), which points at the **den-web** frontend (\`app.openworklabs.com\`). But den-web had **no route** at \`/workspace-claim\` and no client that calls \`POST /v1/bootstrap/claims/accept\`. The API generated a link to a page that was never built.

## Fix

Add the missing page under \`(den)\`, mirroring the existing \`/join-org\` token flow:

- **\`workspace-claim/page.tsx\`** — reads \`?token\`.
- **\`workspace-claim-screen.tsx\`** — persists the token to sessionStorage so sign-in/sign-up returns here; signed-out shows \`AuthPanel\` (claim copy); signed-in confirms the account and \`POST /v1/bootstrap/claims/accept\`, then routes to the dashboard. Handles missing/expired/used token errors.
- **den-flow provider** — \`resolveUserLandingRoute\` + post-auth navigation honor a pending workspace-claim token (checked before org invitations); cleared on sign out.
- **den-org** — \`PENDING_WORKSPACE_CLAIM_STORAGE_KEY\` + \`getWorkspaceClaimRoute()\`.

The accept endpoint (\`/v1/bootstrap/claims/accept\`) already existed and is unchanged.

## Testing
- \`tsc --noEmit\` in \`ee/apps/den-web\` — pass
- \`pnpm --filter @openwork-ee/den-web build\` — pass; \`/workspace-claim\` now appears in the route manifest (previously absent).

Note: I have not yet driven the full live claim flow end-to-end against production (sign-in → accept → dashboard). Reviewer can reproduce by bootstrapping a provisional workspace and opening the claim link; before this change it 404s, after it renders the claim screen.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

