### PR TITLE
fix(den): remove Beta badge from OpenWork Models sidebar

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -226,7 +226,6 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
         href: getInferenceRoute(activeOrg.slug),
         label: "Models",
         icon: Sparkles,
-        badge: "Beta",
         children: [
           { href: getInferenceRoute(activeOrg.slug), label: "OpenWork Models" },
           { href: getCustomLlmProvidersRoute(activeOrg.slug), label: "LLM Providers" },


### PR DESCRIPTION
## Summary
- Removes the "Beta" badge pill next to "OpenWork Models" in the org dashboard sidebar nav.

## What changed
- `ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx`: dropped `badge: "Beta"` from the Models nav item (the field is optional, so this is a pure removal with no type impact).

## Not changed
- The separate "Beta" badge on the Models page header (`inference-screen.tsx`, via `DashboardPageTemplate`'s `badgeLabel` prop) was intentionally left as-is — it's a different element from the sidebar nav badge and wasn't in scope.

## Testing
- No build/typecheck run: `node_modules` isn't installed in this worktree and a full monorepo `pnpm install` is out of proportion for a one-line deletion of an optional field (`badge?: string`). Removing an optional property is type-safe by construction.
- No screenshot/video captured for this change.

🤖 Generated with OpenCode