### PR TITLE
git commit -m "refactor(app): remove old-server compatibility path in…

### DIFF
--- a/apps/app/src/app/lib/opencode.ts
+++ b/apps/app/src/app/lib/opencode.ts
@@ -189,32 +189,6 @@ async function wrapOpenworkRead<T>(
   }
 }
 
-function shouldFallbackToLegacySessionRead(error: unknown): boolean {
-  if (!(error instanceof OpenworkServerError)) return false;
-  return error.status === 404 || error.status === 405 || error.status === 501;
-}
-
-async function wrapOpenworkReadWithFallback<T>(
-  url: string,
-  read: () => Promise<T>,
-  fallback: () => Promise<FieldsResult<T>>,
-  options?: { throwOnError?: boolean },
-): Promise<FieldsResult<T>> {
-  try {
-    return createSyntheticResult(url, "GET", { ok: true, data: await read() });
-  } catch (error) {
-    if (!shouldFallbackToLegacySessionRead(error)) {
-      if (options?.throwOnError) throw error;
-      return createSyntheticResult(url, "GET", {
-        ok: false,
-        error,
-        status: error instanceof OpenworkServerError ? error.status : 500,
-      });
-    }
-    return fallback();
-  }
-}
-
 async function fetchWithTimeout(
   fetchImpl: typeof globalThis.fetch,
   input: RequestInfo | URL,
@@ -376,8 +350,6 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
     openworkMount && auth?.token
       ? createOpenworkServerClient({ baseUrl: openworkMount.baseUrl, token: auth.token })
       : null;
-  // TODO(2026-04-12): remove the old-server compatibility path here once all
-  // OpenWork servers expose the workspace-scoped session read APIs.
   const sessionOverrides = session as any as {
     list: (parameters?: SessionListParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<Session[]>>;
     get: (parameters: SessionLookupParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<Session>>;
@@ -398,10 +370,9 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
     if (parameters?.search?.trim()) query.set("search", parameters.search.trim());
     if (typeof parameters?.limit === "number") query.set("limit", String(parameters.limit));
     const url = `${openworkMount.baseUrl}/workspace/${encodeURIComponent(openworkMount.workspaceId)}/sessions${query.size ? `?${query.toString()}` : ""}`;
-    return wrapOpenworkReadWithFallback(
+    return wrapOpenworkRead(
       url,
       async () => (await openworkSessionClient.listSessions(openworkMount.workspaceId, parameters)).items,
-      () => listOriginal(parameters, options),
       options,
     );
   };
@@ -412,10 +383,9 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
       return getOriginal(parameters, options);
     }
     const url = `${openworkMount.baseUrl}/workspace/${encodeURIComponent(openworkMount.workspaceId)}/sessions/${encodeURIComponent(parameters.sessionID)}`;
-    return wrapOpenworkReadWithFallback(
+    return wrapOpenworkRead(
       url,
       async () => (await openworkSessionClient.getSession(openworkMount.workspaceId, parameters.sessionID)).item,
-      () => getOriginal(parameters, options),
       options,
     );
   };
@@ -428,13 +398,12 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
     const query = new URLSearchParams();
     if (typeof parameters.limit === "number") query.set("limit", String(parameters.limit));
     const url = `${openworkMount.baseUrl}/workspace/${encodeURIComponent(openworkMount.workspaceId)}/sessions/${encodeURIComponent(parameters.sessionID)}/messages${query.size ? `?${query.toString()}` : ""}`;
-    return wrapOpenworkReadWithFallback(
+    return wrapOpenworkRead(
       url,
       async () =>
         (await openworkSessionClient.getSessionMessages(openworkMount.workspaceId, parameters.sessionID, {
           limit: parameters.limit,
         })).items,
-      () => messagesOriginal(parameters, options),
       options,
     );
   };
@@ -445,10 +414,9 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
       return todoOriginal(parameters, options);
     }
     const url = `${openworkMount.baseUrl}/workspace/${encodeURIComponent(openworkMount.workspaceId)}/sessions/${encodeURIComponent(parameters.sessionID)}/snapshot`;
-    return wrapOpenworkReadWithFallback(
+    return wrapOpenworkRead(
       url,
       async () => (await openworkSessionClient.getSessionSnapshot(openworkMount.workspaceId, parameters.sessionID)).item.todos,
-      () => todoOriginal(parameters, options),
       options,
     );
   };


### PR DESCRIPTION
## Summary
- Removed the legacy compatibility fallback path for session reads in the OpenCode client wrapper.
- The client now uses the workspace-scoped OpenWork session APIs directly for listing sessions, reading session details, loading messages, and reading session snapshots/todos.
- Removed the old TODO comment and simplified the wrapper logic around the new session read flow.

## Why
- The previous implementation included a fallback path for older OpenWork servers.
- That compatibility layer added extra branching and made the session-read flow harder to reason about.
- Moving to the workspace-scoped endpoints directly makes the behavior more consistent and easier to maintain.

## Issue
- Closes # N/A (Codebase TODO cleanup)

## Scope
- Updated the OpenCode client integration in `apps/app/src/app/lib/opencode.ts`
- Simplified session read handling for:
  - session listing
  - session lookup
  - session messages
  - session snapshot/todo loading

## Out of scope
- No UI changes
- No new session features
- No changes to prompt/command execution behavior

## Testing
### Ran
- `pnpm --filter @openwork/app test:refactor`
- `pnpm --filter openwork-server exec bun test src/session-read-model.e2e.test.ts`
- `pnpm --filter @openwork/app test`
- `git diff --check -- apps/app/src/app/lib/opencode.ts`

### Result
- pass/fail: **PASS**
- All 8 server workspace session read model tests passed successfully.
- All 83 app Bun tests passed with 0 failures.
- App refactor suite (typecheck, health, sessions) completed with zero regressions.
- Diff whitespace check passed successfully.

## CI status
- pass: Pending (Will update once GitHub Actions complete)
- code-related failures: None
- external/env/auth blockers: None

## Manual verification
1. Connect to an OpenWork server that exposes the workspace-scoped session APIs.
2. Open an existing session and confirm that session details load correctly.
3. Verify that messages and todos/snapshot data load without regressions.

## Evidence
- `N/A (refactor-only)`

## Risk
- Low
- Risk is mostly around compatibility with older server versions that may not yet expose the new workspace-scoped session endpoints.

## Rollback
- Revert the changes in `apps/app/src/app/lib/opencode.ts` to restore the previous fallback-based behavior.