### PR TITLE
feat(den-api): additive search_capabilities tool on the Cloud Control MCP

### DIFF
--- a/ee/apps/den-api/src/mcp/index.ts
+++ b/ee/apps/den-api/src/mcp/index.ts
@@ -1,10 +1,12 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StreamableHTTPTransport } from "@hono/mcp"
 import type { Hono } from "hono"
+import { z } from "zod"
 import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { getMcpResourceUrl, verifyMcpRequest } from "./auth.js"
 import { buildMcpCatalog, getToolDescription, loadOpenApiDocument, type McpToolOperation } from "./catalog.js"
 import { invokeMcpOperation } from "./invoke.js"
+import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities } from "./search.js"
 
 const CATALOG_CACHE_TTL_MS = 5 * 60 * 1000
 
@@ -51,6 +53,29 @@ export function registerMcpRoutes<T extends { Variables: Record<string, unknown>
       name: "openwork-den-api",
       version: "1.0.0",
     })
+
+    server.registerTool(
+      SEARCH_CAPABILITIES_TOOL_NAME,
+      {
+        title: "Search capabilities",
+        description: [
+          "Search this catalog by keyword instead of browsing every tool at once.",
+          "Returns the best-matching tool names with a short summary of each.",
+          "Call the matched tool name directly via the normal tools/call protocol; this tool does not execute anything itself.",
+        ].join(" "),
+        inputSchema: z.object({
+          query: z.string().min(1).describe("Keywords describing the capability you need, e.g. \"create organization\" or \"list workers\"."),
+          limit: z.number().int().min(1).max(20).optional().describe("Max number of matches to return. Defaults to 5."),
+        }),
+      },
+      async ({ query, limit }) => {
+        const matches = searchCapabilities(catalog, query, limit ?? 5)
+        const text = matches.length > 0
+          ? JSON.stringify({ matches }, null, 2)
+          : JSON.stringify({ matches: [], hint: "No matches. Try broader or different keywords." }, null, 2)
+        return { content: [{ type: "text" as const, text }] }
+      },
+    )
 
     for (const operation of catalog) {
       server.registerTool(

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -1,0 +1,89 @@
+import type { McpToolOperation } from "./catalog.js"
+
+/**
+ * `search_capabilities` is the additive "search" half of a search+execute
+ * facade laid on top of the existing OpenAPI-derived catalog (`catalog.ts`)
+ * and its existing in-process "execute" path (`invoke.ts`).
+ *
+ * It does not introduce a new execution mechanism. It only ranks the *same*
+ * tool catalog already registered in `index.ts` so a harness can ask a
+ * question instead of receiving every tool at once, then call the matched
+ * tool name directly via the normal MCP `tools/call` protocol.
+ */
+
+export const SEARCH_CAPABILITIES_TOOL_NAME = "search_capabilities"
+
+export type CapabilityMatch = {
+  name: string
+  method: string
+  path: string
+  score: number
+  summary: string
+}
+
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length > 0)
+}
+
+/**
+ * Splits a camelCase / PascalCase tool name into lowercase word tokens so a
+ * query like "organization" matches a tool named `getOrganizations`.
+ */
+function tokenizeToolName(name: string): string[] {
+  const spaced = name.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+  return tokenize(spaced)
+}
+
+function summaryFor(operation: McpToolOperation): string {
+  return operation.operation.summary ?? operation.operation.description ?? `${operation.method} ${operation.path}`
+}
+
+function scoreOperation(operation: McpToolOperation, queryTokens: string[]): number {
+  if (queryTokens.length === 0) {
+    return 0
+  }
+
+  const nameTokens = tokenizeToolName(operation.name)
+  const summaryTokens = tokenize(summaryFor(operation))
+  const pathTokens = tokenize(operation.path)
+
+  let score = 0
+  for (const queryToken of queryTokens) {
+    if (nameTokens.includes(queryToken)) {
+      score += 5
+    } else if (nameTokens.some((token) => token.startsWith(queryToken) || queryToken.startsWith(token))) {
+      score += 3
+    }
+    if (summaryTokens.includes(queryToken)) {
+      score += 2
+    }
+    if (pathTokens.includes(queryToken)) {
+      score += 1
+    }
+  }
+  return score
+}
+
+export function searchCapabilities(
+  catalog: McpToolOperation[],
+  query: string,
+  limit = 5,
+): CapabilityMatch[] {
+  const queryTokens = tokenize(query)
+  const boundedLimit = Math.max(1, Math.min(20, Math.trunc(limit) || 5))
+
+  return catalog
+    .map((operation) => ({
+      name: operation.name,
+      method: operation.method,
+      path: operation.path,
+      score: scoreOperation(operation, queryTokens),
+      summary: summaryFor(operation),
+    }))
+    .filter((match) => match.score > 0)
+    .sort((a, b) => (b.score - a.score) || a.name.localeCompare(b.name))
+    .slice(0, boundedLimit)
+}

