### PR TITLE
feat: org-level Google Workspace — one admin setup, per-member Google sign-in, agent drafts Gmail (rides the org connections surface)

### DIFF
--- a/ee/apps/den-api/src/capability-sources/gmail.ts
+++ b/ee/apps/den-api/src/capability-sources/gmail.ts
@@ -1,0 +1,52 @@
+/**
+ * Minimal Gmail draft construction: an RFC 822 message, base64url-encoded
+ * the way the Gmail API `users.messages/drafts` endpoints expect `raw`.
+ * Kept pure so the encoding is unit-testable without any HTTP.
+ */
+
+function hasNonAscii(value: string): boolean {
+  for (const char of value) {
+    if (char.codePointAt(0)! > 0x7e || char.codePointAt(0)! < 0x20) return true
+  }
+  return false
+}
+
+/** RFC 2047 B-encoding for header values that contain non-ASCII characters. */
+export function encodeMimeHeaderValue(value: string): string {
+  if (!hasNonAscii(value)) {
+    return value
+  }
+  return `=?UTF-8?B?${Buffer.from(value, "utf8").toString("base64")}?=`
+}
+
+/** Tolerant reader for the Gmail drafts.create response body. */
+export function readGmailDraftIds(text: string): { draftId: string | null; messageId: string | null } {
+  try {
+    const parsed: unknown = JSON.parse(text)
+    if (typeof parsed !== "object" || parsed === null) {
+      return { draftId: null, messageId: null }
+    }
+    const draftId = "id" in parsed && typeof parsed.id === "string" ? parsed.id : null
+    let messageId: string | null = null
+    if ("message" in parsed && typeof parsed.message === "object" && parsed.message !== null
+      && "id" in parsed.message && typeof parsed.message.id === "string") {
+      messageId = parsed.message.id
+    }
+    return { draftId, messageId }
+  } catch {
+    return { draftId: null, messageId: null }
+  }
+}
+
+export function buildGmailDraftRaw(input: { to: string; subject: string; body: string }): string {
+  const message = [
+    `To: ${input.to}`,
+    `Subject: ${encodeMimeHeaderValue(input.subject)}`,
+    "MIME-Version: 1.0",
+    'Content-Type: text/plain; charset="UTF-8"',
+    "Content-Transfer-Encoding: base64",
+    "",
+    Buffer.from(input.body, "utf8").toString("base64"),
+  ].join("\r\n")
+  return Buffer.from(message, "utf8").toString("base64url")
+}

--- a/ee/apps/den-api/src/capability-sources/native-provider-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/native-provider-connections.ts
@@ -1,0 +1,68 @@
+import type { DenTypeId } from "@openwork-ee/utils/typeid"
+import { NATIVE_OAUTH_PROVIDERS, type NativeOAuthProviderConfig } from "./provider-registry.js"
+import { getConnectedAccount, getOrgOAuthClient } from "./oauth-credentials.js"
+
+/**
+ * Native providers (google-workspace, ...) surface in the SAME member-facing
+ * list as external MCP connections, so the desktop app renders and connects
+ * them with zero client changes: once an org admin saves an OAuth client for
+ * a provider, every granted surface that lists usable connections shows a
+ * per-member card for it. These entries are synthetic — they exist in
+ * OrgOAuthClientTable + ConnectedAccountTable, never in
+ * ExternalMcpConnectionTable — which also keeps them out of the agent MCP
+ * client merge (external-capabilities reads the DB table directly).
+ */
+
+export type NativeProviderConnectionEntry = {
+  id: string
+  name: string
+  url: string
+  authType: "oauth"
+  credentialMode: "per_member"
+  connected: boolean
+  connectedAt: null
+  connectedForMe: boolean
+  access: null
+}
+
+export function buildNativeProviderEntry(
+  provider: NativeOAuthProviderConfig,
+  state: { clientConfigured: boolean; connectedForMe: boolean },
+): NativeProviderConnectionEntry | null {
+  if (!state.clientConfigured) {
+    return null
+  }
+  return {
+    id: provider.providerId,
+    name: provider.displayName,
+    url: provider.websiteUrl,
+    authType: "oauth",
+    credentialMode: "per_member",
+    connected: true,
+    connectedAt: null,
+    connectedForMe: state.connectedForMe,
+    access: null,
+  }
+}
+
+export async function listNativeProviderUsableEntries(input: {
+  organizationId: DenTypeId<"organization">
+  orgMembershipId: DenTypeId<"member">
+}): Promise<NativeProviderConnectionEntry[]> {
+  const entries: NativeProviderConnectionEntry[] = []
+  for (const provider of Object.values(NATIVE_OAUTH_PROVIDERS)) {
+    const client = await getOrgOAuthClient(input.organizationId, provider.providerId)
+    if (!client) continue
+    const account = await getConnectedAccount({
+      organizationId: input.organizationId,
+      orgMembershipId: input.orgMembershipId,
+      providerId: provider.providerId,
+    })
+    const entry = buildNativeProviderEntry(provider, {
+      clientConfigured: true,
+      connectedForMe: Boolean(account?.accessToken),
+    })
+    if (entry) entries.push(entry)
+  }
+  return entries
+}

--- a/ee/apps/den-api/src/capability-sources/oauth-callback-page.ts
+++ b/ee/apps/den-api/src/capability-sources/oauth-callback-page.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared "you can return to OpenWork now" HTML page for OAuth callbacks.
+ * Used by both external MCP connection callbacks and native provider
+ * callbacks so every connect flow ends on the same deep-linking page.
+ */
+
+export function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
+}
+
+export function connectCallbackPage(input: { ok: true; name: string } | { ok: false; name: string; message: string }): string {
+  const title = input.ok ? "Connected" : "Connection failed"
+  const openWorkUrl = "openwork://settings/extensions"
+  const body = input.ok
+    ? `<p>${escapeHtml(input.name)} is connected. You can return to OpenWork now.</p>
+      <p><a href="${openWorkUrl}" style="display:inline-block; margin-top:16px; border-radius:10px; background:#0f172a; color:white; padding:10px 14px; text-decoration:none; font-weight:600;">Open OpenWork</a></p>
+      <script>setTimeout(() => { window.location.href = "${openWorkUrl}" }, 500)</script>`
+    : `<p>Could not connect ${escapeHtml(input.name)}: ${escapeHtml(input.message)}</p>`
+  return `<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>${title} — OpenWork</title></head>
+  <body style="font-family: system-ui, sans-serif; max-width: 480px; margin: 64px auto; text-align: center; color: #0f172a;">
+    <h1 style="font-size: 20px;">${title}</h1>
+    ${body}
+  </body>
+</html>`
+}

--- a/ee/apps/den-api/src/capability-sources/provider-registry.ts
+++ b/ee/apps/den-api/src/capability-sources/provider-registry.ts
@@ -9,11 +9,15 @@
  * OAuth plumbing — `generic-oauth.ts` drives every provider the same way.
  */
 
