### PR TITLE
fix(evals): fraimz PR comments narrate the demo step by step (claim → voiceover → assertions → screenshot)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -65,9 +65,11 @@ pnpm fraimz --flow <flow-id> --pr # after the run, post the frame proof as a
 `--pr` uploads each frame screenshot to Vercel Blob so it renders inline in
 the comment (see the `upload-photo` skill); this requires
 `BLOB_READ_WRITE_TOKEN` in the environment (`get-env-var` skill /
-`infisical secrets get BLOB_READ_WRITE_TOKEN --plain --silent`). If the token
-is missing or an upload fails, the comment still posts with a note and the
-screenshots stay available in `evals/results/<run-id>/`.
+`infisical secrets get BLOB_READ_WRITE_TOKEN --plain --silent`). The comment
+renders each frame as claim → voiceover → assertions → screenshot so reviewers
+can follow the demo step by step. If the token is missing or an upload fails,
+the comment still posts with a note and the screenshots stay available in
+`evals/results/<run-id>/`.
 
 Flows load their narration with `loadVoiceoverParagraphs(<flow-id>)`; when a
 script exists for a flow, the runner appends a **Voice-over script coverage**

--- a/evals/flows/voiceover-first-dx.flow.mjs
+++ b/evals/flows/voiceover-first-dx.flow.mjs
@@ -173,15 +173,32 @@ export default {
                 steps: [{
                   status: "passed",
                   evidence: [
-                    { type: "claim", status: "passed", claim: "The demo holds", voiceover: vo[5] },
+                    // Mirrors ctx.prove's recording order for a prove-with-screenshot frame.
+                    { type: "claim", status: "running", name: "The demo holds", claim: "The demo holds", voiceover: vo[5] },
                     { type: "assertion", status: "passed", assertion: "Observable side effect witnessed" },
+                    { type: "frame", status: "passed", file: "demo-01-frame.png", name: "frame", claim: "The demo holds", voiceover: vo[5], validations: [{ label: "PNG exists and is non-empty", passed: true }] },
+                    { type: "claim", status: "passed", name: "The demo holds", claim: "The demo holds", voiceover: "" },
                   ],
                 }],
               }],
             });
+            const claimIndex = body.indexOf("**The demo holds**");
+            const voiceoverIndex = body.indexOf(`🎙 ${vo[5]}`);
+            const assertionIndex = body.indexOf("Observable side effect witnessed");
+            const screenshotIndex = body.indexOf("demo-01-frame.png");
             witness(ctx, body.includes("## fraimz — ✅ PASSED"), "The comment leads with the verdict");
             witness(ctx, body.includes(`🎙 ${vo[5]}`), "Each frame carries its voice-over line");
             witness(ctx, body.includes("Observable side effect witnessed"), "Each frame lists its passing assertions");
+            witness(
+              ctx,
+              claimIndex !== -1 && voiceoverIndex !== -1 && assertionIndex !== -1 && screenshotIndex !== -1 && claimIndex < voiceoverIndex && voiceoverIndex < assertionIndex && assertionIndex < screenshotIndex,
+              "The frame reads in follow-along order: claim, voice-over, assertions, then the screenshot",
+            );
+            witness(
+              ctx,
+              voiceoverIndex !== -1 && voiceoverIndex === body.lastIndexOf(`🎙 ${vo[5]}`),
+              "The narration appears exactly once per frame (screenshot copy deduped)",
+            );
             ctx.output("pr-comment.md (rendered)", body);
           },
         });

