### PR TITLE
feat(den-web): ask for the credential before the endpoint in the guided provider form

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
@@ -871,6 +871,26 @@ export function LlmProviderEditorScreen({
 
                         <label className="grid gap-3">
                             <span className="text-[14px] font-medium text-gray-700">
+                                API key / credential
+                            </span>
+                            <DenInput
+                                type="password"
+                                value={apiKey}
+                                onChange={(event) => setApiKey(event.target.value)}
+                                placeholder={
+                                    provider?.hasApiKey
+                                        ? "Leave blank to keep current credential"
+                                        : "Paste the provider credential"
+                                }
+                            />
+                        </label>
+                        <p className="-mt-3 text-[13px] text-gray-500">
+                            Used right away to check the endpoint and list the
+                            models it serves.
+                        </p>
+
+                        <label className="grid gap-3">
+                            <span className="text-[14px] font-medium text-gray-700">
                                 Base URL
                             </span>
                             <DenInput
@@ -910,7 +930,7 @@ export function LlmProviderEditorScreen({
                         ) : null}
                         {probeState === "idle" && customBaseUrl.trim() && !apiKey.trim() ? (
                             <p className="-mt-2 text-[13px] text-gray-500">
-                                Enter the API key below to load the models this endpoint serves.
+                                Enter the API key above to load the models this endpoint serves.
                             </p>
                         ) : null}
 
@@ -1046,36 +1066,40 @@ export function LlmProviderEditorScreen({
                 )}
             </section>
 
-            <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-                <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-                    <div>
-                        <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
-                            Credential
-                        </h2>
+            {/* The guided custom form collects the credential inline (before
+                the endpoint, so the probe can run as the admin types). */}
+            {source === "custom" && customMode === "form" ? null : (
+                <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                    <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                        <div>
+                            <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                                Credential
+                            </h2>
+                        </div>
+                        {provider?.hasApiKey ? (
+                            <span className="rounded-full bg-emerald-50 px-4 py-2 text-[13px] font-medium text-emerald-700">
+                                Existing credential saved
+                            </span>
+                        ) : null}
                     </div>
-                    {provider?.hasApiKey ? (
-                        <span className="rounded-full bg-emerald-50 px-4 py-2 text-[13px] font-medium text-emerald-700">
-                            Existing credential saved
-                        </span>
-                    ) : null}
-                </div>
 
-                <label className="grid gap-3">
-                    <span className="text-[14px] font-medium text-gray-700">
-                        API key / credential
-                    </span>
-                    <DenInput
-                        type="password"
-                        value={apiKey}
-                        onChange={(event) => setApiKey(event.target.value)}
-                        placeholder={
-                            provider?.hasApiKey
-                                ? "Leave blank to keep current credential"
-                                : "Paste the provider credential"
-                        }
-                    />
-                </label>
-            </section>
+                    <label className="grid gap-3">
+                        <span className="text-[14px] font-medium text-gray-700">
+                            API key / credential
+                        </span>
+                        <DenInput
+                            type="password"
+                            value={apiKey}
+                            onChange={(event) => setApiKey(event.target.value)}
+                            placeholder={
+                                provider?.hasApiKey
+                                    ? "Leave blank to keep current credential"
+                                    : "Paste the provider credential"
+                            }
+                        />
+                    </label>
+                </section>
+            )}
 
             {source === "models_dev" ? (
                 <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">

--- a/evals/flows/llm-provider-blueyonder-foundry.flow.mjs
+++ b/evals/flows/llm-provider-blueyonder-foundry.flow.mjs
@@ -126,6 +126,15 @@ export default {
               ));
             },
             assert: async () => {
+              // The credential is asked for before the endpoint, so the probe
+              // can run the moment the URL is typed.
+              const keyBeforeUrl = await ctx.eval(`(() => {
+                const key = document.querySelector('input[type="password"]');
+                const url = document.querySelector('input[placeholder="https://my-resource.openai.azure.com/openai/v1"]');
+                if (!key || !url) return false;
+                return Boolean(key.compareDocumentPosition(url) & Node.DOCUMENT_POSITION_FOLLOWING);
+              })()`);
+              ctx.assert(keyBeforeUrl === true, "API key field is not before the Base URL field.");
               await ctx.waitForText("Endpoint reachable — 1 model available.", { timeoutMs: 45_000 });
               const healed = await ctx.eval(
                 `document.querySelector('input[placeholder="https://my-resource.openai.azure.com/openai/v1"]')?.value`,


### PR DESCRIPTION
Follow-up to #2431. In the guided custom-provider form, the credential is now asked for **before** the endpoint, and lives inline in the form (the separate Credential section remains for catalog providers and the JSON escape hatch).

Why: the endpoint probe needs URL + key. With the key below the endpoint (in a section further down the page), filling the form top-to-bottom left the probe idle with a "enter the API key below" hint pointing past the models the admin was about to pick. Now the natural top-to-bottom fill (name → id → key → URL) makes the probe fire the moment the URL is typed, and the model picker appears directly beneath it.

Changes:
- Inline `API key / credential` field between Provider ID and Base URL in the guided form (same `apiKey` state, same keep-current-credential placeholder on edit).
- Standalone Credential section hidden in guided form mode only.
- Idle hint updated ("above").
- The Azure Foundry fraimz flow now asserts the key field precedes the Base URL field in the DOM.

## Validation

- `tsc --noEmit` clean (den-web).
- Re-ran the end-to-end fraimz against a Daytona Den stack running this change and the **real** customer Azure resource:

```
pnpm fraimz --flow llm-provider-azure-foundry --cdp-url http://127.0.0.1:9333
Result: PASSED — 1 passed, 0 failed, 0 skipped
```

Frame `01-probe-deployments` shows the new order (Provider ID → API key → Base URL) with the probe already green ("Endpoint reachable — 1 model available."); the remaining frames prove picker + verify-on-save + persisted `@ai-sdk/openai` config are unchanged.
