### PR TITLE
fix(app): silently re-authenticate remote OAuth MCPs on token expiry / app reopen

### DIFF
--- a/apps/app/src/react-app/domains/connections/mcp-silent-reauth.ts
+++ b/apps/app/src/react-app/domains/connections/mcp-silent-reauth.ts
@@ -1,0 +1,138 @@
+import type { McpServerEntry, McpStatusMap } from "../../../app/types";
+
+/**
+ * Silent re-auth for remote OAuth MCP connectors.
+ *
+ * The OpenCode engine only refreshes an expired MCP access token reactively,
+ * and at most once per transport lifetime. After the token expires (~1h for
+ * Google) or after a transient refresh failure at engine startup, the entry
+ * lands in `needs_auth` / `failed` and nothing retries it — users had to
+ * click "Sign in" manually even though the stored refresh token still works.
+ *
+ * `mcp.connect` builds a fresh transport in the engine, so the MCP SDK
+ * retries the stored refresh-token grant on the 401 — the same thing the
+ * manual "Sign in" button does, minus the browser fallback. The engine's
+ * connect path never opens a browser (its OAuth redirect handler is a
+ * no-op), so a genuinely revoked grant simply stays in "Sign in needed".
+ */
+
+/**
+ * Retry an unhealthy entry at most once per cooldown window. Short enough
+ * that a wake-from-sleep heal lands on the next status refresh even when
+ * the first attempt fired while the network was still down; long enough
+ * that a genuinely revoked grant doesn't get hammered on every refresh.
+ */
+export const SILENT_REAUTH_COOLDOWN_MS = 60 * 1000;
+
+export type SilentReauthClient = {
+  mcp: {
+    connect(parameters: { name: string; directory?: string }): Promise<unknown>;
+  };
+};
+
+export function silentReauthAttemptKey(directory: string, name: string): string {
+  return `${directory}\u0000${name}`;
+}
+
+/**
+ * An entry qualifies for silent re-auth when it is a remote, enabled,
+ * OAuth-capable connector (no static auth headers) that the engine reports
+ * as unhealthy. Header-authed entries are written with `oauth: false`, so
+ * they never qualify; neither do entries pending client registration, which
+ * always need an interactive flow.
+ */
+export function isSilentReauthCandidate(entry: McpServerEntry, statuses: McpStatusMap): boolean {
+  const status = statuses[entry.name]?.status;
+  if (status !== "needs_auth" && status !== "failed") return false;
+  const config = entry.config;
+  if (config.type !== "remote") return false;
+  if (config.enabled === false) return false;
+  if (config.oauth === false) return false;
+  if (config.headers && Object.keys(config.headers).length > 0) return false;
+  return true;
+}
+
+export function selectSilentReauthCandidates(input: {
+  directory: string;
+  servers: McpServerEntry[];
+  statuses: McpStatusMap;
+  now: number;
+  attempts: Map<string, number>;
+  cooldownMs?: number;
+}): string[] {
+  const cooldownMs = input.cooldownMs ?? SILENT_REAUTH_COOLDOWN_MS;
+  const names: string[] = [];
+  for (const entry of input.servers) {
+    const key = silentReauthAttemptKey(input.directory, entry.name);
+    if (input.statuses[entry.name]?.status === "connected") {
+      // Recovered — clear the cooldown so the next unhealthy episode gets
+      // a fresh silent attempt.
+      input.attempts.delete(key);
+      continue;
+    }
+    if (!isSilentReauthCandidate(entry, input.statuses)) continue;
+    const lastAttemptAt = input.attempts.get(key);
+    if (lastAttemptAt !== undefined && input.now - lastAttemptAt < cooldownMs) continue;
+    names.push(entry.name);
+  }
+  return names;
+}
+
+// Module-level so the cooldown survives store/component remounts.
+const defaultAttempts = new Map<string, number>();
+const inFlight = new Set<string>();
+
+/**
+ * Fire `mcp.connect` for every eligible unhealthy entry. Returns true when
+ * at least one reconnect was attempted — the caller should then re-fetch
+ * MCP statuses to pick up the healed state. Best-effort by design: failures
+ * leave the entry unhealthy and the manual "Sign in" path untouched.
+ */
+export async function attemptSilentMcpReauth(input: {
+  client: SilentReauthClient;
+  directory: string;
+  servers: McpServerEntry[];
+  statuses: McpStatusMap;
+  now?: number;
+  attempts?: Map<string, number>;
+  cooldownMs?: number;
+}): Promise<boolean> {
+  const directory = input.directory.trim();
+  if (!directory) return false;
+
+  const attempts = input.attempts ?? defaultAttempts;
+  const now = input.now ?? Date.now();
+  const names = selectSilentReauthCandidates({
+    directory,
+    servers: input.servers,
+    statuses: input.statuses,
+    now,
+    attempts,
+    cooldownMs: input.cooldownMs,
+  }).filter((name) => !inFlight.has(silentReauthAttemptKey(directory, name)));
+  if (names.length === 0) return false;
+
+  for (const name of names) {
+    const key = silentReauthAttemptKey(directory, name);
+    attempts.set(key, now);
+    inFlight.add(key);
+  }
+
+  try {
+    await Promise.all(
+      names.map(async (name) => {
+        try {
+          await input.client.mcp.connect({ name, directory });
+        } catch {
+          // Reconnect is best-effort; the entry stays unhealthy and the
+          // user can still sign in manually.
+        }
+      }),
+    );
+  } finally {
+    for (const name of names) {
+      inFlight.delete(silentReauthAttemptKey(directory, name));
+    }
+  }
+  return true;
+}

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -39,6 +39,7 @@ import type {
 import { isDesktopRuntime, normalizeDirectoryPath, safeStringify } from "../../../app/utils";
 
 import type { OpenworkServerStore } from "./openwork-server-store";
+import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
 import {
   CLOUD_MCP_SERVER_NAME,
   clearCloudMcpUserState,
@@ -398,6 +399,37 @@ export function createConnectionsStore(options: {
     return undefined;
   };
 
+  /**
+   * Quiet self-heal for remote OAuth MCPs stuck in "Sign in needed": the
+   * engine only refreshes tokens reactively (once per transport), so an
+   * expired access token strands the entry until the user clicks Sign in.
+   * `mcp.connect` retries the stored refresh-token grant on a fresh
+   * transport — silently, never opening a browser or modal. Mirrors
+   * syncCloudControlMcp, but for user-added connectors.
+   */
+  async function healUnhealthyMcpEntries(servers: McpServerEntry[], statuses: McpStatusMap) {
+    if (disposed || snapshot.mcpAuthModalOpen || snapshot.mcpConnectingName) return;
+    const activeClient = options.client();
+    const projectDir = options.projectDir().trim();
+    if (!activeClient || !projectDir) return;
+    const attempted = await attemptSilentMcpReauth({
+      client: activeClient,
+      directory: projectDir,
+      servers,
+      statuses,
+    }).catch(() => false);
+    if (!attempted || disposed) return;
+    try {
+      const status = unwrap(await activeClient.mcp.status({ directory: projectDir }));
+      setStateField(
+        "mcpStatuses",
+        filterConfiguredStatuses(status as McpStatusMap, snapshot.mcpServers),
+      );
+    } catch {
+      // Post-heal status refresh is best-effort; the next refresh picks it up.
+    }
+  }
+
   async function refreshMcpServers() {
     if (disposed) return;
 
@@ -422,6 +454,7 @@ export function createConnectionsStore(options: {
             ? `Some MCPs could not be registered with the engine: ${failedNames}. They may appear disconnected — try reloading the engine.`
             : serverResult.next.length ? null : "No MCP servers configured yet.",
         }));
+        void healUnhealthyMcpEntries(serverResult.next, serverResult.nextStatuses);
         return;
       }
     } catch (error) {
@@ -539,6 +572,7 @@ export function createConnectionsStore(options: {
         mcpStatuses: nextStatuses,
         mcpStatus: next.length ? null : "No MCP servers configured yet.",
       }));
+      void healUnhealthyMcpEntries(next, nextStatuses);
     } catch (error) {
       mutateState((current) => ({
         ...current,

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -32,6 +32,7 @@ import {
   recordInspectorEvent,
 } from "@/app/lib/app-inspector";
 import { useControlAction, type OpenworkControlAction } from "@/react-app/shell/control/control-provider";
+import { attemptSilentMcpReauth } from "@/react-app/domains/connections/mcp-silent-reauth";
 import { ReactSessionComposer } from "./composer/composer";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./composer/mention-encoding";
 import { desktopBridge } from "@/app/lib/desktop";
@@ -1075,6 +1076,24 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setToolMcpServers(servers);
     setToolMcpStatuses(statuses);
     setToolMcpStatus(status);
+
+    // Quiet self-heal: remote OAuth connectors whose access token expired
+    // show "Sign in needed" even though the stored refresh token still
+    // works. `mcp.connect` retries the refresh grant on a fresh transport
+    // without ever opening a browser; on success the badge flips live.
+    const directory = props.workspaceRoot.trim();
+    if (directory && servers.length) {
+      void attemptSilentMcpReauth({ client: opencodeClient, directory, servers, statuses })
+        .then(async (attempted) => {
+          if (!attempted) return;
+          const healed = unwrap(await opencodeClient.mcp.status({ directory })) as McpStatusMap;
+          setToolMcpStatuses(healed);
+        })
+        .catch(() => {
+          // Best-effort; the manual Sign in path is unaffected.
+        });
+    }
+
     return { servers, statuses, status };
   };
 

--- a/apps/app/tests/mcp-silent-reauth.test.ts
+++ b/apps/app/tests/mcp-silent-reauth.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  attemptSilentMcpReauth,
+  isSilentReauthCandidate,
+  selectSilentReauthCandidates,
+  SILENT_REAUTH_COOLDOWN_MS,
+  silentReauthAttemptKey,
+} from "../src/react-app/domains/connections/mcp-silent-reauth";
+import type { McpServerEntry, McpStatusMap } from "../src/app/types";
+
+const DIR = "/tmp/workspace";
+
+function remoteOauthEntry(name: string, config: Partial<McpServerEntry["config"]> = {}): McpServerEntry {
+  return {
+    name,
+    config: { type: "remote", url: "https://example.com/mcp", ...config },
+  };
+}
+
+describe("isSilentReauthCandidate", () => {
+  test("accepts unhealthy remote oauth entries", () => {
+    const entry = remoteOauthEntry("crm");
+    expect(isSilentReauthCandidate(entry, { crm: { status: "needs_auth" } })).toBe(true);
+    expect(isSilentReauthCandidate(entry, { crm: { status: "failed", error: "Connection closed" } })).toBe(true);
+  });
+
+  test("rejects healthy, interactive-only, and non-oauth entries", () => {
+    const entry = remoteOauthEntry("crm");
+    expect(isSilentReauthCandidate(entry, { crm: { status: "connected" } })).toBe(false);
+    expect(isSilentReauthCandidate(entry, { crm: { status: "disabled" } })).toBe(false);
+    expect(isSilentReauthCandidate(entry, { crm: { status: "needs_client_registration", error: "register" } })).toBe(false);
+    expect(isSilentReauthCandidate(entry, {})).toBe(false);
+
+    const statuses: McpStatusMap = { crm: { status: "needs_auth" } };
+    expect(isSilentReauthCandidate(remoteOauthEntry("crm", { oauth: false }), statuses)).toBe(false);
+    expect(
+      isSilentReauthCandidate(remoteOauthEntry("crm", { headers: { Authorization: "Bearer x" } }), statuses),
+    ).toBe(false);
+    expect(isSilentReauthCandidate(remoteOauthEntry("crm", { enabled: false }), statuses)).toBe(false);
+    expect(
+      isSilentReauthCandidate({ name: "crm", config: { type: "local", command: ["mcp"] } }, statuses),
+    ).toBe(false);
+  });
+});
+
+describe("selectSilentReauthCandidates", () => {
+  test("applies the cooldown per entry and resets it on recovery", () => {
+    const attempts = new Map<string, number>();
+    const servers = [remoteOauthEntry("crm")];
+    const unhealthy: McpStatusMap = { crm: { status: "needs_auth" } };
+
+    expect(
+      selectSilentReauthCandidates({ directory: DIR, servers, statuses: unhealthy, now: 1_000, attempts }),
+    ).toEqual(["crm"]);
+
+    attempts.set(silentReauthAttemptKey(DIR, "crm"), 1_000);
+    expect(
+      selectSilentReauthCandidates({ directory: DIR, servers, statuses: unhealthy, now: 2_000, attempts }),
+    ).toEqual([]);
+    expect(
+      selectSilentReauthCandidates({
+        directory: DIR,
+        servers,
+        statuses: unhealthy,
+        now: 1_000 + SILENT_REAUTH_COOLDOWN_MS,
+        attempts,
+      }),
+    ).toEqual(["crm"]);
+
+    // A connected pass clears the cooldown so the next episode retries
+    // immediately.
+    selectSilentReauthCandidates({
+      directory: DIR,
+      servers,
+      statuses: { crm: { status: "connected" } },
+      now: 2_000,
+      attempts,
+    });
+    expect(attempts.has(silentReauthAttemptKey(DIR, "crm"))).toBe(false);
+    expect(
+      selectSilentReauthCandidates({ directory: DIR, servers, statuses: unhealthy, now: 3_000, attempts }),
+    ).toEqual(["crm"]);
+  });
+
+  test("scopes cooldowns by directory", () => {
+    const attempts = new Map<string, number>([[silentReauthAttemptKey("/other", "crm"), 1_000]]);
+    expect(
+      selectSilentReauthCandidates({
+        directory: DIR,
+        servers: [remoteOauthEntry("crm")],
+        statuses: { crm: { status: "needs_auth" } },
+        now: 1_001,
+        attempts,
+      }),
+    ).toEqual(["crm"]);
+  });
+});
+
+describe("attemptSilentMcpReauth", () => {
+  test("connects each eligible entry once and reports the attempt", async () => {
+    const connected: string[] = [];
+    const client = {
+      mcp: {
+        connect: async ({ name }: { name: string; directory?: string }) => {
+          connected.push(name);
+          return true;
+        },
+      },
+    };
+    const attempts = new Map<string, number>();
+    const servers = [
+      remoteOauthEntry("crm"),
+      remoteOauthEntry("header-authed", { headers: { Authorization: "Bearer x" }, oauth: false }),
+      remoteOauthEntry("healthy"),
+    ];
+    const statuses: McpStatusMap = {
+      crm: { status: "needs_auth" },
+      "header-authed": { status: "needs_auth" },
+      healthy: { status: "connected" },
+    };
+
+    await expect(
+      attemptSilentMcpReauth({ client, directory: DIR, servers, statuses, now: 1_000, attempts }),
+    ).resolves.toBe(true);
+    expect(connected).toEqual(["crm"]);
+
+    // Second pass inside the cooldown window is a no-op.
+    await expect(
+      attemptSilentMcpReauth({ client, directory: DIR, servers, statuses, now: 2_000, attempts }),
+    ).resolves.toBe(false);
+    expect(connected).toEqual(["crm"]);
+  });
+
+  test("swallows connect failures and still records the attempt", async () => {
+    const client = {
+      mcp: {
+        connect: async () => {
+          throw new Error("engine unavailable");
+        },
+      },
+    };
+    const attempts = new Map<string, number>();
+    await expect(
+      attemptSilentMcpReauth({
+        client,
+        directory: DIR,
+        servers: [remoteOauthEntry("crm")],
+        statuses: { crm: { status: "failed", error: "Connection closed" } },
+        now: 1_000,
+        attempts,
+      }),
+    ).resolves.toBe(true);
+    expect(attempts.get(silentReauthAttemptKey(DIR, "crm"))).toBe(1_000);
+  });
+
+  test("returns false for a blank directory", async () => {
+    const client = {
+      mcp: {
+        connect: async () => true,
+      },
+    };
+    await expect(
+      attemptSilentMcpReauth({
+        client,
+        directory: "  ",
+        servers: [remoteOauthEntry("crm")],
+        statuses: { crm: { status: "needs_auth" } },
+        attempts: new Map(),
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/evals/flows/mcp-oauth-silent-reauth.flow.mjs
+++ b/evals/flows/mcp-oauth-silent-reauth.flow.mjs
@@ -1,0 +1,316 @@
+/**
+ * Silent re-auth for remote OAuth MCP connectors (issue: "Sign in needed"
+ * every ~1h / on app reopen even though the stored refresh token works).
+ *
+ * The OpenCode engine only refreshes MCP access tokens reactively — once per
+ * transport — so an expired token or a transient outage at engine boot
+ * strands the connector in "Sign in needed"/"Issue" until the user clicks
+ * Sign in manually. OpenWork now heals this quietly: every MCP status
+ * refresh retries `mcp.connect` for unhealthy remote OAuth entries, which
+ * re-runs the refresh-token grant on a fresh transport without ever opening
+ * a browser or modal (apps/app/src/react-app/domains/connections/mcp-silent-reauth.ts).
+ *
+ * This flow proves it end-to-end against a real OAuth MCP server
+ * (scripts/mock-oauth-mcp-server.mjs — real authorization-code + PKCE +
+ * refresh grants; in-memory access tokens so a restart invalidates them):
+ *
+ *   1. One-time interactive sign-in for a custom "Advanced OAuth"
+ *      (pre-registered client) connector → Ready.
+ *   2. The connector's API goes down and OpenWork "reopens" (engine
+ *      restart) → connector is stranded (the reported bug state).
+ *   3. The API comes back. With zero clicks beyond a status refresh, the
+ *      connector flips back to Ready. Ground truth from the mock IdP's
+ *      request log: exactly a refresh-token grant (POST /token) and NO
+ *      interactive authorization (GET /authorize), no sign-in modal.
+ */
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const MOCK_PORT = 4517;
+const MOCK_BASE = `http://127.0.0.1:${MOCK_PORT}`;
+const MCP_NAME = "mock-oauth-crm";
+const SERVER_SCRIPT = fileURLToPath(new URL("../../scripts/mock-oauth-mcp-server.mjs", import.meta.url));
+
+let mockChild = null;
+
+async function mockHealthy() {
+  try {
+    const response = await fetch(`${MOCK_BASE}/health`, { signal: AbortSignal.timeout(1_500) });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function startMock(ctx) {
+  if (await mockHealthy()) {
+    throw new Error(`Port ${MOCK_PORT} is already serving; stop it before running this flow.`);
+  }
+  mockChild = spawn(process.execPath, [SERVER_SCRIPT], {
+    env: { ...process.env, PORT: String(MOCK_PORT) },
+    stdio: "ignore",
+  });
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    if (await mockHealthy()) {
+      ctx.log(`Mock OAuth MCP server up at ${MOCK_BASE}`);
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("Mock OAuth MCP server did not become healthy.");
+}
+
+async function stopMock(ctx) {
+  if (!mockChild) return;
+  mockChild.kill("SIGKILL");
+  mockChild = null;
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 5_000) {
+    if (!(await mockHealthy())) {
+      ctx.log("Mock OAuth MCP server stopped.");
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error("Mock OAuth MCP server did not stop.");
+}
+
+async function mockRequests() {
+  const response = await fetch(`${MOCK_BASE}/requests`, { signal: AbortSignal.timeout(2_000) });
+  const payload = await response.json();
+  return payload.requests ?? [];
+}
+
+// The connector row in Extensions -> "YOUR APPS": climb from the exact-name
+// leaf to the row and report its friendly status label.
+const CARD_STATUS_EXPR = `(() => {
+  const leaves = [...document.querySelectorAll("*")].filter(
+    (e) => e.children.length === 0 && (e.textContent ?? "").trim() === ${JSON.stringify(MCP_NAME)},
+  );
+  const labels = ["Ready", "Sign in needed", "Issue", "Offline", "Paused"];
+  for (const leaf of leaves) {
+    let node = leaf;
+    for (let i = 0; i < 8 && node; i += 1) {
+      const text = node.textContent ?? "";
+      for (const label of labels) {
+        if (text.includes(label)) return label;
+      }
+      node = node.parentElement;
+    }
+  }
+  return null;
+})()`;
+
+async function cardStatus(ctx) {
+  return ctx.eval(CARD_STATUS_EXPR);
+}
+
+// The connector card lives below the fold in Extensions; frames must show it.
+async function scrollCardIntoView(ctx) {
+  await ctx.eval(`(() => {
+    const leaf = [...document.querySelectorAll("*")].find(
+      (e) => e.children.length === 0 && (e.textContent ?? "").trim() === ${JSON.stringify(MCP_NAME)},
+    );
+    if (leaf) leaf.scrollIntoView({ block: "center" });
+    return Boolean(leaf);
+  })()`);
+  await new Promise((resolve) => setTimeout(resolve, 500));
+}
+
+async function openExtensions(ctx) {
+  await ctx.eval(`(() => {
+    const hash = window.location.hash;
+    const workspace = hash.match(/#\\/workspace\\/[^/]+/);
+    window.location.hash = workspace
+      ? workspace[0].slice(1) + "/settings/extensions/mcp"
+      : "/settings/extensions/mcp";
+    return true;
+  })()`);
+  await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+}
+
+async function refreshStatuses(ctx) {
+  await ctx.eval(`(() => {
+    const btn = [...document.querySelectorAll("button")].find((b) => (b.textContent ?? "").trim() === "Refresh");
+    if (btn) btn.click();
+    return Boolean(btn);
+  })()`);
+}
+
+async function restartEngine(ctx) {
+  await ctx.eval(
+    'window.__OPENWORK_ELECTRON__.invokeDesktop("engineRestart", {})',
+    { awaitPromise: true },
+  );
+  ctx.log("Engine restarted (simulates quitting and reopening OpenWork).");
+  // Give the engine a moment to boot before the next status read.
+  await new Promise((resolve) => setTimeout(resolve, 8_000));
+}
+
+async function waitForCardStatus(ctx, accepted, { timeoutMs, refreshEveryMs = 10_000 } = {}) {
+  const startedAt = Date.now();
+  let lastRefresh = 0;
+  let status = null;
+  while (Date.now() - startedAt < (timeoutMs ?? 60_000)) {
+    if (Date.now() - lastRefresh >= refreshEveryMs) {
+      lastRefresh = Date.now();
+      await refreshStatuses(ctx);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    status = await cardStatus(ctx);
+    if (accepted.includes(status)) return status;
+  }
+  throw new Error(`Timed out waiting for ${MCP_NAME} status in [${accepted.join(", ")}]; last: ${status}`);
+}
+
+export default {
+  id: "mcp-oauth-silent-reauth",
+  title: "Remote OAuth MCP silently re-authenticates after token expiry / app reopen",
+  spec: "evals/browser-extension-flows.md",
+  steps: [
+    {
+      name: "App booted with an open workspace",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000 });
+        await ctx.waitFor("window.location.hash.includes('/workspace/')", {
+          timeoutMs: 30_000,
+          label: "an open workspace (this flow needs one to configure MCPs)",
+        });
+      },
+    },
+    {
+      name: "Setup: start the mock OAuth MCP service",
+      run: async (ctx) => {
+        await startMock(ctx);
+      },
+    },
+    {
+      name: "Add the custom OAuth connector and sign in once (baseline)",
+      run: async (ctx) => {
+        await openExtensions(ctx);
+        await refreshStatuses(ctx);
+        await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+        if (!(await cardStatus(ctx))) {
+          // Add Custom App -> Remote URL + Advanced OAuth (pre-registered client).
+          await ctx.clickText("Add Custom App", { timeoutMs: 20_000 });
+          await ctx.waitForText("Server URL", { timeoutMs: 15_000 });
+          await ctx.fill('input[placeholder="github-copilot"]', MCP_NAME);
+          await ctx.fill('input[placeholder="https://api.githubcopilot.com/mcp/"]', `${MOCK_BASE}/mcp`);
+          await ctx.clickText("Advanced OAuth", { timeoutMs: 10_000 });
+          await ctx.fill('input[placeholder="Paste the OAuth client ID"]', "openwork-eval-preregistered-client");
+          await ctx.clickText("Add App", { timeoutMs: 10_000 });
+          // A sign-in modal may auto-open; the row's Sign in button below is
+          // the canonical path, so close it if present.
+          await new Promise((resolve) => setTimeout(resolve, 3_000));
+          await ctx.eval(`(() => {
+            const dlg = document.querySelector("[role=dialog]");
+            const cancel = dlg && [...dlg.querySelectorAll("button")].find((b) => (b.textContent ?? "").trim() === "Cancel");
+            if (cancel) cancel.click();
+            return true;
+          })()`);
+        }
+
+        // Fresh entries can need an engine reload before they register.
+        let status = await waitForCardStatus(ctx, ["Ready", "Sign in needed", "Issue", "Offline"], { timeoutMs: 30_000 });
+        if (status === "Offline" || status === "Issue") {
+          await restartEngine(ctx);
+          await openExtensions(ctx);
+          status = await waitForCardStatus(ctx, ["Ready", "Sign in needed"], { timeoutMs: 45_000 });
+        }
+
+        if (status !== "Ready") {
+          // Expand the row and run the one-time interactive OAuth sign-in.
+          await ctx.clickText(MCP_NAME, { selector: "button", timeoutMs: 15_000 });
+          await ctx.clickText("Sign in", { timeoutMs: 15_000 });
+          await waitForCardStatus(ctx, ["Ready"], { timeoutMs: 60_000 });
+        }
+
+        await ctx.prove("The custom OAuth connector is connected after a one-time sign-in", {
+          assert: async () => {
+            ctx.assert((await cardStatus(ctx)) === "Ready", "Connector card should show Ready.");
+            await scrollCardIntoView(ctx);
+          },
+          screenshot: {
+            name: "connector-connected-baseline",
+            claim: "mock-oauth-crm shows Ready after the initial OAuth sign-in.",
+            requireText: [MCP_NAME, "Ready"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+    {
+      name: "Token expires and the API is unreachable while OpenWork reopens",
+      run: async (ctx) => {
+        // Restarting the mock wipes its in-memory access tokens (= expiry);
+        // stopping it entirely reproduces the wake-from-sleep outage.
+        await stopMock(ctx);
+        await restartEngine(ctx);
+        await openExtensions(ctx);
+
+        await ctx.prove("The connector is stranded after reopening during an outage (the reported bug state)", {
+          assert: async () => {
+            const status = await waitForCardStatus(ctx, ["Issue", "Sign in needed"], { timeoutMs: 60_000 });
+            ctx.log(`Stranded status: ${status}`);
+            await scrollCardIntoView(ctx);
+          },
+          screenshot: {
+            name: "connector-stranded",
+            claim: "mock-oauth-crm is unhealthy (Issue / Sign in needed) after the engine reconnect failed.",
+            requireText: [MCP_NAME],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+    {
+      name: "API returns; OpenWork silently re-authenticates with the stored refresh token",
+      run: async (ctx) => {
+        await startMock(ctx); // fresh instance: old access tokens invalid, request log empty
+
+        await ctx.prove("The connector heals to Ready with no sign-in modal and no browser", {
+          assert: async () => {
+            // Status refreshes trigger the silent reauth; the cooldown means
+            // the first eligible attempt can land up to ~60s after the
+            // engine-restart attempt that fired while the API was down.
+            await waitForCardStatus(ctx, ["Ready"], { timeoutMs: 180_000 });
+            const modalOpen = await ctx.eval("Boolean(document.querySelector('[role=dialog]'))");
+            ctx.assert(!modalOpen, "No sign-in modal should open during the silent reauth.");
+
+            // Ground truth from the IdP: reconnection used the refresh-token
+            // grant (POST /token) and never the interactive authorization
+            // endpoint (GET /authorize).
+            const requests = await mockRequests();
+            const tokenGrants = requests.filter((r) => r.path === "/token").length;
+            const interactive = requests.filter((r) => r.path === "/authorize").length;
+            ctx.recordEvidence({
+              type: "assertion",
+              status: tokenGrants >= 1 && interactive === 0 ? "passed" : "failed",
+              assertion: `IdP saw refresh grant only (POST /token x${tokenGrants}, GET /authorize x${interactive})`,
+            });
+            ctx.assert(tokenGrants >= 1, "Expected at least one refresh-token grant at the IdP.");
+            ctx.assert(interactive === 0, "Silent reauth must not hit the interactive /authorize endpoint.");
+            await scrollCardIntoView(ctx);
+          },
+          screenshot: {
+            name: "connector-silently-healed",
+            claim: "mock-oauth-crm is Ready again — reconnected via refresh-token grant, zero user interaction.",
+            requireText: [MCP_NAME, "Ready"],
+            rejectText: ["Something went wrong", "Connect mock-oauth-crm"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup: stop the mock OAuth MCP service",
+      run: async (ctx) => {
+        await stopMock(ctx);
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Fixes the reported issue where a custom remote MCP connector (Advanced OAuth, pre-registered client, e.g. Google Workspace) shows **"Sign in needed" every ~1h / on app reopen**, even though clicking Sign in reconnects in 1–2s without a full login — i.e. the stored refresh token works, but nothing uses it automatically.

## Root cause

The OpenCode engine refreshes MCP access tokens only **reactively** (on a 401) and **at most once per transport** (`_hasCompletedAuthFlow` guard in the bundled MCP SDK). Nothing consults the persisted `expiresAt`, and a `needs_auth`/`failed` entry is never retried. So after token expiry or a transient outage at engine boot (wake from sleep), the connector strands until the user clicks Sign in — which builds a fresh transport and succeeds via the refresh grant. The proper engine-side fix (proactive refresh + guard reset) belongs in `anomalyco/opencode`; this PR is the OpenWork-side heal that removes the user-facing pain today.

## Change

- New `mcp-silent-reauth.ts`: on every MCP status refresh, retry `mcp.connect` for unhealthy (`needs_auth`/`failed`) **remote OAuth** entries (never header-authed / disabled / `oauth: false` / local ones). A fresh transport makes the SDK run the stored refresh-token grant on the 401 — the same thing the manual Sign in button does, minus the browser fallback. The engine connect path has a no-op OAuth redirect, so a genuinely revoked grant just stays on "Sign in needed": **no browser, no modal, ever**.
- Wired into both status-fetch paths: the connections store (`refreshMcpServers`, Settings → Extensions) and the session surface (`listMcp`, composer tools menu — badge flips live).
- Guardrails: 60s cooldown per connector/workspace (reset on recovery), in-flight dedupe, skipped while the auth modal is open or a connect is in progress.

## Validation

- `bun test tests/` in `apps/app`: **90 pass / 0 fail** (7 new tests for candidacy rules, cooldown, recovery reset, failure swallowing).
- `pnpm --filter @openwork/app typecheck`: clean.
- **fraimz** (`pnpm fraimz --flow mcp-oauth-silent-reauth`, local Electron via CDP, from a fully clean state): **PASSED** — `evals/results/2026-07-02T18-02-07-825Z/fraimz.html`
  1. Add custom Advanced-OAuth connector against the real mock OAuth MCP server (`scripts/mock-oauth-mcp-server.mjs`, real auth-code + PKCE + refresh grants) → one-time sign-in → **Ready**.
  2. Kill the API + restart the engine (= reopen the app during an outage) → connector stranded (**Issue**) — the reported bug state.
  3. API returns → connector flips back to **Ready** with zero interaction; IdP request log asserts **POST /token ×1, GET /authorize ×0** and no sign-in modal.

The flow is committed (`evals/flows/mcp-oauth-silent-reauth.flow.mjs`) and re-runnable; it manages the mock IdP itself. Screenshots (frames 1–3) attached in the fraimz report. Note: fraimz artifacts are gitignored; happy to attach the three frames here on request.

## Follow-up (upstream)

Engine-side issues to file on `anomalyco/opencode`: proactive refresh keyed off `expiresAt` (mirroring `google-workspace.ts`) and resetting the SDK's one-shot auth guard for refresh-driven 401s — that would also remove the single failed request at the moment of expiry, which this client-side heal can't prevent.
