### PR TITLE
Memory Bank v0 — Backend (den-db + den-api + agent prompt + eval)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ opencode.jsonc
 transcript-analysis
 # Eval runner output
 evals/results/
+.playwright-mcp/

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
@@ -72,7 +72,8 @@ Here is what you can help users with:
 - The browser panel is visible on the right side of the session view.
 
 ## Cross-chat Session Memory
-- Cross-chat memory currently comes from saved OpenWork session history exposed through OpenWork UI actions, not a separate hidden long-term memory store.
+- Two sources of cross-chat memory: (1) the durable Memory Bank — a per-user store the user can explicitly save facts to and recall, reached by discovering a memory capability via search_capabilities and running it via execute_capability (see the "Memory Bank" section of the system prompt); and (2) saved OpenWork session history, exposed through OpenWork UI actions below.
+- To save or recall a durable fact the user wants remembered across sessions, use the Memory Bank capability — never a local file.
 - If the user asks what they said, what happened, or what was decided in another OpenWork session, use the UI control actions: list sessions, open the matching session, then read the transcript.
 - Match sessions by ID, title, workspace, or topic words. Ask a short clarifying question if multiple sessions match.
 - Answer only from the returned transcript. If the returned transcript is limited or missing older context, say that directly instead of guessing.

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -71,6 +71,26 @@ describe("openwork runtime config file", () => {
     expect(Array.isArray(parsed.plugin)).toBe(true);
   });
 
+  test("openwork prompt has a static search-first Memory Bank section, distinct from ## Memory", async () => {
+    const { config } = await setup();
+    await writeOpenworkRuntimeConfigFile(config, "ws_1");
+
+    const parsed = await readConfigFile(config);
+    const agent = parsed.agent as Record<string, { prompt?: string }>;
+    const prompt = agent.openwork?.prompt ?? "";
+
+    // The new Memory Bank section is present and distinct from the existing ## Memory section.
+    expect(prompt).toContain("## Memory Bank");
+    expect(prompt).toContain("## Memory\n");
+    // Search-first (B1): never name tools that do not exist.
+    expect(prompt).toContain("search_capabilities");
+    expect(prompt).toContain("execute_capability");
+    expect(prompt).not.toContain("memory_save");
+    expect(prompt).not.toContain("memory_search");
+    // No-secrets guidance is the only v0 plaintext-at-rest mitigation.
+    expect(prompt).toMatch(/secret|credential|API key|token|PII/i);
+  });
+
   test("keepOpenworkRuntimeConfigFileFresh rewrites the file on runtime-DB writes", async () => {
     const { config } = await setup();
     await writeOpenworkRuntimeConfigFile(config, "ws_1");

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -63,7 +63,24 @@ OpenWork can preview, edit, and download standard artifacts when you create or u
 - After creating or updating an artifact, mention the exact workspace-relative file path in your final response, for example reports/artifact-eval.md or reports/artifact-eval.xlsx.
 - Do not invent Workspace/<id>/... paths unless a tool returns them; prefer clean workspace-relative paths.
 - For websites or React/UI previews, start the dev server when useful and mention the http://localhost:<port> URL.
-- For spreadsheets, use .csv for simple tabular data and .xlsx when the user asks for Excel/XLS specifically.`;
+- For spreadsheets, use .csv for simple tabular data and .xlsx when the user asks for Excel/XLS specifically.
+
+## Memory Bank
+
+The memory bank is a per-user store of durable facts, reached through the meta-MCP. It is NOT a local file — never write memories to .opencode/ or any file. There is no dedicated memory tool: to save or recall a memory, first discover the capability with search_capabilities, then run it with execute_capability — i.e. search for a capability to save a memory, then execute it. The capabilities you find are named like postMemory (save), getMemorySearch (search), getMemory (list), and deleteMemoryById (delete).
+
+Save flow:
+- Draft a candidate memory: a crisp, self-contained content sentence, plus optional cited contexts (a snippet, each with an optional conversation_id/message_id).
+- Show the draft and get the human to confirm or edit it, and flag anything that looks like a secret or personal detail so they can remove it first. Only persist human-confirmed content, never raw agent output.
+- Once confirmed, search for a capability to save a memory (postMemory) and execute it with a body like { "content": "…" }.
+
+Retrieval flow:
+- When the user asks in natural language, search for a capability to search memories (getMemorySearch) and execute it with their phrasing as the query q.
+- Reduce the results to what is relevant and present them. Recall is explicit and lexical: only search when asked, never auto-recall, and do not claim to understand meaning.
+
+Manage: to show what is saved, discover and execute the list capability (getMemory); to remove one, discover and execute the delete capability (deleteMemoryById) after confirming with the human.
+
+Never persist secrets, credentials, API keys, tokens, or sensitive PII into a memory. This applies to both the content sentence and any cited snippets — redact secrets from a snippet before saving it.`;
 
 export async function buildOpenworkRuntimeConfigObject(
   config?: ServerConfig,

--- a/docs/memory-bank-architecture.md
+++ b/docs/memory-bank-architecture.md
@@ -266,6 +266,9 @@ kill switch) is scoped but **not built**. Additive — no contract change.
 - Active org-shared bank (schema-ready, not activated).
 - Hard server-enforced gate + server-side metrics + kill switch.
 - Per-user quota / rate-limiting (only cheap input bounds in v0).
+- **Memory reaping on account/org deletion** — there is no DB FK or offboarding hook, so deleting
+  a user/org does not remove their `memory`/`memory_context` rows. A cleanup hook is a pre-GA
+  requirement alongside encryption at rest (§8); v0 relies on the explicit `deleteMemoryById`.
 - `PATCH` (edit a saved memory) — v0 is view + delete only.
 - Optional desktop save/verify modal (chat-driven is the v0 baseline).
 

--- a/docs/memory-bank-architecture.md
+++ b/docs/memory-bank-architecture.md
@@ -1,0 +1,353 @@
+# Memory Bank — Architecture (v0)
+
+> Status: **Draft for scoping.** Pre-spec architecture doc that feeds
+> `/officeHours` → `/specToProvenPR`. Decisions captured in an interview on
+> 2026-07-02 and revised after a 5-lens `/autoplan` review the same day.
+> **[VERIFY]** = confirm at impl; **[DECISION]** = locked; **[FIX]** = correction
+> applied after the autoplan review (see §13 for the review trail).
+
+---
+
+## 1. Goal & principles
+
+A per-user **memory bank** inside OpenWork. The user opts in by chatting (e.g.
+"save this memory to the memory bank"); the agent drafts a memory + relevant context,
+a human verifies it, and it's persisted **server-side**. Later the user can **explicitly
+search** their memories with natural-language phrasing, and **view/delete** them from a
+lightweight desktop panel.
+
+Principles (priority order):
+
+1. **Durable interface, evolvable implementation.** The long-lived contract is the
+   REST/MCP **tool shape**; storage + search behind it are swappable (lexical today,
+   vector/entity-graph later) with no contract change.
+2. **No new infrastructure dependencies.** MySQL (PlanetScale) + Drizzle only.
+3. **Harness-agnostic.** Memory is a shared knowledge layer keyed to the **principal**.
+4. **Server-side storage, thin client.**
+5. **Human-verified writes.** Persist human-confirmed content, never raw agent output.
+
+Note on recall (revised): v0 is **explicit, lexical** search — the user must ask. We do
+**not** claim semantic/"understands meaning" recall, and we do **not** auto-recall. The
+honest value bar is "saved facts are retrievable across sessions on a natural-language
+query," not "the agent never makes you re-explain."
+
+---
+
+## 2. Surface & the durable contract
+
+Memory is exposed as **den-api REST routes**, auto-surfaced as capabilities through the
+existing meta-MCP (`/mcp/agent`). That rail exposes exactly two tools —
+`search_capabilities` and `execute_capability` — so memory is **reached by executing a
+discovered capability, not by a bespoke `memory_save` tool.** **[FIX B1]**
+
+```
+harness ── search_capabilities("save a memory")   → finds capability "postMemory"
+        └─ execute_capability({ name: "postMemory", body: {...} })
+
+harness ── search_capabilities("search my memories") → finds "getMemorySearch"
+        └─ execute_capability({ name: "getMemorySearch", query: { q, limit } })
+```
+
+### Routes & operationIds [FIX — corrected]
+`buildOperationId` (`ee/apps/den-api/src/openapi.ts:16-38`) strips `v1` and PascalCases
+path segments. The **actual** operationIds / MCP tool names are:
+
+| Route | operationId / tool name | scope |
+|---|---|---|
+| `POST /v1/memory` | `postMemory` | `mcp:write` |
+| `GET /v1/memory/search` | `getMemorySearch` | `mcp:read` |
+| `GET /v1/memory` (list) | `getMemory` | `mcp:read` |
+| `DELETE /v1/memory/:id` | `deleteMemoryById` | `mcp:write` |
+
+Verified: none collide with `BLOCKED_OPERATION_IDS`, all stay ≤49 chars after
+`structuralShorten`, and the two GETs are distinct paths (no collision). **Never** refer
+to `memory_save`/`memory_search` in the prompt or docs — those names do not exist.
+
+### v0 CRUD scope [DECISION]
+save + search + **list + delete** (list + delete back the desktop management panel).
+Owner-scoped everywhere (§8). `PATCH` (edit) and a `bankScope` param are future.
+
+### Catalog inclusion [DECISION: new "Memory" tag]
+Add `"Memory"` to `SAFE_INCLUDED_TAGS` (`ee/apps/den-api/src/mcp/policy.ts:2-23`) and
+tag the routes `tags: ["Memory"]`. This is the only mechanism in active use (`x-mcp:true`
+is dormant). Route pattern to mirror for *structure*: `routes/workers/core.ts` — **but
+its authorization is org-scoped; memory must be user-scoped (see §8, [FIX B4]).**
+
+---
+
+## 3. Data model (MySQL / Drizzle)
+
+```
+memory
+  id           typeid("memory")   PK
+  user_id      typeid("user")     -- owner (v0 always set)
+  org_id       typeid("organization")
+  scope        enum('user','org') default 'user'   -- two-bank model; v0 forces 'user'
+  content      text               -- HUMAN-VERIFIED memory (plaintext in v0, see §8)
+  source       varchar            -- server-set: 'chat' | 'modal'
+  tags         json               -- optional
+  created_at, updated_at (shared `timestamps`)
+  indexes: (user_id)
+  FULLTEXT index on (content)      -- raw SQL; created idempotently, see below
+
+memory_context
+  id           typeid("memctx")   PK
+  memory_id    typeid("memory")   FK → memory.id  (ON DELETE CASCADE)
+  citation     json               -- { conversation_id?, message_id? }  (all optional)
+  snippet      text               -- plaintext in v0
+  origin       enum('active_conversation','searched_conversation')
+  created_at
+  indexes: (memory_id)
+```
+
+### [FIX B5] Register the typeid prefixes
+`memory` and `memctx` must be added to `idTypesMapNameToPrefix`
+(`packages/utils/.../typeid.ts`) or `denTypeIdColumn`/`denTypeIdSchema` won't compile.
+This is a cross-package edit and is part of the schema task, not an afterthought.
+
+### [DECISION] Two-bank model, personal-only in v0
+`scope` present from day one, **hard-enforced to `'user'` server-side** — not merely a
+column default. A client can POST `scope:'org'`; the handler must overwrite it. Every
+read filters `user_id = principal.userId` **and** (defensively) `scope='user'` so a
+future org row can never retroactively leak into personal reads. [FIX]
+
+### On-device provenance
+`memory_context` captures agent-gathered citations + snippets. All citation fields are
+**optional** (floor: a `snippet` with no ids). **[VERIFY]** which ids the agent can read
+on-device.
+
+### Search backend [DECISION: MySQL FULLTEXT] + [FIX B2]
+PlanetScale/Vitess supports `FULLTEXT` + `MATCH … AGAINST`. v0 uses **NATURAL LANGUAGE
+MODE**, owner-scoped, relevance-ranked.
+- **Fresh-install hazard:** new DBs bootstrap via `drizzle-kit push` (which cannot see a
+  raw `FULLTEXT` index — Drizzle mysql-core has no FULLTEXT DSL,
+  [drizzle-orm#1495](https://github.com/drizzle-team/drizzle-orm/issues/1495)) and
+  baseline marks migrations applied-without-executing — so a plain migration-only index
+  is **silently absent in production** while working on incrementally-migrated dev DBs.
+  **[FIX B2]** Create the index **idempotently on a path both bootstrap and migrate
+  hit** — e.g. a startup/bootstrap step that checks `information_schema.STATISTICS` for
+  the index and runs `CREATE FULLTEXT INDEX` if missing. Add a CI/startup assertion that
+  the index exists.
+- **Query safety [FIX]:** bind the query (`MATCH(content) AGAINST(${q} IN NATURAL
+  LANGUAGE MODE)` via Drizzle's `sql` template) — **never** `sql.raw`; combine the MATCH
+  with the `user_id` predicate in a single `and(...)`. (Precedent: `admin-tools.ts` binds
+  correctly.)
+- **PlanetScale caveat [VERIFY]:** `innodb_ft_min_token_size` (default 3) and stopwords
+  are **not tunable** on PlanetScale — short/common query terms silently won't match.
+  The v0 mitigation is honest scoping (§1), not "tune it." If recall is weak, consider
+  also indexing `snippet` or a denormalized column (future).
+
+---
+
+## 4. Save flow (human-verified)
+
+Trigger: *"save this memory to the memory bank."*
+
+1. **Draft (standalone turn).** Agent composes candidate `content` + optional context.
+2. **Human verification.** Human confirms/edits before persisting. Baseline = chat-driven
+   confirm (harness-agnostic); optional desktop modal (deferred, §9).
+3. **Persist** — `POST /v1/memory`. **[FIX B3] Flattened, mostly-optional payload** so the
+   agent (which only sees `hasBody:true`, not the schema) can construct it. The shape is
+   also encoded in the route's OpenAPI `summary` (the one body hint the agent gets):
+   ```jsonc
+   {
+     "content": "User deploys via den-worker-proxy into a Daytona sandbox", // required
+     "tags": ["deploy", "infra"],                                            // optional
+     "contexts": [                                                           // optional
+       { "snippet": "…excerpt…",                                             // required if present
+         "conversation_id": "…", "message_id": "…",                          // optional
+         "origin": "active_conversation" }                                   // optional
+     ]
+   }
+   ```
+   - Server **sets `source`** and **ignores/overwrites client `scope`** (forces `'user'`).
+   - Server wraps the `memory` + N `memory_context` inserts in **one transaction** (no
+     orphaned context rows). [FIX]
+   - **Input bounds [FIX]:** cap `content` length and `contexts` count (cheap abuse guard;
+     full rate-limiting/quota deferred, §9).
+4. **Feedback.** The save must surface an explicit success/failure signal (see §6 states).
+
+---
+
+## 5. Retrieval flow (explicit, lexical)
+
+**[DECISION] Explicit search only** — no auto-recall.
+
+1. User asks in natural language: *"what was that deal with Acme?"*
+2. Agent calls `getMemorySearch` (`GET /v1/memory/search?q=…&limit=…`). `limit` defaults
+   to 20, capped; results relevance-ranked via `MATCH … AGAINST`, owner-scoped.
+3. **No match → empty result set, HTTP 200** (not an error) so the agent reports "nothing
+   found" gracefully. [FIX]
+4. Agent does best-effort set reduction and presents results.
+
+Response (stable): `{ results: [{ id, content, tags, created_at, score, contexts? }] }`.
+
+---
+
+## 6. Desktop client (thin) + gating
+
+### [DECISION] Client self-serve toggle, UI-gate only; v0 metrics are qualitative
+- New Preferences-tab toggle via `useLocal()` `featureFlags.memory` (mirror
+  `feature-flags-preferences.ts`). **Client-only, per-device, never synced.**
+- Gates **UI visibility only** (soft gate): reveals the management panel, copy-prompt
+  button, and optional modal. Routes stay callable (owner-scoped + authz'd).
+- **[DECISION] Metrics are qualitative in v0.** The client-only flag is not
+  server-observable, so we do **not** commit to server-computed adoption/recall metrics;
+  we measure via manual eval + raw save/search counts (see product.md). A server enable
+  event + hard gate are deferred (§7, §9).
+
+### Management panel (list + delete) — states are the product [FIX design]
+The panel and save flow must specify non-happy-path states, **reusing the desktop's
+existing accessible Base UI primitives** (Switch, Dialog/AlertDialog, `ConfirmModal`,
+`Empty`, Sonner `toast`) rather than building from scratch:
+- Save: draft-loading, success (toast), failure/retry, offline, cancel/discard.
+- Panel: loading, **enabled-but-empty** (first-run payoff — use `Empty`), error, offline.
+- Delete: **optimistic delete + undo toast** (resolves the "reversible-feeling vs
+  permanent" tension); focus moves sensibly after removal.
+- Recall: the agent renders results (prompt-owned), but the panel must not imply a search
+  UI it doesn't have.
+- **Accessibility:** icon-button names, destructive-action focus, `aria-live`/toast
+  announcements — mandated via the primitives.
+- **Content is rendered escaped** in the panel (stored-XSS guard; §8). [FIX]
+
+### Agent priming [DECISION: static `## Memory Bank`, search-first]
+Append a static, distinct `## Memory Bank` section to `OPENWORK_AGENT_PROMPT`
+(`apps/server/src/openwork-runtime-config.ts:34-66`) — separate from the existing
+`## Memory` (credential-hygiene) section. It must **[FIX B1]**:
+- Be **search-first**: "to save a memory, search for a capability to save a memory, then
+  execute it" — never name `memory_save`.
+- Cover save (draft → human-confirm → execute `postMemory`) and retrieval (search →
+  reduce → present).
+- **[DECISION, plaintext risk]** Instruct the agent to **not persist secrets,
+  credentials, tokens, or sensitive PII** — this prompt guidance is the *only* v0
+  mitigation for plaintext-at-rest (§8).
+- The copy-prompt button primes non-server harnesses (Claude Code, local opencode); on
+  desktop server workspaces the prompt is already injected, so the button is a secondary
+  cross-tool utility, not the first-run path.
+
+---
+
+## 7. Hard gate (deferred fast-follow) [DECISION: deferred]
+
+v0 gate is client-only + UI-only. A hard, server-enforced gate (server per-user pref or
+org `desktop-policies`, in-handler `403`, optional conditional prompt injection, and a
+kill switch) is scoped but **not built**. Additive — no contract change.
+
+---
+
+## 8. Auth, scoping & security (v0)
+
+- Principal always carries `userId` + `organizationId` (`mcp/auth.ts:19-24`); routes read
+  `c.get("user").id` / `c.get("activeOrganizationId")`. Live session + membership checks
+  already gate every request (revocation is immediate — verified).
+- **[FIX B4] Owner-scoping (the #1 risk).** Do **not** copy the org-scoped worker
+  accessor. Memory reads/list/delete filter on **`user_id = principal.userId`** as the
+  primary predicate. Add a dedicated `getMemoryByIdForUser`; return **404** (non-leaking)
+  for ids the caller doesn't own; add a **cross-user access regression test as a merge
+  gate.**
+- `DELETE` **hard-deletes** the FK'd `memory_context` rows (ON DELETE CASCADE / explicit)
+  for right-to-be-forgotten.
+- **[DECISION — plaintext at rest, risk accepted]** `content`/`snippet` are plaintext in
+  v0. The repo ships `encryptedTextColumn` but v0 does **not** use it. Mitigation is
+  prompt guidance (§6) telling the agent not to store secrets. **This is a documented,
+  accepted v0 risk; encryption at rest is a pre-GA requirement (§9).**
+- Query is parameterized + owner-filtered (§3). Panel escapes content (§6).
+- **Deferred (§9):** per-user quota / rate-limiting (storage-exhaustion DoS). v0 keeps
+  only cheap input bounds (§4).
+
+---
+
+## 9. Out of scope for v0 (explicitly deferred)
+
+- Vector DB / embeddings / semantic recall.
+- **Encryption at rest** for content/snippet — **pre-GA requirement**, accepted risk in v0.
+- Auto-recall / passive session-start recall (considered, cut).
+- Cross-tool entity/relationship synthesis.
+- Active org-shared bank (schema-ready, not activated).
+- Hard server-enforced gate + server-side metrics + kill switch.
+- Per-user quota / rate-limiting (only cheap input bounds in v0).
+- `PATCH` (edit a saved memory) — v0 is view + delete only.
+- Optional desktop save/verify modal (chat-driven is the v0 baseline).
+
+---
+
+## 10. Durability / evolution path
+
+| Concern | v0 | Future (no contract change) |
+|---|---|---|
+| Search | MySQL `FULLTEXT` (NL mode), owner-scoped | vector/embedding or hybrid ranker |
+| Privacy | plaintext + prompt guidance | encryption at rest (pre-GA) |
+| Context | `memory_context` citations + snippets | entity/relationship synthesis |
+| Banks | `scope='user'` enforced | activate `scope='org'` |
+| Gate | client toggle, UI-only, qualitative metrics | server pref / `403` / events / kill switch |
+| Recall | explicit lexical | passive + semantic |
+
+---
+
+## 11. Decisions resolved + items to verify
+
+Resolved (this doc):
+- **Tool access** → search-first via `execute_capability`; real names `postMemory` /
+  `getMemorySearch` / `getMemory` / `deleteMemoryById` (§2). [FIX B1]
+- **FULLTEXT bootstrap** → idempotent index creation on bootstrap+migrate path (§3). [FIX B2]
+- **Save payload** → flattened, mostly-optional, shape in OpenAPI summary (§4). [FIX B3]
+- **Owner-scoping** → `user_id`-primary, 404 non-owned, regression-test gate (§8). [FIX B4]
+- **typeids** → register `memory`/`memctx` in `packages/utils` (§3). [FIX B5]
+- **Encrypt-at-rest** → plaintext v0, prompt-guidance mitigation, pre-GA requirement (§8).
+- **Gate/metrics** → client-only, qualitative metrics; hard gate deferred (§6, §7).
+- **Recall** → explicit lexical only; honest value bar; no `≥60%` metric (§1, §5).
+- **Search backend / tag / two-bank / citation / CRUD** → as prior (§2, §3).
+
+Verify at impl (non-blocking):
+1. **[VERIFY]** On-device citation id availability (§3).
+2. **[VERIFY]** PlanetScale `innodb_ft_min_token_size`/stopword impact on recall (§3).
+
+---
+
+## 12. Handoff
+
+- **Next:** `/specToProvenPR` for staged, proven PRs.
+- **Suggested PR staging:**
+  1. **den-db:** `memory` + `memory_context` tables + migration; **register typeids
+     (`packages/utils`)**; **idempotent `FULLTEXT` index on the bootstrap+migrate path**;
+     `ON DELETE CASCADE`.
+  2. **den-api:** routes `postMemory`, `getMemorySearch` (bound `MATCH…AGAINST`, NL mode,
+     empty-set on no match), `getMemory` (list), `deleteMemoryById` — **all
+     `user_id`-owner-scoped, 404 non-owned, force `scope='user'`, one-tx save, input
+     bounds**; **structured save/search/delete events**; new `"Memory"` tag; OpenAPI
+     `summary` encodes the save body shape; **cross-user regression test (merge gate).**
+  3. **eval:** `memory-save-recall.flow.mjs` (mirror `mcp-search-capabilities.flow.mjs`)
+     proving save→recall end-to-end.
+  4. **apps/server:** static **search-first** `## Memory Bank` prompt incl. no-secrets
+     guidance.
+  5. **Desktop:** `featureFlags.memory` toggle + management panel (list + delete, all
+     states via Base UI, optimistic-delete + undo, escaped content) + copy-prompt button.
+  6. **Fast-follow (deferred):** hard gate, encryption at rest, rate-limit/quota, modal.
+- **Per-PR verification gate (`AGENTS.md`) — applies to every stage above.** Each stage's
+  PR must: (a) **run tests with pnpm and report the exact commands + results** in the PR
+  body; (b) produce **`fraimz` proof** for every experience-affecting change —
+  `evals/results/<run-id>/fraimz.html` via `/fraimz` (or `pnpm fraimz --flow <id>`), each
+  frame binding claim → user action → observable assertion → validated screenshot, and
+  report `Passed` **only** when `fraimz.html` exists with observable assertions (else
+  `Incomplete`/`Failed` with repro); backend-only/types-only stages may skip but must say
+  so and prove the core flow is unchanged; (c) attach **end-to-end evidence** (short video
+  preferred, screenshots otherwise) of save → recall → view/delete; (d) meet coding
+  guidelines (no `any`/`as`, pnpm, `@/components`/shadcn Base UI, smallest diff). See
+  `TASKS.md` TASK-11.
+- **Reference files:** `ee/packages/den-db/src/schema/workers.ts`,
+  `ee/apps/den-api/src/routes/workers/core.ts` (structure only — re-scope authz to user),
+  `ee/apps/den-api/src/openapi.ts` (operationId gen),
+  `ee/apps/den-api/src/mcp/policy.ts:2-23`, `search.ts` / `agent.ts` (rail + error shape),
+  `apps/server/src/openwork-runtime-config.ts:34-66`,
+  `apps/app/src/react-app/domains/settings/state/feature-flags-preferences.ts`,
+  `apps/app/src/react-app/kernel/local-provider.tsx`, `evals/flows/*cloud-mcp*.flow.mjs`.
+
+---
+
+## 13. Review trail
+
+Revised after a 5-lens `/autoplan` review (product · arch · design · devex · security),
+2026-07-02. Full findings + consolidated report:
+`~/.agentic-workflow/joi-fairshare-openwork/plans/20260702-112912-memory-bank/consolidated-review.md`.
+Blockers B1–B5 and the operationId correction are folded in above; the three product/
+security tensions were decided as recorded in §11.

--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -21,6 +21,7 @@ import { registerAdminRoutes } from "./routes/admin/index.js"
 import { registerAuthRoutes } from "./routes/auth/index.js"
 import { registerBootstrapRoutes } from "./routes/bootstrap/index.js"
 import { registerMcpTokenRoutes } from "./routes/mcp/index.js"
+import { registerMemoryRoutes } from "./routes/memory/index.js"
 import { registerMeRoutes } from "./routes/me/index.js"
 import { registerOrgRoutes } from "./routes/org/index.js"
 import { registerTelemetryRoutes } from "./routes/telemetry/index.js"
@@ -163,6 +164,7 @@ registerAdminRoutes(app)
 registerAuthRoutes(app)
 registerBootstrapRoutes(app)
 registerMeRoutes(app)
+registerMemoryRoutes(app)
 registerOrgRoutes(app)
 registerVersionRoutes(app)
 registerWebhookRoutes(app)

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -4,7 +4,7 @@ import type { Hono } from "hono"
 import { z } from "zod"
 import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { getMcpResourceUrl, verifyMcpRequest } from "./auth.js"
-import { invokeMcpOperation, normalizeToolBody } from "./invoke.js"
+import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./invoke.js"
 import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities } from "./search.js"
 
@@ -80,8 +80,8 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         ].join(" "),
         inputSchema: z.object({
           name: z.string().min(1).describe("The exact tool name returned by search_capabilities."),
-          path: z.record(z.string(), z.unknown()).optional().describe("Path parameters, only if the match's pathParams is non-empty."),
-          query: z.record(z.string(), z.unknown()).optional().describe("Query parameters, only if the match's queryParams is non-empty."),
+          path: z.union([z.record(z.string(), z.unknown()), z.string()]).optional().describe("Path parameters, only if the match's pathParams is non-empty."),
+          query: z.union([z.record(z.string(), z.unknown()), z.string()]).optional().describe("Query parameters, only if the match's queryParams is non-empty."),
           body: z.unknown().optional().describe("JSON body, only if the match's hasBody is true."),
         }),
       },
@@ -105,7 +105,11 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
           env: c.env,
           operation,
           principal,
-          toolInput: { path, query, body: normalizeToolBody(body) },
+          toolInput: {
+            path: normalizeToolRecord(path),
+            query: normalizeToolRecord(query),
+            body: normalizeToolBody(body),
+          },
         })
       },
     )

--- a/ee/apps/den-api/src/mcp/invoke.ts
+++ b/ee/apps/den-api/src/mcp/invoke.ts
@@ -41,6 +41,23 @@ export function normalizeToolBody(body: unknown): unknown {
   }
 }
 
