### PR TITLE
Add past chat search tools

### DIFF
--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+
+import { OpenWorkExtensionsPreview } from "./openwork-extensions-preview.js";
+
+const originalServerUrl = process.env.OPENWORK_SERVER_URL;
+const originalServerToken = process.env.OPENWORK_SERVER_TOKEN;
+const stops: Array<() => void> = [];
+
+const searchResultSchema = z.object({
+  ok: z.literal(true),
+  scannedSessions: z.number(),
+  results: z.array(z.object({
+    workspaceId: z.string(),
+    sessionId: z.string(),
+    kind: z.string(),
+    role: z.string().optional(),
+    snippet: z.object({ match: z.string() }).passthrough(),
+  }).passthrough()),
+}).passthrough();
+
+const readResultSchema = z.object({
+  ok: z.literal(true),
+  workspaceId: z.string(),
+  sessionId: z.string(),
+  title: z.string(),
+  messages: z.array(z.object({
+    role: z.string(),
+    text: z.string(),
+  }).passthrough()),
+}).passthrough();
+
+afterEach(() => {
+  while (stops.length) stops.pop()?.();
+  if (originalServerUrl === undefined) delete process.env.OPENWORK_SERVER_URL;
+  else process.env.OPENWORK_SERVER_URL = originalServerUrl;
+  if (originalServerToken === undefined) delete process.env.OPENWORK_SERVER_TOKEN;
+  else process.env.OPENWORK_SERVER_TOKEN = originalServerToken;
+});
+
+function startFakeOpenWorkServer() {
+  const requests: Array<{ pathname: string; search: string; authorization: string | null }> = [];
+
+  const workspaceOne = { id: "ws_1", name: "Main", path: "/tmp/main" };
+  const workspaceTwo = { id: "ws_2", name: "Archive", displayName: "Archive", path: "/tmp/archive" };
+  const sessionAlpha = { id: "ses_alpha", title: "Alpha planning", time: { created: 100, updated: 300 } };
+  const sessionBeta = { id: "ses_beta", title: "Neon backlog", time: { created: 50, updated: 200 } };
+  const sessionArchive = { id: "ses_archive", title: "Archive decisions", time: { created: 10, updated: 100 } };
+
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      requests.push({
+        pathname: url.pathname,
+        search: url.search,
+        authorization: request.headers.get("authorization"),
+      });
+
+      if (request.headers.get("authorization") !== "Bearer test-token") {
+        return Response.json({ message: "Unauthorized" }, { status: 401 });
+      }
+
+      if (url.pathname === "/workspaces") {
+        return Response.json({ items: [workspaceOne, workspaceTwo], workspaces: [workspaceOne, workspaceTwo] });
+      }
+
+      if (url.pathname === "/workspace/ws_1/sessions") {
+        return Response.json({ items: [sessionAlpha, sessionBeta] });
+      }
+      if (url.pathname === "/workspace/ws_2/sessions") {
+        return Response.json({ items: [sessionArchive] });
+      }
+
+      if (url.pathname === "/workspace/ws_1/sessions/ses_alpha") return Response.json({ item: sessionAlpha });
+      if (url.pathname === "/workspace/ws_1/sessions/ses_beta") return Response.json({ item: sessionBeta });
+      if (url.pathname === "/workspace/ws_2/sessions/ses_archive") return Response.json({ item: sessionArchive });
+
+      if (url.pathname === "/workspace/ws_1/sessions/ses_alpha/messages") {
+        return Response.json({
+          items: [
+            {
+              info: { id: "msg_assistant", role: "assistant", time: { created: 301 } },
+              parts: [{ type: "text", text: "The launch checklist can wait." }],
+            },
+            {
+              info: { id: "msg_user", role: "user", time: { created: 302 } },
+              parts: [{ type: "text", text: "Please remember the raven launch checklist." }],
+            },
+          ],
+        });
+      }
+      if (url.pathname === "/workspace/ws_1/sessions/ses_beta/messages") {
+        return Response.json({ items: [] });
+      }
+      if (url.pathname === "/workspace/ws_2/sessions/ses_archive/messages") {
+        return Response.json({
+          items: [
+            {
+              info: { id: "msg_old", role: "assistant", time: { created: 101 } },
+              parts: [{ type: "text", text: "Ignored implementation note", ignored: true }],
+            },
+            {
+              info: { id: "msg_latest", role: "assistant", time: { created: 102 } },
+              parts: [{ type: "text", text: "We decided to ship the archive importer first." }],
+            },
+          ],
+        });
+      }
+
+      return Response.json({ message: "Not found" }, { status: 404 });
+    },
+  });
+  stops.push(() => server.stop(true));
+  process.env.OPENWORK_SERVER_URL = `http://127.0.0.1:${server.port}`;
+  process.env.OPENWORK_SERVER_TOKEN = "test-token";
+  return { requests };
+}
+
+describe("OpenWorkExtensionsPreview session tools", () => {
+  test("searches past chat transcript text and prefers the user's matching message", async () => {
+    const fake = startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview();
+
+    const output = await plugin.tool.openwork_session_search.execute({
+      query: "raven launch",
+      limit: 5,
+      scanLimit: 10,
+    });
+    const parsed = searchResultSchema.parse(JSON.parse(output));
+
+    expect(parsed.scannedSessions).toBe(3);
+    expect(parsed.results[0]).toMatchObject({
+      workspaceId: "ws_1",
+      sessionId: "ses_alpha",
+      kind: "message",
+      role: "user",
+    });
+    expect(parsed.results[0]?.snippet.match.toLowerCase()).toBe("raven launch");
+    expect(fake.requests.some((request) => request.pathname === "/workspace/ws_1/sessions/ses_alpha/messages" && request.search === "?limit=400")).toBe(true);
+  });
+
+  test("reads a transcript by session id without opening the UI", async () => {
+    startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview();
+
+    const output = await plugin.tool.openwork_session_read.execute({
+      sessionId: "ses_archive",
+      count: 2,
+    });
+    const parsed = readResultSchema.parse(JSON.parse(output));
+
+    expect(parsed).toMatchObject({
+      workspaceId: "ws_2",
+      sessionId: "ses_archive",
+      title: "Archive decisions",
+    });
+    expect(parsed.messages).toEqual([
+      {
+        index: 1,
+        id: "msg_latest",
+        role: "assistant",
+        text: "We decided to ship the archive importer first.",
+      },
+    ]);
+  });
+});

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -42,6 +42,70 @@ const browserSetProxyArgsSchema = z.object({
   proxy: z.string().describe("Proxy URL like http://user:pass@host:8080 or socks5://host:1080. Prefer env:NAME (resolves the OPENWORK_BROWSER_PROXY_NAME environment variable on the user's machine) so credentials never enter the conversation."),
 });
 
