### PR TITLE
Add Azure and GCP EE deployment guides

### DIFF
--- a/docs/aws-eks-helm.md
+++ b/docs/aws-eks-helm.md
@@ -1,7 +1,7 @@
 # Deploy OpenWork EE on AWS with EKS and Helm
 
 Status: self-host operator guide
-Related: `packaging/helm/openwork-ee`, `packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml`
+Related: `packaging/helm/openwork-ee`, `packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml`, `packaging/helm/openwork-ee/examples/values.aws-load-balancer-http-smoke.yaml`
 
 This is the recommended AWS path for a first production-like OpenWork EE
 self-host install. Use Helm on Amazon EKS with Amazon RDS for MySQL. For the
@@ -45,6 +45,10 @@ missing chart knobs for AWS service annotations.
 - A domain you control, such as `openwork.example.com` and
   `api.openwork.example.com`.
 
+Do not run production installs as the AWS root account. Use AWS SSO or an IAM
+role with only the permissions needed for the cluster, VPC/load balancer, RDS,
+DNS, and certificate resources.
+
 AWS docs used for this guide:
 
 - EKS Auto Mode: https://docs.aws.amazon.com/eks/latest/userguide/automode.html
@@ -52,6 +56,34 @@ AWS docs used for this guide:
 - EKS Auto Mode NLB service annotations: https://docs.aws.amazon.com/eks/latest/userguide/auto-configure-nlb.html
 - AWS Load Balancer Controller: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
 - RDS TLS: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html
+
+## CloudShell quickstart
+
+If you start from the AWS Console, CloudShell is a reasonable test environment,
+but it may not have every required tool or a default region configured. Set the
+region explicitly even if the console region selector already shows the right
+region:
+
+```bash
+export AWS_REGION=us-east-1
+aws sts get-caller-identity
+aws configure get region
+```
+
+Install Helm and `eksctl` if they are missing:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+curl -fsSL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz" \
+  -o /tmp/eksctl.tar.gz
+tar -xzf /tmp/eksctl.tar.gz -C /tmp
+sudo mv /tmp/eksctl /usr/local/bin/eksctl
+
+helm version
+eksctl version
+kubectl version --client
+```
 
 ## 1. Create the EKS cluster
 
@@ -77,6 +109,10 @@ EKS Auto Mode handles default compute, pod networking, DNS, block storage, and
 load balancer integration. It also makes Network Load Balancers available for
 Kubernetes Services of type `LoadBalancer`.
 
+Fresh EKS Auto Mode clusters can show no nodes at first. Auto Mode provisions
+compute when there is pending workload demand, so `kubectl get nodes` may return
+`No resources found` until the first pods are scheduled.
+
 ## 2. Create RDS MySQL
 
 Create a MySQL database reachable from the EKS worker security group. The exact
@@ -94,11 +130,45 @@ VPC and subnet commands vary by account, so the important requirements are:
 Example database URL:
 
 ```text
-mysql://openwork:<password>@<rds-endpoint>:3306/openwork_den?sslmode=require
+mysql://openwork:<password>@<rds-endpoint>:3306/openwork_den?sslaccept=accept
 ```
 
-Use `?sslmode=require` for RDS. OpenWork passes this through the runtime pool,
-Drizzle migrations, and migration bootstrap scripts.
+Use `?sslaccept=accept` for the simple private-RDS smoke path. This keeps TLS on
+but does not require the RDS CA bundle to be mounted into the OpenWork image.
+Use strict certificate verification later, after you provide the RDS CA bundle,
+with a hardened value such as `sslmode=verify-ca` or `sslmode=verify-full`.
+
+Wait until the EKS cluster is `ACTIVE` before wiring RDS security groups. Then
+allow MySQL traffic from both the EKS cluster security group and the eksctl
+shared node security group:
+
+```bash
+export CLUSTER_SG_ID=$(aws eks describe-cluster \
+  --region "$AWS_REGION" \
+  --name "$CLUSTER_NAME" \
+  --query 'cluster.resourcesVpcConfig.clusterSecurityGroupId' \
+  --output text)
+
+export NODE_SG_ID=$(aws cloudformation describe-stacks \
+  --region "$AWS_REGION" \
+  --stack-name "eksctl-${CLUSTER_NAME}-cluster" \
+  --query 'Stacks[0].Outputs[?OutputKey==`SharedNodeSecurityGroup`].OutputValue' \
+  --output text)
+
+aws ec2 authorize-security-group-ingress \
+  --region "$AWS_REGION" \
+  --group-id "$RDS_SG_ID" \
+  --protocol tcp \
+  --port 3306 \
+  --source-group "$CLUSTER_SG_ID"
+
+aws ec2 authorize-security-group-ingress \
+  --region "$AWS_REGION" \
+  --group-id "$RDS_SG_ID" \
+  --protocol tcp \
+  --port 3306 \
+  --source-group "$NODE_SG_ID"
+```
 
 Before installing OpenWork, verify network access from the cluster. One simple
 way is to run a temporary MySQL client pod:
@@ -125,6 +195,13 @@ Copy the starter file:
 cp packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml values.aws.yaml
 ```
 
+If you do not have DNS and ACM ready yet, use the HTTP smoke-test starter
+instead:
+
+```bash
+cp packaging/helm/openwork-ee/examples/values.aws-load-balancer-http-smoke.yaml values.aws.yaml
+```
+
 Replace every `REPLACE_*` placeholder.
 
 Generate secrets:
@@ -141,6 +218,25 @@ environments.
 Use a values file, not a long list of `--set` flags. Several OpenWork values are
 comma-separated strings, such as `config.public.corsOrigins`, and plain
 `--set` parsing commonly breaks them.
+
+Make sure your file uses the current chart keys. Public URL values belong under
+`config.public.*`; database and app secrets belong under `secret.values.*`.
+Values such as `config.urls`, `config.databaseUrl`, or `secrets.*` are ignored
+by the chart.
+
+Before installing, render the chart and verify the migration Job will use your
+RDS URL:
+
+```bash
+helm template openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+  --version REPLACE_OPENWORK_VERSION \
+  --namespace openwork-ee \
+  -f values.aws.yaml > /tmp/openwork-rendered.yaml
+
+grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN' /tmp/openwork-rendered.yaml
+```
+
+Redact secrets before sharing rendered manifests or terminal output.
 
 ## 4. Install OpenWork
 
@@ -180,7 +276,52 @@ imagePullSecrets:
   - name: ghcr-pull-secret
 ```
 
-## 5. Point DNS at AWS load balancers
+## 5. Migration troubleshooting
+
+The migration Job runs before the Deployments and Services are installed. If it
+fails, fix that before debugging web/API readiness.
+
+Avoid `kubectl describe job openwork-ee-migrate` in shared reports because the
+hook Job currently includes `DATABASE_URL` and `DEN_DB_ENCRYPTION_KEY` in the
+rendered environment. Use logs and redacted rendered manifests instead.
+
+For a retained-log debug attempt, temporarily disable hook behavior:
+
+```yaml
+migrations:
+  enabled: true
+  hook: false
+  backoffLimit: 0
+```
+
+Then run Helm and inspect the normal Job logs:
+
+```bash
+helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+  --version REPLACE_OPENWORK_VERSION \
+  --namespace openwork-ee \
+  --create-namespace \
+  -f values.aws.yaml \
+  --wait=false
+
+kubectl get jobs,pods -n openwork-ee
+kubectl logs -n openwork-ee -l job-name=openwork-ee-migrate --all-containers=true
+```
+
+If you see `self-signed certificate in certificate chain` against RDS, use the
+documented private-RDS smoke URL with `?sslaccept=accept`, or mount/configure
+the RDS CA bundle before using strict certificate verification.
+
+Return to the default hook mode after debugging:
+
+```yaml
+migrations:
+  enabled: true
+  hook: true
+  backoffLimit: 2
+```
+
+## 6. Point DNS at AWS load balancers
 
 Wait for AWS to allocate load balancer hostnames:
 
@@ -225,7 +366,22 @@ For a temporary HTTP-only smoke test, remove the SSL annotations, set
 `denWeb.service.port` back to `3005`, set `denApi.service.port` back to `8788`,
 and use explicit `http://host:port` origins in `values.aws.yaml`.
 
-## 6. Verify readiness
+If you are still using raw AWS load balancer hostnames before DNS/TLS is ready,
+temporarily update the corresponding `config.public.*` origins in
+`values.aws.yaml`, then run `helm upgrade` again. Do not leave production
+deployments on raw load balancer hostnames.
+
+The current chart rolls the Den API, Den Web, and inference pods automatically
+when ConfigMap or Secret content changes. On older chart versions, manually
+restart the deployments after changing public origin values:
+
+```bash
+kubectl rollout restart deployment/openwork-ee-den-api deployment/openwork-ee-den-web -n openwork-ee
+kubectl rollout status deployment/openwork-ee-den-api -n openwork-ee --timeout=180s
+kubectl rollout status deployment/openwork-ee-den-web -n openwork-ee --timeout=180s
+```
+
+## 7. Verify readiness
 
 Check Kubernetes state:
 
