### PR TITLE
feat(den): invite-to-desktop — invite email sells the app, join-org hands off to a signed-in desktop, mobile gets an honest path

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -727,6 +727,7 @@ export default {
   "welcome.subtitle": "Your computer, but it works for you.",
   "welcome.creating_workspace": "Creating workspace\u2026",
   "welcome.get_started": "Get started",
+  "welcome.team_signin": "Joining a team? Sign in",
   "welcome.pick_folder": "Pick a folder to get started",
   "welcome.capability_spreadsheets": "Edit spreadsheets",
   "welcome.capability_spreadsheets_desc": "Create, clean, and transform CSV and Excel files.",

--- a/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
+++ b/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
@@ -127,6 +127,7 @@ type WelcomePageProps = {
   onManualFolderChange?: (value: string) => void;
   onUseManualFolder?: () => void;
   showManualFolder?: boolean;
+  onTeamSignIn?: () => void;
 };
 
 type OnboardingStepProps = {
@@ -158,6 +159,7 @@ export function WelcomePage({
   onManualFolderChange,
   onUseManualFolder,
   showManualFolder,
+  onTeamSignIn,
 }: WelcomePageProps) {
   return (
     <Page className="min-h-screen">
@@ -204,6 +206,17 @@ export function WelcomePage({
                   >
                     {busy ? t("welcome.creating_workspace") : (getStartedLabel || t("welcome.get_started"))}
                   </Button>
+                  {onTeamSignIn ? (
+                    <Button
+                      type="button"
+                      variant="link"
+                      className="h-auto w-full p-0 text-sm text-muted-foreground"
+                      onClick={onTeamSignIn}
+                      data-testid="welcome-team-signin"
+                    >
+                      {t("welcome.team_signin")}
+                    </Button>
+                  ) : null}
                   {error ? (
                     <p className="text-center text-xs text-destructive">{error}</p>
                   ) : null}

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -28,6 +28,7 @@ import { useDenAuth } from "../domains/cloud/den-auth-provider";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { captureAnalyticsEvent } from "../../app/lib/analytics";
 import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../../app/lib/openwork-server";
+import { buildDenAuthUrl, DEFAULT_DEN_BASE_URL, readDenSettings } from "../../app/lib/den";
 import { writeActiveWorkspaceId, writeLastSessionFor } from "./session-memory";
 import { workspaceSessionRoute } from "./workspace-routes";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
@@ -301,6 +302,11 @@ export function WelcomeRoute() {
     await handleCreateWorkspace("starter", folder);
   }, [handleCreateWorkspace, manualFolder]);
 
+  const handleTeamSignIn = useCallback(() => {
+    const settings = readDenSettings();
+    platform.openLink(buildDenAuthUrl(settings.baseUrl || DEFAULT_DEN_BASE_URL, "sign-in"));
+  }, [platform]);
+
   const finishOnboarding = useCallback(() => {
     navigate(state.pendingRoute ?? "/session", { replace: true });
     if (state.pendingSessionId) focusPromptSoon();
@@ -336,6 +342,7 @@ export function WelcomeRoute() {
         onManualFolderChange={setManualFolder}
         onUseManualFolder={handleUseManualFolder}
         showManualFolder={import.meta.env.DEV && isDesktopRuntime()}
+        onTeamSignIn={handleTeamSignIn}
       />
       <CreateWorkspaceModal
         open={state.modalOpen}

--- a/ee/apps/den-api/src/CONSTS.ts
+++ b/ee/apps/den-api/src/CONSTS.ts
@@ -1,1 +1,2 @@
 export const DEN_WORKER_POLL_INTERVAL_MS = 1000
+export const OPENWORK_DOWNLOAD_URL = "https://openworklabs.com/download"

--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -20,6 +20,7 @@ import { buildOperationId, emptyResponse, htmlResponse, jsonResponse } from "./o
 import { registerAdminRoutes } from "./routes/admin/index.js"
 import { registerAuthRoutes } from "./routes/auth/index.js"
 import { registerBootstrapRoutes } from "./routes/bootstrap/index.js"
+import { registerDevRoutes } from "./routes/dev/index.js"
 import { registerMcpTokenRoutes } from "./routes/mcp/index.js"
 import { registerMemoryRoutes } from "./routes/memory/index.js"
 import { registerMeRoutes } from "./routes/me/index.js"
@@ -163,6 +164,7 @@ app.get(
 registerAdminRoutes(app)
 registerAuthRoutes(app)
 registerBootstrapRoutes(app)
+registerDevRoutes(app)
 registerMeRoutes(app)
 registerMemoryRoutes(app)
 registerOrgRoutes(app)

--- a/ee/apps/den-api/src/routes/dev/index.ts
+++ b/ee/apps/den-api/src/routes/dev/index.ts
@@ -1,0 +1,58 @@
+import type { EmailTemplate } from "@openwork/email"
+import type { Hono } from "hono"
+import { env } from "../../env.js"
+import { publicRoute } from "../../middleware/index.js"
+import type { AuthContextVariables } from "../../session.js"
+import { getLastDevEmail, listDevEmails } from "../../utils/email/send-email.js"
+
+function normalizeEmailTemplate(value: string | null): EmailTemplate | null | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  switch (value) {
+    case "verification":
+    case "passwordReset":
+    case "organizationInvite":
+    case "downloadLink":
+    case "feedback":
+      return value
+    default:
+      return null
+  }
+}
+
+export function registerDevRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
+  // Dev/eval-only email outbox. These endpoints intentionally 404 unless
+  // OPENWORK_DEV_MODE=1 so production deployments do not expose email HTML.
+  app.get("/v1/dev/emails", publicRoute, (c) => {
+    if (!env.devMode) {
+      return c.json({ error: "not_found" }, 404)
+    }
+
+    const template = normalizeEmailTemplate(c.req.query("template") ?? null)
+    if (template === null) {
+      return c.json({ error: "invalid_template" }, 400)
+    }
+
+    return c.json({ emails: listDevEmails(template) })
+  })
+
+  app.get("/v1/dev/emails/last", publicRoute, (c) => {
+    if (!env.devMode) {
+      return c.json({ error: "not_found" }, 404)
+    }
+
+    const template = normalizeEmailTemplate(c.req.query("template") ?? null)
+    if (template === null) {
+      return c.json({ error: "invalid_template" }, 400)
+    }
+
+    const email = getLastDevEmail(template)
+    if (!email) {
+      return c.json({ error: "email_not_found" }, 404)
+    }
+
+    return c.html(email.html)
+  })
+}

--- a/ee/apps/den-api/src/routes/me/index.ts
+++ b/ee/apps/den-api/src/routes/me/index.ts
@@ -1,10 +1,11 @@
 import { eq } from "@openwork-ee/den-db/drizzle"
-import { AuthAccountTable } from "@openwork-ee/den-db/schema"
-import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { AuthAccountTable, RateLimitTable } from "@openwork-ee/den-db/schema"
+import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { desktopConfigSchema } from "@openwork/types/den/desktop-policies"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
+import { OPENWORK_DOWNLOAD_URL } from "../../CONSTS.js"
 import { db } from "../../db.js"
 import { authenticatedRoute, jsonValidator, orgMemberRoute, type OrganizationContextVariables, type UserOrganizationsContext } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
@@ -12,6 +13,10 @@ import { normalizeOrganizationMetadata } from "../../organization-limits.js"
 import { resolveUserOrganizations, setSessionActiveOrganization } from "../../orgs.js"
 import type { AuthContextVariables } from "../../session.js"
 import { calculateDesktopPolicyForOrgMember } from "../../desktop-policies.js"
+import { DenEmailSendError, sendEmail } from "../../utils/email/send-email.js"
+
+const DOWNLOAD_LINK_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000
+const DOWNLOAD_LINK_RATE_LIMIT_MAX = 5
 
 const meResponseSchema = z.object({
   user: z.object({}).passthrough(),
@@ -30,6 +35,21 @@ const meOrganizationsResponseSchema = z.object({
 const meDesktopConfigResponseSchema = desktopConfigSchema.meta({
   ref: "CurrentUserDesktopConfigResponse",
 })
+
+const sendDownloadLinkResponseSchema = z.object({
+  ok: z.literal(true),
+}).meta({ ref: "SendDownloadLinkResponse" })
+
+const sendDownloadLinkRateLimitSchema = z.object({
+  error: z.literal("rate_limited"),
+  message: z.string(),
+}).meta({ ref: "SendDownloadLinkRateLimitError" })
+
+const sendDownloadLinkEmailFailedSchema = z.object({
+  error: z.literal("download_link_email_failed"),
+  reason: z.enum(["email_not_configured", "resend_rejected", "resend_network", "nodemailer_rejected"]),
+  message: z.string(),
+}).meta({ ref: "SendDownloadLinkEmailFailedError" })
 
 const setActiveOrganizationSchema = z.object({
   organizationId: denTypeIdSchema("organization").optional(),
@@ -55,6 +75,36 @@ function normalizeAuthProvider(providerId: string) {
     return "scim"
   }
   return normalized || "unknown"
+}
+
+async function checkDownloadLinkRateLimit(userId: string, now: number) {
+  const key = `me:send-download-link:${userId}`
+  const [row] = await db
+    .select({ id: RateLimitTable.id, count: RateLimitTable.count, lastRequest: RateLimitTable.lastRequest })
+    .from(RateLimitTable)
+    .where(eq(RateLimitTable.key, key))
+    .limit(1)
+
+  if (row && now - row.lastRequest <= DOWNLOAD_LINK_RATE_LIMIT_WINDOW_MS && row.count >= DOWNLOAD_LINK_RATE_LIMIT_MAX) {
+    return Math.max(1, Math.ceil((DOWNLOAD_LINK_RATE_LIMIT_WINDOW_MS - (now - row.lastRequest)) / 1000))
+  }
+
+  if (!row) {
+    await db.insert(RateLimitTable).values({
+      id: createDenTypeId("rateLimit"),
+      key,
+      count: 1,
+      lastRequest: now,
+    })
+    return null
+  }
+
+  await db
+    .update(RateLimitTable)
+    .set({ count: now - row.lastRequest > DOWNLOAD_LINK_RATE_LIMIT_WINDOW_MS ? 1 : row.count + 1, lastRequest: now })
+    .where(eq(RateLimitTable.id, row.id))
+
+  return null
 }
 
 export function registerMeRoutes<T extends { Variables: AuthContextVariables & Partial<UserOrganizationsContext> & Partial<OrganizationContextVariables> }>(app: Hono<T>) {
@@ -105,7 +155,7 @@ export function registerMeRoutes<T extends { Variables: AuthContextVariables & P
     }),
     orgMemberRoute({ useUserOrganizations: true }),
     (c) => {
-    const orgs = (c.get("userOrganizations") ?? []) as NonNullable<UserOrganizationsContext["userOrganizations"]>
+    const orgs: UserOrganizationsContext["userOrganizations"] = c.get("userOrganizations") ?? []
 
     return c.json({
       orgs: orgs.map((org) => ({
@@ -115,6 +165,63 @@ export function registerMeRoutes<T extends { Variables: AuthContextVariables & P
       activeOrgId: c.get("activeOrganizationId") ?? null,
       activeOrgSlug: c.get("activeOrganizationSlug") ?? null,
     })
+    },
+  )
+
+  app.post(
+    "/v1/me/send-download-link",
+    describeRoute({
+      tags: ["Users"],
+      summary: "Send current user the OpenWork desktop download link",
+      description: "Emails the authenticated user a link to download the OpenWork desktop app.",
+      responses: {
+        200: jsonResponse("Download link email sent successfully.", sendDownloadLinkResponseSchema),
+        400: jsonResponse("The signed-in account is missing an email address.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to request a download link.", unauthorizedSchema),
+        429: jsonResponse("The user has requested too many download links recently.", sendDownloadLinkRateLimitSchema),
+        502: jsonResponse("The download link email provider rejected or failed to deliver the email.", sendDownloadLinkEmailFailedSchema),
+      },
+    }),
+    authenticatedRoute(),
+    async (c) => {
+      const user = c.get("user")
+      const email = user.email?.trim()
+      if (!email) {
+        return c.json({ error: "user_email_required", message: "This account does not have an email address." }, 400)
+      }
+
+      const retryAfter = await checkDownloadLinkRateLimit(user.id, Date.now())
+      if (retryAfter !== null) {
+        c.header("Retry-After", String(retryAfter))
+        return c.json({ error: "rate_limited", message: "Too many download link emails. Try again later." }, 429)
+      }
+
+      try {
+        await sendEmail({
+          to: email,
+          template: "downloadLink",
+          props: {
+            downloadUrl: OPENWORK_DOWNLOAD_URL,
+          },
+        })
+      } catch (error) {
+        if (error instanceof DenEmailSendError) {
+          return c.json({
+            error: "download_link_email_failed",
+            reason: error.reason,
+            message:
+              error.reason === "email_not_configured"
+                ? "The download email provider is not configured on this deployment."
+                : error.reason === "resend_network"
+                  ? "Could not reach the download email provider. Try again later."
+                  : `The download email provider rejected the send${error.detail ? `: ${error.detail}` : "."}`,
+          }, 502)
+        }
+
+        throw error
+      }
+
+      return c.json({ ok: true })
     },
   )
 

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -5,6 +5,7 @@ import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { ORGANIZATION_AUDIT_ACTIONS, recordOrganizationAuditEvent } from "../../audit-events.js"
+import { OPENWORK_DOWNLOAD_URL } from "../../CONSTS.js"
 import { db } from "../../db.js"
 import { jsonValidator, orgRoleRoute, paramValidator } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
@@ -254,6 +255,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
           invitedByEmail: user.email ?? "",
           organizationName: payload.organization.name,
           role,
+          downloadUrl: OPENWORK_DOWNLOAD_URL,
         },
       })
     } catch (error) {

--- a/ee/apps/den-api/src/utils/email/send-email.ts
+++ b/ee/apps/den-api/src/utils/email/send-email.ts
@@ -1,29 +1,96 @@
-import { EmailSendError, sendEmail as sendSharedEmail, type EmailTemplate, type SendEmailInput } from "@openwork/email"
+import { EmailSendError, emailSubjects, renderEmailHtml, sendEmail as sendSharedEmail, type EmailTemplate, type SendEmailInput } from "@openwork/email"
 import { env } from "../../env.js"
 
 export { EmailSendError as DenEmailSendError }
 
-export function sendEmail<Template extends EmailTemplate>(
+export type DevEmailOutboxEntry = {
+  template: EmailTemplate
+  to: string
+  subject: string
+  html: string
+  at: string
+}
+
+export type DevEmailOutboxMetadata = Omit<DevEmailOutboxEntry, "html">
+
+const DEV_EMAIL_OUTBOX_MAX = 20
+const devEmailOutbox: DevEmailOutboxEntry[] = []
+
+// Dev/eval-only affordance: when OPENWORK_DEV_MODE=1, keep the last few
+// rendered emails in memory so UI evals can inspect real HTML without a mail
+// provider. Never expose or populate this buffer outside dev mode.
+function recordDevEmail(input: DevEmailOutboxEntry) {
+  if (!env.devMode) {
+    return
+  }
+
+  devEmailOutbox.push(input)
+  if (devEmailOutbox.length > DEV_EMAIL_OUTBOX_MAX) {
+    devEmailOutbox.splice(0, devEmailOutbox.length - DEV_EMAIL_OUTBOX_MAX)
+  }
+}
+
+export function listDevEmails(template?: EmailTemplate): DevEmailOutboxMetadata[] {
+  const entries = template
+    ? devEmailOutbox.filter((entry) => entry.template === template)
+    : devEmailOutbox
+
+  return entries
+    .slice()
+    .reverse()
+    .map((entry) => ({
+      template: entry.template,
+      to: entry.to,
+      subject: entry.subject,
+      at: entry.at,
+    }))
+}
+
+export function getLastDevEmail(template?: EmailTemplate): DevEmailOutboxEntry | null {
+  for (let index = devEmailOutbox.length - 1; index >= 0; index -= 1) {
+    const entry = devEmailOutbox[index]
+    if (!template || entry.template === template) {
+      return entry
+    }
+  }
+
+  return null
+}
+
+export async function sendEmail<Template extends EmailTemplate>(
   input: Omit<SendEmailInput<Template>, "config">,
 ) {
+  const to = input.to.trim()
+  const subject = input.subject ?? emailSubjects[input.template](input.props)
+
   console.info(
     `[email] sending template=${input.template} hasFrom=${Boolean(env.email.from)} hasResend=${Boolean(env.resend.apiKey)} hasSmtp=${Boolean(env.smtp.host)}`,
   )
 
-  return sendSharedEmail({
-    ...input,
-    config: {
-      devMode: env.devMode,
-      from: env.email.from,
-      resendApiKey: env.resend.apiKey,
-      smtp: env.smtp,
-    },
-  })
-    .then(() => {
-      console.info(`[email] sent template=${input.template}`)
+  if (env.devMode && to) {
+    recordDevEmail({
+      template: input.template,
+      to,
+      subject,
+      html: await renderEmailHtml(input.template, input.props),
+      at: new Date().toISOString(),
     })
-    .catch((error) => {
-      console.error(`[email] failed template=${input.template}`, error)
-      throw error
+  }
+
+  try {
+    await sendSharedEmail({
+      ...input,
+      subject,
+      config: {
+        devMode: env.devMode,
+        from: env.email.from,
+        resendApiKey: env.resend.apiKey,
+        smtp: env.smtp,
+      },
     })
+    console.info(`[email] sent template=${input.template}`)
+  } catch (error) {
+    console.error(`[email] failed template=${input.template}`, error)
+    throw error
+  }
 }

--- a/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
@@ -15,6 +15,12 @@ import {
 } from "../_lib/den-org";
 import { useDenFlow } from "../_providers/den-flow-provider";
 import { AuthPanel } from "./auth-panel";
+import { JoinOrgSuccess } from "./join-org-success";
+
+type JoinedOrg = {
+  name: string;
+  slug: string;
+};
 
 function LoadingCard({ title, body }: { title: string; body: string }) {
   return (
@@ -56,6 +62,19 @@ function formatAllowedDomains(allowedEmailDomains: readonly string[] | null | un
     : allowedEmailDomains.join(", ");
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getStringProperty(value: unknown, key: string) {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const property = value[key];
+  return typeof property === "string" ? property : null;
+}
+
 export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
   const router = useRouter();
   const { user, sessionHydrated, signOut } = useDenFlow();
@@ -64,6 +83,7 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [joinBusy, setJoinBusy] = useState(false);
   const [joinError, setJoinError] = useState<string | null>(null);
+  const [joinedOrg, setJoinedOrg] = useState<JoinedOrg | null>(null);
 
   const invitedEmailMatches = preview && user
     ? preview.invitation.email.trim().toLowerCase() === user.email.trim().toLowerCase()
@@ -167,9 +187,11 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
         window.sessionStorage.removeItem(PENDING_ORG_INVITATION_STORAGE_KEY);
       }
 
-      const acceptedPayload = typeof payload === "object" && payload ? payload as { organizationSlug?: unknown } : null;
-      const organizationSlug = typeof acceptedPayload?.organizationSlug === "string" ? acceptedPayload.organizationSlug.trim() : "";
-      router.replace(organizationSlug ? getOrgDashboardRoute(organizationSlug) : "/dashboard");
+      const organizationSlug = getStringProperty(payload, "organizationSlug")?.trim() || preview?.organization.slug || "";
+      setJoinedOrg({
+        name: preview?.organization.name ?? "your team",
+        slug: organizationSlug,
+      });
     } catch (error) {
       setJoinError(error instanceof Error ? error.message : "Could not join the organization.");
     } finally {
@@ -187,6 +209,15 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
 
   if (!sessionHydrated || previewBusy) {
     return <LoadingCard title="Loading invite." body="Checking the invite details and your account state..." />;
+  }
+
+  if (joinedOrg) {
+    return (
+      <JoinOrgSuccess
+        organizationName={joinedOrg.name}
+        onContinueInBrowser={() => router.replace(joinedOrg.slug ? getOrgDashboardRoute(joinedOrg.slug) : "/dashboard")}
+      />
+    );
   }
 
   if (!preview) {

--- a/ee/apps/den-web/app/(den)/_components/join-org-success.tsx
+++ b/ee/apps/den-web/app/(den)/_components/join-org-success.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getErrorMessage, requestJson } from "../_lib/den-flow";
+import { isMobileUserAgent } from "../_lib/platform";
+
+const OPENWORK_DOWNLOAD_URL = "https://openworklabs.com/download";
+
+const capabilities = [
+  {
+    title: "Edit spreadsheets",
+    description: "Create, clean, and transform CSV and Excel files.",
+  },
+  {
+    title: "Control your browser",
+    description: "Automate the built-in browser for repetitive web tasks.",
+  },
+  {
+    title: "Organize files",
+    description: "Read, write, and manage files and folders.",
+  },
+  {
+    title: "Automate tasks",
+    description: "Build reusable workflows with skills and commands.",
+  },
+  {
+    title: "Generate content",
+    description: "Draft documents, emails, and reports.",
+  },
+  {
+    title: "Connect to APIs",
+    description: "Plug into external services and tools via MCP.",
+  },
+];
+
+type JoinOrgSuccessProps = {
+  organizationName: string;
+  onContinueInBrowser: () => void;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getOpenworkUrl(payload: unknown): string | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const url = payload.openworkUrl;
+  return typeof url === "string" && url.trim() ? url.trim() : null;
+}
+
+export function JoinOrgSuccess({ organizationName, onContinueInBrowser }: JoinOrgSuccessProps) {
+  const [isMobile, setIsMobile] = useState<boolean | null>(null);
+  const [handoffBusy, setHandoffBusy] = useState(false);
+  const [handoffAttempted, setHandoffAttempted] = useState(false);
+  const [copyBusy, setCopyBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [emailBusy, setEmailBusy] = useState(false);
+  const [emailSent, setEmailSent] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setIsMobile(isMobileUserAgent());
+  }, []);
+
+  async function createDesktopHandoff() {
+    const { response, payload } = await requestJson(
+      "/v1/auth/desktop-handoff",
+      {
+        method: "POST",
+        body: JSON.stringify({ desktopScheme: "openwork" }),
+      },
+      12000,
+    );
+
+    if (!response.ok) {
+      throw new Error(getErrorMessage(payload, `Could not prepare a desktop sign-in link (${response.status}).`));
+    }
+
+    const openworkUrl = getOpenworkUrl(payload);
+    if (!openworkUrl) {
+      throw new Error("Desktop sign-in succeeded, but no app link was returned.");
+    }
+
+    return openworkUrl;
+  }
+
+  async function handleOpenOpenWork() {
+    setHandoffBusy(true);
+    setHandoffAttempted(true);
+    setActionError(null);
+
+    try {
+      window.location.assign(await createDesktopHandoff());
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Could not open OpenWork.");
+    } finally {
+      setHandoffBusy(false);
+    }
+  }
+
+  async function handleCopySignInLink() {
+    setCopyBusy(true);
+    setCopied(false);
+    setActionError(null);
+
+    try {
+      if (!navigator.clipboard) {
+        throw new Error("Clipboard is not available in this browser.");
+      }
+      await navigator.clipboard.writeText(await createDesktopHandoff());
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Could not copy the sign-in link.");
+    } finally {
+      setCopyBusy(false);
+    }
+  }
+
+  async function handleEmailDownload() {
+    setEmailBusy(true);
+    setActionError(null);
+
+    try {
+      const { response, payload } = await requestJson("/v1/me/send-download-link", { method: "POST" }, 12000);
+      if (!response.ok) {
+        setActionError(getErrorMessage(payload, `Could not send the download link (${response.status}).`));
+        return;
+      }
+      setEmailSent(true);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Could not send the download link.");
+    } finally {
+      setEmailBusy(false);
+    }
+  }
+
+  return (
+    <section className="den-page py-4 lg:py-6" data-testid="join-org-success">
+      <div className="den-frame grid max-w-[48rem] gap-6 p-6 md:p-8">
+        <div className="grid gap-2">
+          <p className="den-eyebrow">OpenWork Cloud</p>
+          <h1 className="den-title-xl max-w-[16ch]">You&apos;re in, welcome to {organizationName}</h1>
+          <p className="den-copy">The desktop app is where OpenWork runs on your computer and puts your team&apos;s setup to work.</p>
+        </div>
+
+        {isMobile === null ? (
+          <p className="den-copy">Preparing your next step...</p>
+        ) : isMobile ? (
+          <div className="grid gap-5">
+            <div className="den-frame-inset grid gap-2 rounded-[1.5rem] p-5" data-testid="join-org-mobile-note">
+              <p className="m-0 text-base font-medium text-[var(--dls-text-primary)]">OpenWork runs on your computer.</p>
+              <p className="den-copy">You&apos;re in — next time you&apos;re at your computer, download the desktop app to put your team to work.</p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <button
+                type="button"
+                className="den-button-primary w-full sm:w-auto"
+                onClick={() => void handleEmailDownload()}
+                disabled={emailBusy || emailSent}
+                data-testid="join-org-email-download"
+              >
+                {emailBusy ? "Sending..." : emailSent ? "Sent" : "Email me the download link"}
+              </button>
+            </div>
+            {emailSent ? <div className="den-notice is-info">Sent — check your inbox when you&apos;re back at your desk.</div> : null}
+          </div>
+        ) : (
+          <div className="grid gap-5">
+            <div className="grid gap-3 sm:grid-cols-2">
+              {capabilities.map((capability) => (
+                <div key={capability.title} className="den-frame-inset rounded-[1.25rem] p-4">
+                  <p className="m-0 text-sm font-medium text-[var(--dls-text-primary)]">{capability.title}</p>
+                  <p className="m-0 mt-1 text-xs leading-snug text-[var(--dls-text-secondary)]">{capability.description}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <button
+                type="button"
+                className="den-button-primary w-full sm:w-auto"
+                onClick={() => void handleOpenOpenWork()}
+                disabled={handoffBusy}
+                data-testid="join-org-open-openwork"
+              >
+                {handoffBusy ? "Opening OpenWork..." : "Open OpenWork"}
+              </button>
+              <a
+                href={OPENWORK_DOWNLOAD_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="den-button-secondary w-full sm:w-auto"
+                data-testid="join-org-download"
+              >
+                Download the desktop app
+              </a>
+            </div>
+
+            <button
+              type="button"
+              className="w-fit text-sm text-[var(--dls-text-secondary)] underline-offset-4 hover:underline"
+              onClick={() => void handleCopySignInLink()}
+              disabled={copyBusy}
+            >
+              {copyBusy ? "Copying..." : copied ? "Copied sign-in link" : "Copy sign-in link"}
+            </button>
+
+            {handoffAttempted && !actionError ? (
+              <p className="den-copy text-sm">Opening OpenWork now. If nothing happens, download the app or copy the sign-in link.</p>
+            ) : null}
+          </div>
+        )}
+
+        <button
+          type="button"
+          className="w-fit text-sm text-[var(--dls-text-secondary)] underline-offset-4 hover:underline"
+          onClick={onContinueInBrowser}
+          data-testid="join-org-continue-browser"
+        >
+          Continue in the browser
+        </button>
+
+        {actionError ? <div className="den-notice is-error">{actionError}</div> : null}
+      </div>
+    </section>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_lib/platform.ts
+++ b/ee/apps/den-web/app/(den)/_lib/platform.ts
@@ -1,0 +1,4 @@
+export function isMobileUserAgent(userAgent?: string | null) {
+  const value = userAgent ?? (typeof navigator !== "undefined" ? navigator.userAgent : "")
+  return /Android|iPhone|iPad|iPod/i.test(value)
+}

--- a/evals/flows/invite-to-desktop.flow.mjs
+++ b/evals/flows/invite-to-desktop.flow.mjs
@@ -1,0 +1,733 @@
+import { execSync } from "node:child_process";
+import { connect, debuggerUrlFor, listTargets } from "../runner/cdp.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/invite-to-desktop.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("invite-to-desktop");
+
+const DEN_API_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_API_URL);
+const DEN_WEB_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_WEB_URL);
+const ADMIN_CDP_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_WEB_CDP_ADMIN);
+const INVITEE_CDP_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_WEB_CDP_INVITEE);
+const MOBILE_CDP_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_WEB_CDP_MOBILE);
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MEMBER_PASSWORD = "OpenWorkDemo123!";
+const DOWNLOAD_URL = "https://openworklabs.com/download";
+const RUN_TAG = Date.now().toString(36);
+const MAYA_EMAIL = `maya+${RUN_TAG}@acme.test`;
+const RILEY_EMAIL = `riley+${RUN_TAG}@acme.test`;
+
+const state = {
+  desktopClient: null,
+  adminToken: null,
+  mayaInviteLink: null,
+  mayaInviteToken: null,
+  rileyInviteLink: null,
+  rileyInviteToken: null,
+  copiedDesktopUrl: null,
+};
+
+export default {
+  id: "invite-to-desktop",
+  title: "Invited teammates join Acme, get a desktop handoff, and receive mobile-safe download guidance",
+  kind: "user-facing",
+  requiredEnv: [
+    "OPENWORK_EVAL_DEN_API_URL",
+    "OPENWORK_EVAL_DEN_WEB_URL",
+    "OPENWORK_EVAL_DEN_TOKEN",
+    "OPENWORK_EVAL_WEB_CDP_ADMIN",
+    "OPENWORK_EVAL_WEB_CDP_INVITEE",
+    "OPENWORK_EVAL_WEB_CDP_MOBILE",
+    "OPENWORK_EVAL_MARK_VERIFIED_CMD",
+  ],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        rememberDesktopClient(ctx);
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
+        await ctx.prove("Maya's Acme invite is sent and visible as pending on Members", {
+          voiceover: vo[0],
+          action: async () => {
+            await ensureAdminToken(ctx);
+            await withClient(ctx, ADMIN_CDP_URL, async () => {
+              await signInToDenWeb(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+              await goToDenWeb(ctx, "/dashboard/members");
+              // Alex sends the invite through the real Members UI.
+              await clickExactText(ctx, "Add member", "button");
+              await ctx.fill('input[placeholder="teammate@example.com"]', MAYA_EMAIL);
+              await clickExactText(ctx, "Send invite", "button");
+              await ctx.waitForText(MAYA_EMAIL, { timeoutMs: 30_000 });
+              await ctx.waitForText("Pending", { timeoutMs: 20_000 });
+            });
+          },
+          assert: async () => {
+            await withClient(ctx, ADMIN_CDP_URL, async () => {
+              const invitation = await assertPendingInvitation(ctx, MAYA_EMAIL);
+              state.mayaInviteToken = invitation.inviteToken ?? state.mayaInviteToken;
+              await ctx.expectText(MAYA_EMAIL);
+              await ctx.expectText("Pending");
+            });
+          },
+          screenshot: { name: "maya-pending-invite", requireText: [MAYA_EMAIL, "Pending"] },
+        });
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
+        await ctx.prove("Maya's real invite email explains what the desktop app unlocks", {
+          voiceover: vo[1],
+          action: async () => {
+            await withClient(ctx, ADMIN_CDP_URL, async () => {
+              await navigateToAbsolute(ctx, `${DEN_API_URL}/v1/dev/emails/last?template=organizationInvite`);
+              await ctx.waitForText("Accept invite", { timeoutMs: 20_000 });
+            });
+          },
+          assert: async () => {
+            const { entry, html } = await getLatestDevEmail(ctx, "organizationInvite", MAYA_EMAIL);
+            ctx.assert(html.includes("Edit spreadsheets"), "Invite email is missing the desktop capability copy.");
+            ctx.assert(html.includes("Automate tasks"), "Invite email is missing Automate tasks.");
+            ctx.assert(html.includes("Download the desktop app"), "Invite email is missing the desktop download CTA.");
+            ctx.assert(html.includes("Accept invite"), "Invite email is missing Accept invite.");
+            ctx.assert(html.includes(DOWNLOAD_URL), `Invite email is missing ${DOWNLOAD_URL}.`);
+            const invite = extractInviteFromHtml(html, ctx);
+            state.mayaInviteToken = invite.token;
+            state.mayaInviteLink = rewriteInviteLink(invite.link);
+            ctx.output("maya-invite-email", JSON.stringify({ to: entry.to, subject: entry.subject, inviteLink: state.mayaInviteLink }, null, 2));
+            await withClient(ctx, ADMIN_CDP_URL, async () => {
+              await ctx.expectText("Edit spreadsheets");
+              await ctx.expectText("Automate tasks");
+              await ctx.expectText("Download the desktop app");
+              await ctx.expectText("Accept invite");
+            });
+          },
+          screenshot: {
+            name: "maya-invite-email",
+            requireText: ["Edit spreadsheets", "Automate tasks", "Download the desktop app", "Accept invite"],
+          },
+        });
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await withClient(ctx, INVITEE_CDP_URL, async () => {
+        await ctx.prove("Maya's laptop invite page shows Acme is ready and her role is set", {
+          voiceover: vo[2],
+          action: async () => {
+            await withClient(ctx, INVITEE_CDP_URL, async () => {
+              await clearDenWebSession(ctx);
+              await navigateToAbsolute(ctx, requireStateValue(state.mayaInviteLink, "Maya invite link"));
+              await ctx.waitForText("Acme Robotics", { timeoutMs: 30_000 });
+              await ctx.waitForText("Your team is already set up and waiting.", { timeoutMs: 20_000 });
+            });
+          },
+          assert: async () => {
+            await withClient(ctx, INVITEE_CDP_URL, async () => {
+              await ctx.expectText("Acme Robotics");
+              await ctx.expectText("Role");
+              await ctx.expectText("Your team is already set up and waiting.");
+            });
+          },
+          screenshot: {
+            name: "maya-laptop-join-page",
+            requireText: ["Acme Robotics", "Role", "Your team is already set up and waiting."],
+          },
+        });
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await withClient(ctx, INVITEE_CDP_URL, async () => {
+        await ctx.prove("Maya joins and lands on the desktop-app success step instead of the dashboard", {
+          voiceover: vo[3],
+          action: async () => {
+            await withClient(ctx, INVITEE_CDP_URL, async () => {
+              await completeInviteSignup(ctx, MAYA_EMAIL, MEMBER_PASSWORD);
+            });
+          },
+          assert: async () => {
+            await withClient(ctx, INVITEE_CDP_URL, async () => {
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))", { timeoutMs: 45_000, label: "join-org success" });
+              await ctx.expectText("You're in");
+              await ctx.expectText("Open OpenWork");
+              await ctx.expectText("Download the desktop app");
+              const pathname = await ctx.eval("location.pathname");
+              ctx.assert(typeof pathname === "string" && !pathname.startsWith("/dashboard"), `Join success redirected unexpectedly to ${pathname}.`);
+            });
+          },
+          screenshot: {
+            name: "maya-success-desktop-cta",
+            requireText: ["Open OpenWork", "Download the desktop app", "Edit spreadsheets"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("The desktop welcome screen offers a Joining a team sign-in affordance", {
+          voiceover: vo[4],
+          action: async () => {
+            useDesktopClient(ctx);
+            await ensureDesktopReady(ctx);
+            await showDesktopWelcome(ctx);
+          },
+          assert: async () => {
+            useDesktopClient(ctx);
+            await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"welcome-team-signin\"]'))", { timeoutMs: 30_000, label: "team sign-in affordance" });
+            const label = await ctx.eval("document.querySelector('[data-testid=\"welcome-team-signin\"]')?.textContent?.trim() ?? ''");
+            ctx.assert(label === "Joining a team? Sign in", `Unexpected welcome team sign-in label: ${label}`);
+            const disabled = await ctx.eval("document.querySelector('[data-testid=\"welcome-team-signin\"]')?.disabled === true");
+            ctx.assert(disabled === false, "Welcome team sign-in affordance is disabled.");
+            ctx.output(
+              "desktop-welcome-handler",
+              "WelcomeRoute.handleTeamSignIn calls platform.openLink(buildDenAuthUrl(settings.baseUrl || DEFAULT_DEN_BASE_URL, 'sign-in')); buildDenAuthUrl adds desktopAuth=1 and desktopScheme=openwork in desktop builds.",
+            );
+          },
+          screenshot: {
+            name: "desktop-welcome-team-signin",
+            requireText: ["Joining a team? Sign in"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("Maya clicks Open OpenWork and the Electron app signs into Acme", {
+          voiceover: vo[5],
+          action: async () => {
+            await withClient(ctx, INVITEE_CDP_URL, async () => {
+              await stubClipboardCapture(ctx);
+              await ctx.clickText("Copy sign-in link", { selector: "button", timeoutMs: 20_000 });
+              state.copiedDesktopUrl = await ctx.waitFor(
+                "typeof window.__capturedSignin === 'string' && window.__capturedSignin.startsWith('openwork://den-auth') && window.__capturedSignin",
+                { timeoutMs: 30_000, label: "captured OpenWork sign-in link" },
+              );
+              const clicked = await ctx.eval(`(() => {
+                const button = document.querySelector('[data-testid="join-org-open-openwork"]');
+                button?.scrollIntoView({ block: "center" });
+                button?.click();
+                return Boolean(button);
+              })()`);
+              ctx.assert(clicked, "Open OpenWork button was not available on Maya's success page.");
+            });
+
+            useDesktopClient(ctx);
+            await ensureDesktopReady(ctx);
+            await resetDesktopDenSession(ctx);
+            // Dev Electron does not register the OS openwork:// protocol handler;
+            // this delivers the exact copied URL through the same renderer bridge
+            // event shape used by the native deep-link bridge.
+            await deliverDeepLinkToDesktop(ctx, requireStateValue(state.copiedDesktopUrl, "copied desktop sign-in URL"));
+            ctx.output(
+              "desktop-deep-link-delivery",
+              "Dev Electron lacks OS protocol registration in evals, so the flow dispatches openwork:deep-link with { detail: { urls: [openworkUrl] } } — the same renderer bridge DenAuthProvider consumes.",
+            );
+          },
+          assert: async () => {
+            useDesktopClient(ctx);
+            await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", { timeoutMs: 60_000, label: "persisted Den auth token" });
+            await ctx.waitFor("(localStorage.getItem('openwork.den.activeOrgName') ?? '').includes('Acme Robotics')", { timeoutMs: 60_000, label: "Acme active org" });
+            // The handoff sign-in routes the app into org onboarding; walk the
+            // real journey (choose org -> resources -> workspace) before
+            // asserting the signed-in account surface.
+            await ctx.waitForText("Choose your organization", { timeoutMs: 45_000 });
+            await ctx.expectText("Acme Robotics");
+            await clickExactText(ctx, "Continue with organization", "button");
+            await ctx.waitForText("You have access to the following resources.", { timeoutMs: 45_000 });
+            await clickExactText(ctx, "Continue to workspace", "button");
+            await ctx.waitFor("location.hash.includes('/workspace/')", { timeoutMs: 45_000, label: "workspace route" });
+            await ctx.navigateHash("/settings/cloud-account");
+            await ctx.waitForText("Sign out", { timeoutMs: 45_000 });
+            await ctx.expectText("Acme Robotics", { timeoutMs: 45_000 });
+            await ctx.expectText(MAYA_EMAIL, { timeoutMs: 45_000 });
+          },
+          screenshot: {
+            name: "desktop-signed-into-acme",
+            requireText: ["Acme Robotics", MAYA_EMAIL, "Sign out"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 7",
+      run: async (ctx) => {
+        await withClient(ctx, MOBILE_CDP_URL, async () => {
+        await ctx.prove("Riley accepts the same Acme invite from a mobile browser", {
+          voiceover: vo[6],
+          action: async () => {
+            await createInvitation(ctx, RILEY_EMAIL);
+            const { html } = await getLatestDevEmail(ctx, "organizationInvite", RILEY_EMAIL);
+            const invite = extractInviteFromHtml(html, ctx);
+            state.rileyInviteToken = invite.token;
+            state.rileyInviteLink = rewriteInviteLink(invite.link);
+            await withClient(ctx, MOBILE_CDP_URL, async () => {
+              await applyMobileEmulation(ctx);
+              await clearDenWebSession(ctx);
+              await navigateToAbsolute(ctx, requireStateValue(state.rileyInviteLink, "Riley invite link"));
+              await completeInviteSignup(ctx, RILEY_EMAIL, MEMBER_PASSWORD);
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))", { timeoutMs: 45_000, label: "mobile join success" });
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-mobile-note\"]'))", { timeoutMs: 20_000, label: "mobile note" });
+            });
+          },
+          assert: async () => {
+            await withClient(ctx, MOBILE_CDP_URL, async () => {
+              await ctx.expectText("You're in");
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-mobile-note\"]'))", { timeoutMs: 20_000, label: "mobile note" });
+            });
+          },
+          screenshot: {
+            name: "riley-mobile-success",
+            requireText: ["You're in"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+        });
+      },
+    },
+    {
+      name: "Frame 8",
+      run: async (ctx) => {
+        await withClient(ctx, MOBILE_CDP_URL, async () => {
+        await ctx.prove("Mobile success is honest: email the link, no dead-end app open or download buttons", {
+          voiceover: vo[7],
+          action: async () => {
+            await withClient(ctx, MOBILE_CDP_URL, async () => {
+              await applyMobileEmulation(ctx);
+              await ctx.eval("document.querySelector('[data-testid=\"join-org-mobile-note\"]')?.scrollIntoView({ block: 'center' })");
+              // Step through the page as a keyboard user would; the real Tab
+              // keypress draws a :focus-visible ring on the primary action,
+              // which also keeps this frame visually distinct from frame 7.
+              await ctx.eval("document.body.focus()");
+              for (let presses = 0; presses < 6; presses += 1) {
+                await ctx.client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Tab", code: "Tab", windowsVirtualKeyCode: 9 });
+                await ctx.client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Tab", code: "Tab", windowsVirtualKeyCode: 9 });
+                const focused = await ctx.eval("document.activeElement?.getAttribute('data-testid') ?? ''");
+                if (focused === "join-org-email-download") break;
+              }
+            });
+          },
+          assert: async () => {
+            await withClient(ctx, MOBILE_CDP_URL, async () => {
+              await applyMobileEmulation(ctx);
+              await ctx.expectText("OpenWork runs on your computer.");
+              await ctx.expectText("Email me the download link");
+              await ctx.expectNoText("Open OpenWork");
+              const hiddenDesktopButtons = await ctx.eval(`(() => {
+                return document.querySelector('[data-testid="join-org-open-openwork"]') === null
+                  && document.querySelector('[data-testid="join-org-download"]') === null;
+              })()`);
+              ctx.assert(hiddenDesktopButtons, "Mobile success rendered a desktop-only open or download button.");
+            });
+          },
+          screenshot: {
+            name: "riley-mobile-honest-next-step",
+            requireText: ["OpenWork runs on your computer", "Email me the download link"],
+            rejectText: ["Open OpenWork", "Download the desktop app", "Something went wrong"],
+          },
+        });
+        });
+      },
+    },
+    {
+      name: "Frame 9",
+      run: async (ctx) => {
+        await withClient(ctx, MOBILE_CDP_URL, async () => {
+        await ctx.prove("Riley's download-link email is sent and shows the desktop value", {
+          voiceover: vo[8],
+          action: async () => {
+            await withClient(ctx, MOBILE_CDP_URL, async () => {
+              await applyMobileEmulation(ctx);
+              await clickSelector(ctx, '[data-testid="join-org-email-download"]', "email download button");
+              await ctx.waitForText("Sent — check your inbox", { timeoutMs: 20_000 });
+            });
+          },
+          assert: async () => {
+            const { entry, html } = await getLatestDevEmail(ctx, "downloadLink", RILEY_EMAIL);
+            ctx.assert(html.includes(DOWNLOAD_URL), `Download email is missing ${DOWNLOAD_URL}.`);
+            ctx.assert(html.includes("Download OpenWork"), "Download email is missing its primary heading/CTA.");
+            ctx.output("riley-download-email", JSON.stringify({ to: entry.to, subject: entry.subject }, null, 2));
+            await withClient(ctx, MOBILE_CDP_URL, async () => {
+              await applyMobileEmulation(ctx);
+              await navigateToAbsolute(ctx, `${DEN_API_URL}/v1/dev/emails/last?template=downloadLink`);
+              await ctx.waitForText("Download OpenWork", { timeoutMs: 20_000 });
+              await ctx.expectText("Edit spreadsheets");
+            });
+          },
+          screenshot: {
+            name: "riley-download-email",
+            requireText: ["Download OpenWork", "Edit spreadsheets"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+        });
+      },
+    },
+  ],
+};
+
+function cleanBaseUrl(value) {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
+function rememberDesktopClient(ctx) {
+  if (!state.desktopClient) {
+    state.desktopClient = ctx.client;
+  }
+}
+
+function useDesktopClient(ctx) {
+  rememberDesktopClient(ctx);
+  ctx.client = state.desktopClient;
+}
+
+function requireStateValue(value, label) {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  throw new Error(`${label} was not prepared by an earlier frame.`);
+}
+
+async function withClient(ctx, cdpBaseUrl, fn) {
+  const previous = ctx.client;
+  const target = await firstPageTarget(cdpBaseUrl);
+  const client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+  ctx.client = client;
+  try {
+    return await fn();
+  } finally {
+    ctx.client = previous;
+    // Close the extra websocket so the runner process can exit cleanly.
+    try {
+      client.close();
+    } catch {
+      // Socket already gone.
+    }
+  }
+}
+
+async function firstPageTarget(cdpBaseUrl) {
+  const existing = await listTargets(cdpBaseUrl);
+  const page = existing.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (page) {
+    return page;
+  }
+
+  const base = cdpBaseUrl.replace(/\/+$/, "");
+  let response = await fetch(`${base}/json/new?about:blank`, { method: "PUT" });
+  if (!response.ok) {
+    response = await fetch(`${base}/json/new?about:blank`);
+  }
+  if (!response.ok) {
+    throw new Error(`Could not create a page target at ${cdpBaseUrl}: ${response.status}`);
+  }
+  const created = await response.json();
+  if (created?.type === "page" && created.webSocketDebuggerUrl) {
+    return created;
+  }
+  const targets = await listTargets(cdpBaseUrl);
+  const nextPage = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (!nextPage) {
+    throw new Error(`No page target available at ${cdpBaseUrl}.`);
+  }
+  return nextPage;
+}
+
+async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      origin: DEN_WEB_URL || DEN_API_URL,
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body, text };
+}
+
+async function ensureAdminToken(ctx) {
+  if (state.adminToken) {
+    return state.adminToken;
+  }
+  const signedIn = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }),
+  });
+  if (signedIn.response.ok && typeof signedIn.body?.token === "string") {
+    state.adminToken = signedIn.body.token;
+    return state.adminToken;
+  }
+  const token = process.env.OPENWORK_EVAL_DEN_TOKEN?.trim() ?? "";
+  ctx.assert(token.length > 0, `Admin sign-in failed and OPENWORK_EVAL_DEN_TOKEN is missing: ${signedIn.response.status}`);
+  state.adminToken = token;
+  return token;
+}
+
+async function createInvitation(ctx, email) {
+  const token = await ensureAdminToken(ctx);
+  const invitation = await denApiFetch("/v1/invitations", {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+    body: JSON.stringify({ email, role: "member" }),
+  });
+  ctx.assert(
+    invitation.response.ok,
+    `Invitation failed for ${email}: ${invitation.response.status} ${JSON.stringify(invitation.body).slice(0, 300)}`,
+  );
+  if (email === MAYA_EMAIL && typeof invitation.body?.inviteToken === "string") {
+    state.mayaInviteToken = invitation.body.inviteToken;
+    state.mayaInviteLink = rewriteInviteLink(`/join-org?invite=${encodeURIComponent(invitation.body.inviteToken)}`);
+  }
+  if (email === RILEY_EMAIL && typeof invitation.body?.inviteToken === "string") {
+    state.rileyInviteToken = invitation.body.inviteToken;
+    state.rileyInviteLink = rewriteInviteLink(`/join-org?invite=${encodeURIComponent(invitation.body.inviteToken)}`);
+  }
+  return invitation.body;
+}
+
+async function assertPendingInvitation(ctx, email) {
+  const token = await ensureAdminToken(ctx);
+  const org = await denApiFetch("/v1/org", {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(org.response.ok, `Organization lookup failed: ${org.response.status}`);
+  const invitations = Array.isArray(org.body?.invitations) ? org.body.invitations : [];
+  const members = Array.isArray(org.body?.members) ? org.body.members : [];
+  const invitation = invitations.find((entry) => entry?.email === email && entry?.status === "pending") ?? null;
+  const pendingMember = members.find((member) => member?.user?.email === email && !member?.joinedAt) ?? null;
+  ctx.assert(Boolean(invitation || pendingMember), `No pending invitation for ${email} in /v1/org.`);
+  return invitation ?? pendingMember ?? {};
+}
+
+async function goToDenWeb(ctx, path) {
+  await navigateToAbsolute(ctx, `${DEN_WEB_URL}${path}`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${path}` });
+}
+
+async function navigateToAbsolute(ctx, url) {
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+}
+
+async function signInToDenWeb(ctx, email, password) {
+  await goToDenWeb(ctx, "/");
+  await ctx.eval(
+    `fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`,
+    { awaitPromise: true },
+  );
+  await goToDenWeb(ctx, "/");
+  await ctx.waitFor("document.body.innerText.includes('Sign in')", { timeoutMs: 30_000, label: "sign-in screen" });
+  await clickExactText(ctx, "Sign in", "button, a");
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"], input[name=\"email\"]'))", { timeoutMs: 15_000, label: "email input" });
+  await ctx.fill('input[type="email"], input[name="email"]', email);
+  await ctx.fill('input[type="password"]', password);
+  await clickLastExactText(ctx, "Sign in", "button");
+  await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 45_000, label: "dashboard after sign-in" });
+}
+
+async function clearDenWebSession(ctx) {
+  await goToDenWeb(ctx, "/");
+  await ctx.eval(
+    `fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).catch(() => null).then(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+      return true;
+    })`,
+    { awaitPromise: true },
+  );
+}
+
+async function clickExactText(ctx, text, selector) {
+  const clicked = await ctx.waitFor(`(() => {
+    const candidates = [...document.querySelectorAll(${JSON.stringify(selector)})];
+    const element = candidates.find((candidate) => (candidate.textContent ?? '').trim() === ${JSON.stringify(text)} && !candidate.disabled);
+    element?.scrollIntoView({ block: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: 20_000, label: `click exact text ${text}` });
+  return clicked;
+}
+
+async function clickLastExactText(ctx, text, selector) {
+  const clicked = await ctx.waitFor(`(() => {
+    const candidates = [...document.querySelectorAll(${JSON.stringify(selector)})]
+      .filter((candidate) => (candidate.textContent ?? '').trim() === ${JSON.stringify(text)} && !candidate.disabled);
+    const element = candidates[candidates.length - 1];
+    element?.scrollIntoView({ block: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: 20_000, label: `click last exact text ${text}` });
+  return clicked;
+}
+
+async function clickSelector(ctx, selector, label) {
+  await ctx.waitFor(`(() => {
+    const element = document.querySelector(${JSON.stringify(selector)});
+    element?.scrollIntoView({ block: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: 20_000, label });
+}
+
+async function completeInviteSignup(ctx, email, password) {
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", { timeoutMs: 30_000, label: "invite password field" });
+  await ctx.fill('input[type="password"]', password);
+  await ctx.clickText("Join Acme Robotics", { selector: "button", timeoutMs: 20_000 });
+  await ctx.waitFor(
+    `document.body.innerText.includes("You're one click away from the team workspace.") || Boolean(document.querySelector('[data-testid="join-org-success"]'))`,
+    { timeoutMs: 45_000, label: "signed in invite accept step" },
+  );
+  const alreadySuccess = await ctx.eval("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))");
+  if (!alreadySuccess) {
+    await ctx.expectText(email, { timeoutMs: 20_000 });
+    markEmailVerified(ctx, email);
+    await ctx.clickText("Join Acme Robotics", { selector: "button", timeoutMs: 20_000 });
+  }
+  await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))", { timeoutMs: 45_000, label: "join org success" });
+}
+
+function markEmailVerified(ctx, email) {
+  ctx.assert(
+    MARK_VERIFIED_CMD.length > 0,
+    "Invitation acceptance requires a verified email; set OPENWORK_EVAL_MARK_VERIFIED_CMD (shell template with {email}).",
+  );
+  execSync(MARK_VERIFIED_CMD.replaceAll("{email}", email), { stdio: "ignore" });
+}
+
+async function getLatestDevEmail(ctx, template, expectedTo) {
+  const listResponse = await fetch(`${DEN_API_URL}/v1/dev/emails?template=${encodeURIComponent(template)}`);
+  const listText = await listResponse.text();
+  ctx.assert(listResponse.ok, `Could not list ${template} emails: ${listResponse.status} ${listText.slice(0, 200)}`);
+  const list = JSON.parse(listText);
+  const emails = Array.isArray(list.emails) ? list.emails : [];
+  const entry = emails.find((candidate) => candidate?.to === expectedTo) ?? null;
+  ctx.assert(Boolean(entry), `No ${template} email found for ${expectedTo}.`);
+  ctx.assert(emails[0]?.to === expectedTo, `Latest ${template} email is ${emails[0]?.to ?? "none"}, expected ${expectedTo}.`);
+
+  const htmlResponse = await fetch(`${DEN_API_URL}/v1/dev/emails/last?template=${encodeURIComponent(template)}`);
+  const html = await htmlResponse.text();
+  ctx.assert(htmlResponse.ok, `Could not fetch latest ${template} email HTML: ${htmlResponse.status} ${html.slice(0, 200)}`);
+  return { entry, html };
+}
+
+function decodeHtmlAttribute(value) {
+  return value
+    .replaceAll("&amp;", "&")
+    .replaceAll("&#x2F;", "/")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'");
+}
+
+function extractInviteFromHtml(html, ctx) {
+  const absoluteMatch = html.match(/https?:\/\/[^"'<>\s]+\/join-org\?invite=[^"'<>\s]+/);
+  const relativeMatch = html.match(/\/join-org\?invite=[^"'<>\s]+/);
+  const rawLink = absoluteMatch?.[0] ?? relativeMatch?.[0] ?? "";
+  const link = decodeHtmlAttribute(rawLink);
+  ctx.assert(link.length > 0, "Invite email did not contain a /join-org?invite= link.");
+  const parsed = new URL(link, DEN_WEB_URL);
+  const token = parsed.searchParams.get("invite")?.trim() ?? "";
+  ctx.assert(token.length > 0, `Invite link did not include an invite token: ${link}`);
+  return { link: parsed.toString(), token };
+}
+
+function rewriteInviteLink(inviteLink) {
+  // The local stack's trusted-origin used to render email links can differ from
+  // the den-web origin the eval browser drives, so keep the path/search and
+  // explicitly trust OPENWORK_EVAL_DEN_WEB_URL for the browser navigation.
+  const parsed = new URL(inviteLink, DEN_WEB_URL);
+  return new URL(`${parsed.pathname}${parsed.search}${parsed.hash}`, DEN_WEB_URL).toString();
+}
+
+async function ensureDesktopReady(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "desktop control API" });
+}
+
+async function showDesktopWelcome(ctx) {
+  await ctx.eval(`(() => {
+    const raw = localStorage.getItem('openwork.preferences');
+    let prefs = {};
+    try { prefs = raw ? JSON.parse(raw) : {}; } catch { prefs = {}; }
+    localStorage.setItem('openwork.preferences', JSON.stringify({ ...prefs, hasCompletedOnboarding: false }));
+    location.hash = '#/welcome';
+    location.reload();
+    return true;
+  })()`);
+  await ensureDesktopReady(ctx);
+  await ctx.waitFor("location.hash.includes('/welcome')", { timeoutMs: 30_000, label: "welcome hash" });
+  await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"welcome-team-signin\"]'))", { timeoutMs: 30_000, label: "welcome team sign-in" });
+}
+
+async function stubClipboardCapture(ctx) {
+  await ctx.eval(`(() => {
+    window.__capturedSignin = '';
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText(value) {
+          window.__capturedSignin = String(value);
+          return Promise.resolve();
+        },
+      },
+    });
+    return true;
+  })()`);
+}
+
+async function deliverDeepLinkToDesktop(ctx, openworkUrl) {
+  await ctx.eval(`(() => {
+    const url = ${JSON.stringify(openworkUrl)};
+    window.__OPENWORK__ = window.__OPENWORK__ || {};
+    const pending = window.__OPENWORK__.deepLinks || [];
+    window.__OPENWORK__.deepLinks = [...pending, url];
+    window.dispatchEvent(new CustomEvent("openwork:deep-link", { detail: { urls: [url] } }));
+    return true;
+  })()`);
+}
+
+async function resetDesktopDenSession(ctx) {
+  await ctx.eval(`(() => {
+    for (const key of [
+      'openwork.den.authToken',
+      'openwork.den.activeOrgId',
+      'openwork.den.activeOrgSlug',
+      'openwork.den.activeOrgName',
+    ]) {
+      localStorage.removeItem(key);
+    }
+    window.dispatchEvent(new CustomEvent('openwork-den-session-updated', { detail: { status: 'signed_out' } }));
+    return true;
+  })()`);
+}
+
+async function applyMobileEmulation(ctx) {
+  await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 390,
+    height: 844,
+    deviceScaleFactor: 3,
+    mobile: true,
+  });
+  await ctx.client.send("Emulation.setUserAgentOverride", {
+    userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+  });
+}

--- a/evals/scripts/launch-web-profiles.mjs
+++ b/evals/scripts/launch-web-profiles.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const CHROME_BIN = process.env.CHROME_BIN?.trim() || "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const PROFILES = [
+  ["ADMIN", 9333],
+  ["INVITEE", 9334],
+  ["MOBILE", 9335],
+];
+
+async function isListening(port) {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(700) });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function alive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function killPidfile(userDataDir) {
+  const pidPath = join(userDataDir, "openwork-eval-chrome.pid");
+  let pid = 0;
+  try {
+    pid = Number((await readFile(pidPath, "utf8")).trim());
+  } catch {
+    return;
+  }
+  if (Number.isInteger(pid) && pid > 0 && alive(pid)) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {}
+  }
+}
+
+async function waitForPort(port) {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (await isListening(port)) return;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Chrome did not open CDP port ${port}.`);
+}
+
+async function ensureProfile(port) {
+  const userDataDir = `/tmp/openwork-evals-web-${port}`;
+  await mkdir(userDataDir, { recursive: true });
+  if (await isListening(port)) return;
+  await killPidfile(userDataDir);
+
+  const child = spawn(CHROME_BIN, [
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${userDataDir}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--disable-popup-blocking",
+    "about:blank",
+  ], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  await writeFile(join(userDataDir, "openwork-eval-chrome.pid"), `${child.pid}\n`);
+  await waitForPort(port);
+}
+
+for (const [, port] of PROFILES) {
+  await ensureProfile(port);
+}
+
+for (const [name, port] of PROFILES) {
+  console.log(`export OPENWORK_EVAL_WEB_CDP_${name}=http://127.0.0.1:${port}`);
+}

--- a/evals/voiceovers/invite-to-desktop.md
+++ b/evals/voiceovers/invite-to-desktop.md
@@ -1,0 +1,25 @@
+# invite-to-desktop — An invited teammate lands in a signed-in desktop app
+
+PR-1 of the invite-to-desktop experience: an enriched invite email that sells
+the desktop app, a post-accept "get the app" step with mobile-aware handling,
+a "send me the download link" email, and a "Joining a team? Sign in"
+affordance on the desktop welcome screen. Download CTAs point at the generic
+download page for now; the org-stamped installer is a follow-up PR.
+
+1. Alex runs Acme Robotics on OpenWork, and inviting Maya is one line on the team page — type her email, pick a role, send.
+
+2. Maya's invite is more than a join button — the email shows what she's actually getting: an AI coworker that edits spreadsheets, controls her browser, organizes files, and automates her team's workflows, with a link to download the desktop app.
+
+3. On her laptop, the invite link opens Acme's join page — her team is already set up and waiting, and joining is just picking a password.
+
+4. The moment she joins, OpenWork shows the one next step that matters: get the desktop app — everything it unlocks, a download button, and Open OpenWork if it's already installed.
+
+5. And the app meets her halfway — on its very first screen there's now Joining a team? Sign in, so even someone who downloads first is one click from their team.
+
+6. Back on the join page she clicks Open OpenWork, and the desktop app signs itself in to Acme Robotics — no retyped credentials, her team's workspace right there.
+
+7. Riley gets the same kind of invite but opens it on a phone — accepting works right from the couch, same team, no computer needed yet.
+
+8. OpenWork is honest about where it runs: on the phone there's no dead-end download button — it tells Riley to grab the app at a computer, and offers to email the link instead.
+
+9. One tap and the download email is on its way — platform links and everything the app unlocks, waiting in Riley's inbox at the next real keyboard.

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -6,12 +6,14 @@ export {
   type SendEmailInput,
   type SmtpEmailConfig,
 } from "./send-email.js"
+export { renderEmailHtml } from "./render-email.js"
 export {
   emailSubjects,
   emailReplyTo,
   renderEmailTemplate,
   type EmailTemplate,
   type EmailTemplateProps,
+  type DownloadLinkEmailProps,
   type FeedbackEmailProps,
   type OrganizationInviteEmailProps,
   type PasswordResetEmailProps,

--- a/packages/email/src/render-email.ts
+++ b/packages/email/src/render-email.ts
@@ -1,0 +1,9 @@
+import { render } from "@react-email/render"
+import { renderEmailTemplate, type EmailTemplate, type EmailTemplateProps } from "./templates/index.js"
+
+export function renderEmailHtml<Template extends EmailTemplate>(
+  template: Template,
+  props: EmailTemplateProps[Template],
+) {
+  return render(renderEmailTemplate(template, props))
+}

--- a/packages/email/src/templates/desktop-capabilities.ts
+++ b/packages/email/src/templates/desktop-capabilities.ts
@@ -1,0 +1,33 @@
+export const DEFAULT_OPENWORK_DOWNLOAD_URL = "https://openworklabs.com/download"
+
+export type DesktopCapability = {
+  title: string
+  description: string
+}
+
+export const desktopCapabilities: DesktopCapability[] = [
+  {
+    title: "Edit spreadsheets",
+    description: "Create, clean, and transform CSV and Excel files.",
+  },
+  {
+    title: "Control your browser",
+    description: "Automate the built-in browser for repetitive web tasks.",
+  },
+  {
+    title: "Organize files",
+    description: "Read, write, and manage files and folders.",
+  },
+  {
+    title: "Automate tasks",
+    description: "Build reusable workflows with skills and commands.",
+  },
+  {
+    title: "Generate content",
+    description: "Draft documents, emails, and reports.",
+  },
+  {
+    title: "Connect to APIs",
+    description: "Plug into external services and tools via MCP.",
+  },
+]

--- a/packages/email/src/templates/download-link.tsx
+++ b/packages/email/src/templates/download-link.tsx
@@ -1,0 +1,106 @@
+import type { CSSProperties } from "react"
+import { Body, Button, Container, Head, Heading, Html, Preview, Section, Text } from "@react-email/components"
+import { desktopCapabilities } from "./desktop-capabilities.js"
+
+export type DownloadLinkEmailProps = {
+  organizationName?: string
+  downloadUrl: string
+}
+
+export function DownloadLinkEmail({ organizationName, downloadUrl }: DownloadLinkEmailProps) {
+  const intro = organizationName
+    ? `Here's your link to download the OpenWork desktop app for ${organizationName}.`
+    : "Here's your link to download the OpenWork desktop app."
+
+  return (
+    <Html>
+      <Head />
+      <Preview>Your OpenWork download link</Preview>
+      <Body style={styles.body}>
+        <Container style={styles.container}>
+          <Text style={styles.eyebrow}>OpenWork desktop</Text>
+          <Heading style={styles.heading}>Download OpenWork</Heading>
+          <Text style={styles.text}>{intro}</Text>
+
+          <Section style={styles.capabilitiesBox}>
+            {desktopCapabilities.map((capability) => (
+              <Text key={capability.title} style={styles.capability}>
+                <strong>{capability.title}</strong> — {capability.description}
+              </Text>
+            ))}
+          </Section>
+
+          <Button href={downloadUrl} style={styles.button}>Download OpenWork</Button>
+          <Text style={styles.footer}>Signing in inside the app syncs your team&apos;s shared skills.</Text>
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+const styles = {
+  body: {
+    backgroundColor: "#f6f4ef",
+    color: "#171412",
+    fontFamily: "Arial, sans-serif",
+    margin: 0,
+  },
+  container: {
+    backgroundColor: "#fffdf8",
+    border: "1px solid #e8dfd0",
+    borderRadius: "20px",
+    margin: "40px auto",
+    maxWidth: "560px",
+    padding: "32px",
+  },
+  eyebrow: {
+    color: "#8a5a28",
+    fontSize: "13px",
+    fontWeight: 700,
+    letterSpacing: "0.08em",
+    margin: "0 0 12px",
+    textTransform: "uppercase",
+  },
+  heading: {
+    color: "#171412",
+    fontSize: "28px",
+    lineHeight: "34px",
+    margin: "0 0 16px",
+  },
+  text: {
+    color: "#4d4640",
+    fontSize: "16px",
+    lineHeight: "24px",
+    margin: "0 0 24px",
+  },
+  capabilitiesBox: {
+    backgroundColor: "#f8f1e6",
+    border: "1px solid #eadcc8",
+    borderRadius: "16px",
+    margin: "0 0 24px",
+    padding: "20px",
+  },
+  capability: {
+    color: "#4d4640",
+    fontSize: "14px",
+    lineHeight: "21px",
+    margin: "0 0 8px",
+  },
+  button: {
+    backgroundColor: "#171412",
+    borderRadius: "999px",
+    color: "#fff8eb",
+    display: "inline-block",
+    fontSize: "15px",
+    fontWeight: 700,
+    marginBottom: "24px",
+    padding: "13px 22px",
+    textDecoration: "none",
+  },
+  footer: {
+    color: "#756c62",
+    fontSize: "14px",
+    lineHeight: "21px",
+    margin: 0,
+  },
+} satisfies Record<string, CSSProperties>

--- a/packages/email/src/templates/index.ts
+++ b/packages/email/src/templates/index.ts
@@ -1,9 +1,11 @@
 import { createElement, type ReactElement } from "react"
+import { DownloadLinkEmail, type DownloadLinkEmailProps } from "./download-link.js"
 import { FeedbackEmail, type FeedbackEmailProps } from "./feedback.js"
 import { OrganizationInviteEmail, type OrganizationInviteEmailProps } from "./organization-invite.js"
 import { PasswordResetEmail, type PasswordResetEmailProps } from "./password-reset.js"
 import { VerificationEmail, type VerificationEmailProps } from "./verification.js"
 
+export type { DownloadLinkEmailProps } from "./download-link.js"
 export type { FeedbackEmailProps } from "./feedback.js"
 export type { OrganizationInviteEmailProps } from "./organization-invite.js"
 export type { PasswordResetEmailProps } from "./password-reset.js"
@@ -13,6 +15,7 @@ export type EmailTemplateProps = {
   verification: VerificationEmailProps
   passwordReset: PasswordResetEmailProps
   organizationInvite: OrganizationInviteEmailProps
+  downloadLink: DownloadLinkEmailProps
   feedback: FeedbackEmailProps
 }
 
@@ -22,6 +25,7 @@ export const emailSubjects: { [Template in EmailTemplate]: (props: EmailTemplate
   verification: ({ verificationCode }) => `Your OpenWork verification code is ${verificationCode}`,
   passwordReset: () => "Reset your OpenWork password",
   organizationInvite: ({ organizationName }) => `You're invited to join ${organizationName} on OpenWork`,
+  downloadLink: () => "Your OpenWork download link",
   feedback: ({ name, source }) => `OpenWork feedback from ${name}${source ? ` (${source})` : ""}`,
 }
 
@@ -29,23 +33,21 @@ export const emailReplyTo: { [Template in EmailTemplate]: (props: EmailTemplateP
   verification: () => undefined,
   passwordReset: () => undefined,
   organizationInvite: () => undefined,
+  downloadLink: () => undefined,
   feedback: ({ email }) => email,
+}
+
+const emailRenderers: { [Template in EmailTemplate]: (props: EmailTemplateProps[Template]) => ReactElement } = {
+  verification: (props) => createElement(VerificationEmail, props),
+  passwordReset: (props) => createElement(PasswordResetEmail, props),
+  organizationInvite: (props) => createElement(OrganizationInviteEmail, props),
+  downloadLink: (props) => createElement(DownloadLinkEmail, props),
+  feedback: (props) => createElement(FeedbackEmail, props),
 }
 
 export function renderEmailTemplate<Template extends EmailTemplate>(
   template: Template,
   props: EmailTemplateProps[Template],
 ): ReactElement {
-  switch (template) {
-    case "verification":
-      return createElement(VerificationEmail, props as EmailTemplateProps["verification"])
-    case "passwordReset":
-      return createElement(PasswordResetEmail, props as EmailTemplateProps["passwordReset"])
-    case "organizationInvite":
-      return createElement(OrganizationInviteEmail, props as EmailTemplateProps["organizationInvite"])
-    case "feedback":
-      return createElement(FeedbackEmail, props as EmailTemplateProps["feedback"])
-    default:
-      throw new Error(`Unknown email template: ${String(template)}`)
-  }
+  return emailRenderers[template](props)
 }

--- a/packages/email/src/templates/organization-invite.tsx
+++ b/packages/email/src/templates/organization-invite.tsx
@@ -1,4 +1,6 @@
-import { Body, Button, Container, Head, Heading, Hr, Html, Preview, Text } from "@react-email/components"
+import type { CSSProperties } from "react"
+import { Body, Button, Container, Head, Heading, Hr, Html, Preview, Section, Text } from "@react-email/components"
+import { DEFAULT_OPENWORK_DOWNLOAD_URL, desktopCapabilities } from "./desktop-capabilities.js"
 
 export type OrganizationInviteEmailProps = {
   inviteLink: string
@@ -6,6 +8,7 @@ export type OrganizationInviteEmailProps = {
   invitedByEmail: string
   organizationName: string
   role: string
+  downloadUrl?: string
 }
 
 export function OrganizationInviteEmail({
@@ -14,6 +17,7 @@ export function OrganizationInviteEmail({
   invitedByEmail,
   organizationName,
   role,
+  downloadUrl = DEFAULT_OPENWORK_DOWNLOAD_URL,
 }: OrganizationInviteEmailProps) {
   const inviter = invitedByEmail ? `${invitedByName} (${invitedByEmail})` : invitedByName
 
@@ -27,6 +31,15 @@ export function OrganizationInviteEmail({
           <Heading style={styles.heading}>Join {organizationName}</Heading>
           <Text style={styles.text}>{inviter} invited you to join {organizationName} as {articleFor(role)} {role}.</Text>
           <Button href={inviteLink} style={styles.button}>Accept invite</Button>
+          <Section style={styles.desktopSection}>
+            <Text style={styles.sectionHeading}>What you&apos;ll get in the OpenWork desktop app</Text>
+            {desktopCapabilities.map((capability) => (
+              <Text key={capability.title} style={styles.capability}>
+                <strong>{capability.title}</strong> — {capability.description}
+              </Text>
+            ))}
+            <Button href={downloadUrl} style={styles.secondaryButton}>Download the desktop app</Button>
+          </Section>
           <Hr style={styles.hr} />
           <Text style={styles.footer}>If the button does not work, paste this link into your browser:</Text>
           <Text style={styles.link}>{inviteLink}</Text>
@@ -61,7 +74,7 @@ const styles = {
     fontWeight: 700,
     letterSpacing: "0.08em",
     margin: "0 0 12px",
-    textTransform: "uppercase" as const,
+    textTransform: "uppercase",
   },
   heading: {
     color: "#171412",
@@ -85,6 +98,38 @@ const styles = {
     padding: "13px 22px",
     textDecoration: "none",
   },
+  desktopSection: {
+    backgroundColor: "#f8f1e6",
+    border: "1px solid #eadcc8",
+    borderRadius: "16px",
+    margin: "26px 0 0",
+    padding: "20px",
+  },
+  sectionHeading: {
+    color: "#171412",
+    fontSize: "16px",
+    fontWeight: 700,
+    lineHeight: "22px",
+    margin: "0 0 12px",
+  },
+  capability: {
+    color: "#4d4640",
+    fontSize: "14px",
+    lineHeight: "21px",
+    margin: "0 0 8px",
+  },
+  secondaryButton: {
+    backgroundColor: "#fffdf8",
+    border: "1px solid #d9c8af",
+    borderRadius: "999px",
+    color: "#5b3a18",
+    display: "inline-block",
+    fontSize: "14px",
+    fontWeight: 700,
+    marginTop: "8px",
+    padding: "11px 18px",
+    textDecoration: "none",
+  },
   hr: {
     borderColor: "#e8dfd0",
     margin: "28px 0 18px",
@@ -100,6 +145,6 @@ const styles = {
     fontSize: "13px",
     lineHeight: "19px",
     margin: 0,
-    wordBreak: "break-all" as const,
+    wordBreak: "break-all",
   },
-}
+} satisfies Record<string, CSSProperties>


### PR DESCRIPTION
## What

The invite → desktop journey, end to end (PR 1 of the invite-to-desktop track — generic download links; the org-stamped installer is a follow-up):

- **Invite email** (`organization-invite`) now shows what the desktop app unlocks (6 capabilities, same copy as the desktop welcome screen) + a **Download the desktop app** CTA. Props stay backward compatible.
- **New `downloadLink` email** + authenticated, rate-limited (5/h) `POST /v1/me/send-download-link`.
- **/join-org success step** (was: silent redirect to dashboard): capabilities grid, **Open OpenWork** (mints `/v1/auth/desktop-handoff` → `openwork://den-auth`, same proven pattern as workspace-claim), **Download**, **Copy sign-in link**, **Continue in the browser**.
- **Mobile** (UA-detected): no dead-end buttons — “OpenWork runs on your computer” + **Email me the download link**.
- **Desktop welcome screen**: quiet **“Joining a team? Sign in”** link wired to the existing browser-auth roundtrip (`desktopAuth=1`) — a vanilla install is no longer an empty vessel with cloud sign-in buried in settings.
- **Dev/eval-only email outbox** in den-api (404s unless `OPENWORK_DEV_MODE=1`): evals now assert on the real rendered email and drive the browser with the invite link extracted from it, instead of bypassing the inbox.

## Proof (fraimz)

9-frame validated run across four surfaces (admin web, invitee web, mobile-emulated web, dev Electron): admin invites via the real Members UI → email renders capabilities + download → invitee joins → success step → deep-link handoff signs the Electron app into Acme (org onboarding → workspace → settings shows *Signed in as maya+…* / *Sign out* / *Acme Robotics — Member*) → mobile accept → honest mobile step → download email delivered. Fraimz comment with all frames follows below.

Result: `PASSED — 9/9 frames`, `evals/results/2026-07-04T06-58-04-424Z/fraimz.html`.

## Tests run

- `pnpm --filter @openwork/email build` + `tsc --noEmit` — pass
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` — pass
- `pnpm --filter @openwork-ee/den-web exec tsc --noEmit` + `next build` — pass
- `pnpm --filter @openwork/app typecheck` — pass
- `pnpm evals --flow invite-to-desktop --stack den` (+ den-web prod build on :3005, 3 Chrome profiles via `evals/scripts/launch-web-profiles.mjs`, `OPENWORK_EVAL_MARK_VERIFIED_CMD` mysql template) — **PASSED, 9/9**

## Repro

```bash
pnpm evals --flow invite-to-desktop --stack den   # brings up MySQL + den-api + dev Electron
DEN_API_BASE=http://127.0.0.1:8790 DEN_AUTH_ORIGIN=http://localhost:8790 OPENWORK_DEV_MODE=1 pnpm --filter @openwork-ee/den-web start
node evals/scripts/launch-web-profiles.mjs        # 3 CDP Chrome profiles (9333/9334/9335)
# then re-run the first command with OPENWORK_EVAL_DEN_WEB_URL/WEB_CDP_*/MARK_VERIFIED_CMD set (see flow header)
```

## Notes

- den-web **dev** server (`next dev`) has a pre-existing client-hydration hang in this environment (reproduced with this branch's changes stashed); the eval runs den-web's **production** build. Not introduced here.
- Dev Electron doesn't register the OS `openwork://` handler; the flow delivers the captured deep link through the same renderer bridge event the OS path uses (noted honestly in the flow + fraimz output). The grant-exchange half is the same code path proven by `cloud-signin-handoff`.