### PR TITLE
fix(analytics): keep dev out of production PostHog everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ apps/*/node_modules/
 ee/apps/*/node_modules/
 ee/packages/*/node_modules/
 .next/
+ee/apps/landing/.next-prod-eval/
 out/
 dist/
 packages/*/dist/

--- a/apps/app/src/app/lib/analytics-key.ts
+++ b/apps/app/src/app/lib/analytics-key.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_POSTHOG_KEY = "phc_4YnPTlDVYPjgwKvLuNxhbHjV5kadgvd7XLzVHWnCXAI";
+
+/**
+ * Resolve the PostHog project key. `raw` is VITE_OPENWORK_POSTHOG_KEY.
+ * Unset uses the default key in prod builds and stays silent in dev builds.
+ * Explicit strings are used after trim; an empty string disables analytics in any build.
+ */
+export function resolvePosthogKey(raw: unknown, isDev: boolean): string {
+  if (typeof raw === "string") return raw.trim(); // explicit value wins; "" disables
+  return isDev ? "" : DEFAULT_POSTHOG_KEY;
+}

--- a/apps/app/src/app/lib/analytics.ts
+++ b/apps/app/src/app/lib/analytics.ts
@@ -8,27 +8,25 @@
  *   into an explicit survey field (e.g. the onboarding attribution survey).
  * - Fire-and-forget: analytics must never break or slow the app.
  * - Respect the user: a single `analyticsEnabled` preference (Settings ->
- *   Preferences) turns everything off; no key baked in means no network.
+ *   Preferences) turns everything off; an explicitly blank PostHog key means
+ *   no network.
  * - Every capture is mirrored into the local app inspector
  *   (`window.__openwork.record("analytics.<event>")`) so coded evals can
  *   assert instrumentation without any analytics backend.
  */
 import { denSessionUpdatedEvent, type DenSessionUpdatedDetail } from "./den-session-events";
 import { recordInspectorEvent } from "./app-inspector";
+import { resolvePosthogKey } from "./analytics-key";
 
-const ENV_POSTHOG_KEY = String(import.meta.env.VITE_OPENWORK_POSTHOG_KEY ?? "").trim();
 const ENV_POSTHOG_HOST = String(import.meta.env.VITE_OPENWORK_POSTHOG_HOST ?? "").trim();
 const ENV_APP_VERSION = String(import.meta.env.VITE_OPENWORK_APP_VERSION ?? "").trim();
 
-// Same public project key the landing page and den-web use; PostHog client
-// keys are publishable by design. Override or blank via VITE_OPENWORK_POSTHOG_KEY.
-const DEFAULT_POSTHOG_KEY = "phc_4YnPTlDVYPjgwKvLuNxhbHjV5kadgvd7XLzVHWnCXAI";
 const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
 
-// Dev builds send nothing unless a key is explicitly provided, so local
-// runs, CI, and evals never pollute production analytics. The inspector
-// mirror still records events locally either way.
-const POSTHOG_KEY = ENV_POSTHOG_KEY || (import.meta.env.DEV ? "" : DEFAULT_POSTHOG_KEY);
+// Packaged releases use the default publishable key; dev builds stay silent
+// unless VITE_OPENWORK_POSTHOG_KEY is set. Set it to "" to disable analytics
+// in any build. The inspector mirror still records events locally either way.
+const POSTHOG_KEY = resolvePosthogKey(import.meta.env.VITE_OPENWORK_POSTHOG_KEY, import.meta.env.DEV);
 const POSTHOG_HOST = (ENV_POSTHOG_HOST || DEFAULT_POSTHOG_HOST).replace(/\/+$/, "");
 
 const PREFS_STORAGE_KEY = "openwork.preferences";

--- a/apps/app/tests/analytics-key.test.ts
+++ b/apps/app/tests/analytics-key.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { DEFAULT_POSTHOG_KEY, resolvePosthogKey } from "../src/app/lib/analytics-key";
+
+describe("analytics-key", () => {
+  test("uses the default key for packaged release builds without an env override", () => {
+    expect(resolvePosthogKey(undefined, false)).toBe(DEFAULT_POSTHOG_KEY);
+  });
+
+  test("stays silent for dev builds without an env override", () => {
+    expect(resolvePosthogKey(undefined, true)).toBe("");
+  });
+
+  test("treats an explicit blank as disabled in prod builds", () => {
+    expect(resolvePosthogKey("", false)).toBe("");
+  });
+
+  test("trims whitespace to disabled", () => {
+    expect(resolvePosthogKey("  ", true)).toBe("");
+  });
+
+  test("uses an explicit key in dev builds", () => {
+    expect(resolvePosthogKey("phc_custom", true)).toBe("phc_custom");
+  });
+
+  test("uses an explicit key in prod builds", () => {
+    expect(resolvePosthogKey("phc_custom", false)).toBe("phc_custom");
+  });
+});

