### PR TITLE
fix(app): add composer spellcheck toggle and disable by default

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1070,6 +1070,8 @@ export default {
   "settings.group_workspace": "Workspace",
   "settings.hide_titlebar": "Hide titlebar",
   "settings.hide_titlebar_desc": "Hide the window titlebar. Useful for tiling window",
+  "settings.composer_spellcheck": "Composer spell check",
+  "settings.composer_spellcheck_desc": "Show red underlines for misspelled words while typing prompts. Off by default for non-English text.",
   "settings.join_discord": "Join Discord",
   "settings.language": "Language",
   "settings.language.description": "Choose your preferred language",

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, type ForwardedRef } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState, type ForwardedRef } from "react";
 import { LexicalComposer } from "@lexical/react/LexicalComposer.js";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin.js";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable.js";
@@ -33,6 +33,11 @@ import {
 } from "lexical";
 import type { InitialConfigType } from "@lexical/react/LexicalComposer.js";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./mention-encoding";
+import {
+  COMPOSER_SPELLCHECK_CHANGED_EVENT,
+  readComposerSpellcheckEnabled,
+  watchSpellcheckOnEditableRoot,
+} from "./spellcheck";
 
 type EditorProps = {
   value: string;
@@ -787,6 +792,29 @@ function MentionChipNavigationPlugin() {
   return null;
 }
 
+function SpellcheckPlugin() {
+  const [editor] = useLexicalComposerContext();
+  const [enabled, setEnabled] = useState(() => readComposerSpellcheckEnabled());
+
+  useEffect(() => {
+    const sync = () => setEnabled(readComposerSpellcheckEnabled());
+    window.addEventListener("storage", sync);
+    window.addEventListener(COMPOSER_SPELLCHECK_CHANGED_EVENT, sync);
+    return () => {
+      window.removeEventListener("storage", sync);
+      window.removeEventListener(COMPOSER_SPELLCHECK_CHANGED_EVENT, sync);
+    };
+  }, []);
+
+  useEffect(() => {
+    const root = editor.getRootElement();
+    if (!root) return;
+    return watchSpellcheckOnEditableRoot(root, enabled);
+  }, [editor, enabled]);
+
+  return null;
+}
+
 function ImperativeHandlePlugin(props: { editorRef: ForwardedRef<LexicalPromptEditorHandle> }) {
   const [editor] = useLexicalComposerContext();
 
@@ -803,6 +831,17 @@ function ImperativeHandlePlugin(props: { editorRef: ForwardedRef<LexicalPromptEd
 export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorProps>(function LexicalPromptEditor(props, ref) {
   const valueRef = useRef(props.value);
   const onChangeRef = useRef(props.onChange);
+  const [spellcheckEnabled, setSpellcheckEnabled] = useState(() => readComposerSpellcheckEnabled());
+
+  useEffect(() => {
+    const sync = () => setSpellcheckEnabled(readComposerSpellcheckEnabled());
+    window.addEventListener("storage", sync);
+    window.addEventListener(COMPOSER_SPELLCHECK_CHANGED_EVENT, sync);
+    return () => {
+      window.removeEventListener("storage", sync);
+      window.removeEventListener(COMPOSER_SPELLCHECK_CHANGED_EVENT, sync);
+    };
+  }, []);
 
   useEffect(() => {
     valueRef.current = props.value;
@@ -872,6 +911,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
           contentEditable={
             <ContentEditable
               className="min-h-[60px] max-h-[280px] w-full resize-none overflow-y-auto bg-transparent text-[15px] leading-6 text-dls-text outline-none placeholder:text-dls-secondary [&_p]:min-h-[1.5rem] [&_p]:m-0"
+              spellCheck={spellcheckEnabled}
               aria-placeholder={props.placeholder}
               placeholder={<span />}
               onPaste={props.onPaste}
@@ -893,6 +933,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
         <SubmitPlugin onSubmit={props.onSubmit} disabled={props.disabled} />
         <PasteChipPlugin onPasteText={props.onPasteText} />
         <MentionChipNavigationPlugin />
+        <SpellcheckPlugin />
         <ImperativeHandlePlugin editorRef={ref} />
       </div>
     </LexicalComposer>

--- a/apps/app/src/react-app/domains/session/surface/composer/spellcheck.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/spellcheck.ts
@@ -1,0 +1,36 @@
+export const COMPOSER_SPELLCHECK_ENABLED_KEY = "openwork.react.settings.composer-spellcheck";
+export const COMPOSER_SPELLCHECK_CHANGED_EVENT = "openwork-composer-spellcheck-changed";
+
+export function readComposerSpellcheckEnabled() {
+  try {
+    return window.localStorage.getItem(COMPOSER_SPELLCHECK_ENABLED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function writeComposerSpellcheckEnabled(enabled: boolean) {
+  try {
+    window.localStorage.setItem(COMPOSER_SPELLCHECK_ENABLED_KEY, enabled ? "true" : "false");
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+export function applySpellcheckToEditableRoot(root: ParentNode, enabled: boolean) {
+  const selector = '[contenteditable="true"], textarea';
+  root.querySelectorAll(selector).forEach((element) => {
+    if (!(element instanceof HTMLElement)) return;
+    element.spellcheck = enabled;
+    element.setAttribute("spellcheck", enabled ? "true" : "false");
+  });
+}
+
+export function watchSpellcheckOnEditableRoot(root: ParentNode, enabled: boolean) {
+  applySpellcheckToEditableRoot(root, enabled);
+  const observer = new MutationObserver(() => {
+    applySpellcheckToEditableRoot(root, enabled);
+  });
+  observer.observe(root, { childList: true, subtree: true, attributes: true, attributeFilter: ["contenteditable"] });
+  return () => observer.disconnect();
+}

--- a/apps/app/src/react-app/domains/settings/appearance/window-section.tsx
+++ b/apps/app/src/react-app/domains/settings/appearance/window-section.tsx
@@ -15,7 +15,10 @@ import {
 } from "../settings-layout";
 
 interface WindowSectionProps
-  extends Pick<AppearanceViewProps, "busy" | "hideTitlebar" | "toggleHideTitlebar"> {}
+  extends Pick<
+    AppearanceViewProps,
+    "busy" | "hideTitlebar" | "toggleHideTitlebar" | "composerSpellcheckEnabled" | "toggleComposerSpellcheck"
+  > {}
 
 export function WindowSection(props: WindowSectionProps) {
   return (
@@ -34,6 +37,20 @@ export function WindowSection(props: WindowSectionProps) {
               checked={props.hideTitlebar}
               disabled={props.busy}
               onCheckedChange={props.toggleHideTitlebar}
+            />
+          </LayoutSectionItemHeaderActions>
+        </LayoutSectionItemHeader>
+      </LayoutSectionItem>
+
+      <LayoutSectionItem>
+        <LayoutSectionItemHeader>
+          <LayoutSectionItemTitle>{t("settings.composer_spellcheck")}</LayoutSectionItemTitle>
+          <LayoutSectionItemDescription>{t("settings.composer_spellcheck_desc")}</LayoutSectionItemDescription>
+          <LayoutSectionItemHeaderActions>
+            <Switch
+              checked={props.composerSpellcheckEnabled}
+              disabled={props.busy}
+              onCheckedChange={props.toggleComposerSpellcheck}
             />
           </LayoutSectionItemHeaderActions>
         </LayoutSectionItemHeader>

--- a/apps/app/src/react-app/domains/settings/pages/appearance-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/appearance-view.tsx
@@ -15,6 +15,8 @@ export type AppearanceViewProps = {
   setLanguage: (value: Language) => void;
   hideTitlebar: boolean;
   toggleHideTitlebar: () => void;
+  composerSpellcheckEnabled: boolean;
+  toggleComposerSpellcheck: () => void;
 };
 
 export function AppearanceView(props: AppearanceViewProps) {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -73,6 +73,11 @@ import { AuthorizedFoldersPanel } from "@/react-app/domains/settings/panels/auth
 import { SettingsStack } from "@/react-app/domains/settings/settings-section";
 import { AdvancedView } from "@/react-app/domains/settings/pages/advanced-view";
 import { AppearanceView } from "@/react-app/domains/settings/pages/appearance-view";
+import {
+  COMPOSER_SPELLCHECK_CHANGED_EVENT,
+  readComposerSpellcheckEnabled,
+  writeComposerSpellcheckEnabled,
+} from "@/react-app/domains/session/surface/composer/spellcheck";
 import { CloudAccountView } from "@/react-app/domains/settings/pages/cloud-account-view";
 import { CloudMarketplacesView } from "@/react-app/domains/settings/pages/cloud-marketplaces-view";
 import { CloudProvidersView } from "@/react-app/domains/settings/pages/cloud-providers-view";
@@ -403,6 +408,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   });
   const [themeMode, setThemeModeState] = useState<ThemeMode>(getInitialThemeMode);
   const [hideTitlebar, setHideTitlebar] = useState(() => readStoredBoolean(SETTINGS_HIDE_TITLEBAR_KEY, false));
+  const [composerSpellcheckEnabled, setComposerSpellcheckEnabled] = useState(() => readComposerSpellcheckEnabled());
   const [updateAutoCheck, setUpdateAutoCheck] = useState(() =>
     readStoredBoolean(SETTINGS_UPDATE_AUTO_CHECK_KEY, true),
   );
@@ -1068,6 +1074,15 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   useEffect(() => {
     writeStoredBoolean(SETTINGS_HIDE_TITLEBAR_KEY, hideTitlebar);
   }, [hideTitlebar]);
+
+  useEffect(() => {
+    writeComposerSpellcheckEnabled(composerSpellcheckEnabled);
+    window.dispatchEvent(new Event(COMPOSER_SPELLCHECK_CHANGED_EVENT));
+    void window.__OPENWORK_ELECTRON__?.invokeDesktop?.(
+      "__setSpellCheckerEnabled",
+      composerSpellcheckEnabled,
+    );
+  }, [composerSpellcheckEnabled]);
 
   useEffect(() => {
     writeStoredBoolean(SETTINGS_UPDATE_AUTO_CHECK_KEY, updateAutoCheck);
@@ -2233,6 +2248,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             setLanguage={setLocale}
             hideTitlebar={hideTitlebar}
             toggleHideTitlebar={() => setHideTitlebar((current) => !current)}
+            composerSpellcheckEnabled={composerSpellcheckEnabled}
+            toggleComposerSpellcheck={() => setComposerSpellcheckEnabled((current) => !current)}
           />
         );
       case "updates":

--- a/apps/app/tests/composer-spellcheck.test.ts
+++ b/apps/app/tests/composer-spellcheck.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+class FakeHTMLElement {
+  spellcheck = true;
+  private attrs = new Map<string, string>();
+
+  setAttribute(name: string, value: string) {
+    this.attrs.set(name, value);
+    if (name === "spellcheck") {
+      this.spellcheck = value === "true";
+    }
+  }
+
+  getAttribute(name: string) {
+    return this.attrs.get(name) ?? null;
+  }
+}
+
+const originalWindow = globalThis.window;
+const originalHTMLElement = globalThis.HTMLElement;
+
+const {
+  applySpellcheckToEditableRoot,
+  readComposerSpellcheckEnabled,
+  writeComposerSpellcheckEnabled,
+} = await import("../src/react-app/domains/session/surface/composer/spellcheck");
+
+describe("composer spellcheck preference", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { localStorage: memoryStorage() },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  test("defaults to disabled", () => {
+    writeComposerSpellcheckEnabled(false);
+    expect(readComposerSpellcheckEnabled()).toBe(false);
+  });
+
+  test("persists enabled preference", () => {
+    writeComposerSpellcheckEnabled(true);
+    expect(readComposerSpellcheckEnabled()).toBe(true);
+    writeComposerSpellcheckEnabled(false);
+  });
+});
+
+describe("applySpellcheckToEditableRoot", () => {
+  beforeEach(() => {
+    globalThis.HTMLElement = FakeHTMLElement as typeof HTMLElement;
+  });
+
+  afterEach(() => {
+    globalThis.HTMLElement = originalHTMLElement;
+  });
+
+  test("updates contenteditable and textarea elements", () => {
+    const editor = new FakeHTMLElement();
+    editor.setAttribute("contenteditable", "true");
+    const textarea = new FakeHTMLElement();
+    const root = {
+      querySelectorAll: () => [editor, textarea],
+    };
+
+    applySpellcheckToEditableRoot(root, false);
+    expect(editor.getAttribute("spellcheck")).toBe("false");
+    expect(editor.spellcheck).toBe(false);
+    expect(textarea.getAttribute("spellcheck")).toBe("false");
+    expect(textarea.spellcheck).toBe(false);
+
+    applySpellcheckToEditableRoot(root, true);
+    expect(editor.getAttribute("spellcheck")).toBe("true");
+    expect(editor.spellcheck).toBe(true);
+  });
+});

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1417,6 +1417,13 @@ const desktopCommandHandlers = {
   "__setApplicationMenuVisible": async (event, ...args) => {
       return applicationMenu.setVisible(args[0]);
   },
+  "__setSpellCheckerEnabled": async (event, ...args) => {
+      const enabled = args[0] === true;
+      const window = activeWindowFromEvent(event);
+      if (!window) return false;
+      window.webContents.session.setSpellCheckerEnabled(enabled);
+      return true;
+  },
 };
 
 async function handleDesktopInvoke(event, command, ...args) {
@@ -1460,6 +1467,9 @@ async function createMainWindow() {
       // Enable Chromium's built-in PDF viewer so PDFs render inside the
       // artifact panel (<embed> pointed at a blob URL).
       plugins: true,
+      // Chromium spellcheck is distracting for non-English prompts and ignores
+      // Windows OS spell settings. Users can re-enable it in Settings > Appearance.
+      spellcheck: false,
     },
   });
   applicationMenu.applyVisibility(mainWindow);

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -501,6 +501,7 @@ export type DesktopCommandMap = {
   __setZoomFactor: { args: [factor: number]; result: boolean };
   __setNativeTheme: { args: [theme: string]; result: unknown };
   __setApplicationMenuVisible: { args: [visible: boolean]; result: unknown };
+  __setSpellCheckerEnabled: { args: [enabled: boolean]; result: boolean };
 };
 
 export type DesktopCommandName = keyof DesktopCommandMap;


### PR DESCRIPTION
Fixes #2441

## Summary
- Disable Chromium spellcheck by default in the Electron desktop app (fixes red underlines when typing Vietnamese and other non-English prompts on Windows)
- Add **Settings → Appearance → Composer spell check** toggle; preference persists in localStorage
- Sync preference to the Lexical composer (`spellCheck` + mutation observer) and Electron `session.setSpellCheckerEnabled`

Fixes #2441

## Test plan
- [ ] On Windows desktop, type Vietnamese in the composer - no red underlines by default
- [ ] Enable **Composer spell check** in Settings → Appearance - underlines appear for misspelled words
- [ ] Disable toggle again - underlines disappear without DevTools workaround
- [ ] `pnpm typecheck`
- [ ] `pnpm --filter @openwork/app exec bun test tests/composer-spellcheck.test.ts`
-
