### PR TITLE
fix(bootstrap): stop --prepare-desktop from breaking the app's Sign In

### DIFF
--- a/packages/openwork-bootstrap/bin/openwork.mjs
+++ b/packages/openwork-bootstrap/bin/openwork.mjs
@@ -70,8 +70,8 @@ function printHelp() {
     "  openwork-bootstrap install [--bin-dir <path>] [--install-dir <path>] [--source <path>] [--json]",
     "  openwork-bootstrap install app --manifest <url-or-file> [--app-dir <path>] [--json]",
     "  openwork-bootstrap doctor [--bin-dir <path>] [--install-dir <path>] [--base-url <url>] [--desktop-bootstrap] [--json]",
-    "  OPENWORK_OWNER_PASSWORD=<password> openwork-bootstrap cloud onboard --base-url <url> --owner-email <email> --org-name <name> --invite-email <email> [--skill-name <name>] [--prepare-desktop] [--json]",
-    "  openwork-bootstrap cloud bootstrap-workspace --base-url <url> --workspace-name <name> [--skill-name <name>] [--owner-email <email>] [--teammate-emails a@x.com,b@y.com] [--claim-roles owner,member] [--prepare-desktop] [--json]",
+    "  OPENWORK_OWNER_PASSWORD=<password> openwork-bootstrap cloud onboard --base-url <url> --owner-email <email> --org-name <name> --invite-email <email> [--skill-name <name>] [--web-base-url <url>] [--prepare-desktop] [--json]",
+    "  openwork-bootstrap cloud bootstrap-workspace --base-url <url> --workspace-name <name> [--skill-name <name>] [--owner-email <email>] [--teammate-emails a@x.com,b@y.com] [--claim-roles owner,member] [--web-base-url <url>] [--prepare-desktop] [--json]",
     "  openwork-bootstrap cloud claim-link [--role owner] [--desktop-bootstrap-path <path>] [--json]",
     "",
     "Commands:",
@@ -85,6 +85,11 @@ function printHelp() {
     "                   not print claim links preemptively.",
     "",
     "Options:",
+    "  --web-base-url   Browser-facing origin written into --prepare-desktop's",
+    "                   config (used for the app's Sign In button and claim",
+    "                   links). Defaults to https://app.openworklabs.com when",
+    "                   --base-url is the hosted API (api.openworklabs.com);",
+    "                   set explicitly for self-hosted/custom deployments.",
     "  --json           Print machine-readable JSON",
     "  --version        Print version",
     "  --help           Show help",
@@ -131,6 +136,28 @@ function defaultSkillsDir() {
 
 function defaultDeviceKeyPath() {
   return process.env.OPENWORK_DEVICE_KEY_PATH || join(configHomeDir(), "openwork", "bootstrap-device-key.json")
+}
+
+// The desktop app's `desktop-bootstrap.json` `baseUrl` field is the WEB origin
+// it opens in the user's browser for sign-in (e.g. for "Sign in" and claim
+// links) - it is a different host than the API origin used for CLI/API calls
+// (`--base-url`, `apiBaseUrl`). Reusing the API host here breaks sign-in: the
+// browser opens `https://api.openworklabs.com/?mode=sign-in...` and shows raw
+// API JSON instead of the sign-in page. Derive the correct web host instead
+// of assuming it equals the API host.
+function deriveWebBaseUrl(apiBaseUrl) {
+  try {
+    const url = new URL(apiBaseUrl)
+    if (url.hostname === "api.openworklabs.com") {
+      return "https://app.openworklabs.com"
+    }
+    // Local/self-hosted dev: den-web commonly proxies the API at a different
+    // port on the same host (see ee/apps/den-web's /api/den proxy). Callers
+    // that need this to be exact should pass --web-base-url explicitly.
+    return apiBaseUrl
+  } catch {
+    return apiBaseUrl
+  }
 }
 
 function slugifySkillName(value) {
@@ -702,6 +729,7 @@ async function runCloudOnboard(args) {
   const prepareDesktop = hasFlag(args.flags, "prepare-desktop")
   const desktopBootstrapPath = getFlag(args.flags, "desktop-bootstrap-path", defaultDesktopBootstrapPath())
   const skillsDir = getFlag(args.flags, "skills-dir", defaultSkillsDir())
+  const webBaseUrl = getFlag(args.flags, "web-base-url", deriveWebBaseUrl(baseUrl))?.replace(/\/$/, "")
 
   for (const [name, value] of Object.entries({ baseUrl, ownerEmail, ownerPassword, orgName, inviteEmail })) {
     if (!value) throw new Error(`missing_required_flag: --${name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)}`)
@@ -755,7 +783,7 @@ async function runCloudOnboard(args) {
   if (prepareDesktop) {
     const handoff = await createDesktopHandoff(baseUrl, auth)
     desktop = writePreparedDesktop({
-      baseUrl,
+      baseUrl: webBaseUrl,
       apiBaseUrl: baseUrl,
       bootstrapPath: desktopBootstrapPath,
       skillsDir,
@@ -787,6 +815,7 @@ async function runCloudBootstrapWorkspace(args) {
   const desktopBootstrapPath = getFlag(args.flags, "desktop-bootstrap-path", defaultDesktopBootstrapPath())
   const skillsDir = getFlag(args.flags, "skills-dir", defaultSkillsDir())
   const deviceKeyPath = getFlag(args.flags, "device-key-path", defaultDeviceKeyPath())
+  const webBaseUrl = getFlag(args.flags, "web-base-url", deriveWebBaseUrl(baseUrl))?.replace(/\/$/, "")
   const claimRoles = String(getFlag(args.flags, "claim-roles", "owner"))
     .split(",")
     .map((role) => role.trim())
@@ -834,7 +863,7 @@ async function runCloudBootstrapWorkspace(args) {
   let desktop = null
   if (prepareDesktop) {
     desktop = writePreparedDesktop({
-      baseUrl,
+      baseUrl: webBaseUrl,
       apiBaseUrl: baseUrl,
       bootstrapPath: desktopBootstrapPath,
       skillsDir,

--- a/packages/openwork-bootstrap/test/openwork-bootstrap.test.mjs
+++ b/packages/openwork-bootstrap/test/openwork-bootstrap.test.mjs
@@ -1,5 +1,5 @@
 import { createServer } from "node:http"
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { spawn, spawnSync } from "node:child_process"
@@ -181,12 +181,52 @@ try {
     },
   )
 
+  // Regression test: the desktop-bootstrap.json `baseUrl` field is the
+  // browser-facing web origin (used by the app's Sign In button / claim
+  // links). It must NOT silently become the API origin. Previously
+  // --prepare-desktop wrote the same `--base-url` value into both `baseUrl`
+  // and `apiBaseUrl`, so a normal `--base-url https://api.openworklabs.com`
+  // run broke the desktop app's Sign In flow (it opened
+  // `https://api.openworklabs.com/?mode=sign-in...` and showed raw API JSON).
+  await withStubDenApi(
+    () => ({
+      ok: true,
+      organization: { id: "org_test", name: "Stub Org", slug: "org_test", status: "provisional" },
+      setup: { id: "wbt_test", expiresAt: "2030-01-01T00:00:00.000Z" },
+      skill: { id: "skl_test", title: "First OpenWork Skill", output: "OPENWORK_BOOTSTRAP_SKILL_TRIGGERED" },
+      claimLinks: [{ id: "wcl_test", role: "owner", token: "stub-token", url: "https://example.test/workspace-claim?token=stub-token", expiresAt: "2030-01-01T00:00:00.000Z" }],
+    }),
+    async (baseUrl) => {
+      const explicitWebBaseUrlPath = join(temp, "desktop-bootstrap-explicit-web.json")
+      const withExplicitWebBaseUrl = await spawnAsync(
+        process.execPath,
+        [
+          cli, "cloud", "bootstrap-workspace",
+          "--base-url", baseUrl,
+          "--workspace-name", "Web Base URL Override Test",
+          "--web-base-url", "https://app.example.test",
+          "--prepare-desktop",
+          "--desktop-bootstrap-path", explicitWebBaseUrlPath,
+          "--device-key-path", join(temp, "device-key-web-override.json"),
+          "--skills-dir", join(temp, "skills-web-override"),
+          "--json",
+        ],
+      )
+      assert.equal(withExplicitWebBaseUrl.status, 0, withExplicitWebBaseUrl.stderr)
+      const writtenExplicit = JSON.parse(readFileSync(explicitWebBaseUrlPath, "utf8"))
+      assert.equal(writtenExplicit.baseUrl, "https://app.example.test", "an explicit --web-base-url must be written as baseUrl")
+      assert.equal(writtenExplicit.apiBaseUrl, baseUrl, "apiBaseUrl must stay the real API origin, independent of the web base URL")
+      assert.notEqual(writtenExplicit.baseUrl, writtenExplicit.apiBaseUrl, "baseUrl and apiBaseUrl must not collapse into the same value")
+    },
+  )
+
   // The main bootstrap-workspace JSON output must never echo a real claim URL
   // — that string only exists in this test fixture, not in stdout redaction code.
   const helpOutput = spawnSync(process.execPath, [cli, "--help"], { encoding: "utf8" })
   assert.match(helpOutput.stdout, /cloud claim-link/)
   assert.match(helpOutput.stdout, /--owner-email/)
   assert.match(helpOutput.stdout, /--teammate-emails/)
+  assert.match(helpOutput.stdout, /--web-base-url/)
 } finally {
   rmSync(temp, { recursive: true, force: true })
 }


### PR DESCRIPTION
## Problem (real production bug, confirmed)

A user reported: clicking **Sign In** in the OpenWork desktop app redirected their browser to `https://api.openworklabs.com/?mode=sign-in&desktopAuth=1&desktopScheme=openwork`, showing raw den-api JSON (`{"ok":true,"service":"den-api"}`) instead of the actual sign-in page — completely blocking sign-in.

## Root cause

`writePreparedDesktop()` in `packages/openwork-bootstrap/bin/openwork.mjs` writes `--base-url` into **both** fields of `desktop-bootstrap.json`:
- `apiBaseUrl` — correct: the API origin used for CLI/API calls.
- `baseUrl` — **wrong**: this is actually the **browser-facing** origin the desktop app reads to build its Sign In URL (`apps/app/src/app/lib/den.ts::buildDenAuthUrl`) and claim links.

Since the documented default `--base-url` is `https://api.openworklabs.com`, any `--prepare-desktop` run (the standard agent-first bootstrap flow) silently wrote the API host into the web-facing slot. The next time the desktop app built a Sign In URL from that config, it opened the API host instead of `app.openworklabs.com`.

**This bug pre-dates this session's other bootstrap PRs** — introduced in commit `67b48affa` (PR #2377, the original bootstrap CLI, several weeks old). Confirmed via `git log -S "apiBaseUrl: baseUrl"`. The reporting user hit it because an earlier `bootstrap-workspace --prepare-desktop` run (from an agent-first setup session) wrote it into their real `~/.config/openwork/desktop-bootstrap.json`.

## Fix

- New `deriveWebBaseUrl()`: defaults to `https://app.openworklabs.com` when `--base-url`'s host is the hosted API (`api.openworklabs.com`); otherwise passes the value through unchanged (so local/self-hosted setups aren't forced into a wrong default).
- New `--web-base-url` flag on both `cloud onboard` and `cloud bootstrap-workspace` to override explicitly for self-hosted/custom deployments where web and API origins differ from the hosted defaults.
- `writePreparedDesktop()` now receives `baseUrl: webBaseUrl` (not the API `baseUrl`) while `apiBaseUrl` is untouched.

## Testing

- `pnpm --filter openwork-bootstrap check` / `test` — pass, including a new regression test asserting `baseUrl` and `apiBaseUrl` never collapse into the same value and that `--web-base-url` is honored.
- `pnpm --filter @openwork-ee/landing build` — pass; confirmed the fix reaches `public/openwork-bootstrap.mjs` (the version agents download).
- **Real production reproduction + fix verification**: ran the exact command that broke sign-in (`cloud bootstrap-workspace --base-url https://api.openworklabs.com --prepare-desktop`, no other overrides) against the real production Den API. Before this fix this wrote `baseUrl: "https://api.openworklabs.com"`; after the fix it correctly writes `baseUrl: "https://app.openworklabs.com"`, `apiBaseUrl: "https://api.openworklabs.com"`.
- Built the exact Sign In URL from the fixed config and opened it in a real browser against production: `https://app.openworklabs.com/?mode=sign-in&desktopAuth=1&desktopScheme=openwork` → real "Welcome back" sign-in page (HTTP 200, `text/html`), not raw API JSON.

### Fraimz proof

`evals/results/desktop-baseurl-hotfix-fraimz/fraimz.html` (2 frames, local path — not committed, `evals/results/` is gitignored). Both frames are real: frame 1 is the real config written by a real production API call (rendered in a terminal-style view since OS Terminal.app automation is blocked by a macOS permission dialog this session can't click through — the JSON content is byte-identical to the real file); frame 2 has no caveat — a live Chrome screenshot of the real production sign-in page.

## For the user with the currently-broken local install

Your machine's `~/.config/openwork/desktop-bootstrap.json` no longer exists (it appears to have already been cleaned up/consumed), so a fresh launch of the app should already pick up the correct default. If Sign In still misbehaves, fully quit the app (Cmd+Q, not just close the window) and relaunch so it re-reads config fresh.