--- a/ee/apps/landing/app/layout.tsx
+++ b/ee/apps/landing/app/layout.tsx
@@ -6,6 +6,11 @@ import { WebMcpProvider } from "../components/webmcp-provider";
 import { StructuredData } from "../components/structured-data";
 import { POSTHOG_PROJECT_KEY } from "../lib/posthog-client";
 
+// Matches the server-side gate in lib/posthog-server.ts.
+// Local pnpm dev, local prod builds, and Vercel previews load no PostHog at all (no autocapture/pageviews), so only real production traffic reaches analytics.
+// VERCEL_ENV is baked at build time for static pages, which is correct on Vercel production builds.
+const posthogEnabled = process.env.VERCEL_ENV === "production";
+
 const organizationSchema = {
   "@context": "https://schema.org",
   "@type": "Organization",
@@ -67,18 +72,20 @@ export default function RootLayout({
       <head>
         <StructuredData data={organizationSchema} />
         <BotIdClient protect={protectedRoutes} />
-        <Script
-          id="posthog"
-          strategy="beforeInteractive"
-          dangerouslySetInnerHTML={{
+        {posthogEnabled ? (
+          <Script
+            id="posthog"
+            strategy="beforeInteractive"
+            dangerouslySetInnerHTML={{
             __html: `!function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init rs ls wi ns us ts ss capture calculateEventProperties vs register register_once register_for_session unregister unregister_for_session gs getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty fs ds createPersonProfile setInternalOrTestUser ps Qr opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing hs debug M cs getPageViewId captureTraceFeedback captureTraceMetric Kr".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     posthog.init('${POSTHOG_PROJECT_KEY}', {
         api_host: 'https://us.i.posthog.com',
         defaults: '2025-11-30',
         person_profiles: 'identified_only',
     })`
-          }}
-        />
+            }}
+          />
+        ) : null}
       </head>
       <body className="overflow-x-hidden antialiased">
         <WebMcpProvider />

--- a/ee/apps/landing/next.config.js
+++ b/ee/apps/landing/next.config.js
@@ -6,6 +6,14 @@ const mintlifyOrigin = "https://differentai.mintlify.dev";
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@openwork/email", "@openwork/ui"],
+  // Lets evals build/serve a production instance beside next dev without clobbering .next.
+  distDir: process.env.LANDING_DIST_DIR || ".next",
+  // Bake VERCEL_ENV at build time so the PostHog gates (app/layout.tsx and
+  // lib/posthog-server.ts) behave per-deployment: on Vercel the build env
+  // matches the runtime env, and local `next start` mirrors what was built.
+  env: {
+    VERCEL_ENV: process.env.VERCEL_ENV || "",
+  },
   async rewrites() {
     return [
       {

--- a/evals/flows/landing-posthog-prod-gate.flow.mjs
+++ b/evals/flows/landing-posthog-prod-gate.flow.mjs
@@ -1,0 +1,192 @@
+const COPY_BUTTON_SELECTOR = 'button[aria-label="Copy the agent setup prompt"]';
+const POSTHOG_SCRIPT_MARKERS = ['id="posthog"', '"id":"posthog"'];
+const POSTHOG_KEY_PREFIX = "phc_";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function pageUrl(baseUrl) {
+  return new URL("/", baseUrl).toString();
+}
+
+function recordAssertion(ctx, assertion, passed, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: passed ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(passed, `${assertion}. Actual: ${JSON.stringify(actual)}`);
+}
+
+function hasPosthogScriptMarker(html) {
+  return POSTHOG_SCRIPT_MARKERS.some((marker) => html.includes(marker));
+}
+
+async function scanHomeHtml(baseUrl) {
+  const response = await fetch(pageUrl(baseUrl));
+  const html = await response.text();
+  return {
+    status: response.status,
+    hasPosthogScript: hasPosthogScriptMarker(html),
+    hasPosthogKeyPrefix: html.includes(POSTHOG_KEY_PREFIX),
+  };
+}
+
+// The production-mode instance ships the real snippet with the production
+// project key. Block PostHog's hosts so driving it in an eval never sends
+// $pageview/autocapture to real analytics: the inline snippet still runs
+// (window.posthog queue exists), but array.js and capture posts are dropped.
+async function setPosthogNetworkBlocked(ctx, blocked) {
+  if (!ctx.client?.send) {
+    ctx.log("PostHog network block skipped: no raw CDP send method on context.");
+    return;
+  }
+  try {
+    await ctx.client.send("Network.enable", {});
+    await ctx.client.send("Network.setBlockedURLs", { urls: blocked ? ["*posthog.com*"] : [] });
+  } catch (error) {
+    ctx.log(`PostHog network block ${blocked ? "enable" : "clear"} failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function grantClipboardPermissions(ctx, baseUrl) {
+  if (!ctx.client?.send) {
+    ctx.log("Clipboard permission grant skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  const origin = new URL(baseUrl).origin;
+  await ctx.client.send("Browser.grantPermissions", {
+    origin,
+    permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
+  }).catch((error) => {
+    ctx.log(`Clipboard permission grant skipped: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+export default {
+  id: "landing-posthog-prod-gate",
+  title: "Landing PostHog loads in production only",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_LANDING_URL", "OPENWORK_EVAL_LANDING_PROD_URL"],
+  steps: [
+    {
+      name: "Dev server ships no PostHog, and Copy Prompt still works",
+      run: async (ctx) => {
+        let htmlScan = null;
+        let runtimeScan = null;
+        let copyScan = null;
+
+        await ctx.prove("Dev server ships no PostHog, and Copy Prompt still works.", {
+          action: async () => {
+            htmlScan = await scanHomeHtml(ctx.env.OPENWORK_EVAL_LANDING_URL);
+            await ctx.eval(`location.href = ${JSON.stringify(pageUrl(ctx.env.OPENWORK_EVAL_LANDING_URL))}; true`);
+            await ctx.waitFor(
+              `Boolean(document.querySelector(${JSON.stringify(COPY_BUTTON_SELECTOR)}))`,
+              { timeoutMs: 30_000, label: "Copy Prompt button on dev landing" },
+            );
+            runtimeScan = await ctx.eval(`(() => ({
+              posthogUndefined: window.posthog === undefined,
+              posthogScriptAbsent: document.getElementById("posthog") === null,
+            }))()`);
+            await grantClipboardPermissions(ctx, ctx.env.OPENWORK_EVAL_LANDING_URL);
+            await ctx.eval(`(() => {
+              const button = document.querySelector(${JSON.stringify(COPY_BUTTON_SELECTOR)});
+              button.scrollIntoView({ block: "center" });
+              button.click();
+              return true;
+            })()`);
+            await ctx.waitFor(
+              `Boolean(document.querySelector('[data-feedback="true"]')) && window.posthog === undefined`,
+              { timeoutMs: 10_000, label: "Copy Prompt feedback without PostHog" },
+            );
+            copyScan = await ctx.eval(`(() => ({
+              feedbackActive: Boolean(document.querySelector('[data-feedback="true"]')),
+              posthogUndefined: window.posthog === undefined,
+            }))()`);
+            await sleep(400);
+          },
+          assert: async () => {
+            ctx.recordEvidence({
+              type: "output",
+              name: "Dev homepage PostHog scan",
+              text: JSON.stringify(htmlScan, null, 2),
+            });
+            recordAssertion(
+              ctx,
+              "Dev homepage HTML omits the PostHog inline script and project key prefix",
+              htmlScan?.status === 200 && htmlScan.hasPosthogScript === false && htmlScan.hasPosthogKeyPrefix === false,
+              htmlScan,
+            );
+            recordAssertion(
+              ctx,
+              "Dev browser runtime has no PostHog global and no inline script tag",
+              runtimeScan?.posthogUndefined === true && runtimeScan.posthogScriptAbsent === true,
+              runtimeScan,
+            );
+            recordAssertion(
+              ctx,
+              "Copy Prompt enters feedback state while PostHog remains absent",
+              copyScan?.feedbackActive === true && copyScan.posthogUndefined === true,
+              copyScan,
+            );
+          },
+          screenshot: {
+            name: "dev-no-posthog-copied",
+            requireText: ["Copied"],
+          },
+        });
+      },
+    },
+    {
+      name: "Production build ships PostHog",
+      run: async (ctx) => {
+        let htmlScan = null;
+        let runtimeScan = null;
+
+        await ctx.prove("Production build ships PostHog.", {
+          action: async () => {
+            htmlScan = await scanHomeHtml(ctx.env.OPENWORK_EVAL_LANDING_PROD_URL);
+            await setPosthogNetworkBlocked(ctx, true);
+            await ctx.eval(`location.href = ${JSON.stringify(pageUrl(ctx.env.OPENWORK_EVAL_LANDING_PROD_URL))}; true`);
+            await ctx.waitFor(
+              `Boolean(document.querySelector(${JSON.stringify(COPY_BUTTON_SELECTOR)}))`,
+              { timeoutMs: 30_000, label: "Copy Prompt button on production landing" },
+            );
+            await ctx.waitFor(
+              `typeof window.posthog !== "undefined"`,
+              { timeoutMs: 10_000, label: "PostHog global from production inline snippet" },
+            );
+            runtimeScan = await ctx.eval(`(() => ({
+              posthogPresent: Boolean(window.posthog),
+              posthogScriptPresent: Boolean(document.querySelector('script#posthog')) || Array.from(document.scripts).some((script) => (script.textContent || "").includes("posthog.init") && (script.textContent || "").includes("phc_")),
+            }))()`);
+          },
+          assert: async () => {
+            ctx.recordEvidence({
+              type: "output",
+              name: "Production homepage PostHog scan",
+              text: JSON.stringify(htmlScan, null, 2),
+            });
+            recordAssertion(
+              ctx,
+              "Production homepage HTML includes the PostHog inline script and project key prefix",
+              htmlScan?.status === 200 && htmlScan.hasPosthogScript === true && htmlScan.hasPosthogKeyPrefix === true,
+              htmlScan,
+            );
+            recordAssertion(
+              ctx,
+              "Production browser runtime has the PostHog global and inline script tag",
+              runtimeScan?.posthogPresent === true && runtimeScan.posthogScriptPresent === true,
+              runtimeScan,
+            );
+          },
+          screenshot: "prod-posthog-present",
+        });
+
+        await setPosthogNetworkBlocked(ctx, false);
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Why

Audit follow-up from #2479: two ways local development could pollute the production PostHog project (and skew the DAU/WAU/retention + Copy Prompt dashboards):

1. **Landing client leak** — `app/layout.tsx` loaded the inline PostHog snippet with the prod key **unconditionally**: every `pnpm dev` session on localhost (and every Vercel preview) sent $pageview, autocapture, and `landing_copy_prompt_clicked` into prod analytics.
2. **Desktop off-switch bug** — the comment in `analytics.ts` claimed `VITE_OPENWORK_POSTHOG_KEY` could blank the key, but `ENV_KEY || DEFAULT` meant an empty string fell through to the default key in prod builds. Locally-built binaries had **no working way to disable analytics**.

## What

- **Landing**: the PostHog `<Script>` renders only when `VERCEL_ENV === "production"` — same gate as the server-side `lib/posthog-server.ts`. Dev, local prod builds, and previews load no PostHog at all. `VERCEL_ENV` is baked at build time via `next.config env` so a built instance behaves per-deployment (on Vercel, build env == runtime env; no behavior change in real deploys).
- **Desktop**: key resolution extracted to a pure `resolvePosthogKey(raw, isDev)` — unset → default key in prod builds / silent in dev builds (unchanged mainline behavior); explicitly set → used after trim, and an explicit `""` now genuinely disables analytics in **any** build. Covered by bun tests.
- **Evals**: `LANDING_DIST_DIR` support in `next.config.js` lets a production build run beside `next dev` without the two clobbering `.next`. New flow `landing-posthog-prod-gate` proves both sides; it also blocks `*.posthog.com` via CDP while driving the prod instance so the eval itself never emits real events.

## Behavior matrix after this PR

| Surface | dev | local prod build | Vercel preview | Vercel production |
|---|---|---|---|---|
| Landing client (pageviews/autocapture/copy-prompt) | silent | silent | silent | ✅ sends |
| Landing server (`landing_start_md_fetched`) | silent (unchanged) | silent | silent | ✅ sends |
| Desktop app events | silent (unchanged) | default key **unless** `VITE_OPENWORK_POSTHOG_KEY=""` | n/a | packaged releases send (unchanged) |

## Tests run

- `pnpm --dir apps/app test` — 117 pass, 0 fail (includes new `analytics-key.test.ts`)
- `pnpm --dir apps/app typecheck` and `pnpm --dir ee/apps/landing exec tsc --noEmit` — clean
- `pnpm --dir ee/apps/landing build` (default) and `VERCEL_ENV=production LANDING_DIST_DIR=.next-prod-eval build` — both pass
- Reality check: dev homepage HTML contains **0** occurrences of the `phc_` key; production-mode instance contains it and boots `window.posthog`
- Coded flow `landing-posthog-prod-gate` against live dev (:3421) + prod-mode (:3422) instances via headless Chrome CDP — PASSED; fraimz proof below

Reproduce:
```sh
OPENWORK_DEV_MODE=1 pnpm --dir ee/apps/landing exec next dev --port 3421 &
VERCEL_ENV=production LANDING_DIST_DIR=.next-prod-eval pnpm --dir ee/apps/landing build
LANDING_DIST_DIR=.next-prod-eval pnpm --dir ee/apps/landing exec next start --port 3422 &
OPENWORK_EVAL_LANDING_URL=http://127.0.0.1:3421 OPENWORK_EVAL_LANDING_PROD_URL=http://127.0.0.1:3422 \
  pnpm fraimz --flow landing-posthog-prod-gate --cdp-url http://127.0.0.1:<cdp-port>
```

Note for dashboard hygiene: this stops **new** dev pollution; consider also enabling PostHog's *"Filter out internal and test users"* ($host = localhost) to clean historical localhost events out of insights.