@@ -245,12 +401,14 @@ curl -fsS https://api.openwork.example.com/ready
 curl -fsS https://openwork.example.com/api/ready
 ```
 
-If you are still using raw AWS load balancer hostnames before DNS/TLS is ready,
-temporarily update the corresponding `config.public.*` origins in
-`values.aws.yaml`, then run `helm upgrade` again. Do not leave production
-deployments on raw load balancer hostnames.
+For HTTP smoke tests, use the raw NLB hostnames and ports:
 
-## 7. Bootstrap the first owner
+```bash
+curl -fsS http://REPLACE_API_NLB_HOST:8788/ready
+curl -fsS http://REPLACE_WEB_NLB_HOST:3005/api/ready
+```
+
+## 8. Bootstrap the first owner
 
 The chart defaults to `single_org`. Set these before first sign-in:
 
@@ -271,7 +429,7 @@ creates the singleton organization and makes that user the owner. Later users
 join the same organization. If `ownerEmails` is blank, the first user to reach
 the deployment can claim ownership, which is not recommended for production.
 
-## 8. Configure SSO with a test IdP
+## 9. Configure SSO with a test IdP
 
 Self-hosted installs keep plan gating off unless the operator explicitly sets
 `DEN_PLAN_GATING_ENABLED=true`, so SSO management should be available in the EE
@@ -302,21 +460,24 @@ assertions.
 After SSO is configured, root sign-in shows the SSO-only experience for the
 single organization. Password sign-in for that organization is rejected.
 
-## 9. Troubleshooting
+## 10. Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `helm` is missing in CloudShell | CloudShell does not always include Helm | Install Helm in CloudShell or run Helm locally with AWS credentials |
 | `aws sts get-caller-identity` returns `NoCredentials` | AWS CLI is not authenticated | Configure AWS SSO/profile or use authenticated CloudShell |
-| Pods are pending | EKS cluster has no schedulable capacity or Auto Mode is not enabled | Confirm `kubectl get nodes` and EKS Auto Mode status |
-| Migration Job fails to connect to MySQL | RDS security group or DB credentials are wrong | Allow TCP `3306` from EKS, verify the user/password, and test with `mysql-client` |
+| Initial `kubectl get nodes` is empty | EKS Auto Mode has not needed to provision nodes yet | Continue after the cluster is active; nodes appear when workloads are pending |
+| Pods show untolerated Auto Mode taints | Auto Mode is still selecting/provisioning matching capacity | Wait for the NodeClaim, then check pod events again |
+| Pod sandbox fails with `aws-cni failed ... failed to assign an IP address` | Subnet/IP or EKS CNI capacity problem | Check subnet free IPs, node events, and retry after Auto Mode provisions replacement capacity |
+| Migration Job fails to connect to MySQL | RDS security group, DB credentials, or TLS mode are wrong | Allow TCP `3306` from EKS, verify with `mysql-client`, and use `?sslaccept=accept` for the private-RDS smoke path |
+| Migration Job logs show `self-signed certificate in certificate chain` | Strict certificate verification is being used without the RDS CA bundle | Use `?sslaccept=accept` for the smoke path or mount/configure the RDS CA bundle before strict verification |
 | Runtime is ready but migration failed | Helm hook did not complete | Check `kubectl get jobs` and the migration Job logs before testing web |
 | `ImagePullBackOff` from GHCR | Private image or missing pull token | Add `imagePullSecrets` |
 | Browser auth loops or CORS errors | Public origins do not match DNS/TLS | Set `webOrigin`, `apiOrigin`, `corsOrigins`, `betterAuthTrustedOrigins`, and `authCallbackUrl` to the final HTTPS domains |
 | SSO callback rejected | IdP callback URL does not match OpenWork | Use the callback/ACS URL shown by OpenWork for that org/provider |
 | SSO settings show Enterprise gating | `DEN_PLAN_GATING_ENABLED=true` or org is not entitled | Leave plan gating off for self-host smoke tests, or grant enterprise entitlement |
 
-## 10. Cleanup
+## 11. Cleanup
 
 For a disposable test:
 

--- a/docs/azure-aks-helm.md
+++ b/docs/azure-aks-helm.md
@@ -138,11 +138,14 @@ resources in that delegated subnet.
 Example database URL:
 
 ```text
-mysql://openwork:<password>@<server>.mysql.database.azure.com:3306/openwork_den?sslmode=require
+mysql://openwork:<password>@<server>.mysql.database.azure.com:3306/openwork_den?sslaccept=accept
 ```
 
-Use `?sslmode=require` for Azure. OpenWork passes this through the runtime pool,
-Drizzle migrations, and migration bootstrap scripts.
+Use `?sslaccept=accept` for the simple private-MySQL smoke path. This keeps TLS
+on without requiring a cloud CA bundle to be mounted into the OpenWork image.
+Use strict certificate verification later, after you provide the required CA
+bundle, with a hardened value such as `sslmode=verify-ca` or
+`sslmode=verify-full`.
 
 Before installing OpenWork, verify network access from the cluster:
 
@@ -184,6 +187,25 @@ environments.
 Use a values file, not a long list of `--set` flags. Several OpenWork values are
 comma-separated strings, such as `config.public.corsOrigins`, and plain `--set`
 parsing commonly breaks them.
+
+Make sure your file uses the current chart keys. Public URL values belong under
+`config.public.*`; database and app secrets belong under `secret.values.*`.
+Values such as `config.urls`, `config.databaseUrl`, or `secrets.*` are ignored
+by the chart.
+
+Before installing, render the chart and verify the migration Job will use your
+Azure MySQL URL:
+
+```bash
+helm template openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+  --version REPLACE_OPENWORK_VERSION \
+  --namespace openwork-ee \
+  -f values.azure.yaml > /tmp/openwork-rendered.yaml
+
+grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN' /tmp/openwork-rendered.yaml
+```
+
+Redact secrets before sharing rendered manifests or terminal output.
 
 ## 4. Configure TLS for the Ingress
 
@@ -249,7 +271,48 @@ imagePullSecrets:
   - name: ghcr-pull-secret
 ```
 
-## 6. Point DNS at the Azure ingress address
+## 6. Migration troubleshooting
+
+The migration Job runs before the Deployments are useful. If it fails, fix that
+before debugging web/API readiness.
+
+Avoid `kubectl describe job openwork-ee-migrate` in shared reports because the
+hook Job currently includes `DATABASE_URL` and `DEN_DB_ENCRYPTION_KEY` in the
+rendered environment. Use logs and redacted rendered manifests instead.
+
+For a retained-log debug attempt, temporarily disable hook behavior:
+
+```yaml
+migrations:
+  enabled: true
+  hook: false
+  backoffLimit: 0
+```
+
+Then run Helm and inspect the normal Job logs:
+
+```bash
+helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+  --version REPLACE_OPENWORK_VERSION \
+  --namespace openwork-ee \
+  --create-namespace \
+  -f values.azure.yaml \
+  --wait=false
+
+kubectl get jobs,pods -n openwork-ee
+kubectl logs -n openwork-ee -l job-name=openwork-ee-migrate --all-containers=true
+```
+
+Return to the default hook mode after debugging:
+
+```yaml
+migrations:
+  enabled: true
+  hook: true
+  backoffLimit: 2
+```
+
+## 7. Point DNS at the Azure ingress address
 
 Wait for AKS to allocate an ingress address:
 
@@ -267,7 +330,22 @@ For production domains, prefer HTTPS before testing SSO. Browser auth cookies
 and identity-provider callback policies are much easier to validate on stable
 HTTPS origins than on raw ingress IP addresses.
 
-## 7. Verify readiness
+If you are still using temporary hosts before DNS/TLS is ready, temporarily
+update the corresponding `config.public.*` origins in `values.azure.yaml`, then
+run `helm upgrade` again. Do not leave production deployments on raw ingress IPs
+or placeholder hostnames.
+
+The current chart rolls the Den API, Den Web, and inference pods automatically
+when ConfigMap or Secret content changes. On older chart versions, manually
+restart the deployments after changing public origin values:
+
+```bash
+kubectl rollout restart deployment/openwork-ee-den-api deployment/openwork-ee-den-web -n openwork-ee
+kubectl rollout status deployment/openwork-ee-den-api -n openwork-ee --timeout=180s
+kubectl rollout status deployment/openwork-ee-den-web -n openwork-ee --timeout=180s
+```
+
+## 8. Verify readiness
 
 Check Kubernetes state:
 
