### PR TITLE
fix(app): fetch live LM Studio models in picker and settings

### DIFF
--- a/apps/app/public/ext-lmstudio.svg
+++ b/apps/app/public/ext-lmstudio.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" fill="none">
+  <title>LM Studio</title>
+  <rect width="24" height="24" rx="5" fill="#111827"/>
+  <text x="12" y="15.5" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#ffffff">LM</text>
+</svg>

--- a/apps/app/src/app/extensions.ts
+++ b/apps/app/src/app/extensions.ts
@@ -353,4 +353,31 @@ export const BUILT_IN_OPENWORK_EXTENSION_MANIFESTS: OpenWorkExtensionManifest[] 
     ],
     lifecycle: { reload: ["config"], detection: ["provider:ollama"] },
   },
+  {
+    schemaVersion: 1,
+    id: "lmstudio",
+    name: "LM Studio",
+    description: "Local model provider at http://127.0.0.1:1234.",
+    source: { format: "openwork-builtin", origin: "builtin", trusted: true },
+    icon: { src: "/ext-lmstudio.svg" },
+    composer: { prompt: "Use the LM Studio extension to " },
+    setup: {
+      instructions:
+        "Start LM Studio's local server (Developer tab), choose a downloaded model, then add it as an OpenCode provider.",
+      primaryCta: "Add LM Studio model",
+    },
+    resources: [
+      { type: "local-service", id: "lmstudio-api", label: "LM Studio API", description: "http://127.0.0.1:1234", required: true },
+      { type: "provider", id: "lmstudio", providerId: "lmstudio", packageName: "@ai-sdk/openai-compatible", required: true },
+    ],
+    contributions: [
+      { type: "settings-panel", ref: "openwork.lmstudio.settings", location: "settings-detail" },
+      { type: "test-action", ref: "openwork.lmstudio.listModels", label: "Check local models" },
+      { type: "composer-prompt", prompt: "Use the LM Studio extension to ", location: "composer" },
+    ],
+    enablement: [
+      { type: "provider-connected", ref: "lmstudio", label: "LM Studio provider" },
+    ],
+    lifecycle: { reload: ["config"], detection: ["provider:lmstudio"] },
+  },
 ];

--- a/apps/app/src/react-app/domains/settings/extension-registry.tsx
+++ b/apps/app/src/react-app/domains/settings/extension-registry.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import type { McpDirectoryInfo } from "../../../app/constants";
 import { extensionContribution } from "../../../app/extensions";
 import type { OpenworkServerClient } from "../../../app/lib/openwork-server";
