### PR TITLE
feat(skills): get-env-var (Infisical) and upload-photo (Vercel Blob)

### DIFF
--- a/.opencode/skills/get-env-var/SKILL.md
+++ b/.opencode/skills/get-env-var/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: get-env-var
+description: "get an env var, fetch a secret, missing env var, missing token/API key, load secrets from Infisical, infisical. Fetch secrets from the team's Infisical workspace into the shell environment so subsequent commands can use them."
+---
+
+# Skill: get-env-var
+
+Fetch a secret from the team's Infisical workspace into the current shell so the next command can use it.
+
+## When to use
+
+- A command or script needs an env var that is not set, such as `BLOB_READ_WRITE_TOKEN`.
+- A token, API key, or other secret is missing from the environment.
+- The user asks to load secrets from Infisical.
+
+## Setup (once per machine)
+
+- Install the CLI on macOS: `brew install infisical/get-cli/infisical`.
+- Check auth with `infisical user get`; if it fails, run `infisical login` and complete the browser flow.
+- For CI or other non-interactive runs, set `INFISICAL_TOKEN` from a machine identity; the CLI skips login when it is present.
+- This repo is already project-linked via tracked `.infisical.json` (`workspaceId: "e9f4542a-8714-46c3-a8fd-99d8cb370aeb"`, empty `defaultEnvironment`). From the repo root, `infisical` defaults to the `dev` environment slug when `--env` is omitted.
+
+## Fetch one secret into the environment
+
+Run from the repo root:
+
+```bash
+export NAME="$(infisical secrets get NAME --plain --silent)"
+```
+
+- Replace `NAME` with the secret name.
+- Add `--env <slug>` for a non-default environment; this repo defaults to `dev`.
+- Add `--path /some/folder` when secrets are organized in folders.
+
+## Inject everything into a command
+
+Run the command through Infisical so all project secrets are available only to that process:
+
+```bash
+infisical run -- <command>
+```
+
+## Rules
+
+- Never echo, print, or otherwise log secret values.
+- Never write secrets to files, logs, commit messages, PR bodies, or comments.
+- Only use `--plain` inside command substitution, as in `export NAME="$(...)"`.
+- If a secret does not exist, STOP and tell the user exactly which secret name and environment to add in Infisical; do not invent values.

--- a/.opencode/skills/upload-photo/SKILL.md
+++ b/.opencode/skills/upload-photo/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: upload-photo
+description: upload a photo/image/screenshot, host an image, get a public image URL, put images on Vercel Blob, embed images in a PR/comment/doc. Upload local images to Vercel Blob and print public URLs.
+---
+
+# Skill: upload-photo
+
+Upload local image files to Vercel Blob and return public URLs for sharing.
+
+## When to use
+
+Use whenever an image or screenshot needs a public URL, including PR comments, docs, and sharing.
+
+## Requires
+
+`BLOB_READ_WRITE_TOKEN` must be set in the environment. If it is missing, use the `get-env-var` skill to fetch it from Infisical:
+
+```bash
+export BLOB_READ_WRITE_TOKEN="$(infisical secrets get BLOB_READ_WRITE_TOKEN --plain --silent)"
+```
+
+## Upload
+
+Run the bundled script from the repo root:
+
+```bash
+node .opencode/skills/upload-photo/scripts/upload.mjs <file.png> [more files...] [--prefix <path/prefix>] [--stable]
+```
+
+It prints one public URL per line (`https://<store>.public.blob.vercel-storage.com/...`). `--prefix` defaults to `uploads/<YYYY-MM-DD>`. By default Vercel Blob appends a random suffix to the pathname for collision safety; `--stable` disables that (`x-add-random-suffix: 0`) for deterministic URLs, so overwrites are possible.
+
+## Embed
+
+Use Markdown:
+
+```markdown
+![alt](url)
+```
+
+Or HTML for size control in GitHub comments:
+
+```html
+<img src="url" width="700">
+```
+
+## Rules
+
+- Never log `BLOB_READ_WRITE_TOKEN`.
+- The store is public; do not upload anything sensitive.
+- Prefer PNG, JPEG, or WebP images.

