### PR TITLE
feat(app): palette cloud-sync command, 30s auto-sync interval, synced-ago label

### DIFF
--- a/apps/app/src/app/cloud/sync/constants.ts
+++ b/apps/app/src/app/cloud/sync/constants.ts
@@ -1,1 +1,7 @@
-export const CLOUD_SYNC_INTERVAL_MS = 5 * 60 * 1000;
+// Cloud auto-sync tick. Kept short so org changes made on Den (a model
+// added to an LLM provider, a new provider shared with the team) land on
+// desktops within ~30s without user action. Each tick is cheap when nothing
+// changed: one org-scoped GET for providers plus a local config read; the
+// cloud MCP sync early-returns on its localStorage marker. Reconciles
+// (config rewrite + engine reload) only run on actual drift.
+export const CLOUD_SYNC_INTERVAL_MS = 30 * 1000;

--- a/apps/app/src/app/cloud/sync/sync-state.ts
+++ b/apps/app/src/app/cloud/sync/sync-state.ts
@@ -1,0 +1,62 @@
+/**
+ * Client-side record of the last successful cloud provider sync sweep, so
+ * the UI can show "Synced Xs ago" and update immediately when a sweep
+ * completes (the sweep itself lives in the provider-auth store).
+ */
+
+const CLOUD_PROVIDERS_SYNCED_AT_KEY = "openwork.den.providers.syncedAt";
+
+export const cloudProvidersSyncedEvent = "openwork-cloud-providers-synced";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+let storageOverrideForTest: StorageLike | null = null;
+
+export function __setCloudSyncStateStorageForTest(storage: StorageLike | null) {
+  storageOverrideForTest = storage;
+}
+
+function getStorage(): StorageLike | null {
+  if (storageOverrideForTest) return storageOverrideForTest;
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readCloudProvidersSyncedAt(): number | null {
+  try {
+    const raw = getStorage()?.getItem(CLOUD_PROVIDERS_SYNCED_AT_KEY);
+    if (!raw) return null;
+    const value = Number.parseInt(raw, 10);
+    return Number.isFinite(value) && value > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCloudProvidersSyncedAt(at: number = Date.now()) {
+  try {
+    getStorage()?.setItem(CLOUD_PROVIDERS_SYNCED_AT_KEY, String(at));
+  } catch {
+    // Storage unavailable — the label simply stays empty.
+  }
+  if (typeof window !== "undefined") {
+    try {
+      window.dispatchEvent(new CustomEvent(cloudProvidersSyncedEvent));
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/** "Synced just now" / "Synced 42s ago" / "Synced 3m ago" / "Synced 2h ago". */
+export function formatSyncedAgo(syncedAt: number, now: number = Date.now()): string {
+  const elapsedMs = Math.max(0, now - syncedAt);
+  if (elapsedMs < 10_000) return "Synced just now";
+  if (elapsedMs < 60_000) return `Synced ${Math.floor(elapsedMs / 1000)}s ago`;
+  if (elapsedMs < 60 * 60_000) return `Synced ${Math.floor(elapsedMs / 60_000)}m ago`;
+  return `Synced ${Math.floor(elapsedMs / (60 * 60_000))}h ago`;
+}

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -68,6 +68,7 @@ import {
   isCloudProviderOutOfSync,
 } from "./cloud-provider-config";
 import { refreshDesktopCloudSync } from "../../../../app/cloud/desktop-cloud-sync";
+import { writeCloudProvidersSyncedAt } from "../../../../app/cloud/sync/sync-state";
 import { dispatchNewProviders } from "../../../../app/lib/provider-events";
 import {
   isDesktopProviderBlocked,
@@ -75,7 +76,12 @@ import {
 } from "../../../../app/cloud/desktop-app-restrictions";
 
 type ProviderReturnFocusTarget = "none" | "composer";
-type CloudProviderSyncReason = "sign_in" | "app_launch" | "interval" | "settings_cloud_opened";
+type CloudProviderSyncReason =
+  | "sign_in"
+  | "app_launch"
+  | "interval"
+  | "settings_cloud_opened"
+  | "manual";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -1314,15 +1320,15 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           }
         }
       }
-      const updatedConfig = await updateProjectConfigFile((raw) =>
+      // `false` means the provider block is already identical — a valid
+      // reconcile outcome (e.g. re-import after a lost baseline). Continue so
+      // the import record and credentials still get refreshed.
+      await updateProjectConfigFile((raw) =>
         formatConfigWithCloudProvider(raw, provider, localProviderId, {
           previousProviderId: existingImported?.providerId ?? null,
           disabledProviders: options.disabledProviders(),
         }),
       );
-      if (!updatedConfig) {
-        throw new Error("Could not update opencode.jsonc for this workspace.");
-      }
 
       const nextImportedProviders = {
         ...state.importedCloudProviders,
@@ -1385,12 +1391,13 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           throw error;
         }
       }
-      const updatedConfig = await updateProjectConfigFile((raw) =>
+      // `false` here means the rewrite produced no change — the provider
+      // block is already absent (e.g. a previous partial removal). Treat it
+      // as success so removal stays idempotent; a stale import record must
+      // not fail the whole sync sweep forever.
+      await updateProjectConfigFile((raw) =>
         formatConfigWithoutCloudProvider(raw, imported.providerId, options.disabledProviders()),
       );
-      if (!updatedConfig) {
-        throw new Error("Could not update opencode.jsonc for this workspace.");
-      }
 
       const nextImportedProviders = { ...state.importedCloudProviders };
       delete nextImportedProviders[cloudProviderId];
@@ -1537,6 +1544,8 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     if (failures.length > 0) {
       throw new Error(failures.join("\n"));
     }
+
+    writeCloudProvidersSyncedAt();
   }
 
   async function runCloudProviderSync(reason: CloudProviderSyncReason) {
@@ -1545,10 +1554,17 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       return cloudProviderSyncInFlight;
     }
 
+    if (reason === "manual") {
+      // A user-initiated sync (command palette) reports through
+      // providerAuthError; clear stale state so the caller can read the
+      // outcome of this run.
+      setStateField("providerAuthError", null);
+    }
+
     const request = performCloudProviderSync(reason)
       .catch((error) => {
         const message = logCloudProviderSyncError(reason, error);
-        if (reason === "settings_cloud_opened") {
+        if (reason === "settings_cloud_opened" || reason === "manual") {
           setStateField("providerAuthError", message);
         }
       })

--- a/apps/app/src/react-app/domains/settings/cloud/sections.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/sections.tsx
@@ -791,6 +791,8 @@ export interface CloudProvidersSectionProps {
   actionKind: ResourceActionKind | null;
   busy: boolean;
   rows: CloudProviderRow[];
+  /** e.g. "Synced 42s ago" — from the background cloud sync sweep. */
+  lastSyncedLabel?: string | null;
   onImport: (cloudProviderId: string, providerName: string) => void | Promise<void>;
   onRefresh: () => void | Promise<void>;
   onRemove?: (cloudProviderId: string, providerName: string) => void | Promise<void>;
@@ -803,6 +805,7 @@ export function CloudProvidersSection({
   actionKind,
   busy,
   rows,
+  lastSyncedLabel,
   onImport,
   onRefresh,
   onRemove,
@@ -828,6 +831,9 @@ export function CloudProvidersSection({
           <SettingsSectionHeaderDescription>{t("den.cloud_providers_hint")}</SettingsSectionHeaderDescription>
         </SettingsSectionHeaderContent>
         <SettingsSectionHeaderActions>
+          {lastSyncedLabel ? (
+            <span className="text-[11px] text-muted-foreground">{lastSyncedLabel}</span>
+          ) : null}
           <RefreshButton
             busy={busy}
             disabled={[busy, !hasActiveOrg].some(Boolean)}

--- a/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
@@ -3,6 +3,11 @@ import * as React from "react";
 import { toast } from "@/components/ui/sonner";
 
 import type { CloudImportedProvider } from "@/app/cloud/import-state";
+import {
+  cloudProvidersSyncedEvent,
+  formatSyncedAgo,
+  readCloudProvidersSyncedAt,
+} from "@/app/cloud/sync/sync-state";
 import type { DenOrgLlmProvider } from "@/app/lib/den";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -35,6 +40,28 @@ const sortStrings = (values: string[]) => values.toSorted();
 const sameStringList = (a: string[], b: string[]) =>
   a.length === b.length && a.every((value, index) => value === b[index]);
 
+function computeSyncedLabel(): string | null {
+  const syncedAt = readCloudProvidersSyncedAt();
+  return syncedAt === null ? null : formatSyncedAgo(syncedAt);
+}
+
+/** "Synced Xs ago" label, refreshed on sweep completion and every 10s. */
+function useLastSyncedLabel(): string | null {
+  const [label, setLabel] = React.useState<string | null>(computeSyncedLabel);
+
+  React.useEffect(() => {
+    const update = () => setLabel(computeSyncedLabel());
+    window.addEventListener(cloudProvidersSyncedEvent, update);
+    const timer = window.setInterval(update, 10_000);
+    return () => {
+      window.removeEventListener(cloudProvidersSyncedEvent, update);
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  return label;
+}
+
 export function CloudProvidersView({
   cloudOrgProviders,
   connectCloudProvider,
@@ -47,6 +74,7 @@ export function CloudProvidersView({
   session,
 }: CloudProvidersViewProps) {
   const { activeOrganization: activeOrg, authToken, isSignedIn, user } = useCloudSession();
+  const lastSyncedLabel = useLastSyncedLabel();
   const [busy, setBusy] = React.useState(false);
   const [actionId, setActionId] = React.useState<string | null>(null);
   const [actionKind, setActionKind] = React.useState<ProviderActionKind | null>(null);
@@ -228,6 +256,7 @@ export function CloudProvidersView({
       actionKind={actionKind}
       busy={busy}
       rows={rows}
+      lastSyncedLabel={lastSyncedLabel}
       onImport={importProvider}
       onRefresh={refresh}
       onRemove={undefined}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1453,6 +1453,35 @@ export function SessionRoute() {
     },
   }), [reloadCoordinator.canReloadWorkspaceEngine, reloadCoordinator.reloadWorkspaceEngine]);
 
+  const syncCloudConfigPaletteItem = useMemo<PaletteItem>(() => ({
+    id: "cloud-sync.force",
+    title: "Sync cloud config",
+    detail: "Pull org providers and models from OpenWork Cloud now",
+    meta: "Cloud",
+    searchText: "sync cloud config pull force refresh den providers models org llm now",
+    action: () => {
+      setCommandPaletteOpen(false);
+      void (async () => {
+        const settings = readDenSettings();
+        if (!settings.authToken?.trim() || !settings.activeOrgId?.trim()) {
+          toast.info("Sign in to OpenWork Cloud with an active org to sync cloud config.");
+          return;
+        }
+        try {
+          await sessionProviderAuthStore.runCloudProviderSync("manual");
+          const error = sessionProviderAuthStore.getSnapshot().providerAuthError;
+          if (error) {
+            toast.error(error);
+          } else {
+            toast.success("Cloud config synced.");
+          }
+        } catch (error) {
+          toast.error(error instanceof Error ? error.message : "Cloud sync failed.");
+        }
+      })();
+    },
+  }), [sessionProviderAuthStore]);
+
   const handleReorderWorkspaces = useCallback((workspaceIds: string[]) => {
     const activeWorkspaceIds = new Set(workspacesRef.current.map((workspace) => workspace.id));
     const nextOrderIds: string[] = [];
@@ -2004,7 +2033,7 @@ export function SessionRoute() {
       currentSessionForGroupMove={currentSessionForGroupMove}
       currentSessionGroupId={currentSessionGroupId}
       onMoveCurrentSessionToGroup={handleMoveCurrentSessionToGroup}
-      extraItems={[sessionSearchPaletteItem, ...terminalPaletteItems, developerModePaletteItem, nextSessionTabPaletteItem, prevSessionTabPaletteItem, reloadConfigPaletteItem]}
+      extraItems={[sessionSearchPaletteItem, ...terminalPaletteItems, developerModePaletteItem, nextSessionTabPaletteItem, prevSessionTabPaletteItem, reloadConfigPaletteItem, syncCloudConfigPaletteItem]}
       listAgents={listAgents}
       selectedAgent={selectedAgent}
       onSelectAgent={setSelectedAgent}

--- a/apps/app/tests/cloud-sync-state.test.ts
+++ b/apps/app/tests/cloud-sync-state.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  __setCloudSyncStateStorageForTest,
+  formatSyncedAgo,
+  readCloudProvidersSyncedAt,
+  writeCloudProvidersSyncedAt,
+} from "../src/app/cloud/sync/sync-state";
+
+function installStorageStub() {
+  const backing = new Map<string, string>();
+  __setCloudSyncStateStorageForTest({
+    getItem: (key: string) => backing.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      backing.set(key, value);
+    },
+    removeItem: (key: string) => {
+      backing.delete(key);
+    },
+  });
+  return backing;
+}
+
+afterAll(() => {
+  __setCloudSyncStateStorageForTest(null);
+});
+
+describe("cloud providers synced-at record", () => {
+  beforeEach(() => {
+    installStorageStub();
+  });
+
+  test("round-trips a timestamp", () => {
+    expect(readCloudProvidersSyncedAt()).toBeNull();
+    writeCloudProvidersSyncedAt(1_700_000_000_000);
+    expect(readCloudProvidersSyncedAt()).toBe(1_700_000_000_000);
+  });
+
+  test("ignores corrupt values", () => {
+    const backing = installStorageStub();
+    backing.set("openwork.den.providers.syncedAt", "banana");
+    expect(readCloudProvidersSyncedAt()).toBeNull();
+  });
+});
+
+describe("formatSyncedAgo", () => {
+  const now = 1_700_000_000_000;
+
+  test("buckets by elapsed time", () => {
+    expect(formatSyncedAgo(now - 3_000, now)).toBe("Synced just now");
+    expect(formatSyncedAgo(now - 42_000, now)).toBe("Synced 42s ago");
+    expect(formatSyncedAgo(now - 3 * 60_000, now)).toBe("Synced 3m ago");
+    expect(formatSyncedAgo(now - 2 * 60 * 60_000, now)).toBe("Synced 2h ago");
+  });
+
+  test("clamps future timestamps to just now", () => {
+    expect(formatSyncedAgo(now + 60_000, now)).toBe("Synced just now");
+  });
+});

--- a/evals/flows/cloud-config-sync-latency.flow.mjs
+++ b/evals/flows/cloud-config-sync-latency.flow.mjs
@@ -1,0 +1,305 @@
+/**
+ * Cloud config propagation: the command palette has a "Sync cloud config"
+ * action that force-pulls org providers from OpenWork Cloud, and a model
+ * added to an org LLM provider on Den lands in the desktop engine within
+ * ~30 seconds with NO user action (background auto-sync tick).
+ *
+ * Flow (real app + real Den):
+ *   1. Sign in via desktop handoff.
+ *   2. Create a custom LLM provider on Den via API.
+ *   3. Run the palette "Sync cloud config" action — the provider is imported
+ *      immediately and the engine reports its model.
+ *   4. PATCH the provider on Den to add a second model. Do nothing in the
+ *      app. Assert the engine reports the new model within 45s (30s tick +
+ *      sweep + engine reload margin).
+ *   5. Settings -> Cloud shows the "Synced ... ago" label.
+ *   6. Cleanup: delete the provider on Den; palette-sync removes it locally.
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_API_URL  Den API base
+ * - OPENWORK_EVAL_DEN_TOKEN    Bearer session token for a seeded org owner
+ */
+
+const PROVIDER_NAME = "Sync Latency Eval";
+const MODEL_A = "sync-model-a";
+const MODEL_B = "sync-model-b";
+const LATENCY_BUDGET_MS = 45_000;
+
+const providerConfig = (modelIds) => ({
+  id: "sync-latency-eval",
+  name: PROVIDER_NAME,
+  npm: "@ai-sdk/openai-compatible",
+  env: ["SYNC_LATENCY_EVAL_API_KEY"],
+  api: "https://sync-latency.example.com/v1",
+  models: modelIds.map((id) => ({ id, name: id })),
+});
+
+// Reads the engine-reported provider list through the OpenWork server proxy,
+// using the app's own token/port/workspace from inside the page. Returns the
+// models of the imported cloud provider matched by its lpr_* id (name matching
+// would hit stale orphan blocks from earlier imports), or null when absent.
+const engineProviderModelsExpr = (cloudProviderId) => `(async () => {
+  const port = localStorage.getItem("openwork.server.port");
+  const token = localStorage.getItem("openwork.server.token");
+  const workspaceId = (window.location.hash.match(/workspace\\/(ws_[a-z0-9]+)/) ?? [])[1];
+  if (!port || !token || !workspaceId) return null;
+  const base = "http://127.0.0.1:" + port;
+  const headers = { Authorization: "Bearer " + token };
+  const wsResponse = await fetch(base + "/workspaces", { headers });
+  if (!wsResponse.ok) return null;
+  const wsPayload = await wsResponse.json();
+  const workspaceList = Array.isArray(wsPayload) ? wsPayload : wsPayload.items ?? [];
+  const workspace = workspaceList.find((entry) => entry.id === workspaceId);
+  const directory = workspace?.path ?? "";
+  const url = base + "/workspace/" + workspaceId + "/opencode/provider" +
+    (directory ? "?directory=" + encodeURIComponent(directory) : "");
+  const response = await fetch(url, { headers });
+  if (!response.ok) return null;
+  const payload = await response.json();
+  const provider = (payload.all ?? []).find((entry) => entry.id === ${JSON.stringify(cloudProviderId)});
+  if (!provider) return null;
+  return Object.keys(provider.models ?? {}).sort();
+})()`;
+
+async function denRequest(ctx, path, init = {}) {
+  const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+  const response = await fetch(`${apiBase}${path}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+      "content-type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+  const body = await response.text();
+  ctx.assert(response.ok || init.allowStatuses?.includes(response.status), `${init.method ?? "GET"} ${path} failed: ${response.status} ${body.slice(0, 200)}`);
+  return body ? JSON.parse(body) : null;
+}
+
+// Navigate to the active workspace session route (where the palette and the
+// session-scoped auto-sync live) regardless of which route we start on.
+async function ensureWorkspaceRoute(ctx) {
+  const PALETTE_ACTION_READY =
+    "Boolean(window.__openworkControl && window.__openworkControl.listActions().some((a) => a.id === 'command_palette.open'))";
+  // The palette action only registers on the session route (a workspace
+  // settings route also matches '/workspace/', so check the action itself).
+  const ready = await ctx.eval(PALETTE_ACTION_READY);
+  if (ready) return;
+  const workspaceId = await ctx.eval(
+    "localStorage.getItem('openwork.react.activeWorkspace') ?? ''",
+  );
+  ctx.assert(Boolean(workspaceId), "No active workspace recorded; cannot open the session route.");
+  await ctx.navigateHash(`/workspace/${workspaceId}/session`);
+  await ctx.waitFor(PALETTE_ACTION_READY, {
+    timeoutMs: 30_000,
+    label: "command palette control action registered",
+  });
+}
+
+// ctx.waitFor cannot await promises, so async engine reads poll from flow code.
+async function pollEngineModels(ctx, predicate, timeoutMs, label) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const models = await ctx
+      .eval(engineProviderModelsExpr(ctx.providerId), { awaitPromise: true })
+      .catch(() => undefined);
+    if (models !== undefined && predicate(models)) return models;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for: ${label}`);
+}
+
+async function runPaletteSync(ctx) {
+  await ctx.control("command_palette.open");
+  // Placeholders are not innerText; wait for the input element itself.
+  await ctx.waitFor(
+    `Boolean(document.querySelector('input[placeholder="Search actions"]'))`,
+    { timeoutMs: 15_000, label: "command palette input" },
+  );
+  await ctx.fill('input[placeholder="Search actions"]', "sync cloud");
+  await ctx.clickText("Sync cloud config", { selector: "button, [role=option], [role=button], li, div[data-item]", timeoutMs: 15_000 });
+  await ctx.waitForText("Cloud config synced.", { timeoutMs: 60_000 });
+}
+
+export default {
+  id: "cloud-config-sync-latency",
+  title: "Palette force-sync + Den model change lands within 45s hands-free",
+  spec: "evals/cloud-provider-sync-flows.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000 });
+      },
+    },
+    {
+      name: "Sign in to OpenWork Cloud via desktop handoff",
+      run: async (ctx) => {
+        const signedIn = await ctx.eval(
+          "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+        );
+        if (signedIn) {
+          ctx.log("Already signed in; reusing session.");
+          return;
+        }
+        const payload = await denRequest(ctx, "/v1/auth/desktop-handoff", {
+          method: "POST",
+          body: JSON.stringify({ desktopScheme: "openwork" }),
+        });
+        ctx.assert(typeof payload.openworkUrl === "string" && payload.openworkUrl.length > 0, "No openworkUrl in handoff response.");
+        await ctx.navigateHash("/settings/cloud-account");
+        await ctx.clickText("Paste sign-in code", { timeoutMs: 30_000 });
+        await ctx.fill("#den-signin-link", payload.openworkUrl);
+        await ctx.clickText("Finish sign-in");
+        await ctx.waitFor(
+          "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+          { timeoutMs: 45_000, label: "persisted den auth token" },
+        );
+      },
+    },
+    {
+      name: "Create the org LLM provider on Den (cleanup leftovers first)",
+      run: async (ctx) => {
+        const existing = await denRequest(ctx, "/v1/llm-providers");
+        for (const provider of existing.llmProviders ?? []) {
+          if (provider.name === PROVIDER_NAME) {
+            await denRequest(ctx, `/v1/llm-providers/${encodeURIComponent(provider.id)}`, { method: "DELETE", allowStatuses: [204, 404] });
+          }
+        }
+        const created = await denRequest(ctx, "/v1/llm-providers", {
+          method: "POST",
+          body: JSON.stringify({
+            name: PROVIDER_NAME,
+            source: "custom",
+            customConfig: providerConfig([MODEL_A]),
+            apiKey: "sk-sync-latency-eval",
+            memberIds: [],
+            teamIds: [],
+          }),
+        });
+        ctx.providerId = created.llmProvider?.id;
+        ctx.assert(typeof ctx.providerId === "string" && ctx.providerId.length > 0, "Provider create returned no id.");
+        ctx.log(`Created Den provider ${ctx.providerId}`);
+      },
+    },
+    {
+      name: "Palette 'Sync cloud config' imports the provider immediately",
+      run: async (ctx) => {
+        // Land on a workspace session first (palette lives there).
+        await ensureWorkspaceRoute(ctx);
+        await ctx.prove("The command palette can force-pull cloud config", {
+          action: async () => {
+            await runPaletteSync(ctx);
+          },
+          assert: async () => {
+            await pollEngineModels(
+              ctx,
+              (models) => Array.isArray(models) && models.includes(MODEL_A),
+              90_000,
+              "engine reports the imported provider with its model",
+            );
+          },
+          screenshot: {
+            name: "palette-sync-imported",
+            claim: "Palette sync imported the Den provider; the engine now serves it.",
+            requireText: ["Cloud config synced."],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "A model added on Den lands hands-free within the latency budget",
+      run: async (ctx) => {
+        await ctx.prove(`A Den model add propagates to the engine within ${LATENCY_BUDGET_MS / 1000}s with no user action`, {
+          action: async () => {
+            await denRequest(ctx, `/v1/llm-providers/${encodeURIComponent(ctx.providerId)}`, {
+              method: "PATCH",
+              body: JSON.stringify({
+                name: PROVIDER_NAME,
+                source: "custom",
+                customConfig: providerConfig([MODEL_A, MODEL_B]),
+                memberIds: [],
+                teamIds: [],
+              }),
+            });
+            ctx.patchAt = Date.now();
+            ctx.log(`Patched provider at ${new Date(ctx.patchAt).toISOString()}`);
+          },
+          assert: async () => {
+            await pollEngineModels(
+              ctx,
+              (models) => Array.isArray(models) && models.includes(MODEL_B),
+              LATENCY_BUDGET_MS,
+              `engine reports ${MODEL_B} within ${LATENCY_BUDGET_MS / 1000}s`,
+            );
+            const elapsed = Date.now() - ctx.patchAt;
+            ctx.log(`Model landed after ${Math.round(elapsed / 1000)}s`);
+            ctx.recordEvidence({
+              type: "assertion",
+              status: "passed",
+              assertion: `Den model add propagated hands-free in ${Math.round(elapsed / 1000)}s (budget ${LATENCY_BUDGET_MS / 1000}s)`,
+            });
+          },
+          screenshot: {
+            name: "hands-free-propagation",
+            claim: "The engine serves the model added on Den without any user action.",
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Settings -> Cloud shows the synced-ago label",
+      run: async (ctx) => {
+        await ctx.navigateHash("/settings/cloud-providers");
+        await ctx.waitFor("window.location.hash.includes('/settings/cloud-providers')", { timeoutMs: 20_000 });
+        await ctx.prove("The Cloud providers view shows when the last sync ran", {
+          assert: async () => {
+            await ctx.waitFor(
+              `document.body.innerText.match(/Synced (just now|\\d+[smh] ago)/) !== null`,
+              { timeoutMs: 30_000, label: "'Synced ... ago' label visible" },
+            );
+          },
+          screenshot: {
+            name: "synced-ago-label",
+            claim: "Settings -> Cloud providers shows the last-synced label.",
+            requireText: ["Synced"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/cloud-providers",
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup: delete the provider on Den and strip the local block",
+      run: async (ctx) => {
+        await denRequest(ctx, `/v1/llm-providers/${encodeURIComponent(ctx.providerId)}`, { method: "DELETE", allowStatuses: [204, 404] });
+        // Known gap (follow-up): the removal sweep depends on the persisted
+        // import record, and a pre-existing read-modify-write race between
+        // cloudImports writers can lose it — so a Den-side delete is not yet
+        // reliably propagated. Until that lands, strip the imported block
+        // directly through the config-file API to leave the workspace clean.
+        await ctx.eval(`(async () => {
+          const port = localStorage.getItem("openwork.server.port");
+          const token = localStorage.getItem("openwork.server.token");
+          const workspaceId = (window.location.hash.match(/workspace\\/(ws_[a-z0-9]+)/) ?? [])[1];
+          if (!port || !token || !workspaceId) return "missing context";
+          const base = "http://127.0.0.1:" + port;
+          const headers = { Authorization: "Bearer " + token, "Content-Type": "application/json" };
+          const file = await (await fetch(base + "/workspace/" + workspaceId + "/opencode-config?scope=project", { headers })).json();
+          const raw = file.content ?? "";
+          const pattern = new RegExp('\\\\n\\\\s*// OpenWork Cloud import: ' + ${JSON.stringify(PROVIDER_NAME)} + '[^\\\\n]*\\\\n\\\\s*"lpr_[a-z0-9]+": \\\\{[\\\\s\\\\S]*?\\\\n    \\\\},?', 'g');
+          const next = raw.replace(pattern, "");
+          if (next === raw) return "no block to strip";
+          const write = await fetch(base + "/workspace/" + workspaceId + "/opencode-config", {
+            method: "POST", headers,
+            body: JSON.stringify({ scope: "project", content: next }),
+          });
+          return "stripped: " + write.status;
+        })()`, { awaitPromise: true }).then((result) => ctx.log(`Cleanup: ${result}`)).catch(() => {});
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Why

Org changes made on Den (a model added to an LLM provider, a new provider shared with the team) took up to **5 minutes** to reach desktops, with no way to force a pull and no visibility into when the last sync ran. Observed live on a customer call: *"that was seventeen minutes ago, so it hasn't synced the new ones yet… quit the app and restart it."*

## What

1. **Command palette → "Sync cloud config"** — force-runs the cloud provider sweep on demand. New `manual` sync reason clears/surfaces `providerAuthError` so the palette can toast success or the real failure.
2. **Auto-sync interval 5min → 30s** (`CLOUD_SYNC_INTERVAL_MS`). An idle tick costs one org-scoped GET + a local config read; reconciles (config rewrite + engine reload) only run on drift.
3. **"Synced Xs ago" label** in Settings → Cloud providers, written after each successful sweep, live-updating.
4. **Sweep-poisoning fix**: `removeCloudProviderInternal`/`connectCloudProviderInternal` treated a no-change config rewrite as a hard failure ("Could not update opencode.jsonc"), so one stale import record failed **every subsequent sweep forever** (this is how stale `lpr_*` blocks accumulated). No-change is now a valid idempotent outcome.

## Tests / evidence

- `pnpm typecheck` + `bun test tests/` (apps/app) — clean / 87 pass, 0 fail on latest `dev` (new: `cloud-sync-state.test.ts`)
- fraimz e2e (`evals/flows/cloud-config-sync-latency.flow.mjs`) against the real Electron app + real local Den — **PASSED**:
  - palette "Sync cloud config" imports a freshly created Den provider in **~1.2s** (engine round-trip verified via the engine's provider list, matched by `lpr_*` id)
  - a model PATCHed onto the Den provider lands in the engine **hands-free in 1.5–4.9s** (budget 45s, no user action; the 30s tick + drift reconcile)
  - Settings → Cloud shows the "Synced … ago" label
  - cleanup deletes the Den provider and strips the local block

## Known follow-up (pre-existing, not introduced here)

While validating we found a **read-modify-write race between `cloudImports` writers** (provider-auth store vs extensions store): each persists the whole `cloudImports` object from its own read, so a stale read can drop another section's records. Consequence: import baselines can be lost after a route remount, which silently breaks **removal** propagation (deleted-on-Den providers leave orphan `lpr_*` blocks). Verified empirically (a probe record written via the config API was clobbered within 30s). Fix tracked separately — likely per-section patching or server-side deep merge for `cloudImports`.