### PR TITLE
feat(dx): pave the voiceover-first path — script → worktree → build → fraimz → PR

### DIFF
--- a/.opencode/agents/orchestrator.md
+++ b/.opencode/agents/orchestrator.md
@@ -16,98 +16,13 @@ You are the orchestrator. You are responsible for **thinking and verification** 
   3. **Verification**: after the executor reports back, independently verify the result — read the diffs, run typechecks/tests/builds, and validate the experience (fraimz) before declaring anything done.
 - If the executor's output fails verification, send it back with precise repair instructions; do not silently fix it yourself unless the fix is trivial.
 
-Everything below is the standard repo guidance and applies to all work you orchestrate.
+## The paved path for feature work
 
----
+Follow demo-driven development (see AGENTS.md): `/voiceover` to align on the
+demo script before any code, build on a fresh worktree (`git worktree add`),
+verify with the `fraimz` skill until every frame holds, then open the PR and
+post the proof with `pnpm fraimz --flow <id> --pr`.
 
-# AGENTS.md
-
-OpenWork helps users run agents, skills, and MCP. It is an open-source alternative to Claude Cowork/Codex as a desktop app.
-
-## What OpenWork Is
-
-OpenWork is a practical control surface for agentic work:
-
-* Run local and remote agent workflows from one place.
-* Use OpenCode capabilities directly through OpenWork.
-* Compose desktop app, server, and messaging connectors without lock-in.
-* Treat the OpenWork app as a client of the OpenWork server API surface.
-* Connect to hosted workers through a simple user flow: `Add a worker` -> `Connect remote`.
-
-## Core Philosophy
-
-* **Local-first, cloud-ready**: OpenWork runs on your machine in one click and can connect to cloud workflows when needed.
-* **Server-consumption first**: the app should consume OpenWork server surfaces (self-hosted or hosted), not invent parallel behavior.
-* **Composable**: use the desktop app, WhatsApp/Slack/Telegram connectors, or server mode based on the task.
-* **Ejectable**: OpenWork is powered by OpenCode, so anything OpenCode can do is available in OpenWork, even before a dedicated UI exists.
-* **Sharing is caring**: start solo, then share quickly; one CLI or desktop command can spin up an instantly shareable instance.
-
-
-## Pull Request Expectations (Fast Merge)
-
-If you open a PR, you must run tests and report what you ran (commands + result).
-
-To maximize merge speed, include evidence of the end-to-end flow:
-
-* Ideally: attach a short video/screen recording showing the flow running successfully.
-* Otherwise: screenshots are acceptable, but video is preferred.
-
-If you cannot run tests or capture the video, say so explicitly and explain why, and include the exact commands/steps for the reviewer to reproduce.
-
-## Validate Every Experience
-
-Almost everything we change has an effect on the outside world — the
-filesystem, the runtime DB, server API responses, provisioning, sessions,
-or config. So the default is not "write code and hope"; it is **propose a
-flow, then drive it as the end user and validate it against reality until
-it actually holds.**
-
-A change is an *experience*: it might be a persistent feature, a single new
-button, or an entirely new screen. Every experience gets validated the same
-way — by producing **fraimz**, the frame-by-frame proof
-(`evals/results/<run-id>/fraimz.html`) where each frame binds a claim, the user
-action, an observable assertion, and a validated screenshot.
-
-The deliverable and the full loop (frame → coded flow → drive the real app via
-CDP → validate/repair → verdict) live in the **`fraimz` skill** — load it
-whenever a task asks you to "create a fraimz" / "prove it works", or whenever a
-change touches anything observable outside the process. Run it via the
-`/fraimz` command or `pnpm fraimz --flow <id>`.
-
-Report `Passed` only when `fraimz.html` exists and every claim is backed by an
-observable assertion; otherwise `Incomplete` / `Failed`, stated honestly with
-repro steps. Pure docs/comments and types-only changes with no runtime path may
-skip — but say so explicitly. For changes you expect to be inert, the `fraimz`
-skill's canonical core flow proves the core experience is unchanged.
-
-## Coding Guidelines
-
-### TypeScript
-
-- Never use `any`, typecasts, or `as`, unless 100% necessary or specifically instructed.
-
-### Package Managers
-
-- Use pnpm.
-- Never use npm or yarn.
-
-### UI and UX
-
-- Use components from @/components when possible.
-- When creating new components, we prefer using shadcn/ui with (Base UI).
-- Assume most end users of OpenWork are non-technical.
-
-### Tech Stack Preferences
-
-When uncertain, prefer: Tailwind, TypeScript, React, shadcn/ui (Base UI), TanStack Query, Zustand, Zod, Drizzle, Better-Auth.
-
-### Code Style
-
-- Always strive for concise, simple solutions.
-- If a problem can be solved in a simpler way, propose it.
-- Use the smallest possible diff to make a change. Then think of how to make it smaller and do that again.
-- Avoid fallback expressions when types or control flow already guarantee a value.
-
-### Workflow
-
-- If asked to do too much work at once, stop and state that clearly.
+Repo conventions (philosophy, PR expectations, validation standard, coding
+guidelines) live in AGENTS.md, which is loaded automatically — do not duplicate
+it here.

--- a/.opencode/commands/fraimz.md
+++ b/.opencode/commands/fraimz.md
@@ -49,5 +49,5 @@ Run the full loop, in order, and stop on any failure:
    reproduce.
 
 The loop and its pitfalls live in the **`fraimz` skill** (load it first); the
-deeper mechanics live in `evals/README.md` and the `run-evals` /
-`daytona-flow-validator` skills — use them as the source of truth.
+deeper mechanics live in `evals/README.md`, and Daytona launch/validation
+specifics in the `daytona-electron-test` / `daytona-flow-validator` skills.

--- a/.opencode/commands/voiceover.md
+++ b/.opencode/commands/voiceover.md
@@ -1,26 +1,27 @@
 ---
-description: Start a feature the demo-driven way — align on the demo voice-over (instead of a PRD) before any code
+description: Start a feature the demo-driven way — approve the voice-over (instead of a PRD), build on a fresh worktree, ship a PR with the proof on it
 ---
 
-You are starting the **voice-over alignment phase** of demo-driven development.
-The voice-over is the spec: the narration the user would record over a demo if
-the feature had already shipped. **No code until the script is approved.**
+You are starting **voiceover-first development**: the demo voice-over is the
+spec — the narration the user would record over a demo if the feature had
+already shipped (instead of a PRD). **No code until the script is approved.**
 
 Arguments: `$ARGUMENTS` — the feature, in a sentence. If empty, ask for one.
 
-Load the **`voiceover` skill** and follow its loop:
+Load the **`voiceover` skill** and follow its journey end to end:
 
-1. Draft the demo script end to end — one numbered paragraph per frame,
-   spoken style, the end user as protagonist, what the viewer sees and why it
-   matters. If a frame is hard to narrate, the feature is wrong: say so.
+1. Draft the demo script — one numbered paragraph per frame, spoken style,
+   the end user as protagonist. If a frame is hard to narrate, the feature is
+   wrong: say so.
 2. Iterate on the words with the user until they would actually record it.
-3. On approval, land it at `evals/voiceovers/<flow-id>.md` and run
-   `pnpm fraimz scaffold <flow-id>` to generate the flow stub (one `ctx.prove`
-   per paragraph, narration wired to the script; the runner fails the flow if
-   narration ever drifts from the file).
-4. Hand off to the `fraimz` skill: build the feature and re-enact the demo
-   until every frame holds, then put the proof on the PR with
-   `pnpm fraimz --flow <flow-id> --pr`.
+3. On approval, start clean: create a fresh worktree + branch
+   (`git worktree add ../_worktrees/openwork-<flow-id> -b feat/<flow-id> origin/dev`),
+   land the script at `evals/voiceovers/<flow-id>.md` there, and scaffold the
+   flow with `pnpm fraimz scaffold <flow-id>`.
+4. Build until the demo holds: delegate the coding (executor subagent when
+   orchestrating), and verify with the `fraimz` skill until every frame passes.
+5. Ship: push the branch, open the PR (`gh pr create --base dev`), and post
+   the proof on it with `pnpm fraimz --flow <flow-id> --pr`.
 
 Do not write feature code, and do not scaffold, before the user has approved
 the script.

--- a/.opencode/skills/agent-first-screenshots/SKILL.md
+++ b/.opencode/skills/agent-first-screenshots/SKILL.md
@@ -5,277 +5,91 @@ description: Agent-first screenshots — an agent drives the real app via CDP an
 
 # Agent-First Screenshots
 