@@ -288,12 +366,7 @@ curl -fsS https://api.openwork.example.com/ready
 curl -fsS https://openwork.example.com/api/ready
 ```
 
-If you are still using temporary hosts before DNS/TLS is ready, temporarily
-update the corresponding `config.public.*` origins in `values.azure.yaml`, then
-run `helm upgrade` again. Do not leave production deployments on raw ingress IPs
-or placeholder hostnames.
-
-## 8. Bootstrap the first owner
+## 9. Bootstrap the first owner
 
 The chart defaults to `single_org`. Set these before first sign-in:
 
@@ -314,7 +387,7 @@ creates the singleton organization and makes that user the owner. Later users
 join the same organization. If `ownerEmails` is blank, the first user to reach
 the deployment can claim ownership, which is not recommended for production.
 
-## 9. Configure SSO with a test IdP
+## 10. Configure SSO with a test IdP
 
 Self-hosted installs keep plan gating off unless the operator explicitly sets
 `DEN_PLAN_GATING_ENABLED=true`, so SSO management should be available in the EE
@@ -345,21 +418,22 @@ assertions.
 After SSO is configured, root sign-in shows the SSO-only experience for the
 single organization. Password sign-in for that organization is rejected.
 
-## 10. Troubleshooting
+## 11. Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `kubectl get ingressclass` does not show `webapprouting.kubernetes.azure.com` | Application routing is not enabled | Run `az aks approuting enable` or install a different supported ingress controller and update `ingress.className` |
 | Ingress has no address | Application routing controller is still reconciling or lacks public IP permission | Check `kubectl get pods -n app-routing-system` and the Ingress events |
 | Browser shows certificate warnings | TLS secret is missing, wrong, or does not cover both hosts | Recreate `openwork-ee-tls` or configure the platform certificate automation |
-| Migration Job fails to connect to MySQL | VNet, private DNS, credentials, or TLS settings are wrong | Test from `mysql-client`, confirm DNS resolves inside AKS, and use `?sslmode=require` |
-| `ERROR 3159` from MySQL | Azure requires encrypted transport and the client is not using TLS | Keep `?sslmode=require` in `DATABASE_URL` |
+| Migration Job fails to connect to MySQL | VNet, private DNS, credentials, or TLS settings are wrong | Test from `mysql-client`, confirm DNS resolves inside AKS, and use `?sslaccept=accept` for the private-MySQL smoke path |
+| `ERROR 3159` from MySQL | Azure requires encrypted transport and the client is not using TLS | Keep TLS enabled with `?sslaccept=accept`, or configure strict CA verification explicitly |
+| Migration Job logs show `self-signed certificate in certificate chain` | Strict certificate verification is being used without the cloud MySQL CA bundle | Use `?sslaccept=accept` for the smoke path or mount/configure the CA bundle before strict verification |
 | `ImagePullBackOff` from GHCR | Private image or missing pull token | Add `imagePullSecrets` |
 | Browser auth loops or CORS errors | Public origins do not match DNS/TLS | Set `webOrigin`, `apiOrigin`, `corsOrigins`, `betterAuthTrustedOrigins`, and `authCallbackUrl` to the final HTTPS domains |
 | SSO callback rejected | IdP callback URL does not match OpenWork | Use the callback/ACS URL shown by OpenWork for that org/provider |
 | SSO settings show Enterprise gating | `DEN_PLAN_GATING_ENABLED=true` or org is not entitled | Leave plan gating off for self-host smoke tests, or grant enterprise entitlement |
 
-## 11. Cleanup
+## 12. Cleanup
 
 For a disposable test:
 

--- a/docs/azure-aks-helm.md
+++ b/docs/azure-aks-helm.md
@@ -1,0 +1,372 @@
+# Deploy OpenWork EE on Azure with AKS and Helm
+
+Status: self-host operator guide
+Related: `packaging/helm/openwork-ee`, `packaging/helm/openwork-ee/examples/values.azure-ingress.yaml`
+
+This is the recommended Azure path for a first production-like OpenWork EE
+self-host install. Use Helm on Azure Kubernetes Service with Azure Database for
+MySQL Flexible Server. For web/API exposure, use the AKS application routing
+add-on's managed NGINX Ingress controller so OpenWork gets stable HTTPS host
+names through a standard Kubernetes `Ingress`.
+
+Azure is moving long-term L7 traffic management toward Gateway API, and
+Microsoft notes that AKS application routing NGINX remains supported for
+production workloads through November 2026. The current OpenWork chart emits
+Ingress resources, so managed NGINX application routing is the simplest
+supported Azure path today. Treat Gateway API support as a future chart/platform
+hardening item.
+
+Do not use raw Kubernetes `LoadBalancer` Services as the normal Azure path for
+OpenWork. Azure Load Balancer is a layer 4 load balancer. It is useful for TCP
+services and quick smoke tests, but it does not provide the browser-facing HTTPS
+and host routing experience customers expect for auth and SSO.
+
+## What this deploys
+
+- Den API on port `8788`
+- Den Web on port `3005`
+- optional inference service, disabled by default
+- one Azure Database for MySQL Flexible Server database
+- one single-org OpenWork deployment
+- one managed NGINX Ingress entry point for web and API hosts
+
+Azure owns the AKS cluster, node lifecycle, VNet networking, managed ingress
+controller, DNS, TLS certificate storage, MySQL Flexible Server, managed
+identities, and network security groups. The OpenWork Helm chart owns OpenWork
+Deployments, Services, ConfigMaps, Secrets, health probes, the optional Ingress,
+and the database migration Job.
+
+## Use Helm or something else?
+
+Use Helm on AKS for Azure unless the customer explicitly cannot run Kubernetes.
+The OpenWork EE release artifact is already a Helm chart, and AKS gives the
+cleanest fit for separate web/API services, migration Jobs, and later enterprise
+network controls. The gap to fill is Azure-specific infrastructure guidance,
+not a different OpenWork packaging format.
+
+## Prerequisites
+
+- Azure CLI authenticated to the target subscription.
+- `kubectl` and `helm`.
+- Permission to create AKS, virtual networks, managed identities, Azure Database
+  for MySQL Flexible Server, Private DNS, Azure DNS, Key Vault or TLS secrets,
+  and public IP resources.
+- A real admin email address for the first owner account.
+- A domain you control, such as `openwork.example.com` and
+  `api.openwork.example.com`.
+
+Azure docs used for this guide:
+
+- AKS application routing add-on: https://learn.microsoft.com/en-us/azure/aks/app-routing
+- AKS public Standard Load Balancer: https://learn.microsoft.com/en-us/azure/aks/load-balancer-standard
+- MySQL Flexible Server private network access: https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-networking-vnet
+- MySQL Flexible Server private access with Azure CLI: https://learn.microsoft.com/en-us/azure/mysql/flexible-server/how-to-manage-virtual-network-cli
+- MySQL Flexible Server TLS: https://learn.microsoft.com/en-us/azure/mysql/flexible-server/security-tls-how-to-connect
+
+## 1. Create the AKS cluster
+
+For a first deployment, create an AKS cluster with the managed application
+routing add-on enabled:
+
+```bash
+export AZURE_LOCATION=eastus
+export RESOURCE_GROUP=openwork-ee-rg
+export AKS_CLUSTER=openwork-ee
+
+az group create \
+  --name "$RESOURCE_GROUP" \
+  --location "$AZURE_LOCATION"
+
+az aks create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$AKS_CLUSTER" \
+  --location "$AZURE_LOCATION" \
+  --enable-app-routing \
+  --generate-ssh-keys
+
+az aks get-credentials \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$AKS_CLUSTER"
+
+kubectl get nodes
+kubectl get ingressclass
+```
+
+The application routing add-on creates an Ingress class named
+`webapprouting.kubernetes.azure.com`. The starter values file uses that class.
+
+If you are using an existing AKS cluster, enable the add-on instead:
+
+```bash
+az aks approuting enable \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$AKS_CLUSTER"
+```
+
+## 2. Create Azure Database for MySQL
+
+Create Azure Database for MySQL Flexible Server with private access in the same
+virtual network reachability boundary as AKS. The most important requirements
+are:
+
+- MySQL 8-compatible Flexible Server.
+- Database name: `openwork_den`.
+- Private access through VNet integration or Private Link.
+- AKS pods can resolve and reach the MySQL FQDN on TCP `3306`.
+- TLS enforcement remains enabled.
+- Backups enabled.
+- Public access disabled for production unless there is a documented exception.
+
+Azure's CLI can create a private-access server and delegate the MySQL subnet:
+
+```bash
+az mysql flexible-server create \
+  --resource-group "$RESOURCE_GROUP" \
+  --location "$AZURE_LOCATION" \
+  --name REPLACE_MYSQL_SERVER_NAME \
+  --admin-user openwork \
+  --admin-password REPLACE_DB_PASSWORD \
+  --database-name openwork_den \
+  --version 8.0.21 \
+  --vnet REPLACE_VNET_NAME \
+  --subnet REPLACE_MYSQL_DELEGATED_SUBNET_NAME
+```
+
+Use a separate delegated subnet for MySQL Flexible Server. Do not put AKS node
+resources in that delegated subnet.
+
+Example database URL:
+
+```text
+mysql://openwork:<password>@<server>.mysql.database.azure.com:3306/openwork_den?sslmode=require
+```
+
+Use `?sslmode=require` for Azure. OpenWork passes this through the runtime pool,
+Drizzle migrations, and migration bootstrap scripts.
+
+Before installing OpenWork, verify network access from the cluster:
+
+```bash
+kubectl run mysql-client \
+  --rm \
+  -it \
+  --restart=Never \
+  --image=mysql:8 \
+  -- mysql \
+    --host="REPLACE_MYSQL_SERVER_NAME.mysql.database.azure.com" \
+    --user=openwork \
+    --password \
+    --ssl-mode=REQUIRED \
+    --execute "select 1"
+```
+
+## 3. Prepare Helm values
+
+Copy the starter file:
+
+```bash
+cp packaging/helm/openwork-ee/examples/values.azure-ingress.yaml values.azure.yaml
+```
+
+Replace every `REPLACE_*` placeholder.
+
+Generate secrets:
+
+```bash
+openssl rand -base64 48
+openssl rand -base64 48
+```
+
+Use the first value for `secret.values.betterAuthSecret` and the second for
+`secret.values.denDbEncryptionKey`. Do not reuse either value across
+environments.
+
+Use a values file, not a long list of `--set` flags. Several OpenWork values are
+comma-separated strings, such as `config.public.corsOrigins`, and plain `--set`
+parsing commonly breaks them.
+
+## 4. Configure TLS for the Ingress
+
+The starter values reference this TLS secret:
+
+```yaml
+ingress:
+  tls:
+    - secretName: openwork-ee-tls
+```
+
+Create that secret from a certificate that covers both OpenWork hosts:
+
+```bash
+kubectl create namespace openwork-ee
+
+kubectl create secret tls openwork-ee-tls \
+  --namespace openwork-ee \
+  --cert=REPLACE_FULL_CHAIN_CERT.pem \
+  --key=REPLACE_PRIVATE_KEY.pem
+```
+
+For production, prefer an automated certificate flow owned by the platform team:
+AKS application routing with Azure DNS and Key Vault, cert-manager, or an
+existing ingress platform. Keep the Kubernetes secret name in the values file
+aligned with whichever controller creates the certificate.
+
+## 5. Install OpenWork
+
+Published chart releases live in GHCR:
+
+```bash
+helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+  --version REPLACE_OPENWORK_VERSION \
+  --namespace openwork-ee \
+  --create-namespace \
+  -f values.azure.yaml
+```
+
+For a checkout-local test:
+
+```bash
+helm upgrade --install openwork-ee ./packaging/helm/openwork-ee \
+  --namespace openwork-ee \
+  --create-namespace \
+  -f values.azure.yaml
+```
+
+If GHCR image pulls fail with `ImagePullBackOff`, authenticate to GHCR and add
+an `imagePullSecrets` entry. Public releases should not require this, but
+private packages or private forks do:
+
+```bash
+kubectl create secret docker-registry ghcr-pull-secret \
+  --namespace openwork-ee \
+  --docker-server=ghcr.io \
+  --docker-username="$GITHUB_USER" \
+  --docker-password="$GITHUB_TOKEN"
+```
+
+```yaml
+imagePullSecrets:
+  - name: ghcr-pull-secret
+```
+
+## 6. Point DNS at the Azure ingress address
+
+Wait for AKS to allocate an ingress address:
+
+```bash
+kubectl get ingress -n openwork-ee
+kubectl get service -n app-routing-system nginx
+```
+
+Create DNS records:
+
+- `openwork.example.com` -> the application routing public IP.
+- `api.openwork.example.com` -> the same application routing public IP.
+
+For production domains, prefer HTTPS before testing SSO. Browser auth cookies
+and identity-provider callback policies are much easier to validate on stable
+HTTPS origins than on raw ingress IP addresses.
+
+## 7. Verify readiness
+
+Check Kubernetes state:
+
+```bash
+helm status openwork-ee -n openwork-ee
+kubectl get pods -n openwork-ee
+kubectl get jobs -n openwork-ee
+kubectl get ingress -n openwork-ee
+kubectl describe ingress openwork-ee -n openwork-ee
+kubectl logs -n openwork-ee deploy/openwork-ee-den-api
+kubectl logs -n openwork-ee deploy/openwork-ee-den-web
+```
+
+Check readiness from your machine:
+
+```bash
+curl -fsS https://api.openwork.example.com/ready
+curl -fsS https://openwork.example.com/api/ready
+```
+
+If you are still using temporary hosts before DNS/TLS is ready, temporarily
+update the corresponding `config.public.*` origins in `values.azure.yaml`, then
+run `helm upgrade` again. Do not leave production deployments on raw ingress IPs
+or placeholder hostnames.
+
+## 8. Bootstrap the first owner
+
+The chart defaults to `single_org`. Set these before first sign-in:
+
+```yaml
+config:
+  tenancy:
+    mode: "single_org"
+    singleOrgName: "Acme"
+    singleOrgSlug: "acme"
+    ownerEmails: "admin@acme.com"
+    requireEmailVerification: "false"
+  public:
+    bootstrapAdminEmails: "admin@acme.com"
+```
+
+Open `https://openwork.example.com` and sign up with the owner email. OpenWork
+creates the singleton organization and makes that user the owner. Later users
+join the same organization. If `ownerEmails` is blank, the first user to reach
+the deployment can claim ownership, which is not recommended for production.
+
+## 9. Configure SSO with a test IdP
+
+Self-hosted installs keep plan gating off unless the operator explicitly sets
+`DEN_PLAN_GATING_ENABLED=true`, so SSO management should be available in the EE
+self-host default.
+
+Use OIDC first for a smoke test because most IdPs provide discovery metadata.
+Auth0, Okta trial, and Microsoft Entra test tenants all work as realistic demo
+IdPs.
+
+Configure the IdP application with this callback URL:
+
+```text
+https://openwork.example.com/api/auth/sso/callback/openwork-sso-<org-id>
+```
+
+In OpenWork, sign in as the owner, open the organization SSO settings, and enter
+the IdP issuer/client details. After saving, the organization sign-in path is:
+
+```text
+https://openwork.example.com/sso/<singleOrgSlug>
+```
+
+For SAML, OpenWork shows the generated ACS URL and metadata URL after the SAML
+connection is registered. Use those values in the IdP rather than guessing.
+OpenWork rejects unsigned or weak SAML responses, so configure the IdP to sign
+assertions.
+
+After SSO is configured, root sign-in shows the SSO-only experience for the
+single organization. Password sign-in for that organization is rejected.
+
+## 10. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `kubectl get ingressclass` does not show `webapprouting.kubernetes.azure.com` | Application routing is not enabled | Run `az aks approuting enable` or install a different supported ingress controller and update `ingress.className` |
+| Ingress has no address | Application routing controller is still reconciling or lacks public IP permission | Check `kubectl get pods -n app-routing-system` and the Ingress events |
+| Browser shows certificate warnings | TLS secret is missing, wrong, or does not cover both hosts | Recreate `openwork-ee-tls` or configure the platform certificate automation |
+| Migration Job fails to connect to MySQL | VNet, private DNS, credentials, or TLS settings are wrong | Test from `mysql-client`, confirm DNS resolves inside AKS, and use `?sslmode=require` |
+| `ERROR 3159` from MySQL | Azure requires encrypted transport and the client is not using TLS | Keep `?sslmode=require` in `DATABASE_URL` |
+| `ImagePullBackOff` from GHCR | Private image or missing pull token | Add `imagePullSecrets` |
+| Browser auth loops or CORS errors | Public origins do not match DNS/TLS | Set `webOrigin`, `apiOrigin`, `corsOrigins`, `betterAuthTrustedOrigins`, and `authCallbackUrl` to the final HTTPS domains |
+| SSO callback rejected | IdP callback URL does not match OpenWork | Use the callback/ACS URL shown by OpenWork for that org/provider |
+| SSO settings show Enterprise gating | `DEN_PLAN_GATING_ENABLED=true` or org is not entitled | Leave plan gating off for self-host smoke tests, or grant enterprise entitlement |
+
+## 11. Cleanup
+
+For a disposable test:
+
+```bash
+helm uninstall openwork-ee -n openwork-ee
+az group delete --name "$RESOURCE_GROUP"
+```
+
+Delete any DNS records, Key Vault certificates, public IP resources, and
+database backups or retained restore points if they were only for the test.

