### PR TITLE
feat(landing): anonymous analytics for the Copy Prompt install funnel

### DIFF
--- a/ee/apps/landing/app/layout.tsx
+++ b/ee/apps/landing/app/layout.tsx
@@ -4,6 +4,7 @@ import Script from "next/script";
 import { BotIdClient } from "botid/client";
 import { WebMcpProvider } from "../components/webmcp-provider";
 import { StructuredData } from "../components/structured-data";
+import { POSTHOG_PROJECT_KEY } from "../lib/posthog-client";
 
 const organizationSchema = {
   "@context": "https://schema.org",
@@ -71,7 +72,7 @@ export default function RootLayout({
           strategy="beforeInteractive"
           dangerouslySetInnerHTML={{
             __html: `!function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init rs ls wi ns us ts ss capture calculateEventProperties vs register register_once register_for_session unregister unregister_for_session gs getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty fs ds createPersonProfile setInternalOrTestUser ps Qr opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing hs debug M cs getPageViewId captureTraceFeedback captureTraceMetric Kr".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('phc_4YnPTlDVYPjgwKvLuNxhbHjV5kadgvd7XLzVHWnCXAI', {
+    posthog.init('${POSTHOG_PROJECT_KEY}', {
         api_host: 'https://us.i.posthog.com',
         defaults: '2025-11-30',
         person_profiles: 'identified_only',

--- a/ee/apps/landing/app/start.md/route.ts
+++ b/ee/apps/landing/app/start.md/route.ts
@@ -1,3 +1,8 @@
+import { capturePosthogServerEvent } from "../../lib/posthog-server";
+
+// Force per-request execution so start-guide fetch counts stay accurate.
+export const dynamic = "force-dynamic";
+
 const startMarkdown = [
   "# OpenWork Start",
   "",
@@ -139,7 +144,14 @@ const startMarkdown = [
   "",
 ].join("\n");
 
-export function GET() {
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  await capturePosthogServerEvent("landing_start_md_fetched", {
+    variant: url.searchParams.get("v"),
+    user_agent: request.headers.get("user-agent"),
+    referer: request.headers.get("referer")
+  });
+
   return new Response(startMarkdown, {
     headers: {
       "content-type": "text/markdown; charset=utf-8",

--- a/ee/apps/landing/components/copy-prompt-button.tsx
+++ b/ee/apps/landing/components/copy-prompt-button.tsx
@@ -20,9 +20,10 @@
  */
 
 import { useEffect, useRef, useState } from "react";
+import { capturePosthogEvent } from "../lib/posthog-client";
 
-const AGENT_START_PROMPT =
-  "Read https://openworklabs.com/start.md?v=bootstrap-workspace then install OpenWork, prepare my first workspace, and prove it is ready.";
+const PROMPT_VARIANT = "bootstrap-workspace";
+const AGENT_START_PROMPT = `Read https://openworklabs.com/start.md?v=${PROMPT_VARIANT} then install OpenWork, prepare my first workspace, and prove it is ready.`;
 
 export function CopyPromptButton({ className }: { className?: string }) {
   const [feedback, setFeedback] = useState(false);
@@ -37,9 +38,11 @@ export function CopyPromptButton({ className }: { className?: string }) {
 
   const onClick = async () => {
     let copied = false;
+    let method: "clipboard" | "execCommand" | "none" = "none";
     try {
       await navigator.clipboard.writeText(AGENT_START_PROMPT);
       copied = true;
+      method = "clipboard";
     } catch {
       const textarea = document.createElement("textarea");
       textarea.value = AGENT_START_PROMPT;
@@ -49,11 +52,13 @@ export function CopyPromptButton({ className }: { className?: string }) {
       textarea.select();
       try {
         copied = document.execCommand("copy");
+        if (copied) method = "execCommand";
       } catch {}
       textarea.remove();
     }
     setCopyError(!copied);
     setFeedback(true);
+    capturePosthogEvent("landing_copy_prompt_clicked", { copied, method, variant: PROMPT_VARIANT });
     if (resetTimer.current) clearTimeout(resetTimer.current);
     resetTimer.current = setTimeout(() => {
       setFeedback(false);

--- a/ee/apps/landing/lib/posthog-client.ts
+++ b/ee/apps/landing/lib/posthog-client.ts
@@ -1,0 +1,23 @@
+type PosthogClient = {
+  capture?: (event: string, properties?: Record<string, unknown>) => void;
+};
+
+declare global {
+  interface Window {
+    posthog?: PosthogClient;
+  }
+}
+
+export const POSTHOG_PROJECT_KEY = "phc_4YnPTlDVYPjgwKvLuNxhbHjV5kadgvd7XLzVHWnCXAI";
+
+export function capturePosthogEvent(event: string, properties?: Record<string, unknown>): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.posthog?.capture?.(event, properties);
+  } catch {
+    // Ignore analytics delivery failures.
+  }
+}

--- a/ee/apps/landing/lib/posthog-server.ts
+++ b/ee/apps/landing/lib/posthog-server.ts
@@ -1,0 +1,32 @@
+import { POSTHOG_PROJECT_KEY } from "./posthog-client";
+
+const POSTHOG_SERVER_TIMEOUT_MS = 400;
+
+export async function capturePosthogServerEvent(event: string, properties: Record<string, unknown>): Promise<void> {
+  if (process.env.VERCEL_ENV !== "production" && !process.env.LANDING_POSTHOG_HOST) {
+    return;
+  }
+
+  const host = process.env.LANDING_POSTHOG_HOST?.trim() || "https://us.i.posthog.com";
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), POSTHOG_SERVER_TIMEOUT_MS);
+
+  try {
+    await fetch(`${host}/i/v0/e/`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      signal: controller.signal,
+      body: JSON.stringify({
+        api_key: POSTHOG_PROJECT_KEY,
+        event,
+        // Random per-event ID plus disabled person processing keeps captures anonymous and unlinkable.
+        distinct_id: crypto.randomUUID(),
+        properties: { ...properties, $process_person_profile: false }
+      })
+    });
+  } catch {
+    // Ignore analytics delivery failures.
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/evals/drivers/posthog-capture-mock.mjs
+++ b/evals/drivers/posthog-capture-mock.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Tiny PostHog capture mock.
+ *
+ * Usage:
+ *   node evals/drivers/posthog-capture-mock.mjs --port 19877
+ *   LANDING_POSTHOG_HOST=http://127.0.0.1:19877 pnpm --dir ee/apps/landing dev
+ */
+
+import { createServer } from "node:http";
+
+const DEFAULT_PORT = 19877;
+const events = [];
+
+function selectedPort() {
+  const index = process.argv.indexOf("--port");
+  const value = index === -1 ? process.env.POSTHOG_MOCK_PORT : process.argv[index + 1];
+  return Number(value ?? DEFAULT_PORT);
+}
+
+function sendJson(response, statusCode, body) {
+  response.writeHead(statusCode, {
+    "access-control-allow-origin": "*",
+    "access-control-allow-methods": "GET,POST,DELETE,OPTIONS",
+    "access-control-allow-headers": "content-type",
+    "content-type": "application/json; charset=utf-8"
+  });
+  response.end(JSON.stringify(body));
+}
+
+function readJson(request, response) {
+  let body = "";
+  request.setEncoding("utf8");
+  request.on("data", (chunk) => {
+    body += chunk;
+    if (body.length > 1_000_000) request.destroy();
+  });
+  request.on("end", () => {
+    try {
+      events.push(body ? JSON.parse(body) : {});
+      sendJson(response, 200, { status: 1 });
+    } catch {
+      sendJson(response, 400, { status: 0, error: "invalid_json" });
+    }
+  });
+}
+
+const server = createServer((request, response) => {
+  const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "127.0.0.1"}`);
+  const method = request.method ?? "GET";
+
+  if (method === "OPTIONS") {
+    sendJson(response, 204, {});
+    return;
+  }
+
+  if (url.pathname === "/i/v0/e/" && method === "POST") {
+    readJson(request, response);
+    return;
+  }
+
+  if (url.pathname === "/events" && method === "GET") {
+    sendJson(response, 200, events);
+    return;
+  }
+
+  if (url.pathname === "/events" && method === "DELETE") {
+    events.length = 0;
+    sendJson(response, 200, { status: 1 });
+    return;
+  }
+
+  sendJson(response, 404, { status: 0, error: "not_found" });
+});
+
+const port = selectedPort();
+
+if (!Number.isInteger(port) || port <= 0) {
+  throw new Error(`Invalid port: ${port}`);
+}
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`PostHog capture mock listening at http://127.0.0.1:${port}`);
+});

--- a/evals/flows/landing-copy-prompt-analytics.flow.mjs
+++ b/evals/flows/landing-copy-prompt-analytics.flow.mjs
@@ -78,13 +78,22 @@ export default {
               `Boolean(document.querySelector(${JSON.stringify(COPY_BUTTON_SELECTOR)}))`,
               { timeoutMs: 30_000, label: "Copy Prompt nav button" },
             );
+            // Freeze the recording stub onto window.posthog: PostHog's async
+            // array.js loader assigns window.posthog when it arrives, and on a
+            // fresh navigation that write can land after this step. A frozen
+            // property makes the late assignment a silent no-op, so captures
+            // deterministically reach the stub (and never real PostHog).
             await ctx.eval(`(() => {
               window.__capturedPosthogEvents = [];
-              window.posthog = {
-                capture: (event, properties) => {
-                  window.__capturedPosthogEvents.push({ event, properties });
+              Object.defineProperty(window, "posthog", {
+                value: {
+                  capture: (event, properties) => {
+                    window.__capturedPosthogEvents.push({ event, properties });
+                  },
                 },
-              };
+                writable: false,
+                configurable: false,
+              });
               return true;
             })()`);
             await grantClipboardPermissions(ctx);
@@ -99,7 +108,7 @@ export default {
                 const events = window.__capturedPosthogEvents || [];
                 return events.some((entry) => entry.event === ${JSON.stringify(POSTHOG_CLIENT_EVENT)}) && Boolean(document.querySelector('[data-feedback="true"]'));
               })()`,
-              { timeoutMs: 5_000, label: "client PostHog event and feedback state" },
+              { timeoutMs: 10_000, label: "client PostHog event and feedback state" },
             );
             // Let the 200ms copy-feedback morph settle so the frame shows a
             // clean "Copied" state instead of overlapping transition labels.

--- a/evals/flows/landing-copy-prompt-analytics.flow.mjs
+++ b/evals/flows/landing-copy-prompt-analytics.flow.mjs
@@ -1,0 +1,223 @@
+const COPY_BUTTON_SELECTOR = 'button[aria-label="Copy the agent setup prompt"]';
+const POSTHOG_CLIENT_EVENT = "landing_copy_prompt_clicked";
+const POSTHOG_SERVER_EVENT = "landing_start_md_fetched";
+const PROMPT_VARIANT = "bootstrap-workspace";
+const AGENT_USER_AGENT = "fraimz-eval-agent/1.0";
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function routeUrl(ctx, path) {
+  return new URL(path, ctx.env.OPENWORK_EVAL_LANDING_URL).toString();
+}
+
+function mockUrl(ctx, path) {
+  return new URL(path, ctx.env.OPENWORK_EVAL_POSTHOG_MOCK_URL).toString();
+}
+
+function recordAssertion(ctx, assertion, passed, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: passed ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(passed, `${assertion}. Actual: ${JSON.stringify(actual)}`);
+}
+
+async function readMockEvents(ctx) {
+  const response = await fetch(mockUrl(ctx, "/events"));
+  const body = await response.json();
+  return Array.isArray(body) ? body : [];
+}
+
+async function waitForMockEvents(ctx, eventName, minimumCount) {
+  const startedAt = Date.now();
+  let latestMatches = [];
+  while (Date.now() - startedAt < 5_000) {
+    const events = await readMockEvents(ctx);
+    latestMatches = events.filter((event) => event?.event === eventName);
+    if (latestMatches.length >= minimumCount) return latestMatches;
+    await sleep(250);
+  }
+  return latestMatches;
+}
+
+async function grantClipboardPermissions(ctx) {
+  if (!ctx.client?.send) {
+    ctx.log("Clipboard permission grant skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  const origin = new URL(ctx.env.OPENWORK_EVAL_LANDING_URL).origin;
+  await ctx.client.send("Browser.grantPermissions", {
+    origin,
+    permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
+  }).catch((error) => {
+    ctx.log(`Clipboard permission grant skipped: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+export default {
+  id: "landing-copy-prompt-analytics",
+  title: "Landing Copy Prompt analytics fire end-to-end",
+  kind: "user-facing",
+  spec: "evals/README.md",
+  // The landing website has no theme system or __openworkControl API; skip the
+  // desktop-app light-mode bootstrap instead of waiting for it to time out.
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_LANDING_URL", "OPENWORK_EVAL_POSTHOG_MOCK_URL"],
+  steps: [
+    {
+      name: "Copy Prompt click captures the analytics event",
+      run: async (ctx) => {
+        await ctx.prove("Copy Prompt click captures the analytics event.", {
+          action: async () => {
+            await ctx.eval(`location.href = ${JSON.stringify(routeUrl(ctx, "/"))}; true`);
+            await ctx.waitFor(
+              `Boolean(document.querySelector(${JSON.stringify(COPY_BUTTON_SELECTOR)}))`,
+              { timeoutMs: 30_000, label: "Copy Prompt nav button" },
+            );
+            await ctx.eval(`(() => {
+              window.__capturedPosthogEvents = [];
+              window.posthog = {
+                capture: (event, properties) => {
+                  window.__capturedPosthogEvents.push({ event, properties });
+                },
+              };
+              return true;
+            })()`);
+            await grantClipboardPermissions(ctx);
+            await ctx.eval(`(() => {
+              const button = document.querySelector(${JSON.stringify(COPY_BUTTON_SELECTOR)});
+              button.scrollIntoView({ block: "center" });
+              button.click();
+              return true;
+            })()`);
+            await ctx.waitFor(
+              `(() => {
+                const events = window.__capturedPosthogEvents || [];
+                return events.some((entry) => entry.event === ${JSON.stringify(POSTHOG_CLIENT_EVENT)}) && Boolean(document.querySelector('[data-feedback="true"]'));
+              })()`,
+              { timeoutMs: 5_000, label: "client PostHog event and feedback state" },
+            );
+            // Let the 200ms copy-feedback morph settle so the frame shows a
+            // clean "Copied" state instead of overlapping transition labels.
+            await sleep(400);
+          },
+          assert: async () => {
+            const clientCapture = await ctx.eval(`(() => {
+              const events = window.__capturedPosthogEvents || [];
+              const matches = events.filter((entry) => entry.event === ${JSON.stringify(POSTHOG_CLIENT_EVENT)});
+              return {
+                count: matches.length,
+                event: matches[0] || null,
+                feedbackActive: Boolean(document.querySelector('[data-feedback="true"]')),
+              };
+            })()`);
+            ctx.recordEvidence({
+              type: "output",
+              name: "Captured client PostHog event",
+              text: JSON.stringify(clientCapture.event, null, 2),
+            });
+
+            const properties = clientCapture.event?.properties ?? {};
+            const method = properties.method;
+            recordAssertion(
+              ctx,
+              "Exactly one landing_copy_prompt_clicked event was captured with variant, copied, and method properties",
+              clientCapture.count === 1
+                && properties.variant === PROMPT_VARIANT
+                && typeof properties.copied === "boolean"
+                && (method === "clipboard" || method === "execCommand" || method === "none"),
+              clientCapture,
+            );
+            recordAssertion(
+              ctx,
+              "The Copy Prompt button entered its post-click feedback state",
+              clientCapture.feedbackActive === true,
+              clientCapture,
+            );
+          },
+          screenshot: {
+            name: "copy-prompt-feedback",
+            requireText: ["Copied"],
+          },
+        });
+      },
+    },
+    {
+      name: "Agent fetch of start.md is captured server-side",
+      run: async (ctx) => {
+        let guideFetch = null;
+        let agentEvent = null;
+        let browserEvents = [];
+
+        await ctx.prove("Agent fetch of start.md is captured server-side.", {
+          action: async () => {
+            await fetch(mockUrl(ctx, "/events"), { method: "DELETE" });
+            const response = await fetch(routeUrl(ctx, `/start.md?v=${PROMPT_VARIANT}`), {
+              headers: { "user-agent": AGENT_USER_AGENT },
+            });
+            const body = await response.text();
+            guideFetch = {
+              status: response.status,
+              firstLines: body.split("\n").slice(0, 3).join("\n"),
+              startsWithGuide: body.startsWith("# OpenWork Start"),
+            };
+            const agentEvents = await waitForMockEvents(ctx, POSTHOG_SERVER_EVENT, 1);
+            agentEvent = agentEvents[0] || null;
+
+            await ctx.eval(`location.href = ${JSON.stringify(routeUrl(ctx, `/start.md?v=${PROMPT_VARIANT}`))}; true`);
+            await ctx.waitFor(
+              `document.body.innerText.includes(${JSON.stringify("OpenWork Start")})`,
+              { timeoutMs: 30_000, label: "start.md guide in browser" },
+            );
+            browserEvents = await waitForMockEvents(ctx, POSTHOG_SERVER_EVENT, 2);
+          },
+          assert: async () => {
+            ctx.recordEvidence({
+              type: "output",
+              name: "start.md fetch preview",
+              text: guideFetch?.firstLines ?? "",
+            });
+            recordAssertion(
+              ctx,
+              "Agent fetch returns HTTP 200 and the OpenWork start guide markdown",
+              guideFetch?.status === 200 && guideFetch.startsWithGuide === true,
+              guideFetch,
+            );
+
+            ctx.recordEvidence({
+              type: "output",
+              name: "PostHog mock event after agent fetch",
+              text: JSON.stringify(agentEvent, null, 2),
+            });
+            const properties = agentEvent?.properties ?? {};
+            recordAssertion(
+              ctx,
+              "Mock captured an anonymous landing_start_md_fetched event with the expected agent properties",
+              agentEvent?.event === POSTHOG_SERVER_EVENT
+                && properties.variant === PROMPT_VARIANT
+                && properties.user_agent === AGENT_USER_AGENT
+                && properties.$process_person_profile === false
+                && typeof agentEvent.distinct_id === "string"
+                && UUID_PATTERN.test(agentEvent.distinct_id),
+              agentEvent,
+            );
+            recordAssertion(
+              ctx,
+              "Browser navigation to start.md produced a second server capture",
+              browserEvents.filter((event) => event?.event === POSTHOG_SERVER_EVENT).length >= 2,
+              browserEvents,
+            );
+          },
+          screenshot: {
+            name: "start-md-guide",
+            requireText: ["OpenWork Start"],
+          },
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Why

We ship an agent-first install path — **Copy Prompt** in the landing nav copies a prompt that tells the user's agent to read `openworklabs.com/start.md?v=bootstrap-workspace` and install OpenWork — but we have zero visibility into whether anyone can actually use it. This PR adds the two missing funnel stages, anonymously.

## What

Two PostHog events (PostHog is already loaded on the landing site; no new deps, no cookies, no identity):

| Stage | Event | Properties | Where |
|---|---|---|---|
| Copy clicked | `landing_copy_prompt_clicked` | `copied` (did the clipboard write work), `method` (`clipboard` / `execCommand` / `none`), `variant` | client, rides the existing anonymous PostHog snippet |
| Agent actually read the guide | `landing_start_md_fetched` | `variant` (`?v=` param), `user_agent` (which agent tool fetched), `referer` | server, in the `start.md` route handler |

The funnel bottom (workspace bootstrapped) already lands in the Den DB (`WorkspaceBootstrapTable`), so click → agent-read → bootstrap is now fully measurable.

## Anonymity & safety

- Server events use a random UUID `distinct_id` per event + `$process_person_profile: false` — no person profiles, nothing linkable across events.
- Server capture only sends on production Vercel (`VERCEL_ENV=production`) or when `LANDING_POSTHOG_HOST` is explicitly set (used by the eval to point at a local mock) — local dev and previews stay silent (verified: dev server without the override → mock receives nothing, route still 200).
- Capture is fire-and-safe: try/catch everything, 400ms abort cap; analytics can never break or hang `start.md`.
- `start.md` becomes `force-dynamic` so fetch counts are real (it already sent `cache-control: no-store`); `install.sh` / `openwork-bootstrap.mjs` intentionally stay static/CDN-cached and untracked.
- PostHog project key single-sourced from `lib/posthog-client.ts` (public by design).

## Proof

Coded eval flow `landing-copy-prompt-analytics` + a tiny dependency-free PostHog capture mock (`evals/drivers/posthog-capture-mock.mjs`) drive the real dev server through headless Chrome via CDP:

1. Click Copy Prompt on `/` → exactly one `landing_copy_prompt_clicked` with `copied: true, method: "clipboard", variant: "bootstrap-workspace"`, button shows the ✓ Copied state.
2. Fetch `start.md?v=bootstrap-workspace` as an agent UA → HTTP 200 with the intact guide, and the mock receives the anonymous `landing_start_md_fetched` event (UUID distinct_id, `$process_person_profile: false`).

fraimz proof comment with validated screenshots follows below.

## Tests run

- `pnpm --dir ee/apps/landing exec tsc --noEmit` — passed
- `pnpm --dir ee/apps/landing build` — passed; route table shows `ƒ /start.md` (dynamic) while `install.sh`/`openwork-bootstrap.mjs` stay static
- `node evals/runner/run.mjs --flow landing-copy-prompt-analytics` against live dev server + mock — PASSED (all assertions, both frames)

Reproduce locally:
```sh
node evals/drivers/posthog-capture-mock.mjs --port 19877 &
LANDING_POSTHOG_HOST=http://127.0.0.1:19877 OPENWORK_DEV_MODE=1 pnpm --dir ee/apps/landing exec next dev --port 3411 &
# Chrome with --remote-debugging-port=<cdp>, then:
OPENWORK_EVAL_LANDING_URL=http://127.0.0.1:3411 OPENWORK_EVAL_POSTHOG_MOCK_URL=http://127.0.0.1:19877 \
  pnpm fraimz --flow landing-copy-prompt-analytics --cdp-url http://127.0.0.1:<cdp>
```