### PR TITLE
feat(app): add favicon fallback for extension icons

### DIFF
--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -1,9 +1,8 @@
 /** @jsxImportSource react */
 import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
 import type { ExtensionKind } from "../../app/constants";
 import type { EnablementResult } from "../../app/extensions";
-import { resolveExtensionIconSrc } from "./extension-icon-src";
+import { resolveExtensionIconUrl } from "./extension-icon-src";
 import { ExtensionMeshAvatar } from "./extension-mesh-avatar";
 
 export type ExtensionCardProps = {
@@ -13,8 +12,8 @@ export type ExtensionCardProps = {
   iconSlug?: string;
   /** Direct icon URL (e.g. local SVG). Takes priority over iconSlug. */
   iconSrc?: string;
-  /** Lucide icon fallback when no iconSlug or iconSrc is provided. */
-  fallbackIcon?: LucideIcon;
+  /** Related service URL used for favicon fallback when no icon is configured. */
+  url?: string;
   /** Extension category badge. */
   kind?: ExtensionKind;
   /** Whether the extension is already installed/connected. */
@@ -57,7 +56,7 @@ const kindStyle: Record<ExtensionKind, string> = {
 /**
  * A reusable card for displaying an extension (MCP server, plugin, or skill)
  * in the extensions directory. Supports brand icons from Simple Icons CDN,
- * Lucide icon fallbacks, kind badges, and connected/connecting states.
+ * favicon fallbacks, kind badges, and connected/connecting states.
  */
 export function ExtensionCard(props: ExtensionCardProps) {
   const {
@@ -65,6 +64,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
     description,
     iconSlug,
     iconSrc,
+    url,
     kind = "mcp",
     connected: connectedProp = false,
     connectedLabel = "Connected",
@@ -82,7 +82,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
   const allMet = enablement ? enablement.every((r) => r.met) : connectedProp;
   const someMet = enablement ? enablement.some((r) => r.met) && !allMet : false;
   const connected = allMet;
-  const resolvedIconSrc = iconSrc ? resolveExtensionIconSrc(iconSrc) : undefined;
+  const resolvedIconSrc = resolveExtensionIconUrl({ iconSrc, iconSlug, serviceUrl: url });
 
   return (
     <button
@@ -110,10 +110,6 @@ export function ExtensionCard(props: ExtensionCardProps) {
             ) : resolvedIconSrc ? (
               <div className="flex size-6 items-center justify-center rounded-md bg-white">
                 <img src={resolvedIconSrc} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
-              </div>
-            ) : iconSlug ? (
-              <div className="flex size-6 items-center justify-center rounded-md bg-white">
-                <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
               </div>
             ) : (
               <ExtensionMeshAvatar

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource react */
 import { CheckCircle2, ExternalLink, Loader2 } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -27,7 +26,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { ExtensionKind } from "@/app/constants";
 import { MarkdownBlock } from "../domains/session/surface/markdown";
-import { resolveExtensionIconSrc } from "./extension-icon-src";
+import { resolveExtensionIconUrl } from "./extension-icon-src";
 import { ExtensionMeshAvatar } from "./extension-mesh-avatar";
 
 export type ExtensionDetailModalProps = {
@@ -37,7 +36,6 @@ export type ExtensionDetailModalProps = {
   description: string;
   iconSlug?: string;
   iconSrc?: string;
-  fallbackIcon?: LucideIcon;
   kind?: ExtensionKind;
   connected?: boolean;
   connectedLabel?: string;
@@ -215,6 +213,7 @@ export function ExtensionDetailModal({
   size = "default",
 }: ExtensionDetailModalProps) {
   "use memo";
+  const resolvedIconSrc = resolveExtensionIconUrl({ iconSrc, iconSlug, serviceUrl: url });
 
   return (
     <Dialog
@@ -239,13 +238,9 @@ export function ExtensionDetailModal({
                   connected ? "border-green-6 bg-green-2" : "border-dls-border bg-dls-hover",
                 )}
               >
-                {iconSrc ? (
+                {resolvedIconSrc ? (
                   <div className="flex size-8 items-center justify-center rounded-md bg-white">
-                    <img src={resolveExtensionIconSrc(iconSrc)} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
-                  </div>
-                ) : iconSlug ? (
-                  <div className="flex size-8 items-center justify-center rounded-md bg-white">
-                    <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
+                    <img src={resolvedIconSrc} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
                   </div>
                 ) : (
                   <ExtensionMeshAvatar

--- a/apps/app/src/react-app/design-system/extension-icon-src.ts
+++ b/apps/app/src/react-app/design-system/extension-icon-src.ts
@@ -6,3 +6,24 @@ export function resolveExtensionIconSrc(iconSrc: string): string {
   const base = import.meta.env.BASE_URL || "/";
   return `${base.replace(/\/?$/, "/")}${iconSrc.replace(/^\/+/, "")}`;
 }
+
+export function resolveExtensionIconUrl(input: {
+  iconSrc?: string;
+  iconSlug?: string;
+  serviceUrl?: string;
+}): string | undefined {
+  if (input.iconSrc) {
+    return resolveExtensionIconSrc(input.iconSrc);
+  }
+
+  if (input.iconSlug) {
+    return `https://cdn.simpleicons.org/${input.iconSlug}`;
+  }
+
+  const serviceUrl = input.serviceUrl?.trim();
+  if (!serviceUrl?.match(/^https?:\/\//i)) {
+    return undefined;
+  }
+
+  return `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(serviceUrl)}`;
+}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -12,6 +12,7 @@ import { formatBytes, isMacPlatform } from "@/app/utils";
 import { t } from "@/i18n";
 import { isOpenWorkExtensionEnabled, isOpenWorkExtensionHidden, OPENWORK_EXTENSION_STATE_CHANGED } from "@/react-app/domains/settings/extension-state";
 import { useDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
+import { resolveExtensionIconUrl } from "@/react-app/design-system/extension-icon-src";
 import { ModelBehaviorSelect } from "@/components/model-behavior-select";
 import { ModelSelect } from "@/components/model-select";
 import { LexicalPromptEditor, type LexicalPromptEditorHandle } from "./editor";
@@ -241,11 +242,10 @@ function mcpStatusBadgeClass(status: McpServerStatus) {
 }
 
 function extensionIcon(entry: McpDirectoryInfo, size = 16) {
-  if (entry.iconSrc) {
-    return <img src={entry.iconSrc} alt="" width={size} height={size} loading="lazy" style={{ display: "block" }} />;
-  }
-  if (entry.iconSlug) {
-    return <img src={`https://cdn.simpleicons.org/${entry.iconSlug}`} alt="" width={size} height={size} loading="lazy" style={{ display: "block" }} />;
+  const serviceUrl = typeof entry.url === "string" ? entry.url : undefined;
+  const iconUrl = resolveExtensionIconUrl({ iconSrc: entry.iconSrc, iconSlug: entry.iconSlug, serviceUrl });
+  if (iconUrl) {
+    return <img src={iconUrl} alt="" width={size} height={size} loading="lazy" style={{ display: "block" }} />;
   }
   return <Plug size={size} className="text-gray-9" />;
 }

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -712,6 +712,7 @@ function MarketplaceCard(props: {
 
   if (row.source === "built-in") {
     const actionBusy = props.builtInConnectingName === row.entry.name;
+    const entryUrl = typeof row.entry.url === "string" ? row.entry.url : undefined;
     return (
       <div ref={highlightRef} className={highlightClass}>
         <ExtensionCard
@@ -719,6 +720,7 @@ function MarketplaceCard(props: {
           description={row.entry.description}
           iconSlug={row.entry.iconSlug}
           iconSrc={row.entry.iconSrc}
+          url={entryUrl}
           kind={row.entry.kind ?? "extension"}
           preview={row.entry.preview}
           connected={row.active}
@@ -741,6 +743,7 @@ function MarketplaceCard(props: {
           name={row.item.name}
           description={row.item.description ?? "Available from your organization."}
           kind="mcp"
+          url={row.connection.url}
           connected={false}
           connecting={actionBusy}
           actionLabel={actionBusy ? "Waiting for browser..." : orgMcpConnectionActionLabel(row.connection)}
@@ -802,6 +805,7 @@ function BuiltInMarketplaceDetailModal(props: {
       description={entry.description}
       iconSlug={entry.iconSlug}
       iconSrc={entry.iconSrc}
+      url={typeof entry.url === "string" ? entry.url : undefined}
       kind={entry.kind ?? "extension"}
       connected={row.active}
       connectedLabel={entry.defaultEnabled ? "Ready" : "Active"}

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -745,7 +745,6 @@ export function McpView(props: McpViewProps) {
             description={detailEntry.description}
             iconSlug={detailEntry.iconSlug}
             iconSrc={detailEntry.iconSrc}
-            fallbackIcon={serviceIcon(detailEntry.name)}
             kind={detailEntry.kind ?? "mcp"}
             connected={isConnected}
             connecting={props.mcpConnectingName === detailEntry.name}
@@ -933,9 +932,9 @@ function McpQuickConnectSection(props: {
           const configured = props.isConfigured(entry);
           const enablement = props.enablementForEntry?.(entry);
           const connecting = props.connectingName === entry.name;
-          const FallbackIcon = serviceIcon(entry.name);
           const hidden = props.isEntryHidden(entry);
           const disabledReason = props.disabledReasonForEntry(entry);
+          const entryUrl = typeof entry.url === "string" ? entry.url : undefined;
 
           return (
             <ExtensionCard
@@ -944,7 +943,7 @@ function McpQuickConnectSection(props: {
               description={entry.description}
               iconSlug={entry.iconSlug}
               iconSrc={entry.iconSrc}
-              fallbackIcon={FallbackIcon}
+              url={entryUrl}
               kind={entry.kind ?? "mcp"}
               connected={configured}
               enablement={enablement?.results}
@@ -1001,6 +1000,7 @@ function McpQuickConnectSection(props: {
               name={item.name}
               description={item.description ?? "Shared by your organization."}
               kind="mcp"
+              url={connection.url}
               connected={true}
               connectedLabel={orgMcpConnectionActionLabel(connection)}
               actionLabel="View details"


### PR DESCRIPTION
## Summary
- Centralizes extension icon URL resolution for desktop extension cards, detail modals, and the composer picker.
- Keeps existing precedence: bundled/direct `iconSrc` first, then Simple Icons `iconSlug`.
- Adds a service URL favicon fallback through Google's favicon endpoint for remote MCPs with no curated icon metadata.
- Wires org-shared MCP cards/details through the shared resolver so they can show real service favicons instead of always falling back to generated mesh avatars.
- Removes the unused `fallbackIcon` prop from `ExtensionCard` / `ExtensionDetailModal`.

## What changed
- `extension-icon-src.ts`: added `resolveExtensionIconUrl({ iconSrc, iconSlug, serviceUrl })`.
- `extension-card.tsx` and `extension-detail-modal.tsx`: use the shared resolver.
- `composer.tsx`: uses the same resolver while preserving the existing plug-icon fallback.
- `mcp-view.tsx` and `cloud-marketplaces-view.tsx`: pass remote MCP URLs into extension cards/details for favicon fallback.

## Testing
- `pnpm --filter @openwork/app typecheck` passed.
- `pnpm --filter @openwork/app build` passed.

## Validation note
- No fraimz/screenshot attached for this first plumbing PR: the visible improvement depends on having an org-shared remote MCP connection with no icon metadata in the local workspace. This PR is intentionally the small reusable resolver/plumbing layer; the later registry-search PR will include the full user-facing fraimz flow.

🤖 Generated with OpenCode