### PR TITLE
fix(app): unbreak cloud-mcp-user-state test on Linux CI

### DIFF
--- a/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
@@ -17,10 +17,31 @@ const CLOUD_MCP_USER_STATE_KEY = "openwork.den.mcp.cloudControlUserState";
 
 export type CloudMcpUserState = "disabled" | "removed";
 
-export function readCloudMcpUserState(): CloudMcpUserState | null {
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+let storageOverrideForTest: StorageLike | null = null;
+
+/**
+ * Bun on Linux exposes a readonly `globalThis.window`, so tests cannot stub
+ * the global. Inject a storage instead (pass null to restore the default).
+ */
+export function __setCloudMcpUserStateStorageForTest(storage: StorageLike | null) {
+  storageOverrideForTest = storage;
+}
+
+function getStorage(): StorageLike | null {
+  if (storageOverrideForTest) return storageOverrideForTest;
   if (typeof window === "undefined") return null;
   try {
-    const raw = window.localStorage.getItem(CLOUD_MCP_USER_STATE_KEY);
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readCloudMcpUserState(): CloudMcpUserState | null {
+  try {
+    const raw = getStorage()?.getItem(CLOUD_MCP_USER_STATE_KEY);
     if (raw === "disabled" || raw === "removed") return raw;
   } catch {
     // Storage unavailable — treat as no recorded intent.
@@ -29,9 +50,8 @@ export function readCloudMcpUserState(): CloudMcpUserState | null {
 }
 
 export function writeCloudMcpUserState(state: CloudMcpUserState) {
-  if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(CLOUD_MCP_USER_STATE_KEY, state);
+    getStorage()?.setItem(CLOUD_MCP_USER_STATE_KEY, state);
   } catch {
     // Storage unavailable — the reconciler may resurrect the entry; the
     // enabled-flag guard in syncCloudControlMcp still applies.
@@ -39,9 +59,8 @@ export function writeCloudMcpUserState(state: CloudMcpUserState) {
 }
 
 export function clearCloudMcpUserState() {
-  if (typeof window === "undefined") return;
   try {
-    window.localStorage.removeItem(CLOUD_MCP_USER_STATE_KEY);
+    getStorage()?.removeItem(CLOUD_MCP_USER_STATE_KEY);
   } catch {
     // ignore
   }

--- a/apps/app/tests/cloud-mcp-user-state.test.ts
+++ b/apps/app/tests/cloud-mcp-user-state.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import {
+  __setCloudMcpUserStateStorageForTest,
   clearCloudMcpUserState,
   isCloudMcpSyncMarkerFresh,
   readCloudMcpUserState,
@@ -9,20 +10,11 @@ import {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-// Bun runs every test file in one process: restore the global after this
-// file so the window stub does not leak into other tests.
-const originalWindow = (globalThis as Record<string, unknown>).window;
-afterAll(() => {
-  if (originalWindow === undefined) {
-    delete (globalThis as Record<string, unknown>).window;
-  } else {
-    (globalThis as Record<string, unknown>).window = originalWindow;
-  }
-});
-
-function installWindowStub() {
+// Bun on Linux exposes a readonly `globalThis.window`, so the storage is
+// injected via the test hook instead of stubbing the global.
+function installStorageStub() {
   const backing = new Map<string, string>();
-  const localStorage = {
+  __setCloudMcpUserStateStorageForTest({
     getItem: (key: string) => backing.get(key) ?? null,
     setItem: (key: string, value: string) => {
       backing.set(key, value);
@@ -30,14 +22,17 @@ function installWindowStub() {
     removeItem: (key: string) => {
       backing.delete(key);
     },
-  };
-  (globalThis as Record<string, unknown>).window = { localStorage };
+  });
   return backing;
 }
 
+afterAll(() => {
+  __setCloudMcpUserStateStorageForTest(null);
+});
+
 describe("cloud MCP user state", () => {
   beforeEach(() => {
-    installWindowStub();
+    installStorageStub();
   });
 
   test("round-trips disabled and removed intents", () => {
@@ -51,7 +46,7 @@ describe("cloud MCP user state", () => {
   });
 
   test("ignores corrupt stored values", () => {
-    const backing = installWindowStub();
+    const backing = installStorageStub();
     backing.set("openwork.den.mcp.cloudControlUserState", "banana");
     expect(readCloudMcpUserState()).toBeNull();
   });


### PR DESCRIPTION
Fast-follow for #2412: the new test stubbed `globalThis.window`, which Bun on Linux exposes as a readonly property — the ubuntu `openwork-tests` job failed with `Attempted to assign to readonly property` (macOS passed, and the PR auto-merged before the job finished, leaving `dev` red).

Fix: inject storage via a `__setCloudMcpUserStateStorageForTest` hook (same `*ForTest` pattern as session-sync) and route the helpers through it; the test no longer touches the global at all.

Ran: `bun test tests/` (83 pass / 0 fail on latest dev) + `pnpm typecheck` (clean). Runtime path unchanged apart from the storage accessor; the e2e proof from #2412 still applies.