### PR TITLE
Grouped cross-session search + sidebar entry; fraimz demo kinds with mandatory voiceover

### DIFF
--- a/.opencode/skills/fraimz/SKILL.md
+++ b/.opencode/skills/fraimz/SKILL.md
@@ -8,12 +8,51 @@ description: create a fraimz, make fraimz, prove it works, frame proof, PR proof
 **fraimz** is the canonical proof artifact: a single `fraimz.html`
 (`evals/results/<run-id>/fraimz.html`) with one frame per step. Each frame binds
 a **claim**, the **action** the end user took, the **assertion** that witnesses
-the side effect, and a validated **screenshot**. It is the atomic thing a human
-looks at to understand, at a glance, that an experience works.
+the side effect, a **voiceover** that narrates the step, and a validated
+**screenshot**. It is the atomic thing a human looks at (and listens to) to
+understand, at a glance, that an experience works.
 
 This skill owns the whole loop. Trigger phrases: "create a fraimz", "make
 fraimz", "prove it works", "frame proof", "PR proof". The `/fraimz` command runs
 the same loop.
+
+## Every fraimz is a demo
+
+A fraimz is never a bare test log. It is always one of exactly two demos, and
+the flow declares which via `kind` in `evals/flows/<id>.flow.mjs`:
+
+- **`kind: "user-facing"`** — a flow demo. The end user is the protagonist; the
+  frames walk a real journey through the UI ("discover the button, click it,
+  see the result, land somewhere"). This is the default for any feature, fix,
+  or UX change.
+- **`kind: "internal"`** — an internal demo for changes with no visible surface:
+  perf improvements, storage swaps, invariants, refactors. The frames
+  demonstrate the internal claim (timings before/after, unchanged core flow,
+  identical output) in a way a reviewer can still follow frame by frame.
+
+If you cannot say which of the two your fraimz is, you have not framed the
+experience yet — go back to step 1 of the loop.
+
+## Voiceover first, always
+
+Every frame carries a **voiceover**: one or two spoken-style sentences that
+explain what the viewer is seeing and why it matters, as if narrating a demo
+video. The runner renders it on each frame in `fraimz.html` with a play button
+(Web Speech API), plus a "Play full voiceover" per flow.
+
+Rules:
+
+- **Write the voiceover script before coding the flow.** Narrate the whole demo
+  end to end (one paragraph per frame), state it back, and only then translate
+  each paragraph into a `ctx.prove` step. If a step is hard to narrate, the
+  step is wrong.
+- Every `ctx.prove` must pass `voiceover`. Frames without one are flagged
+  ("No voiceover for this frame") in the artifact — treat that flag as a
+  failure for any flow you add or touch.
+- Voiceovers describe **what the user sees** ("results are grouped, each label
+  shows a count"), not implementation ("the memo re-computes").
+- For `internal` demos the voiceover explains the invariant being witnessed
+  ("same session list, half the queries").
 
 ## When this applies
 
@@ -26,21 +65,25 @@ changes with no runtime path may skip — but say so explicitly.
 
 ## The loop (never report success from a click or a return value alone)
 
-1. **Frame the experience** as a one-line claim ("user can do X and sees Y").
-   State it back before proceeding.
-2. **Express it as a flow.** Reuse or add a coded flow in
-   `evals/flows/<id>.flow.mjs`. The end user is the protagonist (driven via CDP).
-   REST/DB/filesystem checks are *only* how you witness the expected side
-   effects — never the thing being tested. Every meaningful step must use
-   `ctx.prove("claim", { action, assert, screenshot })`.
-3. **Drive it for real.** Launch the app (Daytona preferred, local Electron
+1. **Frame the experience** as a one-line claim ("user can do X and sees Y")
+   and pick the demo kind (`user-facing` or `internal`). State both back
+   before proceeding.
+2. **Write the voiceover script.** One narrated paragraph per planned frame,
+   covering the whole demo end to end (see "Voiceover first, always").
+3. **Express it as a flow.** Reuse or add a coded flow in
+   `evals/flows/<id>.flow.mjs` with `kind` set. The end user is the protagonist
+   (driven via CDP). REST/DB/filesystem checks are *only* how you witness the
+   expected side effects — never the thing being tested. Every meaningful step
+   must use `ctx.prove("claim", { voiceover, action, assert, screenshot })`,
+   with `voiceover` taken from the script.
+4. **Drive it for real.** Launch the app (Daytona preferred, local Electron
    fallback) and run `pnpm fraimz --flow <id> --cdp-url <electron-cdp-url>`.
    Observe → act → observe → assert.
-4. **Validate, repair, repeat.** If a frame does not support its claim (wrong
-   route, error state, missing text, stale dialog, duplicate image), fix the
-   visible state or the code and rerun until every claim has a passing assertion
-   and a valid screenshot.
-5. **Output fraimz + verdict.** The run writes `fraimz.html` plus
+5. **Validate, repair, repeat.** If a frame does not support its claim (wrong
+   route, error state, missing text, stale dialog, duplicate image, missing
+   voiceover), fix the visible state or the code and rerun until every claim
+   has a passing assertion, a narrated voiceover, and a valid screenshot.
+6. **Output fraimz + verdict.** The run writes `fraimz.html` plus
    `report.md` / `report.json` to `evals/results/<run-id>/`. Report the path to
    `fraimz.html` as the headline deliverable. Report `Passed` only when fraimz
    exists and every claim is backed by an observable assertion; otherwise
@@ -51,7 +94,8 @@ changes with no runtime path may skip — but say so explicitly.
 When a change is expected to be inert, re-run the core flow —
 **open the app → write a message → get a response → close → reopen and confirm
 the session survived** (`evals/flows/core-flow.flow.mjs`). If it stays green, the
-inertness claim is backed by evidence.
+inertness claim is backed by evidence. This is the standard `internal` demo for
+"nothing user-visible changed".
 
 ## Driving the real app
 
@@ -97,14 +141,25 @@ Pass `--cdp-url` for any other port.
 - **`screenshot` validation takes arrays.** `requireText: ["foo"]`,
   `rejectText: [...]`, `hashIncludes: "/route"`. A screenshot with no validation
   metadata is a checkpoint, not proof.
+- **Flows must be idempotent.** A failed previous run can leave dialogs open or
+  state dirty; begin steps by restoring the state you need (e.g. Escape a stale
+  dialog) instead of assuming a fresh app.
+- **Don't race streamed results.** Debounced/async UI (deep search, scans)
+  starts *after* your input lands; wait for the concrete artifact you assert on
+  (the rendered row), not for a spinner to disappear — the spinner may not have
+  appeared yet.
 
 ## ctx.* helpers (the flow API)
 
 `ctx.eval`, `ctx.waitFor`, `ctx.waitForText`, `ctx.clickText`, `ctx.fill`,
 `ctx.navigateHash`, `ctx.control(actionId, args)`, `ctx.expectText`,
 `ctx.expectNoText`, `ctx.expectHashIncludes`, `ctx.assert`,
-`ctx.screenshot(name, { claim, requireText, rejectText, hashIncludes })`, and
-the headline `ctx.prove("claim", { action, assert, screenshot })`.
+`ctx.screenshot(name, { claim, voiceover, requireText, rejectText, hashIncludes })`,
+and the headline
+`ctx.prove("claim", { voiceover, action, assert, screenshot })`.
+
+Reference example (demo kind + per-frame voiceover):
+`evals/flows/session-search-grouped.flow.mjs`.
 
 ## Source of truth
 

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1558,6 +1558,7 @@ export default {
   "workspace_list.session_actions": "Session actions",
   "workspace_list.session_active": "Session active",
   "workspace_list.session_streaming": "Session streaming",
+  "workspace_list.search_sessions": "Search sessions",
   "workspace_list.share": "Share...",
   "workspace_list.show_child_sessions": "Show child sessions",
   "workspace_list.show_more": "Show {count} more",

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -119,6 +119,8 @@ export type SessionPageSidebarProps = {
   onEditWorkspaceConnection: (workspaceId: string) => void;
   onForgetWorkspace: (workspaceId: string) => void;
   onOpenCreateWorkspace: () => void;
+  /** Opens the cross-session message search dialog (Cmd/Ctrl+Shift+F). */
+  onOpenSessionSearch?: () => void;
   onReorderWorkspaces?: (workspaceIds: string[]) => void;
 };
 
@@ -858,6 +860,7 @@ export function SessionPage(props: SessionPageProps) {
           onEditWorkspaceConnection={props.sidebar.onEditWorkspaceConnection}
           onForgetWorkspace={props.sidebar.onForgetWorkspace}
           onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
+          onOpenSessionSearch={props.sidebar.onOpenSessionSearch}
           onReorderWorkspaces={props.sidebar.onReorderWorkspaces}
           onStartResize={startLeftSidebarResize}
         />

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Pin,
   PinOff,
   Plus,
+  Search,
   Share2,
   Trash2,
   RefreshCw,
@@ -33,6 +34,7 @@ import {
   isRemoteConnectionErrorMessage,
   getWorkspaceTaskLoadErrorDisplay,
   isRemoteConnectionWorkspace,
+  isMacPlatform,
   isWindowsPlatform,
 } from "../../../../app/utils";
 import { t } from "../../../../i18n";
@@ -41,6 +43,7 @@ import {
   Sidebar,
   SidebarFooter,
   SidebarGroup,
+  SidebarHeader,
   SidebarGroupContent,
   SidebarMenu,
   SidebarMenuButton,
@@ -582,6 +585,8 @@ export type AppSidebarProps = {
   onEditWorkspaceConnection: (workspaceId: string) => void;
   onForgetWorkspace: (workspaceId: string) => void;
   onOpenCreateWorkspace: () => void;
+  /** Opens the cross-session message search dialog (Cmd/Ctrl+Shift+F). */
+  onOpenSessionSearch?: () => void;
   onReorderWorkspaces?: (workspaceIds: string[]) => void;
   onStartResize?: React.PointerEventHandler<HTMLButtonElement>;
 };
@@ -744,6 +749,25 @@ export function AppSidebar(props: AppSidebarProps) {
               className="h-9 max-h-9 w-auto max-w-[180px] object-contain object-left"
             />
           </div>
+        ) : null}
+        {props.onOpenSessionSearch ? (
+          <SidebarHeader className="pb-0">
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  onClick={props.onOpenSessionSearch}
+                  aria-keyshortcuts={isMacPlatform() ? "Meta+Shift+F" : "Control+Shift+F"}
+                  className="text-sidebar-foreground/70"
+                >
+                  <Search className="size-4" />
+                  <span className="flex-1 truncate">{t("workspace_list.search_sessions")}</span>
+                  <kbd className="ml-auto font-sans text-[11px] tracking-wide text-sidebar-foreground/50">
+                    {isMacPlatform() ? "⌘⇧F" : "Ctrl+Shift+F"}
+                  </kbd>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarHeader>
         ) : null}
         <LazyMotion features={domMax}>
           <m.div

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1840,6 +1840,7 @@ export function SessionRoute() {
         onEditWorkspaceConnection: remoteWorkspaceConnectionEditor.open,
         onForgetWorkspace: (id) => void handleForgetWorkspace(id),
         onOpenCreateWorkspace: handleOpenCreateWorkspace,
+        onOpenSessionSearch: () => setSessionSearchOpen(true),
         onReorderWorkspaces: handleReorderWorkspaces,
       }}
       surface={surfaceProps}

--- a/apps/app/src/react-app/shell/session-search-dialog.tsx
+++ b/apps/app/src/react-app/shell/session-search-dialog.tsx
@@ -5,11 +5,14 @@ import { ClockIcon, Loader2Icon, MessageSquareTextIcon, TypeIcon } from "lucide-
 
 import {
   Command,
+  CommandCollection,
   CommandDialog,
   CommandDialogPopup,
   CommandDialogTitle,
   CommandEmpty,
   CommandFooter,
+  CommandGroup,
+  CommandGroupLabel,
   CommandHeader,
   CommandInput,
   CommandItem,
@@ -39,6 +42,12 @@ type ResultItem = {
   session: SearchableSession;
   role?: "user" | "assistant";
   snippet?: SessionSearchSnippet;
+};
+
+type ResultGroup = {
+  value: string;
+  kind: ResultItem["kind"];
+  items: ResultItem[];
 };
 
 export type SessionSearchDialogProps = {
@@ -139,10 +148,10 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
     return () => run.cancel();
   }, [props.open, props.sessions, searcher, deepQuery]);
 
-  const items = useMemo<ResultItem[]>(() => {
+  const groups = useMemo<ResultGroup[]>(() => {
     const trimmed = query.trim();
     if (!trimmed) {
-      return [...props.sessions]
+      const recent = [...props.sessions]
         .sort((a, b) => b.updatedAt - a.updatedAt)
         .slice(0, RECENT_LIMIT)
         .map((session) => ({
@@ -150,11 +159,14 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
           kind: "recent" as const,
           session,
         }));
+      return recent.length > 0
+        ? [{ value: "Recent sessions", kind: "recent", items: recent }]
+        : [];
     }
 
-    const out: ResultItem[] = [];
     const seen = new Set<string>();
 
+    const titleItems: ResultItem[] = [];
     const titleHits = fuzzysort.go(trimmed, props.sessions, {
       keys: ["title", "workspaceTitle"],
       limit: TITLE_LIMIT,
@@ -162,20 +174,22 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
     for (const hit of titleHits) {
       const session = hit.obj;
       seen.add(session.sessionId);
-      out.push({
+      titleItems.push({
         id: `title:${session.workspaceId}:${session.sessionId}`,
         kind: "title",
         session,
       });
     }
 
+    const messageItems: ResultItem[] = [];
     const messageHits = [...matches].sort(
       (a, b) => b.session.updatedAt - a.session.updatedAt,
     );
     for (const match of messageHits) {
       if (seen.has(match.session.sessionId)) continue;
       seen.add(match.session.sessionId);
-      out.push({
+      if (titleItems.length + messageItems.length >= RESULT_LIMIT) break;
+      messageItems.push({
         id: `message:${match.session.workspaceId}:${match.session.sessionId}`,
         kind: "message",
         session: match.session,
@@ -183,8 +197,21 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
         snippet: match.snippet,
       });
     }
-    return out.slice(0, RESULT_LIMIT);
+
+    const out: ResultGroup[] = [];
+    if (titleItems.length > 0) {
+      out.push({ value: "Session titles", kind: "title", items: titleItems });
+    }
+    if (messageItems.length > 0) {
+      out.push({ value: "Messages", kind: "message", items: messageItems });
+    }
+    return out;
   }, [matches, props.sessions, query]);
+
+  const resultCount = useMemo(
+    () => groups.reduce((sum, group) => sum + group.items.length, 0),
+    [groups],
+  );
 
   const trimmedQuery = query.trim();
   const searching = Boolean(deepQuery) && progress !== null && !progress.done;
@@ -200,7 +227,7 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
     ? "Recent sessions"
     : searching
       ? `Searching messages… ${progress.scanned}/${progress.total}`
-      : `${items.length.toLocaleString()} ${items.length === 1 ? "result" : "results"}`;
+      : `${resultCount.toLocaleString()} ${resultCount === 1 ? "result" : "results"}`;
 
   return (
     <CommandDialog
@@ -212,7 +239,7 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
       <CommandDialogPopup>
         <CommandDialogTitle>Search sessions</CommandDialogTitle>
         <Command
-          items={items}
+          items={groups}
           filter={null}
           value={query}
           onValueChange={setQuery}
@@ -226,31 +253,46 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
           <CommandPanel>
             <CommandEmpty>{emptyText}</CommandEmpty>
             <CommandList>
-              {(item: ResultItem) => (
-                <CommandItem
-                  key={item.id}
-                  value={item.id}
-                  onClick={() => {
-                    props.onClose();
-                    props.onOpenSession(item.session.workspaceId, item.session.sessionId);
-                  }}
-                >
-                  <span className="mr-2 shrink-0">{resultIcon(item.kind)}</span>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-baseline gap-2">
-                      <span className="truncate font-medium">{item.session.title}</span>
-                      {item.kind === "message" ? (
-                        <span className="shrink-0 truncate text-[11px] text-muted-foreground/72">
-                          {item.session.workspaceTitle}
-                        </span>
-                      ) : null}
-                    </div>
-                    <SnippetLine item={item} />
-                  </div>
-                  <CommandShortcut className="ps-3">
-                    {formatRelativeTime(item.session.updatedAt)}
-                  </CommandShortcut>
-                </CommandItem>
+              {(group: ResultGroup) => (
+                <CommandGroup key={group.value} items={group.items}>
+                  <CommandGroupLabel className="flex items-center gap-1.5">
+                    {group.value}
+                    <span className="font-normal text-muted-foreground/72 tabular-nums">
+                      {group.items.length.toLocaleString()}
+                    </span>
+                    {group.kind === "message" && searching ? (
+                      <Loader2Icon className="size-3 animate-spin text-muted-foreground/72" />
+                    ) : null}
+                  </CommandGroupLabel>
+                  <CommandCollection>
+                    {(item: ResultItem) => (
+                      <CommandItem
+                        key={item.id}
+                        value={item.id}
+                        onClick={() => {
+                          props.onClose();
+                          props.onOpenSession(item.session.workspaceId, item.session.sessionId);
+                        }}
+                      >
+                        <span className="mr-2 shrink-0">{resultIcon(item.kind)}</span>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-baseline gap-2">
+                            <span className="truncate font-medium">{item.session.title}</span>
+                            {item.kind === "message" ? (
+                              <span className="shrink-0 truncate text-[11px] text-muted-foreground/72">
+                                {item.session.workspaceTitle}
+                              </span>
+                            ) : null}
+                          </div>
+                          <SnippetLine item={item} />
+                        </div>
+                        <CommandShortcut className="ps-3">
+                          {formatRelativeTime(item.session.updatedAt)}
+                        </CommandShortcut>
+                      </CommandItem>
+                    )}
+                  </CommandCollection>
+                </CommandGroup>
               )}
             </CommandList>
           </CommandPanel>

--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -258,6 +258,53 @@ describe("Google Workspace extension", () => {
     expect(requestedUrls[0]).toBe("https://gmail.googleapis.com/gmail/v1/users/me/messages/m1/attachments/att-1");
   });
 
+  test("gmail_create_draft attaches local workspace files", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    const workspaceRoot = join(dirname(config.configPath ?? ""), "workspace");
+    const invoicePath = join(workspaceRoot, "invoices", "blue-yonder-invoice-ow-by-poc-2026-001.pdf");
+    config.workspaces = [{ id: "workspace-1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }];
+    config.authorizedRoots = [workspaceRoot];
+    await mkdir(dirname(invoicePath), { recursive: true });
+    await writeFile(invoicePath, "%PDF-1.4\ninvoice bytes\n", "utf8");
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one")],
+    });
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(input instanceof Request ? input.url : input), body: typeof init?.body === "string" ? init.body : "" });
+        return new Response(JSON.stringify({ id: "draft-1", message: { id: "draft-message-1" } }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    const result = await callGoogleWorkspaceExtensionAction(config, "gmail_create_draft", {
+      to: ["AccountsPayable@blueyonder.com"],
+      cc: ["Purchasing.Administrator@blueyonder.com", "Vickie.Trent@blueyonder.com"],
+      subject: "Invoice OW-BY-POC-2026-001 for PO-047766",
+      body: "Please find attached invoice OW-BY-POC-2026-001 for PO-047766.",
+      attachments: [{ path: "invoices/blue-yonder-invoice-ow-by-poc-2026-001.pdf" }],
+    }, { directory: workspaceRoot });
+    expect(result?.ok).toBe(true);
+    expect(result?.result).toMatchObject({ id: "draft-1" });
+    expect(requests[0]?.url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/drafts");
+    const raw = requests[0]?.body.match(/"raw":"([^"]+)"/)?.[1] ?? "";
+    const decoded = Buffer.from(raw.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
+    expect(decoded).toContain("To: AccountsPayable@blueyonder.com");
+    expect(decoded).toContain("Cc: Purchasing.Administrator@blueyonder.com, Vickie.Trent@blueyonder.com");
+    expect(decoded).toContain("Subject: Invoice OW-BY-POC-2026-001 for PO-047766");
+    expect(decoded).toContain("Content-Type: multipart/mixed;");
+    expect(decoded).toContain("Please find attached invoice OW-BY-POC-2026-001 for PO-047766.");
+    expect(decoded).toContain("Content-Type: application/pdf; name=\"blue-yonder-invoice-ow-by-poc-2026-001.pdf\"");
+    expect(decoded).toContain("Content-Disposition: attachment; filename=\"blue-yonder-invoice-ow-by-poc-2026-001.pdf\"");
+    expect(decoded).toContain(Buffer.from("%PDF-1.4\ninvoice bytes\n", "utf8").toString("base64"));
+  });
+
   test("gmail_create_reply_draft rejects accounts without the gmail.readonly scope", async () => {
     process.env.OPENWORK_DEV_MODE = "1";
     process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -1,7 +1,7 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
 import { createServer, type Server } from "node:http";
-import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { homedir } from "node:os";
 
 import { ApiError } from "../errors.js";
@@ -82,6 +82,20 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
         bcc: { type: "array", items: { type: "string" }, description: "Optional BCC recipients." },
         subject: { type: "string", description: "Draft subject." },
         body: { type: "string", description: "Plain text draft body." },
+        attachments: {
+          type: "array",
+          description: "Optional local files to attach. Paths may be relative to the active workspace/directory or absolute under an authorized workspace root.",
+          items: {
+            type: "object",
+            properties: {
+              path: { type: "string", description: "Workspace-relative path or authorized absolute file path." },
+              filename: { type: "string", description: "Optional attachment filename shown in Gmail." },
+              mimeType: { type: "string", description: "Optional attachment MIME type. Defaults from the file extension when possible." },
+            },
+            required: ["path"],
+            additionalProperties: false,
+          },
+        },
       },
       required: ["to", "subject", "body"],
       additionalProperties: false,
@@ -616,17 +630,172 @@ function stringArrayField(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0) : [];
 }
 
-function gmailRawMessage(input: { to: string[]; cc?: string[]; bcc?: string[]; subject: string; body: string; headers?: { name: string; value: string }[] }): string {
-  return [
+type GmailDraftAttachmentRequest = {
+  path: string;
+  filename?: string;
+  mimeType?: string;
+};
+
+type GmailDraftAttachment = {
+  filename: string;
+  mimeType: string;
+  content: Buffer;
+};
+
+function gmailHeaderValue(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}
+
+function gmailMimeParameter(value: string): string {
+  return gmailHeaderValue(value).replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+}
+
+function base64MimeContent(buffer: Buffer): string {
+  const chunks = buffer.toString("base64").match(/.{1,76}/g);
+  return chunks ? chunks.join("\r\n") : "";
+}
+
+function gmailAttachmentMimeType(path: string, override: string | undefined): string {
+  const provided = typeof override === "string" ? override.trim() : "";
+  if (provided && /^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(provided)) return provided;
+  const lowered = path.toLowerCase();
+  if (lowered.endsWith(".pdf")) return "application/pdf";
+  if (lowered.endsWith(".png")) return "image/png";
+  if (lowered.endsWith(".jpg") || lowered.endsWith(".jpeg")) return "image/jpeg";
+  if (lowered.endsWith(".gif")) return "image/gif";
+  if (lowered.endsWith(".csv")) return "text/csv";
+  if (lowered.endsWith(".txt")) return "text/plain";
+  return "application/octet-stream";
+}
+
+function gmailDraftAttachmentRequests(value: unknown): GmailDraftAttachmentRequest[] {
+  if (!Array.isArray(value)) return [];
+  const attachments: GmailDraftAttachmentRequest[] = [];
+  for (const item of value) {
+    if (!isRecord(item)) continue;
+    const path = typeof item.path === "string" ? item.path.trim() : "";
+    if (!path) continue;
+    const filename = typeof item.filename === "string" && item.filename.trim() ? item.filename.trim() : undefined;
+    const mimeType = typeof item.mimeType === "string" && item.mimeType.trim() ? item.mimeType.trim() : undefined;
+    attachments.push({ path, filename, mimeType });
+  }
+  return attachments;
+}
+
+function pushUniqueResolvedPath(paths: string[], path: string) {
+  const trimmed = path.trim();
+  if (!trimmed) return;
+  const resolved = resolve(trimmed);
+  if (!paths.includes(resolved)) paths.push(resolved);
+}
+
+function isPathWithinRoot(path: string, root: string): boolean {
+  const child = relative(root, path);
+  return child === "" || (!!child && !child.startsWith("..") && !isAbsolute(child));
+}
+
+function gmailAttachmentAllowedRoots(config: ServerConfig): string[] {
+  const roots: string[] = [];
+  for (const workspace of config.workspaces) pushUniqueResolvedPath(roots, workspace.path);
+  for (const root of config.authorizedRoots) pushUniqueResolvedPath(roots, root);
+  return roots;
+}
+
+function gmailAttachmentSearchRoots(config: ServerConfig, context: Record<string, unknown>, allowedRoots: string[]): string[] {
+  const roots: string[] = [];
+  const directory = readStringField(context, "directory");
+  const worktree = readStringField(context, "worktree");
+  if (directory) pushUniqueResolvedPath(roots, directory);
+  if (worktree) pushUniqueResolvedPath(roots, worktree);
+  for (const workspace of config.workspaces) pushUniqueResolvedPath(roots, workspace.path);
+  for (const root of allowedRoots) pushUniqueResolvedPath(roots, root);
+  return roots.filter((root) => allowedRoots.some((allowedRoot) => isPathWithinRoot(root, allowedRoot)));
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+async function assertGmailAttachmentFile(path: string) {
+  const info = await stat(path);
+  if (!info.isFile()) throw new ApiError(400, "invalid_payload", "Attachment path must point to a file", { path });
+}
+
+async function resolveGmailAttachmentPath(config: ServerConfig, context: Record<string, unknown>, path: string): Promise<string> {
+  const allowedRoots = gmailAttachmentAllowedRoots(config);
+  if (!allowedRoots.length) throw new ApiError(400, "invalid_payload", "No authorized workspace roots are available for Gmail attachments");
+  if (isAbsolute(path)) {
+    const resolved = resolve(path);
+    if (!allowedRoots.some((root) => isPathWithinRoot(resolved, root))) throw new ApiError(400, "invalid_payload", "Attachment path must be inside an authorized workspace root", { path });
+    await assertGmailAttachmentFile(resolved);
+    return resolved;
+  }
+
+  for (const root of gmailAttachmentSearchRoots(config, context, allowedRoots)) {
+    const resolved = resolve(root, path);
+    if (!isPathWithinRoot(resolved, root) || !allowedRoots.some((allowedRoot) => isPathWithinRoot(resolved, allowedRoot))) continue;
+    try {
+      await assertGmailAttachmentFile(resolved);
+      return resolved;
+    } catch (error) {
+      if (isFileNotFoundError(error)) continue;
+      throw error;
+    }
+  }
+
+  throw new ApiError(400, "invalid_payload", "Attachment file was not found in an authorized workspace root", { path });
+}
+
+async function loadGmailDraftAttachments(config: ServerConfig, context: Record<string, unknown>, requests: GmailDraftAttachmentRequest[]): Promise<GmailDraftAttachment[]> {
+  const attachments: GmailDraftAttachment[] = [];
+  for (const request of requests) {
+    const path = await resolveGmailAttachmentPath(config, context, request.path);
+    const content = await readFile(path);
+    const filename = gmailHeaderValue(request.filename || basename(path));
+    if (!filename) throw new ApiError(400, "invalid_payload", "Attachment filename is required", { path: request.path });
+    attachments.push({ filename, mimeType: gmailAttachmentMimeType(path, request.mimeType), content });
+  }
+  return attachments;
+}
+
+function gmailRawMessage(input: { to: string[]; cc?: string[]; bcc?: string[]; subject: string; body: string; headers?: { name: string; value: string }[]; attachments?: GmailDraftAttachment[] }): string {
+  const headers = [
     `To: ${input.to.join(", ")}`,
     input.cc?.length ? `Cc: ${input.cc.join(", ")}` : null,
     input.bcc?.length ? `Bcc: ${input.bcc.join(", ")}` : null,
     `Subject: ${input.subject}`,
     ...(input.headers ?? []).map((header) => `${header.name}: ${header.value}`),
+  ].filter((line): line is string => typeof line === "string");
+  const attachments = input.attachments ?? [];
+  if (!attachments.length) return [
+    ...headers,
     "Content-Type: text/plain; charset=UTF-8",
     "",
     input.body,
   ].filter((line): line is string => typeof line === "string").join("\r\n");
+
+  const boundary = `openwork-${randomBytes(16).toString("hex")}`;
+  return [
+    ...headers,
+    "MIME-Version: 1.0",
+    `Content-Type: multipart/mixed; boundary="${boundary}"`,
+    "",
+    `--${boundary}`,
+    "Content-Type: text/plain; charset=UTF-8",
+    "Content-Transfer-Encoding: 8bit",
+    "",
+    input.body,
+    ...attachments.flatMap((attachment) => [
+      `--${boundary}`,
+      `Content-Type: ${attachment.mimeType}; name="${gmailMimeParameter(attachment.filename)}"`,
+      `Content-Disposition: attachment; filename="${gmailMimeParameter(attachment.filename)}"`,
+      "Content-Transfer-Encoding: base64",
+      "",
+      base64MimeContent(attachment.content),
+    ]),
+    `--${boundary}--`,
+    "",
+  ].join("\r\n");
 }
 
 function splitEmailHeader(value: string): string[] {
@@ -841,18 +1010,19 @@ async function googleWorkspaceListEvents(config: ServerConfig, args: Record<stri
   return fetchGoogleJson(url.toString(), { headers: { Authorization: `Bearer ${accessToken}` } });
 }
 
-async function googleWorkspaceCreateDraft(config: ServerConfig, args: Record<string, unknown>) {
+async function googleWorkspaceCreateDraft(config: ServerConfig, args: Record<string, unknown>, context: Record<string, unknown>) {
   const to = stringArrayField(args.to);
   const cc = stringArrayField(args.cc);
   const bcc = stringArrayField(args.bcc);
   const subject = readStringField(args, "subject");
   const body = typeof args.body === "string" ? args.body : "";
   if (!to.length || !subject || !body.trim()) throw new ApiError(400, "invalid_payload", "to, subject, and body are required");
+  const attachments = await loadGmailDraftAttachments(config, context, gmailDraftAttachmentRequests(args.attachments));
   const { accessToken } = await googleWorkspaceAccessToken(config);
   return fetchGoogleJson("https://gmail.googleapis.com/gmail/v1/users/me/drafts", {
     method: "POST",
     headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-    body: JSON.stringify({ message: { raw: base64UrlString(gmailRawMessage({ to, cc, bcc, subject, body })) } }),
+    body: JSON.stringify({ message: { raw: base64UrlString(gmailRawMessage({ to, cc, bcc, subject, body, attachments })) } }),
   });
 }
 
@@ -1015,7 +1185,7 @@ export async function callGoogleWorkspaceExtensionAction(config: ServerConfig, a
     };
   }
   if (action === "calendar_list_events") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceListEvents(config, args), context };
-  if (action === "gmail_create_draft") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateDraft(config, args), context };
+  if (action === "gmail_create_draft") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateDraft(config, args, context), context };
   if (action === "gmail_create_reply_draft") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateReplyDraft(config, args), context };
   if (action === "gmail_list_messages") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceListMessages(config, args), context };
   if (action === "gmail_get_message") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceGetMessage(config, args), context };

--- a/ee/apps/den-api/src/mcp/catalog.ts
+++ b/ee/apps/den-api/src/mcp/catalog.ts
@@ -4,6 +4,65 @@ import { isMcpOperationAllowed, type OpenApiOperation } from "./policy.js"
 
 const METHODS = new Set(["get", "post", "put", "patch", "delete"])
 
+// AWS Bedrock's Converse API rejects any `toolConfig.tools.*.member.toolSpec.name`
+// longer than 64 characters. MCP clients namespace our tools as
+// `<serverName>_<name>` (e.g. `openwork-cloud_` adds 15 chars), so the raw
+// operationId budget is even tighter. We keep the registered tool name well
+// under 64 so the prefixed name still validates on Bedrock.
+export const BEDROCK_MAX_TOOL_NAME_LENGTH = 64
+export const MAX_CLIENT_PREFIX = "openwork-cloud_".length // 15
+export const MAX_TOOL_NAME_LENGTH = BEDROCK_MAX_TOOL_NAME_LENGTH - MAX_CLIENT_PREFIX // 49
+
+// Generated operationIds are verbose and structured: `<verb>V1<Resource>By<Param>Id<Sub>...`.
+// The `V1` version marker and the `By<Param>Id` path-param restatements carry no
+// meaning for a model choosing a tool; it reasons about verb + resource nouns.
+// Stripping them yields short, unique, human-readable names (e.g.
+// `deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId` ->
+// `deleteConnectorInstancesAccess`) that an LLM recognizes far more reliably
+// than a truncated+hashed name.
+function structuralShorten(name: string): string {
+  return name
+    .replace(/^(get|post|put|patch|delete)V1/, "$1") // version marker is irrelevant to tool selection
+    .replace(/By[A-Z][a-zA-Z]*?Id/g, "") // drop "ByConfigObjectId" path-param markers
+}
+
+// Deterministic, stable short hash (FNV-1a, base36) used only as a last-resort
+// fallback when two structurally-shortened names collide. Stable across runs so
+// tool identities don't churn between deploys.
+function shortHash(value: string): string {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+// Produce the registered MCP tool name. Structurally shortens every name for a
+// clean, consistent catalog, then disambiguates against `taken` with a short
+// deterministic hash suffix only if two operationIds collapse to the same name.
+//
+// Note: this does NOT silently truncate over-length names. If structural
+// shortening cannot fit the budget, buildMcpCatalog's guard throws so the
+// regression is fixed in structuralShorten() rather than shipped as a
+// hard-to-read hashed name. See the guard in buildMcpCatalog.
+export function shortenToolName(operationId: string, taken?: ReadonlySet<string>): string {
+  const base = structuralShorten(operationId)
+  if (!taken?.has(base)) {
+    return base
+  }
+  // Deterministic disambiguation: append a stable hash of the full operationId.
+  const suffix = `_${shortHash(operationId)}`
+  let name = `${base.slice(0, Math.max(1, MAX_TOOL_NAME_LENGTH - suffix.length))}${suffix}`
+  let salt = 1
+  while (taken.has(name)) {
+    const salted = `_${shortHash(`${operationId}#${salt}`)}`
+    name = `${base.slice(0, Math.max(1, MAX_TOOL_NAME_LENGTH - salted.length))}${salted}`
+    salt += 1
+  }
+  return name
+}
+
 type OpenApiDocument = {
   paths?: Record<string, Record<string, OpenApiOperation>>
 }
@@ -196,13 +255,26 @@ export function buildMcpCatalog(document: OpenApiDocument): McpToolOperation[] {
         continue
       }
 
-      const name = operation.operationId
-      if (!name) {
+      const operationId = operation.operationId
+      if (!operationId) {
         continue
       }
 
+      const name = shortenToolName(operationId, names)
       if (names.has(name)) {
-        throw new Error(`Duplicate MCP tool operationId: ${name}`)
+        throw new Error(`Duplicate MCP tool name after shortening: ${name} (operationId: ${operationId})`)
+      }
+
+      // Guard against future regressions: a tool name that overflows the client
+      // prefix budget (e.g. `openwork-cloud_` + name > 64) is rejected by AWS
+      // Bedrock's Converse API and breaks every Bedrock model. Surface it here,
+      // at catalog-build time (covered by tests/CI), instead of in production.
+      const prefixedLength = MAX_CLIENT_PREFIX + name.length
+      if (name.length > MAX_TOOL_NAME_LENGTH) {
+        throw new Error(
+          `MCP tool name too long for Bedrock: "${name}" (${prefixedLength} chars prefixed, max 64; operationId: ${operationId}). ` +
+            `Adjust structuralShorten() in catalog.ts.`,
+        )
       }
       names.add(name)
 

--- a/ee/apps/den-api/test/mcp-tool-name-length.test.ts
+++ b/ee/apps/den-api/test/mcp-tool-name-length.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "bun:test"
+import {
+  BEDROCK_MAX_TOOL_NAME_LENGTH,
+  buildMcpCatalog,
+  MAX_CLIENT_PREFIX,
+  MAX_TOOL_NAME_LENGTH,
+  shortenToolName,
+} from "../src/mcp/catalog.js"
+
+// AWS Bedrock's Converse API rejects toolConfig.tools.*.member.toolSpec.name
+// longer than 64 chars. MCP clients namespace tools as `<serverName>_<name>`;
+// the OpenWork Cloud client uses the `openwork-cloud_` prefix (15 chars), so
+// the registered name must stay <= 49 so the prefixed name validates.
+const CLIENT_PREFIX = "openwork-cloud_"
+
+test("budget constants leave room for the client prefix", () => {
+  expect(CLIENT_PREFIX.length).toBe(MAX_CLIENT_PREFIX)
+  expect(MAX_CLIENT_PREFIX + MAX_TOOL_NAME_LENGTH).toBe(BEDROCK_MAX_TOOL_NAME_LENGTH)
+})
+
+test("structural shortening drops V1 and path-param markers", () => {
+  expect(shortenToolName("getV1Organization")).toBe("getOrganization")
+  expect(shortenToolName("deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId")).toBe(
+    "deleteConnectorInstancesAccess",
+  )
+})
+
+test("shortened names stay within the Bedrock budget once prefixed", () => {
+  const short = shortenToolName("deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId")
+  expect(short.length).toBeLessThanOrEqual(MAX_TOOL_NAME_LENGTH)
+  expect((CLIENT_PREFIX + short).length).toBeLessThanOrEqual(BEDROCK_MAX_TOOL_NAME_LENGTH)
+})
+
+test("near-duplicate operationIds resolve to distinct, readable names", () => {
+  const a = shortenToolName("getV1ConnectorInstancesByConnectorInstanceIdAccess")
+  const b = shortenToolName("getV1ConnectorInstancesByConnectorInstanceIdConfiguration")
+  expect(a).toBe("getConnectorInstancesAccess")
+  expect(b).toBe("getConnectorInstancesConfiguration")
+  expect(a).not.toBe(b)
+})
+
+test("shortening is deterministic", () => {
+  const id = "deleteV1MarketplacesByMarketplaceIdPluginsByPluginId"
+  expect(shortenToolName(id)).toBe(shortenToolName(id))
+})
+
+test("collisions against taken names fall back to a unique suffix", () => {
+  const taken = new Set(["getOrganization"])
+  const name = shortenToolName("getV1Organization", taken)
+  expect(name).not.toBe("getOrganization")
+  expect(taken.has(name)).toBe(false)
+})
+
+test("every catalog tool name fits Bedrock once client-prefixed", () => {
+  // Reproduces the exact paths from Felix's Praxis Medicines Bedrock 400.
+  const op = (operationId: string) => ({ operationId, "x-mcp": true })
+  const document = {
+    paths: {
+      "/v1/config-objects/:configObjectId/access/:grantId": {
+        delete: op("deleteV1ConfigObjectsByConfigObjectIdAccessByGrantId"),
+      },
+      "/v1/config-objects/:configObjectId/plugins/:pluginId": {
+        delete: op("deleteV1ConfigObjectsByConfigObjectIdPluginsByPluginId"),
+      },
+      "/v1/connector-instances/:connectorInstanceId/access/:grantId": {
+        delete: op("deleteV1ConnectorInstancesByConnectorInstanceIdAccessByGrantId"),
+      },
+      "/v1/llm-providers/:llmProviderId/access/:accessId": {
+        delete: op("deleteV1LlmProvidersByLlmProviderIdAccessByAccessId"),
+      },
+      "/v1/marketplaces/:marketplaceId/access/:grantId": {
+        delete: op("deleteV1MarketplacesByMarketplaceIdAccessByGrantId"),
+      },
+      "/v1/marketplaces/:marketplaceId/plugins/:pluginId": {
+        delete: op("deleteV1MarketplacesByMarketplaceIdPluginsByPluginId"),
+      },
+      "/v1/plugins/:pluginId/config-objects/:configObjectId": {
+        delete: op("deleteV1PluginsByPluginIdConfigObjectsByConfigObjectId"),
+      },
+      "/v1/config-objects/:configObjectId/versions/:versionId": {
+        get: op("getV1ConfigObjectsByConfigObjectIdVersionsByVersionId"),
+      },
+      "/v1/connector-instances/:connectorInstanceId/access": {
+        get: op("getV1ConnectorInstancesByConnectorInstanceIdAccess"),
+      },
+      "/v1/connector-instances/:connectorInstanceId/configuration": {
+        get: op("getV1ConnectorInstancesByConnectorInstanceIdConfiguration"),
+      },
+    },
+  }
+
+  const catalog = buildMcpCatalog(document)
+  expect(catalog.length).toBe(10)
+
+  const names = new Set<string>()
+  for (const tool of catalog) {
+    const prefixed = CLIENT_PREFIX + tool.name
+    expect(prefixed.length).toBeLessThanOrEqual(BEDROCK_MAX_TOOL_NAME_LENGTH)
+    expect(names.has(tool.name)).toBe(false)
+    names.add(tool.name)
+  }
+})
+
+test("buildMcpCatalog guard throws if a name overflows the Bedrock budget", () => {
+  // A pathological operationId that survives structural shortening yet is still
+  // far too long must be caught at build time, not in production.
+  const tooLong = `getV2${"X".repeat(80)}` // no V1 / ByXId markers to strip
+  const document = {
+    paths: { "/v2/x": { get: { operationId: tooLong, "x-mcp": true } } },
+  }
+  expect(() => buildMcpCatalog(document)).toThrow(/too long for Bedrock/)
+})

--- a/evals/README.md
+++ b/evals/README.md
@@ -122,12 +122,23 @@ plugin (configured in `.opencode/opencode.json`). Every tool takes
 ## Conventions
 
 - Prefer coded flows in `evals/flows/*.flow.mjs` over ad hoc browser tool calls.
+- Declare the demo kind on every new flow: `kind: "user-facing"` (a flow demo
+  where the end user is the protagonist) or `kind: "internal"` (an internal
+  demo, e.g. perf improvements or invariants). The runner rejects other values
+  and flags legacy flows without one in `fraimz.html`.
 - Use runner helpers such as `ctx.clickText`, `ctx.fill`, `ctx.waitFor`,
   `ctx.expectText`, `ctx.expectNoText`, `ctx.expectHashIncludes`,
   `ctx.control`, `ctx.prove`, and validated `ctx.screenshot` calls.
-- Prefer `ctx.prove("claim", { action, assert, screenshot })` for PR evidence.
-  It records the claim, assertions, screenshot, and validation results together
-  so the HTML frame proof explains why each image proves the step.
+- Prefer `ctx.prove("claim", { voiceover, action, assert, screenshot })` for PR
+  evidence. It records the claim, voiceover, assertions, screenshot, and
+  validation results together so the HTML frame proof explains why each image
+  proves the step.
+- Every `ctx.prove` should carry a `voiceover`: one or two spoken-style
+  sentences narrating what the viewer sees in that frame. `fraimz.html` renders
+  it per frame with a play button (Web Speech API) and a per-flow "Play full
+  voiceover". Write the voiceover script for the whole demo before coding the
+  flow. See `evals/flows/session-search-grouped.flow.mjs` for the reference
+  shape.
 - Screenshots should include `claim`, `requireText`, `rejectText`, or
   `hashIncludes` whenever possible. A screenshot without an assertion is only a
   visual checkpoint, not proof that the workflow passed.

--- a/evals/flows/session-search-grouped.flow.mjs
+++ b/evals/flows/session-search-grouped.flow.mjs
@@ -1,0 +1,181 @@
+/**
+ * User-facing flow demo: cross-session message search is discoverable from the
+ * sidebar and returns grouped results (Recent / Session titles / Messages).
+ *
+ * The deep-search query defaults to "joke" and can be overridden with
+ * OPENWORK_EVAL_SEARCH_QUERY for profiles seeded with different data. The flow
+ * expects the query to match at least one session title or message.
+ */
+const SEARCH_INPUT = 'input[placeholder="Search all sessions and messages…"]';
+
+export default {
+  id: "session-search-grouped",
+  title: "Cross-session search: sidebar entry, grouped results, jump to match",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "App boots with at least one session in the sidebar",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 30_000,
+          label: "window.__openworkControl",
+        });
+        await ctx.waitFor("document.body.innerText.trim().length > 40", {
+          label: "rendered body text",
+        });
+      },
+    },
+    {
+      name: "Search is discoverable in the sidebar",
+      run: async (ctx) => {
+        await ctx.prove("Sidebar exposes a Search sessions entry", {
+          claim: "The sidebar shows a 'Search sessions' button with its keyboard shortcut, so cross-message search is one click away.",
+          voiceover:
+            "This is OpenWork. Every workspace and conversation lives in the sidebar on the left. At the very top there is a new entry: Search sessions. Cross-message search used to be hidden behind a keyboard shortcut — now it is one click away, and the shortcut hint is printed right on the button.",
+          assert: async () => {
+            await ctx.expectText("Search sessions");
+          },
+          screenshot: {
+            name: "sidebar-search-entry",
+            requireText: ["Search sessions"],
+          },
+        });
+      },
+    },
+    {
+      name: "Opening search shows recent sessions grouped",
+      run: async (ctx) => {
+        await ctx.prove("Empty query shows a Recent sessions group", {
+          claim: "Clicking the sidebar entry opens the search dialog; before typing, results are grouped under 'Recent sessions' with a count.",
+          voiceover:
+            "Clicking it opens the search dialog. Before you type anything, it shows your most recent conversations under a Recent sessions header, with a count — so the dialog is useful from the very first frame.",
+          action: async () => {
+            // Idempotence: a previous run may have left the dialog open.
+            const alreadyOpen = await ctx.eval(`Boolean(document.querySelector(${JSON.stringify(SEARCH_INPUT)}))`);
+            if (alreadyOpen) {
+              await ctx.eval(`(() => {
+                const input = document.querySelector(${JSON.stringify(SEARCH_INPUT)});
+                input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+                return true;
+              })()`);
+              await ctx.waitFor(`!document.querySelector(${JSON.stringify(SEARCH_INPUT)})`, {
+                label: "stale search dialog to close",
+              });
+            }
+            await ctx.clickText("Search sessions");
+            await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(SEARCH_INPUT)}))`, {
+              label: "session search dialog input",
+            });
+          },
+          assert: async () => {
+            await ctx.expectText("Recent sessions");
+          },
+          screenshot: {
+            name: "search-dialog-recent",
+            requireText: ["Recent sessions"],
+          },
+        });
+      },
+    },
+    {
+      name: "Typing a query groups results by match kind",
+      run: async (ctx) => {
+        const query = ctx.env.OPENWORK_EVAL_SEARCH_QUERY?.trim() || "joke";
+        await ctx.prove("Query results are grouped with counts", {
+          claim: `Typing "${query}" shows results grouped by why they matched (Session titles and/or Messages), each with a count.`,
+          voiceover:
+            "I type a query. Results are no longer one flat list: they are grouped. Session titles collects the conversations whose name matches, and each group label shows exactly how many results it holds.",
+          action: async () => {
+            await ctx.fill(SEARCH_INPUT, query);
+            await ctx.waitFor(
+              `(() => {
+                const text = document.body.innerText;
+                return text.includes("Session titles") || text.includes("Messages");
+              })()`,
+              { timeoutMs: 30_000, label: "grouped search results" },
+            );
+          },
+          assert: async () => {
+            const groups = await ctx.eval(`(() => {
+              const text = document.body.innerText;
+              return {
+                titles: text.includes("Session titles"),
+                messages: text.includes("Messages"),
+              };
+            })()`);
+            ctx.assert(groups.titles || groups.messages, `No result group rendered for query "${query}".`);
+            ctx.log(`Groups rendered: ${JSON.stringify(groups)}`);
+          },
+          screenshot: {
+            name: "search-grouped-results",
+            rejectText: ["No sessions or messages match your search."],
+          },
+        });
+      },
+    },
+    {
+      name: "Message matches show highlighted transcript snippets",
+      run: async (ctx) => {
+        await ctx.prove("Messages group carries snippet, role, and workspace", {
+          claim: "The Messages group shows transcript matches with the matched text highlighted, the speaker role, and the owning workspace.",
+          voiceover:
+            "Below that, the Messages group shows conversations where the words appear inside the transcript itself — with the matched text highlighted, who said it, and which workspace it came from. While transcripts are still being scanned, a spinner sits right on the group label.",
+          action: async () => {
+            // The deep scan is debounced and streams in asynchronously: wait for
+            // an actual message match to render, not just for the spinner state.
+            await ctx.waitFor(
+              `(() => {
+                const items = Array.from(document.querySelectorAll('[data-slot="command-item"]'));
+                return items.some((item) => /You:|Agent:/.test(item.innerText));
+              })()`,
+              { timeoutMs: 60_000, label: "a transcript match with a role-prefixed snippet" },
+            );
+          },
+          assert: async () => {
+            const snippet = await ctx.eval(`(() => {
+              const items = Array.from(document.querySelectorAll('[data-slot="command-item"]'));
+              const withSnippet = items.find((item) => /You:|Agent:/.test(item.innerText));
+              return withSnippet ? withSnippet.innerText.slice(0, 200) : null;
+            })()`);
+            ctx.assert(Boolean(snippet), "No message result with a role-prefixed snippet rendered.");
+            ctx.log(`Message snippet: ${snippet}`);
+          },
+          screenshot: {
+            name: "search-message-snippet",
+            requireText: ["Messages"],
+          },
+        });
+      },
+    },
+    {
+      name: "Choosing a result jumps into the conversation",
+      run: async (ctx) => {
+        await ctx.prove("Selecting a result navigates to its session", {
+          claim: "Clicking a result closes the dialog and lands the user directly in the matched conversation.",
+          voiceover:
+            "Press Enter or click any result, and you land directly in that conversation. That is the whole loop: discover, search, and jump — in under five seconds.",
+          action: async () => {
+            await ctx.eval(`(() => {
+              const items = Array.from(document.querySelectorAll('[data-slot="command-item"]'));
+              const target = items.find((item) => /You:|Agent:/.test(item.innerText)) ?? items[0];
+              if (!target) throw new Error("no result to click");
+              target.click();
+              return true;
+            })()`);
+            await ctx.waitFor(
+              `!document.querySelector(${JSON.stringify(SEARCH_INPUT)})`,
+              { label: "search dialog to close" },
+            );
+          },
+          assert: async () => {
+            await ctx.expectHashIncludes("/session/");
+          },
+          screenshot: {
+            name: "opened-session",
+            hashIncludes: "/session/",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/runner/context.mjs
+++ b/evals/runner/context.mjs
@@ -107,16 +107,17 @@ export class EvalContext {
 
   async prove(name, options) {
     const claim = options?.claim ?? name;
-    this.recordEvidence({ type: "claim", status: "running", name, claim });
+    const voiceover = typeof options?.voiceover === "string" ? options.voiceover.trim() : "";
+    this.recordEvidence({ type: "claim", status: "running", name, claim, voiceover });
     if (typeof options?.action === "function") await options.action();
     if (typeof options?.assert === "function") await options.assert();
     if (options?.screenshot) {
       const screenshot = typeof options.screenshot === "string"
         ? { name: options.screenshot }
         : options.screenshot;
-      await this.screenshot(screenshot.name ?? slug(name), { claim, ...screenshot });
+      await this.screenshot(screenshot.name ?? slug(name), { claim, voiceover, ...screenshot });
     }
-    this.recordEvidence({ type: "claim", status: "passed", name, claim });
+    this.recordEvidence({ type: "claim", status: "passed", name, claim, voiceover });
   }
 
   /**
@@ -262,6 +263,7 @@ export class EvalContext {
       file: fileName,
       name,
       claim: options.claim ?? null,
+      voiceover: typeof options.voiceover === "string" && options.voiceover.trim() ? options.voiceover.trim() : null,
       url,
       validations,
     };

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -57,6 +57,9 @@ async function loadFlows() {
     if (!flow?.id || !Array.isArray(flow.steps)) {
       throw new Error(`Flow file ${entry} must default-export { id, title, steps }.`);
     }
+    if (flow.kind !== undefined && flow.kind !== "user-facing" && flow.kind !== "internal") {
+      throw new Error(`Flow file ${entry} has invalid kind ${JSON.stringify(flow.kind)}. Use "user-facing" (flow demo) or "internal" (internal demo, e.g. perf).`);
+    }
     flows.push({ ...flow, file: entry });
   }
   return flows;
@@ -71,6 +74,7 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
     id: flow.id,
     title: flow.title,
     spec: flow.spec ?? null,
+    kind: flow.kind ?? null,
     status: "passed",
     skipReason: null,
     steps: [],
@@ -153,6 +157,7 @@ function renderMarkdown(report) {
   for (const flow of report.flows) {
     const icon = flow.status === "passed" ? "✅" : flow.status === "skipped" ? "⏭️" : "❌";
     lines.push(`## ${icon} ${flow.id} — ${flow.title}`);
+    if (flow.kind) lines.push(`Kind: ${flow.kind === "user-facing" ? "user-facing flow demo" : "internal demo"}`);
     if (flow.spec) lines.push(`Spec: ${flow.spec}`);
     if (flow.skipReason) lines.push(`Skipped: ${flow.skipReason}`);
     lines.push("");
@@ -160,7 +165,10 @@ function renderMarkdown(report) {
       const stepIcon = step.status === "passed" ? "✅" : "❌";
       lines.push(`- ${stepIcon} ${step.name} (${step.durationMs}ms)${step.error ? ` — ${step.error}` : ""}`);
       for (const evidence of step.evidence ?? []) {
-        if (evidence.type === "frame") lines.push(`  - Frame: ${evidence.file} (${evidence.status})`);
+        if (evidence.type === "frame") {
+          lines.push(`  - Frame: ${evidence.file} (${evidence.status})`);
+          if (evidence.voiceover) lines.push(`    - Voiceover: ${evidence.voiceover}`);
+        }
         if (evidence.type === "assertion") lines.push(`  - Assertion: ${evidence.assertion} (${evidence.status})`);
       }
     }
@@ -180,6 +188,12 @@ function escapeHtml(value) {
     .replaceAll('"', "&quot;");
 }
 
+function flowKindBadge(kind) {
+  if (kind === "user-facing") return `<span class="kind kind-user">User-facing flow demo</span>`;
+  if (kind === "internal") return `<span class="kind kind-internal">Internal demo</span>`;
+  return `<span class="kind kind-legacy">Legacy flow — no demo kind declared</span>`;
+}
+
 function renderFrameIndex(report) {
   const flowSections = report.flows.map((flow) => {
     const steps = (flow.steps ?? []).map((step) => `
@@ -192,8 +206,9 @@ function renderFrameIndex(report) {
           ${renderEvidence(step.evidence ?? [])}
         </article>`).join("\n");
     return `
-      <section>
+      <section data-flow="${escapeHtml(flow.id)}">
         <h2>${escapeHtml(flow.id)} - ${escapeHtml(flow.title)}</h2>
+        <p>${flowKindBadge(flow.kind)} <button type="button" class="speak-all" data-flow-id="${escapeHtml(flow.id)}">▶ Play full voiceover</button></p>
         ${flow.spec ? `<p class="muted">Spec: ${escapeHtml(flow.spec)}</p>` : ""}
         ${flow.skipReason ? `<p class="skipped">Skipped: ${escapeHtml(flow.skipReason)}</p>` : ""}
         <div class="steps">${steps}</div>
@@ -220,6 +235,14 @@ function renderFrameIndex(report) {
     .eyebrow { color: #5f6368; font-size: 12px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
     .evidence { display: grid; gap: 12px; }
     .claim { padding: 10px 12px; border-left: 4px solid #7c3aed; background: #f5f3ff; border-radius: 8px; }
+    .voiceover { display: flex; gap: 10px; align-items: flex-start; padding: 10px 12px; border-left: 4px solid #0e7490; background: #ecfeff; border-radius: 8px; font-style: italic; }
+    .voiceover-missing { padding: 8px 12px; border-left: 4px solid #d97706; background: #fffbeb; border-radius: 8px; color: #92400e; font-size: 13px; }
+    .speak, .speak-all { flex-shrink: 0; border: 1px solid #0e7490; border-radius: 999px; background: white; color: #0e7490; font-size: 12px; padding: 3px 10px; cursor: pointer; }
+    .speak:hover, .speak-all:hover { background: #cffafe; }
+    .kind { display: inline-block; padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 700; }
+    .kind-user { background: #ecfdf5; color: #047857; border: 1px solid #a7f3d0; }
+    .kind-internal { background: #eff6ff; color: #1d4ed8; border: 1px solid #bfdbfe; }
+    .kind-legacy { background: #fffbeb; color: #92400e; border: 1px solid #fde68a; }
     .assertions, .validations { margin: 8px 0 0; padding-left: 20px; }
     .assertions li, .validations li { margin: 5px 0; }
     figure { margin: 0; overflow: hidden; border: 1px solid #ddd; border-radius: 12px; background: white; box-shadow: 0 1px 4px rgba(0,0,0,.06); }
@@ -249,6 +272,36 @@ function renderFrameIndex(report) {
     </div>
     ${flowSections}
   </main>
+  <script>
+    (function () {
+      if (!("speechSynthesis" in window)) return;
+      var speak = function (texts) {
+        window.speechSynthesis.cancel();
+        texts.forEach(function (text) {
+          var utterance = new SpeechSynthesisUtterance(text);
+          utterance.rate = 1.05;
+          window.speechSynthesis.speak(utterance);
+        });
+      };
+      document.querySelectorAll(".voiceover .speak").forEach(function (button) {
+        button.addEventListener("click", function () {
+          var host = button.closest(".voiceover");
+          if (host) speak([host.getAttribute("data-voiceover") || ""]);
+        });
+      });
+      document.querySelectorAll(".speak-all").forEach(function (button) {
+        button.addEventListener("click", function () {
+          var section = button.closest("section");
+          if (!section) return;
+          var texts = Array.prototype.map.call(
+            section.querySelectorAll(".voiceover[data-voiceover]"),
+            function (node) { return node.getAttribute("data-voiceover"); }
+          ).filter(Boolean);
+          speak(texts);
+        });
+      });
+    })();
+  </script>
 </body>
 </html>`;
 }
@@ -268,7 +321,11 @@ function renderEvidence(evidence) {
         const cls = validation.passed ? "passed-text" : "failed-text";
         return `<li><span class="${cls}">${validation.passed ? "PASS" : "FAIL"}</span> ${escapeHtml(validation.label)}${validation.detail ? ` <span class="muted">${escapeHtml(validation.detail)}</span>` : ""}</li>`;
       }).join("\n");
+      const voiceover = item.voiceover
+        ? `<div class="voiceover" data-voiceover="${escapeHtml(item.voiceover)}"><button type="button" class="speak" title="Play voiceover">🎙 Play</button><span>${escapeHtml(item.voiceover)}</span></div>`
+        : `<div class="voiceover-missing">No voiceover for this frame. Every fraimz frame should narrate what the user sees.</div>`;
       return `<figure>
+        ${voiceover}
         <a href="${escapeHtml(item.file)}"><img src="${escapeHtml(item.file)}" alt="${escapeHtml(item.claim ?? item.name ?? item.file)}" /></a>
         <figcaption>
           <strong>${escapeHtml(item.name ?? item.file)}</strong>${item.claim ? `<br />Claim: ${escapeHtml(item.claim)}` : ""}


### PR DESCRIPTION
## What

### 1. Cross-session search UI step-up (user-facing)
- **Grouped results** in the session search dialog (`Cmd/Ctrl+Shift+F`): results are now grouped by why they matched — **Recent sessions** (empty query), **Session titles**, and **Messages** — instead of one flat list.
- Each group label shows a **live result count**; the Messages group shows a **spinner** while transcripts are still being scanned.
- **Discoverability:** new **"Search sessions"** entry at the top of the sidebar with the shortcut hint printed on it, wired to the existing search dialog.

### 2. fraimz: every proof is a narrated demo (evals + skill)
- Flows now declare a demo kind: `kind: "user-facing"` (flow demo) or `kind: "internal"` (internal demo, e.g. perf). The runner validates the value and badges it in `fraimz.html`; legacy flows are flagged, not broken.
- `ctx.prove(...)` accepts a **`voiceover`** — one or two spoken-style sentences per frame. `fraimz.html` renders it per frame with a 🎙 play button (Web Speech API) and a per-flow **"Play full voiceover"**; frames without narration get a visible warning.
- The fraimz skill and `evals/README.md` now codify the workflow: **write the voiceover script first**, then code the flow, then execute.
- Reference flow: `evals/flows/session-search-grouped.flow.mjs` — a 5-frame narrated user-facing demo of the search change in this PR.

## Tests run

- `pnpm typecheck` — pass
- `apps/app`: `bun test tests/` — 77 pass, 0 fail
- `pnpm fraimz --flow session-search-grouped --cdp-url http://127.0.0.1:9841` — **PASSED** (6/6 steps), artifact at `evals/results/2026-07-01T23-51-17-420Z/fraimz.html` (gitignored; frames: sidebar entry → recent group → grouped query results → highlighted message snippet → jump to session, each with voiceover)
- `pnpm fraimz --flow app-smoke --cdp-url http://127.0.0.1:9841` — **PASSED** (legacy flow unaffected by runner changes)

## Reproduce

```bash
OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9826 pnpm dev   # background
pnpm fraimz --flow session-search-grouped --cdp-url http://127.0.0.1:9826
open evals/results/<run-id>/fraimz.html   # per-frame voiceover + play buttons
```

The deep-search query defaults to `joke`; override with `OPENWORK_EVAL_SEARCH_QUERY` for differently-seeded profiles.

Note: fraimz artifacts are gitignored, so the proof run is local; the flow is committed and reproducible with the commands above. No video captured — the narrated fraimz artifact is the evidence.