### PR TITLE
Add AWS EKS self-host deployment guide

### DIFF
--- a/docs/aws-eks-helm.md
+++ b/docs/aws-eks-helm.md
@@ -1,0 +1,330 @@
+# Deploy OpenWork EE on AWS with EKS and Helm
+
+Status: self-host operator guide
+Related: `packaging/helm/openwork-ee`, `packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml`
+
+This is the recommended AWS path for a first production-like OpenWork EE
+self-host install. Use Helm on Amazon EKS with Amazon RDS for MySQL. For the
+simplest customer deployment, use EKS Auto Mode and Kubernetes
+`LoadBalancer` Services so AWS provisions Network Load Balancers directly from
+the chart. Use an Ingress/ALB path later when you need one shared ALB, advanced
+HTTP routing, WAF rules, or an existing ingress platform.
+
+## What this deploys
+
+- Den API on port `8788`
+- Den Web on port `3005`
+- optional inference service, disabled by default
+- one RDS MySQL database
+- one single-org OpenWork deployment
+- two public AWS Network Load Balancers by default: one for web and one for API
+
+AWS owns the EKS cluster, node lifecycle, VPC networking, load balancers, RDS,
+DNS, TLS certificates, IAM, and security groups. The OpenWork Helm chart owns
+OpenWork Deployments, Services, ConfigMaps, Secrets, health probes, and the
+database migration Job.
+
+## Use Helm or something else?
+
+Use Helm on EKS for AWS unless the customer explicitly cannot run Kubernetes.
+The OpenWork EE release artifact is already a Helm chart, the service split maps
+cleanly to Kubernetes, and EKS Auto Mode removes most node and load balancer
+setup from the customer path. A VM or ECS guide can be useful later, but it
+would be a separate packaging surface to maintain. The practical gap found by
+AWS testing was not Helm itself; it was missing AWS-specific infra guidance and
+missing chart knobs for AWS service annotations.
+
+## Prerequisites
+
+- AWS CLI authenticated to the target account.
+- `kubectl`, `helm`, and `eksctl`.
+- `eksctl` version `0.195.0` or newer for EKS Auto Mode.
+- Permission to create EKS, EC2/VPC, IAM, Elastic Load Balancing, RDS, Secrets
+  Manager, Route 53, and ACM resources.
+- A real admin email address for the first owner account.
+- A domain you control, such as `openwork.example.com` and
+  `api.openwork.example.com`.
+
+AWS docs used for this guide:
+
+- EKS Auto Mode: https://docs.aws.amazon.com/eks/latest/userguide/automode.html
+- EKS Auto Mode with `eksctl`: https://docs.aws.amazon.com/eks/latest/userguide/automode-get-started-eksctl.html
+- EKS Auto Mode NLB service annotations: https://docs.aws.amazon.com/eks/latest/userguide/auto-configure-nlb.html
+- AWS Load Balancer Controller: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
+- RDS TLS: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html
+
+## 1. Create the EKS cluster
+
+For a first deployment, create an EKS Auto Mode cluster:
+
+```bash
+export AWS_REGION=us-east-1
+export CLUSTER_NAME=openwork-ee
+
+eksctl create cluster \
+  --name "$CLUSTER_NAME" \
+  --region "$AWS_REGION" \
+  --enable-auto-mode
+
+aws eks update-kubeconfig \
+  --region "$AWS_REGION" \
+  --name "$CLUSTER_NAME"
+
+kubectl get nodes
+```
+
+EKS Auto Mode handles default compute, pod networking, DNS, block storage, and
+load balancer integration. It also makes Network Load Balancers available for
+Kubernetes Services of type `LoadBalancer`.
+
+## 2. Create RDS MySQL
+
+Create a MySQL database reachable from the EKS worker security group. The exact
+VPC and subnet commands vary by account, so the important requirements are:
+
+- RDS MySQL 8-compatible engine.
+- Database name: `openwork_den`.
+- Private subnets in the same VPC as the EKS cluster.
+- RDS security group inbound TCP `3306` from the EKS node/pod security group.
+- Storage encryption enabled.
+- Backups enabled.
+- Public accessibility disabled for production.
+- TLS required or at least supported.
+
+Example database URL:
+
+```text
+mysql://openwork:<password>@<rds-endpoint>:3306/openwork_den?sslmode=require
+```
+
+Use `?sslmode=require` for RDS. OpenWork passes this through the runtime pool,
+Drizzle migrations, and migration bootstrap scripts.
+
+Before installing OpenWork, verify network access from the cluster. One simple
+way is to run a temporary MySQL client pod:
+
+```bash
+kubectl run mysql-client \
+  --rm \
+  -it \
+  --restart=Never \
+  --image=mysql:8 \
+  -- mysql \
+    --host="$RDS_ENDPOINT" \
+    --user=openwork \
+    --password \
+    --ssl-mode=REQUIRED \
+    --execute "select 1"
+```
+
+## 3. Prepare Helm values
+
+Copy the starter file:
+
+```bash
+cp packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml values.aws.yaml
+```
+
+Replace every `REPLACE_*` placeholder.
+
+Generate secrets:
+
+```bash
+openssl rand -base64 48
+openssl rand -base64 48
+```
+
+Use the first value for `secret.values.betterAuthSecret` and the second for
+`secret.values.denDbEncryptionKey`. Do not reuse either value across
+environments.
+
+Use a values file, not a long list of `--set` flags. Several OpenWork values are
+comma-separated strings, such as `config.public.corsOrigins`, and plain
+`--set` parsing commonly breaks them.
+
+## 4. Install OpenWork
+
+Published chart releases live in GHCR:
+
+```bash
+helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+  --version REPLACE_OPENWORK_VERSION \
+  --namespace openwork-ee \
+  --create-namespace \
+  -f values.aws.yaml
+```
+
+For a checkout-local test:
+
+```bash
+helm upgrade --install openwork-ee ./packaging/helm/openwork-ee \
+  --namespace openwork-ee \
+  --create-namespace \
+  -f values.aws.yaml
+```
+
+If GHCR image pulls fail with `ImagePullBackOff`, authenticate to GHCR and add
+an `imagePullSecrets` entry. Public releases should not require this, but
+private packages or private forks do:
+
+```bash
+kubectl create secret docker-registry ghcr-pull-secret \
+  --namespace openwork-ee \
+  --docker-server=ghcr.io \
+  --docker-username="$GITHUB_USER" \
+  --docker-password="$GITHUB_TOKEN"
+```
+
+```yaml
+imagePullSecrets:
+  - name: ghcr-pull-secret
+```
+
+## 5. Point DNS at AWS load balancers
+
+Wait for AWS to allocate load balancer hostnames:
+
+```bash
+kubectl get svc -n openwork-ee
+```
+
+You should see external hostnames for:
+
+- `openwork-ee-den-web`
+- `openwork-ee-den-api`
+
+Create DNS records:
+
+- `openwork.example.com` -> Den Web load balancer hostname.
+- `api.openwork.example.com` -> Den API load balancer hostname.
+
+The starter values terminate TLS on port `443` at each Network Load Balancer
+and forward clear HTTP to the Kubernetes service target port. Use an ACM
+certificate that covers both the web and API hosts:
+
+```yaml
+denWeb:
+  service:
+    port: 443
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:...
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+denApi:
+  service:
+    port: 443
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:...
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+```
+
+For production domains, prefer HTTPS before testing SSO. Browser auth cookies
+and identity-provider callback policies are much easier to validate on stable
+HTTPS origins than on raw load balancer hostnames.
+
+For a temporary HTTP-only smoke test, remove the SSL annotations, set
+`denWeb.service.port` back to `3005`, set `denApi.service.port` back to `8788`,
+and use explicit `http://host:port` origins in `values.aws.yaml`.
+
+## 6. Verify readiness
+
+Check Kubernetes state:
+
+```bash
+helm status openwork-ee -n openwork-ee
+kubectl get pods -n openwork-ee
+kubectl get jobs -n openwork-ee
+kubectl describe pods -n openwork-ee
+kubectl logs -n openwork-ee deploy/openwork-ee-den-api
+kubectl logs -n openwork-ee deploy/openwork-ee-den-web
+```
+
+Check service readiness from your machine:
+
+```bash
+curl -fsS https://api.openwork.example.com/ready
+curl -fsS https://openwork.example.com/api/ready
+```
+
+If you are still using raw AWS load balancer hostnames before DNS/TLS is ready,
+temporarily update the corresponding `config.public.*` origins in
+`values.aws.yaml`, then run `helm upgrade` again. Do not leave production
+deployments on raw load balancer hostnames.
+
+## 7. Bootstrap the first owner
+
+The chart defaults to `single_org`. Set these before first sign-in:
+
+```yaml
+config:
+  tenancy:
+    mode: single_org
+    singleOrgName: "Acme"
+    singleOrgSlug: "acme"
+    ownerEmails: "admin@acme.com"
+    requireEmailVerification: "false"
+  public:
+    bootstrapAdminEmails: "admin@acme.com"
+```
+
+Open `https://openwork.example.com` and sign up with the owner email. OpenWork
+creates the singleton organization and makes that user the owner. Later users
+join the same organization. If `ownerEmails` is blank, the first user to reach
+the deployment can claim ownership, which is not recommended for production.
+
+## 8. Configure SSO with a test IdP
+
+Self-hosted installs keep plan gating off unless the operator explicitly sets
+`DEN_PLAN_GATING_ENABLED=true`, so SSO management should be available in the EE
+self-host default.
+
+Use OIDC first for a smoke test because most IdPs provide discovery metadata.
+Auth0, Okta trial, and Microsoft Entra test tenants all work as realistic demo
+IdPs.
+
+Configure the IdP application with these callback URLs:
+
+```text
+https://openwork.example.com/api/auth/sso/callback/openwork-sso-<org-id>
+```
+
+In OpenWork, sign in as the owner, open the organization SSO settings, and enter
+the IdP issuer/client details. After saving, the organization sign-in path is:
+
+```text
+https://openwork.example.com/sso/<singleOrgSlug>
+```
+
+For SAML, OpenWork shows the generated ACS URL and metadata URL after the SAML
+connection is registered. Use those values in the IdP rather than guessing.
+OpenWork rejects unsigned or weak SAML responses, so configure the IdP to sign
+assertions.
+
+After SSO is configured, root sign-in shows the SSO-only experience for the
+single organization. Password sign-in for that organization is rejected.
+
+## 9. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `helm` is missing in CloudShell | CloudShell does not always include Helm | Install Helm in CloudShell or run Helm locally with AWS credentials |
+| `aws sts get-caller-identity` returns `NoCredentials` | AWS CLI is not authenticated | Configure AWS SSO/profile or use authenticated CloudShell |
+| Pods are pending | EKS cluster has no schedulable capacity or Auto Mode is not enabled | Confirm `kubectl get nodes` and EKS Auto Mode status |
+| Migration Job fails to connect to MySQL | RDS security group or DB credentials are wrong | Allow TCP `3306` from EKS, verify the user/password, and test with `mysql-client` |
+| Runtime is ready but migration failed | Helm hook did not complete | Check `kubectl get jobs` and the migration Job logs before testing web |
+| `ImagePullBackOff` from GHCR | Private image or missing pull token | Add `imagePullSecrets` |
+| Browser auth loops or CORS errors | Public origins do not match DNS/TLS | Set `webOrigin`, `apiOrigin`, `corsOrigins`, `betterAuthTrustedOrigins`, and `authCallbackUrl` to the final HTTPS domains |
+| SSO callback rejected | IdP callback URL does not match OpenWork | Use the callback/ACS URL shown by OpenWork for that org/provider |
+| SSO settings show Enterprise gating | `DEN_PLAN_GATING_ENABLED=true` or org is not entitled | Leave plan gating off for self-host smoke tests, or grant enterprise entitlement |
+
+## 10. Cleanup
+
+For a disposable test:
+
+```bash
+helm uninstall openwork-ee -n openwork-ee
+eksctl delete cluster --name "$CLUSTER_NAME" --region "$AWS_REGION"
+```
+
+Delete RDS snapshots, Secrets Manager secrets, Route 53 records, ACM
+certificates, and any manually created security groups if they were only for
+the test.

