### PR TITLE
feat(server): search + execute capability pattern — server shard, ui/mcp federation, share plan

### DIFF
--- a/apps/server/src/capabilities.test.ts
+++ b/apps/server/src/capabilities.test.ts
@@ -69,7 +69,7 @@ describe("capability index", () => {
   });
 
   test("search ranks by intent terms", () => {
-    const exportHits = searchCapabilities("export mcp for marketplace");
+    const exportHits = searchCapabilities("portable export of an mcp");
     expect(exportHits.at(0)?.id).toBe("extensions.export");
     const skillHits = searchCapabilities("save repeatable work as a skill");
     expect(skillHits.map((card) => card.id)).toContain("skills.upsert");
@@ -192,6 +192,209 @@ describe("capability execution over HTTP", () => {
   });
 });
 
+describe("marketplace.share_plan", () => {
+  test("compiles a secret-free publish plan with required inputs and fingerprint", async () => {
+    await withWorkspace(async ({ root, config }) => {
+      await writeSkill(root, "plan-skill");
+      await addMcp(config, WORKSPACE_ID, "plan-mcp", {
+        type: "remote",
+        url: "https://mcp.example.com/plan",
+        enabled: false,
+        headers: { Authorization: SECRET },
+        oauth: { clientId: "plan-client", clientSecret: "plan-oauth-secret-999", scope: "plan.read" },
+      });
+
+      const server = await startServer(config) as Served;
+      try {
+        const response = await fetch(`http://127.0.0.1:${server.port}/workspace/${WORKSPACE_ID}/capabilities/execute`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${config.token}`, "content-type": "application/json" },
+          body: JSON.stringify({
+            id: "marketplace.share_plan",
+            args: { skills: ["plan-skill"], mcps: ["plan-mcp"], marketplace: "BY IT Marketplace" },
+          }),
+        });
+        expect(response.status).toBe(200);
+        const raw = await response.text();
+        // Secrets are dropped, not placeholdered: neither the values nor
+        // the <redacted> marker may appear in a publishable plan.
+        expect(raw).not.toContain(SECRET);
+        expect(raw).not.toContain("plan-oauth-secret-999");
+        expect(raw).not.toContain("<redacted>");
+
+        const payload = JSON.parse(raw) as {
+          result: {
+            plan: {
+              pluginName: string;
+              stepCount: number;
+              secretsExcluded: string[];
+              planFingerprint: string;
+              steps: Array<{ method: string; path: string; body?: Record<string, unknown> }>;
+            };
+          };
+        };
+        const plan = payload.result.plan;
+        expect(plan.pluginName).toBe("Plan Skill");
+        expect(plan.secretsExcluded.sort()).toEqual(["headers.Authorization", "oauth.clientSecret"]);
+        expect(plan.planFingerprint).toMatch(/^[0-9a-f]{16}$/);
+        expect(plan.steps.at(0)?.path).toContain("/v1/marketplaces");
+        expect(plan.steps.at(-1)?.body?.pluginId).toBe("{pluginId}");
+        const mcpStep = plan.steps.find((step) => JSON.stringify(step).includes("mcpServers"));
+        const mcpJson = JSON.stringify(mcpStep);
+        expect(mcpJson).toContain("plan-client");
+        expect(mcpJson).toContain("plan.read");
+        expect(mcpJson).not.toContain("clientSecret");
+        // Skill content travels verbatim in its config object.
+        const skillStep = plan.steps.find((step) => JSON.stringify(step).includes("rawSourceText"));
+        expect(JSON.stringify(skillStep)).toContain("Test skill plan-skill");
+
+        // Same args -> same fingerprint (plan is deterministic).
+        const again = await fetch(`http://127.0.0.1:${server.port}/workspace/${WORKSPACE_ID}/capabilities/execute`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${config.token}`, "content-type": "application/json" },
+          body: JSON.stringify({
+            id: "marketplace.share_plan",
+            args: { skills: ["plan-skill"], mcps: ["plan-mcp"], marketplace: "BY IT Marketplace" },
+          }),
+        });
+        const againPlan = (await again.json() as typeof payload).result.plan;
+        expect(againPlan.planFingerprint).toBe(plan.planFingerprint);
+      } finally {
+        await server.stop(true);
+      }
+    });
+  });
+
+  test("404s with the missing component names", async () => {
+    await withWorkspace(async ({ config }) => {
+      const server = await startServer(config) as Served;
+      try {
+        const response = await fetch(`http://127.0.0.1:${server.port}/workspace/${WORKSPACE_ID}/capabilities/execute`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${config.token}`, "content-type": "application/json" },
+          body: JSON.stringify({ id: "marketplace.share_plan", args: { skills: ["ghost"], marketplace: "M" } }),
+        });
+        expect(response.status).toBe(404);
+        expect(await response.text()).toContain("ghost");
+      } finally {
+        await server.stop(true);
+      }
+    });
+  });
+
+  test("search finds the plan capability for share intent", () => {
+    const hits = searchCapabilities("share this skill with my team marketplace");
+    expect(hits.at(0)?.id).toBe("marketplace.share_plan");
+  });
+});
+
+describe("federated search across server + ui + mcp shards", () => {
+  test("merges ui bridge actions and mcp pointer cards; execute dispatches by origin", async () => {
+    await withWorkspace(async ({ root, config }) => {
+      await addMcp(config, WORKSPACE_ID, "fed-mcp", {
+        type: "remote",
+        url: "https://mcp.example.com/fed",
+        enabled: false,
+      });
+
+      // Mock UI control bridge: /actions catalog + /execute echo.
+      const executed: Array<{ actionId: string; args: unknown }> = [];
+      const bridge = Bun.serve({
+        port: 0,
+        fetch: async (request) => {
+          const url = new URL(request.url);
+          if (url.pathname === "/actions") {
+            return Response.json({
+              ok: true,
+              actions: [
+                {
+                  id: "settings.panel.open",
+                  label: "Open settings panel",
+                  description: "Open a settings panel in the OpenWork app.",
+                  sideEffect: "navigation",
+                  args: [{ name: "panel", description: "Panel id, e.g. extensions." }],
+                  disabled: false,
+                },
+                { id: "hidden.action", label: "Hidden", sideEffect: "none", disabled: true },
+              ],
+            });
+          }
+          if (url.pathname === "/execute") {
+            const body = await request.json() as { actionId: string; args: unknown };
+            executed.push(body);
+            return Response.json({ ok: true, result: { route: "/settings/extensions" } });
+          }
+          return Response.json({ ok: false }, { status: 404 });
+        },
+      });
+      const discoveryPath = join(root, "ui-bridge.json");
+      await writeFile(discoveryPath, JSON.stringify({ baseUrl: `http://127.0.0.1:${bridge.port}`, token: "bridge-token" }), "utf8");
+
+      const server = await startServer(config) as Served;
+      const previous = {
+        url: process.env.OPENWORK_SERVER_URL,
+        token: process.env.OPENWORK_SERVER_TOKEN,
+        discovery: process.env.OPENWORK_UI_CONTROL_DISCOVERY,
+      };
+      process.env.OPENWORK_SERVER_URL = `http://127.0.0.1:${server.port}`;
+      process.env.OPENWORK_SERVER_TOKEN = config.token;
+      process.env.OPENWORK_UI_CONTROL_DISCOVERY = discoveryPath;
+      try {
+        const { OpenWorkExtensionsPreview } = await import("./opencode-plugins/openwork-extensions-preview.js");
+        const plugin = await OpenWorkExtensionsPreview();
+
+        const searchOutput = await plugin.tool.openwork_search.execute(
+          { query: "open the settings panel" },
+          { directory: root },
+        );
+        const search = JSON.parse(searchOutput) as {
+          ok: boolean;
+          origins: { server: number; ui: number; mcp: number };
+          items: Array<{ id: string; origin: string }>;
+        };
+        expect(search.ok).toBe(true);
+        expect(search.origins.ui).toBeGreaterThanOrEqual(2);
+        expect(search.origins.mcp).toBe(1);
+        expect(search.items.at(0)?.id).toBe("ui.settings.panel.open");
+        // Disabled UI actions never surface.
+        expect(search.items.some((item) => item.id === "ui.hidden.action")).toBe(false);
+
+        const mcpSearch = JSON.parse(await plugin.tool.openwork_search.execute(
+          { query: "fed-mcp connected app" },
+          { directory: root },
+        )) as { items: Array<{ id: string }> };
+        expect(mcpSearch.items.at(0)?.id).toBe("mcp:fed-mcp");
+
+        const uiExec = JSON.parse(await plugin.tool.openwork_execute.execute(
+          { id: "ui.settings.panel.open", args: { panel: "extensions" } },
+          { directory: root },
+        )) as { ok: boolean; origin: string };
+        expect(uiExec.ok).toBe(true);
+        expect(uiExec.origin).toBe("ui");
+        expect(executed).toEqual([{ actionId: "settings.panel.open", args: { panel: "extensions" } }]);
+
+        const pointer = JSON.parse(await plugin.tool.openwork_execute.execute(
+          { id: "mcp:fed-mcp" },
+          { directory: root },
+        )) as { ok: boolean; origin: string; result: { pointer: boolean; message: string } };
+        expect(pointer.ok).toBe(true);
+        expect(pointer.origin).toBe("mcp");
+        expect(pointer.result.pointer).toBe(true);
+        expect(pointer.result.message).toContain('extensions.export');
+      } finally {
+        if (previous.url === undefined) delete process.env.OPENWORK_SERVER_URL;
+        else process.env.OPENWORK_SERVER_URL = previous.url;
+        if (previous.token === undefined) delete process.env.OPENWORK_SERVER_TOKEN;
+        else process.env.OPENWORK_SERVER_TOKEN = previous.token;
+        if (previous.discovery === undefined) delete process.env.OPENWORK_UI_CONTROL_DISCOVERY;
+        else process.env.OPENWORK_UI_CONTROL_DISCOVERY = previous.discovery;
+        bridge.stop(true);
+        await server.stop(true);
+      }
+    });
+  });
+});
+
 describe("openwork_search + openwork_execute plugin tools", () => {
   test("agent finds extensions.export by intent and executes it", async () => {
     await withWorkspace(async ({ root, config }) => {
@@ -213,7 +416,7 @@ describe("openwork_search + openwork_execute plugin tools", () => {
         const plugin = await OpenWorkExtensionsPreview();
 
         const searchOutput = await plugin.tool.openwork_search.execute(
-          { query: "export mcp for marketplace" },
+          { query: "portable export of an mcp" },
           { directory: root },
         );
         const search = JSON.parse(searchOutput) as { ok: boolean; items: Array<{ id: string }> };

--- a/apps/server/src/capabilities.test.ts
+++ b/apps/server/src/capabilities.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { addMcp } from "./mcp.js";
+import { getCapability, listCapabilities, searchCapabilities } from "./capabilities.js";
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+import { exists } from "./utils.js";
+
+const WORKSPACE_ID = "ws_capabilities_test";
+const SECRET = "Bearer capability-secret-555";
+
+type Served = {
+  port: number;
+  stop: (closeActiveConnections?: boolean) => void | Promise<void>;
+};
+
+function serverConfig(root: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    hostToken: "host-token",
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [{ id: WORKSPACE_ID, name: "Test", path: root, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  } satisfies ServerConfig;
+}
+
+async function withWorkspace(fn: (input: { root: string; config: ServerConfig }) => Promise<void>) {
+  const root = await mkdtemp(join(tmpdir(), "openwork-capabilities-"));
+  const previousDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  try {
+    await mkdir(join(root, ".git"), { recursive: true });
+    await fn({ root, config: serverConfig(root) });
+  } finally {
+    if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+    else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function writeSkill(root: string, name: string) {
+  const dir = join(root, ".opencode", "skills", name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "SKILL.md"), `---\nname: ${name}\ndescription: Test skill ${name}\n---\n\nBody\n`, "utf8");
+}
+
+describe("capability index", () => {
+  test("cards carry intent metadata and effects", () => {
+    const cards = listCapabilities();
+    expect(cards.length).toBeGreaterThanOrEqual(5);
+    for (const card of cards) {
+      expect(card.id).toMatch(/^[a-z]+\.[a-z_]+$/);
+      expect(card.when.length).toBeGreaterThan(10);
+      expect(card.origin).toBe("server");
+      expect(["read", "write:workspace"]).toContain(card.effects);
+    }
+  });
+
+  test("search ranks by intent terms", () => {
+    const exportHits = searchCapabilities("export mcp for marketplace");
+    expect(exportHits.at(0)?.id).toBe("extensions.export");
+    const skillHits = searchCapabilities("save repeatable work as a skill");
+    expect(skillHits.map((card) => card.id)).toContain("skills.upsert");
+    expect(searchCapabilities("quantum blockchain karaoke")).toEqual([]);
+  });
+
+  test("empty query lists everything up to the limit", () => {
+    expect(searchCapabilities("", 2).length).toBe(2);
+  });
+
+  test("unknown capability id resolves to null", () => {
+    expect(getCapability("nope.nothing")).toBeNull();
+  });
+});
+
+describe("capability execution over HTTP", () => {
+  test("read capability: mcp.list redacts secrets", async () => {
+    await withWorkspace(async ({ root, config }) => {
+      await addMcp(config, WORKSPACE_ID, "cap-mcp", {
+        type: "remote",
+        url: "https://mcp.example.com/cap",
+        headers: { Authorization: SECRET },
+        enabled: false,
+      });
+      const server = await startServer(config) as Served;
+      try {
+        const response = await fetch(`http://127.0.0.1:${server.port}/workspace/${WORKSPACE_ID}/capabilities/execute`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${config.token}`, "content-type": "application/json" },
+          body: JSON.stringify({ id: "mcp.list" }),
+        });
+        expect(response.status).toBe(200);
+        const raw = await response.text();
+        expect(raw).not.toContain(SECRET);
+        const payload = JSON.parse(raw) as { result: { items: Array<{ name: string; redactedKeys: string[] }> } };
+        const item = payload.result.items.find((entry) => entry.name === "cap-mcp");
+        expect(item?.redactedKeys).toEqual(["headers.Authorization"]);
+      } finally {
+        await server.stop(true);
+      }
+    });
+  });
+
+  test("search endpoint returns ranked cards", async () => {
+    await withWorkspace(async ({ config }) => {
+      const server = await startServer(config) as Served;
+      try {
+        const response = await fetch(
+          `http://127.0.0.1:${server.port}/workspace/${WORKSPACE_ID}/capabilities/search?q=${encodeURIComponent("portable export")}`,
+          { headers: { authorization: `Bearer ${config.token}` } },
+        );
+        expect(response.status).toBe(200);
+        const payload = await response.json() as { items: Array<{ id: string; argsSchema: unknown }> };
+        expect(payload.items.at(0)?.id).toBe("extensions.export");
+        expect(payload.items.at(0)?.argsSchema).toBeDefined();
+      } finally {
+        await server.stop(true);
+      }
+    });
+  });
+
+  test("write capability creates the skill and unknown ids 404", async () => {
+    await withWorkspace(async ({ root, config }) => {
+      const server = await startServer(config) as Served;
+      try {
+        const response = await fetch(`http://127.0.0.1:${server.port}/workspace/${WORKSPACE_ID}/capabilities/execute`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${config.token}`, "content-type": "application/json" },
+          body: JSON.stringify({
+            id: "skills.upsert",
+            args: { name: "cap-made-skill", content: "Do the thing.", description: "Made through execute." },
+          }),
+        });
+        expect(response.status).toBe(200);
+        expect(await exists(join(root, ".opencode", "skills", "cap-made-skill", "SKILL.md"))).toBe(true);
+
+        const missing = await fetch(`http://127.0.0.1:${server.port}/workspace/${WORKSPACE_ID}/capabilities/execute`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${config.token}`, "content-type": "application/json" },
+          body: JSON.stringify({ id: "nope.nothing" }),
+        });
+        expect(missing.status).toBe(404);
+      } finally {
+        await server.stop(true);
+      }
+    });
+  });
+
+  test("write capability is denied for viewer-scope tokens", async () => {
+    await withWorkspace(async ({ root, config }) => {
+      const server = await startServer(config) as Served;
+      try {
+        const tokenResponse = await fetch(`http://127.0.0.1:${server.port}/tokens`, {
+          method: "POST",
+          headers: { "x-openwork-host-token": config.hostToken, "content-type": "application/json" },
+          body: JSON.stringify({ scope: "viewer", label: "cap viewer" }),
+        });
+        expect(tokenResponse.status).toBe(201);
+        const viewerToken = (await tokenResponse.json() as { token: string }).token;
+
+        const denied = await fetch(`http://127.0.0.1:${server.port}/workspace/${WORKSPACE_ID}/capabilities/execute`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${viewerToken}`, "content-type": "application/json" },
+          body: JSON.stringify({ id: "skills.upsert", args: { name: "viewer-skill", content: "x", description: "d" } }),
+        });
+        expect(denied.status).toBe(403);
+        expect(await exists(join(root, ".opencode", "skills", "viewer-skill"))).toBe(false);
+
+        // Read capabilities remain available to viewers.
+        const allowed = await fetch(`http://127.0.0.1:${server.port}/workspace/${WORKSPACE_ID}/capabilities/execute`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${viewerToken}`, "content-type": "application/json" },
+          body: JSON.stringify({ id: "skills.list" }),
+        });
+        expect(allowed.status).toBe(200);
+      } finally {
+        await server.stop(true);
+      }
+    });
+  });
+});
+
+describe("openwork_search + openwork_execute plugin tools", () => {
+  test("agent finds extensions.export by intent and executes it", async () => {
+    await withWorkspace(async ({ root, config }) => {
+      await writeSkill(root, "cap-skill");
+      await addMcp(config, WORKSPACE_ID, "cap-oauth-mcp", {
+        type: "remote",
+        url: "https://mcp.example.com/oauth",
+        enabled: false,
+        oauth: { clientId: "cap-client", clientSecret: "cap-oauth-secret-777" },
+      });
+
+      const server = await startServer(config) as Served;
+      const previousUrl = process.env.OPENWORK_SERVER_URL;
+      const previousToken = process.env.OPENWORK_SERVER_TOKEN;
+      process.env.OPENWORK_SERVER_URL = `http://127.0.0.1:${server.port}`;
+      process.env.OPENWORK_SERVER_TOKEN = config.token;
+      try {
+        const { OpenWorkExtensionsPreview } = await import("./opencode-plugins/openwork-extensions-preview.js");
+        const plugin = await OpenWorkExtensionsPreview();
+
+        const searchOutput = await plugin.tool.openwork_search.execute(
+          { query: "export mcp for marketplace" },
+          { directory: root },
+        );
+        const search = JSON.parse(searchOutput) as { ok: boolean; items: Array<{ id: string }> };
+        expect(search.ok).toBe(true);
+        expect(search.items.at(0)?.id).toBe("extensions.export");
+
+        const executeOutput = await plugin.tool.openwork_execute.execute(
+          { id: "extensions.export", args: { skills: ["cap-skill"], mcps: ["cap-oauth-mcp"] } },
+          { directory: root },
+        );
+        expect(executeOutput).not.toContain("cap-oauth-secret-777");
+        const executed = JSON.parse(executeOutput) as {
+          ok: boolean;
+          result: { components: Array<{ kind: string; name: string; config?: { oauth?: Record<string, unknown> } }> };
+        };
+        expect(executed.ok).toBe(true);
+        const mcp = executed.result.components.find((item) => item.kind === "mcp");
+        expect(mcp?.config?.oauth?.clientSecret).toBe("<redacted>");
+        expect(mcp?.config?.oauth?.clientId).toBe("cap-client");
+      } finally {
+        if (previousUrl === undefined) delete process.env.OPENWORK_SERVER_URL;
+        else process.env.OPENWORK_SERVER_URL = previousUrl;
+        if (previousToken === undefined) delete process.env.OPENWORK_SERVER_TOKEN;
+        else process.env.OPENWORK_SERVER_TOKEN = previousToken;
+        await server.stop(true);
+      }
+    });
+  });
+});

--- a/apps/server/src/capabilities.ts
+++ b/apps/server/src/capabilities.ts
@@ -18,11 +18,12 @@
  * - "read"            -> no approval, viewer scope
  * - "write:workspace" -> writable server, collaborator scope, approval
  */
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ReloadReason, ReloadTrigger, ServerConfig } from "./types.js";
 import { ApiError } from "./errors.js";
-import { exportExtensions, redactMcpConfig } from "./extensions-export.js";
+import { exportExtensions, redactMcpConfig, type ExportedMcp, type ExportedSkill } from "./extensions-export.js";
 import { listMcp } from "./mcp.js";
 import { listSkills, upsertSkill } from "./skills.js";
 
@@ -209,6 +210,212 @@ const DEFINITIONS: CapabilityDefinition[] = [
     },
   },
 ];
+
+const REDACTED_VALUE = "<redacted>";
+
+type SharePlanStep = {
+  note: string;
+  method: "GET" | "POST";
+  path: string;
+  body?: Record<string, unknown>;
+  /** Reuse an existing resource instead of creating a duplicate. */
+  findOrCreate?: { matchField: string; matchValue: string };
+};
+
+function slugify(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "shared-plugin";
+}
+
+/**
+ * Build the publish-ready MCP payload from a REDACTED export: every redacted
+ * value is dropped (never published, even as a placeholder) and reported as
+ * a required input the installer must provide — or, for OAuth, obtain by
+ * signing in as themselves.
+ */
+function publishableMcpConfig(mcp: ExportedMcp): { config: Record<string, unknown>; requiredInputs: string[] } {
+  const requiredInputs = [...mcp.redactedKeys];
+  const source = mcp.config;
+  const config: Record<string, unknown> = {};
+  if (typeof source.url === "string") {
+    config.type = "remote";
+    config.url = source.url;
+  } else {
+    config.type = "local";
+    if (Array.isArray(source.command)) config.command = source.command;
+  }
+  const oauth = source.oauth;
+  if (oauth && typeof oauth === "object" && !Array.isArray(oauth)) {
+    const kept = Object.fromEntries(Object.entries(oauth).filter(([, value]) => value !== REDACTED_VALUE));
+    config.oauth = kept;
+  } else if (oauth !== undefined) {
+    config.oauth = oauth;
+  }
+  return { config, requiredInputs };
+}
+
+function buildSharePlan(input: {
+  marketplace: string;
+  pluginName: string;
+  description: string;
+  skills: ExportedSkill[];
+  mcps: ExportedMcp[];
+}): { steps: SharePlanStep[]; requiredInputs: string[]; planFingerprint: string } {
+  const steps: SharePlanStep[] = [];
+  const requiredInputs: string[] = [];
+
+  steps.push({
+    note: `Find the marketplace named ${JSON.stringify(input.marketplace)}; reuse its id as {marketplaceId} if it exists.`,
+    method: "GET",
+    path: "/v1/marketplaces?status=active&limit=100",
+    findOrCreate: { matchField: "name", matchValue: input.marketplace },
+  });
+  steps.push({
+    note: "Create the marketplace only when the lookup found none; then grant org-wide viewer access so members can see it.",
+    method: "POST",
+    path: "/v1/marketplaces",
+    body: { name: input.marketplace },
+  });
+  steps.push({
+    note: "Org-wide viewer grant on the marketplace (only needed when it was just created).",
+    method: "POST",
+    path: "/v1/marketplaces/{marketplaceId}/access",
+    body: { orgWide: true, role: "viewer" },
+  });
+  steps.push({
+    note: "Create the plugin; use the returned id as {pluginId}.",
+    method: "POST",
+    path: "/v1/plugins",
+    body: { name: input.pluginName, description: input.description },
+  });
+  steps.push({
+    note: "Org-wide viewer grant on the plugin.",
+    method: "POST",
+    path: "/v1/plugins/{pluginId}/access",
+    body: { orgWide: true, role: "viewer" },
+  });
+
+  for (const skill of input.skills) {
+    steps.push({
+      note: `Skill config object for ${skill.name} (exported SKILL.md verbatim).`,
+      method: "POST",
+      path: "/v1/config-objects",
+      body: {
+        type: "skill",
+        sourceMode: "cloud",
+        pluginIds: ["{pluginId}"],
+        input: {
+          rawSourceText: skill.content,
+          metadata: { name: skill.name, description: skill.description },
+        },
+      },
+    });
+  }
+
+  for (const mcp of input.mcps) {
+    const publishable = publishableMcpConfig(mcp);
+    requiredInputs.push(...publishable.requiredInputs);
+    steps.push({
+      note: `MCP config object for ${mcp.name}. Secret values were removed at the source; installers provide required inputs or sign in as themselves.`,
+      method: "POST",
+      path: "/v1/config-objects",
+      body: {
+        type: "mcp",
+        sourceMode: "cloud",
+        pluginIds: ["{pluginId}"],
+        input: {
+          normalizedPayloadJson: { mcpServers: { [mcp.name]: publishable.config } },
+          metadata: { name: mcp.name, description: `Shared MCP connection ${mcp.name}` },
+        },
+      },
+    });
+  }
+
+  steps.push({
+    note: "Org-wide viewer grant on each created config object ({configObjectId} per creation response).",
+    method: "POST",
+    path: "/v1/config-objects/{configObjectId}/access",
+    body: { orgWide: true, role: "viewer" },
+  });
+  steps.push({
+    note: "Publish the plugin into the marketplace.",
+    method: "POST",
+    path: "/v1/marketplaces/{marketplaceId}/plugins",
+    body: { pluginId: "{pluginId}" },
+  });
+
+  const planFingerprint = createHash("sha256").update(JSON.stringify(steps)).digest("hex").slice(0, 16);
+  return { steps, requiredInputs, planFingerprint };
+}
+
+const SHARE_PLAN_DEFINITION: CapabilityDefinition = {
+  id: "marketplace.share_plan",
+  title: "Plan sharing skills + MCPs to a marketplace",
+  description: "Compiles a complete, secret-free publish plan: exports the requested skills and MCP connections (secrets removed at the source), wraps them as one plugin, and emits the exact ordered cloud requests (find-or-create marketplace, grants, config objects, publish) plus a plan fingerprint. Nothing is written by this capability.",
+  when: "Use when the user wants to share, publish, or distribute skills or MCP connections to their team or a marketplace. Execute this first, show the user the plan summary, then run the plan's steps with your OpenWork Cloud access after they approve.",
+  origin: "server",
+  effects: "read",
+  argsSchema: {
+    type: "object",
+    required: ["marketplace"],
+    properties: {
+      skills: { type: "array", items: { type: "string" }, description: "Skill names to include." },
+      mcps: { type: "array", items: { type: "string" }, description: "MCP server names to include." },
+      marketplace: { type: "string", description: "Target marketplace name, e.g. 'BY IT Marketplace'. Reused when it already exists." },
+      pluginName: { type: "string", description: "Plugin name; derived from the first component when omitted." },
+    },
+  },
+  related: ["extensions.export", "skills.list", "mcp.list"],
+  async run(context, args) {
+    const skills = stringList(args.skills);
+    const mcps = stringList(args.mcps);
+    const marketplace = typeof args.marketplace === "string" ? args.marketplace.trim() : "";
+    if (!marketplace) throw new ApiError(400, "invalid_args", "marketplace is required");
+    if (skills.length === 0 && mcps.length === 0) {
+      throw new ApiError(400, "invalid_args", "At least one skill or mcp name is required");
+    }
+    const exported = await exportExtensions({
+      serverConfig: context.serverConfig,
+      workspaceId: context.workspaceId,
+      workspaceRoot: context.workspaceRoot,
+      skills,
+      mcps,
+    });
+    if (exported.missing.skills.length > 0 || exported.missing.mcps.length > 0) {
+      throw new ApiError(
+        404,
+        "components_not_found",
+        `Not installed — skills: [${exported.missing.skills.join(", ")}], mcps: [${exported.missing.mcps.join(", ")}]`,
+      );
+    }
+    const exportedSkills = exported.components.filter((item): item is ExportedSkill => item.kind === "skill");
+    const exportedMcps = exported.components.filter((item): item is ExportedMcp => item.kind === "mcp");
+    const firstName = exportedSkills.at(0)?.name ?? exportedMcps.at(0)?.name ?? "shared";
+    const pluginName = typeof args.pluginName === "string" && args.pluginName.trim()
+      ? args.pluginName.trim()
+      : firstName.split("-").map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(" ");
+    const description = exportedSkills.at(0)?.description ?? `Shared bundle: ${slugify(pluginName)}`;
+    const plan = buildSharePlan({ marketplace, pluginName, description, skills: exportedSkills, mcps: exportedMcps });
+    return {
+      output: {
+        plan: {
+          pluginName,
+          marketplace,
+          components: {
+            skills: exportedSkills.map((item) => item.name),
+            mcps: exportedMcps.map((item) => item.name),
+          },
+          secretsExcluded: plan.requiredInputs,
+          installerNote: "Secret values never leave this machine. Installers provide the listed required inputs or sign in to OAuth connections as themselves.",
+          steps: plan.steps,
+          stepCount: plan.steps.length,
+          planFingerprint: plan.planFingerprint,
+        },
+      },
+    };
+  },
+};
+
+DEFINITIONS.push(SHARE_PLAN_DEFINITION);
 
 const definitionById = new Map(DEFINITIONS.map((definition) => [definition.id, definition]));
 

--- a/apps/server/src/capabilities.ts
+++ b/apps/server/src/capabilities.ts
@@ -1,0 +1,263 @@
+/**
+ * Search + Execute: the OpenWork capability pattern.
+ *
+ * Instead of shipping one bespoke agent tool per feature (each schema riding
+ * in every request), OpenWork exposes two primitives — search and execute —
+ * over an index of capability cards. A card binds an id, intent-level
+ * description ("when to reach for this"), an args schema, an effects class,
+ * and where it runs. The agent discovers capabilities by intent and invokes
+ * them through one gateway, which is the single choke point for approvals,
+ * scope checks, and audit.
+ *
+ * A capability executes wherever its data lives. This module holds the
+ * server-origin registry (runtime-DB MCPs, workspace skills — things only
+ * the OpenWork server can read). UI-origin and cloud-origin capabilities
+ * federate into the same search surface in follow-ups.
+ *
+ * Effects contract enforced by the execute route in server.ts:
+ * - "read"            -> no approval, viewer scope
+ * - "write:workspace" -> writable server, collaborator scope, approval
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { ReloadReason, ReloadTrigger, ServerConfig } from "./types.js";
+import { ApiError } from "./errors.js";
+import { exportExtensions, redactMcpConfig } from "./extensions-export.js";
+import { listMcp } from "./mcp.js";
+import { listSkills, upsertSkill } from "./skills.js";
+
+export type CapabilityEffects = "read" | "write:workspace";
+
+export type CapabilityCard = {
+  id: string;
+  title: string;
+  description: string;
+  /** When the agent should reach for this — the search snippet is the teaching. */
+  when: string;
+  origin: "server";
+  effects: CapabilityEffects;
+  /** Documentation-grade JSON schema for execute args. */
+  argsSchema: Record<string, unknown>;
+  /** Composes-with hints: capability ids that typically follow this one. */
+  related: string[];
+};
+
+export type CapabilityContext = {
+  serverConfig: ServerConfig;
+  workspaceId: string;
+  workspaceRoot: string;
+};
+
+export type CapabilityApproval = {
+  summary: string;
+  paths: string[];
+};
+
+export type CapabilityReload = {
+  reason: ReloadReason;
+  detail: ReloadTrigger;
+};
+
+export type CapabilityResult = {
+  output: unknown;
+  reload?: CapabilityReload;
+};
+
+type CapabilityDefinition = CapabilityCard & {
+  run(context: CapabilityContext, args: Record<string, unknown>): Promise<CapabilityResult>;
+  approval?(context: CapabilityContext, args: Record<string, unknown>): CapabilityApproval;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    : [];
+}
+
+const DEFINITIONS: CapabilityDefinition[] = [
+  {
+    id: "skills.list",
+    title: "List installed skills",
+    description: "Lists every skill installed for this workspace (project and global), with name, description, and trigger.",
+    when: "Use when the user asks what skills exist, or before exporting, sharing, or editing a skill by name.",
+    origin: "server",
+    effects: "read",
+    argsSchema: {
+      type: "object",
+      properties: {
+        includeGlobal: { type: "boolean", description: "Include user-global skills (default true)." },
+      },
+    },
+    related: ["extensions.export", "skills.upsert"],
+    async run(context, args) {
+      const includeGlobal = args.includeGlobal !== false;
+      const items = await listSkills(context.workspaceRoot, includeGlobal);
+      return { output: { items } };
+    },
+  },
+  {
+    id: "skills.read",
+    title: "Read a skill's full SKILL.md",
+    description: "Returns the full markdown content of one installed skill by name.",
+    when: "Use when you need the exact instructions inside a skill, e.g. before improving it or packaging it.",
+    origin: "server",
+    effects: "read",
+    argsSchema: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: { type: "string", description: "Skill name as shown by skills.list." },
+      },
+    },
+    related: ["skills.upsert", "extensions.export"],
+    async run(context, args) {
+      const name = typeof args.name === "string" ? args.name.trim() : "";
+      if (!name) throw new ApiError(400, "invalid_args", "name is required");
+      const items = await listSkills(context.workspaceRoot, true);
+      const item = items.find((skill) => skill.name === name);
+      if (!item) throw new ApiError(404, "skill_not_found", `Skill not found: ${name}`);
+      const content = await readFile(item.path, "utf8");
+      return { output: { item, content } };
+    },
+  },
+  {
+    id: "mcp.list",
+    title: "List connected MCP servers (secrets redacted)",
+    description: "Lists every MCP server configured for this workspace — including OpenWork-managed runtime MCPs that are not visible as files. Secret header/environment/OAuth values are redacted.",
+    when: "Use when the user asks what connections or MCPs exist, or to find an MCP's name before exporting or sharing it.",
+    origin: "server",
+    effects: "read",
+    argsSchema: { type: "object", properties: {} },
+    related: ["extensions.export"],
+    async run(context) {
+      const items = await listMcp(context.serverConfig, context.workspaceId, context.workspaceRoot);
+      const redacted = items.map((item) => {
+        const { config, redactedKeys } = redactMcpConfig(item.config);
+        return { ...item, config, redactedKeys };
+      });
+      return { output: { items: redacted } };
+    },
+  },
+  {
+    id: "extensions.export",
+    title: "Export skills and MCPs as a portable bundle",
+    description: "Returns portable definitions of installed skills (full SKILL.md) and MCP servers — including OpenWork-managed runtime MCPs. Secret values (headers, environment, OAuth secrets) are always redacted and listed in redactedKeys.",
+    when: "Use when packaging skills or MCP connections into a plugin, publishing to a marketplace, or moving them to another machine. Declare redacted keys as required inputs; never inline secret values.",
+    origin: "server",
+    effects: "read",
+    argsSchema: {
+      type: "object",
+      properties: {
+        skills: { type: "array", items: { type: "string" }, description: "Skill names to export." },
+        mcps: { type: "array", items: { type: "string" }, description: "MCP server names to export." },
+      },
+    },
+    related: ["skills.list", "mcp.list"],
+    async run(context, args) {
+      const skills = stringList(args.skills);
+      const mcps = stringList(args.mcps);
+      if (skills.length === 0 && mcps.length === 0) {
+        throw new ApiError(400, "invalid_args", "At least one skill or mcp name is required");
+      }
+      const result = await exportExtensions({
+        serverConfig: context.serverConfig,
+        workspaceId: context.workspaceId,
+        workspaceRoot: context.workspaceRoot,
+        skills,
+        mcps,
+      });
+      return { output: result };
+    },
+  },
+  {
+    id: "skills.upsert",
+    title: "Create or update a skill",
+    description: "Writes a skill's SKILL.md into the workspace (.opencode/skills/<name>/SKILL.md). Creates the skill when missing, updates it otherwise.",
+    when: "Use when the user asks to save repeatable work as a skill, or to edit an existing skill's instructions.",
+    origin: "server",
+    effects: "write:workspace",
+    argsSchema: {
+      type: "object",
+      required: ["name", "content"],
+      properties: {
+        name: { type: "string", description: "Kebab-case skill name." },
+        content: { type: "string", description: "Full SKILL.md content (frontmatter optional; name/description are normalized)." },
+        description: { type: "string", description: "Skill description when the content has no frontmatter." },
+      },
+    },
+    related: ["skills.read", "extensions.export"],
+    approval(context, args) {
+      const name = typeof args.name === "string" ? args.name.trim() : "";
+      return {
+        summary: `Upsert skill ${name}`,
+        paths: [join(context.workspaceRoot, ".opencode", "skills", name, "SKILL.md")],
+      };
+    },
+    async run(context, args) {
+      const name = typeof args.name === "string" ? args.name : "";
+      const content = typeof args.content === "string" ? args.content : "";
+      const description = typeof args.description === "string" ? args.description : undefined;
+      const result = await upsertSkill(context.workspaceRoot, { name, content, description });
+      return {
+        output: { name, ...result },
+        reload: { reason: "skills", detail: { type: "skill", name, action: result.action, path: result.path } },
+      };
+    },
+  },
+];
+
+const definitionById = new Map(DEFINITIONS.map((definition) => [definition.id, definition]));
+
+function toCard(definition: CapabilityDefinition): CapabilityCard {
+  const { id, title, description, when, origin, effects, argsSchema, related } = definition;
+  return { id, title, description, when, origin, effects, argsSchema, related };
+}
+
+export function listCapabilities(): CapabilityCard[] {
+  return DEFINITIONS.map(toCard);
+}
+
+function scoreCapability(definition: CapabilityDefinition, terms: string[]): number {
+  const id = definition.id.toLowerCase();
+  const title = definition.title.toLowerCase();
+  const description = definition.description.toLowerCase();
+  const when = definition.when.toLowerCase();
+  return terms.reduce((score, term) => {
+    if (id.includes(term)) score += 8;
+    if (title.includes(term)) score += 6;
+    if (when.includes(term)) score += 4;
+    if (description.includes(term)) score += 2;
+    return score;
+  }, 0);
+}
+
+/**
+ * Intent-based capability search. An empty query lists everything so the
+ * agent can browse; otherwise cards are ranked by term matches across
+ * id/title/when/description.
+ */
+export function searchCapabilities(query: string, limit = 8): CapabilityCard[] {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return listCapabilities().slice(0, limit);
+  return DEFINITIONS
+    .map((definition) => ({ definition, score: scoreCapability(definition, terms) }))
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) => right.score - left.score || left.definition.id.localeCompare(right.definition.id))
+    .slice(0, limit)
+    .map((entry) => toCard(entry.definition));
+}
+
+export function getCapability(id: string): (CapabilityCard & {
+  run(context: CapabilityContext, args: Record<string, unknown>): Promise<CapabilityResult>;
+  approval?(context: CapabilityContext, args: Record<string, unknown>): CapabilityApproval;
+}) | null {
+  return definitionById.get(id) ?? null;
+}
+
+export function readExecuteArgs(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
@@ -88,10 +88,13 @@ Here is what you can help users with:
 - Manageable via Settings > Skills.
 - Users can install skill templates or create custom skills in \`.opencode/skills/\`.
 
+## Workspace Capabilities: Search + Execute
+- OpenWork workspace capabilities (skills, MCP connections, portable exports) are discovered with openwork_search and run with openwork_execute. Search by intent in plain words; each card tells you when to use it, its argsSchema, and its effects class. Write capabilities are approval-gated and audited by the OpenWork server automatically.
+- Some skills and MCP servers are managed by OpenWork at runtime (stored server-side and injected into the engine config), so they are not visible as plain workspace files. Do not try to read the OPENCODE_CONFIG file or runtime database directly — search for the matching capability instead (e.g. 'mcp.list', 'extensions.export').
+
 ## Packaging & Publishing Skills and MCPs
-- Some skills and MCP servers are managed by OpenWork at runtime (stored server-side and injected into the engine config), so they are not visible as plain workspace files. Do not try to read the OPENCODE_CONFIG file or runtime database directly.
-- To get portable definitions of installed skills and MCP servers — including runtime-managed ones — use the openwork_extensions_export tool. It returns full SKILL.md content and MCP configs with secret header/environment values redacted (listed in redactedKeys).
-- When packaging exported components into a plugin or publishing to a marketplace, never inline secret values; declare the redacted keys as required inputs the installer must provide.
+- To get portable definitions of installed skills and MCP servers — including runtime-managed ones — execute the 'extensions.export' capability. It returns full SKILL.md content and MCP configs with secret header/environment/OAuth values redacted (listed in redactedKeys).
+- When packaging exported components into a plugin or publishing to a marketplace, never inline secret values; declare the redacted keys as required inputs the installer must provide. Installers sign in to OAuth MCPs as themselves.
 - To publish to an OpenWork Cloud marketplace, use the OpenWork Cloud MCP (plugins, config-objects, marketplaces resources) with the exported components.
 
 ## Creating Plugins

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -585,30 +585,207 @@ async function exportOpenWorkExtensions(rawArgs: unknown, context: OpenCodeConte
   return Object.assign(base, { result: payload });
 }
 
+// ── Capability federation ──
+//
+// openwork_search / openwork_execute are the facade over the capability
+// index. The index is federated: each shard is owned by the boundary that
+// holds its data and credentials, and this plugin only routes.
+//   server shard -> /workspace/:id/capabilities/*  (skills, runtime MCPs)
+//   ui shard     -> the desktop UI control bridge  (navigation, settings)
+//   mcp shard    -> connected MCP servers          (native tools, pointers)
+// Cloud-origin cards federate in a follow-up.
+
+type FederatedCard = {
+  id: string;
+  title: string;
+  description: string;
+  when: string;
+  origin: "server" | "ui" | "mcp";
+  effects: string;
+  argsSchema?: unknown;
+  related?: string[];
+  disabled?: boolean;
+};
+
+function scoreFederatedCard(card: FederatedCard, terms: string[]): number {
+  const id = card.id.toLowerCase();
+  const title = card.title.toLowerCase();
+  const when = card.when.toLowerCase();
+  const description = card.description.toLowerCase();
+  return terms.reduce((score, term) => {
+    if (id.includes(term)) score += 8;
+    if (title.includes(term)) score += 6;
+    if (when.includes(term)) score += 4;
+    if (description.includes(term)) score += 2;
+    return score;
+  }, 0);
+}
+
+const federatedCardSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  when: z.string(),
+  effects: z.string(),
+  argsSchema: z.unknown().optional(),
+  related: z.array(z.string()).optional(),
+}).passthrough();
+
+const serverCardsEnvelopeSchema = z.object({
+  items: z.array(federatedCardSchema),
+}).passthrough();
+
+async function collectServerCards(workspaceId: string): Promise<FederatedCard[]> {
+  try {
+    const payload = await serverGet(`/workspace/${encodeURIComponent(workspaceId)}/capabilities/search?q=&limit=20`);
+    return serverCardsEnvelopeSchema.parse(payload).items.map((item) => ({ ...item, origin: "server" as const }));
+  } catch {
+    return [];
+  }
+}
+
+const uiActionSchema = z.object({
+  id: z.string(),
+  label: z.string().optional(),
+  description: z.string().optional(),
+  sideEffect: z.string().optional(),
+  args: z.array(z.object({ name: z.string().optional(), description: z.string().optional() }).passthrough()).optional(),
+  disabled: z.boolean().optional(),
+}).passthrough();
+
+const uiActionsEnvelopeSchema = z.object({
+  actions: z.array(uiActionSchema),
+}).passthrough();
+
+async function collectUiCards(): Promise<FederatedCard[]> {
+  const payload = await uiBridgeRequest("/actions");
+  const parsed = uiActionsEnvelopeSchema.safeParse(payload);
+  if (!parsed.success) return [];
+  return parsed.data.actions.map((action) => ({
+    id: `ui.${action.id}`,
+    title: action.label ?? action.id,
+    description: action.description ?? `OpenWork app UI action ${action.id}.`,
+    when: `Use to ${(action.label ?? action.id).toLowerCase()} in the OpenWork desktop app UI.`,
+    origin: "ui" as const,
+    effects: action.sideEffect && action.sideEffect !== "none" ? `write:ui` : "read",
+    argsSchema: action.args && action.args.length > 0
+      ? {
+          type: "object",
+          properties: Object.fromEntries(action.args.map((arg, index) => [
+            arg.name ?? `arg${index}`,
+            { description: arg.description ?? "" },
+          ])),
+        }
+      : { type: "object", properties: {} },
+    disabled: action.disabled === true,
+  }));
+}
+
+const mcpItemSchema = z.object({
+  name: z.string(),
+  config: z.record(z.string(), z.unknown()).optional(),
+  source: z.string().optional(),
+}).passthrough();
+
+const mcpEnvelopeSchema = z.object({
+  items: z.array(mcpItemSchema),
+}).passthrough();
+
+async function collectMcpCards(workspaceId: string): Promise<FederatedCard[]> {
+  try {
+    const payload = await serverGet(`/workspace/${encodeURIComponent(workspaceId)}/mcp`);
+    const parsed = mcpEnvelopeSchema.safeParse(payload);
+    if (!parsed.success) return [];
+    return parsed.data.items.map((item) => {
+      const config = item.config ?? {};
+      const target = typeof config.url === "string" ? config.url : "local command";
+      const paused = config.enabled === false;
+      return {
+        id: `mcp:${item.name}`,
+        title: `Connected app ${item.name}`,
+        description: `MCP server ${item.name} (${target})${paused ? " — currently paused" : ""}. Its tools are exposed natively in your toolbox.`,
+        when: `Use the native ${item.name} tools directly for tasks involving this connected app; execute this card to see its connection details and auth state.`,
+        origin: "mcp" as const,
+        effects: "read",
+        argsSchema: { type: "object", properties: {} },
+        related: ["extensions.export"],
+        disabled: paused,
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
 async function searchOpenWorkCapabilities(rawArgs: unknown, context: OpenCodeContext): Promise<object> {
   const args = capabilitySearchArgsSchema.parse(rawArgs);
   const workspace = await resolveContextWorkspace(args.workspaceId, context);
-  const query = new URLSearchParams({ q: args.query, ...(args.limit ? { limit: String(args.limit) } : {}) });
-  const payload = await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/capabilities/search?${query.toString()}`);
-  const base = { ok: true, workspaceId: workspace.id, workspace: workspaceLabel(workspace) };
-  if (typeof payload === "object" && payload !== null && !Array.isArray(payload)) {
-    return Object.assign(base, payload);
-  }
-  return Object.assign(base, { result: payload });
+  const limit = args.limit ?? 8;
+  const [serverCards, uiCards, mcpCards] = await Promise.all([
+    collectServerCards(workspace.id),
+    collectUiCards(),
+    collectMcpCards(workspace.id),
+  ]);
+  const cards = [...serverCards, ...uiCards.filter((card) => !card.disabled), ...mcpCards];
+  const terms = args.query.toLowerCase().split(/\s+/).filter(Boolean);
+  const items = terms.length === 0
+    ? cards.slice(0, limit)
+    : cards
+        .map((card) => ({ card, score: scoreFederatedCard(card, terms) }))
+        .filter((entry) => entry.score > 0)
+        .sort((left, right) => right.score - left.score || left.card.id.localeCompare(right.card.id))
+        .slice(0, limit)
+        .map((entry) => entry.card);
+  return {
+    ok: true,
+    workspaceId: workspace.id,
+    workspace: workspaceLabel(workspace),
+    origins: { server: serverCards.length, ui: uiCards.length, mcp: mcpCards.length },
+    items,
+  };
 }
 
 async function executeOpenWorkCapability(rawArgs: unknown, context: OpenCodeContext): Promise<object> {
   const args = capabilityExecuteArgsSchema.parse(rawArgs);
   const workspace = await resolveContextWorkspace(args.workspaceId, context);
+  const base = { ok: true, workspaceId: workspace.id, workspace: workspaceLabel(workspace) };
+
+  // ui shard: dispatch through the desktop UI control bridge.
+  if (args.id.startsWith("ui.")) {
+    const result = await uiBridgeRequest("/execute", {
+      method: "POST",
+      body: { actionId: args.id.slice(3), args: args.args ?? {} },
+    });
+    return Object.assign(base, { id: args.id, origin: "ui", result });
+  }
+
+  // mcp shard: pointer cards — the tools already exist natively.
+  if (args.id.startsWith("mcp:")) {
+    const name = args.id.slice(4);
+    const cards = await collectMcpCards(workspace.id);
+    const card = cards.find((entry) => entry.id === args.id);
+    if (!card) {
+      return { ok: false, error: `No connected MCP named ${name}.` };
+    }
+    return Object.assign(base, {
+      id: args.id,
+      origin: "mcp",
+      result: {
+        pointer: true,
+        message: `${card.description} Call its native tools directly instead of this card. To package or share it, execute extensions.export with mcps ["${name}"].`,
+      },
+    });
+  }
+
+  // server shard: the approval-gated execute gateway.
   const payload = await postJson(`/workspace/${encodeURIComponent(workspace.id)}/capabilities/execute`, {
     id: args.id,
     args: args.args ?? {},
   });
-  const base = { ok: true, workspaceId: workspace.id, workspace: workspaceLabel(workspace) };
   if (typeof payload === "object" && payload !== null && !Array.isArray(payload)) {
-    return Object.assign(base, payload);
+    return Object.assign(base, { origin: "server" }, payload);
   }
-  return Object.assign(base, { result: payload });
+  return Object.assign(base, { origin: "server", result: payload });
 }
 
 async function postJson(path: string, body: ExtensionActionPayload | Record<string, unknown>): Promise<unknown> {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -62,6 +62,18 @@ const extensionsExportArgsSchema = z.object({
   workspaceId: z.string().trim().optional().describe("Optional OpenWork workspace id/name. Defaults to the workspace containing the current directory."),
 });
 
+const capabilitySearchArgsSchema = z.object({
+  query: z.string().trim().describe("What you want to do, in plain words — e.g. 'export mcp for marketplace' or 'save this as a skill'. Empty string lists everything."),
+  limit: z.number().int().min(1).max(20).optional().describe("Maximum capability cards to return (default 8)."),
+  workspaceId: z.string().trim().optional().describe("Optional OpenWork workspace id/name. Defaults to the workspace containing the current directory."),
+});
+
+const capabilityExecuteArgsSchema = z.object({
+  id: z.string().trim().min(1).describe("Capability id from openwork_search, e.g. 'extensions.export'."),
+  args: z.record(z.string(), z.unknown()).optional().describe("Arguments matching the capability's argsSchema."),
+  workspaceId: z.string().trim().optional().describe("Optional OpenWork workspace id/name. Defaults to the workspace containing the current directory."),
+});
+
 const workspaceSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
@@ -114,6 +126,9 @@ const sessionMessagesEnvelopeSchema = z.object({
 
 const OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION =
   "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
+
+const OPENWORK_CAPABILITY_INSTRUCTION =
+  "OpenWork exposes workspace capabilities through search + execute: call openwork_search with what you want to do in plain words (e.g. 'export mcp for marketplace', 'save this as a skill'), then run the matching card with openwork_execute using its id and argsSchema. Capability cards state when to use them and what they touch (effects); write capabilities go through OpenWork's approval flow automatically. Prefer this over guessing at file layouts or internal config for skills, MCP connections, and portable exports.";
 
 const OPENWORK_UI_CONTROL_INSTRUCTION =
   `IMPORTANT: You are running inside the OpenWork desktop app. When the user asks you to open settings, navigate the app, add providers, or control the OpenWork UI in any way, ALWAYS use the openwork_ui_* tools — NOT the browser_* tools. The browser tools are for external websites only. The openwork_ui_* tools control the app directly and are instant (one tool call).
@@ -570,6 +585,32 @@ async function exportOpenWorkExtensions(rawArgs: unknown, context: OpenCodeConte
   return Object.assign(base, { result: payload });
 }
 
+async function searchOpenWorkCapabilities(rawArgs: unknown, context: OpenCodeContext): Promise<object> {
+  const args = capabilitySearchArgsSchema.parse(rawArgs);
+  const workspace = await resolveContextWorkspace(args.workspaceId, context);
+  const query = new URLSearchParams({ q: args.query, ...(args.limit ? { limit: String(args.limit) } : {}) });
+  const payload = await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/capabilities/search?${query.toString()}`);
+  const base = { ok: true, workspaceId: workspace.id, workspace: workspaceLabel(workspace) };
+  if (typeof payload === "object" && payload !== null && !Array.isArray(payload)) {
+    return Object.assign(base, payload);
+  }
+  return Object.assign(base, { result: payload });
+}
+
+async function executeOpenWorkCapability(rawArgs: unknown, context: OpenCodeContext): Promise<object> {
+  const args = capabilityExecuteArgsSchema.parse(rawArgs);
+  const workspace = await resolveContextWorkspace(args.workspaceId, context);
+  const payload = await postJson(`/workspace/${encodeURIComponent(workspace.id)}/capabilities/execute`, {
+    id: args.id,
+    args: args.args ?? {},
+  });
+  const base = { ok: true, workspaceId: workspace.id, workspace: workspaceLabel(workspace) };
+  if (typeof payload === "object" && payload !== null && !Array.isArray(payload)) {
+    return Object.assign(base, payload);
+  }
+  return Object.assign(base, { result: payload });
+}
+
 async function postJson(path: string, body: ExtensionActionPayload | Record<string, unknown>): Promise<unknown> {
   const { url, token } = requireOpenWorkServer();
   const response = await fetch(url + path, {
@@ -600,6 +641,7 @@ function contextPayload(context: OpenCodeContext) {
 export const OpenWorkExtensionsPreview = async () => ({
   "experimental.chat.system.transform": async (_input: unknown, output: { system: string[] }) => {
     output.system.push(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
+    output.system.push(OPENWORK_CAPABILITY_INSTRUCTION);
     output.system.push(OPENWORK_UI_CONTROL_INSTRUCTION);
   },
   tool: {
@@ -676,8 +718,30 @@ export const OpenWorkExtensionsPreview = async () => ({
         return JSON.stringify(result, null, 2);
       },
     },
+    openwork_search: {
+      description: `Search OpenWork's capability index by intent and get back capability cards (id, when to use, argsSchema, effects). ${OPENWORK_CAPABILITY_INSTRUCTION}`,
+      args: capabilitySearchArgsSchema.shape,
+      async execute(rawArgs: unknown, context: OpenCodeContext) {
+        try {
+          return JSON.stringify(await searchOpenWorkCapabilities(rawArgs, context), null, 2);
+        } catch (error) {
+          return JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) }, null, 2);
+        }
+      },
+    },
+    openwork_execute: {
+      description: `Execute an OpenWork capability by id with args matching its argsSchema. Use openwork_search first to find the right capability card. Write capabilities are approval-gated and audited by the server. ${OPENWORK_CAPABILITY_INSTRUCTION}`,
+      args: capabilityExecuteArgsSchema.shape,
+      async execute(rawArgs: unknown, context: OpenCodeContext) {
+        try {
+          return JSON.stringify(await executeOpenWorkCapability(rawArgs, context), null, 2);
+        } catch (error) {
+          return JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) }, null, 2);
+        }
+      },
+    },
     openwork_extensions_export: {
-      description: "Export portable definitions of installed skills and MCP servers from OpenWork, including OpenWork-managed runtime MCPs that are not visible as workspace files. Returns full SKILL.md content and MCP configs with secret header/environment values redacted (listed in redactedKeys). Use this when packaging skills/MCPs into a plugin or publishing them to a marketplace; declare redacted keys as required inputs instead of inlining values.",
+      description: "DEPRECATED: prefer openwork_search + openwork_execute with capability id 'extensions.export'. Export portable definitions of installed skills and MCP servers from OpenWork, including OpenWork-managed runtime MCPs that are not visible as workspace files. Returns full SKILL.md content and MCP configs with secret header/environment values redacted (listed in redactedKeys). Declare redacted keys as required inputs instead of inlining values.",
       args: extensionsExportArgsSchema.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         try {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -9,6 +9,7 @@ import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plu
 import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
 import { addMcp, listMcp, removeMcp, setMcpEnabled } from "./mcp.js";
 import { exportExtensions } from "./extensions-export.js";
+import { getCapability, readExecuteArgs, searchCapabilities } from "./capabilities.js";
 import { deleteSkill, listSkills, upsertSkill } from "./skills.js";
 import { installHubSkill, listHubSkills } from "./skill-hub.js";
 import { deleteCommand, listCommands, repairCommands, upsertCommand } from "./commands.js";
@@ -2170,6 +2171,63 @@ function createRoutes(
       mcps,
     });
     return jsonResponse(result);
+  });
+
+  // Search + Execute: intent-based discovery over capability cards, and a
+  // single execute gateway that owns scope checks, approvals, and audit.
+  // See apps/server/src/capabilities.ts for the pattern.
+  addRoute(routes, "GET", "/workspace/:id/capabilities/search", "client", async (ctx) => {
+    await resolveWorkspace(config, ctx.params.id);
+    const query = ctx.url.searchParams.get("q")?.trim() ?? "";
+    const limitRaw = Number.parseInt(ctx.url.searchParams.get("limit") ?? "", 10);
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(limitRaw, 20) : 8;
+    return jsonResponse({ items: searchCapabilities(query, limit) });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/capabilities/execute", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const capabilityId = typeof body.id === "string" ? body.id.trim() : "";
+    if (!capabilityId) {
+      throw new ApiError(400, "invalid_payload", "Capability id is required");
+    }
+    const capability = getCapability(capabilityId);
+    if (!capability) {
+      throw new ApiError(404, "capability_not_found", `Unknown capability: ${capabilityId}`);
+    }
+    const args = readExecuteArgs(body.args);
+    const context = { serverConfig: config, workspaceId: workspace.id, workspaceRoot: workspace.path };
+
+    if (capability.effects !== "read") {
+      ensureWritable(config);
+      requireClientScope(ctx, "collaborator");
+      const approval = capability.approval?.(context, args);
+      await requireApproval(ctx, {
+        workspaceId: workspace.id,
+        action: `capabilities.${capabilityId}`,
+        summary: approval?.summary ?? `Execute capability ${capabilityId}`,
+        paths: approval?.paths ?? [],
+      });
+    }
+
+    const result = await capability.run(context, args);
+
+    if (capability.effects !== "read") {
+      await recordAudit(workspace.path, {
+        id: shortId(),
+        workspaceId: workspace.id,
+        actor: ctx.actor ?? { type: "remote" },
+        action: `capabilities.${capabilityId}`,
+        target: capabilityId,
+        summary: `Executed capability ${capabilityId}`,
+        timestamp: Date.now(),
+      });
+    }
+    if (result.reload) {
+      emitReloadEvent(ctx.reloadEvents, workspace, result.reload.reason, result.reload.detail);
+    }
+
+    return jsonResponse({ ok: true, id: capabilityId, effects: capability.effects, result: result.output });
   });
 
   addRoute(routes, "POST", "/workspace/:id/mcp", "client", async (ctx) => {

--- a/evals/flows/capability-federation.flow.mjs
+++ b/evals/flows/capability-federation.flow.mjs
@@ -1,0 +1,204 @@
+/**
+ * Federated search + execute, agent-driven:
+ *
+ *   1. UI shard — asked in plain words to "open the Extensions settings
+ *      screen", the agent searches, finds a ui-origin card, and executes it
+ *      through the gateway. The witness is unfakeable: the app's route
+ *      actually changes to /settings/extensions.
+ *   2. Share plan — asked to plan sharing a skill + OAuth connection to a
+ *      marketplace, the agent discovers marketplace.share_plan and executes
+ *      it. Its reply must echo the executed id, the plan's step count, and
+ *      the secretsExcluded entries — values that exist only in the execute
+ *      result, so the line cannot be produced without running the plan.
+ *      The OAuth client secret must never appear anywhere.
+ *
+ * Run: pnpm fraimz --flow capability-federation --cdp-url http://127.0.0.1:9826
+ */
+
+const SKILL_NAME = "fed-eval-skill";
+const MCP_NAME = "fed-eval-mcp";
+const SECRET = "fed-eval-oauth-secret-8899";
+const MARKETPLACE = "BY IT Marketplace";
+
+const UI_MESSAGE = [
+  "Open the Extensions settings screen of the OpenWork app for me.",
+  "Use openwork_search to find the right capability and run it with openwork_execute.",
+  "After it executes, reply with exactly one line: UI-RESULT <the capability id you executed>.",
+  "Do not run any other tools.",
+].join(" ");
+
+const PLAN_MESSAGE = [
+  `Plan sharing the skill "${SKILL_NAME}" and the connection "${MCP_NAME}" to the marketplace "${MARKETPLACE}".`,
+  "Use openwork_search to find the right capability and run it with openwork_execute. Do not run the plan's cloud steps.",
+  "Reply with exactly one line: SHARE-PLAN <the capability id you executed> <the plan's stepCount> <the secretsExcluded entries joined with commas>.",
+  "Write values verbatim without quotes or angle brackets.",
+].join(" ");
+
+// The step count and excluded-secret key are only in the execute result.
+const PLAN_REPLY_RE = "SHARE-PLAN\\s+marketplace\\.share_plan\\s+9\\s+oauth\\.clientSecret";
+
+const serverCallExpr = (pathTemplate, init) => `(async () => {
+  const port = localStorage.getItem("openwork.server.port");
+  const token = localStorage.getItem("openwork.server.token");
+  if (!port || !token) return { ok: false, error: "no server port/token in localStorage" };
+  const base = "http://127.0.0.1:" + port;
+  const headers = { Authorization: "Bearer " + token, "Content-Type": "application/json" };
+  const wsResponse = await fetch(base + "/workspaces", { headers });
+  if (!wsResponse.ok) return { ok: false, error: "workspaces " + wsResponse.status };
+  const wsPayload = await wsResponse.json();
+  const workspaces = Array.isArray(wsPayload) ? wsPayload : wsPayload.items ?? [];
+  const fromHash = (window.location.hash.match(/workspace\\/(ws_[a-z0-9]+)/) ?? [])[1];
+  const active = localStorage.getItem("openwork.react.activeWorkspace");
+  const workspace = workspaces.find((entry) => entry.id === (fromHash || active)) ?? workspaces[0];
+  if (!workspace) return { ok: false, error: "no workspace" };
+  const response = await fetch(base + ${JSON.stringify(pathTemplate)}.replace(":id", workspace.id), {
+    headers,
+    ...${JSON.stringify(init ?? {})},
+  });
+  const text = await response.text();
+  let payload = null;
+  try { payload = JSON.parse(text); } catch { payload = { message: text }; }
+  return { ok: response.ok, status: response.status, workspaceId: workspace.id, payload, raw: text };
+})()`;
+
+async function serverCall(ctx, pathTemplate, init, { tolerate = false } = {}) {
+  const result = await ctx.eval(serverCallExpr(pathTemplate, init), { awaitPromise: true });
+  if (!tolerate) {
+    ctx.assert(result?.ok, `Server call ${pathTemplate} failed: ${result?.status ?? "?"} ${JSON.stringify(result?.payload ?? {}).slice(0, 300)}`);
+  }
+  return result;
+}
+
+async function sendAgentMessage(ctx, message) {
+  await ctx.navigateHash("/");
+  await ctx.waitFor(
+    "window.__openworkControl.listActions().some((a) => a.id === 'session.create_task' && !a.disabled)",
+    { timeoutMs: 45_000, label: "session.create_task available" },
+  );
+  await ctx.control("session.create_task");
+  await ctx.waitFor(
+    `(() => /ses_[A-Za-z0-9]+/.test(window.__openworkControl.snapshot().route || ""))()`,
+    { timeoutMs: 30_000, label: "active session" },
+  );
+  const pasted = await ctx.eval(
+    `(() => {
+      const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
+        || document.querySelector('[contenteditable="true"]');
+      if (!editor) return { ok: false, reason: 'composer not found' };
+      editor.focus();
+      const data = new DataTransfer();
+      data.setData('text/plain', ${JSON.stringify(message)});
+      editor.dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: data }));
+      return { ok: true };
+    })()`,
+  );
+  ctx.assert(pasted?.ok, `Composer not ready: ${pasted?.reason ?? "unknown"}`);
+  const ran = await ctx.eval(`(() => {
+    const byLabel = Array.from(document.querySelectorAll('button'))
+      .find((b) => /run task|send|run/i.test((b.textContent || "").trim()) && !b.disabled);
+    if (byLabel) { byLabel.click(); return "clicked"; }
+    const editor = document.querySelector('[contenteditable="true"]');
+    if (editor) {
+      editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      return "enter";
+    }
+    return "none";
+  })()`);
+  ctx.assert(ran !== "none", "Could not submit the composer message.");
+}
+
+export default {
+  id: "capability-federation",
+  title: "Agent uses federated search to drive the UI and compile a share plan",
+  spec: "apps/server/src/capabilities.ts",
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+    const route = await ctx.eval("window.__openworkControl.snapshot().route");
+    return typeof route === "string" && (route.startsWith("/welcome") || route.startsWith("/signin"))
+      ? "Profile is not onboarded (welcome/signin); flow requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "Fixtures installed (skill + OAuth MCP with secret)",
+      run: async (ctx) => {
+        await ctx.prove("Workspace holds the components to be shared", {
+          action: async () => {
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+            await ctx.navigateHash("/");
+            await ctx.waitFor("document.body.innerText.trim().length > 40", { label: "rendered body" });
+            await serverCall(ctx, `/workspace/:id/skills/${SKILL_NAME}`, { method: "DELETE" }, { tolerate: true });
+            await serverCall(ctx, "/workspace/:id/skills", {
+              method: "POST",
+              body: JSON.stringify({ name: SKILL_NAME, content: "Federation eval fixture.", description: "Federation eval fixture skill." }),
+            });
+            await serverCall(ctx, "/workspace/:id/mcp", {
+              method: "POST",
+              body: JSON.stringify({
+                name: MCP_NAME,
+                config: {
+                  type: "remote",
+                  url: "https://mcp.eval.example/fed",
+                  enabled: false,
+                  oauth: { clientId: "fed-eval-client", clientSecret: SECRET, scope: "fed.read" },
+                },
+              }),
+            });
+          },
+          assert: async () => {
+            const mcp = await serverCall(ctx, "/workspace/:id/mcp");
+            ctx.assert((mcp.payload.items ?? []).some((item) => item.name === MCP_NAME), "Fixture MCP missing.");
+          },
+          screenshot: { name: "booted", rejectText: [SECRET, "Something went wrong"] },
+        });
+      },
+    },
+    {
+      name: "Agent drives the app UI through a federated ui-origin card",
+      run: async (ctx) => {
+        await ctx.prove("Executing the discovered ui card actually changes the app route", {
+          action: async () => {
+            await sendAgentMessage(ctx, UI_MESSAGE);
+          },
+          assert: async () => {
+            // Unfakeable witness: the renderer route really navigates.
+            await ctx.waitFor(
+              "(window.__openworkControl.snapshot().route || '').includes('/settings/extensions')",
+              { timeoutMs: 180_000, label: "route changed to /settings/extensions" },
+            );
+            await ctx.expectNoText(SECRET);
+          },
+          screenshot: {
+            name: "ui-card-navigated",
+            requireText: ["Extensions"],
+            rejectText: [SECRET],
+            hashIncludes: "/settings/extensions",
+          },
+        });
+      },
+    },
+    {
+      name: "Agent compiles a secret-free share plan by intent",
+      run: async (ctx) => {
+        await ctx.prove("Reply carries plan-result-only values; secret never appears", {
+          action: async () => {
+            await sendAgentMessage(ctx, PLAN_MESSAGE);
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `Boolean(document.body.innerText.match(new RegExp(${JSON.stringify(PLAN_REPLY_RE)})))`,
+              { timeoutMs: 180_000, label: "agent SHARE-PLAN reply" },
+            );
+            await ctx.expectNoText(SECRET);
+            await ctx.expectNoText("Something went wrong");
+          },
+          screenshot: {
+            name: "share-plan-proof",
+            requireText: ["SHARE-PLAN", "oauth.clientSecret"],
+            rejectText: [SECRET],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/capability-search-execute.flow.mjs
+++ b/evals/flows/capability-search-execute.flow.mjs
@@ -1,0 +1,198 @@
+/**
+ * Search + Execute: the agent discovers a capability by intent and runs it
+ * through the single execute gateway — no bespoke tool name, no memorized
+ * id, no internal file paths.
+ *
+ * Setup (as the user): a skill and an OAuth MCP (clientId + clientSecret)
+ * exist in the workspace; the MCP is OpenWork-managed (runtime DB), so it
+ * is invisible as a file. Then:
+ *   1. Witness the index: capabilities/search ranks extensions.export first
+ *      for the intent phrase "portable export of an mcp".
+ *   2. The REAL agent is asked, in plain words, to find and run the right
+ *      capability. Its reply must echo the executed capability id, the
+ *      exported MCP url, and the redactedKeys — the url and key names exist
+ *      only in the execute result, so the line cannot be produced without
+ *      actually searching and executing. The OAuth client secret must never
+ *      appear anywhere.
+ *
+ * Run: pnpm fraimz --flow capability-search-execute --cdp-url http://127.0.0.1:9826
+ */
+
+const SKILL_NAME = "cap-eval-skill";
+const SKILL_DESCRIPTION = "Capability eval fixture skill.";
+const MCP_NAME = "cap-eval-mcp";
+const MCP_URL = "https://mcp.eval.example/cap";
+const SECRET = "cap-eval-oauth-secret-4242";
+
+const AGENT_MESSAGE = [
+  `I need a portable definition of the MCP server "${MCP_NAME}" so I can put it on a marketplace.`,
+  "Use openwork_search to find the right capability, then run it with openwork_execute.",
+  "Reply with exactly one line: CAPABILITY-RESULT <the capability id you executed> <the exported MCP config url> <the redactedKeys entries joined with commas>.",
+  "Write values verbatim without quotes or angle brackets. Do not run any other tools.",
+].join(" ");
+
+// Unguessable from the prompt: the capability id, the MCP url, and the
+// redacted key name all come from search/execute results only.
+const AGENT_REPLY_RE = "CAPABILITY-RESULT\\s+extensions\\.export\\s+https:\\/\\/mcp\\.eval\\.example\\/cap\\s+oauth\\.clientSecret";
+
+const serverCallExpr = (pathTemplate, init) => `(async () => {
+  const port = localStorage.getItem("openwork.server.port");
+  const token = localStorage.getItem("openwork.server.token");
+  if (!port || !token) return { ok: false, error: "no server port/token in localStorage" };
+  const base = "http://127.0.0.1:" + port;
+  const headers = { Authorization: "Bearer " + token, "Content-Type": "application/json" };
+  const wsResponse = await fetch(base + "/workspaces", { headers });
+  if (!wsResponse.ok) return { ok: false, error: "workspaces " + wsResponse.status };
+  const wsPayload = await wsResponse.json();
+  const workspaces = Array.isArray(wsPayload) ? wsPayload : wsPayload.items ?? [];
+  const fromHash = (window.location.hash.match(/workspace\\/(ws_[a-z0-9]+)/) ?? [])[1];
+  const active = localStorage.getItem("openwork.react.activeWorkspace");
+  const workspace = workspaces.find((entry) => entry.id === (fromHash || active)) ?? workspaces[0];
+  if (!workspace) return { ok: false, error: "no workspace" };
+  const response = await fetch(base + ${JSON.stringify(pathTemplate)}.replace(":id", workspace.id), {
+    headers,
+    ...${JSON.stringify(init ?? {})},
+  });
+  const text = await response.text();
+  let payload = null;
+  try { payload = JSON.parse(text); } catch { payload = { message: text }; }
+  return { ok: response.ok, status: response.status, workspaceId: workspace.id, payload, raw: text };
+})()`;
+
+async function serverCall(ctx, pathTemplate, init, { tolerate = false } = {}) {
+  const result = await ctx.eval(serverCallExpr(pathTemplate, init), { awaitPromise: true });
+  if (!tolerate) {
+    ctx.assert(result?.ok, `Server call ${pathTemplate} failed: ${result?.status ?? "?"} ${JSON.stringify(result?.payload ?? {}).slice(0, 300)}`);
+  }
+  return result;
+}
+
+async function pasteComposer(ctx, text) {
+  return ctx.eval(
+    `(() => {
+      const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
+        || document.querySelector('[contenteditable="true"]');
+      if (!editor) return { ok: false, reason: 'composer not found' };
+      editor.focus();
+      const data = new DataTransfer();
+      data.setData('text/plain', ${JSON.stringify(text)});
+      editor.dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: data }));
+      return { ok: true };
+    })()`,
+  );
+}
+
+export default {
+  id: "capability-search-execute",
+  title: "Agent discovers a capability by intent and executes it through the gateway",
+  spec: "apps/server/src/capabilities.ts",
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+    const route = await ctx.eval("window.__openworkControl.snapshot().route");
+    return typeof route === "string" && (route.startsWith("/welcome") || route.startsWith("/signin"))
+      ? "Profile is not onboarded (welcome/signin); flow requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "App boots; fixtures installed (skill + OAuth MCP with secret)",
+      run: async (ctx) => {
+        await ctx.prove("Workspace holds a skill and a runtime OAuth MCP", {
+          action: async () => {
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+            await ctx.navigateHash("/");
+            await ctx.waitFor("document.body.innerText.trim().length > 40", { label: "rendered body" });
+            await serverCall(ctx, `/workspace/:id/skills/${SKILL_NAME}`, { method: "DELETE" }, { tolerate: true });
+            await serverCall(ctx, "/workspace/:id/skills", {
+              method: "POST",
+              body: JSON.stringify({ name: SKILL_NAME, content: "Capability eval fixture.", description: SKILL_DESCRIPTION }),
+            });
+            await serverCall(ctx, "/workspace/:id/mcp", {
+              method: "POST",
+              body: JSON.stringify({
+                name: MCP_NAME,
+                config: {
+                  type: "remote",
+                  url: MCP_URL,
+                  enabled: false,
+                  oauth: { clientId: "cap-eval-client", clientSecret: SECRET, scope: "eval.read" },
+                },
+              }),
+            });
+          },
+          assert: async () => {
+            const mcp = await serverCall(ctx, "/workspace/:id/mcp");
+            ctx.assert((mcp.payload.items ?? []).some((item) => item.name === MCP_NAME), "Fixture MCP missing.");
+          },
+          screenshot: { name: "booted", rejectText: [SECRET, "Something went wrong"] },
+        });
+      },
+    },
+    {
+      name: "Capability index ranks the right card for the intent",
+      run: async (ctx) => {
+        await ctx.prove("Search by intent returns extensions.export first, with teaching metadata", {
+          action: async () => {},
+          assert: async () => {
+            const search = await serverCall(
+              ctx,
+              `/workspace/:id/capabilities/search?q=${encodeURIComponent("portable export of an mcp")}`,
+            );
+            const top = (search.payload.items ?? [])[0];
+            ctx.assert(top?.id === "extensions.export", `Expected extensions.export first, got ${top?.id}.`);
+            ctx.assert(typeof top.when === "string" && top.when.length > 10, "Card has no 'when' teaching.");
+            ctx.assert(top.effects === "read", `Unexpected effects: ${top.effects}.`);
+            ctx.assert(Boolean(top.argsSchema), "Card has no argsSchema.");
+            ctx.log(`top card: ${top.id} — ${top.when}`);
+          },
+        });
+      },
+    },
+    {
+      name: "Agent discovers and executes the capability by intent",
+      run: async (ctx) => {
+        await ctx.prove("Agent reply carries execute-result-only values; secret never appears", {
+          action: async () => {
+            await ctx.navigateHash("/");
+            await ctx.waitFor(
+              "window.__openworkControl.listActions().some((a) => a.id === 'session.create_task' && !a.disabled)",
+              { timeoutMs: 45_000, label: "session.create_task available" },
+            );
+            await ctx.control("session.create_task");
+            await ctx.waitFor(
+              `(() => /ses_[A-Za-z0-9]+/.test(window.__openworkControl.snapshot().route || ""))()`,
+              { timeoutMs: 30_000, label: "active session" },
+            );
+            const pasted = await pasteComposer(ctx, AGENT_MESSAGE);
+            ctx.assert(pasted?.ok, `Composer not ready: ${pasted?.reason ?? "unknown"}`);
+            const ran = await ctx.eval(`(() => {
+              const byLabel = Array.from(document.querySelectorAll('button'))
+                .find((b) => /run task|send|run/i.test((b.textContent || "").trim()) && !b.disabled);
+              if (byLabel) { byLabel.click(); return "clicked"; }
+              const editor = document.querySelector('[contenteditable="true"]');
+              if (editor) {
+                editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+                return "enter";
+              }
+              return "none";
+            })()`);
+            ctx.assert(ran !== "none", "Could not submit the composer message.");
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `Boolean(document.body.innerText.match(new RegExp(${JSON.stringify(AGENT_REPLY_RE)})))`,
+              { timeoutMs: 180_000, label: "agent CAPABILITY-RESULT reply" },
+            );
+            await ctx.expectNoText(SECRET);
+            await ctx.expectNoText("Something went wrong");
+          },
+          screenshot: {
+            name: "agent-capability-proof",
+            requireText: ["CAPABILITY-RESULT", MCP_URL],
+            rejectText: [SECRET],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/capability-search-execute.flow.mjs
+++ b/evals/flows/capability-search-execute.flow.mjs
@@ -25,7 +25,7 @@ const MCP_URL = "https://mcp.eval.example/cap";
 const SECRET = "cap-eval-oauth-secret-4242";
 
 const AGENT_MESSAGE = [
-  `I need a portable definition of the MCP server "${MCP_NAME}" so I can put it on a marketplace.`,
+  `I need a portable definition of the MCP server "${MCP_NAME}" so I can inspect it and move it to another machine.`,
   "Use openwork_search to find the right capability, then run it with openwork_execute.",
   "Reply with exactly one line: CAPABILITY-RESULT <the capability id you executed> <the exported MCP config url> <the redactedKeys entries joined with commas>.",
   "Write values verbatim without quotes or angle brackets. Do not run any other tools.",


### PR DESCRIPTION
## What this is

**Search + execute** — the agent has exactly two primitives (`openwork_search`, `openwork_execute`) over a **federated index of capability cards**, instead of one bespoke tool per feature. A card binds `id`, `title`, `when` (the search snippet *is* the teaching), `argsSchema`, `effects`, `origin`, `related`. A capability executes **wherever its data lives**; the facade only routes — no boundary gains new credentials.

```
openwork_search / openwork_execute            (facade, bundled plugin)
  ├─ server shard  /workspace/:id/capabilities/*   skills, runtime MCPs, export, share plan
  ├─ ui shard      desktop UI control bridge        navigation/settings actions (ui.*)
  ├─ mcp shard     connected MCP servers            pointer cards with export guidance (mcp:*)
  └─ cloud shard   Den / Cloud MCP                  follow-up
```

## Commit 1 — server shard + gateway

- `capabilities.ts`: card model, intent-scored search, registry: `skills.list/read/upsert`, `mcp.list` (secrets redacted), `extensions.export` (#2429/#2434 reclassified as a card).
- `GET /workspace/:id/capabilities/search` + `POST .../execute` — the execute gateway is the single choke point: `effects !== "read"` ⇒ writable + collaborator scope + `requireApproval` + audit + reload events.
- Thin `openwork_search`/`openwork_execute` tools; `openwork_extensions_export` deprecated in place.

## Commit 2 — federation + `marketplace.share_plan`

- **UI shard**: bridge `/actions` merged as `ui.*` cards (disabled actions filtered); `execute("ui.…")` dispatches to the bridge.
- **MCP shard**: connected MCPs as `mcp:*` pointer cards (native tools + paused state + "to share it, run extensions.export").
- **`marketplace.share_plan`** (effects: read — writes nothing): compiles the entire share ceremony deterministically — exports components, **drops** every redacted secret (no `<redacted>` placeholders in publishable payloads), lists them as `secretsExcluded` required inputs, emits the exact ordered Den requests (find-or-create marketplace, grants, config objects, publish) + a stable `planFingerprint`. The agent shows the plan, gets approval, commits with **its own cloud auth** — Den credentials still never touch the local server. This turns the 6-call improvisation from the customer call into "execute prepared steps".

## Tests

- `bun test src/capabilities.test.ts` — **13 pass, 0 fail**: card invariants, intent ranking (share intent → `share_plan`, portable-export intent → `extensions.export`), HTTP search/execute, viewer 403-on-write / 200-on-read, secret redaction over the wire, **federated merge against a mock UI bridge** (ui card ranked first, disabled filtered, execute POSTs to the bridge, mcp pointer round-trip), share plan (no secret and no placeholder anywhere, deterministic fingerprint, verbatim skill content, 404 lists missing names).
- `bun test src` — **283 pass, 0 fail**; typecheck clean.

## fraimz: 2 flows, both Passed (real agent + Electron from this branch)

```
▶ capability-search-execute      — agent told only the *intent*, never the id
  ✓ index ranks extensions.export for "portable export of an mcp"
  ✓ agent searches → executes → replies with result-only values (id, url, redactedKeys)
▶ capability-federation
  ✓ agent asked "open the Extensions settings screen" — discovers ui card, executes it,
    and the app route REALLY changes to /settings/extensions (unfakeable witness) + screenshot
  ✓ agent asked to plan sharing skill+OAuth MCP — discovers marketplace.share_plan, replies
    "SHARE-PLAN marketplace.share_plan 9 oauth.clientSecret" (stepCount + excluded key exist
    only in the execute result); OAuth secret asserted absent from every frame/response
```

Anti-fabrication: every agent assertion requires values learnable only from tool results, and the UI frame is proven by actual renderer navigation, not transcript text.

## Follow-ups

1. Cloud shard federation (Den cards when signed in) + one composite `POST /v1/plugins/publish` on den-api so commit is a single call.
2. Plan/commit enforcement via `planFingerprint` (mirrors workspace-import-preview).
3. Remove the deprecated bespoke export tool after one release of overlap.