### PR TITLE
Mark Connections feature as beta: badges, black accents, ordered last

### DIFF
--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -29,6 +29,8 @@ export type ExtensionCardProps = {
   hidden?: boolean;
   /** Whether this extension is still in preview. */
   preview?: boolean;
+  /** Whether this extension is beta / untested. */
+  beta?: boolean;
   /** Reason this item is visible but unavailable. */
   disabledReason?: string | null;
   /** Action label shown at bottom. */
@@ -73,6 +75,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
     disabled = false,
     hidden = false,
     preview = false,
+    beta = false,
     disabledReason = null,
     actionLabel,
     onClick,
@@ -155,6 +158,11 @@ export function ExtensionCard(props: ExtensionCardProps) {
             {preview ? (
               <span className="rounded-md bg-blue-3 px-1.5 py-0.5 text-[10px] font-medium text-blue-11">
                 Preview
+              </span>
+            ) : null}
+            {beta ? (
+              <span className="shrink-0 rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
+                Beta
               </span>
             ) : null}
             {disabledReason ? (

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -45,6 +45,8 @@ export type ExtensionDetailModalProps = {
   hidden?: boolean;
   /** Whether this extension is still in preview. */
   preview?: boolean;
+  /** Whether this extension is beta / untested. */
+  beta?: boolean;
   /** Reason this item is visible but unavailable. */
   disabledReason?: string | null;
   /** Remote URL if applicable. */
@@ -189,6 +191,7 @@ export function ExtensionDetailModal({
   connecting = false,
   hidden = false,
   preview = false,
+  beta = false,
   disabledReason = null,
   url,
   setupInstructions,
@@ -264,6 +267,11 @@ export function ExtensionDetailModal({
                 {preview ? (
                   <span className="rounded-md bg-blue-3 px-1.5 py-0.5 text-[10px] font-medium text-blue-11">
                     Preview
+                  </span>
+                ) : null}
+                {beta ? (
+                  <span className="rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
+                    Beta
                   </span>
                 ) : null}
               </DialogDescription>
@@ -395,6 +403,13 @@ export function ExtensionDetailModal({
                     <div className="flex items-center justify-between text-sm">
                       <span className="text-muted-foreground">Release stage</span>
                       <span className="font-medium text-blue-11">Preview</span>
+                    </div>
+                  ) : null}
+
+                  {beta ? (
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-muted-foreground">Release stage</span>
+                      <span className="font-medium text-amber-11">Beta</span>
                     </div>
                   ) : null}
 

--- a/apps/app/src/react-app/domains/settings/extension-items.ts
+++ b/apps/app/src/react-app/domains/settings/extension-items.ts
@@ -274,7 +274,8 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
   }));
 
   return {
-    items: [...builtInItems, ...cloudPluginItems, ...importedPluginItems, ...orgMcpConnectionItems, ...standaloneMcpEntries.map((entry): ExtensionItem => ({
+    // Org-managed MCP connections are beta, so keep them last in unified lists.
+    items: [...builtInItems, ...cloudPluginItems, ...importedPluginItems, ...standaloneMcpEntries.map((entry): ExtensionItem => ({
       id: `mcp:${getMcpServerName(entry)}`,
       source: "mcp-directory",
       name: entry.name,
@@ -285,7 +286,7 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
       enablement: null,
       resources: [{ id: getMcpServerName(entry), type: "mcp", title: entry.name }],
       mcpEntry: entry,
-    })), ...standaloneSkillItems],
+    })), ...standaloneSkillItems, ...orgMcpConnectionItems],
     builtInItems,
     cloudPluginItems: [...cloudPluginItems, ...importedPluginItems],
     orgMcpConnectionItems,

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -322,7 +322,7 @@ export function CloudMarketplacesView({
     });
   }, [extensionItems]);
 
-  const rows = React.useMemo<MarketplaceRow[]>(() => canShowRows ? [...builtInRows, ...orgMcpRows, ...cloudRows] : [], [builtInRows, canShowRows, cloudRows, orgMcpRows]);
+  const rows = React.useMemo<MarketplaceRow[]>(() => canShowRows ? [...builtInRows, ...cloudRows, ...orgMcpRows] : [], [builtInRows, canShowRows, cloudRows, orgMcpRows]);
 
   React.useEffect(() => {
     if (detailRow?.source !== "org-mcp") return;
@@ -343,8 +343,8 @@ export function CloudMarketplacesView({
   const marketplaceOptions = React.useMemo(
     () => canShowRows ? [
       ...(builtInRows.length > 0 ? [{ id: "openwork-builtins", name: "OpenWork Built-ins" }] : []),
-      ...(orgMcpRows.length > 0 ? [{ id: "org-mcp-connections", name: "Organization MCP Connections" }] : []),
       ...marketplaces.map((marketplace) => ({ id: marketplace.marketplace.id, name: marketplace.marketplace.name })),
+      ...(orgMcpRows.length > 0 ? [{ id: "org-mcp-connections", name: "Organization MCP Connections" }] : []),
     ] : [],
     [builtInRows.length, canShowRows, marketplaces, orgMcpRows.length],
   );
@@ -745,6 +745,7 @@ function MarketplaceCard(props: {
           kind="mcp"
           url={row.connection.url}
           connected={false}
+          beta
           connecting={actionBusy}
           actionLabel={actionBusy ? "Waiting for browser..." : orgMcpConnectionActionLabel(row.connection)}
           onClick={() => onOpenDetail(row)}
@@ -842,6 +843,7 @@ function OrgMcpConnectionDetailModal(props: {
       description={row.item.description ?? "Available from your organization."}
       kind="mcp"
       connected={false}
+      beta
       connecting={connecting}
       connectLabel={orgMcpConnectionActionLabel(row.connection)}
       connectingLabel="Waiting for browser..."

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -839,6 +839,7 @@ export function McpView(props: McpViewProps) {
             kind="mcp"
             connected={true}
             connectedLabel={orgMcpConnectionActionLabel(connection)}
+            beta
             url={connection.url}
             oauth={connection.authType === "oauth"}
             showEnablementCard={false}
@@ -1003,6 +1004,7 @@ function McpQuickConnectSection(props: {
               url={connection.url}
               connected={true}
               connectedLabel={orgMcpConnectionActionLabel(connection)}
+              beta
               actionLabel="View details"
               onClick={() => props.onOrgMcpDetail?.(item)}
             />

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -96,8 +96,9 @@ export function McpConnectionsScreen() {
     <DashboardPageTemplate
       icon={Plug}
       title="Connections"
+      badgeLabel="Beta"
       description="Connect any MCP server — Notion, Linear, Stripe, or a custom URL — once for the whole org. search_capabilities and execute_capability pick these up automatically."
-      colors={["#EDE9FE", "#4C1D95", "#7C3AED", "#C4B5FD"]}
+      colors={["#E2E8F0", "#020617", "#0F172A", "#94A3B8"]}
     >
       {error ? (
         <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">
@@ -139,7 +140,7 @@ export function McpConnectionsScreen() {
               </p>
             </div>
           </div>
-          <p className="mt-2 text-[12px] font-medium text-violet-600">
+          <p className="mt-2 text-[12px] font-medium text-gray-900">
             {googleConfigured ? "Configured — tap to update" : "Tap to set up"}
           </p>
         </button>
@@ -163,7 +164,7 @@ export function McpConnectionsScreen() {
                   <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">{preset.description}</p>
                 </div>
               </div>
-              <p className="mt-2 text-[12px] font-medium text-violet-600">
+              <p className="mt-2 text-[12px] font-medium text-gray-900">
                 {alreadyAdded ? "Already added" : "Tap to add"}
               </p>
             </button>
@@ -338,7 +339,7 @@ function ConnectionRow({
           <div className="flex flex-wrap items-center gap-2">
             <p className="truncate text-[14px] font-semibold text-gray-900">{connection.name}</p>
             {isPerMember ? (
-              <span className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-700">
+              <span className="inline-flex items-center gap-1 rounded-full bg-gray-900 px-2 py-0.5 text-[11px] font-medium text-white">
                 <Users className="h-3 w-3" />
                 Per-member accounts
               </span>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -205,19 +205,19 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
 
   // Seven top-level rows: Dashboard, Your Connections, Extensions, Models,
   // Members, Analytics, Settings. Everything tool-shaped groups under
-  // Extensions (in pipeline order: connect tools, plugins come from Sources,
-  // fill the Plugins library, share via Marketplaces); model config groups
+  // Extensions (in pipeline order: Sources feed Plugins, share via
+  // Marketplaces, beta Connections last); model config groups
   // under Models; set-once governance groups under Settings.
   const extensionsGroup: DashboardNavItem | null = access.isAdmin && activeOrg
     ? {
-        href: getMcpConnectionsRoute(activeOrg.slug),
+        href: getIntegrationsRoute(activeOrg.slug),
         label: "Extensions",
         icon: Puzzle,
         children: [
-          { href: getMcpConnectionsRoute(activeOrg.slug), label: "Connections" },
           { href: getIntegrationsRoute(activeOrg.slug), label: "Sources" },
           { href: getPluginsRoute(activeOrg.slug), label: "Plugins" },
           { href: getMarketplacesRoute(activeOrg.slug), label: "Marketplaces" },
+          { href: getMcpConnectionsRoute(activeOrg.slug), label: "Connections", badge: "Beta" },
         ],
       }
     : null;
@@ -267,6 +267,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
       href: activeOrg ? getYourConnectionsRoute(activeOrg.slug) : "#",
       label: "Your Connections",
       icon: Plug,
+      badge: "Beta",
     },
     ...(extensionsGroup ? [extensionsGroup] : []),
     ...(modelsGroup ? [modelsGroup] : []),

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -69,6 +69,7 @@ export function YourConnectionsScreen() {
     <DashboardPageTemplate
       icon={Plug}
       title="Your Connections"
+      badgeLabel="Beta"
       description="Tools your organization has made available to you. Connect your own account where needed — your AI coworker then acts as you, with your permissions."
       colors={["#DBEAFE", "#1E3A8A", "#2563EB", "#93C5FD"]}
     >

--- a/evals/flows/connections-beta-desktop.flow.mjs
+++ b/evals/flows/connections-beta-desktop.flow.mjs
@@ -1,0 +1,356 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("connections-beta-desktop");
+
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? DEN_API_URL).trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const RUN_TAG = Date.now();
+const CONNECTION_NAME = `beta-proof-desktop-${RUN_TAG}`;
+const CONNECTION_URL = "https://beta-proof.example.com/mcp";
+const WORKSPACE_PATH = "/tmp/openwork-connections-beta-desktop";
+
+const state = {
+  adminSession: null,
+  connectionId: null,
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+async function signIn(email, password) {
+  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  if (!response.ok) return null;
+  return body.token;
+}
+
+async function ensureAdminSession(ctx) {
+  if (state.adminSession) return state.adminSession;
+  state.adminSession = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+  ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+  return state.adminSession;
+}
+
+async function cleanupBetaProofConnections(ctx, token) {
+  const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(existing.response.ok, `Connection list failed: ${existing.response.status}`);
+  for (const connection of existing.body.connections ?? []) {
+    if (typeof connection.name !== "string" || !connection.name.startsWith("beta-proof-")) continue;
+    const removed = await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    ctx.assert(removed.response.ok, `Leftover cleanup failed for ${connection.name}: ${removed.response.status}`);
+  }
+}
+
+async function createPerMemberConnection(ctx) {
+  const token = await ensureAdminSession(ctx);
+  await cleanupBetaProofConnections(ctx, token);
+  const created = await denApiFetch("/v1/mcp-connections", {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      name: CONNECTION_NAME,
+      url: CONNECTION_URL,
+      authType: "oauth",
+      credentialMode: "per_member",
+      access: { orgWide: true },
+    }),
+  });
+  ctx.assert(created.response.ok, `Connection create failed: ${created.response.status} ${JSON.stringify(created.body).slice(0, 200)}`);
+  state.connectionId = created.body.id ?? created.body.connection?.id;
+  ctx.assert(Boolean(state.connectionId), `Connection create response did not include an id: ${JSON.stringify(created.body).slice(0, 200)}`);
+}
+
+async function closeStaleDialogs(ctx) {
+  await ctx.eval(`(() => {
+    const event = new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true, cancelable: true });
+    (document.activeElement ?? document.body).dispatchEvent(event);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true, cancelable: true }));
+    return true;
+  })()`);
+  await sleep(300);
+}
+
+async function signDesktopIntoCloud(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 120_000 });
+
+  const alreadySignedIn = await ctx.eval("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())");
+  if (!alreadySignedIn) {
+    // Point the app at the local Den control plane the designed way:
+    // desktop-bootstrap.json (via the desktop bridge). Everything derives
+    // from it — including getDenMcpUrl(), which the cloud MCP auto-config
+    // uses; localStorage overrides alone are not enough.
+    await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", { timeoutMs: 30_000, label: "desktop bridge" });
+    const bootstrap = {
+      baseUrl: DEN_API_URL,
+      apiBaseUrl: DEN_API_URL,
+      requireSignin: false,
+      handoff: null,
+    };
+    const written = await ctx.eval(`(async () => {
+      const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+      if (!bridge) return { ok: false };
+      await bridge("setDesktopBootstrapConfig", ${JSON.stringify(bootstrap)});
+      return { ok: true };
+    })()`, { awaitPromise: true });
+    ctx.assert(written?.ok, "Failed to write desktop bootstrap config.");
+    await ctx.eval(`(() => {
+      localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(DEN_API_URL)});
+      localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(DEN_API_URL)});
+      return true;
+    })()`);
+    await ctx.eval("location.reload()");
+    await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after bootstrap reload" });
+    const handoff = await denApiFetch("/v1/auth/desktop-handoff", {
+      method: "POST",
+      headers: { authorization: `Bearer ${state.adminSession}` },
+      body: JSON.stringify({ desktopScheme: "openwork" }),
+    });
+    ctx.assert(handoff.response.ok, `Handoff create failed: ${handoff.response.status}`);
+    await ctx.control("auth.exchange-grant", { grant: handoff.body.grant, baseUrl: DEN_API_URL });
+  }
+  await ctx.waitFor(
+    "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+    { timeoutMs: 45_000, label: "persisted den auth token" },
+  );
+  await ctx.waitFor(
+    "Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())",
+    { timeoutMs: 60_000, label: "active org resolved" },
+  );
+}
+
+async function ensureWorkspace(ctx) {
+  const inWorkspace = await ctx.eval("window.location.hash.includes('/workspace/')");
+  if (!inWorkspace) {
+    // Fresh userdata + cloud sign-in: org picker -> resources -> folder.
+    await ctx.clickText("Continue with organization", { timeoutMs: 20_000 }).catch(() => {});
+    await ctx.clickText("Continue to workspace", { timeoutMs: 30_000 }).catch(() => {});
+    await ctx.waitFor(
+      "Boolean(document.querySelector('input[placeholder=\"/workspace/my-project\"]')) || window.location.hash.includes('/workspace/')",
+      { timeoutMs: 30_000, label: "folder form or workspace" },
+    );
+    const needsFolder = await ctx.eval("Boolean(document.querySelector('input[placeholder=\"/workspace/my-project\"]'))");
+    if (needsFolder) {
+      await ctx.fill('input[placeholder="/workspace/my-project"]', WORKSPACE_PATH);
+      await ctx.clickText("Use this folder", { timeoutMs: 20_000 });
+    }
+    await ctx.waitFor("window.location.hash.includes('/workspace/')", { timeoutMs: 60_000, label: "workspace open" });
+  }
+  // Dismiss the OpenWork Models upsell if it appears.
+  await ctx.eval(`(() => {
+    const btn = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === 'Continue without OpenWork Models');
+    btn?.click();
+    return true;
+  })()`);
+}
+
+async function navigateToExtensionsMarketplace(ctx) {
+  await closeStaleDialogs(ctx);
+  const workspaceId = await ctx.eval("(window.location.hash.match(/\\/workspace\\/([^/]+)/) ?? [])[1] ?? null");
+  ctx.assert(Boolean(workspaceId), "No workspace id in URL.");
+  await ctx.navigateHash(`/workspace/${workspaceId}/settings/extensions/mcp`);
+  await ctx.waitFor("window.location.hash.includes('/settings/extensions/mcp')", { timeoutMs: 30_000, label: "extensions settings route" });
+  await ctx.waitFor(
+    "[...document.querySelectorAll('button')].some((entry) => entry.textContent.trim() === 'Marketplace')",
+    { timeoutMs: 30_000, label: "marketplace toggle rendered" },
+  );
+  const clicked = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => entry.textContent.trim() === 'Marketplace');
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(clicked, "Marketplace toggle button was not found.");
+  await ctx.waitFor("document.body.innerText.includes('Extension Marketplace')", { timeoutMs: 20_000, label: "marketplace view" });
+}
+
+async function clickRefreshIfAvailable(ctx) {
+  const clicked = await ctx.eval(`(() => {
+    const buttons = [...document.querySelectorAll('button')].filter((button) => button.textContent.trim() === 'Refresh' && !button.disabled);
+    buttons[buttons.length - 1]?.click();
+    return buttons.length > 0;
+  })()`);
+  if (clicked) await sleep(2_000);
+}
+
+async function waitForMarketplaceCard(ctx, name) {
+  const deadline = Date.now() + 90_000;
+  let refreshed = false;
+  while (Date.now() < deadline) {
+    const found = await ctx.eval(`(() => {
+      return [...document.querySelectorAll('button')].some((button) => button.querySelector('h4')?.textContent.trim() === ${JSON.stringify(name)});
+    })()`);
+    if (found) return;
+    if (!refreshed && Date.now() > deadline - 60_000) {
+      await clickRefreshIfAvailable(ctx);
+      refreshed = true;
+    }
+    await sleep(2_000);
+  }
+  ctx.assert(false, `Marketplace card did not render: ${name}`);
+}
+
+async function clickExtensionCard(ctx, name) {
+  const clicked = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => entry.querySelector('h4')?.textContent.trim() === ${JSON.stringify(name)});
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(clicked, `Extension card not found: ${name}`);
+}
+
+export default {
+  id: "connections-beta-desktop",
+  title: "Desktop Marketplace: beta org connections are labeled and last",
+  kind: "user-facing",
+  spec: "evals/voiceovers/connections-beta-desktop.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("Setup signs the desktop into the org after publishing the beta proof connection", {
+          voiceover: vo[0],
+          action: async () => {
+            state.adminSession = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+            ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+            await createPerMemberConnection(ctx);
+            await signDesktopIntoCloud(ctx);
+            await ensureWorkspace(ctx);
+          },
+          assert: async () => {
+            const auth = await ctx.eval(`(() => ({
+              token: (localStorage.getItem('openwork.den.authToken') ?? '').trim(),
+              activeOrgId: (localStorage.getItem('openwork.den.activeOrgId') ?? '').trim(),
+            }))()`);
+            ctx.assert(Boolean(auth.token), "Desktop Den auth token was not persisted.");
+            ctx.assert(Boolean(auth.activeOrgId), "Desktop active org was not resolved.");
+            await ctx.waitFor("window.location.hash.includes('/workspace/')", { timeoutMs: 20_000, label: "workspace hash" });
+          },
+          screenshot: {
+            name: "connections-beta-desktop-signed-in",
+            claim: "The desktop app is signed into Acme after the admin publishes the beta proof org connection.",
+            requireText: [],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The org tool appears in the Marketplace, last and wearing Beta", {
+          voiceover: vo[1],
+          action: async () => {
+            await navigateToExtensionsMarketplace(ctx);
+            await waitForMarketplaceCard(ctx, CONNECTION_NAME);
+            // The claim is about the LAST card: scroll it into the picture and
+            // let the marketplace load toast clear so the frame shows it.
+            await ctx.eval(`(() => {
+              const card = [...document.querySelectorAll('button')].find((button) => button.querySelector('h4')?.textContent.trim() === ${JSON.stringify(CONNECTION_NAME)});
+              card?.scrollIntoView({ block: 'center' });
+              return true;
+            })()`);
+            await ctx.waitFor(
+              "!document.body.innerText.includes('marketplace extensions for')",
+              { timeoutMs: 10_000, label: "marketplace load toast cleared" },
+            ).catch(() => {});
+            await sleep(500);
+          },
+          assert: async () => {
+            const proof = await ctx.eval(`(() => {
+              const compact = (entry) => (entry?.textContent ?? '').replace(/\\s+/g, ' ').trim();
+              const card = [...document.querySelectorAll('button')].find((button) => button.querySelector('h4')?.textContent.trim() === ${JSON.stringify(CONNECTION_NAME)});
+              const grid = card?.closest('.grid') ?? null;
+              const cards = grid ? [...grid.querySelectorAll('button')].filter((button) => button.querySelector('h4')) : [];
+              const select = [...document.querySelectorAll('select')].find((entry) => [...entry.options].some((option) => option.textContent.trim() === 'Organization MCP Connections'));
+              return {
+                cardText: compact(card),
+                lastCardText: compact(cards[cards.length - 1]),
+                filterOptions: select ? [...select.options].map((option) => option.textContent.trim()) : [],
+              };
+            })()`);
+            ctx.assert(proof.cardText.includes(CONNECTION_NAME), `Marketplace card not found: ${JSON.stringify(proof)}`);
+            ctx.assert(proof.cardText.includes("Beta"), `Marketplace card must include the Beta pill: ${proof.cardText}`);
+            ctx.assert(proof.lastCardText.includes(CONNECTION_NAME), `Org connection must be the last marketplace card: ${proof.lastCardText}`);
+            ctx.assert(proof.filterOptions[proof.filterOptions.length - 1] === "Organization MCP Connections", `Marketplace filter order was wrong: ${JSON.stringify(proof.filterOptions)}`);
+          },
+          screenshot: {
+            name: "connections-beta-desktop-marketplace-last",
+            claim: "The Marketplace shows the beta org MCP connection as the last card and the last marketplace filter option.",
+            requireText: [CONNECTION_NAME, "Beta"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("The detail modal says Beta before anyone connects", {
+          voiceover: vo[2],
+          action: async () => {
+            await clickExtensionCard(ctx, CONNECTION_NAME);
+            await ctx.waitFor("document.body.innerText.includes('Release stage')", { timeoutMs: 15_000, label: "detail modal release stage" });
+          },
+          assert: async () => {
+            const modal = await ctx.eval(`(() => {
+              const roots = [...document.querySelectorAll('[role="dialog"], [data-slot="dialog-content"]')];
+              const root = roots.find((entry) => entry.textContent.includes(${JSON.stringify(CONNECTION_NAME)}))
+                ?? [...document.querySelectorAll('div')].find((entry) => entry.textContent.includes(${JSON.stringify(CONNECTION_NAME)}) && entry.textContent.includes('Release stage'));
+              const text = (root?.textContent ?? '').replace(/\\s+/g, ' ').trim();
+              const betaPill = root ? [...root.querySelectorAll('span')].some((span) => span.textContent.trim() === 'Beta') : false;
+              return { text, betaPill };
+            })()`);
+            ctx.assert(modal.text.includes(CONNECTION_NAME), `Detail modal missing connection name: ${modal.text}`);
+            ctx.assert(modal.betaPill, "Detail modal missing Beta pill.");
+            ctx.assert(/Release stage\s*Beta/.test(modal.text), `Detail modal missing Release stage Beta row: ${modal.text}`);
+            ctx.assert(modal.text.includes("Connect your account"), `Detail modal missing connect label: ${modal.text}`);
+          },
+          screenshot: {
+            name: "connections-beta-desktop-detail-modal",
+            claim: "The org MCP connection detail modal shows Beta, Release stage, and Connect your account before authorization.",
+            requireText: [CONNECTION_NAME, "Release stage", "Beta"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+        await closeStaleDialogs(ctx);
+      },
+    },
+    {
+      name: "Cleanup",
+      run: async (ctx) => {
+        if (!state.connectionId) return;
+        const token = await ensureAdminSession(ctx);
+        const removed = await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${token}` },
+        });
+        ctx.assert(removed.response.ok, `Cleanup delete failed: ${removed.response.status}`);
+      },
+    },
+  ],
+};

--- a/evals/flows/connections-beta.flow.mjs
+++ b/evals/flows/connections-beta.flow.mjs
@@ -1,0 +1,330 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("connections-beta");
+
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const RUN_TAG = Date.now();
+const CONNECTION_NAME = `beta-proof-${RUN_TAG}`;
+const CONNECTION_URL = "https://beta-proof.example.com/mcp";
+const NAV_TEXT = "(document.querySelector('nav')?.innerText ?? '')";
+
+const state = {
+  adminSession: null,
+  connectionId: null,
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+async function apiSignIn(email, password) {
+  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  return response.ok ? body.token : null;
+}
+
+async function ensureAdminSession(ctx) {
+  if (state.adminSession) return state.adminSession;
+  state.adminSession = await apiSignIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+  ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+  return state.adminSession;
+}
+
+async function cleanupBetaProofConnections(ctx, token) {
+  const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(existing.response.ok, `Connection list failed: ${existing.response.status}`);
+  for (const connection of existing.body.connections ?? []) {
+    if (typeof connection.name !== "string" || !connection.name.startsWith("beta-proof-")) continue;
+    const removed = await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    ctx.assert(removed.response.ok, `Leftover cleanup failed for ${connection.name}: ${removed.response.status}`);
+  }
+}
+
+async function createPerMemberConnection(ctx) {
+  const token = await ensureAdminSession(ctx);
+  await cleanupBetaProofConnections(ctx, token);
+  const created = await denApiFetch("/v1/mcp-connections", {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      name: CONNECTION_NAME,
+      url: CONNECTION_URL,
+      authType: "oauth",
+      credentialMode: "per_member",
+      access: { orgWide: true },
+    }),
+  });
+  ctx.assert(created.response.ok, `Connection create failed: ${created.response.status} ${JSON.stringify(created.body).slice(0, 200)}`);
+  state.connectionId = created.body.id ?? created.body.connection?.id;
+  ctx.assert(Boolean(state.connectionId), `Connection create response did not include an id: ${JSON.stringify(created.body).slice(0, 200)}`);
+}
+
+async function goTo(ctx, path) {
+  await ctx.eval(`location.assign(${JSON.stringify(`${DEN_WEB_URL}${path}`)})`);
+  await sleep(1_500);
+}
+
+async function uiSignIn(ctx, email, password) {
+  await goTo(ctx, "/");
+  if (await ctx.eval("location.pathname.startsWith('/dashboard')")) {
+    await uiSignOut(ctx);
+    await goTo(ctx, "/");
+  }
+  await ctx.waitFor("document.body.innerText.includes('Sign in')", { timeoutMs: 30_000, label: "auth screen" });
+  await ctx.eval(`(() => {
+    const tab = [...document.querySelectorAll('button, a')].find((el) => el.textContent.trim() === 'Sign in');
+    tab?.click();
+    return true;
+  })()`);
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"], input[name=\"email\"]'))", { timeoutMs: 15_000, label: "email input" });
+  const filled = await ctx.eval(`(() => {
+    const setNative = (el, value) => {
+      const proto = Object.getPrototypeOf(el);
+      const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+      desc.set.call(el, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+    const email = document.querySelector('input[type="email"], input[name="email"]');
+    const password = document.querySelector('input[type="password"]');
+    if (!email || !password) return false;
+    setNative(email, ${JSON.stringify(email)});
+    setNative(password, ${JSON.stringify(password)});
+    const buttons = [...document.querySelectorAll('button')].filter((el) => el.textContent.trim() === 'Sign in' && !el.disabled);
+    buttons[buttons.length - 1]?.click();
+    return buttons.length > 0;
+  })()`);
+  ctx.assert(filled, "Could not fill and submit the sign-in form.");
+  await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 45_000, label: "dashboard after sign-in" });
+  await ctx.waitFor("Boolean(document.querySelector('nav'))", { timeoutMs: 30_000, label: "sidebar rendered" });
+  await sleep(1_000);
+}
+
+async function uiSignOut(ctx) {
+  const opened = await ctx.eval(`(() => {
+    const trigger = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('Acme Robotics') || el.textContent.includes('Owner') || el.textContent.includes('Member'));
+    trigger?.click();
+    return Boolean(trigger);
+  })()`);
+  ctx.assert(opened, "Could not open the org switcher.");
+  await ctx.waitFor("[...document.querySelectorAll('button')].some((el) => el.textContent.trim() === 'Sign out')", { timeoutMs: 10_000, label: "sign out option" });
+  await ctx.eval(`(() => {
+    const btn = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === 'Sign out');
+    btn?.click();
+    return true;
+  })()`);
+  await ctx.waitFor("!location.pathname.startsWith('/dashboard') || document.body.innerText.includes('Sign in')", { timeoutMs: 30_000, label: "signed out" });
+  await sleep(1_000);
+}
+
+async function clickNav(ctx, label) {
+  const clicked = await ctx.eval(`(() => {
+    const link = [...document.querySelectorAll('nav a')].find((el) => el.textContent.trim().startsWith(${JSON.stringify(label)}));
+    link?.click();
+    return Boolean(link);
+  })()`);
+  ctx.assert(clicked, `Sidebar entry not found: ${label}`);
+  await sleep(1_500);
+}
+
+async function navChildLabels(ctx) {
+  return ctx.eval(`(() => {
+    const groups = [...document.querySelectorAll('nav .border-l')];
+    const active = groups[0];
+    return active ? [...active.querySelectorAll('a')].map((el) => el.textContent.trim()) : [];
+  })()`);
+}
+
+function stripBetaLabel(label) {
+  return label.replace(/beta$/i, "").trim();
+}
+
+async function hasPageBetaBadge(ctx) {
+  return ctx.eval(`(() => {
+    return [...document.querySelectorAll('span')].some((span) => {
+      const className = String(span.className ?? '');
+      return span.textContent.trim() === 'Beta' && className.includes('rounded-full') && !span.closest('nav');
+    });
+  })()`);
+}
+
+export default {
+  id: "connections-beta",
+  title: "Connections beta treatment: visible, black, and last",
+  kind: "user-facing",
+  spec: "evals/voiceovers/connections-beta.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("Beta is visible before you ever click", {
+          voiceover: vo[0],
+          action: async () => {
+            await uiSignIn(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+          },
+          assert: async () => {
+            await ctx.waitFor(`${NAV_TEXT}.includes('Dashboard')`, { timeoutMs: 15_000, label: "dashboard nav" });
+            const nav = await ctx.eval(NAV_TEXT);
+            ctx.assert(/Your Connections\s*Beta/i.test(nav), `Your Connections must carry Beta in the resting nav: ${nav}`);
+            ctx.assert(nav.includes("Extensions"), "Extensions group must be present for the admin.");
+          },
+          screenshot: {
+            name: "connections-beta-resting-sidebar",
+            claim: "The resting admin sidebar shows Your Connections marked Beta before Alex opens anything.",
+            requireText: ["Your Connections", "Dashboard"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("Extensions no longer lands on the beta feature", {
+          voiceover: vo[1],
+          action: async () => {
+            await clickNav(ctx, "Extensions");
+          },
+          assert: async () => {
+            await ctx.waitFor("location.pathname.includes('/integrations')", { timeoutMs: 15_000, label: "sources route" });
+            ctx.assert(!(await ctx.eval("location.pathname.includes('/mcp-connections')")), "Extensions must not default to the Connections route.");
+            const children = await navChildLabels(ctx);
+            ctx.assert(
+              JSON.stringify(children.map(stripBetaLabel)) === JSON.stringify(["Sources", "Plugins", "Marketplaces", "Connections"]),
+              `Extensions children are out of order: ${JSON.stringify(children)}`,
+            );
+            ctx.assert(/Connections\s*Beta/i.test(children[children.length - 1] ?? ""), `Connections child must be last with Beta: ${JSON.stringify(children)}`);
+          },
+          screenshot: {
+            name: "connections-beta-extensions-default-sources",
+            claim: "Clicking Extensions lands Alex on Sources while Connections remains last and badged Beta.",
+            requireText: ["Sources"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("The Connections page says Beta and wears black, not purple", {
+          voiceover: vo[2],
+          action: async () => {
+            await clickNav(ctx, "Connections");
+          },
+          assert: async () => {
+            await ctx.waitFor("location.pathname.includes('/mcp-connections')", { timeoutMs: 15_000, label: "connections route" });
+            await ctx.expectText("Google Workspace", { timeoutMs: 20_000 });
+            const proof = await ctx.eval(`(() => {
+              const addCustom = [...document.querySelectorAll('button')].find((button) => button.textContent.trim().includes('Add Custom'));
+              return {
+                beta: [...document.querySelectorAll('span')].some((span) => span.textContent.trim() === 'Beta' && String(span.className ?? '').includes('rounded-full') && !span.closest('nav')),
+                purple: document.querySelector('[class*="violet"], [class*="purple"]') !== null,
+                addCustomBackground: addCustom ? getComputedStyle(addCustom).backgroundColor : null,
+              };
+            })()`);
+            ctx.assert(proof.beta, "Connections hero Beta pill was not visible.");
+            ctx.assert(!proof.purple, "Connections page must not render violet or purple classes.");
+            ctx.assert(proof.addCustomBackground === "rgb(15, 23, 42)", `Add Custom should be black slate, got ${proof.addCustomBackground}`);
+          },
+          screenshot: {
+            name: "connections-beta-black-page",
+            claim: "The Connections page shows a Beta hero pill, black Add Custom button, and no purple styling.",
+            requireText: ["Connections", "Add Custom", "Google Workspace"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("A per-member connection wears the black pill", {
+          voiceover: vo[3],
+          action: async () => {
+            await createPerMemberConnection(ctx);
+            await goTo(ctx, "/dashboard/mcp-connections");
+          },
+          assert: async () => {
+            await ctx.expectText(CONNECTION_NAME, { timeoutMs: 20_000 });
+            const pill = await ctx.eval(`(() => {
+              const span = [...document.querySelectorAll('span')].find((entry) => entry.textContent.includes('Per-member accounts'));
+              return span ? { classes: [...span.classList], text: span.textContent.trim() } : null;
+            })()`);
+            ctx.assert(Boolean(pill), "Per-member accounts pill was not rendered.");
+            ctx.assert(pill.classes.includes("bg-gray-900"), `Per-member pill must be black: ${JSON.stringify(pill.classes)}`);
+            ctx.assert(pill.classes.includes("text-white"), `Per-member pill text must be white: ${JSON.stringify(pill.classes)}`);
+            ctx.assert(!pill.classes.some((className) => /violet|purple/i.test(className)), `Per-member pill must not be purple: ${JSON.stringify(pill.classes)}`);
+          },
+          screenshot: {
+            name: "connections-beta-per-member-pill",
+            claim: "A per-member org connection renders with the black Per-member accounts pill.",
+            requireText: [CONNECTION_NAME, "Per-member accounts"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("Your Connections is marked beta for members too", {
+          voiceover: vo[4],
+          action: async () => {
+            await goTo(ctx, "/dashboard/your-connections");
+          },
+          assert: async () => {
+            await ctx.waitFor("location.pathname.includes('/your-connections')", { timeoutMs: 15_000, label: "your connections route" });
+            ctx.assert(await hasPageBetaBadge(ctx), "Your Connections hero Beta pill was not visible.");
+            await ctx.expectText(CONNECTION_NAME, { timeoutMs: 20_000 });
+            await ctx.expectText("Connect your account", { timeoutMs: 10_000 });
+          },
+          screenshot: {
+            name: "connections-beta-your-connections",
+            claim: "The member-facing Your Connections page is also Beta and asks the user to connect their own account.",
+            requireText: ["Your Connections", CONNECTION_NAME, "Connect your account"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup",
+      run: async (ctx) => {
+        if (!state.connectionId) return;
+        const token = await ensureAdminSession(ctx);
+        const removed = await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${token}` },
+        });
+        ctx.assert(removed.response.ok, `Cleanup delete failed: ${removed.response.status}`);
+      },
+    },
+  ],
+};

--- a/evals/flows/den-sidebar-simplified.flow.mjs
+++ b/evals/flows/den-sidebar-simplified.flow.mjs
@@ -162,6 +162,10 @@ async function navChildLabels(ctx) {
   })()`);
 }
 
+function stripBetaLabel(label) {
+  return label.replace(/beta$/i, "").trim();
+}
+
 export default {
   id: "den-sidebar-simplified",
   title: "Den sidebar: sixteen rows become seven — tools, models, people, settings",
@@ -172,7 +176,7 @@ export default {
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("The admin sidebar is seven top-level entries with no New badges", {
+        await ctx.prove("The admin sidebar is seven top-level entries with only Your Connections marked Beta", {
           voiceover: vo[0],
           action: async () => {
             await ensureJordanInAcme(ctx);
@@ -187,11 +191,13 @@ export default {
               ctx.assert(!nav.includes(retired), `Retired top-level label still in the resting sidebar: ${retired}`);
             }
             ctx.assert(!/\bnew\b/i.test(nav), "The sidebar must not show New badges anymore.");
-            ctx.assert(/\bbeta\b/i.test(nav), "Models keeps its single Beta badge.");
+            ctx.assert(/Your Connections\s*Beta/i.test(nav), "Your Connections keeps the visible Beta badge.");
+            const betaMatches = nav.match(/\bbeta\b/gi) ?? [];
+            ctx.assert(betaMatches.length === 1, `Only Your Connections should be badged at rest, saw ${betaMatches.length}: ${nav}`);
           },
           screenshot: {
             name: "sidebar-seven",
-            claim: "The admin sidebar shows exactly seven top-level entries and no New badges.",
+            claim: "The admin sidebar shows seven top-level entries, no New badges, and the remaining Beta badge on Your Connections.",
             requireText: ["Dashboard", "Your Connections", "Extensions", "Models", "Members", "Analytics", "Settings"],
             rejectText: ["MCP Connections", "SCIM"],
           },
@@ -201,22 +207,21 @@ export default {
     {
       name: "Frame 2",
       run: async (ctx) => {
-        await ctx.prove("Extensions opens on Connections — the org tools admins publish", {
+        await ctx.prove("Extensions opens on Sources — where plugins come from", {
           voiceover: vo[1],
           action: async () => {
             await clickNav(ctx, "Extensions");
           },
           assert: async () => {
-            await ctx.waitFor("location.pathname.includes('/mcp-connections')", { timeoutMs: 15_000, label: "connections route" });
-            await ctx.expectText("Google Workspace", { timeoutMs: 20_000 });
-            await ctx.expectText("Notion", { timeoutMs: 10_000 });
-            const children = await navChildLabels(ctx);
-            ctx.assert(children.includes("Connections"), `Extensions children missing Connections: ${JSON.stringify(children)}`);
+            await ctx.waitFor("location.pathname.includes('/integrations')", { timeoutMs: 15_000, label: "sources route (old integrations URL)" });
+            ctx.assert(!(await ctx.eval("location.pathname.includes('/mcp-connections')")), "Extensions must not land on the beta Connections route.");
+            await ctx.expectText("Sources", { timeoutMs: 15_000 });
+            await ctx.expectText("GitHub", { timeoutMs: 15_000 });
           },
           screenshot: {
-            name: "extensions-connections",
-            claim: "Extensions lands on Connections with the tool presets (Google Workspace, Notion) visible.",
-            requireText: ["Extensions", "Connections", "Google Workspace", "Notion"],
+            name: "extensions-sources-default",
+            claim: "Extensions lands on Sources, not the beta Connections page.",
+            requireText: ["Extensions", "Sources", "GitHub"],
             rejectText: ["Something went wrong"],
           },
         });
@@ -225,26 +230,27 @@ export default {
     {
       name: "Frame 3",
       run: async (ctx) => {
-        await ctx.prove("The Extensions children read in pipeline order and Sources is the plugin supply", {
+        await ctx.prove("Connections is last in Extensions, wearing a Beta badge", {
           voiceover: vo[2],
           action: async () => {
             const children = await navChildLabels(ctx);
+            const stripped = children.map(stripBetaLabel);
             ctx.assert(
-              JSON.stringify(children.map((label) => label.replace(/Beta$/, "").trim())) === JSON.stringify(["Connections", "Sources", "Plugins", "Marketplaces"]),
+              JSON.stringify(stripped) === JSON.stringify(["Sources", "Plugins", "Marketplaces", "Connections"]),
               `Extensions children must read in pipeline order, got ${JSON.stringify(children)}`,
             );
-            await clickNav(ctx, "Sources");
+            ctx.assert(/Connections\s*Beta/i.test(children[children.length - 1] ?? ""), `Connections child must carry the Beta badge, got ${JSON.stringify(children)}`);
+            await clickNav(ctx, "Connections");
           },
           assert: async () => {
-            await ctx.waitFor("location.pathname.includes('/integrations')", { timeoutMs: 15_000, label: "sources route (old integrations URL)" });
-            await ctx.expectText("Sources", { timeoutMs: 15_000 });
-            await ctx.expectText("GitHub", { timeoutMs: 15_000 });
-            await ctx.expectText("Plugins page", { timeoutMs: 15_000 });
+            await ctx.waitFor("location.pathname.includes('/mcp-connections')", { timeoutMs: 15_000, label: "connections route" });
+            await ctx.expectText("Google Workspace", { timeoutMs: 20_000 });
+            await ctx.expectText("Notion", { timeoutMs: 10_000 });
           },
           screenshot: {
-            name: "extensions-sources",
-            claim: "Sources explains where plugins come from, inside Extensions.",
-            requireText: ["Sources", "GitHub"],
+            name: "extensions-connections-beta-last",
+            claim: "Connections is reachable only after choosing the last Beta child in Extensions.",
+            requireText: ["Connections", "Google Workspace", "Notion"],
             rejectText: ["Something went wrong"],
           },
         });
@@ -336,7 +342,7 @@ export default {
             await ctx.waitFor("location.pathname.includes('/mcp-connections')", { timeoutMs: 15_000, label: "old URL renders" });
             await ctx.expectText("Google Workspace", { timeoutMs: 20_000 });
             const children = await navChildLabels(ctx);
-            ctx.assert(children.includes("Connections"), "The old URL must highlight the Extensions group with Connections active.");
+            ctx.assert(children.map(stripBetaLabel).includes("Connections"), "The old URL must highlight the Extensions group with Connections active.");
           },
           screenshot: {
             name: "old-bookmark",

--- a/evals/runner/pr.mjs
+++ b/evals/runner/pr.mjs
@@ -5,10 +5,11 @@
  * artifact with validated screenshots.
  */
 import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-export function renderPrComment(report) {
+export function renderPrComment(report, imageUrls = null) {
   const verdict = report.summary.failed > 0 ? "❌ FAILED" : "✅ PASSED";
   const lines = [
     `## fraimz — ${verdict}`,
@@ -40,6 +41,9 @@ export function renderPrComment(report) {
           lines.push(
             `   - 📸 \`${evidence.file}\` — ${failed.length === 0 ? `${(evidence.validations ?? []).length} validations passed` : `FAILED: ${failed.map((validation) => validation.label).join(", ")}`}`,
           );
+          if (imageUrls?.[evidence.file]) {
+            lines.push("", `   <img src="${imageUrls[evidence.file]}" alt="${evidence.file}" width="700">`, "");
+          }
         }
       }
       if (step.status === "failed") lines.push(`   - ❌ **${step.name}** — ${step.error}`);
@@ -49,12 +53,96 @@ export function renderPrComment(report) {
   return lines.join("\n");
 }
 
+export async function uploadRunImages(report, outDir) {
+  const files = [];
+  const seen = new Set();
+  for (const flow of report.flows) {
+    for (const step of flow.steps ?? []) {
+      for (const evidence of step.evidence ?? []) {
+        if (evidence.type === "frame" && !seen.has(evidence.file) && existsSync(join(outDir, evidence.file))) {
+          seen.add(evidence.file);
+          files.push(evidence.file);
+        }
+      }
+    }
+  }
+  if (files.length === 0) return null;
+
+  const repoResult = spawnSync("gh", ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"], { encoding: "utf8" });
+  if (repoResult.error || repoResult.status !== 0) {
+    const detail = repoResult.error?.message ?? repoResult.stderr?.trim() ?? `gh exited ${repoResult.status}`;
+    throw new Error(`gh repo view failed: ${detail}`);
+  }
+  const nameWithOwner = repoResult.stdout.trim();
+  if (!nameWithOwner) throw new Error("gh repo view failed: empty nameWithOwner");
+
+  const payloadPath = join(outDir, ".gh-api-payload.json");
+  const ghApi = (args, inputJson = null) => {
+    const ghArgs = ["api", ...args];
+    if (inputJson !== null) {
+      writeFileSync(payloadPath, `${JSON.stringify(inputJson)}\n`);
+      ghArgs.push("--input", payloadPath);
+    }
+    const result = spawnSync("gh", ghArgs, { encoding: "utf8" });
+    if (result.error || result.status !== 0) {
+      const detail = result.error?.message ?? result.stderr?.trim() ?? `gh exited ${result.status}`;
+      throw new Error(`gh api ${args.join(" ")} failed: ${detail}`);
+    }
+    return result.stdout.trim();
+  };
+
+  try {
+    const uploads = [];
+    for (const file of files) {
+      const blobSha = ghApi([`repos/${nameWithOwner}/git/blobs`, "--jq", ".sha"], {
+        content: readFileSync(join(outDir, file)).toString("base64"),
+        encoding: "base64",
+      });
+      uploads.push({ file, blobSha });
+    }
+
+    const headResult = spawnSync("gh", ["api", `repos/${nameWithOwner}/git/ref/heads/fraimz-assets`, "--jq", ".object.sha"], { encoding: "utf8" });
+    if (headResult.error) throw new Error(`gh api repos/${nameWithOwner}/git/ref/heads/fraimz-assets failed: ${headResult.error.message}`);
+    const headSha = headResult.status === 0 ? headResult.stdout.trim() : null;
+    const parentTreeSha = headSha ? ghApi([`repos/${nameWithOwner}/git/commits/${headSha}`, "--jq", ".tree.sha"]) : null;
+    const treePayload = parentTreeSha
+      ? { base_tree: parentTreeSha, tree: uploads.map(({ file, blobSha }) => ({ path: `${report.runId}/${file}`, mode: "100644", type: "blob", sha: blobSha })) }
+      : { tree: uploads.map(({ file, blobSha }) => ({ path: `${report.runId}/${file}`, mode: "100644", type: "blob", sha: blobSha })) };
+    const treeSha = ghApi([`repos/${nameWithOwner}/git/trees`, "--jq", ".sha"], treePayload);
+    const commitSha = ghApi([`repos/${nameWithOwner}/git/commits`, "--jq", ".sha"], {
+      message: `fraimz assets ${report.runId}`,
+      tree: treeSha,
+      parents: headSha ? [headSha] : [],
+    });
+    if (headSha) {
+      ghApi(["-X", "PATCH", `repos/${nameWithOwner}/git/refs/heads/fraimz-assets`], { sha: commitSha });
+    } else {
+      ghApi([`repos/${nameWithOwner}/git/refs`], { ref: "refs/heads/fraimz-assets", sha: commitSha });
+    }
+
+    const imageUrls = {};
+    for (const file of files) {
+      imageUrls[file] = `https://raw.githubusercontent.com/${nameWithOwner}/${commitSha}/${report.runId}/${encodeURIComponent(file)}`;
+    }
+    return imageUrls;
+  } finally {
+    rmSync(payloadPath, { force: true });
+  }
+}
+
 /**
  * Post the comment with `gh pr comment`. `prNumber` may be null: gh then
  * targets the PR of the current branch. Returns { posted, detail }.
  */
 export async function postPrComment(report, { outDir, prNumber = null } = {}) {
-  const body = renderPrComment(report);
+  let imageUrls = null;
+  let uploadError = null;
+  try {
+    imageUrls = await uploadRunImages(report, outDir);
+  } catch (error) {
+    uploadError = error instanceof Error ? error.message : String(error);
+  }
+  const body = `${renderPrComment(report, imageUrls)}${uploadError ? `\n\n_(screenshot upload failed: ${uploadError} — images available in the run directory)_` : ""}`;
   const bodyPath = join(outDir, "pr-comment.md");
   await writeFile(bodyPath, body);
   const args = ["pr", "comment", ...(prNumber ? [String(prNumber)] : []), "--body-file", bodyPath];

--- a/evals/voiceovers/connections-beta-desktop.md
+++ b/evals/voiceovers/connections-beta-desktop.md
@@ -1,0 +1,9 @@
+# connections-beta-desktop — Desktop Marketplace shows beta org connections last
+
+Cast is Alex, the Acme Robotics admin, using the OpenWork desktop app. This demo covers only display and navigation: the admin has published a per-member org MCP connection, but nobody connects a real account during the proof.
+
+1. Setup happens first: Alex publishes a beta-proof per-member tool for the org, then signs this desktop app into Acme through the real cloud handoff. The workspace opens cleanly, so the desktop is ready to show exactly what members will see.
+
+2. In Settings, Alex switches from My Extensions to Marketplace. The org tool appears with a Beta pill, it sits as the last card in the grid, and the filter menu lists Organization MCP Connections last — beta means available, but deliberately out of the default path.
+
+3. Alex opens the tool details before anyone connects. The modal repeats the Beta label, includes a Release stage row, and the action says Connect your account, so the desktop explains the untested per-member state before any authorization begins.

--- a/evals/voiceovers/connections-beta.md
+++ b/evals/voiceovers/connections-beta.md
@@ -1,0 +1,13 @@
+# connections-beta — Connections is beta, black, and last
+
+Cast is Alex, the Acme Robotics admin, in OpenWork Cloud. This demo shows the new Connections treatment: beta means untested, the page uses black instead of purple, and the feature sits last so admins land on the safer Sources path first.
+
+1. Alex signs in and has not clicked anything yet. The sidebar already tells the truth: Your Connections carries a Beta tag, Dashboard is still the default, and Extensions is present without pushing the beta feature into his path.
+
+2. He opens Extensions and lands on Sources, not Connections. The children read like the workflow — Sources, Plugins, Marketplaces — and only then Connections, wearing Beta at the end so the untested surface stays out of the default route.
+
+3. Now Alex deliberately opens Connections. The page itself says Beta, the primary Add Custom button is black like the rest of the app, and there is no purple styling left around the hero or quick-add tools.
+
+4. The admin has already published a per-member tool for the team. When the page reloads, that tool appears with a black Per-member accounts pill, making it clear that every person connects their own account instead of sharing one admin credential.
+
+5. Alex opens the member-facing Your Connections page. It is also marked Beta, and the same tool asks for each person to connect their account before an agent can use it, keeping the experimental feature clearly labeled from both sides.

--- a/evals/voiceovers/den-sidebar-simplified.md
+++ b/evals/voiceovers/den-sidebar-simplified.md
@@ -4,14 +4,15 @@ Cast is Alex (org admin) and Jordan (member), in OpenWork Cloud (den-web).
 Phase 1 scope: the grouped sidebar, the two renames ("MCP Connections" to
 "Connections", "Integrations" to "Sources"), badge cleanup, and old-URL
 compatibility. Page-level tab merges are phase 2 and not narrated here. All
-existing routes keep working — the final frame pins it. Extensions children
-are ordered in pipeline order: Connections, Sources, Plugins, Marketplaces.
+existing routes keep working — the final frame pins it. Extensions opens on
+Sources, and its children are ordered in pipeline order: Sources, Plugins,
+Marketplaces — with beta Connections last.
 
-1. Alex opens the company dashboard. The sidebar that used to be sixteen rows deep is now seven things he can say out loud: Dashboard, Your Connections, Extensions, Models, Members, Analytics, Settings. And the wall of NEW badges is gone.
+1. Alex opens the company dashboard. The sidebar that used to be sixteen rows deep is now seven things he can say out loud: Dashboard, Your Connections, Extensions, Models, Members, Analytics, Settings. The wall of NEW badges is gone, and the remaining badges are Beta tags on the untested Connections surfaces.
 
-2. He opens Extensions and lands on Connections — the tools he publishes for the whole team, like Google Workspace and Notion. It is the admin side of the same coin every member sees as Your Connections: he publishes once, they each sign in as themselves.
+2. He opens Extensions and lands on Sources, still on the old integrations URL. This is where plugins come from — starting with the company GitHub — so the default path starts with supply, not the beta Connections surface.
 
-3. The rest of Extensions is the plugin pipeline, laid out in the order it actually flows: Sources is where plugins come from — the company GitHub — Plugins is the library that fills up from it, and Marketplaces is how that library gets shared out to the team. One flow, left to right, instead of three unrelated rows scattered down a sidebar.
+3. The rest of Extensions is the plugin pipeline, laid out in the order it actually flows: Sources, Plugins, Marketplaces, and then Connections last with a Beta badge. Connections is still there — Google Workspace and Notion are ready to prove the page — but it is clearly untested and out of the default path.
 
 4. Models next: the managed OpenWork Models plan and the company own provider keys, side by side — one place to answer what the org can run.
 


### PR DESCRIPTION
## What

The org MCP **Connections** feature is untested, so this PR surfaces it as such everywhere it appears:

### Beta marking
- den-web: `badgeLabel="Beta"` hero pill on **Connections** and **Your Connections** pages
- den-web sidebar: `Beta` badge on the Connections nav child and the top-level Your Connections item
- Desktop: new `beta` prop on `ExtensionCard` / `ExtensionDetailModal` (amber Beta pill + "Release stage: Beta" row), set on all four org-connection surfaces (My Extensions card + modal, Marketplace row + modal)

### Purple → black (match primary buttons, `#0f172a`)
- Connections hero gradient: violet palette → slate/black
- "Tap to set up / Tap to add" CTAs: `text-violet-600` → `text-gray-900`
- "Per-member accounts" pill: violet → black-on-white

### Ordering: first → last
- Sidebar Extensions group is now `Sources, Plugins, Marketplaces, Connections`; the group's own href moved to Sources so clicking Extensions no longer lands on the beta feature
- Desktop Marketplace rows + filter dropdown: org connections moved last
- `buildExtensionItems().items`: org connections moved to the end

### Evals
- New fraimz flows `connections-beta` (den-web) and `connections-beta-desktop` (Electron), with approved voiceover scripts
- `den-sidebar-simplified` updated to the new truth (it asserted Extensions-lands-on-Connections and the old child order; also fixes its stale Models-Beta-badge assertion from #2457)

## Tests run
- `pnpm -C apps/app typecheck` — pass
- `pnpm -C ee/apps/den-web exec tsc --noEmit` — pass
- `bun test` extension-items / cloud-marketplaces-view / org-mcp-connections / den-extension-projection — 11 pass, 0 fail

## Evidence (fraimz, real app runs)
All three flows ran against the local den stack (MySQL + den-api + seeded Acme Robotics + den-web + this branch's dev Electron):

- ✅ `connections-beta` + `den-sidebar-simplified` (den-web via Chrome CDP) — frame proof: https://github.com/different-ai/openwork/pull/2468#issuecomment-4882122058
- ✅ `connections-beta-desktop` (Electron marketplace) — frame proof: https://github.com/different-ai/openwork/pull/2468#issuecomment-4882122407

Validated screenshots live in the run artifacts (`evals/results/<run-id>/fraimz.html`, gitignored). Reproduce locally:

```bash
pnpm evals --flow connections-beta-desktop --stack den --cdp-url http://127.0.0.1:9823
# den-web flows: pnpm dev:den:web + a Chrome with --remote-debugging-port, then
OPENWORK_EVAL_DEN_API_URL=http://127.0.0.1:8790 OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3005 \
  pnpm fraimz --flow connections-beta --flow den-sidebar-simplified --cdp-url http://127.0.0.1:9224
```

No screen recording captured — the fraimz frame proofs above are the evidence; each frame binds claim → action → assertion → validated screenshot.