+import type { LocalProviderInstallInput } from "./openai-image-extension";
 
 /**
  * Context bag that the settings route passes to extension config factories.
@@ -41,14 +42,7 @@ export type ExtensionConfigContext = {
     busy: boolean;
     status: string | null;
     error: string | null;
-    onInstall: (input: {
-      providerId: string;
-      name: string;
-      baseURL: string;
-      modelId: string;
-      modelName: string;
-      setDefault: boolean;
-    }) => void | Promise<void>;
+    onInstall: (input: LocalProviderInstallInput) => void | Promise<void>;
   };
 };
 

--- a/apps/app/src/react-app/domains/settings/lmstudio-config.tsx
+++ b/apps/app/src/react-app/domains/settings/lmstudio-config.tsx
@@ -1,0 +1,283 @@
+/** @jsxImportSource react */
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { CheckCircle2, Download, Loader2, RefreshCw, XCircle } from "lucide-react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+  FieldTitle,
+} from "@/components/ui/field";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { LMSTUDIO_PROVIDER_CONFIG, type LocalProviderInstallInput } from "./openai-image-extension";
+import { registerExtensionConfig, type ExtensionConfigContext } from "./extension-registry";
+import {
+  fetchLMStudioModels,
+  LMSTUDIO_BASE_URL,
+  reconcileLMStudioSelectedModel,
+  type LMStudioModel,
+} from "./lmstudio-models";
+
+const lmstudioConfigFactory = (ctx: ExtensionConfigContext) => (
+  <LMStudioConfig
+    busy={ctx.localProvider.busy}
+    status={ctx.localProvider.status}
+    error={ctx.localProvider.error}
+    onInstall={ctx.localProvider.onInstall}
+  />
+);
+
+registerExtensionConfig("openwork.lmstudio.settings", lmstudioConfigFactory);
+registerExtensionConfig("lmstudio", lmstudioConfigFactory);
+
+type LMStudioStatus = "checking" | "running" | "unreachable";
+
+function useLMStudioModels() {
+  const { data, isFetching, refetch } = useQuery({
+    queryKey: ["lmstudio", "models"],
+    queryFn: () => fetchLMStudioModels(),
+    refetchOnWindowFocus: false,
+  });
+
+  const status: LMStudioStatus = isFetching ? "checking" : (data?.status ?? "unreachable");
+
+  return { data, isFetching, refetch, status };
+}
+
+export type LMStudioConfigProps = {
+  busy: boolean;
+  status: string | null;
+  error: string | null;
+  onInstall: (input: LocalProviderInstallInput) => void | Promise<void>;
+};
+
+export function LMStudioConfig(props: LMStudioConfigProps) {
+  const [selectedModel, setSelectedModel] = useState("");
+  const [setDefault, setSetDefault] = useState(true);
+
+  const { data, isFetching, refetch, status } = useLMStudioModels();
+  const models = data?.models ?? [];
+
+  useEffect(() => {
+    setSelectedModel((current) => reconcileLMStudioSelectedModel(current, models));
+  }, [models]);
+
+  const handleInstall = () => {
+    if (!selectedModel) {
+      return;
+    }
+
+    void props.onInstall({
+      providerId: LMSTUDIO_PROVIDER_CONFIG.providerId,
+      name: LMSTUDIO_PROVIDER_CONFIG.name,
+      baseURL: LMSTUDIO_PROVIDER_CONFIG.baseURL,
+      modelId: selectedModel,
+      modelName: selectedModel,
+      setDefault,
+      allModelIds: models.map((model) => model.id),
+    });
+  };
+
+  if (status === "unreachable") {
+    return (
+      <Card variant="outline" size="sm">
+        <CardHeader>
+          <CardTitle>Configuration</CardTitle>
+          <CardDescription>Connect to a local LM Studio instance and choose a model.</CardDescription>
+          <CardAction>
+            <Button variant="ghost" size="icon-sm" onClick={() => void refetch()} disabled={isFetching}>
+              <RefreshCw className={isFetching ? "animate-spin" : ""} />
+            </Button>
+          </CardAction>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {props.error ? (
+            <Alert variant="destructive">
+              <XCircle />
+              <AlertDescription>{props.error}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <Empty className="flex-none p-6" variant="ghost">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Download />
+              </EmptyMedia>
+              <EmptyTitle>LM Studio isn&apos;t running</EmptyTitle>
+              <EmptyDescription>
+                Start LM Studio and enable its local server (Developer tab) so OpenWork can list your
+                downloaded models from {LMSTUDIO_BASE_URL}.
+              </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button
+                render={
+                  <a href="https://lmstudio.ai/" target="_blank" rel="noopener noreferrer" />
+                }
+              >
+                Download LM Studio
+              </Button>
+            </EmptyContent>
+          </Empty>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card variant="outline" size="sm">
+      <CardHeader>
+        <CardTitle>Configuration</CardTitle>
+        <CardDescription>Connect to a local LM Studio instance and choose a model.</CardDescription>
+        <CardAction>
+          <Button variant="ghost" size="icon-sm" onClick={() => void refetch()} disabled={isFetching}>
+            <RefreshCw className={isFetching ? "animate-spin" : ""} />
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {props.error ? (
+          <Alert variant="destructive">
+            <XCircle />
+            <AlertDescription>{props.error}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <Alert>
+          {status === "checking" ? (
+            <Loader2 className="animate-spin" />
+          ) : status === "running" ? (
+            <CheckCircle2 className="text-green-11!" />
+          ) : (
+            <XCircle />
+          )}
+          <AlertDescription>
+            {status === "checking"
+              ? "Checking LM Studio..."
+              : status === "running"
+                ? `LM Studio running (${models.length} model${models.length === 1 ? "" : "s"})`
+                : "LM Studio not reachable"}
+          </AlertDescription>
+        </Alert>
+
+        {status === "running" && models.length > 0 ? (
+          <div className="flex flex-col gap-2">
+            <FieldSet className="gap-3">
+              <FieldLegend variant="label">Available models</FieldLegend>
+              <FieldDescription>Select from models available in LM Studio.</FieldDescription>
+              <ModelList value={selectedModel} onValueChange={setSelectedModel}>
+                {models.map((model) => (
+                  <ModelListItem key={model.id} model={model} />
+                ))}
+              </ModelList>
+            </FieldSet>
+          </div>
+        ) : null}
+
+        {status === "running" && models.length === 0 ? (
+          <Empty className="flex-none p-6" variant="ghost">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Download />
+              </EmptyMedia>
+              <EmptyTitle>No models available</EmptyTitle>
+              <EmptyDescription>
+                Download a model in LM Studio, then refresh to add it to your workspace.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : null}
+
+        {props.status ? (
+          <Alert>
+            <CheckCircle2 />
+            <AlertDescription>{props.status}</AlertDescription>
+          </Alert>
+        ) : null}
+      </CardContent>
+      <CardFooter className="border-t border-border">
+        <FieldGroup className="gap-3">
+          <Field orientation="horizontal">
+            <Checkbox
+              id="lmstudio-set-default"
+              name="lmstudio-set-default"
+              checked={setDefault}
+              onCheckedChange={setSetDefault}
+              nativeButton
+              render={<button type="button" />}
+            />
+            <FieldLabel htmlFor="lmstudio-set-default">Use as default model in workspace</FieldLabel>
+          </Field>
+        </FieldGroup>
+        <Button
+          onClick={handleInstall}
+          disabled={props.busy || !selectedModel || status !== "running"}
+        >
+          {props.busy && <Loader2 className="size-4 animate-spin" />}
+          Add to workspace
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+interface ModelListProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  children: React.ReactNode;
+}
+
+export function ModelList({ value, onValueChange, children }: ModelListProps) {
+  return (
+    <RadioGroup className="w-full gap-2" value={value} onValueChange={onValueChange}>
+      {children}
+    </RadioGroup>
+  );
+}
+
+interface ModelListItemProps {
+  model: LMStudioModel;
+}
+
+function ModelListItem({ model }: ModelListItemProps) {
+  const detail = model.maxContextLength
+    ? `${Math.round(model.maxContextLength / 1024)}K ctx`
+    : model.type;
+
+  return (
+    <FieldLabel htmlFor={model.id}>
+      <Field orientation="horizontal" size="sm">
+        <RadioGroupItem value={model.id} id={model.id} />
+        <FieldContent className="flex-row justify-between w-full">
+          <FieldTitle>{model.id}</FieldTitle>
+          {detail ? <FieldDescription>{detail}</FieldDescription> : null}
+        </FieldContent>
+      </Field>
+    </FieldLabel>
+  );
+}

--- a/apps/app/src/react-app/domains/settings/lmstudio-models.ts
+++ b/apps/app/src/react-app/domains/settings/lmstudio-models.ts
@@ -1,0 +1,164 @@
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
+
+import type { ProviderListItem } from "@/app/types";
+
+import { LMSTUDIO_PROVIDER_CONFIG } from "./openai-image-extension";
+
+export const LMSTUDIO_PROVIDER_ID = LMSTUDIO_PROVIDER_CONFIG.providerId;
+
+/** Base URL for the LM Studio server without the trailing OpenAI "/v1" segment. */
+export const LMSTUDIO_BASE_URL = LMSTUDIO_PROVIDER_CONFIG.baseURL.replace(/\/v1\/?$/, "");
+
+/** A model entry surfaced by the LM Studio local server. */
+export type LMStudioModel = {
+  id: string;
+  /** "llm" | "vlm" | "embeddings" from the native /api/v0/models endpoint. */
+  type?: string;
+  state?: string;
+  maxContextLength?: number;
+};
+
+export type LMStudioFetchResult = {
+  status: "running" | "unreachable";
+  models: LMStudioModel[];
+};
+
+type FetchLike = typeof fetch;
+
+export function isLikelyEmbeddingModelId(modelId: string) {
+  const normalized = modelId.trim().toLowerCase();
+  return (
+    normalized.includes("embed") ||
+    normalized.includes("embedding") ||
+    normalized.includes("nomic-embed")
+  );
+}
+
+export function parseLMStudioNativeModelsResponse(data: unknown): LMStudioModel[] {
+  const entries = Array.isArray((data as { data?: unknown })?.data)
+    ? (data as { data: Array<Record<string, unknown>> }).data
+    : [];
+
+  return entries
+    .map((entry): LMStudioModel => ({
+      id: String(entry.id ?? ""),
+      type: typeof entry.type === "string" ? entry.type : undefined,
+      state: typeof entry.state === "string" ? entry.state : undefined,
+      maxContextLength:
+        typeof entry.max_context_length === "number" ? entry.max_context_length : undefined,
+    }))
+    .filter((model) => model.id && model.type !== "embeddings");
+}
+
+export function parseLMStudioOpenAIModelsResponse(data: unknown): LMStudioModel[] {
+  const entries = Array.isArray((data as { data?: unknown })?.data)
+    ? (data as { data: Array<Record<string, unknown>> }).data
+    : [];
+
+  return entries
+    .map((entry): LMStudioModel => ({ id: String(entry.id ?? "") }))
+    .filter((model) => model.id && !isLikelyEmbeddingModelId(model.id));
+}
+
+/**
+ * Fetch models from the running LM Studio instance.
+ *
+ * Prefers `/api/v0/models` (type + load state) and falls back to the
+ * OpenAI-compatible `/v1/models` endpoint on older builds.
+ */
+export async function fetchLMStudioModels(
+  fetchImpl: FetchLike = fetch,
+): Promise<LMStudioFetchResult> {
+  try {
+    const response = await fetchImpl(`${LMSTUDIO_BASE_URL}/api/v0/models`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (response.ok) {
+      const data = await response.json();
+      const models = parseLMStudioNativeModelsResponse(data);
+      return { status: "running", models };
+    }
+  } catch {
+    // Fall through to the OpenAI-compatible endpoint below.
+  }
+
+  try {
+    const response = await fetchImpl(`${LMSTUDIO_PROVIDER_CONFIG.baseURL}/models`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!response.ok) {
+      return { status: "unreachable", models: [] };
+    }
+    const data = await response.json();
+    const models = parseLMStudioOpenAIModelsResponse(data);
+    return { status: "running", models };
+  } catch {
+    return { status: "unreachable", models: [] };
+  }
+}
+
+export function buildLMStudioProviderModelsRecord(
+  existingModels: ProviderListItem["models"],
+  models: LMStudioModel[],
+): ProviderListItem["models"] {
+  const template = Object.values(existingModels)[0];
+  if (!template) {
+    return existingModels;
+  }
+
+  const merged: ProviderListItem["models"] = {};
+  for (const model of models) {
+    const current = existingModels[model.id];
+    merged[model.id] = current ?? {
+      ...template,
+      id: model.id,
+      name: model.id,
+    };
+  }
+  return merged;
+}
+
+export function reconcileLMStudioSelectedModel(
+  selectedModel: string,
+  models: LMStudioModel[],
+) {
+  if (models.length === 0) {
+    return "";
+  }
+  if (selectedModel && models.some((model) => model.id === selectedModel)) {
+    return selectedModel;
+  }
+  return models[0]?.id ?? "";
+}
+
+/**
+ * Replace the static models.dev catalog for a connected LM Studio provider
+ * with the models reported by the local LM Studio server.
+ */
+export async function enrichProviderListWithLiveLMStudioModels(
+  value: ProviderListResponse,
+  fetchImpl?: FetchLike,
+): Promise<ProviderListResponse> {
+  const connected = new Set(value.connected ?? []);
+  if (!connected.has(LMSTUDIO_PROVIDER_ID)) {
+    return value;
+  }
+
+  const live = await fetchLMStudioModels(fetchImpl);
+  if (live.status !== "running" || live.models.length === 0) {
+    return value;
+  }
+
+  return {
+    ...value,
+    all: (value.all ?? []).map((provider) => {
+      if (provider.id !== LMSTUDIO_PROVIDER_ID) {
+        return provider;
+      }
+      return {
+        ...provider,
+        models: buildLMStudioProviderModelsRecord(provider.models ?? {}, live.models),
+      };
+    }),
+  };
+}

--- a/apps/app/src/react-app/domains/settings/openai-image-extension.ts
+++ b/apps/app/src/react-app/domains/settings/openai-image-extension.ts
@@ -5,6 +5,8 @@ export type LocalProviderInstallInput = {
   modelId: string;
   modelName: string;
   setDefault: boolean;
+  /** When set, every listed model is written into the provider config. */
+  allModelIds?: string[];
 };
 
 export const OLLAMA_PROVIDER_CONFIG = {
@@ -12,6 +14,12 @@ export const OLLAMA_PROVIDER_CONFIG = {
   name: "Ollama (local)",
   baseURL: "http://localhost:11434/v1",
   defaultModelId: "qwen2.5-coder:7b",
+};
+
+export const LMSTUDIO_PROVIDER_CONFIG = {
+  providerId: "lmstudio",
+  name: "LM Studio (local)",
+  baseURL: "http://127.0.0.1:1234/v1",
 };
 
 export const OPENAI_IMAGE_EXTENSION_ID = "openai-image-generation";

--- a/apps/app/src/react-app/infra/provider-list-query.ts
+++ b/apps/app/src/react-app/infra/provider-list-query.ts
@@ -3,6 +3,7 @@ import { useQuery, type QueryClient } from "@tanstack/react-query";
 import type { Client, ModelRef, ProviderListItem } from "../../app/types";
 import { unwrap } from "../../app/lib/opencode";
 import { dispatchNewProviders } from "../../app/lib/provider-events";
+import { enrichProviderListWithLiveLMStudioModels } from "../domains/settings/lmstudio-models";
 import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
 
 export const PROVIDER_LIST_CACHE_MS = 5 * 60 * 1000;
@@ -50,8 +51,9 @@ export async function fetchProviderList(input: {
       directory: input.directory?.trim() || undefined,
     }),
   );
-  recordConnectedProviderSnapshot(input, value);
-  return value;
+  const enriched = await enrichProviderListWithLiveLMStudioModels(value);
+  recordConnectedProviderSnapshot(input, enriched);
+  return enriched;
 }
 
 export function getConnectedProviderItems(value: ProviderListResponse | null | undefined) {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -59,6 +59,7 @@ import { AiSettingsView } from "@/react-app/domains/settings/pages/ai-view";
 // Side-effect imports: register extension config components into the registry.
 import "@/react-app/domains/settings/openai-image-gen-config";
 import "@/react-app/domains/settings/ollama-config";
+import "@/react-app/domains/settings/lmstudio-config";
 import "@/react-app/domains/settings/computer-use-config";
 import "@/react-app/domains/settings/browser-extension-config";
 import "@/react-app/domains/settings/openwork-voice-config";
@@ -1017,6 +1018,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     setLocalProviderStatus(null);
     setLocalProviderError(null);
     try {
+      const modelEntries = (input.allModelIds ?? [])
+        .map((id) => id.trim())
+        .filter(Boolean);
+      const models =
+        modelEntries.length > 0
+          ? Object.fromEntries(modelEntries.map((id) => [id, { name: id }]))
+          : { [modelId]: { name: input.modelName.trim() || modelId } };
+
       await client.patchConfig(workspaceId, {
         opencode: {
           provider: {
@@ -1024,7 +1033,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               npm: "@ai-sdk/openai-compatible",
               name: input.name,
               options: { baseURL: input.baseURL },
-              models: { [modelId]: { name: input.modelName.trim() || modelId } },
+              models,
             },
           },
         },

--- a/apps/app/tests/lmstudio-models.test.ts
+++ b/apps/app/tests/lmstudio-models.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  enrichProviderListWithLiveLMStudioModels,
+  isLikelyEmbeddingModelId,
+  parseLMStudioNativeModelsResponse,
+  parseLMStudioOpenAIModelsResponse,
+  reconcileLMStudioSelectedModel,
+} from "../src/react-app/domains/settings/lmstudio-models";
+
+describe("lmstudio model parsing", () => {
+  test("parses native models and drops embeddings", () => {
+    const models = parseLMStudioNativeModelsResponse({
+      data: [
+        { id: "google/gemma-4-12b", type: "llm", max_context_length: 8192 },
+        { id: "text-embedding-nomic-embed-text-v1.5", type: "embeddings" },
+      ],
+    });
+
+    expect(models).toEqual([
+      {
+        id: "google/gemma-4-12b",
+        type: "llm",
+        state: undefined,
+        maxContextLength: 8192,
+      },
+    ]);
+  });
+
+  test("filters likely embedding models from the OpenAI-compatible fallback", () => {
+    const models = parseLMStudioOpenAIModelsResponse({
+      data: [
+        { id: "liquid/lfm2.5-1.2b" },
+        { id: "text-embedding-nomic-embed-text-v1.5" },
+      ],
+    });
+
+    expect(models).toEqual([{ id: "liquid/lfm2.5-1.2b" }]);
+  });
+
+  test("detects embedding-like model ids", () => {
+    expect(isLikelyEmbeddingModelId("text-embedding-nomic-embed-text-v1.5")).toBe(true);
+    expect(isLikelyEmbeddingModelId("google/gemma-4-12b")).toBe(false);
+  });
+
+  test("reselects the first live model when the previous selection disappears", () => {
+    expect(
+      reconcileLMStudioSelectedModel("qwen/qwen3-coder-30b", [
+        { id: "google/gemma-4-12b" },
+        { id: "liquid/lfm2.5-1.2b" },
+      ]),
+    ).toBe("google/gemma-4-12b");
+  });
+});
+
+describe("lmstudio provider list enrichment", () => {
+  test("replaces static catalog models with live LM Studio models", async () => {
+    const fetchImpl = async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/api/v0/models")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              { id: "google/gemma-4-12b", type: "llm" },
+              { id: "liquid/lfm2.5-1.2b", type: "llm" },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const enriched = await enrichProviderListWithLiveLMStudioModels(
+      {
+        connected: ["lmstudio"],
+        default: {},
+        all: [
+          {
+            id: "lmstudio",
+            name: "LMStudio",
+            source: "builtin",
+            models: {
+              "openai/gpt-oss-20b": { name: "GPT OSS 20B" },
+              "qwen/qwen3-30b-a3b-2507": { name: "Qwen3 30B A3B 2507" },
+            },
+          },
+        ],
+      },
+      fetchImpl,
+    );
+
+    expect(Object.keys(enriched.all[0]?.models ?? {})).toEqual([
+      "google/gemma-4-12b",
+      "liquid/lfm2.5-1.2b",
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #2364 by replacing the static models.dev catalog with models from the local LM Studio server when the provider is connected. Adds an LM Studio settings extension (mirroring Ollama) and unit tests for parsing and provider-list enrichment.

## Summary
- Fixes #2364 — LM Studio model picker showed 3 hardcoded catalog models instead of the user's downloaded models
- Fetches live models from `http://127.0.0.1:1234/api/v0/models` (fallback: `/v1/models`)
- Replaces static catalog in the **model picker** when LM Studio is connected (addresses UX gap noted on #2367)
- Adds LM Studio settings extension panel (Ollama-style) and syncs all live models into opencode config on install

## Related
Builds on the approach i with model-picker integration, stale-selection handling, embedding filtering on fallback, and unit tests.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm --filter @openwork/app exec bun test tests/lmstudio-models.test.ts`
- [ ] With LM Studio running on :1234, open Models → LM Studio shows live models (e.g. gemma), not gpt-oss/qwen3
- [ ] Settings → Extensions → LM Studio → refresh lists live models and Add to workspace works

## Comments
Working on #2364 in #. Related to #2367 - this also updates the model picker flow from the bug report, not only the extensions panel