### PR TITLE
fix(app): make the OpenWork Cloud Control MCP disableable

### DIFF
--- a/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
@@ -1,0 +1,65 @@
+/**
+ * Durable record of the user's intent for the auto-configured OpenWork
+ * Cloud Control MCP ("openwork-cloud").
+ *
+ * A background reconciler (`syncCloudControlMcp`) keeps that entry
+ * configured with a fresh first-party token while the user is signed in to
+ * OpenWork Cloud. Its writes hardcode `enabled: true` and recreate removed
+ * entries, so without a durable record of "the user turned this off" the
+ * reconciler resurrected the MCP on every sync tick — making it impossible
+ * to disable. These helpers persist that intent; the reconciler consults it
+ * before touching the entry, and any explicit user reconnect clears it.
+ */
+
+export const CLOUD_MCP_SERVER_NAME = "openwork-cloud";
+
+const CLOUD_MCP_USER_STATE_KEY = "openwork.den.mcp.cloudControlUserState";
+
+export type CloudMcpUserState = "disabled" | "removed";
+
+export function readCloudMcpUserState(): CloudMcpUserState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(CLOUD_MCP_USER_STATE_KEY);
+    if (raw === "disabled" || raw === "removed") return raw;
+  } catch {
+    // Storage unavailable — treat as no recorded intent.
+  }
+  return null;
+}
+
+export function writeCloudMcpUserState(state: CloudMcpUserState) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(CLOUD_MCP_USER_STATE_KEY, state);
+  } catch {
+    // Storage unavailable — the reconciler may resurrect the entry; the
+    // enabled-flag guard in syncCloudControlMcp still applies.
+  }
+}
+
+export function clearCloudMcpUserState() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(CLOUD_MCP_USER_STATE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Pure marker-freshness check for the cloud MCP sync marker. Extracted so
+ * the margin arithmetic is unit-testable: the previous inline check used a
+ * refresh margin equal to the minted token's TTL (both 7 days), which made
+ * the marker stale the moment it was written and turned the reconciler into
+ * an every-tick config rewrite.
+ */
+export function isCloudMcpSyncMarkerFresh(input: {
+  expiresAt: string;
+  now: number;
+  refreshMarginMs: number;
+}): boolean {
+  const expiresAt = new Date(input.expiresAt).getTime();
+  if (!Number.isFinite(expiresAt)) return false;
+  return expiresAt - input.now > input.refreshMarginMs;
+}

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -39,11 +39,22 @@ import type {
 import { isDesktopRuntime, normalizeDirectoryPath, safeStringify } from "../../../app/utils";
 
 import type { OpenworkServerStore } from "./openwork-server-store";
+import {
+  CLOUD_MCP_SERVER_NAME,
+  clearCloudMcpUserState,
+  isCloudMcpSyncMarkerFresh,
+  readCloudMcpUserState,
+  writeCloudMcpUserState,
+} from "./cloud-mcp-user-state";
 
 type SetStateAction<T> = T | ((current: T) => T);
 
 const CLOUD_MCP_SYNC_MARKER_KEY = "openwork.den.mcp.sync";
-const CLOUD_MCP_REFRESH_MARGIN_MS = 7 * 24 * 60 * 60 * 1000;
+// Re-mint when less than a day of token validity remains. Must be well
+// below the minted token TTL (7 days, DEN_FIRST_PARTY_MCP_TOKEN_TTL_MS in
+// den-api): when the two were equal, the marker was stale the instant it
+// was written and every sync tick re-wrote the MCP config.
+const CLOUD_MCP_REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
 
 type CloudMcpSyncMarker = { orgId: string; expiresAt: string };
 
@@ -809,6 +820,11 @@ export function createConnectionsStore(options: {
       }
 
       await refreshMcpServers();
+      if (slug === CLOUD_MCP_SERVER_NAME) {
+        // An explicit connect overrides any earlier disable/remove intent,
+        // letting the background reconciler manage the entry again.
+        clearCloudMcpUserState();
+      }
       finishPerf(options.developerMode(), "mcp.connect", "done", startedAt, {
         name: entry.name,
         type: entryType,
@@ -851,15 +867,27 @@ export function createConnectionsStore(options: {
     const orgId = settings.activeOrgId?.trim() ?? "";
     if (!orgId || !settings.authToken?.trim()) return "skipped";
 
-    const entry = MCP_QUICK_CONNECT.find((candidate) => candidate.serverName === "openwork-cloud");
+    const entry = MCP_QUICK_CONNECT.find((candidate) => candidate.serverName === CLOUD_MCP_SERVER_NAME);
     if (!entry) return "skipped";
     const slug = entry.id ?? getMcpServerName(entry);
+
+    // Respect explicit user intent: a Cloud Control MCP the user disabled
+    // or removed must stay that way. Without this guard the reconciler
+    // rewrote the entry with `enabled: true` on every tick, making it
+    // impossible to turn off. Any explicit reconnect clears the record.
+    if (readCloudMcpUserState() !== null) return "skipped";
+    const configuredEntry = snapshot.mcpServers.find((server) => server.name === slug);
+    if (configuredEntry?.config.enabled === false) return "skipped";
 
     const marker = readCloudMcpSyncMarker();
     const markerFresh =
       marker !== null &&
       marker.orgId === orgId &&
-      new Date(marker.expiresAt).getTime() - Date.now() > CLOUD_MCP_REFRESH_MARGIN_MS;
+      isCloudMcpSyncMarkerFresh({
+        expiresAt: marker.expiresAt,
+        now: Date.now(),
+        refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+      });
 
     // A revoked/expired token surfaces as needs_auth or failed from opencode;
     // while signed in, that means re-mint instead of standing pat — but only
@@ -874,7 +902,6 @@ export function createConnectionsStore(options: {
     // Builds before #2116's follow-up wrote the MCP URL against the bare
     // web-app origin (https://app.openworklabs.com/mcp), which 404s.
     // Reconfigure those entries even when the marker is still fresh.
-    const configuredEntry = snapshot.mcpServers.find((server) => server.name === slug);
     const hasLegacyUrl =
       configuredEntry?.config.type === "remote" && isLegacyWebAppMcpUrl(configuredEntry.config.url);
 
@@ -1030,6 +1057,9 @@ export function createConnectionsStore(options: {
         await removeMcpFromConfig(projectDir, name);
       }
 
+      if (name === CLOUD_MCP_SERVER_NAME) {
+        writeCloudMcpUserState("removed");
+      }
       options.markReloadRequired?.("mcp", { type: "mcp", name, action: "removed" });
       await refreshMcpServers();
       if (snapshot.selectedMcp === name) {
@@ -1097,6 +1127,13 @@ export function createConnectionsStore(options: {
       }
 
       await openworkClient.setMcpEnabled(openworkWorkspaceId, name, enabled);
+      if (name === CLOUD_MCP_SERVER_NAME) {
+        if (enabled) {
+          clearCloudMcpUserState();
+        } else {
+          writeCloudMcpUserState("disabled");
+        }
+      }
       options.markReloadRequired?.("mcp", { type: "mcp", name, action: "updated" });
       await refreshMcpServers();
     } catch (error) {

--- a/apps/app/tests/cloud-mcp-user-state.test.ts
+++ b/apps/app/tests/cloud-mcp-user-state.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  clearCloudMcpUserState,
+  isCloudMcpSyncMarkerFresh,
+  readCloudMcpUserState,
+  writeCloudMcpUserState,
+} from "../src/react-app/domains/connections/cloud-mcp-user-state";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Bun runs every test file in one process: restore the global after this
+// file so the window stub does not leak into other tests.
+const originalWindow = (globalThis as Record<string, unknown>).window;
+afterAll(() => {
+  if (originalWindow === undefined) {
+    delete (globalThis as Record<string, unknown>).window;
+  } else {
+    (globalThis as Record<string, unknown>).window = originalWindow;
+  }
+});
+
+function installWindowStub() {
+  const backing = new Map<string, string>();
+  const localStorage = {
+    getItem: (key: string) => backing.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      backing.set(key, value);
+    },
+    removeItem: (key: string) => {
+      backing.delete(key);
+    },
+  };
+  (globalThis as Record<string, unknown>).window = { localStorage };
+  return backing;
+}
+
+describe("cloud MCP user state", () => {
+  beforeEach(() => {
+    installWindowStub();
+  });
+
+  test("round-trips disabled and removed intents", () => {
+    expect(readCloudMcpUserState()).toBeNull();
+    writeCloudMcpUserState("disabled");
+    expect(readCloudMcpUserState()).toBe("disabled");
+    writeCloudMcpUserState("removed");
+    expect(readCloudMcpUserState()).toBe("removed");
+    clearCloudMcpUserState();
+    expect(readCloudMcpUserState()).toBeNull();
+  });
+
+  test("ignores corrupt stored values", () => {
+    const backing = installWindowStub();
+    backing.set("openwork.den.mcp.cloudControlUserState", "banana");
+    expect(readCloudMcpUserState()).toBeNull();
+  });
+});
+
+describe("isCloudMcpSyncMarkerFresh", () => {
+  const now = Date.parse("2026-07-01T00:00:00.000Z");
+
+  test("a marker written for a 7-day token is fresh with a 1-day margin", () => {
+    expect(
+      isCloudMcpSyncMarkerFresh({
+        expiresAt: new Date(now + 7 * DAY_MS).toISOString(),
+        now,
+        refreshMarginMs: DAY_MS,
+      }),
+    ).toBe(true);
+  });
+
+  test("regression: margin equal to the token TTL makes the marker stale immediately", () => {
+    // This was the bug that turned the reconciler into an every-tick config
+    // rewrite: refresh margin == token TTL (both 7 days).
+    expect(
+      isCloudMcpSyncMarkerFresh({
+        expiresAt: new Date(now + 7 * DAY_MS).toISOString(),
+        now,
+        refreshMarginMs: 7 * DAY_MS,
+      }),
+    ).toBe(false);
+  });
+
+  test("goes stale once less than the margin remains", () => {
+    expect(
+      isCloudMcpSyncMarkerFresh({
+        expiresAt: new Date(now + DAY_MS / 2).toISOString(),
+        now,
+        refreshMarginMs: DAY_MS,
+      }),
+    ).toBe(false);
+  });
+
+  test("treats unparseable expiry as stale", () => {
+    expect(
+      isCloudMcpSyncMarkerFresh({ expiresAt: "not-a-date", now, refreshMarginMs: DAY_MS }),
+    ).toBe(false);
+  });
+});

--- a/evals/flows/cloud-mcp-disable-sticks.flow.mjs
+++ b/evals/flows/cloud-mcp-disable-sticks.flow.mjs
@@ -1,0 +1,285 @@
+/**
+ * Regression proof: disabling the auto-configured OpenWork Cloud Control MCP
+ * ("openwork-cloud") sticks.
+ *
+ * Previously the background reconciler (syncCloudControlMcp) rewrote the
+ * entry with `enabled: true` on every sync tick — settings mount, sign-in,
+ * org change, and a 5-minute interval — because (a) it never consulted the
+ * user's disable/remove intent and (b) its "recently synced" marker used a
+ * refresh margin equal to the minted token TTL, so it was stale the instant
+ * it was written. Users could not turn the MCP off.
+ *
+ * The fix persists the user's intent (localStorage
+ * `openwork.den.mcp.cloudControlUserState`), makes the reconciler respect it
+ * (plus an enabled:false guard), and fixes the marker margin. This flow
+ * drives the real app:
+ *   1. Sign in to OpenWork Cloud via desktop handoff.
+ *   2. Wait for the reconciler to auto-configure openwork-cloud.
+ *   3. Disable it via the Settings toggle.
+ *   4. Remount settings (the exact trigger that used to resurrect it) and
+ *      assert it is still Paused and the intent record persists.
+ *   5. Re-enable it and assert the intent record clears.
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_API_URL  Den API base
+ * - OPENWORK_EVAL_DEN_TOKEN    Bearer session token for a seeded user
+ */
+
+const CLOUD_TITLE = "OpenWork Cloud Control";
+const USER_STATE_KEY = "openwork.den.mcp.cloudControlUserState";
+const CLICK_ANY = "button, [role=button], a, div, article, li, label";
+
+// The configured-server row shows the friendly status next to the title;
+// catalog cards do not. Use that to target the configured row.
+const cloudRowExpr = (statuses) => `(() => {
+  const buttons = [...document.querySelectorAll("button")];
+  return buttons.some((el) => {
+    const text = el.textContent ?? "";
+    return text.includes(${JSON.stringify(CLOUD_TITLE)}) &&
+      ${JSON.stringify(statuses)}.some((status) => text.includes(status));
+  });
+})()`;
+
+// Background refreshes can collapse an expanded row between two separate
+// clicks. This expression converges regardless: click the detail button when
+// visible, otherwise (re-)expand the row and let the poll retry.
+const expandAndClickDetailExpr = (statuses, label) => `(() => {
+  const buttons = [...document.querySelectorAll("button")];
+  const detail = buttons.find((el) => (el.textContent ?? "").trim() === ${JSON.stringify(label)});
+  if (detail && !detail.disabled) {
+    detail.click();
+    return true;
+  }
+  const row = buttons.find((el) => {
+    const text = el.textContent ?? "";
+    return text.includes(${JSON.stringify(CLOUD_TITLE)}) &&
+      ${JSON.stringify(statuses)}.some((status) => text.includes(status));
+  });
+  if (row) {
+    row.scrollIntoView({ block: "center" });
+    row.click();
+  }
+  return false;
+})()`;
+
+const CONFIGURED_STATUSES = ["Ready", "Paused", "Needs sign-in", "Offline", "Issue", "Checking"];
+
+// Note: the catalog card up top also contains the title; the configured row
+// is the one that shows a friendly status (Ready/Paused/...).
+const scrollCloudRowExpr = `(() => {
+  const statuses = ${JSON.stringify(CONFIGURED_STATUSES)};
+  const buttons = [...document.querySelectorAll("button")];
+  const row = buttons.find((el) => {
+    const text = el.textContent ?? "";
+    return text.includes(${JSON.stringify(CLOUD_TITLE)}) && statuses.some((status) => text.includes(status));
+  });
+  if (row) row.scrollIntoView({ block: "center" });
+  return true;
+})()`;
+
+export default {
+  id: "cloud-mcp-disable-sticks",
+  title: "Disabling the OpenWork Cloud Control MCP sticks across sync",
+  spec: "evals/cloud-mcp-agent-flows.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000 });
+      },
+    },
+    {
+      name: "Sign in to OpenWork Cloud via desktop handoff",
+      run: async (ctx) => {
+        const signedIn = await ctx.eval(
+          "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+        );
+        if (signedIn) {
+          ctx.log("Already signed in; reusing session.");
+          return;
+        }
+        const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+        const response = await fetch(`${apiBase}/v1/auth/desktop-handoff`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ desktopScheme: "openwork" }),
+        });
+        const body = await response.text();
+        ctx.assert(response.ok, `Handoff create failed: ${response.status} ${body.slice(0, 200)}`);
+        const payload = JSON.parse(body);
+        ctx.assert(typeof payload.openworkUrl === "string" && payload.openworkUrl.length > 0, "No openworkUrl in handoff response.");
+
+        await ctx.navigateHash("/settings/cloud-account");
+        await ctx.expectHashIncludes("/settings/cloud-account");
+        await ctx.clickText("Paste sign-in code", { timeoutMs: 30_000 });
+        await ctx.fill("#den-signin-link", payload.openworkUrl);
+        await ctx.clickText("Finish sign-in");
+        await ctx.waitFor(
+          "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+          { timeoutMs: 45_000, label: "persisted den auth token" },
+        );
+        // Post-sign-in org onboarding may appear; drive through it best-effort.
+        await ctx.clickText("Acme Robotics", { selector: CLICK_ANY, timeoutMs: 10_000 }).catch(() => {});
+        await ctx.clickText("Continue with organization", { timeoutMs: 10_000 }).catch(() => {});
+        await ctx.clickText("Continue to workspace", { timeoutMs: 10_000 }).catch(() => {});
+      },
+    },
+    {
+      name: "Reconciler auto-configures the Cloud Control MCP",
+      run: async (ctx) => {
+        // Start from a clean slate for idempotent re-runs: clear any prior
+        // user-intent record so the reconciler is allowed to configure it.
+        await ctx.eval(`(() => { localStorage.removeItem(${JSON.stringify(USER_STATE_KEY)}); localStorage.removeItem("openwork.den.mcp.sync"); return true; })()`);
+        await ctx.navigateHash("/settings/extensions/mcp");
+        await ctx.waitFor("window.location.hash.includes('/settings/extensions/mcp')", { timeoutMs: 30_000 });
+        await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+        await ctx.waitFor(cloudRowExpr(CONFIGURED_STATUSES), {
+          timeoutMs: 90_000,
+          label: "openwork-cloud configured row",
+        });
+        // Idempotent re-runs: a previous run may have left the entry Paused.
+        // Restore the enabled baseline before proving the disable behavior.
+        const paused = await ctx.eval(cloudRowExpr(["Paused"]));
+        if (paused) {
+          ctx.log("Entry starts Paused from a previous run; re-enabling first.");
+          await ctx.waitFor(expandAndClickDetailExpr(["Paused"], "Enable"), {
+            timeoutMs: 30_000,
+            label: "re-enable paused entry for a clean baseline",
+          });
+          await ctx.waitFor(`!${cloudRowExpr(["Paused"])}`, {
+            timeoutMs: 60_000,
+            label: "entry no longer Paused",
+          });
+        }
+        await ctx.prove("Signing in auto-configures the openwork-cloud MCP", {
+          assert: async () => {
+            await ctx.waitFor(cloudRowExpr(CONFIGURED_STATUSES.filter((status) => status !== "Paused")), {
+              timeoutMs: 90_000,
+              label: "openwork-cloud configured row (enabled)",
+            });
+            await ctx.eval(scrollCloudRowExpr);
+          },
+          screenshot: {
+            name: "cloud-mcp-configured",
+            claim: "OpenWork Cloud Control appears as a configured MCP after cloud sign-in.",
+            requireText: [CLOUD_TITLE],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+    {
+      name: "Disable the Cloud Control MCP",
+      run: async (ctx) => {
+        await ctx.prove("The user can disable the Cloud Control MCP and it reports Paused", {
+          action: async () => {
+            await ctx.waitFor(expandAndClickDetailExpr(CONFIGURED_STATUSES, "Disable"), {
+              timeoutMs: 30_000,
+              label: "expand openwork-cloud row and click Disable",
+            });
+          },
+          assert: async () => {
+            await ctx.waitFor(cloudRowExpr(["Paused"]), {
+              timeoutMs: 30_000,
+              label: "openwork-cloud row shows Paused",
+            });
+            const intent = await ctx.eval(`localStorage.getItem(${JSON.stringify(USER_STATE_KEY)})`);
+            ctx.assert(intent === "disabled", `Expected persisted intent "disabled", got ${JSON.stringify(intent)}`);
+            await ctx.eval(scrollCloudRowExpr);
+          },
+          screenshot: {
+            name: "cloud-mcp-disabled",
+            claim: "OpenWork Cloud Control is Paused after the user disables it.",
+            requireText: [CLOUD_TITLE, "Paused"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+    {
+      name: "Disable survives the resurrection trigger (settings remount + sync)",
+      run: async (ctx) => {
+        await ctx.prove("Remounting Settings no longer re-enables the disabled MCP", {
+          action: async () => {
+            // Leaving and re-entering Settings remounts the cloud auto-sync
+            // hook, which fires syncCloudControlMcp immediately — the exact
+            // path that used to rewrite the entry with enabled: true.
+            await ctx.navigateHash("/settings/general");
+            await ctx.waitFor("window.location.hash.includes('/settings/general')", { timeoutMs: 20_000 });
+            await ctx.navigateHash("/settings/extensions/mcp");
+            await ctx.waitFor("window.location.hash.includes('/settings/extensions/mcp')", { timeoutMs: 20_000 });
+            await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+            // Give the sync tick time to run (it fires on mount).
+            await new Promise((resolve) => setTimeout(resolve, 6_000));
+          },
+          assert: async () => {
+            await ctx.waitFor(cloudRowExpr(["Paused"]), {
+              timeoutMs: 30_000,
+              label: "openwork-cloud row still Paused after remount",
+            });
+            const intent = await ctx.eval(`localStorage.getItem(${JSON.stringify(USER_STATE_KEY)})`);
+            ctx.assert(intent === "disabled", `Persisted intent lost after sync tick: ${JSON.stringify(intent)}`);
+            // Expand the row details (shows the Enable action) so this frame
+            // is visually distinct from the pre-remount Paused frame.
+            await ctx.waitFor(`(() => {
+              const buttons = [...document.querySelectorAll("button")];
+              if (buttons.some((el) => (el.textContent ?? "").trim() === "Enable")) return true;
+              const row = buttons.find((el) => {
+                const text = el.textContent ?? "";
+                return text.includes(${JSON.stringify(CLOUD_TITLE)}) && text.includes("Paused");
+              });
+              if (row) { row.scrollIntoView({ block: "center" }); row.click(); }
+              return false;
+            })()`, { timeoutMs: 15_000, label: "expanded paused row details" });
+          },
+          screenshot: {
+            name: "cloud-mcp-still-disabled",
+            claim: "OpenWork Cloud Control stays Paused after the settings remount sync tick.",
+            requireText: [CLOUD_TITLE, "Paused"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+    {
+      name: "Re-enabling clears the intent and hands control back to the reconciler",
+      run: async (ctx) => {
+        await ctx.prove("The user can re-enable the Cloud Control MCP", {
+          action: async () => {
+            await ctx.waitFor(expandAndClickDetailExpr(["Paused"], "Enable"), {
+              timeoutMs: 30_000,
+              label: "expand paused openwork-cloud row and click Enable",
+            });
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `localStorage.getItem(${JSON.stringify(USER_STATE_KEY)}) === null`,
+              { timeoutMs: 20_000, label: "user intent cleared on enable" },
+            );
+            await ctx.waitFor(cloudRowExpr(CONFIGURED_STATUSES.filter((status) => status !== "Paused")), {
+              timeoutMs: 60_000,
+              label: "openwork-cloud row no longer Paused",
+            });
+            // Bring the row into the viewport so the frame is visually
+            // distinct from the previous capture (defeats the dedup guard).
+            await ctx.eval(scrollCloudRowExpr);
+          },
+          screenshot: {
+            name: "cloud-mcp-reenabled",
+            claim: "OpenWork Cloud Control leaves Paused after re-enable and the intent record is cleared.",
+            requireText: [CLOUD_TITLE],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Why

Users could not turn off the auto-configured **OpenWork Cloud Control** MCP (`openwork-cloud`): the Disable toggle and Remove both worked and persisted, but a background reconciler silently resurrected the entry — observed live on a customer call. This also mattered because the old `/mcp` catalog contributed ~128 tools, pushing requests past Azure/OpenAI's 128-tool cap on older models (`Invalid 'tools': array too long`). #2400 fixed the tool count; this fixes the resurrection.

## Root cause (two bugs compounding)

1. `syncCloudControlMcp` (connections/store.ts) reconnects the entry via `connectMcp`, which hardcodes `enabled: true`, and the server-side `addMcp` overwrites the stored entry wholesale — so disable → re-enabled, removed → re-added. It never consulted any record of user intent.
2. Its "recently synced" marker used `CLOUD_MCP_REFRESH_MARGIN_MS` = **7 days**, exactly equal to the minted token TTL (`DEN_FIRST_PARTY_MCP_TOKEN_TTL_MS`), so `expiresAt − now > margin` was false the instant the marker was written. The reconciler therefore re-wrote the MCP config on **every** tick: settings mount, sign-in, org change, and a 5-minute interval.

## Fix

- New `cloud-mcp-user-state.ts`: persist the user's disable/remove intent (`openwork.den.mcp.cloudControlUserState`), written by `setMcpEnabled`/`removeMcp` for this entry and cleared by an explicit reconnect or re-enable.
- `syncCloudControlMcp` bails when the intent record exists or the configured entry has `enabled: false`.
- Marker margin fixed to 24h (re-mint when <1 day of token validity remains), with the arithmetic extracted into a pure, unit-tested helper.

## Tests (commands + results)

- `bun test tests/` (apps/app) — **83 pass / 0 fail** on top of latest `dev` (6 new tests incl. the margin-regression case)
- `pnpm typecheck` (apps/app) — clean
- fraimz e2e against the real Electron app + real local Den (seeded org, real sign-in handoff): `evals/flows/cloud-mcp-disable-sticks.flow.mjs` — **PASSED**:
  1. sign-in auto-configures `openwork-cloud`
  2. user disables it → row shows **Paused**, intent persisted
  3. **settings remount + sync tick (the exact path that used to resurrect it) → still Paused**
  4. re-enable → intent cleared, row returns to Ready, reconciler back in charge

Repro: `OPENWORK_EVAL_DEN_API_URL=... OPENWORK_EVAL_DEN_TOKEN=... pnpm fraimz --flow cloud-mcp-disable-sticks --cdp-url http://127.0.0.1:9826`