### PR TITLE
fix(app): style native scrollbars to match the theme

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -317,6 +317,33 @@ select:disabled {
   cursor: not-allowed;
 }
 
+/* Native scrollbars: thin, pill-shaped, and theme-aware instead of the
+   OS default. The slate alpha tokens flip with the theme, so the thumb
+   stays a subtle translucent gray on both light and dark surfaces.
+   Elements that opt out (`no-scrollbar`, ScrollArea) are unaffected. */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--slate-a6);
+  border-radius: 9999px;
+  box-shadow: inset 0 0 0 1px var(--slate-a3);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--slate-a8);
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 @utility animate-spin-slow {
   animation: spin 3s linear infinite;
 }


### PR DESCRIPTION
## Summary

Fixes #2444

The desktop app currently renders the raw OS scrollbar — square corners, flat, visually out of place against the app design, most noticeably in long conversations and thinking sections.

This adds global WebKit scrollbar styling in `apps/app/src/app/index.css`, matching the spec in the issue:

- 8px wide (and 8px high for horizontal bars), always visible
- pill-shaped thumb (`border-radius: 9999px`) with a subtle inset border for depth
- transparent track and corner
- thumb color comes from the slate alpha tokens (`--slate-a6`, `--slate-a8` on hover), which the palette flips per theme — so it's a translucent dark gray on light surfaces and a translucent light gray on dark surfaces, rather than the issue's hardcoded `rgba(255,255,255,…)` which would only suit dark mode

Radix `ScrollArea` components draw their own scrollbars and `no-scrollbar` opt-outs hide theirs entirely; neither is affected by these rules.

## Testing

- `pnpm build` — clean; verified all five `::-webkit-scrollbar*` rules are present in the emitted CSS bundle
- `bun test tests/` — 110 pass, 0 fail
- CSS-only change; no runtime code paths touched

Could not capture a recording in this environment; the quickest manual check is opening any long conversation and comparing the scrollbar in both themes.