### PR TITLE
fix(app): render code blocks with theme-aware Shiki palette

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -439,6 +439,19 @@ select:disabled {
   --sidebar-ring: var(--slate-8);
 }
 
+/* Shiki emits both palettes as CSS variables (themes option in markdown.tsx);
+   swap token colors to the dark palette when the app theme is dark. */
+.dark .shiki,
+.dark .shiki span,
+[data-theme="dark"] .shiki,
+[data-theme="dark"] .shiki span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+
 @theme inline {
   --font-sans: 'Geist Variable', sans-serif;
   --font-heading: 'IBM Plex Sans Variable', sans-serif;

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -340,7 +340,8 @@ const highlightedMarkdownParser = new Marked({
       return codeToHtml(code, {
         lang: language,
         meta: { __raw: props.join(" ") },
-        theme: "github-light",
+        themes: { light: "github-light", dark: "github-dark" },
+        defaultColor: "light",
         transformers: [
           transformerNotationDiff({ matchAlgorithm: "v3" }),
           transformerNotationHighlight({ matchAlgorithm: "v3" }),

--- a/apps/app/src/react-app/domains/session/surface/markdown.tsx
+++ b/apps/app/src/react-app/domains/session/surface/markdown.tsx
@@ -175,7 +175,8 @@ const highlightedMarkdownParser = new Marked<string, string>({
       return codeToHtml(code, {
         lang: language,
         meta: { __raw: props.join(" ") },
-        theme: "github-light",
+        themes: { light: "github-light", dark: "github-dark" },
+        defaultColor: "light",
         transformers: [
           transformerNotationDiff({ matchAlgorithm: "v3" }),
           transformerNotationHighlight({ matchAlgorithm: "v3" }),


### PR DESCRIPTION
## Summary
- Code blocks in assistant messages (and artifact/extension markdown) were always highlighted with Shiki's `github-light` theme, so tokens were unreadable in dark mode.
- Switched `codeToHtml` to dual themes (`themes: { light: "github-light", dark: "github-dark" }`, `defaultColor: "light"`), which emits the dark palette as `--shiki-dark*` CSS variables alongside the unchanged light colors.
- Added a small CSS rule in `src/app/index.css` that activates the dark variables under `.dark` / `[data-theme="dark"]` (matching the app's existing dark variant selectors).

## Why
- Fixes low-contrast/unreadable code in dark mode. The dual-theme approach also means code blocks flip instantly when the user switches theme — no re-parse or re-highlight needed, unlike checking the DOM theme at highlight time (the app sets `data-theme` on the root, not a `dark` class, so the snippet suggested in the issue would not have matched).

## Issue
- Closes #2440

## Scope
- `apps/app/src/components/markdown/markdown.tsx` (chat message renderer, the file cited in the issue)
- `apps/app/src/react-app/domains/session/surface/markdown.tsx` (artifact preview / extension detail renderer — identical hardcoded theme, same 2-line fix)
- `apps/app/src/app/index.css` (one CSS rule to activate the dark palette)

## Out of scope
- `src/components/ui/code-block.tsx` (already takes `theme` as a prop; callers can opt in separately)
- Any change to light-mode rendering — the light palette is still emitted inline exactly as before.

## Testing
### Ran
- `pnpm install`
- `pnpm --filter @openwork/app typecheck`

### Result
- pass/fail: pass (no type errors)

## CI status
- pass: Vercel Preview Comments, Vercel openwork-landing
- code-related failures: none
- external/env/auth blockers: the three "Vercel – openwork-app / openwork-den / openwork-den-worker-proxy" checks fail with "Authorization required to deploy" — a fork-deploy authorization gate, unrelated to this change (which only touches the Electron app's renderer, not any Vercel-deployed app).

## Manual verification
1. Rendered real output through the repo's own `shiki@4` with the new options and confirmed the HTML contains both the inline light colors and `--shiki-dark` / `--shiki-dark-bg` variables.
2. Loaded that output in a page with the new CSS rule and captured light vs dark side by side (screenshot below).
3. In-app repro for reviewers: Settings > Appearance > Dark, send a message containing a fenced code block, confirm tokens use the github-dark palette; switch back to Light and confirm rendering is unchanged.

## Evidence
![before/after in light and dark themes](https://raw.githubusercontent.com/magic-peach/openwork/assets-2440/assets/shiki-fix-evidence.png)

Left: light theme after the fix (unchanged). Right top: current dark-mode bug (light palette on dark background). Right bottom: dark theme after the fix.

I was not able to capture an in-app video for this one — the verification above was done against the real Shiki pipeline and CSS outside Electron; the 3-step in-app repro is listed for the reviewer.

## Risk
- Low. Light mode output is byte-identical apart from added CSS variables; the dark override is scoped to `.shiki` elements under the dark theme selectors.

## Rollback
- Revert this commit; no data or config migrations involved.