+/**
+ * MCP clients frequently pass `path`/`query` as a JSON-encoded string instead of an
+ * object. Parse such strings back into a record so a stringified `{"q":"acme"}` does not
+ * fail tool-input validation (the same hazard `normalizeToolBody` guards for the body).
+ */
+export function normalizeToolRecord(value: unknown): Record<string, unknown> | undefined {
+  const parsed = typeof value === "string" ? normalizeToolBody(value) : value
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return undefined
+  }
+  const record: Record<string, unknown> = {}
+  for (const [key, entry] of Object.entries(parsed)) {
+    record[key] = entry
+  }
+  return record
+}
+
 function buildPath(template: string, values: Record<string, unknown>) {
   return template.replace(/\{([^}]+)\}/g, (_match, key: string) => {
     const value = values[key]

--- a/ee/apps/den-api/src/mcp/policy.ts
+++ b/ee/apps/den-api/src/mcp/policy.ts
@@ -14,6 +14,7 @@ const SAFE_INCLUDED_TAGS = new Set([
   "Workers",
   "Worker Runtime",
   "Worker Activity",
+  "Memory",
   "Config Objects",
   "Plugins",
   "Marketplaces",

--- a/ee/apps/den-api/src/routes/memory/core.ts
+++ b/ee/apps/den-api/src/routes/memory/core.ts
@@ -6,7 +6,7 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
 import { authenticatedRoute, jsonValidator, paramValidator, queryValidator } from "../../middleware/index.js"
-import { invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
+import { emptyResponse, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 import {
   getMemoryByIdForUser,
@@ -56,6 +56,9 @@ export function registerMemoryCoreRoutes<T extends { Variables: AuthContextVaria
     async (c) => {
       const user = c.get("user")
       if (!user) return c.json({ error: "unauthorized" }, 401)
+      // org id comes from the resolved session (hydrated by the global sessionMiddleware for
+      // cookie/bearer sessions and from the signed principal on the MCP path); the desktop
+      // hydrates the active org via /v1/me/orgs on load. A caller with no active org gets 400.
       const activeOrganizationId = c.get("session")?.activeOrganizationId
       if (!activeOrganizationId) return c.json({ error: "organization_unavailable" }, 400)
 
@@ -63,17 +66,26 @@ export function registerMemoryCoreRoutes<T extends { Variables: AuthContextVaria
       const orgId = normalizeDenTypeId("org", activeOrganizationId)
       const input = c.req.valid("json")
       const memoryId = createDenTypeId("memory")
+      // One app-clock timestamp for the whole save: the memory row, its context rows, and the
+      // 201 body all carry `now`, so the response is authoritative (matches a later
+      // getMemory/getMemorySearch) — MySQL has no INSERT ... RETURNING. memory.created_at is
+      // the ordering authority for the list. `row` is the single source for the insert AND the
+      // response, so the persisted row and the returned body cannot drift.
+      const now = new Date()
+      const row = {
+        id: memoryId,
+        user_id: userId,
+        org_id: orgId,
+        scope: "user",
+        content: input.content,
+        source: "chat",
+        tags: input.tags ?? null,
+        created_at: now,
+        updated_at: now,
+      } satisfies typeof MemoryTable.$inferInsert
 
       await db.transaction(async (tx) => {
-        await tx.insert(MemoryTable).values({
-          id: memoryId,
-          user_id: userId,
-          org_id: orgId,
-          scope: "user",
-          content: input.content,
-          source: "chat",
-          tags: input.tags ?? null,
-        })
+        await tx.insert(MemoryTable).values(row)
         if (input.contexts && input.contexts.length > 0) {
           await tx.insert(MemoryContextTable).values(
             input.contexts.map((ctx) => ({
@@ -82,6 +94,7 @@ export function registerMemoryCoreRoutes<T extends { Variables: AuthContextVaria
               snippet: ctx.snippet,
               citation: buildCitation(ctx),
               origin: ctx.origin ?? null,
+              created_at: now,
             })),
           )
         }
@@ -89,21 +102,7 @@ export function registerMemoryCoreRoutes<T extends { Variables: AuthContextVaria
 
       logMemoryEvent("save", { memoryId, userId, contexts: input.contexts?.length ?? 0 })
 
-      const now = new Date().toISOString()
-      return c.json(
-        {
-          memory: {
-            id: memoryId,
-            content: input.content,
-            tags: input.tags ?? null,
-            source: "chat",
-            scope: "user",
-            createdAt: now,
-            updatedAt: now,
-          },
-        },
-        201,
-      )
+      return c.json({ memory: toMemoryResponse(row) }, 201)
     },
   )
 
@@ -128,6 +127,9 @@ export function registerMemoryCoreRoutes<T extends { Variables: AuthContextVaria
       const { q, limit } = c.req.valid("query")
 
       const relevance = memoryRelevance(q)
+      // v0 memory is a single per-user pool: reads are scoped by user_id (+ defensive
+      // scope='user'), intentionally NOT by org_id, so a user recalls their memories across
+      // all of their orgs. org_id is recorded for the future org-shared bank (§8).
       const rows = await db
         .select({
           id: MemoryTable.id,
@@ -199,7 +201,7 @@ export function registerMemoryCoreRoutes<T extends { Variables: AuthContextVaria
       summary: "Delete one of your saved memories.",
       description: "Hard-deletes a memory and its captured context rows. Returns 404 for an id the caller does not own.",
       responses: {
-        204: { description: "Memory deleted successfully." },
+        204: emptyResponse("Memory deleted successfully."),
         400: jsonResponse("The memory id path parameter was invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to delete memories.", unauthorizedSchema),
         404: jsonResponse("The memory could not be found.", notFoundSchema),

--- a/ee/apps/den-api/src/routes/memory/core.ts
+++ b/ee/apps/den-api/src/routes/memory/core.ts
@@ -3,9 +3,9 @@ import { MemoryContextTable, MemoryTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
-import { z } from "zod"
 import { db } from "../../db.js"
-import { authenticatedRoute, jsonValidator, paramValidator, queryValidator } from "../../middleware/index.js"
+import { authenticatedRoute, jsonValidator, orgMemberRoute, paramValidator, queryValidator } from "../../middleware/index.js"
+import type { OrganizationContextVariables } from "../../middleware/index.js"
 import { emptyResponse, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 import {
@@ -25,10 +25,6 @@ import {
   toMemoryResponse,
 } from "./shared.js"
 
-const organizationUnavailableSchema = z
-  .object({ error: z.literal("organization_unavailable") })
-  .meta({ ref: "MemoryOrganizationUnavailableError" })
-
 function buildCitation(ctx: { conversation_id?: string; message_id?: string }): Record<string, string> | null {
   const citation: Record<string, string> = {}
   if (ctx.conversation_id) citation.conversation_id = ctx.conversation_id
@@ -36,7 +32,7 @@ function buildCitation(ctx: { conversation_id?: string; message_id?: string }): 
   return Object.keys(citation).length > 0 ? citation : null
 }
 
-export function registerMemoryCoreRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
+export function registerMemoryCoreRoutes<T extends { Variables: AuthContextVariables & Partial<OrganizationContextVariables> }>(app: Hono<T>) {
   app.post(
     "/v1/memory",
     describeRoute({
@@ -47,23 +43,26 @@ export function registerMemoryCoreRoutes<T extends { Variables: AuthContextVaria
         "Persists a human-confirmed memory for the calling user. The server sets the source and always stores it as a personal ('user') memory regardless of any scope sent by the client.",
       responses: {
         201: jsonResponse("Memory saved successfully.", saveMemoryResponseSchema),
-        400: jsonResponse("The save payload was invalid, or the caller has no active organization.", z.union([invalidRequestSchema, organizationUnavailableSchema])),
+        400: jsonResponse("The save payload was invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to save a memory.", unauthorizedSchema),
+        404: jsonResponse("The caller has no active organization they are a member of to save the memory to.", notFoundSchema),
       },
     }),
-    authenticatedRoute(),
+    orgMemberRoute(),
     jsonValidator(saveMemorySchema),
     async (c) => {
       const user = c.get("user")
       if (!user) return c.json({ error: "unauthorized" }, 401)
-      // org id comes from the resolved session (hydrated by the global sessionMiddleware for
-      // cookie/bearer sessions and from the signed principal on the MCP path); the desktop
-      // hydrates the active org via /v1/me/orgs on load. A caller with no active org gets 400.
-      const activeOrganizationId = c.get("session")?.activeOrganizationId
-      if (!activeOrganizationId) return c.json({ error: "organization_unavailable" }, 400)
+      // orgMemberRoute() resolved the caller's active org (from the cookie/bearer session, or the
+      // signed principal on the MCP path) AND verified they are a member of it — a non-member or
+      // no-active-org caller was already rejected with 404. So a memory is only ever saved to an
+      // org the user actually belongs to. org_id is recorded for the future org-shared bank (§8);
+      // v0 reads stay per-user across all of the caller's orgs.
+      const organizationContext = c.get("organizationContext")
+      if (!organizationContext) return c.json({ error: "organization_not_found" }, 404)
 
       const userId = normalizeDenTypeId("user", user.id)
-      const orgId = normalizeDenTypeId("org", activeOrganizationId)
+      const orgId = normalizeDenTypeId("org", organizationContext.organization.id)
       const input = c.req.valid("json")
       const memoryId = createDenTypeId("memory")
       // One app-clock timestamp for the whole save: the memory row, its context rows, and the

--- a/ee/apps/den-api/src/routes/memory/core.ts
+++ b/ee/apps/den-api/src/routes/memory/core.ts
@@ -1,0 +1,231 @@
+import { and, desc, eq } from "@openwork-ee/den-db/drizzle"
+import { MemoryContextTable, MemoryTable } from "@openwork-ee/den-db/schema"
+import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import type { Hono } from "hono"
+import { describeRoute } from "hono-openapi"
+import { z } from "zod"
+import { db } from "../../db.js"
+import { authenticatedRoute, jsonValidator, paramValidator, queryValidator } from "../../middleware/index.js"
+import { invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
+import type { AuthContextVariables } from "../../session.js"
+import {
+  getMemoryByIdForUser,
+  listMemoryQuerySchema,
+  listMemoryResponseSchema,
+  loadContextsByMemoryId,
+  logMemoryEvent,
+  memoryIdParamSchema,
+  memoryRelevance,
+  parseMemoryIdParam,
+  saveMemoryResponseSchema,
+  saveMemorySchema,
+  searchMemoryQuerySchema,
+  searchMemoryResponseSchema,
+  toMemoryContextResponse,
+  toMemoryResponse,
+} from "./shared.js"
+
+const organizationUnavailableSchema = z
+  .object({ error: z.literal("organization_unavailable") })
+  .meta({ ref: "MemoryOrganizationUnavailableError" })
+
+function buildCitation(ctx: { conversation_id?: string; message_id?: string }): Record<string, string> | null {
+  const citation: Record<string, string> = {}
+  if (ctx.conversation_id) citation.conversation_id = ctx.conversation_id
+  if (ctx.message_id) citation.message_id = ctx.message_id
+  return Object.keys(citation).length > 0 ? citation : null
+}
+
+export function registerMemoryCoreRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
+  app.post(
+    "/v1/memory",
+    describeRoute({
+      tags: ["Memory"],
+      summary:
+        "Save a memory to the memory bank. Body: { content: string (required); tags?: string[]; contexts?: Array<{ snippet: string (required); conversation_id?: string; message_id?: string; origin?: \"active_conversation\" | \"searched_conversation\" }> }.",
+      description:
+        "Persists a human-confirmed memory for the calling user. The server sets the source and always stores it as a personal ('user') memory regardless of any scope sent by the client.",
+      responses: {
+        201: jsonResponse("Memory saved successfully.", saveMemoryResponseSchema),
+        400: jsonResponse("The save payload was invalid, or the caller has no active organization.", z.union([invalidRequestSchema, organizationUnavailableSchema])),
+        401: jsonResponse("The caller must be signed in to save a memory.", unauthorizedSchema),
+      },
+    }),
+    authenticatedRoute(),
+    jsonValidator(saveMemorySchema),
+    async (c) => {
+      const user = c.get("user")
+      if (!user) return c.json({ error: "unauthorized" }, 401)
+      const activeOrganizationId = c.get("session")?.activeOrganizationId
+      if (!activeOrganizationId) return c.json({ error: "organization_unavailable" }, 400)
+
+      const userId = normalizeDenTypeId("user", user.id)
+      const orgId = normalizeDenTypeId("org", activeOrganizationId)
+      const input = c.req.valid("json")
+      const memoryId = createDenTypeId("memory")
+
+      await db.transaction(async (tx) => {
+        await tx.insert(MemoryTable).values({
+          id: memoryId,
+          user_id: userId,
+          org_id: orgId,
+          scope: "user",
+          content: input.content,
+          source: "chat",
+          tags: input.tags ?? null,
+        })
+        if (input.contexts && input.contexts.length > 0) {
+          await tx.insert(MemoryContextTable).values(
+            input.contexts.map((ctx) => ({
+              id: createDenTypeId("memctx"),
+              memory_id: memoryId,
+              snippet: ctx.snippet,
+              citation: buildCitation(ctx),
+              origin: ctx.origin ?? null,
+            })),
+          )
+        }
+      })
+
+      logMemoryEvent("save", { memoryId, userId, contexts: input.contexts?.length ?? 0 })
+
+      const now = new Date().toISOString()
+      return c.json(
+        {
+          memory: {
+            id: memoryId,
+            content: input.content,
+            tags: input.tags ?? null,
+            source: "chat",
+            scope: "user",
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+        201,
+      )
+    },
+  )
+
+  app.get(
+    "/v1/memory/search",
+    describeRoute({
+      tags: ["Memory"],
+      summary: "Search your memories with a natural-language query.",
+      description: "Runs a relevance-ranked full-text search over the caller's own memories. Returns an empty result set (not an error) when nothing matches.",
+      responses: {
+        200: jsonResponse("Search results returned successfully.", searchMemoryResponseSchema),
+        400: jsonResponse("The search query was invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to search memories.", unauthorizedSchema),
+      },
+    }),
+    authenticatedRoute(),
+    queryValidator(searchMemoryQuerySchema),
+    async (c) => {
+      const user = c.get("user")
+      if (!user) return c.json({ error: "unauthorized" }, 401)
+      const userId = normalizeDenTypeId("user", user.id)
+      const { q, limit } = c.req.valid("query")
+
+      const relevance = memoryRelevance(q)
+      const rows = await db
+        .select({
+          id: MemoryTable.id,
+          user_id: MemoryTable.user_id,
+          org_id: MemoryTable.org_id,
+          scope: MemoryTable.scope,
+          content: MemoryTable.content,
+          source: MemoryTable.source,
+          tags: MemoryTable.tags,
+          created_at: MemoryTable.created_at,
+          updated_at: MemoryTable.updated_at,
+          score: relevance,
+        })
+        .from(MemoryTable)
+        .where(and(eq(MemoryTable.user_id, userId), eq(MemoryTable.scope, "user"), relevance))
+        .orderBy(desc(relevance))
+        .limit(limit)
+
+      logMemoryEvent("search", { userId, queryLength: q.length, resultCount: rows.length })
+
+      return c.json({
+        results: rows.map((row) => ({ ...toMemoryResponse(row), score: Number(row.score) })),
+      })
+    },
+  )
+
+  app.get(
+    "/v1/memory",
+    describeRoute({
+      tags: ["Memory"],
+      summary: "List your saved memories with their provenance.",
+      description: "Returns the caller's own memories, newest first, each with its captured context (citations + snippets).",
+      responses: {
+        200: jsonResponse("Memories returned successfully.", listMemoryResponseSchema),
+        400: jsonResponse("The list query parameters were invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to list memories.", unauthorizedSchema),
+      },
+    }),
+    authenticatedRoute(),
+    queryValidator(listMemoryQuerySchema),
+    async (c) => {
+      const user = c.get("user")
+      if (!user) return c.json({ error: "unauthorized" }, 401)
+      const userId = normalizeDenTypeId("user", user.id)
+      const { limit } = c.req.valid("query")
+
+      const rows = await db
+        .select()
+        .from(MemoryTable)
+        .where(and(eq(MemoryTable.user_id, userId), eq(MemoryTable.scope, "user")))
+        .orderBy(desc(MemoryTable.created_at))
+        .limit(limit)
+
+      const contexts = await loadContextsByMemoryId(rows.map((row) => row.id))
+
+      return c.json({
+        memories: rows.map((row) => ({
+          ...toMemoryResponse(row),
+          contexts: (contexts.get(row.id) ?? []).map(toMemoryContextResponse),
+        })),
+      })
+    },
+  )
+
+  app.delete(
+    "/v1/memory/:id",
+    describeRoute({
+      tags: ["Memory"],
+      summary: "Delete one of your saved memories.",
+      description: "Hard-deletes a memory and its captured context rows. Returns 404 for an id the caller does not own.",
+      responses: {
+        204: { description: "Memory deleted successfully." },
+        400: jsonResponse("The memory id path parameter was invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to delete memories.", unauthorizedSchema),
+        404: jsonResponse("The memory could not be found.", notFoundSchema),
+      },
+    }),
+    authenticatedRoute(),
+    paramValidator(memoryIdParamSchema),
+    async (c) => {
+      const user = c.get("user")
+      if (!user) return c.json({ error: "unauthorized" }, 401)
+      const userId = normalizeDenTypeId("user", user.id)
+      const { id } = c.req.valid("param")
+
+      const memoryId = parseMemoryIdParam(id)
+      if (!memoryId) return c.json({ error: "memory_not_found" }, 404)
+
+      const existing = await getMemoryByIdForUser(memoryId, userId)
+      if (!existing) return c.json({ error: "memory_not_found" }, 404)
+
+      await db.transaction(async (tx) => {
+        await tx.delete(MemoryContextTable).where(eq(MemoryContextTable.memory_id, memoryId))
+        await tx.delete(MemoryTable).where(and(eq(MemoryTable.id, memoryId), eq(MemoryTable.user_id, userId)))
+      })
+
+      logMemoryEvent("delete", { memoryId, userId })
+      return c.body(null, 204)
+    },
+  )
+}

--- a/ee/apps/den-api/src/routes/memory/index.ts
+++ b/ee/apps/den-api/src/routes/memory/index.ts
@@ -1,0 +1,7 @@
+import type { Hono } from "hono"
+import type { AuthContextVariables } from "../../session.js"
+import { registerMemoryCoreRoutes } from "./core.js"
+
+export function registerMemoryRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
+  registerMemoryCoreRoutes(app)
+}

--- a/ee/apps/den-api/src/routes/memory/index.ts
+++ b/ee/apps/den-api/src/routes/memory/index.ts
@@ -1,7 +1,10 @@
 import type { Hono } from "hono"
+import type { OrganizationContextVariables } from "../../middleware/index.js"
 import type { AuthContextVariables } from "../../session.js"
 import { registerMemoryCoreRoutes } from "./core.js"
 
-export function registerMemoryRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
+export function registerMemoryRoutes<T extends { Variables: AuthContextVariables & Partial<OrganizationContextVariables> }>(
+  app: Hono<T>,
+) {
   registerMemoryCoreRoutes(app)
 }

--- a/ee/apps/den-api/src/routes/memory/shared.ts
+++ b/ee/apps/den-api/src/routes/memory/shared.ts
@@ -63,7 +63,7 @@ const memoryContextResponseSchema = z
   })
   .meta({ ref: "MemoryContext" })
 
-export const memoryResponseSchema = z
+const memoryResponseSchema = z
   .object({
     id: denTypeIdSchema("memory"),
     content: z.string(),
@@ -75,7 +75,7 @@ export const memoryResponseSchema = z
   })
   .meta({ ref: "Memory" })
 
-export const memoryWithContextsSchema = memoryResponseSchema
+const memoryWithContextsSchema = memoryResponseSchema
   .extend({ contexts: z.array(memoryContextResponseSchema) })
   .meta({ ref: "MemoryWithContexts" })
 

--- a/ee/apps/den-api/src/routes/memory/shared.ts
+++ b/ee/apps/den-api/src/routes/memory/shared.ts
@@ -1,0 +1,180 @@
+import { and, desc, eq, inArray, type SQL, sql } from "@openwork-ee/den-db/drizzle"
+import { MemoryContextOrigin, MemoryContextTable, MemoryTable } from "@openwork-ee/den-db/schema"
+import { type DenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { z } from "zod"
+import { db } from "../../db.js"
+import { denTypeIdSchema } from "../../openapi.js"
+
+// Input bounds — a cheap abuse guard (§8); full per-user quota/rate-limiting is deferred.
+export const MAX_CONTENT_LENGTH = 8_000
+export const MAX_TAGS = 32
+export const MAX_TAG_LENGTH = 64
+export const MAX_CONTEXTS = 16
+export const MAX_SNIPPET_LENGTH = 4_000
+export const MAX_CITATION_ID_LENGTH = 128
+export const MAX_QUERY_LENGTH = 512
+export const DEFAULT_LIMIT = 20
+export const MAX_SEARCH_LIMIT = 50
+export const MAX_LIST_LIMIT = 100
+
+// The save body shape is intentionally flat and mostly-optional so the agent — which only
+// sees `hasBody:true`, not the schema — can construct it; the shape is also spelled out in
+// the route's OpenAPI summary (memory-bank-architecture.md §4, B3).
+export const saveMemorySchema = z
+  .object({
+    content: z.string().trim().min(1).max(MAX_CONTENT_LENGTH),
+    tags: z.array(z.string().trim().min(1).max(MAX_TAG_LENGTH)).max(MAX_TAGS).optional(),
+    contexts: z
+      .array(
+        z.object({
+          snippet: z.string().trim().min(1).max(MAX_SNIPPET_LENGTH),
+          conversation_id: z.string().min(1).max(MAX_CITATION_ID_LENGTH).optional(),
+          message_id: z.string().min(1).max(MAX_CITATION_ID_LENGTH).optional(),
+          origin: z.enum(MemoryContextOrigin).optional(),
+        }),
+      )
+      .max(MAX_CONTEXTS)
+      .optional(),
+  })
+  .meta({ ref: "SaveMemoryRequest" })
+
+export const searchMemoryQuerySchema = z
+  .object({
+    q: z.string().trim().min(1).max(MAX_QUERY_LENGTH),
+    limit: z.coerce.number().int().min(1).max(MAX_SEARCH_LIMIT).default(DEFAULT_LIMIT),
+  })
+  .meta({ ref: "MemorySearchQuery" })
+
+export const listMemoryQuerySchema = z
+  .object({
+    limit: z.coerce.number().int().min(1).max(MAX_LIST_LIMIT).default(DEFAULT_LIMIT),
+  })
+  .meta({ ref: "MemoryListQuery" })
+
+export const memoryIdParamSchema = z.object({ id: z.string() }).meta({ ref: "MemoryIdParam" })
+
+const memoryContextResponseSchema = z
+  .object({
+    id: denTypeIdSchema("memctx"),
+    snippet: z.string(),
+    citation: z.record(z.string(), z.unknown()).nullable(),
+    origin: z.string().nullable(),
+    createdAt: z.string().datetime(),
+  })
+  .meta({ ref: "MemoryContext" })
+
+export const memoryResponseSchema = z
+  .object({
+    id: denTypeIdSchema("memory"),
+    content: z.string(),
+    tags: z.array(z.string()).nullable(),
+    source: z.string(),
+    scope: z.string(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .meta({ ref: "Memory" })
+
+export const memoryWithContextsSchema = memoryResponseSchema
+  .extend({ contexts: z.array(memoryContextResponseSchema) })
+  .meta({ ref: "MemoryWithContexts" })
+
+export const saveMemoryResponseSchema = z
+  .object({ memory: memoryResponseSchema })
+  .meta({ ref: "SaveMemoryResponse" })
+
+export const listMemoryResponseSchema = z
+  .object({ memories: z.array(memoryWithContextsSchema) })
+  .meta({ ref: "MemoryListResponse" })
+
+export const searchMemoryResponseSchema = z
+  .object({
+    results: z.array(memoryResponseSchema.extend({ score: z.number() })),
+  })
+  .meta({ ref: "MemorySearchResponse" })
+
+type MemoryRow = typeof MemoryTable.$inferSelect
+type MemoryContextRow = typeof MemoryContextTable.$inferSelect
+
+function normalizeTags(value: unknown): string[] | null {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : null
+}
+
+function normalizeCitation(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? { ...value }
+    : null
+}
+
+export function toMemoryResponse(row: MemoryRow) {
+  return {
+    id: row.id,
+    content: row.content,
+    tags: normalizeTags(row.tags),
+    source: row.source,
+    scope: row.scope,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  }
+}
+
+export function toMemoryContextResponse(row: MemoryContextRow) {
+  return {
+    id: row.id,
+    snippet: row.snippet,
+    citation: normalizeCitation(row.citation),
+    origin: row.origin,
+    createdAt: row.created_at.toISOString(),
+  }
+}
+
+/** Owner-scoped read (B4): user_id is the PRIMARY predicate, plus defensive scope='user'. */
+export async function getMemoryByIdForUser(
+  memoryId: DenTypeId<"memory">,
+  userId: DenTypeId<"user">,
+): Promise<MemoryRow | null> {
+  const rows = await db
+    .select()
+    .from(MemoryTable)
+    .where(and(eq(MemoryTable.id, memoryId), eq(MemoryTable.user_id, userId), eq(MemoryTable.scope, "user")))
+    .limit(1)
+  return rows[0] ?? null
+}
+
+export async function loadContextsByMemoryId(
+  memoryIds: DenTypeId<"memory">[],
+): Promise<Map<string, MemoryContextRow[]>> {
+  const grouped = new Map<string, MemoryContextRow[]>()
+  if (memoryIds.length === 0) {
+    return grouped
+  }
+  const rows = await db
+    .select()
+    .from(MemoryContextTable)
+    .where(inArray(MemoryContextTable.memory_id, memoryIds))
+    .orderBy(desc(MemoryContextTable.created_at))
+  for (const row of rows) {
+    const bucket = grouped.get(row.memory_id) ?? []
+    bucket.push(row)
+    grouped.set(row.memory_id, bucket)
+  }
+  return grouped
+}
+
+/** Bound MATCH … AGAINST in NATURAL LANGUAGE MODE — never sql.raw (B/§3). */
+export function memoryRelevance(query: string): SQL<number> {
+  return sql<number>`MATCH(${MemoryTable.content}) AGAINST (${query} IN NATURAL LANGUAGE MODE)`
+}
+
+export function parseMemoryIdParam(raw: string): DenTypeId<"memory"> | null {
+  try {
+    return normalizeDenTypeId("memory", raw)
+  } catch {
+    return null
+  }
+}
+
+/** Structured, server-observable event (TR-10) — distinguishes "never saved" from "save failed". */
+export function logMemoryEvent(event: "save" | "search" | "delete", fields: Record<string, unknown>): void {
+  console.log(JSON.stringify({ event: `memory.${event}`, ...fields }))
+}

--- a/ee/apps/den-api/test/memory-ownership.test.ts
+++ b/ee/apps/den-api/test/memory-ownership.test.ts
@@ -1,0 +1,144 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, beforeAll, expect, test } from "bun:test"
+
+// TASK-2 [B4]: the cross-user access regression test — the merge gate. Requires a local
+// MySQL with the memory schema pushed (pnpm --filter @openwork-ee/den-db db:push).
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let app: typeof import("../src/app.js").default
+let db: typeof import("../src/db.js").db
+let schema: typeof import("@openwork-ee/den-db/schema")
+let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+let session: typeof import("../src/session.js")
+
+const alice = createDenTypeId("user")
+const bob = createDenTypeId("user")
+const aliceOrg = createDenTypeId("organization")
+const bobOrg = createDenTypeId("organization")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  const [appMod, dbMod, schemaMod, drizzleMod, sessionMod] = await Promise.all([
+    import("../src/app.js"),
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+    import("../src/session.js"),
+  ])
+  app = appMod.default
+  db = dbMod.db
+  schema = schemaMod
+  drizzle = drizzleMod
+  session = sessionMod
+
+  await db.insert(schema.AuthUserTable).values([
+    { id: alice, name: "Alice", email: `alice+${alice}@memory.test.local` },
+    { id: bob, name: "Bob", email: `bob+${bob}@memory.test.local` },
+  ])
+})
+
+afterAll(async () => {
+  const ids = [alice, bob]
+  const memories = await db
+    .select({ id: schema.MemoryTable.id })
+    .from(schema.MemoryTable)
+    .where(drizzle.inArray(schema.MemoryTable.user_id, ids))
+  const memoryIds = memories.map((row) => row.id)
+  if (memoryIds.length > 0) {
+    await db.delete(schema.MemoryContextTable).where(drizzle.inArray(schema.MemoryContextTable.memory_id, memoryIds))
+    await db.delete(schema.MemoryTable).where(drizzle.inArray(schema.MemoryTable.id, memoryIds))
+  }
+  await db.delete(schema.AuthUserTable).where(drizzle.inArray(schema.AuthUserTable.id, ids))
+})
+
+function request(
+  method: string,
+  path: string,
+  who: { userId: string; organizationId: string },
+  body?: unknown,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader(who),
+  }
+  if (body !== undefined) headers["content-type"] = "application/json"
+  return app.fetch(
+    new Request(`http://den-api.local${path}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }),
+  )
+}
+
+test("cross-user access is denied — save, IDOR 404, recall, cascade delete", async () => {
+  const aliceCreds = { userId: alice, organizationId: aliceOrg }
+  const bobCreds = { userId: bob, organizationId: bobOrg }
+
+  // Alice saves a memory with a context.
+  const saveRes = await request("POST", "/v1/memory", aliceCreds, {
+    content: "Acme renewal deal closes in Q3 at 5000 per month",
+    tags: ["acme", "deal"],
+    contexts: [{ snippet: "we agreed on 5000/mo", origin: "active_conversation" }],
+  })
+  expect(saveRes.status).toBe(201)
+  const saved = await saveRes.json()
+  const memoryId: string = saved.memory.id
+  expect(memoryId.startsWith("mem_")).toBe(true)
+  expect(saved.memory.scope).toBe("user")
+
+  // Bob cannot delete Alice's memory — 404, non-leaking.
+  const bobDelete = await request("DELETE", `/v1/memory/${memoryId}`, bobCreds)
+  expect(bobDelete.status).toBe(404)
+
+  // Bob's list + search never surface Alice's memory.
+  const bobList = await (await request("GET", "/v1/memory", bobCreds)).json()
+  expect(bobList.memories.some((m: { id: string }) => m.id === memoryId)).toBe(false)
+  const bobSearch = await (await request("GET", "/v1/memory/search?q=Acme", bobCreds)).json()
+  expect(bobSearch.results.some((m: { id: string }) => m.id === memoryId)).toBe(false)
+
+  // Alice still owns it after Bob's attempts, and natural-language recall finds it.
+  const aliceSearch = await (await request("GET", "/v1/memory/search?q=Acme%20renewal%20deal", aliceCreds)).json()
+  expect(aliceSearch.results.some((m: { id: string }) => m.id === memoryId)).toBe(true)
+
+  // Owner delete cascades to context rows and is idempotent (second delete → 404).
+  const aliceDelete = await request("DELETE", `/v1/memory/${memoryId}`, aliceCreds)
+  expect(aliceDelete.status).toBe(204)
+  const remainingContexts = await db
+    .select({ id: schema.MemoryContextTable.id })
+    .from(schema.MemoryContextTable)
+    .where(drizzle.eq(schema.MemoryContextTable.memory_id, memoryId))
+  expect(remainingContexts.length).toBe(0)
+  expect((await request("DELETE", `/v1/memory/${memoryId}`, aliceCreds)).status).toBe(404)
+})
+
+test("empty search returns 200 with an empty result set (not an error)", async () => {
+  const res = await request("GET", "/v1/memory/search?q=zzzznonexistentqueryzzzz", { userId: alice, organizationId: aliceOrg })
+  expect(res.status).toBe(200)
+  const body = await res.json()
+  expect(body.results).toEqual([])
+})
+
+test("client-supplied scope='org' is forced to 'user' server-side", async () => {
+  const res = await request("POST", "/v1/memory", { userId: alice, organizationId: aliceOrg }, {
+    content: "scope forcing check",
+    scope: "org",
+  })
+  expect(res.status).toBe(201)
+  const saved = await res.json()
+  expect(saved.memory.scope).toBe("user")
+  const row = await db.select().from(schema.MemoryTable).where(drizzle.eq(schema.MemoryTable.id, saved.memory.id))
+  expect(row[0]?.scope).toBe("user")
+})
+
+test("input bounds are enforced (400)", async () => {
+  const res = await request("POST", "/v1/memory", { userId: alice, organizationId: aliceOrg }, {
+    content: "x".repeat(100_000),
+  })
+  expect(res.status).toBe(400)
+})

--- a/ee/apps/den-api/test/memory-ownership.test.ts
+++ b/ee/apps/den-api/test/memory-ownership.test.ts
@@ -41,6 +41,16 @@ beforeAll(async () => {
     { id: alice, name: "Alice", email: `alice+${alice}@memory.test.local` },
     { id: bob, name: "Bob", email: `bob+${bob}@memory.test.local` },
   ])
+  // orgMemberRoute() on POST /v1/memory only lets a caller save to an org they are a member of,
+  // so each user needs a real org + membership row (slug carries the id to stay unique).
+  await db.insert(schema.OrganizationTable).values([
+    { id: aliceOrg, name: "Alice Org", slug: `alice-org-${aliceOrg}` },
+    { id: bobOrg, name: "Bob Org", slug: `bob-org-${bobOrg}` },
+  ])
+  await db.insert(schema.MemberTable).values([
+    { id: createDenTypeId("member"), organizationId: aliceOrg, userId: alice, role: "owner" },
+    { id: createDenTypeId("member"), organizationId: bobOrg, userId: bob, role: "owner" },
+  ])
 })
 
 afterAll(async () => {
@@ -54,6 +64,10 @@ afterAll(async () => {
     await db.delete(schema.MemoryContextTable).where(drizzle.inArray(schema.MemoryContextTable.memory_id, memoryIds))
     await db.delete(schema.MemoryTable).where(drizzle.inArray(schema.MemoryTable.id, memoryIds))
   }
+  const orgIds = [aliceOrg, bobOrg]
+  await db.delete(schema.MemberTable).where(drizzle.inArray(schema.MemberTable.organizationId, orgIds))
+  await db.delete(schema.OrganizationRoleTable).where(drizzle.inArray(schema.OrganizationRoleTable.organizationId, orgIds))
+  await db.delete(schema.OrganizationTable).where(drizzle.inArray(schema.OrganizationTable.id, orgIds))
   await db.delete(schema.AuthUserTable).where(drizzle.inArray(schema.AuthUserTable.id, ids))
 })
 
@@ -141,4 +155,18 @@ test("input bounds are enforced (400)", async () => {
     content: "x".repeat(100_000),
   })
   expect(res.status).toBe(400)
+})
+
+test("saving to an org the caller is not a member of is rejected (404) — orgMemberRoute gate", async () => {
+  // Alice presents a principal scoped to Bob's org, which she does not belong to.
+  const res = await request("POST", "/v1/memory", { userId: alice, organizationId: bobOrg }, {
+    content: "should never persist under a non-member org",
+  })
+  expect(res.status).toBe(404)
+  // Nothing was written for Alice under Bob's org.
+  const rows = await db
+    .select({ id: schema.MemoryTable.id })
+    .from(schema.MemoryTable)
+    .where(drizzle.and(drizzle.eq(schema.MemoryTable.user_id, alice), drizzle.eq(schema.MemoryTable.org_id, bobOrg)))
+  expect(rows.length).toBe(0)
 })

--- a/ee/apps/den-api/test/memory-routes.test.ts
+++ b/ee/apps/den-api/test/memory-routes.test.ts
@@ -1,0 +1,79 @@
+import { beforeAll, expect, test } from "bun:test"
+import { buildOperationId } from "../src/openapi.js"
+import { isMcpOperationAllowed, requiredScopeForMethod } from "../src/mcp/policy.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let shared: typeof import("../src/routes/memory/shared.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  shared = await import("../src/routes/memory/shared.js")
+})
+
+// TASK-3: the real MCP tool names must be exactly these (buildOperationId strips v1), stay
+// <= 49 chars, and be distinct — the prompt (Stage 4) and catalog must not drift (B1).
+test("memory operationIds resolve to the pinned MCP tool names", () => {
+  expect(buildOperationId("POST", "/v1/memory")).toBe("postMemory")
+  expect(buildOperationId("GET", "/v1/memory/search")).toBe("getMemorySearch")
+  expect(buildOperationId("GET", "/v1/memory")).toBe("getMemory")
+  expect(buildOperationId("DELETE", "/v1/memory/:id")).toBe("deleteMemoryById")
+
+  const names = ["postMemory", "getMemorySearch", "getMemory", "deleteMemoryById"]
+  expect(new Set(names).size).toBe(names.length)
+  for (const name of names) {
+    expect(name.length).toBeLessThanOrEqual(49)
+  }
+  // memory_save / memory_search must never be produced.
+  expect(names).not.toContain("memory_save")
+  expect(names).not.toContain("memory_search")
+})
+
+test("Memory-tagged operations are MCP-allowed with the right scopes", () => {
+  expect(
+    isMcpOperationAllowed({ method: "POST", path: "/v1/memory", operation: { operationId: "postMemory", tags: ["Memory"] } }),
+  ).toBe(true)
+  expect(
+    isMcpOperationAllowed({ method: "GET", path: "/v1/memory/search", operation: { operationId: "getMemorySearch", tags: ["Memory"] } }),
+  ).toBe(true)
+  expect(requiredScopeForMethod("POST")).toBe("mcp:write")
+  expect(requiredScopeForMethod("DELETE")).toBe("mcp:write")
+  expect(requiredScopeForMethod("GET")).toBe("mcp:read")
+})
+
+test("save payload accepts a minimal body and ignores client-supplied scope/source", () => {
+  const parsed = shared.saveMemorySchema.parse({ content: "deploys via daytona", scope: "org", source: "modal" })
+  expect(parsed.content).toBe("deploys via daytona")
+  // scope + source are not part of the schema, so a client cannot set them — the server does.
+  expect("scope" in parsed).toBe(false)
+  expect("source" in parsed).toBe(false)
+})
+
+test("save payload enforces input bounds", () => {
+  expect(shared.saveMemorySchema.safeParse({ content: "" }).success).toBe(false)
+  expect(shared.saveMemorySchema.safeParse({ content: "x".repeat(shared.MAX_CONTENT_LENGTH + 1) }).success).toBe(false)
+  expect(
+    shared.saveMemorySchema.safeParse({
+      content: "ok",
+      contexts: Array.from({ length: shared.MAX_CONTEXTS + 1 }, () => ({ snippet: "s" })),
+    }).success,
+  ).toBe(false)
+  expect(
+    shared.saveMemorySchema.safeParse({ content: "ok", tags: Array.from({ length: shared.MAX_TAGS + 1 }, () => "t") })
+      .success,
+  ).toBe(false)
+  // a context requires a snippet
+  expect(shared.saveMemorySchema.safeParse({ content: "ok", contexts: [{ conversation_id: "c" }] }).success).toBe(false)
+})
+
+test("search query defaults + caps the limit and requires q", () => {
+  const parsed = shared.searchMemoryQuerySchema.parse({ q: "acme" })
+  expect(parsed.limit).toBe(shared.DEFAULT_LIMIT)
+  expect(shared.searchMemoryQuerySchema.safeParse({ q: "acme", limit: shared.MAX_SEARCH_LIMIT + 1 }).success).toBe(false)
+  expect(shared.searchMemoryQuerySchema.safeParse({ limit: 5 }).success).toBe(false)
+})

--- a/ee/packages/den-db/drizzle/0028_memory_bank.sql
+++ b/ee/packages/den-db/drizzle/0028_memory_bank.sql
@@ -1,0 +1,29 @@
+CREATE TABLE `memory_context` (
+	`id` varchar(64) NOT NULL,
+	`memory_id` varchar(64) NOT NULL,
+	`citation` json,
+	`snippet` text NOT NULL,
+	`origin` enum('active_conversation','searched_conversation'),
+	`created_at` timestamp(3) NOT NULL DEFAULT (now()),
+	CONSTRAINT `memory_context_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `memory` (
+	`id` varchar(64) NOT NULL,
+	`user_id` varchar(64) NOT NULL,
+	`org_id` varchar(64) NOT NULL,
+	`scope` enum('user','org') NOT NULL DEFAULT 'user',
+	`content` text NOT NULL,
+	`source` varchar(64) NOT NULL,
+	`tags` json,
+	`created_at` timestamp(3) NOT NULL DEFAULT (now()),
+	`updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+	CONSTRAINT `memory_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE INDEX `memory_context_memory_id` ON `memory_context` (`memory_id`);--> statement-breakpoint
+CREATE INDEX `memory_user_id` ON `memory` (`user_id`);--> statement-breakpoint
+-- FULLTEXT indexes cannot be expressed via Drizzle's mysql-core DSL (drizzle-orm#1495), so
+-- it is appended here for the migrate path. The fresh-install (push + baseline) path skips
+-- this migration, so `ensureMemoryFulltextIndex` (bootstrap.ts) creates it idempotently there.
+CREATE FULLTEXT INDEX `memory_content_fulltext` ON `memory` (`content`);

--- a/ee/packages/den-db/drizzle/meta/0028_snapshot.json
+++ b/ee/packages/den-db/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,8186 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "1af15352-aad8-4525-98d9-c55437c6732c",
+  "prevId": "754a5bdf-a3b1-4cca-beb7-27c518d8912b",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "account_user_id": {
+          "name": "account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "account_id": {
+          "name": "account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id": {
+          "name": "apikey_config_id",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_reference_id": {
+          "name": "apikey_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key": {
+          "name": "apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "apikey_id": {
+          "name": "apikey_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "jwks": {
+      "name": "jwks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alg": {
+          "name": "alg",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crv": {
+          "name": "crv",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jwks_id": {
+          "name": "jwks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "session_token": {
+          "name": "session_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_id": {
+          "name": "session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_id": {
+          "name": "session_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "user_email": {
+          "name": "user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_id": {
+          "name": "user_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "verification_identifier": {
+          "name": "verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_id": {
+          "name": "verification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_identity": {
+      "name": "external_identity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_provider_id": {
+          "name": "scim_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_json": {
+          "name": "name_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emails_json": {
+          "name": "emails_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes_json": {
+          "name": "attributes_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_scim_sync_at": {
+          "name": "last_scim_sync_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sso_login_at": {
+          "name": "last_sso_login_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "external_identity_org_user": {
+          "name": "external_identity_org_user",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_sso_remote": {
+          "name": "external_identity_org_sso_remote",
+          "columns": [
+            "organization_id",
+            "sso_provider_id",
+            "remote_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_scim_external": {
+          "name": "external_identity_org_scim_external",
+          "columns": [
+            "organization_id",
+            "scim_provider_id",
+            "external_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_email": {
+          "name": "external_identity_org_email",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        },
+        "external_identity_sso_provider": {
+          "name": "external_identity_sso_provider",
+          "columns": [
+            "sso_provider_id"
+          ],
+          "isUnique": false
+        },
+        "external_identity_scim_provider": {
+          "name": "external_identity_scim_provider",
+          "columns": [
+            "scim_provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id": {
+          "name": "oauth_access_token_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_session_id": {
+          "name": "oauth_access_token_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_user_id": {
+          "name": "oauth_access_token_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_reference_id": {
+          "name": "oauth_access_token_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_refresh_id": {
+          "name": "oauth_access_token_refresh_id",
+          "columns": [
+            "refresh_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthAccessToken_id": {
+          "name": "oauthAccessToken_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthClient": {
+      "name": "oauthClient",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id": {
+          "name": "oauth_client_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauth_client_user_id": {
+          "name": "oauth_client_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_client_reference_id": {
+          "name": "oauth_client_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthClient_id": {
+          "name": "oauthClient_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthConsent": {
+      "name": "oauthConsent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id": {
+          "name": "oauth_consent_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_consent_user_id": {
+          "name": "oauth_consent_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_consent_reference_id": {
+          "name": "oauth_consent_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthConsent_id": {
+          "name": "oauthConsent_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthRefreshToken": {
+      "name": "oauthRefreshToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_client_id": {
+          "name": "oauth_refresh_token_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_session_id": {
+          "name": "oauth_refresh_token_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_user_id": {
+          "name": "oauth_refresh_token_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_reference_id": {
+          "name": "oauth_refresh_token_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthRefreshToken_id": {
+          "name": "oauthRefreshToken_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_provider": {
+      "name": "scim_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_token": {
+          "name": "scim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "scim_provider_provider_id": {
+          "name": "scim_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "scim_provider_organization_id": {
+          "name": "scim_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_provider_id": {
+          "name": "scim_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_sync_event": {
+      "name": "scim_sync_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "scim_sync_event_org_status": {
+          "name": "scim_sync_event_org_status",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_provider_status": {
+          "name": "scim_sync_event_provider_status",
+          "columns": [
+            "provider_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_next_retry": {
+          "name": "scim_sync_event_next_retry",
+          "columns": [
+            "next_retry_at"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_user": {
+          "name": "scim_sync_event_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_sync_event_id": {
+          "name": "scim_sync_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sso_connection": {
+      "name": "sso_connection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'enabled'"
+        },
+        "sign_in_path": {
+          "name": "sign_in_path",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "sso_connection_organization_id": {
+          "name": "sso_connection_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "sso_connection_provider_id": {
+          "name": "sso_connection_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "sso_connection_domain": {
+          "name": "sso_connection_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sso_connection_id": {
+          "name": "sso_connection_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sso_provider": {
+      "name": "sso_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "sso_provider_provider_id": {
+          "name": "sso_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "sso_provider_domain": {
+          "name": "sso_provider_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "sso_provider_organization_id": {
+          "name": "sso_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "sso_provider_user_id": {
+          "name": "sso_provider_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_policy_member": {
+      "name": "desktop_policy_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "desktop_policy_id": {
+          "name": "desktop_policy_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_member_id": {
+          "name": "org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_policy_member_organization_id": {
+          "name": "desktop_policy_member_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_policy_id": {
+          "name": "desktop_policy_member_policy_id",
+          "columns": [
+            "desktop_policy_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_org_member_id": {
+          "name": "desktop_policy_member_org_member_id",
+          "columns": [
+            "org_member_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_team_id": {
+          "name": "desktop_policy_member_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_policy_org_member": {
+          "name": "desktop_policy_member_policy_org_member",
+          "columns": [
+            "desktop_policy_id",
+            "org_member_id"
+          ],
+          "isUnique": true
+        },
+        "desktop_policy_member_policy_team": {
+          "name": "desktop_policy_member_policy_team",
+          "columns": [
+            "desktop_policy_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_policy_member_id": {
+          "name": "desktop_policy_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_policy": {
+      "name": "desktop_policy",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_name": {
+          "name": "policy_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "policy": {
+          "name": "policy",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_object())"
+        },
+        "created_by_org_member_id": {
+          "name": "created_by_org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "desktop_policy_organization_id": {
+          "name": "desktop_policy_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_created_by_member_id": {
+          "name": "desktop_policy_created_by_member_id",
+          "columns": [
+            "created_by_org_member_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_is_enabled": {
+          "name": "desktop_policy_is_enabled",
+          "columns": [
+            "is_enabled"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_deleted_at": {
+          "name": "desktop_policy_deleted_at",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_org_default": {
+          "name": "desktop_policy_org_default",
+          "columns": [
+            "organization_id",
+            "is_default"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_policy_id": {
+          "name": "desktop_policy_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_keys": {
+      "name": "inference_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','revoked')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_keys_key_hash": {
+          "name": "inference_keys_key_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "inference_keys_organization_id": {
+          "name": "inference_keys_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_keys_org_membership_id": {
+          "name": "inference_keys_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "inference_keys_status": {
+          "name": "inference_keys_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_keys_id": {
+          "name": "inference_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_limit_policies": {
+      "name": "inference_org_limit_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "enum('five_hour','weekly','monthly')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset_strategy": {
+          "name": "reset_strategy",
+          "type": "enum('anchored','activity_based')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchor_at": {
+          "name": "anchor_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_bucket_id": {
+          "name": "current_bucket_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_limit_policies_organization_id": {
+          "name": "inference_org_limit_policies_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_org_limit_policies_org_window_type": {
+          "name": "inference_org_limit_policies_org_window_type",
+          "columns": [
+            "organization_id",
+            "window_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_limit_policies_id": {
+          "name": "inference_org_limit_policies_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_upstream_provider_keys": {
+      "name": "inference_org_upstream_provider_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openrouter'"
+        },
+        "external_key_hash": {
+          "name": "external_key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_workspace_id": {
+          "name": "external_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','revoked')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_upstream_provider_keys_organization_id": {
+          "name": "inference_org_upstream_provider_keys_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_org_upstream_provider_keys_external_key_hash": {
+          "name": "inference_org_upstream_provider_keys_external_key_hash",
+          "columns": [
+            "external_key_hash"
+          ],
+          "isUnique": false
+        },
+        "inference_org_upstream_provider_keys_org_provider": {
+          "name": "inference_org_upstream_provider_keys_org_provider",
+          "columns": [
+            "organization_id",
+            "provider"
+          ],
+          "isUnique": true
+        },
+        "inference_org_upstream_provider_keys_status": {
+          "name": "inference_org_upstream_provider_keys_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_upstream_provider_keys_id": {
+          "name": "inference_org_upstream_provider_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_usage_buckets": {
+      "name": "inference_org_usage_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_amount": {
+          "name": "limit_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_amount": {
+          "name": "used_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_usage_buckets_org_window": {
+          "name": "inference_org_usage_buckets_org_window",
+          "columns": [
+            "organization_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        },
+        "inference_org_usage_buckets_policy_id": {
+          "name": "inference_org_usage_buckets_policy_id",
+          "columns": [
+            "policy_id"
+          ],
+          "isUnique": false
+        },
+        "inference_org_usage_buckets_policy_window": {
+          "name": "inference_org_usage_buckets_policy_window",
+          "columns": [
+            "policy_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_usage_buckets_id": {
+          "name": "inference_org_usage_buckets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_usage_ledger_bucket_charges": {
+      "name": "inference_usage_ledger_bucket_charges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ledger_entry_id": {
+          "name": "ledger_entry_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket_id": {
+          "name": "bucket_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "inference_usage_ledger_bucket_charges_bucket_id": {
+          "name": "inference_usage_ledger_bucket_charges_bucket_id",
+          "columns": [
+            "bucket_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_bucket_charges_entry_bucket": {
+          "name": "inference_usage_ledger_bucket_charges_entry_bucket",
+          "columns": [
+            "ledger_entry_id",
+            "bucket_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_usage_ledger_bucket_charges_id": {
+          "name": "inference_usage_ledger_bucket_charges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_usage_ledger_entries": {
+      "name": "inference_usage_ledger_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inference_key_id": {
+          "name": "inference_key_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_job_id": {
+          "name": "external_job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "inference_usage_ledger_entries_organization_id": {
+          "name": "inference_usage_ledger_entries_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_org_membership_id": {
+          "name": "inference_usage_ledger_entries_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_inference_key_id": {
+          "name": "inference_usage_ledger_entries_inference_key_id",
+          "columns": [
+            "inference_key_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_external_event_id": {
+          "name": "inference_usage_ledger_entries_external_event_id",
+          "columns": [
+            "external_event_id"
+          ],
+          "isUnique": true
+        },
+        "inference_usage_ledger_entries_job_event_type": {
+          "name": "inference_usage_ledger_entries_job_event_type",
+          "columns": [
+            "external_job_id",
+            "event_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_usage_ledger_entries_id": {
+          "name": "inference_usage_ledger_entries_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "memory_context": {
+      "name": "memory_context",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "citation": {
+          "name": "citation",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "enum('active_conversation','searched_conversation')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "memory_context_memory_id": {
+          "name": "memory_context_memory_id",
+          "columns": [
+            "memory_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "memory_context_id": {
+          "name": "memory_context_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "memory": {
+      "name": "memory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "enum('user','org')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "memory_user_id": {
+          "name": "memory_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "memory_id": {
+          "name": "memory_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_handoff_grant": {
+      "name": "desktop_handoff_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_handoff_grant_user_id": {
+          "name": "desktop_handoff_grant_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_handoff_grant_expires_at": {
+          "name": "desktop_handoff_grant_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_handoff_grant_id": {
+          "name": "desktop_handoff_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_member_id": {
+          "name": "org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id": {
+          "name": "invitation_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email": {
+          "name": "invitation_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "invitation_status": {
+          "name": "invitation_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "invitation_team_id": {
+          "name": "invitation_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_org_member_id": {
+          "name": "invitation_org_member_id",
+          "columns": [
+            "org_member_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_invite_token": {
+          "name": "invitation_invite_token",
+          "columns": [
+            "invite_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "invitation_id": {
+          "name": "invitation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invited_by_org_member": {
+          "name": "invited_by_org_member",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by_org_member": {
+          "name": "removed_by_org_member",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "member_organization_id": {
+          "name": "member_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_user_id": {
+          "name": "member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "member_invite_id": {
+          "name": "member_invite_id",
+          "columns": [
+            "invite_id"
+          ],
+          "isUnique": false
+        },
+        "member_invited_by_org_member": {
+          "name": "member_invited_by_org_member",
+          "columns": [
+            "invited_by_org_member"
+          ],
+          "isUnique": false
+        },
+        "member_removed_at": {
+          "name": "member_removed_at",
+          "columns": [
+            "removed_at"
+          ],
+          "isUnique": false
+        },
+        "member_removed_by_org_member": {
+          "name": "member_removed_by_org_member",
+          "columns": [
+            "removed_by_org_member"
+          ],
+          "isUnique": false
+        },
+        "member_organization_user": {
+          "name": "member_organization_user",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "member_id": {
+          "name": "member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_role": {
+      "name": "organization_role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_role_organization_id": {
+          "name": "organization_role_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_role_name": {
+          "name": "organization_role_name",
+          "columns": [
+            "organization_id",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_role_id": {
+          "name": "organization_role_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_app_restrictions": {
+          "name": "desktop_app_restrictions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_object())"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_slug": {
+          "name": "organization_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_id": {
+          "name": "organization_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workspace_bootstrap": {
+      "name": "workspace_bootstrap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "setup_member_id": {
+          "name": "setup_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_public_key": {
+          "name": "device_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_key_fingerprint": {
+          "name": "device_key_fingerprint",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provisional'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "workspace_bootstrap_organization_id": {
+          "name": "workspace_bootstrap_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_bootstrap_status": {
+          "name": "workspace_bootstrap_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "workspace_bootstrap_expires_at": {
+          "name": "workspace_bootstrap_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workspace_bootstrap_id": {
+          "name": "workspace_bootstrap_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workspace_claim": {
+      "name": "workspace_claim",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bootstrap_id": {
+          "name": "bootstrap_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "workspace_claim_token_hash": {
+          "name": "workspace_claim_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "workspace_claim_bootstrap_id": {
+          "name": "workspace_claim_bootstrap_id",
+          "columns": [
+            "bootstrap_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_organization_id": {
+          "name": "workspace_claim_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_status": {
+          "name": "workspace_claim_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_expires_at": {
+          "name": "workspace_claim_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workspace_claim_id": {
+          "name": "workspace_claim_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connected_account": {
+      "name": "connected_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_code_verifier": {
+          "name": "pending_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connected_account_organization_id": {
+          "name": "connected_account_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connected_account_org_membership_id": {
+          "name": "connected_account_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connected_account_member_provider": {
+          "name": "connected_account_member_provider",
+          "columns": [
+            "org_membership_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_mcp_connection": {
+      "name": "external_mcp_connection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "enum('oauth','apikey','none')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "external_mcp_connection_organization_id": {
+          "name": "external_mcp_connection_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_mcp_connection_id": {
+          "name": "external_mcp_connection_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "org_oauth_client": {
+      "name": "org_oauth_client",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_oauth_client_organization_id": {
+          "name": "org_oauth_client_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "org_oauth_client_org_provider": {
+          "name": "org_oauth_client_org_provider",
+          "columns": [
+            "organization_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_oauth_client_id": {
+          "name": "org_oauth_client_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_access": {
+      "name": "llm_provider_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "llm_provider_access_llm_provider_id": {
+          "name": "llm_provider_access_llm_provider_id",
+          "columns": [
+            "llm_provider_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_org_membership_id": {
+          "name": "llm_provider_access_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_team_id": {
+          "name": "llm_provider_access_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_provider_org_membership": {
+          "name": "llm_provider_access_provider_org_membership",
+          "columns": [
+            "llm_provider_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "llm_provider_access_provider_team": {
+          "name": "llm_provider_access_provider_team",
+          "columns": [
+            "llm_provider_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_access_id": {
+          "name": "llm_provider_access_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_model": {
+      "name": "llm_provider_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_config": {
+          "name": "model_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "llm_provider_model_llm_provider_id": {
+          "name": "llm_provider_model_llm_provider_id",
+          "columns": [
+            "llm_provider_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_model_model_id": {
+          "name": "llm_provider_model_model_id",
+          "columns": [
+            "model_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_model_provider_model": {
+          "name": "llm_provider_model_provider_model",
+          "columns": [
+            "llm_provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_model_id": {
+          "name": "llm_provider_model_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider": {
+      "name": "llm_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "enum('models_dev','custom','openwork')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "llm_provider_organization_id": {
+          "name": "llm_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_created_by_org_membership_id": {
+          "name": "llm_provider_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_source": {
+          "name": "llm_provider_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_provider_id": {
+          "name": "llm_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object_access_grant": {
+      "name": "config_object_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_object_access_grant_organization_id": {
+          "name": "config_object_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_config_object_id": {
+          "name": "config_object_access_grant_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_org_membership_id": {
+          "name": "config_object_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_team_id": {
+          "name": "config_object_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_org_wide": {
+          "name": "config_object_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_object_org_membership": {
+          "name": "config_object_access_grant_object_org_membership",
+          "columns": [
+            "config_object_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "config_object_access_grant_object_team": {
+          "name": "config_object_access_grant_object_team",
+          "columns": [
+            "config_object_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_access_grant_id": {
+          "name": "config_object_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object": {
+      "name": "config_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "enum('skill','agent','command','tool','mcp','hook','context','custom')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_mode": {
+          "name": "source_mode",
+          "type": "enum('cloud','import','connector')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_file_name": {
+          "name": "current_file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_file_extension": {
+          "name": "current_file_extension",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_relative_path": {
+          "name": "current_relative_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived','ingestion_error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_object_organization_id": {
+          "name": "config_object_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_type": {
+          "name": "config_object_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "config_object_source_mode": {
+          "name": "config_object_source_mode",
+          "columns": [
+            "source_mode"
+          ],
+          "isUnique": false
+        },
+        "config_object_status": {
+          "name": "config_object_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "config_object_created_by_org_membership_id": {
+          "name": "config_object_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_connector_instance_id": {
+          "name": "config_object_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_current_relative_path": {
+          "name": "config_object_current_relative_path",
+          "columns": [
+            "current_relative_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_id": {
+          "name": "config_object_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object_version": {
+      "name": "config_object_version",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_payload_json": {
+          "name": "normalized_payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_source_text": {
+          "name": "raw_source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "enum('cloud','import','connector','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connector_sync_event_id": {
+          "name": "connector_sync_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_revision_ref": {
+          "name": "source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_deleted_version": {
+          "name": "is_deleted_version",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "config_object_version_organization_id": {
+          "name": "config_object_version_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_config_object_id": {
+          "name": "config_object_version_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_created_by_org_membership_id": {
+          "name": "config_object_version_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_connector_sync_event_id": {
+          "name": "config_object_version_connector_sync_event_id",
+          "columns": [
+            "connector_sync_event_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_source_revision_ref": {
+          "name": "config_object_version_source_revision_ref",
+          "columns": [
+            "source_revision_ref"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_lookup_latest": {
+          "name": "config_object_version_lookup_latest",
+          "columns": [
+            "config_object_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_version_id": {
+          "name": "config_object_version_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_account": {
+      "name": "connector_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_ref": {
+          "name": "external_account_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','disconnected','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_account_organization_id": {
+          "name": "connector_account_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_account_created_by_org_membership_id": {
+          "name": "connector_account_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_account_connector_type": {
+          "name": "connector_account_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_account_status": {
+          "name": "connector_account_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_account_org_type_remote_id": {
+          "name": "connector_account_org_type_remote_id",
+          "columns": [
+            "organization_id",
+            "connector_type",
+            "remote_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_instance_access_grant": {
+      "name": "connector_instance_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instance_access_grant_organization_id": {
+          "name": "connector_instance_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_instance_id": {
+          "name": "connector_instance_access_grant_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_org_membership_id": {
+          "name": "connector_instance_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_team_id": {
+          "name": "connector_instance_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_org_wide": {
+          "name": "connector_instance_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_instance_org_membership": {
+          "name": "connector_instance_access_grant_instance_org_membership",
+          "columns": [
+            "connector_instance_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "connector_instance_access_grant_instance_team": {
+          "name": "connector_instance_access_grant_instance_team",
+          "columns": [
+            "connector_instance_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_instance_access_grant_id": {
+          "name": "connector_instance_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_instance": {
+      "name": "connector_instance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','disabled','archived','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "instance_config_json": {
+          "name": "instance_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "enum('pending','queued','running','completed','failed','partial','ignored')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_cursor": {
+          "name": "last_sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_instance_organization_id": {
+          "name": "connector_instance_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_connector_account_id": {
+          "name": "connector_instance_connector_account_id",
+          "columns": [
+            "connector_account_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_created_by_org_membership_id": {
+          "name": "connector_instance_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_connector_type": {
+          "name": "connector_instance_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_status": {
+          "name": "connector_instance_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_org_name": {
+          "name": "connector_instance_org_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_mapping": {
+      "name": "connector_mapping",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mapping_kind": {
+          "name": "mapping_kind",
+          "type": "enum('path','api','custom')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "enum('skill','agent','command','tool','mcp','hook','context','custom')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_add_to_plugin": {
+          "name": "auto_add_to_plugin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "mapping_config_json": {
+          "name": "mapping_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_mapping_organization_id": {
+          "name": "connector_mapping_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_connector_instance_id": {
+          "name": "connector_mapping_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_connector_target_id": {
+          "name": "connector_mapping_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_object_type": {
+          "name": "connector_mapping_object_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_plugin_id": {
+          "name": "connector_mapping_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_target_selector_object_type": {
+          "name": "connector_mapping_target_selector_object_type",
+          "columns": [
+            "connector_target_id",
+            "selector",
+            "object_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_source_binding": {
+      "name": "connector_source_binding",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_locator": {
+          "name": "external_locator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_stable_ref": {
+          "name": "external_stable_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_source_revision_ref": {
+          "name": "last_seen_source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived','ingestion_error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_source_binding_organization_id": {
+          "name": "connector_source_binding_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_config_object_id": {
+          "name": "connector_source_binding_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_instance_id": {
+          "name": "connector_source_binding_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_target_id": {
+          "name": "connector_source_binding_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_mapping_id": {
+          "name": "connector_source_binding_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_external_locator": {
+          "name": "connector_source_binding_external_locator",
+          "columns": [
+            "external_locator"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_config_object": {
+          "name": "connector_source_binding_config_object",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_source_binding_id": {
+          "name": "connector_source_binding_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_source_tombstone": {
+      "name": "connector_source_tombstone",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_locator": {
+          "name": "external_locator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "former_config_object_id": {
+          "name": "former_config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_in_sync_event_id": {
+          "name": "deleted_in_sync_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_source_revision_ref": {
+          "name": "deleted_source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "connector_source_tombstone_organization_id": {
+          "name": "connector_source_tombstone_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_instance_id": {
+          "name": "connector_source_tombstone_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_target_id": {
+          "name": "connector_source_tombstone_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_mapping_id": {
+          "name": "connector_source_tombstone_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_external_locator": {
+          "name": "connector_source_tombstone_external_locator",
+          "columns": [
+            "external_locator"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_former_config_object_id": {
+          "name": "connector_source_tombstone_former_config_object_id",
+          "columns": [
+            "former_config_object_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_source_tombstone_id": {
+          "name": "connector_source_tombstone_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_sync_event": {
+      "name": "connector_sync_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum('push','installation','installation_repositories','repository','manual_resync')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_ref": {
+          "name": "external_event_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_revision_ref": {
+          "name": "source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','queued','running','completed','failed','partial','ignored')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_sync_event_organization_id": {
+          "name": "connector_sync_event_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_connector_instance_id": {
+          "name": "connector_sync_event_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_connector_target_id": {
+          "name": "connector_sync_event_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_event_type": {
+          "name": "connector_sync_event_event_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_status": {
+          "name": "connector_sync_event_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_source_revision_ref": {
+          "name": "connector_sync_event_source_revision_ref",
+          "columns": [
+            "source_revision_ref"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_external_event_ref": {
+          "name": "connector_sync_event_external_event_ref",
+          "columns": [
+            "external_event_ref"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_sync_event_id": {
+          "name": "connector_sync_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_target": {
+      "name": "connector_target",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "enum('repository_branch')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_target_ref": {
+          "name": "external_target_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_config_json": {
+          "name": "target_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_target_organization_id": {
+          "name": "connector_target_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_target_connector_instance_id": {
+          "name": "connector_target_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_target_connector_type": {
+          "name": "connector_target_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_target_target_kind": {
+          "name": "connector_target_target_kind",
+          "columns": [
+            "target_kind"
+          ],
+          "isUnique": false
+        },
+        "connector_target_instance_remote_id": {
+          "name": "connector_target_instance_remote_id",
+          "columns": [
+            "connector_instance_id",
+            "remote_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace_access_grant": {
+      "name": "marketplace_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_access_grant_organization_id": {
+          "name": "marketplace_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_marketplace_id": {
+          "name": "marketplace_access_grant_marketplace_id",
+          "columns": [
+            "marketplace_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_org_membership_id": {
+          "name": "marketplace_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_team_id": {
+          "name": "marketplace_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_org_wide": {
+          "name": "marketplace_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_marketplace_org_membership": {
+          "name": "marketplace_access_grant_marketplace_org_membership",
+          "columns": [
+            "marketplace_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "marketplace_access_grant_marketplace_team": {
+          "name": "marketplace_access_grant_marketplace_team",
+          "columns": [
+            "marketplace_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_access_grant_id": {
+          "name": "marketplace_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace_plugin": {
+      "name": "marketplace_plugin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_source": {
+          "name": "membership_source",
+          "type": "enum('manual','connector','api','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_plugin_organization_id": {
+          "name": "marketplace_plugin_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_marketplace_id": {
+          "name": "marketplace_plugin_marketplace_id",
+          "columns": [
+            "marketplace_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_plugin_id": {
+          "name": "marketplace_plugin_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_marketplace_plugin": {
+          "name": "marketplace_plugin_marketplace_plugin",
+          "columns": [
+            "marketplace_id",
+            "plugin_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_plugin_id": {
+          "name": "marketplace_plugin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace": {
+      "name": "marketplace",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_organization_id": {
+          "name": "marketplace_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_created_by_org_membership_id": {
+          "name": "marketplace_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_status": {
+          "name": "marketplace_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "marketplace_name": {
+          "name": "marketplace_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_access_grant": {
+      "name": "plugin_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_access_grant_organization_id": {
+          "name": "plugin_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_plugin_id": {
+          "name": "plugin_access_grant_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_org_membership_id": {
+          "name": "plugin_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_team_id": {
+          "name": "plugin_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_org_wide": {
+          "name": "plugin_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_plugin_org_membership": {
+          "name": "plugin_access_grant_plugin_org_membership",
+          "columns": [
+            "plugin_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "plugin_access_grant_plugin_team": {
+          "name": "plugin_access_grant_plugin_team",
+          "columns": [
+            "plugin_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_access_grant_id": {
+          "name": "plugin_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_config_object": {
+      "name": "plugin_config_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_source": {
+          "name": "membership_source",
+          "type": "enum('manual','connector','api','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_config_object_organization_id": {
+          "name": "plugin_config_object_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_plugin_id": {
+          "name": "plugin_config_object_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_config_object_id": {
+          "name": "plugin_config_object_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_connector_mapping_id": {
+          "name": "plugin_config_object_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_plugin_config_object": {
+          "name": "plugin_config_object_plugin_config_object",
+          "columns": [
+            "plugin_id",
+            "config_object_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_config_object_id": {
+          "name": "plugin_config_object_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin": {
+      "name": "plugin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_organization_id": {
+          "name": "plugin_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_created_by_org_membership_id": {
+          "name": "plugin_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_status": {
+          "name": "plugin_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "plugin_name": {
+          "name": "plugin_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill_hub_member": {
+      "name": "skill_hub_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_hub_id": {
+          "name": "skill_hub_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "skill_hub_member_skill_hub_id": {
+          "name": "skill_hub_member_skill_hub_id",
+          "columns": [
+            "skill_hub_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_member_org_membership_id": {
+          "name": "skill_hub_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_member_team_id": {
+          "name": "skill_hub_member_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_member_hub_org_membership": {
+          "name": "skill_hub_member_hub_org_membership",
+          "columns": [
+            "skill_hub_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "skill_hub_member_hub_team": {
+          "name": "skill_hub_member_hub_team",
+          "columns": [
+            "skill_hub_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_hub_member_id": {
+          "name": "skill_hub_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill_hub_skill": {
+      "name": "skill_hub_skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_hub_id": {
+          "name": "skill_hub_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "skill_hub_skill_skill_hub_id": {
+          "name": "skill_hub_skill_skill_hub_id",
+          "columns": [
+            "skill_hub_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_skill_skill_id": {
+          "name": "skill_hub_skill_skill_id",
+          "columns": [
+            "skill_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_skill_hub_skill": {
+          "name": "skill_hub_skill_hub_skill",
+          "columns": [
+            "skill_hub_id",
+            "skill_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_hub_skill_id": {
+          "name": "skill_hub_skill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill_hub": {
+      "name": "skill_hub",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "skill_hub_organization_id": {
+          "name": "skill_hub_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_created_by_org_membership_id": {
+          "name": "skill_hub_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_hub_id": {
+          "name": "skill_hub_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill": {
+      "name": "skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skill_text": {
+          "name": "skill_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared": {
+          "name": "shared",
+          "type": "enum('org','public')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "skill_organization_id": {
+          "name": "skill_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "skill_created_by_org_membership_id": {
+          "name": "skill_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "skill_shared": {
+          "name": "skill_shared",
+          "columns": [
+            "shared"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_id": {
+          "name": "skill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "org_subscriptions": {
+      "name": "org_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('inference','seat')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('incomplete','incomplete_expired','trialing','active','past_due','canceled','unpaid','paused','expired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'incomplete'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_organization_id": {
+          "name": "org_subscriptions_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "org_subscriptions_customer_id": {
+          "name": "org_subscriptions_customer_id",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": false
+        },
+        "org_subscriptions_subscription_id": {
+          "name": "org_subscriptions_subscription_id",
+          "columns": [
+            "stripe_subscription_id"
+          ],
+          "isUnique": true
+        },
+        "org_subscriptions_org_type": {
+          "name": "org_subscriptions_org_type",
+          "columns": [
+            "organization_id",
+            "type"
+          ],
+          "isUnique": true
+        },
+        "org_subscriptions_status": {
+          "name": "org_subscriptions_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_subscriptions_id": {
+          "name": "org_subscriptions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_member": {
+      "name": "team_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "team_member_team_id": {
+          "name": "team_member_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_org_membership_id": {
+          "name": "team_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_team_org_membership": {
+          "name": "team_member_team_org_membership",
+          "columns": [
+            "team_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_member_id": {
+          "name": "team_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team": {
+      "name": "team",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "team_organization_id": {
+          "name": "team_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "team_organization_name": {
+          "name": "team_organization_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_id": {
+          "name": "team_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_event": {
+      "name": "audit_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "audit_event_org_id": {
+          "name": "audit_event_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "audit_event_worker_id": {
+          "name": "audit_event_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "daytona_sandbox": {
+      "name": "daytona_sandbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_volume_id": {
+          "name": "workspace_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_volume_id": {
+          "name": "data_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url": {
+          "name": "signed_preview_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url_expires_at": {
+          "name": "signed_preview_url_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "daytona_sandbox_worker_id": {
+          "name": "daytona_sandbox_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": true
+        },
+        "daytona_sandbox_sandbox_id": {
+          "name": "daytona_sandbox_sandbox_id",
+          "columns": [
+            "sandbox_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daytona_sandbox_id": {
+          "name": "daytona_sandbox_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_bundle": {
+      "name": "worker_bundle",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "worker_bundle_worker_id": {
+          "name": "worker_bundle_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_bundle_id": {
+          "name": "worker_bundle_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_instance": {
+      "name": "worker_instance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_instance_worker_id": {
+          "name": "worker_instance_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_instance_id": {
+          "name": "worker_instance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker": {
+      "name": "worker",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination": {
+          "name": "destination",
+          "type": "enum('local','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_version": {
+          "name": "image_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandbox_backend": {
+          "name": "sandbox_backend",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_org_id": {
+          "name": "worker_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "worker_created_by_user_id": {
+          "name": "worker_created_by_user_id",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "worker_status": {
+          "name": "worker_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "worker_last_heartbeat_at": {
+          "name": "worker_last_heartbeat_at",
+          "columns": [
+            "last_heartbeat_at"
+          ],
+          "isUnique": false
+        },
+        "worker_last_active_at": {
+          "name": "worker_last_active_at",
+          "columns": [
+            "last_active_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_id": {
+          "name": "worker_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_token": {
+      "name": "worker_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "enum('client','host','activity')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "worker_token_worker_id": {
+          "name": "worker_token_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        },
+        "worker_token_token": {
+          "name": "worker_token_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_token_id": {
+          "name": "worker_token_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "admin_allowlist": {
+      "name": "admin_allowlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "admin_allowlist_email": {
+          "name": "admin_allowlist_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "admin_allowlist_id": {
+          "name": "admin_allowlist_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "rate_limit": {
+      "name": "rate_limit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limit_key": {
+          "name": "rate_limit_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_id": {
+          "name": "rate_limit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "telemetry_event": {
+      "name": "telemetry_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_timestamp": {
+          "name": "event_timestamp",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "telemetry_event_org_id_type_ts": {
+          "name": "telemetry_event_org_id_type_ts",
+          "columns": [
+            "org_id",
+            "event_type",
+            "event_timestamp"
+          ],
+          "isUnique": false
+        },
+        "telemetry_event_org_id_member_id": {
+          "name": "telemetry_event_org_id_member_id",
+          "columns": [
+            "org_id",
+            "member_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telemetry_event_id": {
+          "name": "telemetry_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1782866555987,
       "tag": "0027_hard_beast",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "5",
+      "when": 1783019129840,
+      "tag": "0028_memory_bank",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/package.json
+++ b/ee/packages/den-db/package.json
@@ -78,8 +78,9 @@
     "db:baseline": "node --import tsx scripts/baseline-migrations.ts",
     "db:bootstrap": "pnpm run build && node --import tsx scripts/bootstrap.ts",
     "db:generate": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs generate --config drizzle.config.ts",
-    "db:migrate": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs migrate --config drizzle.config.ts",
-    "db:push": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs push --config drizzle.config.ts"
+    "db:migrate": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs migrate --config drizzle.config.ts && node --import tsx scripts/ensure-fulltext-indexes.ts",
+    "db:push": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs push --config drizzle.config.ts && node --import tsx scripts/ensure-fulltext-indexes.ts",
+    "db:verify-memory": "pnpm run build && node --import tsx scripts/verify-memory-schema.ts"
   },
   "dependencies": {
     "@openwork/types": "workspace:*",

--- a/ee/packages/den-db/scripts/bootstrap.ts
+++ b/ee/packages/den-db/scripts/bootstrap.ts
@@ -13,54 +13,12 @@ import "../src/load-env.ts"
 import { spawnSync } from "node:child_process"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import { ensureMemoryFulltextIndex } from "../src/fulltext.ts"
+import { ensureFulltextIndexes } from "../src/fulltext.ts"
+import { createExecutor, type Executor } from "./db-executor.ts"
 
 const MIGRATIONS_TABLE = "__drizzle_migrations"
 
 const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
-
-type Executor = {
-  query: (sql: string, args?: (string | number)[]) => Promise<Record<string, unknown>[]>
-  close: () => Promise<void>
-}
-
-async function createExecutor(): Promise<Executor> {
-  const databaseUrl = process.env.DATABASE_URL?.trim()
-
-  if (databaseUrl) {
-    const mysql = await import("mysql2/promise")
-    const connection = await mysql.createConnection(databaseUrl)
-    return {
-      query: async (sql, args = []) => {
-        const [rows] = await connection.query(sql, args)
-        return Array.isArray(rows) ? rows.filter(isRecord) : []
-      },
-      close: () => connection.end(),
-    }
-  }
-
-  const host = process.env.DATABASE_HOST?.trim()
-  const username = process.env.DATABASE_USERNAME?.trim()
-  const password = process.env.DATABASE_PASSWORD ?? ""
-
-  if (!host || !username) {
-    throw new Error("Provide DATABASE_URL, or DATABASE_HOST/DATABASE_USERNAME/DATABASE_PASSWORD.")
-  }
-
-  const { Client } = await import("@planetscale/database")
-  const client = new Client({ host, username, password })
-  return {
-    query: async (sql, args = []) => {
-      const result = await client.execute(sql, args)
-      return result.rows.filter(isRecord)
-    },
-    close: async () => {},
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
-}
 
 function run(command: string, args: string[]) {
   const result = spawnSync(command, args, {
@@ -109,13 +67,12 @@ async function main() {
   run("node", ["--import", "tsx", "./node_modules/drizzle-kit/bin.cjs", "migrate", "--config", "drizzle.config.ts"])
 
   // FULLTEXT indexes cannot be expressed via Drizzle's DSL and are baselined-away on the
-  // fresh-install (push + baseline) path, so create them idempotently here — a step both
-  // the bootstrap and migrate paths reach (memory-bank-architecture.md §3, B2).
+  // fresh-install (push + baseline) path, so create them idempotently here — the same seam
+  // the post-`db:migrate` hook runs, so the two apply paths cannot drift (§3, B2).
   console.log("[den-db] ensuring FULLTEXT indexes")
   const indexExecutor = await createExecutor()
   try {
-    const { created } = await ensureMemoryFulltextIndex(indexExecutor)
-    console.log(`[den-db] memory.content FULLTEXT index ${created ? "created" : "already present"}`)
+    await ensureFulltextIndexes(indexExecutor)
   } finally {
     await indexExecutor.close()
   }

--- a/ee/packages/den-db/scripts/bootstrap.ts
+++ b/ee/packages/den-db/scripts/bootstrap.ts
@@ -13,6 +13,7 @@ import "../src/load-env.ts"
 import { spawnSync } from "node:child_process"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { ensureMemoryFulltextIndex } from "../src/fulltext.ts"
 
 const MIGRATIONS_TABLE = "__drizzle_migrations"
 
@@ -106,6 +107,18 @@ async function main() {
 
   console.log("[den-db] running migrations")
   run("node", ["--import", "tsx", "./node_modules/drizzle-kit/bin.cjs", "migrate", "--config", "drizzle.config.ts"])
+
+  // FULLTEXT indexes cannot be expressed via Drizzle's DSL and are baselined-away on the
+  // fresh-install (push + baseline) path, so create them idempotently here — a step both
+  // the bootstrap and migrate paths reach (memory-bank-architecture.md §3, B2).
+  console.log("[den-db] ensuring FULLTEXT indexes")
+  const indexExecutor = await createExecutor()
+  try {
+    const { created } = await ensureMemoryFulltextIndex(indexExecutor)
+    console.log(`[den-db] memory.content FULLTEXT index ${created ? "created" : "already present"}`)
+  } finally {
+    await indexExecutor.close()
+  }
 }
 
 main().catch((error) => {

--- a/ee/packages/den-db/scripts/db-executor.ts
+++ b/ee/packages/den-db/scripts/db-executor.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared query executor for den-db operational scripts (bootstrap, migrate hooks,
+ * index backfills). Supports both a direct mysql2 connection (DATABASE_URL) and the
+ * PlanetScale HTTP driver (DATABASE_HOST/USERNAME/PASSWORD), normalizing both to a
+ * common `{ query, close }` shape.
+ */
+
+export type Executor = {
+  query: (sql: string, args?: (string | number)[]) => Promise<Record<string, unknown>[]>
+  close: () => Promise<void>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export async function createExecutor(): Promise<Executor> {
+  const databaseUrl = process.env.DATABASE_URL?.trim()
+
+  if (databaseUrl) {
+    const mysql = await import("mysql2/promise")
+    const connection = await mysql.createConnection(databaseUrl)
+    return {
+      query: async (sql, args = []) => {
+        const [rows] = await connection.query(sql, args)
+        return Array.isArray(rows) ? rows.filter(isRecord) : []
+      },
+      close: () => connection.end(),
+    }
+  }
+
+  const host = process.env.DATABASE_HOST?.trim()
+  const username = process.env.DATABASE_USERNAME?.trim()
+  const password = process.env.DATABASE_PASSWORD ?? ""
+
+  if (!host || !username) {
+    throw new Error("Provide DATABASE_URL, or DATABASE_HOST/DATABASE_USERNAME/DATABASE_PASSWORD.")
+  }
+
+  const { Client } = await import("@planetscale/database")
+  const client = new Client({ host, username, password })
+  return {
+    query: async (sql, args = []) => {
+      const result = await client.execute(sql, args)
+      return result.rows.filter(isRecord)
+    },
+    close: async () => {},
+  }
+}

--- a/ee/packages/den-db/scripts/ensure-fulltext-indexes.ts
+++ b/ee/packages/den-db/scripts/ensure-fulltext-indexes.ts
@@ -1,0 +1,29 @@
+/**
+ * Idempotently create the FULLTEXT indexes that Drizzle's DSL cannot express.
+ *
+ * Runs as a post-`db:migrate` step (and is reachable via bootstrap) so the index exists on
+ * every apply path — including a `db:migrate`-only run on a database where the memory
+ * migration was already baselined/recorded, which would otherwise leave the index silently
+ * absent (memory-bank-architecture.md §3, B2).
+ *
+ * Usage:
+ *   DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_den \
+ *     node --import tsx scripts/ensure-fulltext-indexes.ts
+ */
+import "../src/load-env.ts"
+import { ensureFulltextIndexes } from "../src/fulltext.ts"
+import { createExecutor } from "./db-executor.ts"
+
+async function main() {
+  const executor = await createExecutor()
+  try {
+    await ensureFulltextIndexes(executor)
+  } finally {
+    await executor.close()
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/ee/packages/den-db/scripts/verify-memory-schema.ts
+++ b/ee/packages/den-db/scripts/verify-memory-schema.ts
@@ -119,6 +119,9 @@ async function main() {
       console.log(`   • ${label}`)
     }
   } finally {
+    // Roll back first: if an assertion threw inside step 5's open transaction, cleanup must
+    // run with autocommit restored, else connection.end() discards it and leaks marker rows.
+    await connection.rollback().catch(() => {})
     // Best-effort cleanup in case an assertion failed mid-way.
     await connection.query(`DELETE FROM memory_context WHERE memory_id = ?`, [marker]).catch(() => {})
     await connection.query(`DELETE FROM memory WHERE id = ?`, [marker]).catch(() => {})

--- a/ee/packages/den-db/scripts/verify-memory-schema.ts
+++ b/ee/packages/den-db/scripts/verify-memory-schema.ts
@@ -1,0 +1,132 @@
+/**
+ * Stage 1 proof harness (TASK-1). Verifies, against a real database, that the memory
+ * schema, typeids, and FULLTEXT index are actually in place — the claims that must hold
+ * on a freshly bootstrapped DB where migration-only indexes are silently dropped (B2).
+ *
+ * Usage:
+ *   DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_den \
+ *     node --import tsx scripts/verify-memory-schema.ts
+ *
+ * Exits non-zero on the first failed assertion so it can gate CI.
+ */
+import "../src/load-env.ts"
+import mysql from "mysql2/promise"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import {
+  assertMemoryFulltextIndexExists,
+  ensureMemoryFulltextIndex,
+  type FulltextIndexExecutor,
+} from "../src/fulltext.ts"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL?.trim()
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required (e.g. mysql://root:password@127.0.0.1:3306/openwork_den)")
+  }
+
+  const connection = await mysql.createConnection(databaseUrl)
+  const executor: FulltextIndexExecutor = {
+    query: async (sql, args = []) => {
+      const [rows] = await connection.query(sql, args)
+      return Array.isArray(rows) ? rows.filter(isRecord) : []
+    },
+  }
+
+  const marker = createDenTypeId("memory")
+  const passed: string[] = []
+
+  function check(label: string, condition: boolean): void {
+    if (!condition) {
+      throw new Error(`FAIL: ${label}`)
+    }
+    passed.push(label)
+  }
+
+  try {
+    // 1. Tables exist.
+    const tables = await executor.query(
+      `SELECT table_name FROM information_schema.TABLES
+       WHERE table_schema = DATABASE() AND table_name IN ('memory','memory_context')`,
+    )
+    const tableNames = tables
+      .map((row) => Object.values(row).find((value) => typeof value === "string"))
+      .filter((value): value is string => Boolean(value))
+    check("memory table exists", tableNames.includes("memory"))
+    check("memory_context table exists", tableNames.includes("memory_context"))
+
+    // 2. FULLTEXT index exists (direct information_schema read — independent of ensure code).
+    const indexRows = await executor.query(
+      `SELECT index_type FROM information_schema.STATISTICS
+       WHERE table_schema = DATABASE() AND table_name = 'memory'
+         AND index_name = 'memory_content_fulltext'`,
+    )
+    check("memory_content_fulltext index present", indexRows.length > 0)
+    check(
+      "index type is FULLTEXT",
+      indexRows.some((row) => row.index_type === "FULLTEXT" || row.INDEX_TYPE === "FULLTEXT"),
+    )
+    // The exported assertion agrees.
+    await assertMemoryFulltextIndexExists(executor)
+    passed.push("assertMemoryFulltextIndexExists passes")
+
+    // 3. Insert memory + 2 contexts (typeid round-trip) with content that MATCH can find.
+    const content = `User deploys via den-worker-proxy into a Daytona sandbox [${marker}]`
+    const orgId = createDenTypeId("org")
+    const userId = createDenTypeId("user")
+    await executor.query(
+      `INSERT INTO memory (id, user_id, org_id, scope, content, source) VALUES (?, ?, ?, 'user', ?, 'chat')`,
+      [marker, userId, orgId, content],
+    )
+    const ctx1 = createDenTypeId("memctx")
+    const ctx2 = createDenTypeId("memctx")
+    await executor.query(
+      `INSERT INTO memory_context (id, memory_id, snippet, origin) VALUES (?, ?, 'excerpt one', 'active_conversation')`,
+      [ctx1, marker],
+    )
+    await executor.query(
+      `INSERT INTO memory_context (id, memory_id, snippet, origin) VALUES (?, ?, 'excerpt two', 'searched_conversation')`,
+      [ctx2, marker],
+    )
+    const readBack = await executor.query(`SELECT id, scope FROM memory WHERE id = ?`, [marker])
+    check("memory id round-trips through denTypeIdColumn", readBack[0]?.id === marker)
+    check("scope defaults/stores 'user'", readBack[0]?.scope === "user")
+
+    // 4. NL search matches on the FULLTEXT index.
+    const matched = await executor.query(
+      `SELECT id FROM memory WHERE MATCH(content) AGAINST (? IN NATURAL LANGUAGE MODE) AND id = ?`,
+      ["Daytona", marker],
+    )
+    check("MATCH ... AGAINST finds the inserted memory", matched.length === 1)
+
+    // 5. Explicit cascade (the exact tx Stage 2's delete handler will use).
+    await connection.beginTransaction()
+    await connection.query(`DELETE FROM memory_context WHERE memory_id = ?`, [marker])
+    await connection.query(`DELETE FROM memory WHERE id = ?`, [marker])
+    await connection.commit()
+    const orphans = await executor.query(`SELECT id FROM memory_context WHERE memory_id = ?`, [marker])
+    check("explicit cascade leaves 0 orphaned context rows", orphans.length === 0)
+
+    // 6. Idempotency: ensure is a no-op when the index already exists.
+    const second = await ensureMemoryFulltextIndex(executor)
+    check("ensureMemoryFulltextIndex is idempotent (no re-create)", second.created === false)
+
+    console.log(`\n✅ Stage 1 schema verified (${passed.length} checks):`)
+    for (const label of passed) {
+      console.log(`   • ${label}`)
+    }
+  } finally {
+    // Best-effort cleanup in case an assertion failed mid-way.
+    await connection.query(`DELETE FROM memory_context WHERE memory_id = ?`, [marker]).catch(() => {})
+    await connection.query(`DELETE FROM memory WHERE id = ?`, [marker]).catch(() => {})
+    await connection.end()
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/ee/packages/den-db/src/fulltext.ts
+++ b/ee/packages/den-db/src/fulltext.ts
@@ -1,0 +1,63 @@
+import { MEMORY_CONTENT_FULLTEXT_INDEX } from "./schema/memory"
+
+/**
+ * Minimal query surface satisfied by both the mysql2 and PlanetScale executors used
+ * across den-db scripts. Positional `?` args are bound by the driver.
+ */
+export type FulltextIndexExecutor = {
+  query: (sql: string, args?: (string | number)[]) => Promise<Record<string, unknown>[]>
+}
+
+const MEMORY_TABLE = "memory"
+
+async function memoryFulltextIndexExists(executor: FulltextIndexExecutor): Promise<boolean> {
+  const rows = await executor.query(
+    `SELECT 1 AS present FROM information_schema.STATISTICS
+     WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ? LIMIT 1`,
+    [MEMORY_TABLE, MEMORY_CONTENT_FULLTEXT_INDEX],
+  )
+  return rows.length > 0
+}
+
+/**
+ * Idempotently create the FULLTEXT index on `memory.content`.
+ *
+ * This MUST run on a path both the fresh-install bootstrap and the incremental migrate
+ * paths hit: `drizzle-kit push` cannot emit a raw FULLTEXT index and the baseline step
+ * marks migrations applied-without-executing, so a migration-only index is silently
+ * absent on freshly bootstrapped databases (memory-bank-architecture.md §3, B2).
+ */
+export async function ensureMemoryFulltextIndex(
+  executor: FulltextIndexExecutor,
+): Promise<{ created: boolean }> {
+  if (await memoryFulltextIndexExists(executor)) {
+    return { created: false }
+  }
+  try {
+    await executor.query(
+      `CREATE FULLTEXT INDEX \`${MEMORY_CONTENT_FULLTEXT_INDEX}\` ON \`${MEMORY_TABLE}\` (\`content\`)`,
+    )
+  } catch (error) {
+    // Another concurrent bootstrap may have created it between the check and the create.
+    if (await memoryFulltextIndexExists(executor)) {
+      return { created: false }
+    }
+    throw error
+  }
+  return { created: true }
+}
+
+/**
+ * Startup / CI assertion that the FULLTEXT index exists. Throws if it is missing so a
+ * misconfigured database fails loudly instead of silently degrading search to no matches.
+ */
+export async function assertMemoryFulltextIndexExists(
+  executor: FulltextIndexExecutor,
+): Promise<void> {
+  if (!(await memoryFulltextIndexExists(executor))) {
+    throw new Error(
+      `Missing FULLTEXT index '${MEMORY_CONTENT_FULLTEXT_INDEX}' on '${MEMORY_TABLE}.content'. ` +
+        "Run `pnpm --filter @openwork-ee/den-db db:bootstrap` (or call ensureMemoryFulltextIndex) to create it.",
+    )
+  }
+}

--- a/ee/packages/den-db/src/fulltext.ts
+++ b/ee/packages/den-db/src/fulltext.ts
@@ -48,6 +48,17 @@ export async function ensureMemoryFulltextIndex(
 }
 
 /**
+ * Single seam that creates every FULLTEXT index the schema needs but Drizzle's DSL cannot
+ * express. Both DB apply paths call this — the bootstrap step and the post-`db:migrate`
+ * hook — so the two paths cannot drift (memory-bank-architecture.md §3, B2). Add future
+ * FULLTEXT indexes here.
+ */
+export async function ensureFulltextIndexes(executor: FulltextIndexExecutor): Promise<void> {
+  const memory = await ensureMemoryFulltextIndex(executor)
+  console.log(`[den-db] memory.content FULLTEXT index ${memory.created ? "created" : "already present"}`)
+}
+
+/**
  * Startup / CI assertion that the FULLTEXT index exists. Throws if it is missing so a
  * misconfigured database fails loudly instead of silently degrading search to no matches.
  */

--- a/ee/packages/den-db/src/index.ts
+++ b/ee/packages/den-db/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./client"
 export * from "./columns"
+export * from "./fulltext"
 export * from "./mysql-config"
 export * from "./schema"

--- a/ee/packages/den-db/src/schema/index.ts
+++ b/ee/packages/den-db/src/schema/index.ts
@@ -1,6 +1,7 @@
 export * from "./auth"
 export * from "./desktop-policies"
 export * from "./inference"
+export * from "./memory"
 export * from "./org"
 export * from "./sharables/capability-credentials"
 export * from "./sharables/llm-providers"

--- a/ee/packages/den-db/src/schema/memory.ts
+++ b/ee/packages/den-db/src/schema/memory.ts
@@ -1,0 +1,41 @@
+import { index, json, mysqlEnum, mysqlTable, text, varchar } from "drizzle-orm/mysql-core"
+import { denTypeIdColumn, timestamps } from "../columns"
+
+export const MemoryScope = ["user", "org"] as const
+export const MemoryContextOrigin = ["active_conversation", "searched_conversation"] as const
+
+// Name of the FULLTEXT index on memory.content. Drizzle mysql-core has no FULLTEXT DSL
+// (drizzle-orm#1495), so this index is created out-of-band by `ensureMemoryFulltextIndex`
+// (bootstrap path) and the memory migration (migrate path); both reference this name.
+export const MEMORY_CONTENT_FULLTEXT_INDEX = "memory_content_fulltext"
+
+export const MemoryTable = mysqlTable(
+  "memory",
+  {
+    id: denTypeIdColumn("memory", "id").notNull().primaryKey(),
+    user_id: denTypeIdColumn("user", "user_id").notNull(),
+    org_id: denTypeIdColumn("org", "org_id").notNull(),
+    scope: mysqlEnum("scope", MemoryScope).notNull().default("user"),
+    content: text("content").notNull(),
+    source: varchar("source", { length: 64 }).notNull(),
+    tags: json("tags"),
+    ...timestamps,
+  },
+  (table) => [index("memory_user_id").on(table.user_id)],
+)
+
+export const MemoryContextTable = mysqlTable(
+  "memory_context",
+  {
+    id: denTypeIdColumn("memctx", "id").notNull().primaryKey(),
+    // No DB-level FK: den-db avoids FK constraints (PlanetScale/Vitess convention). The
+    // memory -> memory_context cascade is enforced explicitly in the delete handler,
+    // supported by this index.
+    memory_id: denTypeIdColumn("memory", "memory_id").notNull(),
+    citation: json("citation"),
+    snippet: text("snippet").notNull(),
+    origin: mysqlEnum("origin", MemoryContextOrigin),
+    created_at: timestamps.created_at,
+  },
+  (table) => [index("memory_context_memory_id").on(table.memory_id)],
+)

--- a/ee/packages/utils/src/typeid.ts
+++ b/ee/packages/utils/src/typeid.ts
@@ -81,6 +81,8 @@ export const idTypesMapNameToPrefix = {
   orgOAuthClient: "ooc",
   connectedAccount: "cta",
   externalMcpConnection: "emc",
+  memory: "mem",
+  memctx: "mctx",
 } as const
 
 export const denTypeIdPrefixes = idTypesMapNameToPrefix

--- a/evals/flows/memory-save-recall.flow.mjs
+++ b/evals/flows/memory-save-recall.flow.mjs
@@ -207,20 +207,22 @@ export default {
         const recallMatch = (search.matches ?? []).find((match) => /memory/i.test(match.name) && /search/i.test(match.name));
         ctx.assert(Boolean(recallMatch), `Expected a memory-search capability, got: ${(search.matches ?? []).map((m) => m.name).join(", ")}`);
 
+        // Query tokens ("Acme", "account") are guaranteed to be in the stored content.
+        const recallQuery = "Acme account renewal";
         const recall = await mcpAgentCall(ctx, ctx.mcpToken, "tools/call", {
           name: "execute_capability",
-          arguments: { name: recallMatch.name, query: { q: "Acme renewal deal" } },
+          arguments: { name: recallMatch.name, query: { q: recallQuery } },
         });
         ctx.assert(recall.isError !== true, `Recall execute errored: ${recall.content?.[0]?.text ?? ""}`);
         const results = callText(recall).results ?? [];
         const found = results.find((entry) => entry.id === ctx.memoryId);
         ctx.assert(Boolean(found), `Recall did not return the saved memory. Got ids: ${results.map((r) => r.id).join(", ")}`);
-        ctx.assert(found.content.includes(MEMORY_MARKER), "Recalled memory content did not match what was saved.");
+        ctx.assert((found.content ?? "").includes(MEMORY_MARKER), "Recalled memory content did not match what was saved.");
         ctx.recordEvidence({
           type: "assertion",
           status: "passed",
           assertion: "A fresh search_capabilities -> execute_capability recalled the saved memory by natural-language query — cross-session lexical recall works end-to-end.",
-          actual: { query: "Acme renewal deal", recalledId: found.id },
+          actual: { query: recallQuery, recalledId: found.id },
         });
       },
     },
@@ -233,11 +235,12 @@ export default {
             await ctx.expectHashIncludes("/settings/memory");
           },
           assert: async () => {
-            await ctx.expectText("Acme renewal deal", { timeoutMs: 30_000 });
+            // Assert a phrase that is actually persisted in the memory content.
+            await ctx.expectText("Acme account renews", { timeoutMs: 30_000 });
           },
           screenshot: {
             name: "memory-panel-shows-saved-memory",
-            requireText: ["Acme renewal deal"],
+            requireText: ["Acme account renews"],
             rejectText: ["Something went wrong", "Sign in to your OpenWork account"],
             hashIncludes: "/settings/memory",
           },

--- a/evals/flows/memory-save-recall.flow.mjs
+++ b/evals/flows/memory-save-recall.flow.mjs
@@ -139,7 +139,7 @@ export default {
         const minted = await denFetch(ctx, "/v1/mcp/token", {
           method: "POST",
           headers: { authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}` },
-          body: JSON.stringify({}),
+          body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
         });
         ctx.assert(typeof minted.token === "string" && minted.token.startsWith("ow_mcp_at_"), "Expected a real opaque MCP token.");
         ctx.mcpToken = minted.token;

--- a/evals/flows/memory-save-recall.flow.mjs
+++ b/evals/flows/memory-save-recall.flow.mjs
@@ -1,0 +1,267 @@
+/**
+ * Memory Bank v0 — end-to-end save -> recall proof (TASK-9).
+ *
+ * Mirrors mcp-search-capabilities.flow.mjs. Proves, on top of the real Den MCP
+ * infrastructure and a signed-in desktop app, that:
+ *
+ * 1. The agent DISCOVERS the memory-save capability search-first (via
+ *    search_capabilities on /mcp/agent) — it is never a bespoke `memory_save`
+ *    tool, only `search_capabilities` + `execute_capability` exist here.
+ * 2. Executing the matched save capability persists a human-confirmed memory
+ *    (POST /v1/memory, owner-scoped) for real.
+ * 3. A SEPARATE, fresh MCP call (a new server instance — no session carried)
+ *    recalls that memory via a natural-language query (getMemorySearch),
+ *    proving cross-session lexical recall.
+ * 4. The desktop Memory panel shows the saved memory (UI matches the API).
+ *
+ * This flow also fails loudly on the B1 (search-first) and B3 (flattened save
+ * payload) regressions.
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_API_URL    Den API base (e.g. http://127.0.0.1:8788)
+ * - OPENWORK_EVAL_DEN_TOKEN      Bearer session token for the demo owner
+ * - OPENWORK_EVAL_WORKSPACE_PATH A folder to use as the workspace
+ */
+
+async function denFetch(ctx, path, options = {}) {
+  const base = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+  const response = await fetch(`${base}${path}`, {
+    ...options,
+    headers: { "content-type": "application/json", ...(options.headers || {}) },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  if (!response.ok) {
+    throw new Error(`${options.method || "GET"} ${path} -> ${response.status}: ${typeof body === "string" ? body : JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+/** JSON-RPC over MCP streamable-HTTP; each request is a fresh server instance. */
+async function mcpAgentCall(ctx, mcpToken, method, params) {
+  const base = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+  const response = await fetch(`${base}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${mcpToken}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params: params ?? {} }),
+  });
+  const raw = await response.text();
+  ctx.assert(response.ok, `MCP ${method} (/mcp/agent) failed: ${response.status} ${raw.slice(0, 300)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  ctx.assert(Boolean(dataLine), `MCP ${method} returned no data frame: ${raw.slice(0, 300)}`);
+  const parsed = JSON.parse(dataLine.slice(5));
+  ctx.assert(!parsed.error, `MCP ${method} returned a JSON-RPC error: ${JSON.stringify(parsed.error)}`);
+  return parsed.result;
+}
+
+function callText(result) {
+  return JSON.parse(result.content?.[0]?.text ?? "{}");
+}
+
+const MEMORY_MARKER = `acme-renewal-${Date.now()}`;
+const MEMORY_CONTENT = `User's Acme account renews in Q3 at 5000 per month — marker ${MEMORY_MARKER}.`;
+
+export default {
+  id: "memory-save-recall",
+  title: "Agent discovers the memory capability, saves a memory, and recalls it in a fresh session via natural language",
+  spec: "docs/memory-bank-architecture.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_WORKSPACE_PATH"],
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000 });
+      },
+    },
+    {
+      name: "Sign in via desktop handoff (skipped when already signed in)",
+      run: async (ctx) => {
+        const signedIn = await ctx.eval("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())");
+        if (signedIn) {
+          ctx.log("Already signed in; reusing session.");
+          return;
+        }
+        const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+        const response = await fetch(`${apiBase}/v1/auth/desktop-handoff`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`, "content-type": "application/json" },
+          body: JSON.stringify({}),
+        });
+        ctx.assert(response.ok, `Handoff create failed: ${response.status}`);
+        const payload = await response.json();
+        await ctx.control("auth.exchange-grant", { grant: payload.grant });
+        await ctx.waitFor(
+          "window.__openworkControl.execute('auth.status').then(r => r.result?.status === 'signed_in')",
+          { timeoutMs: 15_000, label: "auth signed_in" },
+        );
+      },
+    },
+    {
+      name: "Active organization resolves and Cloud Control MCP auto-configures",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", {
+          timeoutMs: 60_000,
+          label: "active org",
+        });
+        const onWelcome = await ctx.eval("location.hash.includes('/welcome')");
+        if (onWelcome) {
+          await ctx.fill("input", ctx.env.OPENWORK_EVAL_WORKSPACE_PATH.trim());
+          await ctx.clickText("Use this folder", { timeoutMs: 10_000 });
+          await ctx.waitFor("location.hash.includes('/workspace/')", { timeoutMs: 30_000, label: "workspace route" });
+        }
+      },
+    },
+    {
+      name: "Enable the Memory Bank preview flag so the panel surfaces",
+      run: async (ctx) => {
+        await ctx.eval(`(() => {
+          const key = 'openwork.preferences';
+          let prefs = {};
+          try { prefs = JSON.parse(localStorage.getItem(key) ?? '{}'); } catch {}
+          prefs.featureFlags = { ...(prefs.featureFlags ?? {}), memory: true };
+          localStorage.setItem(key, JSON.stringify(prefs));
+          return true;
+        })()`);
+      },
+    },
+    {
+      name: "Mint a real org-scoped MCP token",
+      run: async (ctx) => {
+        const minted = await denFetch(ctx, "/v1/mcp/token", {
+          method: "POST",
+          headers: { authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}` },
+          body: JSON.stringify({}),
+        });
+        ctx.assert(typeof minted.token === "string" && minted.token.startsWith("ow_mcp_at_"), "Expected a real opaque MCP token.");
+        ctx.mcpToken = minted.token;
+        ctx.organizationId = minted.organizationId;
+      },
+    },
+    {
+      name: "Discover the SAVE capability search-first (B1) — no bespoke memory_save tool",
+      run: async (ctx) => {
+        const agentTools = await mcpAgentCall(ctx, ctx.mcpToken, "tools/list", {});
+        const toolNames = agentTools.tools.map((tool) => tool.name).sort();
+        ctx.assert(
+          toolNames.join(",") === "execute_capability,search_capabilities",
+          `Expected only search_capabilities + execute_capability, got: ${toolNames.join(", ")}`,
+        );
+        ctx.assert(!toolNames.includes("memory_save") && !toolNames.includes("memory_search"), "A bespoke memory tool must not exist (B1).");
+
+        const search = callText(await mcpAgentCall(ctx, ctx.mcpToken, "tools/call", {
+          name: "search_capabilities",
+          arguments: { query: "save a memory to the memory bank", limit: 5 },
+        }));
+        const matches = search.matches ?? [];
+        const saveMatch = matches.find((match) => /memory/i.test(match.name) && /post/i.test(match.name));
+        ctx.assert(Boolean(saveMatch), `Expected a memory-save capability in matches, got: ${matches.map((m) => m.name).join(", ")}`);
+        ctx.assert(saveMatch.hasBody === true, "Save capability must advertise a body (B3 flattened payload).");
+        ctx.saveCapability = saveMatch.name;
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "The agent discovered the memory-save capability search-first via search_capabilities; no memory_save tool exists.",
+          actual: { saveCapability: saveMatch.name, hasBody: saveMatch.hasBody },
+        });
+        ctx.log(`save capability: ${saveMatch.name}`);
+      },
+    },
+    {
+      name: "Execute the save capability — a human-confirmed memory is persisted (B3 flattened body)",
+      run: async (ctx) => {
+        const result = await mcpAgentCall(ctx, ctx.mcpToken, "tools/call", {
+          name: "execute_capability",
+          arguments: { name: ctx.saveCapability, body: { content: MEMORY_CONTENT, tags: ["acme", "deal"] } },
+        });
+        ctx.assert(result.isError !== true, `Save execute errored: ${result.content?.[0]?.text ?? ""}`);
+        const saved = callText(result);
+        ctx.assert(typeof saved.memory?.id === "string" && saved.memory.id.startsWith("mem_"), `Expected a mem_ id, got: ${JSON.stringify(saved.memory)}`);
+        ctx.assert(saved.memory.scope === "user", "Server must force scope='user'.");
+        ctx.memoryId = saved.memory.id;
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "execute_capability persisted a memory via the real POST /v1/memory owner-scoped route, scope forced to 'user'.",
+          actual: { memoryId: saved.memory.id, scope: saved.memory.scope },
+        });
+      },
+    },
+    {
+      name: "Recall it in a FRESH MCP call via a natural-language query (cross-session lexical recall)",
+      run: async (ctx) => {
+        // A brand-new /mcp/agent request = a fresh server instance with no
+        // carried session, so a successful recall proves cross-session persistence.
+        const search = callText(await mcpAgentCall(ctx, ctx.mcpToken, "tools/call", {
+          name: "search_capabilities",
+          arguments: { query: "search my saved memories", limit: 5 },
+        }));
+        const recallMatch = (search.matches ?? []).find((match) => /memory/i.test(match.name) && /search/i.test(match.name));
+        ctx.assert(Boolean(recallMatch), `Expected a memory-search capability, got: ${(search.matches ?? []).map((m) => m.name).join(", ")}`);
+
+        const recall = await mcpAgentCall(ctx, ctx.mcpToken, "tools/call", {
+          name: "execute_capability",
+          arguments: { name: recallMatch.name, query: { q: "Acme renewal deal" } },
+        });
+        ctx.assert(recall.isError !== true, `Recall execute errored: ${recall.content?.[0]?.text ?? ""}`);
+        const results = callText(recall).results ?? [];
+        const found = results.find((entry) => entry.id === ctx.memoryId);
+        ctx.assert(Boolean(found), `Recall did not return the saved memory. Got ids: ${results.map((r) => r.id).join(", ")}`);
+        ctx.assert(found.content.includes(MEMORY_MARKER), "Recalled memory content did not match what was saved.");
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "A fresh search_capabilities -> execute_capability recalled the saved memory by natural-language query — cross-session lexical recall works end-to-end.",
+          actual: { query: "Acme renewal deal", recalledId: found.id },
+        });
+      },
+    },
+    {
+      name: "The desktop Memory panel shows the saved memory (UI matches the API)",
+      run: async (ctx) => {
+        await ctx.prove("The memory saved via the agent capability appears in the desktop Memory management panel.", {
+          action: async () => {
+            await ctx.navigateHash("/settings/memory");
+            await ctx.expectHashIncludes("/settings/memory");
+          },
+          assert: async () => {
+            await ctx.expectText("Acme renewal deal", { timeoutMs: 30_000 });
+          },
+          screenshot: {
+            name: "memory-panel-shows-saved-memory",
+            requireText: ["Acme renewal deal"],
+            rejectText: ["Something went wrong", "Sign in to your OpenWork account"],
+            hashIncludes: "/settings/memory",
+          },
+        });
+      },
+    },
+    {
+      name: "Clean up the test memory via execute_capability(delete)",
+      run: async (ctx) => {
+        const search = callText(await mcpAgentCall(ctx, ctx.mcpToken, "tools/call", {
+          name: "search_capabilities",
+          arguments: { query: "delete a memory", limit: 5 },
+        }));
+        const deleteMatch = (search.matches ?? []).find((match) => /memory/i.test(match.name) && /delete/i.test(match.name));
+        if (!deleteMatch) {
+          ctx.log("Delete capability not found; leaving test memory (harmless).");
+          return;
+        }
+        await mcpAgentCall(ctx, ctx.mcpToken, "tools/call", {
+          name: "execute_capability",
+          arguments: { name: deleteMatch.name, path: { id: ctx.memoryId } },
+        });
+        ctx.log(`deleted test memory ${ctx.memoryId}`);
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Memory Bank v0 — Backend (den-db + den-api + agent prompt + eval)

The per-user Memory Bank server side: schema, owner-scoped REST routes surfaced through the existing meta-MCP, the agent prompt that primes search-first save/recall, a save→recall eval, and a general meta-MCP robustness fix. Frontend (desktop UI) is a separate PR.

Authoritative design: `docs/memory-bank-architecture.md`.

### What's here
**Schema (den-db) [TASK-1]** — `memory` + `memory_context` tables; `memory`/`memctx` typeids registered in `packages/utils`; migration `0028`. FULLTEXT index on `memory.content` created **idempotently on all apply paths** (`bootstrap`, `db:push`, `db:migrate` chain) via `ensureMemoryFulltextIndex` — because `drizzle-kit push` + baseline silently drop a migration-only FULLTEXT index on fresh installs [B2]. No DB-level FK (PlanetScale/Vitess convention); the memory→context cascade is app-enforced.

**Routes (den-api) [TASK-2/3]** — `postMemory` / `getMemorySearch` / `getMemory` / `deleteMemoryById`. Reads (search/list) and delete are **owner-scoped on `user_id`** (not the org pattern) with non-leaking 404 [B4] — v0 recalls a user's memories across all of their orgs. **Save uses `orgMemberRoute()`**: the memory is only written to an org the caller is verified to be a **member** of (`resolveOrganizationContextMiddleware` → `getOrganizationContextForUser`, 404 otherwise, on both the cookie/bearer and MCP-principal paths); `org_id` comes from the verified `organizationContext.organization.id`, never a raw/forgeable `session.activeOrganizationId`. Also: flattened, mostly-optional save payload with the shape in the OpenAPI summary, server-set `source`, forced `scope='user'`, one-transaction save, input bounds [B3]; bound `MATCH … AGAINST` NL search (never `sql.raw`), empty→200; structured save/search/delete events. `"Memory"` added to `SAFE_INCLUDED_TAGS` so the four capabilities surface via `search_capabilities`/`execute_capability`.

**Agent prompt (apps/server) [TASK-4]** — static, search-first `## Memory Bank` section (never names `memory_save`); draft→human-confirm→execute save, explicit lexical recall, no-secrets guidance (the only v0 plaintext-at-rest mitigation). Also corrects the capabilities-knowledge plugin that previously said there was "no separate memory store."

**Eval (evals) [TASK-9]** — `memory-save-recall.flow.mjs`: discover→save→recall in a fresh session via the live meta-MCP.

**Meta-MCP fix (den-api)** — `execute_capability` now accepts `path`/`query` passed as a JSON string (LLMs stringify args), mirroring the existing `normalizeToolBody`. Fixes a real `-32602 "expected record, received string"` and unblocks `getMemorySearch` recall. General — applies to every capability.

### Tests run — all pass
```
# den-api (bun, against MySQL 8.4 openwork_test)
bun test test/memory-routes.test.ts        → 5 pass   (operationIds, MCP allow+scopes, payload bounds, scope/source not client-settable)
bun test test/memory-ownership.test.ts     → 5 pass   (IDOR merge gate: member save → Bob 404 → recall → cascade delete → empty→200 → bounds → NON-MEMBER save 404)
bun test test/mcp-invoke-body.test.ts      → 8 pass   (query fix — no regression)
bun test test/route-access-policy.test.ts  → 1 pass
tsc --noEmit (den-api)                      → 0 errors
# den-db
db:verify-memory (bootstrap + db:push paths) → 10/10 checks (FULLTEXT present on both paths, NL MATCH, cascade, idempotency)
tsc/DTS (den-db, utils)                     → build OK
# apps/server
bun test src/openwork-runtime-config.test.ts → 4 pass   (## Memory Bank present, distinct, no memory_save/search, no-secrets)
tsc --noEmit (server)                       → 0 errors
```

### fraimz / end-to-end proof
The save→recall flow was **proven live end-to-end** against the running stack (den-api + MySQL + a real MCP token):
```
✓ /mcp/agent exposes exactly execute_capability, search_capabilities (no memory_save/search)
✓ discovered save capability search-first: postMemory (hasBody:true)
✓ saved mem_… (scope forced 'user') → recalled via NL "Acme account renewal" (FULLTEXT score 0.18)
✓ stringified query param accepted (the execute_capability fix) → cleaned up via delete capability
```
`evals/flows/memory-save-recall.flow.mjs` drives this via the eval runner (`pnpm fraimz --flow memory-save-recall`, needs a signed-in app + `--stack den`). Backend-only PR — no desktop UI surface here.

### Review
Every stage driven to **zero findings at every severity** via multi-lens reviews (security/IDOR · data-migration · data-integrity · TypeScript · architecture · performance), each with an address-and-re-review round. Accepted-in-writing LOWs documented in code/§9.

### Coding guidelines
No `any`/`as`/typecasts (only required `as const` on enum tuples + one `satisfies`); pnpm/bun; additive; smallest diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
