### PR TITLE
feat(den-web): show real icons for integrations and MCP connections

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/integration-icon.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/integration-icon.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { Plug } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+function faviconUrl(serviceUrl?: string) {
+  const trimmed = serviceUrl?.trim();
+  if (!trimmed?.match(/^https?:\/\//i)) return undefined;
+  return `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(trimmed)}`;
+}
+
+function resolveIconUrl(input: {
+  iconUrl?: string;
+  simpleIconSlug?: string;
+  serviceUrl?: string;
+}) {
+  if (input.iconUrl) return input.iconUrl;
+  if (input.simpleIconSlug) return `https://cdn.simpleicons.org/${input.simpleIconSlug}`;
+  return faviconUrl(input.serviceUrl);
+}
+
+export function IntegrationIcon({
+  name,
+  iconUrl,
+  simpleIconSlug,
+  serviceUrl,
+  fallbackIcon: FallbackIcon = Plug,
+  className = "h-10 w-10 rounded-[12px]",
+  imageClassName = "h-5 w-5",
+}: {
+  name: string;
+  iconUrl?: string;
+  simpleIconSlug?: string;
+  serviceUrl?: string;
+  fallbackIcon?: LucideIcon;
+  className?: string;
+  imageClassName?: string;
+}) {
+  const resolvedUrl = resolveIconUrl({ iconUrl, simpleIconSlug, serviceUrl });
+  const [erroredUrl, setErroredUrl] = useState<string | null>(null);
+  const showImage = resolvedUrl && erroredUrl !== resolvedUrl;
+
+  return (
+    <div className={`flex shrink-0 items-center justify-center border border-gray-100 bg-white shadow-sm ${className}`}>
+      {showImage ? (
+        <img
+          src={resolvedUrl}
+          alt={`${name} icon`}
+          loading="lazy"
+          onError={() => setErroredUrl(resolvedUrl)}
+          className={`object-contain ${imageClassName}`}
+        />
+      ) : (
+        <FallbackIcon className="h-5 w-5 text-gray-500" aria-hidden />
+      )}
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/integrations-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/integrations-screen.tsx
@@ -2,11 +2,12 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { Cable, Check, GitBranch, Github, Loader2, Plus, Settings, Trash2 } from "lucide-react";
+import { Cable, Check, GitBranch, Loader2, Plus, Settings, Trash2 } from "lucide-react";
 import { getGithubIntegrationAccountRoute, getGithubIntegrationRoute, getGithubIntegrationSetupRoute } from "../../_lib/den-org";
 import { DenButton } from "../../_components/ui/button";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { IntegrationConnectDialog } from "./integration-connect-dialog";
+import { IntegrationIcon } from "./integration-icon";
 import {
   type ConnectedIntegration,
   type IntegrationProvider,
@@ -366,16 +367,13 @@ function DisconnectConfirmDialog({
 }
 
 function ProviderLogo({ provider }: { provider: IntegrationProvider }) {
-  if (provider === "github") {
-    return (
-      <div className="flex h-10 w-10 items-center justify-center rounded-[12px] bg-[#0f172a] text-white">
-        <Github className="h-5 w-5" aria-hidden />
-      </div>
-    );
-  }
-  return (
-    <div className="flex h-10 w-10 items-center justify-center rounded-[12px] bg-[#2684FF] text-[13px] font-semibold text-white">
-      BB
-    </div>
-  );
+  const providerIconSlugs: Record<IntegrationProvider, string> = {
+    github: "github",
+    bitbucket: "bitbucket",
+  };
+  const providerNames: Record<IntegrationProvider, string> = {
+    github: "GitHub",
+    bitbucket: "Bitbucket",
+  };
+  return <IntegrationIcon name={providerNames[provider]} simpleIconSlug={providerIconSlugs[provider]} fallbackIcon={Cable} />;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -5,6 +5,7 @@ import { Check, Loader2, Plug, Plus, Trash2, Users } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { IntegrationIcon } from "./integration-icon";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
   type CreateMcpConnectionInput,
@@ -129,10 +130,15 @@ export function McpConnectionsScreen() {
           onClick={() => setGoogleDialogOpen(true)}
           className="rounded-2xl border border-gray-100 bg-white px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
         >
-          <p className="text-[14px] font-semibold text-gray-900">Google Workspace</p>
-          <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">
-            Your company&apos;s Google. Set it up once — every member connects their own account.
-          </p>
+          <div className="flex items-start gap-3">
+            <IntegrationIcon name="Google Workspace" simpleIconSlug="google" />
+            <div className="min-w-0 flex-1">
+              <p className="text-[14px] font-semibold text-gray-900">Google Workspace</p>
+              <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">
+                Your company&apos;s Google. Set it up once — every member connects their own account.
+              </p>
+            </div>
+          </div>
           <p className="mt-2 text-[12px] font-medium text-violet-600">
             {googleConfigured ? "Configured — tap to update" : "Tap to set up"}
           </p>
@@ -150,8 +156,13 @@ export function McpConnectionsScreen() {
               }}
               className="rounded-2xl border border-gray-100 bg-white px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
             >
-              <p className="text-[14px] font-semibold text-gray-900">{preset.displayName}</p>
-              <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">{preset.description}</p>
+              <div className="flex items-start gap-3">
+                <IntegrationIcon name={preset.displayName} serviceUrl={preset.url} />
+                <div className="min-w-0 flex-1">
+                  <p className="text-[14px] font-semibold text-gray-900">{preset.displayName}</p>
+                  <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">{preset.description}</p>
+                </div>
+              </div>
               <p className="mt-2 text-[12px] font-medium text-violet-600">
                 {alreadyAdded ? "Already added" : "Tap to add"}
               </p>
@@ -321,38 +332,41 @@ function ConnectionRow({
 
   return (
     <div className="flex items-center justify-between gap-4 px-6 py-4">
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <p className="truncate text-[14px] font-semibold text-gray-900">{connection.name}</p>
-          {isPerMember ? (
-            <span className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-700">
-              <Users className="h-3 w-3" />
-              Per-member accounts
-            </span>
-          ) : connection.connected ? (
-            <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
-              <Check className="h-3 w-3" />
-              Connected
-            </span>
-          ) : polling ? (
-            <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
-              <Loader2 className="h-3 w-3 animate-spin" />
-              Waiting for authorization…
-            </span>
-          ) : (
-            <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
-              Not connected
-            </span>
-          )}
-          {connection.access ? (
-            <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
-              {accessSummaryLabel(connection)}
-            </span>
-          ) : null}
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <IntegrationIcon name={connection.name} serviceUrl={connection.url} />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="truncate text-[14px] font-semibold text-gray-900">{connection.name}</p>
+            {isPerMember ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-700">
+                <Users className="h-3 w-3" />
+                Per-member accounts
+              </span>
+            ) : connection.connected ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+                <Check className="h-3 w-3" />
+                Connected
+              </span>
+            ) : polling ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Waiting for authorization…
+              </span>
+            ) : (
+              <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
+                Not connected
+              </span>
+            )}
+            {connection.access ? (
+              <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
+                {accessSummaryLabel(connection)}
+              </span>
+            ) : null}
+          </div>
+          <p className="mt-0.5 truncate text-[12px] text-gray-500">
+            {connection.url} · {formatMcpConnectedTimestamp(connection.connectedAt)}
+          </p>
         </div>
-        <p className="mt-0.5 truncate text-[12px] text-gray-500">
-          {connection.url} · {formatMcpConnectedTimestamp(connection.connectedAt)}
-        </p>
       </div>
 
       <div className="flex shrink-0 items-center gap-2">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { Check, Loader2, Plug } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { IntegrationIcon } from "./integration-icon";
 import {
   type ExternalMcpConnection,
   useMcpConnections,
@@ -118,30 +119,33 @@ function YourConnectionRow({
 
   return (
     <div className="flex items-center justify-between gap-4 px-6 py-4">
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <p className="truncate text-[14px] font-semibold text-gray-900">{connection.name}</p>
-          {connection.connectedForMe ? (
-            <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
-              <Check className="h-3 w-3" />
-              {isPerMember ? "Connected as you" : "Connected"}
-            </span>
-          ) : polling ? (
-            <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
-              <Loader2 className="h-3 w-3 animate-spin" />
-              Waiting for authorization…
-            </span>
-          ) : needsMyConnect ? (
-            <span className="inline-flex rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
-              Connect your account
-            </span>
-          ) : (
-            <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
-              Not connected yet
-            </span>
-          )}
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <IntegrationIcon name={connection.name} serviceUrl={connection.url} />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="truncate text-[14px] font-semibold text-gray-900">{connection.name}</p>
+            {connection.connectedForMe ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+                <Check className="h-3 w-3" />
+                {isPerMember ? "Connected as you" : "Connected"}
+              </span>
+            ) : polling ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Waiting for authorization…
+              </span>
+            ) : needsMyConnect ? (
+              <span className="inline-flex rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                Connect your account
+              </span>
+            ) : (
+              <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
+                Not connected yet
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 truncate text-[12px] text-gray-500">{connection.url}</p>
         </div>
-        <p className="mt-0.5 truncate text-[12px] text-gray-500">{connection.url}</p>
       </div>
 
       <div className="flex shrink-0 items-center gap-2">


### PR DESCRIPTION
## Summary
- Adds a shared den-web `IntegrationIcon` tile for brand/service icons.
- Shows real Simple Icons logos for Sources providers like GitHub and Bitbucket.
- Shows favicons for MCP quick-add presets and org MCP connection rows using their server URLs.
- Adds the same favicon treatment to member-facing Your Connections rows.

## What changed
- New `integration-icon.tsx` component with precedence: direct icon URL → Simple Icons slug → Google favicon by service URL → lucide fallback.
- `integrations-screen.tsx`: replaces the GitHub lucide tile and Bitbucket letter tile with real brand icons.
- `mcp-connections-screen.tsx`: adds icons to Google Workspace, preset quick-add tiles, and connection rows.
- `your-connections-screen.tsx`: adds icons to usable connection rows.

## Testing
- `pnpm --filter @openwork-ee/den-web build` passed.

## Validation note
- No fraimz/screenshot attached for this small display-only PR. The production den-web build verifies the component and page TypeScript paths; the larger registry-search PR will include a full user-facing fraimz flow.

🤖 Generated with OpenCode