--- a/.opencode/skills/upload-photo/scripts/upload.mjs
+++ b/.opencode/skills/upload-photo/scripts/upload.mjs
@@ -1,0 +1,120 @@
+import { basename } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+
+const usage = "Usage: node .opencode/skills/upload-photo/scripts/upload.mjs <file.png> [more files...] [--prefix <path/prefix>] [--stable]";
+
+function printUsage(message = null) {
+  if (message) console.error(message);
+  console.error(usage);
+}
+
+function parseArgs(argv) {
+  const files = [];
+  let prefix = `uploads/${new Date().toISOString().slice(0, 10)}`;
+  let stable = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--stable") {
+      stable = true;
+      continue;
+    }
+    if (arg === "--prefix") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) return null;
+      prefix = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--")) return null;
+    files.push(arg);
+  }
+
+  if (files.length === 0) return null;
+  return { files, prefix, stable };
+}
+
+function contentTypeFor(file) {
+  const lower = file.toLowerCase();
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  if (lower.endsWith(".gif")) return "image/gif";
+  if (lower.endsWith(".webp")) return "image/webp";
+  if (lower.endsWith(".svg")) return "image/svg+xml";
+  if (lower.endsWith(".avif")) return "image/avif";
+  return "application/octet-stream";
+}
+
+function encodePathname(pathname) {
+  return pathname.split("/").map((segment) => encodeURIComponent(segment)).join("/");
+}
+
+function buildPathname(prefix, file) {
+  const cleanPrefix = prefix.replace(/^\/+|\/+$/g, "");
+  return encodePathname([cleanPrefix, basename(file)].filter(Boolean).join("/"));
+}
+
+async function uploadFile({ file, prefix, stable, token }) {
+  if (!existsSync(file)) {
+    console.error(`File does not exist: ${file}`);
+    return 1;
+  }
+
+  const pathname = buildPathname(prefix, file);
+  const headers = {
+    authorization: `Bearer ${token}`,
+    "x-content-type": contentTypeFor(file),
+  };
+  if (stable) headers["x-add-random-suffix"] = "0";
+
+  const response = await fetch(`https://blob.vercel-storage.com/${pathname}`, {
+    method: "PUT",
+    headers,
+    body: readFileSync(file),
+  });
+
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 300);
+    console.error(`Upload failed (${response.status}) for ${file}: ${detail}`);
+    return 1;
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    console.error(`Upload failed for ${file}: response was not JSON`);
+    return 1;
+  }
+
+  if (!payload || typeof payload.url !== "string" || payload.url.length === 0) {
+    console.error(`Upload failed for ${file}: response did not include url`);
+    return 1;
+  }
+
+  console.log(payload.url);
+  return 0;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args) {
+    printUsage();
+    return 1;
+  }
+
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) {
+    console.error("BLOB_READ_WRITE_TOKEN is not set — fetch it with the get-env-var skill: export BLOB_READ_WRITE_TOKEN=\"$(infisical secrets get BLOB_READ_WRITE_TOKEN --plain --silent)\"");
+    return 1;
+  }
+
+  for (const file of args.files) {
+    const status = await uploadFile({ file, prefix: args.prefix, stable: args.stable, token });
+    if (status !== 0) return status;
+  }
+
+  return 0;
+}
+
+process.exitCode = await main();


### PR DESCRIPTION
## What

Two small skills, split out from the connections-beta work (the pr.mjs screenshot-embedding change already landed in dev via #2468's squash-merge — this PR is just the two skills that were pushed after that merge):

### `get-env-var`
Fetches secrets from the team's Infisical workspace into the shell. This repo is already project-linked via the tracked `.infisical.json` (`workspaceId: e9f4542a-…`), so from the repo root:
```bash
export NAME="$(infisical secrets get NAME --plain --silent)"
```
Covers CLI install, `infisical login` / `INFISICAL_TOKEN` for CI, `infisical run -- <cmd>` to inject everything, and hard rules (never print/log/commit secret values; stop and ask if a secret doesn't exist rather than inventing one).

### `upload-photo`
Zero-dependency Node script that PUTs an image to Vercel Blob and prints its public URL, for embedding screenshots in PR comments/docs. If `BLOB_READ_WRITE_TOKEN` isn't set, it points at the `get-env-var` skill to fetch it from Infisical first.
```bash
node .opencode/skills/upload-photo/scripts/upload.mjs shot.png [--prefix path] [--stable]
```

## Tests run
- `node --check .opencode/skills/upload-photo/scripts/upload.mjs` — pass
- No-args run → usage + exit 1 — pass
- Missing-token run → points to the `get-env-var` skill, exit 1 — pass
- Live request against the real Vercel Blob API with a deliberately fake token → clean `store_not_found` rejection, confirming the endpoint, headers, and token format are wired correctly

Full `infisical login` + a real `BLOB_READ_WRITE_TOKEN` upload is blocked on this machine needing an interactive browser login and the token existing in the workspace — noted as the remaining manual step, not simulated.

This is docs/tooling only (skills + a standalone script), no product code touched.