### PR TITLE
fix(app): replace color classes that are missing from the Tailwind palette

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -573,7 +573,7 @@ function ErrorMessage({ error }: ErrorMessageProps) {
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
       <div className="group flex w-full flex-col items-start gap-0">
-        <div className="text-foreground flex min-w-0 flex-1 flex-row items-start gap-2 rounded-lg border-2 border-red-300 bg-red-300/20 px-2 py-1">
+        <div className="text-foreground flex min-w-0 flex-1 flex-row items-start gap-2 rounded-lg border-2 border-red-7 bg-red-3 px-2 py-1">
           <AlertTriangle size={16} className="mt-0.5 shrink-0 text-destructive" />
           <p className="whitespace-pre-wrap text-destructive">{error}</p>
         </div>
@@ -591,7 +591,7 @@ function RetryActionButton(props: { link: string; label: string }) {
     <Button
       variant="outline"
       size="sm"
-      className="h-7 border-amber-500/70 bg-amber-50 text-xs text-amber-950 hover:bg-amber-100"
+      className="h-7 border-amber-8/70 bg-amber-2 text-xs text-amber-12 hover:bg-amber-3"
       onClick={() => void openDesktopUrl(props.link)}
     >
       {props.label}
@@ -617,18 +617,18 @@ const RetryMessage = React.memo(({ status }: RetryMessageProps) => {
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
       <div className="group flex w-full flex-col items-start gap-0">
-        <div className="text-foreground flex min-w-0 flex-1 flex-col gap-2 rounded-lg border-2 border-amber-300 bg-amber-300/20 px-3 py-2">
+        <div className="text-foreground flex min-w-0 flex-1 flex-col gap-2 rounded-lg border-2 border-amber-7 bg-amber-3 px-3 py-2">
           <div className="flex items-start gap-2">
-            <LoaderCircle size={16} className="mt-0.5 shrink-0 animate-spin text-amber-700" />
+            <LoaderCircle size={16} className="mt-0.5 shrink-0 animate-spin text-amber-11" />
             <div className="min-w-0 space-y-1">
-              <p className="whitespace-pre-wrap text-sm font-medium text-amber-900">{status.message}</p>
-              <p className="text-xs text-amber-800">{info}</p>
+              <p className="whitespace-pre-wrap text-sm font-medium text-amber-12">{status.message}</p>
+              <p className="text-xs text-amber-11">{info}</p>
             </div>
           </div>
           {action ? (
-            <div className="ml-6 space-y-1 border-t border-amber-400/60 pt-2">
-              <p className="text-xs font-medium text-amber-950">{action.title}</p>
-              <p className="text-xs text-amber-900">{action.message}</p>
+            <div className="ml-6 space-y-1 border-t border-amber-7/60 pt-2">
+              <p className="text-xs font-medium text-amber-12">{action.title}</p>
+              <p className="text-xs text-amber-12">{action.message}</p>
               {action.link ? (
                 <RetryActionButton link={action.link} label={action.label} />
               ) : null}

--- a/apps/app/src/components/ui/image.tsx
+++ b/apps/app/src/components/ui/image.tsx
@@ -100,7 +100,7 @@ export const Image = ({
         aria-label={alt}
         role="img"
         className={cn(
-          "h-auto max-w-full animate-pulse overflow-hidden rounded-md bg-gray-100 dark:bg-neutral-800",
+          "h-auto max-w-full animate-pulse overflow-hidden rounded-md bg-gray-3",
           className
         )}
         {...props}

--- a/apps/app/src/components/ui/sonner.tsx
+++ b/apps/app/src/components/ui/sonner.tsx
@@ -82,7 +82,7 @@ const toastTile = cva(
     variants: {
       type: {
         default: "text-sky-11",
-        success: "text-emerald-11",
+        success: "text-green-11",
         info: "text-sky-11",
         warning: "text-amber-11",
         error: "text-red-11",
@@ -94,7 +94,7 @@ const toastTile = cva(
     },
     compoundVariants: [
       { size: "default", type: "default", className: "border-sky-6/40 bg-sky-4/80" },
-      { size: "default", type: "success", className: "border-emerald-6/40 bg-emerald-4/80" },
+      { size: "default", type: "success", className: "border-green-6/40 bg-green-4/80" },
       { size: "default", type: "info", className: "border-sky-6/40 bg-sky-4/80" },
       { size: "default", type: "warning", className: "border-amber-6/40 bg-amber-4/80" },
       { size: "default", type: "error", className: "border-red-6/40 bg-red-4/80" },

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -794,7 +794,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                                   method.type === "oauth"
                                     ? "bg-indigo-3/30 text-indigo-11 border-indigo-5/30"
                                     : method.type === "cloud"
-                                      ? "bg-emerald-3/30 text-emerald-11 border-emerald-5/30"
+                                      ? "bg-green-3/30 text-green-11 border-green-5/30"
                                       : "bg-gray-3/40 text-gray-11 border-gray-6/40"
                                 }`}
                               >

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1181,7 +1181,7 @@ function WorkspaceSidebarGroup({
                   <SidebarMenuSubItem>
                     <SidebarMenuSubButton
                       aria-disabled
-                      className={cn("text-xs", taskLoadError.tone === "offline" ? "text-amber-600" : "text-destructive")}
+                      className={cn("text-xs", taskLoadError.tone === "offline" ? "text-amber-11" : "text-destructive")}
                     >
                       <span className="truncate">{taskLoadError.message}</span>
                     </SidebarMenuSubButton>

--- a/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
+++ b/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
@@ -76,7 +76,7 @@ function ThemePicker(props: ThemePickerProps) {
         value="dark"
         label={t("settings.theme_dark")}
       >
-        <ThemePreview value="dark" className="bg-zinc-950" />
+        <ThemePreview value="dark" className="bg-black" />
         <ThemePickerLabel>{t("settings.theme_dark")}</ThemePickerLabel>
       </ThemePickerItem>
     </ToggleGroup>
@@ -117,7 +117,7 @@ function ThemePreview(props: ThemePreviewProps) {
       {props.value === "system" && (
         <div className="flex h-full">
           <div className="w-1/2 bg-white" />
-          <div className="w-1/2 bg-zinc-950" />
+          <div className="w-1/2 bg-black" />
         </div>
       )}
     </div>

--- a/apps/app/src/react-app/domains/settings/pages/messaging-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/messaging-view.tsx
@@ -300,7 +300,7 @@ export function MessagingView(props: MessagingViewProps) {
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2.5">
                     {isWorkerOnline ? (
-                      <div className="size-2.5 rounded-full bg-emerald-9 animate-pulse" />
+                      <div className="size-2.5 rounded-full bg-green-9 animate-pulse" />
                     ) : (
                       <div className="size-2.5 rounded-full bg-gray-8" />
                     )}
@@ -315,7 +315,7 @@ export function MessagingView(props: MessagingViewProps) {
                   <span
                     className={`rounded-full border px-2.5 py-0.5 text-[11px] font-semibold ${
                       isWorkerOnline
-                        ? "border-emerald-7/25 bg-emerald-1/40 text-emerald-11"
+                        ? "border-green-7/25 bg-green-1/40 text-green-11"
                         : props.healthError
                           ? "border-red-7/20 bg-red-1/40 text-red-12"
                           : "border-amber-7/25 bg-amber-1/40 text-amber-12"
@@ -358,7 +358,7 @@ export function MessagingView(props: MessagingViewProps) {
                 <div className="flex flex-col gap-2.5">
                   <div
                     className={`overflow-hidden rounded-xl border transition-colors ${
-                      hasTelegramConnected ? "border-emerald-7/30 bg-emerald-1/20" : "border-gray-4 bg-gray-1"
+                      hasTelegramConnected ? "border-green-7/30 bg-green-1/20" : "border-gray-4 bg-gray-1"
                     }`}
                   >
                     <button
@@ -371,7 +371,7 @@ export function MessagingView(props: MessagingViewProps) {
                         <div className="flex items-center gap-2">
                           <span className="text-[15px] font-semibold text-gray-12">Telegram</span>
                           {hasTelegramConnected ? (
-                            <span className="rounded-full bg-emerald-1/40 px-2 py-0.5 text-[10px] font-semibold text-emerald-11">
+                            <span className="rounded-full bg-green-1/40 px-2 py-0.5 text-[10px] font-semibold text-green-11">
                               {t("identities.connected_badge")}
                             </span>
                           ) : null}
@@ -405,7 +405,7 @@ export function MessagingView(props: MessagingViewProps) {
                                   <div className="min-w-0">
                                     <div className="flex items-center gap-2">
                                       <div
-                                        className={`size-1.5 shrink-0 rounded-full ${item.running ? "bg-emerald-9" : "bg-gray-8"}`}
+                                        className={`size-1.5 shrink-0 rounded-full ${item.running ? "bg-green-9" : "bg-gray-8"}`}
                                       />
                                       <span className="truncate text-[13px] font-semibold text-gray-12">
                                         <span className="font-mono text-[12px]">{item.id}</span>
@@ -433,13 +433,13 @@ export function MessagingView(props: MessagingViewProps) {
                                 <div className="flex items-center gap-1.5">
                                   <div
                                     className={`size-1.5 rounded-full ${
-                                      props.telegram.identities.some((item) => item.running) ? "bg-emerald-9" : "bg-gray-8"
+                                      props.telegram.identities.some((item) => item.running) ? "bg-green-9" : "bg-gray-8"
                                     }`}
                                   />
                                   <span
                                     className={`text-[13px] font-semibold ${
                                       props.telegram.identities.some((item) => item.running)
-                                        ? "text-emerald-11"
+                                        ? "text-green-11"
                                         : "text-gray-10"
                                     }`}
                                   >

--- a/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
@@ -64,7 +64,7 @@ export type CreateWorkspaceLocalPanelProps = {
 
 function stepIcon(status: CreateWorkspaceProgressStep["status"]) {
   if (status === "done")
-    return <XCircle size={16} className="text-emerald-10" />;
+    return <XCircle size={16} className="text-green-10" />;
   if (status === "active")
     return <Loader2 size={16} className="animate-spin text-dls-accent" />;
   if (status === "error") return <XCircle size={16} className="text-red-10" />;
@@ -107,15 +107,15 @@ export function CreateWorkspaceLocalPanel(
             </div>
             <ul className="mt-3 space-y-1.5 pl-1">
               <li className="flex items-start gap-2 text-[13px] text-dls-secondary">
-                <Check size={14} className="mt-0.5 shrink-0 text-emerald-10" />
+                <Check size={14} className="mt-0.5 shrink-0 text-green-10" />
                 {t("welcome.folder_read")}
               </li>
               <li className="flex items-start gap-2 text-[13px] text-dls-secondary">
-                <Check size={14} className="mt-0.5 shrink-0 text-emerald-10" />
+                <Check size={14} className="mt-0.5 shrink-0 text-green-10" />
                 {t("welcome.folder_write")}
               </li>
               <li className="flex items-start gap-2 text-[13px] text-dls-secondary">
-                <Check size={14} className="mt-0.5 shrink-0 text-emerald-10" />
+                <Check size={14} className="mt-0.5 shrink-0 text-green-10" />
                 {t("welcome.folder_anything")}
               </li>
             </ul>

--- a/apps/app/src/react-app/domains/workspace/modal-styles.ts
+++ b/apps/app/src/react-app/domains/workspace/modal-styles.ts
@@ -49,13 +49,13 @@ export const errorBannerClass =
   "rounded-[20px] border border-red-7/20 bg-red-1/40 px-4 py-3 text-[13px] text-red-11";
 
 export const successBannerClass =
-  "rounded-[20px] border border-emerald-7/20 bg-emerald-3/30 px-4 py-3 text-[13px] text-emerald-11";
+  "rounded-[20px] border border-green-7/20 bg-green-3/30 px-4 py-3 text-[13px] text-green-11";
 
 export const modalNoticeNeutralClass =
   "rounded-xl border border-dls-border bg-dls-hover px-3 py-2.5 text-[13px] leading-relaxed text-dls-text";
 
 export const modalNoticeSuccessClass =
-  "rounded-xl border border-dls-border bg-emerald-2/25 px-3 py-2.5 text-[13px] leading-relaxed text-dls-text";
+  "rounded-xl border border-dls-border bg-green-2/25 px-3 py-2.5 text-[13px] leading-relaxed text-dls-text";
 
 export const modalNoticeErrorClass =
   "rounded-xl border border-dls-border bg-red-2/20 px-3 py-2.5 text-[13px] leading-relaxed text-dls-text";

--- a/apps/app/src/react-app/domains/workspace/share-workspace-access-panel.tsx
+++ b/apps/app/src/react-app/domains/workspace/share-workspace-access-panel.tsx
@@ -77,7 +77,7 @@ function CredentialField(props: CredentialFieldProps) {
           title="Copy"
         >
           {props.copiedKey === props.fieldKey ? (
-            <Check size={14} className="text-emerald-600" />
+            <Check size={14} className="text-green-10" />
           ) : (
             <Copy size={14} />
           )}
@@ -172,7 +172,7 @@ export function ShareWorkspaceAccessPanel(
                 }
                 disabled={props.remoteAccess.busy}
               />
-              <div className="h-6 w-11 rounded-full bg-zinc-300 transition-colors peer-checked:bg-[var(--dls-accent)] peer-disabled:opacity-50 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-5" />
+              <div className="h-6 w-11 rounded-full bg-gray-6 transition-colors peer-checked:bg-[var(--dls-accent)] peer-disabled:opacity-50 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-5" />
             </label>
           </div>
 

--- a/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
+++ b/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
@@ -103,7 +103,7 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
         <section className="w-full overflow-hidden rounded-[32px] border border-white/10 bg-white/[0.04] shadow-2xl shadow-black/40">
           <div className="grid gap-0 lg:grid-cols-[1.05fr_0.95fr]">
             <div className="space-y-8 p-8 sm:p-10 lg:p-12">
-              <div className="inline-flex rounded-full border border-amber-300/30 bg-amber-300/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-amber-100">
+              <div className="inline-flex rounded-full border border-[#fcd34d]/30 bg-[#fcd34d]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-[#fef3c7]">
                 Architecture mismatch
               </div>
               <div className="space-y-4">
@@ -121,10 +121,10 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
                   <div className="mt-2 text-2xl font-semibold text-white">{info.appArchLabel}</div>
                   <div className="mt-1 font-mono text-xs text-white/45">{info.appArch}</div>
                 </div>
-                <div className="rounded-2xl border border-emerald-300/20 bg-emerald-300/10 p-4">
-                  <div className="text-xs uppercase tracking-[0.2em] text-emerald-100/70">Your system</div>
-                  <div className="mt-2 text-2xl font-semibold text-emerald-50">{info.systemArchLabel}</div>
-                  <div className="mt-1 font-mono text-xs text-emerald-100/55">{info.systemArch}</div>
+                <div className="rounded-2xl border border-[#6ee7b7]/20 bg-[#6ee7b7]/10 p-4">
+                  <div className="text-xs uppercase tracking-[0.2em] text-[#d1fae5]/70">Your system</div>
+                  <div className="mt-2 text-2xl font-semibold text-[#ecfdf5]">{info.systemArchLabel}</div>
+                  <div className="mt-1 font-mono text-xs text-[#d1fae5]/55">{info.systemArch}</div>
                 </div>
               </div>
 
@@ -132,7 +132,7 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
                 <button
                   type="button"
                   onClick={openDownload}
-                  className="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-black transition hover:bg-emerald-100"
+                  className="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-black transition hover:bg-[#d1fae5]"
                 >
                   Download correct version
                 </button>
@@ -146,7 +146,7 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
               </div>
             </div>
 
-            <aside className="border-t border-white/10 bg-gradient-to-br from-emerald-300/12 via-sky-300/8 to-transparent p-8 sm:p-10 lg:border-l lg:border-t-0 lg:p-12">
+            <aside className="border-t border-white/10 bg-gradient-to-br from-[#6ee7b7]/12 via-[#7dd3fc]/8 to-transparent p-8 sm:p-10 lg:border-l lg:border-t-0 lg:p-12">
               <div className="space-y-5 rounded-[28px] border border-white/10 bg-black/25 p-6 text-sm leading-6 text-white/68">
                 <div className="text-lg font-semibold text-white">Why OpenWork stopped here</div>
                 <p>

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -65,7 +65,7 @@ function targetIcon(target: AccessibleTargetOption) {
   if (target.kind === "url") return <Globe className="size-4 text-primary" />;
   if (target.preview === "sheet") {
     return (
-      <span className="inline-flex h-4 min-w-6 shrink-0 items-center justify-center rounded-[4px] border border-emerald-500/30 bg-emerald-500/10 px-0.5 text-[7px] font-bold leading-none text-emerald-700">
+      <span className="inline-flex h-4 min-w-6 shrink-0 items-center justify-center rounded-[4px] border border-green-9/30 bg-green-9/10 px-0.5 text-[7px] font-bold leading-none text-green-11">
         XLS
       </span>
     );

--- a/apps/app/src/react-app/shell/notification-center.tsx
+++ b/apps/app/src/react-app/shell/notification-center.tsx
@@ -34,7 +34,7 @@ const SEVERITY_ICONS: Record<NotificationSeverity, LucideIcon> = {
 
 const SEVERITY_CLASSES: Record<NotificationSeverity, string> = {
   info: "text-sky-11",
-  success: "text-emerald-11",
+  success: "text-green-11",
   warning: "text-amber-11",
   error: "text-red-11",
 };

--- a/apps/app/tests/tailwind-color-classes.test.ts
+++ b/apps/app/tests/tailwind-color-classes.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { radixColors } from "../src/styles/tailwind-colors"
+
+// The app's Tailwind theme replaces the default palette entirely with the
+// Radix families in tailwind-colors.ts (steps 1-12 plus a1-a12). Any class
+// using a family or step outside that set compiles to no CSS rule at all and
+// the element silently renders unstyled. This test scans source for color
+// utility classes and fails on ones that cannot resolve.
+
+const SRC_DIR = join(import.meta.dir, "..", "src")
+
+const COLOR_PREFIXES =
+  "bg|text|border|ring|outline|divide|decoration|accent|caret|fill|stroke|shadow|from|via|to"
+
+// e.g. bg-emerald-500, text-amber-11/70, via-sky-300
+const COLOR_CLASS = new RegExp(`\\b(?:${COLOR_PREFIXES})-([a-z]+)-(a?\\d+)(?:/\\d+)?\\b`, "g")
+
+const RADIX_FAMILIES = new Set(Object.keys(radixColors))
+
+// Default Tailwind families that do not exist in the Radix palette. Only
+// these are treated as errors when seen with a numeric step; other unmatched
+// words (t, x, y, ...) are directional modifiers, not colors.
+const REMOVED_TAILWIND_FAMILIES = new Set([
+  "zinc",
+  "neutral",
+  "stone",
+  "emerald",
+  "rose",
+  "fuchsia",
+])
+
+const VALID_STEPS = new Set(
+  Array.from({ length: 12 }, (_, i) => `${i + 1}`).concat(
+    Array.from({ length: 12 }, (_, i) => `a${i + 1}`),
+  ),
+)
+
+function listSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) return listSourceFiles(path)
+    return /\.tsx?$/.test(entry.name) ? [path] : []
+  })
+}
+
+describe("Tailwind color classes", () => {
+  test("every color class resolves to a token in the Radix palette", () => {
+    const offenders: string[] = []
+    for (const file of listSourceFiles(SRC_DIR)) {
+      const content = readFileSync(file, "utf8")
+      for (const match of content.matchAll(COLOR_CLASS)) {
+        const [cls, family, step] = match
+        const familyExists = RADIX_FAMILIES.has(family)
+        if (familyExists && VALID_STEPS.has(step)) continue
+        if (!familyExists && !REMOVED_TAILWIND_FAMILIES.has(family)) continue
+        const line = content.slice(0, match.index).split("\n").length
+        offenders.push(`${file}:${line} ${cls}`)
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #2341

`apps/app` overrides Tailwind's `theme.colors` entirely with the Radix palette from `src/styles/tailwind-colors.ts` (31 families, steps 1–12). Any class outside that set compiles to **no CSS rule at all**, so the element silently renders unstyled — an invisible toggle track, warning/error banners with no background or border, success states with no green.

This PR fixes all such classes found by the sweep in the issue (13 files) and adds a regression test so new ones can't land unnoticed.

## Changes

- **`emerald-*` → `green-*`**: Radix has no `emerald`; `green` is now the single success alias, matching the sky/amber/red Radix families already used for the other severities (sonner, notification center, messaging view, modal styles, provider auth modal, create-workspace panel, command palette).
- **Theme previews** (`theme-section.tsx`): `bg-zinc-950` → `bg-black`. Previews must stay fixed regardless of the active theme (see #2328), so a literal black is correct here, not a theme-aware token.
- **Remote-access toggle** (`share-workspace-access-panel.tsx`): `bg-zinc-300` → `bg-gray-6` — the off-state track is visible again in both themes.
- **Image skeleton** (`image.tsx`): `bg-gray-100 dark:bg-neutral-800` → `bg-gray-3`. The Radix variable already flips with the theme, so the `dark:` variant is unnecessary.
- **Chat error/retry banners** (`message-list.tsx`) and the offline notice in `app-sidebar.tsx`: default-scale `amber-*`/`red-*` steps mapped to the Radix idiom (6–8 borders, 3 subtle backgrounds, 11/12 text).
- **Architecture-mismatch gate**: this screen is a fixed dark page (`bg-[#05070c]`), so theme-aware Radix variables would break it in light mode. It keeps its exact design via literal hex values (the file already uses arbitrary values).

## Regression guard

`apps/app/tests/tailwind-color-classes.test.ts` scans `src` for color utility classes and fails when a class uses a family missing from the palette (`zinc`, `neutral`, `emerald`, …) or a step outside Radix's 1–12/a1–a12 — as suggested in the issue discussion.

## Testing

- `bun test tests/` — 111 pass, 0 fail (includes the new guard test)
- `pnpm typecheck` — clean
- Verified the guard test fails when a bad class (e.g. `bg-emerald-500`) is injected into `src`
- Repo-wide re-run of both grep sweeps from the issue returns zero matches

Could not capture a screen recording in this environment; the clearest manual check is Settings → Appearance (dark preview card now stays black when Light is active) and the workspace Share panel (remote-access toggle track now visible when off).