### PR TITLE
Voice-over-first demo-driven DX: script as spec, scaffold, drift check, fraimz on PR

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -1,0 +1,40 @@
+name: Warden
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+# contents: write required for resolving review threads via GraphQL
+# See: https://github.com/orgs/community/discussions/44650
+permissions:
+  contents: write
+  pull-requests: write
+  checks: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    env:
+      WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
+      WARDEN_SENTRY_DSN: ${{ secrets.WARDEN_SENTRY_DSN }}
+      # Add the WARDEN_<PROVIDER>_API_KEY that matches your WARDEN_MODEL provider:
+      WARDEN_OPENAI_API_KEY: ${{ secrets.WARDEN_OPENAI_API_KEY }}
+      WARDEN_ANTHROPIC_API_KEY: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
+      # WARDEN_FIREWORKS_API_KEY: ${{ secrets.WARDEN_FIREWORKS_API_KEY }}
+      # WARDEN_OPENROUTER_API_KEY: ${{ secrets.WARDEN_OPENROUTER_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Analyze
+        id: warden-analyze
+        uses: getsentry/warden@v0
+        with:
+          mode: analyze
+
+      - name: Report
+        uses: getsentry/warden@v0
+        with:
+          mode: report
+          findings-file: ${{ steps.warden-analyze.outputs.findings-file }}

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ transcript-analysis
 # Eval runner output
 evals/results/
 .playwright-mcp/
+.warden/

--- a/.opencode/commands/fraimz.md
+++ b/.opencode/commands/fraimz.md
@@ -19,12 +19,16 @@ Run the full loop, in order, and stop on any failure:
 
 1. **Frame the experience** as a one-line claim ("user can do X and sees Y").
    State it back before proceeding.
-2. **Create or pick the eval.** If no coded flow covers it, write one in
-   `evals/flows/<id>.flow.mjs` using the `ctx.*` helpers (`clickText`, `fill`,
-   `control`, `waitFor`, `expectText`, `prove`, `screenshot`). The end user is
-   the protagonist (drive via CDP). REST/DB/filesystem checks are ONLY how you
-   witness the expected side effects — never the thing being tested. Every
-   meaningful step must use `ctx.prove("claim", { action, assert, screenshot })`.
+2. **Create or pick the eval.** If an approved voice-over script exists at
+   `evals/voiceovers/<id>.md` (see the `voiceover` skill / `/voiceover`),
+   generate the flow from it: `pnpm fraimz scaffold <id>` — narration is wired
+   to the script and the runner fails the flow if it drifts. Otherwise write
+   one in `evals/flows/<id>.flow.mjs` using the `ctx.*` helpers (`clickText`,
+   `fill`, `control`, `waitFor`, `expectText`, `prove`, `screenshot`). The end
+   user is the protagonist (drive via CDP). REST/DB/filesystem checks are ONLY
+   how you witness the expected side effects — never the thing being tested.
+   Every meaningful step must use
+   `ctx.prove("claim", { voiceover, action, assert, screenshot })`.
 3. **Drive it for real.** Launch the app (Daytona preferred via
    `bash .devcontainer/test-on-daytona.sh`, local Electron `pnpm dev` as
    fallback), then run:
@@ -34,9 +38,10 @@ Run the full loop, in order, and stop on any failure:
    route, error state, missing text, stale dialog, duplicate image), fix the
    visible state or the code and rerun until every claim has a passing
    assertion and a valid screenshot.
-5. **Output fraimz.** The run writes `fraimz.html` (frame proof) plus
-   `report.md` / `report.json` to `evals/results/<run-id>/`. Report the path to
-   `fraimz.html` as the headline deliverable.
+5. **Output fraimz — on the PR when one exists.** The run writes `fraimz.html`
+   (frame proof) plus `report.md` / `report.json` to `evals/results/<run-id>/`.
+   Report the path to `fraimz.html` as the headline deliverable, and post the
+   proof as a PR comment with `pnpm fraimz --flow <id> --pr [number]`.
 6. **Verdict.** `Passed` only when the proof exists and every claim is backed by
    an observable assertion in the frames. Otherwise report `Incomplete` or
    `Failed`, honestly, with repro steps. If the app could not run (no model,

--- a/.opencode/commands/voiceover.md
+++ b/.opencode/commands/voiceover.md
@@ -1,0 +1,26 @@
+---
+description: Start a feature the demo-driven way — align on the demo voice-over (instead of a PRD) before any code
+---
+
+You are starting the **voice-over alignment phase** of demo-driven development.
+The voice-over is the spec: the narration the user would record over a demo if
+the feature had already shipped. **No code until the script is approved.**
+
+Arguments: `$ARGUMENTS` — the feature, in a sentence. If empty, ask for one.
+
+Load the **`voiceover` skill** and follow its loop:
+
+1. Draft the demo script end to end — one numbered paragraph per frame,
+   spoken style, the end user as protagonist, what the viewer sees and why it
+   matters. If a frame is hard to narrate, the feature is wrong: say so.
+2. Iterate on the words with the user until they would actually record it.
+3. On approval, land it at `evals/voiceovers/<flow-id>.md` and run
+   `pnpm fraimz scaffold <flow-id>` to generate the flow stub (one `ctx.prove`
+   per paragraph, narration wired to the script; the runner fails the flow if
+   narration ever drifts from the file).
+4. Hand off to the `fraimz` skill: build the feature and re-enact the demo
+   until every frame holds, then put the proof on the PR with
+   `pnpm fraimz --flow <flow-id> --pr`.
+
+Do not write feature code, and do not scaffold, before the user has approved
+the script.

--- a/.opencode/skills/fraimz/SKILL.md
+++ b/.opencode/skills/fraimz/SKILL.md
@@ -29,6 +29,10 @@ the flow declares which via `kind` in `evals/flows/<id>.flow.mjs`:
   perf improvements, storage swaps, invariants, refactors. The frames
   demonstrate the internal claim (timings before/after, unchanged core flow,
   identical output) in a way a reviewer can still follow frame by frame.
+  Internal demos of terminal/tooling experiences may set `requiresApp: false`
+  to run without a CDP connection; their frames are claims + assertions +
+  recorded command output (`ctx.output`) instead of screenshots (see
+  `evals/flows/voiceover-first-dx.flow.mjs`).
 
 If you cannot say which of the two your fraimz is, you have not framed the
 experience yet — go back to step 1 of the loop.
@@ -42,9 +46,14 @@ video. The runner renders it on each frame in `fraimz.html` with a play button
 
 Rules:
 
-- **Write the voiceover script before coding the flow.** Narrate the whole demo
-  end to end (one paragraph per frame), state it back, and only then translate
-  each paragraph into a `ctx.prove` step. If a step is hard to narrate, the
+- **Write the voiceover script before coding the flow — ideally before the
+  feature.** The script is the spec (the PRD replacement): align on it with
+  the user via the **`voiceover` skill** / `/voiceover` command, then land it
+  at `evals/voiceovers/<flow-id>.md` (numbered paragraphs = frames) and
+  generate the flow from it with `pnpm fraimz scaffold <flow-id>`. Flows load
+  their narration from the script (`loadVoiceoverParagraphs`), and the runner
+  **fails any flow whose narration drifts** from the approved file (missing
+  scripted frames or unapproved lines). If a step is hard to narrate, the
   step is wrong.
 - Every `ctx.prove` must pass `voiceover`. Frames without one are flagged
   ("No voiceover for this frame") in the artifact — treat that flag as a
@@ -83,11 +92,13 @@ changes with no runtime path may skip — but say so explicitly.
    route, error state, missing text, stale dialog, duplicate image, missing
    voiceover), fix the visible state or the code and rerun until every claim
    has a passing assertion, a narrated voiceover, and a valid screenshot.