+const sessionSearchArgsSchema = z.object({
+  query: z.string().trim().min(1).describe("Text to search for across OpenWork session titles and message transcripts."),
+  workspaceId: z.string().trim().optional().describe("Optional OpenWork workspace id/name to limit the search."),
+  limit: z.number().int().positive().max(20).optional().describe("Maximum matching sessions to return. Defaults to 10, max 20."),
+  scanLimit: z.number().int().positive().max(500).optional().describe("Maximum newest sessions to scan across matching workspaces. Defaults to 100, max 500."),
+  messageLimit: z.number().int().positive().max(1000).optional().describe("Maximum recent messages to load per scanned session. Defaults to 400, max 1000."),
+});
+
+const sessionReadArgsSchema = z.object({
+  sessionId: z.string().trim().min(1).describe("OpenWork/OpenCode session ID returned by openwork_session_search."),
+  workspaceId: z.string().trim().optional().describe("Optional OpenWork workspace id/name. Omit to resolve the session across all workspaces."),
+  count: z.number().int().positive().max(100).optional().describe("Number of recent transcript messages to return. Defaults to 30, max 100."),
+});
+
+const workspaceSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  path: z.string().optional(),
+  displayName: z.string().optional(),
+}).passthrough();
+
+const workspaceListEnvelopeSchema = z.object({
+  items: z.array(workspaceSchema),
+}).passthrough();
+
+const sessionTimeSchema = z.object({
+  created: z.number().optional(),
+  updated: z.number().optional(),
+}).passthrough();
+
+const sessionInfoSchema = z.object({
+  id: z.string(),
+  title: z.string().nullish(),
+  time: sessionTimeSchema.optional(),
+}).passthrough();
+
+const sessionListEnvelopeSchema = z.object({
+  items: z.array(sessionInfoSchema),
+}).passthrough();
+
+const sessionEnvelopeSchema = z.object({
+  item: sessionInfoSchema,
+}).passthrough();
+
+const sessionPartSchema = z.object({
+  type: z.string().optional(),
+  text: z.string().optional(),
+  synthetic: z.boolean().optional(),
+  ignored: z.boolean().optional(),
+}).passthrough();
+
+const sessionMessageSchema = z.object({
+  info: z.object({
+    id: z.string(),
+    role: z.string(),
+    time: sessionTimeSchema.optional(),
+  }).passthrough(),
+  parts: z.array(sessionPartSchema),
+}).passthrough();
+
+const sessionMessagesEnvelopeSchema = z.object({
+  items: z.array(sessionMessageSchema),
+}).passthrough();
+
 const OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION =
   "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
 
