### PR TITLE
perf(den): create plugin, components, sharing, and marketplace publish in one request

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
@@ -372,7 +372,7 @@ export const pluginArchEndpointContracts: Record<string, EndpointContract> = {
   },
   createPlugin: {
     audience: "admin",
-    description: "Create a private-by-default plugin.",
+    description: "Create a private-by-default plugin, optionally bundled with components, org-wide sharing, and marketplace publishing.",
     method: "POST",
     path: pluginArchRoutePaths.plugins,
     request: { body: pluginCreateSchema },

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -1,5 +1,6 @@
 import type { Context, Hono } from "hono"
 import { describeRoute } from "hono-openapi"
+import type { z } from "zod"
 import { queryValidator, jsonValidator, orgMemberRoute, paramValidator, resolveMemberTeamsMiddleware } from "../../../middleware/index.js"
 import { emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../../openapi.js"
 import type { OrgRouteVariables } from "../shared.js"
@@ -112,7 +113,7 @@ import {
   createConnectorMapping,
   createGithubConnectorAccount,
   createMarketplace,
-  createPlugin,
+  createPluginBundle,
   createResourceAccessGrant,
   createConnectorTarget,
   deleteConnectorMapping,
@@ -170,6 +171,7 @@ import {
 } from "./store.js"
 
 type OrgContext = Context<{ Variables: OrgRouteVariables }>
+type PluginCreateBody = z.infer<typeof pluginCreateSchema>
 
 function validRequestPart<T>(c: OrgContext, target: "json" | "param" | "query") {
   return (c.req as unknown as { valid: (part: typeof target) => unknown }).valid(target) as T
@@ -648,20 +650,34 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
     describeRoute({
       tags: ["Plugins"],
       summary: "Create plugin",
-      description: "Creates a new private plugin and grants the creator manager access.",
+      description: "Creates a plugin and can also create components, share org-wide, and publish to a marketplace in one request.",
       responses: {
         201: jsonResponse("Plugin created successfully.", pluginMutationResponseSchema),
         400: jsonResponse("The plugin creation request was invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to create plugins.", unauthorizedSchema),
         403: jsonResponse("The caller lacks permission to create plugins.", forbiddenSchema),
+        404: jsonResponse("The marketplace could not be found.", notFoundSchema),
       },
     }),
     async (c: OrgContext) => {
       try {
         const context = actorContext(c)
         await requirePluginArchCapability(context, "plugin.create")
-        const body = validJson<any>(c)
-        return c.json({ ok: true, item: await createPlugin({ context, description: body.description, name: body.name }) }, 201)
+        const body = validJson<PluginCreateBody>(c)
+        if ((body.components?.length ?? 0) > 0) {
+          await requirePluginArchCapability(context, "config_object.create")
+        }
+        return c.json({
+          ok: true,
+          item: await createPluginBundle({
+            components: body.components?.map((component) => ({ type: component.type, value: component.input })),
+            context,
+            description: body.description,
+            marketplaceId: body.marketplaceId,
+            name: body.name,
+            orgWide: body.orgWide,
+          }),
+        }, 201)
       } catch (error) {
         return routeErrorResponse(c, error)
       }

--- a/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
@@ -207,9 +207,17 @@ export const resourceAccessGrantWriteSchema = z.object({
   }
 })
 
+export const pluginCreateComponentSchema = z.object({
+  type: configObjectTypeSchema,
+  input: configObjectInputSchema,
+})
+
 export const pluginCreateSchema = z.object({
   name: z.string().trim().min(1).max(255),
   description: nullableStringSchema.optional(),
+  components: z.array(pluginCreateComponentSchema).max(100).optional(),
+  orgWide: z.boolean().optional(),
+  marketplaceId: marketplaceIdSchema.optional(),
 })
 
 export const pluginUpdateSchema = z.object({

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -1596,6 +1596,55 @@ export async function createPlugin(input: { context: PluginArchActorContext; des
   return serializePlugin(row, 0)
 }
 
+export async function createPluginBundle(input: {
+  components?: { type: ConfigObjectRow["objectType"]; value: ConfigObjectInput }[]
+  context: PluginArchActorContext
+  description?: string | null
+  marketplaceId?: MarketplaceId
+  name: string
+  orgWide?: boolean
+}) {
+  if (input.marketplaceId) {
+    // Validate the publish target before creating anything so a bad marketplace cannot leave an orphan plugin.
+    await ensureEditableMarketplace(input.context, input.marketplaceId)
+  }
+
+  const plugin = await createPlugin({ context: input.context, description: input.description, name: input.name })
+
+  for (const component of input.components ?? []) {
+    const configObject = await createConfigObject({
+      context: input.context,
+      objectType: component.type,
+      pluginIds: [plugin.id],
+      sourceMode: "cloud",
+      value: component.value,
+    })
+    if (input.orgWide) {
+      await createResourceAccessGrant({
+        context: input.context,
+        resourceId: configObject.id,
+        resourceKind: "config_object",
+        value: { orgWide: true, role: "viewer" },
+      })
+    }
+  }
+
+  if (input.orgWide) {
+    await createResourceAccessGrant({
+      context: input.context,
+      resourceId: plugin.id,
+      resourceKind: "plugin",
+      value: { orgWide: true, role: "viewer" },
+    })
+  }
+
+  if (input.marketplaceId) {
+    await attachPluginToMarketplace({ context: input.context, marketplaceId: input.marketplaceId, pluginId: plugin.id })
+  }
+
+  return getPluginDetail(input.context, plugin.id)
+}
+
 export async function updatePlugin(input: { context: PluginArchActorContext; description?: string | null; name?: string; pluginId: PluginId }) {
   const row = await ensureEditablePlugin(input.context, input.pluginId)
   const updatedAt = new Date()

--- a/ee/apps/den-api/test/plugin-system-create-bundle.test.ts
+++ b/ee/apps/den-api/test/plugin-system-create-bundle.test.ts
@@ -1,0 +1,328 @@
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import {
+  ConfigObjectAccessGrantTable,
+  ConfigObjectTable,
+  ConfigObjectVersionTable,
+  MarketplacePluginTable,
+  MarketplaceTable,
+  PluginAccessGrantTable,
+  PluginConfigObjectTable,
+  PluginTable,
+} from "@openwork-ee/den-db/schema"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import type { PluginArchActorContext } from "../src/routes/org/plugin-system/access.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+type TableName =
+  | "config_object"
+  | "config_object_access_grant"
+  | "config_object_version"
+  | "marketplace"
+  | "marketplace_plugin"
+  | "plugin"
+  | "plugin_access_grant"
+  | "plugin_config_object"
+
+type Row = Record<string, unknown>
+
+type QueryChain = {
+  from: (table: unknown) => QueryChain
+  innerJoin: () => QueryChain
+  limit: (count?: number) => Promise<Row[]>
+  orderBy: () => QueryChain
+  then: <TResult1 = Row[], TResult2 = never>(
+    onfulfilled?: ((value: Row[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ) => Promise<TResult1 | TResult2>
+  where: () => QueryChain
+}
+
+type WriteBuilder = {
+  set: (value: unknown) => { where: () => Promise<void> }
+  values: (value: unknown) => Promise<void>
+  where: () => Promise<void>
+}
+
+type TransactionStub = {
+  insert: (table: unknown) => WriteBuilder
+  select: () => QueryChain
+  update: (table: unknown) => WriteBuilder
+}
+
+type InsertRecord = {
+  table: TableName
+  value: Row
+}
+
+const tableNames: TableName[] = [
+  "config_object",
+  "config_object_access_grant",
+  "config_object_version",
+  "marketplace",
+  "marketplace_plugin",
+  "plugin",
+  "plugin_access_grant",
+  "plugin_config_object",
+]
+
+const rowsByTable: Record<TableName, Row[]> = {
+  config_object: [],
+  config_object_access_grant: [],
+  config_object_version: [],
+  marketplace: [],
+  marketplace_plugin: [],
+  plugin: [],
+  plugin_access_grant: [],
+  plugin_config_object: [],
+}
+
+const recordedInserts: InsertRecord[] = []
+let insertCalls = 0
+let updateCalls = 0
+
+function tableName(table: unknown): TableName | null {
+  if (table === ConfigObjectTable) return "config_object"
+  if (table === ConfigObjectAccessGrantTable) return "config_object_access_grant"
+  if (table === ConfigObjectVersionTable) return "config_object_version"
+  if (table === MarketplaceTable) return "marketplace"
+  if (table === MarketplacePluginTable) return "marketplace_plugin"
+  if (table === PluginTable) return "plugin"
+  if (table === PluginAccessGrantTable) return "plugin_access_grant"
+  if (table === PluginConfigObjectTable) return "plugin_config_object"
+  return null
+}
+
+function isRecord(value: unknown): value is Row {
+  return typeof value === "object" && value !== null
+}
+
+function resetDb(seed: Partial<Record<TableName, Row[]>> = {}) {
+  for (const name of tableNames) {
+    rowsByTable[name] = [...(seed[name] ?? [])]
+  }
+  recordedInserts.length = 0
+  insertCalls = 0
+  updateCalls = 0
+}
+
+function rowsFor(table: TableName | null) {
+  if (!table) return []
+  if (table === "config_object_access_grant" || table === "plugin_access_grant") {
+    return []
+  }
+  return rowsByTable[table]
+}
+
+function queryChain(): QueryChain {
+  let selectedTable: TableName | null = null
+  const resolveRows = (count?: number) => {
+    const rows = rowsFor(selectedTable)
+    return count === undefined ? [...rows] : rows.slice(0, count)
+  }
+  const chain: QueryChain = {
+    from: (table) => {
+      selectedTable = tableName(table)
+      return chain
+    },
+    innerJoin: () => chain,
+    limit: (count) => Promise.resolve(resolveRows(count)),
+    orderBy: () => chain,
+    then: (onfulfilled, onrejected) => Promise.resolve(resolveRows()).then(onfulfilled, onrejected),
+    where: () => chain,
+  }
+  return chain
+}
+
+function recordInsert(table: TableName | null, value: unknown) {
+  if (!table) return
+  const values = Array.isArray(value) ? value : [value]
+  for (const entry of values) {
+    if (!isRecord(entry)) continue
+    const stored = { ...entry }
+    rowsByTable[table].push(stored)
+    recordedInserts.push({ table, value: stored })
+  }
+}
+
+function insertBuilder(table: unknown): WriteBuilder {
+  const name = tableName(table)
+  insertCalls += 1
+  return {
+    set: () => ({ where: () => Promise.resolve() }),
+    values: (value) => {
+      recordInsert(name, value)
+      return Promise.resolve()
+    },
+    where: () => Promise.resolve(),
+  }
+}
+
+function updateBuilder(_table: unknown): WriteBuilder {
+  updateCalls += 1
+  return {
+    set: () => ({ where: () => Promise.resolve() }),
+    values: () => Promise.resolve(),
+    where: () => Promise.resolve(),
+  }
+}
+
+const transactionStub: TransactionStub = {
+  insert: insertBuilder,
+  select: queryChain,
+  update: updateBuilder,
+}
+
+let storeModule: typeof import("../src/routes/org/plugin-system/store.js")
+let schemas: typeof import("../src/routes/org/plugin-system/schemas.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+
+  mock.module("../src/db.js", () => ({
+    db: {
+      insert: insertBuilder,
+      select: queryChain,
+      transaction: async <TResult>(callback: (tx: TransactionStub) => Promise<TResult>) => callback(transactionStub),
+      update: updateBuilder,
+    },
+  }))
+
+  schemas = await import("../src/routes/org/plugin-system/schemas.js")
+  storeModule = await import("../src/routes/org/plugin-system/store.js")
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+function ownerContext(organizationId = createDenTypeId("organization"), memberId = createDenTypeId("member")): PluginArchActorContext {
+  const now = new Date("2026-07-05T00:00:00.000Z")
+  return {
+    memberTeams: [],
+    organizationContext: {
+      organization: {
+        id: organizationId,
+        name: "Acme Robotics",
+        slug: "acme-robotics-demo",
+        logo: null,
+        allowedEmailDomains: null,
+        metadata: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      currentMember: {
+        id: memberId,
+        userId: "user_admin",
+        role: "owner",
+        createdAt: now,
+        joinedAt: now,
+        isOwner: true,
+      },
+      invitations: [],
+      members: [],
+      roles: [],
+      teams: [],
+    },
+    session: { createdAt: new Date() },
+  }
+}
+
+function errorStatus(error: unknown) {
+  if (typeof error === "object" && error !== null && "status" in error && typeof error.status === "number") {
+    return error.status
+  }
+  return null
+}
+
+test("pluginCreateSchema accepts legacy and bundle bodies while rejecting empty component input", () => {
+  expect(schemas.pluginCreateSchema.safeParse({ name: "X" }).success).toBe(true)
+
+  expect(schemas.pluginCreateSchema.safeParse({
+    name: "Sales call prep",
+    description: "Help the team prepare for calls.",
+    components: [{
+      type: "skill",
+      input: {
+        rawSourceText: "---\nname: sales-call-prep\ndescription: Prep calls\n---\nReview the account notes.",
+      },
+    }],
+    orgWide: true,
+    marketplaceId: createDenTypeId("marketplace"),
+  }).success).toBe(true)
+
+  expect(schemas.pluginCreateSchema.safeParse({
+    name: "Broken",
+    components: [{ type: "skill", input: { metadata: { name: "Broken" } } }],
+  }).success).toBe(false)
+})
+
+test("createPluginBundle rejects an unknown marketplace before any write", async () => {
+  resetDb()
+
+  let status: number | null = null
+  try {
+    await storeModule.createPluginBundle({
+      context: ownerContext(),
+      marketplaceId: createDenTypeId("marketplace"),
+      name: "Bundle with missing marketplace",
+    })
+    throw new Error("expected rejection")
+  } catch (error) {
+    status = errorStatus(error)
+  }
+
+  expect(status).toBe(404)
+  expect(insertCalls).toBe(0)
+  expect(updateCalls).toBe(0)
+})
+
+test("createPluginBundle composes component creation, org-wide grants, and marketplace publishing", async () => {
+  const organizationId = createDenTypeId("organization")
+  const memberId = createDenTypeId("member")
+  const now = new Date("2026-07-05T00:00:00.000Z")
+  const marketplace = {
+    id: createDenTypeId("marketplace"),
+    organizationId,
+    name: "OpenWork Marketplace",
+    description: "Company extensions",
+    logoUrl: null,
+    status: "active",
+    createdByOrgMembershipId: memberId,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+  }
+  resetDb({ marketplace: [marketplace] })
+
+  await storeModule.createPluginBundle({
+    components: [{
+      type: "skill",
+      value: {
+        rawSourceText: "---\nname: sales-call-prep\ndescription: Prep calls\n---\nReview the account notes.",
+      },
+    }],
+    context: ownerContext(organizationId, memberId),
+    description: "Help the team prepare for sales calls.",
+    marketplaceId: marketplace.id,
+    name: "Sales call prep",
+    orgWide: true,
+  })
+
+  expect(recordedInserts).toHaveLength(9)
+  expect(recordedInserts.filter((entry) => entry.table === "plugin")).toHaveLength(1)
+  expect(recordedInserts.filter((entry) => entry.table === "plugin_access_grant")).toHaveLength(2)
+  expect(recordedInserts.filter((entry) => entry.table === "config_object")).toHaveLength(1)
+  expect(recordedInserts.filter((entry) => entry.table === "config_object_version")).toHaveLength(1)
+  expect(recordedInserts.filter((entry) => entry.table === "config_object_access_grant")).toHaveLength(2)
+  expect(recordedInserts.filter((entry) => entry.table === "plugin_config_object")).toHaveLength(1)
+  expect(recordedInserts.filter((entry) => entry.table === "marketplace_plugin")).toHaveLength(1)
+  expect(recordedInserts.some((entry) => entry.table === "config_object_access_grant" && entry.value.orgWide === true && entry.value.role === "viewer")).toBe(true)
+  expect(recordedInserts.some((entry) => entry.table === "plugin_access_grant" && entry.value.orgWide === true && entry.value.role === "viewer")).toBe(true)
+  expect(recordedInserts.some((entry) => entry.table === "marketplace_plugin" && entry.value.marketplaceId === marketplace.id)).toBe(true)
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-editor-screen.tsx
@@ -67,13 +67,11 @@ function buildSkillMarkdown(component: DraftComponent): string {
   ].join("\n");
 }
 
-function buildConfigObjectBody(pluginId: string, component: DraftComponent): Record<string, unknown> {
+function buildComponentBody(component: DraftComponent): Record<string, unknown> {
   if (component.kind === "mcp") {
     const serverName = slugify(component.name);
     return {
       type: "mcp",
-      sourceMode: "cloud",
-      pluginIds: [pluginId],
       input: {
         normalizedPayloadJson: {
           mcpServers: {
@@ -90,8 +88,6 @@ function buildConfigObjectBody(pluginId: string, component: DraftComponent): Rec
 
   return {
     type: component.kind,
-    sourceMode: "cloud",
-    pluginIds: [pluginId],
     input: {
       rawSourceText:
         component.kind === "skill" ? buildSkillMarkdown(component) : `${component.content.trim()}\n`,
@@ -145,7 +141,6 @@ export function PluginEditorScreen() {
     }
   }, [marketplaceId, marketplaceTouched, marketplaces]);
   const [saving, setSaving] = useState(false);
-  const [progress, setProgress] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
 
   const addComponent = (kind: ComponentKind) => {
@@ -193,61 +188,22 @@ export function PluginEditorScreen() {
     setSaving(true);
     setSaveError(null);
     try {
-      setProgress("Creating plugin...");
       let pluginPayload: unknown = null;
       await runReauthableAction("create-plugin", async () => {
         pluginPayload = await postJson(
           "/v1/plugins",
-          { name: name.trim(), description: description.trim() || null },
+          {
+            name: name.trim(),
+            description: description.trim() || null,
+            components: components.map(buildComponentBody),
+            orgWide: shareOrgWide,
+            marketplaceId: marketplaceId || undefined,
+          },
           "Failed to create the plugin",
         );
       });
       const pluginId = createdItemId(pluginPayload);
       if (!pluginId) throw new Error("The plugin was created, but no id was returned.");
-
-      for (const [index, component] of components.entries()) {
-        setProgress(`Adding ${COMPONENT_META[component.kind].label.toLowerCase()} ${index + 1} of ${components.length}...`);
-        let objectPayload: unknown = null;
-        await runReauthableAction("create-plugin-config-object", async () => {
-          objectPayload = await postJson(
-            "/v1/config-objects",
-            buildConfigObjectBody(pluginId, component),
-            `Failed to add "${component.name}"`,
-          );
-        });
-        const configObjectId = createdItemId(objectPayload);
-        if (shareOrgWide && configObjectId) {
-          await runReauthableAction("share-plugin-config-object", async () => {
-            await postJson(
-              `/v1/config-objects/${encodeURIComponent(configObjectId)}/access`,
-              { orgWide: true, role: "viewer" },
-              `Failed to share "${component.name}" with the organization`,
-            );
-          });
-        }
-      }
-
-      if (shareOrgWide) {
-        setProgress("Sharing with your organization...");
-        await runReauthableAction("share-plugin", async () => {
-          await postJson(
-            `/v1/plugins/${encodeURIComponent(pluginId)}/access`,
-            { orgWide: true, role: "viewer" },
-            "Failed to share the plugin with the organization",
-          );
-        });
-      }
-
-      if (marketplaceId) {
-        setProgress("Publishing to the marketplace...");
-        await runReauthableAction("publish-plugin", async () => {
-          await postJson(
-            `/v1/marketplaces/${encodeURIComponent(marketplaceId)}/plugins`,
-            { pluginId },
-            "Failed to publish to the marketplace",
-          );
-        });
-      }
 
       await queryClient.invalidateQueries({ queryKey: pluginQueryKeys.all });
       router.push(getPluginRoute(orgSlug, pluginId));
@@ -256,7 +212,6 @@ export function PluginEditorScreen() {
       setSaveError(error instanceof Error ? error.message : "Failed to create the plugin.");
     } finally {
       setSaving(false);
-      setProgress(null);
     }
   }
 
@@ -437,7 +392,7 @@ export function PluginEditorScreen() {
 
       <div className="mt-6 flex items-center gap-3">
         <DenButton onClick={() => void createPlugin()} disabled={saving}>
-          {saving ? progress ?? "Creating..." : "Create plugin"}
+          {saving ? "Creating..." : "Create plugin"}
         </DenButton>
         <Link href={getPluginsRoute(orgSlug)} className="text-[14px] text-gray-500 hover:text-gray-900">
           Cancel

--- a/evals/flows/create-plugin-single-request.flow.mjs
+++ b/evals/flows/create-plugin-single-request.flow.mjs
@@ -1,0 +1,349 @@
+/**
+ * Create plugin single request (spec: evals/voiceovers/create-plugin-single-request.md):
+ * creating a plugin with one skill, org-wide sharing, and marketplace publish
+ * should save through a single browser POST.
+ */
+
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("create-plugin-single-request");
+
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+
+const state = {
+  pluginId: "",
+  pluginName: "",
+  saveDurationMs: 0,
+  skillName: "Sales call checklist",
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+async function apiSignIn(email, password) {
+  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  return response.ok ? body.token : null;
+}
+
+async function apiJson(ctx, path, token) {
+  const result = await denApiFetch(path, { headers: { authorization: `Bearer ${token}` } });
+  ctx.assert(result.response.ok, `${path} failed: ${result.response.status} ${JSON.stringify(result.body)}`);
+  return result.body;
+}
+
+async function goTo(ctx, path) {
+  await ctx.eval(`location.assign(${JSON.stringify(`${DEN_WEB_URL}${path}`)})`);
+  await sleep(1_500);
+}
+
+async function uiSignIn(ctx, email, password) {
+  await goTo(ctx, "/");
+  // Idempotency: a previous run (or frame) may have left someone signed in,
+  // in which case "/" redirects straight to the dashboard.
+  if (await ctx.eval("location.pathname.startsWith('/dashboard')")) {
+    await uiSignOut(ctx);
+    await goTo(ctx, "/");
+  }
+  await ctx.waitFor("document.body.innerText.includes('Sign in')", { timeoutMs: 30_000, label: "auth screen" });
+  // Ensure the sign-in mode is selected (the screen defaults to sign-up).
+  await ctx.eval(`(() => {
+    const tab = [...document.querySelectorAll('button, a')].find((el) => el.textContent.trim() === 'Sign in');
+    tab?.click();
+    return true;
+  })()`);
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"], input[name=\"email\"]'))", { timeoutMs: 15_000, label: "email input" });
+  const filled = await ctx.eval(`(() => {
+    const setNative = (el, value) => {
+      const proto = Object.getPrototypeOf(el);
+      const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+      desc.set.call(el, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+    const email = document.querySelector('input[type="email"], input[name="email"]');
+    const password = document.querySelector('input[type="password"]');
+    if (!email || !password) return false;
+    setNative(email, ${JSON.stringify(email)});
+    setNative(password, ${JSON.stringify(password)});
+    const buttons = [...document.querySelectorAll('button')].filter((el) => el.textContent.trim() === 'Sign in' && !el.disabled);
+    buttons[buttons.length - 1]?.click();
+    return buttons.length > 0;
+  })()`);
+  ctx.assert(filled, "Could not fill and submit the sign-in form.");
+  await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 45_000, label: "dashboard after sign-in" });
+  await ctx.waitFor("Boolean(document.querySelector('nav'))", { timeoutMs: 30_000, label: "sidebar rendered" });
+  await sleep(1_000);
+}
+
+async function uiSignOut(ctx) {
+  // Idempotency plumbing, not a demo claim: end any leftover session through
+  // the auth endpoint and drop the locally persisted auth token so the flow
+  // always starts from the sign-in screen.
+  await ctx.eval("fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true)");
+  await ctx.eval("localStorage.clear(); sessionStorage.clear(); true");
+  await sleep(1_000);
+  await goTo(ctx, "/");
+  await ctx.waitFor("document.body.innerText.includes('Sign in')", { timeoutMs: 30_000, label: "signed out" });
+}
+
+async function fillPluginEditor(ctx) {
+  state.pluginName = `Sales call prep ${Date.now().toString(36)}`;
+  const pluginDescription = "A team plugin for preparing sales calls.";
+  const skillDescription = "Use before every customer call.";
+  const skillInstructions = "Review the account notes, recent objections, and next-best questions before the call.";
+
+  await ctx.waitFor("document.body.innerText.includes('Create a plugin')", { timeoutMs: 20_000, label: "create plugin editor" });
+  const filledPlugin = await ctx.eval(`(() => {
+    const setNative = (el, value) => {
+      const proto = Object.getPrototypeOf(el);
+      const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+      desc.set.call(el, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+    const name = document.querySelector('input[placeholder="e.g. Sales call prep"]');
+    const description = document.querySelector('textarea[placeholder="What does this plugin help people do?"]');
+    if (!name || !description) return false;
+    setNative(name, ${JSON.stringify(state.pluginName)});
+    setNative(description, ${JSON.stringify(pluginDescription)});
+    return true;
+  })()`);
+  ctx.assert(filledPlugin, "Could not fill plugin metadata.");
+
+  const addedSkill = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === 'Skill' && !el.disabled);
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(addedSkill, "Could not add a skill component.");
+  await ctx.waitFor("Boolean(document.querySelector('input[placeholder^=\"Name (e.g. Prep a sales call)\"]'))", { timeoutMs: 10_000, label: "skill fields" });
+
+  const filledSkill = await ctx.eval(`(() => {
+    const setNative = (el, value) => {
+      const proto = Object.getPrototypeOf(el);
+      const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+      desc.set.call(el, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+    const name = document.querySelector('input[placeholder^="Name (e.g. Prep a sales call)"]');
+    const description = document.querySelector('input[placeholder^="One-line description"]');
+    const instructions = document.querySelector('textarea[placeholder^="Write the instructions"]');
+    if (!name || !description || !instructions) return false;
+    setNative(name, ${JSON.stringify(state.skillName)});
+    setNative(description, ${JSON.stringify(skillDescription)});
+    setNative(instructions, ${JSON.stringify(skillInstructions)});
+    return true;
+  })()`);
+  ctx.assert(filledSkill, "Could not fill the skill fields.");
+  // The marketplace picker is a custom listbox button (no native <select>);
+  // its trigger shows the selected marketplace name once the list loads.
+  await ctx.waitFor(MARKETPLACE_SELECTED_EXPR, { timeoutMs: 20_000, label: "marketplace pre-selected" });
+}
+
+// True once the Share card's listbox trigger shows a real marketplace name
+// instead of the empty-state label ("Don't publish yet").
+const MARKETPLACE_SELECTED_EXPR = `(() => {
+  const share = [...document.querySelectorAll('h2')].find((el) => el.textContent.trim() === 'Share');
+  const trigger = share?.parentElement?.querySelector('button[aria-haspopup="listbox"]');
+  const label = (trigger?.textContent ?? '').trim();
+  return label.length > 0 && !label.includes('publish yet');
+})()`;
+
+async function installFetchLogger(ctx) {
+  await ctx.eval(`(() => {
+    const original = window.__openworkOriginalFetch ?? window.fetch.bind(window);
+    window.__openworkOriginalFetch = original;
+    window.fetch = async (...args) => {
+      const at = Date.now();
+      const input = args[0];
+      const init = args[1] ?? {};
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      const method = (init.method || (input instanceof Request ? input.method : 'GET') || 'GET').toUpperCase();
+      const started = performance.now();
+      try {
+        return await original(...args);
+      } finally {
+        if (url.includes('/api/den/')) {
+          const entry = { at, method, ms: Math.round(performance.now() - started), url };
+          const current = JSON.parse(localStorage.getItem('__fetchLog') || '[]');
+          current.push(entry);
+          localStorage.setItem('__fetchLog', JSON.stringify(current));
+        }
+      }
+    };
+    localStorage.setItem('__fetchLog', '[]');
+    localStorage.setItem('__createStart', String(Date.now()));
+    return true;
+  })()`);
+}
+
+function summarizeFetches(entries) {
+  return entries.map((entry) => `${entry.method} ${entry.url} (${entry.ms}ms)`).join("\n");
+}
+
+export default {
+  id: "create-plugin-single-request",
+  title: "Create plugin: one save request preserves sharing and publish side effects",
+  kind: "user-facing",
+  spec: "evals/voiceovers/create-plugin-single-request.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("An admin opens Create plugin and fills a plugin with a skill", {
+          voiceover: vo[0],
+          action: async () => {
+            await uiSignIn(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+            await goTo(ctx, "/dashboard/plugins/new");
+            await fillPluginEditor(ctx);
+          },
+          assert: async () => {
+            const shareState = await ctx.eval(`(() => {
+              const share = [...document.querySelectorAll('h2')].find((el) => el.textContent.trim() === 'Share');
+              const card = share?.parentElement;
+              const checkbox = card?.querySelector('input[type="checkbox"]');
+              return { checked: Boolean(checkbox?.checked), marketplaceSelected: ${MARKETPLACE_SELECTED_EXPR}, text: card?.innerText ?? '' };
+            })()`);
+            ctx.assert(shareState.text.includes("Marketplace"), "The Share card should include Marketplace.");
+            ctx.assert(shareState.marketplaceSelected, "The first marketplace should be pre-selected.");
+            ctx.assert(shareState.checked, "Org-wide sharing should be checked by default.");
+            // Input values are not part of innerText, so witness the filled
+            // skill through the DOM value instead of expectText.
+            const skillFilled = await ctx.eval(`document.querySelector('input[placeholder^="Name (e.g. Prep a sales call)"]')?.value === ${JSON.stringify(state.skillName)}`);
+            ctx.assert(skillFilled, "The skill name input should hold the filled value.");
+          },
+          screenshot: {
+            name: "create-plugin-filled",
+            claim: "The Create plugin editor is filled with one skill, org-wide sharing, and a marketplace selection.",
+            requireText: ["Create a plugin", "Skill", "Share"],
+            rejectText: ["Failed", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("One click creates the plugin with one Den request", {
+          voiceover: vo[1],
+          action: async () => {
+            await installFetchLogger(ctx);
+            const clicked = await ctx.eval(`(() => {
+              const button = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === 'Create plugin' && !el.disabled);
+              button?.click();
+              return Boolean(button);
+            })()`);
+            ctx.assert(clicked, "Could not click Create plugin.");
+            await ctx.waitFor("location.pathname.includes('/dashboard/plugins/plg_') && !location.pathname.endsWith('/new')", { timeoutMs: 45_000, label: "plugin detail route" });
+            state.pluginId = await ctx.eval("location.pathname.split('/').filter(Boolean).at(-1)");
+            ctx.assert(typeof state.pluginId === "string" && state.pluginId.startsWith("plg_"), `Could not read plugin id from URL: ${state.pluginId}`);
+          },
+          assert: async () => {
+            await ctx.expectText(state.pluginName, { timeoutMs: 20_000 });
+            const fetchResult = await ctx.eval(`(() => {
+              const start = Number(localStorage.getItem('__createStart') || '0');
+              const entries = JSON.parse(localStorage.getItem('__fetchLog') || '[]').filter((entry) => entry.at >= start);
+              const maxEnd = entries.length ? Math.max(...entries.map((entry) => entry.at + entry.ms)) : Date.now();
+              return { durationMs: maxEnd - start, entries };
+            })()`);
+            const entries = fetchResult.entries;
+            // The structural invariant: the whole save is ONE mutation. The
+            // detail page issues follow-up GETs, so assert on POSTs only.
+            const posts = entries.filter((entry) => entry.method === "POST");
+            ctx.assert(posts.length === 1, `Expected exactly one POST during the save, saw ${posts.length}:\n${summarizeFetches(posts)}`);
+            const createPost = posts[0];
+            ctx.assert(
+              createPost.url.includes("/v1/plugins") && !createPost.url.includes("/access") && !createPost.url.includes("/marketplaces") && !createPost.url.includes("/config-objects"),
+              `The single POST must be the plugin create, saw: ${createPost.method} ${createPost.url}`,
+            );
+            const lastPostEnd = Math.max(...posts.map((entry) => entry.at + entry.ms));
+            const start = Number(await ctx.eval("localStorage.getItem('__createStart')"));
+            state.saveDurationMs = lastPostEnd - start;
+            ctx.assert(state.saveDurationMs < 15_000, `Sanity ceiling: save took ${state.saveDurationMs}ms`);
+            ctx.output("create-plugin-save", `Saved in ${Math.round(state.saveDurationMs)}ms with one POST:\n${summarizeFetches(posts)}\nAll den requests during save+landing:\n${summarizeFetches(entries)}`);
+          },
+          screenshot: {
+            name: "plugin-detail-after-single-request",
+            claim: "The newly created plugin opens after a single create request.",
+            requireText: [state.pluginName],
+            rejectText: ["Failed", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Nothing was lost by batching", {
+          voiceover: vo[2],
+          action: async () => {
+            // The detail page still shows the skill, then Alex returns to the
+            // catalog where the new plugin sits with its marketplace badge.
+            await ctx.expectText(state.skillName, { timeoutMs: 20_000 });
+            await goTo(ctx, "/dashboard/plugins");
+            await ctx.waitFor(`document.body.innerText.includes(${JSON.stringify(state.pluginName)})`, { timeoutMs: 30_000, label: "plugin in catalog" });
+          },
+          assert: async () => {
+            const token = await apiSignIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+            ctx.assert(Boolean(token), "Admin API sign-in failed.");
+            const pluginId = state.pluginId;
+
+            const pluginAccess = await apiJson(ctx, `/v1/plugins/${encodeURIComponent(pluginId)}/access`, token);
+            const pluginGrant = (pluginAccess.items ?? []).find((grant) => grant.orgWide === true && grant.role === "viewer" && !grant.removedAt);
+            ctx.assert(Boolean(pluginGrant), `Plugin org-wide viewer grant missing: ${JSON.stringify(pluginAccess)}`);
+
+            const memberships = await apiJson(ctx, `/v1/plugins/${encodeURIComponent(pluginId)}/config-objects`, token);
+            ctx.assert((memberships.items ?? []).length === 1, `Expected exactly one plugin component: ${JSON.stringify(memberships)}`);
+            const configObjectId = memberships.items[0]?.configObjectId;
+            ctx.assert(typeof configObjectId === "string", `Missing config object id: ${JSON.stringify(memberships)}`);
+
+            const configAccess = await apiJson(ctx, `/v1/config-objects/${encodeURIComponent(configObjectId)}/access`, token);
+            const configGrant = (configAccess.items ?? []).find((grant) => grant.orgWide === true && grant.role === "viewer" && !grant.removedAt);
+            ctx.assert(Boolean(configGrant), `Config object org-wide viewer grant missing: ${JSON.stringify(configAccess)}`);
+
+            const marketplaces = await apiJson(ctx, "/v1/marketplaces", token);
+            const marketplaceId = marketplaces.items?.[0]?.id;
+            ctx.assert(typeof marketplaceId === "string", `No marketplace available: ${JSON.stringify(marketplaces)}`);
+            const marketplacePlugins = await apiJson(ctx, `/v1/marketplaces/${encodeURIComponent(marketplaceId)}/plugins`, token);
+            ctx.assert((marketplacePlugins.items ?? []).some((item) => item.pluginId === pluginId), `Marketplace does not include plugin ${pluginId}: ${JSON.stringify(marketplacePlugins)}`);
+
+            // The catalog card carries the marketplace badge and the skill count.
+            await ctx.expectText(state.pluginName, { timeoutMs: 20_000 });
+            await ctx.expectText("1 Skill", { timeoutMs: 20_000 });
+            ctx.output("create-plugin-side-effects", JSON.stringify({ configObjectId, marketplaceId, pluginId }, null, 2));
+          },
+          screenshot: {
+            name: "plugin-catalog-with-published-plugin",
+            claim: "The catalog lists the new plugin with its marketplace badge and one skill after the batched save.",
+            requireText: [state.pluginName, "Marketplace"],
+            rejectText: ["Failed", "Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/create-plugin-single-request.md
+++ b/evals/voiceovers/create-plugin-single-request.md
@@ -1,0 +1,11 @@
+# create-plugin-single-request — Create plugin saves in one stroke
+
+Cast is Alex (org admin) in OpenWork Cloud (den-web). The demo follows the
+happy path for creating a team plugin with one skill, organization sharing, and
+the pre-selected marketplace.
+
+1. Alex opens Create plugin and fills in a sales-call prep plugin with one skill. The sharing card is already set up for the team: everyone in the organization can see it, and the marketplace is ready.
+
+2. He clicks Create plugin once, and the save happens in a single stroke instead of a slow chain of separate steps. The new plugin opens right away, with no failure banner in sight.
+
+3. The plugin still has everything Alex asked for: the skill is attached, the team can view it, and the marketplace includes it. Faster save, same complete result.


### PR DESCRIPTION
## Why

"Create plugin" in the den-web dashboard took **2–5 seconds**. The editor issued **2 + 2N + 1 sequential POSTs** (N = components) through the Next proxy to den-api — for the default single-skill case (share org-wide checked, marketplace pre-selected) that is **5 sequential round trips**, each paying proxy + session/org/teams middleware overhead:

```
POST /v1/plugins
POST /v1/config-objects
POST /v1/config-objects/:id/access
POST /v1/plugins/:id/access
POST /v1/marketplaces/:id/plugins
```

## What

`POST /v1/plugins` now accepts optional, backward-compatible `components[]`, `orgWide`, and `marketplaceId`, and composes the existing store functions (`createPlugin`, `createConfigObject`, `createResourceAccessGrant`, `attachPluginToMarketplace`) server-side. The editor sends **one request**.

- Authorization is unchanged: the handler still requires `plugin.create`, additionally requires `config_object.create` when components are present (parity with the standalone route), and every composed store function keeps its own resource-role checks.
- Bonus fix: the marketplace target is validated **before** anything is created — previously a bad marketplace failed on the last request and left an orphan plugin.
- The multi-step progress UI collapses to a single "Creating..." state; reauth retry now replays one atomic request instead of a partial chain.
- Only consumer of this endpoint was the editor (desktop app only reads `/v1/plugins/:id/resolved`).

## Measured (local stack, seeded Acme org, CDP-driven real UI)

| | requests during save | save chain |
|---|---|---|
| before | **5 sequential POSTs** | 112ms |
| after | **1 POST** | **36ms** |

Local round trips are ~20ms; on real deployments each round trip is 400–1000ms, so 5→1 round trips is what removes the 2–5s.

Also validated manually: the reauth (security check) path retries the single batched request and creates exactly one plugin; side effects verified via API (org-wide viewer grants on plugin + component, skill membership, marketplace membership).

## Tests run

- `cd ee/apps/den-api && bun test` — **302 pass / 7 fail**; the same 7 failures reproduce on a clean `origin/dev` checkout (299 pass / 7 fail) — pre-existing, unrelated (`route-guard-policy`, order-dependent `memory-ownership`). New file `test/plugin-system-create-bundle.test.ts` (3 tests): schema backward-compat, fail-fast unknown marketplace with **zero writes**, full composition (9 inserts incl. org-wide grants + marketplace membership).
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` — clean.
- `pnpm --filter @openwork-ee/den-web exec tsc --noEmit` — clean.
- `pnpm fraimz --flow create-plugin-single-request` — **PASSED** (3 frames + voice-over coverage); proof posted as a comment below.

## Repro

```
pnpm evals --stack den            # mysql + schema + den-api + seed
# den-web: DEN_API_BASE=http://127.0.0.1:8790 DEN_AUTH_ORIGIN=http://localhost:8790 pnpm --filter @openwork-ee/den-web dev
OPENWORK_EVAL_DEN_API_URL=http://127.0.0.1:8790 OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3005 \
  pnpm fraimz --flow create-plugin-single-request --cdp-url <chrome-cdp>
```
