### PR TITLE
feat(den-api): LLM provider test-connection endpoint (probe /models)

### DIFF
--- a/ee/apps/den-api/src/llm/endpoint-probe.ts
+++ b/ee/apps/den-api/src/llm/endpoint-probe.ts
@@ -1,0 +1,296 @@
+/**
+ * Endpoint probing for custom LLM providers ("test connection").
+ *
+ * Given a base URL and credential, discover what the endpoint actually
+ * serves: normalize common URL mistakes (trailing `/responses`, Azure host
+ * twins), call the OpenAI-compatible `GET /models`, and return the model
+ * ids — on Azure these are the deployment names, which is exactly what the
+ * provider config needs. Pure logic is separated from I/O so it can be
+ * unit-tested with an injected fetch.
+ */
+
+type JsonRecord = Record<string, unknown>
+
+export type ProbeVendor = "azure" | "openai-compatible"
+
+export type EndpointProbeResult = {
+  ok: boolean
+  vendor: ProbeVendor
+  /** The candidate base URL that answered /models, when ok. */
+  normalizedApi: string | null
+  /** Every candidate URL that was attempted, in order. */
+  attempted: string[]
+  models: Array<{ id: string }>
+  /** Human guidance when not ok. */
+  hint: string | null
+  /** Upstream HTTP status of the last failed attempt, when relevant. */
+  status: number | null
+}
+
+const AZURE_HOST_PATTERN = /\.(openai\.azure\.com|services\.ai\.azure\.com|cognitiveservices\.azure\.com)$/i
+
+const STRIP_SUFFIXES = [
+  "/chat/completions",
+  "/completions",
+  "/responses",
+  "/models",
+]
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function detectVendor(url: string): ProbeVendor {
+  try {
+    const { hostname } = new URL(url)
+    if (AZURE_HOST_PATTERN.test(hostname)) return "azure"
+  } catch {
+    // fall through
+  }
+  return "openai-compatible"
+}
+
+function normalizeBase(raw: string): string | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  try {
+    const url = new URL(trimmed)
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null
+    url.hash = ""
+    url.search = ""
+    let pathname = url.pathname.replace(/\/+$/, "")
+    for (const suffix of STRIP_SUFFIXES) {
+      if (pathname.toLowerCase().endsWith(suffix)) {
+        pathname = pathname.slice(0, -suffix.length)
+        break
+      }
+    }
+    url.pathname = pathname
+    return url.toString().replace(/\/+$/, "")
+  } catch {
+    return null
+  }
+}
+
+function azureHostTwin(base: string): string | null {
+  try {
+    const url = new URL(base)
+    if (/\.openai\.azure\.com$/i.test(url.hostname)) {
+      url.hostname = url.hostname.replace(/\.openai\.azure\.com$/i, ".services.ai.azure.com")
+      return url.toString().replace(/\/+$/, "")
+    }
+    if (/\.services\.ai\.azure\.com$/i.test(url.hostname)) {
+      url.hostname = url.hostname.replace(/\.services\.ai\.azure\.com$/i, ".openai.azure.com")
+      return url.toString().replace(/\/+$/, "")
+    }
+  } catch {
+    // ignore
+  }
+  return null
+}
+
+function withAzureV1Path(base: string): string | null {
+  try {
+    const url = new URL(base)
+    if (!AZURE_HOST_PATTERN.test(url.hostname)) return null
+    if (url.pathname === "" || url.pathname === "/") {
+      url.pathname = "/openai/v1"
+      return url.toString().replace(/\/+$/, "")
+    }
+  } catch {
+    // ignore
+  }
+  return null
+}
+
+/**
+ * Ordered, deduplicated list of base URLs to try. The user's (normalized)
+ * input always comes first; Azure-specific rewrites follow — the host twin
+ * (`openai.azure.com` <-> `services.ai.azure.com`) and the bare-origin
+ * `/openai/v1` path, both mistakes we have watched real users make.
+ */
+export function buildCandidateBaseUrls(raw: string): string[] {
+  const first = normalizeBase(raw)
+  if (!first) return []
+  const candidates: string[] = [first]
+
+  const v1 = withAzureV1Path(first)
+  if (v1) candidates.push(v1)
+
+  const twin = azureHostTwin(first)
+  if (twin) {
+    candidates.push(twin)
+    const twinV1 = withAzureV1Path(twin)
+    if (twinV1) candidates.push(twinV1)
+  }
+
+  return [...new Set(candidates)].slice(0, 6)
+}
+
+function isBlockedHostname(hostname: string, allowLoopback: boolean): boolean {
+  const normalized = hostname.trim().toLowerCase().replace(/^\[|\]$/g, "")
+  if (normalized === "metadata.google.internal") return true
+  if (normalized === "169.254.169.254" || normalized.startsWith("169.254.")) return true
+  if (normalized === "fd00:ec2::254") return true
+  const loopback =
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    /^127\./.test(normalized)
+  if (loopback) return !allowLoopback
+  // Private ranges: allowed for self-hosted installs reaching internal
+  // gateways; the metadata/link-local blocks above are the hard rule.
+  return false
+}
+
+export function assertProbeUrlAllowed(url: string, options?: { allowLoopback?: boolean }) {
+  const allowLoopback = options?.allowLoopback ?? process.env.OPENWORK_DEV_MODE === "1"
+  const parsed = new URL(url)
+  if (isBlockedHostname(parsed.hostname, allowLoopback)) {
+    throw new EndpointProbeBlockedError(`Probing ${parsed.hostname} is not allowed.`)
+  }
+}
+
+export class EndpointProbeBlockedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "EndpointProbeBlockedError"
+  }
+}
+
+const MAX_RESPONSE_BYTES = 512 * 1024
+const PROBE_TIMEOUT_MS = 8_000
+
+type FetchLike = (url: string, init: RequestInit) => Promise<Response>
+
+async function readBoundedJson(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (text.length > MAX_RESPONSE_BYTES) {
+    throw new Error("Response too large.")
+  }
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+function parseModelIds(payload: unknown): string[] | null {
+  if (!isRecord(payload)) return null
+  const data = payload.data
+  if (!Array.isArray(data)) return null
+  const ids = data.flatMap((entry) => {
+    if (!isRecord(entry)) return []
+    const id = typeof entry.id === "string" ? entry.id.trim() : ""
+    return id ? [id] : []
+  })
+  return [...new Set(ids)].sort()
+}
+
+function hintFor(vendor: ProbeVendor, status: number | null): string {
+  if (status === 401 || status === 403) {
+    return vendor === "azure"
+      ? "The endpoint rejected the key. Check Keys & Endpoint on the Azure resource — the key must belong to the same resource as the base URL."
+      : "The endpoint rejected the key. Double-check the credential for this endpoint."
+  }
+  if (status === 404) {
+    return vendor === "azure"
+      ? "No OpenAI-compatible /models endpoint found. Azure base URLs usually end in /openai/v1 — copy the endpoint from the Azure portal and check the resource name."
+      : "No /models endpoint found at this base URL. Most OpenAI-compatible endpoints end in /v1."
+  }
+  if (status !== null) {
+    return `The endpoint answered /models with HTTP ${status}.`
+  }
+  return "Could not reach the endpoint. Check the URL, network access, and that the endpoint allows requests from OpenWork Cloud."
+}
+
+/**
+ * Try each candidate base URL until one serves /models. Sends both
+ * `Authorization: Bearer` and `api-key` headers — Azure accepts either,
+ * OpenAI-compatible servers ignore the extra header.
+ */
+export async function probeEndpoint(input: {
+  api: string
+  apiKey: string
+  fetchImpl?: FetchLike
+  allowLoopback?: boolean
+}): Promise<EndpointProbeResult> {
+  const fetchImpl: FetchLike = input.fetchImpl ?? ((url, init) => fetch(url, init))
+  const vendor = detectVendor(input.api)
+  const candidates = buildCandidateBaseUrls(input.api)
+  const attempted: string[] = []
+
+  if (candidates.length === 0) {
+    return {
+      ok: false,
+      vendor,
+      normalizedApi: null,
+      attempted,
+      models: [],
+      hint: "Enter a valid http(s) base URL.",
+      status: null,
+    }
+  }
+
+  let lastStatus: number | null = null
+
+  for (const base of candidates) {
+    attempted.push(base)
+    try {
+      assertProbeUrlAllowed(base, { allowLoopback: input.allowLoopback })
+    } catch (error) {
+      if (error instanceof EndpointProbeBlockedError) {
+        return { ok: false, vendor, normalizedApi: null, attempted, models: [], hint: error.message, status: null }
+      }
+      throw error
+    }
+
+    try {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+      let response: Response
+      try {
+        response = await fetchImpl(`${base}/models`, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${input.apiKey}`,
+            "api-key": input.apiKey,
+          },
+          signal: controller.signal,
+          redirect: "error",
+        })
+      } finally {
+        clearTimeout(timer)
+      }
+
+      lastStatus = response.status
+      if (!response.ok) continue
+
+      const payload = await readBoundedJson(response)
+      const ids = parseModelIds(payload)
+      if (!ids) continue
+
+      return {
+        ok: true,
+        vendor,
+        normalizedApi: base,
+        attempted,
+        models: ids.map((id) => ({ id })),
+        hint: null,
+        status: response.status,
+      }
+    } catch {
+      // Network error or abort — try the next candidate.
+      continue
+    }
+  }
+
+  return {
+    ok: false,
+    vendor,
+    normalizedApi: null,
+    attempted,
+    models: [],
+    hint: hintFor(vendor, lastStatus),
+    status: lastStatus,
+  }
+}

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -14,6 +14,7 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
 import { CustomProviderConfigError, normalizeCustomProviderConfig } from "../../llm/custom-provider.js"
+import { probeEndpoint } from "../../llm/endpoint-probe.js"
 import {
   jsonValidator,
   orgMemberRoute,
@@ -91,6 +92,23 @@ const llmProviderWriteSchema = z.object({
     })
   }
 })
+
+const endpointProbeRequestSchema = z.object({
+  api: z.string().trim().min(1).max(2048),
+  apiKey: z.string().trim().max(65535).optional(),
+})
+
+const endpointProbeResponseSchema = z.object({
+  result: z.object({
+    ok: z.boolean(),
+    vendor: z.enum(["azure", "openai-compatible"]),
+    normalizedApi: z.string().nullable(),
+    attempted: z.array(z.string()),
+    models: z.array(z.object({ id: z.string() })),
+    hint: z.string().nullable(),
+    status: z.number().nullable(),
+  }),
+}).meta({ ref: "LlmProviderTestConnectionResponse" })
 
 const providerCatalogListResponseSchema = z.object({
   providers: z.array(z.object({}).passthrough()),
@@ -478,6 +496,27 @@ async function loadLlmProviders(input: {
 }
 
 export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVariables & Partial<MemberTeamsContext> }>(app: Hono<T>) {
+  app.post(
+    "/v1/llm-providers/test-connection",
+    describeRoute({
+      tags: ["LLM Providers"],
+      summary: "Test a custom LLM provider endpoint",
+      description: "Probes an OpenAI-compatible endpoint (Azure AI Foundry, LiteLLM, vLLM, gateways) with the given credential: normalizes common base-URL mistakes, calls GET /models, and returns the model ids the endpoint actually serves — on Azure these are the deployment names. Nothing is stored.",
+      responses: {
+        200: jsonResponse("Probe completed (ok=false carries a human hint).", endpointProbeResponseSchema),
+        400: jsonResponse("The probe request was invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to test provider endpoints.", unauthorizedSchema),
+      },
+    }),
+    orgMemberRoute(),
+    jsonValidator(endpointProbeRequestSchema),
+    async (c) => {
+      const input = c.req.valid("json")
+      const result = await probeEndpoint({ api: input.api, apiKey: input.apiKey ?? "" })
+      return c.json({ result })
+    },
+  )
+
   app.get(
     "/v1/llm-provider-catalog",
     describeRoute({

--- a/ee/apps/den-api/test/llm-endpoint-probe.test.ts
+++ b/ee/apps/den-api/test/llm-endpoint-probe.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  buildCandidateBaseUrls,
+  detectVendor,
+  probeEndpoint,
+} from "../src/llm/endpoint-probe.js"
+
+const jsonResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } })
+
+const modelsPayload = (ids: string[]) => ({ data: ids.map((id) => ({ id, object: "model" })) })
+
+describe("detectVendor", () => {
+  test("recognizes Azure host families", () => {
+    expect(detectVendor("https://res.openai.azure.com/openai/v1")).toBe("azure")
+    expect(detectVendor("https://res.services.ai.azure.com/openai/v1")).toBe("azure")
+    expect(detectVendor("https://res.cognitiveservices.azure.com")).toBe("azure")
+    expect(detectVendor("https://llm.internal.example.com/v1")).toBe("openai-compatible")
+  })
+})
+
+describe("buildCandidateBaseUrls", () => {
+  test("strips known suffixes and trailing slashes", () => {
+    expect(buildCandidateBaseUrls("https://x.example.com/v1/")[0]).toBe("https://x.example.com/v1")
+    expect(buildCandidateBaseUrls("https://x.example.com/v1/chat/completions")[0]).toBe("https://x.example.com/v1")
+    // The exact mistake from the Blue Yonder session: /responses pasted from the portal.
+    expect(
+      buildCandidateBaseUrls("https://r.services.ai.azure.com/openai/v1/responses")[0],
+    ).toBe("https://r.services.ai.azure.com/openai/v1")
+  })
+
+  test("adds the Azure host twin and bare-origin /openai/v1 variants", () => {
+    const candidates = buildCandidateBaseUrls("https://r.openai.azure.com/openai/v1")
+    expect(candidates).toContain("https://r.openai.azure.com/openai/v1")
+    expect(candidates).toContain("https://r.services.ai.azure.com/openai/v1")
+
+    const bare = buildCandidateBaseUrls("https://r.openai.azure.com")
+    expect(bare).toContain("https://r.openai.azure.com/openai/v1")
+  })
+
+  test("rejects garbage", () => {
+    expect(buildCandidateBaseUrls("not a url")).toEqual([])
+    expect(buildCandidateBaseUrls("ftp://x.example.com")).toEqual([])
+  })
+})
+
+describe("probeEndpoint", () => {
+  test("returns sorted deduped model ids from /models", async () => {
+    const result = await probeEndpoint({
+      api: "https://llm.example.com/v1",
+      apiKey: "k",
+      allowLoopback: false,
+      fetchImpl: async (url) => {
+        expect(url).toBe("https://llm.example.com/v1/models")
+        return jsonResponse(200, modelsPayload(["gpt-5-mini", "dall-e-2", "gpt-5-mini"]))
+      },
+    })
+    expect(result.ok).toBe(true)
+    expect(result.normalizedApi).toBe("https://llm.example.com/v1")
+    expect(result.models.map((m) => m.id)).toEqual(["dall-e-2", "gpt-5-mini"])
+  })
+
+  test("falls through to the Azure host twin when the first candidate 404s", async () => {
+    const calls: string[] = []
+    const result = await probeEndpoint({
+      api: "https://r.openai.azure.com/openai/v1",
+      apiKey: "k",
+      allowLoopback: false,
+      fetchImpl: async (url) => {
+        calls.push(url)
+        if (url.startsWith("https://r.services.ai.azure.com")) {
+          return jsonResponse(200, modelsPayload(["gpt-5-mini"]))
+        }
+        return jsonResponse(404, { error: { code: "404" } })
+      },
+    })
+    expect(result.ok).toBe(true)
+    expect(result.normalizedApi).toBe("https://r.services.ai.azure.com/openai/v1")
+    expect(calls[0]).toBe("https://r.openai.azure.com/openai/v1/models")
+  })
+
+  test("401 yields a key hint with the upstream status", async () => {
+    const result = await probeEndpoint({
+      api: "https://r.openai.azure.com/openai/v1",
+      apiKey: "bad",
+      allowLoopback: false,
+      fetchImpl: async () => jsonResponse(401, { error: "unauthorized" }),
+    })
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(401)
+    expect(result.hint).toContain("key")
+  })
+
+  test("blocks cloud metadata endpoints", async () => {
+    const result = await probeEndpoint({
+      api: "http://169.254.169.254/v1",
+      apiKey: "k",
+      allowLoopback: true,
+      fetchImpl: async () => {
+        throw new Error("must not be called")
+      },
+    })
+    expect(result.ok).toBe(false)
+    expect(result.hint).toContain("not allowed")
+  })
+
+  test("blocks loopback unless explicitly allowed", async () => {
+    const blocked = await probeEndpoint({
+      api: "http://127.0.0.1:9999/v1",
+      apiKey: "k",
+      allowLoopback: false,
+      fetchImpl: async () => {
+        throw new Error("must not be called")
+      },
+    })
+    expect(blocked.ok).toBe(false)
+
+    const allowed = await probeEndpoint({
+      api: "http://127.0.0.1:9999/v1",
+      apiKey: "k",
+      allowLoopback: true,
+      fetchImpl: async () => jsonResponse(200, modelsPayload(["m"])),
+    })
+    expect(allowed.ok).toBe(true)
+  })
+
+  test("network failure on every candidate yields the reachability hint", async () => {
+    const result = await probeEndpoint({
+      api: "https://nowhere.example.com/v1",
+      apiKey: "k",
+      allowLoopback: false,
+      fetchImpl: async () => {
+        throw new Error("ECONNREFUSED")
+      },
+    })
+    expect(result.ok).toBe(false)
+    expect(result.status).toBeNull()
+    expect(result.hint).toContain("reach")
+  })
+})

--- a/evals/flows/llm-provider-test-connection-api.flow.mjs
+++ b/evals/flows/llm-provider-test-connection-api.flow.mjs
@@ -1,0 +1,194 @@
+/**
+ * den-api `POST /v1/llm-providers/test-connection`: probing an
+ * OpenAI-compatible endpoint returns the models it actually serves, heals
+ * common base-URL mistakes, distinguishes bad keys, and refuses cloud
+ * metadata targets.
+ *
+ * Driven from a real signed-in Den web session (Chrome CDP): every request
+ * goes through the dashboard's `/api/den` proxy with the session cookie —
+ * i.e. exactly what the provider editor will call in the follow-up PR. The
+ * upstream endpoint is a real local HTTP server started by this flow.
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_WEB_URL   Den web origin (e.g. http://localhost:3015)
+ * - OPENWORK_EVAL_DEN_EMAIL     Seeded user email (sign-in fallback)
+ * - OPENWORK_EVAL_DEN_PASSWORD  Seeded user password (sign-in fallback)
+ */
+
+import { createServer } from "node:http";
+
+const MOCK_PORT = 18091;
+const GOOD_KEY = "test-key-123";
+const MOCK_MODELS = ["gpt-5-mini", "gpt-5.2-chat", "dall-e-2"];
+
+function startMockOpenAiServer() {
+  const server = createServer((req, res) => {
+    const auth = req.headers.authorization ?? "";
+    const apiKey = req.headers["api-key"];
+    const authorized = auth === `Bearer ${GOOD_KEY}` || apiKey === GOOD_KEY;
+    if (req.method === "GET" && req.url === "/v1/models") {
+      if (!authorized) {
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { message: "invalid api key" } }));
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ object: "list", data: MOCK_MODELS.map((id) => ({ id, object: "model" })) }));
+      return;
+    }
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: { message: "not found" } }));
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(MOCK_PORT, "127.0.0.1", () => resolve(server));
+  });
+}
+
+// Runs a probe from inside the signed-in dashboard page (session cookie +
+// same-origen /api/den proxy — the exact path the provider editor uses).
+const probeExpr = (body) => `(async () => {
+  const response = await fetch("/api/den/v1/llm-providers/test-connection", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: ${JSON.stringify(JSON.stringify(body))},
+  });
+  const payload = await response.json().catch(() => null);
+  return { status: response.status, result: payload?.result ?? null };
+})()`;
+
+export default {
+  id: "llm-provider-test-connection-api",
+  title: "Provider test-connection probe returns real models and heals URLs",
+  spec: "evals/cloud-provider-sync-flows.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_EMAIL", "OPENWORK_EVAL_DEN_PASSWORD"],
+  steps: [
+    {
+      name: "Signed-in dashboard session is available (signs in if needed)",
+      run: async (ctx) => {
+        const origin = ctx.env.OPENWORK_EVAL_DEN_WEB_URL.trim().replace(/\/+$/, "");
+        const onOrigin = await ctx.eval(`location.origin === ${JSON.stringify(origin)}`);
+        if (!onOrigin) {
+          await ctx.eval(`(() => { location.href = ${JSON.stringify(`${origin}/`)}; return true; })()`);
+        }
+        await ctx.waitFor(
+          `location.origin === ${JSON.stringify(origin)} && document.readyState === "complete"`,
+          { timeoutMs: 30_000, label: "den web loaded" },
+        );
+
+        const me = await ctx.eval(
+          `fetch("/api/den/v1/me", { credentials: "include" }).then((r) => r.status)`,
+          { awaitPromise: true },
+        );
+        if (me !== 200) {
+          ctx.log("No session; signing in via the auth API.");
+          const signIn = await ctx.eval(`(async () => {
+            const response = await fetch("/api/auth/sign-in/email", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              credentials: "include",
+              body: JSON.stringify({
+                email: ${JSON.stringify(ctx.env.OPENWORK_EVAL_DEN_EMAIL)},
+                password: ${JSON.stringify(ctx.env.OPENWORK_EVAL_DEN_PASSWORD)},
+              }),
+            });
+            return response.status;
+          })()`, { awaitPromise: true });
+          ctx.assert(signIn === 200, `Sign-in failed (${signIn}).`);
+          const meAfter = await ctx.eval(
+            `fetch("/api/den/v1/me", { credentials: "include" }).then((r) => r.status)`,
+            { awaitPromise: true },
+          );
+          ctx.assert(meAfter === 200, `Session still not valid after sign-in (GET /v1/me -> ${meAfter}).`);
+        }
+      },
+    },
+    {
+      name: "Start the mock OpenAI-compatible endpoint",
+      run: async (ctx) => {
+        ctx.mockServer = await startMockOpenAiServer();
+        ctx.log(`Mock endpoint listening on 127.0.0.1:${MOCK_PORT}`);
+      },
+    },
+    {
+      name: "Probe heals a wrong URL suffix and returns the served models",
+      run: async (ctx) => {
+        await ctx.prove("A probe with the exact real-world URL mistake still finds the models", {
+          action: async () => {
+            // The literal mistake from the customer session: a pasted URL
+            // ending in /chat/completions instead of the bare /v1 base.
+            ctx.probe = await ctx.eval(
+              probeExpr({ api: `http://127.0.0.1:${MOCK_PORT}/v1/chat/completions`, apiKey: GOOD_KEY }),
+              { awaitPromise: true },
+            );
+          },
+          assert: async () => {
+            const { status, result } = ctx.probe;
+            ctx.assert(status === 200, `Probe endpoint returned ${status}`);
+            ctx.assert(result?.ok === true, `Probe not ok: ${JSON.stringify(result)}`);
+            ctx.assert(
+              result.normalizedApi === `http://127.0.0.1:${MOCK_PORT}/v1`,
+              `URL not normalized: ${result.normalizedApi}`,
+            );
+            const ids = (result.models ?? []).map((m) => m.id);
+            for (const id of MOCK_MODELS) {
+              ctx.assert(ids.includes(id), `Missing model ${id} in ${ids.join(",")}`);
+            }
+            ctx.recordEvidence({
+              type: "assertion",
+              status: "passed",
+              assertion: `Probe normalized ${MOCK_PORT}/v1/chat/completions -> /v1 and returned ${ids.length} real models`,
+            });
+          },
+          screenshot: {
+            name: "probe-ok",
+            claim: "Signed-in dashboard session can probe an endpoint and get its real model list.",
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "A bad key is reported as a key problem, not a mystery",
+      run: async (ctx) => {
+        const { status, result } = await ctx.eval(
+          probeExpr({ api: `http://127.0.0.1:${MOCK_PORT}/v1`, apiKey: "wrong-key" }),
+          { awaitPromise: true },
+        );
+        ctx.assert(status === 200, `Probe endpoint returned ${status}`);
+        ctx.assert(result?.ok === false, "Expected ok=false for a rejected key");
+        ctx.assert(result.status === 401, `Expected upstream 401, got ${result.status}`);
+        ctx.assert(/key/i.test(result.hint ?? ""), `Hint does not mention the key: ${result.hint}`);
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "Rejected key produced ok=false, upstream 401, and a key-focused hint",
+        });
+      },
+    },
+    {
+      name: "Cloud metadata targets are refused",
+      run: async (ctx) => {
+        const { status, result } = await ctx.eval(
+          probeExpr({ api: "http://169.254.169.254/v1", apiKey: "k" }),
+          { awaitPromise: true },
+        );
+        ctx.assert(status === 200, `Probe endpoint returned ${status}`);
+        ctx.assert(result?.ok === false, "Expected ok=false for a metadata target");
+        ctx.assert(/not allowed/i.test(result.hint ?? ""), `Hint missing block reason: ${result.hint}`);
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "SSRF guard refused the cloud metadata endpoint",
+        });
+      },
+    },
+    {
+      name: "Stop the mock endpoint",
+      run: async (ctx) => {
+        await new Promise((resolve) => ctx.mockServer?.close(resolve));
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Why

PR 1 of the provider-setup wizard series (probe → pick models → verify-on-save). Every provider-setup failure in the customer onboarding sessions — `DeploymentNotFound`, wrong base URL (`/responses` suffix, `openai.azure.com` vs `services.ai.azure.com`), bad keys — was discoverable by asking the endpoint itself. This adds the server capability the editor UI will consume in PR 2.

## What

`POST /v1/llm-providers/test-connection` (org-member guarded, nothing stored):

- **URL healing**: strips `/responses`, `/chat/completions`, `/models`, trailing slashes; tries the Azure host twin and bare-origin `/openai/v1` variants in order — the exact real-world mistakes we watched happen
- **`GET /models` probe** with both `Authorization: Bearer` and `api-key` headers (Azure accepts either; compatible servers ignore the extra) → returns served model ids (= Azure deployment names)
- **Human hints on failure**: bad key (401/403) vs wrong URL (404) vs unreachable, plus upstream status
- **SSRF guards**: cloud metadata + link-local always blocked, loopback only in `OPENWORK_DEV_MODE`, response size + timeout bounds, redirects refused

Pure logic (`llm/endpoint-probe.ts`) is separated from I/O with injectable fetch.

## Tests / evidence

- `bun test test/llm-endpoint-probe.test.ts` — **10 pass** (URL candidates incl. the literal customer mistakes, twin fallback, 401 hinting, metadata/loopback blocks, network failure)
- `tsc --noEmit` (den-api) — clean
- fraimz (`llm-provider-test-connection-api`) — **PASSED** against the real local Den stack: a signed-in Den web session probes a real local mock OpenAI endpoint through the dashboard's `/api/den` proxy and the flow asserts: `/v1/chat/completions` input healed to `/v1` + full model list returned; wrong key → `ok:false`, upstream 401, key-focused hint; `169.254.169.254` refused
- Full den-api suite: 194/195 — the 1 failure (`route-guard-policy`) **fails identically on clean origin/dev** (pre-existing uncovered routes like `ALL /mcp/agent`); the new route is guarded by `orgMemberRoute`

## Next in series

PR 2: den-web editor consumes this — probe on URL+key entry, model picker replaces free-text IDs. PR 3: verify-on-save (per-model test completion + automatic `max_completion_tokens`/npm remediation).