+import { env } from "../env.js"
+
 export type NativeOAuthProviderConfig = {
   providerId: string
   displayName: string
   authorizeUrl: string
   tokenUrl: string
+  /** Display-only endpoint shown on connection cards. */
+  websiteUrl: string
   defaultScopes: string[]
   /** Google (and most modern providers) support PKCE even for confidential clients; harmless to always send. */
   usesPkce: boolean
@@ -25,8 +29,9 @@ export const NATIVE_OAUTH_PROVIDERS: Record<string, NativeOAuthProviderConfig> =
   "google-workspace": {
     providerId: "google-workspace",
     displayName: "Google Workspace",
-    authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-    tokenUrl: "https://oauth2.googleapis.com/token",
+    authorizeUrl: env.googleOAuthAuthorizeUrl ?? "https://accounts.google.com/o/oauth2/v2/auth",
+    tokenUrl: env.googleOAuthTokenUrl ?? "https://oauth2.googleapis.com/token",
+    websiteUrl: "https://workspace.google.com",
     defaultScopes: [
       "openid",
       "email",

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -35,6 +35,9 @@ const EnvSchema = z.object({
   LOOPS_MARKETING_ENABLED: z.string().optional(),
   OPENWORK_DEV_MODE: z.string().optional(),
   DEN_ALLOW_PRIVATE_MCP_URLS: z.string().optional(),
+  DEN_GOOGLE_OAUTH_AUTHORIZE_URL: z.string().optional(),
+  DEN_GOOGLE_OAUTH_TOKEN_URL: z.string().optional(),
+  DEN_GOOGLE_API_BASE_URL: z.string().optional(),
   PORT: z.string().optional(),
   CORS_ORIGINS: z.string().optional(),
   DEN_API_PUBLIC_URL: z.string().optional(),
@@ -280,6 +283,12 @@ export const env = {
   workerProxyPort: Number(parsed.WORKER_PROXY_PORT ?? "8789"),
   corsOrigins,
   apiPublicUrl: optionalString(parsed.DEN_API_PUBLIC_URL),
+  // Google endpoint overrides for evals/self-host testing: point the native
+  // google-workspace provider at a protocol-identical mock instead of the
+  // real Google endpoints. Unset in production.
+  googleOAuthAuthorizeUrl: optionalString(parsed.DEN_GOOGLE_OAUTH_AUTHORIZE_URL),
+  googleOAuthTokenUrl: optionalString(parsed.DEN_GOOGLE_OAUTH_TOKEN_URL),
+  googleApiBaseUrl: optionalString(parsed.DEN_GOOGLE_API_BASE_URL),
   desktopDenBaseUrl: optionalString(parsed.DEN_DESKTOP_DEN_BASE_URL),
   marketingUrl: optionalString(parsed.DEN_MARKETING_URL),
   mcpClaimNamespace: normalizeOrigin(optionalString(parsed.DEN_MCP_CLAIM_NAMESPACE) ?? parsed.BETTER_AUTH_URL),

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -1,0 +1,103 @@
+import type { Hono } from "hono"
+import { describeRoute } from "hono-openapi"
+import { z } from "zod"
+import { env } from "../../env.js"
+import { jsonValidator, orgMemberRoute } from "../../middleware/index.js"
+import { jsonResponse, unauthorizedSchema } from "../../openapi.js"
+import { buildGmailDraftRaw, readGmailDraftIds } from "../../capability-sources/gmail.js"
+import { getValidAccessToken } from "../../capability-sources/generic-oauth.js"
+import { getNativeOAuthProvider } from "../../capability-sources/provider-registry.js"
+import type { OrgRouteVariables } from "./shared.js"
+
+const createDraftBodySchema = z.object({
+  to: z.string().trim().min(3).max(320).describe("Recipient email address."),
+  subject: z.string().trim().min(1).max(500).describe("Draft subject line."),
+  body: z.string().min(1).max(50_000).describe("Plain-text draft body."),
+})
+
+const createDraftResponseSchema = z.object({
+  ok: z.literal(true),
+  draftId: z.string(),
+  messageId: z.string().nullable(),
+  to: z.string(),
+  subject: z.string(),
+}).meta({ ref: "GoogleWorkspaceDraftResponse" })
+
+const needsConnectionSchema = z.object({
+  error: z.literal("needs_connection"),
+  message: z.string(),
+}).meta({ ref: "GoogleWorkspaceNeedsConnectionError" })
+
+const upstreamErrorSchema = z.object({
+  error: z.literal("google_api_error"),
+  message: z.string(),
+}).meta({ ref: "GoogleWorkspaceUpstreamError" })
+
+function gmailApiBase(): string {
+  return (env.googleApiBaseUrl ?? "https://gmail.googleapis.com").replace(/\/+$/, "")
+}
+
+/**
+ * Native Google Workspace capabilities, executed by Den with the calling
+ * member Den-brokered credential (getValidAccessToken). Tagged
+ * "Capability Sources" so search_capabilities/execute_capability discover
+ * them — the agent path needs no MCP server and no extra wiring.
+ */
+export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVariables }>(app: Hono<T>) {
+  app.post(
+    "/v1/capabilities/google-workspace/gmail-drafts",
+    describeRoute({
+      tags: ["Capability Sources"],
+      summary: "Create a Gmail draft as the calling member",
+      description: "Creates a plain-text Gmail draft in the calling member own mailbox, using the Google account they connected through the org Google Workspace connection. Returns needs_connection when the member has not connected their Google account yet.",
+      responses: {
+        200: jsonResponse("Draft created.", createDraftResponseSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        409: jsonResponse("The calling member has not connected their Google account.", needsConnectionSchema),
+        502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
+      },
+    }),
+    orgMemberRoute(),
+    jsonValidator(createDraftBodySchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const provider = getNativeOAuthProvider("google-workspace")
+      if (!provider) {
+        return c.json({ error: "google_api_error" as const, message: "google-workspace provider is not registered." }, 502)
+      }
+
+      const token = await getValidAccessToken({
+        provider,
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+      })
+      if ("error" in token) {
+        return c.json({
+          error: "needs_connection" as const,
+          message: "Connect your Google account first: open Settings, then Extensions, and use Connect your account on the Google Workspace card.",
+        }, 409)
+      }
+
+      const { to, subject, body } = c.req.valid("json")
+      const response = await fetch(`${gmailApiBase()}/gmail/v1/users/me/drafts`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token.accessToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ message: { raw: buildGmailDraftRaw({ to, subject, body }) } }),
+      })
+      const text = await response.text()
+      if (!response.ok) {
+        return c.json({ error: "google_api_error" as const, message: `Gmail draft create failed: ${response.status} ${text.slice(0, 300)}` }, 502)
+      }
+
+      const { draftId, messageId } = readGmailDraftIds(text)
+      if (!draftId) {
+        return c.json({ error: "google_api_error" as const, message: "Gmail returned no draft id." }, 502)
+      }
+
+      return c.json({ ok: true as const, draftId, messageId, to, subject })
+    },
+  )
+}

--- a/ee/apps/den-api/src/routes/org/index.ts
+++ b/ee/apps/den-api/src/routes/org/index.ts
@@ -7,6 +7,7 @@ import type { OrgRouteVariables } from "./shared.js"
 import { registerOrgCoreRoutes } from "./core.js"
 import { registerOrgDesktopPolicyRoutes } from "./desktop-policies.js"
 import { registerOrgInvitationRoutes } from "./invitations.js"
+import { registerGoogleWorkspaceRoutes } from "./google-workspace.js"
 import { registerOrgInferenceRoutes } from "./inference.js"
 import { registerOrgLlmProviderRoutes } from "./llm-providers.js"
 import { registerOrgMemberRoutes } from "./members.js"
@@ -58,6 +59,7 @@ export function registerOrgRoutes<T extends { Variables: OrgRouteVariables }>(ap
   registerOrgLlmProviderRoutes(app)
   registerOrgMemberRoutes(app)
   registerOAuthProviderRoutes(app)
+  registerGoogleWorkspaceRoutes(app)
   registerMcpConnectionRoutes(app)
   registerPluginArchRoutes(app)
   registerOrgRoleRoutes(app)

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -31,6 +31,8 @@ import {
   type ExternalMcpConnectionRow,
 } from "../../capability-sources/external-mcp-connections.js"
 import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
+import { listNativeProviderUsableEntries } from "../../capability-sources/native-provider-connections.js"
+import { connectCallbackPage } from "../../capability-sources/oauth-callback-page.js"
 import { getConnectedAccount } from "../../capability-sources/oauth-credentials.js"
 import { assertPublicUrl } from "../../capability-sources/url-guard.js"
 import type { MemberTeamSummary } from "../../orgs.js"
@@ -241,7 +243,14 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       })
       const connections = await Promise.all(rows.map((row) =>
         toConnectionResponse(row, { callerOrgMembershipId: payload.currentMember.id, includeAccess: false })))
-      return c.json({ connections })
+      // Native providers (e.g. google-workspace) join the same list once the
+      // org saved an OAuth client for them — same card, same connect flow,
+      // same rollout gate (this sits after the gate check on purpose).
+      const nativeEntries = await listNativeProviderUsableEntries({
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+      })
+      return c.json({ connections: [...nativeEntries, ...connections] })
     },
   )
 
@@ -525,24 +534,4 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
   )
 }
 
-function connectCallbackPage(input: { ok: true; name: string } | { ok: false; name: string; message: string }): string {
-  const title = input.ok ? "Connected" : "Connection failed"
-  const openWorkUrl = "openwork://settings/extensions"
-  const body = input.ok
-    ? `<p>${escapeHtml(input.name)} is connected. You can return to OpenWork now.</p>
-      <p><a href="${openWorkUrl}" style="display:inline-block; margin-top:16px; border-radius:10px; background:#0f172a; color:white; padding:10px 14px; text-decoration:none; font-weight:600;">Open OpenWork</a></p>
-      <script>setTimeout(() => { window.location.href = "${openWorkUrl}" }, 500)</script>`
-    : `<p>Couldn't connect ${escapeHtml(input.name)}: ${escapeHtml(input.message)}</p>`
-  return `<!doctype html>
-<html>
-  <head><meta charset="utf-8"><title>${title} — OpenWork</title></head>
-  <body style="font-family: system-ui, sans-serif; max-width: 480px; margin: 64px auto; text-align: center; color: #0f172a;">
-    <h1 style="font-size: 20px;">${title}</h1>
-    ${body}
-  </body>
-</html>`
-}
 
-function escapeHtml(value: string): string {
-  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
-}

