### PR TITLE
fix(settings): fix theme picker previews inheriting active theme (#2328)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ transcript-analysis
 evals/results/
 .playwright-mcp/
 .warden/
+.vscode/

--- a/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
+++ b/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
@@ -76,7 +76,7 @@ function ThemePicker(props: ThemePickerProps) {
         value="dark"
         label={t("settings.theme_dark")}
       >
-        <ThemePreview value="dark" className="bg-zinc-950" />
+        <ThemePreview value="dark" className="bg-black" />
         <ThemePickerLabel>{t("settings.theme_dark")}</ThemePickerLabel>
       </ThemePickerItem>
     </ToggleGroup>
@@ -117,7 +117,7 @@ function ThemePreview(props: ThemePreviewProps) {
       {props.value === "system" && (
         <div className="flex h-full">
           <div className="w-1/2 bg-white" />
-          <div className="w-1/2 bg-zinc-950" />
+          <div className="w-1/2 bg-black" />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Replaced `bg-zinc-950` with `bg-black` in the dark theme card and the system theme split card.

## Why
- The theme picker cards in Settings > Appearance did not maintain their preview colors and instead inherited the active theme (e.g. the dark card became white in light mode).
- This happened because `bg-zinc-950` was used, but the theme's custom Tailwind color palette overrides default colors and does not include the `zinc` scale. Replacing it with `bg-black` ensures the preview background displays solid black.

## Issue
- Closes #2328

## Scope
- `apps/app/src/react-app/domains/settings/appearance/theme-section.tsx`

## Out of scope
- Changing global theme CSS classes or modifying Tailwind colors configuration.

## Testing
### Ran
- `pnpm typecheck`
- `pnpm test:e2e`
- `pnpm fraimz --flow app-smoke`

### Result
- pass/fail: pass

## CI status
- pass: pass (typecheck and Playwright e2e test suite complete)

## Manual verification
1. Open settings in the desktop app and select **Appearance**.
2. Switch active theme mode to **Light**.
3. Confirm that the Dark preview card remains black, and the System preview card remains split white and black.

## Evidence
<img width="1092" height="575" alt="image" src="https://github.com/user-attachments/assets/5ea0fa99-494e-4cc9-b7d7-d28e756f1b32" />

## Risk
- Low. Only styles dark and split elements in theme preview items.