### PR TITLE
chore(landing): tighten /download hero copy

### DIFF
--- a/ee/apps/landing/app/download/page.tsx
+++ b/ee/apps/landing/app/download/page.tsx
@@ -57,19 +57,15 @@ export default async function Download() {
       <main className="pb-24 pt-20">
         <div className="content-max-width px-6">
           <div className="animate-fade-up max-w-2xl">
-            <div className="mb-3 text-[12px] font-bold uppercase tracking-wider text-gray-500">
-              OpenWork desktop
-            </div>
             <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
               Download now
             </h1>
             <p className="mb-6 text-[17px] leading-relaxed text-gray-700">
-              A local-first AI coworker for your desktop. Pick your platform
-              below and start working.
+              Free and open source. No account required.
             </p>
           </div>
 
-          <section className="my-12">
+          <section className="my-8">
             <DownloadOpenWorkCard installers={github.installers} releaseTag={releaseTag} />
           </section>
 


### PR DESCRIPTION
## What

The /download hero was repeating what the download card below it already says:

- ❌ eyebrow "OPENWORK DESKTOP" — removed (redundant with the nav + card title)
- ❌ "A local-first AI coworker for your desktop. Pick your platform below and start working." — replaced with one factual, friction-killing line: **"Free and open source. No account required."** (matches the page's own SEO description)
- ✅ h1 "Download now" stays

Also tightened the card's top margin (`my-12` → `my-8`) to match the shorter hero.

## Tests / proof

- `pnpm --dir ee/apps/landing exec tsc --noEmit` ✅ and `pnpm --dir ee/apps/landing build` ✅
- `pnpm fraimz --flow download-light-card` against the live landing dev server on this branch: **PASSED 5/5 frames** (card render/light check, 8 links, detection, both emulated-device recommendation frames) — proof comment below.

New hero:

<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/download-hero/browser-screenshot-1783271940694-jE3jH9t8zi79zIWDqomQhjYzu3zbed.png" width="800">