### PR TITLE
wip: provider wizard PR3 — verify-on-save + automatic max_completion_tokens remediation

### DIFF
--- a/ee/apps/den-api/src/llm/endpoint-probe.ts
+++ b/ee/apps/den-api/src/llm/endpoint-probe.ts
@@ -294,3 +294,137 @@ export async function probeEndpoint(input: {
     status: lastStatus,
   }
 }
+
+export type ModelVerification = {
+  id: string
+  /**
+   * ok       — works with the default openai-compatible request shape
+   * adjusted — works after switching to the OpenAI package request shape
+   *            (max_completion_tokens; GPT-5/o-series on Azure)
+   * failed   — neither shape produced a successful completion
+   */
+  status: "ok" | "adjusted" | "failed"
+  /** The AI SDK package the provider config should use for this model. */
+  npm: "@ai-sdk/openai-compatible" | "@ai-sdk/openai"
+  message: string | null
+}
+
+const VERIFY_TIMEOUT_MS = 20_000
+const MAX_VERIFY_MODELS = 8
+
+function truncate(value: string, max = 300): string {
+  return value.length <= max ? value : `${value.slice(0, max - 3)}...`
+}
+
+function readErrorMessage(payload: unknown): { message: string; param: string | null } {
+  if (isRecord(payload) && isRecord(payload.error)) {
+    const message = typeof payload.error.message === "string" ? payload.error.message : ""
+    const param = typeof payload.error.param === "string" ? payload.error.param : null
+    return { message, param }
+  }
+  return { message: "", param: null }
+}
+
+async function completionAttempt(
+  fetchImpl: FetchLike,
+  base: string,
+  apiKey: string,
+  modelId: string,
+  tokenParam: "max_tokens" | "max_completion_tokens",
+): Promise<{ ok: boolean; needsCompletionTokens: boolean; message: string | null }> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS)
+  try {
+    const response = await fetchImpl(`${base}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "api-key": apiKey,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: modelId,
+        messages: [{ role: "user", content: "Reply with the single word: ok" }],
+        [tokenParam]: 16,
+      }),
+      signal: controller.signal,
+      redirect: "error",
+    })
+    if (response.ok) {
+      return { ok: true, needsCompletionTokens: false, message: null }
+    }
+    const payload = await readBoundedJson(response)
+    const { message, param } = readErrorMessage(payload)
+    const needsCompletionTokens =
+      response.status === 400 &&
+      (param === "max_tokens" || /max_completion_tokens/i.test(message))
+    return {
+      ok: false,
+      needsCompletionTokens,
+      message: truncate(message || `HTTP ${response.status}`),
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      needsCompletionTokens: false,
+      message: truncate(error instanceof Error ? error.message : "Request failed."),
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Send one tiny real completion per model to determine the request shape
+ * the model accepts. GPT-5/o-series models on Azure reject `max_tokens`
+ * (the openai-compatible default) and require `max_completion_tokens`
+ * (the OpenAI package behavior) — detected here so the editor can pick
+ * the right package automatically instead of surfacing a 400 in chat.
+ */
+export async function verifyModels(input: {
+  api: string
+  apiKey: string
+  modelIds: string[]
+  fetchImpl?: FetchLike
+  allowLoopback?: boolean
+}): Promise<ModelVerification[]> {
+  const fetchImpl: FetchLike = input.fetchImpl ?? ((url, init) => fetch(url, init))
+  const base = normalizeBase(input.api)
+  const ids = [...new Set(input.modelIds.map((id) => id.trim()).filter(Boolean))].slice(
+    0,
+    MAX_VERIFY_MODELS,
+  )
+  if (!base || ids.length === 0) return []
+  assertProbeUrlAllowed(base, { allowLoopback: input.allowLoopback })
+
+  const results: ModelVerification[] = []
+  for (const id of ids) {
+    const first = await completionAttempt(fetchImpl, base, input.apiKey, id, "max_tokens")
+    if (first.ok) {
+      results.push({ id, status: "ok", npm: "@ai-sdk/openai-compatible", message: null })
+      continue
+    }
+    if (first.needsCompletionTokens) {
+      const second = await completionAttempt(
+        fetchImpl,
+        base,
+        input.apiKey,
+        id,
+        "max_completion_tokens",
+      )
+      if (second.ok) {
+        results.push({
+          id,
+          status: "adjusted",
+          npm: "@ai-sdk/openai",
+          message: "Model requires max_completion_tokens; using the OpenAI request shape.",
+        })
+        continue
+      }
+      results.push({ id, status: "failed", npm: "@ai-sdk/openai", message: second.message })
+      continue
+    }
+    results.push({ id, status: "failed", npm: "@ai-sdk/openai-compatible", message: first.message })
+  }
+  return results
+}

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -14,7 +14,7 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
 import { CustomProviderConfigError, normalizeCustomProviderConfig } from "../../llm/custom-provider.js"
-import { probeEndpoint } from "../../llm/endpoint-probe.js"
+import { probeEndpoint, verifyModels } from "../../llm/endpoint-probe.js"
 import {
   jsonValidator,
   orgMemberRoute,
@@ -96,6 +96,7 @@ const llmProviderWriteSchema = z.object({
 const endpointProbeRequestSchema = z.object({
   api: z.string().trim().min(1).max(2048),
   apiKey: z.string().trim().max(65535).optional(),
+  modelIds: z.array(z.string().trim().min(1).max(255)).max(8).optional(),
 })
 
 const endpointProbeResponseSchema = z.object({
@@ -108,6 +109,12 @@ const endpointProbeResponseSchema = z.object({
     hint: z.string().nullable(),
     status: z.number().nullable(),
   }),
+  verifications: z.array(z.object({
+    id: z.string(),
+    status: z.enum(["ok", "adjusted", "failed"]),
+    npm: z.enum(["@ai-sdk/openai-compatible", "@ai-sdk/openai"]),
+    message: z.string().nullable(),
+  })).optional(),
 }).meta({ ref: "LlmProviderTestConnectionResponse" })
 
 const providerCatalogListResponseSchema = z.object({
@@ -513,6 +520,14 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
     async (c) => {
       const input = c.req.valid("json")
       const result = await probeEndpoint({ api: input.api, apiKey: input.apiKey ?? "" })
+      if (result.ok && result.normalizedApi && input.modelIds?.length) {
+        const verifications = await verifyModels({
+          api: result.normalizedApi,
+          apiKey: input.apiKey ?? "",
+          modelIds: input.modelIds,
+        })
+        return c.json({ result, verifications })
+      }
       return c.json({ result })
     },
   )

--- a/ee/apps/den-api/test/llm-endpoint-probe.test.ts
+++ b/ee/apps/den-api/test/llm-endpoint-probe.test.ts
@@ -139,3 +139,84 @@ describe("probeEndpoint", () => {
     expect(result.hint).toContain("reach")
   })
 })
+
+import { verifyModels } from "../src/llm/endpoint-probe.js"
+
+const azureMaxTokensError = () =>
+  jsonResponse(400, {
+    error: {
+      message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+      type: "invalid_request_error",
+      param: "max_tokens",
+      code: "unsupported_parameter",
+    },
+  })
+
+describe("verifyModels", () => {
+  test("a classic model passes with the compatible request shape", async () => {
+    const results = await verifyModels({
+      api: "https://llm.example.com/v1",
+      apiKey: "k",
+      modelIds: ["classic"],
+      allowLoopback: false,
+      fetchImpl: async (url, init) => {
+        expect(url).toBe("https://llm.example.com/v1/chat/completions")
+        const body = JSON.parse(String(init.body))
+        expect(body.max_tokens).toBe(16)
+        return jsonResponse(200, { choices: [{ message: { content: "ok" } }] })
+      },
+    })
+    expect(results).toEqual([
+      { id: "classic", status: "ok", npm: "@ai-sdk/openai-compatible", message: null },
+    ])
+  })
+
+  test("a GPT-5-style model is auto-adjusted to the OpenAI request shape", async () => {
+    const bodies: Array<Record<string, unknown>> = []
+    const results = await verifyModels({
+      api: "https://r.services.ai.azure.com/openai/v1",
+      apiKey: "k",
+      modelIds: ["gpt-5-mini"],
+      allowLoopback: false,
+      fetchImpl: async (_url, init) => {
+        const body = JSON.parse(String(init.body))
+        bodies.push(body)
+        if (body.max_tokens !== undefined) return azureMaxTokensError()
+        expect(body.max_completion_tokens).toBe(16)
+        return jsonResponse(200, { choices: [{ message: { content: "ok" } }] })
+      },
+    })
+    expect(bodies.length).toBe(2)
+    expect(results[0].status).toBe("adjusted")
+    expect(results[0].npm).toBe("@ai-sdk/openai")
+  })
+
+  test("a model failing both shapes reports the upstream message", async () => {
+    const results = await verifyModels({
+      api: "https://llm.example.com/v1",
+      apiKey: "k",
+      modelIds: ["broken"],
+      allowLoopback: false,
+      fetchImpl: async () =>
+        jsonResponse(404, { error: { message: "The API deployment for this resource does not exist.", code: "DeploymentNotFound" } }),
+    })
+    expect(results[0].status).toBe("failed")
+    expect(results[0].message).toContain("deployment")
+  })
+
+  test("dedupes and caps the model list", async () => {
+    let calls = 0
+    const results = await verifyModels({
+      api: "https://llm.example.com/v1",
+      apiKey: "k",
+      modelIds: ["a", "a", "b"],
+      allowLoopback: false,
+      fetchImpl: async () => {
+        calls += 1
+        return jsonResponse(200, {})
+      },
+    })
+    expect(results.length).toBe(2)
+    expect(calls).toBe(2)
+  })
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-data.tsx
@@ -365,6 +365,22 @@ export type LlmProviderProbeResult = {
   status: number | null;
 };
 
+export type LlmProviderModelVerification = {
+  id: string;
+  status: "ok" | "adjusted" | "failed";
+  npm: "@ai-sdk/openai-compatible" | "@ai-sdk/openai";
+  message: string | null;
+};
+
+function asModelVerification(value: unknown): LlmProviderModelVerification | null {
+  if (!isRecord(value)) return null;
+  const id = asString(value.id);
+  const status = value.status === "ok" || value.status === "adjusted" || value.status === "failed" ? value.status : null;
+  const npm = value.npm === "@ai-sdk/openai" ? "@ai-sdk/openai" : "@ai-sdk/openai-compatible";
+  if (!id || !status) return null;
+  return { id, status, npm, message: asString(value.message) };
+}
+
 function asProbeResult(value: unknown): LlmProviderProbeResult | null {
   if (!isRecord(value)) return null;
   const models = Array.isArray(value.models)
@@ -389,11 +405,16 @@ function asProbeResult(value: unknown): LlmProviderProbeResult | null {
  * Probe an OpenAI-compatible endpoint through den-api: heals common URL
  * mistakes and returns the model ids the endpoint actually serves.
  */
-export async function requestLlmProviderTestConnection(input: { api: string; apiKey?: string }) {
+export async function requestLlmProviderTestConnection(input: {
+  api: string;
+  apiKey?: string;
+  modelIds?: string[];
+}) {
+  const timeoutMs = input.modelIds?.length ? 60000 : 20000;
   const { response, payload } = await requestJson(
     `/v1/llm-providers/test-connection`,
     { method: "POST", body: JSON.stringify(input) },
-    20000,
+    timeoutMs,
   );
   if (!response.ok) {
     throw new Error(getErrorMessage(payload, `Endpoint test failed (${response.status}).`));
@@ -402,7 +423,12 @@ export async function requestLlmProviderTestConnection(input: { api: string; api
   if (!result) {
     throw new Error("Endpoint test returned an unexpected response.");
   }
-  return result;
+  const verifications = isRecord(payload) && Array.isArray(payload.verifications)
+    ? payload.verifications
+        .map(asModelVerification)
+        .filter((entry): entry is LlmProviderModelVerification => entry !== null)
+    : [];
+  return { ...result, verifications };
 }
 
 export async function requestLlmProviderCatalog(orgId: string) {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-guided.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-guided.ts
@@ -10,6 +10,9 @@
 type JsonRecord = Record<string, unknown>;
 
 export const GUIDED_PROVIDER_NPM = "@ai-sdk/openai-compatible";
+export const GUIDED_PROVIDER_NPM_OPENAI = "@ai-sdk/openai";
+
+const GUIDED_PROVIDER_NPM_PACKAGES = new Set([GUIDED_PROVIDER_NPM, GUIDED_PROVIDER_NPM_OPENAI]);
 
 const GUIDED_PROVIDER_CONFIG_KEYS = new Set(["id", "name", "npm", "env", "api", "doc"]);
 const GUIDED_MODEL_KEYS = new Set(["id", "name"]);
@@ -19,6 +22,7 @@ export type GuidedCustomProviderFields = {
     baseUrl: string;
     modelIds: string[];
     envName: string | null;
+    npm: string;
 };
 
 function isRecord(value: unknown): value is JsonRecord {
@@ -90,12 +94,14 @@ export function buildGuidedCustomProviderConfig(input: {
     baseUrl: string;
     modelIds: string[];
     envName?: string | null;
+    /** AI SDK package; verification may upgrade this to the OpenAI package. */
+    npm?: string | null;
 }): JsonRecord {
     const providerId = input.providerId.trim();
     return {
         id: providerId,
         name: input.name.trim() || providerId,
-        npm: GUIDED_PROVIDER_NPM,
+        npm: input.npm && GUIDED_PROVIDER_NPM_PACKAGES.has(input.npm) ? input.npm : GUIDED_PROVIDER_NPM,
         env: [input.envName?.trim() || buildGuidedProviderEnvName(providerId)],
         api: input.baseUrl.trim().replace(/\/+$/, ""),
         models: input.modelIds.map((modelId) => ({ id: modelId, name: modelId })),
@@ -120,7 +126,8 @@ export function readGuidedCustomProviderFields(
         return null;
     }
 
-    if (asString(config.npm) !== GUIDED_PROVIDER_NPM) {
+    const npm = asString(config.npm);
+    if (!npm || !GUIDED_PROVIDER_NPM_PACKAGES.has(npm)) {
         return null;
     }
 
@@ -178,6 +185,7 @@ export function readGuidedCustomProviderFields(
         baseUrl,
         modelIds,
         envName: env[0] ?? null,
+        npm,
     };
 }
 


### PR DESCRIPTION
**DO NOT MERGE — WIP, stacked on #2421** (which itself is held until tomorrow evening per the dev stability hold).

The customer gpt-5 blocker fix: on Create, run one real completion per picked model; models that reject `max_tokens` (GPT-5/o-series on Azure) are silently switched to the OpenAI package (`max_completion_tokens`), failures get a per-model message + Save anyway.

Done: server `verifyModels` (+14 unit tests), endpoint extension, client data helper, guided-config npm override + round-trip.
Remaining: editor save wiring, guided tests update, fraimz flow.