--- a/docs/gcp-gke-helm.md
+++ b/docs/gcp-gke-helm.md
@@ -166,10 +166,13 @@ inject Cloud SQL Auth Proxy sidecars. Cloud SQL Auth Proxy is a stronger future
 hardening path when the chart supports sidecars or an operator-managed proxy
 pattern.
 
-If the Cloud SQL instance enforces client SSL certificates or encrypted client
-connections, add the required MySQL SSL parameters to `DATABASE_URL` and verify
-the same URL works for both the migration Job and runtime pods before testing
-the browser flow.
+If the Cloud SQL instance enforces encrypted client connections, use
+`?sslaccept=accept` for the simple private-MySQL smoke path. This keeps TLS on
+without requiring a cloud CA bundle to be mounted into the OpenWork image. Use
+strict certificate verification later, after you provide the required CA bundle,
+with a hardened value such as `sslmode=verify-ca` or `sslmode=verify-full`.
+Verify the same URL works for both the migration Job and runtime pods before
+testing the browser flow.
 
 Before installing OpenWork, verify network access from the cluster:
 
@@ -274,6 +277,25 @@ Use a values file, not a long list of `--set` flags. Several OpenWork values are
 comma-separated strings, such as `config.public.corsOrigins`, and plain `--set`
 parsing commonly breaks them.
 
+Make sure your file uses the current chart keys. Public URL values belong under
+`config.public.*`; database and app secrets belong under `secret.values.*`.
+Values such as `config.urls`, `config.databaseUrl`, or `secrets.*` are ignored
+by the chart.
+
+Before installing, render the chart and verify the migration Job will use your
+Cloud SQL URL:
+
+```bash
+helm template openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+  --version REPLACE_OPENWORK_VERSION \
+  --namespace openwork-ee \
+  -f values.gcp.yaml > /tmp/openwork-rendered.yaml
+
+grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN' /tmp/openwork-rendered.yaml
+```
+
+Redact secrets before sharing rendered manifests or terminal output.
+
 ## 5. Install OpenWork
 
 Published chart releases live in GHCR:
@@ -312,7 +334,48 @@ imagePullSecrets:
   - name: ghcr-pull-secret
 ```
 
-## 6. Point DNS at the global load balancer IP
+## 6. Migration troubleshooting
+
+The migration Job runs before the Deployments are useful. If it fails, fix that
+before debugging web/API readiness.
+
+Avoid `kubectl describe job openwork-ee-migrate` in shared reports because the
+hook Job currently includes `DATABASE_URL` and `DEN_DB_ENCRYPTION_KEY` in the
+rendered environment. Use logs and redacted rendered manifests instead.
+
+For a retained-log debug attempt, temporarily disable hook behavior:
+
+```yaml
+migrations:
+  enabled: true
+  hook: false
+  backoffLimit: 0
+```
+
+Then run Helm and inspect the normal Job logs:
+
+```bash
+helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+  --version REPLACE_OPENWORK_VERSION \
+  --namespace openwork-ee \
+  --create-namespace \
+  -f values.gcp.yaml \
+  --wait=false
+
+kubectl get jobs,pods -n openwork-ee
+kubectl logs -n openwork-ee -l job-name=openwork-ee-migrate --all-containers=true
+```
+
+Return to the default hook mode after debugging:
+
+```yaml
+migrations:
+  enabled: true
+  hook: true
+  backoffLimit: 2
+```
+
+## 7. Point DNS at the global load balancer IP
 
 Get the reserved IP address:
 
@@ -339,7 +402,22 @@ kubectl describe managedcertificate openwork-ee-cert -n openwork-ee
 kubectl describe ingress openwork-ee -n openwork-ee
 ```
 
