### PR TITLE
feat(den): org capability flags — per-org feature gating controlled from /admin

### DIFF
--- a/ee/apps/den-api/src/organization-capabilities.ts
+++ b/ee/apps/den-api/src/organization-capabilities.ts
@@ -1,0 +1,58 @@
+import { z } from "zod"
+
+/**
+ * Per-organization capability flags ("org capabilities").
+ *
+ * Capabilities let platform admins enable shipped-but-dark features
+ * org-by-org from the /admin backoffice. Every capability defaults to OFF
+ * for every organization; only an explicit `true` in the organization's
+ * metadata JSON (`metadata.capabilities.<key>`) turns one on.
+ *
+ * Storage rides the existing organization metadata JSON column — the same
+ * home as `limits`, `plan`, and `requireSso` — so no schema change is needed.
+ */
+export const ORGANIZATION_CAPABILITY_KEYS = ["installLinks"] as const
+
+export const organizationCapabilityKeySchema = z.enum(ORGANIZATION_CAPABILITY_KEYS)
+
+export type OrganizationCapabilityKey = z.infer<typeof organizationCapabilityKeySchema>
+
+export type OrganizationCapabilities = Record<OrganizationCapabilityKey, boolean>
+
+type MetadataInput = Record<string, unknown> | string | null | undefined
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function parseMetadata(input: MetadataInput): Record<string, unknown> {
+  if (!input) {
+    return {}
+  }
+
+  if (typeof input === "string") {
+    try {
+      const parsed = JSON.parse(input) as unknown
+      return isRecord(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+
+  return isRecord(input) ? input : {}
+}
+
+/** Every capability key resolved to a boolean, defaulting to false. */
+export function normalizeOrganizationCapabilities(metadata: MetadataInput): OrganizationCapabilities {
+  const parsed = parseMetadata(metadata)
+  const raw = isRecord(parsed.capabilities) ? parsed.capabilities : {}
+
+  return {
+    installLinks: raw.installLinks === true,
+  }
+}
+
+/** Whether the organization has an explicit opt-in for the capability. */
+export function organizationHasCapability(metadata: MetadataInput, key: OrganizationCapabilityKey): boolean {
+  return normalizeOrganizationCapabilities(metadata)[key]
+}

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -26,6 +26,7 @@ import { db } from "../../db.js"
 import { parseOrganizationPlan, type PlanTier } from "../../entitlements.js"
 import { adminRoute, queryValidator } from "../../middleware/index.js"
 import { denTypeIdSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
+import { normalizeOrganizationCapabilities } from "../../organization-capabilities.js"
 import { DEFAULT_ORGANIZATION_LIMITS, normalizeOrganizationMetadata } from "../../organization-limits.js"
 import type { AuthContextVariables } from "../../session.js"
 import { calculateOrganizationSeatBillingCounts, getOrganizationSeatBillingCounts, refreshOrgSubscriptionFromStripe, syncSeatSubscriptionQuantityAfterMemberChange } from "../../stripe-billing.js"
@@ -56,6 +57,12 @@ const updateOrganizationPlanSchema = z.object({
 
 const updateOrganizationFreeSeatsSchema = z.object({
   totalFreeSeats: z.number().int().min(DEFAULT_ORGANIZATION_FREE_SEAT_COUNT).max(100000),
+})
+
+const updateOrganizationCapabilitiesSchema = z.object({
+  capabilities: z.object({
+    installLinks: z.boolean().optional(),
+  }),
 })
 
 const adminOverviewResponseSchema = z.object({
@@ -390,6 +397,74 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
   )
 
   app.get(
+    "/v1/admin/organizations/:organizationId/capabilities",
+    adminRoute(),
+    async (c) => {
+      const organizationId = c.req.param("organizationId")
+      if (!isOrganizationId(organizationId)) {
+        return c.json({ error: "invalid_request", message: "Invalid organization id." }, 400)
+      }
+
+      const rows = await db
+        .select({ id: OrganizationTable.id, metadata: OrganizationTable.metadata })
+        .from(OrganizationTable)
+        .where(eq(OrganizationTable.id, organizationId))
+        .limit(1)
+
+      const organization = rows[0]
+      if (!organization) {
+        return c.json({ error: "not_found", message: "Organization not found." }, 404)
+      }
+
+      return c.json({ capabilities: normalizeOrganizationCapabilities(organization.metadata) })
+    },
+  )
+
+  app.put(
+    "/v1/admin/organizations/:organizationId/capabilities",
+    adminRoute(),
+    async (c) => {
+      const body = updateOrganizationCapabilitiesSchema.safeParse(await c.req.json().catch(() => null))
+      if (!body.success) {
+        return c.json({ error: "invalid_request", message: body.error.issues[0]?.message ?? "Invalid organization capabilities request." }, 400)
+      }
+
+      const organizationId = c.req.param("organizationId")
+      if (!isOrganizationId(organizationId)) {
+        return c.json({ error: "invalid_request", message: "Invalid organization id." }, 400)
+      }
+
+      const rows = await db
+        .select({ id: OrganizationTable.id, metadata: OrganizationTable.metadata })
+        .from(OrganizationTable)
+        .where(eq(OrganizationTable.id, organizationId))
+        .limit(1)
+
+      const organization = rows[0]
+      if (!organization) {
+        return c.json({ error: "not_found", message: "Organization not found." }, 404)
+      }
+
+      const capabilities = normalizeOrganizationCapabilities(organization.metadata)
+      if (body.data.capabilities.installLinks !== undefined) {
+        capabilities.installLinks = body.data.capabilities.installLinks
+      }
+
+      const metadata = {
+        ...normalizeOrganizationMetadata(organization.metadata).metadata,
+        capabilities,
+      }
+
+      await db
+        .update(OrganizationTable)
+        .set({ metadata })
+        .where(eq(OrganizationTable.id, organizationId))
+
+      return c.json({ ok: true, organization: { id: organizationId }, capabilities })
+    },
+  )
+
+  app.get(
     "/v1/admin/overview",
     describeRoute({
       tags: ["Admin"],
@@ -591,6 +666,7 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         freeSeatCount: seatCounts.free,
         seatsFreeAdditional: seatCounts.additionalFree,
         billableSeatCount: seatCounts.chargeable,
+        capabilities: normalizeOrganizationCapabilities(metadata),
       }
     })
 

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -11,6 +11,7 @@ import { env } from "../../env.js"
 import { findEnterpriseAuthRequirementForEmail } from "../../enterprise-auth-requirement.js"
 import { authenticatedRoute, jsonValidator, orgMemberRoute, orgRoleRoute, publicRoute, queryValidator, resolveMemberTeamsMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, enterprisePlanRequiredSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
+import { normalizeOrganizationCapabilities } from "../../organization-capabilities.js"
 import { validateInvitationAcceptVerification } from "../../organization-join-verification.js"
 import { normalizeOrganizationMetadata } from "../../organization-limits.js"
 import {
@@ -440,6 +441,7 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
         currentMemberTeams: c.get("memberTeams") ?? [],
         plan: parseOrganizationPlan(payload.organization.metadata),
         entitlements: getOrganizationEntitlements(payload.organization.metadata),
+        capabilities: normalizeOrganizationCapabilities(payload.organization.metadata),
         authMethods: {
           sso: Boolean(ssoRows[0]),
           scim: Boolean(scimRows[0]),

--- a/ee/apps/den-api/test/organization-capabilities.test.ts
+++ b/ee/apps/den-api/test/organization-capabilities.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import {
+  normalizeOrganizationCapabilities,
+  organizationHasCapability,
+} from "../src/organization-capabilities.js"
+
+describe("normalizeOrganizationCapabilities", () => {
+  test("defaults every capability to false when metadata is empty", () => {
+    expect(normalizeOrganizationCapabilities(null)).toEqual({ installLinks: false })
+    expect(normalizeOrganizationCapabilities(undefined)).toEqual({ installLinks: false })
+    expect(normalizeOrganizationCapabilities({})).toEqual({ installLinks: false })
+    expect(normalizeOrganizationCapabilities("")).toEqual({ installLinks: false })
+  })
+
+  test("reads an explicit opt-in from record metadata", () => {
+    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: true } })).toEqual({ installLinks: true })
+    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: false } })).toEqual({ installLinks: false })
+  })
+
+  test("reads an explicit opt-in from JSON string metadata", () => {
+    expect(normalizeOrganizationCapabilities(JSON.stringify({ capabilities: { installLinks: true } }))).toEqual({ installLinks: true })
+  })
+
+  test("treats anything but literal true as off", () => {
+    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: "true" } })).toEqual({ installLinks: false })
+    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: 1 } })).toEqual({ installLinks: false })
+    expect(normalizeOrganizationCapabilities({ capabilities: null })).toEqual({ installLinks: false })
+    expect(normalizeOrganizationCapabilities({ capabilities: [] })).toEqual({ installLinks: false })
+    expect(normalizeOrganizationCapabilities("not json")).toEqual({ installLinks: false })
+  })
+
+  test("ignores unrelated metadata keys", () => {
+    const metadata = {
+      limits: { members: 5, workers: 1 },
+      plan: { tier: "enterprise", source: "manual" },
+      capabilities: { installLinks: true },
+    }
+    expect(normalizeOrganizationCapabilities(metadata)).toEqual({ installLinks: true })
+  })
+})
+
+describe("organizationHasCapability", () => {
+  test("is false by default and true only with an explicit opt-in", () => {
+    expect(organizationHasCapability(null, "installLinks")).toBe(false)
+    expect(organizationHasCapability({ capabilities: {} }, "installLinks")).toBe(false)
+    expect(organizationHasCapability({ capabilities: { installLinks: true } }, "installLinks")).toBe(true)
+    expect(organizationHasCapability(JSON.stringify({ capabilities: { installLinks: true } }), "installLinks")).toBe(true)
+  })
+})

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -188,6 +188,7 @@ export type DenOrgContext = {
   currentMemberTeams: DenCurrentMemberTeam[];
   entitlements: DenOrgEntitlements;
   authMethods: DenOrgAuthMethods;
+  capabilities: DenOrgCapabilities;
 };
 
 export type DenOrgAuthMethods = {
@@ -200,6 +201,11 @@ export type DenOrgEntitlements = {
   desktopPolicies: boolean;
   orgControls: boolean;
   analytics: boolean;
+};
+
+/** Per-org feature flags controlled by platform admins; everything defaults to off. */
+export type DenOrgCapabilities = {
+  installLinks: boolean;
 };
 
 export type DenOrganizationMetadata = {
@@ -714,6 +720,7 @@ export function parseOrgContextPayload(payload: unknown): DenOrgContext | null {
     currentMemberTeams,
     entitlements: parseOrgEntitlements(payload.entitlements),
     authMethods: parseOrgAuthMethods(payload.authMethods),
+    capabilities: parseOrgCapabilities(payload.capabilities),
   };
 }
 
@@ -725,6 +732,16 @@ function parseOrgAuthMethods(value: unknown): DenOrgAuthMethods {
   return {
     sso: value.sso === true,
     scim: value.scim === true,
+  };
+}
+
+function parseOrgCapabilities(value: unknown): DenOrgCapabilities {
+  if (!isRecord(value)) {
+    return { installLinks: false };
+  }
+
+  return {
+    installLinks: value.installLinks === true,
   };
 }
 

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -93,6 +93,10 @@ type AdminUser = {
   organizations: AdminUserOrganization[];
 };
 
+type AdminOrganizationCapabilities = {
+  installLinks: boolean;
+};
+
 type AdminOrganization = {
   id: string;
   name: string;
@@ -108,6 +112,7 @@ type AdminOrganization = {
   freeSeatCount: number;
   seatsFreeAdditional: number;
   billableSeatCount: number;
+  capabilities: AdminOrganizationCapabilities;
 };
 
 type AdminPayload = {
@@ -273,6 +278,7 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
 
         const plan = isRecord(value.plan) ? value.plan : {};
         const tier = plan.tier === "team" || plan.tier === "enterprise" ? plan.tier : "free";
+        const capabilities = isRecord(value.capabilities) ? value.capabilities : {};
 
         return {
           id: value.id,
@@ -288,7 +294,10 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
           seatLimit: toNumberValue(value.seatLimit),
           freeSeatCount: toNumberValue(value.freeSeatCount) || DEFAULT_FREE_SEAT_COUNT,
           seatsFreeAdditional: toNumberValue(value.seatsFreeAdditional),
-          billableSeatCount: toNumberValue(value.billableSeatCount)
+          billableSeatCount: toNumberValue(value.billableSeatCount),
+          capabilities: {
+            installLinks: capabilities.installLinks === true
+          }
         };
       })
       .filter((value): value is AdminOrganization => value !== null)
@@ -406,6 +415,31 @@ async function requestJson(path: string) {
 async function patchJson(path: string, body: unknown) {
   const response = await fetch(`/api/den${path}`, {
     method: "PATCH",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+
+  const text = await response.text();
+  let payload: unknown = null;
+
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
+
+  return { response, payload };
+}
+
+async function putJson(path: string, body: unknown) {
+  const response = await fetch(`/api/den${path}`, {
+    method: "PUT",
     credentials: "include",
     headers: {
       Accept: "application/json",
@@ -796,6 +830,7 @@ export function DenAdminPanel() {
   const [savingOrgId, setSavingOrgId] = useState<string | null>(null);
   const [freeSeatsDialog, setFreeSeatsDialog] = useState<{ org: AdminOrganization; totalFreeSeats: string } | null>(null);
   const [savingFreeSeatsOrgId, setSavingFreeSeatsOrgId] = useState<string | null>(null);
+  const [savingCapabilityOrgId, setSavingCapabilityOrgId] = useState<string | null>(null);
   const [deleteUserDialog, setDeleteUserDialog] = useState<AdminUser | null>(null);
   const [deletingUserId, setDeletingUserId] = useState<string | null>(null);
 
@@ -1063,6 +1098,44 @@ export function DenAdminPanel() {
     }
   }, [freeSeatsDialog, includeBilling, loadOverview]);
 
+  const setOrganizationCapabilityLocally = useCallback((orgId: string, key: keyof AdminOrganizationCapabilities, enabled: boolean) => {
+    setPayload((current) => {
+      if (!current) {
+        return current;
+      }
+
+      return {
+        ...current,
+        organizations: current.organizations.map((org) =>
+          org.id === orgId ? { ...org, capabilities: { ...org.capabilities, [key]: enabled } } : org
+        )
+      };
+    });
+  }, []);
+
+  const saveOrganizationCapability = useCallback(async (org: AdminOrganization, key: keyof AdminOrganizationCapabilities, enabled: boolean) => {
+    setSavingCapabilityOrgId(org.id);
+    setError(null);
+    // Optimistic: flip the toggle immediately, roll back if the PUT fails.
+    setOrganizationCapabilityLocally(org.id, key, enabled);
+
+    try {
+      const { response, payload: nextPayload } = await putJson(`/v1/admin/organizations/${org.id}/capabilities`, {
+        capabilities: { [key]: enabled }
+      });
+
+      if (!response.ok) {
+        setOrganizationCapabilityLocally(org.id, key, !enabled);
+        setError(getErrorMessage(nextPayload, `Could not update capabilities for ${org.name}.`));
+      }
+    } catch (nextError) {
+      setOrganizationCapabilityLocally(org.id, key, !enabled);
+      setError(nextError instanceof Error ? nextError.message : "Unknown network error");
+    } finally {
+      setSavingCapabilityOrgId(null);
+    }
+  }, [setOrganizationCapabilityLocally]);
+
   const deleteUser = useCallback(async () => {
     if (!deleteUserDialog) {
       return;
@@ -1319,7 +1392,7 @@ export function DenAdminPanel() {
         ) : null}
 
         {viewMode === "organizations" ? (
-          <div className="mt-4">
+          <div className="mt-4" data-testid="admin-orgs-page">
             <label className="grid w-full max-w-xl gap-2">
               <span className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Search organizations</span>
               <input
@@ -1448,7 +1521,7 @@ export function DenAdminPanel() {
               const changed = draft.tier !== org.plan.tier || draft.seatLimit !== String(org.seatLimit);
 
               return (
-                <div key={org.id} className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
+                <div key={org.id} data-testid={`admin-org-row-${org.slug}`} className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
                   <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
@@ -1492,6 +1565,24 @@ export function DenAdminPanel() {
                         {org.seatsFreeAdditional > 0 ? `${org.seatsFreeAdditional} additional` : "Default included"}
                       </p>
                     </div>
+                  </div>
+
+                  <div className="mt-4 border-t border-slate-200 pt-4">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Capabilities</p>
+                    <label className="mt-2 inline-flex items-center gap-2 text-sm text-slate-700">
+                      <input
+                        type="checkbox"
+                        data-testid="admin-capability-installLinks"
+                        checked={org.capabilities.installLinks}
+                        disabled={savingCapabilityOrgId === org.id}
+                        onChange={(event) => {
+                          void saveOrganizationCapability(org, "installLinks", event.target.checked);
+                        }}
+                        className="h-4 w-4 rounded border-slate-300"
+                      />
+                      Install links
+                    </label>
+                    <p className="mt-1 text-xs text-slate-400">Off by default. Lets workspace admins mint desktop install links for this organization.</p>
                   </div>
 
                   <div className="mt-4 grid gap-3 border-t border-slate-200 pt-4 lg:grid-cols-[12rem_10rem_auto] lg:items-end">

--- a/evals/flows/org-capability-flags.flow.mjs
+++ b/evals/flows/org-capability-flags.flow.mjs
@@ -1,0 +1,551 @@
+import { execSync } from "node:child_process";
+import { connect, debuggerUrlFor, listTargets } from "../runner/cdp.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/org-capability-flags.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("org-capability-flags");
+
+const DEN_API_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_API_URL);
+const DEN_WEB_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_WEB_URL);
+const ADMIN_CDP_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_WEB_CDP_ADMIN);
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const PLATFORM_ADMIN_EMAIL = process.env.OPENWORK_EVAL_PLATFORM_ADMIN_EMAIL?.trim() || "";
+const PLATFORM_ADMIN_PASSWORD = process.env.OPENWORK_EVAL_PLATFORM_ADMIN_PASSWORD?.trim() || "";
+// alex is the ORG admin: his /v1/org payload is the proof that an org can read
+// its own capabilities. He takes part through his API session only — the whole
+// visible demo happens in the platform admin's browser.
+const ORG_ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ORG_ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+
+const ORG_FILTER_INPUT = 'input[placeholder="Org name, slug, or id"]';
+
+const state = {
+  platformAdminToken: null,
+  orgAdminToken: null,
+  orgId: null,
+  orgSlug: null,
+  otherOrgsOnBeforeToggle: null,
+};
+
+export default {
+  id: "org-capability-flags",
+  title: "Platform admins flip per-org capability flags from /admin; every org starts dark and reports its own state through /v1/org",
+  kind: "user-facing",
+  requiredEnv: [
+    "OPENWORK_EVAL_DEN_API_URL",
+    "OPENWORK_EVAL_DEN_TOKEN",
+    "OPENWORK_EVAL_DEN_WEB_URL",
+    "OPENWORK_EVAL_WEB_CDP_ADMIN",
+    "OPENWORK_EVAL_PLATFORM_ADMIN_EMAIL",
+    "OPENWORK_EVAL_PLATFORM_ADMIN_PASSWORD",
+    "OPENWORK_EVAL_MARK_VERIFIED_CMD",
+  ],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
+          await ctx.prove("The platform admin finds Acme's Capabilities controls in /admin, everything off", {
+            voiceover: vo[0],
+            action: async () => {
+              await ensurePlatformAdmin(ctx);
+              await ensureOrgAdminContext(ctx);
+              // Idempotency affordance: a previous run may have left the flag ON.
+              // Force it OFF through the admin API (as the platform admin) before
+              // asserting the dark state — the demo itself then turns it on and
+              // back off through the UI.
+              await setCapabilityViaAdminApi(ctx, { installLinks: false });
+              await signInToDenWebWithoutOrg(ctx, PLATFORM_ADMIN_EMAIL, PLATFORM_ADMIN_PASSWORD);
+              await goToDenWeb(ctx, "/admin");
+              await ctx.waitForText("User backoffice", { timeoutMs: 45_000 });
+              await clickOrganizationsTab(ctx);
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"admin-orgs-page\"]'))", {
+                timeoutMs: 20_000,
+                label: "admin organizations view",
+              });
+              await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(acmeRowSelector())}))`, {
+                timeoutMs: 20_000,
+                label: "Acme organization row",
+              });
+              await scrollAcmeRowIntoView(ctx);
+            },
+            assert: async () => {
+              await ctx.expectText("Acme Robotics");
+              // The section header renders uppercase via CSS, so innerText
+              // sees "CAPABILITIES"; assert on the untransformed label.
+              await ctx.expectText("Install links");
+              const checked = await readAcmeInstallLinksCheckbox(ctx);
+              ctx.assert(checked === false, "Install links checkbox was already checked before the demo toggled it.");
+
+              const admin = await fetchAdminCapabilities(ctx);
+              ctx.assert(admin.installLinks === false, "Admin API reported installLinks on before the toggle.");
+
+              const orgView = await fetchOrgCapabilities(ctx);
+              ctx.assert(orgView.installLinks === false, "/v1/org reported installLinks on while the flag is off.");
+              ctx.output("capabilities-start-dark", JSON.stringify({ admin, orgView }, null, 2));
+            },
+            screenshot: {
+              name: "admin-acme-capabilities-off",
+              requireText: ["User backoffice", "Acme Robotics", "Install links"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
+          await ctx.prove("One checkbox in /admin turns the capability on for Acme, and only Acme", {
+            voiceover: vo[1],
+            action: async () => {
+              // Filter to Acme first — a real admin narrowing to one org, and it
+              // keeps this capture visually distinct from frame 1's full list.
+              await ctx.fill(ORG_FILTER_INPUT, "Acme");
+              await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(acmeRowSelector())}))`, {
+                timeoutMs: 20_000,
+                label: "Acme row after filtering",
+              });
+              state.otherOrgsOnBeforeToggle = await fetchOtherOrgsWithCapabilityOn(ctx);
+              await clickAcmeInstallLinksCheckbox(ctx);
+              await ctx.waitFor(`(() => {
+                const checkbox = document.querySelector(${JSON.stringify(acmeInstallLinksCheckboxSelector())});
+                return Boolean(checkbox && checkbox.checked && !checkbox.disabled);
+              })()`, { timeoutMs: 20_000, label: "capability checkbox saved as checked" });
+            },
+            assert: async () => {
+              const checked = await readAcmeInstallLinksCheckbox(ctx);
+              ctx.assert(checked === true, "Capability checkbox did not stay checked.");
+
+              const admin = await fetchAdminCapabilities(ctx);
+              ctx.assert(admin.installLinks === true, "Admin API did not report the capability on after the toggle.");
+
+              // "Just Acme": the toggle must not have changed any other org.
+              const before = state.otherOrgsOnBeforeToggle;
+              ctx.assert(Array.isArray(before), "Frame 2 did not snapshot the other orgs before the toggle.");
+              const after = await fetchOtherOrgsWithCapabilityOn(ctx);
+              ctx.assert(
+                JSON.stringify(after) === JSON.stringify(before),
+                `Other orgs changed with Acme's toggle: before=${JSON.stringify(before)} after=${JSON.stringify(after)}`,
+              );
+              ctx.output("capability-enabled-for-acme-only", JSON.stringify({ admin, otherOrgsWithCapabilityOn: after }, null, 2));
+            },
+            screenshot: {
+              name: "admin-acme-capabilities-on",
+              requireText: ["Acme Robotics", "Install links"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
+          await ctx.prove("Acme's own workspace reads the capability as on through /v1/org", {
+            voiceover: vo[2],
+            action: async () => {
+              // Clear the filter — back to the full backoffice list, now with
+              // Acme's row checked (and a visibly different capture from frame 2).
+              await ctx.fill(ORG_FILTER_INPUT, "");
+              await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(acmeRowSelector())}))`, {
+                timeoutMs: 20_000,
+                label: "Acme row after clearing the filter",
+              });
+              await scrollAcmeRowIntoView(ctx);
+            },
+            assert: async () => {
+              // The payload Acme's own admin reads — fetched with alex's session.
+              const orgView = await fetchOrgCapabilities(ctx);
+              ctx.assert(orgView.installLinks === true, "/v1/org did not report the capability on to Acme's own admin.");
+              ctx.output("acme-org-payload-on", JSON.stringify({ orgAdmin: ORG_ADMIN_EMAIL, capabilities: orgView }, null, 2));
+
+              const checked = await readAcmeInstallLinksCheckbox(ctx);
+              ctx.assert(checked === true, "Admin row stopped showing the capability on.");
+              await ctx.expectText("Acme Robotics");
+            },
+            screenshot: {
+              name: "acme-reports-capability-on",
+              requireText: ["Acme Robotics", "Install links"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
+          await ctx.prove("Flipping the toggle back off makes Acme report dark again", {
+            voiceover: vo[3],
+            action: async () => {
+              await ctx.fill(ORG_FILTER_INPUT, "Acme");
+              await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(acmeRowSelector())}))`, {
+                timeoutMs: 20_000,
+                label: "Acme row after filtering again",
+              });
+              await clickAcmeInstallLinksCheckbox(ctx);
+              await ctx.waitFor(`(() => {
+                const checkbox = document.querySelector(${JSON.stringify(acmeInstallLinksCheckboxSelector())});
+                return Boolean(checkbox && !checkbox.checked && !checkbox.disabled);
+              })()`, { timeoutMs: 20_000, label: "capability checkbox saved as unchecked" });
+            },
+            assert: async () => {
+              const admin = await fetchAdminCapabilities(ctx);
+              ctx.assert(admin.installLinks === false, "Admin API still reported the capability on after turning it off.");
+
+              const orgView = await fetchOrgCapabilities(ctx);
+              ctx.assert(orgView.installLinks === false, "/v1/org still reported the capability on after turning it off.");
+              ctx.output("acme-org-payload-dark-again", JSON.stringify({ orgAdmin: ORG_ADMIN_EMAIL, capabilities: orgView }, null, 2));
+
+              await ctx.expectText("Install links");
+            },
+            screenshot: {
+              name: "admin-acme-capabilities-back-off",
+              requireText: ["Acme Robotics", "Install links"],
+            },
+          });
+        });
+      },
+    },
+  ],
+};
+
+function cleanBaseUrl(value) {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
+function requireStateValue(value, label) {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  throw new Error(`${label} was not prepared by an earlier frame.`);
+}
+
+async function withClient(ctx, cdpBaseUrl, fn) {
+  const previous = ctx.client;
+  const target = await firstPageTarget(cdpBaseUrl);
+  const client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+  ctx.client = client;
+  try {
+    return await fn();
+  } finally {
+    ctx.client = previous;
+    // Close the extra websocket so the runner process can exit cleanly.
+    try {
+      client.close();
+    } catch {
+      // Socket already gone.
+    }
+  }
+}
+
+async function firstPageTarget(cdpBaseUrl) {
+  const existing = await listTargets(cdpBaseUrl);
+  const page = existing.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (page) {
+    return page;
+  }
+
+  const base = cdpBaseUrl.replace(/\/+$/, "");
+  let response = await fetch(`${base}/json/new?about:blank`, { method: "PUT" });
+  if (!response.ok) {
+    response = await fetch(`${base}/json/new?about:blank`);
+  }
+  if (!response.ok) {
+    throw new Error(`Could not create a page target at ${cdpBaseUrl}: ${response.status}`);
+  }
+  const created = await response.json();
+  if (created?.type === "page" && created.webSocketDebuggerUrl) {
+    return created;
+  }
+  const targets = await listTargets(cdpBaseUrl);
+  const nextPage = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (!nextPage) {
+    throw new Error(`No page target available at ${cdpBaseUrl}.`);
+  }
+  return nextPage;
+}
+
+async function denApiFetch(pathname, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${pathname}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      origin: DEN_WEB_URL || DEN_API_URL,
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body, text };
+}
+
+function markEmailVerified(ctx, email) {
+  ctx.assert(
+    MARK_VERIFIED_CMD.length > 0,
+    "Platform-admin provisioning requires a verified email; set OPENWORK_EVAL_MARK_VERIFIED_CMD (shell template with {email}).",
+  );
+  execSync(MARK_VERIFIED_CMD.replaceAll("{email}", email), { stdio: "ignore" });
+}
+
+/**
+ * The platform admin is an ordinary account whose email is on the Den admin
+ * allowlist. The account is created here (idempotently); allowlist membership
+ * comes from DEN_BOOTSTRAP_ADMIN_EMAILS on the den-api under test, which
+ * upserts the email into admin_allowlist on boot.
+ */
+async function ensurePlatformAdmin(ctx) {
+  if (state.platformAdminToken) {
+    return state.platformAdminToken;
+  }
+
+  const signup = await denApiFetch("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ name: "Priya Platform", email: PLATFORM_ADMIN_EMAIL, password: PLATFORM_ADMIN_PASSWORD }),
+  });
+  const signupAccepted = signup.response.ok || [400, 403, 409, 422].includes(signup.response.status);
+  ctx.assert(signupAccepted, `Platform admin sign-up failed: ${signup.response.status} ${signup.text.slice(0, 300)}`);
+  markEmailVerified(ctx, PLATFORM_ADMIN_EMAIL);
+
+  const signedIn = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: PLATFORM_ADMIN_EMAIL, password: PLATFORM_ADMIN_PASSWORD }),
+  });
+  ctx.assert(
+    signedIn.response.ok && typeof signedIn.body?.token === "string",
+    `Platform admin sign-in failed: ${signedIn.response.status} ${signedIn.text.slice(0, 300)}`,
+  );
+  state.platformAdminToken = signedIn.body.token;
+
+  const probe = await denApiFetch("/v1/admin/overview", {
+    method: "GET",
+    headers: { authorization: `Bearer ${state.platformAdminToken}` },
+  });
+  ctx.assert(
+    probe.response.ok,
+    `${PLATFORM_ADMIN_EMAIL} is not a platform admin (overview probe ${probe.response.status}). Start den-api with DEN_BOOTSTRAP_ADMIN_EMAILS=${PLATFORM_ADMIN_EMAIL} or insert the email into admin_allowlist.`,
+  );
+  return state.platformAdminToken;
+}
+
+async function ensureOrgAdminContext(ctx) {
+  if (state.orgAdminToken && state.orgId) {
+    return;
+  }
+
+  const signedIn = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: ORG_ADMIN_EMAIL, password: ORG_ADMIN_PASSWORD }),
+  });
+  ctx.assert(
+    signedIn.response.ok && typeof signedIn.body?.token === "string",
+    `Org admin sign-in failed for ${ORG_ADMIN_EMAIL}: ${signedIn.response.status} ${signedIn.text.slice(0, 300)}`,
+  );
+  state.orgAdminToken = signedIn.body.token;
+
+  const org = await denApiFetch("/v1/org", {
+    method: "GET",
+    headers: { authorization: `Bearer ${state.orgAdminToken}` },
+  });
+  ctx.assert(org.response.ok, `Could not load ${ORG_ADMIN_EMAIL}'s organization: ${org.response.status} ${org.text.slice(0, 300)}`);
+  const organization = org.body?.organization;
+  ctx.assert(typeof organization?.id === "string" && typeof organization?.slug === "string", "Organization payload was missing id/slug.");
+  state.orgId = organization.id;
+  state.orgSlug = organization.slug;
+}
+
+async function setCapabilityViaAdminApi(ctx, capabilities) {
+  const token = requireStateValue(state.platformAdminToken, "platform admin token");
+  const orgId = requireStateValue(state.orgId, "organization id");
+  const updated = await denApiFetch(`/v1/admin/organizations/${orgId}/capabilities`, {
+    method: "PUT",
+    headers: { authorization: `Bearer ${token}` },
+    body: JSON.stringify({ capabilities }),
+  });
+  ctx.assert(updated.response.ok, `Admin capability update failed: ${updated.response.status} ${updated.text.slice(0, 300)}`);
+}
+
+async function fetchAdminCapabilities(ctx) {
+  const token = requireStateValue(state.platformAdminToken, "platform admin token");
+  const orgId = requireStateValue(state.orgId, "organization id");
+  const result = await denApiFetch(`/v1/admin/organizations/${orgId}/capabilities`, {
+    method: "GET",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(result.response.ok, `Admin capability fetch failed: ${result.response.status} ${result.text.slice(0, 300)}`);
+  ctx.assert(isRecord(result.body?.capabilities), "Admin capability response was missing capabilities.");
+  return result.body.capabilities;
+}
+
+async function fetchOrgCapabilities(ctx) {
+  const token = requireStateValue(state.orgAdminToken, "org admin token");
+  const result = await denApiFetch("/v1/org", {
+    method: "GET",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(result.response.ok, `/v1/org fetch failed: ${result.response.status} ${result.text.slice(0, 300)}`);
+  ctx.assert(isRecord(result.body?.capabilities), "/v1/org response was missing capabilities.");
+  return result.body.capabilities;
+}
+
+/**
+ * Slugs of every organization other than Acme whose installLinks capability is
+ * on, read from the admin overview rows (which expose capabilities). Used to
+ * prove Acme's toggle changed Acme and nothing else.
+ */
+async function fetchOtherOrgsWithCapabilityOn(ctx) {
+  const token = requireStateValue(state.platformAdminToken, "platform admin token");
+  const orgId = requireStateValue(state.orgId, "organization id");
+  const result = await denApiFetch("/v1/admin/overview", {
+    method: "GET",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(result.response.ok, `Admin overview fetch failed: ${result.response.status} ${result.text.slice(0, 300)}`);
+  const organizations = result.body?.organizations;
+  ctx.assert(Array.isArray(organizations), "Admin overview response was missing organizations.");
+  return organizations
+    .filter((org) => isRecord(org) && org.id !== orgId && isRecord(org.capabilities) && org.capabilities.installLinks === true)
+    .map((org) => org.slug)
+    .sort();
+}
+
+async function goToDenWeb(ctx, pathname) {
+  await navigateToAbsolute(ctx, `${DEN_WEB_URL}${pathname}`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${pathname}` });
+}
+
+async function navigateToAbsolute(ctx, url) {
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+}
+
+/**
+ * The platform admin has no organization, so den-web never lands on
+ * /dashboard after sign-in. Wait for the auth session instead, then let the
+ * caller navigate straight to /admin.
+ */
+async function signInToDenWebWithoutOrg(ctx, email, password) {
+  await submitDenWebSignIn(ctx, email, password);
+  await waitForDenWebSession(ctx, email);
+}
+
+async function submitDenWebSignIn(ctx, email, password) {
+  await clearDenWebSession(ctx);
+  await goToDenWeb(ctx, "/");
+  await ctx.waitFor("document.body.innerText.includes('Sign in')", { timeoutMs: 30_000, label: "sign-in screen" });
+  await clickExactText(ctx, "Sign in", "button, a");
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"], input[name=\"email\"]'))", { timeoutMs: 15_000, label: "email input" });
+  await ctx.fill('input[type="email"], input[name="email"]', email);
+  await ctx.fill('input[type="password"]', password);
+  await clickLastExactText(ctx, "Sign in", "button");
+}
+
+async function waitForDenWebSession(ctx, email) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 45_000) {
+    const sessionEmail = await ctx.eval(
+      `fetch('/api/den/api/auth/get-session', { credentials: 'include', headers: { accept: 'application/json' } })
+        .then((response) => (response.ok ? response.json() : null))
+        .then((payload) => payload?.user?.email ?? "")
+        .catch(() => "")`,
+      { awaitPromise: true },
+    );
+    if (typeof sessionEmail === "string" && sessionEmail.toLowerCase() === email.toLowerCase()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`den-web session for ${email} did not appear within 45s.`);
+}
+
+async function clearDenWebSession(ctx) {
+  await goToDenWeb(ctx, "/");
+  // Sign out via the den-web proxy path (den-api sits behind /api/den) and
+  // clear browser cookies so stale profile sessions from previous runs can
+  // never leak into this one.
+  await ctx.eval(
+    `fetch('/api/den/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).catch(() => null).then(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+      return true;
+    })`,
+    { awaitPromise: true },
+  );
+  await ctx.client.send("Network.clearBrowserCookies", {});
+}
+
+async function clickExactText(ctx, text, selector) {
+  const clicked = await ctx.waitFor(`(() => {
+    const candidates = [...document.querySelectorAll(${JSON.stringify(selector)})];
+    const element = candidates.find((candidate) => (candidate.textContent ?? '').trim() === ${JSON.stringify(text)} && !candidate.disabled);
+    element?.scrollIntoView({ block: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: 20_000, label: `click exact text ${text}` });
+  return clicked;
+}
+
+async function clickLastExactText(ctx, text, selector) {
+  const clicked = await ctx.waitFor(`(() => {
+    const candidates = [...document.querySelectorAll(${JSON.stringify(selector)})]
+      .filter((candidate) => (candidate.textContent ?? '').trim() === ${JSON.stringify(text)} && !candidate.disabled);
+    const element = candidates[candidates.length - 1];
+    element?.scrollIntoView({ block: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: 20_000, label: `click last exact text ${text}` });
+  return clicked;
+}
+
+async function clickOrganizationsTab(ctx) {
+  await ctx.waitFor(`(() => {
+    const button = [...document.querySelectorAll('button')].find((candidate) => (candidate.textContent ?? '').trim().startsWith('Organizations ('));
+    button?.click();
+    return Boolean(button);
+  })()`, { timeoutMs: 20_000, label: "organizations tab" });
+}
+
+function acmeRowSelector() {
+  const slug = requireStateValue(state.orgSlug, "organization slug");
+  return `[data-testid="admin-org-row-${slug}"]`;
+}
+
+function acmeInstallLinksCheckboxSelector() {
+  return `${acmeRowSelector()} [data-testid="admin-capability-installLinks"]`;
+}
+
+async function scrollAcmeRowIntoView(ctx) {
+  await ctx.eval(`(() => {
+    document.querySelector(${JSON.stringify(acmeRowSelector())})?.scrollIntoView({ block: 'center' });
+    return true;
+  })()`);
+}
+
+async function readAcmeInstallLinksCheckbox(ctx) {
+  return ctx.eval(`(() => {
+    const checkbox = document.querySelector(${JSON.stringify(acmeInstallLinksCheckboxSelector())});
+    return checkbox ? checkbox.checked : null;
+  })()`);
+}
+
+async function clickAcmeInstallLinksCheckbox(ctx) {
+  await ctx.waitFor(`(() => {
+    const checkbox = document.querySelector(${JSON.stringify(acmeInstallLinksCheckboxSelector())});
+    if (!checkbox || checkbox.disabled) {
+      return false;
+    }
+    checkbox.scrollIntoView({ block: 'center' });
+    checkbox.click();
+    return true;
+  })()`, { timeoutMs: 20_000, label: "toggle capability checkbox" });
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/evals/voiceovers/org-capability-flags.md
+++ b/evals/voiceovers/org-capability-flags.md
@@ -1,0 +1,16 @@
+# org-capability-flags — Features ship dark, then light up one org at a time
+
+Per-organization capability flags. Platform admins control them from the
+/admin backoffice; every capability defaults to OFF for every org. Flags
+live in the org metadata JSON — no schema change, no deploy. Each org reads
+its own flags from the /v1/org payload, so a feature can check its flag the
+moment it ships. The first key, `installLinks`, ships dark: nothing reads
+it until the install-links PR lands.
+
+1. Priya, a platform admin, opens the /admin backoffice and right on Acme's card there's a new Capabilities section — every flag starts off, for every org.
+
+2. She flips Install links on for Acme — just Acme. No deploy, no environment variable, one checkbox in the backoffice.
+
+3. Acme's own workspace now reports the capability as on — the /v1/org payload Acme's admins already read carries the flag, so any feature can read it the moment it ships.
+
+4. She flips it back off and Acme reports dark again — org-by-org control of shipped-but-dark features, all from one screen.


### PR DESCRIPTION
## What

Standalone per-organization capability flags: platform admins light features up org-by-org from the `/admin` backoffice. Flags live in the org metadata JSON (`metadata.capabilities.<key>`) — no schema change — and **default to `false` for every org**.

This PR is the framework + admin control only. The `installLinks` key **ships dark**: nothing reads it until the install-links PR (#2480) lands — that PR will gate its feature on this flag and is now stacked on this branch.

## Endpoints & payload shapes

- `GET /v1/admin/organizations/:id/capabilities` (platform admin)
  ```json
  { "capabilities": { "installLinks": false } }
  ```
- `PUT /v1/admin/organizations/:id/capabilities` (platform admin, partial update)
  ```json
  // request
  { "capabilities": { "installLinks": true } }
  // response
  { "ok": true, "organization": { "id": "org_..." }, "capabilities": { "installLinks": true } }
  ```
- `GET /v1/admin/overview` — each organization row now carries `capabilities`.
- `GET /v1/org` — the member payload now carries `capabilities`, so an org's own workspace can read its flags the moment a gated feature ships.

## UI

- `/admin` → Organizations: per-org **Capabilities** section with an Install links checkbox — optimistic flip with rollback on failure (`admin-orgs-page`, `admin-org-row-<slug>`, `admin-capability-installLinks` testids).
- den-web org context (`den-org.ts`) parses `capabilities` (defaults false when absent).

## Server-side helpers

`ee/apps/den-api/src/organization-capabilities.ts`: `ORGANIZATION_CAPABILITY_KEYS` zod enum, `normalizeOrganizationCapabilities` (tolerates string/record/garbage metadata; only literal `true` counts), `organizationHasCapability`.

## Tests run

- `bun test test/organization-capabilities.test.ts` — 6 pass, 0 fail (17 asserts)
- `npx tsc --noEmit` in `ee/apps/den-api` and `ee/apps/den-web` — clean
- `pnpm --filter @openwork-ee/den-web build` — succeeds
- fraimz flow `org-capability-flags` — PASSED (4 frames; proof posted as a PR comment): admin finds Capabilities off → flips Acme on (only Acme changes) → alex@acme.test's `/v1/org` reports `installLinks: true` → flips off, org reports dark again.

## Repro runbook

```bash
pnpm install
pnpm --filter @openwork/email build && pnpm --filter @openwork/types build \
  && pnpm --filter @openwork-ee/utils build && pnpm --filter @openwork-ee/den-db build
# den-api on :8790 with DEN_BOOTSTRAP_ADMIN_EMAILS=platform.admin@openwork.test (see evals/README.md den stack)
# den-web prod on :3005: pnpm --filter @openwork-ee/den-web build && DEN_API_BASE=http://127.0.0.1:8790 DEN_AUTH_ORIGIN=http://localhost:8790 pnpm --filter @openwork-ee/den-web start
node evals/scripts/launch-web-profiles.mjs
env OPENWORK_EVAL_DEN_WEB_URL=http://127.0.0.1:3005 \
    OPENWORK_EVAL_WEB_CDP_ADMIN=http://127.0.0.1:9333 \
    OPENWORK_EVAL_PLATFORM_ADMIN_EMAIL=platform.admin@openwork.test \
    OPENWORK_EVAL_PLATFORM_ADMIN_PASSWORD='OpenWorkDemo123!' \
    OPENWORK_EVAL_MARK_VERIFIED_CMD="docker exec openwork-web-local-mysql mysql -uroot -ppassword openwork_den -e \"UPDATE user SET email_verified=1 WHERE email='{email}'\"" \
    pnpm evals --flow org-capability-flags --stack den --cdp-url http://127.0.0.1:9333
```