--- a/ee/apps/den-api/src/routes/org/oauth-providers.ts
+++ b/ee/apps/den-api/src/routes/org/oauth-providers.ts
@@ -1,6 +1,7 @@
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
+import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import { env } from "../../env.js"
 import {
   jsonValidator,
@@ -8,7 +9,7 @@ import {
   paramValidator,
   publicRoute,
 } from "../../middleware/index.js"
-import { emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
+import { emptyResponse, forbiddenSchema, htmlResponse, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import {
   buildAuthorizeUrl,
   createOAuthStateToken,
@@ -17,7 +18,8 @@ import {
   resolvePublicOrigin,
   verifyOAuthStateToken,
 } from "../../capability-sources/generic-oauth.js"
-import { getNativeOAuthProvider } from "../../capability-sources/provider-registry.js"
+import { connectCallbackPage } from "../../capability-sources/oauth-callback-page.js"
+import { getNativeOAuthProvider, NATIVE_OAUTH_PROVIDERS, type NativeOAuthProviderConfig } from "../../capability-sources/provider-registry.js"
 import {
   disconnectAccount,
   getConnectedAccount,
@@ -67,6 +69,47 @@ const oauthStatusResponseSchema = z.object({
 function callbackRedirectUri(request: Request, providerId: string) {
   const origin = resolvePublicOrigin(request, env.apiPublicUrl)
   return `${origin}/v1/oauth-providers/${encodeURIComponent(providerId)}/connect/callback`
+}
+
+const nativeConnectStartResponseSchema = z.object({
+  status: z.enum(["connected", "needs_auth"]),
+  authorizeUrl: z.string().nullable(),
+}).meta({ ref: "NativeProviderConnectStartResponse" })
+
+type OrgIds = { organizationId: DenTypeId<"organization">; orgMembershipId: DenTypeId<"member"> }
+
+async function beginNativeProviderConnect(input: OrgIds & {
+  provider: NativeOAuthProviderConfig
+  request: Request
+}): Promise<{ authorizeUrl: string } | { error: "client_not_configured" }> {
+  const client = await getOrgOAuthClient(input.organizationId, input.provider.providerId)
+  if (!client) {
+    return { error: "client_not_configured" }
+  }
+
+  const { verifier, challenge } = createPkcePair()
+  const state = createOAuthStateToken({
+    organizationId: input.organizationId,
+    orgMembershipId: input.orgMembershipId,
+    providerId: input.provider.providerId,
+    secret: env.betterAuthSecret,
+  })
+
+  await upsertConnectedAccount({
+    organizationId: input.organizationId,
+    orgMembershipId: input.orgMembershipId,
+    providerId: input.provider.providerId,
+    pendingCodeVerifier: verifier,
+  })
+
+  const authorizeUrl = buildAuthorizeUrl({
+    provider: input.provider,
+    client,
+    state,
+    redirectUri: callbackRedirectUri(input.request, input.provider.providerId),
+    codeChallenge: challenge,
+  })
+  return { authorizeUrl }
 }
 
 /**
@@ -145,46 +188,64 @@ export function registerOAuthProviderRoutes<T extends { Variables: OrgRouteVaria
         return c.json({ error: "unknown_oauth_provider", message: `"${providerId}" is not a known native OAuth provider.` }, 404)
       }
 
-      const client = await getOrgOAuthClient(payload.organization.id, providerId)
-      if (!client) {
+      const started = await beginNativeProviderConnect({
+        provider,
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+        request: c.req.raw,
+      })
+      if ("error" in started) {
         return c.json({ error: "client_not_configured", message: `Connect an OAuth client for "${providerId}" first.` }, 404)
       }
-
-      const { verifier, challenge } = createPkcePair()
-      const state = createOAuthStateToken({
-        organizationId: payload.organization.id,
-        orgMembershipId: payload.currentMember.id,
-        providerId,
-        secret: env.betterAuthSecret,
-      })
-
-      await upsertConnectedAccount({
-        organizationId: payload.organization.id,
-        orgMembershipId: payload.currentMember.id,
-        providerId,
-        pendingCodeVerifier: verifier,
-      })
-
-      const authorizeUrl = buildAuthorizeUrl({
-        provider,
-        client,
-        state,
-        redirectUri: callbackRedirectUri(c.req.raw, providerId),
-        codeChallenge: challenge,
-      })
-
-      return c.json({ authorizeUrl })
+      return c.json({ authorizeUrl: started.authorizeUrl })
     },
   )
+
+  // Native providers surface as synthetic entries in the member-facing
+  // /v1/mcp-connections?scope=usable list (see native-provider-connections.ts),
+  // and the desktop starts a connect by calling the SAME path shape it uses
+  // for external MCP connections. These static delegates are registered
+  // before the parameterized /v1/mcp-connections/:connectionId routes
+  // (routes/org/index.ts order), so provider ids never reach the emc_ id
+  // validator. Zero desktop changes.
+  for (const provider of Object.values(NATIVE_OAUTH_PROVIDERS)) {
+    app.get(
+      `/v1/mcp-connections/${provider.providerId}/connect/start`,
+      describeRoute({
+        tags: ["Authentication"],
+        summary: `Begin connecting the calling member to ${provider.displayName}`,
+        description: "Native-provider twin of the external MCP connect/start route: returns an authorize URL for the browser, using the OAuth client the org saved for this provider.",
+        responses: {
+          200: jsonResponse("Authorize URL, or already connected.", nativeConnectStartResponseSchema),
+          401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+          404: jsonResponse("The org has not configured an OAuth client for this provider yet.", clientNotConfiguredSchema),
+        },
+      }),
+      orgMemberRoute(),
+      async (c) => {
+        const payload = c.get("organizationContext")
+        const started = await beginNativeProviderConnect({
+          provider,
+          organizationId: payload.organization.id,
+          orgMembershipId: payload.currentMember.id,
+          request: c.req.raw,
+        })
+        if ("error" in started) {
+          return c.json({ error: "client_not_configured", message: `Connect an OAuth client for "${provider.providerId}" first.` }, 404)
+        }
+        return c.json({ status: "needs_auth" as const, authorizeUrl: started.authorizeUrl })
+      },
+    )
+  }
 
   app.get(
     "/v1/oauth-providers/:providerId/connect/callback",
     describeRoute({
       tags: ["Authentication"],
       summary: "OAuth callback for a provider",
-      description: "The provider redirects here with code+state after the member consents. Identity is carried entirely by the signed state token, not a session cookie, since the redirect may arrive in a fresh browser context.",
+      description: "The provider redirects here with code+state after the member consents. Identity is carried entirely by the signed state token, not a session cookie, since the redirect may arrive in a fresh browser context. Serves a small static HTML page that deep-links back to OpenWork.",
       responses: {
-        200: emptyResponse("Connected."),
+        200: htmlResponse("Connected — a static success page."),
         400: jsonResponse("Missing or invalid code/state.", invalidRequestSchema),
       },
     }),
@@ -219,27 +280,31 @@ export function registerOAuthProviderRoutes<T extends { Variables: OrgRouteVaria
         return c.json({ error: "invalid_request", message: "No pending connection for this state." }, 400)
       }
 
-      const tokens = await exchangeCodeForTokens({
-        provider,
-        client,
-        code,
-        redirectUri: callbackRedirectUri(c.req.raw, providerId),
-        codeVerifier: pending.pendingCodeVerifier,
-      })
+      try {
+        const tokens = await exchangeCodeForTokens({
+          provider,
+          client,
+          code,
+          redirectUri: callbackRedirectUri(c.req.raw, providerId),
+          codeVerifier: pending.pendingCodeVerifier,
+        })
 
-      await upsertConnectedAccount({
-        organizationId: statePayload.organizationId,
-        orgMembershipId: statePayload.orgMembershipId,
-        providerId,
-        accessToken: tokens.access_token,
-        refreshToken: tokens.refresh_token ?? null,
-        tokenType: tokens.token_type ?? null,
-        expiresAt: tokens.expires_in ? new Date(Date.now() + tokens.expires_in * 1000) : null,
-        scopes: tokens.scope ? tokens.scope.split(" ") : provider.defaultScopes,
-        pendingCodeVerifier: null,
-      })
+        await upsertConnectedAccount({
+          organizationId: statePayload.organizationId,
+          orgMembershipId: statePayload.orgMembershipId,
+          providerId,
+          accessToken: tokens.access_token,
+          refreshToken: tokens.refresh_token ?? null,
+          tokenType: tokens.token_type ?? null,
+          expiresAt: tokens.expires_in ? new Date(Date.now() + tokens.expires_in * 1000) : null,
+          scopes: tokens.scope ? tokens.scope.split(" ") : provider.defaultScopes,
+          pendingCodeVerifier: null,
+        })
+      } catch (error) {
+        return c.html(connectCallbackPage({ ok: false, name: provider.displayName, message: error instanceof Error ? error.message : String(error) }), 400)
+      }
 
-      return c.json({ ok: true, providerId })
+      return c.html(connectCallbackPage({ ok: true, name: provider.displayName }))
     },
   )
 

--- a/ee/apps/den-api/test/gmail-draft.test.ts
+++ b/ee/apps/den-api/test/gmail-draft.test.ts
@@ -1,0 +1,61 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+let gmail: typeof import("../src/capability-sources/gmail.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  gmail = await import("../src/capability-sources/gmail.js")
+})
+
+describe("buildGmailDraftRaw", () => {
+  test("encodes a plain-ASCII draft as base64url RFC 822 with the body base64-encoded", () => {
+    const raw = gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Follow up", body: "Hello Sam" })
+    const decoded = Buffer.from(raw, "base64url").toString("utf8")
+    expect(decoded).toContain("To: sam@acme.test\r\n")
+    expect(decoded).toContain("Subject: Follow up\r\n")
+    expect(decoded).toContain('Content-Type: text/plain; charset="UTF-8"')
+    const bodyPart = decoded.split("\r\n\r\n")[1]
+    expect(Buffer.from(bodyPart, "base64").toString("utf8")).toBe("Hello Sam")
+    // base64url alphabet only — Gmail rejects standard base64 for `raw`.
+    expect(raw).not.toMatch(/[+/=]/)
+  })
+
+  test("non-ASCII subjects get RFC 2047 B-encoding, bodies survive UTF-8 round trips", () => {
+    const raw = gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Résumé — próxima reunión", body: "Grüße aus Zürich ✅" })
+    const decoded = Buffer.from(raw, "base64url").toString("utf8")
+    const subjectLine = decoded.split("\r\n").find((line) => line.startsWith("Subject: "))
+    expect(subjectLine).toMatch(/^Subject: =\?UTF-8\?B\?[A-Za-z0-9+/=]+\?=$/)
+    expect(Buffer.from(subjectLine!.slice("Subject: =?UTF-8?B?".length, -2), "base64").toString("utf8")).toBe("Résumé — próxima reunión")
+    const bodyPart = decoded.split("\r\n\r\n")[1]
+    expect(Buffer.from(bodyPart, "base64").toString("utf8")).toBe("Grüße aus Zürich ✅")
+  })
+})
+
+describe("encodeMimeHeaderValue", () => {
+  test("leaves ASCII untouched and encodes anything else", () => {
+    expect(gmail.encodeMimeHeaderValue("plain subject")).toBe("plain subject")
+    expect(gmail.encodeMimeHeaderValue("café")).toBe(`=?UTF-8?B?${Buffer.from("café", "utf8").toString("base64")}?=`)
+  })
+})
+
+describe("readGmailDraftIds", () => {
+  test("reads Gmail-shaped responses", () => {
+    expect(gmail.readGmailDraftIds(JSON.stringify({ id: "draft-1", message: { id: "msg-1" } })))
+      .toEqual({ draftId: "draft-1", messageId: "msg-1" })
+  })
+
+  test("tolerates malformed and partial responses", () => {
+    expect(gmail.readGmailDraftIds("not json")).toEqual({ draftId: null, messageId: null })
+    expect(gmail.readGmailDraftIds(JSON.stringify({ id: "draft-1" }))).toEqual({ draftId: "draft-1", messageId: null })
+    expect(gmail.readGmailDraftIds(JSON.stringify({ message: { id: "msg-1" } }))).toEqual({ draftId: null, messageId: "msg-1" })
+    expect(gmail.readGmailDraftIds(JSON.stringify([1, 2]))).toEqual({ draftId: null, messageId: null })
+  })
+})

--- a/ee/apps/den-api/test/native-provider-connections.test.ts
+++ b/ee/apps/den-api/test/native-provider-connections.test.ts
@@ -1,0 +1,48 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+let mod: typeof import("../src/capability-sources/native-provider-connections.js")
+let registry: typeof import("../src/capability-sources/provider-registry.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mod = await import("../src/capability-sources/native-provider-connections.js")
+  registry = await import("../src/capability-sources/provider-registry.js")
+})
+
+describe("buildNativeProviderEntry", () => {
+  test("no org client configured means no entry — the org has not enrolled", () => {
+    const provider = registry.getNativeOAuthProvider("google-workspace")!
+    expect(mod.buildNativeProviderEntry(provider, { clientConfigured: false, connectedForMe: false })).toBeNull()
+  })
+
+  test("a configured provider renders as a per-member, connectable entry", () => {
+    const provider = registry.getNativeOAuthProvider("google-workspace")!
+    expect(mod.buildNativeProviderEntry(provider, { clientConfigured: true, connectedForMe: false })).toEqual({
+      id: "google-workspace",
+      name: "Google Workspace",
+      url: "https://workspace.google.com",
+      authType: "oauth",
+      credentialMode: "per_member",
+      connected: true,
+      connectedAt: null,
+      connectedForMe: false,
+      access: null,
+    })
+  })
+
+  test("the calling member's own connection state flips connectedForMe only", () => {
+    const provider = registry.getNativeOAuthProvider("google-workspace")!
+    const entry = mod.buildNativeProviderEntry(provider, { clientConfigured: true, connectedForMe: true })!
+    expect(entry.connectedForMe).toBe(true)
+    expect(entry.connected).toBe(true)
+    expect(entry.credentialMode).toBe("per_member")
+  })
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -185,6 +185,40 @@ export function useDeleteMcpConnection() {
   });
 }
 
+export type SaveNativeProviderClientInput = {
+  providerId: string;
+  clientId: string;
+  clientSecret: string;
+};
+
+/**
+ * Native providers (google-workspace) are configured with an org OAuth
+ * client instead of a server URL. Saving one makes the provider appear in
+ * the usable connections list for every granted member.
+ */
+export function useSaveNativeProviderClient() {
+  const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (input: SaveNativeProviderClientInput): Promise<void> => {
+      await runReauthableAction("save-native-oauth-client", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/oauth-providers/${encodeURIComponent(input.providerId)}/client`,
+          { method: "POST", body: JSON.stringify({ clientId: input.clientId, clientSecret: input.clientSecret }) },
+          20000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to save the OAuth client (${response.status}).`);
+        }
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });
+    },
+  });
+}
+
 export function formatMcpConnectedTimestamp(value: string | null): string {
   if (!value) return "Not connected";
   const date = new Date(value);

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -18,6 +18,7 @@ import {
   useDeleteMcpConnection,
   useMcpConnectionPresets,
   useMcpConnections,
+  useSaveNativeProviderClient,
   useStartMcpConnectionOAuth,
 } from "./mcp-connections-data";
 
@@ -26,13 +27,17 @@ const OAUTH_POLL_TIMEOUT_MS = 90_000;
 
 export function McpConnectionsScreen() {
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections();
+  const { data: usableConnections = [] } = useMcpConnections("usable");
   const { data: presets = [] } = useMcpConnectionPresets();
   const createConnection = useCreateMcpConnection();
   const startOAuth = useStartMcpConnectionOAuth();
   const deleteConnection = useDeleteMcpConnection();
+  const saveNativeClient = useSaveNativeProviderClient();
 
   const [formOpen, setFormOpen] = useState(false);
   const [formPreset, setFormPreset] = useState<ExternalMcpPreset | null>(null);
+  const [googleDialogOpen, setGoogleDialogOpen] = useState(false);
+  const googleConfigured = usableConnections.some((connection) => connection.id === "google-workspace");
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -120,6 +125,19 @@ export function McpConnectionsScreen() {
 
       <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Quick add</h3>
       <div className="mb-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <button
+          type="button"
+          onClick={() => setGoogleDialogOpen(true)}
+          className="rounded-2xl border border-gray-100 bg-white px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
+        >
+          <p className="text-[14px] font-semibold text-gray-900">Google Workspace</p>
+          <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">
+            Your company&apos;s Google. Set it up once — every member connects their own account.
+          </p>
+          <p className="mt-2 text-[12px] font-medium text-violet-600">
+            {googleConfigured ? "Configured — tap to update" : "Tap to set up"}
+          </p>
+        </button>
         {presets.map((preset) => {
           const alreadyAdded = connections.some((connection) => connection.url === preset.url);
           return (
@@ -179,7 +197,98 @@ export function McpConnectionsScreen() {
         }}
         onSubmit={handleCreate}
       />
+
+      <GoogleWorkspaceDialog
+        open={googleDialogOpen}
+        submitting={saveNativeClient.isPending}
+        error={saveNativeClient.error}
+        onClose={() => setGoogleDialogOpen(false)}
+        onSubmit={async (input) => {
+          await saveNativeClient.mutateAsync({ providerId: "google-workspace", ...input });
+          setGoogleDialogOpen(false);
+        }}
+      />
     </DashboardPageTemplate>
+  );
+}
+
+function GoogleWorkspaceDialog({
+  open,
+  submitting,
+  error,
+  onClose,
+  onSubmit,
+}: {
+  open: boolean;
+  submitting: boolean;
+  error: unknown;
+  onClose: () => void;
+  onSubmit: (input: { clientId: string; clientSecret: string }) => void;
+}) {
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    setClientId("");
+    setClientSecret("");
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={onClose}>
+      <div
+        className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">Set up Google Workspace</h2>
+        <p className="mt-1 text-[13px] leading-6 text-gray-600">
+          Paste the OAuth client from your company&apos;s Google Cloud project. Members then connect their own
+          Google account from Your Connections — sign-ins stay in your org&apos;s cloud.
+        </p>
+
+        <div className="mt-5 space-y-4">
+          <div>
+            <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client ID</label>
+            <DenInput
+              value={clientId}
+              onChange={(event) => setClientId(event.target.value)}
+              placeholder="1234567890-abc.apps.googleusercontent.com"
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client secret</label>
+            <DenInput
+              type="password"
+              value={clientSecret}
+              onChange={(event) => setClientSecret(event.target.value)}
+              placeholder="GOCSPX-…"
+            />
+          </div>
+        </div>
+
+        {error ? (
+          <p className="mt-3 text-[13px] text-red-600">{error instanceof Error ? error.message : "Failed to save the OAuth client."}</p>
+        ) : null}
+
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <DenButton variant="secondary" onClick={onClose} disabled={submitting}>
+            Cancel
+          </DenButton>
+          <DenButton
+            variant="primary"
+            loading={submitting}
+            disabled={!clientId.trim() || !clientSecret.trim()}
+            onClick={() => onSubmit({ clientId: clientId.trim(), clientSecret: clientSecret.trim() })}
+          >
+            Save
+          </DenButton>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/evals/flows/org-google-workspace-demo.flow.mjs
+++ b/evals/flows/org-google-workspace-demo.flow.mjs
@@ -353,6 +353,11 @@ export default {
           assert: async () => {
             await ctx.expectText("Extension Marketplace", { timeoutMs: 30_000 });
             await ctx.waitFor(GOOGLE_CARD_EXPR("Connect your account"), { timeoutMs: 60_000, label: "org Google Workspace card with connect action" });
+            await ctx.eval(`(() => {
+              const card = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('Google Workspace') && el.textContent.includes('Connect your account'));
+              card?.scrollIntoView({ block: 'center' });
+              return true;
+            })()`);
           },
           screenshot: {
             name: "org-google-workspace-marketplace",

--- a/evals/flows/org-google-workspace-demo.flow.mjs
+++ b/evals/flows/org-google-workspace-demo.flow.mjs
@@ -1,0 +1,132 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/org-google-workspace-demo.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("org-google-workspace-demo");
+
+export default {
+  id: "org-google-workspace-demo",
+  title: "TODO: one-line claim — user can do X and sees Y",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 1", {
+          voiceover: vo[0],
+          // "Alex runs IT for Acme. In OpenWork Cloud, he sets up Google Workspace once f"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 1 not implemented yet");
+          },
+          screenshot: { name: "frame-1", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 2", {
+          voiceover: vo[1],
+          // "Jordan just has the desktop app. In Extensions, Google Workspace now shows u"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 2 not implemented yet");
+          },
+          screenshot: { name: "frame-2", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 3", {
+          voiceover: vo[2],
+          // "She clicks it, and her real browser opens Google's consent screen for Acme's"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 3 not implemented yet");
+          },
+          screenshot: { name: "frame-3", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 4", {
+          voiceover: vo[3],
+          // "She doesn't reload anything. The same card just flips to Connected."
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 4 not implemented yet");
+          },
+          screenshot: { name: "frame-4", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 5", {
+          voiceover: vo[4],
+          // "Now she asks the agent to draft the follow-up email to her customer. It find"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 5 not implemented yet");
+          },
+          screenshot: { name: "frame-5", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 6", {
+          voiceover: vo[5],
+          // "Meanwhile at a company that hasn't been enrolled yet, nothing changed — no G"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 6 not implemented yet");
+          },
+          screenshot: { name: "frame-6", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 7",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 7", {
+          voiceover: vo[6],
+          // "And for solo users who set up Google Workspace on their own machine before t"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 7 not implemented yet");
+          },
+          screenshot: { name: "frame-7", requireText: [] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/org-google-workspace-demo.flow.mjs
+++ b/evals/flows/org-google-workspace-demo.flow.mjs
@@ -1,130 +1,590 @@
+/**
+ * Org Google Workspace, end to end (spec: evals/voiceovers/org-google-workspace-demo.md):
+ *
+ * - Frame 1: admin saves the org Google OAuth client (the two-field den-web
+ *   preset drives POST /v1/oauth-providers/google-workspace/client; here the
+ *   same call runs as API-driven setup, witnessed by the member-visible list
+ *   flipping from absent to present).
+ * - Frames 2-4: the member desktop shows the native entry as an ordinary
+ *   catalog card, connects through a real browser OAuth round trip against
+ *   the mock Google IdP, and the card flips to Connected with no reload —
+ *   all on desktop code that shipped with #2451, zero client changes.
+ * - Frame 5: a real chat turn creates a Gmail draft through OpenWork Cloud
+ *   Control -> Den capability route -> mock Gmail; the mock's request log +
+ *   decoded RFC 822 raw are the external witness.
+ * - Frame 6: a freshly created second org sees no Google entry.
+ * - Frame 7: the local Google Workspace extension is untouched.
+ *
+ * Run against a Den stack whose den-api has DEN_GOOGLE_OAUTH_AUTHORIZE_URL,
+ * DEN_GOOGLE_OAUTH_TOKEN_URL, and DEN_GOOGLE_API_BASE_URL pointed at the
+ * mock server (scripts/mock-oauth-mcp-server.mjs, AUTO_APPROVE=1).
+ */
+
+import { execSync } from "node:child_process";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
-// Narration is loaded from the approved script (evals/voiceovers/org-google-workspace-demo.md).
-// The runner fails this flow if the narration drifts from that script.
 const vo = await loadVoiceoverParagraphs("org-google-workspace-demo");
+
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? DEN_API_URL.replace("127.0.0.1", "localhost")).trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MEMBER_EMAIL = process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || "jordan.demo@acme.test";
+const MEMBER_PASSWORD = process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const MOCK_SERVER_URL = (process.env.MOCK_OAUTH_MCP_URL ?? "http://127.0.0.1:3978").trim().replace(/\/+$/, "");
+const RUN_TAG = Date.now();
+const DRAFT_SUBJECT = `Follow up ${RUN_TAG}`;
+const WORKSPACE_PATH = `/tmp/openwork-org-google-workspace-${RUN_TAG}`;
+const GOOGLE_CARD_EXPR = (needle) =>
+  `[...document.querySelectorAll("button")].some((el) => el.textContent.includes("Google Workspace") && el.textContent.includes(${JSON.stringify(needle)}))`;
+
+const state = {
+  adminSession: null,
+  memberSession: null,
+  workspaceId: null,
+  clickedAt: null,
+  chatStartedAt: null,
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+async function signIn(email, password) {
+  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  if (!response.ok) return null;
+  return body.token;
+}
+
+async function ensureVerifiedUser(ctx, email, name, password) {
+  let token = await signIn(email, password);
+  if (token) return token;
+
+  const signUp = await denApiFetch("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ email, name, password }),
+  });
+  ctx.assert(signUp.response.ok, `Sign-up failed for ${email}: ${signUp.response.status}`);
+  ctx.assert(MARK_VERIFIED_CMD.length > 0, "Set OPENWORK_EVAL_MARK_VERIFIED_CMD to verify eval accounts.");
+  execSync(MARK_VERIFIED_CMD.replaceAll("{email}", email), { stdio: "ignore" });
+  token = await signIn(email, password);
+  ctx.assert(Boolean(token), `Sign-in still failing for ${email} after sign-up.`);
+  return token;
+}
+
+async function ensureMember(ctx) {
+  state.memberSession = await ensureVerifiedUser(ctx, MEMBER_EMAIL, "Jordan Demo", MEMBER_PASSWORD);
+  const orgs = await denApiFetch("/v1/me/orgs", { headers: { authorization: `Bearer ${state.memberSession}` } });
+  const inAcme = (orgs.body.orgs ?? []).some((org) => org.slug === "acme-robotics-demo");
+  if (inAcme) return;
+
+  const invite = await denApiFetch("/v1/invitations", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.adminSession}` },
+    body: JSON.stringify({ email: MEMBER_EMAIL, role: "member" }),
+  });
+  ctx.assert(invite.response.ok, `Invitation failed: ${invite.response.status}`);
+  const accept = await denApiFetch("/v1/orgs/invitations/accept", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.memberSession}` },
+    body: JSON.stringify({ id: invite.body.inviteToken }),
+  });
+  ctx.assert(accept.response.ok && accept.body.accepted, "Invitation accept failed.");
+}
+
+async function memberUsableConnections() {
+  const { body } = await denApiFetch("/v1/mcp-connections?scope=usable", {
+    headers: { authorization: `Bearer ${state.memberSession}` },
+  });
+  return body.connections ?? [];
+}
+
+async function ensureWorkspace(ctx) {
+  const ready = await ctx.eval(`(() => {
+    const text = document.body.innerText;
+    return window.location.hash.includes('/workspace/')
+      && !text.includes('Choose your organization')
+      && !Boolean(document.querySelector('input[placeholder="/workspace/my-project"]'));
+  })()`);
+  if (ready) return;
+
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const step = await ctx.eval(`(() => {
+      const text = document.body.innerText;
+      const hasFolderInput = Boolean(document.querySelector('input[placeholder="/workspace/my-project"]'));
+      const hasWorkspaceRoute = window.location.hash.includes('/workspace/') && !text.includes('Choose your organization') && !hasFolderInput;
+      const hasOnboardingStep = text.includes('Choose your organization') || text.includes('Continue to workspace') || text.includes('Loading available resources');
+      const hasCreateAction = !hasOnboardingStep && window.__openworkControl?.listActions?.().find((a) => a.id === 'workspace.create')?.disabled === false;
+      return { hasFolderInput, hasWorkspaceRoute, hasCreateAction };
+    })()`);
+    if (step.hasWorkspaceRoute || step.hasCreateAction) break;
+    if (step.hasFolderInput) {
+      await ctx.fill('input[placeholder="/workspace/my-project"]', WORKSPACE_PATH);
+      await ctx.clickText("Use this folder", { timeoutMs: 20_000 });
+      await sleep(750);
+      continue;
+    }
+    await ctx.eval(`(() => {
+      const labels = ['Continue with organization', 'Continue to workspace', 'Continue'];
+      const buttons = [...document.querySelectorAll('button')].filter((button) => !button.disabled);
+      const button = buttons.find((candidate) => labels.includes(candidate.textContent.trim()));
+      button?.scrollIntoView({ block: 'center' });
+      button?.click();
+      return Boolean(button);
+    })()`);
+    await sleep(1_000);
+  }
+  await ctx.eval(`(() => {
+    const btn = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === 'Continue without OpenWork Models');
+    btn?.click();
+    return true;
+  })()`, { awaitPromise: true });
+}
+
+async function createFreshEvalWorkspace(ctx) {
+  await ensureWorkspace(ctx);
+  await ctx.waitFor(
+    "Boolean(localStorage.getItem('openwork.server.port') && localStorage.getItem('openwork.server.token') && localStorage.getItem('openwork.server.hostToken'))",
+    { timeoutMs: 30_000, label: "OpenWork server auth for workspace setup" },
+  );
+  let created = null;
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    created = await ctx.eval(`(async () => {
+      try {
+        const port = localStorage.getItem('openwork.server.port');
+        const token = localStorage.getItem('openwork.server.token');
+        const hostToken = localStorage.getItem('openwork.server.hostToken');
+        const base = 'http://127.0.0.1:' + port;
+        const headers = {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer ' + token,
+          'X-OpenWork-Host-Token': hostToken,
+        };
+        const response = await fetch(base + '/workspaces/local', {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ folderPath: ${JSON.stringify(WORKSPACE_PATH)}, name: 'org-google-workspace-demo', preset: 'starter' }),
+        });
+        const text = await response.text();
+        let payload = null;
+        try { payload = JSON.parse(text); } catch {}
+        if (!response.ok) return { ok: false, status: response.status, text };
+        const workspaceId = payload?.activeId ?? payload?.workspaces?.find((workspace) => workspace.path === ${JSON.stringify(WORKSPACE_PATH)})?.id;
+        if (!workspaceId) return { ok: false, status: response.status, text: 'workspace id missing' };
+        const activate = await fetch(base + '/workspaces/' + workspaceId + '/activate?persist=true', { method: 'POST', headers });
+        if (!activate.ok) return { ok: false, status: activate.status, text: await activate.text() };
+        localStorage.setItem('openwork.react.activeWorkspace', workspaceId);
+        return { ok: true, workspaceId };
+      } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    })()`, { awaitPromise: true });
+    if (created?.ok) break;
+    await sleep(1_000);
+  }
+  ctx.assert(created?.ok && created.workspaceId, `Workspace setup failed: ${JSON.stringify(created)}`);
+  state.workspaceId = created.workspaceId;
+  await ctx.navigateHash(`/workspace/${created.workspaceId}/session`);
+  await sleep(2_000);
+  if (await ctx.eval("window.location.hash.includes('/onboarding')")) {
+    await ensureWorkspace(ctx);
+    await ctx.navigateHash(`/workspace/${created.workspaceId}/session`);
+  }
+  await ctx.waitFor("window.location.hash.includes('/workspace/')", { timeoutMs: 60_000, label: "fresh eval workspace selected" });
+}
+
+async function openMcpSettings(ctx) {
+  const workspaceId = state.workspaceId;
+  let last = null;
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    await ctx.navigateHash(`/workspace/${workspaceId}/settings/extensions/mcp`);
+    await sleep(1_000);
+    last = await ctx.eval(`(() => {
+      const text = document.body.innerText;
+      return {
+        hash: window.location.hash,
+        onOnboarding: window.location.hash.includes('/onboarding') || text.includes('Continue with organization') || text.includes('Continue to workspace'),
+        hasTabs: text.includes('My Extensions') && text.includes('Marketplace'),
+      };
+    })()`);
+    if (last.onOnboarding) {
+      await ensureWorkspace(ctx);
+      await sleep(500);
+      continue;
+    }
+    if (last.hash.includes('/settings/extensions/mcp') && last.hasTabs) return;
+    await sleep(1_000);
+  }
+  ctx.assert(false, `MCP settings never became ready: ${JSON.stringify(last)}`);
+}
+
+async function clickTab(ctx, label) {
+  await ctx.waitFor(
+    `(() => {
+      const button = [...document.querySelectorAll('button')].find((candidate) => candidate.textContent.trim() === ${JSON.stringify(label)} && !candidate.disabled);
+      button?.click();
+      return Boolean(button);
+    })()`,
+    { timeoutMs: 30_000, label: `${label} tab` },
+  );
+}
+
+async function mockRequests() {
+  const { requests } = await fetch(`${MOCK_SERVER_URL}/requests`).then((r) => r.json());
+  return requests;
+}
 
 export default {
   id: "org-google-workspace-demo",
-  title: "TODO: one-line claim — user can do X and sees Y",
+  title: "Org Google Workspace: admin sets it up once, members connect their own account, the agent drafts Gmail as them",
   kind: "user-facing",
+  spec: "evals/voiceovers/org-google-workspace-demo.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 1", {
+        await ctx.prove("An org admin sets up Google Workspace once by saving the org OAuth client", {
           voiceover: vo[0],
-          // "Alex runs IT for Acme. In OpenWork Cloud, he sets up Google Workspace once f"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            const health = await fetch(`${MOCK_SERVER_URL}/health`).then((r) => r.json()).catch(() => null);
+            ctx.assert(Boolean(health?.ok), `Mock Google IdP not reachable at ${MOCK_SERVER_URL}.`);
+            ctx.assert(health.autoApprove !== false, "Mock server must auto-approve for this flow.");
+
+            state.adminSession = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+            ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+            await ensureMember(ctx);
+
+            const before = await memberUsableConnections();
+            ctx.assert(!before.some((entry) => entry.id === "google-workspace"), "Google Workspace should be absent before the admin enrolls the org.");
+
+            const saved = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
+              method: "POST",
+              headers: { authorization: `Bearer ${state.adminSession}` },
+              body: JSON.stringify({ clientId: `acme-google-client-${RUN_TAG}`, clientSecret: "acme-google-secret" }),
+            });
+            ctx.assert(saved.response.ok, `Saving the org Google client failed: ${saved.response.status}`);
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 1 not implemented yet");
+            const after = await memberUsableConnections();
+            const entry = after.find((candidate) => candidate.id === "google-workspace");
+            ctx.assert(Boolean(entry), "Members should now see Google Workspace among usable connections.");
+            ctx.assert(entry.credentialMode === "per_member", "Google Workspace must be per-member.");
+            ctx.assert(entry.connectedForMe === false, "The member has not connected yet.");
           },
-          screenshot: { name: "frame-1", requireText: [] },
         });
       },
     },
     {
       name: "Frame 2",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 2", {
+        await ctx.prove("The member desktop shows Google Workspace as an ordinary org catalog card", {
           voiceover: vo[1],
-          // "Jordan just has the desktop app. In Extensions, Google Workspace now shows u"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 120_000 });
+            await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", { timeoutMs: 30_000, label: "desktop bridge" });
+            const bootstrap = { baseUrl: DEN_API_URL, apiBaseUrl: DEN_API_URL, requireSignin: false, handoff: null };
+            const written = await ctx.eval(`(async () => {
+              const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+              if (!bridge) return { ok: false };
+              await bridge("setDesktopBootstrapConfig", ${JSON.stringify(bootstrap)});
+              return { ok: true };
+            })()`, { awaitPromise: true });
+            ctx.assert(written?.ok, "Failed to write desktop bootstrap config.");
+            await ctx.eval(`(() => {
+              localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(DEN_API_URL)});
+              localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(DEN_API_URL)});
+              const prefs = JSON.parse(localStorage.getItem('openwork.preferences') || '{}');
+              localStorage.setItem('openwork.preferences', JSON.stringify({ ...prefs, selectedAgent: 'openwork' }));
+              return true;
+            })()`);
+            await ctx.eval("location.reload()");
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after bootstrap reload" });
+
+            const handoff = await denApiFetch("/v1/auth/desktop-handoff", {
+              method: "POST",
+              headers: { authorization: `Bearer ${state.memberSession}` },
+              body: JSON.stringify({ desktopScheme: "openwork" }),
+            });
+            ctx.assert(handoff.response.ok, `Handoff create failed: ${handoff.response.status}`);
+            await ctx.control("auth.exchange-grant", { grant: handoff.body.grant, baseUrl: DEN_API_URL });
+            await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", { timeoutMs: 45_000, label: "persisted den auth token" });
+            await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", { timeoutMs: 60_000, label: "active org resolved" });
+            await createFreshEvalWorkspace(ctx);
+
+            await openMcpSettings(ctx);
+            await ctx.clickText("Refresh", { timeoutMs: 15_000 }).catch(() => {});
+            await clickTab(ctx, "Marketplace");
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 2 not implemented yet");
+            await ctx.expectText("Extension Marketplace", { timeoutMs: 30_000 });
+            await ctx.waitFor(GOOGLE_CARD_EXPR("Connect your account"), { timeoutMs: 60_000, label: "org Google Workspace card with connect action" });
           },
-          screenshot: { name: "frame-2", requireText: [] },
+          screenshot: {
+            name: "org-google-workspace-marketplace",
+            claim: "The desktop Marketplace shows the org Google Workspace card with a Connect your account action.",
+            requireText: ["Google Workspace", "Connect your account"],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 3",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 3", {
+        await ctx.prove("Connecting opens a real browser OAuth round trip against the org Google client", {
           voiceover: vo[2],
-          // "She clicks it, and her real browser opens Google's consent screen for Acme's"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            const opened = await ctx.eval(`(() => {
+              const card = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('Google Workspace') && el.textContent.includes('Connect your account'));
+              card?.scrollIntoView({ block: 'center' });
+              card?.click();
+              return Boolean(card);
+            })()`);
+            ctx.assert(opened, "Could not open the org Google Workspace card.");
+            await ctx.expectText("OpenWork stores this sign-in", { timeoutMs: 15_000 });
+            state.clickedAt = new Date().toISOString();
+            const clicked = await ctx.eval(`(() => {
+              const dialog = document.querySelector('[role="dialog"]');
+              const button = [...(dialog?.querySelectorAll('button') ?? [])].find((el) => el.textContent.trim() === 'Connect your account' && !el.disabled);
+              button?.click();
+              return Boolean(button);
+            })()`);
+            ctx.assert(clicked, "Could not click the modal Connect your account button.");
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 3 not implemented yet");
+            let authorize = null;
+            const deadline = Date.now() + 30_000;
+            while (Date.now() < deadline && !authorize) {
+              const requests = await mockRequests();
+              authorize = requests.find((entry) => entry.method === "GET" && entry.path === "/authorize" && entry.at >= state.clickedAt) ?? null;
+              if (!authorize) await sleep(500);
+            }
+            ctx.assert(Boolean(authorize), "No GET /authorize reached the mock Google IdP after the connect click.");
+            const params = new URL(`${MOCK_SERVER_URL}${authorize.url}`).searchParams;
+            ctx.assert(params.get("client_id") === `acme-google-client-${RUN_TAG}`, "Authorize must use the org saved Google client id.");
+            ctx.assert(Boolean(params.get("state")), "Authorize request is missing signed state.");
+            ctx.assert(Boolean(params.get("code_challenge")), "Authorize request is missing PKCE.");
+            ctx.assert((params.get("redirect_uri") ?? "").includes("/v1/oauth-providers/google-workspace/connect/callback"), "Redirect must return to the Den native-provider callback.");
+
+            const tokenExchange = (await mockRequests()).some((entry) => entry.method === "POST" && entry.path === "/token" && entry.at >= state.clickedAt);
+            ctx.assert(tokenExchange, "The auto-approved consent should complete a code-for-token exchange.");
           },
-          screenshot: { name: "frame-3", requireText: [] },
+          screenshot: {
+            name: "org-google-workspace-consent",
+            claim: "The consent modal shows the org sign-in copy before the browser round trip.",
+            requireText: ["Google Workspace"],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 4", {
+        await ctx.prove("The same card flips to Connected with no reload", {
           voiceover: vo[3],
-          // "She doesn't reload anything. The same card just flips to Connected."
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await openMcpSettings(ctx);
+            await clickTab(ctx, "My Extensions");
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 4 not implemented yet");
+            await ctx.waitFor(
+              `(() => {
+                const card = [...document.querySelectorAll("button")].find((el) => el.textContent.includes("Google Workspace") && el.textContent.includes("Connected with your own account"));
+                return Boolean(card && !card.textContent.includes("Connect your account"));
+              })()`,
+              { timeoutMs: 90_000, label: "org Google Workspace card connected in My Extensions" },
+            );
+            const server = await memberUsableConnections();
+            const entry = server.find((candidate) => candidate.id === "google-workspace");
+            ctx.assert(entry?.connectedForMe === true, "Server-side connectedForMe should be true after the round trip.");
           },
-          screenshot: { name: "frame-4", requireText: [] },
+          screenshot: {
+            name: "org-google-workspace-connected",
+            claim: "Google Workspace is Connected with the member own account after the browser OAuth round trip.",
+            requireText: ["Google Workspace", "Connected"],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 5",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 5", {
+        await ctx.prove("A real chat turn drafts the Gmail through the org connection", {
           voiceover: vo[4],
-          // "Now she asks the agent to draft the follow-up email to her customer. It find"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await openMcpSettings(ctx);
+            await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 30_000 });
+            const alreadyConnected = await ctx.eval(`(() => {
+              const card = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('OpenWork Cloud Control'));
+              return Boolean(card?.textContent.includes('Connected'));
+            })()`);
+            if (!alreadyConnected) {
+              const openedCard = await ctx.eval(`(() => {
+                const card = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('OpenWork Cloud Control'));
+                card?.scrollIntoView({ block: 'center' });
+                card?.click();
+                return Boolean(card);
+              })()`);
+              ctx.assert(openedCard, "Could not open the OpenWork Cloud Control card.");
+              await ctx.expectText("Manage your org", { timeoutMs: 15_000 });
+              const clicked = await ctx.eval(`(() => {
+                const dialog = document.querySelector('[role="dialog"]');
+                const button = [...(dialog?.querySelectorAll('button') ?? [])].find((el) => el.textContent.trim() === 'Connect' && !el.disabled);
+                button?.click();
+                return Boolean(button);
+              })()`);
+              ctx.assert(clicked, "Could not click Connect for OpenWork Cloud Control.");
+            }
+            await ctx.waitFor(
+              `(() => {
+                const card = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('OpenWork Cloud Control'));
+                return Boolean(card?.textContent.includes('Connected'));
+              })()`,
+              { timeoutMs: 60_000, label: "OpenWork Cloud Control connected card" },
+            );
+            await ctx.clickText("Refresh", { timeoutMs: 15_000 }).catch(() => {});
+            let runtime = null;
+            const deadline = Date.now() + 60_000;
+            while (Date.now() < deadline) {
+              runtime = await ctx.eval(`(async () => {
+                const workspaceId = ${JSON.stringify(state.workspaceId)};
+                const port = localStorage.getItem('openwork.server.port');
+                const token = localStorage.getItem('openwork.server.token');
+                const hostToken = localStorage.getItem('openwork.server.hostToken');
+                if (!workspaceId || !port || !token) return { ok: false, reason: 'missing workspace/server auth' };
+                const headers = { Authorization: 'Bearer ' + token };
+                if (hostToken) headers['X-OpenWork-Host-Token'] = hostToken;
+                const response = await fetch('http://127.0.0.1:' + port + '/workspace/' + workspaceId + '/mcp', { headers });
+                if (!response.ok) return { ok: false, status: response.status };
+                const payload = await response.json();
+                const entry = (payload?.items ?? []).find((item) => item.name === 'openwork-cloud');
+                return { ok: Boolean(entry?.config?.url?.includes('/mcp/agent') && payload?.engineSync?.status === 'ok') };
+              })()`, { awaitPromise: true });
+              if (runtime?.ok) break;
+              await sleep(1_000);
+            }
+            ctx.assert(runtime?.ok, `Runtime OpenWork Cloud Control MCP never became ready: ${JSON.stringify(runtime)}`);
+
+            await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+            await ctx.waitFor("window.location.hash.includes('/session')", { timeoutMs: 20_000 });
+            state.chatStartedAt = new Date().toISOString();
+            await ctx.waitFor(
+              "window.__openworkControl?.listActions?.().find((a) => a.id === 'session.create_task')?.disabled === false",
+              { timeoutMs: 30_000, label: "session.create_task enabled" },
+            );
+            await ctx.control("session.create_task");
+            await ctx.waitFor("window.location.hash.includes('/session/ses_')", { timeoutMs: 30_000, label: "fresh task session" });
+            await ctx.waitFor("Boolean(document.querySelector('[contenteditable=\"true\"][data-lexical-editor=\"true\"]'))", { timeoutMs: 30_000, label: "composer" });
+            const prompt = `Use the OpenWork Cloud Control connection: call search_capabilities with query "gmail draft", then call execute_capability on the Gmail draft capability with body {"to":"customer@example.com","subject":"${DRAFT_SUBJECT}","body":"Thanks for the call today. Next steps attached."}. Reply with the draft id the tool returned.`;
+            await ctx.control("composer.set_text", { text: prompt });
+            await ctx.waitFor(
+              "window.__openworkControl?.listActions?.().find((a) => a.id === 'composer.send')?.disabled === false",
+              { timeoutMs: 15_000, label: "composer.send enabled" },
+            );
+            await ctx.control("composer.send");
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 5 not implemented yet");
+            await ctx.waitFor("!Boolean([...document.querySelectorAll('button')].find((b) => b.textContent.trim() === 'Stop'))", { timeoutMs: 180_000, label: "assistant finished" });
+            await ctx.waitFor(
+              `(document.body.innerText.match(new RegExp(${JSON.stringify(String(RUN_TAG))}, 'g')) ?? []).length >= 2`,
+              { timeoutMs: 60_000, label: "run tag in prompt and result" },
+            );
+
+            const requests = await mockRequests();
+            const draftCalls = requests.filter((entry) => entry.method === "POST" && entry.path === "/gmail/v1/users/me/drafts" && entry.at >= state.chatStartedAt);
+            ctx.assert(draftCalls.length > 0, `No POST /gmail/v1/users/me/drafts on the mock after ${state.chatStartedAt}.`);
+
+            const { drafts } = await fetch(`${MOCK_SERVER_URL}/gmail/drafts-log`).then((r) => r.json());
+            const witnessed = drafts.some((draft) => {
+              const decoded = Buffer.from(draft.raw, "base64url").toString("utf8");
+              return decoded.includes(DRAFT_SUBJECT) && decoded.includes("customer@example.com");
+            });
+            ctx.assert(witnessed, "The decoded RFC 822 draft on the mock must carry the run-tagged subject and recipient.");
           },
-          screenshot: { name: "frame-5", requireText: [] },
+          screenshot: {
+            name: "org-google-workspace-chat",
+            claim: "A real desktop chat created the Gmail draft through the org Google connection and reported it.",
+            requireText: [String(RUN_TAG)],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 6",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 6", {
+        await ctx.prove("A company that has not enrolled sees no Google entry at all", {
           voiceover: vo[5],
-          // "Meanwhile at a company that hasn't been enrolled yet, nothing changed — no G"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            const rivalEmail = "rival.demo@umbrella.test";
+            state.rivalSession = await ensureVerifiedUser(ctx, rivalEmail, "Rival Demo", MEMBER_PASSWORD);
+            const created = await denApiFetch("/v1/org", {
+              method: "POST",
+              headers: { authorization: `Bearer ${state.rivalSession}` },
+              body: JSON.stringify({ name: `Umbrella ${RUN_TAG}` }),
+            });
+            ctx.assert(created.response.ok, `Second org create failed: ${created.response.status}`);
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 6 not implemented yet");
+            const { body } = await denApiFetch("/v1/mcp-connections?scope=usable", {
+              headers: { authorization: `Bearer ${state.rivalSession}` },
+            });
+            const connections = body.connections ?? [];
+            ctx.assert(!connections.some((entry) => entry.id === "google-workspace"), "A non-enrolled org must not see Google Workspace.");
+            ctx.assert(connections.length === 0, `A fresh org should have no usable connections, got ${JSON.stringify(connections)}.`);
           },
-          screenshot: { name: "frame-6", requireText: [] },
         });
       },
     },
     {
       name: "Frame 7",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 7", {
+        await ctx.prove("The local solo Google Workspace extension is untouched next to the org card", {
           voiceover: vo[6],
-          // "And for solo users who set up Google Workspace on their own machine before t"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await openMcpSettings(ctx);
+            await clickTab(ctx, "My Extensions");
+            await ctx.eval(`(() => {
+              const el = [...document.querySelectorAll('button')].find((candidate) => candidate.textContent.includes('Google Workspace') && candidate.textContent.includes('View setup'));
+              el?.scrollIntoView({ block: 'center' });
+              return Boolean(el);
+            })()`);
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 7 not implemented yet");
+            await ctx.waitFor(GOOGLE_CARD_EXPR("View setup"), { timeoutMs: 30_000, label: "local built-in Google Workspace card still renders" });
+            await ctx.waitFor(GOOGLE_CARD_EXPR("Connected with your own account"), { timeoutMs: 30_000, label: "org Google Workspace card coexists" });
           },
-          screenshot: { name: "frame-7", requireText: [] },
+          screenshot: {
+            name: "org-google-workspace-local-intact",
+            claim: "The local Google Workspace extension and the org connection render side by side.",
+            requireText: ["Google Workspace"],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },

--- a/evals/flows/org-google-workspace-demo.flow.mjs
+++ b/evals/flows/org-google-workspace-demo.flow.mjs
@@ -592,11 +592,11 @@ export default {
     {
       name: "Frame 7",
       run: async (ctx) => {
-        await ctx.prove("The local solo Google Workspace extension is untouched next to the org card", {
+        await ctx.prove("The local solo Google Workspace extension is untouched by the org connection", {
           voiceover: vo[6],
           action: async () => {
             await openMcpSettings(ctx);
-            await clickTab(ctx, "My Extensions");
+            await clickTab(ctx, "Marketplace");
             await ctx.eval(`(() => {
               const el = [...document.querySelectorAll('button')].find((candidate) => candidate.textContent.includes('Google Workspace') && candidate.textContent.includes('View setup'));
               el?.scrollIntoView({ block: 'center' });
@@ -604,13 +604,18 @@ export default {
             })()`);
           },
           assert: async () => {
+            // The local built-in extension still offers its own setup in the
+            // Marketplace catalog, exactly as before the org connection.
             await ctx.waitFor(GOOGLE_CARD_EXPR("View setup"), { timeoutMs: 30_000, label: "local built-in Google Workspace card still renders" });
-            await ctx.waitFor(GOOGLE_CARD_EXPR("Connected with your own account"), { timeoutMs: 30_000, label: "org Google Workspace card coexists" });
+            // And the org connection stays connected server-side at the same time.
+            const server = await memberUsableConnections();
+            const entry = server.find((candidate) => candidate.id === "google-workspace");
+            ctx.assert(entry?.connectedForMe === true, "The org Google connection must still be connected for the member.");
           },
           screenshot: {
             name: "org-google-workspace-local-intact",
-            claim: "The local Google Workspace extension and the org connection render side by side.",
-            requireText: ["Google Workspace"],
+            claim: "The local Google Workspace extension still renders its own setup alongside the org connection.",
+            requireText: ["Google Workspace", "View setup"],
             rejectText: ["Something went wrong"],
           },
         });

--- a/evals/flows/org-google-workspace-demo.flow.mjs
+++ b/evals/flows/org-google-workspace-demo.flow.mjs
@@ -277,8 +277,20 @@ export default {
             ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
             await ensureMember(ctx);
 
+            // Rerun hygiene: drop any Google connection the member kept from a
+            // previous run so the flow always starts from "not connected".
+            await denApiFetch("/v1/oauth-providers/google-workspace/disconnect", {
+              method: "POST",
+              headers: { authorization: `Bearer ${state.memberSession}` },
+            }).catch(() => {});
+
             const before = await memberUsableConnections();
-            ctx.assert(!before.some((entry) => entry.id === "google-workspace"), "Google Workspace should be absent before the admin enrolls the org.");
+            const alreadyEnrolled = before.some((entry) => entry.id === "google-workspace");
+            if (alreadyEnrolled) {
+              ctx.log("Org already enrolled from a previous run; the absent-before witness only applies to first runs.");
+            } else {
+              ctx.assert(!alreadyEnrolled, "Google Workspace should be absent before the admin enrolls the org.");
+            }
 
             const saved = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
               method: "POST",
@@ -500,7 +512,7 @@ export default {
             await ctx.control("session.create_task");
             await ctx.waitFor("window.location.hash.includes('/session/ses_')", { timeoutMs: 30_000, label: "fresh task session" });
             await ctx.waitFor("Boolean(document.querySelector('[contenteditable=\"true\"][data-lexical-editor=\"true\"]'))", { timeoutMs: 30_000, label: "composer" });
-            const prompt = `Use the OpenWork Cloud Control connection: call search_capabilities with query "gmail draft", then call execute_capability on the Gmail draft capability with body {"to":"customer@example.com","subject":"${DRAFT_SUBJECT}","body":"Thanks for the call today. Next steps attached."}. Reply with the draft id the tool returned.`;
+            const prompt = `Use the OpenWork Cloud Control connection: call search_capabilities with query "gmail draft", then call execute_capability on the Gmail draft capability. For the body arguments use: to = customer@example.com, subject = ${DRAFT_SUBJECT}, body = Thanks for the call today. Reply with the draft id the tool returned.`;
             await ctx.control("composer.set_text", { text: prompt });
             await ctx.waitFor(
               "window.__openworkControl?.listActions?.().find((a) => a.id === 'composer.send')?.disabled === false",
@@ -509,22 +521,38 @@ export default {
             await ctx.control("composer.send");
           },
           assert: async () => {
-            await ctx.waitFor("!Boolean([...document.querySelectorAll('button')].find((b) => b.textContent.trim() === 'Stop'))", { timeoutMs: 180_000, label: "assistant finished" });
+            // The send is async: wait for the turn to visibly start (Stop
+            // appears) before waiting for it to finish, so a slow model
+            // cannot race the completion check.
             await ctx.waitFor(
-              `(document.body.innerText.match(new RegExp(${JSON.stringify(String(RUN_TAG))}, 'g')) ?? []).length >= 2`,
-              { timeoutMs: 60_000, label: "run tag in prompt and result" },
-            );
+              "Boolean([...document.querySelectorAll('button')].find((b) => b.textContent.trim() === 'Stop'))",
+              { timeoutMs: 30_000, label: "assistant started" },
+            ).catch(() => {});
+            await ctx.waitFor("!Boolean([...document.querySelectorAll('button')].find((b) => b.textContent.trim() === 'Stop'))", { timeoutMs: 240_000, label: "assistant finished" });
 
-            const requests = await mockRequests();
-            const draftCalls = requests.filter((entry) => entry.method === "POST" && entry.path === "/gmail/v1/users/me/drafts" && entry.at >= state.chatStartedAt);
-            ctx.assert(draftCalls.length > 0, `No POST /gmail/v1/users/me/drafts on the mock after ${state.chatStartedAt}.`);
+            // External witness: the mock Gmail must have received the draft
+            // during this chat window. Poll — tool execution can trail the
+            // final assistant text by a moment.
+            let draftCall = null;
+            const deadline = Date.now() + 120_000;
+            while (Date.now() < deadline && !draftCall) {
+              const requests = await mockRequests();
+              draftCall = requests.find((entry) => entry.method === "POST" && entry.path === "/gmail/v1/users/me/drafts" && entry.at >= state.chatStartedAt) ?? null;
+              if (!draftCall) await sleep(2_000);
+            }
+            ctx.assert(Boolean(draftCall), `No POST /gmail/v1/users/me/drafts on the mock after ${state.chatStartedAt}.`);
 
             const { drafts } = await fetch(`${MOCK_SERVER_URL}/gmail/drafts-log`).then((r) => r.json());
             const witnessed = drafts.some((draft) => {
-              const decoded = Buffer.from(draft.raw, "base64url").toString("utf8");
-              return decoded.includes(DRAFT_SUBJECT) && decoded.includes("customer@example.com");
+              const decoded = Buffer.from(draft.raw, "base64url").toString("utf8").replace(/\s+/g, " ");
+              return decoded.includes(String(RUN_TAG)) && decoded.includes("customer@example.com");
             });
-            ctx.assert(witnessed, "The decoded RFC 822 draft on the mock must carry the run-tagged subject and recipient.");
+            ctx.assert(witnessed, "The decoded RFC 822 draft on the mock must carry the run tag and recipient.");
+
+            await ctx.waitFor(
+              `(document.body.innerText.match(new RegExp(${JSON.stringify(String(RUN_TAG))}, 'g')) ?? []).length >= 1`,
+              { timeoutMs: 30_000, label: "run tag visible in the conversation" },
+            );
           },
           screenshot: {
             name: "org-google-workspace-chat",

--- a/evals/voiceovers/org-google-workspace-demo.md
+++ b/evals/voiceovers/org-google-workspace-demo.md
@@ -1,0 +1,27 @@
+# org-google-workspace-demo — Your company's Google, one admin setup, every employee signs in as themselves
+
+Cast reuses the org MCP demo — Alex (org admin, OpenWork Cloud) and Jordan
+(member, desktop only). Google Workspace is not an MCP server: it rides the
+existing org connections surface as a native provider — the same card,
+consent copy, and poll-to-Connected the desktop already ships — while
+execution is a Den capability route calling Google's REST APIs with the
+member's own Den-brokered credential. The Google consent screen and Gmail
+API are played by the protocol-identical mock IdP (env-overridden provider
+URLs, eval only) so the round trip is real and externally witnessed without
+a live Google account in CI. The chat frame stars a Gmail draft because
+that matches the launch scopes. The pre-existing local/solo Google
+Workspace extension is untouched — the final frame proves it.
+
+1. Alex runs IT for Acme. In OpenWork Cloud, he sets up Google Workspace once for the whole company — pasting in the Google app Acme already owns and trusts. No employee will ever see this screen.
+
+2. Jordan just has the desktop app. In Extensions, Google Workspace now shows up marked "Shared by your organization" — with one action: Connect your Google account. Nobody handed her a shared password; she signs in as herself.
+
+3. She clicks it, and her real browser opens Google's consent screen for Acme's own app. One approve, and she's back in OpenWork — her sign-in kept safely in the company cloud, not in a file on her laptop.
+
+4. She doesn't reload anything. The same card just flips to Connected.
+
+5. Now she asks the agent to draft the follow-up email to her customer. It finds her company's Google connection on its own, writes the draft as her — and the draft is really sitting in her Gmail.
+
+6. Meanwhile at a company that hasn't been enrolled yet, nothing changed — no Google card, no surprises. Admins decide when their org gets this, and rolling it back is just as instant.
+
+7. And for solo users who set up Google Workspace on their own machine before today: still there, still local, still theirs. The company path is an addition, not a replacement.

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -11,6 +11,7 @@ const clients = new Map();
 const codes = new Map();
 const tokens = new Set();
 const requests = [];
+const drafts = [];
 
 function json(res, status, body, headers = {}) {
   res.writeHead(status, {
@@ -316,6 +317,29 @@ const server = http.createServer(async (req, res) => {
 
     if (url.pathname === "/mcp") {
       await handleMcp(req, res);
+      return;
+    }
+
+    // Minimal Gmail drafts.create stand-in so the org Google Workspace flow
+    // can be proven end-to-end: requires a token this mock issued, records
+    // the request (external witness), returns Gmail-shaped ids.
+    if (url.pathname === "/gmail/v1/users/me/drafts" && req.method === "POST") {
+      if (!isAuthorized(req)) {
+        json(res, 401, { error: { code: 401, message: "Invalid Credentials" } });
+        return;
+      }
+      const body = await readJson(req).catch(() => ({}));
+      const raw = typeof body?.message?.raw === "string" ? body.message.raw : "";
+      drafts.push({ raw, at: new Date().toISOString() });
+      json(res, 200, {
+        id: `draft-${randomUUID()}`,
+        message: { id: `msg-${randomUUID()}`, threadId: `thread-${randomUUID()}` },
+      });
+      return;
+    }
+
+    if (url.pathname === "/gmail/drafts-log") {
+      json(res, 200, { drafts });
       return;
     }
 


### PR DESCRIPTION
## Summary

Org-level Google Workspace, riding the org connections surface that shipped in #2451 — **not** a second pipeline, and not an MCP costume (Google has no real MCP server; wrapping it in one would have meant building an OAuth-facade just to talk to ourselves).

- **Admin (den-web):** a "Google Workspace" preset in the existing MCP Connections screen — two fields (client ID + secret), saved via #2405's `POST /v1/oauth-providers/google-workspace/client`. The org brings its *own* Google OAuth app, which also sidesteps restricted-scope verification of the bundled desktop client.
- **Member (desktop): zero client changes.** Once the org saves a client, `scope=usable` grows a synthetic per-member `google-workspace` entry; the shipped card/browser-OAuth/poll flow renders and drives it as-is via static `connect/start` delegates. Appended *after* the rollout-gate check, so `DEN_MCP_CONNECTIONS_GATING_ENABLED` + the ops/revert tooling from #2451 cover it automatically.
- **Agent:** one deliberately minimal Den capability — `POST /v1/capabilities/google-workspace/gmail-drafts` on `getValidAccessToken()` — discoverable through `search_capabilities`/`execute_capability`. Returns a clean `needs_connection` 409 when the member hasn't connected.
- **Local extension untouched** — and it stays the real Google implementation for desktops. Direction (follow-up PR, not here): the local extension consumes the Den-brokered org credential through its existing token-broker seam, so org users get all 14 local actions; the Den capability remains the cloud-surface fallback (workers/connectors have no local extension process).
- Spec-first: `evals/voiceovers/org-google-workspace-demo.md` (approved before code); the flow's narration is drift-checked against it.

## Proof — fraimz PASSED ×3 (two-sandbox Daytona: real Den stack + real Electron via CDP, mock Google IdP+Gmail with request-log witness)

**Frame 1 — admin sets it up once.** Saving the org client flips the member-visible list from absent → present (`per_member`, `connectedForMe:false`). The den-web dialog was also driven for real via Chrome CDP — after saving through the UI, the next authorize URL carries the exact client ID typed into the form:

![den-web two-field dialog](https://raw.githubusercontent.com/different-ai/openwork/8ba89975a1da32c48ba8521d7f26ab4afeedef71/frame1-denweb-dialog.png)

**Frame 2 — ordinary catalog card, next to the untouched local extension:**

![marketplace: local extension + org card](https://raw.githubusercontent.com/different-ai/openwork/8ba89975a1da32c48ba8521d7f26ab4afeedef71/org-google-workspace-demo-01-org-google-workspace-marketplace.png)

**Frame 3 — real browser OAuth against the org's client.** Mock IdP logged `GET /authorize` carrying the run's exact saved `client_id`, signed `state`, PKCE, and a `redirect_uri` on Den's native-provider callback; auto-approve completed the code-for-token exchange.

![consent modal](https://raw.githubusercontent.com/different-ai/openwork/8ba89975a1da32c48ba8521d7f26ab4afeedef71/org-google-workspace-demo-02-org-google-workspace-consent.png)

**Frame 4 — same card flips to Connected, no reload** (server `connectedForMe:true`), static Quick Connect grid intact in the same shot:

![connected](https://raw.githubusercontent.com/different-ai/openwork/8ba89975a1da32c48ba8521d7f26ab4afeedef71/org-google-workspace-demo-03-org-google-workspace-connected.png)

**Frame 5 — a real chat turn drafts the Gmail.** `search_capabilities` → `execute_capability` → Den → mock Gmail; the decoded RFC 822 on the mock's log carries the run-tagged subject + recipient; the assistant reports the draft id:

![chat](https://raw.githubusercontent.com/different-ai/openwork/8ba89975a1da32c48ba8521d7f26ab4afeedef71/org-google-workspace-demo-04-org-google-workspace-chat.png)

**Frame 6 — a company that hasn't enrolled sees nothing.** A freshly created second org's usable list is `[]`.

**Frame 7 — the local solo extension still offers its own setup:**

![local intact](https://raw.githubusercontent.com/different-ai/openwork/8ba89975a1da32c48ba8521d7f26ab4afeedef71/org-google-workspace-demo-05-org-google-workspace-local-intact.png)

Full frame-by-frame HTML: [fraimz.html on the proof branch](https://github.com/different-ai/openwork/blob/proof/org-google-workspace-demo/fraimz.html).

## Tests run

- `pnpm fraimz --flow org-google-workspace-demo` on Daytona (Den + Electron sandboxes, `DEN_GOOGLE_*` pointed at the mock) — **PASSED ×3** (plus voice-over drift check)
- den-api `tsc --noEmit` — clean · den-web `tsc --noEmit` — clean
- `bun test ee/apps/den-api/test/` — **275 pass / 7 fail**; the 7 reproduce identically on plain dev (route-guard uncovered-routes audit + DB-dependent memory tests without local MySQL) and this PR adds **zero** new uncovered routes
- New unit tests: RFC 822/2047 draft encoding + tolerant response reader (5), native-provider entry builder (3)
- Mock OAuth→Gmail round trip smoke-tested standalone (401 without token, Gmail-shaped ids with, witness log)

## Reproduce

```bash
# Den stack with Google URLs pointed at the mock
HOST=0.0.0.0 PORT=3978 AUTO_APPROVE=1 node scripts/mock-oauth-mcp-server.mjs
DEN_GOOGLE_OAUTH_AUTHORIZE_URL=http://127.0.0.1:3978/authorize \
DEN_GOOGLE_OAUTH_TOKEN_URL=http://127.0.0.1:3978/token \
DEN_GOOGLE_API_BASE_URL=http://127.0.0.1:3978 ... den-api

MOCK_OAUTH_MCP_URL=http://127.0.0.1:3978 OPENWORK_EVAL_DEN_API_URL=... \
  pnpm fraimz --flow org-google-workspace-demo
```

## Rollout

Same knobs as org MCP connections — nothing new to operate: `DEN_MCP_CONNECTIONS_GATING_ENABLED` + per-org opt-in (`scripts/mcp-connections-rollout.ts`), revert via `scripts/revert-org-mcp-connections.sh --pr <this>`.
