### PR TITLE
fix(app): move cloud sign-in CTA to header

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,10 +2,11 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { Columns2, FileText, Globe, Mic2, Settings2, X, Zap } from "lucide-react";
+import { Cloud, Columns2, FileText, Globe, Mic2, Settings2, X, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { OPENWORK_EXTENSION_CATALOG } from "../../../../app/constants";
+import { buildDenAuthUrl, readDenBootstrapConfig } from "../../../../app/lib/den";
 import { type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
@@ -30,6 +31,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
+import { usePlatform } from "../../../kernel/platform";
+import { useDenAuth } from "../../cloud/den-auth-provider";
 import ProviderAuthModal, { type ProviderAuthModalProps } from "../../connections/provider-auth/provider-auth-modal";
 import { RenameSessionModal } from "../modals/rename-session-modal";
 import { AppSidebar } from "../sidebar/app-sidebar";
@@ -284,6 +287,8 @@ function controlStringArg(args: unknown, key: string) {
 
 export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
+  const platform = usePlatform();
+  const denAuth = useDenAuth();
   const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
   const setSidebarOpen = useUiStateStore((state) => state.setSidebarOpen);
   const sessionSidePanel = useUiStateStore((state) => (
@@ -323,6 +328,12 @@ export function SessionPage(props: SessionPageProps) {
     [],
   );
   const voiceExtensionEnabled = voiceExtension ? isOpenWorkExtensionEnabled(voiceExtension) : false;
+  const showCloudSignIn = shellConfig.cloudSignin && !denAuth.isSignedIn && denAuth.status !== "checking";
+  const openCloudSignIn = useCallback(() => {
+    const baseUrl = readDenBootstrapConfig().baseUrl;
+    // Label stays "Sign in"; opens the sign-up tab so new users aren't defaulted into sign-in.
+    platform.openLink(buildDenAuthUrl(baseUrl, "sign-up"));
+  }, [platform]);
 
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
@@ -899,6 +910,18 @@ export function SessionPage(props: SessionPageProps) {
             <div className="flex items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
               {/* Revert/redo moved to per-message actions */}
               <NotificationBell />
+              {showCloudSignIn ? (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={openCloudSignIn}
+                  title={t("den.signin_title")}
+                  aria-label={t("den.signin_title")}
+                >
+                  <Cloud className="size-3.5" />
+                  <span>{t("den.signin_button")}</span>
+                </Button>
+              ) : null}
               {props.developerMode ? (
                 <Button
                   variant="ghost"

--- a/apps/app/src/react-app/domains/session/chat/status-bar.tsx
+++ b/apps/app/src/react-app/domains/session/chat/status-bar.tsx
@@ -1,13 +1,12 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowRight, BookOpen, Cloud, MessageCircleMore, Settings, Sparkles, X } from "lucide-react";
+import { ArrowRight, BookOpen, MessageCircleMore, Settings, Sparkles, X } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { t } from "@/i18n";
-import { buildDenAuthUrl, readDenBootstrapConfig } from "@/app/lib/den";
 import { usePlatform } from "../../../kernel/platform";
 import { useDenAuth } from "../../cloud/den-auth-provider";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
@@ -328,29 +327,6 @@ export function StatusBar(props: StatusBarProps) {
                 <X className="size-3" />
               </button>
             </div>
-          ) : null}
-          {shellConfig.cloudSignin && !denAuth.isSignedIn && denAuth.status !== "checking" ? (
-            <Tooltip>
-              <TooltipTrigger
-                render={(
-                  <Button
-                    variant="secondary"
-                    size="xs"
-                    onClick={() => {
-                      const baseUrl = readDenBootstrapConfig().baseUrl;
-                      // Label stays "Sign in"; opens the sign-up tab so new
-                      // users aren't defaulted into sign-in (they can toggle).
-                      platform.openLink(buildDenAuthUrl(baseUrl, "sign-up"));
-                    }}
-                    aria-label={t("den.signin_title")}
-                  >
-                    <Cloud className="size-3.5" />
-                    <span>{t("den.signin_button")}</span>
-                  </Button>
-                )}
-              />
-              <TooltipContent>{t("den.signin_title")}</TooltipContent>
-            </Tooltip>
           ) : null}
           {shellConfig.docsButton ? (
             <Button


### PR DESCRIPTION
## Summary
- Moves the signed-out OpenWork Cloud sign-in CTA from the bottom status bar into the session header.
- Places it in the top-right action group immediately after the notification bell, matching the intended account/identity slot.
- Removes the old status-bar sign-in button so the CTA is not duplicated.

## What changed
- `session-page.tsx`: adds the signed-out `Sign in` button after `<NotificationBell />`, preserving the existing sign-up-first auth URL behavior.
- `status-bar.tsx`: removes the old signed-out sign-in button and now keeps status/docs/feedback/settings concerns only.

## Testing
- `pnpm --filter @openwork/app typecheck` passed.
- `pnpm --filter @openwork/app build` passed.
- No screenshot/fraimz captured locally before opening this PR; validation is static/build plus CI for this small header placement change.

🤖 Generated with OpenCode