@@ -55,10 +119,9 @@ To list all available actions: openwork_ui_list_actions
 To ask what OpenWork can do: openwork_ui_execute_action with actionId "help.capabilities"
 
 ## Cross-session memory
-When the user asks what they said, what happened, or what was decided in another OpenWork chat/session, treat it as a session-history lookup through the OpenWork UI, not hidden model memory.
-Use openwork_ui_execute_action with actionId "session.list_sessions" to find matching sessions by title, workspace, topic, or session ID.
-If there is one clear match, use actionId "session.open" with args {sessionId:"..."}, then use actionId "session.read_transcript" with args {count:30} to read recent messages.
-Answer only from the returned transcript. If multiple sessions match, ask a short clarifying question. If the returned transcript is limited or missing the older context needed, say so instead of guessing.
+When the user asks what they said, what happened, or what was decided in another OpenWork chat/session, treat it as a session-history lookup, not hidden model memory.
+Use openwork_session_search first to search session titles and message transcripts across workspaces. If there is one clear match, use openwork_session_read with the returned sessionId/workspaceId to retrieve transcript context without navigating the UI.
+Answer only from the returned search/read results. If multiple sessions match, ask a short clarifying question. If the returned transcript is limited or missing the older context needed, say so instead of guessing.
 
 Do NOT use browser_navigate, browser_click, or browser_snapshot to interact with the OpenWork app itself. Those are for browsing external websites.
 
@@ -73,6 +136,30 @@ let cachedBridge: UiBridge | null = null;
 let cachedBridgeAt = 0;
 const BRIDGE_CACHE_MS = 2_000;
 const BRIDGE_TIMEOUT_MS = 5_000;
