### PR TITLE
feat(den-api): minimal /mcp/agent surface (search_capabilities + execute_capability only) for the desktop's Cloud Control connection

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -155,13 +155,15 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     serverName: "openwork-cloud",
     get description() { return t("mcp.quick_connect_openwork_cloud_desc"); },
     get url() {
-      // The Den MCP server is hosted by den-api (see
-      // packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx), never at the
-      // web app's root — getDenMcpUrl heals stale web-app origins.
+      // The desktop app connects to the minimal, harness-facing surface
+      // (/mcp/agent: search_capabilities + execute_capability only), not the
+      // full catalog at bare /mcp. getDenMcpUrl heals stale web-app origins;
+      // never at the web app's root (see
+      // packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx).
       try {
-        return getDenMcpUrl();
+        return `${getDenMcpUrl()}/agent`;
       } catch {
-        return "https://api.openworklabs.com/mcp";
+        return "https://api.openworklabs.com/mcp/agent";
       }
     },
     type: "remote",

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -632,8 +632,8 @@ export function createConnectionsStore(options: {
 
       // Signed-in cloud users connect the Den MCPs with a first-party token —
       // no browser OAuth round-trip. Signed-out users fall back to OAuth.
-      // The same minted token works for both /mcp (openwork-cloud) and
-      // /mcp/admin (openwork-admin); den-api enforces the platform-admin
+      // The same minted token works for /mcp/agent (openwork-cloud), /mcp,
+      // and /mcp/admin (openwork-admin); den-api enforces the platform-admin
       // allowlist on the admin endpoint server-side.
       if (entry.serverName === "openwork-cloud" || entry.serverName === "openwork-admin") {
         try {
@@ -642,9 +642,13 @@ export function createConnectionsStore(options: {
             if (entry.serverName === "openwork-cloud") {
               // Never trust `minted.resource` verbatim: older den-api builds
               // mint the bare web-app origin (https://app.openworklabs.com/mcp)
-              // where MCP 404s. Heal it, falling back to the entry's
-              // bootstrap-derived URL.
-              resolvedUrl = resolveCloudMcpResourceUrl(minted.resource) ?? resolvedUrl;
+              // where MCP 404s. Heal it to the canonical /mcp origin, then
+              // route the desktop app to the minimal, harness-facing
+              // /mcp/agent surface (search_capabilities + execute_capability
+              // only) rather than the full catalog — falling back to the
+              // entry's bootstrap-derived URL (which already targets /agent).
+              const healed = resolveCloudMcpResourceUrl(minted.resource);
+              resolvedUrl = healed ? `${healed}/agent` : resolvedUrl;
             }
             resolvedHeaders = { Authorization: `Bearer ${minted.token}` };
           }

--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -13,6 +13,7 @@ import { db } from "./db.js"
 import { env } from "./env.js"
 import { publicRoute } from "./middleware/index.js"
 import { registerAdminMcpRoutes } from "./mcp/admin.js"
+import { registerAgentMcpRoutes } from "./mcp/agent.js"
 import { registerMcpRoutes } from "./mcp/index.js"
 import type { MemberTeamsContext, OrganizationContextVariables, UserOrganizationsContext } from "./middleware/index.js"
 import { buildOperationId, emptyResponse, htmlResponse, jsonResponse } from "./openapi.js"
@@ -168,6 +169,7 @@ registerWebhookRoutes(app)
 registerWorkerRoutes(app)
 registerMcpTokenRoutes(app)
 registerMcpRoutes(app)
+registerAgentMcpRoutes(app)
 registerAdminMcpRoutes(app)
 registerTelemetryRoutes(app)
 

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -1,0 +1,118 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StreamableHTTPTransport } from "@hono/mcp"
+import type { Hono } from "hono"
+import { z } from "zod"
+import { publicRoute, tokenRoute } from "../middleware/index.js"
+import { getMcpResourceUrl, verifyMcpRequest } from "./auth.js"
+import { invokeMcpOperation, normalizeToolBody } from "./invoke.js"
+import { getCatalog, protectedResourceMetadata } from "./index.js"
+import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities } from "./search.js"
+
+export const EXECUTE_CAPABILITY_TOOL_NAME = "execute_capability"
+
+/**
+ * The minimal, harness-facing MCP surface: exactly two tools, full stop.
+ *
+ * `/mcp` (index.ts) stays exactly as it is — every catalog operation
+ * individually registered, ~129 tools today. That's unchanged and still
+ * useful for scripts/admin tooling that want to call a known operation by
+ * name directly.
+ *
+ * `/mcp/agent` is a *different* endpoint for a *different* consumer: the
+ * desktop app's "OpenWork Cloud Control" connection, which is what an
+ * OpenCode/Claude Code/Codex-style harness actually sees. It registers only
+ * `search_capabilities` and `execute_capability`, both backed by the exact
+ * same catalog and the exact same `invokeMcpOperation` execute path used by
+ * the rich endpoint — no new auth, no new policy, no new execution logic.
+ * A harness connected here can only discover and call capabilities through
+ * these two tools; the other ~127 operations are not individually callable
+ * on this endpoint.
+ */
+export function registerAgentMcpRoutes<T extends { Variables: Record<string, unknown> }>(app: Hono<T>) {
+  app.get("/.well-known/oauth-protected-resource/mcp/agent", publicRoute, (c) =>
+    c.json(protectedResourceMetadata(c.req.raw)))
+  app.get("/mcp/agent/.well-known/oauth-protected-resource", publicRoute, (c) =>
+    c.json(protectedResourceMetadata(c.req.raw)))
+
+  app.all("/mcp/agent", tokenRoute, async (c) => {
+    const principal = await verifyMcpRequest(c.req.raw.headers, getMcpResourceUrl(c.req.raw))
+    if (principal instanceof Response) {
+      return principal
+    }
+
+    const catalog = await getCatalog(app as unknown as Hono, c.env)
+    const server = new McpServer({
+      name: "openwork-den-api-agent",
+      version: "1.0.0",
+    })
+
+    server.registerTool(
+      SEARCH_CAPABILITIES_TOOL_NAME,
+      {
+        title: "Search capabilities",
+        description: [
+          "Search for a capability by keyword. This connection only exposes this tool and execute_capability —",
+          "there is no list of individually-named tools to browse. Always search first.",
+          "Each match includes pathParams/queryParams/hasBody describing exactly what execute_capability needs.",
+        ].join(" "),
+        inputSchema: z.object({
+          query: z.string().min(1).describe("Keywords describing the capability you need, e.g. \"create organization\" or \"list workers\"."),
+          limit: z.number().int().min(1).max(20).optional().describe("Max number of matches to return. Defaults to 5."),
+        }),
+      },
+      async ({ query, limit }) => {
+        const matches = searchCapabilities(catalog, query, limit ?? 5)
+        const text = matches.length > 0
+          ? JSON.stringify({ matches }, null, 2)
+          : JSON.stringify({ matches: [], hint: "No matches. Try broader or different keywords." }, null, 2)
+        return { content: [{ type: "text" as const, text }] }
+      },
+    )
+
+    server.registerTool(
+      EXECUTE_CAPABILITY_TOOL_NAME,
+      {
+        title: "Execute capability",
+        description: [
+          "Call a capability found via search_capabilities, by its exact name.",
+          "Pass path/query/body only as described by that match's pathParams/queryParams/hasBody.",
+          "Returns unknown_capability if name doesn't match a current capability — call search_capabilities again.",
+        ].join(" "),
+        inputSchema: z.object({
+          name: z.string().min(1).describe("The exact tool name returned by search_capabilities."),
+          path: z.record(z.string(), z.unknown()).optional().describe("Path parameters, only if the match's pathParams is non-empty."),
+          query: z.record(z.string(), z.unknown()).optional().describe("Query parameters, only if the match's queryParams is non-empty."),
+          body: z.unknown().optional().describe("JSON body, only if the match's hasBody is true."),
+        }),
+      },
+      async ({ name, path, query, body }) => {
+        const operation = catalog.find((candidate) => candidate.name === name)
+        if (!operation) {
+          return {
+            isError: true,
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "unknown_capability",
+                message: `No capability named "${name}". Call search_capabilities to find a valid name.`,
+              }),
+            }],
+          }
+        }
+
+        return invokeMcpOperation({
+          app: app as unknown as Hono,
+          env: c.env,
+          operation,
+          principal,
+          toolInput: { path, query, body: normalizeToolBody(body) },
+        })
+      },
+    )
+
+    const transport = new StreamableHTTPTransport()
+    await server.connect(transport)
+    const response = await transport.handleRequest(c)
+    return response ?? new Response(null, { status: 204 })
+  })
+}