-## 7. Verify readiness
+If you are still using temporary hosts before DNS/TLS is ready, temporarily
+update the corresponding `config.public.*` origins in `values.gcp.yaml`, then
+run `helm upgrade` again. Do not leave production deployments on raw IPs or
+placeholder hostnames.
+
+The current chart rolls the Den API, Den Web, and inference pods automatically
+when ConfigMap or Secret content changes. On older chart versions, manually
+restart the deployments after changing public origin values:
+
+```bash
+kubectl rollout restart deployment/openwork-ee-den-api deployment/openwork-ee-den-web -n openwork-ee
+kubectl rollout status deployment/openwork-ee-den-api -n openwork-ee --timeout=180s
+kubectl rollout status deployment/openwork-ee-den-web -n openwork-ee --timeout=180s
+```
+
+## 8. Verify readiness
 
 Check Kubernetes state:
 
@@ -361,12 +439,7 @@ curl -fsS https://api.openwork.example.com/ready
 curl -fsS https://openwork.example.com/api/ready
 ```
 
-If you are still using temporary hosts before DNS/TLS is ready, temporarily
-update the corresponding `config.public.*` origins in `values.gcp.yaml`, then
-run `helm upgrade` again. Do not leave production deployments on raw IPs or
-placeholder hostnames.
-
-## 8. Bootstrap the first owner
+## 9. Bootstrap the first owner
 
 The chart defaults to `single_org`. Set these before first sign-in:
 
@@ -387,7 +460,7 @@ creates the singleton organization and makes that user the owner. Later users
 join the same organization. If `ownerEmails` is blank, the first user to reach
 the deployment can claim ownership, which is not recommended for production.
 
-## 9. Configure SSO with a test IdP
+## 10. Configure SSO with a test IdP
 
 Self-hosted installs keep plan gating off unless the operator explicitly sets
 `DEN_PLAN_GATING_ENABLED=true`, so SSO management should be available in the EE
@@ -418,20 +491,21 @@ assertions.
 After SSO is configured, root sign-in shows the SSO-only experience for the
 single organization. Password sign-in for that organization is rejected.
 
-## 10. Troubleshooting
+## 11. Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | Ingress does not reconcile | HTTP load balancing add-on is disabled or Ingress annotation is wrong | Keep HTTP load balancing enabled and use `kubernetes.io/ingress.class: gce` |
 | Backends are unhealthy | GKE load balancer health checks do not match OpenWork readiness endpoints | Apply the `BackendConfig` resources and keep the service annotations from the starter values |
 | Managed certificate is not `Active` | DNS does not point at the load balancer or provisioning is still running | Point both hosts at the reserved global IP and wait; check `kubectl describe managedcertificate` |
-| Migration Job fails to connect to MySQL | Private services access, VPC, credentials, or IP are wrong | Test from `mysql-client`, confirm the private IP, and confirm GKE and Cloud SQL share VPC reachability |
+| Migration Job fails to connect to MySQL | Private services access, VPC, credentials, IP, or TLS mode are wrong | Test from `mysql-client`, confirm the private IP, and confirm GKE and Cloud SQL share VPC reachability |
+| Migration Job logs show `self-signed certificate in certificate chain` | Strict certificate verification is being used without the cloud MySQL CA bundle | Use `?sslaccept=accept` for the smoke path or mount/configure the CA bundle before strict verification |
 | `ImagePullBackOff` from GHCR | Private image or missing pull token | Add `imagePullSecrets` |
 | Browser auth loops or CORS errors | Public origins do not match DNS/TLS | Set `webOrigin`, `apiOrigin`, `corsOrigins`, `betterAuthTrustedOrigins`, and `authCallbackUrl` to the final HTTPS domains |
 | SSO callback rejected | IdP callback URL does not match OpenWork | Use the callback/ACS URL shown by OpenWork for that org/provider |
 | SSO settings show Enterprise gating | `DEN_PLAN_GATING_ENABLED=true` or org is not entitled | Leave plan gating off for self-host smoke tests, or grant enterprise entitlement |
 
-## 11. Cleanup
+## 12. Cleanup
 
 For a disposable test:
 

--- a/docs/gcp-gke-helm.md
+++ b/docs/gcp-gke-helm.md
@@ -1,0 +1,446 @@
+# Deploy OpenWork EE on Google Cloud with GKE and Helm
+
+Status: self-host operator guide
+Related: `packaging/helm/openwork-ee`, `packaging/helm/openwork-ee/examples/values.gcp-ingress.yaml`
+
+This is the recommended Google Cloud path for a first production-like OpenWork
+EE self-host install. Use Helm on GKE Autopilot with Cloud SQL for MySQL. For
+web/API exposure, use GKE Ingress with Google-managed certificates, a reserved
+global IP address, and explicit backend health checks.
+
+Google recommends Gateway API for new L7 traffic management, and GKE Ingress is
+in maintenance mode. The current OpenWork chart emits Ingress resources, so GKE
+Ingress is the simplest supported GCP path today. Treat Gateway API support as a
+future chart/platform hardening item.
+
+Do not use raw Kubernetes `LoadBalancer` Services as the normal GCP path for
+OpenWork. GKE `LoadBalancer` Services are useful for TCP services and quick
+smoke tests, but the customer-facing web app and SSO flow need HTTP(S) load
+balancing, host routing, managed certificates, and backend health checks.
+
+## What this deploys
+
+- Den API on port `8788`
+- Den Web on port `3005`
+- optional inference service, disabled by default
+- one Cloud SQL for MySQL database
+- one single-org OpenWork deployment
+- one external GKE Ingress backed by a Google Cloud Application Load Balancer
+- one Google-managed certificate covering web and API hosts
+
+Google Cloud owns the GKE cluster, Autopilot compute lifecycle, VPC networking,
+Cloud Load Balancing, managed certificates, Cloud SQL, IAM, and firewall rules.
+The OpenWork Helm chart owns OpenWork Deployments, Services, ConfigMaps,
+Secrets, health probes, the optional Ingress, and the database migration Job.
+The `BackendConfig` and `ManagedCertificate` resources in this guide are
+GKE-specific platform resources applied alongside the chart.
+
+## Use Helm or something else?
+
+Use Helm on GKE for Google Cloud unless the customer explicitly cannot run
+Kubernetes. The OpenWork EE release artifact is already a Helm chart, and GKE
+Autopilot keeps the first customer path small while still supporting migration
+Jobs, separate web/API services, SSO-ready HTTPS, and later enterprise network
+controls. The practical gap to fill is GCP-specific ingress and database
+guidance, not a different OpenWork packaging format.
+
+## Prerequisites
+
+- Google Cloud CLI authenticated to the target project.
+- `kubectl` and `helm`.
+- Permission to create GKE, Compute Engine networking and global addresses,
+  Cloud SQL, Service Networking, DNS, IAM, and Kubernetes resources.
+- Enabled APIs: Kubernetes Engine API, Compute Engine API, Cloud SQL Admin API,
+  and Service Networking API.
+- A real admin email address for the first owner account.
+- A domain you control, such as `openwork.example.com` and
+  `api.openwork.example.com`.
+
+Google Cloud docs used for this guide:
+
+- GKE Autopilot clusters: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-an-autopilot-cluster
+- GKE Ingress for Application Load Balancers: https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+- GKE external Ingress and NEGs: https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
+- GKE managed certificates: https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs
+- GKE Ingress configuration and BackendConfig: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration
+- GKE Ingress health checks: https://cloud.google.com/kubernetes-engine/docs/troubleshooting/ingress-health-checks
+- Cloud SQL private IP: https://cloud.google.com/sql/docs/mysql/private-ip
+- Cloud SQL from GKE: https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine
+
+## 1. Create the GKE cluster
+
+For a first deployment, create a regional Autopilot cluster:
+
+```bash
+export GCP_PROJECT=REPLACE_PROJECT_ID
+export GCP_REGION=us-central1
+export GKE_CLUSTER=openwork-ee
+
+gcloud config set project "$GCP_PROJECT"
+
+gcloud services enable \
+  container.googleapis.com \
+  compute.googleapis.com \
+  sqladmin.googleapis.com \
+  servicenetworking.googleapis.com
+
+gcloud container clusters create-auto "$GKE_CLUSTER" \
+  --location "$GCP_REGION" \
+  --project "$GCP_PROJECT"
+
+gcloud container clusters get-credentials "$GKE_CLUSTER" \
+  --location "$GCP_REGION" \
+  --project "$GCP_PROJECT"
+
+kubectl get nodes
+```
+
+GKE enables HTTP load balancing by default. Do not disable it; GKE Ingress needs
+that add-on.
+
+## 2. Create Cloud SQL for MySQL
+
+Create Cloud SQL for MySQL with private IP in the same VPC as the GKE cluster.
+The most important requirements are:
+
+- MySQL 8-compatible Cloud SQL instance.
+- Database name: `openwork_den`.
+- Private services access configured for the VPC.
+- Private IP enabled on the Cloud SQL instance.
+- GKE is VPC-native and can reach the private IP.
+- Backups enabled.
+- Public IP disabled for production unless there is a documented exception.
+
+Private IP requires a one-time private services access connection for the VPC:
+
+```bash
+export VPC_NETWORK=default
+export SQL_RANGE=openwork-sql-range
+
+gcloud compute addresses create "$SQL_RANGE" \
+  --global \
+  --purpose=VPC_PEERING \
+  --prefix-length=16 \
+  --network="$VPC_NETWORK"
+
+gcloud services vpc-peerings connect \
+  --service=servicenetworking.googleapis.com \
+  --ranges="$SQL_RANGE" \
+  --network="$VPC_NETWORK"
+```
+
+Create the instance and database:
+
+```bash
+export SQL_INSTANCE=openwork-ee-mysql
+
+gcloud sql instances create "$SQL_INSTANCE" \
+  --database-version=MYSQL_8_0 \
+  --region="$GCP_REGION" \
+  --network="projects/$GCP_PROJECT/global/networks/$VPC_NETWORK" \
+  --no-assign-ip
+
+gcloud sql databases create openwork_den \
+  --instance="$SQL_INSTANCE"
+
+gcloud sql users create openwork \
+  --instance="$SQL_INSTANCE" \
+  --password=REPLACE_DB_PASSWORD
+```
+
+Get the private IP:
+
+```bash
+gcloud sql instances describe "$SQL_INSTANCE" \
+  --format='value(ipAddresses[0].ipAddress)'
+```
+
+Example database URL:
+
+```text
+mysql://openwork:<password>@<cloud-sql-private-ip>:3306/openwork_den
+```
+
+This guide uses direct private IP because the current OpenWork chart does not
+inject Cloud SQL Auth Proxy sidecars. Cloud SQL Auth Proxy is a stronger future
+hardening path when the chart supports sidecars or an operator-managed proxy
+pattern.
+
+If the Cloud SQL instance enforces client SSL certificates or encrypted client
+connections, add the required MySQL SSL parameters to `DATABASE_URL` and verify
+the same URL works for both the migration Job and runtime pods before testing
+the browser flow.
+
+Before installing OpenWork, verify network access from the cluster:
+
+```bash
+kubectl run mysql-client \
+  --rm \
+  -it \
+  --restart=Never \
+  --image=mysql:8 \
+  -- mysql \
+    --host="REPLACE_CLOUD_SQL_PRIVATE_IP" \
+    --user=openwork \
+    --password \
+    --execute "select 1"
+```
+
+## 3. Reserve a global IP and create GKE resources
+
+Reserve a global IP address for the HTTPS load balancer:
+
+```bash
+gcloud compute addresses create openwork-ee-ip \
+  --global
+
+gcloud compute addresses describe openwork-ee-ip \
+  --global \
+  --format='value(address)'
+```
+
+Create the namespace:
+
+```bash
+kubectl create namespace openwork-ee
+```
+
+Create a Google-managed certificate resource:
+
+```bash
+kubectl apply -n openwork-ee -f - <<'YAML'
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: openwork-ee-cert
+spec:
+  domains:
+    - REPLACE_WEB_HOST
+    - REPLACE_API_HOST
+YAML
+```
+
+Create explicit backend health checks for the two OpenWork services:
+
+```bash
+kubectl apply -n openwork-ee -f - <<'YAML'
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: openwork-ee-den-api-backend
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: /ready
+    port: 8788
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: openwork-ee-den-web-backend
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: /api/ready
+    port: 3005
+YAML
+```
+
+The Helm values annotate the OpenWork Services so GKE associates these
+`BackendConfig` objects with the Google Cloud backend services.
+
+## 4. Prepare Helm values
+
+Copy the starter file:
+
+```bash
+cp packaging/helm/openwork-ee/examples/values.gcp-ingress.yaml values.gcp.yaml
+```
+
+Replace every `REPLACE_*` placeholder.
+
+Generate secrets:
+
+```bash
+openssl rand -base64 48
+openssl rand -base64 48
+```
+
+Use the first value for `secret.values.betterAuthSecret` and the second for
+`secret.values.denDbEncryptionKey`. Do not reuse either value across
+environments.
+
+Use a values file, not a long list of `--set` flags. Several OpenWork values are
+comma-separated strings, such as `config.public.corsOrigins`, and plain `--set`
+parsing commonly breaks them.
+
+## 5. Install OpenWork
+
+Published chart releases live in GHCR:
+
+```bash
+helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+  --version REPLACE_OPENWORK_VERSION \
+  --namespace openwork-ee \
+  --create-namespace \
+  -f values.gcp.yaml
+```
+
+For a checkout-local test:
+
+```bash
+helm upgrade --install openwork-ee ./packaging/helm/openwork-ee \
+  --namespace openwork-ee \
+  --create-namespace \
+  -f values.gcp.yaml
+```
+
+If GHCR image pulls fail with `ImagePullBackOff`, authenticate to GHCR and add
+an `imagePullSecrets` entry. Public releases should not require this, but
+private packages or private forks do:
+
+```bash
+kubectl create secret docker-registry ghcr-pull-secret \
+  --namespace openwork-ee \
+  --docker-server=ghcr.io \
+  --docker-username="$GITHUB_USER" \
+  --docker-password="$GITHUB_TOKEN"
+```
+
+```yaml
+imagePullSecrets:
+  - name: ghcr-pull-secret
+```
+
+## 6. Point DNS at the global load balancer IP
+
+Get the reserved IP address:
+
+```bash
+gcloud compute addresses describe openwork-ee-ip \
+  --global \
+  --format='value(address)'
+```
+
+Create DNS records:
+
+- `openwork.example.com` -> the reserved global IP address.
+- `api.openwork.example.com` -> the reserved global IP address.
+
+GKE can take several minutes to provision the load balancer. Google-managed
+certificates can take up to an hour to become active after DNS points at the
+load balancer.
+
+Check status:
+
+```bash
+kubectl get ingress -n openwork-ee
+kubectl describe managedcertificate openwork-ee-cert -n openwork-ee
+kubectl describe ingress openwork-ee -n openwork-ee
+```
+
+## 7. Verify readiness
+
+Check Kubernetes state:
+
+```bash
+helm status openwork-ee -n openwork-ee
+kubectl get pods -n openwork-ee
+kubectl get jobs -n openwork-ee
+kubectl get ingress -n openwork-ee
+kubectl describe backendconfig openwork-ee-den-api-backend -n openwork-ee
+kubectl describe backendconfig openwork-ee-den-web-backend -n openwork-ee
+kubectl logs -n openwork-ee deploy/openwork-ee-den-api
+kubectl logs -n openwork-ee deploy/openwork-ee-den-web
+```
+
+Check readiness from your machine:
+
+```bash
+curl -fsS https://api.openwork.example.com/ready
+curl -fsS https://openwork.example.com/api/ready
+```
+
+If you are still using temporary hosts before DNS/TLS is ready, temporarily
+update the corresponding `config.public.*` origins in `values.gcp.yaml`, then
+run `helm upgrade` again. Do not leave production deployments on raw IPs or
+placeholder hostnames.
+
+## 8. Bootstrap the first owner
+
+The chart defaults to `single_org`. Set these before first sign-in:
+
+```yaml
+config:
+  tenancy:
+    mode: "single_org"
+    singleOrgName: "Acme"
+    singleOrgSlug: "acme"
+    ownerEmails: "admin@acme.com"
+    requireEmailVerification: "false"
+  public:
+    bootstrapAdminEmails: "admin@acme.com"
+```
+
+Open `https://openwork.example.com` and sign up with the owner email. OpenWork
+creates the singleton organization and makes that user the owner. Later users
+join the same organization. If `ownerEmails` is blank, the first user to reach
+the deployment can claim ownership, which is not recommended for production.
+
+## 9. Configure SSO with a test IdP
+
+Self-hosted installs keep plan gating off unless the operator explicitly sets
+`DEN_PLAN_GATING_ENABLED=true`, so SSO management should be available in the EE
+self-host default.
+
+Use OIDC first for a smoke test because most IdPs provide discovery metadata.
+Auth0, Okta trial, and Google Cloud Identity test tenants all work as realistic
+demo IdPs.
+
+Configure the IdP application with this callback URL:
+
+```text
+https://openwork.example.com/api/auth/sso/callback/openwork-sso-<org-id>
+```
+
+In OpenWork, sign in as the owner, open the organization SSO settings, and enter
+the IdP issuer/client details. After saving, the organization sign-in path is:
+
+```text
+https://openwork.example.com/sso/<singleOrgSlug>
+```
+
+For SAML, OpenWork shows the generated ACS URL and metadata URL after the SAML
+connection is registered. Use those values in the IdP rather than guessing.
+OpenWork rejects unsigned or weak SAML responses, so configure the IdP to sign
+assertions.
+
+After SSO is configured, root sign-in shows the SSO-only experience for the
+single organization. Password sign-in for that organization is rejected.
+
+## 10. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Ingress does not reconcile | HTTP load balancing add-on is disabled or Ingress annotation is wrong | Keep HTTP load balancing enabled and use `kubernetes.io/ingress.class: gce` |
+| Backends are unhealthy | GKE load balancer health checks do not match OpenWork readiness endpoints | Apply the `BackendConfig` resources and keep the service annotations from the starter values |
+| Managed certificate is not `Active` | DNS does not point at the load balancer or provisioning is still running | Point both hosts at the reserved global IP and wait; check `kubectl describe managedcertificate` |
+| Migration Job fails to connect to MySQL | Private services access, VPC, credentials, or IP are wrong | Test from `mysql-client`, confirm the private IP, and confirm GKE and Cloud SQL share VPC reachability |
+| `ImagePullBackOff` from GHCR | Private image or missing pull token | Add `imagePullSecrets` |
+| Browser auth loops or CORS errors | Public origins do not match DNS/TLS | Set `webOrigin`, `apiOrigin`, `corsOrigins`, `betterAuthTrustedOrigins`, and `authCallbackUrl` to the final HTTPS domains |
+| SSO callback rejected | IdP callback URL does not match OpenWork | Use the callback/ACS URL shown by OpenWork for that org/provider |
+| SSO settings show Enterprise gating | `DEN_PLAN_GATING_ENABLED=true` or org is not entitled | Leave plan gating off for self-host smoke tests, or grant enterprise entitlement |
+
+## 11. Cleanup
+
+For a disposable test:
+
+```bash
+helm uninstall openwork-ee -n openwork-ee
+gcloud compute addresses delete openwork-ee-ip --global
+gcloud container clusters delete "$GKE_CLUSTER" --location "$GCP_REGION"
+gcloud sql instances delete "$SQL_INSTANCE"
+```
+
+Delete DNS records, retained backups, private service access ranges, and any IAM
+resources if they were only for the test.

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -15,7 +15,7 @@ Published releases are available as an OCI Helm chart:
 
 ```bash
 helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
-  --version 0.17.1 \
+  --version REPLACE_OPENWORK_VERSION \
   -f values.prod.yaml
 ```
 