-An **agent-first screenshot** is a screenshot produced by an agent driving the real
-app through automation, where the agent's "eyes" are the DOM and the pixels (not human
-vision), and the frame is gated by **structural + visual verification** before it ships.
-It turns screenshots from hand-crafted artifacts into a regenerable pipeline.
+An **agent-first screenshot** is produced by an agent driving the real app via
+CDP, gated by **structural + pixel + vision verification** before it ships. It
+turns screenshots from hand-crafted artifacts into a regenerable pipeline.
 
-Use this skill for any "take screenshots of the app / redo these screenshots / make
-marketing images" task. Use `daytona-flow-validator` or `daytona-recording-artifacts`
-for pass/fail e2e evidence instead.
+Use this for "take/redo screenshots / make marketing images" tasks. It is NOT
+e2e evidence — for pass/fail proof use the `fraimz` skill.
 
-## The Zero-Defect Bar (the one that matters most)
+## The Zero-Defect Bar
 
-**A demo screenshot must have ZERO obvious visual defects.** The bar is not "the
-content is present" or "it's a valid state" — the bar is: *would a human glancing at
-this immediately spot something broken?* If yes, it is disqualified. Full stop.
-
-Obvious defects include (this is a class, not a list):
-- Overlapping text or elements
-- Clipped / cut-off text or controls
-- Misaligned, broken, or collapsed layout
-- Garbled, double-rendered, or mid-transition content
-- Empty/blank regions where content should be
-- Stray modals, tooltips, or panels covering content
-
-A screenshot is shippable only when **a person would look at it and notice nothing
-wrong.** Everything below exists to enforce that bar.
+**A shippable screenshot has ZERO obvious visual defects** — the bar is not
+"the content is present", it is: *would a human glancing at it immediately spot
+something broken?* Overlapping or clipped text, misaligned/collapsed layout,
+garbled or mid-transition content, blank regions, stray modals/tooltips — any
+of these disqualifies the frame. Full stop.
 
 ## The One Method
 
-**Operate the app like a power user preparing a demo, not like a developer hacking the DOM.**
-
-A great screenshot shows a real, working app doing real things — composed beautifully,
-with distractions removed and **no visible defects**. The app already looks great. The
-agent's job is to get it into a real, settled state and capture it cleanly, not to
-rebuild it.
+**Operate the app like a power user preparing a demo, not like a developer
+hacking the DOM.** The app already looks great: get it into a real, settled
+state through the UI and capture it cleanly. Never rebuild or fake it.
 
 ## Golden Rules
 
-### 1. Only remove, never add
+1. **Only remove, never add.** Hiding a leaf distraction (notification badge,
+   "Sign in" footer link, status text) via `display:none` is safe. Never
+   inject fake HTML, override flex/height/width on structural containers, add
+   fixed-position overlays, or mutate the DOM tree — the layout engine will
+   collapse (scroll areas shrink to 0, content disappears).
+2. **If a feature isn't available, don't fake it.** Enable it through the
+   settings UI like a real user, or skip the shot and say so.
+3. **Each shot starts from a clean reload.** `location.reload()`, wait for
+   full render, navigate through the UI, minimal leaf cleanup, verify, capture.
+   Never carry CSS hacks across shots.
+4. **Get state naturally.** Click the real tabs/buttons/pickers; close panels
+   via their close buttons (not CSS); run real multi-turn tasks so content is
+   impressive — no toy data, no mid-stream captures.
+5. **Match the target aspect ratio** via CDP metrics override (e.g. 1440x900
+   at `deviceScaleFactor: 2`), then wait ~1s and re-verify — the override can
+   trigger re-layout.
 
-Hiding a specific notification badge or "Sign in" button via `display: none` is safe —
-it's a leaf element that doesn't affect layout flow.
+## Verify with three channels, in a loop
 
-**Never** do these — they break the layout engine:
+`innerText` existing does not mean visible; a healthy DOM rect does not mean it
+rendered. Every frame must pass all three before it ships:
 
-- Inject fake HTML components (voice panels, model lists, chart data)
-- Override CSS flex properties (`flex-grow`, `flex-basis`, `height: 100%`)
-- Add `margin`, `padding`, or `width` overrides to structural containers
-- Add `position: fixed` overlays that cover real content
-- Modify the DOM tree structure (insertBefore, appendChild on app containers)
+1. **DOM pre-check (cheap, before capture):** scroll area height > 100px (not
+   collapsed), hero text inside the viewport rect, no unexpected modal/overlay.
+   If it fails: reload and redo — never fix with more CSS.
+2. **Pixel post-check (truth, after capture):** decode the PNG and sample the
+   DOM-derived hero rects. Calibration: for text-on-white UI, background ratio
+   is a bad signal (85–92% background is normal). **Variance is the reliable
+   signal**: content-filled region variance > ~200 (often 1000+); blank/flat
+   region < 50. Whole-image `bgRatio > 0.97` → blank frame.
+3. **Vision check (mandatory gate):** deterministic stats CANNOT catch the
+   defects that matter most — overlap, clipping, misalignment,
+   double-rendering. Hand the PNG to a vision-capable model with a zero-defect
+   rubric returning JSON:
 
-The app's CSS is a carefully balanced flex system. Any structural modification risks
-collapse — scroll areas shrink to 0, content disappears, and the screenshot is blank.
+   ```
+   { any_obvious_defect: bool,   // the gate — if true, REJECT
+     overlapping_text_or_elements: bool, clipped_or_cutoff: bool,
+     misaligned_or_broken_layout: bool, blank_or_empty_regions: bool,
+     stray_modal_tooltip_or_panel: bool, legible: bool,
+     polish_score: 1-5, defects: ["..."] }
+   ```
 
-### 2. If a feature isn't available, don't fake it
+   If `any_obvious_defect` is true the frame is rejected regardless of layers
+   1–2. Diagnose, fix the root cause (settle the state, close the picker,
+   reload), recapture.
 
-If the voice extension isn't enabled, either:
-- Enable it through the settings UI (like a real user would)
-- Or skip that shot and tell the user it's not available
+Reusable scripts in this skill's directory: `screenshot-verify.mjs` (verify an
+existing PNG) and `capture-verify.mjs` (capture at 2x + verify regions + save
+only on pass); both use `sharp`.
 
-A fake panel will never match the real component's rendering. It will always look
-wrong to someone who has seen the app.
+## Common failure modes
 
