### PR TITLE
fix(app): scope find-in-conversation to one split-screen pane

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -750,6 +750,7 @@ export function SessionPage(props: SessionPageProps) {
       props.surface,
   );
   const canRenderSplitSurface = Boolean(canRenderReactSurface && splitSessionId && splitSessionId !== props.selectedSessionId);
+  const findButtonSessionId = props.selectedSessionId;
 
   const openSessionTab = useCallback((workspaceId: string, sessionId: string) => {
     setSessionTabs((current) => {
@@ -911,7 +912,7 @@ export function SessionPage(props: SessionPageProps) {
 
             <div className="flex items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
               {/* Revert/redo moved to per-message actions */}
-              {props.selectedSessionId ? (
+              {findButtonSessionId ? (
                 <Tooltip>
                   <TooltipTrigger
                     render={
@@ -920,7 +921,7 @@ export function SessionPage(props: SessionPageProps) {
                         size="icon-sm"
                         className="rounded-xl text-gray-10 transition-colors hover:bg-muted hover:text-foreground"
                         aria-label="Find in conversation"
-                        onClick={() => useSessionFindStore.getState().openFind()}
+                        onClick={() => useSessionFindStore.getState().openFind({ sessionId: findButtonSessionId })}
                       >
                         <TextSearch size={17} />
                       </Button>
@@ -1017,6 +1018,7 @@ export function SessionPage(props: SessionPageProps) {
                         return (
                           <div
                             key={tab.sessionId}
+                            data-session-tab-id={tab.sessionId}
                             className={cn(
                               "group flex max-w-56 shrink-0 items-center gap-1 rounded-lg border px-2 py-1 text-xs transition-colors",
                               active

--- a/apps/app/src/react-app/domains/session/surface/find-bar.tsx
+++ b/apps/app/src/react-app/domains/session/surface/find-bar.tsx
@@ -86,6 +86,7 @@ export function SessionFindBar({
   onBeforeJump,
 }: SessionFindBarProps) {
   const open = useSessionFindStore((state) => state.open);
+  const ownerSessionId = useSessionFindStore((state) => state.sessionId);
   const query = useSessionFindStore((state) => state.query);
   const appliedQuery = useSessionFindStore((state) => state.appliedQuery);
   const target = useSessionFindStore((state) => state.target);
@@ -102,7 +103,8 @@ export function SessionFindBar({
   const [matches, setMatchesState] = useState<HTMLElement[]>([]);
   const [activeIndex, setActiveIndexState] = useState(0);
   const activeQuery = appliedQuery.trim();
-  const searchActive = open && activeQuery.length >= MIN_QUERY_LENGTH;
+  const owned = open && ownerSessionId === sessionId;
+  const searchActive = owned && activeQuery.length >= MIN_QUERY_LENGTH;
 
   const setMatches = useCallback((nextMatches: HTMLElement[]) => {
     matchesRef.current = nextMatches;
@@ -146,7 +148,7 @@ export function SessionFindBar({
 
   const collectMatches = useCallback((reason: CollectReason) => {
     const container = scrollRef.current;
-    if (!open || activeQuery.length < MIN_QUERY_LENGTH || !container) {
+    if (!owned || activeQuery.length < MIN_QUERY_LENGTH || !container) {
       setMatches([]);
       setActiveIndex(0);
       setActiveHighlight(activeElementRef, null);
@@ -204,25 +206,25 @@ export function SessionFindBar({
     if (shouldScroll && nextActive) {
       jumpToElement(nextActive);
     }
-  }, [activeQuery.length, jumpToElement, open, scrollRef, sessionId, setActiveIndex, setMatches]);
+  }, [activeQuery.length, jumpToElement, owned, scrollRef, sessionId, setActiveIndex, setMatches]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!owned) return;
     const frame = window.requestAnimationFrame(() => {
       inputRef.current?.focus();
       inputRef.current?.select();
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [focusNonce, open]);
+  }, [focusNonce, owned]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!owned) return;
     const timer = window.setTimeout(() => setAppliedQuery(query), DEBOUNCE_MS);
     return () => window.clearTimeout(timer);
-  }, [open, query, setAppliedQuery]);
+  }, [owned, query, setAppliedQuery]);
 
   useEffect(() => {
-    if (!open) {
+    if (!owned) {
       setMatches([]);
       setActiveIndex(0);
       setActiveHighlight(activeElementRef, null);
@@ -236,7 +238,7 @@ export function SessionFindBar({
 
     const timer = window.setTimeout(() => collectMatches("query"), COLLECT_AFTER_RENDER_MS);
     return () => window.clearTimeout(timer);
-  }, [activeQuery, collectMatches, open, setActiveIndex, setMatches]);
+  }, [activeQuery, collectMatches, owned, setActiveIndex, setMatches]);
 
   useEffect(() => {
     if (!searchActive) return;
@@ -278,7 +280,7 @@ export function SessionFindBar({
     setActiveHighlight(activeElementRef, null);
   }, []);
 
-  if (!open) {
+  if (!owned) {
     return null;
   }
 

--- a/apps/app/src/react-app/domains/session/surface/find-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/find-store.ts
@@ -6,17 +6,21 @@ export type SessionFindTarget = {
 };
 
 type OpenFindOptions = {
+  sessionId: string;
   query?: string;
   target?: SessionFindTarget;
 };
 
 type SessionFindStore = {
   open: boolean;
+  sessionId: string | null;
+  lastFocusedSessionId: string | null;
   query: string;
   appliedQuery: string;
   target: SessionFindTarget | null;
   focusNonce: number;
-  openFind: (opts?: OpenFindOptions) => void;
+  openFind: (opts: OpenFindOptions) => void;
+  setLastFocused: (sessionId: string) => void;
   setQuery: (query: string) => void;
   setAppliedQuery: (query: string) => void;
   closeFind: () => void;
@@ -24,20 +28,26 @@ type SessionFindStore = {
 
 export const useSessionFindStore = create<SessionFindStore>((set) => ({
   open: false,
+  sessionId: null,
+  lastFocusedSessionId: null,
   query: "",
   appliedQuery: "",
   target: null,
   focusNonce: 0,
   openFind: (opts) => set((state) => {
-    const query = opts?.query ?? state.query;
+    const query = opts.query ?? state.query;
     return {
       open: true,
+      sessionId: opts.sessionId,
       query,
       appliedQuery: query,
-      target: opts?.target ?? null,
+      target: opts.target ?? null,
       focusNonce: state.focusNonce + 1,
     };
   }),
+  setLastFocused: (lastFocusedSessionId) => set((state) => (
+    state.lastFocusedSessionId === lastFocusedSessionId ? state : { lastFocusedSessionId }
+  )),
   setQuery: (query) => set((state) => (
     state.query === query ? state : { query }
   )),
@@ -46,6 +56,7 @@ export const useSessionFindStore = create<SessionFindStore>((set) => ({
   )),
   closeFind: () => set({
     open: false,
+    sessionId: null,
     query: "",
     appliedQuery: "",
     target: null,

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -84,6 +84,7 @@ import {
 const EMPTY_TRANSCRIPT: UIMessage[] = [];
 const IDLE_STATUS: SessionStatus = { type: "idle" };
 const DEFAULT_COMPOSER_CONTROL_TEXT = "Help me outline the next OpenWork task.";
+const SESSION_SURFACE_SELECTOR = "[data-session-surface-id]";
 
 type SessionError = {
   message: string;
@@ -170,6 +171,30 @@ function transcriptToText(messages: UIMessage[]) {
       return text ? [text] : [];
     })
     .join("\n\n---\n\n");
+}
+
+function isSessionSurfaceMounted(sessionId: string) {
+  for (const surface of document.querySelectorAll(SESSION_SURFACE_SELECTOR)) {
+    if (surface.getAttribute("data-session-surface-id") === sessionId) return true;
+  }
+  return false;
+}
+
+function firstMountedSessionSurfaceId() {
+  return document.querySelector(SESSION_SURFACE_SELECTOR)?.getAttribute("data-session-surface-id") ?? null;
+}
+
+function resolveFindOwnerSessionId() {
+  const focusedRoot = document.activeElement?.closest(SESSION_SURFACE_SELECTOR);
+  const focusedSessionId = focusedRoot?.getAttribute("data-session-surface-id") ?? null;
+  if (focusedSessionId) return focusedSessionId;
+
+  const lastFocusedSessionId = useSessionFindStore.getState().lastFocusedSessionId;
+  if (lastFocusedSessionId && isSessionSurfaceMounted(lastFocusedSessionId)) {
+    return lastFocusedSessionId;
+  }
+
+  return firstMountedSessionSurfaceId();
 }
 
 function statusLabel(snapshot: OpenworkSessionSnapshot | undefined, busy: boolean) {
@@ -405,8 +430,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const { config: shellConfig } = useShellConfig();
   const showThinking = local.prefs.showThinking;
   const findOpen = useSessionFindStore((state) => state.open);
+  const findSessionId = useSessionFindStore((state) => state.sessionId);
   const findAppliedQuery = useSessionFindStore((state) => state.appliedQuery);
-  const findHighlightQuery = findOpen && findAppliedQuery.trim().length >= 2 ? findAppliedQuery : "";
+  const setFindLastFocused = useSessionFindStore((state) => state.setLastFocused);
+  const findOwned = findOpen && findSessionId === props.sessionId;
+  const findHighlightQuery = findOwned && findAppliedQuery.trim().length >= 2 ? findAppliedQuery : "";
   const sessionActivityStatus = useSessionActivityStore(
     (state) => state.statusesByWorkspaceId[props.workspaceId]?.[props.sessionId] ?? "idle",
   );
@@ -1135,13 +1163,19 @@ export function SessionSurface(props: SessionSurfaceProps) {
     sessionScroll.markScrollGesture(scrollRef.current);
   }, [sessionScroll.markScrollGesture]);
 
+  const handleFindSurfaceInteraction = useCallback(() => {
+    setFindLastFocused(props.sessionId);
+  }, [props.sessionId, setFindLastFocused]);
+
   const handleFindShortcut = useEffectEvent((event: KeyboardEvent) => {
     const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
     const mod = isMac ? event.metaKey : event.ctrlKey;
     if (!mod || event.shiftKey || event.altKey || event.key?.toLowerCase() !== "f") return;
 
     event.preventDefault();
-    useSessionFindStore.getState().openFind();
+    if (resolveFindOwnerSessionId() === props.sessionId) {
+      useSessionFindStore.getState().openFind({ sessionId: props.sessionId });
+    }
   });
 
   useEffect(() => {
@@ -1152,10 +1186,21 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   useEffect(() => {
     const state = useSessionFindStore.getState();
-    if (state.open && state.target?.sessionId !== props.sessionId) {
+    if (state.open && state.sessionId && state.sessionId !== props.sessionId && !isSessionSurfaceMounted(state.sessionId)) {
       state.closeFind();
     }
   }, [props.sessionId]);
+
+  const sessionIdRef = useRef(props.sessionId);
+  useEffect(() => {
+    sessionIdRef.current = props.sessionId;
+  }, [props.sessionId]);
+  useEffect(() => () => {
+    const state = useSessionFindStore.getState();
+    if (state.sessionId === sessionIdRef.current) {
+      state.closeFind();
+    }
+  }, []);
 
   const handleMessageListDispatchAction = useCallback((action: DispatchAction) => {
     if (action.target === "settings" && action.action === "open") {
@@ -1262,7 +1307,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   return (
     <DevProfiler id="SessionSurface">
-    <div className="flex h-full min-h-0 flex-col">
+    <div
+      data-session-surface-id={props.sessionId}
+      onPointerDownCapture={handleFindSurfaceInteraction}
+      onFocusCapture={handleFindSurfaceInteraction}
+      className="flex h-full min-h-0 flex-col"
+    >
       {model.transitionState === "switching" && showDelayedLoading ? (
         <div className="flex justify-center px-6 pt-4">
           <div className="rounded-full border border-dls-border bg-dls-hover/80 px-3 py-1 text-xs text-dls-secondary">
@@ -1290,7 +1340,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
           onScroll={sessionScroll.handleScroll}
           // Extra top padding while the find bar is open so it never covers
           // the first message (short transcripts cannot scroll it clear).
-          className={`absolute inset-0 overflow-x-hidden overflow-y-auto overscroll-y-contain px-3 pb-4 sm:px-5 ${findOpen ? "pt-16" : "pt-4"}`}
+          className={`absolute inset-0 overflow-x-hidden overflow-y-auto overscroll-y-contain px-3 pb-4 sm:px-5 ${findOwned ? "pt-16" : "pt-4"}`}
         >
           {/* Chat column: tighter than the composer (800px) so messages
                keep a comfortable reading width and don't feel "too big". */}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1395,7 +1395,7 @@ export function SessionRoute() {
       searchText: "find search current conversation session messages transcript",
       action: () => {
         setCommandPaletteOpen(false);
-        useSessionFindStore.getState().openFind();
+        useSessionFindStore.getState().openFind({ sessionId: selectedSessionId });
       },
     };
   }, [selectedSessionId]);

--- a/apps/app/src/react-app/shell/session-search-dialog.tsx
+++ b/apps/app/src/react-app/shell/session-search-dialog.tsx
@@ -279,7 +279,7 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
                             const target = item.messageId
                               ? { sessionId: item.session.sessionId, messageId: item.messageId }
                               : { sessionId: item.session.sessionId };
-                            useSessionFindStore.getState().openFind({ query: trimmedQuery, target });
+                            useSessionFindStore.getState().openFind({ sessionId: item.session.sessionId, query: trimmedQuery, target });
                           }
                         }}
                       >

--- a/apps/app/tests/find-store.test.ts
+++ b/apps/app/tests/find-store.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { useSessionFindStore } from "../src/react-app/domains/session/surface/find-store";
+
+function resetFindStore() {
+  useSessionFindStore.setState({
+    open: false,
+    sessionId: null,
+    lastFocusedSessionId: null,
+    query: "",
+    appliedQuery: "",
+    target: null,
+    focusNonce: 0,
+  });
+}
+
+describe("session find store", () => {
+  beforeEach(resetFindStore);
+
+  test("openFind sets owner, query, target, and bumps focus nonce", () => {
+    const target = { sessionId: "session-a", messageId: "message-a" };
+    useSessionFindStore.getState().openFind({
+      sessionId: "session-a",
+      query: "zebra",
+      target,
+    });
+
+    const state = useSessionFindStore.getState();
+    expect(state.open).toBe(true);
+    expect(state.sessionId).toBe("session-a");
+    expect(state.query).toBe("zebra");
+    expect(state.appliedQuery).toBe("zebra");
+    expect(state.target).toBe(target);
+    expect(state.focusNonce).toBe(1);
+  });
+
+  test("openFind can move ownership to another session", () => {
+    useSessionFindStore.getState().openFind({ sessionId: "session-a", query: "zebra" });
+    useSessionFindStore.getState().openFind({ sessionId: "session-b" });
+
+    const state = useSessionFindStore.getState();
+    expect(state.open).toBe(true);
+    expect(state.sessionId).toBe("session-b");
+    expect(state.query).toBe("zebra");
+    expect(state.focusNonce).toBe(2);
+  });
+
+  test("closeFind clears find state but keeps the last focused session", () => {
+    const store = useSessionFindStore.getState();
+    store.setLastFocused("session-a");
+    store.openFind({ sessionId: "session-a", query: "zebra", target: { sessionId: "session-a" } });
+    useSessionFindStore.getState().closeFind();
+
+    const state = useSessionFindStore.getState();
+    expect(state.open).toBe(false);
+    expect(state.sessionId).toBeNull();
+    expect(state.query).toBe("");
+    expect(state.appliedQuery).toBe("");
+    expect(state.target).toBeNull();
+    expect(state.lastFocusedSessionId).toBe("session-a");
+  });
+
+  test("setLastFocused no-ops when the session is unchanged", () => {
+    useSessionFindStore.getState().setLastFocused("session-a");
+    const before = useSessionFindStore.getState();
+    before.setLastFocused("session-a");
+
+    expect(useSessionFindStore.getState()).toBe(before);
+  });
+});

--- a/evals/flows/find-split-screen.flow.mjs
+++ b/evals/flows/find-split-screen.flow.mjs
@@ -1,0 +1,375 @@
+/**
+ * User-facing flow demo: Find in conversation is owned by one split-screen pane,
+ * so only that pane renders the bar and receives highlights.
+ */
+
+const FIND_INPUT = 'input[aria-label="Find in conversation"]';
+const HIGHLIGHT = 'mark[data-search-highlight="true"]';
+const SURFACE = '[data-session-surface-id]';
+const PROMPT = "Reply with exactly this sentence and nothing else: The calm walrus watched the quiet harbor.";
+const QUERY = "walrus";
+
+let sessionA = null;
+let sessionB = null;
+
+async function pasteComposer(ctx, text) {
+  return ctx.eval(
+    `(() => {
+      const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
+        || document.querySelector('[contenteditable="true"]');
+      if (!editor) return { ok: false, reason: 'composer not found' };
+      editor.focus();
+      const data = new DataTransfer();
+      data.setData('text/plain', ${JSON.stringify(text)});
+      editor.dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: data }));
+      return { ok: true, text: editor.innerText };
+    })()`,
+  );
+}
+
+async function submitComposer(ctx) {
+  return ctx.eval(`(() => {
+    const byLabel = Array.from(document.querySelectorAll('button'))
+      .find((button) => /run task|send|run/i.test((button.textContent || "").trim()) && !button.disabled);
+    if (byLabel) { byLabel.click(); return "clicked"; }
+    const editor = document.querySelector('[contenteditable="true"]');
+    if (editor) {
+      editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      return "enter";
+    }
+    return "none";
+  })()`);
+}
+
+async function currentRouteSessionId(ctx) {
+  return ctx.eval(`(() => {
+    const route = window.__openworkControl.snapshot().route || "";
+    const match = route.match(/ses_[A-Za-z0-9]+/);
+    return match ? match[0] : null;
+  })()`);
+}
+
+async function waitForNewRouteSessionId(ctx, previousId, label) {
+  return ctx.waitFor(
+    `(() => {
+      const route = window.__openworkControl.snapshot().route || "";
+      const match = route.match(/ses_[A-Za-z0-9]+/);
+      if (!match) return null;
+      return match[0] === ${JSON.stringify(previousId)} ? null : match[0];
+    })()`,
+    { timeoutMs: 30_000, label },
+  );
+}
+
+async function closeFindBarIfOpen(ctx) {
+  const closed = await ctx.eval(`(() => {
+    const input = document.querySelector(${JSON.stringify(FIND_INPUT)});
+    if (!input) return false;
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    return true;
+  })()`);
+  if (closed) {
+    await ctx.waitFor(
+      `(() => !document.querySelector(${JSON.stringify(FIND_INPUT)})
+        && document.querySelectorAll(${JSON.stringify(HIGHLIGHT)}).length === 0)()`,
+      { label: "stale find bar and highlights to clear" },
+    );
+  }
+}
+
+function surfaceStateExpression() {
+  return `(() => {
+    const roots = Array.from(document.querySelectorAll(${JSON.stringify(SURFACE)}));
+    return roots.map((root) => root.getAttribute('data-session-surface-id'));
+  })()`;
+}
+
+function paneMatchStateExpression(paneId) {
+  return `(() => {
+    const root = Array.from(document.querySelectorAll(${JSON.stringify(SURFACE)}))
+      .find((candidate) => candidate.getAttribute('data-session-surface-id') === ${JSON.stringify(paneId)});
+    if (!root) return { mounted: false, marks: 0, counter: "", input: false };
+    const input = root.querySelector(${JSON.stringify(FIND_INPUT)});
+    const bar = input ? input.parentElement : null;
+    const counter = bar ? bar.querySelector('[aria-live="polite"]') : null;
+    return {
+      mounted: true,
+      marks: root.querySelectorAll(${JSON.stringify(HIGHLIGHT)}).length,
+      counter: counter ? counter.textContent.trim() : "",
+      input: Boolean(input),
+    };
+  })()`;
+}
+
+export default {
+  id: "find-split-screen",
+  title: "Find in conversation stays scoped to one split-screen pane",
+  kind: "user-facing",
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 60_000,
+      label: "control API",
+    });
+    const state = await ctx.waitFor(
+      `(() => {
+        const control = window.__openworkControl;
+        const route = control.snapshot().route;
+        if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+        const action = control.listActions().find((a) => a.id === "session.create_task");
+        if (action && !action.disabled) return "ready";
+        return null;
+      })()`,
+      { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" },
+    );
+    return state === "blocked"
+      ? "Profile is not onboarded (welcome/signin); split-screen find requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "Seed session A with a searchable reply",
+      run: async (ctx) => {
+        await ctx.prove("Session A contains walrus in both the prompt and assistant reply", {
+          claim: "The flow creates a first session where 'walrus' appears in both user and assistant messages, so pane-scoped highlighting can be proven later.",
+          voiceover:
+            "First I seed a conversation on the left side of our story. The word walrus appears in my prompt and in the assistant's exact reply, so this session will have multiple readable matches.",
+          action: async () => {
+            const previous = await currentRouteSessionId(ctx);
+            await ctx.control("session.create_task");
+            sessionA = await waitForNewRouteSessionId(ctx, previous, "session A id in route");
+            ctx.assert(Boolean(sessionA), "No session A id was captured from the route.");
+
+            const pasted = await pasteComposer(ctx, PROMPT);
+            ctx.assert(pasted?.ok, `Composer not ready: ${pasted?.reason ?? "unknown"}`);
+            const submitted = await submitComposer(ctx);
+            ctx.assert(submitted !== "none", "Could not submit the composer message.");
+            ctx.log(`session A: ${sessionA}; submit: ${submitted}`);
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `(() => {
+                const root = Array.from(document.querySelectorAll(${JSON.stringify(SURFACE)}))
+                  .find((candidate) => candidate.getAttribute('data-session-surface-id') === ${JSON.stringify(sessionA)});
+                if (!root) return false;
+                const userHasWalrus = Array.from(root.querySelectorAll('[data-message-role="user"]'))
+                  .some((message) => message.innerText.toLowerCase().includes(${JSON.stringify(QUERY)}));
+                const assistantHasWalrus = Array.from(root.querySelectorAll('[data-message-role="assistant"]'))
+                  .some((message) => message.innerText.toLowerCase().includes(${JSON.stringify(QUERY)}));
+                return userHasWalrus && assistantHasWalrus;
+              })()`,
+              { timeoutMs: 60_000, label: "walrus appears in user and assistant messages in session A" },
+            );
+            const settleStarted = await ctx.eval("Date.now()");
+            await ctx.waitFor(`Date.now() - ${settleStarted} >= 1500`, {
+              timeoutMs: 3_000,
+              label: "session A transcript settled",
+            });
+            await ctx.expectNoText("Something went wrong");
+          },
+          screenshot: {
+            name: "split-find-seeded-session-a",
+            requireText: ["walrus"],
+          },
+        });
+      },
+    },
+    {
+      name: "Open session B and split session A beside it",
+      run: async (ctx) => {
+        await ctx.prove("Split screen shows B as the primary pane and A as the split pane", {
+          claim: "Creating a second session and opening session A in split view mounts exactly two session surfaces: B first and A second.",
+          voiceover:
+            "Next I create a second, empty conversation and use the tab strip to open the first one in split view. The app now shows two live transcript panes side by side: the new session first, and the walrus session beside it.",
+          action: async () => {
+            const previous = await currentRouteSessionId(ctx);
+            await ctx.control("session.create_task");
+            sessionB = await waitForNewRouteSessionId(ctx, previous, "session B id in route");
+            ctx.assert(Boolean(sessionB), "No session B id was captured from the route.");
+            ctx.assert(sessionB !== sessionA, `Expected session B to differ from session A, saw ${sessionB}.`);
+
+            // Idempotence: a previous run may have left a split pane open.
+            const closedStaleSplit = await ctx.eval(`(() => {
+              const button = document.querySelector('button[aria-label="Close split"]');
+              if (!button) return false;
+              button.click();
+              return true;
+            })()`);
+            if (closedStaleSplit) {
+              await ctx.waitFor(
+                `document.querySelectorAll(${JSON.stringify(SURFACE)}).length === 1`,
+                { label: "stale split pane to close" },
+              );
+            }
+
+            // Target session A's tab specifically: the tab strip persists
+            // tabs from earlier sessions, so "first enabled split button"
+            // could split a stale session.
+            const clicked = await ctx.eval(`(() => {
+              const tab = document.querySelector('[data-session-tab-id=${JSON.stringify(sessionA)}]');
+              if (!tab) return { ok: false, reason: "tab for session A not found" };
+              const button = tab.querySelector('button[aria-label="Open in split view"]');
+              if (!button || button.disabled) return { ok: false, reason: "split button missing or disabled" };
+              button.click();
+              return { ok: true };
+            })()`);
+            ctx.assert(clicked.ok, `Could not split session A's tab: ${JSON.stringify(clicked)}.`);
+          },
+          assert: async () => {
+            const ids = await ctx.waitFor(
+              `(() => {
+                const ids = ${surfaceStateExpression()};
+                return ids.length === 2 ? ids : null;
+              })()`,
+              { timeoutMs: 30_000, label: "two split-screen session surfaces" },
+            );
+            ctx.assert(ids.includes(sessionA) && ids.includes(sessionB), `Expected panes ${sessionA} and ${sessionB}, saw ${ids.join(", ")}.`);
+            ctx.assert(ids[0] === sessionB && ids[1] === sessionA, `Expected DOM order B then A, saw ${ids.join(", ")}.`);
+          },
+          screenshot: {
+            name: "split-find-two-panes",
+          },
+        });
+      },
+    },
+    {
+      name: "Cmd/Ctrl+F opens exactly one find bar",
+      run: async (ctx) => {
+        await ctx.prove("Only one split-screen pane claims the find shortcut", {
+          claim: "Pressing Cmd/Ctrl+F in split-screen renders exactly one Find in conversation bar, not one per mounted session surface.",
+          voiceover:
+            "With both panes visible, I press the find shortcut. The important fix is visible immediately: only one compact find bar appears, so the two panes no longer compete with duplicate search chrome.",
+          action: async () => {
+            await closeFindBarIfOpen(ctx);
+            await ctx.eval(`(() => {
+              window.dispatchEvent(new KeyboardEvent("keydown", {
+                key: "f",
+                metaKey: true,
+                ctrlKey: true,
+                bubbles: true,
+              }));
+              return true;
+            })()`);
+            await ctx.waitFor(
+              `document.querySelectorAll(${JSON.stringify(FIND_INPUT)}).length === 1`,
+              { timeoutMs: 10_000, label: "one find input after shortcut" },
+            );
+          },
+          assert: async () => {
+            const state = await ctx.eval(`(() => {
+              const inputs = Array.from(document.querySelectorAll(${JSON.stringify(FIND_INPUT)}));
+              const root = inputs[0] ? inputs[0].closest(${JSON.stringify(SURFACE)}) : null;
+              return {
+                count: inputs.length,
+                scopedCount: document.querySelectorAll('[data-session-surface-id] input[aria-label="Find in conversation"]').length,
+                owner: root ? root.getAttribute('data-session-surface-id') : null,
+              };
+            })()`);
+            ctx.assert(state.count === 1, `Expected one find input, saw ${state.count}.`);
+            ctx.assert(state.scopedCount === 1, `Expected one pane-scoped find input, saw ${state.scopedCount}.`);
+            ctx.assert(Boolean(state.owner), "The single find input was not inside a session surface.");
+            ctx.log(`find owner after shortcut: ${state.owner}`);
+          },
+          screenshot: {
+            name: "split-find-one-bar",
+          },
+        });
+      },
+    },
+    {
+      name: "Clicking the split pane makes Cmd/Ctrl+F target it",
+      run: async (ctx) => {
+        await ctx.prove("Interacting with pane A scopes find and highlights only pane A", {
+          claim: "After clicking the split pane, Cmd/Ctrl+F opens the bar inside session A; typing 'walrus' highlights A and leaves session B unmarked.",
+          voiceover:
+            "Now I click inside the split pane that contains the walrus conversation and press the same shortcut again. The find bar moves to that pane, the walrus matches highlight there, and the empty pane stays completely unmarked.",
+          action: async () => {
+            await closeFindBarIfOpen(ctx);
+            const clickedPane = await ctx.eval(`(() => {
+              const root = Array.from(document.querySelectorAll(${JSON.stringify(SURFACE)}))
+                .find((candidate) => candidate.getAttribute('data-session-surface-id') === ${JSON.stringify(sessionA)});
+              if (!root) return false;
+              const target = root.querySelector('[data-message-role]') || root;
+              target.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+              target.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+              target.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+              return true;
+            })()`);
+            ctx.assert(clickedPane, `Could not dispatch pointer events inside split pane ${sessionA}.`);
+            await ctx.eval(`(() => {
+              window.dispatchEvent(new KeyboardEvent("keydown", {
+                key: "f",
+                metaKey: true,
+                ctrlKey: true,
+                bubbles: true,
+              }));
+              return true;
+            })()`);
+            await ctx.waitFor(
+              `(() => {
+                const pane = ${paneMatchStateExpression(sessionA)};
+                return pane.input && document.querySelectorAll(${JSON.stringify(FIND_INPUT)}).length === 1;
+              })()`,
+              { timeoutMs: 10_000, label: "find input owned by split pane A" },
+            );
+            await ctx.fill(FIND_INPUT, QUERY);
+            await ctx.waitFor(
+              `(() => {
+                const paneA = ${paneMatchStateExpression(sessionA)};
+                const paneB = ${paneMatchStateExpression(sessionB)};
+                return paneA.marks >= 2 && paneB.marks === 0 && paneA.counter.startsWith("1/");
+              })()`,
+              { timeoutMs: 10_000, label: "walrus highlights only in pane A" },
+            );
+          },
+          assert: async () => {
+            const paneA = await ctx.eval(paneMatchStateExpression(sessionA));
+            const paneB = await ctx.eval(paneMatchStateExpression(sessionB));
+            ctx.assert(paneA.input, `Find input is not inside split pane ${sessionA}.`);
+            ctx.assert(paneA.marks >= 2, `Expected at least two pane A highlights, saw ${paneA.marks}.`);
+            ctx.assert(paneB.marks === 0, `Expected pane B to have zero highlights, saw ${paneB.marks}.`);
+            ctx.assert(paneA.counter.startsWith("1/"), `Expected pane A counter to start with 1/, saw '${paneA.counter}'.`);
+          },
+          screenshot: {
+            name: "split-find-pane-a-highlighted",
+            requireText: ["walrus"],
+          },
+        });
+      },
+    },
+    {
+      name: "Escape closes find and clears both panes",
+      run: async (ctx) => {
+        await ctx.prove("Escape removes the pane-owned find state everywhere", {
+          claim: "Pressing Escape closes the only find bar and clears all search highlight marks from both split-screen panes.",
+          voiceover:
+            "Finally I close find with Escape. The search chrome disappears and every highlight is gone across both panes, leaving split-screen clean again.",
+          action: async () => {
+            await ctx.eval(`(() => {
+              const input = document.querySelector(${JSON.stringify(FIND_INPUT)});
+              if (!input) throw new Error("find input missing");
+              input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+              return true;
+            })()`);
+            await ctx.waitFor(
+              `(() => !document.querySelector(${JSON.stringify(FIND_INPUT)})
+                && document.querySelectorAll(${JSON.stringify(HIGHLIGHT)}).length === 0)()`,
+              { timeoutMs: 10_000, label: "no find inputs and no highlights" },
+            );
+          },
+          assert: async () => {
+            const state = await ctx.eval(`(() => ({
+              inputs: document.querySelectorAll(${JSON.stringify(FIND_INPUT)}).length,
+              marks: document.querySelectorAll(${JSON.stringify(HIGHLIGHT)}).length,
+            }))()`);
+            ctx.assert(state.inputs === 0, `Expected zero find inputs, saw ${state.inputs}.`);
+            ctx.assert(state.marks === 0, `Expected zero highlights, saw ${state.marks}.`);
+          },
+          screenshot: {
+            name: "split-find-closed-cleared",
+            rejectText: ["No matches"],
+          },
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Bug
In split screen (two sessions side by side), opening Find in conversation rendered **a find bar in every pane** — same query in both, competing counters ("1/1" next to "No matches"), both transcripts highlighted, duplicate window ⌘F listeners, and the split pane's mount effect could close the primary pane's find.

Root cause: the find store is global and `SessionSurface` (one per pane) gated everything on `open` alone.

## Fix — ownership by session
- **Store**: `openFind` now requires an owning `sessionId`; `lastFocusedSessionId` tracks the last-interacted pane; `closeFind` clears ownership.
- **Deterministic ⌘F claim**: each pane's listener resolves the same owner — pane containing focus → last-interacted mounted pane → first pane in DOM order — so exactly one pane opens the bar (VS Code split-editor semantics). Pane roots carry `data-session-surface-id` + capture-phase pointer/focus tracking.
- **Owner-scoped rendering**: bar, highlights, and the find top-padding apply only to the owning pane.
- **Lifecycle**: close-on-navigate now only fires when the owning session no longer has any mounted pane (previously the split pane's mount closed the primary's find); true-unmount cleanup closes find when the owning split pane is closed, without breaking cross-session handoff ordering.
- Header button / palette entry target the selected session; cross-session search handoff owns the destination session.
- Session tabs expose `data-session-tab-id` (deterministic anchors for evals).

## Testing
- `pnpm typecheck` ✓
- `bun test tests/find-store.test.ts tests/session-search.test.ts` ✓ (5 tests — new store ownership coverage)
- `pnpm fraimz --flow find-split-screen` ✓ — new 5-frame proof: seed pane A → split A beside B → ⌘F renders exactly ONE bar → clicking pane A then ⌘F moves the bar there, highlights only pane A (pane B zero marks) → Escape clears everything
- `pnpm fraimz --flow in-chat-find` ✓ — single-pane find regression (ran with a split pane still mounted)
- `pnpm fraimz --flow core-flow` ✓ — canonical flow stays green

fraimz proof incoming as a PR comment.