@@ -25,7 +25,7 @@ Create a values file for the target environment:
 
 ```yaml
 image:
-  tag: "0.17.1"
+  tag: "REPLACE_OPENWORK_VERSION"
 
 config:
   tenancy:
@@ -51,7 +51,7 @@ config:
 
 secret:
   values:
-    databaseUrl: "mysql://openwork:REPLACE_ME@mysql.example.internal:3306/openwork_den"
+    databaseUrl: "mysql://openwork:REPLACE_ME@mysql.example.internal:3306/openwork_den?sslaccept=accept"
     betterAuthSecret: "REPLACE_WITH_AT_LEAST_32_CHARACTERS"
     denDbEncryptionKey: "REPLACE_WITH_AT_LEAST_32_CHARACTERS"
 
@@ -92,7 +92,8 @@ Provider-specific starter guides:
 
 - AWS EKS:
   [guide](../../../docs/aws-eks-helm.md),
-  [`examples/values.aws-load-balancer.yaml`](examples/values.aws-load-balancer.yaml).
+  [`examples/values.aws-load-balancer.yaml`](examples/values.aws-load-balancer.yaml),
+  [`examples/values.aws-load-balancer-http-smoke.yaml`](examples/values.aws-load-balancer-http-smoke.yaml).
   The recommended first AWS path is EKS Auto Mode plus `LoadBalancer` Services,
   which provisions AWS Network Load Balancers without installing an ingress
   controller.
@@ -236,6 +237,13 @@ The same shape is available under `denApi.service` and `inference.service`.
 `ingress.enabled=true` only emits Kubernetes `Ingress` resources; it does not
 install an ingress controller.
 
+## Config Rollouts
+
+Den API, Den Web, and inference pods include checksums for the chart-managed
+ConfigMap and Secret. Helm upgrades that change runtime config or secrets roll
+the pods automatically so environment variables such as public origins, CORS
+origins, and database URLs are refreshed.
+
 ## Isolated Networks
 
 The chart disables external password breach screening by default so isolated self-hosted installs do not depend on the Have I Been Pwned Pwned Passwords range API. If your deployment has approved egress and you want password creation and reset to reject known-compromised passwords through that service, enable it:
@@ -255,11 +263,28 @@ The migration Job runs as a Helm `pre-install,pre-upgrade` hook by default:
 ```yaml
 migrations:
   enabled: true
