### PR TITLE
Redesign sign-in/sign-up screen; route desktop "Sign in" to sign-up tab

### DIFF
--- a/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
@@ -319,7 +319,10 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
               <button
                 type="button"
                 className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-full bg-dls-accent text-sm font-semibold text-[var(--dls-accent-fg)] transition-all hover:bg-[var(--dls-accent-hover)] disabled:opacity-60 disabled:cursor-not-allowed"
-                onClick={() => props.onOpenBrowserAuth("sign-in")}
+                // Opens on the sign-up tab (label stays "Sign in"): most
+                // people hitting this are new, and the web page's tabs let
+                // returning users switch to sign-in in one tap.
+                onClick={() => props.onOpenBrowserAuth("sign-up")}
                 disabled={props.authBusy || props.sessionBusy}
               >
                 Sign in with OpenWork Cloud

--- a/apps/app/src/react-app/domains/session/chat/status-bar.tsx
+++ b/apps/app/src/react-app/domains/session/chat/status-bar.tsx
@@ -338,7 +338,9 @@ export function StatusBar(props: StatusBarProps) {
                     size="xs"
                     onClick={() => {
                       const baseUrl = readDenBootstrapConfig().baseUrl;
-                      platform.openLink(buildDenAuthUrl(baseUrl, "sign-in"));
+                      // Label stays "Sign in"; opens the sign-up tab so new
+                      // users aren't defaulted into sign-in (they can toggle).
+                      platform.openLink(buildDenAuthUrl(baseUrl, "sign-up"));
                     }}
                     aria-label={t("den.signin_title")}
                   >

--- a/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
@@ -545,7 +545,8 @@ export function SkillsView(props: SkillsViewProps) {
 
   const openCloudSignIn = useCallback(() => {
     const base = readDenSettings().baseUrl?.trim() || DEFAULT_DEN_BASE_URL;
-    props.onOpenLink(buildDenAuthUrl(base, "sign-in"));
+    // Label stays "Sign in"; opens the sign-up tab (returning users can toggle).
+    props.onOpenLink(buildDenAuthUrl(base, "sign-up"));
   }, [props]);
 
   const openShareLink = useCallback(
@@ -558,7 +559,8 @@ export function SkillsView(props: SkillsViewProps) {
 
   const startShareSkillSignIn = useCallback(() => {
     const settings = readDenSettings();
-    props.onOpenLink(buildDenAuthUrl(settings.baseUrl, "sign-in"));
+    // Label stays "Sign in"; opens the sign-up tab (returning users can toggle).
+    props.onOpenLink(buildDenAuthUrl(settings.baseUrl, "sign-up"));
   }, [props]);
 
   const publishSkillToTeam = useCallback(async () => {

--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -12,8 +12,6 @@ type PanelContent = {
   title: string;
   copy: string;
   submitLabel: string;
-  togglePrompt?: string;
-  toggleActionLabel?: string;
 };
 
 function getDesktopGrant(url: string | null) {
@@ -78,6 +76,7 @@ export function AuthPanel({
   hideSocialAuth = false,
   hideEmailField = false,
   eyebrow = "Account",
+  bare = false,
   signUpContent,
   signInContent,
   verificationContent,
@@ -89,6 +88,10 @@ export function AuthPanel({
   hideSocialAuth?: boolean;
   hideEmailField?: boolean;
   eyebrow?: string;
+  // When true the panel renders without its own `den-frame`/padding, so a parent
+  // (the unified split auth card) can own the surface. Defaults to a self-framed
+  // card for standalone callers (invite, workspace-claim).
+  bare?: boolean;
   signUpContent?: Partial<PanelContent>;
   signInContent?: Partial<PanelContent>;
   verificationContent?: Partial<PanelContent>;
@@ -118,7 +121,6 @@ export function AuthPanel({
     desktopRedirectUrl,
     desktopRedirectBusy,
     showAuthFeedback,
-    continueSignInWithEmail,
     submitAuth,
     submitVerificationCode,
     resendVerificationCode,
@@ -126,14 +128,11 @@ export function AuthPanel({
     beginSocialAuth,
     resolveUserLandingRoute,
   } = useDenFlow();
-  const [signInEmailConfirmed, setSignInEmailConfirmed] = useState(false);
 
   const resolvedSignUpContent: PanelContent = {
     title: "Get started.",
     copy: "Free to try. Team plans from $50/mo.",
     submitLabel: "Create account",
-    togglePrompt: "Have an account?",
-    toggleActionLabel: "Sign in",
     ...signUpContent,
   };
 
@@ -141,8 +140,6 @@ export function AuthPanel({
     title: "Welcome back.",
     copy: "Sign in to open your team workspace.",
     submitLabel: "Sign in",
-    togglePrompt: "Need an account?",
-    toggleActionLabel: "Create one",
     ...signInContent,
   };
 
@@ -161,23 +158,21 @@ export function AuthPanel({
 
   const desktopGrant = getDesktopGrant(desktopRedirectUrl);
   const isPasswordResetRequest = authMode === "sign-in" && passwordResetRequested && !verificationRequired;
-  const isEmailFirstSignIn = authMode === "sign-in" && !verificationRequired && !isPasswordResetRequest && !hideEmailField;
-  const isSignInEmailStep = isEmailFirstSignIn && !signInEmailConfirmed;
   const formBusy = isPasswordResetRequest ? passwordResetBusy : authBusy || desktopRedirectBusy;
   const activeContent = verificationRequired
     ? resolvedVerificationContent
     : isPasswordResetRequest
       ? passwordResetContent
-      : isSignInEmailStep
-      ? {
-          ...resolvedSignInContent,
-          copy: "Enter your email and we’ll send you to the right sign-in method.",
-          submitLabel: "Next",
-        }
       : authMode === "sign-in"
       ? resolvedSignInContent
       : resolvedSignUpContent;
   const showLockedEmailSummary = Boolean(prefilledEmail && lockEmail && hideEmailField);
+  const shellClass = (gap: string, padding: string) =>
+    bare ? `grid ${gap}` : `den-frame grid ${gap} ${padding}`;
+  // The segmented tabs are the primary sign-in/sign-up switch. Hide them for the
+  // focused sub-flows (email verification, password reset) where switching mode
+  // mid-step would be confusing.
+  const showModeTabs = !verificationRequired && !isPasswordResetRequest;
 
   useEffect(() => {
     const key = prefillKey ?? prefilledEmail?.trim() ?? null;
@@ -190,8 +185,17 @@ export function AuthPanel({
     setEmail(prefilledEmail?.trim() ?? "");
     setPassword("");
     setVerificationCode("");
-    setSignInEmailConfirmed(false);
   }, [initialMode, prefillKey, prefilledEmail, setAuthMode, setEmail, setPassword, setVerificationCode]);
+
+  const switchMode = (mode: AuthMode) => {
+    if (mode === authMode && !passwordResetRequested) {
+      return;
+    }
+    setPasswordResetRequested(false);
+    setPasswordResetInfo("");
+    setPasswordResetError(null);
+    setAuthMode(mode);
+  };
 
   const copyDesktopValue = async (field: "link" | "code", value: string | null) => {
     if (!value) return;
@@ -242,7 +246,7 @@ export function AuthPanel({
 
   if (isSignedInWithDesktopHandoff) {
     return (
-      <div className="den-frame grid gap-6 p-6 md:p-7">
+      <div className={shellClass("gap-6", "p-6 md:p-7")}>
         <div className="grid gap-3">
           <p className="den-eyebrow">{eyebrow}</p>
           <div className="grid gap-2">
@@ -301,7 +305,7 @@ export function AuthPanel({
   }
 
   return (
-    <div className="den-frame grid gap-4 p-5 sm:gap-5 sm:p-6 md:p-7">
+    <div className={shellClass("gap-4 sm:gap-5", "p-5 sm:p-6 md:p-7")}>
       <div className="grid gap-3">
         <p className="den-eyebrow">{eyebrow}</p>
         <div className="grid gap-2">
@@ -309,6 +313,39 @@ export function AuthPanel({
           <p className="den-copy">{activeContent.copy}</p>
         </div>
       </div>
+
+      {showModeTabs ? (
+        <div
+          className="grid grid-cols-2 gap-1 rounded-full border border-[var(--dls-border)] bg-[var(--dls-hover)] p-1"
+          role="group"
+          aria-label="Choose sign in or create account"
+        >
+          <button
+            type="button"
+            aria-pressed={authMode === "sign-in"}
+            onClick={() => switchMode("sign-in")}
+            className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+              authMode === "sign-in"
+                ? "bg-[var(--dls-surface)] text-[var(--dls-text-primary)] shadow-[0_1px_2px_rgba(15,23,42,0.08)]"
+                : "text-[var(--dls-text-secondary)] hover:text-[var(--dls-text-primary)]"
+            }`}
+          >
+            Sign in
+          </button>
+          <button
+            type="button"
+            aria-pressed={authMode === "sign-up"}
+            onClick={() => switchMode("sign-up")}
+            className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+              authMode === "sign-up"
+                ? "bg-[var(--dls-surface)] text-[var(--dls-text-primary)] shadow-[0_1px_2px_rgba(15,23,42,0.08)]"
+                : "text-[var(--dls-text-secondary)] hover:text-[var(--dls-text-primary)]"
+            }`}
+          >
+            Create account
+          </button>
+        </div>
+      ) : null}
 
       {desktopAuthRequested && desktopRedirectUrl ? (
         <div className="grid gap-3">
@@ -334,15 +371,6 @@ export function AuthPanel({
             return;
           }
 
-          if (isSignInEmailStep) {
-            event.preventDefault();
-            const shouldContinue = await continueSignInWithEmail();
-            if (shouldContinue) {
-              setSignInEmailConfirmed(true);
-            }
-            return;
-          }
-
           const next = verificationRequired
             ? await submitVerificationCode(event)
             : await submitAuth(event);
@@ -361,15 +389,13 @@ export function AuthPanel({
       >
         {!verificationRequired && !isPasswordResetRequest && !hideSocialAuth ? (
           <>
-            {authMode !== "sign-in" ? (
-              <SocialButton
-                onClick={() => void beginSocialAuth("github")}
-                disabled={authBusy || desktopRedirectBusy}
-              >
-                <GitHubLogo />
-                <span>Continue with GitHub</span>
-              </SocialButton>
-            ) : null}
+            <SocialButton
+              onClick={() => void beginSocialAuth("github")}
+              disabled={authBusy || desktopRedirectBusy}
+            >
+              <GitHubLogo />
+              <span>Continue with GitHub</span>
+            </SocialButton>
 
             <SocialButton
               onClick={() => void beginSocialAuth("google")}
@@ -399,12 +425,7 @@ export function AuthPanel({
               className="den-input disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500"
               type="email"
               value={email}
-              onChange={(event) => {
-                setEmail(event.target.value);
-                if (authMode === "sign-in") {
-                  setSignInEmailConfirmed(false);
-                }
-              }}
+              onChange={(event) => setEmail(event.target.value)}
               autoComplete="email"
               readOnly={lockEmail}
               disabled={lockEmail}
@@ -413,7 +434,7 @@ export function AuthPanel({
           </label>
         ) : null}
 
-        {!verificationRequired && !isPasswordResetRequest && !isSignInEmailStep ? (
+        {!verificationRequired && !isPasswordResetRequest ? (
           <label className="grid gap-2">
             <span className="den-label">Password</span>
             <input
@@ -443,10 +464,14 @@ export function AuthPanel({
           </label>
         ) : null}
 
-        {authMode === "sign-in" && !verificationRequired && !isPasswordResetRequest && !isSignInEmailStep && !hideEmailField ? (
-          <div className="-mt-2 flex justify-end">
+        {!verificationRequired && !isPasswordResetRequest && !hideEmailField ? (
+          // Always rendered (invisible in sign-up) so switching modes never
+          // changes the card height.
+          <div className={`-mt-2 flex justify-end ${authMode === "sign-in" ? "" : "invisible"}`}>
             <button
               type="button"
+              tabIndex={authMode === "sign-in" ? 0 : -1}
+              aria-hidden={authMode !== "sign-in"}
               className="text-sm font-medium text-[var(--dls-text-primary)] transition hover:opacity-70"
               onClick={() => {
                 setAuthMode("sign-in");
@@ -483,7 +508,6 @@ export function AuthPanel({
               type="button"
               className="den-button-secondary w-full"
               onClick={() => {
-                setSignInEmailConfirmed(false);
                 cancelVerification();
               }}
               disabled={authBusy || desktopRedirectBusy}
@@ -504,34 +528,10 @@ export function AuthPanel({
               setPasswordResetRequested(false);
               setPasswordResetInfo("");
               setPasswordResetError(null);
-              setSignInEmailConfirmed(false);
               setAuthMode("sign-in");
             }}
           >
             Back to sign in
-          </button>
-        </div>
-      ) : !verificationRequired ? (
-        <div className="flex flex-col gap-2 border-t border-[var(--dls-border)] pt-4 text-sm text-[var(--dls-text-secondary)] sm:flex-row sm:items-center sm:justify-between sm:gap-3">
-          <p className="m-0">
-            {authMode === "sign-in"
-              ? resolvedSignInContent.togglePrompt
-              : resolvedSignUpContent.togglePrompt}
-          </p>
-          <button
-            type="button"
-            className="font-medium text-[var(--dls-text-primary)] transition hover:opacity-70"
-            onClick={() => {
-              setPasswordResetRequested(false);
-              setPasswordResetInfo("");
-              setPasswordResetError(null);
-              setSignInEmailConfirmed(false);
-              setAuthMode(authMode === "sign-in" ? "sign-up" : "sign-in");
-            }}
-          >
-            {authMode === "sign-in"
-              ? resolvedSignInContent.toggleActionLabel
-              : resolvedSignUpContent.toggleActionLabel}
           </button>
         </div>
       ) : null}
@@ -558,6 +558,16 @@ export function AuthPanel({
               <CheckCircle2 className="h-3.5 w-3.5" />
               <span>Waiting for your verification code</span>
             </div>
+          ) : null}
+          {authError && authMode === "sign-in" && !verificationRequired ? (
+            <button
+              type="button"
+              className="mt-1 inline-flex items-center justify-center gap-1 font-medium text-[var(--dls-text-primary)] transition hover:opacity-70"
+              onClick={() => switchMode("sign-up")}
+            >
+              New here? Create an account
+              <ArrowRight className="h-3.5 w-3.5" />
+            </button>
           ) : null}
         </div>
       ) : null}

--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -2,6 +2,7 @@
 
 import { PaperMeshGradient } from "@openwork/ui/react";
 import { Dithering } from "@paper-design/shaders-react";
+import { Bot, Boxes, Share, type LucideIcon } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef } from "react";
 import { isSamePathname } from "../_lib/client-route";
@@ -9,11 +10,16 @@ import { getMcpOAuthSelectOrganizationRoute } from "../_lib/mcp-oauth-route";
 import { useDenFlow } from "../_providers/den-flow-provider";
 import { AuthPanel } from "./auth-panel";
 
-function FeatureCard({ title, body }: { title: string; body: string }) {
+function Feature({ icon: Icon, title, body }: { icon: LucideIcon; title: string; body: string }) {
   return (
-    <div className="den-stat-card grid gap-2">
-      <p className="m-0 text-[14px] font-medium text-[var(--dls-text-primary)]">{title}</p>
-      <p className="m-0 text-[13px] leading-[1.6] text-[var(--dls-text-secondary)]">{body}</p>
+    <div className="flex flex-col items-start gap-3.5 px-4 py-5 sm:px-5">
+      <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-white/15 bg-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] backdrop-blur-md">
+        <Icon className="h-[18px] w-[18px] text-white" strokeWidth={1.75} />
+      </span>
+      <div className="min-w-0">
+        <p className="m-0 text-[13px] font-medium leading-tight text-white">{title}</p>
+        <p className="m-0 mt-1 text-[11.5px] leading-snug text-white/60">{body}</p>
+      </div>
     </div>
   );
 }
@@ -30,7 +36,7 @@ function SessionStatusPanel({ mode }: { mode: "checking" | "redirecting" }) {
       };
 
   return (
-    <div className="den-frame flex min-h-[420px] flex-col justify-between gap-8 p-6 md:p-7" role="status" aria-live="polite">
+    <div className="grid gap-6" role="status" aria-live="polite">
       <div className="grid gap-3">
         <p className="den-eyebrow">Account</p>
         <div className="rounded-[1.5rem] border border-[var(--dls-border)] bg-[var(--dls-hover)]/60 p-4">
@@ -85,9 +91,10 @@ export function AuthScreen() {
 
   return (
     <section className="den-page flex w-full items-start py-3 sm:py-4 lg:min-h-[calc(100vh-2.5rem)] lg:items-center">
-      <div className="grid w-full gap-4 sm:gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(360px,440px)]">
-        <div className="order-1 flex flex-col gap-4 sm:gap-6">
-          <div className="den-frame relative min-h-[210px] overflow-hidden px-5 py-6 sm:min-h-[260px] sm:px-7 sm:py-8 md:px-10 md:py-10 lg:min-h-[300px]">
+      <div className="den-frame relative w-full overflow-hidden">
+        <div className="grid lg:grid-cols-[2fr_1fr]">
+          {/* Brand panel — hidden on mobile; form-only on small screens */}
+          <div className="relative hidden min-h-[220px] overflow-hidden px-6 py-7 sm:px-8 sm:py-9 md:px-10 md:py-10 lg:block lg:min-h-[560px]">
             <div className="absolute inset-0 z-0">
               <Dithering
                 speed={0}
@@ -113,16 +120,18 @@ export function AuthScreen() {
               </Dithering>
             </div>
 
-            <div className="relative z-10 flex h-full flex-col justify-between gap-10">
+            <div className="relative z-10 flex h-full flex-col">
               <div className="flex items-center gap-3">
                 <img src="/openwork-logo-transparent.svg" alt="OpenWork" className="h-9 w-auto" />
                 <span className="text-[13px] font-medium text-white/80">OpenWork Cloud</span>
               </div>
 
+              {/* Spacers split the space below the logo ~1:2, so the headline
+                  starts about a third of the way down and the features sit at
+                  the bottom. */}
+              <div className="flex-[1]" aria-hidden />
+
               <div className="grid gap-3 sm:gap-4">
-                <span className="inline-flex w-fit rounded-full border border-white/20 bg-white/15 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.18em] text-white backdrop-blur-md">
-                  OpenWork Cloud
-                </span>
                 <h1 className="max-w-[13ch] text-[2rem] font-semibold leading-[0.95] tracking-[-0.06em] text-white sm:text-[2.35rem] md:text-[3rem]">
                   One setup, every seat.
                 </h1>
@@ -130,33 +139,48 @@ export function AuthScreen() {
                   Configure once. Your whole team gets the same tools, agents, and providers.
                 </p>
               </div>
+
+              <div className="flex-[2]" aria-hidden />
+
+              <div className="overflow-hidden rounded-[1.5rem] border border-white/10 bg-white/[0.06] backdrop-blur-md">
+                <div className="grid divide-y divide-white/10 sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+                  <Feature
+                    icon={Share}
+                    title="Shared config"
+                    body="Set once, push to the org."
+                  />
+                  <Feature
+                    icon={Bot}
+                    title="Cloud agents"
+                    body="Keep running while you're away."
+                  />
+                  <Feature
+                    icon={Boxes}
+                    title="Your models"
+                    body="Bring your own provider."
+                  />
+                </div>
+              </div>
             </div>
           </div>
 
-          <div className="hidden gap-4 md:grid md:grid-cols-3">
-            <FeatureCard
-              title="Shared config"
-              body="Set it up once, then push it to the org."
-            />
-            <FeatureCard
-              title="Cloud agents"
-              body="Workflows that keep running while your team is away."
-            />
-            <FeatureCard
-              title="Your models"
-              body="Bring your own provider when the team is ready."
-            />
+          {/* Auth form */}
+          <div className="flex flex-col justify-center border-[var(--dls-border)] px-5 py-6 sm:px-7 sm:py-8 md:px-9 md:py-10 lg:border-l">
+            {/* Mobile-only brand header — desktop shows the logo in the gradient panel */}
+            <div className="mb-6 flex items-center gap-2 lg:hidden">
+              <img src="/openwork-mark.svg" alt="OpenWork" className="h-7 w-auto" />
+              <span className="text-[1.15rem] font-semibold tracking-tight text-[var(--dls-text-primary)]">
+                OpenWork
+              </span>
+            </div>
+            {!sessionHydrated ? (
+              <SessionStatusPanel mode="checking" />
+            ) : hasResolvedSession ? (
+              <SessionStatusPanel mode="redirecting" />
+            ) : (
+              <AuthPanel bare />
+            )}
           </div>
-        </div>
-
-        <div className="order-2">
-          {!sessionHydrated ? (
-            <SessionStatusPanel mode="checking" />
-          ) : hasResolvedSession ? (
-            <SessionStatusPanel mode="redirecting" />
-          ) : (
-            <AuthPanel />
-          )}
         </div>
       </div>
     </section>

--- a/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
@@ -270,15 +270,11 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
             title: `Join ${preview.organization.name}.`,
             copy: "Pick a password and you're in.",
             submitLabel: `Join ${preview.organization.name}`,
-            togglePrompt: "Already on Cloud?",
-            toggleActionLabel: "Sign in",
           }}
           signInContent={{
             title: `Join ${preview.organization.name}.`,
             copy: `Sign in as ${preview.invitation.email} to accept this invite.`,
             submitLabel: "Sign in to join",
-            togglePrompt: "Need a new account?",
-            toggleActionLabel: "Create one",
           }}
           verificationContent={{
             title: "Check your inbox.",

--- a/ee/apps/den-web/app/(den)/_components/workspace-claim-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/workspace-claim-screen.tsx
@@ -271,15 +271,11 @@ export function WorkspaceClaimScreen({
             title: "Claim your workspace.",
             copy: "Create an account to take ownership.",
             submitLabel: "Create account and claim",
-            togglePrompt: "Already on Cloud?",
-            toggleActionLabel: "Sign in",
           }}
           signInContent={{
             title: "Claim your workspace.",
             copy: "Sign in to take ownership.",
             submitLabel: "Sign in to claim",
-            togglePrompt: "Need a new account?",
-            toggleActionLabel: "Create one",
           }}
         />
       </section>

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -89,7 +89,6 @@ type DenFlowContextValue = {
   desktopRedirectUrl: string | null;
   desktopRedirectBusy: boolean;
   showAuthFeedback: boolean;
-  continueSignInWithEmail: () => Promise<boolean>;
   submitAuth: (event: FormEvent<HTMLFormElement>) => Promise<AuthNavigationResult>;
   submitVerificationCode: (event: FormEvent<HTMLFormElement>) => Promise<AuthNavigationResult>;
   resendVerificationCode: () => Promise<void>;
@@ -395,38 +394,6 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     nextUrl.searchParams.set("loginHint", trimmedEmail);
     window.location.assign(nextUrl.toString());
     return true;
-  }
-
-  async function continueSignInWithEmail() {
-    const trimmedEmail = email.trim();
-    if (!trimmedEmail) {
-      setAuthError("Enter your email to continue.");
-      return false;
-    }
-
-    setAuthBusy(true);
-    setAuthError(null);
-    setAuthInfo("Checking your workspace sign-in settings...");
-    trackPosthogEvent("den_auth_submitted", {
-      mode: "sign-in",
-      method: "email_next",
-      email_domain: getEmailDomain(trimmedEmail),
-    });
-
-    try {
-      if (await redirectToRequiredSso(trimmedEmail)) {
-        return false;
-      }
-
-      setAuthInfo("Enter your password to finish signing in.");
-      return true;
-    } catch (error) {
-      setAuthError(error instanceof Error ? error.message : "Could not check workspace sign-in settings.");
-      setAuthInfo(getAuthInfoForMode("sign-in"));
-      return false;
-    } finally {
-      setAuthBusy(false);
-    }
   }
 
   async function finalizeEmailPasswordSignIn(
@@ -2080,7 +2047,6 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     desktopRedirectUrl,
     desktopRedirectBusy,
     showAuthFeedback,
-    continueSignInWithEmail,
     submitAuth,
     submitVerificationCode,
     resendVerificationCode,


### PR DESCRIPTION
## What & why

When a user clicks **"Sign in"** in the desktop app they land on the web login already forced into sign-in mode (`?mode=sign-in`). A **new** user then had no obvious way to create an account — the switch was buried at the bottom — so people got stuck. The screen also had a lot going on (animated hero + feature cards + an extra email-first step).

This PR fixes the trap and gives the login a cleaner, standard flow.

## Changes

**Web login (`ee/apps/den-web`)**
- Always-visible **Sign in / Create account** toggle at the top of the form — one tap to switch, so nobody gets stuck. `?mode=` now just preselects a tab instead of locking it.
- Removed the redundant **email-first sign-in step** (`continueSignInWithEmail`). SSO enforcement is unchanged — `submitAuth` and `beginSocialAuth` already call `redirectToRequiredSso` on every path, before any credential is accepted.
- **GitHub + Google** now show in both modes (GitHub was previously hidden in sign-in mode).
- Rebuilt as a single split card: gradient/brand panel (2/3) + form (1/3). On **mobile** the gradient is hidden and only the form shows, with an OpenWork logo header.
- Card height stays fixed when toggling modes. Removed now-unused toggle-copy props on the invite/claim screens.

**Desktop app (`apps/app`)**
- The standalone **"Sign in"** buttons (full-screen sign-in, chat status bar, Skills page) now open the **sign-up** tab (label unchanged), so new users aren't defaulted into sign-in; returning users just tap the toggle. Screens that already show a separate "Create account" button (Settings → Cloud, compact strip) are unchanged.

## Safety / testing
- **SSO enforcement verified preserved** across email/password, GitHub, and Google paths (plus the existing server-side backstop in `den-api`).
- OTP verification, password reset, invite, workspace-claim, and desktop-handoff flows all intact.
- Type-checks pass for both `den-web` and `apps/app`. No automated UI tests exist for this screen, so verification was type-check + two independent code reviews + a live click-through in the real Electron desktop app.

## Note
This branch spans **two areas** (web login + desktop buttons) on purpose — they're one change: the desktop buttons only make sense now that the web page has the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