+
+type OpenWorkWorkspace = z.infer<typeof workspaceSchema>;
+type SessionInfo = z.infer<typeof sessionInfoSchema>;
+type SessionMessage = z.infer<typeof sessionMessageSchema>;
+type SessionSearchSnippet = { before: string; match: string; after: string };
+type SessionSearchResult = {
+  workspaceId: string;
+  workspace: string;
+  sessionId: string;
+  title: string;
+  updatedAt: number;
+  kind: "title" | "message";
+  snippet: SessionSearchSnippet;
+  role?: string;
+  messageId?: string;
+  messageIndex?: number;
+};
+
+const SESSION_SEARCH_DEFAULT_LIMIT = 10;
+const SESSION_SEARCH_DEFAULT_SCAN_LIMIT = 100;
+const SESSION_SEARCH_DEFAULT_MESSAGE_LIMIT = 400;
+const SESSION_SEARCH_CONCURRENCY = 6;
+const SESSION_SNIPPET_BEFORE = 36;
+const SESSION_SNIPPET_AFTER = 72;
 
 function userAppDataDir(): string {
   if (platform() === "darwin") return join(homedir(), "Library", "Application Support");
@@ -128,6 +215,259 @@ async function uiBridgeRequest(path: string, options: { method?: string; body?: 
   }
 }
 
+async function serverGet(path: string): Promise<unknown> {
+  const { url, token } = requireOpenWorkServer();
+  const response = await fetch(`${url}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const payload = await parseResponse(response);
+  if (!response.ok) throw new Error(errorMessage(payload, "OpenWork server request failed"));
+  return payload;
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ");
+}
+
+function buildSessionSnippet(text: string, index: number, length: number): SessionSearchSnippet {
+  const start = Math.max(0, index - SESSION_SNIPPET_BEFORE);
+  const end = Math.min(text.length, index + length + SESSION_SNIPPET_AFTER);
+  const before = `${start > 0 ? "..." : ""}${collapseWhitespace(text.slice(start, index)).trimStart()}`;
+  const after = `${collapseWhitespace(text.slice(index + length, end)).trimEnd()}${end < text.length ? "..." : ""}`;
+  return { before, match: text.slice(index, index + length), after };
+}
+
+function workspaceLabel(workspace: OpenWorkWorkspace): string {
+  return workspace.displayName?.trim() || workspace.name?.trim() || workspace.path?.trim() || workspace.id;
+}
+
+function sessionTitle(session: SessionInfo): string {
+  return session.title?.trim() || session.id;
+}
+
+function sessionUpdatedAt(session: SessionInfo): number {
+  return session.time?.updated ?? session.time?.created ?? 0;
+}
+
+function messageText(message: SessionMessage): string {
+  const parts: string[] = [];
+  for (const part of message.parts) {
+    if (part.type !== "text") continue;
+    if (part.synthetic || part.ignored) continue;
+    const text = part.text?.trim();
+    if (text) parts.push(text);
+  }
+  return parts.join("\n\n");
+}
+
+function findTextMatch(text: string, queryLower: string): { index: number; length: number } | null {
+  const lower = text.toLowerCase();
+  const exact = lower.indexOf(queryLower);
+  if (exact >= 0) return { index: exact, length: queryLower.length };
+
+  const terms = queryLower.split(/\s+/).filter((term) => term.length > 1);
+  if (terms.length < 2) return null;
+
+  let firstIndex = Number.POSITIVE_INFINITY;
+  let firstLength = 0;
+  for (const term of terms) {
+    const index = lower.indexOf(term);
+    if (index < 0) return null;
+    if (index < firstIndex) {
+      firstIndex = index;
+      firstLength = term.length;
+    }
+  }
+  return Number.isFinite(firstIndex) ? { index: firstIndex, length: firstLength } : null;
+}
+
+function titleSearchResult(workspace: OpenWorkWorkspace, session: SessionInfo, queryLower: string): SessionSearchResult | null {
+  const title = sessionTitle(session);
+  const text = `${title} ${workspaceLabel(workspace)}`;
+  const match = findTextMatch(text, queryLower);
+  if (!match) return null;
+  return {
+    workspaceId: workspace.id,
+    workspace: workspaceLabel(workspace),
+    sessionId: session.id,
+    title,
+    updatedAt: sessionUpdatedAt(session),
+    kind: "title",
+    snippet: buildSessionSnippet(text, match.index, match.length),
+  };
+}
+
+function messageSearchResult(workspace: OpenWorkWorkspace, session: SessionInfo, messages: SessionMessage[], queryLower: string): SessionSearchResult | null {
+  let fallback: SessionSearchResult | null = null;
+  for (const [index, message] of messages.entries()) {
+    const role = message.info.role;
+    if (role !== "user" && role !== "assistant") continue;
+    const text = messageText(message);
+    if (!text) continue;
+    const match = findTextMatch(text, queryLower);
+    if (!match) continue;
+    const result: SessionSearchResult = {
+      workspaceId: workspace.id,
+      workspace: workspaceLabel(workspace),
+      sessionId: session.id,
+      title: sessionTitle(session),
+      updatedAt: sessionUpdatedAt(session),
+      kind: "message",
+      role,
+      messageId: message.info.id,
+      messageIndex: index,
+      snippet: buildSessionSnippet(text, match.index, match.length),
+    };
+    if (role === "user") return result;
+    if (!fallback) fallback = result;
+  }
+  return fallback;
+}
+
+async function listOpenWorkWorkspaces(): Promise<OpenWorkWorkspace[]> {
+  return workspaceListEnvelopeSchema.parse(await serverGet("/workspaces")).items;
+}
+
+function filterWorkspaces(workspaces: OpenWorkWorkspace[], workspaceId?: string): OpenWorkWorkspace[] {
+  const query = workspaceId?.trim().toLowerCase();
+  if (!query) return workspaces;
+  return workspaces.filter((workspace) => {
+    const labels = [workspace.id, workspace.name, workspace.displayName, workspace.path]
+      .filter((label): label is string => typeof label === "string" && label.trim().length > 0)
+      .map((label) => label.trim().toLowerCase());
+    return labels.includes(query);
+  });
+}
+
+async function listWorkspaceSessions(workspace: OpenWorkWorkspace, limit: number): Promise<SessionInfo[]> {
+  const query = new URLSearchParams({ roots: "true", limit: String(limit) });
+  return sessionListEnvelopeSchema.parse(
+    await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/sessions?${query.toString()}`),
+  ).items;
+}
+
+async function readWorkspaceSession(workspace: OpenWorkWorkspace, sessionId: string): Promise<SessionInfo> {
+  return sessionEnvelopeSchema.parse(
+    await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/sessions/${encodeURIComponent(sessionId)}`),
+  ).item;
+}
+
+async function readSessionMessages(workspace: OpenWorkWorkspace, sessionId: string, limit: number): Promise<SessionMessage[]> {
+  const query = new URLSearchParams({ limit: String(limit) });
+  return sessionMessagesEnvelopeSchema.parse(
+    await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/sessions/${encodeURIComponent(sessionId)}/messages?${query.toString()}`),
+  ).items;
+}
+
+async function forEachWithConcurrency<T>(items: T[], concurrency: number, run: (item: T) => Promise<void>): Promise<void> {
+  let index = 0;
+  const worker = async () => {
+    while (index < items.length) {
+      const item = items[index];
+      index += 1;
+      if (item !== undefined) await run(item);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(Math.max(1, concurrency), Math.max(1, items.length)) }, () => worker()));
+}
+
+async function searchOpenWorkSessions(rawArgs: unknown): Promise<object> {
+  const args = sessionSearchArgsSchema.parse(rawArgs);
+  const resultLimit = args.limit ?? SESSION_SEARCH_DEFAULT_LIMIT;
+  const scanLimit = args.scanLimit ?? SESSION_SEARCH_DEFAULT_SCAN_LIMIT;
+  const messageLimit = args.messageLimit ?? SESSION_SEARCH_DEFAULT_MESSAGE_LIMIT;
+  const queryLower = args.query.trim().toLowerCase();
+  const workspaces = filterWorkspaces(await listOpenWorkWorkspaces(), args.workspaceId);
+  if (!workspaces.length) {
+    return { ok: false, error: args.workspaceId ? `No workspace matched ${args.workspaceId}` : "No OpenWork workspaces are available" };
+  }
+
+  const sessions: Array<{ workspace: OpenWorkWorkspace; session: SessionInfo }> = [];
+  const workspaceErrors: Array<{ workspaceId: string; workspace: string; error: string }> = [];
+  await Promise.all(workspaces.map(async (workspace) => {
+    try {
+      const items = await listWorkspaceSessions(workspace, scanLimit);
+      for (const session of items) sessions.push({ workspace, session });
+    } catch (error) {
+      workspaceErrors.push({ workspaceId: workspace.id, workspace: workspaceLabel(workspace), error: unknownErrorMessage(error) });
+    }
+  }));
+
+  const sessionsToScan = sessions
+    .sort((left, right) => sessionUpdatedAt(right.session) - sessionUpdatedAt(left.session))
+    .slice(0, scanLimit);
+  const matches: SessionSearchResult[] = [];
+
+  await forEachWithConcurrency(sessionsToScan, SESSION_SEARCH_CONCURRENCY, async ({ workspace, session }) => {
+    const titleMatch = titleSearchResult(workspace, session, queryLower);
+    try {
+      const messages = await readSessionMessages(workspace, session.id, messageLimit);
+      const messageMatch = messageSearchResult(workspace, session, messages, queryLower);
+      if (messageMatch) matches.push(messageMatch);
+      else if (titleMatch) matches.push(titleMatch);
+    } catch {
+      if (titleMatch) matches.push(titleMatch);
+    }
+  });
+
+  const results = matches
+    .filter((match) => match !== undefined)
+    .sort((left, right) => right.updatedAt - left.updatedAt);
+
+  return {
+    ok: true,
+    query: args.query,
+    workspaceCount: workspaces.length,
+    totalCandidateSessions: sessions.length,
+    scannedSessions: sessionsToScan.length,
+    scanLimit,
+    messageLimit,
+    resultLimit,
+    workspaceErrors,
+    truncated: sessions.length > sessionsToScan.length || results.length > resultLimit,
+    results: results.slice(0, resultLimit),
+  };
+}
+
+async function readOpenWorkSession(rawArgs: unknown): Promise<object> {
+  const args = sessionReadArgsSchema.parse(rawArgs);
+  const count = args.count ?? 30;
+  const workspaces = filterWorkspaces(await listOpenWorkWorkspaces(), args.workspaceId);
+  if (!workspaces.length) {
+    return { ok: false, error: args.workspaceId ? `No workspace matched ${args.workspaceId}` : "No OpenWork workspaces are available" };
+  }
+
+  for (const workspace of workspaces) {
+    try {
+      const session = await readWorkspaceSession(workspace, args.sessionId);
+      const messages = await readSessionMessages(workspace, args.sessionId, count);
+      const readable = messages
+        .map((message, index) => ({
+          index,
+          id: message.info.id,
+          role: message.info.role,
+          text: messageText(message),
+        }))
+        .filter((message) => message.text.trim().length > 0);
+      return {
+        ok: true,
+        workspaceId: workspace.id,
+        workspace: workspaceLabel(workspace),
+        sessionId: session.id,
+        title: sessionTitle(session),
+        updatedAt: sessionUpdatedAt(session),
+        returned: readable.length,
+        requested: count,
+        messages: readable,
+      };
+    } catch {
+      if (args.workspaceId) break;
+    }
+  }
+
+  return { ok: false, error: `Session ${args.sessionId} was not found in matching OpenWork workspaces` };
+}
+
 function serverUrl(): string {
   return String(process.env.OPENWORK_SERVER_URL || "").replace(/\/$/, "");
 }
