### PR TITLE
fix(app): route mounted workspace promptAsync/command through the OpenWork wrapper path

### DIFF
--- a/apps/app/src/app/lib/opencode.ts
+++ b/apps/app/src/app/lib/opencode.ts
@@ -455,7 +455,7 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
 
   const promptAsyncOriginal = sessionOverrides.promptAsync.bind(session);
   sessionOverrides.promptAsync = (parameters: PromptAsyncParameters, options?: { throwOnError?: boolean }) => {
-    if (!("reasoning_effort" in parameters)) {
+    if (!openworkMount && !("reasoning_effort" in parameters)) {
       return promptAsyncOriginal(parameters, options);
     }
     const { sessionID, directory: requestDirectory, ...body } = parameters;
@@ -468,7 +468,7 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
 
   const commandOriginal = sessionOverrides.command.bind(session);
   sessionOverrides.command = (parameters: CommandParameters, options?: { throwOnError?: boolean }) => {
-    if (!("reasoning_effort" in parameters)) {
+    if (!openworkMount && !("reasoning_effort" in parameters)) {
       return commandOriginal(parameters, options);
     }
     const { sessionID, directory: requestDirectory, ...body } = parameters;


### PR DESCRIPTION
Split out of #2439/#2451 so this shared-path change ships and bisects independently of the org MCP connections feature.

The read-side session overrides (list/get/messages/todo) already go through the OpenWork wrapper when the client is openwork-mounted; promptAsync and command still used the generated SDK call unless the caller passed `reasoning_effort`. This makes the write path consistent with the read path: openwork-mounted clients always use `postSessionRequest`, which preserves unknown body fields and passes the directory via header.

Originally validated as part of #2439's full desktop fraimz (real chat turn executing an org MCP tool end-to-end): https://github.com/different-ai/openwork/pull/2439#issuecomment-4867257637

Tests: `pnpm --filter @openwork/app typecheck` clean; `bun test apps/app/tests/` passing on the source branch.