### PR TITLE
feat(connections): Slack in cloud Connections via pre-registered OAuth apps

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
@@ -11,6 +11,7 @@ export type ExternalMcpPreset = {
   description: string
   url: string
   authType: "oauth" | "apikey" | "none"
+  requiresOAuthClient?: boolean
 }
 
 export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
@@ -41,6 +42,14 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
     description: "Track releases and resolve production errors.",
     url: "https://mcp.sentry.dev/mcp",
     authType: "oauth",
+  },
+  {
+    presetId: "slack",
+    displayName: "Slack",
+    description: "Channels, DMs, and search. Slack has no automatic app registration — paste your Slack app's OAuth client once; each person then connects their own account.",
+    url: "https://mcp.slack.com/mcp",
+    authType: "oauth",
+    requiresOAuthClient: true,
   },
   {
     presetId: "context7",

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -34,7 +34,7 @@ import {
 import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
 import { listNativeProviderUsableEntries } from "../../capability-sources/native-provider-connections.js"
 import { connectCallbackPage } from "../../capability-sources/oauth-callback-page.js"
-import { getConnectedAccount } from "../../capability-sources/oauth-credentials.js"
+import { getConnectedAccount, upsertOrgOAuthClient } from "../../capability-sources/oauth-credentials.js"
 import { assertPublicUrl } from "../../capability-sources/url-guard.js"
 import type { MemberTeamSummary } from "../../orgs.js"
 import { EXTERNAL_MCP_PRESETS } from "../../capability-sources/external-mcp-presets.js"
@@ -55,6 +55,10 @@ const createConnectionBodySchema = z.object({
   authType: z.enum(["oauth", "apikey", "none"]),
   credentialMode: z.enum(["shared", "per_member"]).optional().default("shared"),
   apiKey: z.string().trim().min(1).max(4096).optional(),
+  oauthClient: z.object({
+    clientId: z.string().trim().min(1).max(512),
+    clientSecret: z.string().trim().min(1).max(4096).optional(),
+  }).optional(),
   /** Who can USE the connection. Defaults to org-wide so the naive quick-add path matches expectations, but it's an explicit, editable choice. */
   access: accessInputSchema.optional().default({ orgWide: true, memberIds: [], teamIds: [] }),
 })
@@ -96,6 +100,8 @@ const connectionCreatedResponseSchema = connectionResponseSchema.extend({
   links: z.object({
     /** Where members connect their own account for per_member connections. Share this with the team. */
     yourConnections: z.string(),
+    /** The exact OAuth redirect URL to whitelist in pre-registered provider apps. */
+    oauthCallback: z.string(),
   }),
 }).meta({ ref: "ExternalMcpConnectionCreatedResponse" })
 
@@ -104,12 +110,19 @@ const connectionCreatedResponseSchema = connectionResponseSchema.extend({
  * connection, members connect their own account in the den-web dashboard.
  * betterAuthUrl is the den-web public origin in every deployment layout.
  */
-function memberConnectLinks() {
-  return { yourConnections: `${env.betterAuthUrl}/dashboard/your-connections` }
+function memberConnectLinks(request: Request, connectionId: string) {
+  return {
+    yourConnections: `${env.betterAuthUrl}/dashboard/your-connections`,
+    oauthCallback: callbackRedirectUri(request, connectionId),
+  }
 }
 
 export function isAgentApiKeyConnection(input: { authType: string; sessionId?: string | null }) {
   return input.authType === "apikey" && input.sessionId === "mcp_internal"
+}
+
+export function isAgentOAuthClientConnection(input: { oauthClient?: unknown; sessionId?: string | null }) {
+  return Boolean(input.oauthClient) && input.sessionId === "mcp_internal"
 }
 
 const listConnectionsQuerySchema = z.object({
@@ -123,6 +136,7 @@ const presetResponseSchema = z.object({
   description: z.string(),
   url: z.string(),
   authType: z.enum(["oauth", "apikey", "none"]),
+  requiresOAuthClient: z.boolean().optional(),
 }).meta({ ref: "ExternalMcpPresetResponse" })
 
 const presetListResponseSchema = z.object({
@@ -209,7 +223,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
     describeRoute({
       tags: ["Capability Sources"],
       summary: "List predefined External MCP Connection presets",
-      description: "Common third-party MCP servers (Notion, Linear, Stripe, ...) an admin can add with one click, prefilled with a real name and URL.",
+      description: "Common third-party MCP servers (Notion, Linear, Stripe, Slack, ...) an admin can add with one click, prefilled with a real name and URL.",
       responses: {
         200: jsonResponse("Presets.", presetListResponseSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
@@ -285,7 +299,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       // (connect/start, callbacks, client secrets) stays agent-blocked.
       tags: ["Capability Sources"],
       summary: "Register a new External MCP Connection for the org",
-      description: "Admin-only. Registers a third-party MCP server by name + URL and grants access (org-wide, teams, or members). Use GET /v1/mcp-connections/presets for known server URLs (Notion, Linear, Stripe, Sentry, Context7). For credentialMode per_member, each member connects their own account afterwards — share links.yourConnections from the response so teammates know where to sign in. API-key connections cannot be created through the agent surface; use the dashboard.",
+      description: "Admin-only. Registers a third-party MCP server by name + URL and grants access (org-wide, teams, or members). Use GET /v1/mcp-connections/presets for known server URLs (Notion, Linear, Stripe, Sentry, Slack, Context7). For credentialMode per_member, each member connects their own account afterwards — share links.yourConnections from the response so teammates know where to sign in. For servers with pre-registered OAuth apps, whitelist links.oauthCallback. API-key and OAuth-client credentials cannot be created through the agent surface; use the dashboard.",
       responses: {
         200: jsonResponse("Connection created.", connectionCreatedResponseSchema),
         400: jsonResponse("Invalid request.", invalidRequestSchema),
@@ -301,10 +315,17 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       if (!admin.ok) return c.json(admin.response, orgAccessFailureStatus(admin.response))
 
       const body = c.req.valid("json")
+      const sessionId = c.get("session")?.id
       // Secrets must not travel through chat transcripts: when the caller is
       // the agent (internal MCP principal), refuse API-key connections.
-      if (isAgentApiKeyConnection({ authType: body.authType, sessionId: c.get("session")?.id })) {
+      if (isAgentOAuthClientConnection({ oauthClient: body.oauthClient, sessionId })) {
+        return c.json({ error: "invalid_request", message: "OAuth client credentials cannot be set from the agent. Add them in the OpenWork Cloud dashboard under Extensions." }, 400)
+      }
+      if (isAgentApiKeyConnection({ authType: body.authType, sessionId })) {
         return c.json({ error: "invalid_request", message: "API-key connections cannot be created from the agent. Add them in the OpenWork Cloud dashboard under Extensions." }, 400)
+      }
+      if (body.oauthClient && body.authType !== "oauth") {
+        return c.json({ error: "invalid_request", message: "oauthClient is only allowed when authType is oauth." }, 400)
       }
       if (body.authType === "apikey" && !body.apiKey) {
         return c.json({ error: "invalid_request", message: "apiKey is required when authType is apikey." }, 400)
@@ -337,6 +358,16 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         },
       })
 
+      if (body.oauthClient) {
+        await upsertOrgOAuthClient({
+          organizationId: payload.organization.id,
+          providerId: created.id,
+          clientId: body.oauthClient.clientId,
+          clientSecret: body.oauthClient.clientSecret ?? null,
+          createdByOrgMembershipId: payload.currentMember.id,
+        })
+      }
+
       if (body.authType !== "oauth") {
         // No OAuth dance needed — validate the server is real and reachable now.
         await connectExternalMcp(created, callbackRedirectUri(c.req.raw, created.id))
@@ -346,7 +377,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       const response = await toConnectionResponse(refreshed ?? created, { callerOrgMembershipId: payload.currentMember.id, includeAccess: true })
       // The classical handoff: whoever created this (human or agent) gets
       // the link where members connect their own account, ready to share.
-      return c.json({ ...response, links: memberConnectLinks() })
+      return c.json({ ...response, links: memberConnectLinks(c.req.raw, created.id) })
     },
   )
 

--- a/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
@@ -14,6 +14,7 @@ type OpenApiDocument = {
 
 let isMcpOperationAllowed: typeof import("../src/mcp/policy.js")["isMcpOperationAllowed"]
 let isAgentApiKeyConnection: typeof import("../src/routes/org/mcp-connections.js")["isAgentApiKeyConnection"]
+let isAgentOAuthClientConnection: typeof import("../src/routes/org/mcp-connections.js")["isAgentOAuthClientConnection"]
 let document: OpenApiDocument
 
 function findOperation(operationId: string) {
@@ -35,7 +36,9 @@ function allowed(operationId: string) {
 beforeAll(async () => {
   seedRequiredEnv()
   isMcpOperationAllowed = (await import("../src/mcp/policy.js")).isMcpOperationAllowed
-  isAgentApiKeyConnection = (await import("../src/routes/org/mcp-connections.js")).isAgentApiKeyConnection
+  const mcpConnections = await import("../src/routes/org/mcp-connections.js")
+  isAgentApiKeyConnection = mcpConnections.isAgentApiKeyConnection
+  isAgentOAuthClientConnection = mcpConnections.isAgentOAuthClientConnection
   const app = (await import("../src/app.js")).default
   const response = await app.request("http://127.0.0.1:8790/openapi.json")
   document = await response.json()
@@ -67,5 +70,12 @@ describe("agent-configurable org connections policy", () => {
     expect(isAgentApiKeyConnection({ authType: "none", sessionId: "mcp_internal" })).toBe(false)
     expect(isAgentApiKeyConnection({ authType: "apikey", sessionId: "normal_session" })).toBe(false)
     expect(isAgentApiKeyConnection({ authType: "apikey", sessionId: null })).toBe(false)
+  })
+
+  test("OAuth clients are blocked only for the internal agent principal", () => {
+    expect(isAgentOAuthClientConnection({ oauthClient: { clientId: "client" }, sessionId: "mcp_internal" })).toBe(true)
+    expect(isAgentOAuthClientConnection({ oauthClient: { clientId: "client" }, sessionId: "normal_session" })).toBe(false)
+    expect(isAgentOAuthClientConnection({ sessionId: "mcp_internal" })).toBe(false)
+    expect(isAgentOAuthClientConnection({ oauthClient: null, sessionId: "mcp_internal" })).toBe(false)
   })
 })

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -32,6 +32,14 @@ export type ExternalMcpPreset = {
   description: string;
   url: string;
   authType: ExternalMcpAuthType;
+  requiresOAuthClient?: boolean;
+};
+
+export type CreatedMcpConnection = ExternalMcpConnection & {
+  links?: {
+    yourConnections?: string;
+    oauthCallback?: string;
+  };
 };
 
 export const mcpConnectionQueryKeys = {
@@ -85,6 +93,10 @@ export type CreateMcpConnectionInput = {
   authType: ExternalMcpAuthType;
   credentialMode: ExternalMcpCredentialMode;
   apiKey?: string;
+  oauthClient?: {
+    clientId: string;
+    clientSecret?: string;
+  };
   access: McpConnectionAccessInput;
 };
 
@@ -93,8 +105,8 @@ export function useCreateMcpConnection() {
   const { orgId, runReauthableAction } = useOrgDashboard();
 
   return useMutation({
-    mutationFn: async (input: CreateMcpConnectionInput): Promise<ExternalMcpConnection> => {
-      let created: ExternalMcpConnection | null = null;
+    mutationFn: async (input: CreateMcpConnectionInput): Promise<CreatedMcpConnection> => {
+      let created: CreatedMcpConnection | null = null;
       await runReauthableAction("create-mcp-connection", async () => {
         const { response, payload } = await requestJson(
           "/v1/mcp-connections",
@@ -104,7 +116,7 @@ export function useCreateMcpConnection() {
         if (!response.ok) {
           throw getRequestError(payload, response, `Failed to add MCP connection (${response.status}).`);
         }
-        created = payload as ExternalMcpConnection;
+        created = payload as CreatedMcpConnection;
       });
       if (!created) throw new Error("Create MCP connection response was incomplete.");
       return created;

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -493,39 +493,32 @@ function AddConnectionDialog({
     return null;
   }
 
-  if (oauthCallback) {
-    return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={onClose}>
-        <div
-          className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
-          onClick={(event) => event.stopPropagation()}
-        >
-          <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">Almost done — add this redirect URL to your app:</h2>
-          <p className="mt-2 text-[13px] leading-6 text-gray-600">
-            Copy this into the OAuth redirect URLs for your pre-registered app before teammates connect.
-          </p>
-          <div className="mt-4 rounded-2xl border border-gray-200 bg-gray-50 p-3">
-            <p className="break-all font-mono text-[12px] leading-5 text-gray-800">{oauthCallback}</p>
-          </div>
-          <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-            <DenButton variant="secondary" onClick={copyOAuthCallback}>
-              {copiedCallback ? "Copied" : "Copy"}
-            </DenButton>
-            <DenButton variant="primary" onClick={onClose}>
-              Done
-            </DenButton>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={onClose}>
       <div
         className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
         onClick={(event) => event.stopPropagation()}
       >
+        {oauthCallback ? (
+          <>
+            <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">Almost done — add this redirect URL to your app:</h2>
+            <p className="mt-2 text-[13px] leading-6 text-gray-600">
+              Copy this into the OAuth redirect URLs for your pre-registered app before teammates connect.
+            </p>
+            <div className="mt-4 rounded-2xl border border-gray-200 bg-gray-50 p-3">
+              <p className="break-all font-mono text-[12px] leading-5 text-gray-800">{oauthCallback}</p>
+            </div>
+            <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <DenButton variant="secondary" onClick={copyOAuthCallback}>
+                {copiedCallback ? "Copied" : "Copy"}
+              </DenButton>
+              <DenButton variant="primary" onClick={onClose}>
+                Done
+              </DenButton>
+            </div>
+          </>
+        ) : (
+          <>
         <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
           {preset ? `Add ${preset.displayName}` : "Add a custom MCP server"}
         </h2>
@@ -609,7 +602,7 @@ function AddConnectionDialog({
                     type="password"
                     value={oauthClientSecret}
                     onChange={(event) => setOAuthClientSecret(event.target.value)}
-                    placeholder="Slack client secret"
+                    placeholder="Client secret"
                   />
                 </div>
               </div>
@@ -725,6 +718,8 @@ function AddConnectionDialog({
             Add connection
           </DenButton>
         </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -8,6 +8,7 @@ import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-templ
 import { IntegrationIcon } from "./integration-icon";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
+  type CreatedMcpConnection,
   type CreateMcpConnectionInput,
   type ExternalMcpAuthType,
   type ExternalMcpConnection,
@@ -80,8 +81,11 @@ export function McpConnectionsScreen() {
     }
   }
 
-  async function handleCreate(input: CreateMcpConnectionInput) {
+  async function handleCreate(input: CreateMcpConnectionInput): Promise<CreatedMcpConnection> {
     const created = await createConnection.mutateAsync(input);
+    if (input.oauthClient) {
+      return created;
+    }
     setFormOpen(false);
     setFormPreset(null);
     // Shared-credential OAuth: the admin authorizes the org's single account
@@ -90,6 +94,7 @@ export function McpConnectionsScreen() {
     if (input.authType === "oauth" && input.credentialMode === "shared") {
       await handleConnectOAuth(created.id);
     }
+    return created;
   }
 
   return (
@@ -404,7 +409,7 @@ function AddConnectionDialog({
   submitting: boolean;
   error: unknown;
   onClose: () => void;
-  onSubmit: (input: CreateMcpConnectionInput) => void;
+  onSubmit: (input: CreateMcpConnectionInput) => Promise<CreatedMcpConnection>;
 }) {
   const { orgContext } = useOrgDashboard();
   const [name, setName] = useState(preset?.displayName ?? "");
@@ -412,6 +417,11 @@ function AddConnectionDialog({
   const [authType, setAuthType] = useState<ExternalMcpAuthType>(preset?.authType ?? "oauth");
   const [credentialMode, setCredentialMode] = useState<ExternalMcpCredentialMode>("per_member");
   const [apiKey, setApiKey] = useState("");
+  const [showOAuthClient, setShowOAuthClient] = useState(Boolean(preset?.requiresOAuthClient));
+  const [oauthClientId, setOAuthClientId] = useState("");
+  const [oauthClientSecret, setOAuthClientSecret] = useState("");
+  const [oauthCallback, setOAuthCallback] = useState<string | null>(null);
+  const [copiedCallback, setCopiedCallback] = useState(false);
   const [accessMode, setAccessMode] = useState<"everyone" | "teams" | "people">("everyone");
   const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
   const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
@@ -423,6 +433,11 @@ function AddConnectionDialog({
     setAuthType(preset?.authType ?? "oauth");
     setCredentialMode("per_member");
     setApiKey("");
+    setShowOAuthClient(Boolean(preset?.requiresOAuthClient));
+    setOAuthClientId("");
+    setOAuthClientSecret("");
+    setOAuthCallback(null);
+    setCopiedCallback(false);
     setAccessMode("everyone");
     setSelectedTeamIds([]);
     setSelectedMemberIds([]);
@@ -438,14 +453,72 @@ function AddConnectionDialog({
     return list.includes(id) ? list.filter((entry) => entry !== id) : [...list, id];
   }
 
-  if (!open) {
-    return null;
-  }
-
+  const showOAuthClientFields = authType === "oauth" && (Boolean(preset?.requiresOAuthClient) || showOAuthClient);
+  const oauthClientRequired = authType === "oauth" && Boolean(preset?.requiresOAuthClient);
   const access: McpConnectionAccessInput = accessMode === "everyone"
     ? { orgWide: true, memberIds: [], teamIds: [] }
     : { orgWide: false, memberIds: accessMode === "people" ? selectedMemberIds : [], teamIds: accessMode === "teams" ? selectedTeamIds : [] };
   const accessIncomplete = accessMode === "teams" ? selectedTeamIds.length === 0 : accessMode === "people" ? selectedMemberIds.length === 0 : false;
+
+  async function submit() {
+    const trimmedClientId = oauthClientId.trim();
+    const trimmedClientSecret = oauthClientSecret.trim();
+    const input: CreateMcpConnectionInput = {
+      name: name.trim(),
+      url: url.trim(),
+      authType,
+      credentialMode: authType === "oauth" ? credentialMode : "shared",
+      apiKey: authType === "apikey" ? apiKey.trim() : undefined,
+      oauthClient: showOAuthClientFields && trimmedClientId
+        ? {
+          clientId: trimmedClientId,
+          ...(trimmedClientSecret ? { clientSecret: trimmedClientSecret } : {}),
+        }
+        : undefined,
+      access,
+    };
+    const created = await onSubmit(input);
+    if (input.oauthClient && created.links?.oauthCallback) {
+      setOAuthCallback(created.links.oauthCallback);
+      setCopiedCallback(false);
+    }
+  }
+
+  function copyOAuthCallback() {
+    if (!oauthCallback) return;
+    void navigator.clipboard.writeText(oauthCallback).then(() => setCopiedCallback(true));
+  }
+
+  if (!open) {
+    return null;
+  }
+
+  if (oauthCallback) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={onClose}>
+        <div
+          className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">Almost done — add this redirect URL to your app:</h2>
+          <p className="mt-2 text-[13px] leading-6 text-gray-600">
+            Copy this into the OAuth redirect URLs for your pre-registered app before teammates connect.
+          </p>
+          <div className="mt-4 rounded-2xl border border-gray-200 bg-gray-50 p-3">
+            <p className="break-all font-mono text-[12px] leading-5 text-gray-800">{oauthCallback}</p>
+          </div>
+          <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <DenButton variant="secondary" onClick={copyOAuthCallback}>
+              {copiedCallback ? "Copied" : "Copy"}
+            </DenButton>
+            <DenButton variant="primary" onClick={onClose}>
+              Done
+            </DenButton>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={onClose}>
@@ -482,7 +555,10 @@ function AddConnectionDialog({
                   <button
                     key={option}
                     type="button"
-                    onClick={() => setAuthType(option)}
+                    onClick={() => {
+                      setAuthType(option);
+                      if (option !== "oauth") setShowOAuthClient(false);
+                    }}
                     className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition ${
                       authType === option
                         ? "border-gray-900 bg-gray-900 text-white"
@@ -499,6 +575,44 @@ function AddConnectionDialog({
             <div>
               <label className="mb-1.5 block text-[12px] font-medium text-gray-700">API key</label>
               <DenInput type="password" value={apiKey} onChange={(event) => setApiKey(event.target.value)} placeholder="sk-..." />
+            </div>
+          ) : null}
+
+          {authType === "oauth" && !preset?.requiresOAuthClient && !showOAuthClient ? (
+            <button
+              type="button"
+              onClick={() => setShowOAuthClient(true)}
+              className="text-left text-[12px] font-medium text-gray-500 underline decoration-gray-300 underline-offset-4 transition hover:text-gray-900"
+            >
+              This server needs a pre-registered OAuth app
+            </button>
+          ) : null}
+
+          {showOAuthClientFields ? (
+            <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
+              <p className="text-[13px] font-semibold text-gray-900">OAuth app</p>
+              <p className="mt-1 text-[12px] leading-5 text-gray-500">
+                Create an app for your workspace, then paste its OAuth client here. Each person connects their own account with it — sign-ins stay in your org&apos;s cloud.
+              </p>
+              <div className="mt-3 space-y-3">
+                <div>
+                  <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client ID</label>
+                  <DenInput
+                    value={oauthClientId}
+                    onChange={(event) => setOAuthClientId(event.target.value)}
+                    placeholder="1234567890.1234567890123"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client secret</label>
+                  <DenInput
+                    type="password"
+                    value={oauthClientSecret}
+                    onChange={(event) => setOAuthClientSecret(event.target.value)}
+                    placeholder="Slack client secret"
+                  />
+                </div>
+              </div>
             </div>
           ) : null}
 
@@ -605,17 +719,8 @@ function AddConnectionDialog({
           <DenButton
             variant="primary"
             loading={submitting}
-            disabled={!name.trim() || !url.trim() || (authType === "apikey" && !apiKey.trim()) || accessIncomplete}
-            onClick={() =>
-              onSubmit({
-                name: name.trim(),
-                url: url.trim(),
-                authType,
-                credentialMode: authType === "oauth" ? credentialMode : "shared",
-                apiKey: authType === "apikey" ? apiKey.trim() : undefined,
-                access,
-              })
-            }
+            disabled={!name.trim() || !url.trim() || (authType === "apikey" && !apiKey.trim()) || (oauthClientRequired && !oauthClientId.trim()) || accessIncomplete}
+            onClick={() => void submit()}
           >
             Add connection
           </DenButton>

--- a/evals/flows/slack-org-connection.flow.mjs
+++ b/evals/flows/slack-org-connection.flow.mjs
@@ -1,0 +1,333 @@
+/**
+ * Slack-style org MCP connection: Slack's real MCP server requires a
+ * pre-registered OAuth app because it does not support dynamic client
+ * registration. CI cannot complete real Slack OAuth, so this flow uses a
+ * DCR-less mock OAuth+MCP server as Slack's stand-in while still proving the
+ * real Cloud UX and the exact no-DCR OAuth path Slack needs.
+ */
+
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("slack-org-connection");
+
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MOCK_SERVER_URL = (process.env.MOCK_DCRLESS_MCP_URL ?? "http://127.0.0.1:3979").trim().replace(/\/+$/, "");
+const MOCK_CLIENT_ID = process.env.MOCK_CLIENT_ID || "mock-preregistered-client";
+const MOCK_CLIENT_SECRET = process.env.MOCK_CLIENT_SECRET || "mock-preregistered-secret";
+const RUN_TAG = Date.now();
+const CONNECTION_NAME = `slack-style-${RUN_TAG}`;
+
+const state = {
+  adminSession: null,
+  connectionId: null,
+  callbackUrl: null,
+};
+
+async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+async function signIn(email, password) {
+  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  if (!response.ok) return null;
+  return body.token;
+}
+
+async function signInViaBrowser(ctx, email, password) {
+  // Land on the den-web origin first so the relative sign-out fetch below
+  // actually reaches den-web (a leftover session would otherwise bounce the
+  // root URL straight to /dashboard with no sign-in card).
+  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
+  await ctx.eval(`fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`, { awaitPromise: true });
+  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
+  await ctx.waitFor(
+    "Boolean(document.querySelector('input[type=\"email\"]')) && Boolean(document.querySelector('input[type=\"password\"]'))",
+    { timeoutMs: 30_000, label: "email + password fields" },
+  );
+  await ctx.fill('input[type="email"]', email);
+  await ctx.fill('input[type="password"]', password);
+  const submitted = await ctx.eval(`(() => {
+    const button = document.querySelector('button[type="submit"]');
+    if (!button) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(submitted, "No submit button found on the sign-in card.");
+  await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
+}
+
+async function openConnections(ctx) {
+  await ctx.waitFor(
+    `(() => {
+      if (window.location.pathname.endsWith('/mcp-connections')) return true;
+      const link = [...document.querySelectorAll('nav a')].find((a) => a.getAttribute('href')?.endsWith('/mcp-connections'));
+      if (link) {
+        link.click();
+        return false;
+      }
+      const group = [...document.querySelectorAll('nav a, nav button')].find((el) => (el.textContent ?? '').trim().startsWith('Extensions'));
+      group?.click();
+      return false;
+    })()`,
+    { timeoutMs: 30_000, label: "Extensions -> Connections nav" },
+  );
+  await ctx.waitFor("window.location.pathname.endsWith('/mcp-connections')", { timeoutMs: 20_000, label: "Connections route" });
+}
+
+async function openYourConnections(ctx) {
+  await ctx.waitFor(
+    `(() => {
+      if (window.location.pathname.endsWith('/your-connections')) return true;
+      const link = [...document.querySelectorAll('a')].find((a) => a.getAttribute('href')?.endsWith('/your-connections'));
+      if (!link) return false;
+      link.click();
+      return false;
+    })()`,
+    { timeoutMs: 30_000, label: "Your Connections nav" },
+  );
+  await ctx.waitFor("window.location.pathname.endsWith('/your-connections')", { timeoutMs: 20_000, label: "Your Connections route" });
+}
+
+function clickSlackCardScript() {
+  return `(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => {
+      const text = entry.textContent ?? '';
+      return text.includes('Slack') && text.includes('Tap to add');
+    });
+    button?.scrollIntoView({ block: 'center' });
+    button?.click();
+    return Boolean(button);
+  })()`;
+}
+
+function callbackUrlScript() {
+  return `(() => {
+    const elements = [...document.querySelectorAll('*')];
+    return elements.find((entry) => (entry.textContent ?? '').includes('/connect/callback'))?.textContent?.trim() ?? null;
+  })()`;
+}
+
+function clickConnectionButtonScript() {
+  return `(() => {
+    const leaves = [...document.querySelectorAll('*')].filter((el) => el.children.length === 0 && (el.textContent ?? '').trim() === ${JSON.stringify(CONNECTION_NAME)});
+    for (const leaf of leaves) {
+      let el = leaf;
+      for (let i = 0; i < 5 && el; i++) {
+        const text = el.textContent ?? '';
+        const button = [...el.querySelectorAll('button')].find((candidate) => (candidate.textContent ?? '').trim() === 'Connect');
+        if (text.includes('Connect your account') && button) {
+          el.scrollIntoView({ block: 'center' });
+          button.click();
+          return true;
+        }
+        el = el.parentElement;
+      }
+    }
+    return false;
+  })()`;
+}
+
+function rowConnectedAsYouScript() {
+  return `(() => {
+    const leaves = [...document.querySelectorAll('*')].filter((el) => el.children.length === 0 && (el.textContent ?? '').trim() === ${JSON.stringify(CONNECTION_NAME)});
+    return leaves.some((leaf) => {
+      let el = leaf;
+      for (let i = 0; i < 5 && el; i++) {
+        if ((el.textContent ?? '').includes('Connected as you')) {
+          el.scrollIntoView({ block: 'center' });
+          return true;
+        }
+        el = el.parentElement;
+      }
+      return false;
+    });
+  })()`;
+}
+
+export default {
+  id: "slack-org-connection",
+  title: "Slack-style Cloud Connection uses a pre-registered OAuth client instead of DCR",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  spec: "evals/org-mcp-connections-ux.md",
+  steps: [
+    {
+      name: "Setup: DCR-less mock is healthy, admin signs in, and leftover slack-style connections are removed",
+      run: async (ctx) => {
+        const health = await fetch(`${MOCK_SERVER_URL}/health`).catch(() => null);
+        ctx.assert(Boolean(health?.ok), `DCR-less mock OAuth+MCP server not reachable at ${MOCK_SERVER_URL}.`);
+        const healthBody = await health.json();
+        ctx.assert(healthBody.disableDcr === true, `Mock server at ${MOCK_SERVER_URL} must run with DISABLE_DCR=1.`);
+        const metadata = await fetch(`${MOCK_SERVER_URL}/.well-known/oauth-authorization-server`).then((response) => response.json());
+        ctx.assert(!("registration_endpoint" in metadata), "DCR-less mock metadata unexpectedly advertised registration_endpoint.");
+
+        state.adminSession = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+        ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+
+        const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+          headers: { authorization: `Bearer ${state.adminSession}` },
+        });
+        ctx.assert(existing.response.ok, `Listing manageable connections failed: ${existing.response.status}`);
+        for (const connection of existing.body.connections ?? []) {
+          if (connection.name.startsWith("slack-style-")) {
+            const removed = await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+              method: "DELETE",
+              headers: { authorization: `Bearer ${state.adminSession}` },
+            });
+            ctx.assert(removed.response.ok, `Cleanup delete failed for leftover ${connection.id}.`);
+          }
+        }
+      },
+    },
+    {
+      name: "Admin opens Extensions -> Connections and sees Slack quick-add",
+      run: async (ctx) => {
+        await ctx.prove("The real Slack preset is visible in Cloud Connections quick-add", {
+          voiceover: vo[0],
+          action: async () => {
+            await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+            await openConnections(ctx);
+          },
+          assert: async () => {
+            // The section heading is CSS-uppercased ("QUICK ADD" in innerText),
+            // so anchor on the Slack card itself.
+            await ctx.waitForText("Slack", { timeoutMs: 20_000 });
+            await ctx.expectText("Tap to add");
+          },
+          screenshot: {
+            name: "slack-quick-add-card",
+            claim: "Slack is a first-class quick-add preset on the Cloud Connections screen.",
+            requireText: ["Slack", "Tap to add"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Admin opens Add Slack and confirms the OAuth app fields, then cancels before real Slack OAuth",
+      run: async (ctx) => {
+        await ctx.prove("The Slack preset asks for a pre-registered OAuth app before anyone connects", {
+          voiceover: vo[1],
+          action: async () => {
+            const clicked = await ctx.eval(clickSlackCardScript());
+            ctx.assert(clicked, "Slack quick-add card with Tap to add was not found.");
+            await ctx.waitForText("Add Slack", { timeoutMs: 10_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Client ID");
+            await ctx.expectText("Client secret");
+            await ctx.expectText("OAuth app");
+          },
+          screenshot: {
+            name: "add-slack-oauth-app-fields",
+            claim: "The Add Slack dialog makes the pre-registered OAuth app requirement explicit.",
+            requireText: ["Add Slack", "Client ID", "Client secret"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+        await ctx.clickText("Cancel", { timeoutMs: 10_000 });
+      },
+    },
+    {
+      name: "Admin adds a Slack-style custom server and receives the redirect URL to whitelist",
+      run: async (ctx) => {
+        await ctx.prove("A DCR-less custom server accepts a pre-registered client and hands back the exact redirect URL", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.clickText("Add Custom", { timeoutMs: 20_000 });
+            await ctx.waitFor("Boolean(document.querySelector('input[placeholder=\"notion\"]'))", { timeoutMs: 10_000, label: "Add Custom dialog" });
+            await ctx.fill('input[placeholder="notion"]', CONNECTION_NAME);
+            await ctx.fill('input[placeholder="https://mcp.example.com/mcp"]', `${MOCK_SERVER_URL}/mcp`);
+            await ctx.clickText("This server needs a pre-registered OAuth app", { timeoutMs: 10_000 });
+            await ctx.fill('input[placeholder="1234567890.1234567890123"]', MOCK_CLIENT_ID);
+            await ctx.fill('input[placeholder="Slack client secret"]', MOCK_CLIENT_SECRET);
+            await ctx.clickText("Add connection", { timeoutMs: 15_000 });
+          },
+          assert: async () => {
+            await ctx.waitForText("Almost done", { timeoutMs: 20_000 });
+            await ctx.expectText("redirect URL");
+            await ctx.expectText("/connect/callback");
+            state.callbackUrl = await ctx.eval(callbackUrlScript());
+            ctx.assert(Boolean(state.callbackUrl), "The redirect URL handoff did not render a callback URL.");
+            ctx.assert(state.callbackUrl.includes("/v1/mcp-connections/"), `Callback URL did not include the connection route: ${state.callbackUrl}`);
+
+            const list = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+              headers: { authorization: `Bearer ${state.adminSession}` },
+            });
+            ctx.assert(list.response.ok, `Listing manageable connections failed: ${list.response.status}`);
+            const connection = (list.body.connections ?? []).find((entry) => entry.name === CONNECTION_NAME);
+            ctx.assert(Boolean(connection), "Created Slack-style connection not found via API.");
+            state.connectionId = connection.id;
+          },
+          screenshot: {
+            name: "slack-style-redirect-url-handoff",
+            claim: "After create, OpenWork shows the exact redirect URL the admin must whitelist in the app.",
+            requireText: ["redirect URL", "/connect/callback"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+        await ctx.clickText("Done", { timeoutMs: 10_000 });
+      },
+    },
+    {
+      name: "Admin connects from Your Connections; popup succeeds and the mock proves /register was never called",
+      run: async (ctx) => {
+        await ctx.prove("The member connection completes OAuth with the pre-registered client and no dynamic registration", {
+          voiceover: vo[3],
+          action: async () => {
+            await openYourConnections(ctx);
+            await ctx.waitForText(CONNECTION_NAME, { timeoutMs: 20_000 });
+            const clicked = await ctx.eval(clickConnectionButtonScript());
+            ctx.assert(clicked, `No scoped Connect button found for ${CONNECTION_NAME}.`);
+            await ctx.switchToNewTab({ timeoutMs: 20_000, label: "OAuth popup" });
+            await ctx.waitForText("Connected", { timeoutMs: 30_000 });
+            ctx.switchBack();
+          },
+          assert: async () => {
+            await ctx.waitFor(rowConnectedAsYouScript(), { timeoutMs: 60_000, label: `${CONNECTION_NAME} shows Connected as you` });
+            const requestLog = await fetch(`${MOCK_SERVER_URL}/requests`).then((response) => response.json());
+            const registerCall = (requestLog.requests ?? []).find((entry) => entry.path === "/register");
+            ctx.assert(!registerCall, `The DCR-less Slack-style flow unexpectedly called /register: ${JSON.stringify(registerCall)}`);
+          },
+          screenshot: {
+            name: "slack-style-connected-without-dcr",
+            claim: "Your Connections shows the account connected, while the mock request log proves no dynamic registration happened.",
+            requireText: [CONNECTION_NAME, "Connected as you"],
+            rejectText: ["Something went wrong", "Connection failed"],
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup: delete the Slack-style connection",
+      run: async (ctx) => {
+        if (!state.connectionId) return;
+        const removed = await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${state.adminSession}` },
+        });
+        ctx.assert(removed.response.ok, `Cleanup delete failed for ${state.connectionId}.`);
+      },
+    },
+  ],
+};

--- a/evals/flows/slack-org-connection.flow.mjs
+++ b/evals/flows/slack-org-connection.flow.mjs
@@ -7,11 +7,10 @@
  */
 
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, openAdminConnections as openConnections, openYourConnections, signInApi as signIn, signInViaBrowser } from "./lib/den-web.mjs";
 
 const vo = await loadVoiceoverParagraphs("slack-org-connection");
 
-const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
-const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
 const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
 const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
 const MOCK_SERVER_URL = (process.env.MOCK_DCRLESS_MCP_URL ?? "http://127.0.0.1:3979").trim().replace(/\/+$/, "");
@@ -25,87 +24,6 @@ const state = {
   connectionId: null,
   callbackUrl: null,
 };
-
-async function denApiFetch(path, options = {}) {
-  const response = await fetch(`${DEN_API_URL}${path}`, {
-    ...options,
-    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
-  });
-  const text = await response.text();
-  let body;
-  try {
-    body = JSON.parse(text);
-  } catch {
-    body = text;
-  }
-  return { response, body };
-}
-
-async function signIn(email, password) {
-  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
-    method: "POST",
-    body: JSON.stringify({ email, password }),
-  });
-  if (!response.ok) return null;
-  return body.token;
-}
-
-async function signInViaBrowser(ctx, email, password) {
-  // Land on the den-web origin first so the relative sign-out fetch below
-  // actually reaches den-web (a leftover session would otherwise bounce the
-  // root URL straight to /dashboard with no sign-in card).
-  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
-  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
-  await ctx.eval(`fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`, { awaitPromise: true });
-  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(DEN_WEB_URL)}; return true; })()`);
-  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
-  await ctx.waitFor(
-    "Boolean(document.querySelector('input[type=\"email\"]')) && Boolean(document.querySelector('input[type=\"password\"]'))",
-    { timeoutMs: 30_000, label: "email + password fields" },
-  );
-  await ctx.fill('input[type="email"]', email);
-  await ctx.fill('input[type="password"]', password);
-  const submitted = await ctx.eval(`(() => {
-    const button = document.querySelector('button[type="submit"]');
-    if (!button) return false;
-    button.click();
-    return true;
-  })()`);
-  ctx.assert(submitted, "No submit button found on the sign-in card.");
-  await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
-}
-
-async function openConnections(ctx) {
-  await ctx.waitFor(
-    `(() => {
-      if (window.location.pathname.endsWith('/mcp-connections')) return true;
-      const link = [...document.querySelectorAll('nav a')].find((a) => a.getAttribute('href')?.endsWith('/mcp-connections'));
-      if (link) {
-        link.click();
-        return false;
-      }
-      const group = [...document.querySelectorAll('nav a, nav button')].find((el) => (el.textContent ?? '').trim().startsWith('Extensions'));
-      group?.click();
-      return false;
-    })()`,
-    { timeoutMs: 30_000, label: "Extensions -> Connections nav" },
-  );
-  await ctx.waitFor("window.location.pathname.endsWith('/mcp-connections')", { timeoutMs: 20_000, label: "Connections route" });
-}
-
-async function openYourConnections(ctx) {
-  await ctx.waitFor(
-    `(() => {
-      if (window.location.pathname.endsWith('/your-connections')) return true;
-      const link = [...document.querySelectorAll('a')].find((a) => a.getAttribute('href')?.endsWith('/your-connections'));
-      if (!link) return false;
-      link.click();
-      return false;
-    })()`,
-    { timeoutMs: 30_000, label: "Your Connections nav" },
-  );
-  await ctx.waitFor("window.location.pathname.endsWith('/your-connections')", { timeoutMs: 20_000, label: "Your Connections route" });
-}
 
 function clickSlackCardScript() {
   return `(() => {
@@ -260,7 +178,7 @@ export default {
             await ctx.fill('input[placeholder="https://mcp.example.com/mcp"]', `${MOCK_SERVER_URL}/mcp`);
             await ctx.clickText("This server needs a pre-registered OAuth app", { timeoutMs: 10_000 });
             await ctx.fill('input[placeholder="1234567890.1234567890123"]', MOCK_CLIENT_ID);
-            await ctx.fill('input[placeholder="Slack client secret"]', MOCK_CLIENT_SECRET);
+            await ctx.fill('input[placeholder="Client secret"]', MOCK_CLIENT_SECRET);
             await ctx.clickText("Add connection", { timeoutMs: 15_000 });
           },
           assert: async () => {

--- a/evals/voiceovers/slack-org-connection.md
+++ b/evals/voiceovers/slack-org-connection.md
@@ -1,0 +1,7 @@
+1. Slack now appears as a real OpenWork Cloud Connections preset, so an admin can find it in the same quick-add grid as Notion and Linear instead of hand-copying the server URL.
+
+2. Because Slack's MCP server does not support automatic OAuth app registration, the Slack dialog asks for a pre-registered OAuth app up front. We stop before real Slack OAuth in CI, but this is the exact admin handoff Slack requires.
+
+3. For the end-to-end proof, a DCR-less stand-in server plays Slack's role: the admin pastes a pre-registered client, and OpenWork returns the exact redirect URL to whitelist in that app.
+
+4. When the admin connects their own account from Your Connections, OAuth completes without any dynamic client registration call, proving OpenWork used the org's pre-registered client path.

--- a/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
+++ b/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
@@ -39,6 +39,20 @@ On `Your Connections`, an unconnected One org account connection shows
 `Waiting for an admin to connect` to members. Workspace owners and admins get a
 `Connect` button on that row so they can finish the org account sign-in there.
 
+## Slack
+
+Slack's MCP server requires a pre-registered Slack OAuth app.
+
+1. Create or open a Slack app in [Slack API apps](https://api.slack.com/apps).
+2. In OpenWork Cloud, add the Slack connection and paste the app's client ID
+   and client secret.
+3. Copy the OAuth redirect URL OpenWork shows after creating the connection,
+   then add it to the Slack app's `OAuth & Permissions` redirect URLs.
+4. Members open `Your Connections` and connect their own Slack account.
+
+For the local desktop-only setup, see
+[Connect Slack MCP](/start-here/connect-your-stack/connect-slack-mcp).
+
 ## What members see in the desktop app
 
 Granted members find the connection in `Settings -> Extensions`, in the same

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -6,6 +6,9 @@ const host = process.env.HOST || "127.0.0.1";
 const port = Number(process.env.PORT || 3978);
 const issuer = process.env.ISSUER || `http://${host}:${port}`;
 const autoApprove = process.env.AUTO_APPROVE !== "0";
+const disableDcr = process.env.DISABLE_DCR === "1";
+const mockClientId = process.env.MOCK_CLIENT_ID || "mock-preregistered-client";
+const mockClientSecret = process.env.MOCK_CLIENT_SECRET || "mock-preregistered-secret";
 
 const clients = new Map();
 const codes = new Map();
@@ -81,13 +84,53 @@ function authorizationServerMetadata() {
     issuer,
     authorization_endpoint: `${issuer}/authorize`,
     token_endpoint: `${issuer}/token`,
-    registration_endpoint: `${issuer}/register`,
+    ...(disableDcr ? {} : { registration_endpoint: `${issuer}/register` }),
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     token_endpoint_auth_methods_supported: ["none", "client_secret_post", "client_secret_basic"],
     code_challenge_methods_supported: ["S256", "plain"],
     scopes_supported: ["mcp:read", "mcp:write"],
   };
+}
+
+function basicClient(req) {
+  const header = req.headers.authorization || "";
+  const match = header.match(/^Basic\s+(.+)$/i);
+  if (!match) return null;
+  const decoded = Buffer.from(match[1], "base64").toString("utf8");
+  const separator = decoded.indexOf(":");
+  if (separator === -1) return { clientId: decoded, clientSecret: "" };
+  return {
+    clientId: decoded.slice(0, separator),
+    clientSecret: decoded.slice(separator + 1),
+  };
+}
+
+function rejectInvalidPreregisteredClient(res) {
+  json(res, 400, { error: "invalid_client" });
+}
+
+function requirePreregisteredAuthorizeClient(res, params) {
+  if (!disableDcr) return true;
+  if (params.get("client_id") === mockClientId) return true;
+  rejectInvalidPreregisteredClient(res);
+  return false;
+}
+
+function requirePreregisteredTokenClient(req, res, form, grant) {
+  if (!disableDcr) return true;
+  const basic = basicClient(req);
+  const clientId = basic?.clientId || form.client_id || grant?.clientId || "";
+  if (clientId !== mockClientId) {
+    rejectInvalidPreregisteredClient(res);
+    return false;
+  }
+  const suppliedSecret = basic?.clientSecret ?? form.client_secret;
+  if (suppliedSecret !== undefined && suppliedSecret !== mockClientSecret) {
+    rejectInvalidPreregisteredClient(res);
+    return false;
+  }
+  return true;
 }
 
 function redirectWithCode(res, params) {
@@ -115,6 +158,9 @@ function redirectWithCode(res, params) {
 }
 
 function authorize(req, res, url) {
+  if (!requirePreregisteredAuthorizeClient(res, url.searchParams)) {
+    return;
+  }
   if (autoApprove) {
     redirectWithCode(res, url.searchParams);
     return;
@@ -136,6 +182,10 @@ function authorize(req, res, url) {
 }
 
 async function registerClient(req, res) {
+  if (disableDcr) {
+    json(res, 404, { error: "not_found" });
+    return;
+  }
   const body = await readJson(req).catch(() => ({}));
   const clientId = `mock-client-${randomUUID()}`;
   const client = {
@@ -161,6 +211,9 @@ async function issueToken(req, res) {
       json(res, 400, { error: "invalid_grant" });
       return;
     }
+    if (!requirePreregisteredTokenClient(req, res, form, grant)) {
+      return;
+    }
     if (grant.codeChallenge) {
       const verifier = form.code_verifier || "";
       const expected =
@@ -172,6 +225,8 @@ async function issueToken(req, res) {
         return;
       }
     }
+  } else if (!requirePreregisteredTokenClient(req, res, form, null)) {
+    return;
   }
 
   if (form.code) codes.delete(form.code);
@@ -269,7 +324,7 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (url.pathname === "/health") {
-      json(res, 200, { ok: true, issuer, autoApprove, requests: requests.length });
+      json(res, 200, { ok: true, issuer, autoApprove, disableDcr, requests: requests.length });
       return;
     }
 


### PR DESCRIPTION
> Stacked on #2492 (admin connect on Your Connections + Individual/Org-account terminology). Review only the last commit; GitHub will retarget to `dev` when #2492 merges.

## What

Slack couldn't be offered as a cloud org connection: its MCP server (`https://mcp.slack.com/mcp`) doesn't support automatic client registration, and the cloud add-connection flow had no way to provide a pre-registered OAuth app (that only existed on the desktop's Advanced OAuth path). This brings the **Google Workspace pattern** to any such server:

- **Slack quick-add preset** on the Connections screen (`requiresOAuthClient` on presets).
- **Add dialog OAuth app fields**: Client ID + Client secret — required for Slack-like presets, opt-in ("This server needs a pre-registered OAuth app") for custom servers.
- **Server**: `POST /v1/mcp-connections` accepts optional `oauthClient`; it's stored as the connection's org OAuth client, which the MCP SDK already prefers over dynamic registration. Agent principals are refused (client secrets stay out of chat transcripts). The create response returns `links.oauthCallback` — the exact redirect URL to whitelist in the provider app.
- **Handoff UX**: right after create, the dialog shows "Almost done — add this redirect URL to your app:" with the URL and a Copy button. Then every member connects **their own** Slack from Your Connections ("Individual accounts", the default) — acts-as-you, with their permissions.
- **Mock server** (`scripts/mock-oauth-mcp-server.mjs`): `DISABLE_DCR=1`, `MOCK_CLIENT_ID`/`MOCK_CLIENT_SECRET`, and `GET /requests` introspection — so the no-DCR path is provable in CI. Default behavior unchanged.
- Docs: cloud Slack setup section in `shared-mcp-connections.mdx`.

## Tests / proof

- `pnpm --dir ee/apps/den-web exec tsc --noEmit` — passed; `pnpm --dir ee/apps/den-api exec tsc --noEmit` — passed.
- `pnpm --dir ee/apps/den-api exec bun test test/mcp-agent-config-policy.test.ts` — 5 pass (includes the new agent OAuth-client refusal).
- New coded flow `slack-org-connection` (voiceover-scripted) ran against a real local stack — **PASSED**, fraimz below. Honest framing: CI cannot complete real Slack OAuth, so a DCR-less stand-in server plays Slack's role while the flow proves the exact mechanism Slack needs: the Slack preset + OAuth-app dialog are the real UI; the OAuth run uses the pre-registered client, and the mock's request log proves **/register was never called**.
- Regression: `your-connections-admin-shared-connect`, `mcp-connections-cloud-oauth`, `mcp-connections-member-scoped` all re-ran **PASSED** after the dialog changes.

Repro:
```bash
pnpm dev:den:mysql && pnpm dev:den:api   # + pnpm dev:den:web (+ seed)
PORT=3978 AUTO_APPROVE=1 node scripts/mock-oauth-mcp-server.mjs
DISABLE_DCR=1 AUTO_APPROVE=1 PORT=3979 node scripts/mock-oauth-mcp-server.mjs
# Chrome with --remote-debugging-port=9333 --disable-popup-blocking
OPENWORK_EVAL_DEN_API_URL=http://127.0.0.1:8790 OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3005 \
  pnpm fraimz --flow slack-org-connection --cdp-url http://127.0.0.1:9333
```