-6. **Output fraimz + verdict.** The run writes `fraimz.html` plus
-   `report.md` / `report.json` to `evals/results/<run-id>/`. Report the path to
-   `fraimz.html` as the headline deliverable. Report `Passed` only when fraimz
-   exists and every claim is backed by an observable assertion; otherwise
-   `Incomplete` / `Failed`, stated honestly with repro steps.
+6. **Output fraimz + verdict — on the PR.** The run writes `fraimz.html` plus
+   `report.md` / `report.json` to `evals/results/<run-id>/`. When a PR exists,
+   post the proof on it: `pnpm fraimz --flow <id> --pr [number]` renders the
+   frames (verdict, claims, voiceovers, assertions) as a PR comment via `gh`
+   (`--pr` alone targets the current branch's PR). Report `Passed` only when
+   fraimz exists and every claim is backed by an observable assertion;
+   otherwise `Incomplete` / `Failed`, stated honestly with repro steps.
 
 ## The canonical core flow
 
@@ -167,6 +178,9 @@ Keep this skill as the loop. The deeper mechanics live in:
 
 - `evals/README.md` — runner, flags, conventions, full `ctx.*` reference.
 - `evals/flows/` — existing coded flows to reuse or pattern-match.
+- `evals/voiceovers/` + `evals/runner/voiceover.mjs` — approved scripts,
+  parser, drift check, scaffolder; the `voiceover` skill owns the alignment
+  phase before any code.
 - Skills: `run-evals` (launch + run), `daytona-flow-validator` (observe → act →
   assert → repair → verdict), `daytona-electron-test`,
   `daytona-recording-artifacts` (optional video).

--- a/.opencode/skills/voiceover/SKILL.md
+++ b/.opencode/skills/voiceover/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: voiceover
+description: write the voice-over, demo script first, voiceover instead of PRD, align on the demo, script the demo, demo-driven development intake. The alignment phase of demo-driven development — draft and approve the demo narration BEFORE any code, land it as evals/voiceovers/<id>.md, then scaffold the flow from it. Use when a feature request arrives, or when the user runs /voiceover.
+---
+
+# Skill: voiceover
+
+The voice-over is the spec. Instead of a PRD, a feature starts as the demo
+narration the user would record if the feature had already shipped. This skill
+owns the alignment phase that precedes all implementation.
+
+**The contract: no code until the script is approved.**
+
+## The loop
+
+1. **Take the feature in a sentence.** Ask only what you need to narrate a
+   demo of it.
+2. **Draft the script.** Write the voice-over end to end — one numbered
+   paragraph per frame, 4–8 frames for most features. Spoken style, present
+   tense, the end user as protagonist. Describe what the viewer sees and why
+   it matters, never implementation. If a frame is hard to narrate, the
+   feature (or the frame) is wrong — say so and reshape it.
+3. **Iterate on words, not code.** State the script back and revise with the
+   user until they would actually record it. This conversation is the review
+   that used to happen on a PRD.
+4. **Land the script.** Write it to `evals/voiceovers/<flow-id>.md`:
+   a title, optional context prose, then the numbered frame paragraphs. From
+   this point the file is what the code gets held to — the runner fails any
+   flow whose narration drifts from it.
+5. **Scaffold the flow.** `pnpm fraimz scaffold <flow-id>` generates
+   `evals/flows/<flow-id>.flow.mjs` with one `ctx.prove` stub per paragraph,
+   narration pre-wired via `loadVoiceoverParagraphs`. Do not renumber or
+   reword paragraphs after this without re-approval.
+6. **Hand off to the fraimz skill.** Build the feature and drive the demo
+   (sandbox preferred, local Electron fallback) until every frame holds; the
+   fraimz loop owns validate/repair/verdict and posting the proof on the PR
+   (`pnpm fraimz --flow <id> --pr`).
+
+## Script format
+
+```markdown
+# <flow-id> — <one-line claim>
+
+Optional context prose (not narrated).
+
+1. First frame narration, one or two spoken sentences.
+
+2. Second frame narration.
+```
+
+Only numbered paragraphs become frames. Keep each to one or two sentences a
+human could speak over the screen while it shows exactly that state.
+
+## Source of truth
+
+- `evals/runner/voiceover.mjs` — parser, drift check, scaffolder.
+- `evals/voiceovers/voiceover-first-dx.md` — the reference script (this
+  workflow demoing itself).
+- The `fraimz` skill — everything after the script is approved.

--- a/evals/README.md
+++ b/evals/README.md
@@ -46,6 +46,31 @@ pnpm fraimz --flow <id>           # same runner; headline output is fraimz.html
 pnpm fraimz --flow core-flow --cdp-url http://127.0.0.1:9825
 ```
 
+### Voice-over first: the script is the spec
+
+Demo-driven development starts with the narration, not a PRD. The `/voiceover`
+command (and `voiceover` skill) aligns on the demo script with the user before
+any code; the approved script lands at `evals/voiceovers/<flow-id>.md` — a
+title, optional context prose, and one **numbered paragraph per frame**.
+
+```bash
+pnpm fraimz scaffold <flow-id>    # generate evals/flows/<flow-id>.flow.mjs
+                                  # from the approved script: one ctx.prove
+                                  # stub per paragraph, narration pre-wired
+pnpm fraimz --flow <flow-id> --pr # after the run, post the frame proof as a
+                                  # PR comment via gh (--pr <number> to target)
+```
+
+Flows load their narration with `loadVoiceoverParagraphs(<flow-id>)`; when a
+script exists for a flow, the runner appends a **Voice-over script coverage**
+step that fails the flow if the run's narration drifts from the approved file
+(a scripted frame never narrated, or an unapproved line narrated).
+
+Internal demos of terminal/tooling experiences can set `requiresApp: false` to
+run without a CDP endpoint; their frames carry claims, assertions, and
+`ctx.output(name, text)` command output instead of screenshots. The reference
+is `voiceover-first-dx` — this workflow demoing itself.
+
 The runner probes `http://127.0.0.1:9825` (Daytona) then `:9823` (local
 `pnpm dev`) by default. Flows that need cloud credentials declare
 `requiredEnv` and are skipped (not failed) when the env is missing — e.g.

