### PR TITLE
feat(installer): generic installer ships as public release assets; den-api serves stamped downloads from them

### DIFF
--- a/.github/workflows/release-generic-installer.yml
+++ b/.github/workflows/release-generic-installer.yml
@@ -1,0 +1,367 @@
+name: Release Generic Installer
+
+# Builds the GENERIC (unbranded) OpenWork installer — the committed
+# apps/installer build-config placeholder stays empty, so the binary carries
+# no deployment values and resolves its config at run time (sidecar stamped by
+# den-api, filename tag, or pasted install link; see #2480) — and publishes it
+# as PUBLIC release assets. den-api serves org-stamped downloads straight from
+# these published assets, so production deployments need no local artifact
+# directory.
+#
+# Asset names are a contract with den-api's artifactFileName()
+# (ee/apps/den-api/src/routes/org/install-links.ts):
+#   openwork-installer-mac-arm64.zip   (.app at the zip root, signed+notarized)
+#   openwork-installer-mac-x64.zip     (.app at the zip root, signed+notarized)
+#   openwork-installer-win-x64.exe
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to attach the installer assets to (e.g. v0.17.9)"
+        required: true
+        type: string
+      platforms:
+        description: "Platforms to build and publish"
+        required: false
+        type: choice
+        default: "mac-arm64,mac-x64,win-x64"
+        options:
+          - "mac-arm64,mac-x64,win-x64"
+          - "mac-arm64,mac-x64"
+          - "mac-arm64"
+          - "mac-x64"
+          - "win-x64"
+      sign_windows:
+        description: "Sign the Windows installer via SignPath"
+        required: false
+        type: boolean
+        default: false
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-generic-installer-${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve release + platforms
+    # Auto-attach only to published app releases (vX.Y.Z); skip prereleases
+    # and secondary releases like openwork-orchestrator-v*.
+    if: github.event_name == 'workflow_dispatch' || (github.event.release.prerelease == false && startsWith(github.event.release.tag_name, 'v'))
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.resolve.outputs.release_tag }}
+      sign_windows: ${{ steps.resolve.outputs.sign_windows }}
+      matrix: ${{ steps.resolve.outputs.matrix }}
+    steps:
+      - name: Resolve inputs
+        id: resolve
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          INPUT_PLATFORMS: ${{ github.event.inputs.platforms }}
+          INPUT_SIGN_WINDOWS: ${{ github.event.inputs.sign_windows }}
+          RELEASE_EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "release" ]; then
+            RELEASE_TAG="$RELEASE_EVENT_TAG"
+            PLATFORMS="mac-arm64,mac-x64,win-x64"
+            SIGN_WINDOWS="false"
+          else
+            RELEASE_TAG="$INPUT_RELEASE_TAG"
+            PLATFORMS="${INPUT_PLATFORMS:-mac-arm64,mac-x64,win-x64}"
+            SIGN_WINDOWS="${INPUT_SIGN_WINDOWS:-false}"
+          fi
+
+          if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null; then
+            echo "Release $RELEASE_TAG does not exist on $GITHUB_REPOSITORY" >&2
+            exit 1
+          fi
+
+          ALL='[
+            {"platform_id":"mac-arm64","runner":"macos-14","os_type":"macos","bun_target":"bun-darwin-arm64","asset":"openwork-installer-mac-arm64.zip"},
+            {"platform_id":"mac-x64","runner":"macos-14","os_type":"macos","bun_target":"bun-darwin-x64","asset":"openwork-installer-mac-x64.zip"},
+            {"platform_id":"win-x64","runner":"windows-2022","os_type":"windows","bun_target":"bun-windows-x64","asset":"openwork-installer-win-x64.exe"}
+          ]'
+          MATRIX=$(jq -cn --arg csv "$PLATFORMS" --argjson all "$ALL" \
+            '$all | map(select(.platform_id as $id | ($csv | split(",") | map(gsub("\\s";"")) | index($id)) != null))')
+          if [ "$(jq 'length' <<<"$MATRIX")" -eq 0 ]; then
+            echo "No known platforms in: $PLATFORMS" >&2
+            exit 1
+          fi
+
+          {
+            echo "release_tag=$RELEASE_TAG"
+            echo "sign_windows=$SIGN_WINDOWS"
+            echo "matrix=$MATRIX"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build + publish (${{ matrix.platform_id }})
+    needs: resolve
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    env:
+      RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+      SIGN_WINDOWS: ${{ needs.resolve.outputs.sign_windows }}
+      SIGNPATH_ORGANIZATION_ID: ${{ secrets.SIGNPATH_ORGANIZATION_ID || vars.SIGNPATH_ORGANIZATION_ID }}
+      SIGNPATH_PROJECT_SLUG: ${{ secrets.SIGNPATH_PROJECT_SLUG || vars.SIGNPATH_PROJECT_SLUG }}
+      SIGNPATH_SIGNING_POLICY_SLUG: ${{ secrets.SIGNPATH_SIGNING_POLICY_SLUG || vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+      SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: ${{ secrets.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG || vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.resolve.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Verify build config is the generic placeholder
+        shell: bash
+        run: |
+          bun -e '
+            const config = await import("./apps/installer/src/generated/build-config.ts")
+            const values = [config.BUILD_CLIENT_NAME, config.BUILD_WEB_URL, config.BUILD_API_URL, config.BUILD_LOGO_URL]
+            if (values.some((value) => value !== "") || config.BUILD_REQUIRE_SIGNIN !== false) {
+              console.error("build-config.ts is not the empty generic placeholder; refusing to publish a client-configured build publicly.")
+              process.exit(1)
+            }
+          '
+
+      - name: Install dependencies
+        shell: bash
+        run: bun install --cwd apps/installer
+
+      - name: Test
+        shell: bash
+        run: cd apps/installer && bun test
+
+      - name: Compile installer
+        shell: bash
+        run: |
+          cd apps/installer
+          bun build --compile --minify --target=${{ matrix.bun_target }} \
+            src/index.ts src/server-worker.ts \
+            --outfile "dist/openwork-installer"
+
+      - name: Smoke test (generic build refuses to run unconfigured)
+        # Cross-compiled mac x64 output cannot run on the arm64 runner.
+        if: matrix.bun_target != 'bun-darwin-x64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd apps/installer
+          binary=dist/openwork-installer
+          if [ "${{ matrix.os_type }}" = "windows" ]; then binary=dist/openwork-installer.exe; fi
+          set +e
+          output=$("$binary" --headless --dry-run 2>&1)
+          status=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$status" -ne 2 ]; then
+            echo "Expected the unconfigured generic installer to exit 2, got $status" >&2
+            exit 1
+          fi
+          case "$output" in
+            *"Paste an OpenWork install link"*) ;;
+            *) echo "Generic installer did not ask for an install link" >&2; exit 1 ;;
+          esac
+
+      # --- macOS: wrap in a .app bundle, sign, notarize, staple, zip --------
+      - name: Bundle macOS app
+        if: matrix.os_type == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd apps/installer
+          APP="dist/OpenWork Installer.app"
+          rm -rf "$APP"
+          mkdir -p "$APP/Contents/MacOS"
+          cp dist/openwork-installer "$APP/Contents/MacOS/openwork-installer"
+          cat > "$APP/Contents/Info.plist" <<'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleName</key><string>OpenWork Installer</string>
+            <key>CFBundleDisplayName</key><string>OpenWork Installer</string>
+            <key>CFBundleIdentifier</key><string>com.differentai.openwork.installer</string>
+            <key>CFBundleExecutable</key><string>openwork-installer</string>
+            <key>CFBundlePackageType</key><string>APPL</string>
+            <key>CFBundleShortVersionString</key><string>1.0.0</string>
+            <key>CFBundleVersion</key><string>1</string>
+            <key>LSMinimumSystemVersion</key><string>11.0</string>
+            <key>NSHighResolutionCapable</key><true/>
+          </dict>
+          </plist>
+          PLIST
+
+      - name: Sign and notarize macOS app
+        if: matrix.os_type == 'macos'
+        shell: bash
+        env:
+          APPLE_CODESIGN_CERT_P12_BASE64: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
+          APPLE_CODESIGN_CERT_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
+          APPLE_NOTARY_API_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_API_KEY_P8_BASE64 }}
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          APPLE_NOTARY_API_ISSUER_ID: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            APPLE_CODESIGN_CERT_P12_BASE64 \
+            APPLE_CODESIGN_CERT_PASSWORD \
+            APPLE_NOTARY_API_KEY_P8_BASE64 \
+            APPLE_NOTARY_API_KEY_ID \
+            APPLE_NOTARY_API_ISSUER_ID; do
+            if [ -z "${!name:-}" ]; then missing+=("$name"); fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing macOS signing secrets: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+          cd apps/installer
+          APP="dist/OpenWork Installer.app"
+
+          KEYCHAIN="$RUNNER_TEMP/installer.keychain-db"
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          printf '%s' "$APPLE_CODESIGN_CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$APPLE_CODESIGN_CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | awk -F'"' 'NR==1{print $2}')
+          if [ -z "$IDENTITY" ]; then
+            echo "No codesigning identity found in imported certificate" >&2
+            exit 1
+          fi
+
+          # Bun-compiled binaries need JIT entitlements to pass notarization.
+          cat > "$RUNNER_TEMP/entitlements.plist" <<'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>com.apple.security.cs.allow-jit</key><true/>
+            <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+            <key>com.apple.security.cs.disable-library-validation</key><true/>
+          </dict>
+          </plist>
+          PLIST
+
+          codesign --force --options runtime --timestamp \
+            --entitlements "$RUNNER_TEMP/entitlements.plist" \
+            --sign "$IDENTITY" "$APP/Contents/MacOS/openwork-installer"
+          codesign --force --options runtime --timestamp \
+            --entitlements "$RUNNER_TEMP/entitlements.plist" \
+            --sign "$IDENTITY" "$APP"
+          codesign --verify --deep --strict "$APP"
+
+          NOTARY_KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          printf '%s' "$APPLE_NOTARY_API_KEY_P8_BASE64" | base64 --decode > "$NOTARY_KEY_PATH"
+          chmod 600 "$NOTARY_KEY_PATH"
+          ditto -c -k --keepParent "$APP" "$RUNNER_TEMP/notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+            --key "$NOTARY_KEY_PATH" \
+            --key-id "$APPLE_NOTARY_API_KEY_ID" \
+            --issuer "$APPLE_NOTARY_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "$APP"
+
+      - name: Package macOS asset (.app at the zip root)
+        if: matrix.os_type == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd apps/installer
+          mkdir -p "$RUNNER_TEMP/out"
+          ditto -c -k --keepParent "dist/OpenWork Installer.app" "$RUNNER_TEMP/out/${{ matrix.asset }}"
+
+      # --- Windows: optional SignPath signing --------------------------------
+      - name: Stage unsigned Windows installer for SignPath
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/signpath-unsigned"
+          cp apps/installer/dist/openwork-installer.exe "$RUNNER_TEMP/signpath-unsigned/"
+
+      - name: Upload unsigned Windows installer for SignPath
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
+        id: upload-unsigned-windows-installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-generic-installer-windows-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/signpath-unsigned/*.exe
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Submit Windows signing request to SignPath
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true' && env.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG == ''
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ env.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ env.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned-windows-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: ${{ runner.temp }}/signpath-signed
+
+      - name: Submit Windows signing request to SignPath (artifact configuration)
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true' && env.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG != ''
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ env.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ env.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ env.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned-windows-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: ${{ runner.temp }}/signpath-signed
+
+      - name: Package Windows asset
+        if: matrix.os_type == 'windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/out"
+          if [ "$SIGN_WINDOWS" = "true" ]; then
+            signed=$(find "$RUNNER_TEMP/signpath-signed" -name '*.exe' | head -n 1)
+            if [ -z "$signed" ]; then
+              echo "SignPath returned no signed executable" >&2
+              exit 1
+            fi
+            cp "$signed" "$RUNNER_TEMP/out/${{ matrix.asset }}"
+          else
+            echo "::warning::Publishing UNSIGNED Windows installer (sign_windows=false)."
+            cp apps/installer/dist/openwork-installer.exe "$RUNNER_TEMP/out/${{ matrix.asset }}"
+          fi
+
+      - name: Upload release asset
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" "$RUNNER_TEMP/out/${{ matrix.asset }}" \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release-generic-installer.yml
+++ b/.github/workflows/release-generic-installer.yml
@@ -145,7 +145,21 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: bun install --cwd apps/installer
+        run: |
+          set -euo pipefail
+          # Build the workspace dependency's dist first: @openwork/install-config's
+          # "default" export points at dist/, which a fresh checkout lacks.
+          (cd packages/install-config && bun install && bun run build)
+          # bun 1.3.9 on Windows can fail to create the parent-relative
+          # workspace symlink (ENOENT) after installing every other package;
+          # the copy fallback below repairs exactly that case.
+          (cd apps/installer && bun install) || [ "${{ matrix.os_type }}" = "windows" ]
+          if [ ! -e "apps/installer/node_modules/@openwork/install-config/package.json" ]; then
+            rm -rf "apps/installer/node_modules/@openwork/install-config"
+            mkdir -p "apps/installer/node_modules/@openwork"
+            cp -R "packages/install-config" "apps/installer/node_modules/@openwork/install-config"
+          fi
+          test -e "apps/installer/node_modules/@openwork/install-config/package.json"
 
       - name: Test
         shell: bash

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -119,7 +119,10 @@ describe("resolveInstallerConfig", () => {
     }
   })
 
-  test("reads sidecar next to the enclosing app bundle", async () => {
+  // macOS-only semantics: .app bundles (and their slash-separated exec paths)
+  // do not exist on Windows, where path.join builds a backslashed path the
+  // bundle matcher rightly rejects.
+  test.skipIf(process.platform === "win32")("reads sidecar next to the enclosing app bundle", async () => {
     const dir = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-app-sidecar-"))
     try {
       const macOsDir = path.join(dir, "OpenWork Installer.app", "Contents", "MacOS")

--- a/docs/org-install-links.md
+++ b/docs/org-install-links.md
@@ -1,0 +1,88 @@
+# Organization Install Links
+
+Status: self-host operator guide
+Owner: platform/self-host
+Related: `ee/apps/den-api/src/routes/org/install-links.ts`, `ee/apps/den-api/src/utils/installer-artifacts.ts`, `packaging/helm/openwork-ee/README.md`
+
+## What it is
+
+Organization install links let org admins mint shareable desktop install links
+for their workspace. Den serves one generic signed installer and stamps it per
+org at serve time. The installed app boots into forced sign-in against your
+deployment, so possession of an install link does not grant workspace access.
+
+## Upgrade checklist
+
+> **Dark launch:** Upgrading changes nothing visible. Install links stay dark
+> until a platform admin enables the `Install links` capability for an org.
+
+### Helm
+
+1. Keep `migrations.enabled=true` for the upgrade. The migration Job creates
+   the `install_link` table automatically; see the
+   [Helm migration Job docs](../packaging/helm/openwork-ee/README.md#migrations).
+2. Set `config.public.bootstrapAdminEmails` (renders
+   `DEN_BOOTSTRAP_ADMIN_EMAILS`) to the platform admin email allowlist.
+3. Restart/roll the deployment with the new values.
+4. Sign in to den-web, open `/admin`, and toggle `Install links` for each org
+   that should be allowed to mint links.
+
+### Docker Compose
+
+1. Run the migration once from the repo root:
+
+   ```bash
+   docker compose -f packaging/docker/docker-compose.den-dev.yml exec den sh -lc "pnpm --dir /app/ee/packages/den-db run db:bootstrap"
+   ```
+
+   If your stack was launched with a custom Compose project name, include the
+   same `-p <project>` flag.
+2. Set `DEN_BOOTSTRAP_ADMIN_EMAILS` on the Den API service, then restart it.
+3. Sign in to den-web, open `/admin`, and toggle `Install links` for each org
+   that should be allowed to mint links.
+
+## Trusted origins requirement
+
+> **Hard requirement:** The first entry of
+> `DEN_BETTER_AUTH_TRUSTED_ORIGINS` must be your den-web origin (for example,
+> `https://openwork.example.com`). Minted install links and invitation links
+> are both built from that origin.
+
+## Installer artifacts
+
+Den resolves Mac and Windows installer artifacts in this order:
+
+1. `OPENWORK_INSTALLER_ARTIFACTS_DIR`, when set and the file exists.
+2. `OPENWORK_INSTALLER_CACHE_DIR/<tag>/<file>`, defaulting to the OS temp dir.
+3. The GitHub release asset for `OPENWORK_INSTALLER_RELEASE_REPO` and
+   `OPENWORK_INSTALLER_RELEASE_TAG`.
+
+| Mode | Configure | Behavior |
+|---|---|---|
+| Internet-connected | Default. `OPENWORK_INSTALLER_RELEASE_TAG` resolves to `v<pinned app version>`; override it when needed. `v0.17.9` is the first tag carrying installer assets. | Den downloads the public release asset on first Mac/Windows download, then serves cached bytes. |
+| Fork/mirror | Set `OPENWORK_INSTALLER_RELEASE_REPO`, for example `your-org/openwork`. | Den downloads assets from your fork or mirror release instead of `different-ai/openwork`. |
+| Air-gapped | Mount a volume at `OPENWORK_INSTALLER_ARTIFACTS_DIR` containing exactly `openwork-installer-mac-arm64.zip`, `openwork-installer-mac-x64.zip`, and `openwork-installer-win-x64.exe`. | The mounted artifact directory takes precedence and requires zero egress. |
+
+## Egress
+
+`den-api` makes outbound HTTPS requests to `github.com` only when serving a Mac
+or Windows installer download and the artifact is not already cached. The Linux
+setup script and every other install-link feature need no egress.
+
+## Security notes
+
+- Install-link tokens are stored SHA-256 hashed.
+- Minting a new link rotates by default and revokes older active links.
+- A leaked link reveals the org name and server URLs only; users still must
+  sign in to access the workspace.
+- Public install-link endpoints are rate-limited.
+- Stamped Mac zips keep the signed `.app` byte-identical, so Gatekeeper
+  verification still applies.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `503` mentions a release tag | That release has no installer assets. Pin `OPENWORK_INSTALLER_RELEASE_TAG` to a tag with assets, or publish them with the `release-generic-installer` workflow. |
+| Links point at the wrong host | Put your den-web origin first in `DEN_BETTER_AUTH_TRUSTED_ORIGINS`, then restart `den-api`. |
+| Re-uploaded assets under the same tag keep serving old bytes | Clear the installer cache directory or bump the tag. The cache key is `<cacheDir>/<tag>/<file>`. |

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -1,4 +1,7 @@
+import os from "node:os"
+import path from "node:path"
 import { DEN_WORKER_POLL_INTERVAL_MS } from "./CONSTS.js"
+import { denApiAppVersion } from "./version.js"
 import { z } from "zod"
 
 const EnvSchema = z.object({
@@ -42,6 +45,9 @@ const EnvSchema = z.object({
   CORS_ORIGINS: z.string().optional(),
   DEN_API_PUBLIC_URL: z.string().optional(),
   OPENWORK_INSTALLER_ARTIFACTS_DIR: z.string().optional(),
+  OPENWORK_INSTALLER_RELEASE_TAG: z.string().optional(),
+  OPENWORK_INSTALLER_RELEASE_REPO: z.string().optional(),
+  OPENWORK_INSTALLER_CACHE_DIR: z.string().optional(),
   DEN_DESKTOP_DEN_BASE_URL: z.string().optional(),
   DEN_MARKETING_URL: z.string().optional(),
   DEN_MCP_CLAIM_NAMESPACE: z.string().optional(),
@@ -285,6 +291,12 @@ export const env = {
   corsOrigins,
   apiPublicUrl: optionalString(parsed.DEN_API_PUBLIC_URL),
   installerArtifactsDir: optionalString(parsed.OPENWORK_INSTALLER_ARTIFACTS_DIR),
+  // Generic installer release assets (release-generic-installer.yml): the
+  // release tag to download from, defaulting to the pinned app release this
+  // den-api build shipped with.
+  installerReleaseTag: optionalString(parsed.OPENWORK_INSTALLER_RELEASE_TAG) ?? `v${denApiAppVersion.latestAppVersion}`,
+  installerReleaseRepo: optionalString(parsed.OPENWORK_INSTALLER_RELEASE_REPO) ?? "different-ai/openwork",
+  installerCacheDir: optionalString(parsed.OPENWORK_INSTALLER_CACHE_DIR) ?? path.join(os.tmpdir(), "openwork-installer-artifacts"),
   // Google endpoint overrides for evals/self-host testing: point the native
   // google-workspace provider at a protocol-identical mock instead of the
   // real Google endpoints. Unset in production.

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -3,8 +3,6 @@ import { and, eq, gt, isNull, or } from "@openwork-ee/den-db/drizzle"
 import { InstallLinkTable, OrganizationTable, RateLimitTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { createHash, randomBytes } from "node:crypto"
-import { readFile } from "node:fs/promises"
-import path from "node:path"
 import type { MiddlewareHandler } from "hono"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
@@ -16,6 +14,7 @@ import { env } from "../../env.js"
 import { jsonValidator, orgRoleRoute, publicRoute, queryValidator } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, textResponse, unauthorizedSchema } from "../../openapi.js"
 import { organizationCapabilityKeySchema, organizationHasCapability } from "../../organization-capabilities.js"
+import { resolveInstallerArtifact } from "../../utils/installer-artifacts.js"
 import { appendStoredEntryToZip } from "../../utils/zip-append.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureInviteManager, getInvitationOrigin, orgAccessFailureStatus } from "./shared.js"
@@ -166,22 +165,10 @@ function artifactFileName(platform: InstallPlatform) {
       : null
 }
 
-async function readInstallerArtifact(fileName: string) {
-  if (!env.installerArtifactsDir) {
-    return null
-  }
-
-  try {
-    return await readFile(path.join(env.installerArtifactsDir, fileName))
-  } catch {
-    return null
-  }
-}
-
 function installerArtifactsUnavailable() {
   return {
     error: "installer_artifacts_unavailable",
-    message: "Installer artifacts are unavailable in this environment. They ship with the OpenWork release pipeline.",
+    message: `Installer artifacts are unavailable in this environment (tried release ${env.installerReleaseTag}). They ship with the OpenWork release pipeline.`,
   }
 }
 
@@ -407,7 +394,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         return c.json(installerArtifactsUnavailable(), 503)
       }
 
-      const artifact = await readInstallerArtifact(fileName)
+      const artifact = await resolveInstallerArtifact(fileName)
       if (!artifact) {
         return c.json(installerArtifactsUnavailable(), 503)
       }

--- a/ee/apps/den-api/src/utils/installer-artifacts.ts
+++ b/ee/apps/den-api/src/utils/installer-artifacts.ts
@@ -1,0 +1,127 @@
+import { createWriteStream } from "node:fs"
+import { mkdir, readFile, rename, rm } from "node:fs/promises"
+import { randomUUID } from "node:crypto"
+import path from "node:path"
+import { env } from "../env.js"
+
+/**
+ * Resolves a generic installer artifact (openwork-installer-mac-arm64.zip,
+ * openwork-installer-mac-x64.zip, openwork-installer-win-x64.exe) so
+ * install-link downloads work without any local artifact directory:
+ *
+ *   1. OPENWORK_INSTALLER_ARTIFACTS_DIR file, when set and present
+ *      (self-hosted/dev override — the pre-#2480 behavior, moved here).
+ *   2. Disk cache under OPENWORK_INSTALLER_CACHE_DIR/<releaseTag>/<fileName>.
+ *   3. The public release asset published by release-generic-installer.yml:
+ *      https://github.com/<repo>/releases/download/<releaseTag>/<fileName>,
+ *      streamed to a temp file then atomically renamed into the cache.
+ *
+ * A missing asset (404) resolves to null so the route can 503. Concurrent
+ * requests for the same artifact share one in-flight download.
+ */
+
+export type InstallerArtifactFetcher = (url: string, init: { redirect: "follow"; signal: AbortSignal }) => Promise<Response>
+
+type InstallerArtifactOptions = {
+  artifactsDir?: string
+  cacheDir?: string
+  releaseTag?: string
+  releaseRepo?: string
+  fetcher?: InstallerArtifactFetcher
+}
+
+const DOWNLOAD_TIMEOUT_MS = 60_000
+
+const inFlightDownloads = new Map<string, Promise<Buffer | null>>()
+
+async function readFileOrNull(filePath: string) {
+  try {
+    return await readFile(filePath)
+  } catch {
+    return null
+  }
+}
+
+async function streamResponseToFile(response: Response, filePath: string) {
+  const body = response.body
+  if (!body) {
+    throw new Error("release asset response had no body")
+  }
+  const reader = body.getReader()
+  const file = createWriteStream(filePath)
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (!value) continue
+      await new Promise<void>((resolve, reject) => {
+        file.write(value, (error) => (error ? reject(error) : resolve()))
+      })
+    }
+  } finally {
+    await new Promise<void>((resolve) => file.end(() => resolve()))
+  }
+}
+
+async function downloadReleaseAsset(input: {
+  fileName: string
+  cachePath: string
+  releaseTag: string
+  releaseRepo: string
+  fetcher: InstallerArtifactFetcher
+}): Promise<Buffer | null> {
+  const url = `https://github.com/${input.releaseRepo}/releases/download/${encodeURIComponent(input.releaseTag)}/${encodeURIComponent(input.fileName)}`
+  console.info(`[installer-artifacts] downloading ${input.fileName} from ${input.releaseTag}`)
+
+  const tempPath = `${input.cachePath}.download-${process.pid}-${randomUUID()}`
+  try {
+    const response = await input.fetcher(url, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+    })
+    if (!response.ok) {
+      console.warn(`[installer-artifacts] ${input.fileName} unavailable at ${input.releaseTag} (${response.status})`)
+      return null
+    }
+    await mkdir(path.dirname(input.cachePath), { recursive: true })
+    await streamResponseToFile(response, tempPath)
+    await rename(tempPath, input.cachePath)
+    return await readFileOrNull(input.cachePath)
+  } catch (error) {
+    console.warn(`[installer-artifacts] download of ${input.fileName} failed: ${error instanceof Error ? error.message : String(error)}`)
+    return null
+  } finally {
+    await rm(tempPath, { force: true }).catch(() => undefined)
+  }
+}
+
+export async function resolveInstallerArtifact(fileName: string, options: InstallerArtifactOptions = {}): Promise<Buffer | null> {
+  const artifactsDir = options.artifactsDir ?? env.installerArtifactsDir
+  if (artifactsDir) {
+    const local = await readFileOrNull(path.join(artifactsDir, fileName))
+    if (local) {
+      return local
+    }
+  }
+
+  const releaseTag = options.releaseTag ?? env.installerReleaseTag
+  const releaseRepo = options.releaseRepo ?? env.installerReleaseRepo
+  const cacheDir = options.cacheDir ?? env.installerCacheDir
+  const fetcher = options.fetcher ?? fetch
+  const cachePath = path.join(cacheDir, releaseTag, fileName)
+
+  const cached = await readFileOrNull(cachePath)
+  if (cached) {
+    console.info(`[installer-artifacts] cache hit ${fileName}`)
+    return cached
+  }
+
+  const inFlight = inFlightDownloads.get(cachePath)
+  if (inFlight) {
+    return inFlight
+  }
+  const download = downloadReleaseAsset({ fileName, cachePath, releaseTag, releaseRepo, fetcher })
+    .finally(() => inFlightDownloads.delete(cachePath))
+  inFlightDownloads.set(cachePath, download)
+  return download
+}