--- a/evals/runner/pr.mjs
+++ b/evals/runner/pr.mjs
@@ -1,8 +1,8 @@
 /**
  * fraimz on the PR: render the frame-by-frame proof as a PR comment and post
- * it with `gh`. The comment is the reviewable demo (verdict + per-frame claim,
- * voiceover, assertions); `fraimz.html` in the run directory stays the full
- * artifact with validated screenshots.
+ * it with `gh`. The comment is the follow-along demo: each frame reads as
+ * claim → voiceover → assertions → validated screenshot; `fraimz.html` in the
+ * run directory stays the full artifact.
  *
  * Frame screenshots are uploaded to Vercel Blob (see the `upload-photo`
  * skill) so they render inline in the PR comment. Requires
@@ -42,16 +42,54 @@ export function renderPrComment(report, imageUrls = null) {
     lines.push("");
     let frame = 0;
     for (const step of flow.steps ?? []) {
-      for (const evidence of step.evidence ?? []) {
-        if (evidence.type === "claim" && evidence.status === "passed") {
-          frame += 1;
-          lines.push(`${frame}. **${evidence.claim ?? evidence.name}**`);
-          if (evidence.voiceover) lines.push(`   > 🎙 ${evidence.voiceover}`);
+      const evidenceItems = step.evidence ?? [];
+      const opened = new Set();
+      let openClaim = null;
+      let narrated = null;
+      for (const [index, evidence] of evidenceItems.entries()) {
+        if (evidence.type === "claim") {
+          const key = evidence.name ?? evidence.claim;
+          const claim = evidence.claim ?? evidence.name;
+          if (evidence.status === "running") {
+            const closed = evidenceItems.slice(index + 1).some((item) => {
+              const itemKey = item.name ?? item.claim;
+              return item.type === "claim" && item.status === "passed" && itemKey === key;
+            });
+            frame += 1;
+            lines.push(`${frame}. ${closed ? "" : "❌ "}**${claim}**`);
+            opened.add(key);
+            openClaim = claim ?? null;
+            narrated = null;
+            if (evidence.voiceover) {
+              lines.push(`   > 🎙 ${evidence.voiceover}`);
+              narrated = evidence.voiceover;
+            }
+          } else if (evidence.status === "passed" && !opened.has(key)) {
+            frame += 1;
+            lines.push(`${frame}. **${claim}**`);
+            opened.add(key);
+            openClaim = claim ?? null;
+            narrated = null;
+            if (evidence.voiceover) {
+              lines.push(`   > 🎙 ${evidence.voiceover}`);
+              narrated = evidence.voiceover;
+            }
+          }
         }
         if (evidence.type === "assertion") {
           lines.push(`   - ${evidence.status === "passed" ? "✅" : "❌"} ${evidence.assertion}`);
         }
         if (evidence.type === "frame") {
+          if (evidence.claim && evidence.claim !== openClaim) {
+            frame += 1;
+            lines.push(`${frame}. **${evidence.claim}**`);
+            openClaim = evidence.claim;
+            narrated = null;
+          }
+          if (evidence.voiceover && evidence.voiceover !== narrated) {
+            lines.push(`   > 🎙 ${evidence.voiceover}`);
+            narrated = evidence.voiceover;
+          }
           const failed = (evidence.validations ?? []).filter((validation) => !validation.passed);
           lines.push(
             `   - 📸 \`${evidence.file}\` — ${failed.length === 0 ? `${(evidence.validations ?? []).length} validations passed` : `FAILED: ${failed.map((validation) => validation.label).join(", ")}`}`,


### PR DESCRIPTION
## What

`pnpm fraimz --flow <id> --pr` posted proof comments that were screenshots + broad confirmations — the step-by-step voiceover never made it to GitHub, and the numbered claims rendered *under the previous frame's screenshot*. Reviewers couldn't follow the demo along.

Two bugs in `renderPrComment` (`evals/runner/pr.mjs`):

1. **Narration dropped.** `ctx.prove` moves the voiceover onto the screenshot frame and blanks it on the closing claim (so `fraimz.html` narrates each frame once), but the PR renderer only read voiceovers from claim evidence → in the common prove-with-screenshot case, zero 🎙 lines in the comment.
2. **Wrong order.** Claims were numbered on the *closing* (`passed`) record, which `ctx.prove` writes after the assertions and screenshot → each claim rendered beneath the previous frame's image.

## How

The comment now renders each frame as a follow-along beat: **numbered claim → 🎙 voiceover → ✅ assertions → 📸 validated screenshot (+ inline image)**.

- Beats open at the `running` claim (so claim + narration precede their evidence); the closing record is skipped; a prove that never closed renders with ❌ instead of silently disappearing.
- Bare `ctx.screenshot(name, { claim, voiceover })` beats get their own number; lone `passed` claims (app-less proves) still render.
- The voiceover `ctx.prove` copies onto its screenshot frame is deduped — each beat narrates exactly once.
- `voiceover-first-dx` fixture now mirrors `ctx.prove`'s real recording order, with new witnesses pinning the follow-along order and exactly-once narration (honoring the approved script's frame 6: *"my script, frame by frame, each line backed by a passing assertion"*).

## Before / after (real run from #2477, re-rendered)

Before — no narration, claim trails its screenshot:

```md
   - ✅ Visible text does not include "Something went wrong"
   - 📸 `in-chat-find-01-seeded-zebra-conversation.png` — 4 validations passed
1. **The flow creates a fresh conversation where 'zebra' appears in both the user's message and the assistant's visible prose.**
   - 📸 `in-chat-find-02-find-bar-open-focused.png` — 3 validations passed
```

After — follow-along:

```md
1. **The flow creates a fresh conversation where 'zebra' appears in both the user's message and the assistant's visible prose.**
   > 🎙 First I create a fresh conversation and ask for one exact sentence. When the assistant answers, the word zebra is visible in both my bubble and the assistant prose, giving the find bar real matches to work with.
   - ✅ Visible text does not include "Something went wrong"
   - 📸 `in-chat-find-01-seeded-zebra-conversation.png` — 4 validations passed
```

The fraimz comment below (posted with `pnpm fraimz --flow voiceover-first-dx --pr`) is rendered by the new code — the proof demonstrates itself.

## Tests

- `pnpm fraimz --flow voiceover-first-dx` — **PASSED** (all 7 frames + voice-over script coverage), including the new follow-along-order and exactly-once-narration witnesses.
- Synthetic render check covering prove-with-screenshot, bare frame with claim, lone passed claim (app-less), and a failed prove (❌-marked): all assertions pass.
- Re-rendered the real `in-chat-find` run (`2026-07-04T14-18-06-860Z`, posted on #2477): old renderer = 0 🎙 lines; new = 6 🎙 lines, one per frame, in order.
- `node --check` on both changed modules.

No runtime app surface touched (evals tooling only), so no Electron flow is affected; the canonical core-flow behavior is unchanged by construction.