--- a/evals/flows/mcp-search-capabilities.flow.mjs
+++ b/evals/flows/mcp-search-capabilities.flow.mjs
@@ -1,0 +1,330 @@
+/**
+ * Proves the additive "search_capabilities" tool on the existing, real Den
+ * MCP server ("OpenWork Cloud Control"): a harness can search the existing
+ * OpenAPI-derived catalog by keyword instead of receiving the full tool
+ * list, then call the matched real tool name via the normal MCP
+ * tools/call protocol and get a genuine server-side execution result.
+ *
+ * Nothing about auth, policy, or invoke changes. This flow proves the
+ * addition is purely additive: the existing UI-visible Cloud Control
+ * connection still works, and the new search tool sits alongside the
+ * existing catalog tools, dispatching through the same unchanged execute
+ * path (invoke.ts).
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_API_URL    Den API base (e.g. http://127.0.0.1:8793)
+ * - OPENWORK_EVAL_DEN_TOKEN      Bearer session token for the demo owner
+ */
+
+async function denFetch(ctx, path, options = {}) {
+  const base = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+  const response = await fetch(`${base}${path}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  if (!response.ok) {
+    throw new Error(`${options.method || "GET"} ${path} -> ${response.status}: ${typeof body === "string" ? body : JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+/** The Den /mcp endpoint speaks MCP-over-streamable-HTTP; each request gets a
+ * fresh server instance (no session to carry between calls), so a single
+ * JSON-RPC POST per call is sufficient. Responses are SSE-framed even for a
+ * single message, so unwrap the `data: {...}` line.
+ */
+async function mcpCall(ctx, mcpToken, method, params) {
+  const base = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+  const response = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${mcpToken}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params: params ?? {} }),
+  });
+  const raw = await response.text();
+  ctx.assert(response.ok, `MCP ${method} failed: ${response.status} ${raw.slice(0, 300)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  ctx.assert(Boolean(dataLine), `MCP ${method} returned no data frame: ${raw.slice(0, 300)}`);
+  const parsed = JSON.parse(dataLine.slice(5));
+  ctx.assert(!parsed.error, `MCP ${method} returned a JSON-RPC error: ${JSON.stringify(parsed.error)}`);
+  return parsed.result;
+}
+
+export default {
+  id: "mcp-search-capabilities",
+  title: "search_capabilities ranks the real Den MCP catalog and the matched tool executes for real",
+  spec: "evals/cloud-mcp-agent-flows.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_WORKSPACE_PATH"],
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000 });
+      },
+    },
+    {
+      name: "Sign in via desktop handoff (skipped when already signed in)",
+      run: async (ctx) => {
+        const signedIn = await ctx.eval(
+          "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+        );
+        if (signedIn) {
+          ctx.log("Already signed in; reusing session.");
+          return;
+        }
+        const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+        const response = await fetch(`${apiBase}/v1/auth/desktop-handoff`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({}),
+        });
+        ctx.assert(response.ok, `Handoff create failed: ${response.status}`);
+        const payload = await response.json();
+
+        // Exchange via the control action (not the "paste link" UI field): the
+        // UI field would follow the deep link's embedded denBaseUrl, which
+        // assumes a den-web reverse proxy. The control action exchanges
+        // directly against the app's own already-configured apiBaseUrl.
+        await ctx.control("auth.exchange-grant", { grant: payload.grant });
+        await ctx.waitFor(
+          "window.__openworkControl.execute('auth.status').then(r => r.result?.status === 'signed_in')",
+          { timeoutMs: 15_000, label: "auth signed_in" },
+        );
+      },
+    },
+    {
+      name: "Active organization resolves and Cloud Control MCP auto-configures",
+      run: async (ctx) => {
+        await ctx.waitFor(
+          "Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())",
+          { timeoutMs: 60_000, label: "active org" },
+        );
+
+        // Onboarding shows an org picker before the desktop fully activates
+        // the resolved org. Click through it (idempotent if already past it).
+        const onOnboarding = await ctx.eval("location.hash.includes('/onboarding')");
+        if (onOnboarding) {
+          await ctx.clickText("Continue with organization", { timeoutMs: 20_000 }).catch(() => {});
+          await ctx.clickText("Continue to workspace", { timeoutMs: 20_000 }).catch(() => {});
+        }
+
+        // Cloud MCP auto-config syncs once a workspace exists. Create one if
+        // we landed on /welcome (idempotent if a workspace already exists).
+        const onWelcome = await ctx.eval("location.hash.includes('/welcome')");
+        if (onWelcome) {
+          const wsPath = ctx.env.OPENWORK_EVAL_WORKSPACE_PATH.trim();
+          await ctx.fill("input", wsPath);
+          await ctx.clickText("Use this folder", { timeoutMs: 10_000 });
+          await ctx.waitFor("location.hash.includes('/workspace/')", {
+            timeoutMs: 30_000,
+            label: "workspace route after creation",
+          });
+        }
+
+        await ctx.waitFor(
+          "Boolean(localStorage.getItem('openwork.den.mcp.sync'))",
+          { timeoutMs: 180_000, label: "openwork.den.mcp.sync marker" },
+        );
+      },
+    },
+    {
+      name: "OpenWork Cloud Control is connected — the unchanged existing surface still works",
+      run: async (ctx) => {
+        await ctx.prove("Adding search_capabilities did not break the existing, already-shipped Cloud Control connection.", {
+          action: async () => {
+            await ctx.navigateHash("/settings/extensions/mcp");
+            await ctx.expectHashIncludes("/settings/extensions/mcp");
+          },
+          assert: async () => {
+            await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 30_000 });
+          },
+          screenshot: {
+            name: "cloud-control-still-connected",
+            requireText: ["OpenWork Cloud Control"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+    {
+      name: "Mint a real org-scoped MCP token for this org",
+      run: async (ctx) => {
+        const minted = await denFetch(ctx, "/v1/mcp/token", {
+          method: "POST",
+          headers: { authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}` },
+          body: JSON.stringify({}),
+        });
+        ctx.assert(typeof minted.token === "string" && minted.token.startsWith("ow_mcp_at_"), "Expected a real opaque MCP token.");
+        ctx.mcpToken = minted.token;
+        ctx.organizationId = minted.organizationId;
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "A real, org-scoped MCP access token was minted via the existing first-party token route.",
+          actual: { organizationId: minted.organizationId, scopes: minted.scopes },
+        });
+      },
+    },
+    {
+      name: "search_capabilities is present in the real tools/list alongside the existing catalog",
+      run: async (ctx) => {
+        const result = await mcpCall(ctx, ctx.mcpToken, "tools/list", {});
+        const names = result.tools.map((tool) => tool.name);
+        ctx.assert(names.includes("search_capabilities"), "search_capabilities missing from tools/list.");
+        ctx.assert(names.includes("getOrg"), "Existing catalog tool getOrg missing — addition must be purely additive.");
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "tools/list includes the new search_capabilities tool plus the full existing OpenAPI-derived catalog, unchanged.",
+          actual: { totalTools: names.length, hasSearch: true },
+        });
+        ctx.log(`tools/list: ${names.length} tools, search_capabilities present.`);
+      },
+    },
+    {
+      name: "Calling search_capabilities ranks the real catalog by keyword",
+      run: async (ctx) => {
+        const result = await mcpCall(ctx, ctx.mcpToken, "tools/call", {
+          name: "search_capabilities",
+          arguments: { query: "list organization", limit: 5 },
+        });
+        const text = result.content?.[0]?.text ?? "";
+        const parsed = JSON.parse(text);
+        ctx.matches = parsed.matches ?? [];
+        ctx.assert(ctx.matches.length > 0, "Expected at least one ranked match for 'list organization'.");
+        const topMatchNames = ctx.matches.map((match) => match.name);
+        ctx.assert(topMatchNames.includes("getOrg"), `Expected getOrg among top matches, got: ${topMatchNames.join(", ")}`);
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "search_capabilities returned real, ranked matches from the live catalog for a natural-language-ish query.",
+          actual: ctx.matches,
+        });
+        ctx.log(`search matches: ${topMatchNames.join(", ")}`);
+      },
+    },
+    {
+      name: "Executing the matched real tool runs the existing, unchanged invoke path against live data",
+      run: async (ctx) => {
+        const topMatch = ctx.matches[0];
+        ctx.assert(topMatch?.name === "getOrg", `Expected top match to be getOrg, got ${topMatch?.name}`);
+
+        const result = await mcpCall(ctx, ctx.mcpToken, "tools/call", { name: topMatch.name, arguments: {} });
+        const text = result.content?.[0]?.text ?? "";
+        const parsed = JSON.parse(text);
+        ctx.assert(parsed.organization?.id === ctx.organizationId, "Executed tool did not return the real, current organization.");
+        ctx.orgName = parsed.organization?.name;
+        ctx.assert(typeof ctx.orgName === "string" && ctx.orgName.length > 0, "Real organization name missing from executed tool result.");
+
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "search -> execute completed end-to-end: the tool search_capabilities matched was called via the unchanged real invoke path and returned genuine organization data.",
+          actual: { organizationId: parsed.organization?.id, organizationName: ctx.orgName },
+        });
+      },
+    },
+    {
+      name: "The organization name returned by the protocol call matches what the UI shows",
+      run: async (ctx) => {
+        await ctx.prove("The data returned by search -> execute is the same real organization the signed-in desktop app is showing, not a mock.", {
+          action: async () => {
+            await ctx.navigateHash("/settings/cloud-account");
+            await ctx.expectHashIncludes("/settings/cloud-account");
+          },
+          assert: async () => {
+            await ctx.expectText(ctx.orgName, { timeoutMs: 30_000 });
+          },
+          screenshot: {
+            name: "org-name-matches-ui",
+            requireText: [ctx.orgName],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/cloud-account",
+          },
+        });
+      },
+    },
+    {
+      name: "A real chat message triggers search_capabilities then the matched tool through the actual agent",
+      run: async (ctx) => {
+        // This is the strongest proof: not a direct protocol call from the
+        // eval script, but a real chat turn -> real OpenCode agent -> real
+        // tool calls against the live, authenticated Cloud Control MCP ->
+        // real Den API data, surfaced back in the chat transcript. The agent
+        // is instructed to use search_capabilities first so this run
+        // specifically exercises the new tool, not just any cloud capability.
+        await ctx.prove("Chat-triggered: the agent calls search_capabilities, then calls the tool it matched, against the real backend.", {
+          action: async () => {
+            // The previous step left us on /settings/cloud-account;
+            // session.create_task is only registered on a session route.
+            await ctx.navigateHash("/session");
+            await ctx.waitFor(
+              "Boolean(window.__openworkControl?.listActions().find((a) => a.id === 'session.create_task' && !a.disabled))",
+              { timeoutMs: 15_000, label: "session.create_task available" },
+            );
+            await ctx.control("session.create_task");
+            await ctx.waitFor(
+              `(() => {
+                const route = window.__openworkControl.snapshot().route || "";
+                return /ses_[A-Za-z0-9]+/.test(route);
+              })()`,
+              { timeoutMs: 30_000, label: "new session active" },
+            );
+
+            const pasted = await ctx.eval(`(() => {
+              const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
+                || document.querySelector('[contenteditable="true"]');
+              if (!editor) return { ok: false, reason: "composer not found" };
+              editor.focus();
+              const data = new DataTransfer();
+              data.setData('text/plain', ${JSON.stringify(
+                'On the OpenWork Cloud Control MCP, first call the search_capabilities tool with query "organization" to find the right tool, then call whichever tool it matches to tell me my organization name. Use search_capabilities first, do not skip it.',
+              )});
+              editor.dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: data }));
+              return { ok: true };
+            })()`);
+            ctx.assert(pasted?.ok, `Composer not ready: ${pasted?.reason ?? "unknown"}`);
+
+            const submitted = await ctx.waitFor(`(() => {
+              const byLabel = Array.from(document.querySelectorAll('button'))
+                .find((b) => /run task|send|run/i.test((b.textContent || "").trim()) && !b.disabled);
+              if (byLabel) { byLabel.click(); return "clicked"; }
+              return null;
+            })()`, { timeoutMs: 10_000, label: "submit button enabled" });
+            ctx.log(`submit: ${submitted}`);
+          },
+          assert: async () => {
+            // Real LLM tool-calling latency: generous timeouts, two real
+            // network calls (search, then execute) plus model reasoning.
+            await ctx.waitForText("search capabilities", { timeoutMs: 90_000 });
+            await ctx.waitForText("getOrg", { timeoutMs: 60_000 });
+            await ctx.waitForText(ctx.orgName, { timeoutMs: 60_000 });
+            await ctx.expectNoText("Something went wrong");
+          },
+          screenshot: {
+            name: "chat-triggered-search-then-execute",
+            requireText: ["search capabilities", "getOrg", ctx.orgName],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## What

Adds one new tool, `search_capabilities`, to the existing, already-shipped Den `/mcp` endpoint ("OpenWork Cloud Control" as seen by the desktop app). It ranks the same OpenAPI-derived catalog already registered there by keyword, so a harness can search instead of being handed the full ~129-tool list, then call whichever real tool it matched via the normal MCP `tools/call` protocol.

## Why

This is the smallest real step toward a "search then execute" facade on top of infrastructure that already exists and is already live in the desktop app. It also directly addresses the original OpenCode-reload pain point: because the harness can rely on `search_capabilities` instead of needing every tool individually surfaced, capabilities can grow behind that one stable tool without the tool list itself needing to change.

## Change

- `ee/apps/den-api/src/mcp/search.ts` (new): pure `searchCapabilities(catalog, query, limit)` — tokenized keyword scoring against tool name (camelCase-aware), summary, and path. No new infra, no new dependencies.
- `ee/apps/den-api/src/mcp/index.ts`: registers `search_capabilities` as one additional `server.registerTool(...)` call, alongside the existing catalog loop. **Purely additive — 25 lines, nothing removed or changed.**
- `evals/flows/mcp-search-capabilities.flow.mjs` (new): a real, end-to-end fraimz flow (see Tests run below).

No change to auth (`auth.ts`), policy (`policy.ts`), or the existing in-process execute path (`invoke.ts`). The existing Cloud Control connection and every existing catalog tool are unaffected — verified explicitly in the flow (`tools/list` still includes `getOrg` etc. alongside the new tool).

## Tests run

`npx tsc -p ee/apps/den-api/tsconfig.json --noEmit` — clean.

Ran the real coded flow (`pnpm fraimz --flow mcp-search-capabilities`) against:
- the real Den API (local, same MySQL-backed demo org seed used elsewhere in `evals/`)
- the real desktop Electron app, signed in as the seeded demo owner

All steps passed:
1. App boots, signs in (skipped if already signed in), resolves the active org, creates a workspace if needed.
2. **OpenWork Cloud Control still shows "Connected"** — proves the addition didn't break the existing, already-shipped surface.
3. Mints a real org-scoped MCP token via the existing `/v1/mcp/token` route.
4. `tools/list` over real JSON-RPC → `search_capabilities` present alongside the full, unchanged 128-tool catalog.
5. `tools/call search_capabilities({query:"list organization"})` → real ranked matches from the live catalog, top hit `getOrg`.
6. `tools/call getOrg` (the matched tool, called via the normal protocol) → runs through the **unchanged** `invoke.ts` path and returns genuine organization data.
7. That same organization name is then confirmed visible in the actual desktop UI (Cloud Account screen) — ties the protocol proof to a real visual fact, not just a JSON blob.
8. **A real chat message in the desktop app** ("...first call search_capabilities... then call whichever tool it matches...") causes the actual OpenCode agent — using a real, already-connected model provider (no manual provider setup needed) — to call `search_capabilities`, then call the matched `getOrg`, with the real result surfaced back in the chat transcript. This is the strongest proof: not a direct protocol call from a test script, but the real chat → real agent → real cloud MCP path.

fraimz: `evals/results/2026-06-30T22-41-53-138Z/fraimz.html` (local; not committed, gitignored results dir). 10/10 steps passed.

## Honest limitations

- The harness still sees the full catalog (`search_capabilities` was added *alongside* the existing 128 tools, not in place of them). In my first manual chat test, the model skipped search entirely and called `getOrg` directly by name, because it already had it in its tool list — I had to explicitly instruct it to use search first to specifically exercise the new tool. Getting the harness down to a true minimal two-tool surface (search + execute only, with the other 128 tools no longer individually registered) is a deliberate follow-up, not included here.
- The chat-triggered step depends on a live LLM call, so it's real but not as deterministic as the pure protocol steps.
- Only tested against one organization (the seeded demo org).
- Screenshots in the local fraimz run were captured using the light-mode runner default from #2398; that PR is not a code dependency of this one (this PR's diff stands alone and was typechecked independently), but pairs well with it for readable evidence.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

