### PR TITLE
feat(den): allow agents to publish org MCP connections

### DIFF
--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -92,6 +92,26 @@ const connectionListResponseSchema = z.object({
   connections: z.array(connectionResponseSchema),
 }).meta({ ref: "ExternalMcpConnectionListResponse" })
 
+const connectionCreatedResponseSchema = connectionResponseSchema.extend({
+  links: z.object({
+    /** Where members connect their own account for per_member connections. Share this with the team. */
+    yourConnections: z.string(),
+  }),
+}).meta({ ref: "ExternalMcpConnectionCreatedResponse" })
+
+/**
+ * The classical member handoff: after an admin (or their agent) publishes a
+ * connection, members connect their own account in the den-web dashboard.
+ * betterAuthUrl is the den-web public origin in every deployment layout.
+ */
+function memberConnectLinks() {
+  return { yourConnections: `${env.betterAuthUrl}/dashboard/your-connections` }
+}
+
+export function isAgentApiKeyConnection(input: { authType: string; sessionId?: string | null }) {
+  return input.authType === "apikey" && input.sessionId === "mcp_internal"
+}
+
 const listConnectionsQuerySchema = z.object({
   /** usable (default): connections the calling member has been granted. manageable: every org connection, admin-only. */
   scope: z.enum(["usable", "manageable"]).optional().default("usable"),
@@ -259,11 +279,15 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
   app.post(
     "/v1/mcp-connections",
     describeRoute({
-      tags: ["Authentication"],
-      summary: "Register a new External MCP Connection",
-      description: "Admin-only. Registers a third-party MCP server by name + URL. For authType=oauth, call connect/start next. For authType=apikey/none, the connection is validated immediately.",
+      // Tagged Capability Sources (not Authentication) on purpose: this is
+      // plain admin CRUD with no secrets for oauth/none connections, so an
+      // org admin can publish connections from chat. The OAuth plumbing
+      // (connect/start, callbacks, client secrets) stays agent-blocked.
+      tags: ["Capability Sources"],
+      summary: "Register a new External MCP Connection for the org",
+      description: "Admin-only. Registers a third-party MCP server by name + URL and grants access (org-wide, teams, or members). Use GET /v1/mcp-connections/presets for known server URLs (Notion, Linear, Stripe, Sentry, Context7). For credentialMode per_member, each member connects their own account afterwards — share links.yourConnections from the response so teammates know where to sign in. API-key connections cannot be created through the agent surface; use the dashboard.",
       responses: {
-        200: jsonResponse("Connection created.", connectionResponseSchema),
+        200: jsonResponse("Connection created.", connectionCreatedResponseSchema),
         400: jsonResponse("Invalid request.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
         403: jsonResponse("Only workspace owners and admins can add MCP connections.", forbiddenSchema),
@@ -277,6 +301,11 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       if (!admin.ok) return c.json(admin.response, orgAccessFailureStatus(admin.response))
 
       const body = c.req.valid("json")
+      // Secrets must not travel through chat transcripts: when the caller is
+      // the agent (internal MCP principal), refuse API-key connections.
+      if (isAgentApiKeyConnection({ authType: body.authType, sessionId: c.get("session")?.id })) {
+        return c.json({ error: "invalid_request", message: "API-key connections cannot be created from the agent. Add them in the OpenWork Cloud dashboard under Extensions." }, 400)
+      }
       if (body.authType === "apikey" && !body.apiKey) {
         return c.json({ error: "invalid_request", message: "apiKey is required when authType is apikey." }, 400)
       }
@@ -314,16 +343,21 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       }
 
       const refreshed = await getExternalMcpConnection({ organizationId: payload.organization.id, connectionId: created.id })
-      return c.json(await toConnectionResponse(refreshed ?? created, { callerOrgMembershipId: payload.currentMember.id, includeAccess: true }))
+      const response = await toConnectionResponse(refreshed ?? created, { callerOrgMembershipId: payload.currentMember.id, includeAccess: true })
+      // The classical handoff: whoever created this (human or agent) gets
+      // the link where members connect their own account, ready to share.
+      return c.json({ ...response, links: memberConnectLinks() })
     },
   )
 
   app.put(
     "/v1/mcp-connections/:connectionId/access",
     describeRoute({
-      tags: ["Authentication"],
+      // Capability Sources (not Authentication): pure grant management, no
+      // credentials involved — lets an admin reshape access from chat.
+      tags: ["Capability Sources"],
       summary: "Replace who can use an External MCP Connection",
-      description: "Admin-only. Full-replace semantics: send the complete desired access set (orgWide, or memberIds + teamIds).",
+      description: "Admin-only. Full-replace semantics: send the complete desired access set (orgWide, or memberIds + teamIds). Team and member ids come from GET /v1/org.",
       responses: {
         200: jsonResponse("Access updated.", connectionResponseSchema),
         400: jsonResponse("Invalid request.", invalidRequestSchema),

--- a/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
@@ -1,0 +1,71 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+type OpenApiDocument = {
+  paths: Record<string, Record<string, { operationId?: string; tags?: string[] }>>
+}
+
+let isMcpOperationAllowed: typeof import("../src/mcp/policy.js")["isMcpOperationAllowed"]
+let isAgentApiKeyConnection: typeof import("../src/routes/org/mcp-connections.js")["isAgentApiKeyConnection"]
+let document: OpenApiDocument
+
+function findOperation(operationId: string) {
+  for (const [path, methods] of Object.entries(document.paths)) {
+    for (const [method, operation] of Object.entries(methods)) {
+      if (operation && typeof operation === "object" && operation.operationId === operationId) {
+        return { method, path, operation }
+      }
+    }
+  }
+  throw new Error(`Operation not found in openapi.json: ${operationId}`)
+}
+
+function allowed(operationId: string) {
+  const { method, path, operation } = findOperation(operationId)
+  return isMcpOperationAllowed({ method, path, operation })
+}
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  isMcpOperationAllowed = (await import("../src/mcp/policy.js")).isMcpOperationAllowed
+  isAgentApiKeyConnection = (await import("../src/routes/org/mcp-connections.js")).isAgentApiKeyConnection
+  const app = (await import("../src/app.js")).default
+  const response = await app.request("http://127.0.0.1:8790/openapi.json")
+  document = await response.json()
+})
+
+describe("agent-configurable org connections policy", () => {
+  test("the agent can create connections and manage access (admin-enforced in-route)", () => {
+    expect(allowed("postV1McpConnections")).toBe(true)
+    expect(allowed("putV1McpConnectionsByConnectionIdAccess")).toBe(true)
+  })
+
+  test("OAuth plumbing and destructive operations stay human-only", () => {
+    expect(allowed("getV1McpConnectionsByConnectionIdConnectStart")).toBe(false)
+    expect(allowed("getV1McpConnectionsByConnectionIdConnectCallback")).toBe(false)
+    expect(allowed("deleteV1McpConnectionsByConnectionId")).toBe(false)
+    expect(allowed("postV1McpConnectionsByConnectionIdDisconnect")).toBe(false)
+    expect(allowed("postV1OauthProvidersByProviderIdClient")).toBe(false)
+    expect(allowed("postV1OauthProvidersByProviderIdDisconnect")).toBe(false)
+  })
+
+  test("discovery surfaces the agent needs are readable", () => {
+    expect(allowed("getV1McpConnections")).toBe(true)
+    expect(allowed("getV1McpConnectionsPresets")).toBe(true)
+  })
+
+  test("API-key connections are blocked only for the internal agent principal", () => {
+    expect(isAgentApiKeyConnection({ authType: "apikey", sessionId: "mcp_internal" })).toBe(true)
+    expect(isAgentApiKeyConnection({ authType: "oauth", sessionId: "mcp_internal" })).toBe(false)
+    expect(isAgentApiKeyConnection({ authType: "none", sessionId: "mcp_internal" })).toBe(false)
+    expect(isAgentApiKeyConnection({ authType: "apikey", sessionId: "normal_session" })).toBe(false)
+    expect(isAgentApiKeyConnection({ authType: "apikey", sessionId: null })).toBe(false)
+  })
+})

--- a/evals/flows/org-mcp-agent-config-demo.flow.mjs
+++ b/evals/flows/org-mcp-agent-config-demo.flow.mjs
@@ -1,0 +1,378 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { execSync } from "node:child_process";
+
+const FLOW_ID = "org-mcp-agent-config-demo";
+const vo = await loadVoiceoverParagraphs("org-mcp-agent-config-demo");
+
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? DEN_API_URL.replace("127.0.0.1", "localhost")).trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MEMBER_EMAIL = process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || "jordan.demo@acme.test";
+const MEMBER_PASSWORD = process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const MOCK_SERVER_URL = (process.env.MOCK_OAUTH_MCP_URL ?? "http://127.0.0.1:3978").trim().replace(/\/+$/, "");
+const RUN_TAG = Date.now();
+const CONNECTION_NAME = `Agent Config Knowledge Base ${RUN_TAG}`;
+
+const state = {
+  adminSession: process.env.OPENWORK_EVAL_DEN_TOKEN?.trim() || null,
+  memberSession: null,
+  adminMcpToken: null,
+  memberMcpToken: null,
+  organizationId: null,
+  connectionId: null,
+  createResponse: null,
+  createCapability: null,
+  accessCapability: null,
+  listCapability: null,
+};
+
+async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+async function signIn(email, password) {
+  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  if (!response.ok) return null;
+  return body.token;
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, assertion + (actual === undefined ? "" : ` (actual: ${JSON.stringify(actual).slice(0, 500)})`));
+}
+
+function parseToolJson(result) {
+  const text = result?.content?.[0]?.text ?? "{}";
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text };
+  }
+}
+
+async function mcpAgentCall(ctx, mcpToken, method, params = {}) {
+  const response = await fetch(`${DEN_API_URL}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${mcpToken}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
+  });
+  const raw = await response.text();
+  witness(ctx, response.ok, `MCP ${method} returned HTTP 200`, raw.slice(0, 300));
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  witness(ctx, Boolean(dataLine), `MCP ${method} returned a data frame`, raw.slice(0, 300));
+  const payload = JSON.parse(dataLine.slice(5));
+  witness(ctx, !payload.error, `MCP ${method} returned no JSON-RPC error`, payload.error ?? null);
+  return payload.result;
+}
+
+async function mintMcpToken(ctx, sessionToken, label) {
+  const { response, body } = await denApiFetch("/v1/mcp/token", {
+    method: "POST",
+    headers: { authorization: `Bearer ${sessionToken}` },
+    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  });
+  witness(ctx, response.ok, `${label} can mint an MCP token`, body);
+  return body.token;
+}
+
+async function findCapability(ctx, mcpToken, input) {
+  const result = await mcpAgentCall(ctx, mcpToken, "tools/call", {
+    name: "search_capabilities",
+    arguments: { query: input.query, limit: 10 },
+  });
+  const parsed = parseToolJson(result);
+  const matches = Array.isArray(parsed.matches) ? parsed.matches : [];
+  const match = matches.find((candidate) => candidate.method === input.method && candidate.path === input.path) ?? null;
+  witness(ctx, Boolean(match), `search_capabilities exposes ${input.method} ${input.path}`, {
+    query: input.query,
+    matches: matches.map((candidate) => ({ name: candidate.name, method: candidate.method, path: candidate.path })),
+  });
+  return match;
+}
+
+async function executeCapability(ctx, mcpToken, capabilityName, args) {
+  return mcpAgentCall(ctx, mcpToken, "tools/call", {
+    name: "execute_capability",
+    arguments: { name: capabilityName, ...args },
+  });
+}
+
+async function ensureAdmin(ctx) {
+  if (!state.adminSession) {
+    state.adminSession = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+  }
+  witness(ctx, Boolean(state.adminSession), `Admin sign-in succeeds for ${ADMIN_EMAIL}`);
+
+  const org = await denApiFetch("/v1/org", {
+    headers: { authorization: `Bearer ${state.adminSession}` },
+  });
+  witness(ctx, org.response.ok, "Admin session resolves an active organization", org.body);
+  state.organizationId = org.body.organization?.id ?? null;
+  witness(ctx, Boolean(state.organizationId), "Admin organization id is present", org.body.organization ?? null);
+}
+
+async function ensureMember(ctx) {
+  state.memberSession = await signIn(MEMBER_EMAIL, MEMBER_PASSWORD);
+
+  if (!state.memberSession) {
+    const signUp = await denApiFetch("/api/auth/sign-up/email", {
+      method: "POST",
+      body: JSON.stringify({ email: MEMBER_EMAIL, name: "Jordan Demo", password: MEMBER_PASSWORD }),
+    });
+    witness(ctx, signUp.response.ok, `Member sign-up succeeds for ${MEMBER_EMAIL}`, signUp.body);
+    state.memberSession = await signIn(MEMBER_EMAIL, MEMBER_PASSWORD);
+    witness(ctx, Boolean(state.memberSession), "Member can sign in after sign-up");
+  }
+
+  const orgs = await denApiFetch("/v1/me/orgs", {
+    headers: { authorization: `Bearer ${state.memberSession}` },
+  });
+  witness(ctx, orgs.response.ok, "Member org list is readable", orgs.body);
+  const alreadyInOrg = (orgs.body.orgs ?? []).some((org) => org.id === state.organizationId);
+  if (alreadyInOrg) return;
+
+  const invite = await denApiFetch("/v1/invitations", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.adminSession}` },
+    body: JSON.stringify({ email: MEMBER_EMAIL, role: "member" }),
+  });
+  witness(ctx, invite.response.ok, "Admin can invite the member to the org", invite.body);
+
+  if (MARK_VERIFIED_CMD) {
+    execSync(MARK_VERIFIED_CMD.replaceAll("{email}", MEMBER_EMAIL), { stdio: "ignore" });
+  }
+
+  const accept = await denApiFetch("/v1/orgs/invitations/accept", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.memberSession}` },
+    body: JSON.stringify({ id: invite.body.inviteToken }),
+  });
+  if (!accept.response.ok && accept.body?.error === "email_verification_required" && !MARK_VERIFIED_CMD) {
+    witness(ctx, false, "Member invitation accept needs OPENWORK_EVAL_MARK_VERIFIED_CMD in this environment", accept.body);
+  }
+  witness(ctx, accept.response.ok && accept.body.accepted === true, "Member accepts the invitation into the admin org", accept.body);
+  state.memberSession = await signIn(MEMBER_EMAIL, MEMBER_PASSWORD);
+  witness(ctx, Boolean(state.memberSession), "Member can sign in after joining the org");
+}
+
+async function cleanupConnections(ctx) {
+  if (!state.adminSession) return;
+  const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+    headers: { authorization: `Bearer ${state.adminSession}` },
+  });
+  if (!existing.response.ok) return;
+  for (const connection of existing.body.connections ?? []) {
+    if (connection.name.startsWith("Agent Config Knowledge Base ") || connection.name.startsWith("Agent Config API Key Guard ")) {
+      await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${state.adminSession}` },
+      });
+    }
+  }
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Org admins can publish an MCP connection through the agent surface, hand members the existing connect path, and members cannot exceed their role",
+  kind: "internal",
+  requiresApp: false,
+  spec: "evals/voiceovers/org-mcp-agent-config-demo.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("Alex's agent discovers the org MCP create capability and publishes a per-member connection for everyone", {
+          voiceover: vo[0],
+          action: async () => {
+            await ensureAdmin(ctx);
+            await ensureMember(ctx);
+            await cleanupConnections(ctx);
+            state.adminMcpToken = await mintMcpToken(ctx, state.adminSession, "Admin");
+
+            const tools = await mcpAgentCall(ctx, state.adminMcpToken, "tools/list", {});
+            const toolNames = (tools.tools ?? []).map((tool) => tool.name).sort();
+            witness(ctx, toolNames.join(",") === "execute_capability,search_capabilities", "The agent endpoint only exposes search_capabilities and execute_capability", toolNames);
+
+            state.createCapability = await findCapability(ctx, state.adminMcpToken, {
+              query: "register MCP connection",
+              method: "POST",
+              path: "/v1/mcp-connections",
+            });
+
+            const created = await executeCapability(ctx, state.adminMcpToken, state.createCapability.name, {
+              body: {
+                name: CONNECTION_NAME,
+                url: `${MOCK_SERVER_URL}/mcp`,
+                authType: "oauth",
+                credentialMode: "per_member",
+                access: { orgWide: true, memberIds: [], teamIds: [] },
+              },
+            });
+            witness(ctx, created.isError !== true, "execute_capability creates the org MCP connection", parseToolJson(created));
+            const createdBody = parseToolJson(created);
+            state.connectionId = createdBody.id;
+            state.createResponse = createdBody;
+            ctx.output("created-connection.json", JSON.stringify(createdBody, null, 2));
+          },
+          assert: async () => {
+            witness(ctx, Boolean(state.connectionId), "Created connection id is present", state.connectionId);
+            const manageable = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+              headers: { authorization: `Bearer ${state.adminSession}` },
+            });
+            const connection = (manageable.body.connections ?? []).find((entry) => entry.id === state.connectionId);
+            witness(ctx, Boolean(connection), "The connection exists in Den's manageable org list", manageable.body);
+            witness(ctx, connection?.credentialMode === "per_member" && connection?.authType === "oauth", "The connection is OAuth per-member, not a shared secret", connection);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The create response gives Alex the member handoff link and refuses API-key secrets through the agent", {
+          voiceover: vo[1],
+          action: async () => {
+            const rejected = await executeCapability(ctx, state.adminMcpToken, state.createCapability.name, {
+              body: {
+                name: `Agent Config API Key Guard ${RUN_TAG}`,
+                url: `${MOCK_SERVER_URL}/mcp`,
+                authType: "apikey",
+                credentialMode: "shared",
+                apiKey: "eval-placeholder-not-a-real-secret",
+                access: { orgWide: true, memberIds: [], teamIds: [] },
+              },
+            });
+            witness(ctx, rejected.isError === true, "API-key connection creation is rejected on the agent surface", parseToolJson(rejected));
+            ctx.output("apikey-guard-response.json", JSON.stringify(parseToolJson(rejected), null, 2));
+          },
+          assert: async () => {
+            state.listCapability = await findCapability(ctx, state.adminMcpToken, {
+              query: "list MCP connections",
+              method: "GET",
+              path: "/v1/mcp-connections",
+            });
+            const listed = await executeCapability(ctx, state.adminMcpToken, state.listCapability.name, {
+              query: { scope: "manageable" },
+            });
+            const body = parseToolJson(listed);
+            const connection = (body.connections ?? []).find((entry) => entry.id === state.connectionId);
+            witness(ctx, Boolean(connection), "The created connection is readable through execute_capability", body);
+            witness(ctx, connection?.name === CONNECTION_NAME, "The agent-created connection is named in the readback", connection);
+            ctx.output("handoff-link-response.json", JSON.stringify({ id: state.createResponse.id, name: state.createResponse.name, links: state.createResponse.links }, null, 2));
+            witness(ctx, typeof state.createResponse.links?.yourConnections === "string" && state.createResponse.links.yourConnections.endsWith("/dashboard/your-connections"), "Create response includes links.yourConnections for teammates", state.createResponse.links);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Alex's agent can manage and read back who can use the connection", {
+          voiceover: vo[2],
+          action: async () => {
+            state.accessCapability = await findCapability(ctx, state.adminMcpToken, {
+              query: "replace MCP connection access",
+              method: "PUT",
+              path: "/v1/mcp-connections/{connectionId}/access",
+            });
+            const updated = await executeCapability(ctx, state.adminMcpToken, state.accessCapability.name, {
+              path: { connectionId: state.connectionId },
+              body: { access: { orgWide: true, memberIds: [], teamIds: [] } },
+            });
+            witness(ctx, updated.isError !== true, "execute_capability can update connection access", parseToolJson(updated));
+            ctx.output("access-update-response.json", JSON.stringify(parseToolJson(updated), null, 2));
+          },
+          assert: async () => {
+            const listed = await executeCapability(ctx, state.adminMcpToken, state.listCapability.name, {
+              query: { scope: "manageable" },
+            });
+            const body = parseToolJson(listed);
+            const connection = (body.connections ?? []).find((entry) => entry.id === state.connectionId);
+            witness(ctx, connection?.access?.orgWide === true, "Access readback says everyone in the org can use it", connection?.access ?? connection);
+            witness(ctx, Array.isArray(connection?.access?.memberIds) && connection.access.memberIds.length === 0, "Access readback has no individual-only restriction", connection?.access ?? connection);
+            witness(ctx, Array.isArray(connection?.access?.teamIds) && connection.access.teamIds.length === 0, "Access readback has no team-only restriction", connection?.access ?? connection);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Jordan's member-scoped connection list contains the org-published card in Connect your account state", {
+          voiceover: vo[3],
+          action: async () => {
+            state.memberMcpToken = await mintMcpToken(ctx, state.memberSession, "Member");
+          },
+          assert: async () => {
+            const usable = await denApiFetch("/v1/mcp-connections?scope=usable", {
+              headers: { authorization: `Bearer ${state.memberSession}` },
+            });
+            witness(ctx, usable.response.ok, "Member can read usable org MCP connections", usable.body);
+            const connection = (usable.body.connections ?? []).find((entry) => entry.id === state.connectionId);
+            ctx.output("member-usable-connections.json", JSON.stringify(usable.body, null, 2));
+            witness(ctx, Boolean(connection), "The member-visible list includes Alex's connection", usable.body);
+            witness(ctx, connection?.connectedForMe === false, "The member-visible connection is waiting for Jordan to connect her own account", connection);
+            witness(ctx, connection?.credentialMode === "per_member", "The member-visible connection preserves per-member credential mode", connection);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("Jordan's agent cannot publish an org MCP connection because Jordan is not an admin", {
+          voiceover: vo[4],
+          action: async () => {
+            state.createCapability = await findCapability(ctx, state.memberMcpToken, {
+              query: "register MCP connection",
+              method: "POST",
+              path: "/v1/mcp-connections",
+            });
+          },
+          assert: async () => {
+            const denied = await executeCapability(ctx, state.memberMcpToken, state.createCapability.name, {
+              body: {
+                name: `Agent Config Knowledge Base Member Denied ${RUN_TAG}`,
+                url: `${MOCK_SERVER_URL}/mcp`,
+                authType: "oauth",
+                credentialMode: "per_member",
+                access: { orgWide: true, memberIds: [], teamIds: [] },
+              },
+            });
+            const body = parseToolJson(denied);
+            ctx.output("member-denied-response.json", JSON.stringify(body, null, 2));
+            witness(ctx, denied.isError === true, "Member execute_capability create attempt is an error", body);
+            witness(ctx, body.error === "forbidden" || String(body.message ?? "").includes("admins"), "The denial is the normal admin-required route guard", body);
+            await cleanupConnections(ctx);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/org-mcp-agent-config-ux.md
+++ b/evals/org-mcp-agent-config-ux.md
@@ -1,0 +1,63 @@
+# Configuring org connections from the agent — two paths
+
+An org admin should be able to say, in chat, "add the Notion MCP for my
+team" and have it happen — then teammates get a proper handoff to connect
+their own account. Two delivery paths, one shipped now, one mapped for next.
+
+## Path A — classical (this PR)
+
+The agent creates the connection and **hands members a link** to the place
+they already connect things (den-web Your Connections / desktop Extensions).
+
+Mechanics, all server-side:
+
+1. **Retag two routes** from `Authentication` to `Capability Sources` so the
+   agent catalog includes them (`mcp/policy.ts` allowlist):
+   - `POST /v1/mcp-connections` — create (admin-enforced in-route).
+   - `PUT /v1/mcp-connections/:id/access` — grants (admin-enforced in-route).
+   Everything else stays deliberately human-only: connect/start + callbacks
+   (browser consent), `POST /v1/oauth-providers/:id/client` (client secret),
+   disconnect + delete (destructive, and disconnect is in
+   `BLOCKED_OPERATION_IDS`).
+2. **No secrets through chat**: when the caller is the internal MCP
+   principal (`session.id === "mcp_internal"`), reject `authType: "apikey"`
+   bodies with a message pointing at the dashboard.
+3. **The handoff is in the response**: the create response gains
+   `links.yourConnections` (den-web origin + `/dashboard/your-connections`),
+   and the route description tells the agent to share it. Members also see
+   the connection in desktop Extensions and get `needs_connection` hints —
+   the entire member half is the shipped #2451/#2455 machinery.
+4. Invoke-time safety is unchanged: the agent's ceiling is the signed-in
+   human's real org role (a member's agent gets a clean 403), the desktop
+   Cloud Control token is already `mcp:read mcp:write`, and the staged
+   rollout gate + ops/revert tooling apply because it is the same table.
+
+## Path B — new wave (mapped, next PR)
+
+Instead of a link, the **desktop chat renders the real connect component
+inline**: the agent's "created it" reply carries a card with the live
+connection state and a working `Connect your account` button; a member whose
+tool call returns `needs_connection` gets the same card in-chat.
+
+Mechanics, building on precedent that already exists:
+
+1. **Marker in tool results** (server): `POST /v1/mcp-connections` responses
+   and `needs_connection` error payloads include a well-known envelope,
+   e.g. `"openwork": { "component": "org-connection", "connectionId": ... }`.
+2. **Rich tool-part mapping** (desktop): the session tool-part mapper
+   already special-cases certain tools for rich chat rendering (see the
+   env-var request mapping and its tests in
+   `apps/app/tests/session-sync-tool-parts.test.ts`). Add one case: results
+   carrying the envelope map to an `org-connection` part.
+3. **Render the shipped components** (desktop): the chat renderer mounts the
+   existing extension card + connect modal wired to
+   `use-org-mcp-connections`'s `connect()` — the exact card/browser-OAuth/
+   poll loop proven in #2451/#2455, now mounted inside a chat bubble. No new
+   connect logic; the component is fed, not rebuilt.
+4. Same governance: the card renders from the member's own `scope=usable`
+   view, so grants and the rollout gate hold automatically.
+
+Path B risk notes: keep the envelope out of model-visible text (structured
+result metadata, not prose) so prompts cannot forge it; the renderer must
+treat `connectionId` as untrusted input and re-fetch state via the usual
+hook rather than trusting envelope fields.

--- a/evals/voiceovers/org-mcp-agent-config-demo.md
+++ b/evals/voiceovers/org-mcp-agent-config-demo.md
@@ -1,0 +1,20 @@
+# org-mcp-agent-config-demo — An admin publishes a team connection from chat, and everyone gets a clean way in
+
+Cast: Alex (org admin) and Jordan (member), both in the OpenWork desktop app
+against a real Den stack. The external tool is played by the mock MCP server
+(protocol-identical to Notion). This is Path A (classical) from
+evals/org-mcp-agent-config-ux.md: the agent creates and configures the
+connection, and members are handed the existing connect experience — a link
+to Your Connections on the web, and the same card in desktop Extensions.
+Path B (the connect card rendered inline in chat) is mapped in the same doc
+and not narrated here.
+
+1. Alex does not open a dashboard. He just tells his agent to publish the team knowledge base connection for the whole company, with everyone signing in as themselves — and the agent finds the right capability on its own.
+
+2. The agent sets it up and reports back like a colleague: it names the connection it created, and it hands Alex the exact link where teammates connect their own account on the web — ready to paste into Slack.
+
+3. Alex asks who can use it, and the agent reads the access back: everyone in the org, each with their own sign-in. Governance you can ask about in plain language.
+
+4. Jordan opens her own OpenWork and there it is — the connection her admin created in a chat window, waiting in Extensions with Connect your account. Same card, same flow she already knows.
+
+5. And when Jordan asks her own agent to publish a connection, it politely declines: that needs an admin. The agent's power is your role, nothing more.


### PR DESCRIPTION
## Summary
- Expose org MCP connection create/access routes to the agent catalog while leaving OAuth callbacks, deletes, disconnects, and client-secret setup human-only.
- Return `links.yourConnections` on create so agents can hand teammates to the existing connect flow.
- Block API-key connection creation from the internal MCP principal to keep secrets out of chat transcripts.
- Add policy tests, UX path map, voiceover script, and fraimz proof flow.

## Validation
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit` passed.
- `bun test test/mcp-agent-config-policy.test.ts` passed: 4 pass / 0 fail / 15 assertions.
- `pnpm fraimz --flow org-mcp-agent-config-demo --stack den` passed.
- fraimz: `/var/folders/d9/xqhkvsp94rg0n0n523snqztm0000gn/T/opencode/fraimz-runtime/2026-07-04T03-49-50-378Z/fraimz.html`

## Notes
- The fraimz run used the local Den stack after refreshing the demo seed and pushing the current Den DB schema to local MySQL.