### PR TITLE
fix(app): add spacing below sidebar 'Search sessions' button

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -751,7 +751,7 @@ export function AppSidebar(props: AppSidebarProps) {
           </div>
         ) : null}
         {props.onOpenSessionSearch ? (
-          <SidebarHeader className="pb-0">
+          <SidebarHeader className="pb-2">
             <SidebarMenu>
               <SidebarMenuItem>
                 <SidebarMenuButton


### PR DESCRIPTION
## Summary
- Adds a small bottom padding below the "Search sessions" button in the sidebar so it isn't flush against the workspace/session list below it.

## What changed
- `apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx`: changed the `SidebarHeader` wrapping the search button from `pb-0` to `pb-2` (8px), matching the header's default `p-2` spacing used elsewhere in the sidebar.

## Why
- The search button's wrapper explicitly zeroed out bottom padding (`pb-0`) while the list below adds no top spacing of its own, so the button sat directly against the first workspace row with no visual separation.

## Testing
- One-line Tailwind class change (`pb-0` → `pb-2`), matching the header's own default spacing token — no logic/behavior change.
- Did not run the dev app for a screenshot: this is a fresh worktree without `node_modules` installed, and installing the full monorepo to capture a screenshot of a single spacing-token change was not proportionate. Reviewers can verify by running `pnpm dev` in `apps/app` and opening the sidebar.

🤖 Generated with OpenCode