+  hook: true
+  hookDeletePolicy: before-hook-creation,hook-succeeded
   args:
     - pnpm --dir /app/ee/packages/den-db run db:bootstrap
 ```
 
 `db:bootstrap` uses `db:migrate` for normal upgrades. On a completely empty database it applies the current schema once, records the committed migrations as the baseline, then runs migrations. On an existing schema without a Drizzle ledger, it records the baseline before migrating.
+
+For retained-log troubleshooting, temporarily disable hook behavior and reduce
+retries:
+
+```yaml
+migrations:
+  enabled: true
+  hook: false
+  backoffLimit: 0
+```
+
+The hook Job currently renders `DATABASE_URL` and `DEN_DB_ENCRYPTION_KEY` into
+the Job environment when `secret.create=true`, because pre-install hooks run
+before normal chart resources. Avoid sharing `kubectl describe job` output
+without redacting secrets.
 
 ## Install links
 

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -88,13 +88,28 @@ helm template openwork-ee ./packaging/helm/openwork-ee -f values.prod.yaml
 helm upgrade --install openwork-ee ./packaging/helm/openwork-ee -f values.prod.yaml
 ```
 
-For AWS EKS, start with the [AWS deployment guide](../../../docs/aws-eks-helm.md)
-and the starter values file at
-[`examples/values.aws-load-balancer.yaml`](examples/values.aws-load-balancer.yaml).
-The recommended first AWS path is EKS Auto Mode plus `LoadBalancer` Services,
-which provisions AWS Network Load Balancers without installing an ingress
-controller. Use `ingress.enabled=true` only when the cluster already has an
-Ingress controller such as the AWS Load Balancer Controller.
+Provider-specific starter guides:
+
+- AWS EKS:
+  [guide](../../../docs/aws-eks-helm.md),
+  [`examples/values.aws-load-balancer.yaml`](examples/values.aws-load-balancer.yaml).
+  The recommended first AWS path is EKS Auto Mode plus `LoadBalancer` Services,
+  which provisions AWS Network Load Balancers without installing an ingress
+  controller.
+- Azure AKS:
+  [guide](../../../docs/azure-aks-helm.md),
+  [`examples/values.azure-ingress.yaml`](examples/values.azure-ingress.yaml).
+  The recommended first Azure path is AKS application routing plus
+  `ingress.enabled=true`.
+- Google Cloud GKE:
+  [guide](../../../docs/gcp-gke-helm.md),
+  [`examples/values.gcp-ingress.yaml`](examples/values.gcp-ingress.yaml).
+  The recommended first GCP path is GKE Ingress with a reserved global IP,
+  Google-managed certificate, and BackendConfig health checks.
+
+`ingress.enabled=true` only emits Kubernetes `Ingress` resources; it does not
+install an ingress controller. Use it only when the cluster already has a
+compatible provider ingress controller.
 
 ## Secrets
 

--- a/packaging/helm/openwork-ee/examples/values.aws-load-balancer-http-smoke.yaml
+++ b/packaging/helm/openwork-ee/examples/values.aws-load-balancer-http-smoke.yaml
@@ -1,4 +1,5 @@
-# AWS EKS Auto Mode starter values for a first OpenWork EE self-host install.
+# AWS EKS Auto Mode HTTP smoke-test values for a first OpenWork EE install when
+# DNS and ACM TLS are not ready yet.
 #
 # Copy this file, replace every REPLACE_* value, and install with:
 #
@@ -6,11 +7,12 @@
 #     --version REPLACE_OPENWORK_VERSION \
 #     --namespace openwork-ee \
 #     --create-namespace \
-#     -f values.aws.yaml
+#     -f values.aws-http-smoke.yaml
 #
-# This example exposes Den Web and Den API through separate AWS Network Load
-# Balancers created from Kubernetes Services. Use it for the first AWS smoke
-# test and for installs where separate web/API hostnames are acceptable.
+# This creates two public AWS Network Load Balancers on clear HTTP ports. After
+# the first successful install, replace the pending origins with the real NLB
+# hostnames, run helm upgrade again, and then validate browser auth. Prefer the
+# HTTPS/ACM example for production.
 
 image:
   tag: "REPLACE_OPENWORK_VERSION"
@@ -27,16 +29,16 @@ config:
   auth:
     passwordBreachScreeningEnabled: "false"
   public:
-    webOrigin: "https://REPLACE_WEB_HOST"
-    apiOrigin: "https://REPLACE_API_HOST"
-    mcpResourceUrl: "https://REPLACE_API_HOST/mcp"
-    mcpClaimNamespace: "https://REPLACE_WEB_HOST"
-    desktopDenBaseUrl: "https://REPLACE_WEB_HOST"
-    corsOrigins: "https://REPLACE_WEB_HOST,https://REPLACE_API_HOST"
-    betterAuthTrustedOrigins: "https://REPLACE_WEB_HOST"
-    webAppHosts: "REPLACE_WEB_HOST"
+    webOrigin: "http://pending-web-nlb:3005"
+    apiOrigin: "http://pending-api-nlb:8788"
+    mcpResourceUrl: "http://pending-api-nlb:8788/mcp"
+    mcpClaimNamespace: "http://pending-web-nlb:3005"
+    desktopDenBaseUrl: "http://pending-web-nlb:3005"
+    corsOrigins: "http://pending-web-nlb:3005,http://pending-api-nlb:8788"
+    betterAuthTrustedOrigins: "http://pending-web-nlb:3005"
+    webAppHosts: "pending-web-nlb"
     bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
-    authCallbackUrl: "https://REPLACE_WEB_HOST"
+    authCallbackUrl: "http://pending-web-nlb:3005"
   provisioner:
     mode: stub
 
@@ -55,29 +57,25 @@ denApi:
   replicaCount: 1
   service:
     type: LoadBalancer
-    port: 443
+    port: 8788
     loadBalancerClass: eks.amazonaws.com/nlb
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
       service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: HTTP
       service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /ready
-      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: REPLACE_ACM_CERT_ARN
-      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
 
 denWeb:
   replicaCount: 1
   service:
     type: LoadBalancer
-    port: 443
+    port: 3005
     loadBalancerClass: eks.amazonaws.com/nlb
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
       service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: HTTP
       service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /api/ready
-      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: REPLACE_ACM_CERT_ARN
-      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
 
 inference:
   enabled: false

--- a/packaging/helm/openwork-ee/examples/values.azure-ingress.yaml
+++ b/packaging/helm/openwork-ee/examples/values.azure-ingress.yaml
@@ -43,9 +43,9 @@ config:
 secret:
   create: true
   values:
-    # Azure Database for MySQL Flexible Server example. The sslmode=require flag
-    # is understood by the app, Drizzle migrations, and bootstrap scripts.
-    databaseUrl: "mysql://openwork:REPLACE_DB_PASSWORD@REPLACE_MYSQL_SERVER.mysql.database.azure.com:3306/openwork_den?sslmode=require"
+    # Azure Database for MySQL Flexible Server private-network smoke path.
+    # sslaccept=accept preserves TLS without requiring a mounted CA bundle.
+    databaseUrl: "mysql://openwork:REPLACE_DB_PASSWORD@REPLACE_MYSQL_SERVER.mysql.database.azure.com:3306/openwork_den?sslaccept=accept"
     # Generate with: openssl rand -base64 48
     betterAuthSecret: "REPLACE_BETTER_AUTH_SECRET"
     # Generate separately with: openssl rand -base64 48

