### PR TITLE
fix(evals): force light mode by default for fraimz screenshot evidence

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -140,6 +140,11 @@ plugin (configured in `.opencode/opencode.json`). Every tool takes
   `__reactFiber$` → reducer dispatch pattern documented in `daytona-flows.md`.
 - Prefer poll-until-condition waits (`ctx.waitFor`, `ctx.waitForText`) over
   fixed sleeps.
+- The runner forces **light mode** by default before every flow runs
+  (`ctx.ensureLightMode()`, called automatically in `runner/run.mjs`) so
+  screenshot evidence stays readable regardless of the host machine's OS theme.
+  A flow that is itself testing theme/dark-mode behavior can opt out with
+  `preserveTheme: true` on the flow definition; no current flow needs this.
 
 ## Evidence and repair standard
 

--- a/evals/runner/context.mjs
+++ b/evals/runner/context.mjs
@@ -143,6 +143,40 @@ export class EvalContext {
   }
 
   /**
+   * Force light mode for screenshot readability, reloading only if the app
+   * isn't already light. fraimz frame proofs are reviewed as images (in
+   * fraimz.html and exported to docs/PRs); the OS-following "system" default
+   * renders dark-on-dark text illegible whenever the host machine is in dark
+   * mode. Light mode is the readable baseline for evidence, so the runner
+   * applies it automatically unless a flow opts out via `preserveTheme: true`
+   * (for a flow that is itself testing theme/dark-mode behavior).
+   */
+  async ensureLightMode() {
+    await this.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 30_000,
+      label: "control API before theme check",
+    });
+    const currentTheme = await this.eval("document.documentElement.dataset.theme").catch(() => null);
+    if (currentTheme === "light") {
+      return;
+    }
+    await this.eval(`(() => {
+      localStorage.setItem('openwork.react.settings.theme-mode', 'light');
+      return true;
+    })()`);
+    await this.eval("location.reload()");
+    await this.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 30_000,
+      label: "control API after forcing light mode",
+    });
+    await this.waitFor("document.documentElement.dataset.theme === 'light'", {
+      timeoutMs: 10_000,
+      label: "light theme applied",
+    });
+    this.log(`Forced light mode for screenshot readability (was: ${currentTheme ?? "unknown"}).`);
+  }
+
+  /**
    * Poll until the page's visible text contains `text`.
    */
   async waitForText(text, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -89,6 +89,17 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
   const ctx = new EvalContext({ client, outDir, flowId: flow.id, env });
 
   try {
+    // Force light mode by default so screenshot evidence is readable. Flows
+    // that are themselves testing theme/dark-mode behavior can opt out with
+    // `preserveTheme: true` in the flow definition.
+    if (!flow.preserveTheme) {
+      try {
+        await ctx.ensureLightMode();
+      } catch (error) {
+        ctx.log(`Could not force light mode (continuing anyway): ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
     if (typeof flow.precondition === "function") {
       const startedAt = Date.now();
       try {


### PR DESCRIPTION
## What

`evals/runner` now forces light mode automatically before every flow runs, instead of relying on each flow to remember to do it. Only 2 of ~20 existing flows did this themselves.

## Why

fraimz frame proofs are reviewed as images. The app follows the OS theme (`system`) by default, so on any machine running macOS Dark mode, every screenshot rendered dark-on-dark and was hard to read.

## Change

- `evals/runner/context.mjs`: new `ctx.ensureLightMode()` — checks the current theme; if not already light, sets `openwork.react.settings.theme-mode=light` and reloads (the same mechanism two existing flows already used manually). No-ops if already light (no extra reload).
- `evals/runner/run.mjs`: calls `ctx.ensureLightMode()` automatically before every flow, wrapped so a failure to force light mode never fails the flow itself. Opt-out via `preserveTheme: true` on a flow definition for any future flow that's itself testing theme/dark-mode behavior — no current flow needs this.
- `evals/README.md`: documented as a runner convention.

Diff is additive only; no existing flow file was modified.

## Tests run

- `node --check evals/runner/run.mjs evals/runner/context.mjs` — clean.
- Confirmed root cause first: `defaults read -g AppleInterfaceStyle` → `Dark` on the test machine.
- Launched a completely fresh, unconfigured Electron app profile (no localStorage, no prior settings) and confirmed via `browser_eval` it booted with `dataset.theme === "dark"` and no stored preference — proves the bug exists from a clean slate, not just a previously-configured one.
- With the fix active, ran `settings-extensions-mcp` (the exact Extensions/MCP screen reported as unreadable) on that same fresh dark-defaulting profile → passed, screenshot is light and fully readable.
- Ran `app-smoke` and `cloud-account-renders` afterward on the same already-light instance → both passed, no regression, and no extra reload was triggered (confirms the "skip if already light" check works).

fraimz: `evals/results/2026-06-30T22-10-16-876Z/fraimz.html` (local; not committed, gitignored results dir).

## Screenshot evidence

Before (reported by the user, this exact screen, dark/unreadable):
the Extensions/MCP settings screen rendering dark-on-dark.

After (this fix, same screen, same dark-mode machine):
light background, full contrast, all text and cards readable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