--- a/ee/apps/den-api/test/installer-artifacts.test.ts
+++ b/ee/apps/den-api/test/installer-artifacts.test.ts
@@ -1,0 +1,111 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let resolveInstallerArtifact: typeof import("../src/utils/installer-artifacts.js")["resolveInstallerArtifact"]
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  ;({ resolveInstallerArtifact } = await import("../src/utils/installer-artifacts.js"))
+})
+
+const FILE_NAME = "openwork-installer-mac-arm64.zip"
+
+function tempDir(prefix: string) {
+  return mkdtempSync(path.join(os.tmpdir(), prefix))
+}
+
+function fetcherReturning(status: number, body: string | null, calls: string[]) {
+  return (url: string) => {
+    calls.push(url)
+    return Promise.resolve(new Response(body, { status }))
+  }
+}
+
+describe("resolveInstallerArtifact", () => {
+  test("prefers the local artifacts dir over cache and network", async () => {
+    const artifactsDir = tempDir("ow-installer-artifacts-dir-")
+    const cacheDir = tempDir("ow-installer-cache-")
+    writeFileSync(path.join(artifactsDir, FILE_NAME), "from-artifacts-dir")
+    mkdirSync(path.join(cacheDir, "v9.9.9"), { recursive: true })
+    writeFileSync(path.join(cacheDir, "v9.9.9", FILE_NAME), "from-cache")
+    const calls: string[] = []
+
+    const resolved = await resolveInstallerArtifact(FILE_NAME, {
+      artifactsDir,
+      cacheDir,
+      releaseTag: "v9.9.9",
+      releaseRepo: "different-ai/openwork",
+      fetcher: fetcherReturning(200, "from-network", calls),
+    })
+
+    expect(resolved?.toString("utf8")).toBe("from-artifacts-dir")
+    expect(calls).toEqual([])
+  })
+
+  test("serves the disk cache without touching the network", async () => {
+    const cacheDir = tempDir("ow-installer-cache-")
+    mkdirSync(path.join(cacheDir, "v9.9.9"), { recursive: true })
+    writeFileSync(path.join(cacheDir, "v9.9.9", FILE_NAME), "from-cache")
+    const calls: string[] = []
+
+    const resolved = await resolveInstallerArtifact(FILE_NAME, {
+      cacheDir,
+      releaseTag: "v9.9.9",
+      releaseRepo: "different-ai/openwork",
+      fetcher: fetcherReturning(200, "from-network", calls),
+    })
+
+    expect(resolved?.toString("utf8")).toBe("from-cache")
+    expect(calls).toEqual([])
+  })
+
+  test("downloads the release asset once and fills the cache", async () => {
+    const cacheDir = tempDir("ow-installer-cache-")
+    const calls: string[] = []
+    const options = {
+      cacheDir,
+      releaseTag: "v9.9.9",
+      releaseRepo: "different-ai/openwork",
+      fetcher: fetcherReturning(200, "from-network", calls),
+    }
+
+    const [first, second] = await Promise.all([
+      resolveInstallerArtifact(FILE_NAME, options),
+      resolveInstallerArtifact(FILE_NAME, options),
+    ])
+    expect(first?.toString("utf8")).toBe("from-network")
+    expect(second?.toString("utf8")).toBe("from-network")
+    // Concurrent callers share one in-flight download.
+    expect(calls).toEqual([`https://github.com/different-ai/openwork/releases/download/v9.9.9/${FILE_NAME}`])
+    expect(readFileSync(path.join(cacheDir, "v9.9.9", FILE_NAME), "utf8")).toBe("from-network")
+
+    // The follow-up request is a cache hit, still no extra network call.
+    const third = await resolveInstallerArtifact(FILE_NAME, options)
+    expect(third?.toString("utf8")).toBe("from-network")
+    expect(calls.length).toBe(1)
+  })
+
+  test("resolves null when the release asset is missing (404)", async () => {
+    const cacheDir = tempDir("ow-installer-cache-")
+    const calls: string[] = []
+
+    const resolved = await resolveInstallerArtifact(FILE_NAME, {
+      cacheDir,
+      releaseTag: "v0.0.0-missing",
+      releaseRepo: "different-ai/openwork",
+      fetcher: fetcherReturning(404, null, calls),
+    })
+
+    expect(resolved).toBeNull()
+    expect(calls.length).toBe(1)
+  })
+})