@@ -171,6 +511,10 @@ function addContext(payload: unknown, context: OpenCodeContext): object {
 
 function errorMessage(payload: unknown, fallback: string): string {
   return getStringProperty(payload, "message") ?? getStringProperty(payload, "code") ?? fallback;
+}
+
+function unknownErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function postJson(path: string, body: ExtensionActionPayload): Promise<unknown> {
@@ -260,6 +604,22 @@ export const OpenWorkExtensionsPreview = async () => ({
           method: "POST",
           body: { actionId, args: args ?? {} },
         });
+        return JSON.stringify(result, null, 2);
+      },
+    },
+    openwork_session_search: {
+      description: "Search OpenWork past chat sessions by title and full message transcript text without navigating the UI. Use this when the user refers to another/past chat or asks what was said, decided, or done previously.",
+      args: sessionSearchArgsSchema.shape,
+      async execute(rawArgs: unknown) {
+        const result = await searchOpenWorkSessions(rawArgs);
+        return JSON.stringify(result, null, 2);
+      },
+    },
+    openwork_session_read: {
+      description: "Read recent transcript messages from a specific OpenWork session without opening it. Use sessionId/workspaceId from openwork_session_search, then answer only from the returned transcript.",
+      args: sessionReadArgsSchema.shape,
+      async execute(rawArgs: unknown) {
+        const result = await readOpenWorkSession(rawArgs);
         return JSON.stringify(result, null, 2);
       },
     },