--- a/ee/packages/den-db/scripts/baseline-migrations.ts
+++ b/ee/packages/den-db/scripts/baseline-migrations.ts
@@ -18,6 +18,7 @@ import crypto from "node:crypto"
 import { readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { parseMySqlConnectionConfig } from "../src/mysql-config.ts"
 
 const MIGRATIONS_TABLE = "__drizzle_migrations"
 
@@ -48,7 +49,7 @@ async function createExecutor(): Promise<Executor> {
 
   if (databaseUrl) {
     const mysql = await import("mysql2/promise")
-    const connection = await mysql.createConnection(databaseUrl)
+    const connection = await mysql.createConnection(parseMySqlConnectionConfig(databaseUrl))
     return {
       query: async (sql, args = []) => {
         const [rows] = await connection.query(sql, args)

--- a/ee/packages/den-db/scripts/db-executor.ts
+++ b/ee/packages/den-db/scripts/db-executor.ts
@@ -5,6 +5,8 @@
  * common `{ query, close }` shape.
  */
 
+import { parseMySqlConnectionConfig } from "../src/mysql-config.ts"
+
 export type Executor = {
   query: (sql: string, args?: (string | number)[]) => Promise<Record<string, unknown>[]>
   close: () => Promise<void>
@@ -19,7 +21,7 @@ export async function createExecutor(): Promise<Executor> {
 
   if (databaseUrl) {
     const mysql = await import("mysql2/promise")
-    const connection = await mysql.createConnection(databaseUrl)
+    const connection = await mysql.createConnection(parseMySqlConnectionConfig(databaseUrl))
     return {
       query: async (sql, args = []) => {
         const [rows] = await connection.query(sql, args)

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -88,6 +88,14 @@ helm template openwork-ee ./packaging/helm/openwork-ee -f values.prod.yaml
 helm upgrade --install openwork-ee ./packaging/helm/openwork-ee -f values.prod.yaml
 ```
 
+For AWS EKS, start with the [AWS deployment guide](../../../docs/aws-eks-helm.md)
+and the starter values file at
+[`examples/values.aws-load-balancer.yaml`](examples/values.aws-load-balancer.yaml).
+The recommended first AWS path is EKS Auto Mode plus `LoadBalancer` Services,
+which provisions AWS Network Load Balancers without installing an ingress
+controller. Use `ingress.enabled=true` only when the cluster already has an
+Ingress controller such as the AWS Load Balancer Controller.
+
 ## Secrets
 
 The chart can create an Opaque Secret from `secret.values`, or consume an existing Secret:
@@ -189,6 +197,29 @@ By default, the chart wires internal services through Kubernetes DNS:
 - `INFERENCE_PROXY_BASE_URL=http://<release>-openwork-ee-inference:8791` when `inference.enabled=true`
 
 Override `config.internal.*` only when routing through a mesh, gateway, or external service.
+
+## Service Exposure
+
+Each service supports Kubernetes Service metadata and load balancer settings:
+
+```yaml
+denWeb:
+  service:
+    type: LoadBalancer
+    port: 443
+    loadBalancerClass: eks.amazonaws.com/nlb
+    loadBalancerSourceRanges:
+      - 203.0.113.0/24
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:...
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+```
+
+The same shape is available under `denApi.service` and `inference.service`.
+`ingress.enabled=true` only emits Kubernetes `Ingress` resources; it does not
+install an ingress controller.
 
 ## Isolated Networks
 

--- a/packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml
+++ b/packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml
@@ -1,0 +1,90 @@
+# AWS EKS Auto Mode starter values for a first OpenWork EE self-host install.
+#
+# Copy this file, replace every REPLACE_* value, and install with:
+#
+#   helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+#     --version REPLACE_OPENWORK_VERSION \
+#     --namespace openwork-ee \
+#     --create-namespace \
+#     -f values.aws.yaml
+#
+# This example exposes Den Web and Den API through separate AWS Network Load
+# Balancers created from Kubernetes Services. Use it for the first AWS smoke
+# test and for installs where separate web/API hostnames are acceptable.
+
+image:
+  tag: "REPLACE_OPENWORK_VERSION"
+  pullPolicy: IfNotPresent
+
+config:
+  tenancy:
+    mode: single_org
+    singleOrgName: "REPLACE_COMPANY_NAME"
+    singleOrgSlug: "REPLACE_COMPANY_SLUG"
+    ownerEmails: "REPLACE_ADMIN_EMAIL"
+    allowPublicSignup: "false"
+    requireEmailVerification: "false"
+  auth:
+    passwordBreachScreeningEnabled: "false"
+  public:
+    webOrigin: "https://REPLACE_WEB_HOST"
+    apiOrigin: "https://REPLACE_API_HOST"
+    mcpResourceUrl: "https://REPLACE_API_HOST/mcp"
+    mcpClaimNamespace: "https://REPLACE_WEB_HOST"
+    desktopDenBaseUrl: "https://REPLACE_WEB_HOST"
+    corsOrigins: "https://REPLACE_WEB_HOST,https://REPLACE_API_HOST"
+    betterAuthTrustedOrigins: "https://REPLACE_WEB_HOST"
+    webAppHosts: "REPLACE_WEB_HOST"
+    bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
+    authCallbackUrl: "https://REPLACE_WEB_HOST"
+  provisioner:
+    mode: stub
+
+secret:
+  create: true
+  values:
+    # RDS MySQL example. The sslmode=require flag is understood by the app,
+    # Drizzle migrations, and the bootstrap scripts.
+    databaseUrl: "mysql://openwork:REPLACE_DB_PASSWORD@REPLACE_RDS_ENDPOINT:3306/openwork_den?sslmode=require"
+    # Generate with: openssl rand -base64 48
+    betterAuthSecret: "REPLACE_BETTER_AUTH_SECRET"
+    # Generate separately with: openssl rand -base64 48
+    denDbEncryptionKey: "REPLACE_DEN_DB_ENCRYPTION_KEY"
+
+denApi:
+  replicaCount: 1
+  service:
+    type: LoadBalancer
+    port: 443
+    loadBalancerClass: eks.amazonaws.com/nlb
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: HTTP
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /ready
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: REPLACE_ACM_CERT_ARN
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+
+denWeb:
+  replicaCount: 1
+  service:
+    type: LoadBalancer
+    port: 443
+    loadBalancerClass: eks.amazonaws.com/nlb
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: HTTP
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /api/ready
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: REPLACE_ACM_CERT_ARN
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+
+inference:
+  enabled: false
+
+migrations:
+  enabled: true
+  hook: true
+
+ingress:
+  enabled: false

--- a/packaging/helm/openwork-ee/templates/den-api.yaml
+++ b/packaging/helm/openwork-ee/templates/den-api.yaml
@@ -4,8 +4,19 @@ metadata:
   name: {{ include "openwork-ee.denApiServiceName" . }}
   labels:
     {{- include "openwork-ee.componentLabels" (dict "root" . "component" "den-api") | nindent 4 }}
+  {{- with .Values.denApi.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.denApi.service.type }}
+  {{- with .Values.denApi.service.loadBalancerClass }}
+  loadBalancerClass: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.denApi.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.denApi.service.port }}

--- a/packaging/helm/openwork-ee/templates/den-web.yaml
+++ b/packaging/helm/openwork-ee/templates/den-web.yaml
@@ -4,8 +4,19 @@ metadata:
   name: {{ include "openwork-ee.denWebServiceName" . }}
   labels:
     {{- include "openwork-ee.componentLabels" (dict "root" . "component" "den-web") | nindent 4 }}
+  {{- with .Values.denWeb.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.denWeb.service.type }}
+  {{- with .Values.denWeb.service.loadBalancerClass }}
+  loadBalancerClass: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.denWeb.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.denWeb.service.port }}

--- a/packaging/helm/openwork-ee/templates/inference.yaml
+++ b/packaging/helm/openwork-ee/templates/inference.yaml
@@ -5,8 +5,19 @@ metadata:
   name: {{ include "openwork-ee.inferenceServiceName" . }}
   labels:
     {{- include "openwork-ee.componentLabels" (dict "root" . "component" "inference") | nindent 4 }}
+  {{- with .Values.inference.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.inference.service.type }}
+  {{- with .Values.inference.service.loadBalancerClass }}
+  loadBalancerClass: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.inference.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.inference.service.port }}

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -121,6 +121,9 @@ denApi:
   service:
     type: ClusterIP
     port: 8788
+    annotations: {}
+    loadBalancerClass: ""
+    loadBalancerSourceRanges: []
   containerPort: 8788
   env: {}
   podAnnotations: {}
@@ -146,6 +149,9 @@ denWeb:
   service:
     type: ClusterIP
     port: 3005
+    annotations: {}
+    loadBalancerClass: ""
+    loadBalancerSourceRanges: []
   containerPort: 3005
   env: {}
   podAnnotations: {}
@@ -172,6 +178,9 @@ inference:
   service:
     type: ClusterIP
     port: 8791
+    annotations: {}
+    loadBalancerClass: ""
+    loadBalancerSourceRanges: []
   containerPort: 8791
   env: {}
   podAnnotations: {}


### PR DESCRIPTION
## Summary
- add an AWS EKS/Helm self-host deployment guide covering EKS Auto Mode, RDS MySQL, DNS/TLS, first-owner bootstrap, SSO smoke testing, verification, troubleshooting, and cleanup
- add an AWS LoadBalancer starter values file for EKS Auto Mode/NLB deployments
- expose Service annotations, loadBalancerClass, and loadBalancerSourceRanges in the Helm chart for den-api, den-web, and inference
- route den-db migration helpers through the shared MySQL parser so RDS URLs with sslmode=require work consistently

## AWS path
The recommended first AWS path remains Helm on EKS. EKS Auto Mode plus Kubernetes LoadBalancer Services gives the simplest customer-style install because AWS provisions NLBs directly from the chart without requiring an ingress controller. Ingress/ALB is documented as the follow-up path for customers with an existing ingress platform or advanced HTTP routing needs.

## Testing
- helm lint packaging/helm/openwork-ee
- helm template openwork-ee packaging/helm/openwork-ee -n openwork-ee -f packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml
- pnpm --filter @openwork-ee/den-db build

## Notes
- fraimz not run: this is docs/chart/backend packaging work and no live AWS/OpenWork deployment URL exists in this branch.
- live AWS deployment not run in this PR because it would create billable AWS resources.