### PR TITLE
feat(server): per-provider runtime config merge with null deletion

### DIFF
--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -153,6 +153,27 @@ export function runtimeExternalDirectory(config: RuntimeOpencodeConfig): Record<
   return externalDirectory ?? {};
 }
 
+/**
+ * Per-provider merge for runtime config patches: record values upsert the
+ * provider, explicit `null` deletes it (so clients can remove runtime-managed
+ * providers, e.g. cloud imports, without racing a read-modify-write of the
+ * whole map). Returns undefined when the resulting map is empty.
+ */
+export function mergeRuntimeProviderUpdate(
+  current: unknown,
+  update: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const next: Record<string, unknown> = { ...(isRecord(current) ? current : {}) };
+  for (const [providerId, value] of Object.entries(update)) {
+    if (value === null) {
+      delete next[providerId];
+    } else if (isRecord(value)) {
+      next[providerId] = value;
+    }
+  }
+  return Object.keys(next).length ? next : undefined;
+}
+
 export async function readRuntimeOpencodeConfig(config: ServerConfig, workspaceId: string): Promise<RuntimeOpencodeConfig> {
   const db = await runtimeDb(config);
   const row = db.get(workspaceId);

--- a/apps/server/src/runtime-provider-merge.test.ts
+++ b/apps/server/src/runtime-provider-merge.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { mergeRuntimeProviderUpdate } from "./runtime-opencode-config-store.js";
+
+describe("mergeRuntimeProviderUpdate", () => {
+  const ollama = { npm: "@ai-sdk/openai-compatible", name: "Ollama" };
+  const cloud = { npm: "@ai-sdk/openai-compatible", name: "Cloud Provider" };
+
+  test("upserts new providers and keeps existing ones", () => {
+    expect(mergeRuntimeProviderUpdate({ ollama }, { lpr_x: cloud })).toEqual({
+      ollama,
+      lpr_x: cloud,
+    });
+  });
+
+  test("replaces an existing provider wholesale", () => {
+    const next = { ...cloud, name: "Renamed" };
+    expect(mergeRuntimeProviderUpdate({ lpr_x: cloud }, { lpr_x: next })).toEqual({ lpr_x: next });
+  });
+
+  test("null deletes a provider without touching others", () => {
+    expect(mergeRuntimeProviderUpdate({ ollama, lpr_x: cloud }, { lpr_x: null })).toEqual({
+      ollama,
+    });
+  });
+
+  test("returns undefined when the map empties", () => {
+    expect(mergeRuntimeProviderUpdate({ lpr_x: cloud }, { lpr_x: null })).toBeUndefined();
+  });
+
+  test("ignores non-record, non-null values", () => {
+    expect(mergeRuntimeProviderUpdate({ ollama }, { bad: "string", worse: 42 })).toEqual({
+      ollama,
+    });
+  });
+
+  test("deleting a missing provider is a no-op", () => {
+    expect(mergeRuntimeProviderUpdate({ ollama }, { lpr_missing: null })).toEqual({ ollama });
+  });
+});

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -62,6 +62,7 @@ import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerWorkspaceRoutes } from "./routes/workspaces.js";
 import {
   mergeOpencodeConfigs,
+  mergeRuntimeProviderUpdate,
   readRuntimeOpencodeConfig,
   runtimeMcpMap,
   type RuntimeOpencodeConfig,
@@ -1831,13 +1832,13 @@ function createRoutes(
       const { permission, provider, ...topLevelUpdates } = nextOpencode;
       const logicalUpdates: Record<string, unknown> = { ...topLevelUpdates };
 
-      const providerUpdate = ensurePlainObject(provider);
+      // Per-provider merge: record values upsert, explicit `null` deletes
+      // (mergeRuntimeProviderUpdate) — so clients can remove runtime-managed
+      // providers (e.g. cloud imports) without read-modify-write races.
+      const providerUpdate = isRecord(provider) ? provider : {};
       if (Object.keys(providerUpdate).length) {
         const currentRuntime = await readRuntimeOpencodeConfig(config, workspace.id);
-        logicalUpdates.provider = {
-          ...(ensurePlainObject(currentRuntime.provider)),
-          ...providerUpdate,
-        };
+        logicalUpdates.provider = mergeRuntimeProviderUpdate(currentRuntime.provider, providerUpdate);
       }
 
       const permissionUpdate = ensurePlainObject(permission);


### PR DESCRIPTION
## Why

`PATCH /workspace/:id/config` merges `opencode.provider` per-key for **upserts only** — there is no way to remove a runtime-managed provider. This blocks moving cloud (`lpr_*`) provider imports from `opencode.jsonc` edits into the runtime config (the jsonc path is what produced the orphan-block accumulation and removal-propagation issues we hit this week).

## What

- `mergeRuntimeProviderUpdate` (runtime-opencode-config-store): record values upsert, explicit `null` deletes, non-record/non-null values are ignored; an emptied map drops the `provider` key.
- PATCH handler uses it for the `opencode.provider` section.
- Backward compatible: existing callers (Ollama's `installLocalProvider`) send record values only — behavior unchanged.

This is the server half; the client half (cloud provider imports writing to runtime config + legacy jsonc migration) follows in a separate PR that builds on these semantics.

## Tests

- `bun test src/runtime-provider-merge.test.ts` — 6 pass (upsert / replace / delete / empty-map / ignore-garbage / delete-missing)
- `bun test` (apps/server, full) — 265 pass, 0 fail
- `tsc --noEmit` (apps/server) — clean

Runtime-path change is small and covered by unit tests; end-to-end proof (import → runtime entry → engine serves models → Den delete → runtime entry removed) ships with the client PR that exercises this endpoint against the real stack.