-### 3. Each shot starts from a clean reload
-
-Don't carry DOM state across shots. After each capture:
-
-1. Reload the page (`location.reload()`)
-2. Wait for the app to fully render
-3. Navigate to the desired screen
-4. Do minimal cleanup (hide leaf distractions only)
-5. Verify content is visible
-6. Capture
-
-This eliminates accumulated CSS hacks that cause layout collapse.
-
-### 4. Verify with BOTH the DOM and the pixels, in a loop
-
-`innerText` existing doesn't mean it's visible, and a healthy DOM rect doesn't
-mean it actually rendered. Use two complementary channels:
-
-**DOM pre-check (cheap, before capture):** the scroll area must have real height
-(not collapsed to 32px); hero text must be inside the viewport rect; no
-unexpected modal/overlay in the tree.
-
-```js
-var scrollArea = document.querySelector('.scrollable-selector');
-var rect = scrollArea.getBoundingClientRect();
-if (rect.height < 100) { /* ABORT — layout broken, reload and redo */ }
-```
-
-**Pixel post-check (truth, after capture):** decode the PNG and sample the
-DOM-derived hero rects (scaled by deviceScaleFactor). This catches blank renders
-the DOM can't see.
-
-**Calibration insight (critical):** for text-on-white UI, **background ratio is
-a bad signal** — a full conversation is naturally 85-92% background pixels (text
-is sparse). **Variance is the reliable signal:** a content-filled region has
-luminance variance > ~200 (often 1000+); a blank/flat region is < 50. Use:
-- whole-image `bgRatio > 0.97` → blank frame
-- per-region `variance < 200` → that region didn't render (the real catch)
-- per-region `bgRatio > 0.96` → only as a secondary blank check
-
-Reusable scripts live in this skill's directory:
-`screenshot-verify.mjs` (verify an existing PNG) and `capture-verify.mjs`
-(capture at 2x + verify regions + save only on pass). Both use `sharp` for
-raw-pixel access. The loop: operate -> DOM pre-check -> capture -> pixel verify
--> if fail, diagnose and fix -> recapture, until both channels pass.
-
-**Layer 3 (vision) — MANDATORY, not optional.** Deterministic stats CANNOT catch
-the defect class that matters most: overlapping text, clipping, misalignment,
-double-rendering. Overlapping text still has high variance and normal background
-ratio — Layers 1-2 pass it happily. **Only a vision pass catches it.** So every
-frame that passes Layers 1-2 must then pass a vision check before shipping.
-
-Hand the PNG to a vision-capable model (vision subagent, or an API call whose
-JSON the orchestrator reads) with a zero-defect rubric:
-
-```
-"You are QA for a product screenshot. A real person must notice NOTHING wrong.
-Return JSON:
-{
-  any_obvious_defect: bool,        // the gate — if true, REJECT
-  overlapping_text_or_elements: bool,
-  clipped_or_cutoff: bool,
-  misaligned_or_broken_layout: bool,
-  blank_or_empty_regions: bool,
-  stray_modal_tooltip_or_panel: bool,
-  legible: bool,
-  polish_score: 1-5,
-  defects: ['title overlaps Save button', ...]
-}"
-```
-
-If `any_obvious_defect` is true, the frame is rejected no matter what Layers 1-2
-said. Map each defect to a fix (see table below) and recapture.
-
-### 5. Get the app into the right state naturally
-
-- Navigate through the UI (click tabs, open panels, run tasks)
-- Run real tasks that produce impressive output (not toy data)
-- Open split view by clicking the actual "Open in split view" button
-- Open the model picker by clicking the actual model selector
-- Close panels by clicking the actual close button
-
-If a panel is open that shouldn't be, close it through the UI — don't hide it
-with CSS.
-
-### 6. Hide only leaf distractions
-
-Safe to hide (leaf elements that don't affect layout):
-
-- Notification badges (`[aria-label*="Notification"]`)
-- Footer links ("Sign in", "Docs", "Feedback")
-- Status text ("Ready for new tasks")
-- Right rail icon buttons (Browser, Extensions, Settings)
-
-Never hide:
-
-- Flex container children (causes layout collapse)
-- Scroll areas
-- Main content wrappers
-- Panel containers (close via UI instead)
-
-### 7. Use real, impressive content
-
-- Run multi-turn tasks so conversations have depth
-- Use realistic data (org names, revenue numbers, code that looks like real work)
-- Wait for streaming, animations, and loading to fully settle
-- No "alice.johnson@example.com" toy data
-
-### 8. Match the target aspect ratio
-
-Set the viewport to match the newsletter/landing page target:
-
-- 1440x900 at 2x DPR = 2880x1800 (good for most web use)
-- 1920x1080 at 2x DPR = 3840x2160 (4K, for full-bleed hero shots)
-
-Apply via CDP:
-```js
-await send("Emulation.setDeviceMetricsOverride", {
-  width: 1440, height: 900, deviceScaleFactor: 2, mobile: false
-});
-```
-
-After applying metrics override, wait 1s and re-verify content visibility —
-the override can trigger re-layout.
-
-## Workflow
-
-### 1. Plan the shot list
-
-Decide what story each frame tells. Tie every shot to a value prop. If a frame
-doesn't answer "why would I want this?", drop it.
-
-### 2. For each shot (the loop):
-
-1. **Reload** the page to get a clean state
-2. **Navigate** to the desired screen through the UI
-3. **Wait** for content to fully render (3s for SPA navigation) and **settle**
-   (no mid-transition, no edit-mode unless intended)
-4. **Hide leaf distractions** only (badges, footer links, status text)
-5. **Apply 2x metrics** via CDP, **wait 1s** for re-layout
-6. **DOM pre-check**: scroll area height > 100px, hero text in viewport, no stray modal
-7. **If DOM check fails**: reload and redo — never fix with more CSS
-8. **Capture** via `Page.captureScreenshot`
-9. **Pixel verify (Layers 1-2)**: file size 200KB+, region variance > 200
-10. **Vision verify (Layer 3, mandatory)**: `any_obvious_defect` must be false —
-    catches overlap/clipping/misalignment that Layers 1-2 cannot
-11. **If any layer fails**: diagnose, fix the root cause, recapture. Ship only when
-    all three pass and a person would notice nothing wrong.
-
-### 3. Common failure modes
-
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| Overlapping text (e.g. title over Save button) | Captured an unsettled / edit-mode / wrong-width state; only vision catches it | Open in preview (not edit) mode, let layout settle, gate on the vision check |
-| Screenshot is blank/empty | Flex container collapsed | Reload page, don't hide structural elements |
-| Scroll area is 32px tall | Sibling panel was hidden with `display:none` | Close panel via UI, don't CSS-hide it |
-| Model picker overlay on all shots | Picker was opened and never closed | Close picker (Escape) before capturing other shots |
-| Content in DOM but not in pixels | Element clipped/hidden/blank render | Pixel variance check + vision check, not `innerText` |
-| Voice panel overlaps chat | Fixed-position overlay covers content | Don't inject overlays — enable feature through UI |
-| File size under 150KB | Mostly blank image | Re-verify content visibility before capture |
-
-## Technical Reference
-
-### Capture via direct CDP (retina)
-
-```js
-await send("Page.enable");
-await send("Emulation.setDeviceMetricsOverride", {
-  width: 1440, height: 900, deviceScaleFactor: 2, mobile: false
-});
-await wait(1000); // let layout settle
-
-// VERIFY before capture
-const check = await evalJs(`(() => {
-  var sa = document.querySelector('.scrollable-selector');
-  if (!sa) return { ok: false };
-  var rect = sa.getBoundingClientRect();
-  return { ok: rect.height > 100, height: rect.height };
-})()`);
-if (!check.ok) { /* ABORT, reload and redo */ }
-
-const shot = await send("Page.captureScreenshot", {
-  format: "png", fromSurface: true, captureBeyondViewport: false
-});
-fs.writeFileSync(path, Buffer.from(shot.data, "base64"));
-await send("Emulation.clearDeviceMetricsOverride");
-```
-
-### Hide leaf distractions (safe)
-
-```js
-// Only hide specific buttons/badges, never structural containers
-document.querySelectorAll('[aria-label*="Notification"]').forEach(el => el.style.display = 'none');
-document.querySelectorAll('button').forEach(b => {
-  if (['Sign in', 'Docs', 'Feedback'].includes(b.innerText.trim())) b.style.display = 'none';
-});
-```
+| Symptom | Fix |
+|---------|-----|
+| Overlapping/clipped text (layers 1–2 pass) | Unsettled/edit-mode/wrong-width state — settle, use preview mode, gate on vision |
+| Blank screenshot / 32px scroll area | Structural element was CSS-hidden — reload, close panels via UI |
+| Overlay (picker/modal) on every shot | It was opened and never closed — Escape before capturing |
+| In DOM but not in pixels | Clipped/blank render — trust variance + vision, not `innerText` |
 
 ## Anti-patterns
 
-- **Injecting fake components.** A fake voice panel or fake chart data will never
-  match the real app's rendering. Enable the feature through the UI or skip the shot.
-- **Overriding flex properties.** Changing `flex-grow`, `height`, or `flex-basis`
-  on containers breaks the layout engine. Reload instead.
-- **Fixed-position overlays.** A `position:fixed` div covering the right side
-  hides the real content behind it. Never use overlays.
-- **Carrying state across shots.** CSS hacks accumulate and eventually break
-  layout. Reload between shots.
-- **Verifying via innerText only.** Text in the DOM doesn't mean it's visible.
-  Always check `getBoundingClientRect`.
-- **Proof-frame mindset.** This is not e2e evidence. The goal is "I want that,"
-  not "it didn't crash."
+Injecting fake components; overriding flex properties; fixed-position
+overlays; carrying state across shots; verifying via `innerText` only;
+proof-frame mindset (the goal is "I want that", not "it didn't crash").

--- a/.opencode/skills/fraimz/SKILL.md
+++ b/.opencode/skills/fraimz/SKILL.md
@@ -9,156 +9,122 @@ description: create a fraimz, make fraimz, prove it works, frame proof, PR proof
 (`evals/results/<run-id>/fraimz.html`) with one frame per step. Each frame binds
 a **claim**, the **action** the end user took, the **assertion** that witnesses
 the side effect, a **voiceover** that narrates the step, and a validated
-**screenshot**. It is the atomic thing a human looks at (and listens to) to
-understand, at a glance, that an experience works.
+**screenshot**. It is the thing a human looks at (and listens to) to understand,
+at a glance, that an experience works.
 
-This skill owns the whole loop. Trigger phrases: "create a fraimz", "make
-fraimz", "prove it works", "frame proof", "PR proof". The `/fraimz` command runs
-the same loop.
+This skill owns the prove-it loop. In the demo-driven journey (`voiceover`
+skill: script → worktree → build → fraimz → PR) this is how the build is
+verified; when orchestrating, the orchestrator drives this loop and delegates
+code repairs to the executor.
 
 ## Every fraimz is a demo
 
-A fraimz is never a bare test log. It is always one of exactly two demos, and
-the flow declares which via `kind` in `evals/flows/<id>.flow.mjs`:
+A fraimz is never a bare test log. The flow declares which demo it is via
+`kind` in `evals/flows/<id>.flow.mjs`:
 
-- **`kind: "user-facing"`** — a flow demo. The end user is the protagonist; the
-  frames walk a real journey through the UI ("discover the button, click it,
-  see the result, land somewhere"). This is the default for any feature, fix,
-  or UX change.
-- **`kind: "internal"`** — an internal demo for changes with no visible surface:
-  perf improvements, storage swaps, invariants, refactors. The frames
-  demonstrate the internal claim (timings before/after, unchanged core flow,
-  identical output) in a way a reviewer can still follow frame by frame.
-  Internal demos of terminal/tooling experiences may set `requiresApp: false`
-  to run without a CDP connection; their frames are claims + assertions +
-  recorded command output (`ctx.output`) instead of screenshots (see
+- **`kind: "user-facing"`** — the end user is the protagonist; the frames walk
+  a real journey through the UI. Default for any feature, fix, or UX change.
+- **`kind: "internal"`** — for changes with no visible surface (perf, storage
+  swaps, invariants, refactors): the frames demonstrate the internal claim in
+  a way a reviewer can still follow. Terminal/tooling demos may set
+  `requiresApp: false` to run without CDP; their frames carry claims,
+  assertions, and `ctx.output` command output instead of screenshots (see
   `evals/flows/voiceover-first-dx.flow.mjs`).
 
 If you cannot say which of the two your fraimz is, you have not framed the
-experience yet — go back to step 1 of the loop.
+experience yet.
 
-## Voiceover first, always
+## Voiceover first
 
-Every frame carries a **voiceover**: one or two spoken-style sentences that
-explain what the viewer is seeing and why it matters, as if narrating a demo
-video. The runner renders it on each frame in `fraimz.html` with a play button
-(Web Speech API), plus a "Play full voiceover" per flow.
-
-Rules:
-
-- **Write the voiceover script before coding the flow — ideally before the
-  feature.** The script is the spec (the PRD replacement): align on it with
-  the user via the **`voiceover` skill** / `/voiceover` command, then land it
-  at `evals/voiceovers/<flow-id>.md` (numbered paragraphs = frames) and
-  generate the flow from it with `pnpm fraimz scaffold <flow-id>`. Flows load
-  their narration from the script (`loadVoiceoverParagraphs`), and the runner
-  **fails any flow whose narration drifts** from the approved file (missing
-  scripted frames or unapproved lines). If a step is hard to narrate, the
-  step is wrong.
-- Every `ctx.prove` must pass `voiceover`. Frames without one are flagged
-  ("No voiceover for this frame") in the artifact — treat that flag as a
-  failure for any flow you add or touch.
-- Voiceovers describe **what the user sees** ("results are grouped, each label
-  shows a count"), not implementation ("the memo re-computes").
-- For `internal` demos the voiceover explains the invariant being witnessed
-  ("same session list, half the queries").
+The narration is the spec and it comes BEFORE the flow (and ideally before the
+feature) — alignment and approval belong to the **`voiceover` skill** /
+`/voiceover`. The approved script lives at `evals/voiceovers/<flow-id>.md`;
+`pnpm fraimz scaffold <flow-id>` generates the flow from it, and the runner
+**fails any flow whose narration drifts** from the approved file. Every
+`ctx.prove` must carry a `voiceover` (one or two spoken-style sentences about
+what the viewer sees, never implementation); frames without one are flagged in
+the artifact — treat that as a failure for any flow you touch.
 
 ## When this applies
 
-Make fraimz whenever a change can alter behavior observable outside the process:
-filesystem, SQLite/runtime DB, server endpoints, sessions, config, provisioning,
-cloud sync, or network. **This also applies to changes you expect to be inert** —
-refactors, storage swaps, renames, dead-code removal: the fraimz job is then to
-prove the canonical core flow is unchanged. Pure docs/comments and types-only
-changes with no runtime path may skip — but say so explicitly.
+Make fraimz whenever a change can alter behavior observable outside the
+process: filesystem, runtime DB, server endpoints, sessions, config,
+provisioning, cloud sync, network. **Also for changes you expect to be inert**
+(refactors, renames, dead-code removal): the job is then to prove the canonical
+core flow is unchanged — open the app → write a message → get a response →
+close → reopen with the session intact (`evals/flows/core-flow.flow.mjs`).
+Pure docs/comments and types-only changes with no runtime path may skip — but
+say so explicitly.
 
-## The loop (never report success from a click or a return value alone)
+## The loop
+
+Never report success from a click or a return value alone. Every meaningful
+step is: **observe → act → observe → assert** — and repair before verdict.
 
 1. **Frame the experience** as a one-line claim ("user can do X and sees Y")
-   and pick the demo kind (`user-facing` or `internal`). State both back
-   before proceeding.
-2. **Write the voiceover script.** One narrated paragraph per planned frame,
-   covering the whole demo end to end (see "Voiceover first, always").
-3. **Express it as a flow.** Reuse or add a coded flow in
-   `evals/flows/<id>.flow.mjs` with `kind` set. The end user is the protagonist
-   (driven via CDP). REST/DB/filesystem checks are *only* how you witness the
-   expected side effects — never the thing being tested. Every meaningful step
-   must use `ctx.prove("claim", { voiceover, action, assert, screenshot })`,
-   with `voiceover` taken from the script.
-4. **Drive it for real.** Launch the app (Daytona preferred, local Electron
-   fallback) and run `pnpm fraimz --flow <id> --cdp-url <electron-cdp-url>`.
-   Observe → act → observe → assert.
+   and pick the demo kind. State both back before proceeding.
+2. **Get the script.** Approved voiceover at `evals/voiceovers/<id>.md`
+   (via the `voiceover` skill), then `pnpm fraimz scaffold <id>` — or reuse an
+   existing flow in `evals/flows/`.
+3. **Code the flow.** The end user is the protagonist (driven via CDP);
+   REST/DB/filesystem checks only witness the side effects. Every meaningful
+   step uses `ctx.prove("claim", { voiceover, action, assert, screenshot })`.
+4. **Drive it for real.** Launch the app (see below), then
+   `pnpm fraimz --flow <id> --cdp-url <electron-cdp-url>`.
 5. **Validate, repair, repeat.** If a frame does not support its claim (wrong
    route, error state, missing text, stale dialog, duplicate image, missing
    voiceover), fix the visible state or the code and rerun until every claim
    has a passing assertion, a narrated voiceover, and a valid screenshot.
-6. **Output fraimz + verdict — on the PR.** The run writes `fraimz.html` plus
-   `report.md` / `report.json` to `evals/results/<run-id>/`. When a PR exists,
-   post the proof on it: `pnpm fraimz --flow <id> --pr [number]` renders the
-   frames (verdict, claims, voiceovers, assertions) as a PR comment via `gh`
-   (`--pr` alone targets the current branch's PR). Report `Passed` only when
-   fraimz exists and every claim is backed by an observable assertion;
-   otherwise `Incomplete` / `Failed`, stated honestly with repro steps.
-
-## The canonical core flow
-
-When a change is expected to be inert, re-run the core flow —
-**open the app → write a message → get a response → close → reopen and confirm
-the session survived** (`evals/flows/core-flow.flow.mjs`). If it stays green, the
-inertness claim is backed by evidence. This is the standard `internal` demo for
-"nothing user-visible changed".
+6. **Verdict, on the PR.** The run writes `fraimz.html` + `report.md` /
+   `report.json` to `evals/results/<run-id>/`; post it as a PR comment with
+   `pnpm fraimz --flow <id> --pr [number]` (`--pr` alone targets the current
+   branch's PR). Report `Passed` only when fraimz exists and every claim is
+   backed by an observable assertion; otherwise `Incomplete` / `Failed`,
+   stated honestly with repro steps.
 
 ## Driving the real app
 
-Preferred (Daytona): `bash .devcontainer/test-on-daytona.sh <branch>` then use
-the printed Electron CDP URL. See the `run-evals` and `daytona-electron-test`
-skills.
-
-Local Electron fallback:
+Local Electron (fastest for a worktree you changed):
 
 ```bash
-# from the worktree you changed
 OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9826 pnpm dev   # & in background
-
-# wait for the renderer, then run the flow against it
 pnpm fraimz --flow <id> --cdp-url http://127.0.0.1:9826
 ```
 
-The runner default-probes `:9825` (Daytona) then `:9823` (local `pnpm dev`).
-Pass `--cdp-url` for any other port.
+Daytona sandbox (isolated, VNC-visible; see `daytona-electron-test`):
 
-## Practical pitfalls (learned the hard way)
+```bash
+bash .devcontainer/test-on-daytona.sh <branch> --artifacts-volume
+pnpm fraimz --flow <id> --cdp-url <printed-electron-cdp-url>
+```
 
-- **Target the right CDP frame.** A sandbox can expose multiple page targets
-  (e.g. a `Google` page plus `OpenWork`). The runner uses `pickAppTarget`, but
-  ad-hoc `browser_eval` defaults to the first target — pass the OpenWork
-  `target_id` explicitly when probing manually.
-- **`__openworkControl` readiness.** It attaches in the renderer after boot and
-  resets on config reload. Always `ctx.waitFor("Boolean(window.__openworkControl)")`
-  before driving; re-wait after any "Reloading OpenCode config".
-- **Panels that auto-mount a browser tab** can steal focus from the artifact
-  view. Re-select the artifact tab inside a `waitFor` and assert geometry in the
-  same poll so the browser sync can't race you mid-measurement.
-- **Reflow timing.** When you change layout/width to force a state, split it:
-  first a `waitFor` that returns true only once the DOM has actually reflowed
-  (e.g. `row.getBoundingClientRect().width <= 380`), then a separate
-  `ctx.eval(MEASURE)` for the measurement.
+The runner default-probes `:9825` (Daytona) then `:9823` (local `pnpm dev`);
+pass `--cdp-url` for any other port. `pnpm evals --all --stack den` brings up
+the cloud stack for env-gated cloud flows.
+
+## Pitfalls (learned the hard way)
+
+- **Target the right CDP page.** A sandbox can expose several targets; ad-hoc
+  `browser_eval` defaults to the first — pass the OpenWork `target_id` when
+  probing manually.
+- **`__openworkControl` readiness.** Attaches after boot and resets on config
+  reload: `ctx.waitFor("Boolean(window.__openworkControl)")` before driving,
+  and re-wait after any "Reloading OpenCode config".
+- **Flows must be idempotent.** A failed run can leave dialogs open or state
+  dirty; start steps by restoring the state you need (e.g. Escape a stale
+  dialog).
+- **Don't race streamed/debounced UI.** Wait for the concrete artifact you
+  assert on (the rendered row), not for a spinner to disappear.
+- **Split reflow from measurement.** First a `waitFor` that returns true only
+  once the DOM actually reflowed, then a separate `ctx.eval` to measure.
+- **Screenshot validation takes arrays** (`requireText: ["foo"]`,
+  `rejectText: [...]`, `hashIncludes: "/route"`). A screenshot with no
+  validation metadata is a checkpoint, not proof.
 - **Assert the regression, not nice-to-haves.** Prove what the change
-  guarantees (e.g. "title truncates and does not overlap the buttons"); don't
-  fail the run on a cosmetic extra the fix never promised.
-- **Eval-only seed affordances are fine.** Adding a dev-only
-  (`import.meta.env.DEV`) arg to an existing `eval.*` control action to make a
-  state reproducible is acceptable; keep it out of production paths and say so.
-- **`screenshot` validation takes arrays.** `requireText: ["foo"]`,
-  `rejectText: [...]`, `hashIncludes: "/route"`. A screenshot with no validation
-  metadata is a checkpoint, not proof.
-- **Flows must be idempotent.** A failed previous run can leave dialogs open or
-  state dirty; begin steps by restoring the state you need (e.g. Escape a stale
-  dialog) instead of assuming a fresh app.
-- **Don't race streamed results.** Debounced/async UI (deep search, scans)
-  starts *after* your input lands; wait for the concrete artifact you assert on
-  (the rendered row), not for a spinner to disappear — the spinner may not have
-  appeared yet.
+  guarantees; don't fail the run on a cosmetic extra the fix never promised.
+- **Eval-only seed affordances are fine** behind `import.meta.env.DEV` on
+  existing `eval.*` control actions; keep them out of production paths and say
+  so.
 
 ## ctx.* helpers (the flow API)
 
@@ -166,21 +132,16 @@ Pass `--cdp-url` for any other port.
 `ctx.navigateHash`, `ctx.control(actionId, args)`, `ctx.expectText`,
 `ctx.expectNoText`, `ctx.expectHashIncludes`, `ctx.assert`,
 `ctx.screenshot(name, { claim, voiceover, requireText, rejectText, hashIncludes })`,
-and the headline
+`ctx.output(name, text)`, and the headline
 `ctx.prove("claim", { voiceover, action, assert, screenshot })`.
-
-Reference example (demo kind + per-frame voiceover):
-`evals/flows/session-search-grouped.flow.mjs`.
+Reference flow: `evals/flows/session-search-grouped.flow.mjs`.
 
 ## Source of truth
-
-Keep this skill as the loop. The deeper mechanics live in:
 
 - `evals/README.md` — runner, flags, conventions, full `ctx.*` reference.
 - `evals/flows/` — existing coded flows to reuse or pattern-match.
 - `evals/voiceovers/` + `evals/runner/voiceover.mjs` — approved scripts,
-  parser, drift check, scaffolder; the `voiceover` skill owns the alignment
-  phase before any code.
-- Skills: `run-evals` (launch + run), `daytona-flow-validator` (observe → act →
-  assert → repair → verdict), `daytona-electron-test`,
-  `daytona-recording-artifacts` (optional video).
+  parser, drift check, scaffolder; the `voiceover` skill owns the journey
+  around this loop.
+- `daytona-electron-test` (sandbox launch), `daytona-flow-validator`
+  (Daytona-native windows/xdotool), `daytona-recording-artifacts` (video).

--- a/.opencode/skills/run-evals/SKILL.md
+++ b/.opencode/skills/run-evals/SKILL.md
@@ -1,247 +1,88 @@
 ---
 name: run-evals
-description: do e2e tests, run e2e, validate feature, prove it works, PR proof, frame proof, pnpm evals. Runs OpenWork UI evals on Daytona or local Electron with CDP and validated HTML frame evidence.
+description: do e2e tests, run e2e, validate feature, prove it works, PR proof, frame proof, pnpm evals. Launches OpenWork on Daytona or local Electron and runs the coded eval flows via CDP. Launch + run mechanics; the proof loop itself is the fraimz skill.
 ---
 
 # Skill: Run Evals
 
-Run the OpenWork UI evaluation flows against a real Electron app. Prefer a fresh Daytona sandbox for each run, with a local test fallback when Daytona is unavailable.
-
-## When to use
-
-- User says "do e2e tests for <feature>", "run e2e", "validate feature", "prove it works", "PR proof", "frame proof", or "run evals on Daytona".
-- User wants to verify a UI change end-to-end against the real Electron app.
-- User wants to test onboarding, session, settings, cloud, Marketplace, provider, or voice flows.
+Launch a real OpenWork app and run coded eval flows against it. This skill owns
+**launch + run**; the prove/repair/verdict loop and evidence standard live in
+the **`fraimz` skill** — load that too for anything that ends in a verdict.
 
 ## Prerequisites
 
-- `daytona` CLI installed and logged in (`daytona login`)
-- Using the right Daytona organization for your workspace (`daytona organization use "<org-name>"`)
-- The `.devcontainer/` files exist in the repo
-- Optional provider coverage: reusable Daytona volume `openwork-eval-secrets`
-  populated with `.env` files using `bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken`
+- `daytona` CLI installed and logged in (`daytona login`), right org selected
+  (`daytona organization use "<org-name>"`)
+- `.devcontainer/` files present in the repo
+- Optional provider coverage: reusable secrets volume populated once with
+  `bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken` (never print
+  keys; sandboxes source every `/daytona-secrets/*.env` before Electron starts)
 
-## Workflow
-
-Use these Daytona skills when an eval touches a specific area:
-
-- `daytona-electron-test` for launching and driving the real Electron app.
-- `daytona-flow-validator` for the observe -> act -> observe/assert -> evidence loop.
-- `daytona-cloud-server` for Den server sandbox startup and health checks.
-- `daytona-electron-den` for two-sandbox Electron + Den cloud flows.
-- `daytona-chrome-cdp` for standalone Chrome in Daytona, separate from Electron.
-- `daytona-secrets-volume` for adding or checking provider keys and eval secrets.
-- `daytona-recording-artifacts` for screenshots, recordings, before/after videos, and PR evidence.
-
-### Preferred path: helper script + coded eval runner
-
-Use the repo helper unless you need to debug a specific Daytona step manually:
+## Preferred path: Daytona sandbox
 
 ```bash
 daytona organization use "<org-name>"
 bash .devcontainer/test-on-daytona.sh <branch-or-commit> --artifacts-volume
 ```
 
-The helper creates a fresh VNC-capable Daytona sandbox from the reusable
-`openwork-eval-vnc` snapshot, mounts the reusable
-`openwork-eval-secrets:/daytona-secrets` volume, mounts the reusable
-`openwork-eval-pnpm-store` pnpm cache volume, starts XFCE/noVNC, Vite, and
-Electron with Daytona-safe graphics flags, waits for CDP, then prints the CDP
-and noVNC URLs. `--artifacts-volume` mounts `/daytona-artifacts` and serves it
-on port 8090 so UI validation can publish frame proof. If the snapshot is
-missing, create it before rerunning.
+The helper creates a fresh VNC-capable sandbox from the `openwork-eval-vnc`
+snapshot, mounts the secrets + pnpm-store volumes, starts XFCE/noVNC, Vite, and
+Electron with Daytona-safe flags, waits for CDP, then prints the CDP and noVNC
+URLs. `--artifacts-volume` mounts `/daytona-artifacts` served on port 8090 for
+published frame proof. Refresh the snapshot when dependencies change:
+`bash .devcontainer/create-daytona-openwork-snapshot.sh`.
 
-Refresh the snapshot when dependencies or base setup change:
-
-```bash
-bash .devcontainer/create-daytona-openwork-snapshot.sh
-```
-
-The snapshot intentionally excludes `node_modules` to stay below Daytona's 20 GB
-snapshot limit. Dependency installs reuse the pnpm store volume.
-
-For provider eval coverage, create/populate the volume once before the
-first run:
-
-```bash
-bash .devcontainer/setup-daytona-secrets-volume.sh .newtoken
-bash .devcontainer/setup-daytona-secrets-volume.sh .anthropic anthropic.env
-```
-
-Do not print keys. Future eval sandboxes reuse the same volume and source every
-`/daytona-secrets/*.env` file before Electron starts.
-
-### Verify helper output
-
-Use the Electron CDP URL printed by `test-on-daytona.sh` with the browser tools:
+Verify the endpoint before running flows:
 
 ```
-browser_list({ browser_url: "<CDP_URL>" })
-→ should show "OpenWork" page target
+browser_list({ browser_url: "<CDP_URL>" })   # must show an "OpenWork" target
 ```
 
-If `browser_list` fails, inspect `/tmp/electron.log`. The real CDP success
-marker is Chromium's `DevTools listening on ws://127.0.0.1:9825/...`, not just
-OpenWork's `Electron CDP exposed` line.
+If it fails, inspect `/tmp/electron.log` — the real success marker is
+Chromium's `DevTools listening on ws://127.0.0.1:9825/...`.
 
-### Step 5: Create a workspace
+If the app shows the Welcome page, create a workspace first (see
+`evals/daytona-flows.md` Flow 1: create `/workspace/hello` on the sandbox,
+"Get started" → "Local workspace" → inject the path → "Create Workspace").
 
-If the app shows the Welcome page, create a workspace:
-
-1. Create directory on sandbox:
-   ```bash
-   daytona exec "$SANDBOX" 'mkdir -p /workspace/hello'
-   ```
-
-2. Follow the workspace creation flow from `evals/daytona-flows.md` Flow 1:
-   - Click "Get started" → "Local workspace"
-   - Inject path via React fiber dispatch: `{ key: "selectedFolder", value: "/workspace/hello" }`
-   - Click "Create Workspace"
-   - Wait 10s for opencode sidecar to boot
-
-### Step 6: Run the requested eval
-
-Prefer coded flows under `evals/flows/` and run them through the eval runner:
+## Run the flows
 
 ```bash
 pnpm evals --list
 pnpm evals --flow <flow-id> --cdp-url <printed-electron-cdp-url>
+pnpm evals --all --stack den     # brings up MySQL + den-api + seed for cloud flows
 ```
 
-The runner uses CDP directly, produces machine-checkable assertions, validates
-proof screenshots, and writes `report.json`, `report.md`, screenshots, and a
-browseable `index.html` frame proof under `evals/results/<run-id>/`.
+The runner produces machine-checkable assertions, validated screenshots, and
+writes `fraimz.html` + `report.md` / `report.json` under
+`evals/results/<run-id>/`. If no coded flow exists for the behavior, add one in
+`evals/flows/<id>.flow.mjs` (see the `fraimz` skill and `evals/README.md` for
+the `ctx.*` API); use manual browser tools only to debug or prototype — a coded
+flow is the PR evidence.
 
-If no coded flow exists yet for the UI behavior under test, add or adapt a
-`evals/flows/*.flow.mjs` file and use the runner helpers:
+## Recording (motion only)
 
-- `ctx.clickText("Button label")`
-- `ctx.fill("input-or-textarea-selector", "value")`
-- `ctx.waitFor("JavaScript condition")`
-- `ctx.expectText("Visible text")`
-- `ctx.expectNoText("Error text")`
-- `ctx.expectHashIncludes("/route")`
-- `ctx.control("action.id", args)`
-- `ctx.prove("claim", { action, assert, screenshot })`
-- `ctx.screenshot("checkpoint-name", { claim, requireText, rejectText, hashIncludes })`
+Frame proof is the default deliverable; record video only when motion matters
+(streaming, animations). Start with
+`bash .devcontainer/test-on-daytona.sh <branch> --record-video --recording-name <name>`,
+stop with `daytona exec "$SANDBOX" -- 'bash .devcontainer/stop-daytona-recording.sh'`,
+download via the port-8090 artifacts URL. Details: `daytona-recording-artifacts`.
 
-For PR evidence, do not leave screenshots as a loose gallery. Each important
-frame should have a claim and validation checks. If screenshot validation fails,
-repair the visible state and recapture before reporting `Passed`.
+## Local fallback
 
-Use manual browser tools only to debug/prototype a flow or when product UI
-cannot expose the needed state yet. Do not report ad hoc browser calls as the
-preferred PR evidence when a coded flow can be created.
-
-When manually replaying a markdown-only eval, execute each step using the
-browser tools and convert the flow to `evals/flows/` if it becomes repeated PR
-coverage.
-
-For each step:
-1. Observe the current state with `browser_snapshot` or `browser_eval`.
-2. Execute the `browser_eval`, `browser_click`, `browser_fill`, or screenshot call.
-3. Observe again.
-4. Assert the expected URL, text, state, process, log, or API result.
-5. Capture screenshot/recording evidence when the visible state matters.
-
-Use the `daytona-flow-validator` skill for pass/fail decisions. If there is no
-post-action assertion or the frame evidence does not visibly support the claim,
-report `Incomplete`, not `Passed`.
-
-### Manual browser-tool fallback techniques
-
-Use these only when debugging, prototyping a flow, or bridging a product gap.
-For repeatable UI proof, prefer `pnpm evals` and `ctx.*` helpers above.
-
-**Clicking buttons:**
-```
-browser_eval({ browser_url: URL, expression: "(function() { var btns = document.querySelectorAll('button'); for (var i = 0; i < btns.length; i++) { if (btns[i].textContent.indexOf('BUTTON_TEXT') !== -1) { btns[i].click(); return 'clicked'; } } return 'not found'; })()" })
-```
-
-**Typing in Lexical editors:**
-```
-browser_eval({ browser_url: URL, expression: "(function() { var e = document.querySelector('[contenteditable=true]'); e.focus(); var d = new DataTransfer(); d.setData('text/plain', 'YOUR TEXT'); e.dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: d })); return e.innerText; })()" })
-```
-
-**Injecting folder path (bypass native picker):**
-Use the `__reactFiber$` → `CreateWorkspaceModal` reducer dispatch with `{ key: "selectedFolder", value: "/path" }`. Full code in `evals/daytona-flows.md` Flow 1 Step 5.
-
-**Checking page state:**
-```
-browser_eval({ browser_url: URL, expression: "document.body.innerText.substring(0, 500)" })
-```
-
-**Screenshots:**
-```
-browser_screenshot({ browser_url: URL })
-```
-
-Also capture persistent Daytona screenshots at critical checkpoints when the
-artifacts volume is mounted:
-
-```bash
-daytona exec "$SANDBOX" -- 'bash .devcontainer/capture-daytona-screenshot.sh'
-```
-
-Use browser snapshots/assertions for AI validation, screenshots for visual
-checkpoints, and recordings for human PR evidence.
-
-### Recording eval runs
-
-Record eval runs when the user asks for PR evidence or the change is visual.
-Use the built-in Daytona recording mechanism:
-
-**Start with recording from the beginning:**
-```bash
-bash .devcontainer/test-on-daytona.sh <branch> --record-video --recording-name <eval-name>
-```
-
-**Start a new recording mid-sandbox** (e.g. after switching branches):
-```bash
-daytona exec "$SANDBOX" -- "bash -lc 'cd /workspace && DISPLAY=:99 .devcontainer/start-daytona-recording.sh --detach --output /daytona-artifacts/recordings/<name>.mp4'"
-```
-
-**Stop recording:**
-```bash
-daytona exec "$SANDBOX" -- 'bash .devcontainer/stop-daytona-recording.sh'
-```
-
-**Get the download URL:**
-```bash
-ARTIFACTS_URL=$(daytona preview-url "$SANDBOX" -p 8090 2>/dev/null | grep -v "^time=")
-echo "${ARTIFACTS_URL}/recordings/<name>.mp4"
-```
-
-Recordings are saved to the persistent `openwork-eval-artifacts` volume and
-survive sandbox deletion. Always use `stop-daytona-recording.sh` (not
-`kill -9`) so ffmpeg finalizes the mp4 properly.
-
-Screenshots are saved to `/daytona-artifacts/screenshots` and are served by the
-same port 8090 artifacts URL.
-
-For before/after comparison recordings, see the "Recording before/after
-comparisons" section in the `daytona-electron-test` skill.
-
-### Local fallback
-
-Always include a local fallback in the result. Use it when Daytona is down, quota-limited, or the sandbox cannot expose CDP. At minimum, run the closest local verification commands and report that the Daytona path was unavailable.
+When Daytona is down or quota-limited:
 
 ```bash
 pnpm install
 pnpm --filter @openwork/app typecheck
-pnpm --filter @openwork/app build
+OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9826 pnpm dev   # then:
+pnpm evals --flow <flow-id> --cdp-url http://127.0.0.1:9826
 ```
 
-For UI flow verification, start the local app and attach browser tools to the local Electron CDP endpoint, then run the same eval steps from `evals/`.
+Report clearly whether the result came from Daytona or the local fallback — a
+local run is not a Daytona validation.
 
-```bash
-pnpm dev
-```
-
-Report clearly whether the result came from Daytona or the local fallback. A
-local fallback cannot be reported as a successful Daytona validation.
-
-### Teardown
+## Teardown
 
 ```bash
 daytona delete "$SANDBOX"

--- a/.opencode/skills/voiceover/SKILL.md
+++ b/.opencode/skills/voiceover/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: voiceover
-description: write the voice-over, demo script first, voiceover instead of PRD, align on the demo, script the demo, demo-driven development intake. The alignment phase of demo-driven development — draft and approve the demo narration BEFORE any code, land it as evals/voiceovers/<id>.md, then scaffold the flow from it. Use when a feature request arrives, or when the user runs /voiceover.
+description: write the voice-over, demo script first, voiceover instead of PRD, voiceover-first development, align on the demo, script the demo, ship a feature demo-first. The whole demo-driven journey — approve the narration BEFORE any code, then build on a fresh worktree until the demo holds and open the PR with the proof on it. Use when a feature request arrives, or when the user runs /voiceover.
 ---
 
 # Skill: voiceover
 
 The voice-over is the spec. Instead of a PRD, a feature starts as the demo
 narration the user would record if the feature had already shipped. This skill
-owns the alignment phase that precedes all implementation.
+owns the whole journey: **script → worktree → build → fraimz → PR.**
 
 **The contract: no code until the script is approved.**
 
-## The loop
+## Phase 1 — Align on words (no code)
 
 1. **Take the feature in a sentence.** Ask only what you need to narrate a
    demo of it.
@@ -23,18 +23,47 @@ owns the alignment phase that precedes all implementation.
 3. **Iterate on words, not code.** State the script back and revise with the
    user until they would actually record it. This conversation is the review
    that used to happen on a PRD.
-4. **Land the script.** Write it to `evals/voiceovers/<flow-id>.md`:
-   a title, optional context prose, then the numbered frame paragraphs. From
-   this point the file is what the code gets held to — the runner fails any
-   flow whose narration drifts from it.
+
+## Phase 2 — Start clean (fresh worktree)
+
+On approval, set up an isolated workspace so the user's checkout stays
+untouched:
+
+```bash
+git fetch origin dev
+git worktree add ../_worktrees/openwork-<flow-id> -b feat/<flow-id> origin/dev
+```
+
+Then, inside the worktree:
+
+4. **Land the script** at `evals/voiceovers/<flow-id>.md`: a title, optional
+   context prose, then the numbered frame paragraphs. From this point the file
+   is what the code gets held to — the runner fails any flow whose narration
+   drifts from it.
 5. **Scaffold the flow.** `pnpm fraimz scaffold <flow-id>` generates
    `evals/flows/<flow-id>.flow.mjs` with one `ctx.prove` stub per paragraph,
    narration pre-wired via `loadVoiceoverParagraphs`. Do not renumber or
    reword paragraphs after this without re-approval.
-6. **Hand off to the fraimz skill.** Build the feature and drive the demo
-   (sandbox preferred, local Electron fallback) until every frame holds; the
-   fraimz loop owns validate/repair/verdict and posting the proof on the PR
-   (`pnpm fraimz --flow <id> --pr`).
+
+## Phase 3 — Build until the demo holds
+
+6. **Build the feature.** The orchestrator decomposes the work and delegates
+   the coding to the `executor` subagent; the fraimz loop (see the `fraimz`
+   skill) is how the orchestrator verifies each round — drive the demo
+   against the real app, repair, and re-run until every frame passes.
+
+## Phase 4 — Ship (PR with the proof on it)
+
+7. **Open the PR and post the proof.** From the worktree:
+
+```bash
+git push -u origin feat/<flow-id>
+gh pr create --base dev --fill
+pnpm fraimz --flow <flow-id> --pr   # posts the frame-by-frame proof as a PR comment
+```
+
+The PR review is the demo review: verdict, claims, voiceovers, and assertions,
+frame by frame.
 
 ## Script format
 
@@ -55,5 +84,5 @@ human could speak over the screen while it shows exactly that state.
 
 - `evals/runner/voiceover.mjs` — parser, drift check, scaffolder.
 - `evals/voiceovers/voiceover-first-dx.md` — the reference script (this
-  workflow demoing itself).
-- The `fraimz` skill — everything after the script is approved.
+  workflow demoing itself, worktree and PR included).
+- The `fraimz` skill — the validate/repair/verdict loop inside Phase 3.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,15 @@ repro steps. Pure docs/comments and types-only changes with no runtime path may
 skip — but say so explicitly. For changes you expect to be inert, the `fraimz`
 skill's canonical core flow proves the core experience is unchanged.
 
+## Demo-Driven Development (the paved path)
+
+Feature work starts with the demo, not a PRD:
+
+1. `/voiceover <feature>` — align on the demo script; **no code until it is approved** (`voiceover` skill).
+2. Build on a fresh worktree/branch (`git worktree add ...`), never on the user's checkout.
+3. Prove it with fraimz until every frame holds (`fraimz` skill).
+4. Open a PR against `dev` and post the proof on it: `pnpm fraimz --flow <id> --pr`.
+
 ## Coding Guidelines
 
 ### TypeScript

--- a/evals/README.md
+++ b/evals/README.md
@@ -52,6 +52,7 @@ Demo-driven development starts with the narration, not a PRD. The `/voiceover`
 command (and `voiceover` skill) aligns on the demo script with the user before
 any code; the approved script lands at `evals/voiceovers/<flow-id>.md` — a
 title, optional context prose, and one **numbered paragraph per frame**.
+On approval the build moves to a fresh worktree/branch; the journey ends with the PR carrying the proof (see the `voiceover` skill).
 
 ```bash
 pnpm fraimz scaffold <flow-id>    # generate evals/flows/<flow-id>.flow.mjs

--- a/evals/flows/voiceover-first-dx.flow.mjs
+++ b/evals/flows/voiceover-first-dx.flow.mjs
@@ -3,7 +3,7 @@
  *
  * Proves the voice-over-first DX end to end: the /voiceover entry point, the
  * "script before code" contract, the approved script as a checked-in artifact,
- * scaffolding + drift detection, the fraimz PR comment, and the merge-blocking
+ * fresh worktree, scaffolding + drift detection, the fraimz PR comment, and the merge-blocking
  * exit-code contract. Runs app-less (requiresApp: false): the protagonist is a
  * developer in a terminal, so evidence is claims + assertions + real command
  * output instead of screenshots.
@@ -81,9 +81,26 @@ export default {
           assert: async () => {
             const scriptPath = voiceoverScriptPath(FLOW_ID);
             witness(ctx, await exists(scriptPath), "The approved script exists at evals/voiceovers/voiceover-first-dx.md");
-            witness(ctx, vo.length === 6, "The script parses into exactly 6 frame paragraphs", String(vo.length));
+            witness(ctx, vo.length === 7, "The script parses into exactly 7 frame paragraphs", String(vo.length));
             witness(ctx, vo[0].includes("PRD"), "Frame 1 names the thing it replaces (the PRD)");
             ctx.output("evals/voiceovers/voiceover-first-dx.md", await readFile(scriptPath, "utf8"));
+          },
+        });
+      },
+    },
+    {
+      name: "The build starts on a fresh worktree and ends as a PR with the proof on it",
+      run: async (ctx) => {
+        await ctx.prove("The paved path is documented end to end: fresh worktree in, PR with fraimz out", {
+          voiceover: vo[3],
+          assert: async () => {
+            const skillPath = join(ROOT, ".opencode", "skills", "voiceover", "SKILL.md");
+            const skill = await readFile(skillPath, "utf8");
+            witness(ctx, skill.includes("git worktree add"), "The voiceover skill starts the build on a fresh worktree (git worktree add)");
+            witness(ctx, skill.includes("--pr"), "The voiceover skill ends with the proof posted on the PR (pnpm fraimz --flow <id> --pr)");
+            const command = await readFile(join(ROOT, ".opencode", "commands", "voiceover.md"), "utf8");
+            witness(ctx, command.toLowerCase().includes("worktree"), "The /voiceover command routes the build through a fresh worktree");
+            ctx.output("The worktree + PR contract (voiceover skill)", skill.split("\n").filter((line) => line.toLowerCase().includes("worktree") || line.includes("--pr")).join("\n"));
           },
         });
       },
@@ -96,7 +113,7 @@ export default {
         const flowsDir = await mkdtemp(join(tmpdir(), "fraimz-scaffold-"));
         try {
           await ctx.prove("One ctx.prove stub per paragraph, narration wired to the script file", {
-            voiceover: vo[3],
+            voiceover: vo[4],
             action: async () => {
               await writeFile(scaffoldScript, "# _scaffold-demo — fixture\n\n1. First fixture frame.\n\n2. Second fixture frame.\n");
             },
@@ -143,7 +160,7 @@ export default {
       name: "The fraimz lands on the PR as the reviewable demo",
       run: async (ctx) => {
         await ctx.prove("pnpm fraimz --flow <id> --pr renders the frame-by-frame proof as a PR comment", {
-          voiceover: vo[4],
+          voiceover: vo[5],
           assert: async () => {
             const body = renderPrComment({
               runId: "demo-run",
@@ -156,14 +173,14 @@ export default {
                 steps: [{
                   status: "passed",
                   evidence: [
-                    { type: "claim", status: "passed", claim: "The demo holds", voiceover: vo[4] },
+                    { type: "claim", status: "passed", claim: "The demo holds", voiceover: vo[5] },
                     { type: "assertion", status: "passed", assertion: "Observable side effect witnessed" },
                   ],
                 }],
               }],
             });
             witness(ctx, body.includes("## fraimz — ✅ PASSED"), "The comment leads with the verdict");
-            witness(ctx, body.includes(`🎙 ${vo[4]}`), "Each frame carries its voice-over line");
+            witness(ctx, body.includes(`🎙 ${vo[5]}`), "Each frame carries its voice-over line");
             witness(ctx, body.includes("Observable side effect witnessed"), "Each frame lists its passing assertions");
             ctx.output("pr-comment.md (rendered)", body);
           },
@@ -177,7 +194,7 @@ export default {
         const outDir = await mkdtemp(join(tmpdir(), "fraimz-red-out-"));
         try {
           await ctx.prove("The runner exits non-zero when any frame fails, while still writing the fraimz", {
-            voiceover: vo[5],
+            voiceover: vo[6],
             action: async () => {
               await writeFile(join(flowsDir, "_red-demo.flow.mjs"), `export default {
   id: "_red-demo",

--- a/evals/voiceovers/voiceover-first-dx.md
+++ b/evals/voiceovers/voiceover-first-dx.md
@@ -1,9 +1,10 @@
 # voiceover-first-dx — Shipping a feature without writing a PRD
 
 The demo of demo-driven development itself: the voice-over is written and
-approved before any code, agents build until the full flow holds, and the
-proof lands on the PR. One paragraph per frame; the flow loads its narration
-from this file, so this script is the spec the code is held to.
+approved before any code, the build happens on a fresh worktree, agents build
+until the full flow holds, and the proof lands on the PR. One paragraph per
+frame; the flow loads its narration from this file, so this script is the spec
+the code is held to.
 
 1. This is a feature request. Normally this is where I'd write a PRD. Instead, I run the voiceover command and describe the feature in a sentence.
 
@@ -11,8 +12,10 @@ from this file, so this script is the spec the code is held to.
 
 3. I approve it, and the script lands in the repo as a file. From this point on, this file is what the code gets held to.
 
-4. The agent scaffolds a proof step per paragraph and goes to work: re-enacting the demo, fixing and re-running until every frame holds. If the flow's narration ever drifts from the approved script, the run fails.
+4. The build starts clean: the agent moves to a fresh worktree and branch, so the demo is built and proven in isolation and my checkout stays untouched.
 
-5. The PR opens with the fraimz on it: my script, frame by frame, each line backed by a passing assertion. I review the demo, not the diff.
+5. The agent scaffolds a proof step per paragraph and goes to work: re-enacting the demo, fixing and re-running until every frame holds. If the flow's narration ever drifts from the approved script, the run fails.
 
-6. And the check is binding — a red demo means a failing run, and a failing run blocks the merge. The voice-over went in as the spec and came out as the proof.
+6. The PR opens with the fraimz on it: my script, frame by frame, each line backed by a passing assertion. I review the demo, not the diff.
+
+7. And the check is binding — a red demo means a failing run, and a failing run blocks the merge. The voice-over went in as the spec and came out as the proof.


### PR DESCRIPTION
## What

Simplifies the validation/demo skills into **one reliable paved path for voiceover-first development**: `/voiceover <feature>` → approve the script (the spec) → **fresh worktree** → scaffold → build → fraimz until green → **PR with the proof posted on it**.

### Skill consolidation (net −409 lines of guidance)

| File | Before | After | Change |
|---|---|---|---|
| `.opencode/skills/voiceover/SKILL.md` | 59 | 88 | Owns the whole journey (4 phases: align → worktree → build → ship); orchestrator delegates coding to executor |
| `.opencode/skills/fraimz/SKILL.md` | 186 | 147 | Absorbs the core observe→act→assert→repair rule + launch paths; trimmed pitfalls; defers mechanics to `evals/README.md` / Daytona skills |
| `.opencode/skills/agent-first-screenshots/SKILL.md` | 281 | 95 | Zero-defect bar + golden rules + 3-channel verify loop; scripts untouched |
| `.opencode/skills/run-evals/SKILL.md` | 248 | 89 | Launch + run only; evidence/verdict standard lives in the fraimz skill |
| `.opencode/agents/orchestrator.md` | 113 | 28 | Drops the embedded (drifting) copy of AGENTS.md — it is loaded automatically; points at the paved path |
| `AGENTS.md` | — | +9 | New **Demo-Driven Development (the paved path)** section |

### The path is asserted, not just documented

`evals/voiceovers/voiceover-first-dx.md` + its flow extended 6 → 7 frames: the new frame machine-checks that the voiceover skill/command route the build through `git worktree add` and end with `pnpm fraimz --flow <id> --pr`. Narration drift from the approved script still fails the run.

## Tests run

```
pnpm fraimz --flow voiceover-first-dx   # app-less internal demo
→ Result: PASSED — 7/7 frames + Voice-over script coverage
node evals/runner/run.mjs --list        # all flows still load
```

This change is skills/docs plus the self-proving eval flow; the runtime path exercised is the eval runner itself. The fraimz proof (frame-by-frame, with the full voiceover script) is posted as a comment below — this PR was itself produced by the workflow it paves (fresh worktree off `origin/dev`, proof posted via `--pr`).

## Reproduce

```
git worktree add ../wt -b check origin/dev && cd ../wt   # or just check out this branch
pnpm fraimz --flow voiceover-first-dx
```