--- a/evals/flows/past-chat-search-tool.flow.mjs
+++ b/evals/flows/past-chat-search-tool.flow.mjs
@@ -1,0 +1,257 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { createServer } from "node:http";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+const TOKEN = "fraimz-token";
+
+const workspaceOne = { id: "ws_1", name: "Main", path: "/tmp/main" };
+const workspaceTwo = { id: "ws_2", name: "Archive", displayName: "Archive", path: "/tmp/archive" };
+const sessionAlpha = { id: "ses_alpha", title: "Alpha planning", time: { created: 100, updated: 300 } };
+const sessionBeta = { id: "ses_beta", title: "Neon backlog", time: { created: 50, updated: 200 } };
+const sessionArchive = { id: "ses_archive", title: "Archive decisions", time: { created: 10, updated: 100 } };
+
+function json(response, status, body) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+function startMockOpenWorkServer() {
+  const requests = [];
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    requests.push({ pathname: url.pathname, search: url.search, authorization: request.headers.authorization ?? null });
+
+    if (request.headers.authorization !== `Bearer ${TOKEN}`) {
+      json(response, 401, { message: "Unauthorized" });
+      return;
+    }
+
+    if (url.pathname === "/workspaces") {
+      json(response, 200, { items: [workspaceOne, workspaceTwo], workspaces: [workspaceOne, workspaceTwo] });
+      return;
+    }
+    if (url.pathname === "/workspace/ws_1/sessions") {
+      json(response, 200, { items: [sessionAlpha, sessionBeta] });
+      return;
+    }
+    if (url.pathname === "/workspace/ws_2/sessions") {
+      json(response, 200, { items: [sessionArchive] });
+      return;
+    }
+    if (url.pathname === "/workspace/ws_1/sessions/ses_alpha") {
+      json(response, 200, { item: sessionAlpha });
+      return;
+    }
+    if (url.pathname === "/workspace/ws_1/sessions/ses_beta") {
+      json(response, 200, { item: sessionBeta });
+      return;
+    }
+    if (url.pathname === "/workspace/ws_2/sessions/ses_archive") {
+      json(response, 200, { item: sessionArchive });
+      return;
+    }
+    if (url.pathname === "/workspace/ws_1/sessions/ses_alpha/messages") {
+      json(response, 200, {
+        items: [
+          {
+            info: { id: "msg_assistant", role: "assistant", time: { created: 301 } },
+            parts: [{ type: "text", text: "The launch checklist can wait." }],
+          },
+          {
+            info: { id: "msg_user", role: "user", time: { created: 302 } },
+            parts: [{ type: "text", text: "Please remember the raven launch checklist." }],
+          },
+        ],
+      });
+      return;
+    }
+    if (url.pathname === "/workspace/ws_1/sessions/ses_beta/messages") {
+      json(response, 200, { items: [] });
+      return;
+    }
+    if (url.pathname === "/workspace/ws_2/sessions/ses_archive/messages") {
+      json(response, 200, {
+        items: [
+          {
+            info: { id: "msg_old", role: "assistant", time: { created: 101 } },
+            parts: [{ type: "text", text: "Ignored implementation note", ignored: true }],
+          },
+          {
+            info: { id: "msg_latest", role: "assistant", time: { created: 102 } },
+            parts: [{ type: "text", text: "We decided to ship the archive importer first." }],
+          },
+        ],
+      });
+      return;
+    }
+
+    json(response, 404, { message: "Not found" });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Mock OpenWork server did not bind a port."));
+        return;
+      }
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        requests,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+}
+
+async function runInjectedSessionTools(baseUrl) {
+  const script = `
+    const { OpenWorkExtensionsPreview } = await import("./apps/server/src/opencode-plugins/openwork-extensions-preview.ts");
+    const plugin = await OpenWorkExtensionsPreview();
+    const search = JSON.parse(await plugin.tool.openwork_session_search.execute({ query: "raven launch", limit: 5, scanLimit: 10 }));
+    const read = JSON.parse(await plugin.tool.openwork_session_read.execute({ sessionId: "ses_archive", count: 2 }));
+    console.log(JSON.stringify({ search, read }));
+  `;
+  const { stdout } = await execFile("bun", ["--eval", script], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      OPENWORK_SERVER_URL: baseUrl,
+      OPENWORK_SERVER_TOKEN: TOKEN,
+    },
+    maxBuffer: 1024 * 1024,
+  });
+  return JSON.parse(stdout.trim());
+}
+
+async function showProofPanel(ctx, title, rows) {
+  await ctx.eval(
+    `(() => {
+      const id = "openwork-fraimz-past-chat-proof";
+      document.getElementById(id)?.remove();
+      const panel = document.createElement("section");
+      panel.id = id;
+      panel.style.cssText = [
+        "position:fixed",
+        "inset:24px",
+        "z-index:2147483647",
+        "background:#fff",
+        "color:#111827",
+        "border:2px solid #4f46e5",
+        "border-radius:18px",
+        "box-shadow:0 24px 80px rgba(15,23,42,.28)",
+        "font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif",
+        "padding:28px",
+        "overflow:auto"
+      ].join(";");
+      const titleEl = document.createElement("h1");
+      titleEl.textContent = ${JSON.stringify(title)};
+      titleEl.style.cssText = "margin:0 0 18px;font-size:30px;line-height:1.1";
+      panel.appendChild(titleEl);
+      for (const row of ${JSON.stringify(rows)}) {
+        const item = document.createElement("div");
+        item.style.cssText = "margin:12px 0;padding:14px 16px;border:1px solid #d1d5db;border-radius:12px;background:#f9fafb";
+        const label = document.createElement("div");
+        label.textContent = row.label;
+        label.style.cssText = "font-size:12px;font-weight:800;letter-spacing:.06em;text-transform:uppercase;color:#4f46e5;margin-bottom:6px";
+        const value = document.createElement("div");
+        value.textContent = row.value;
+        value.style.cssText = "font-size:18px;font-weight:650;white-space:pre-wrap";
+        item.appendChild(label);
+        item.appendChild(value);
+        panel.appendChild(item);
+      }
+      document.body.appendChild(panel);
+      return document.body.innerText;
+    })()`,
+  );
+}
+
+export default {
+  id: "past-chat-search-tool",
+  title: "Injected tools can search and read past OpenWork chats",
+  spec: "OpenWork injected tool surface for cross-session memory",
+  steps: [
+    {
+      name: "Real app boots before tool proof",
+      run: async (ctx) => {
+        await ctx.prove("The real OpenWork app is running for frame proof", {
+          action: async () => {
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+            await ctx.waitFor("document.body.innerText.trim().length > 40", { label: "rendered app text" });
+          },
+          assert: async () => {
+            const route = await ctx.eval("window.__openworkControl.snapshot().route");
+            ctx.assert(typeof route === "string" && route.length > 0, "OpenWork route was not available.");
+            ctx.log(`route: ${route}`);
+          },
+          screenshot: { name: "app-ready", rejectText: ["Something went wrong"] },
+        });
+      },
+    },
+    {
+      name: "Injected search tool finds a past chat transcript match",
+      run: async (ctx) => {
+        const server = await startMockOpenWorkServer();
+        try {
+          const output = await runInjectedSessionTools(server.baseUrl);
+          ctx.toolOutput = output;
+          await ctx.prove("openwork_session_search returns a transcript hit from another chat", {
+            action: async () => {
+              const hit = output.search.results[0];
+              await showProofPanel(ctx, "Past Chat Search Tool Proof", [
+                { label: "Tool called", value: "openwork_session_search" },
+                { label: "Query", value: output.search.query },
+                { label: "Matched session", value: `${hit.workspaceId} / ${hit.sessionId}` },
+                { label: "Match kind", value: `${hit.kind} (${hit.role})` },
+                { label: "Snippet", value: `${hit.snippet.before}${hit.snippet.match}${hit.snippet.after}` },
+              ]);
+            },
+            assert: async () => {
+              const hit = output.search.results[0];
+              ctx.assert(output.search.ok === true, "Search tool did not return ok: true.");
+              ctx.assert(hit?.sessionId === "ses_alpha", "Search did not return ses_alpha as the first result.");
+              ctx.assert(hit?.role === "user", "Search did not prefer the user's matching message.");
+              ctx.assert(hit?.snippet?.match?.toLowerCase() === "raven launch", "Search snippet did not highlight the query.");
+              ctx.assert(
+                server.requests.some((request) => request.pathname === "/workspace/ws_1/sessions/ses_alpha/messages" && request.search === "?limit=400"),
+                "Search did not load transcript messages through the OpenWork server API.",
+              );
+            },
+            screenshot: { name: "session-search-hit", requireText: ["openwork_session_search", "raven launch", "ses_alpha"] },
+          });
+        } finally {
+          await server.close();
+        }
+      },
+    },
+    {
+      name: "Injected read tool retrieves another chat transcript",
+      run: async (ctx) => {
+        const output = ctx.toolOutput;
+        await ctx.prove("openwork_session_read retrieves the referenced session transcript", {
+          action: async () => {
+            await showProofPanel(ctx, "Past Chat Read Tool Proof", [
+              { label: "Tool called", value: "openwork_session_read" },
+              { label: "Session", value: `${output.read.workspaceId} / ${output.read.sessionId}` },
+              { label: "Title", value: output.read.title },
+              { label: "Returned transcript", value: output.read.messages.map((message) => `${message.role}: ${message.text}`).join("\n") },
+            ]);
+          },
+          assert: async () => {
+            ctx.assert(output.read.ok === true, "Read tool did not return ok: true.");
+            ctx.assert(output.read.workspaceId === "ws_2", "Read tool did not resolve ses_archive in ws_2.");
+            ctx.assert(output.read.sessionId === "ses_archive", "Read tool returned the wrong session id.");
+            ctx.assert(
+              output.read.messages.some((message) => message.text === "We decided to ship the archive importer first."),
+              "Read tool did not return the expected transcript text.",
+            );
+          },
+          screenshot: { name: "session-read-transcript", requireText: ["openwork_session_read", "Archive decisions", "ship the archive importer first"] },
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Summary:
- Adds injected OpenWork tools: openwork_session_search and openwork_session_read.
- Searches past session titles and transcripts across workspaces, with bounded scan/result limits and non-navigating transcript reads.
- Updates cross-session memory instructions to prefer the direct tools.
- Adds focused plugin tests and a fraimz flow for PR evidence.

Verification:
- pnpm --filter openwork-server exec bun test src/opencode-plugins/openwork-extensions-preview.test.ts: passed.
- pnpm --filter openwork-server typecheck: passed.
- pnpm --filter openwork-server build: passed.
- pnpm fraimz --flow past-chat-search-tool --cdp-url http://127.0.0.1:9838: passed.

Fraimz:
- evals/results/2026-06-30T18-18-59-618Z/fraimz.html

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

