### PR TITLE
feat(app): add custom OpenAI-compatible providers from the UI

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/custom-provider-config.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/custom-provider-config.ts
@@ -1,0 +1,92 @@
+import { applyEdits, modify } from "jsonc-parser";
+
+/**
+ * Pure helpers for user-defined custom providers (any OpenAI-compatible
+ * endpoint such as Azure AI Foundry, LiteLLM, vLLM, Ollama). These write a
+ * `provider.<id>` block into the workspace `opencode.jsonc` so users no
+ * longer have to hand-edit the file (or paste JSON into Cloud).
+ */
+
+export type CustomProviderInput = {
+  providerId: string;
+  name: string;
+  baseURL: string;
+  apiKey: string;
+  modelIds: string[];
+};
+
+export const CUSTOM_PROVIDER_NPM = "@ai-sdk/openai-compatible";
+
+export const slugifyProviderId = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+export const isValidCustomProviderId = (value: string) =>
+  /^[a-z0-9][a-z0-9_-]*$/i.test(value);
+
+export type NormalizedCustomProvider = {
+  providerId: string;
+  name: string;
+  baseURL: string;
+  apiKey: string;
+  modelIds: string[];
+};
+
+export const normalizeCustomProviderInput = (
+  input: CustomProviderInput,
+): NormalizedCustomProvider => {
+  const providerId = input.providerId.trim();
+  return {
+    providerId,
+    name: input.name.trim() || providerId,
+    baseURL: input.baseURL.trim().replace(/\/+$/, ""),
+    apiKey: input.apiKey.trim(),
+    modelIds: [
+      ...new Set(input.modelIds.map((id) => id.trim()).filter(Boolean)),
+    ],
+  };
+};
+
+export const validateCustomProviderInput = (
+  input: NormalizedCustomProvider,
+): string | null => {
+  if (!input.providerId) return "Provider ID is required.";
+  if (!isValidCustomProviderId(input.providerId)) {
+    return "Provider ID can only contain letters, numbers, dashes, and underscores.";
+  }
+  if (!input.baseURL) return "Base URL is required.";
+  if (!/^https?:\/\//i.test(input.baseURL)) {
+    return "Base URL must start with http:// or https://";
+  }
+  if (input.modelIds.length === 0) return "At least one model ID is required.";
+  return null;
+};
+
+export const buildCustomProviderConfig = (input: NormalizedCustomProvider) => ({
+  npm: CUSTOM_PROVIDER_NPM,
+  name: input.name,
+  options: { baseURL: input.baseURL },
+  models: Object.fromEntries(
+    input.modelIds.map((modelId) => [modelId, { name: modelId }]),
+  ),
+});
+
+export const formatConfigWithCustomProvider = (
+  raw: string,
+  input: NormalizedCustomProvider,
+) => {
+  const base = raw.trim()
+    ? raw
+    : '{\n  "$schema": "https://opencode.ai/config.json"\n}\n';
+  const edits = modify(
+    base,
+    ["provider", input.providerId],
+    buildCustomProviderConfig(input),
+    { formattingOptions: { insertSpaces: true, tabSize: 2 } },
+  );
+  const updated = applyEdits(base, edits);
+  return updated.endsWith("\n") ? updated : `${updated}\n`;
+};

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -3,6 +3,7 @@ import {
   CheckCircle2,
   ChevronRight,
   Loader2,
+  Plus,
   Search,
 } from "lucide-react";
 import {
@@ -33,6 +34,11 @@ import type {
   ProviderAuthProvider,
   ProviderOAuthStartResult,
 } from "./store";
+import {
+  isValidCustomProviderId,
+  slugifyProviderId,
+  type CustomProviderInput,
+} from "./custom-provider-config";
 
 type ProviderAuthEntry = {
   id: string;
@@ -70,6 +76,7 @@ export type ProviderAuthModalProps = {
   authMethods: Record<string, ProviderAuthMethod[]>;
   onSelect: (providerId: string, methodIndex?: number) => Promise<ProviderOAuthStartResult>;
   onSubmitApiKey: (providerId: string, apiKey: string) => Promise<string | void>;
+  onSubmitCustomProvider?: (input: CustomProviderInput) => Promise<string | void>;
   onConnectCloudProvider: (cloudProviderId: string) => Promise<string | void>;
   onSubmitOAuth: (
     providerId: string,
@@ -87,7 +94,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const isRemoteWorker = workerType === "remote";
 
   const [view, setView] = useState<
-    "list" | "method" | "api" | "cloud" | "oauth-code" | "oauth-auto" | "openwork-subscribe"
+    "list" | "method" | "api" | "cloud" | "oauth-code" | "oauth-auto" | "openwork-subscribe" | "custom"
   >("list");
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null);
   const [selectedCloudMethod, setSelectedCloudMethod] = useState<ProviderAuthMethod | null>(null);
@@ -101,6 +108,13 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const [oauthAutoBusy, setOauthAutoBusy] = useState(false);
   const [oauthCodeCopied, setOauthCodeCopied] = useState(false);
   const [oauthBrowserOpened, setOauthBrowserOpened] = useState(false);
+  const [customName, setCustomName] = useState("");
+  const [customProviderId, setCustomProviderId] = useState("");
+  const [customProviderIdTouched, setCustomProviderIdTouched] = useState(false);
+  const [customBaseUrl, setCustomBaseUrl] = useState("");
+  const [customApiKey, setCustomApiKey] = useState("");
+  const [customModels, setCustomModels] = useState("");
+  const [customBusy, setCustomBusy] = useState(false);
 
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const providerPollRef = useRef<number | null>(null);
@@ -218,7 +232,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     [entries, selectedProviderId],
   );
 
-  const resolvedView = selectedEntry ? view : "list";
+  const resolvedView = view === "custom" ? "custom" : selectedEntry ? view : "list";
   const errorMessage = localError ?? props.error;
 
   const filteredEntries = useMemo(() => {
@@ -253,7 +267,20 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const methodLabel = (method: ProviderAuthMethod) =>
     method.label || (method.type === "oauth" ? "OAuth" : "API key");
 
-  const actionDisabled = props.loading || props.submitting;
+  const actionDisabled = props.loading || props.submitting || customBusy;
+
+  const customResolvedProviderId = customProviderIdTouched
+    ? customProviderId.trim()
+    : slugifyProviderId(customName);
+  const customModelIds = customModels
+    .split(/[\n,]+/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const customFormReady =
+    Boolean(customResolvedProviderId) &&
+    isValidCustomProviderId(customResolvedProviderId) &&
+    /^https?:\/\//i.test(customBaseUrl.trim()) &&
+    customModelIds.length > 0;
 
   const resetState = () => {
     if (oauthCodeCopiedResetRef.current !== null && typeof window !== "undefined") {
@@ -271,6 +298,12 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     setLocalError(null);
     setOauthCodeCopied(false);
     setOauthBrowserOpened(false);
+    setCustomName("");
+    setCustomProviderId("");
+    setCustomProviderIdTouched(false);
+    setCustomBaseUrl("");
+    setCustomApiKey("");
+    setCustomModels("");
   };
 
   const stopProviderPolling = () => {
@@ -566,6 +599,28 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     }
   };
 
+  const handleCustomSubmit = async () => {
+    if (!props.onSubmitCustomProvider || actionDisabled || !customFormReady) return;
+
+    setLocalError(null);
+    setCustomBusy(true);
+    try {
+      await props.onSubmitCustomProvider({
+        providerId: customResolvedProviderId,
+        name: customName,
+        baseURL: customBaseUrl,
+        apiKey: customApiKey,
+        modelIds: customModelIds,
+      });
+      props.onClose();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to add custom provider";
+      setLocalError(message);
+    } finally {
+      setCustomBusy(false);
+    }
+  };
+
   const handleCloudSubmit = async () => {
     if (!selectedCloudMethod?.cloudProviderId || actionDisabled) return;
 
@@ -592,7 +647,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   };
 
   const handleBack = () => {
-    if (resolvedView === "openwork-subscribe") {
+    if (resolvedView === "openwork-subscribe" || resolvedView === "custom") {
       resetState();
       return;
     }
@@ -628,6 +683,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   };
 
   const submittingLabel = () => {
+    if (customBusy) return "Adding custom provider...";
     if (!props.submitting) return null;
     if (resolvedView === "api") return "Saving API key...";
     if (resolvedView === "cloud") return "Connecting organization provider...";
@@ -811,6 +867,36 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                     </div>
                   )}
 
+                  {props.onSubmitCustomProvider ? (
+                    <button
+                      type="button"
+                      className="w-full group flex items-start gap-3.5 rounded-xl border border-dashed border-gray-6/70 px-3.5 py-3 text-left transition-all duration-200 hover:bg-gray-3/30 disabled:opacity-60 disabled:cursor-not-allowed"
+                      disabled={actionDisabled}
+                      onClick={() => {
+                        setLocalError(null);
+                        setView("custom");
+                      }}
+                    >
+                      <div className="flex size-8 shrink-0 items-center justify-center rounded-full border border-gray-5/60 bg-gray-2 shadow-sm">
+                        <Plus size={16} className="text-gray-11" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="text-[14px] font-medium text-gray-12 tracking-tight">
+                            Add custom provider
+                          </div>
+                          <div className="text-[12px] font-medium text-gray-9 group-hover:text-gray-12 transition-colors flex items-center gap-0.5 opacity-80 group-hover:opacity-100">
+                            Set up
+                            <ChevronRight size={14} className="opacity-0 -ml-2 group-hover:opacity-100 group-hover:ml-0 transition-all duration-200" />
+                          </div>
+                        </div>
+                        <div className="text-[11px] text-gray-9 mt-0.5">
+                          Connect any OpenAI-compatible endpoint — Azure AI Foundry, LiteLLM, vLLM, Ollama, and more.
+                        </div>
+                      </div>
+                    </button>
+                  ) : null}
+
                   <div className="text-[11px] text-gray-9">Arrow keys to navigate, Enter to select.</div>
                 </div>
               ) : null}
@@ -902,6 +988,106 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       disabled={actionDisabled || !apiKeyInput.trim()}
                     >
                       {props.submitting ? "Saving…" : "Save key"}
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+
+              {resolvedView === "custom" ? (
+                <div className="rounded-xl border border-gray-6/40 bg-gray-2/50 shadow-sm p-5 space-y-4">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div className="text-sm font-medium text-gray-12">Custom provider</div>
+                      <div className="text-xs text-gray-10 mt-1">
+                        Connect any OpenAI-compatible endpoint by name, URL, and model IDs.
+                      </div>
+                    </div>
+                    <Button variant="outline" onClick={handleBack} disabled={actionDisabled}>
+                      Back
+                    </Button>
+                  </div>
+                  <TextInput
+                    label="Name"
+                    type="text"
+                    placeholder="Azure AI Foundry"
+                    value={customName}
+                    onChange={(event) => {
+                      setCustomName(event.currentTarget.value);
+                      if (localError) setLocalError(null);
+                    }}
+                    autoComplete="off"
+                    spellCheck={false}
+                    disabled={actionDisabled}
+                  />
+                  <TextInput
+                    label="Provider ID"
+                    type="text"
+                    placeholder="azure-foundry"
+                    value={customProviderIdTouched ? customProviderId : customResolvedProviderId}
+                    onChange={(event) => {
+                      setCustomProviderId(event.currentTarget.value);
+                      setCustomProviderIdTouched(true);
+                      if (localError) setLocalError(null);
+                    }}
+                    autoComplete="off"
+                    autoCapitalize="off"
+                    spellCheck={false}
+                    disabled={actionDisabled}
+                  />
+                  <TextInput
+                    label="Base URL"
+                    type="text"
+                    placeholder="https://my-resource.openai.azure.com/openai/v1"
+                    value={customBaseUrl}
+                    onChange={(event) => {
+                      setCustomBaseUrl(event.currentTarget.value);
+                      if (localError) setLocalError(null);
+                    }}
+                    autoComplete="off"
+                    autoCapitalize="off"
+                    spellCheck={false}
+                    disabled={actionDisabled}
+                  />
+                  <TextInput
+                    label="API key (optional)"
+                    type="password"
+                    placeholder="sk-..."
+                    value={customApiKey}
+                    onChange={(event) => {
+                      setCustomApiKey(event.currentTarget.value);
+                      if (localError) setLocalError(null);
+                    }}
+                    autoComplete="off"
+                    autoCapitalize="off"
+                    spellCheck={false}
+                    disabled={actionDisabled}
+                  />
+                  <TextInput
+                    label="Model IDs"
+                    type="text"
+                    placeholder="gpt-5.2, my-deployment-name"
+                    value={customModels}
+                    onChange={(event) => {
+                      setCustomModels(event.currentTarget.value);
+                      if (localError) setLocalError(null);
+                    }}
+                    autoComplete="off"
+                    autoCapitalize="off"
+                    spellCheck={false}
+                    disabled={actionDisabled}
+                  />
+                  <div className="text-[11px] text-gray-9">
+                    Comma-separated. Use the model IDs your endpoint serves — on Azure AI Foundry these are your deployment names.
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="text-[11px] text-gray-9">
+                      Saved to opencode.jsonc in this workspace. Keys are stored locally.
+                    </div>
+                    <Button
+                      onClick={() => void handleCustomSubmit()}
+                      disabled={actionDisabled || !customFormReady}
+                    >
+                      {customBusy ? "Adding…" : "Add provider"}
                     </Button>
                   </div>
                 </div>
@@ -1089,7 +1275,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
 
         <DialogFooter className="shrink-0 flex-col gap-3">
           <div className="min-h-[16px] text-xs text-gray-10">
-            {props.submitting ? submittingLabel() : null}
+            {submittingLabel()}
           </div>
           <DialogClose
             disabled={actionDisabled}

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -67,6 +67,13 @@ import {
   isCloudManagedProviderKey,
   isCloudProviderOutOfSync,
 } from "./cloud-provider-config";
+import {
+  buildCustomProviderConfig,
+  formatConfigWithCustomProvider,
+  normalizeCustomProviderInput,
+  validateCustomProviderInput,
+  type CustomProviderInput,
+} from "./custom-provider-config";
 import { refreshDesktopCloudSync } from "../../../../app/cloud/desktop-cloud-sync";
 import { dispatchNewProviders } from "../../../../app/lib/provider-events";
 import {
@@ -1260,6 +1267,77 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
   }
 
+  async function addCustomProvider(input: CustomProviderInput) {
+    setStateField("providerAuthError", null);
+    try {
+      const normalized = normalizeCustomProviderInput(input);
+      const validationError = validateCustomProviderInput(normalized);
+      if (validationError) {
+        throw new Error(validationError);
+      }
+      if (options.checkDesktopAppRestriction({ restriction: "allowCustomProviders" })) {
+        throw new Error("Adding custom providers is disabled by your organization.");
+      }
+      assertProviderAllowedByDesktopPolicy(normalized.providerId);
+      if (isCloudManagedProviderKey(normalized.providerId)) {
+        throw new Error(
+          `${normalized.providerId} is reserved for cloud-managed providers. Choose a different provider ID.`,
+        );
+      }
+      // Re-adding an existing config-defined provider (source "config" or
+      // "custom") is a safe reconcile (update baseURL/models/key). Only block
+      // IDs owned by other sources (built-ins connected via env or API key).
+      const existingSource = options
+        .providers()
+        .find((provider) => provider.id === normalized.providerId)?.source;
+      if (
+        options.providerConnectedIds().includes(normalized.providerId) &&
+        existingSource !== "custom" &&
+        existingSource !== "config"
+      ) {
+        throw new Error(
+          `${normalized.providerId} is already connected in this workspace. Choose a different provider ID.`,
+        );
+      }
+
+      // `updateProjectConfigFile` returns false when the provider block is
+      // already present with identical content — treat that as success so
+      // retries stay idempotent.
+      await updateProjectConfigFile(
+        (raw) => formatConfigWithCustomProvider(raw, normalized),
+        (config) => {
+          const currentProvider = isRecord(config.provider) ? config.provider : {};
+          return {
+            ...config,
+            provider: {
+              ...currentProvider,
+              [normalized.providerId]: buildCustomProviderConfig(normalized),
+            },
+          };
+        },
+      );
+
+      if (normalized.apiKey) {
+        const c = options.client();
+        if (!c) {
+          throw new Error(t("providers.not_connected"));
+        }
+        await c.auth.set({
+          providerID: normalized.providerId,
+          auth: { type: "api", key: normalized.apiKey },
+        });
+      }
+
+      options.markOpencodeConfigReloadRequired();
+      await refreshProviders({ dispose: true });
+      return `${t("status.connected")} ${normalized.name}`;
+    } catch (error) {
+      const message = describeProviderError(error, "Failed to add custom provider.");
+      setStateField("providerAuthError", message);
+      throw error instanceof Error ? error : new Error(message);
+    }
+  }
+
   async function connectCloudProviderInternal(
     cloudProviderId: string,
     optionsArg?: { silent?: boolean },
@@ -1584,10 +1662,40 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       return await removeCloudProvider(trackedImport.cloudProviderId);
     }
 
+    // Providers defined by a `provider.<id>` block in opencode.jsonc are
+    // reported with source "config"/"custom". Removing credentials alone
+    // leaves them connected forever, so disconnecting one also removes the
+    // config block — otherwise the only way out is hand-editing the file.
+    const providerSource = options
+      .providers()
+      .find((provider) => provider.id === resolved)?.source;
+    const isConfigDefined = providerSource === "config" || providerSource === "custom";
+
     try {
-      await removeProviderAuthCredentials(resolved);
-      const updated = await refreshProviders({ dispose: true });
-      if (Array.isArray(updated?.connected) && updated.connected.includes(resolved)) {
+      try {
+        await removeProviderAuthCredentials(resolved);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error ?? "");
+        // Config-defined providers may have no stored credential (e.g. local Ollama).
+        if (!isConfigDefined || !/not found|unknown auth|404/i.test(message.toLowerCase())) {
+          throw error;
+        }
+      }
+      let updated = await refreshProviders({ dispose: true });
+      let stillConnected =
+        Array.isArray(updated?.connected) && updated.connected.includes(resolved);
+      if (stillConnected && isConfigDefined) {
+        const removedBlock = await updateProjectConfigFile((raw) =>
+          formatConfigWithoutCloudProvider(raw, resolved, options.disabledProviders()),
+        );
+        if (removedBlock) {
+          options.markOpencodeConfigReloadRequired();
+          updated = await refreshProviders({ dispose: true });
+          stillConnected =
+            Array.isArray(updated?.connected) && updated.connected.includes(resolved);
+        }
+      }
+      if (stillConnected) {
         // Provider is still connected (e.g. via env var). Just remove
         // stored credentials; do NOT add to disabled_providers.
         return `Removed stored credentials for ${resolved}${t("providers.still_connected_suffix")}`;
@@ -1822,6 +1930,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     refreshProviders,
     completeProviderAuthOAuth,
     submitProviderApiKey,
+    addCustomProvider,
     connectCloudProvider,
     removeCloudProvider,
     disconnectProvider,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1707,6 +1707,13 @@ export function SessionRoute() {
           modelPicker.setOpen(true);
           return result;
         },
+        onSubmitCustomProvider: async (input) => {
+          const result = await sessionProviderAuthStore.addCustomProvider(input);
+          modelPicker.setRecentProviderIds(new Set([input.providerId]));
+          modelPicker.setQuery("");
+          modelPicker.setOpen(true);
+          return result;
+        },
         onConnectCloudProvider: async (cloudProviderId) => {
           const result = await sessionProviderAuthStore.connectCloudProvider(cloudProviderId);
           modelPicker.setRecentProviderIds(new Set([cloudProviderId]));

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2337,6 +2337,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         )}
         onSelect={providerAuthStore.startProviderAuth}
         onSubmitApiKey={providerAuthStore.submitProviderApiKey}
+        onSubmitCustomProvider={providerAuthStore.addCustomProvider}
         onConnectCloudProvider={providerAuthStore.connectCloudProvider}
         onSubmitOAuth={providerAuthStore.completeProviderAuthOAuth}
         onRefreshProviders={providerAuthStore.refreshProviders}

--- a/apps/app/tests/custom-provider-config.test.ts
+++ b/apps/app/tests/custom-provider-config.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { parse } from "jsonc-parser";
+
+import {
+  buildCustomProviderConfig,
+  formatConfigWithCustomProvider,
+  normalizeCustomProviderInput,
+  slugifyProviderId,
+  validateCustomProviderInput,
+} from "../src/react-app/domains/connections/provider-auth/custom-provider-config";
+
+const input = (overrides: Partial<Parameters<typeof normalizeCustomProviderInput>[0]> = {}) =>
+  normalizeCustomProviderInput({
+    providerId: "azure-foundry",
+    name: "Azure AI Foundry",
+    baseURL: "https://my-resource.openai.azure.com/openai/v1",
+    apiKey: "sk-test",
+    modelIds: ["gpt-5.2", "my-deployment"],
+    ...overrides,
+  });
+
+describe("slugifyProviderId", () => {
+  test("derives a config-safe id from a display name", () => {
+    expect(slugifyProviderId("Azure AI Foundry")).toBe("azure-ai-foundry");
+    expect(slugifyProviderId("  My_Provider!! ")).toBe("my-provider");
+  });
+});
+
+describe("normalizeCustomProviderInput", () => {
+  test("trims, dedupes models, and strips trailing slash from baseURL", () => {
+    const normalized = input({
+      baseURL: " https://example.com/v1/ ",
+      modelIds: [" a ", "a", "", "b"],
+      name: "  ",
+    });
+    expect(normalized.baseURL).toBe("https://example.com/v1");
+    expect(normalized.modelIds).toEqual(["a", "b"]);
+    expect(normalized.name).toBe("azure-foundry");
+  });
+});
+
+describe("validateCustomProviderInput", () => {
+  test("accepts a valid input", () => {
+    expect(validateCustomProviderInput(input())).toBeNull();
+  });
+
+  test("rejects missing or malformed fields", () => {
+    expect(validateCustomProviderInput(input({ providerId: "" }))).toContain("Provider ID");
+    expect(validateCustomProviderInput(input({ providerId: "bad id!" }))).toContain("Provider ID");
+    expect(validateCustomProviderInput(input({ baseURL: "" }))).toContain("Base URL");
+    expect(validateCustomProviderInput(input({ baseURL: "ftp://x" }))).toContain("http");
+    expect(validateCustomProviderInput(input({ modelIds: [] }))).toContain("model");
+  });
+});
+
+describe("formatConfigWithCustomProvider", () => {
+  test("writes an openai-compatible provider block into an empty config", () => {
+    const updated = formatConfigWithCustomProvider("", input());
+    const parsed = parse(updated) as Record<string, unknown>;
+    const provider = (parsed.provider as Record<string, unknown>)["azure-foundry"];
+    expect(provider).toEqual({
+      npm: "@ai-sdk/openai-compatible",
+      name: "Azure AI Foundry",
+      options: { baseURL: "https://my-resource.openai.azure.com/openai/v1" },
+      models: {
+        "gpt-5.2": { name: "gpt-5.2" },
+        "my-deployment": { name: "my-deployment" },
+      },
+    });
+  });
+
+  test("preserves existing config content and comments", () => {
+    const raw = [
+      "{",
+      '  "$schema": "https://opencode.ai/config.json",',
+      "  // keep me",
+      '  "provider": {',
+      '    "ollama": { "npm": "@ai-sdk/openai-compatible", "name": "Ollama" }',
+      "  }",
+      "}",
+      "",
+    ].join("\n");
+    const updated = formatConfigWithCustomProvider(raw, input());
+    expect(updated).toContain("// keep me");
+    const parsed = parse(updated) as Record<string, unknown>;
+    const providers = parsed.provider as Record<string, unknown>;
+    expect(Object.keys(providers).sort()).toEqual(["azure-foundry", "ollama"]);
+  });
+
+  test("is idempotent for the same provider", () => {
+    const once = formatConfigWithCustomProvider("", input());
+    const twice = formatConfigWithCustomProvider(once, input());
+    expect(parse(twice)).toEqual(parse(once));
+  });
+});
+
+describe("buildCustomProviderConfig", () => {
+  test("uses the model id as the display name", () => {
+    const config = buildCustomProviderConfig(input({ modelIds: ["m1"] }));
+    expect(config.models).toEqual({ m1: { name: "m1" } });
+  });
+});

--- a/evals/flows/custom-provider-add.flow.mjs
+++ b/evals/flows/custom-provider-add.flow.mjs
@@ -1,0 +1,154 @@
+/**
+ * A user can connect a custom OpenAI-compatible provider (Azure AI Foundry,
+ * LiteLLM, vLLM, ...) entirely from the UI — Settings -> AI -> Connect
+ * provider -> Add custom provider — without hand-editing opencode.jsonc or
+ * pasting JSON into Cloud. The provider block is written to the workspace
+ * config, the engine reloads, and the provider (with its models) comes back
+ * from the engine as connected. Disconnect removes the block again.
+ */
+const PROVIDER_NAME = "Foundry Eval";
+const PROVIDER_ID = "foundry-eval";
+const BASE_URL = "https://eval-foundry.example.com/openai/v1";
+const MODEL_ID = "eval-deployment-1";
+
+export default {
+  id: "custom-provider-add",
+  title: "Add a custom OpenAI-compatible provider from the UI",
+  spec: "packages/docs/start-here/connect-your-stack/add-a-custom-llm.mdx",
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000 });
+      },
+    },
+    {
+      name: "Open Settings -> AI",
+      run: async (ctx) => {
+        await ctx.navigateHash("/settings/ai");
+        await ctx.expectHashIncludes("/settings/ai");
+        await ctx.expectText("Connect provider", { timeoutMs: 30_000 });
+      },
+    },
+    {
+      name: "Connect providers modal offers a custom provider entry",
+      run: async (ctx) => {
+        await ctx.prove("The provider list has an 'Add custom provider' entry point", {
+          action: async () => {
+            await ctx.clickText("Connect provider", { timeoutMs: 30_000 });
+            await ctx.expectText("Connect providers", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Add custom provider", { timeoutMs: 30_000 });
+            await ctx.expectText("OpenAI-compatible endpoint");
+          },
+          screenshot: {
+            name: "connect-modal-custom-entry",
+            requireText: ["Connect providers", "Add custom provider"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Custom provider form captures endpoint details",
+      run: async (ctx) => {
+        await ctx.prove("The custom provider form collects name, ID, URL, key, and models", {
+          action: async () => {
+            await ctx.clickText("Add custom provider", { timeoutMs: 15_000 });
+            await ctx.expectText("Custom provider", { timeoutMs: 15_000 });
+            await ctx.fill('input[placeholder="Azure AI Foundry"]', PROVIDER_NAME);
+            await ctx.fill('input[placeholder="azure-foundry"]', PROVIDER_ID);
+            await ctx.fill('input[placeholder="https://my-resource.openai.azure.com/openai/v1"]', BASE_URL);
+            await ctx.fill('input[placeholder="sk-..."]', "sk-eval-custom-123");
+            await ctx.fill('input[placeholder="gpt-5.2, my-deployment-name"]', MODEL_ID);
+          },
+          assert: async () => {
+            const nameValue = await ctx.eval(
+              `document.querySelector('input[placeholder="Azure AI Foundry"]')?.value`,
+            );
+            ctx.assert(nameValue === PROVIDER_NAME, `Name field holds ${PROVIDER_NAME}`);
+            const urlValue = await ctx.eval(
+              `document.querySelector('input[placeholder="https://my-resource.openai.azure.com/openai/v1"]')?.value`,
+            );
+            ctx.assert(urlValue === BASE_URL, `Base URL field holds ${BASE_URL}`);
+            await ctx.waitFor(
+              `(() => {
+                const buttons = [...document.querySelectorAll("button")];
+                const add = buttons.find((el) => (el.textContent ?? "").trim() === "Add provider");
+                return Boolean(add) && !add.disabled;
+              })()`,
+              { timeoutMs: 10_000, label: "Add provider button enabled" },
+            );
+          },
+          screenshot: {
+            name: "custom-provider-form-filled",
+            requireText: ["Custom provider", "Base URL", "Model IDs"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Provider is installed and reported back by the engine",
+      run: async (ctx) => {
+        await ctx.prove("Submitting installs the provider and it appears as connected in Settings", {
+          action: async () => {
+            await ctx.clickText("Add provider", { timeoutMs: 15_000 });
+            // The store writes opencode.jsonc, stores the key, reloads the
+            // engine, and re-reads the provider list before the modal closes.
+            await ctx.waitFor(
+              `!document.body.innerText.includes("Connect providers") && !document.querySelector("[role=dialog]")`,
+              { timeoutMs: 120_000, label: "connect modal fully dismissed after install" },
+            );
+          },
+          assert: async () => {
+            // The witness: the engine-reported provider list (rendered on the
+            // AI settings page) now includes the new provider by name and ID.
+            await ctx.expectText(PROVIDER_NAME, { timeoutMs: 60_000 });
+            await ctx.expectText(PROVIDER_ID, { timeoutMs: 30_000 });
+          },
+          screenshot: {
+            name: "provider-connected",
+            requireText: [PROVIDER_NAME, PROVIDER_ID],
+            rejectText: ["Something went wrong", "Failed to add custom provider"],
+            hashIncludes: "/settings/ai",
+          },
+        });
+      },
+    },
+    {
+      name: "Disconnect removes the custom provider again",
+      run: async (ctx) => {
+        await ctx.prove("Disconnecting a custom provider removes its config block", {
+          action: async () => {
+            await ctx.waitFor(
+              `(() => {
+                const buttons = [...document.querySelectorAll("button")];
+                const target = buttons.find((el) =>
+                  (el.textContent ?? "").trim() === "Disconnect" &&
+                  (el.parentElement?.textContent ?? "").includes(${JSON.stringify(PROVIDER_ID)}));
+                if (!target) return false;
+                target.click();
+                return true;
+              })()`,
+              { timeoutMs: 30_000, label: "Disconnect button for the custom provider" },
+            );
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `!document.body.innerText.includes(${JSON.stringify(PROVIDER_ID)})`,
+              { timeoutMs: 120_000, label: "custom provider removed from the provider list" },
+            );
+          },
+          screenshot: {
+            name: "provider-removed",
+            requireText: ["Connect provider"],
+            rejectText: [PROVIDER_ID, "Something went wrong"],
+            hashIncludes: "/settings/ai",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/packages/docs/start-here/connect-your-stack/add-a-custom-llm.mdx
+++ b/packages/docs/start-here/connect-your-stack/add-a-custom-llm.mdx
@@ -3,6 +3,17 @@ title: "Add a custom LLM"
 description: "How to connect a custom provider with OpenWork"
 ---
 
+## Add it from the app (recommended)
+
+You can connect any OpenAI-compatible endpoint — Azure AI Foundry, LiteLLM, vLLM, Ollama, an internal gateway — directly from the app:
+
+1. Go to `Settings -> AI -> Connect provider`.
+2. Pick `Add custom provider` at the bottom of the list.
+3. Enter a name, the base URL of your endpoint, an API key (if it needs one), and the model IDs it serves — on Azure AI Foundry these are your deployment names.
+4. Click `Add provider`. OpenWork writes the provider into your workspace `opencode.jsonc`, stores the key locally, and the models appear in the model picker.
+
+## Add it by editing the config file
+
 Because `OpenWork` is built on `OpenCode` primitives, we support everything that you could modify in `.opencode.json`, like adding a [model](https://opencode.ai/docs/models/). However, our recommendation is to add it to `/path-to-your-workspace/.config/opencode/opencode.json` instead of modifying `~/.config/opencode/opencode.json`.
 
 Inside `/path-to-your-workspace/.config/opencode/opencode.json`:


### PR DESCRIPTION
## Why

Until now, connecting a custom LLM endpoint (Azure AI Foundry, LiteLLM, vLLM, Ollama, internal gateways) meant hand-editing `opencode.jsonc` or pasting JSON into the Cloud dashboard. This makes it a first-class UI flow — no Den, no copy-paste.

## What

**Settings → AI → Connect provider → Add custom provider**: form with name, provider ID (auto-slugged), base URL, optional API key, and model IDs (deployment names on Azure AI Foundry).

- New pure helpers in `provider-auth/custom-provider-config.ts` (validate/normalize input, jsonc-preserving `provider.<id>` block writer for `npm: @ai-sdk/openai-compatible` + `baseURL` + models).
- `addCustomProvider()` in the provider-auth store: writes the block through the existing multi-fallback config writer (OpenWork server → desktop IPC → SDK `config.update`), stores the key via `auth.set`, reloads the engine, refreshes the provider list.
- **Disconnect fix**: config-defined providers (engine `source: config|custom`) previously could never be disconnected — credentials were removed but the block stayed, so the provider remained connected forever. Disconnect now removes the config block, escalating only when the provider would otherwise stay connected.
- Re-adding the same custom provider ID is a safe reconcile (update baseURL/models/key). IDs owned by env/API-connected providers and cloud-managed `lpr_*`/`openwork` keys are rejected.
- Respects the existing `allowCustomProviders` desktop policy gate.
- Wired in both the settings route and the session-route connect modal (session flow opens the model picker on the new provider).
- Docs: `add-a-custom-llm.mdx` now leads with the UI flow.

## Tests / evidence

- `pnpm typecheck` (apps/app) — clean, on top of latest `dev`
- `bun test tests/` — 85 pass / 0 fail (includes 8 new unit tests: `apps/app/tests/custom-provider-config.test.ts`)
- fraimz e2e proof against the real Electron app via CDP: `pnpm fraimz --flow custom-provider-add` — **PASSED** (4 frames: custom entry in connect modal → filled form → provider reported connected by the engine on the AI settings page → removed after Disconnect). Verified the `provider.foundry-eval` block was written to and then removed from the workspace `opencode.jsonc` on disk.

Repro: `OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9826 pnpm dev`, then `pnpm fraimz --flow custom-provider-add --cdp-url http://127.0.0.1:9826`.

No video attached (agent-driven run); the coded flow above is the reproducible evidence.