--- a/evals/flows/voiceover-first-dx.flow.mjs
+++ b/evals/flows/voiceover-first-dx.flow.mjs
@@ -1,0 +1,211 @@
+/**
+ * Internal demo: demo-driven development demoing itself.
+ *
+ * Proves the voice-over-first DX end to end: the /voiceover entry point, the
+ * "script before code" contract, the approved script as a checked-in artifact,
+ * scaffolding + drift detection, the fraimz PR comment, and the merge-blocking
+ * exit-code contract. Runs app-less (requiresApp: false): the protagonist is a
+ * developer in a terminal, so evidence is claims + assertions + real command
+ * output instead of screenshots.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs, voiceoverScriptPath } from "../runner/voiceover.mjs";
+import { renderPrComment } from "../runner/pr.mjs";
+
+const FLOW_ID = "voiceover-first-dx";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const RUNNER = join(ROOT, "evals", "runner", "run.mjs");
+
+// Narration comes from the approved script; the runner's coverage step fails
+// this flow if these lines ever drift from evals/voiceovers/voiceover-first-dx.md.
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const exists = (path) => access(path).then(() => true, () => false);
+
+/** Assert + record, so every check shows up as evidence in the frame. */
+function witness(ctx, condition, assertion, actual) {
+  if (!condition) {
+    ctx.recordEvidence({ type: "assertion", status: "failed", assertion, actual });
+    ctx.assert(false, assertion + (actual ? ` (actual: ${actual})` : ""));
+  }
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion, actual });
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Demo-driven development: voice-over instead of PRD, agents build until the demo holds",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "A feature starts with the /voiceover command, not a PRD",
+      run: async (ctx) => {
+        await ctx.prove("The /voiceover entry point exists and takes the feature as its argument", {
+          voiceover: vo[0],
+          assert: async () => {
+            const commandPath = join(ROOT, ".opencode", "commands", "voiceover.md");
+            witness(ctx, await exists(commandPath), ".opencode/commands/voiceover.md exists");
+            const command = await readFile(commandPath, "utf8");
+            witness(ctx, command.includes("$ARGUMENTS"), "The command takes the feature description as $ARGUMENTS");
+            witness(ctx, command.toLowerCase().includes("instead of a prd"), "The command frames the voice-over as the PRD replacement");
+            ctx.output(".opencode/commands/voiceover.md", command.split("\n").slice(0, 12).join("\n"));
+          },
+        });
+      },
+    },
+    {
+      name: "The voiceover skill drives alignment on words, not code",
+      run: async (ctx) => {
+        await ctx.prove("The skill's contract is explicit: no code until the script is approved", {
+          voiceover: vo[1],
+          assert: async () => {
+            const skillPath = join(ROOT, ".opencode", "skills", "voiceover", "SKILL.md");
+            witness(ctx, await exists(skillPath), ".opencode/skills/voiceover/SKILL.md exists");
+            const skill = (await readFile(skillPath, "utf8")).replace(/\s+/g, " ");
+            witness(ctx, skill.toLowerCase().includes("no code until the script is approved"), "Skill states the contract: no code until the script is approved");
+            witness(ctx, skill.includes("one numbered paragraph per frame"), "Skill defines the script format (one numbered paragraph per frame)");
+            ctx.output("The contract", skill.split("\n").filter((line) => line.includes("contract") || line.includes("Iterate on words")).join("\n"));
+          },
+        });
+      },
+    },
+    {
+      name: "The approved script is a checked-in artifact the code is held to",
+      run: async (ctx) => {
+        await ctx.prove("evals/voiceovers/<id>.md exists and parses into the demo's frames", {
+          voiceover: vo[2],
+          assert: async () => {
+            const scriptPath = voiceoverScriptPath(FLOW_ID);
+            witness(ctx, await exists(scriptPath), "The approved script exists at evals/voiceovers/voiceover-first-dx.md");
+            witness(ctx, vo.length === 6, "The script parses into exactly 6 frame paragraphs", String(vo.length));
+            witness(ctx, vo[0].includes("PRD"), "Frame 1 names the thing it replaces (the PRD)");
+            ctx.output("evals/voiceovers/voiceover-first-dx.md", await readFile(scriptPath, "utf8"));
+          },
+        });
+      },
+    },
+    {
+      name: "Scaffold turns the script into proof steps; narration drift fails the run",
+      run: async (ctx) => {
+        const scaffoldId = "_scaffold-demo";
+        const scaffoldScript = voiceoverScriptPath(scaffoldId);
+        const flowsDir = await mkdtemp(join(tmpdir(), "fraimz-scaffold-"));
+        try {
+          await ctx.prove("One ctx.prove stub per paragraph, narration wired to the script file", {
+            voiceover: vo[3],
+            action: async () => {
+              await writeFile(scaffoldScript, "# _scaffold-demo — fixture\n\n1. First fixture frame.\n\n2. Second fixture frame.\n");
+            },
+            assert: async () => {
+              const scaffold = spawnSync(process.execPath, [RUNNER, "scaffold", scaffoldId], {
+                encoding: "utf8",
+                env: { ...process.env, OPENWORK_EVAL_FLOWS_DIR: flowsDir },
+              });
+              witness(ctx, scaffold.status === 0, "pnpm fraimz scaffold <id> exits 0", scaffold.stderr?.trim() || String(scaffold.status));
+              ctx.output("$ pnpm fraimz scaffold _scaffold-demo", scaffold.stdout.trim());
+              const stub = await readFile(join(flowsDir, `${scaffoldId}.flow.mjs`), "utf8");
+              witness(ctx, (stub.match(/ctx\.prove\(/g) ?? []).length === 2, "The generated flow has one ctx.prove per script paragraph");
+              witness(ctx, stub.includes("loadVoiceoverParagraphs"), "The generated flow loads its narration from the script file");
+              // Drift, end to end: a flow that skips a scripted frame and
+              // narrates an unapproved line must fail the real runner.
+              await writeFile(join(flowsDir, `${scaffoldId}.flow.mjs`), `export default {
+  id: ${JSON.stringify(scaffoldId)},
+  title: "Drifted narration fixture",
+  kind: "internal",
+  requiresApp: false,
+  steps: [{ name: "Narrates a drifted line", run: async (ctx) => {
+    await ctx.prove("frame 1", { voiceover: "First fixture frame." });
+    await ctx.prove("frame 2", { voiceover: "A line nobody approved." });
+  } }],
+};
+`);
+              const drifted = spawnSync(process.execPath, [RUNNER, "--flow", scaffoldId, "--out", flowsDir], {
+                encoding: "utf8",
+                env: { ...process.env, OPENWORK_EVAL_FLOWS_DIR: flowsDir },
+                timeout: 60_000,
+              });
+              witness(ctx, drifted.status === 1, "A flow whose narration drifts from the approved script fails the run", String(drifted.status));
+              witness(ctx, drifted.stdout.includes("Voice-over script coverage"), "The failure is attributed to the voice-over coverage step");
+              ctx.output("$ pnpm fraimz --flow _scaffold-demo (drifted fixture)", drifted.stdout.trim().split("\n").slice(-7).join("\n"));
+            },
+          });
+        } finally {
+          await rm(scaffoldScript, { force: true });
+          await rm(flowsDir, { recursive: true, force: true });
+        }
+      },
+    },
+    {
+      name: "The fraimz lands on the PR as the reviewable demo",
+      run: async (ctx) => {
+        await ctx.prove("pnpm fraimz --flow <id> --pr renders the frame-by-frame proof as a PR comment", {
+          voiceover: vo[4],
+          assert: async () => {
+            const body = renderPrComment({
+              runId: "demo-run",
+              summary: { passed: 1, failed: 0, skipped: 0 },
+              flows: [{
+                id: FLOW_ID,
+                title: "Demo-driven development",
+                kind: "internal",
+                status: "passed",
+                steps: [{
+                  status: "passed",
+                  evidence: [
+                    { type: "claim", status: "passed", claim: "The demo holds", voiceover: vo[4] },
+                    { type: "assertion", status: "passed", assertion: "Observable side effect witnessed" },
+                  ],
+                }],
+              }],
+            });
+            witness(ctx, body.includes("## fraimz — ✅ PASSED"), "The comment leads with the verdict");
+            witness(ctx, body.includes(`🎙 ${vo[4]}`), "Each frame carries its voice-over line");
+            witness(ctx, body.includes("Observable side effect witnessed"), "Each frame lists its passing assertions");
+            ctx.output("pr-comment.md (rendered)", body);
+          },
+        });
+      },
+    },
+    {
+      name: "A red demo is a failing run — and a failing run blocks the merge",
+      run: async (ctx) => {
+        const flowsDir = await mkdtemp(join(tmpdir(), "fraimz-red-"));
+        const outDir = await mkdtemp(join(tmpdir(), "fraimz-red-out-"));
+        try {
+          await ctx.prove("The runner exits non-zero when any frame fails, while still writing the fraimz", {
+            voiceover: vo[5],
+            action: async () => {
+              await writeFile(join(flowsDir, "_red-demo.flow.mjs"), `export default {
+  id: "_red-demo",
+  title: "Deliberately red demo (fixture)",
+  kind: "internal",
+  requiresApp: false,
+  steps: [{ name: "This frame fails", run: async (ctx) => { ctx.assert(false, "red on purpose"); } }],
+};
+`);
+            },
+            assert: async () => {
+              const run = spawnSync(process.execPath, [RUNNER, "--flow", "_red-demo", "--out", outDir], {
+                encoding: "utf8",
+                env: { ...process.env, OPENWORK_EVAL_FLOWS_DIR: flowsDir },
+                timeout: 60_000,
+              });
+              witness(ctx, run.status === 1, "A failing frame makes the run exit 1 (the signal a required check consumes)", String(run.status));
+              witness(ctx, run.stdout.includes("Result: FAILED"), "The verdict is stated honestly");
+              const [redRunId] = run.stdout.match(/[\d-]+T[\dZ-]+/) ?? [];
+              witness(ctx, Boolean(redRunId) && (await exists(join(outDir, redRunId, "fraimz.html"))), "The fraimz is still written for a red run, so the failure is reviewable");
+              ctx.output("$ pnpm fraimz --flow _red-demo (fixture)", run.stdout.trim().split("\n").slice(-6).join("\n"));
+            },
+          });
+        } finally {
+          await rm(flowsDir, { recursive: true, force: true });
+          await rm(outDir, { recursive: true, force: true });
+        }
+      },
+    },
+  ],
+};