--- a/evals/flows/installer-release-artifacts.flow.mjs
+++ b/evals/flows/installer-release-artifacts.flow.mjs
@@ -1,0 +1,609 @@
+import { spawn, spawnSync, execSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { connect, debuggerUrlFor, listTargets } from "../runner/cdp.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/installer-release-artifacts.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("installer-release-artifacts");
+
+const DEN_API_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_API_URL);
+const DEN_WEB_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_WEB_URL);
+const ADMIN_CDP_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_WEB_CDP_ADMIN);
+const INVITEE_CDP_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_WEB_CDP_INVITEE);
+const RELEASE_TAG = process.env.OPENWORK_EVAL_RELEASE_TAG?.trim() || "";
+const RELEASE_REPO = process.env.OPENWORK_EVAL_RELEASE_REPO?.trim() || "different-ai/openwork";
+const DEN_API_LOG = process.env.OPENWORK_EVAL_DEN_API_LOG?.trim() || "/tmp/ow-rel-den-api.log";
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const PLATFORM_ADMIN_EMAIL = process.env.OPENWORK_EVAL_PLATFORM_ADMIN_EMAIL?.trim() || "";
+const PLATFORM_ADMIN_PASSWORD = process.env.OPENWORK_EVAL_PLATFORM_ADMIN_PASSWORD?.trim() || "";
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+
+const MAC_ASSET = "openwork-installer-mac-arm64.zip";
+const WIN_ASSET = "openwork-installer-win-x64.exe";
+const INSTALL_SIDECAR_FILENAME = "openwork-installer.json";
+const APP_BUNDLE_NAME = "OpenWork Installer.app";
+// Must match den-api's default OPENWORK_INSTALLER_CACHE_DIR (env.installerCacheDir).
+const INSTALLER_CACHE_DIR = path.join(os.tmpdir(), "openwork-installer-artifacts");
+
+const state = {
+  adminToken: null,
+  platformAdminToken: null,
+  orgId: null,
+  installToken: null,
+  installPageUrl: null,
+  stampedZipPath: null,
+  extractedDir: null,
+  frame3Ui: null,
+};
+
+export default {
+  id: "installer-release-artifacts",
+  title: "One published release feeds every stamped install: the Mac download stays signed and notarized",
+  kind: "user-facing",
+  requiredEnv: [
+    "OPENWORK_EVAL_DEN_API_URL",
+    "OPENWORK_EVAL_DEN_TOKEN",
+    "OPENWORK_EVAL_DEN_WEB_URL",
+    "OPENWORK_EVAL_WEB_CDP_ADMIN",
+    "OPENWORK_EVAL_WEB_CDP_INVITEE",
+    "OPENWORK_EVAL_PLATFORM_ADMIN_EMAIL",
+    "OPENWORK_EVAL_PLATFORM_ADMIN_PASSWORD",
+    "OPENWORK_EVAL_MARK_VERIFIED_CMD",
+    "OPENWORK_EVAL_RELEASE_TAG",
+  ],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
+          await ctx.prove("The public GitHub release carries the generic installer next to the app builds", {
+            voiceover: vo[0],
+            // "Every OpenWork release now ships one more thing: the generic installer..."
+            action: async () => {
+              await navigateToAbsolute(ctx, `https://github.com/${RELEASE_REPO}/releases/tag/${RELEASE_TAG}`);
+              await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 45_000, label: "release page load" });
+              // The assets list lazy-loads (and can render collapsed); expand it if needed.
+              const deadline = Date.now() + 45_000;
+              while (Date.now() < deadline) {
+                if (await hasText(ctx, MAC_ASSET)) break;
+                await ctx.eval(`(() => {
+                  for (const summary of document.querySelectorAll("summary")) {
+                    if ((summary.textContent ?? "").includes("Assets")) { summary.click(); return true; }
+                  }
+                  return false;
+                })()`);
+                await ctx.eval("new Promise((resolve) => setTimeout(() => resolve(true), 500))", { awaitPromise: true });
+              }
+              await ctx.waitForText(MAC_ASSET, { timeoutMs: 15_000 });
+            },
+            assert: async () => {
+              const response = await fetch(`https://api.github.com/repos/${RELEASE_REPO}/releases/tags/${encodeURIComponent(RELEASE_TAG)}`, {
+                headers: { accept: "application/vnd.github+json" },
+              });
+              ctx.assert(response.ok, `GitHub release lookup failed: ${response.status}`);
+              const release = await response.json();
+              const assets = Array.isArray(release.assets) ? release.assets : [];
+              const published = {};
+              for (const name of [MAC_ASSET, "openwork-installer-mac-x64.zip", WIN_ASSET]) {
+                const asset = assets.find((entry) => entry.name === name);
+                ctx.assert(Boolean(asset), `Release ${RELEASE_TAG} is missing public asset ${name}.`);
+                published[name] = { size: asset.size, downloadUrl: asset.browser_download_url, updatedAt: asset.updated_at };
+              }
+              ctx.output("published-release-assets", JSON.stringify({ releaseTag: RELEASE_TAG, assets: published }, null, 2));
+              await ctx.expectText(MAC_ASSET);
+            },
+            screenshot: { name: "release-ships-generic-installer", requireText: [MAC_ASSET] },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("den-api with no artifacts directory serves the stamped Mac download from the published release, then from cache", {
+          voiceover: vo[1],
+          // "A production-shaped server with no local files configured serves the Mac download anyway..."
+          action: async () => {
+            // Setup affordances: platform-admin provisioning, capability ON, mint a link.
+            await ensureAdminToken(ctx);
+            await ensureOrgId(ctx);
+            await ensurePlatformAdmin(ctx);
+            await setCapabilityViaAdminApi(ctx, { installLinks: true });
+            ctx.output(
+              "capability-enabled-by-platform-admin",
+              `${PLATFORM_ADMIN_EMAIL} enabled installLinks for Acme via PUT /v1/admin/organizations/:id/capabilities.`,
+            );
+            const minted = await mintInstallLink(ctx);
+            state.installToken = minted.token;
+            state.installPageUrl = minted.installPageUrl;
+            ctx.output("install-link-minted", JSON.stringify({ installPageUrl: minted.installPageUrl }, null, 2));
+
+            // Reset the release cache so this run always witnesses the
+            // download -> cache transition (keeps the flow idempotent).
+            rmSync(path.join(INSTALLER_CACHE_DIR, RELEASE_TAG), { recursive: true, force: true });
+            const logOffset = denApiLogSize();
+
+            const first = await timedInstallDownload(ctx, "mac-arm64");
+            const second = await timedInstallDownload(ctx, "mac-arm64");
+
+            const tempDir = mkdtempSync(path.join(os.tmpdir(), "ow-release-stamped-"));
+            state.stampedZipPath = path.join(tempDir, "stamped.zip");
+            writeFileSync(state.stampedZipPath, first.bytes);
+
+            const logSlice = readFileSync(DEN_API_LOG, "utf8").slice(logOffset);
+            const downloadLines = logSlice.split("\n").filter((line) => line.includes(`[installer-artifacts] downloading ${MAC_ASSET} from ${RELEASE_TAG}`));
+            const cacheHitLines = logSlice.split("\n").filter((line) => line.includes(`[installer-artifacts] cache hit ${MAC_ASSET}`));
+            ctx.assert(downloadLines.length === 1, `Expected exactly one release download in den-api log, saw ${downloadLines.length}.`);
+            ctx.assert(cacheHitLines.length >= 1, `Expected a cache-hit line in den-api log, saw ${cacheHitLines.length}.`);
+            ctx.assert(first.bytes.length === second.bytes.length, `Stamped downloads differ in size: ${first.bytes.length} vs ${second.bytes.length}.`);
+            ctx.assert(second.durationMs < first.durationMs, `Cache-served download (${second.durationMs}ms) was not faster than the first (${first.durationMs}ms).`);
+            ctx.output(
+              "prod-shaped-serve-then-cache",
+              JSON.stringify(
+                {
+                  denApi: DEN_API_URL,
+                  artifactsDirConfigured: false,
+                  releaseTag: RELEASE_TAG,
+                  firstDownload: { status: first.status, bytes: first.bytes.length, durationMs: first.durationMs },
+                  secondDownload: { status: second.status, bytes: second.bytes.length, durationMs: second.durationMs },
+                  denApiLogLines: [...downloadLines, ...cacheHitLines],
+                },
+                null,
+                2,
+              ),
+            );
+          },
+          assert: async () => {
+            await withClient(ctx, INVITEE_CDP_URL, async () => {
+              await navigateToAbsolute(ctx, requireStateValue(state.installPageUrl, "install page URL"));
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"install-page\"]'))", { timeoutMs: 30_000, label: "install page" });
+              await ctx.waitForText("Download OpenWork for Acme Robotics", { timeoutMs: 30_000 });
+              await ctx.expectText("Download OpenWork for Acme Robotics");
+              await ctx.screenshot("install-page-serves-real-downloads", {
+                claim: "The install page now genuinely serves downloads backed by the published release",
+                voiceover: vo[1],
+                requireText: ["Download OpenWork for Acme Robotics"],
+              });
+            });
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        try {
+          await withClient(ctx, INVITEE_CDP_URL, async () => {
+            await ctx.prove("The stamped download keeps the notarized .app untouched and announces Acme before touching anything", {
+              voiceover: vo[2],
+              // "The download that arrives still opens like it came straight from Apple..."
+              action: async () => {
+                const stampedZipPath = requireStateValue(state.stampedZipPath, "stamped zip path");
+                const workDir = mkdtempSync(path.join(os.tmpdir(), "ow-release-gatekeeper-"));
+                const stampedDir = path.join(workDir, "stamped");
+                const sourceDir = path.join(workDir, "source");
+                mkdirSync(stampedDir);
+                mkdirSync(sourceDir);
+                unzip(stampedZipPath, stampedDir);
+                state.extractedDir = stampedDir;
+
+                const appPath = path.join(stampedDir, APP_BUNDLE_NAME);
+                ctx.assert(existsSync(appPath), `Stamped zip did not contain ${APP_BUNDLE_NAME} at its root.`);
+
+                const codesignResult = runCommand("codesign", ["--verify", "--deep", "--strict", "--verbose=2", appPath]);
+                const spctlResult = runCommand("spctl", ["--assess", "--type", "execute", "--verbose=2", appPath]);
+                const staplerResult = runCommand("xcrun", ["stapler", "validate", appPath]);
+                ctx.assert(codesignResult.status === 0, `codesign --verify failed (${codesignResult.status}): ${codesignResult.combined}`);
+                ctx.assert(spctlResult.status === 0, `spctl --assess failed (${spctlResult.status}): ${spctlResult.combined}`);
+                ctx.assert(spctlResult.combined.includes("accepted"), `spctl did not accept the app: ${spctlResult.combined}`);
+                ctx.assert(staplerResult.status === 0, `stapler validate failed (${staplerResult.status}): ${staplerResult.combined}`);
+                ctx.output(
+                  "gatekeeper-verdict",
+                  [
+                    `$ codesign --verify --deep --strict --verbose=2 "${appPath}"`,
+                    codesignResult.combined.trim(),
+                    "",
+                    `$ spctl --assess --type execute --verbose=2 "${appPath}"`,
+                    spctlResult.combined.trim(),
+                    "",
+                    `$ xcrun stapler validate "${appPath}"`,
+                    staplerResult.combined.trim(),
+                  ].join("\n"),
+                );
+
+                // Byte-identity: the .app's main binary matches the published
+                // (unstamped) artifact den-api cached from the release.
+                const cachedSourceZip = path.join(INSTALLER_CACHE_DIR, RELEASE_TAG, MAC_ASSET);
+                ctx.assert(existsSync(cachedSourceZip), `den-api release cache is missing ${cachedSourceZip}.`);
+                unzip(cachedSourceZip, sourceDir);
+                const binaryRelPath = path.join(APP_BUNDLE_NAME, "Contents", "MacOS", "openwork-installer");
+                const stampedSha = sha256File(path.join(stampedDir, binaryRelPath));
+                const sourceSha = sha256File(path.join(sourceDir, binaryRelPath));
+                ctx.assert(stampedSha === sourceSha, `Installer binary changed between published asset (${sourceSha}) and stamped download (${stampedSha}).`);
+
+                // The sidecar sits at the zip root next to the .app and carries Acme's config.
+                const sidecarPath = path.join(stampedDir, INSTALL_SIDECAR_FILENAME);
+                ctx.assert(existsSync(sidecarPath), "Stamped zip did not contain the sidecar next to the .app.");
+                const sidecar = JSON.parse(readFileSync(sidecarPath, "utf8"));
+                ctx.assert(sidecar.clientName === "Acme Robotics", `Sidecar clientName was ${sidecar.clientName}.`);
+                ctx.assert(sidecar.requireSignin === true, "Sidecar did not require sign-in.");
+                ctx.output(
+                  "stamped-app-byte-identity",
+                  JSON.stringify(
+                    {
+                      binary: binaryRelPath,
+                      publishedSha256: sourceSha,
+                      stampedSha256: stampedSha,
+                      byteIdentical: stampedSha === sourceSha,
+                      sidecar,
+                    },
+                    null,
+                    2,
+                  ),
+                );
+
+                // Run the extracted installer binary itself (manual UI mode):
+                // the .app-bundle sidecar resolution finds Acme's config next
+                // to the bundle, exactly as a real unzip would lay it out.
+                state.frame3Ui = await startExtractedInstallerUi(path.join(stampedDir, APP_BUNDLE_NAME, "Contents", "MacOS", "openwork-installer"), stampedDir);
+                await navigateToAbsolute(ctx, state.frame3Ui.url);
+                await ctx.waitForText("This sets up OpenWork for Acme Robotics", { timeoutMs: 20_000 });
+              },
+              assert: async () => {
+                await ctx.expectText("This sets up OpenWork for Acme Robotics");
+                await ctx.expectText("Configured via install link");
+              },
+              screenshot: {
+                name: "downloaded-installer-announces-acme",
+                requireText: ["This sets up OpenWork for Acme Robotics", "Configured via install link"],
+              },
+            });
+          });
+        } finally {
+          state.frame3Ui?.kill();
+          state.frame3Ui = null;
+        }
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await withClient(ctx, INVITEE_CDP_URL, async () => {
+          await ctx.prove("The same install link serves Windows the tagged exe and Linux the org setup script, all from one release", {
+            voiceover: vo[3],
+            // "And the very same link keeps working for the whole fleet..."
+            action: async () => {
+              const token = requireStateValue(state.installToken, "install token");
+
+              const win = await timedInstallDownload(ctx, "win-x64");
+              const disposition = win.contentDisposition;
+              const expectedFilename = new RegExp(`^attachment; filename="OpenWork-Installer--127\\.0\\.0\\.1_8790--${token}\\.exe"$`);
+              ctx.assert(win.status === 200, `Windows install download returned ${win.status}.`);
+              ctx.assert(expectedFilename.test(disposition), `Windows Content-Disposition was ${disposition}.`);
+
+              const linuxResponse = await fetch(`${DEN_API_URL}/v1/install/linux-x64?token=${encodeURIComponent(token)}`);
+              const linuxScript = await linuxResponse.text();
+              ctx.assert(linuxResponse.status === 200, `Linux install download returned ${linuxResponse.status}.`);
+              ctx.assert(linuxScript.includes("Acme Robotics"), "Linux setup script did not mention the org name.");
+
+              ctx.output(
+                "fleet-downloads-from-one-release",
+                JSON.stringify(
+                  {
+                    windows: { status: win.status, bytes: win.bytes.length, contentDisposition: disposition },
+                    linux: {
+                      status: linuxResponse.status,
+                      contentDisposition: linuxResponse.headers.get("content-disposition"),
+                      scriptPreview: linuxScript.split("\n").slice(0, 6).join("\n"),
+                    },
+                  },
+                  null,
+                  2,
+                ),
+              );
+
+              // Back on the install page, reach the platform list as a
+              // keyboard user: a real Tab keypress switches Chrome into
+              // keyboard modality (macOS Tab skips <a> elements entirely), so
+              // focusing the Windows link then draws its :focus-visible ring
+              // and keeps this frame visually distinct from frame 2.
+              await navigateToAbsolute(ctx, requireStateValue(state.installPageUrl, "install page URL"));
+              await ctx.waitForText("Download OpenWork for Acme Robotics", { timeoutMs: 30_000 });
+              await ctx.waitForText("Windows", { timeoutMs: 15_000 });
+              await ctx.client.send("Input.dispatchKeyEvent", { type: "rawKeyDown", key: "Tab", code: "Tab", windowsVirtualKeyCode: 9 });
+              await ctx.client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Tab", code: "Tab", windowsVirtualKeyCode: 9 });
+              const focusRing = await ctx.eval(`(() => {
+                const link = [...document.querySelectorAll("a")].find((candidate) => (candidate.textContent ?? "").trim() === "Windows");
+                if (!link) return "missing";
+                link.scrollIntoView({ block: "center" });
+                link.focus();
+                return link.matches(":focus-visible") ? "focus-visible" : "focused";
+              })()`);
+              ctx.assert(focusRing === "focus-visible", `Windows platform link did not get a keyboard focus ring (${focusRing}).`);
+            },
+            assert: async () => {
+              await ctx.expectText("Windows");
+              await ctx.expectText("Linux (x64)");
+            },
+            screenshot: {
+              name: "one-link-whole-fleet",
+              requireText: ["Windows", "Linux (x64)"],
+            },
+          });
+        });
+      },
+    },
+  ],
+};
+
+function cleanBaseUrl(value) {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
+function requireStateValue(value, label) {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  throw new Error(`${label} was not prepared by an earlier frame.`);
+}
+
+async function withClient(ctx, cdpBaseUrl, fn) {
+  const previous = ctx.client;
+  const target = await firstPageTarget(cdpBaseUrl);
+  const client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+  ctx.client = client;
+  try {
+    return await fn();
+  } finally {
+    ctx.client = previous;
+    try {
+      client.close();
+    } catch {
+      // Socket already gone.
+    }
+  }
+}
+
+async function firstPageTarget(cdpBaseUrl) {
+  const existing = await listTargets(cdpBaseUrl);
+  const page = existing.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (page) {
+    return page;
+  }
+  const base = cdpBaseUrl.replace(/\/+$/, "");
+  let response = await fetch(`${base}/json/new?about:blank`, { method: "PUT" });
+  if (!response.ok) {
+    response = await fetch(`${base}/json/new?about:blank`);
+  }
+  if (!response.ok) {
+    throw new Error(`Could not create a page target at ${cdpBaseUrl}: ${response.status}`);
+  }
+  const created = await response.json();
+  if (created?.type === "page" && created.webSocketDebuggerUrl) {
+    return created;
+  }
+  const targets = await listTargets(cdpBaseUrl);
+  const nextPage = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (!nextPage) {
+    throw new Error(`No page target available at ${cdpBaseUrl}.`);
+  }
+  return nextPage;
+}
+
+async function navigateToAbsolute(ctx, url) {
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+}
+
+async function hasText(ctx, text) {
+  return Boolean(await ctx.eval(`document.body.innerText.includes(${JSON.stringify(text)})`));
+}
+
+async function denApiFetch(pathname, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${pathname}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      origin: DEN_WEB_URL || DEN_API_URL,
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body, text };
+}
+
+async function ensureAdminToken(ctx) {
+  if (state.adminToken) {
+    return state.adminToken;
+  }
+  const signedIn = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }),
+  });
+  if (signedIn.response.ok && typeof signedIn.body?.token === "string") {
+    state.adminToken = signedIn.body.token;
+    return state.adminToken;
+  }
+  const token = process.env.OPENWORK_EVAL_DEN_TOKEN?.trim() ?? "";
+  ctx.assert(token.length > 0, `Admin sign-in failed and OPENWORK_EVAL_DEN_TOKEN is missing: ${signedIn.response.status}`);
+  state.adminToken = token;
+  return token;
+}
+
+async function ensureOrgId(ctx) {
+  if (state.orgId) {
+    return state.orgId;
+  }
+  const token = requireStateValue(state.adminToken, "org admin token");
+  const org = await denApiFetch("/v1/org", {
+    method: "GET",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(org.response.ok, `Could not load ${ADMIN_EMAIL}'s organization: ${org.response.status} ${org.text.slice(0, 300)}`);
+  const organization = org.body?.organization;
+  ctx.assert(typeof organization?.id === "string", "Organization payload was missing id.");
+  state.orgId = organization.id;
+  return state.orgId;
+}
+
+/**
+ * The platform admin is an ordinary account whose email is on the Den admin
+ * allowlist (DEN_BOOTSTRAP_ADMIN_EMAILS on the den-api under test).
+ */
+async function ensurePlatformAdmin(ctx) {
+  if (state.platformAdminToken) {
+    return state.platformAdminToken;
+  }
+  const signup = await denApiFetch("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ name: "Priya Platform", email: PLATFORM_ADMIN_EMAIL, password: PLATFORM_ADMIN_PASSWORD }),
+  });
+  const signupAccepted = signup.response.ok || [400, 403, 409, 422].includes(signup.response.status);
+  ctx.assert(signupAccepted, `Platform admin sign-up failed: ${signup.response.status} ${signup.text.slice(0, 300)}`);
+  markEmailVerified(ctx, PLATFORM_ADMIN_EMAIL);
+
+  const signedIn = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: PLATFORM_ADMIN_EMAIL, password: PLATFORM_ADMIN_PASSWORD }),
+  });
+  ctx.assert(
+    signedIn.response.ok && typeof signedIn.body?.token === "string",
+    `Platform admin sign-in failed: ${signedIn.response.status} ${signedIn.text.slice(0, 300)}`,
+  );
+  state.platformAdminToken = signedIn.body.token;
+
+  const probe = await denApiFetch("/v1/admin/overview", {
+    method: "GET",
+    headers: { authorization: `Bearer ${state.platformAdminToken}` },
+  });
+  ctx.assert(
+    probe.response.ok,
+    `${PLATFORM_ADMIN_EMAIL} is not a platform admin (overview probe ${probe.response.status}). Start den-api with DEN_BOOTSTRAP_ADMIN_EMAILS=${PLATFORM_ADMIN_EMAIL}.`,
+  );
+  return state.platformAdminToken;
+}
+
+function markEmailVerified(ctx, email) {
+  ctx.assert(
+    MARK_VERIFIED_CMD.length > 0,
+    "Platform-admin provisioning requires a verified email; set OPENWORK_EVAL_MARK_VERIFIED_CMD (shell template with {email}).",
+  );
+  execSync(MARK_VERIFIED_CMD.replaceAll("{email}", email), { stdio: "ignore" });
+}
+
+async function setCapabilityViaAdminApi(ctx, capabilities) {
+  const token = requireStateValue(state.platformAdminToken, "platform admin token");
+  const orgId = requireStateValue(state.orgId, "organization id");
+  const updated = await denApiFetch(`/v1/admin/organizations/${orgId}/capabilities`, {
+    method: "PUT",
+    headers: { authorization: `Bearer ${token}` },
+    body: JSON.stringify({ capabilities }),
+  });
+  ctx.assert(updated.response.ok, `Admin capability update failed: ${updated.response.status} ${updated.text.slice(0, 300)}`);
+}
+
+async function mintInstallLink(ctx) {
+  const token = requireStateValue(state.adminToken, "org admin token");
+  const orgId = requireStateValue(state.orgId, "organization id");
+  const minted = await denApiFetch(`/v1/orgs/${orgId}/install-links`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+    body: JSON.stringify({}),
+  });
+  ctx.assert(minted.response.ok, `Install-link mint failed: ${minted.response.status} ${minted.text.slice(0, 300)}`);
+  ctx.assert(typeof minted.body?.token === "string" && typeof minted.body?.installPageUrl === "string", "Install-link mint response was incomplete.");
+  // The install page URL is minted against den-api's own origin; the demo
+  // walks it through the den-web deployment under test.
+  const pageUrl = new URL(minted.body.installPageUrl);
+  return { token: minted.body.token, installPageUrl: `${DEN_WEB_URL}${pageUrl.pathname}${pageUrl.search}` };
+}
+
+function denApiLogSize() {
+  try {
+    return statSync(DEN_API_LOG).size;
+  } catch {
+    return 0;
+  }
+}
+
+async function timedInstallDownload(ctx, platform) {
+  const token = requireStateValue(state.installToken, "install token");
+  const startedAt = Date.now();
+  const response = await fetch(`${DEN_API_URL}/v1/install/${platform}?token=${encodeURIComponent(token)}`);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const durationMs = Date.now() - startedAt;
+  ctx.assert(
+    response.status === 200,
+    `${platform} install download failed: ${response.status} ${bytes.toString("utf8", 0, Math.min(bytes.length, 300))}`,
+  );
+  return { status: response.status, bytes, durationMs, contentDisposition: response.headers.get("content-disposition") ?? "" };
+}
+
+function runCommand(command, args) {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  return {
+    status: result.status ?? 1,
+    stdout,
+    stderr,
+    combined: [stdout, stderr].filter(Boolean).join("\n"),
+  };
+}
+
+function unzip(zipPath, outputDir) {
+  const result = spawnSync("unzip", ["-oq", zipPath, "-d", outputDir], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`unzip failed: ${result.stderr || result.stdout}`);
+  }
+}
+
+function sha256File(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+/**
+ * Runs the extracted installer binary in manual UI mode (serves its UI over
+ * local HTTP without opening a window) and resolves the served URL from
+ * stdout. The caller must kill() the returned child.
+ */
+async function startExtractedInstallerUi(binaryPath, cwd) {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("OPENWORK_INSTALLER_") || key === "OPENWORK_DESKTOP_BOOTSTRAP_PATH") {
+      delete env[key];
+    }
+  }
+  const child = spawn(binaryPath, [], {
+    cwd,
+    env: { ...env, OPENWORK_INSTALLER_UI: "manual" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  child.stdout.on("data", (chunk) => { output += String(chunk); });
+  child.stderr.on("data", (chunk) => { output += String(chunk); });
+
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 20_000) {
+    const match = output.match(/UI ready at (http:\/\/127\.0\.0\.1:\d+\/?)/);
+    if (match) {
+      return { child, url: match[1], kill: () => { try { child.kill("SIGKILL"); } catch { /* gone */ } } };
+    }
+    if (child.exitCode !== null) {
+      throw new Error(`Installer UI exited early (${child.exitCode}): ${output}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  try { child.kill("SIGKILL"); } catch { /* gone */ }
+  throw new Error(`Installer UI did not print a ready URL in time: ${output}`);
+}

--- a/evals/voiceovers/installer-release-artifacts.md
+++ b/evals/voiceovers/installer-release-artifacts.md
@@ -1,0 +1,15 @@
+# installer-release-artifacts — The generic installer ships with every release and downloads stay signed
+
+PR-3 of the invite-to-desktop track: a release-pipeline job publishes the one
+generic (unbranded) installer as public release assets, and den-api learns to
+serve org-stamped downloads straight from those published artifacts — no
+local artifact directory, no per-org builds. The Mac stamped zip keeps the
+signed, notarized .app byte-identical, so Gatekeeper stays quiet.
+
+1. Every OpenWork release now ships one more thing: the generic installer — a single signed binary per platform, published right next to the app, ready to be stamped for any org.
+
+2. A production-shaped server with no local files configured serves the Mac download anyway — it pulls the published release asset, stamps Acme's config into it on the fly, and caches it for next time.
+
+3. The download that arrives still opens like it came straight from Apple: the app inside is untouched, its signature checks out, and it announces Acme before touching anything.
+
+4. And the very same link keeps working for the whole fleet — Windows gets the tagged installer, Linux gets the setup script, all from one published release and one org toggle.

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -82,6 +82,16 @@ Optional env vars (via `.env` or `export`):
 - `DEN_PROVISIONER_MODE` — `stub` or `render` (defaults to `stub`)
 - `DEN_WORKER_URL_TEMPLATE` — stub worker URL template with `{workerId}` placeholder
 
+### Install links (self-host)
+
+Run the install-link migration once against the Den database:
+
+```bash
+docker compose -f packaging/docker/docker-compose.den-dev.yml exec den sh -lc "pnpm --dir /app/ee/packages/den-db run db:bootstrap"
+```
+
+Set `DEN_BOOTSTRAP_ADMIN_EMAILS` on the Den API service, restart it, open `/admin`, and toggle `Install links` for each org. Optional installer artifact env vars are `OPENWORK_INSTALLER_RELEASE_TAG`, `OPENWORK_INSTALLER_RELEASE_REPO`, and `OPENWORK_INSTALLER_ARTIFACTS_DIR`; see the [operator guide](../../docs/org-install-links.md).
+
 ### Faster inner-loop alternative
 
 If you are iterating on Den locally and do not need the full Dockerized web stack, use the hybrid path instead:

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -132,6 +132,26 @@ migrations:
 
 `db:bootstrap` uses `db:migrate` for normal upgrades. On a completely empty database it applies the current schema once, records the committed migrations as the baseline, then runs migrations. On an existing schema without a Drizzle ledger, it records the baseline before migrating.
 
+## Install links
+
+The migration Job creates the `install_link` table automatically when `migrations.enabled=true`. Install links remain dark until a platform admin opens `/admin` and enables the `Install links` capability for an org. See the [operator guide](../../../docs/org-install-links.md).
+
+Optional installer artifact values:
+
+```yaml
+config:
+  public:
+    installerReleaseTag: "v0.17.9"
+    installerReleaseRepo: "different-ai/openwork"
+
+installerArtifacts:
+  enabled: true
+  existingClaim: openwork-installer-artifacts
+  mountPath: /var/lib/openwork/installer-artifacts
+```
+
+Use either `installerArtifacts.existingClaim` or `installerArtifacts.hostPath`, not both. The mounted directory must contain `openwork-installer-mac-arm64.zip`, `openwork-installer-mac-x64.zip`, and `openwork-installer-win-x64.exe`.
+
 ## Health Probes
 
 The chart uses the existing service health endpoints:

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -20,6 +20,12 @@ data:
   DEN_CORS_ORIGINS: {{ .Values.config.public.corsOrigins | quote }}
   DEN_API_PUBLIC_URL: {{ .Values.config.public.apiOrigin | quote }}
   DEN_DESKTOP_DEN_BASE_URL: {{ .Values.config.public.desktopDenBaseUrl | quote }}
+  {{ if .Values.config.public.installerReleaseTag }}
+  OPENWORK_INSTALLER_RELEASE_TAG: {{ .Values.config.public.installerReleaseTag | quote }}
+  {{ end }}
+  {{ if .Values.config.public.installerReleaseRepo }}
+  OPENWORK_INSTALLER_RELEASE_REPO: {{ .Values.config.public.installerReleaseRepo | quote }}
+  {{ end }}
   PROVISIONER_MODE: {{ .Values.config.provisioner.mode | quote }}
   WORKER_PROVISIONING_RECONCILE_INTERVAL_MS: {{ .Values.config.provisioner.reconcileIntervalMs | quote }}
   WORKER_PROVISIONING_RECONCILE_STALE_MS: {{ .Values.config.provisioner.reconcileStaleMs | quote }}

--- a/packaging/helm/openwork-ee/templates/den-api.yaml
+++ b/packaging/helm/openwork-ee/templates/den-api.yaml
@@ -40,6 +40,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.installerArtifacts.enabled }}
+      {{- if and .Values.installerArtifacts.existingClaim .Values.installerArtifacts.hostPath }}
+      {{- fail "installerArtifacts.existingClaim and installerArtifacts.hostPath are mutually exclusive" }}
+      {{- end }}
+      {{- if not (or .Values.installerArtifacts.existingClaim .Values.installerArtifacts.hostPath) }}
+      {{- fail "installerArtifacts.existingClaim or installerArtifacts.hostPath is required when installerArtifacts.enabled=true" }}
+      {{- end }}
+      volumes:
+        - name: installer-artifacts
+          {{- if .Values.installerArtifacts.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.installerArtifacts.existingClaim | quote }}
+          {{- else }}
+          hostPath:
+            path: {{ .Values.installerArtifacts.hostPath | quote }}
+            type: Directory
+          {{- end }}
+      {{- end }}
       containers:
         - name: den-api
           image: "{{ .Values.denApi.image.repository }}:{{ default .Values.image.tag .Values.denApi.image.tag }}"
@@ -47,6 +65,12 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.denApi.containerPort }}
+          {{- if .Values.installerArtifacts.enabled }}
+          volumeMounts:
+            - name: installer-artifacts
+              mountPath: {{ .Values.installerArtifacts.mountPath | quote }}
+              readOnly: true
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "openwork-ee.configName" . }}
@@ -55,6 +79,10 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.denApi.containerPort | quote }}
+            {{- if .Values.installerArtifacts.enabled }}
+            - name: OPENWORK_INSTALLER_ARTIFACTS_DIR
+              value: {{ .Values.installerArtifacts.mountPath | quote }}
+            {{- end }}
             {{- range $key, $value := .Values.denApi.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -23,6 +23,8 @@ config:
     webAppHosts: openwork.example.com
     bootstrapAdminEmails: ""
     openworkAppConnectUrl: ""
+    installerReleaseTag: ""
+    installerReleaseRepo: ""
     authCallbackUrl: https://openwork.example.com
   internal:
     apiBaseUrl: ""
@@ -97,6 +99,12 @@ secret:
     openRouterManagementApiKey: ""
     inferenceAdminToken: ""
     inferenceWebhookSecret: ""
+
+installerArtifacts:
+  enabled: false
+  existingClaim: ""
+  hostPath: ""
+  mountPath: /var/lib/openwork/installer-artifacts
 
 denApi:
   replicaCount: 1


### PR DESCRIPTION
PR-3 of the invite-to-desktop track (after #2480 install links and #2481 capability flags): the ONE generic installer is now published with every release, and den-api stamps downloads straight from those public assets — production needs no local artifact directory.

## What's in here

### 1. `.github/workflows/release-generic-installer.yml`
- **Triggers**: `workflow_dispatch` (`release_tag` required, `platforms` choice defaulting to `mac-arm64,mac-x64,win-x64`, `sign_windows` bool) **and** `release: [published]` (auto-attach; prereleases and non-`v*` tags like `openwork-orchestrator-v*` are skipped).
- **Reuse-vs-copy decision: copied the minimal steps** instead of making `build-client-installer.yml` `workflow_call`-able. Making it callable required rewriting every `github.event.inputs.*` reference, making `client_name` optional, bypassing the slug step, filtering the linux matrix entries, and re-plumbing artifact names — a larger, riskier diff than a focused workflow. Bonus: the generic build needs **no config-write step at all** — the committed `build-config.ts` placeholder IS the generic config, and a guard step refuses to publish if it ever stops being empty.
- Generic smoke test asserts the unconfigured installer **exits 2** and asks for an install link (that's the #2480 contract).
- macOS: `.app` wrap → codesign (JIT entitlements) → notarytool `--wait` → staple → `ditto` zip with the `.app` at the zip root. Signing+notarization is mandatory for the mac assets.
- Windows: optional SignPath (same dance as the existing workflow), unsigned otherwise. No linux binaries (linux uses the setup script served by den-api).
- Assets uploaded with `gh release upload --clobber`, named exactly as den-api's `artifactFileName()` expects: `openwork-installer-mac-arm64.zip`, `openwork-installer-mac-x64.zip`, `openwork-installer-win-x64.exe`.
- Fixes found by actually running it (the per-client workflow had never run): `@openwork/install-config`'s `default` export points at `dist/` which a fresh checkout lacks (now built first), and bun 1.3.9 on Windows fails the parent-relative workspace symlink (narrow copy-fallback). One **test-only** change outside the workflow: `apps/installer/test/installer.test.ts` skips the mac-only `.app` sidecar test on Windows (path.join builds a backslashed path the mac bundle matcher rightly rejects). No installer runtime behavior changed.

### 2. den-api release-artifact resolver (`src/utils/installer-artifacts.ts`)
`resolveInstallerArtifact(fileName)` source order:
1. `OPENWORK_INSTALLER_ARTIFACTS_DIR` file if set+exists (pre-existing behavior, moved here),
2. disk cache `OPENWORK_INSTALLER_CACHE_DIR/<releaseTag>/<fileName>`,
3. download `https://github.com/<repo>/releases/download/<tag>/<file>` — redirects followed, 60s timeout, streamed to a temp file then **atomic rename** into the cache, concurrent requests **de-duped via an in-flight promise map**. 404 → `null` → route 503 mentioning the tag it tried.

Env: `OPENWORK_INSTALLER_RELEASE_TAG` (default `v<latestAppVersion>` from the pinned build version), `OPENWORK_INSTALLER_RELEASE_REPO` (default `different-ai/openwork`), `OPENWORK_INSTALLER_CACHE_DIR` (default `<tmpdir>/openwork-installer-artifacts`).

Unit tests (`test/installer-artifacts.test.ts`, bun:test, injected fetcher, no network): artifacts-dir precedence, cache-hit short-circuit, single shared download for concurrent callers + cache fill, 404→null.

## The real CI run
- **Run (all green, all three platforms):** https://github.com/different-ai/openwork/actions/runs/28725422705
- Published assets on the latest release: https://github.com/different-ai/openwork/releases/tag/v0.17.9 (`openwork-installer-mac-arm64.zip` 22.2 MB, `openwork-installer-mac-x64.zip` 24.5 MB, `openwork-installer-win-x64.exe` 114.9 MB).
- Notarization log: `status: Accepted` + `The staple and validate action worked!`.
- Deviation, stated honestly: `workflow_dispatch` by name only works once the workflow exists on the default branch, so the pre-merge run was triggered from `ci/installer-release-real-run` — this branch plus one commit adding a temporary `push` trigger (same build steps; branch deleted after the run). After merge, dispatch + release auto-attach work as designed.

## Gatekeeper result (real published asset, stamped exactly like den-api does)
Downloaded `openwork-installer-mac-arm64.zip` from v0.17.9, appended the Acme sidecar via `appendStoredEntryToZip` (same util, same arguments as the route), unzipped, then on this Mac:

```
$ codesign --verify --deep --strict --verbose=2 "stamped/OpenWork Installer.app"
stamped/OpenWork Installer.app: valid on disk
stamped/OpenWork Installer.app: satisfies its Designated Requirement

$ spctl --assess --type execute --verbose=2 "stamped/OpenWork Installer.app"
stamped/OpenWork Installer.app: accepted
source=Notarized Developer ID

$ xcrun stapler validate "stamped/OpenWork Installer.app"
The validate action worked!
```

Main binary sha256 is **byte-identical** between the published and the stamped extraction:
`a0190ca4ebfdb69d8be94e34031e51f15999481d679154c0a40d23d1e7865e44` (both).

## Tests run
- `pnpm install` ✅
- den-api `tsc --noEmit` ✅
- den-api `bun test`: 290 pass / 7 fail — the 7 failures are pre-existing on `origin/dev` (verified by stash-compare: clean tree 286/7, with this diff 290/7; the new resolver tests are the +4)
- `apps/installer` `bun test`: 14 pass ✅
- `actionlint` on the new workflow: clean ✅
- fraimz: `pnpm evals --flow installer-release-artifacts --stack den` → **PASSED** (4 frames + voiceover coverage), against a prod-shaped den-api with **no artifacts dir** and `OPENWORK_INSTALLER_RELEASE_TAG=v0.17.9`. Frame evidence includes the one-download-then-cache-hit den-api log lines (5575ms → 71ms) and the Gatekeeper trio run in-flow.

## Not in here
- CTA swap into the invite email / join-org page = follow-up PR (PR-4).