### PR TITLE
fix(den): make privileged reauth just-in-time

### DIFF
--- a/ee/apps/den-api/src/routes/org/desktop-policies.ts
+++ b/ee/apps/den-api/src/routes/org/desktop-policies.ts
@@ -156,11 +156,6 @@ export function registerOrgDesktopPolicyRoutes<T extends { Variables: OrgRouteVa
     orgRoleRoute(["admin"]),
     async (c) => {
       const payload = c.get("organizationContext")
-      const permission = ensureOrganizationAdmin(c, "Only workspace owners and admins can manage desktop policies.")
-      if (!permission.ok) {
-        return c.json(permission.response, orgAccessFailureStatus(permission.response))
-      }
-
       const desktopPolicies = await loadDesktopPolicies(payload.organization.id)
       return c.json({ definitions: desktopPolicyDefinitions, desktopPolicies })
     },

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -10,6 +10,7 @@ import {
   publicRoute,
   queryValidator,
   resolveMemberTeamsMiddleware,
+  verifyOrgRole,
 } from "../../middleware/index.js"
 import { emptyResponse, forbiddenSchema, htmlResponse, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import { createOAuthStateToken, resolvePublicOrigin, verifyOAuthStateToken } from "../../capability-sources/generic-oauth.js"
@@ -220,8 +221,9 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       const { scope } = c.req.valid("query")
 
       if (scope === "manageable") {
-        const admin = ensureOrganizationAdmin(c, "Only workspace owners and admins can list all MCP connections.")
-        if (!admin.ok) return c.json(admin.response, orgAccessFailureStatus(admin.response))
+        if (!verifyOrgRole({ roles: ["admin"], userContext: payload.currentMember })) {
+          return c.json({ error: "forbidden", message: "Only workspace owners and admins can list all MCP connections." }, 403)
+        }
         const rows = await listExternalMcpConnections(payload.organization.id)
         const connections = await Promise.all(rows.map((row) =>
           toConnectionResponse(row, { callerOrgMembershipId: payload.currentMember.id, includeAccess: true })))
@@ -451,7 +453,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         // Per-member: any member GRANTED the connection may connect their own
         // account (that is the whole point); admins may too.
         const memberTeams: MemberTeamSummary[] = c.get("memberTeams") ?? []
-        const isAdmin = ensureOrganizationAdmin(c, "").ok
+        const isAdmin = verifyOrgRole({ roles: ["admin"], userContext: payload.currentMember })
         const canUse = await memberCanUseExternalMcpConnection({
           connectionId: externalMcpConnectionId,
           orgMembershipId: payload.currentMember.id,
@@ -533,5 +535,3 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
     },
   )
 }
-
-

--- a/ee/apps/den-api/src/routes/org/plugin-system/access.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/access.ts
@@ -107,7 +107,7 @@ function ensureFreshPluginArchAdmin(context: PluginArchActorContext) {
     return
   }
 
-  throw new PluginArchAuthorizationError(403, "reauth", "Sign in again before performing this privileged action.", "fresh_auth_required")
+  throw new PluginArchAuthorizationError(403, "reauth", "For security, confirm it's you before changing workspace settings.", "fresh_auth_required")
 }
 
 function roleSatisfies(role: PluginArchRole | null, required: PluginArchRole) {

--- a/ee/apps/den-api/src/routes/org/shared.ts
+++ b/ee/apps/den-api/src/routes/org/shared.ts
@@ -48,7 +48,7 @@ function ensureFreshPrivilegedSession(c: { get: (key: "session") => OrgRouteVari
     response: {
       error: "reauth",
       reason: "fresh_auth_required",
-      message: "Sign in again before performing this privileged action.",
+      message: "For security, confirm it's you before changing workspace settings.",
     },
   }
 }

--- a/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
@@ -97,7 +97,7 @@ export function ReauthDialog({
   async function submitPassword(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!user?.email) {
-      setError("Sign in again to continue.");
+      setError("Confirm it's you to continue.");
       return;
     }
 
@@ -174,11 +174,11 @@ export function ReauthDialog({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6">
       <div role="dialog" aria-modal="true" className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]">
         <div className="grid gap-3">
-          <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-gray-400">Re-authentication required</p>
+          <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-gray-400">Security check</p>
           <div className="grid gap-2">
-            <h2 className="text-[24px] font-semibold tracking-[-0.03em] text-gray-950">Sign in again to continue</h2>
+            <h2 className="text-[24px] font-semibold tracking-[-0.03em] text-gray-950">Confirm it's you to continue</h2>
             <p className="text-[15px] leading-7 text-gray-600">
-              This admin action needs a recent sign-in. Password verification retries automatically; redirect sign-ins return you here to retry safely.
+              Changing workspace settings requires a recent sign-in. After you confirm, OpenWork retries the action automatically.
             </p>
           </div>
         </div>

--- a/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
@@ -197,7 +197,7 @@ export function OrgDashboardProvider({
   function cancelReauth() {
     const pending = pendingReauthMutation;
     setPendingReauthMutation(null);
-    pending?.reject(new Error("Sign in again before continuing."));
+    pending?.reject(new Error("Confirm it's you before continuing."));
   }
 
   async function retryReauthMutation() {


### PR DESCRIPTION
## Summary
- Let Desktop Policies and manageable MCP Connections list pages load for stale-but-valid owner/admin sessions without triggering the fresh-session reauth guard.
- Keep fresh-session checks on sensitive mutations and shared-credential connect actions.
- Replace raw "privileged action" wording with plain-language security-check copy in the server responses and reauth dialog.

## Validation
- PASS: `pnpm --filter @openwork-ee/den-api exec bun test test/org-identity-access.test.ts`
- PASS: `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json`
- PASS: `pnpm --filter @openwork-ee/den-web build`
- PASS: `git diff --check HEAD~1..HEAD`
- PASS: `pnpm fraimz --flow privileged-reauth-ux`

## Fraimz
- Internal proof passed: `evals/results/2026-07-04T02-03-06-854Z/fraimz.html`
- Note: the Den web e2e environment variables were not present locally, so the fraimz proof records route-contract assertions, dialog copy assertions, and the privileged-session unit test output rather than driving a live Den browser session.