--- a/evals/runner/context.mjs
+++ b/evals/runner/context.mjs
@@ -117,7 +117,15 @@ export class EvalContext {
         : options.screenshot;
       await this.screenshot(screenshot.name ?? slug(name), { claim, voiceover, ...screenshot });
     }
-    this.recordEvidence({ type: "claim", status: "passed", name, claim, voiceover });
+    // When a screenshot frame carries the narration, leave it off the completed
+    // claim so fraimz.html narrates each frame exactly once (app-less proves
+    // narrate via the claim instead).
+    this.recordEvidence({ type: "claim", status: "passed", name, claim, voiceover: options?.screenshot ? "" : voiceover });
+  }
+
+  /** Record a terminal/API output as reviewable evidence (rendered as a code block). */
+  output(name, text) {
+    return this.recordEvidence({ type: "output", name, text: String(text) });
   }
 
   /**

--- a/evals/runner/pr.mjs
+++ b/evals/runner/pr.mjs
@@ -1,0 +1,67 @@
+/**
+ * fraimz on the PR: render the frame-by-frame proof as a PR comment and post
+ * it with `gh`. The comment is the reviewable demo (verdict + per-frame claim,
+ * voiceover, assertions); `fraimz.html` in the run directory stays the full
+ * artifact with validated screenshots.
+ */
+import { spawnSync } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export function renderPrComment(report) {
+  const verdict = report.summary.failed > 0 ? "❌ FAILED" : "✅ PASSED";
+  const lines = [
+    `## fraimz — ${verdict}`,
+    "",
+    `${report.summary.passed} passed · ${report.summary.failed} failed · ${report.summary.skipped} skipped — run \`${report.runId}\``,
+    "",
+    `Full frame proof with validated screenshots: \`evals/results/${report.runId}/fraimz.html\` (re-run: \`pnpm fraimz ${report.flows.map((flow) => `--flow ${flow.id}`).join(" ")}\`)`,
+    "",
+  ];
+  for (const flow of report.flows) {
+    const icon = flow.status === "passed" ? "✅" : flow.status === "skipped" ? "⏭️" : "❌";
+    lines.push(`### ${icon} ${flow.id} — ${flow.title}`);
+    if (flow.kind) lines.push(`_${flow.kind === "user-facing" ? "User-facing flow demo" : "Internal demo"}_`);
+    if (flow.skipReason) lines.push(`Skipped: ${flow.skipReason}`);
+    lines.push("");
+    let frame = 0;
+    for (const step of flow.steps ?? []) {
+      for (const evidence of step.evidence ?? []) {
+        if (evidence.type === "claim" && evidence.status === "passed") {
+          frame += 1;
+          lines.push(`${frame}. **${evidence.claim ?? evidence.name}**`);
+          if (evidence.voiceover) lines.push(`   > 🎙 ${evidence.voiceover}`);
+        }
+        if (evidence.type === "assertion") {
+          lines.push(`   - ${evidence.status === "passed" ? "✅" : "❌"} ${evidence.assertion}`);
+        }
+        if (evidence.type === "frame") {
+          const failed = (evidence.validations ?? []).filter((validation) => !validation.passed);
+          lines.push(
+            `   - 📸 \`${evidence.file}\` — ${failed.length === 0 ? `${(evidence.validations ?? []).length} validations passed` : `FAILED: ${failed.map((validation) => validation.label).join(", ")}`}`,
+          );
+        }
+      }
+      if (step.status === "failed") lines.push(`   - ❌ **${step.name}** — ${step.error}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Post the comment with `gh pr comment`. `prNumber` may be null: gh then
+ * targets the PR of the current branch. Returns { posted, detail }.
+ */
+export async function postPrComment(report, { outDir, prNumber = null } = {}) {
+  const body = renderPrComment(report);
+  const bodyPath = join(outDir, "pr-comment.md");
+  await writeFile(bodyPath, body);
+  const args = ["pr", "comment", ...(prNumber ? [String(prNumber)] : []), "--body-file", bodyPath];
+  const result = spawnSync("gh", args, { encoding: "utf8" });
+  if (result.error || result.status !== 0) {
+    const detail = result.error?.message ?? result.stderr?.trim() ?? `gh exited ${result.status}`;
+    return { posted: false, bodyPath, detail };
+  }
+  return { posted: true, bodyPath, detail: result.stdout.trim() };
+}

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -24,14 +24,16 @@ import { pathToFileURL, fileURLToPath } from "node:url";
 import { connect, debuggerUrlFor, pickAppTarget, resolveCdpBaseUrl } from "./cdp.mjs";
 import { EvalContext } from "./context.mjs";
 import { denStackDown, ensureDenStack } from "./den-stack.mjs";
+import { checkVoiceoverCoverage, loadVoiceoverParagraphs, scaffoldFlow } from "./voiceover.mjs";
+import { postPrComment } from "./pr.mjs";
 
 const RUNNER_DIR = dirname(fileURLToPath(import.meta.url));
-const FLOWS_DIR = join(RUNNER_DIR, "..", "flows");
+const FLOWS_DIR = process.env.OPENWORK_EVAL_FLOWS_DIR?.trim() || join(RUNNER_DIR, "..", "flows");
 const DEFAULT_RESULTS_DIR = join(RUNNER_DIR, "..", "results");
 const DEFAULT_CDP_CANDIDATES = ["http://127.0.0.1:9825", "http://127.0.0.1:9823"];
 
 function parseArgs(argv) {
-  const args = { flows: [], all: false, list: false, cdpUrl: null, out: null, stack: null, stackDown: false };
+  const args = { flows: [], all: false, list: false, cdpUrl: null, out: null, stack: null, stackDown: false, scaffold: null, force: false, pr: null };
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
     if (value === "--flow") args.flows.push(argv[++index]);
@@ -41,7 +43,17 @@ function parseArgs(argv) {
     else if (value === "--out") args.out = argv[++index];
     else if (value === "--stack") args.stack = argv[++index];
     else if (value === "--stack-down") args.stackDown = true;
-    else if (value === "--help" || value === "-h") args.help = true;
+    else if (value === "scaffold") args.scaffold = argv[++index];
+    else if (value === "--force") args.force = true;
+    else if (value === "--pr") {
+      const next = argv[index + 1];
+      if (next && /^\d+$/.test(next)) {
+        args.pr = next;
+        index += 1;
+      } else {
+        args.pr = true;
+      }
+    } else if (value === "--help" || value === "-h") args.help = true;
     else throw new Error(`Unknown argument: ${value}`);
   }
   return args;
@@ -88,15 +100,21 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
     return result;
   }
 
-  const target = await pickAppTarget(cdpBaseUrl);
-  const client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+  // Flows with `requiresApp: false` (e.g. DX/tooling demos) run without a CDP
+  // connection: their frames are claims + assertions + recorded outputs.
+  const requiresApp = flow.requiresApp !== false;
+  let client = null;
+  if (requiresApp) {
+    const target = await pickAppTarget(cdpBaseUrl);
+    client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+  }
   const ctx = new EvalContext({ client, outDir, flowId: flow.id, env });
 
   try {
     // Force light mode by default so screenshot evidence is readable. Flows
     // that are themselves testing theme/dark-mode behavior can opt out with
     // `preserveTheme: true` in the flow definition.
-    if (!flow.preserveTheme) {
+    if (requiresApp && !flow.preserveTheme) {
       try {
         await ctx.ensureLightMode();
       } catch (error) {
@@ -121,7 +139,7 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
           durationMs: Date.now() - startedAt,
           error: error instanceof Error ? error.message : String(error),
         });
-        await ctx.screenshot("failure").catch(() => undefined);
+        if (client) await ctx.screenshot("failure").catch(() => undefined);
         return result;
       }
     }
@@ -141,15 +159,47 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
       stepResult.durationMs = Date.now() - startedAt;
       result.steps.push(stepResult);
       if (stepResult.status === "failed") {
-        await ctx.screenshot("failure").catch(() => undefined);
+        if (client) await ctx.screenshot("failure").catch(() => undefined);
         break;
+      }
+    }
+
+    // Voice-over drift check: when an approved script exists for this flow
+    // (evals/voiceovers/<id>.md), every scripted paragraph must have been
+    // narrated by the run, and the run must not narrate unapproved lines.
+    if (result.status === "passed") {
+      const paragraphs = await loadVoiceoverParagraphs(flow.id);
+      if (paragraphs) {
+        const recorded = new Set();
+        for (const step of result.steps) {
+          for (const evidence of step.evidence ?? []) {
+            if (evidence.voiceover) recorded.add(evidence.voiceover);
+          }
+        }
+        const coverage = checkVoiceoverCoverage(paragraphs, [...recorded]);
+        const evidence = paragraphs.map((paragraph, index) => ({
+          type: "assertion",
+          status: coverage.missing.includes(paragraph) ? "failed" : "passed",
+          assertion: `Script frame ${index + 1} narrated: ${JSON.stringify(paragraph.slice(0, 88))}`,
+        }));
+        for (const line of coverage.extra) {
+          evidence.push({ type: "assertion", status: "failed", assertion: `Narration not in the approved script: ${JSON.stringify(line.slice(0, 88))}` });
+        }
+        result.steps.push({
+          name: "Voice-over script coverage",
+          status: coverage.ok ? "passed" : "failed",
+          durationMs: 0,
+          error: coverage.ok ? null : `Narration drifted from evals/voiceovers/${flow.id}.md (${coverage.missing.length} missing, ${coverage.extra.length} unapproved).`,
+          evidence,
+        });
+        if (!coverage.ok) result.status = "failed";
       }
     }
   } finally {
     result.screenshots = ctx.screenshots;
     result.evidenceFrames = ctx.evidenceFrames;
     result.logs = ctx.logs;
-    client.close();
+    client?.close();
   }
 
   return result;
@@ -264,6 +314,7 @@ function renderFrameIndex(report) {
     .failed-text, .error { color: #b42318; font-weight: 700; }
     .skipped { color: #8a5a00; }
     code { background: #ededf0; padding: 2px 5px; border-radius: 5px; }
+    pre.output { margin: 0; padding: 12px; background: #16181d; color: #d6e2f0; font-size: 12.5px; line-height: 1.5; overflow-x: auto; border-radius: 0 0 12px 12px; }
   </style>
 </head>
 <body>
@@ -321,7 +372,15 @@ function renderEvidence(evidence) {
   if (evidence.length === 0) return `<p class="muted">No structured evidence recorded for this step.</p>`;
   return `<div class="evidence">${evidence.map((item) => {
     if (item.type === "claim") {
-      return `<div class="claim"><strong>${escapeHtml(item.name ?? "Claim")}</strong><br />${escapeHtml(item.claim ?? "")}</div>`;
+      // App-less frames (requiresApp: false) have no screenshot figure, so the
+      // completed claim carries the narration instead.
+      const voiceover = item.status === "passed" && item.voiceover
+        ? `<div class="voiceover" data-voiceover="${escapeHtml(item.voiceover)}"><button type="button" class="speak" title="Play voiceover">🎙 Play</button><span>${escapeHtml(item.voiceover)}</span></div>`
+        : "";
+      return `<div class="claim"><strong>${escapeHtml(item.name ?? "Claim")}</strong><br />${escapeHtml(item.claim ?? "")}</div>${voiceover}`;
+    }
+    if (item.type === "output") {
+      return `<figure><figcaption><strong>${escapeHtml(item.name ?? "Output")}</strong></figcaption><pre class="output">${escapeHtml(item.text ?? "")}</pre></figure>`;
     }
     if (item.type === "assertion") {
       const cls = item.status === "passed" ? "passed-text" : "failed-text";
@@ -352,12 +411,19 @@ function renderEvidence(evidence) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
-    console.log("Usage: node evals/runner/run.mjs [--list | --all | --flow <id> ...] [--cdp-url <url>] [--out <dir>] [--stack den | --stack-down]");
+    console.log("Usage: node evals/runner/run.mjs [--list | --all | --flow <id> ... | scaffold <id> [--force]] [--cdp-url <url>] [--out <dir>] [--pr [number]] [--stack den | --stack-down]");
     return;
   }
 
   if (args.stackDown) {
     await denStackDown({ log: (msg) => console.log(`▸ ${msg}`) });
+    return;
+  }
+
+  if (args.scaffold) {
+    const { flowPath, frames } = await scaffoldFlow(args.scaffold, { flowsDir: FLOWS_DIR, force: args.force });
+    console.log(`Scaffolded ${flowPath} — ${frames} frames from evals/voiceovers/${args.scaffold}.md.`);
+    console.log("Fill in each frame's action/assert, then run: pnpm fraimz --flow " + args.scaffold);
     return;
   }
 
@@ -391,8 +457,12 @@ async function main() {
     );
   }
 
+  // App-less flows (requiresApp: false) don't need a CDP endpoint; only probe
+  // for one when at least one selected flow drives the app.
+  const needsApp = selected.some((flow) => flow.requiresApp !== false);
   const envCdp = process.env.OPENWORK_EVAL_CDP_URL?.trim();
-  const cdpBaseUrl = args.cdpUrl ?? (envCdp || (await resolveCdpBaseUrl(DEFAULT_CDP_CANDIDATES)));
+  const cdpBaseUrl = args.cdpUrl
+    ?? (envCdp || (needsApp ? await resolveCdpBaseUrl(DEFAULT_CDP_CANDIDATES) : null));
 
   const runId = new Date().toISOString().replace(/[:.]/g, "-");
   const outDir = join(args.out ?? DEFAULT_RESULTS_DIR, runId);
@@ -401,7 +471,7 @@ async function main() {
   const report = {
     runId,
     startedAt: new Date().toISOString(),
-    cdpUrl: cdpBaseUrl,
+    cdpUrl: cdpBaseUrl ?? "(app-less run)",
     flows: [],
     summary: { passed: 0, failed: 0, skipped: 0 },
   };
@@ -434,6 +504,16 @@ async function main() {
   );
   console.log(`Report: ${join(outDir, "report.md")}`);
   console.log(`fraimz: ${join(outDir, "fraimz.html")}`);
+
+  // fraimz on the PR: post the frame-by-frame proof as a comment. `--pr`
+  // targets the current branch's PR; `--pr <number>` targets an explicit one.
+  if (args.pr) {
+    const { posted, bodyPath, detail } = await postPrComment(report, {
+      outDir,
+      prNumber: args.pr === true ? null : args.pr,
+    });
+    console.log(posted ? `PR comment posted: ${detail}` : `PR comment NOT posted (${detail}). Body written to ${bodyPath}`);
+  }
 
   if (report.summary.failed > 0) process.exit(1);
 }

--- a/evals/runner/voiceover.mjs
+++ b/evals/runner/voiceover.mjs
@@ -1,0 +1,122 @@
+/**
+ * Voice-over scripts as first-class artifacts.
+ *
+ * A flow's demo narration lives in `evals/voiceovers/<flow-id>.md`, written and
+ * approved BEFORE the flow (or the feature) is coded. Frames are the numbered
+ * paragraphs ("1. ..."); everything else (headings, prose) is context. Flows
+ * load their narration from the script via `loadVoiceoverParagraphs`, and the
+ * runner fails the flow when the narration it recorded drifts from the script.
+ */
+import { readFile, writeFile, access } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RUNNER_DIR = dirname(fileURLToPath(import.meta.url));
+export const VOICEOVERS_DIR = join(RUNNER_DIR, "..", "voiceovers");
+export const FLOWS_DIR = join(RUNNER_DIR, "..", "flows");
+
+export function voiceoverScriptPath(flowId) {
+  return join(VOICEOVERS_DIR, `${flowId}.md`);
+}
+
+/** Frames are the numbered paragraphs: "1. narration...", possibly wrapped. */
+export function parseVoiceoverScript(markdown) {
+  const blocks = markdown
+    .replace(/\r\n/g, "\n")
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .filter(Boolean);
+  const paragraphs = [];
+  for (const block of blocks) {
+    const match = block.match(/^(\d+)[.)]\s+([\s\S]+)$/);
+    if (!match) continue;
+    paragraphs.push(match[2].replace(/\s+/g, " ").trim());
+  }
+  return paragraphs;
+}
+
+/** Returns the script's frame paragraphs, or null when no script exists. */
+export async function loadVoiceoverParagraphs(flowId) {
+  const path = voiceoverScriptPath(flowId);
+  try {
+    await access(path);
+  } catch {
+    return null;
+  }
+  const markdown = await readFile(path, "utf8");
+  const paragraphs = parseVoiceoverScript(markdown);
+  if (paragraphs.length === 0) {
+    throw new Error(`Voice-over script ${path} has no numbered frame paragraphs ("1. ...").`);
+  }
+  return paragraphs;
+}
+
+const normalize = (value) => String(value).replace(/\s+/g, " ").trim();
+
+/**
+ * Drift check: every script paragraph must have been narrated by the run, and
+ * the run must not narrate lines that are not in the approved script.
+ */
+export function checkVoiceoverCoverage(paragraphs, recordedVoiceovers) {
+  const script = paragraphs.map(normalize);
+  const recorded = recordedVoiceovers.filter(Boolean).map(normalize);
+  const missing = script.filter((line) => !recorded.includes(line));
+  const extra = recorded.filter((line) => !script.includes(line));
+  return { ok: missing.length === 0 && extra.length === 0, missing, extra };
+}
+
+function flowStub(flowId, paragraphs) {
+  const steps = paragraphs
+    .map(
+      (paragraph, index) => `    {
+      name: ${JSON.stringify(`Frame ${index + 1}`)},
+      run: async (ctx) => {
+        await ctx.prove(${JSON.stringify(`TODO: claim for frame ${index + 1}`)}, {
+          voiceover: vo[${index}],
+          // ${JSON.stringify(paragraph.slice(0, 76))}
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame ${index + 1} not implemented yet");
+          },
+          screenshot: { name: ${JSON.stringify(`frame-${index + 1}`)}, requireText: [] },
+        });
+      },
+    },`,
+    )
+    .join("\n");
+  return `import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/${flowId}.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs(${JSON.stringify(flowId)});
+
+export default {
+  id: ${JSON.stringify(flowId)},
+  title: "TODO: one-line claim — user can do X and sees Y",
+  kind: "user-facing",
+  steps: [
+${steps}
+  ],
+};
+`;
+}
+
+/** Generate evals/flows/<id>.flow.mjs from the approved voice-over script. */
+export async function scaffoldFlow(flowId, { flowsDir = FLOWS_DIR, force = false } = {}) {
+  const paragraphs = await loadVoiceoverParagraphs(flowId);
+  if (!paragraphs) {
+    throw new Error(
+      `No voice-over script at ${voiceoverScriptPath(flowId)}. Write and approve the script first (see the voiceover skill).`,
+    );
+  }
+  const flowPath = join(flowsDir, `${flowId}.flow.mjs`);
+  if (!force) {
+    const exists = await access(flowPath).then(() => true, () => false);
+    if (exists) throw new Error(`${flowPath} already exists. Pass --force to overwrite.`);
+  }
+  await writeFile(flowPath, flowStub(flowId, paragraphs));
+  return { flowPath, frames: paragraphs.length };
+}

--- a/evals/voiceovers/voiceover-first-dx.md
+++ b/evals/voiceovers/voiceover-first-dx.md
@@ -1,0 +1,18 @@
+# voiceover-first-dx — Shipping a feature without writing a PRD
+
+The demo of demo-driven development itself: the voice-over is written and
+approved before any code, agents build until the full flow holds, and the
+proof lands on the PR. One paragraph per frame; the flow loads its narration
+from this file, so this script is the spec the code is held to.
+
+1. This is a feature request. Normally this is where I'd write a PRD. Instead, I run the voiceover command and describe the feature in a sentence.
+
+2. The agent writes back the demo script — the narration I'd record if the feature already existed. We iterate on words, not code. A dozen sentences. That's the whole spec.
+
+3. I approve it, and the script lands in the repo as a file. From this point on, this file is what the code gets held to.
+
+4. The agent scaffolds a proof step per paragraph and goes to work: re-enacting the demo, fixing and re-running until every frame holds. If the flow's narration ever drifts from the approved script, the run fails.
+
+5. The PR opens with the fraimz on it: my script, frame by frame, each line backed by a passing assertion. I review the demo, not the diff.
+
+6. And the check is binding — a red demo means a failing run, and a failing run blocks the merge. The voice-over went in as the spec and came out as the proof.

--- a/warden.toml
+++ b/warden.toml
@@ -1,0 +1,56 @@
+# Warden Configuration
+# https://github.com/getsentry/warden
+#
+# Warden reviews code using AI-powered skills triggered by GitHub events.
+# Built-in skills are available by name. Add more skills as needed.
+#
+# Add built-in reviews with:
+#   warden add security-review
+#   warden add code-review
+
+version = 1
+
+# Default settings inherited by all skills
+[defaults]
+runtime = "pi"
+# Severity levels: critical, high, medium, low, info
+# failOn: minimum severity that fails the check
+failOn = "high"
+# reportOn: minimum severity that creates PR annotations
+reportOn = "medium"
+
+# Skills define what to analyze and when to run
+# Add built-in reviews with:
+#   warden add security-review
+#   warden add code-review
+#
+# Example skill with path filters and triggers:
+#
+# [[skills]]
+# name = "security-review"
+# paths = ["src/**/*.ts", "src/**/*.tsx"]
+# ignorePaths = ["**/*.test.ts", "**/__fixtures__/**"]
+#
+# [[skills.triggers]]
+# type = "pull_request"
+# actions = ["opened", "synchronize", "reopened", "labeled"]
+# draft = false
+# labels = ["Warden"]
+
+[[skills]]
+name = "security-review"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]
+
+[[skills]]
+name = "code-review"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened", "labeled"]
+draft = false
+labels = ["Warden"]


### PR DESCRIPTION
## What

The voice-over replaces the PRD. This PR adds the alignment-phase surfaces and wires the fraimz pipeline around them:

- **`/voiceover` command + `voiceover` skill** — align on the demo narration with the user *before any code* ("no code until the script is approved").
- **`evals/voiceovers/<id>.md`** — the approved script is a checked-in artifact; numbered paragraphs are the frames.
- **`pnpm fraimz scaffold <id>`** — generates `evals/flows/<id>.flow.mjs` with one `ctx.prove` stub per paragraph, narration wired to the script via `loadVoiceoverParagraphs`.
- **Drift check** — the runner appends a *Voice-over script coverage* step: a scripted frame never narrated, or an unapproved line narrated, fails the run.
- **`pnpm fraimz --flow <id> --pr [number]`** — posts the frame proof (verdict, claims, voiceovers, assertions) as a PR comment via `gh`; body kept at `pr-comment.md` when posting isn't possible.
- **`requiresApp: false`** — internal DX/tooling demos run app-less; frames carry claims + assertions + `ctx.output` command output instead of screenshots.

## Proof (fraimz)

The change is proven by its own meta demo — `evals/flows/voiceover-first-dx.flow.mjs`, this workflow demoing itself. The fraimz will be posted as a comment on this PR by the new `--pr` flag itself.

## Tests run

- `pnpm fraimz --flow voiceover-first-dx --pr` — **PASSED, 7/7 steps** (6 frames + coverage step)
- Drift negative, end-to-end: fixture flow narrating an unapproved line → real runner exits 1, failure attributed to *Voice-over script coverage* (frame 4, runner-in-runner)
- Red-demo contract: failing frame → exit 1 with fraimz still written (frame 6, runner-in-runner)
- `node evals/runner/run.mjs scaffold nonexistent` → clean error pointing at the voiceover skill
- `pnpm evals --list` — all flows (39 existing + 1 new) load

## Not validated

- Electron app flows not re-run (no local app up during dev; app-path changes are guard-level only — `requiresApp` defaults to true and all flows load). Repro: `pnpm dev`, then `pnpm fraimz --flow core-flow --cdp-url http://127.0.0.1:9823`.
- "Blocks the merge" is the exit-code contract; making the check *required* is a branch-protection setting, not code.