### PR TITLE
feat(server): add Google Drive file create/upload tool

### DIFF
--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -373,6 +373,95 @@ describe("Google Workspace extension", () => {
     expect(decoded).not.toContain("one@example.com");
   });
 
+  test("drive_create_file creates a file from inline text content", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one")],
+    });
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input);
+        const body = typeof init?.body === "string" ? init.body : Buffer.isBuffer(init?.body) ? (init.body as Buffer).toString("utf8") : "";
+        requests.push({ url, body });
+        return new Response(JSON.stringify({ id: "file-1", name: "notes.txt", mimeType: "text/plain" }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    const result = await callGoogleWorkspaceExtensionAction(config, "drive_create_file", { name: "notes.txt", content: "Hello Drive" }, {});
+    expect(result?.ok).toBe(true);
+    expect(result?.result).toMatchObject({ id: "file-1", name: "notes.txt" });
+    expect(requests[0]?.url).toContain("/upload/drive/v3/files?uploadType=multipart");
+    expect(requests[0]?.body).toContain('"name":"notes.txt"');
+    expect(requests[0]?.body).toContain('"mimeType":"text/plain"');
+    expect(requests[0]?.body).toContain("Hello Drive");
+  });
+
+  test("drive_create_file uploads a local workspace file as binary content", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    const workspaceRoot = join(dirname(config.configPath ?? ""), "workspace");
+    const reportPath = join(workspaceRoot, "reports", "safe-report.docx");
+    config.workspaces = [{ id: "workspace-1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }];
+    config.authorizedRoots = [workspaceRoot];
+    await mkdir(dirname(reportPath), { recursive: true });
+    await writeFile(reportPath, "binary docx bytes", "utf8");
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one")],
+    });
+    const requests: { url: string; body: Buffer }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input);
+        requests.push({ url, body: Buffer.isBuffer(init?.body) ? (init.body as Buffer) : Buffer.from(String(init?.body ?? "")) });
+        return new Response(JSON.stringify({ id: "file-2", name: "safe-report.docx", mimeType: "application/octet-stream" }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    const result = await callGoogleWorkspaceExtensionAction(
+      config,
+      "drive_create_file",
+      { name: "safe-report.docx", path: "reports/safe-report.docx" },
+      { directory: workspaceRoot },
+    );
+    expect(result?.ok).toBe(true);
+    expect(result?.result).toMatchObject({ id: "file-2" });
+    const body = requests[0]?.body.toString("utf8") ?? "";
+    expect(body).toContain('"name":"safe-report.docx"');
+    expect(body).toContain("Content-Transfer-Encoding: base64");
+    expect(body).toContain(Buffer.from("binary docx bytes", "utf8").toString("base64"));
+  });
+
+  test("drive_create_file rejects both content and path provided together", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one")],
+    });
+
+    expect(callGoogleWorkspaceExtensionAction(config, "drive_create_file", { name: "f.txt", content: "a", path: "f.txt" }, {})).rejects.toThrow(
+      new ApiError(400, "invalid_payload", "Provide only one of path or content, not both"),
+    );
+    expect(callGoogleWorkspaceExtensionAction(config, "drive_create_file", { name: "f.txt" }, {})).rejects.toThrow(
+      new ApiError(400, "invalid_payload", "Either path or content is required"),
+    );
+  });
+
   test("calendar_create_event rejects accounts without the calendar.events scope", async () => {
     process.env.OPENWORK_DEV_MODE = "1";
     process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -206,6 +206,27 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
   },
   {
     extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
+    action: "drive_create_file",
+    title: "Create Drive file",
+    description: "Create a new file in Google Drive, either from inline text content or by uploading a local workspace file (binary-safe, e.g. .docx, .pdf, images).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Name for the new Drive file." },
+        content: { type: "string", description: "Inline plain text content for the new file. Provide this or path, not both." },
+        path: {
+          type: "string",
+          description: "Local file to upload as the new Drive file's content (binary-safe). Workspace-relative path or authorized absolute file path. Provide this or content, not both.",
+        },
+        mimeType: { type: "string", description: "Optional MIME type for the new file. Defaults to the source file's type when uploading a path, or text/plain for inline content." },
+        parentId: { type: "string", description: "Optional Drive folder id to create the file inside." },
+      },
+      required: ["name"],
+      additionalProperties: false,
+    },
+  },
+  {
+    extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
     action: "calendar_create_event",
     title: "Create calendar event",
     description: "Create an event on the connected Google Calendar. Requires calendar editing access (calendar.events scope).",
@@ -621,6 +642,23 @@ function multipartRelatedBody(metadata: Record<string, unknown>, content: string
     "Content-Type: text/plain; charset=UTF-8",
     "",
     content,
+    `--${boundary}--`,
+    "",
+  ].join("\r\n");
+}
+
+function driveMultipartUploadBody(metadata: Record<string, unknown>, contentMimeType: string, content: string | Buffer, boundary: string): string {
+  const isBinary = Buffer.isBuffer(content);
+  return [
+    `--${boundary}`,
+    "Content-Type: application/json; charset=UTF-8",
+    "",
+    JSON.stringify(metadata),
+    `--${boundary}`,
+    `Content-Type: ${contentMimeType}`,
+    ...(isBinary ? ["Content-Transfer-Encoding: base64"] : []),
+    "",
+    isBinary ? base64MimeContent(content) : content,
     `--${boundary}--`,
     "",
   ].join("\r\n");
@@ -1110,6 +1148,37 @@ async function googleWorkspaceUpdateFile(config: ServerConfig, args: Record<stri
   });
 }
 
