### PR TITLE
feat(connections): admin connect on Your Connections + 'Individual accounts' / 'One org account' terminology

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -621,7 +621,7 @@ export default {
   "mcp.org_connection_connected_label": "Connected",
   "mcp.org_connection_desc_per_member": "Available from your organization. Connect your own account to use it.",
   "mcp.org_connection_desc_per_member_connected": "Connected with your own account.",
-  "mcp.org_connection_desc_shared": "Shared connection managed by your organization.",
+  "mcp.org_connection_desc_shared": "One org account managed by your organization — the AI acts as it.",
   "mcp.org_connection_managed_label": "Managed by your organization",
   "mcp.org_connections_connected_badge": "Connected",
   "mcp.org_connections_subtitle": "Shared by your admin",

--- a/apps/app/src/react-app/domains/settings/extension-items.ts
+++ b/apps/app/src/react-app/domains/settings/extension-items.ts
@@ -75,7 +75,7 @@ export function isOrgMcpConnectionReady(connection: Pick<DenExternalMcpConnectio
 }
 
 export function orgMcpConnectionDescription(connection: Pick<DenExternalMcpConnection, "credentialMode" | "connectedForMe">) {
-  if (connection.credentialMode === "shared") return "Shared connection managed by your organization.";
+  if (connection.credentialMode === "shared") return "One org account managed by your organization — the AI acts as it.";
   if (connection.connectedForMe) return "Connected with your own account.";
   return "Available from your organization. Connect your own account to use it.";
 }

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -855,7 +855,7 @@ function OrgMcpConnectionDetailModal(props: {
         <div className="space-y-4">
           <div className="flex flex-wrap gap-2">
             <SettingsPill>Shared by your organization</SettingsPill>
-            <SettingsPill>{row.connection.credentialMode === "shared" ? "Shared credential" : "Your account"}</SettingsPill>
+            <SettingsPill>{row.connection.credentialMode === "shared" ? "Org account" : "Your account"}</SettingsPill>
             <SettingsPill>MCP</SettingsPill>
           </div>
           <SettingsNotice>

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -846,7 +846,7 @@ export function McpView(props: McpViewProps) {
             configSlot={(
               <div className="flex flex-wrap gap-2">
                 <span className="rounded-full border border-dls-border bg-dls-hover px-2 py-1 text-xs text-dls-secondary">Shared by your organization</span>
-                <span className="rounded-full border border-dls-border bg-dls-hover px-2 py-1 text-xs text-dls-secondary">{connection.credentialMode === "shared" ? "Shared credential" : "Your account"}</span>
+                <span className="rounded-full border border-dls-border bg-dls-hover px-2 py-1 text-xs text-dls-secondary">{connection.credentialMode === "shared" ? "Org account" : "Your account"}</span>
               </div>
             )}
           />

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -481,7 +481,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       if (connection.credentialMode === "shared") {
         // Connecting a shared credential IS the org-level integration setup —
         // admin-only, like creating the connection itself.
-        const admin = ensureOrganizationAdmin(c, "Only workspace owners and admins can connect a shared-credential connection.")
+        const admin = ensureOrganizationAdmin(c, "Only workspace owners and admins can connect an org-account connection.")
         if (!admin.ok) return c.json(admin.response, orgAccessFailureStatus(admin.response))
       } else {
         // Per-member: any member GRANTED the connection may connect their own

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -341,7 +341,7 @@ function ConnectionRow({
             {isPerMember ? (
               <span className="inline-flex items-center gap-1 rounded-full bg-gray-900 px-2 py-0.5 text-[11px] font-medium text-white">
                 <Users className="h-3 w-3" />
-                Per-member accounts
+                Individual accounts
               </span>
             ) : connection.connected ? (
               <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
@@ -410,7 +410,7 @@ function AddConnectionDialog({
   const [name, setName] = useState(preset?.displayName ?? "");
   const [url, setUrl] = useState(preset?.url ?? "");
   const [authType, setAuthType] = useState<ExternalMcpAuthType>(preset?.authType ?? "oauth");
-  const [credentialMode, setCredentialMode] = useState<ExternalMcpCredentialMode>("shared");
+  const [credentialMode, setCredentialMode] = useState<ExternalMcpCredentialMode>("per_member");
   const [apiKey, setApiKey] = useState("");
   const [accessMode, setAccessMode] = useState<"everyone" | "teams" | "people">("everyone");
   const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
@@ -421,7 +421,7 @@ function AddConnectionDialog({
     setName(preset?.displayName ?? "");
     setUrl(preset?.url ?? "");
     setAuthType(preset?.authType ?? "oauth");
-    setCredentialMode("shared");
+    setCredentialMode("per_member");
     setApiKey("");
     setAccessMode("everyone");
     setSelectedTeamIds([]);
@@ -504,17 +504,8 @@ function AddConnectionDialog({
 
           {authType === "oauth" ? (
             <div>
-              <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Account</label>
+              <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Whose account does the AI use?</label>
               <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => setCredentialMode("shared")}
-                  className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition ${
-                    credentialMode === "shared" ? "border-gray-900 bg-gray-900 text-white" : "border-gray-200 text-gray-600 hover:border-gray-300"
-                  }`}
-                >
-                  One shared account
-                </button>
                 <button
                   type="button"
                   onClick={() => setCredentialMode("per_member")}
@@ -522,13 +513,22 @@ function AddConnectionDialog({
                     credentialMode === "per_member" ? "border-gray-900 bg-gray-900 text-white" : "border-gray-200 text-gray-600 hover:border-gray-300"
                   }`}
                 >
-                  Each person connects their own
+                  Individual accounts
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setCredentialMode("shared")}
+                  className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition ${
+                    credentialMode === "shared" ? "border-gray-900 bg-gray-900 text-white" : "border-gray-200 text-gray-600 hover:border-gray-300"
+                  }`}
+                >
+                  One org account
                 </button>
               </div>
               <p className="mt-1.5 text-[12px] leading-5 text-gray-500">
-                {credentialMode === "shared"
-                  ? "You'll authorize a single account now; everyone granted access acts as it."
-                  : "You publish the connection; each person authorizes their own account from Your Connections and acts as themselves."}
+                {credentialMode === "per_member"
+                  ? "Each person signs in with their own account from Your Connections. Their AI acts as them, with their permissions."
+                  : "You sign in once with a single account — everyone granted access acts as it. Good for bot or service accounts."}
               </p>
             </div>
           ) : null}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -142,7 +142,7 @@ function YourConnectionRow({
             {connection.connectedForMe ? (
               <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
                 <Check className="h-3 w-3" />
-                {isPerMember ? "Connected as you" : "Connected"}
+                {isPerMember ? "Connected as you" : "Org account connected"}
               </span>
             ) : polling ? (
               <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
@@ -159,7 +159,7 @@ function YourConnectionRow({
               </span>
             ) : (
               <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
-                Not connected yet
+                Waiting for an admin to connect
               </span>
             )}
           </div>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from "react";
 import { Check, Loader2, Plug } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { getOrgAccessFlags } from "../../_lib/den-org";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { IntegrationIcon } from "./integration-icon";
 import {
   type ExternalMcpConnection,
@@ -20,9 +22,17 @@ const OAUTH_POLL_TIMEOUT_MS = 90_000;
  * sees it here. For "per_member" connections this is where each person
  * connects their own account — after which their agent's
  * search_capabilities/execute_capability calls run as them.
+ * Admins can also finish a shared-credential connection's OAuth here when
+ * the org account was published but never authorized.
  */
 export function YourConnectionsScreen() {
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections("usable");
+  const { orgContext } = useOrgDashboard();
+  const access = getOrgAccessFlags(
+    orgContext?.currentMember.role ?? "member",
+    orgContext?.currentMember.isOwner ?? false,
+    orgContext?.roles,
+  );
   const startOAuth = useStartMcpConnectionOAuth();
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -93,6 +103,7 @@ export function YourConnectionsScreen() {
             <YourConnectionRow
               key={connection.id}
               connection={connection}
+              isAdmin={access.isAdmin}
               polling={pollingConnectionId === connection.id}
               connecting={startOAuth.isPending && startOAuth.variables === connection.id}
               onConnect={() => void handleConnectMyAccount(connection.id)}
@@ -106,17 +117,20 @@ export function YourConnectionsScreen() {
 
 function YourConnectionRow({
   connection,
+  isAdmin,
   polling,
   connecting,
   onConnect,
 }: {
   connection: ExternalMcpConnection;
+  isAdmin: boolean;
   polling: boolean;
   connecting: boolean;
   onConnect: () => void;
 }) {
   const isPerMember = connection.credentialMode === "per_member";
   const needsMyConnect = isPerMember && !connection.connectedForMe;
+  const needsAdminConnect = isAdmin && !isPerMember && connection.authType === "oauth" && !connection.connectedForMe;
 
   return (
     <div className="flex items-center justify-between gap-4 px-6 py-4">
@@ -139,6 +153,10 @@ function YourConnectionRow({
               <span className="inline-flex rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
                 Connect your account
               </span>
+            ) : needsAdminConnect ? (
+              <span className="inline-flex rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                Connect the org account
+              </span>
             ) : (
               <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
                 Not connected yet
@@ -150,7 +168,7 @@ function YourConnectionRow({
       </div>
 
       <div className="flex shrink-0 items-center gap-2">
-        {needsMyConnect ? (
+        {needsMyConnect || needsAdminConnect ? (
           <DenButton variant="primary" size="sm" loading={connecting || polling} onClick={onConnect}>
             Connect
           </DenButton>

--- a/evals/flows/connections-beta.flow.mjs
+++ b/evals/flows/connections-beta.flow.mjs
@@ -274,18 +274,18 @@ export default {
           assert: async () => {
             await ctx.expectText(CONNECTION_NAME, { timeoutMs: 20_000 });
             const pill = await ctx.eval(`(() => {
-              const span = [...document.querySelectorAll('span')].find((entry) => entry.textContent.includes('Per-member accounts'));
+              const span = [...document.querySelectorAll('span')].find((entry) => entry.textContent.includes('Individual accounts'));
               return span ? { classes: [...span.classList], text: span.textContent.trim() } : null;
             })()`);
-            ctx.assert(Boolean(pill), "Per-member accounts pill was not rendered.");
-            ctx.assert(pill.classes.includes("bg-gray-900"), `Per-member pill must be black: ${JSON.stringify(pill.classes)}`);
-            ctx.assert(pill.classes.includes("text-white"), `Per-member pill text must be white: ${JSON.stringify(pill.classes)}`);
-            ctx.assert(!pill.classes.some((className) => /violet|purple/i.test(className)), `Per-member pill must not be purple: ${JSON.stringify(pill.classes)}`);
+            ctx.assert(Boolean(pill), "Individual accounts pill was not rendered.");
+            ctx.assert(pill.classes.includes("bg-gray-900"), `Individual accounts pill must be black: ${JSON.stringify(pill.classes)}`);
+            ctx.assert(pill.classes.includes("text-white"), `Individual accounts pill text must be white: ${JSON.stringify(pill.classes)}`);
+            ctx.assert(!pill.classes.some((className) => /violet|purple/i.test(className)), `Individual accounts pill must not be purple: ${JSON.stringify(pill.classes)}`);
           },
           screenshot: {
             name: "connections-beta-per-member-pill",
-            claim: "A per-member org connection renders with the black Per-member accounts pill.",
-            requireText: [CONNECTION_NAME, "Per-member accounts"],
+            claim: "A per-member org connection renders with the black Individual accounts pill.",
+            requireText: [CONNECTION_NAME, "Individual accounts"],
             rejectText: ["Something went wrong"],
           },
         });

--- a/evals/flows/lib/den-web.mjs
+++ b/evals/flows/lib/den-web.mjs
@@ -1,0 +1,102 @@
+/**
+ * Shared den-web browser/API helpers for cloud-connection eval flows.
+ */
+
+export function denWebUrl() {
+  return (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+}
+
+export function denApiUrl() {
+  return (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+}
+
+export async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${denApiUrl()}${path}`, {
+    ...options,
+    // Better Auth rejects auth requests with no Origin header (CSRF
+    // protection); a real browser always sends one, Node's fetch doesn't.
+    headers: { "content-type": "application/json", origin: denWebUrl(), ...(options.headers ?? {}) },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+export async function signInApi(email, password) {
+  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  if (!response.ok) return null;
+  return body.token ?? null;
+}
+
+export async function signInViaBrowser(ctx, email, password) {
+  // Land on the den-web origin first so the relative sign-out fetch below
+  // actually reaches den-web (a leftover session would otherwise bounce the
+  // root URL straight to /dashboard with no sign-in card).
+  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(denWebUrl())}; return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
+  await ctx.eval(`fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`, { awaitPromise: true });
+  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(denWebUrl())}; return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
+  await ctx.waitFor(
+    "Boolean(document.querySelector('input[type=\"email\"]')) && Boolean(document.querySelector('input[type=\"password\"]'))",
+    { timeoutMs: 30_000, label: "email + password fields" },
+  );
+  await ctx.fill('input[type="email"]', email);
+  await ctx.fill('input[type="password"]', password);
+  const submitted = await ctx.eval(`(() => {
+    const button = document.querySelector('button[type="submit"]');
+    if (!button) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(submitted, "No submit button found on the sign-in card.");
+  await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
+}
+
+export async function openAdminConnections(ctx) {
+  // Retry the click: on a fresh page load (especially over higher cloud
+  // latency), the very first click can land before Next.js has finished
+  // hydrating and attaching the link's handler. The Connections link
+  // lives inside the collapsible Extensions nav group, so expand that
+  // first when the link isn't in the DOM yet.
+  await ctx.waitFor(
+    `(() => {
+      if (window.location.pathname.includes('mcp-connections')) return true;
+      const link = [...document.querySelectorAll('nav a')].find((a) => a.getAttribute('href')?.includes('mcp-connections'));
+      if (link) {
+        link.click();
+        return false;
+      }
+      const group = [...document.querySelectorAll('nav a, nav button')].find((el) => (el.textContent ?? '').trim().startsWith('Extensions'));
+      group?.click();
+      return false;
+    })()`,
+    { timeoutMs: 30_000, label: "MCP Connections nav link clicked" },
+  );
+  await ctx.waitFor("window.location.pathname.includes('mcp-connections')", {
+    timeoutMs: 20_000,
+    label: "MCP Connections route",
+  });
+}
+
+export async function openYourConnections(ctx) {
+  await ctx.waitFor(
+    `(() => {
+      const link = [...document.querySelectorAll('a')].find((a) => a.getAttribute('href')?.endsWith('/your-connections'));
+      if (!link) return false;
+      if (window.location.pathname.endsWith('/your-connections')) return true;
+      link.click();
+      return false;
+    })()`,
+    { timeoutMs: 30_000, label: "Your Connections nav" },
+  );
+  await ctx.waitFor("window.location.pathname.endsWith('/your-connections')", { timeoutMs: 20_000, label: "Your Connections route" });
+}

--- a/evals/flows/mcp-connections-cloud-oauth.flow.mjs
+++ b/evals/flows/mcp-connections-cloud-oauth.flow.mjs
@@ -40,30 +40,13 @@
  *   accommodation, not a product behavior change).
  */
 
-const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
-const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+import { denApiFetch, denApiUrl, denWebUrl, openAdminConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+
 const DEMO_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
 const DEMO_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
 const MOCK_SERVER_URL = (process.env.MOCK_OAUTH_MCP_URL ?? "http://127.0.0.1:3978").trim().replace(/\/+$/, "");
 const CONNECTION_NAME = `fraimz-mcp-${Date.now()}`;
 const ECHO_TEXT = "search and execute in the cloud proof";
-
-async function denApiFetch(path, options = {}) {
-  const response = await fetch(`${DEN_API_URL}${path}`, {
-    ...options,
-    // Better Auth rejects auth requests with no Origin header (CSRF
-    // protection); a real browser always sends one, Node's fetch doesn't.
-    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
-  });
-  const text = await response.text();
-  let body;
-  try {
-    body = JSON.parse(text);
-  } catch {
-    body = text;
-  }
-  return { response, body };
-}
 
 export default {
   id: "mcp-connections-cloud-oauth",
@@ -77,9 +60,25 @@ export default {
       run: async (ctx) => {
         const health = await fetch(`${MOCK_SERVER_URL}/health`).catch(() => null);
         ctx.assert(Boolean(health?.ok), `Mock OAuth+MCP server not reachable at ${MOCK_SERVER_URL}.`);
+        const adminSession = await signInApi(DEMO_EMAIL, DEMO_PASSWORD);
+        ctx.assert(Boolean(adminSession), `Den API sign-in failed for ${DEMO_EMAIL}.`);
+        const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+          headers: { authorization: `Bearer ${adminSession}` },
+        });
+        ctx.assert(existing.response.ok, `Listing manageable connections failed: ${existing.response.status}`);
+        for (const connection of existing.body.connections ?? []) {
+          if (connection.name.startsWith("fraimz-mcp-")) {
+            const removed = await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+              method: "DELETE",
+              headers: { authorization: `Bearer ${adminSession}` },
+            });
+            ctx.assert(removed.response.ok, `Cleanup delete failed for leftover ${connection.id}.`);
+          }
+        }
+        const webUrl = denWebUrl();
         const currentUrl = await ctx.eval("window.location.href");
-        if (!currentUrl.includes(new URL(DEN_WEB_URL).host)) {
-          await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
+        if (!currentUrl.includes(new URL(webUrl).host)) {
+          await ctx.eval(`(() => { window.location.href = ${JSON.stringify(webUrl)}; return true; })()`);
         }
         await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "den-web page loaded" });
       },
@@ -97,51 +96,13 @@ export default {
           ctx.log("Already signed in as an admin; reusing session.");
           return;
         }
-        await ctx.eval(`fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`, { awaitPromise: true });
-        await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
-        await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
-        await ctx.waitFor(
-          "Boolean(document.querySelector('input[type=\"email\"]')) && Boolean(document.querySelector('input[type=\"password\"]'))",
-          { timeoutMs: 30_000, label: "email + password fields" },
-        );
-        await ctx.fill('input[type="email"]', DEMO_EMAIL);
-        await ctx.fill("input[type=\"password\"]", DEMO_PASSWORD);
-        const submitted = await ctx.eval(`(() => {
-          const button = document.querySelector('button[type="submit"]');
-          if (!button) return false;
-          button.click();
-          return true;
-        })()`);
-        ctx.assert(submitted, "No submit button found on the sign-in card.");
-        await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
+        await signInViaBrowser(ctx, DEMO_EMAIL, DEMO_PASSWORD);
       },
     },
     {
       name: "Open Settings -> MCP Connections",
       run: async (ctx) => {
-        // Retry the click: on a fresh page load (especially over higher cloud
-        // latency), the very first click can land before Next.js has finished
-        // hydrating and attaching the link's handler. The Connections link
-        // lives inside the collapsible Extensions nav group, so expand that
-        // first when the link isn't in the DOM yet.
-        await ctx.waitFor(
-          `(() => {
-            if (window.location.pathname.includes('mcp-connections')) return true;
-            const link = [...document.querySelectorAll('nav a')].find((a) => a.getAttribute('href')?.includes('mcp-connections'));
-            if (link) {
-              link.click();
-              return false;
-            }
-            const group = [...document.querySelectorAll('nav a, nav button')].find((el) => (el.textContent ?? '').trim().startsWith('Extensions'));
-            group?.click();
-            return false;
-          })()`,
-          { timeoutMs: 30_000, label: "MCP Connections nav link clicked" },
-        );
-        await ctx.waitFor("window.location.pathname.includes('mcp-connections')", {
-          timeoutMs: 20_000,
-          label: "MCP Connections route",
-        });
+        await openAdminConnections(ctx);
         await ctx.prove("The Connections screen renders in Den", {
           assert: async () => {
             await ctx.expectText("Add a custom MCP server");
@@ -276,7 +237,7 @@ export default {
             const mcpToken = mint.body.token;
 
             async function mcpAgentCall(method, params) {
-              const response = await fetch(`${DEN_API_URL}/mcp/agent`, {
+              const response = await fetch(`${denApiUrl()}/mcp/agent`, {
                 method: "POST",
                 headers: {
                   "content-type": "application/json",

--- a/evals/flows/mcp-connections-cloud-oauth.flow.mjs
+++ b/evals/flows/mcp-connections-cloud-oauth.flow.mjs
@@ -100,15 +100,19 @@ export default {
         await ctx.eval(`fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`, { awaitPromise: true });
         await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
         await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
-        await ctx.clickText("Sign in", { timeoutMs: 20_000 });
-        await ctx.fill("input[type=\"email\"], input", DEMO_EMAIL);
-        await ctx.clickText("Next", { timeoutMs: 15_000 });
-        await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", {
-          timeoutMs: 15_000,
-          label: "password field",
-        });
+        await ctx.waitFor(
+          "Boolean(document.querySelector('input[type=\"email\"]')) && Boolean(document.querySelector('input[type=\"password\"]'))",
+          { timeoutMs: 30_000, label: "email + password fields" },
+        );
+        await ctx.fill('input[type="email"]', DEMO_EMAIL);
         await ctx.fill("input[type=\"password\"]", DEMO_PASSWORD);
-        await ctx.clickText("Sign in", { timeoutMs: 15_000 });
+        const submitted = await ctx.eval(`(() => {
+          const button = document.querySelector('button[type="submit"]');
+          if (!button) return false;
+          button.click();
+          return true;
+        })()`);
+        ctx.assert(submitted, "No submit button found on the sign-in card.");
         await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
       },
     },
@@ -117,13 +121,19 @@ export default {
       run: async (ctx) => {
         // Retry the click: on a fresh page load (especially over higher cloud
         // latency), the very first click can land before Next.js has finished
-        // hydrating and attaching the link's handler.
+        // hydrating and attaching the link's handler. The Connections link
+        // lives inside the collapsible Extensions nav group, so expand that
+        // first when the link isn't in the DOM yet.
         await ctx.waitFor(
           `(() => {
-            const link = [...document.querySelectorAll('a')].find((a) => a.getAttribute('href')?.includes('mcp-connections'));
-            if (!link) return false;
             if (window.location.pathname.includes('mcp-connections')) return true;
-            link.click();
+            const link = [...document.querySelectorAll('nav a')].find((a) => a.getAttribute('href')?.includes('mcp-connections'));
+            if (link) {
+              link.click();
+              return false;
+            }
+            const group = [...document.querySelectorAll('nav a, nav button')].find((el) => (el.textContent ?? '').trim().startsWith('Extensions'));
+            group?.click();
             return false;
           })()`,
           { timeoutMs: 30_000, label: "MCP Connections nav link clicked" },
@@ -132,16 +142,16 @@ export default {
           timeoutMs: 20_000,
           label: "MCP Connections route",
         });
-        await ctx.prove("The new MCP Connections screen renders in Den", {
+        await ctx.prove("The Connections screen renders in Den", {
           assert: async () => {
-            await ctx.expectText("MCP Connections");
+            await ctx.expectText("Add a custom MCP server");
             await ctx.expectText("Add Custom");
             await ctx.expectText("Notion");
           },
           screenshot: {
             name: "mcp-connections-screen",
-            claim: "Den has a real MCP Connections settings screen with quick-add presets and a custom-URL form.",
-            requireText: ["MCP Connections", "Add Custom", "Notion"],
+            claim: "Den has a real Connections settings screen with quick-add presets and a custom-URL form.",
+            requireText: ["Add a custom MCP server", "Add Custom", "Notion"],
             rejectText: ["Something went wrong"],
           },
         });
@@ -159,6 +169,16 @@ export default {
             );
             await ctx.fill('input[placeholder="notion"]', CONNECTION_NAME);
             await ctx.fill('input[placeholder="https://mcp.example.com/mcp"]', `${MOCK_SERVER_URL}/mcp`);
+            await ctx.waitFor(
+              "[...document.querySelectorAll('button')].some((button) => button.textContent.trim() === 'One org account')",
+              { timeoutMs: 10_000, label: "One org account button" },
+            );
+            const clicked = await ctx.eval(`(() => {
+              const button = [...document.querySelectorAll('button')].find((entry) => entry.textContent.trim() === 'One org account');
+              button?.click();
+              return Boolean(button);
+            })()`);
+            ctx.assert(clicked, "One org account button was not found.");
           },
           assert: async () => {
             const values = await ctx.eval(`(() => ({

--- a/evals/flows/mcp-connections-member-scoped.flow.mjs
+++ b/evals/flows/mcp-connections-member-scoped.flow.mjs
@@ -36,9 +36,8 @@
  */
 
 import { execSync } from "node:child_process";
+import { denApiFetch, denApiUrl, openAdminConnections, openYourConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
 
-const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
-const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
 const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
 const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
 const MEMBER_EMAIL = process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || "jordan.demo@acme.test";
@@ -58,32 +57,8 @@ const state = {
   createdTeamId: null,
 };
 
-async function denApiFetch(path, options = {}) {
-  const response = await fetch(`${DEN_API_URL}${path}`, {
-    ...options,
-    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
-  });
-  const text = await response.text();
-  let body;
-  try {
-    body = JSON.parse(text);
-  } catch {
-    body = text;
-  }
-  return { response, body };
-}
-
-async function signIn(email, password) {
-  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
-    method: "POST",
-    body: JSON.stringify({ email, password }),
-  });
-  if (!response.ok) return null;
-  return body.token;
-}
-
 async function mcpAgentCall(mcpToken, method, params, ctx) {
-  const response = await fetch(`${DEN_API_URL}/mcp/agent`, {
+  const response = await fetch(`${denApiUrl()}/mcp/agent`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -109,29 +84,6 @@ async function mintMcpToken(sessionToken, ctx) {
   return body.token;
 }
 
-async function signInViaBrowser(ctx, email, password) {
-  // The auth screen is a single split card: email + password + a
-  // type="submit" button (multiple elements read "Sign in", so target the
-  // submit button, not text).
-  await ctx.eval(`fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`, { awaitPromise: true });
-  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
-  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
-  await ctx.waitFor(
-    "Boolean(document.querySelector('input[type=\"email\"]')) && Boolean(document.querySelector('input[type=\"password\"]'))",
-    { timeoutMs: 30_000, label: "email + password fields" },
-  );
-  await ctx.fill('input[type="email"]', email);
-  await ctx.fill('input[type="password"]', password);
-  const submitted = await ctx.eval(`(() => {
-    const button = document.querySelector('button[type="submit"]');
-    if (!button) return false;
-    button.click();
-    return true;
-  })()`);
-  ctx.assert(submitted, "No submit button found on the sign-in card.");
-  await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
-}
-
 export default {
   id: "mcp-connections-member-scoped",
   title: "Per-member MCP connections: admin publishes, employee connects their own account, agent acts as them, grants enforced",
@@ -145,10 +97,10 @@ export default {
         const health = await fetch(`${MOCK_SERVER_URL}/health`).catch(() => null);
         ctx.assert(Boolean(health?.ok), `Mock OAuth+MCP server not reachable at ${MOCK_SERVER_URL}.`);
 
-        state.adminSession = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+        state.adminSession = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
         ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
 
-        state.memberSession = await signIn(MEMBER_EMAIL, MEMBER_PASSWORD);
+        state.memberSession = await signInApi(MEMBER_EMAIL, MEMBER_PASSWORD);
         if (!state.memberSession) {
           ctx.log(`Member ${MEMBER_EMAIL} can't sign in yet — bootstrapping via real invitation flow.`);
           const invite = await denApiFetch("/v1/invitations", {
@@ -167,7 +119,7 @@ export default {
             "Member email must be verified to accept the invitation; set OPENWORK_EVAL_MARK_VERIFIED_CMD (shell template with {email}).",
           );
           execSync(MARK_VERIFIED_CMD.replaceAll("{email}", MEMBER_EMAIL), { stdio: "ignore" });
-          state.memberSession = await signIn(MEMBER_EMAIL, MEMBER_PASSWORD);
+          state.memberSession = await signInApi(MEMBER_EMAIL, MEMBER_PASSWORD);
           ctx.assert(Boolean(state.memberSession), "Member sign-in still failing after sign-up.");
           const accept = await denApiFetch("/v1/orgs/invitations/accept", {
             method: "POST",
@@ -194,30 +146,13 @@ export default {
     {
       name: "Admin signs in to den-web (browser)",
       run: async (ctx) => {
-        await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
-        await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
         await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
       },
     },
     {
       name: "Admin publishes a per-member connection for everyone via the real dialog",
       run: async (ctx) => {
-        // The Connections link lives inside the collapsible Extensions nav
-        // group — expand it first when the link isn't in the DOM yet.
-        await ctx.waitFor(
-          `(() => {
-            if (window.location.pathname.endsWith('/mcp-connections')) return true;
-            const link = [...document.querySelectorAll('nav a')].find((a) => a.getAttribute('href')?.endsWith('/mcp-connections'));
-            if (link) {
-              link.click();
-              return false;
-            }
-            const group = [...document.querySelectorAll('nav a, nav button')].find((el) => (el.textContent ?? '').trim().startsWith('Extensions'));
-            group?.click();
-            return false;
-          })()`,
-          { timeoutMs: 30_000, label: "MCP Connections nav" },
-        );
+        await openAdminConnections(ctx);
         await ctx.waitForText("Add Custom", { timeoutMs: 20_000 });
         await ctx.clickText("Add Custom", { timeoutMs: 20_000 });
         await ctx.waitFor("Boolean(document.querySelector('input[placeholder=\"notion\"]'))", { timeoutMs: 10_000, label: "dialog open" });
@@ -303,16 +238,7 @@ export default {
       name: "Member signs in and sees only what they were granted",
       run: async (ctx) => {
         await signInViaBrowser(ctx, MEMBER_EMAIL, MEMBER_PASSWORD);
-        await ctx.waitFor(
-          `(() => {
-            const link = [...document.querySelectorAll('a')].find((a) => a.getAttribute('href')?.endsWith('/your-connections'));
-            if (!link) return false;
-            if (window.location.pathname.endsWith('/your-connections')) return true;
-            link.click();
-            return false;
-          })()`,
-          { timeoutMs: 30_000, label: "Your Connections nav" },
-        );
+        await openYourConnections(ctx);
         await ctx.prove("The member-facing Your Connections page shows the granted connection needing their account — and NOT the team-restricted one", {
           assert: async () => {
             await ctx.waitForText(CONNECTION_NAME, { timeoutMs: 20_000 });

--- a/evals/flows/mcp-connections-member-scoped.flow.mjs
+++ b/evals/flows/mcp-connections-member-scoped.flow.mjs
@@ -55,6 +55,7 @@ const state = {
   memberSession: null,
   connectionId: null,
   restrictedConnectionId: null,
+  createdTeamId: null,
 };
 
 async function denApiFetch(path, options = {}) {
@@ -109,18 +110,25 @@ async function mintMcpToken(sessionToken, ctx) {
 }
 
 async function signInViaBrowser(ctx, email, password) {
-  // Sign out whoever is signed in (same-origin better-auth endpoint), then
-  // drive the real sign-in form.
+  // The auth screen is a single split card: email + password + a
+  // type="submit" button (multiple elements read "Sign in", so target the
+  // submit button, not text).
   await ctx.eval(`fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`, { awaitPromise: true });
   await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
   await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
-  await ctx.waitForText("Get started", { timeoutMs: 30_000 }).catch(() => {});
-  await ctx.clickText("Sign in", { timeoutMs: 20_000 });
-  await ctx.fill('input[type="email"], input', email);
-  await ctx.clickText("Next", { timeoutMs: 15_000 });
-  await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", { timeoutMs: 15_000, label: "password field" });
+  await ctx.waitFor(
+    "Boolean(document.querySelector('input[type=\"email\"]')) && Boolean(document.querySelector('input[type=\"password\"]'))",
+    { timeoutMs: 30_000, label: "email + password fields" },
+  );
+  await ctx.fill('input[type="email"]', email);
   await ctx.fill('input[type="password"]', password);
-  await ctx.clickText("Sign in", { timeoutMs: 15_000 });
+  const submitted = await ctx.eval(`(() => {
+    const button = document.querySelector('button[type="submit"]');
+    if (!button) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(submitted, "No submit button found on the sign-in card.");
   await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
 }
 
@@ -194,12 +202,18 @@ export default {
     {
       name: "Admin publishes a per-member connection for everyone via the real dialog",
       run: async (ctx) => {
+        // The Connections link lives inside the collapsible Extensions nav
+        // group — expand it first when the link isn't in the DOM yet.
         await ctx.waitFor(
           `(() => {
-            const link = [...document.querySelectorAll('a')].find((a) => a.getAttribute('href')?.endsWith('/mcp-connections'));
-            if (!link) return false;
             if (window.location.pathname.endsWith('/mcp-connections')) return true;
-            link.click();
+            const link = [...document.querySelectorAll('nav a')].find((a) => a.getAttribute('href')?.endsWith('/mcp-connections'));
+            if (link) {
+              link.click();
+              return false;
+            }
+            const group = [...document.querySelectorAll('nav a, nav button')].find((el) => (el.textContent ?? '').trim().startsWith('Extensions'));
+            group?.click();
             return false;
           })()`,
           { timeoutMs: 30_000, label: "MCP Connections nav" },
@@ -209,19 +223,19 @@ export default {
         await ctx.waitFor("Boolean(document.querySelector('input[placeholder=\"notion\"]'))", { timeoutMs: 10_000, label: "dialog open" });
         await ctx.fill('input[placeholder="notion"]', CONNECTION_NAME);
         await ctx.fill('input[placeholder="https://mcp.example.com/mcp"]', `${MOCK_SERVER_URL}/mcp`);
-        await ctx.clickText("Each person connects their own", { timeoutMs: 10_000 });
+        await ctx.clickText("Individual accounts", { timeoutMs: 10_000 });
 
         await ctx.prove("The Add dialog offers per-member credentials and an access picker", {
           assert: async () => {
-            await ctx.expectText("Each person connects their own");
+            await ctx.expectText("Individual accounts");
             await ctx.expectText("Who can use this?");
             await ctx.expectText("Everyone in the org");
-            await ctx.expectText("each person authorizes their own account");
+            await ctx.expectText("acts as them, with their permissions");
           },
           screenshot: {
             name: "admin-dialog-per-member",
             claim: "Admin chooses per-member credentials and who can use the connection, in one dialog.",
-            requireText: ["Each person connects their own", "Who can use this?", "Everyone in the org"],
+            requireText: ["Individual accounts", "Who can use this?", "Everyone in the org"],
             rejectText: ["Something went wrong"],
           },
         });
@@ -229,7 +243,7 @@ export default {
         await ctx.clickText("Add connection", { timeoutMs: 15_000 });
         await ctx.prove("The published connection shows per-member + everyone badges, with no admin OAuth step", {
           assert: async () => {
-            await ctx.waitForText("Per-member accounts", { timeoutMs: 20_000 });
+            await ctx.waitForText("Individual accounts", { timeoutMs: 20_000 });
             await ctx.expectText(CONNECTION_NAME);
             await ctx.expectText("Everyone in the org");
             await ctx.eval(`(() => {
@@ -240,8 +254,8 @@ export default {
           },
           screenshot: {
             name: "admin-connection-published",
-            claim: "The connection row shows Per-member accounts and Everyone in the org — published, nothing to authorize as admin.",
-            requireText: [CONNECTION_NAME, "Per-member accounts", "Everyone in the org"],
+            claim: "The connection row shows Individual accounts and Everyone in the org — published, nothing to authorize as admin.",
+            requireText: [CONNECTION_NAME, "Individual accounts", "Everyone in the org"],
             rejectText: ["Something went wrong", "Waiting for authorization"],
           },
         });
@@ -255,10 +269,21 @@ export default {
 
         // Also create the negative-case connection: scoped to a team the
         // member is NOT in (first team in the org — the bootstrapped member
-        // has no team memberships).
+        // has no team memberships). Seeds without teams get one created for
+        // real via the Teams API (removed again in cleanup).
         const org = await denApiFetch("/v1/org", { headers: { authorization: `Bearer ${state.adminSession}` } });
-        const team = (org.body.teams ?? [])[0];
-        ctx.assert(Boolean(team), "Org has no teams to scope the restricted connection to.");
+        let team = (org.body.teams ?? [])[0];
+        if (!team) {
+          const createdTeam = await denApiFetch("/v1/teams", {
+            method: "POST",
+            headers: { authorization: `Bearer ${state.adminSession}` },
+            body: JSON.stringify({ name: `eval-restricted-${RUN_TAG}` }),
+          });
+          ctx.assert(createdTeam.response.ok, `Creating a team for the negative case failed: ${createdTeam.response.status}`);
+          team = createdTeam.body.team;
+          state.createdTeamId = team?.id ?? null;
+        }
+        ctx.assert(Boolean(team?.id), "Org has no teams to scope the restricted connection to.");
         const restricted = await denApiFetch("/v1/mcp-connections", {
           method: "POST",
           headers: { authorization: `Bearer ${state.adminSession}` },
@@ -401,6 +426,13 @@ export default {
             headers: { authorization: `Bearer ${state.adminSession}` },
           });
           ctx.assert(removed.response.ok, `Cleanup delete failed for ${id}.`);
+        }
+        if (state.createdTeamId) {
+          const removedTeam = await denApiFetch(`/v1/teams/${state.createdTeamId}`, {
+            method: "DELETE",
+            headers: { authorization: `Bearer ${state.adminSession}` },
+          });
+          ctx.assert(removedTeam.response.ok, `Cleanup delete failed for team ${state.createdTeamId}.`);
         }
       },
     },

--- a/evals/flows/your-connections-admin-shared-connect.flow.mjs
+++ b/evals/flows/your-connections-admin-shared-connect.flow.mjs
@@ -6,11 +6,10 @@
  */
 
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, openYourConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
 
 const vo = await loadVoiceoverParagraphs("your-connections-admin-shared-connect");
 
-const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
-const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
 const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
 const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
 const MOCK_SERVER_URL = (process.env.MOCK_OAUTH_MCP_URL ?? "http://127.0.0.1:3978").trim().replace(/\/+$/, "");
@@ -21,53 +20,6 @@ const state = {
   adminSession: null,
   connectionId: null,
 };
-
-async function denApiFetch(path, options = {}) {
-  const response = await fetch(`${DEN_API_URL}${path}`, {
-    ...options,
-    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
-  });
-  const text = await response.text();
-  let body;
-  try {
-    body = JSON.parse(text);
-  } catch {
-    body = text;
-  }
-  return { response, body };
-}
-
-async function signIn(email, password) {
-  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
-    method: "POST",
-    body: JSON.stringify({ email, password }),
-  });
-  if (!response.ok) return null;
-  return body.token;
-}
-
-async function signInViaBrowser(ctx, email, password) {
-  // The auth screen is a single split card: email + password + a
-  // type="submit" button (multiple elements read "Sign in", so target the
-  // submit button, not text).
-  await ctx.eval(`fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`, { awaitPromise: true });
-  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
-  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
-  await ctx.waitFor(
-    "Boolean(document.querySelector('input[type=\"email\"]')) && Boolean(document.querySelector('input[type=\"password\"]'))",
-    { timeoutMs: 30_000, label: "email + password fields" },
-  );
-  await ctx.fill('input[type="email"]', email);
-  await ctx.fill('input[type="password"]', password);
-  const submitted = await ctx.eval(`(() => {
-    const button = document.querySelector('button[type="submit"]');
-    if (!button) return false;
-    button.click();
-    return true;
-  })()`);
-  ctx.assert(submitted, "No submit button found on the sign-in card.");
-  await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
-}
 
 function rowHasAdminConnectButtonScript() {
   return `(() => {
@@ -138,7 +90,7 @@ export default {
         const health = await fetch(`${MOCK_SERVER_URL}/health`).catch(() => null);
         ctx.assert(Boolean(health?.ok), `Mock OAuth+MCP server not reachable at ${MOCK_SERVER_URL}.`);
 
-        state.adminSession = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+        state.adminSession = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
         ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
 
         const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
@@ -175,8 +127,6 @@ export default {
     {
       name: "Admin signs in to den-web (browser)",
       run: async (ctx) => {
-        await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
-        await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
         await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
       },
     },
@@ -186,17 +136,7 @@ export default {
         await ctx.prove("An admin can connect an unconnected shared OAuth row from Your Connections", {
           voiceover: vo[0],
           action: async () => {
-            await ctx.waitFor(
-              `(() => {
-                const link = [...document.querySelectorAll('a')].find((a) => a.getAttribute('href')?.endsWith('/your-connections'));
-                if (!link) return false;
-                if (window.location.pathname.endsWith('/your-connections')) return true;
-                link.click();
-                return false;
-              })()`,
-              { timeoutMs: 30_000, label: "Your Connections nav" },
-            );
-            await ctx.waitFor("window.location.pathname.endsWith('/your-connections')", { timeoutMs: 20_000, label: "Your Connections route" });
+            await openYourConnections(ctx);
           },
           assert: async () => {
             await ctx.waitForText(CONNECTION_NAME, { timeoutMs: 20_000 });

--- a/evals/flows/your-connections-admin-shared-connect.flow.mjs
+++ b/evals/flows/your-connections-admin-shared-connect.flow.mjs
@@ -1,0 +1,278 @@
+/**
+ * Admin-facing rescue path for shared-credential MCP connections: a shared
+ * OAuth connection can be published but not authorized if the original popup
+ * was abandoned. This proves an admin can finish that org-account OAuth from
+ * the member-facing Your Connections page instead of hitting a dead end.
+ */
+
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("your-connections-admin-shared-connect");
+
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MOCK_SERVER_URL = (process.env.MOCK_OAUTH_MCP_URL ?? "http://127.0.0.1:3978").trim().replace(/\/+$/, "");
+const RUN_TAG = Date.now();
+const CONNECTION_NAME = `shared-tool-${RUN_TAG}`;
+
+const state = {
+  adminSession: null,
+  connectionId: null,
+};
+
+async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+async function signIn(email, password) {
+  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  if (!response.ok) return null;
+  return body.token;
+}
+
+async function signInViaBrowser(ctx, email, password) {
+  // The auth screen is a single split card: email + password + a
+  // type="submit" button (multiple elements read "Sign in", so target the
+  // submit button, not text).
+  await ctx.eval(`fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`, { awaitPromise: true });
+  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
+  await ctx.waitFor(
+    "Boolean(document.querySelector('input[type=\"email\"]')) && Boolean(document.querySelector('input[type=\"password\"]'))",
+    { timeoutMs: 30_000, label: "email + password fields" },
+  );
+  await ctx.fill('input[type="email"]', email);
+  await ctx.fill('input[type="password"]', password);
+  const submitted = await ctx.eval(`(() => {
+    const button = document.querySelector('button[type="submit"]');
+    if (!button) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(submitted, "No submit button found on the sign-in card.");
+  await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
+}
+
+function rowHasAdminConnectButtonScript() {
+  return `(() => {
+    const leaves = [...document.querySelectorAll("*")].filter((el) => el.children.length === 0 && (el.textContent ?? "").trim() === ${JSON.stringify(CONNECTION_NAME)});
+    return leaves.some((leaf) => {
+      let el = leaf;
+      for (let i = 0; i < 5 && el; i++) {
+        const text = el.textContent ?? "";
+        const button = [...el.querySelectorAll("button")].find((candidate) => (candidate.textContent ?? "").trim() === "Connect");
+        if (text.includes("Connect the org account") && button) {
+          el.scrollIntoView({ block: "center" });
+          return true;
+        }
+        el = el.parentElement;
+      }
+      return false;
+    });
+  })()`;
+}
+
+function clickAdminConnectButtonScript() {
+  return `(() => {
+    const leaves = [...document.querySelectorAll("*")].filter((el) => el.children.length === 0 && (el.textContent ?? "").trim() === ${JSON.stringify(CONNECTION_NAME)});
+    for (const leaf of leaves) {
+      let el = leaf;
+      for (let i = 0; i < 5 && el; i++) {
+        const text = el.textContent ?? "";
+        const button = [...el.querySelectorAll("button")].find((candidate) => (candidate.textContent ?? "").trim() === "Connect");
+        if (text.includes("Connect the org account") && button) {
+          button.click();
+          return true;
+        }
+        el = el.parentElement;
+      }
+    }
+    return false;
+  })()`;
+}
+
+function rowShowsConnectedScript() {
+  return `(() => {
+    const leaves = [...document.querySelectorAll("*")].filter((el) => el.children.length === 0 && (el.textContent ?? "").trim() === ${JSON.stringify(CONNECTION_NAME)});
+    return leaves.some((leaf) => {
+      let el = leaf;
+      for (let i = 0; i < 4 && el; i++) {
+        if ((el.textContent ?? "").includes("Connected")) {
+          el.scrollIntoView({ block: "center" });
+          return true;
+        }
+        el = el.parentElement;
+      }
+      return false;
+    });
+  })()`;
+}
+
+export default {
+  id: "your-connections-admin-shared-connect",
+  title: "Shared MCP connection: an admin connects the org account right on Your Connections",
+  kind: "user-facing",
+  spec: "evals/org-mcp-connections-ux.md",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Setup: create an unconnected shared OAuth MCP connection",
+      run: async (ctx) => {
+        const health = await fetch(`${MOCK_SERVER_URL}/health`).catch(() => null);
+        ctx.assert(Boolean(health?.ok), `Mock OAuth+MCP server not reachable at ${MOCK_SERVER_URL}.`);
+
+        state.adminSession = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+        ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+
+        const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+          headers: { authorization: `Bearer ${state.adminSession}` },
+        });
+        ctx.assert(existing.response.ok, `Listing manageable connections failed: ${existing.response.status}`);
+        for (const connection of existing.body.connections ?? []) {
+          if (connection.name.startsWith("shared-tool-")) {
+            const removed = await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+              method: "DELETE",
+              headers: { authorization: `Bearer ${state.adminSession}` },
+            });
+            ctx.assert(removed.response.ok, `Cleanup delete failed for leftover ${connection.id}.`);
+          }
+        }
+
+        const created = await denApiFetch("/v1/mcp-connections", {
+          method: "POST",
+          headers: { authorization: `Bearer ${state.adminSession}` },
+          body: JSON.stringify({
+            name: CONNECTION_NAME,
+            url: `${MOCK_SERVER_URL}/mcp`,
+            authType: "oauth",
+            credentialMode: "shared",
+            access: { orgWide: true },
+          }),
+        });
+        ctx.assert(created.response.ok, `Creating shared connection failed: ${created.response.status} ${JSON.stringify(created.body).slice(0, 200)}`);
+        ctx.assert(created.body.connected === false, `Created connection should start unconnected: ${JSON.stringify(created.body).slice(0, 200)}`);
+        state.connectionId = created.body.id;
+        ctx.assert(Boolean(state.connectionId), "Created connection did not return an id.");
+      },
+    },
+    {
+      name: "Admin signs in to den-web (browser)",
+      run: async (ctx) => {
+        await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
+        await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
+        await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+      },
+    },
+    {
+      name: "Admin opens Your Connections and sees an org-account Connect action",
+      run: async (ctx) => {
+        await ctx.prove("An admin can connect an unconnected shared OAuth row from Your Connections", {
+          voiceover: vo[0],
+          action: async () => {
+            await ctx.waitFor(
+              `(() => {
+                const link = [...document.querySelectorAll('a')].find((a) => a.getAttribute('href')?.endsWith('/your-connections'));
+                if (!link) return false;
+                if (window.location.pathname.endsWith('/your-connections')) return true;
+                link.click();
+                return false;
+              })()`,
+              { timeoutMs: 30_000, label: "Your Connections nav" },
+            );
+            await ctx.waitFor("window.location.pathname.endsWith('/your-connections')", { timeoutMs: 20_000, label: "Your Connections route" });
+          },
+          assert: async () => {
+            await ctx.waitForText(CONNECTION_NAME, { timeoutMs: 20_000 });
+            await ctx.expectText("Connect the org account");
+            const hasScopedConnect = await ctx.eval(rowHasAdminConnectButtonScript());
+            ctx.assert(hasScopedConnect, "The shared connection row did not expose a scoped Connect button for the admin.");
+          },
+          screenshot: {
+            name: "admin-shared-row-connect-action",
+            claim: "The previously dead-end shared OAuth row now offers Connect to an admin right on Your Connections.",
+            requireText: [CONNECTION_NAME, "Connect the org account", "Your Connections"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Admin connects the org account through the OAuth popup",
+      run: async (ctx) => {
+        await ctx.prove("The shared connection opens a real OAuth popup and completes authorization", {
+          voiceover: vo[1],
+          action: async () => {
+            const clicked = await ctx.eval(clickAdminConnectButtonScript());
+            ctx.assert(clicked, "No scoped Connect button found on the shared connection row.");
+            await ctx.switchToNewTab({ timeoutMs: 20_000, label: "OAuth popup" });
+            await ctx.waitForText("Connected", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText(CONNECTION_NAME);
+            await ctx.expectNoText("Connection failed");
+          },
+          screenshot: {
+            name: "admin-shared-oauth-popup-connected",
+            claim: "The OAuth popup shows the shared org account connection succeeded.",
+            requireText: ["Connected", CONNECTION_NAME],
+            rejectText: ["Connection failed"],
+          },
+        });
+        ctx.switchBack();
+      },
+    },
+    {
+      name: "Your Connections polling flips the shared row to Connected",
+      run: async (ctx) => {
+        await ctx.prove("The shared row flips to Connected and the API agrees", {
+          voiceover: vo[2],
+          assert: async () => {
+            await ctx.waitFor(rowShowsConnectedScript(), { timeoutMs: 60_000, label: `${CONNECTION_NAME} shows Connected` });
+            const list = await denApiFetch("/v1/mcp-connections?scope=usable", {
+              headers: { authorization: `Bearer ${state.adminSession}` },
+            });
+            ctx.assert(list.response.ok, `Listing usable connections failed: ${list.response.status}`);
+            const connection = (list.body.connections ?? []).find((entry) => entry.id === state.connectionId);
+            ctx.assert(Boolean(connection), "Connected shared connection not found in usable list.");
+            ctx.assert(connection.connected === true, `API did not mark the shared connection connected: ${JSON.stringify(connection).slice(0, 200)}`);
+            ctx.assert(connection.connectedForMe === true, `API did not mark connectedForMe true for the shared connection: ${JSON.stringify(connection).slice(0, 200)}`);
+          },
+          screenshot: {
+            name: "admin-shared-row-connected",
+            claim: "The background poll updates the shared row to Connected without a refresh, matching the API state.",
+            requireText: [CONNECTION_NAME, "Connected"],
+            rejectText: ["Something went wrong", "Waiting for authorization"],
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup: delete the shared connection",
+      run: async (ctx) => {
+        if (!state.connectionId) return;
+        const removed = await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${state.adminSession}` },
+        });
+        ctx.assert(removed.response.ok, `Cleanup delete failed for ${state.connectionId}.`);
+      },
+    },
+  ],
+};

--- a/evals/flows/your-connections-admin-shared-connect.flow.mjs
+++ b/evals/flows/your-connections-admin-shared-connect.flow.mjs
@@ -113,7 +113,7 @@ function rowShowsConnectedScript() {
     return leaves.some((leaf) => {
       let el = leaf;
       for (let i = 0; i < 4 && el; i++) {
-        if ((el.textContent ?? "").includes("Connected")) {
+        if ((el.textContent ?? "").includes("Org account connected")) {
           el.scrollIntoView({ block: "center" });
           return true;
         }
@@ -257,7 +257,7 @@ export default {
           screenshot: {
             name: "admin-shared-row-connected",
             claim: "The background poll updates the shared row to Connected without a refresh, matching the API state.",
-            requireText: [CONNECTION_NAME, "Connected"],
+            requireText: [CONNECTION_NAME, "Org account connected"],
             rejectText: ["Something went wrong", "Waiting for authorization"],
           },
         });

--- a/evals/voiceovers/connections-beta.md
+++ b/evals/voiceovers/connections-beta.md
@@ -8,6 +8,6 @@ Cast is Alex, the Acme Robotics admin, in OpenWork Cloud. This demo shows the ne
 
 3. Now Alex deliberately opens Connections. The page itself says Beta, the primary Add Custom button is black like the rest of the app, and there is no purple styling left around the hero or quick-add tools.
 
-4. The admin has already published a per-member tool for the team. When the page reloads, that tool appears with a black Per-member accounts pill, making it clear that every person connects their own account instead of sharing one admin credential.
+4. The admin has already published a per-member tool for the team. When the page reloads, that tool appears with a black Individual accounts pill, making it clear that every person connects their own account instead of sharing one admin credential.
 
 5. Alex opens the member-facing Your Connections page. It is also marked Beta, and the same tool asks for each person to connect their account before an agent can use it, keeping the experimental feature clearly labeled from both sides.

--- a/evals/voiceovers/your-connections-admin-shared-connect.md
+++ b/evals/voiceovers/your-connections-admin-shared-connect.md
@@ -1,0 +1,14 @@
+# your-connections-admin-shared-connect — Connect a shared tool right where you found it
+
+Cast is Alex, the Acme Robotics admin, in OpenWork Cloud on the web. His org
+published Notion-style tooling as a shared-account connection, but nobody ever
+finished authorizing it — so until now the member-facing Your Connections page
+showed a dead-end "Not connected yet" badge with nothing to click, and the only
+way to get connected was outside the browser. This demo shows the fix: an admin
+can complete the connection right on Your Connections.
+
+1. Alex opens Your Connections and sees the tool his org made available. It is not connected yet — but because Alex is an admin, the row now says Connect the org account and offers a real Connect button right here, instead of a dead end.
+
+2. Clicking Connect opens the service's own authorization page in a new tab. Alex approves once, the standard OAuth handshake completes for real, and the tab confirms the account is connected.
+
+3. Back on Your Connections, nothing needed a refresh: the page's own polling flips the row to Connected on its own. From this moment, everyone granted access — and their AI coworkers — can use the tool.

--- a/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
+++ b/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
@@ -1,20 +1,20 @@
 ---
 title: "Sharing MCP connections with your team"
-description: "Connect Notion, Linear, Stripe, or any MCP server once in OpenWork Cloud and let every member's agent use it — with each person's own account"
+description: "Share Notion, Linear, Stripe, or any MCP server in OpenWork Cloud with Individual accounts by default, or One org account when everyone should act as the same account"
 ---
 
 Use `MCP Connections` when you want the org to manage an MCP integration once
 — the server URL, who can use it, and how people sign in — instead of every
 member configuring Notion or Linear by hand on every machine.
 
-Two ways to handle credentials, chosen per connection:
+Two ways to handle whose account the AI uses, chosen per connection:
 
-- **Shared credential** — an admin connects once (a service account or API
-  key). Every granted member's agent uses that identity. Nothing for members
-  to do.
-- **Each member connects their own account** — for tools like Notion or
-  Linear where people have their own pages, projects, and permissions. The
-  agent acts as *you*, and the provider's own access rules apply.
+- **Individual accounts** — each person signs in as themselves. This is now
+  the default for OAuth servers, and it fits tools like Notion or Linear where
+  people have their own pages, projects, and permissions. The agent acts as
+  *you*, and the provider's own access rules apply.
+- **One org account** — an admin signs in once (a bot, service account, or API
+  key). Every granted member's AI acts as that identity.
 
 ## Publish the connection in OpenWork Cloud
 
@@ -22,8 +22,7 @@ Two ways to handle credentials, chosen per connection:
 2. Click `Add Connection`.
 3. Pick a preset (Notion, Linear, Stripe, Sentry, Context7) or enter any
    MCP server URL.
-4. Choose the credential mode: `Shared` or `Each member connects their own
-   account`.
+4. Choose the account mode: `Individual accounts` or `One org account`.
 5. Choose who can use it: the whole workspace, specific teams, or specific
    people.
 6. Click `Create`.
@@ -32,10 +31,13 @@ Two ways to handle credentials, chosen per connection:
   ![MCP Connections admin screen in OpenWork Cloud](/images/cloud-mcp-connections-admin.png)
 </Frame>
 
-For a shared-credential connection, finish by clicking `Connect` and
-completing the provider's sign-in as the service account. Per-member
-connections are ready to publish immediately — each person connects
-themselves.
+For a One org account connection, finish by clicking `Connect` and completing
+the provider's sign-in as the org account. Individual accounts connections are
+ready to publish immediately — each person connects themselves.
+
+On `Your Connections`, an unconnected One org account connection shows
+`Waiting for an admin to connect` to members. Workspace owners and admins get a
+`Connect` button on that row so they can finish the org account sign-in there.
 
 ## What members see in the desktop app
 
@@ -45,7 +47,7 @@ catalog as everything else the org shares:
 - **Marketplace tab** — connections you can use but haven't connected yet,
   with a `Connect your account` action.
 - **My Extensions tab** — connections that are ready: ones you've connected,
-  and shared-credential ones your admin manages.
+  and One org account connections your admin manages.
 
 <Frame>
   ![An org-shared connection in the Marketplace tab, ready to connect](/images/desktop-org-mcp-marketplace.png)


### PR DESCRIPTION
## What

Two tightly-related fixes to org MCP connections, born from the same confusion: a Notion connection showing a dead-end "Not connected yet" on **Your Connections**, and the terminology that caused it.

### 1. Admins can connect an org-account connection right on Your Connections

A shared-credential OAuth connection that was published but never authorized was a dead end on the member-facing page — no button, no hint, even for admins (whom the server already permits to run `connect/start`). Now: admins see **"Connect the org account"** + a **Connect** button reusing the page's existing OAuth-popup + poll loop. Members see **"Waiting for an admin to connect"** instead of silence. No server behavior changes.

### 2. Terminology: name the modes by whose account the AI uses

The picker asked "Account: One shared account / Each person connects their own" and defaulted to shared — which is how personal tools like Notion end up org-shared by accident. Now the dialog asks **"Whose account does the AI use?"**:

- **Individual accounts** (`per_member`) — each person signs in as themselves from Your Connections; their AI acts as them, with their permissions. **Now the default for OAuth servers.**
- **One org account** (`shared`) — you sign in once with a single account; everyone granted acts as it. Good for bot/service accounts.

Badges follow: "Individual accounts" (admin list), "Org account connected", "Connected as you" (unchanged), "Waiting for an admin to connect". Desktop cards and docs use the same vocabulary. API values (`shared`/`per_member`) are unchanged — no breaking change.

## Tests / proof

- `pnpm --dir ee/apps/den-web exec tsc --noEmit` — passed; `pnpm --dir apps/app exec tsc --noEmit` — passed.
- Three coded flows ran end-to-end against a real local stack (MySQL + den-api + den-web + mock OAuth MCP server with full RFC 9728/7591/PKCE + Chrome CDP) — **all PASSED**, fraimz posted below:
  - `your-connections-admin-shared-connect` (new; voiceover-scripted): reproduces the dead-end shared row, admin connects it on Your Connections, row flips to "Org account connected", API ground truth asserted.
  - `mcp-connections-cloud-oauth`: admin adds a custom server picking "One org account" explicitly (the default is now Individual), real OAuth popup, `search_capabilities`/`execute_capability` use it for real.
  - `mcp-connections-member-scoped`: admin publishes with "Individual accounts", the member connects their own account, agent acts as the member, team grants enforced.
- Eval upkeep in the same PR: repaired the two older flows for the current single-step auth card and Extensions→Connections nav (pre-existing breakage), member-scoped now creates a team via the real Teams API when the seed lacks one.

Repro:
```bash
pnpm dev:den:mysql && pnpm dev:den:api   # + pnpm dev:den:web (+ seed via dev:den:seed-demo)
PORT=3978 AUTO_APPROVE=1 node scripts/mock-oauth-mcp-server.mjs
# Chrome with --remote-debugging-port=9333 --disable-popup-blocking
OPENWORK_EVAL_DEN_API_URL=http://127.0.0.1:8790 OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3005 \
  pnpm fraimz --flow your-connections-admin-shared-connect --flow mcp-connections-cloud-oauth --flow mcp-connections-member-scoped --cdp-url http://127.0.0.1:9333
```