--- a/ee/apps/den-api/src/mcp/catalog.ts
+++ b/ee/apps/den-api/src/mcp/catalog.ts
@@ -99,7 +99,7 @@ function isOpenApiParameter(value: unknown): value is OpenApiParameter {
   return typeof value === "object" && value !== null
 }
 
-function getParameters(operation: OpenApiOperation, location: "path" | "query") {
+export function getParameters(operation: OpenApiOperation, location: "path" | "query") {
   return (operation.parameters ?? [])
     .filter(isOpenApiParameter)
     .filter((parameter) => parameter.in === location && typeof parameter.name === "string" && parameter.name.length > 0)
@@ -141,7 +141,7 @@ function objectForParameters(parameters: OpenApiParameter[], requiredByDefault: 
   return z.object(shape).strict()
 }
 
-function pathParameterNamesFromTemplate(path: string) {
+export function pathParameterNamesFromTemplate(path: string) {
   return [...path.matchAll(/\{([^}]+)\}/g)].map((match) => match[1]).filter(Boolean)
 }
 
@@ -158,7 +158,7 @@ function buildQuerySchema(operation: OpenApiOperation) {
   return parameters.length > 0 ? objectForParameters(parameters, false) : undefined
 }
 
-function hasJsonRequestBody(operation: OpenApiOperation) {
+export function hasJsonRequestBody(operation: OpenApiOperation) {
   const requestBody = getRequestBody(operation)
   const content = requestBody?.content
   return typeof content === "object" && content !== null && "application/json" in content

--- a/ee/apps/den-api/src/mcp/index.ts
+++ b/ee/apps/den-api/src/mcp/index.ts
@@ -1,10 +1,12 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StreamableHTTPTransport } from "@hono/mcp"
 import type { Hono } from "hono"
+import { z } from "zod"
 import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { getMcpResourceUrl, verifyMcpRequest } from "./auth.js"
 import { buildMcpCatalog, getToolDescription, loadOpenApiDocument, type McpToolOperation } from "./catalog.js"
 import { invokeMcpOperation } from "./invoke.js"
+import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities } from "./search.js"
 
 const CATALOG_CACHE_TTL_MS = 5 * 60 * 1000
 
@@ -51,6 +53,29 @@ export function registerMcpRoutes<T extends { Variables: Record<string, unknown>
       name: "openwork-den-api",
       version: "1.0.0",
     })
+
+    server.registerTool(
+      SEARCH_CAPABILITIES_TOOL_NAME,
+      {
+        title: "Search capabilities",
+        description: [
+          "Search this catalog by keyword instead of browsing every tool at once.",
+          "Returns the best-matching tool names with a short summary of each.",
+          "Call the matched tool name directly via the normal tools/call protocol; this tool does not execute anything itself.",
+        ].join(" "),
+        inputSchema: z.object({
+          query: z.string().min(1).describe("Keywords describing the capability you need, e.g. \"create organization\" or \"list workers\"."),
+          limit: z.number().int().min(1).max(20).optional().describe("Max number of matches to return. Defaults to 5."),
+        }),
+      },
+      async ({ query, limit }) => {
+        const matches = searchCapabilities(catalog, query, limit ?? 5)
+        const text = matches.length > 0
+          ? JSON.stringify({ matches }, null, 2)
+          : JSON.stringify({ matches: [], hint: "No matches. Try broader or different keywords." }, null, 2)
+        return { content: [{ type: "text" as const, text }] }
+      },
+    )
 
     for (const operation of catalog) {
       server.registerTool(

--- a/ee/apps/den-api/src/mcp/index.ts
+++ b/ee/apps/den-api/src/mcp/index.ts
@@ -16,8 +16,11 @@ let catalogCache: { catalog: McpToolOperation[]; expiresAt: number } | null = nu
  * The tool catalog is derived from the OpenAPI document, which only changes
  * on deploy. Cache it briefly instead of self-fetching openapi.json and
  * rebuilding the catalog on every /mcp request.
+ *
+ * Exported so the minimal agent-facing endpoint (./agent.ts) shares this
+ * exact cache instead of re-fetching/rebuilding the catalog separately.
  */
-async function getCatalog(app: Hono, env: unknown) {
+export async function getCatalog(app: Hono, env: unknown) {
   if (catalogCache && catalogCache.expiresAt > Date.now()) {
     return catalogCache.catalog
   }

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -1,0 +1,89 @@
+import type { McpToolOperation } from "./catalog.js"
+
+/**
+ * `search_capabilities` is the additive "search" half of a search+execute
+ * facade laid on top of the existing OpenAPI-derived catalog (`catalog.ts`)
+ * and its existing in-process "execute" path (`invoke.ts`).
+ *
+ * It does not introduce a new execution mechanism. It only ranks the *same*
+ * tool catalog already registered in `index.ts` so a harness can ask a
+ * question instead of receiving every tool at once, then call the matched
+ * tool name directly via the normal MCP `tools/call` protocol.
+ */
+
+export const SEARCH_CAPABILITIES_TOOL_NAME = "search_capabilities"
+
+export type CapabilityMatch = {
+  name: string
+  method: string
+  path: string
+  score: number
+  summary: string
+}
+
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length > 0)
+}
+
+/**
+ * Splits a camelCase / PascalCase tool name into lowercase word tokens so a
+ * query like "organization" matches a tool named `getOrganizations`.
+ */
+function tokenizeToolName(name: string): string[] {
+  const spaced = name.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+  return tokenize(spaced)
+}
+
+function summaryFor(operation: McpToolOperation): string {
+  return operation.operation.summary ?? operation.operation.description ?? `${operation.method} ${operation.path}`
+}
+
+function scoreOperation(operation: McpToolOperation, queryTokens: string[]): number {
+  if (queryTokens.length === 0) {
+    return 0
+  }
+
+  const nameTokens = tokenizeToolName(operation.name)
+  const summaryTokens = tokenize(summaryFor(operation))
+  const pathTokens = tokenize(operation.path)
+
+  let score = 0
+  for (const queryToken of queryTokens) {
+    if (nameTokens.includes(queryToken)) {
+      score += 5
+    } else if (nameTokens.some((token) => token.startsWith(queryToken) || queryToken.startsWith(token))) {
+      score += 3
+    }
+    if (summaryTokens.includes(queryToken)) {
+      score += 2
+    }
+    if (pathTokens.includes(queryToken)) {
+      score += 1
+    }
+  }
+  return score
+}
+
+export function searchCapabilities(
+  catalog: McpToolOperation[],
+  query: string,
+  limit = 5,
+): CapabilityMatch[] {
+  const queryTokens = tokenize(query)
+  const boundedLimit = Math.max(1, Math.min(20, Math.trunc(limit) || 5))
+
+  return catalog
+    .map((operation) => ({
+      name: operation.name,
+      method: operation.method,
+      path: operation.path,
+      score: scoreOperation(operation, queryTokens),
+      summary: summaryFor(operation),
+    }))
+    .filter((match) => match.score > 0)
+    .sort((a, b) => (b.score - a.score) || a.name.localeCompare(b.name))
+    .slice(0, boundedLimit)
+}

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -1,14 +1,19 @@
-import type { McpToolOperation } from "./catalog.js"
+import { getParameters, hasJsonRequestBody, pathParameterNamesFromTemplate, type McpToolOperation } from "./catalog.js"
 
 /**
- * `search_capabilities` is the additive "search" half of a search+execute
- * facade laid on top of the existing OpenAPI-derived catalog (`catalog.ts`)
- * and its existing in-process "execute" path (`invoke.ts`).
+ * `search_capabilities` is the "search" half of a search+execute facade laid
+ * on top of the existing OpenAPI-derived catalog (`catalog.ts`) and its
+ * existing in-process "execute" path (`invoke.ts`).
  *
- * It does not introduce a new execution mechanism. It only ranks the *same*
- * tool catalog already registered in `index.ts` so a harness can ask a
- * question instead of receiving every tool at once, then call the matched
- * tool name directly via the normal MCP `tools/call` protocol.
+ * Two consumers use this:
+ * - The rich `/mcp` endpoint (`index.ts`), where matches are informational —
+ *   the harness can call the matched tool name directly, since every
+ *   catalog operation is also individually registered there.
+ * - The minimal `/mcp/agent` endpoint (`agent.ts`), where matches are the
+ *   *only* way to discover what's callable — that endpoint exposes nothing
+ *   but `search_capabilities` and a generic `execute_capability`, so each
+ *   match carries enough shape (`pathParams`/`queryParams`/`hasBody`) for the
+ *   caller to construct a valid `execute_capability` call without guessing.
  */
 
 export const SEARCH_CAPABILITIES_TOOL_NAME = "search_capabilities"
@@ -19,6 +24,12 @@ export type CapabilityMatch = {
   path: string
   score: number
   summary: string
+  /** Path parameter names this tool's `path` template requires, e.g. ["workerId"]. */
+  pathParams: string[]
+  /** Query parameter names this tool documents, if any. */
+  queryParams: string[]
+  /** Whether calling this tool requires a JSON `body`. */
+  hasBody: boolean
 }
 
 function tokenize(value: string): string[] {
@@ -82,6 +93,9 @@ export function searchCapabilities(
       path: operation.path,
       score: scoreOperation(operation, queryTokens),
       summary: summaryFor(operation),
+      pathParams: pathParameterNamesFromTemplate(operation.path),
+      queryParams: getParameters(operation.operation, "query").map((parameter) => parameter.name as string),
+      hasBody: hasJsonRequestBody(operation.operation),
     }))
     .filter((match) => match.score > 0)
     .sort((a, b) => (b.score - a.score) || a.name.localeCompare(b.name))

--- a/evals/flows/mcp-search-capabilities.flow.mjs
+++ b/evals/flows/mcp-search-capabilities.flow.mjs
@@ -1,0 +1,330 @@
+/**
+ * Proves the additive "search_capabilities" tool on the existing, real Den
+ * MCP server ("OpenWork Cloud Control"): a harness can search the existing
+ * OpenAPI-derived catalog by keyword instead of receiving the full tool
+ * list, then call the matched real tool name via the normal MCP
+ * tools/call protocol and get a genuine server-side execution result.
+ *
+ * Nothing about auth, policy, or invoke changes. This flow proves the
+ * addition is purely additive: the existing UI-visible Cloud Control
+ * connection still works, and the new search tool sits alongside the
+ * existing catalog tools, dispatching through the same unchanged execute
+ * path (invoke.ts).
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_API_URL    Den API base (e.g. http://127.0.0.1:8793)
+ * - OPENWORK_EVAL_DEN_TOKEN      Bearer session token for the demo owner
+ */
+
+async function denFetch(ctx, path, options = {}) {
+  const base = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+  const response = await fetch(`${base}${path}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  if (!response.ok) {
+    throw new Error(`${options.method || "GET"} ${path} -> ${response.status}: ${typeof body === "string" ? body : JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+/** The Den /mcp endpoint speaks MCP-over-streamable-HTTP; each request gets a
+ * fresh server instance (no session to carry between calls), so a single
+ * JSON-RPC POST per call is sufficient. Responses are SSE-framed even for a
+ * single message, so unwrap the `data: {...}` line.
+ */
+async function mcpCall(ctx, mcpToken, method, params) {
+  const base = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+  const response = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${mcpToken}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params: params ?? {} }),
+  });
+  const raw = await response.text();
+  ctx.assert(response.ok, `MCP ${method} failed: ${response.status} ${raw.slice(0, 300)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  ctx.assert(Boolean(dataLine), `MCP ${method} returned no data frame: ${raw.slice(0, 300)}`);
+  const parsed = JSON.parse(dataLine.slice(5));
+  ctx.assert(!parsed.error, `MCP ${method} returned a JSON-RPC error: ${JSON.stringify(parsed.error)}`);
+  return parsed.result;
+}
+
+export default {
+  id: "mcp-search-capabilities",
+  title: "search_capabilities ranks the real Den MCP catalog and the matched tool executes for real",
+  spec: "evals/cloud-mcp-agent-flows.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_WORKSPACE_PATH"],
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000 });
+      },
+    },
+    {
+      name: "Sign in via desktop handoff (skipped when already signed in)",
+      run: async (ctx) => {
+        const signedIn = await ctx.eval(
+          "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+        );
+        if (signedIn) {
+          ctx.log("Already signed in; reusing session.");
+          return;
+        }
+        const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+        const response = await fetch(`${apiBase}/v1/auth/desktop-handoff`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({}),
+        });
+        ctx.assert(response.ok, `Handoff create failed: ${response.status}`);
+        const payload = await response.json();
+
+        // Exchange via the control action (not the "paste link" UI field): the
+        // UI field would follow the deep link's embedded denBaseUrl, which
+        // assumes a den-web reverse proxy. The control action exchanges
+        // directly against the app's own already-configured apiBaseUrl.
+        await ctx.control("auth.exchange-grant", { grant: payload.grant });
+        await ctx.waitFor(
+          "window.__openworkControl.execute('auth.status').then(r => r.result?.status === 'signed_in')",
+          { timeoutMs: 15_000, label: "auth signed_in" },
+        );
+      },
+    },
+    {
+      name: "Active organization resolves and Cloud Control MCP auto-configures",
+      run: async (ctx) => {
+        await ctx.waitFor(
+          "Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())",
+          { timeoutMs: 60_000, label: "active org" },
+        );
+
+        // Onboarding shows an org picker before the desktop fully activates
+        // the resolved org. Click through it (idempotent if already past it).
+        const onOnboarding = await ctx.eval("location.hash.includes('/onboarding')");
+        if (onOnboarding) {
+          await ctx.clickText("Continue with organization", { timeoutMs: 20_000 }).catch(() => {});
+          await ctx.clickText("Continue to workspace", { timeoutMs: 20_000 }).catch(() => {});
+        }
+
+        // Cloud MCP auto-config syncs once a workspace exists. Create one if
+        // we landed on /welcome (idempotent if a workspace already exists).
+        const onWelcome = await ctx.eval("location.hash.includes('/welcome')");
+        if (onWelcome) {
+          const wsPath = ctx.env.OPENWORK_EVAL_WORKSPACE_PATH.trim();
+          await ctx.fill("input", wsPath);
+          await ctx.clickText("Use this folder", { timeoutMs: 10_000 });
+          await ctx.waitFor("location.hash.includes('/workspace/')", {
+            timeoutMs: 30_000,
+            label: "workspace route after creation",
+          });
+        }
+
+        await ctx.waitFor(
+          "Boolean(localStorage.getItem('openwork.den.mcp.sync'))",
+          { timeoutMs: 180_000, label: "openwork.den.mcp.sync marker" },
+        );
+      },
+    },
+    {
+      name: "OpenWork Cloud Control is connected — the unchanged existing surface still works",
+      run: async (ctx) => {
+        await ctx.prove("Adding search_capabilities did not break the existing, already-shipped Cloud Control connection.", {
+          action: async () => {
+            await ctx.navigateHash("/settings/extensions/mcp");
+            await ctx.expectHashIncludes("/settings/extensions/mcp");
+          },
+          assert: async () => {
+            await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 30_000 });
+          },
+          screenshot: {
+            name: "cloud-control-still-connected",
+            requireText: ["OpenWork Cloud Control"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+    {
+      name: "Mint a real org-scoped MCP token for this org",
+      run: async (ctx) => {
+        const minted = await denFetch(ctx, "/v1/mcp/token", {
+          method: "POST",
+          headers: { authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}` },
+          body: JSON.stringify({}),
+        });
+        ctx.assert(typeof minted.token === "string" && minted.token.startsWith("ow_mcp_at_"), "Expected a real opaque MCP token.");
+        ctx.mcpToken = minted.token;
+        ctx.organizationId = minted.organizationId;
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "A real, org-scoped MCP access token was minted via the existing first-party token route.",
+          actual: { organizationId: minted.organizationId, scopes: minted.scopes },
+        });
+      },
+    },
+    {
+      name: "search_capabilities is present in the real tools/list alongside the existing catalog",
+      run: async (ctx) => {
+        const result = await mcpCall(ctx, ctx.mcpToken, "tools/list", {});
+        const names = result.tools.map((tool) => tool.name);
+        ctx.assert(names.includes("search_capabilities"), "search_capabilities missing from tools/list.");
+        ctx.assert(names.includes("getOrg"), "Existing catalog tool getOrg missing — addition must be purely additive.");
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "tools/list includes the new search_capabilities tool plus the full existing OpenAPI-derived catalog, unchanged.",
+          actual: { totalTools: names.length, hasSearch: true },
+        });
+        ctx.log(`tools/list: ${names.length} tools, search_capabilities present.`);
+      },
+    },
+    {
+      name: "Calling search_capabilities ranks the real catalog by keyword",
+      run: async (ctx) => {
+        const result = await mcpCall(ctx, ctx.mcpToken, "tools/call", {
+          name: "search_capabilities",
+          arguments: { query: "list organization", limit: 5 },
+        });
+        const text = result.content?.[0]?.text ?? "";
+        const parsed = JSON.parse(text);
+        ctx.matches = parsed.matches ?? [];
+        ctx.assert(ctx.matches.length > 0, "Expected at least one ranked match for 'list organization'.");
+        const topMatchNames = ctx.matches.map((match) => match.name);
+        ctx.assert(topMatchNames.includes("getOrg"), `Expected getOrg among top matches, got: ${topMatchNames.join(", ")}`);
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "search_capabilities returned real, ranked matches from the live catalog for a natural-language-ish query.",
+          actual: ctx.matches,
+        });
+        ctx.log(`search matches: ${topMatchNames.join(", ")}`);
+      },
+    },
+    {
+      name: "Executing the matched real tool runs the existing, unchanged invoke path against live data",
+      run: async (ctx) => {
+        const topMatch = ctx.matches[0];
+        ctx.assert(topMatch?.name === "getOrg", `Expected top match to be getOrg, got ${topMatch?.name}`);
+
+        const result = await mcpCall(ctx, ctx.mcpToken, "tools/call", { name: topMatch.name, arguments: {} });
+        const text = result.content?.[0]?.text ?? "";
+        const parsed = JSON.parse(text);
+        ctx.assert(parsed.organization?.id === ctx.organizationId, "Executed tool did not return the real, current organization.");
+        ctx.orgName = parsed.organization?.name;
+        ctx.assert(typeof ctx.orgName === "string" && ctx.orgName.length > 0, "Real organization name missing from executed tool result.");
+
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "search -> execute completed end-to-end: the tool search_capabilities matched was called via the unchanged real invoke path and returned genuine organization data.",
+          actual: { organizationId: parsed.organization?.id, organizationName: ctx.orgName },
+        });
+      },
+    },
+    {
+      name: "The organization name returned by the protocol call matches what the UI shows",
+      run: async (ctx) => {
+        await ctx.prove("The data returned by search -> execute is the same real organization the signed-in desktop app is showing, not a mock.", {
+          action: async () => {
+            await ctx.navigateHash("/settings/cloud-account");
+            await ctx.expectHashIncludes("/settings/cloud-account");
+          },
+          assert: async () => {
+            await ctx.expectText(ctx.orgName, { timeoutMs: 30_000 });
+          },
+          screenshot: {
+            name: "org-name-matches-ui",
+            requireText: [ctx.orgName],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/cloud-account",
+          },
+        });
+      },
+    },
+    {
+      name: "A real chat message triggers search_capabilities then the matched tool through the actual agent",
+      run: async (ctx) => {
+        // This is the strongest proof: not a direct protocol call from the
+        // eval script, but a real chat turn -> real OpenCode agent -> real
+        // tool calls against the live, authenticated Cloud Control MCP ->
+        // real Den API data, surfaced back in the chat transcript. The agent
+        // is instructed to use search_capabilities first so this run
+        // specifically exercises the new tool, not just any cloud capability.
+        await ctx.prove("Chat-triggered: the agent calls search_capabilities, then calls the tool it matched, against the real backend.", {
+          action: async () => {
+            // The previous step left us on /settings/cloud-account;
+            // session.create_task is only registered on a session route.
+            await ctx.navigateHash("/session");
+            await ctx.waitFor(
+              "Boolean(window.__openworkControl?.listActions().find((a) => a.id === 'session.create_task' && !a.disabled))",
+              { timeoutMs: 15_000, label: "session.create_task available" },
+            );
+            await ctx.control("session.create_task");
+            await ctx.waitFor(
+              `(() => {
+                const route = window.__openworkControl.snapshot().route || "";
+                return /ses_[A-Za-z0-9]+/.test(route);
+              })()`,
+              { timeoutMs: 30_000, label: "new session active" },
+            );
+
+            const pasted = await ctx.eval(`(() => {
+              const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
+                || document.querySelector('[contenteditable="true"]');
+              if (!editor) return { ok: false, reason: "composer not found" };
+              editor.focus();
+              const data = new DataTransfer();
+              data.setData('text/plain', ${JSON.stringify(
+                'On the OpenWork Cloud Control MCP, first call the search_capabilities tool with query "organization" to find the right tool, then call whichever tool it matches to tell me my organization name. Use search_capabilities first, do not skip it.',
+              )});
+              editor.dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: data }));
+              return { ok: true };
+            })()`);
+            ctx.assert(pasted?.ok, `Composer not ready: ${pasted?.reason ?? "unknown"}`);
+
+            const submitted = await ctx.waitFor(`(() => {
+              const byLabel = Array.from(document.querySelectorAll('button'))
+                .find((b) => /run task|send|run/i.test((b.textContent || "").trim()) && !b.disabled);
+              if (byLabel) { byLabel.click(); return "clicked"; }
+              return null;
+            })()`, { timeoutMs: 10_000, label: "submit button enabled" });
+            ctx.log(`submit: ${submitted}`);
+          },
+          assert: async () => {
+            // Real LLM tool-calling latency: generous timeouts, two real
+            // network calls (search, then execute) plus model reasoning.
+            await ctx.waitForText("search capabilities", { timeoutMs: 90_000 });
+            await ctx.waitForText("getOrg", { timeoutMs: 60_000 });
+            await ctx.waitForText(ctx.orgName, { timeoutMs: 60_000 });
+            await ctx.expectNoText("Something went wrong");
+          },
+          screenshot: {
+            name: "chat-triggered-search-then-execute",
+            requireText: ["search capabilities", "getOrg", ctx.orgName],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/mcp-search-capabilities.flow.mjs
+++ b/evals/flows/mcp-search-capabilities.flow.mjs
@@ -1,15 +1,17 @@
 /**
- * Proves the additive "search_capabilities" tool on the existing, real Den
- * MCP server ("OpenWork Cloud Control"): a harness can search the existing
- * OpenAPI-derived catalog by keyword instead of receiving the full tool
- * list, then call the matched real tool name via the normal MCP
- * tools/call protocol and get a genuine server-side execution result.
+ * Proves two things on top of the existing, real Den MCP infrastructure:
  *
- * Nothing about auth, policy, or invoke changes. This flow proves the
- * addition is purely additive: the existing UI-visible Cloud Control
- * connection still works, and the new search tool sits alongside the
- * existing catalog tools, dispatching through the same unchanged execute
- * path (invoke.ts).
+ * 1. The rich `/mcp` endpoint ("OpenWork Cloud Control" as it existed
+ *    before this change) keeps every catalog tool individually registered,
+ *    plus the additive `search_capabilities` tool, unchanged.
+ *
+ * 2. A new, separate, minimal endpoint — `/mcp/agent` — exposes exactly
+ *    two tools: `search_capabilities` and `execute_capability`. The
+ *    desktop app's "OpenWork Cloud Control" connection now points here,
+ *    not at the rich endpoint. Both tools dispatch through the exact same
+ *    unchanged `invoke.ts` execute path as the rich endpoint; nothing
+ *    about auth, policy, or execution changes — only what the harness can
+ *    see changes, from ~129 tools to 2.
  *
  * Required env:
  * - OPENWORK_EVAL_DEN_API_URL    Den API base (e.g. http://127.0.0.1:8793)
@@ -43,9 +45,9 @@ async function denFetch(ctx, path, options = {}) {
  * JSON-RPC POST per call is sufficient. Responses are SSE-framed even for a
  * single message, so unwrap the `data: {...}` line.
  */
-async function mcpCall(ctx, mcpToken, method, params) {
+async function mcpCallTo(ctx, path, mcpToken, method, params) {
   const base = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
-  const response = await fetch(`${base}/mcp`, {
+  const response = await fetch(`${base}${path}`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -55,12 +57,20 @@ async function mcpCall(ctx, mcpToken, method, params) {
     body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params: params ?? {} }),
   });
   const raw = await response.text();
-  ctx.assert(response.ok, `MCP ${method} failed: ${response.status} ${raw.slice(0, 300)}`);
+  ctx.assert(response.ok, `MCP ${method} (${path}) failed: ${response.status} ${raw.slice(0, 300)}`);
   const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
-  ctx.assert(Boolean(dataLine), `MCP ${method} returned no data frame: ${raw.slice(0, 300)}`);
+  ctx.assert(Boolean(dataLine), `MCP ${method} (${path}) returned no data frame: ${raw.slice(0, 300)}`);
   const parsed = JSON.parse(dataLine.slice(5));
-  ctx.assert(!parsed.error, `MCP ${method} returned a JSON-RPC error: ${JSON.stringify(parsed.error)}`);
+  ctx.assert(!parsed.error, `MCP ${method} (${path}) returned a JSON-RPC error: ${JSON.stringify(parsed.error)}`);
   return parsed.result;
+}
+
+async function mcpCall(ctx, mcpToken, method, params) {
+  return mcpCallTo(ctx, "/mcp", mcpToken, method, params);
+}
+
+async function mcpAgentCall(ctx, mcpToken, method, params) {
+  return mcpCallTo(ctx, "/mcp/agent", mcpToken, method, params);
 }
 
 export default {
@@ -262,18 +272,74 @@ export default {
       },
     },
     {
-      name: "A real chat message triggers search_capabilities then the matched tool through the actual agent",
+      name: "The minimal /mcp/agent endpoint exposes exactly two tools",
       run: async (ctx) => {
-        // This is the strongest proof: not a direct protocol call from the
-        // eval script, but a real chat turn -> real OpenCode agent -> real
-        // tool calls against the live, authenticated Cloud Control MCP ->
-        // real Den API data, surfaced back in the chat transcript. The agent
-        // is instructed to use search_capabilities first so this run
-        // specifically exercises the new tool, not just any cloud capability.
-        await ctx.prove("Chat-triggered: the agent calls search_capabilities, then calls the tool it matched, against the real backend.", {
+        const result = await mcpAgentCall(ctx, ctx.mcpToken, "tools/list", {});
+        const names = result.tools.map((tool) => tool.name).sort();
+        ctx.assert(names.length === 2, `Expected exactly 2 tools on /mcp/agent, got ${names.length}: ${names.join(", ")}`);
+        ctx.assert(
+          names.join(",") === "execute_capability,search_capabilities",
+          `Expected exactly [execute_capability, search_capabilities], got: ${names.join(", ")}`,
+        );
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "The harness-facing /mcp/agent endpoint registers only search_capabilities and execute_capability — none of the ~127 other catalog operations are individually callable here.",
+          actual: { tools: names },
+        });
+      },
+    },
+    {
+      name: "search_capabilities on /mcp/agent returns call-shape hints, and execute_capability runs the match for real",
+      run: async (ctx) => {
+        const searchResult = await mcpAgentCall(ctx, ctx.mcpToken, "tools/call", {
+          name: "search_capabilities",
+          arguments: { query: "list organization", limit: 3 },
+        });
+        const searchParsed = JSON.parse(searchResult.content?.[0]?.text ?? "{}");
+        const matches = searchParsed.matches ?? [];
+        const topMatch = matches.find((match) => match.name === "getOrg");
+        ctx.assert(Boolean(topMatch), `Expected getOrg among /mcp/agent search matches, got: ${matches.map((m) => m.name).join(", ")}`);
+        ctx.assert(Array.isArray(topMatch.pathParams) && Array.isArray(topMatch.queryParams) && typeof topMatch.hasBody === "boolean",
+          "Match is missing call-shape hints (pathParams/queryParams/hasBody).");
+
+        const executeResult = await mcpAgentCall(ctx, ctx.mcpToken, "tools/call", {
+          name: "execute_capability",
+          arguments: { name: topMatch.name },
+        });
+        const executeParsed = JSON.parse(executeResult.content?.[0]?.text ?? "{}");
+        ctx.assert(executeParsed.organization?.id === ctx.organizationId, "execute_capability did not return the real, current organization.");
+        ctx.assert(executeParsed.organization?.name === ctx.orgName, "execute_capability returned a different org name than the rich /mcp path.");
+
+        const unknownResult = await mcpAgentCall(ctx, ctx.mcpToken, "tools/call", {
+          name: "execute_capability",
+          arguments: { name: "doesNotExist" },
+        });
+        ctx.assert(unknownResult.isError === true, "execute_capability should error on an unknown capability name.");
+        const unknownParsed = JSON.parse(unknownResult.content?.[0]?.text ?? "{}");
+        ctx.assert(unknownParsed.error === "unknown_capability", `Expected unknown_capability error, got: ${JSON.stringify(unknownParsed)}`);
+
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "On the minimal endpoint, search_capabilities -> execute_capability runs through the exact same invoke.ts path as the rich endpoint, returning identical real data; an unknown name fails with a helpful, actionable error.",
+          actual: { organizationName: executeParsed.organization?.name, pathParams: topMatch.pathParams, queryParams: topMatch.queryParams, hasBody: topMatch.hasBody },
+        });
+      },
+    },
+    {
+      name: "A real, unprompted chat message naturally uses search_capabilities then execute_capability — there is no other tool to call",
+      run: async (ctx) => {
+        // The strongest possible proof: this prompt does not mention
+        // search_capabilities, execute_capability, or any tool name at all.
+        // Unlike the earlier rich-/mcp test (which required explicitly
+        // instructing the agent to search first, because getOrg was sitting
+        // right there in its tool list), the desktop app's Cloud Control
+        // connection now points at /mcp/agent — the agent has no other way
+        // to discover or call anything, so it has to use these two tools by
+        // construction, not by instruction.
+        await ctx.prove("Chat-triggered, unprompted: the agent calls search_capabilities then execute_capability because that's all this connection exposes.", {
           action: async () => {
-            // The previous step left us on /settings/cloud-account;
-            // session.create_task is only registered on a session route.
             await ctx.navigateHash("/session");
             await ctx.waitFor(
               "Boolean(window.__openworkControl?.listActions().find((a) => a.id === 'session.create_task' && !a.disabled))",
@@ -295,7 +361,7 @@ export default {
               editor.focus();
               const data = new DataTransfer();
               data.setData('text/plain', ${JSON.stringify(
-                'On the OpenWork Cloud Control MCP, first call the search_capabilities tool with query "organization" to find the right tool, then call whichever tool it matches to tell me my organization name. Use search_capabilities first, do not skip it.',
+                "On the OpenWork Cloud Control MCP, find and tell me the name of my current organization.",
               )});
               editor.dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: data }));
               return { ok: true };
@@ -314,13 +380,13 @@ export default {
             // Real LLM tool-calling latency: generous timeouts, two real
             // network calls (search, then execute) plus model reasoning.
             await ctx.waitForText("search capabilities", { timeoutMs: 90_000 });
-            await ctx.waitForText("getOrg", { timeoutMs: 60_000 });
+            await ctx.waitForText("execute capability", { timeoutMs: 60_000 });
             await ctx.waitForText(ctx.orgName, { timeoutMs: 60_000 });
             await ctx.expectNoText("Something went wrong");
           },
           screenshot: {
-            name: "chat-triggered-search-then-execute",
-            requireText: ["search capabilities", "getOrg", ctx.orgName],
+            name: "chat-triggered-minimal-surface",
+            requireText: ["search capabilities", "execute capability", ctx.orgName],
             rejectText: ["Something went wrong"],
           },
         });


### PR DESCRIPTION
## What

Two layers, in one PR:

1. Adds `search_capabilities` to the existing, already-shipped Den `/mcp` endpoint ("OpenWork Cloud Control" as the desktop app knew it). Purely additive — ranks the same OpenAPI-derived catalog by keyword instead of the harness receiving the full ~129-tool list at once.
2. Adds a **second, separate, minimal endpoint** — `/mcp/agent` — that exposes **exactly two tools**: `search_capabilities` and `execute_capability`. The desktop app's "OpenWork Cloud Control" connection now points here instead of the rich endpoint. Both tools dispatch through the exact same unchanged `invoke.ts` execute path — no new auth, no new policy, no new execution logic. Only what the harness can *see* changes: from ~129 tools down to 2.

The rich `/mcp` endpoint is untouched and still has every catalog tool individually registered, for scripts/admin tooling that wants to call a known operation by name directly.

## Why

This is the smallest real step toward a true "search then execute" facade, and it directly addresses the original OpenCode-reload pain point: because the harness only ever sees `search_capabilities` + `execute_capability`, capabilities can grow behind those two tools without the tool list itself ever needing to change.

## Change

- `ee/apps/den-api/src/mcp/search.ts`: `searchCapabilities(catalog, query, limit)` — tokenized keyword scoring (camelCase-aware), now also returning call-shape hints (`pathParams`, `queryParams`, `hasBody`) derived from the same catalog data, so a caller can go straight from a match to a valid `execute_capability` call.
- `ee/apps/den-api/src/mcp/catalog.ts`: exported three already-existing helper functions (`getParameters`, `pathParameterNamesFromTemplate`, `hasJsonRequestBody`) so `search.ts` can reuse them — no logic change.
- `ee/apps/den-api/src/mcp/index.ts`: registers `search_capabilities` alongside the existing catalog loop (unchanged); exported `getCatalog` so the new endpoint shares the exact same 5-minute cache.
- `ee/apps/den-api/src/mcp/agent.ts` (new): registers `/mcp/agent` with exactly two tools — `search_capabilities` and `execute_capability({ name, path?, query?, body? })`, which looks up the named operation in the catalog and calls the same `invokeMcpOperation` the rich endpoint uses. Unknown names return a helpful `unknown_capability` error pointing back at `search_capabilities`.
- `ee/apps/den-api/src/app.ts`: wires up `registerAgentMcpRoutes`.
- `apps/app/src/app/constants.ts` + `apps/app/src/react-app/domains/connections/store.ts`: the "OpenWork Cloud Control" entry's URL (both the initial getter and the post-mint-token healing path) now points at `/mcp/agent` instead of bare `/mcp` — mirroring exactly how the existing "OpenWork Admin" entry already appends `/admin` to the same base URL.

## Tests run

`npx tsc -p ee/apps/den-api/tsconfig.json --noEmit` — clean.
`pnpm --filter @openwork/app typecheck` — clean.

Ran the real coded flow (`pnpm fraimz --flow mcp-search-capabilities`) against the real Den API and a completely fresh desktop Electron profile (no prior settings, signed out, no workspace). 12/12 steps passed:

1–8. (unchanged from the previous revision) Rich `/mcp`: Cloud Control connects, real MCP token minted, `search_capabilities` ranks the real catalog, the matched tool executes via the unchanged `invoke.ts` path against live data, and the result matches what the desktop UI shows.
9. **`/mcp/agent` `tools/list` returns exactly `["execute_capability", "search_capabilities"]`** — nothing else.
10. `search_capabilities` on `/mcp/agent` returns the same real ranked matches, now with call-shape hints; `execute_capability(name: "getOrg")` returns the identical real organization data the rich endpoint returns; `execute_capability` with an unknown name returns a helpful `unknown_capability` error.
11. (UI) the org name from the protocol call matches the desktop UI.
12. **A real, completely unprompted chat message** — *"On the OpenWork Cloud Control MCP, find and tell me the name of my current organization."*, no tool names mentioned — causes the actual OpenCode agent to call `search_capabilities`, then `execute_capability`, and surface the real organization name back in the chat. This is the strongest version of the proof: in the previous revision, the model had to be explicitly told to use search first because `getOrg` was sitting directly in its tool list; here it has no other way to discover or call anything, so it does the right thing **by construction, not by instruction**.

fraimz: `evals/results/2026-06-30T23-38-37-208Z/fraimz.html` (local; not committed, gitignored results dir).

### A debugging note, in the interest of an honest test trail

My first two attempts at the chat-triggered minimal-surface test still showed the agent calling `getOrg` directly, even on a brand-new Electron profile. Root cause: `electron-dev.mjs` reuses *any* already-running Vite dev server on port 5173, and a stray Vite process from an earlier, unrelated `pnpm dev` launch (bound to the main repo checkout, not this worktree) had been silently serving every "isolated" test instance in this session its stale renderer code. Confirmed via `curl localhost:5173/src/app/constants.ts` showing the old code, killed the stray process, and reran clean.

## Honest limitations

- Only tested against one organization (the seeded demo org).
- The chat-triggered step depends on a live LLM call, so it's real but not as deterministic as the pure protocol steps.
- Onboarding's org-picker step in the flow occasionally needs a second pass on a brand-new profile (timing, not correctness) — handled manually during this run where the automated click raced ahead of the page.