+async function googleWorkspaceCreateFile(config: ServerConfig, args: Record<string, unknown>, context: Record<string, unknown>) {
+  const name = readStringField(args, "name");
+  if (!name) throw new ApiError(400, "invalid_payload", "name is required");
+  const path = readStringField(args, "path");
+  const content = typeof args.content === "string" ? args.content : "";
+  if (!path && !content) throw new ApiError(400, "invalid_payload", "Either path or content is required");
+  if (path && content) throw new ApiError(400, "invalid_payload", "Provide only one of path or content, not both");
+  const requestedMimeType = readStringField(args, "mimeType");
+  const parentId = readStringField(args, "parentId");
+
+  let body: string | Buffer;
+  let mimeType: string;
+  if (path) {
+    const resolvedPath = await resolveGmailAttachmentPath(config, context, path);
+    body = await readFile(resolvedPath);
+    mimeType = gmailAttachmentMimeType(resolvedPath, requestedMimeType || undefined);
+  } else {
+    body = content;
+    mimeType = requestedMimeType || "text/plain";
+  }
+
+  const { accessToken } = await googleWorkspaceAccessToken(config);
+  const boundary = `openwork_${randomBytes(8).toString("hex")}`;
+  const metadata: Record<string, unknown> = { name, mimeType, ...(parentId ? { parents: [parentId] } : {}) };
+  return fetchGoogleJson("https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,mimeType,webViewLink,parents", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": `multipart/related; boundary=${boundary}` },
+    body: driveMultipartUploadBody(metadata, mimeType, body, boundary),
+  });
+}
+
 async function googleWorkspaceCreateEvent(config: ServerConfig, args: Record<string, unknown>) {
   const summary = readStringField(args, "summary");
   const start = readStringField(args, "start");
@@ -1193,6 +1262,7 @@ export async function callGoogleWorkspaceExtensionAction(config: ServerConfig, a
   if (action === "drive_search_files") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceSearchFiles(config, args), context };
   if (action === "drive_read_file") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceReadFile(config, args), context };
   if (action === "drive_update_file") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceUpdateFile(config, args), context };
+  if (action === "drive_create_file") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateFile(config, args, context), context };
   if (action === "calendar_create_event") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateEvent(config, args), context };
   if (action === "chat_list_spaces") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceListChatSpaces(config, args), context };
   if (action === "chat_list_messages") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceListChatMessages(config, args), context };


### PR DESCRIPTION
## Summary
- Adds a `drive_create_file` action to the Google Workspace extension, closing the gap reported by users where the connected Drive scope only exposed `drive_search_files`, `drive_read_file`, and `drive_update_file` (plain-text-only replace), with no way to create a brand-new Drive file or upload binary content (e.g. `.docx`, `.pdf`, images) without corrupting formatting.
- Supports two input modes:
  - `content`: inline plain text for simple text files.
  - `path`: a local workspace file (binary-safe), uploaded as base64 multipart content with its MIME type inferred from the extension (reusing the same workspace-root path validation already used for Gmail attachments).
- Optional `mimeType` override and `parentId` to create the file inside a specific Drive folder.
- Works under the existing base `drive.file` OAuth scope — no new scope/consent required.

## Test plan
- `cd apps/server && bun test src/extensions/google-workspace.test.ts` — 19 pass, including 3 new tests for `drive_create_file` (inline text, binary file upload, and validation of mutually exclusive `content`/`path`).
- `cd apps/server && pnpm typecheck` — passes.

Note: per repo guidance, PRs should include a video/screenshot proof of the end-to-end flow. This change is server-side extension/tool surface (Google OAuth + Drive API), not a UI experience, so it's not driven through the desktop app's UI — verified via the unit test suite and typecheck above instead.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/different-ai/openwork/pull/2402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

