### PR TITLE
fix(app): use resolved Shiki theme for code blocks

### DIFF
--- a/apps/app/src/app/theme.ts
+++ b/apps/app/src/app/theme.ts
@@ -1,5 +1,6 @@
 export type ThemeMode = "light" | "dark" | "system";
 export type ResolvedThemeMode = "light" | "dark";
+export type ShikiTheme = "github-light" | "github-dark";
 
 const THEME_PREF_KEY = "openwork.react.settings.theme-mode";
 const LEGACY_THEME_PREF_KEYS = ["openwork.themePref"];
@@ -95,6 +96,9 @@ export const bootstrapTheme = () => {
 export const getInitialThemeMode = () => getCurrentMode();
 
 export const getResolvedThemeMode = () => resolveMode(getCurrentMode());
+
+export const getResolvedShikiTheme = (): ShikiTheme =>
+  getResolvedThemeMode() === "dark" ? "github-dark" : "github-light";
 
 const persistThemeMode = (mode: ThemeMode) => {
   if (typeof window === "undefined") return;

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -388,7 +388,7 @@ function MarkdownBlockInner({
     }
     return sanitizeMarkdownHtml(markdownParser.parse(text, { async: false }));
   }, [text]);
-  const [highlightedHtml, setHighlightedHtml] = useState<{ text: string; html: string } | null>(null);
+  const [highlightedHtml, setHighlightedHtml] = useState<{ text: string; theme: string; html: string } | null>(null);
 
   useEffect(() => {
     if (streaming || !hasFencedCodeBlock(text)) {
@@ -401,7 +401,7 @@ function MarkdownBlockInner({
       const sanitizedHtml = sanitizeMarkdownHtml(html);
 
       if (!cancelled && sanitizedHtml.trim()) {
-        setHighlightedHtml({ text, html: sanitizedHtml });
+        setHighlightedHtml({ text, theme: shikiTheme, html: sanitizedHtml });
       }
     }).catch(() => {
       if (!cancelled) {
@@ -413,7 +413,9 @@ function MarkdownBlockInner({
     };
   }, [shikiTheme, streaming, text]);
 
-  const html = !streaming && highlightedHtml?.text === text ? highlightedHtml.html : syncHtml;
+  const html = !streaming && highlightedHtml?.text === text && highlightedHtml.theme === shikiTheme
+    ? highlightedHtml.html
+    : syncHtml;
 
   useEffect(() => {
     const root = rootRef.current;

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { motion } from "motion/react";
 import DOMPurify from "dompurify";
 import { Marked, type Tokens } from "marked";
@@ -17,6 +17,7 @@ import {
 } from "@shikijs/transformers";
 import { bundledLanguages, codeToHtml } from "shiki";
 
+import { getResolvedShikiTheme, subscribeToTheme } from "@/app/theme";
 import { cn } from "@/lib/utils";
 import { useOpenTargets } from "@/lib/target-provider";
 import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
@@ -340,7 +341,7 @@ const highlightedMarkdownParser = new Marked({
       return codeToHtml(code, {
         lang: language,
         meta: { __raw: props.join(" ") },
-        theme: "github-light",
+        theme: getResolvedShikiTheme(),
         transformers: [
           transformerNotationDiff({ matchAlgorithm: "v3" }),
           transformerNotationHighlight({ matchAlgorithm: "v3" }),
@@ -375,6 +376,11 @@ function MarkdownBlockInner({
 }: MarkdownBlockInnerProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const { openTargets, onOpenTarget } = useOpenTargets();
+  const shikiTheme = useSyncExternalStore(
+    subscribeToTheme,
+    getResolvedShikiTheme,
+    getResolvedShikiTheme,
+  );
   const [linkMenu, setLinkMenu] = useState<{ target: OpenTarget; rect: DOMRect } | null>(null);
   const syncHtml = useMemo(() => {
     if (!text.trim()) {
@@ -405,7 +411,7 @@ function MarkdownBlockInner({
     return () => {
       cancelled = true;
     };
-  }, [streaming, text]);
+  }, [shikiTheme, streaming, text]);
 
   const html = !streaming && highlightedHtml?.text === text ? highlightedHtml.html : syncHtml;
 

--- a/apps/app/src/components/ui/code-block.tsx
+++ b/apps/app/src/components/ui/code-block.tsx
@@ -1,5 +1,6 @@
+import { getResolvedShikiTheme, subscribeToTheme } from "@/app/theme"
 import { cn } from "@/lib/utils"
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useState, useSyncExternalStore } from "react"
 import { codeToHtml } from "shiki"
 
 export type CodeBlockProps = {
@@ -32,11 +33,17 @@ export type CodeBlockCodeProps = {
 function CodeBlockCode({
   code,
   language = "tsx",
-  theme = "github-light",
+  theme,
   className,
   ...props
 }: CodeBlockCodeProps) {
   const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null)
+  const resolvedTheme = useSyncExternalStore(
+    subscribeToTheme,
+    getResolvedShikiTheme,
+    getResolvedShikiTheme
+  )
+  const shikiTheme = theme ?? resolvedTheme
 
   useEffect(() => {
     let cancelled = false
@@ -49,7 +56,7 @@ function CodeBlockCode({
         return
       }
 
-      const html = await codeToHtml(code, { lang: language, theme })
+      const html = await codeToHtml(code, { lang: language, theme: shikiTheme })
       if (!cancelled) {
         setHighlightedHtml(html)
       }
@@ -60,7 +67,7 @@ function CodeBlockCode({
     return () => {
       cancelled = true
     }
-  }, [code, language, theme])
+  }, [code, language, shikiTheme])
 
   const classNames = cn(
     "w-full overflow-x-auto text-[13px] [&>pre]:px-4 [&>pre]:py-4",

--- a/apps/app/src/react-app/domains/session/surface/markdown.tsx
+++ b/apps/app/src/react-app/domains/session/surface/markdown.tsx
@@ -207,7 +207,7 @@ function MarkdownBlockInner(props: {
     if (!props.text.trim()) return "";
     return markdownParser.parse(props.text, { async: false });
   }, [props.text]);
-  const [highlightedHtml, setHighlightedHtml] = useState<{ text: string; html: string } | null>(null);
+  const [highlightedHtml, setHighlightedHtml] = useState<{ text: string; theme: string; html: string } | null>(null);
 
   useEffect(() => {
     if (props.streaming || !hasFencedCodeBlock(props.text)) {
@@ -217,7 +217,7 @@ function MarkdownBlockInner(props: {
 
     let cancelled = false;
     void highlightedMarkdownParser.parse(props.text, { async: true }).then((html) => {
-      if (!cancelled && html.trim()) setHighlightedHtml({ text: props.text, html });
+      if (!cancelled && html.trim()) setHighlightedHtml({ text: props.text, theme: shikiTheme, html });
     }).catch(() => {
       if (!cancelled) setHighlightedHtml(null);
     });
@@ -236,7 +236,9 @@ function MarkdownBlockInner(props: {
     });
   }, [props.highlightQuery, props.streaming, props.text]);
 
-  const html = highlightedHtml?.text === props.text ? highlightedHtml.html : syncHtml;
+  const html = highlightedHtml?.text === props.text && highlightedHtml.theme === shikiTheme
+    ? highlightedHtml.html
+    : syncHtml;
 
   if (!html) return null;
 

--- a/apps/app/src/react-app/domains/session/surface/markdown.tsx
+++ b/apps/app/src/react-app/domains/session/surface/markdown.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { Marked, type Tokens } from "marked";
 import { markedEmoji } from "marked-emoji";
 import markedShiki from "marked-shiki";
@@ -15,6 +15,7 @@ import {
 } from "@shikijs/transformers";
 import { bundledLanguages, codeToHtml } from "shiki";
 
+import { getResolvedShikiTheme, subscribeToTheme } from "@/app/theme";
 import { applyTextHighlights } from "./text-highlights";
 
 function escapeHtml(value: string) {
@@ -175,7 +176,7 @@ const highlightedMarkdownParser = new Marked<string, string>({
       return codeToHtml(code, {
         lang: language,
         meta: { __raw: props.join(" ") },
-        theme: "github-light",
+        theme: getResolvedShikiTheme(),
         transformers: [
           transformerNotationDiff({ matchAlgorithm: "v3" }),
           transformerNotationHighlight({ matchAlgorithm: "v3" }),
@@ -197,6 +198,11 @@ function MarkdownBlockInner(props: {
   highlightQuery?: string;
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
+  const shikiTheme = useSyncExternalStore(
+    subscribeToTheme,
+    getResolvedShikiTheme,
+    getResolvedShikiTheme,
+  );
   const syncHtml = useMemo(() => {
     if (!props.text.trim()) return "";
     return markdownParser.parse(props.text, { async: false });
@@ -218,7 +224,7 @@ function MarkdownBlockInner(props: {
     return () => {
       cancelled = true;
     };
-  }, [props.streaming, props.text]);
+  }, [props.streaming, props.text, shikiTheme]);
 
   useEffect(() => {
     const root = rootRef.current;

--- a/apps/app/tests/theme.test.ts
+++ b/apps/app/tests/theme.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { getResolvedShikiTheme, setThemeMode } from "../src/app/theme";
+
+const originalDocument = globalThis.document;
+const originalWindow = globalThis.window;
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+function installThemeTestEnvironment(systemPrefersDark: boolean) {
+  const documentElement = {
+    dataset: {} as Record<string, string>,
+    style: {
+      colorScheme: "",
+    },
+  };
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { documentElement },
+  });
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage: memoryStorage(),
+      matchMedia: () => ({
+        matches: systemPrefersDark,
+        addEventListener() {},
+        removeEventListener() {},
+      }),
+      __OPENWORK_ELECTRON__: {
+        invokeDesktop() {
+          return undefined;
+        },
+      },
+    },
+  });
+}
+
+describe("getResolvedShikiTheme", () => {
+  beforeEach(() => {
+    installThemeTestEnvironment(false);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  test("returns the light Shiki theme in light mode", () => {
+    setThemeMode("light");
+    expect(getResolvedShikiTheme()).toBe("github-light");
+  });
+
+  test("returns the dark Shiki theme in dark mode", () => {
+    setThemeMode("dark");
+    expect(getResolvedShikiTheme()).toBe("github-dark");
+  });
+
+  test("uses the system dark preference in system mode", () => {
+    installThemeTestEnvironment(true);
+    setThemeMode("system");
+    expect(getResolvedShikiTheme()).toBe("github-dark");
+  });
+});


### PR DESCRIPTION
Fixes #2440

## Summary
- use the resolved app theme for Shiki code highlighting instead of hardcoding `github-light`
- fix unreadable code blocks in dark mode
- update shared markdown/code rendering paths so code blocks refresh when theme changes

Fixes #2440

## Test plan
- [x] Switch to dark mode and render a code block in an assistant message
- [x] Confirm syntax colors use the dark Shiki palette
- [x] Switch back to light mode and confirm code blocks update correctly
- [x] `pnpm typecheck`
- [x] `pnpm --filter @openwork/app exec bun test tests/theme.test.ts`