### PR TITLE
fix(app): add horizontal scrollbars to chat code blocks (#2476)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ transcript-analysis
 evals/results/
 .playwright-mcp/
 .warden/
+.vscode/

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -352,7 +352,7 @@ const highlightedMarkdownParser = new Marked({
         ],
       });
     },
-    container: `<div data-openwork-shiki="true" class="my-4 overflow-hidden rounded-lg border border-border/70 bg-gray-1/80 p-4 text-xs leading-6">%s</div>`,
+    container: `<div data-openwork-shiki="true" class="my-4 overflow-x-auto rounded-lg border border-border/70 bg-gray-1/80 p-4 text-xs leading-6">%s</div>`,
   }),
 );
 

--- a/apps/app/src/components/ui/code-block.tsx
+++ b/apps/app/src/components/ui/code-block.tsx
@@ -11,7 +11,7 @@ function CodeBlock({ children, className, ...props }: CodeBlockProps) {
   return (
     <div
       className={cn(
-        "not-prose flex w-full flex-col overflow-clip border",
+        "not-prose flex w-full flex-col border",
         "border-border bg-card text-card-foreground rounded-xl",
         className
       )}

--- a/apps/app/src/react-app/domains/session/surface/markdown.tsx
+++ b/apps/app/src/react-app/domains/session/surface/markdown.tsx
@@ -187,7 +187,7 @@ const highlightedMarkdownParser = new Marked<string, string>({
         ],
       });
     },
-    container: `<div data-openwork-shiki="true" class="my-4 overflow-hidden rounded-[18px] border border-dls-border/70 bg-gray-1/80 p-4 text-xs leading-6">%s</div>`,
+    container: `<div data-openwork-shiki="true" class="my-4 overflow-x-auto rounded-[18px] border border-dls-border/70 bg-gray-1/80 p-4 text-xs leading-6">%s</div>`,
   }),
 );
 


### PR DESCRIPTION
## Summary
- Replaces `overflow-hidden` with `overflow-x-auto` in Shiki code block markdown containers in both components and domains/session directories.
- Removes `overflow-clip` from the base UI `CodeBlock` component container.

## Why
- Code block outer containers are currently styled with `overflow-hidden` and `overflow-clip`. This prevents the browser from rendering horizontal scrollbars when lines exceed the block's width.
- This causes long URLs, multiline shell commands, and wide JSON payloads to be clipped at the container boundary, rendering important information illegible and impossible to copy/read on smaller screens or narrow windows. 
- Restoring `overflow-x-auto` to these containers ensures standard horizontal scrolling behaviors work as expected for all syntax-highlighted code.

## Issue
- Closes #2476

## Scope
- `apps/app/src/components/markdown/markdown.tsx`
- `apps/app/src/components/ui/code-block.tsx`
- `apps/app/src/react-app/domains/session/surface/markdown.tsx`
- `.gitignore`

## Out of scope
- Changing syntax highlighting engine, theme parsing, or custom scrollbar styling definitions.

## Testing
### Ran
- `pnpm typecheck`
- `pnpm test:e2e`
- `pnpm fraimz --flow app-smoke`

### Result
- PASSED — 1 passed, 0 failed, 0 skipped

## CI status
- pass: pass (all local E2E suite assertions and app-smoke flow completed green)
- code-related failures: None
- external/env/auth blockers: None

## Manual verification
1. Open the OpenWork desktop app and navigate to a chat session.
2. Produce or paste a message containing a long line of code/command that exceeds the viewport.
3. Observe that a horizontal scrollbar appears and the long line can be scrolled and read in full.

## Evidence
- <img width="1002" height="652" alt="image" src="https://github.com/user-attachments/assets/25982827-87e3-4965-bb7f-5015652510cc" />


## Risk
- Extremely low. Simple, localized CSS container adjustments.

## Rollback
- Run `git revert <commit-hash>` to restore the layout back to clipping.