--- a/packaging/helm/openwork-ee/examples/values.azure-ingress.yaml
+++ b/packaging/helm/openwork-ee/examples/values.azure-ingress.yaml
@@ -1,0 +1,85 @@
+# Azure AKS starter values for a first OpenWork EE self-host install.
+#
+# Copy this file, replace every REPLACE_* value, and install with:
+#
+#   helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+#     --version REPLACE_OPENWORK_VERSION \
+#     --namespace openwork-ee \
+#     --create-namespace \
+#     -f values.azure.yaml
+#
+# This example exposes Den Web and Den API through the AKS application routing
+# add-on's managed NGINX Ingress controller. Use it for production-like Azure
+# tests where browser auth and SSO need stable HTTPS hostnames.
+
+image:
+  tag: "REPLACE_OPENWORK_VERSION"
+  pullPolicy: IfNotPresent
+
+config:
+  tenancy:
+    mode: single_org
+    singleOrgName: "REPLACE_COMPANY_NAME"
+    singleOrgSlug: "REPLACE_COMPANY_SLUG"
+    ownerEmails: "REPLACE_ADMIN_EMAIL"
+    allowPublicSignup: "false"
+    requireEmailVerification: "false"
+  auth:
+    passwordBreachScreeningEnabled: "false"
+  public:
+    webOrigin: "https://REPLACE_WEB_HOST"
+    apiOrigin: "https://REPLACE_API_HOST"
+    mcpResourceUrl: "https://REPLACE_API_HOST/mcp"
+    mcpClaimNamespace: "https://REPLACE_WEB_HOST"
+    desktopDenBaseUrl: "https://REPLACE_WEB_HOST"
+    corsOrigins: "https://REPLACE_WEB_HOST,https://REPLACE_API_HOST"
+    betterAuthTrustedOrigins: "https://REPLACE_WEB_HOST"
+    webAppHosts: "REPLACE_WEB_HOST"
+    bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
+    authCallbackUrl: "https://REPLACE_WEB_HOST"
+  provisioner:
+    mode: stub
+
+secret:
+  create: true
+  values:
+    # Azure Database for MySQL Flexible Server example. The sslmode=require flag
+    # is understood by the app, Drizzle migrations, and bootstrap scripts.
+    databaseUrl: "mysql://openwork:REPLACE_DB_PASSWORD@REPLACE_MYSQL_SERVER.mysql.database.azure.com:3306/openwork_den?sslmode=require"
+    # Generate with: openssl rand -base64 48
+    betterAuthSecret: "REPLACE_BETTER_AUTH_SECRET"
+    # Generate separately with: openssl rand -base64 48
+    denDbEncryptionKey: "REPLACE_DEN_DB_ENCRYPTION_KEY"
+
+denApi:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 8788
+
+denWeb:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 3005
+
+inference:
+  enabled: false
+
+migrations:
+  enabled: true
+  hook: true
+
+ingress:
+  enabled: true
+  className: webapprouting.kubernetes.azure.com
+  web:
+    host: REPLACE_WEB_HOST
+  api:
+    enabled: true
+    host: REPLACE_API_HOST
+  tls:
+    - secretName: openwork-ee-tls
+      hosts:
+        - REPLACE_WEB_HOST
+        - REPLACE_API_HOST

--- a/packaging/helm/openwork-ee/examples/values.gcp-ingress.yaml
+++ b/packaging/helm/openwork-ee/examples/values.gcp-ingress.yaml
@@ -1,0 +1,90 @@
+# Google Cloud GKE starter values for a first OpenWork EE self-host install.
+#
+# Copy this file, replace every REPLACE_* value, and install with:
+#
+#   helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+#     --version REPLACE_OPENWORK_VERSION \
+#     --namespace openwork-ee \
+#     --create-namespace \
+#     -f values.gcp.yaml
+#
+# This example exposes Den Web and Den API through GKE Ingress with a reserved
+# global IP and Google-managed certificate. Apply the ManagedCertificate and
+# BackendConfig manifests from docs/gcp-gke-helm.md before installing.
+
+image:
+  tag: "REPLACE_OPENWORK_VERSION"
+  pullPolicy: IfNotPresent
+
+config:
+  tenancy:
+    mode: single_org
+    singleOrgName: "REPLACE_COMPANY_NAME"
+    singleOrgSlug: "REPLACE_COMPANY_SLUG"
+    ownerEmails: "REPLACE_ADMIN_EMAIL"
+    allowPublicSignup: "false"
+    requireEmailVerification: "false"
+  auth:
+    passwordBreachScreeningEnabled: "false"
+  public:
+    webOrigin: "https://REPLACE_WEB_HOST"
+    apiOrigin: "https://REPLACE_API_HOST"
+    mcpResourceUrl: "https://REPLACE_API_HOST/mcp"
+    mcpClaimNamespace: "https://REPLACE_WEB_HOST"
+    desktopDenBaseUrl: "https://REPLACE_WEB_HOST"
+    corsOrigins: "https://REPLACE_WEB_HOST,https://REPLACE_API_HOST"
+    betterAuthTrustedOrigins: "https://REPLACE_WEB_HOST"
+    webAppHosts: "REPLACE_WEB_HOST"
+    bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
+    authCallbackUrl: "https://REPLACE_WEB_HOST"
+  provisioner:
+    mode: stub
+
+secret:
+  create: true
+  values:
+    # Direct private IP Cloud SQL example. The current chart does not inject
+    # Cloud SQL Auth Proxy sidecars, so use a private IP reachable from GKE.
+    databaseUrl: "mysql://openwork:REPLACE_DB_PASSWORD@REPLACE_CLOUD_SQL_PRIVATE_IP:3306/openwork_den"
+    # Generate with: openssl rand -base64 48
+    betterAuthSecret: "REPLACE_BETTER_AUTH_SECRET"
+    # Generate separately with: openssl rand -base64 48
+    denDbEncryptionKey: "REPLACE_DEN_DB_ENCRYPTION_KEY"
+
+denApi:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 8788
+    annotations:
+      cloud.google.com/backend-config: '{"default": "openwork-ee-den-api-backend"}'
+      cloud.google.com/neg: '{"ingress": true}'
+
+denWeb:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 3005
+    annotations:
+      cloud.google.com/backend-config: '{"default": "openwork-ee-den-web-backend"}'
+      cloud.google.com/neg: '{"ingress": true}'
+
+inference:
+  enabled: false
+
+migrations:
+  enabled: true
+  hook: true
+
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    kubernetes.io/ingress.class: gce
+    kubernetes.io/ingress.global-static-ip-name: REPLACE_GLOBAL_STATIC_IP_NAME
+    networking.gke.io/managed-certificates: REPLACE_MANAGED_CERTIFICATE_NAME
+  web:
+    host: REPLACE_WEB_HOST
+  api:
+    enabled: true
+    host: REPLACE_API_HOST

--- a/packaging/helm/openwork-ee/templates/den-api.yaml
+++ b/packaging/helm/openwork-ee/templates/den-api.yaml
@@ -42,10 +42,12 @@ spec:
         {{- with .Values.denApi.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.denApi.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.denApi.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/packaging/helm/openwork-ee/templates/den-web.yaml
+++ b/packaging/helm/openwork-ee/templates/den-web.yaml
@@ -42,10 +42,12 @@ spec:
         {{- with .Values.denWeb.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.denWeb.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.denWeb.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/packaging/helm/openwork-ee/templates/inference.yaml
+++ b/packaging/helm/openwork-ee/templates/inference.yaml
@@ -43,10 +43,12 @@ spec:
         {{- with .Values.inference.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.inference.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.inference.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/packaging/helm/openwork-ee/templates/migration-job.yaml
+++ b/packaging/helm/openwork-ee/templates/migration-job.yaml
@@ -9,7 +9,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.migrations.hookDeletePolicy }}
+    "helm.sh/hook-delete-policy": {{ . | quote }}
+    {{- end }}
   {{- end }}
 spec:
   backoffLimit: {{ .Values.migrations.backoffLimit }}

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -201,6 +201,7 @@ inference:
 migrations:
   enabled: true
   hook: true
+  hookDeletePolicy: before-hook-creation,hook-succeeded
   backoffLimit: 2
   activeDeadlineSeconds: 600
   podAnnotations: {}


### PR DESCRIPTION
## Summary

- add Azure AKS self-host guide for OpenWork EE Helm deployments
- add GCP GKE self-host guide for OpenWork EE Helm deployments
- add provider-specific starter Helm values for AKS Ingress and GKE Ingress
- update the Helm README to link AWS, Azure, and GCP deployment paths

## Notes

- Azure path: AKS + Azure Database for MySQL Flexible Server + AKS application routing managed NGINX Ingress.
- GCP path: GKE Autopilot + Cloud SQL MySQL private IP + GKE Ingress, ManagedCertificate, reserved global IP, and BackendConfig health checks.
- Docs-only/config-only change, so no fraimz runtime proof was captured.

## Validation

- `helm lint ./packaging/helm/openwork-ee -f packaging/helm/openwork-ee/examples/values.azure-ingress.yaml` passed
- `helm lint ./packaging/helm/openwork-ee -f packaging/helm/openwork-ee/examples/values.gcp-ingress.yaml` passed
- `helm template openwork-ee ./packaging/helm/openwork-ee -f packaging/helm/openwork-ee/examples/values.azure-ingress.yaml` passed
- `helm template openwork-ee ./packaging/helm/openwork-ee -f packaging/helm/openwork-ee/examples/values.gcp-ingress.yaml` passed
