### PR TITLE
feat(connections): Exa quick-add preset (org API key)

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
@@ -52,6 +52,13 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
     requiresOAuthClient: true,
   },
   {
+    presetId: "exa",
+    displayName: "Exa",
+    description: "AI web search, code search, and research for your agents. Paste your org's Exa API key from dashboard.exa.ai.",
+    url: "https://mcp.exa.ai/mcp",
+    authType: "apikey",
+  },
+  {
     presetId: "context7",
     displayName: "Context7",
     description: "Search product docs with richer context.",

--- a/evals/flows/exa-connection.flow.mjs
+++ b/evals/flows/exa-connection.flow.mjs
@@ -208,6 +208,11 @@ export default {
             } else {
               ctx.log("Skipping real Exa web_search_exa execution because real execution requires OPENWORK_EVAL_EXA_API_KEY; placeholder keys only validate create and tool discovery.");
             }
+
+            // The list polls/re-renders while the API checks above run, which
+            // can reset the scroll position — bring the connected row back
+            // into view so the frame shows what the claim says.
+            await ctx.waitFor(exaConnectedRowScript(), { timeoutMs: 10_000, label: "Exa row back in view" });
           },
           screenshot: {
             name: "exa-connected-row",

--- a/evals/flows/exa-connection.flow.mjs
+++ b/evals/flows/exa-connection.flow.mjs
@@ -1,0 +1,233 @@
+/**
+ * Exa quick-add connection: the real hosted Exa MCP server is added from the
+ * Cloud Connections preset with an org API key, then discovered through the
+ * org's agent-facing MCP surface.
+ */
+
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, denApiUrl, openAdminConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+
+const vo = await loadVoiceoverParagraphs("exa-connection");
+
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const EXA_URL = "https://mcp.exa.ai/mcp";
+const EXA_API_KEY = process.env.OPENWORK_EVAL_EXA_API_KEY?.trim() || "exa-eval-placeholder-key";
+const HAS_REAL_EXA_API_KEY = EXA_API_KEY !== "exa-eval-placeholder-key";
+
+const state = {
+  adminSession: null,
+  connectionId: null,
+};
+
+function clickExaCardScript() {
+  return `(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => {
+      const text = entry.textContent ?? '';
+      return text.includes('Exa') && text.includes('Tap to add');
+    });
+    button?.scrollIntoView({ block: 'center' });
+    button?.click();
+    return Boolean(button);
+  })()`;
+}
+
+function exaConnectedRowScript() {
+  return `(() => {
+    const leaves = [...document.querySelectorAll('*')].filter((el) => el.children.length === 0 && (el.textContent ?? '').trim() === 'Exa');
+    return leaves.some((leaf) => {
+      let el = leaf;
+      for (let i = 0; i < 6 && el; i++) {
+        const text = el.textContent ?? '';
+        if (text.includes('Connected') && text.includes(${JSON.stringify(EXA_URL)})) {
+          el.scrollIntoView({ block: 'center' });
+          return true;
+        }
+        el = el.parentElement;
+      }
+      return false;
+    });
+  })()`;
+}
+
+async function mcpAgentCall(mcpToken, method, params, ctx) {
+  const response = await fetch(`${denApiUrl()}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${mcpToken}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
+  });
+  const raw = await response.text();
+  ctx.assert(response.ok, `MCP ${method} failed: ${response.status} ${raw.slice(0, 200)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  ctx.assert(Boolean(dataLine), `MCP ${method} returned no data frame.`);
+  return JSON.parse(dataLine.slice(5)).result;
+}
+
+async function mintMcpToken(sessionToken, ctx) {
+  const { response, body } = await denApiFetch("/v1/mcp/token", {
+    method: "POST",
+    headers: { authorization: `Bearer ${sessionToken}` },
+    body: "{}",
+  });
+  ctx.assert(response.ok, `Minting an MCP token failed: ${response.status}`);
+  return body.token;
+}
+
+export default {
+  id: "exa-connection",
+  title: "Exa is a quick-add Cloud Connection with org API-key setup",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  spec: "evals/org-mcp-connections-ux.md",
+  steps: [
+    {
+      name: "Setup: admin signs in and leftover Exa connections are removed",
+      run: async (ctx) => {
+        state.adminSession = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
+        ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+
+        const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+          headers: { authorization: `Bearer ${state.adminSession}` },
+        });
+        ctx.assert(existing.response.ok, `Listing manageable connections failed: ${existing.response.status}`);
+
+        for (const connection of existing.body.connections ?? []) {
+          if (connection.url === EXA_URL || connection.name === "Exa") {
+            const removed = await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+              method: "DELETE",
+              headers: { authorization: `Bearer ${state.adminSession}` },
+            });
+            ctx.assert(removed.response.ok, `Cleanup delete failed for leftover ${connection.id}.`);
+          }
+        }
+      },
+    },
+    {
+      name: "Admin opens Connections and sees the Exa quick-add card",
+      run: async (ctx) => {
+        await ctx.prove("The Exa preset is visible in Cloud Connections quick-add", {
+          voiceover: vo[0],
+          action: async () => {
+            await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+            await openAdminConnections(ctx);
+          },
+          assert: async () => {
+            await ctx.waitForText("Exa", { timeoutMs: 20_000 });
+            await ctx.expectText("Tap to add");
+          },
+          screenshot: {
+            name: "exa-quick-add-card",
+            claim: "Exa is available as a first-class quick-add preset on the Cloud Connections screen.",
+            requireText: ["Exa", "Tap to add"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Admin opens Add Exa, pastes the org API key, and submits",
+      run: async (ctx) => {
+        await ctx.prove("The Exa preset opens an API-key-only Add Exa dialog", {
+          voiceover: vo[1],
+          action: async () => {
+            const clicked = await ctx.eval(clickExaCardScript());
+            ctx.assert(clicked, "Exa quick-add card with Tap to add was not found.");
+            await ctx.waitForText("Add Exa", { timeoutMs: 10_000 });
+            await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"][placeholder=\"sk-...\"]'))", {
+              timeoutMs: 10_000,
+              label: "Exa API key input",
+            });
+            await ctx.fill('input[type="password"][placeholder="sk-..."]', EXA_API_KEY);
+          },
+          assert: async () => {
+            await ctx.expectText("Add Exa");
+            await ctx.expectText("API key");
+            const hasPasswordInput = await ctx.eval("Boolean(document.querySelector('input[type=\"password\"]'))");
+            ctx.assert(hasPasswordInput, "Add Exa did not render a password input for the API key.");
+          },
+          screenshot: {
+            name: "add-exa-api-key-field",
+            claim: "Add Exa asks for the org's Exa API key, with no OAuth picker or custom URL work.",
+            requireText: ["Add Exa", "API key"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+
+        await ctx.waitFor(
+          `(() => {
+            const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === 'Add connection');
+            return Boolean(button && !button.disabled);
+          })()`,
+          { timeoutMs: 10_000, label: "enabled Add connection button" },
+        );
+        await ctx.clickText("Add connection", { timeoutMs: 15_000 });
+      },
+    },
+    {
+      name: "Exa is connected and its real tools appear in the agent MCP surface",
+      run: async (ctx) => {
+        await ctx.prove("The Exa row is connected and search_capabilities lists Exa's real MCP tools", {
+          voiceover: vo[2],
+          assert: async () => {
+            await ctx.waitFor(exaConnectedRowScript(), { timeoutMs: 60_000, label: "Exa row shows Connected" });
+
+            const list = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+              headers: { authorization: `Bearer ${state.adminSession}` },
+            });
+            ctx.assert(list.response.ok, `Listing manageable connections failed: ${list.response.status}`);
+            const connection = (list.body.connections ?? []).find((entry) => entry.url === EXA_URL && entry.name === "Exa");
+            ctx.assert(Boolean(connection), "Created Exa connection not found via API.");
+            state.connectionId = connection.id;
+            ctx.assert(connection.connected === true, `Exa connection did not report connected via API: ${JSON.stringify(connection).slice(0, 200)}`);
+
+            const mcpToken = await mintMcpToken(state.adminSession, ctx);
+            const search = await mcpAgentCall(mcpToken, "tools/call", {
+              name: "search_capabilities",
+              arguments: { query: "web search" },
+            }, ctx);
+            const searchText = String(search.content?.[0]?.text ?? "");
+            const exaToolName = `mcp:${state.connectionId}:web_search_exa`;
+            ctx.assert(searchText.includes(exaToolName), `search_capabilities missing ${exaToolName}: ${searchText.slice(0, 500)}`);
+
+            if (HAS_REAL_EXA_API_KEY) {
+              const execute = await mcpAgentCall(mcpToken, "tools/call", {
+                name: "execute_capability",
+                arguments: {
+                  name: exaToolName,
+                  body: { query: "OpenWork AI agents", numResults: 1 },
+                },
+              }, ctx);
+              const executeText = JSON.stringify(execute);
+              ctx.assert(!executeText.includes("Invalid API key"), `Exa execution rejected the API key: ${executeText.slice(0, 500)}`);
+              ctx.assert(execute.isError !== true, `Exa execution returned an error: ${executeText.slice(0, 500)}`);
+            } else {
+              ctx.log("Skipping real Exa web_search_exa execution because real execution requires OPENWORK_EVAL_EXA_API_KEY; placeholder keys only validate create and tool discovery.");
+            }
+          },
+          screenshot: {
+            name: "exa-connected-row",
+            claim: "The Exa row shows Connected, and the org agent surface lists Exa's real web_search_exa tool.",
+            requireText: ["Exa", "Connected"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup: delete the created Exa connection",
+      run: async (ctx) => {
+        if (!state.connectionId) return;
+        const removed = await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${state.adminSession}` },
+        });
+        ctx.assert(removed.response.ok, `Cleanup delete failed for ${state.connectionId}.`);
+      },
+    },
+  ],
+};

--- a/evals/flows/exa-connection.flow.mjs
+++ b/evals/flows/exa-connection.flow.mjs
@@ -33,20 +33,26 @@ function clickExaCardScript() {
 }
 
 function exaConnectedRowScript() {
+  // Returns true only when the connected row is INSIDE the viewport — the
+  // list re-renders on the page's 2s polling, which can reset an earlier
+  // scroll before the screenshot is captured, so keep scrolling until the
+  // row is genuinely visible.
   return `(() => {
     const leaves = [...document.querySelectorAll('*')].filter((el) => el.children.length === 0 && (el.textContent ?? '').trim() === 'Exa');
-    return leaves.some((leaf) => {
+    for (const leaf of leaves) {
       let el = leaf;
       for (let i = 0; i < 6 && el; i++) {
         const text = el.textContent ?? '';
         if (text.includes('Connected') && text.includes(${JSON.stringify(EXA_URL)})) {
+          const rect = el.getBoundingClientRect();
+          if (rect.top >= 0 && rect.bottom <= window.innerHeight) return true;
           el.scrollIntoView({ block: 'center' });
-          return true;
+          return false;
         }
         el = el.parentElement;
       }
-      return false;
-    });
+    }
+    return false;
   })()`;
 }
 

--- a/evals/voiceovers/exa-connection.md
+++ b/evals/voiceovers/exa-connection.md
@@ -1,0 +1,13 @@
+# exa-connection — Exa joins the quick-add connections
+
+Cast is Alex, the Acme Robotics admin, in OpenWork Cloud on the web. Exa is
+the AI search engine his team already uses; its hosted MCP server takes the
+org's Exa API key. This demo shows Exa as a first-class quick-add connection:
+tap the card, paste the key, and the org's AI coworkers can search the web
+through Exa.
+
+1. Alex opens Connections and Exa is right there in quick add, next to Notion and Slack — a real card with a real description, not a custom URL he has to remember.
+
+2. Tapping the card opens Add Exa with the server URL prefilled and one thing to do: paste the org's Exa API key. No OAuth app, no extra choices — the key is the whole setup.
+
+3. After adding, the Exa row shows Connected — the server was reached and validated for real — and the org's agent surface now lists Exa's actual search tools, ready for every AI coworker the org granted access.

--- a/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
+++ b/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sharing MCP connections with your team"
-description: "Share Notion, Linear, Stripe, or any MCP server in OpenWork Cloud with Individual accounts by default, or One org account when everyone should act as the same account"
+description: "Share Notion, Linear, Stripe, Exa, or any MCP server in OpenWork Cloud with Individual accounts by default, or One org account when everyone should act as the same account"
 ---
 
 Use `MCP Connections` when you want the org to manage an MCP integration once
@@ -20,7 +20,7 @@ Two ways to handle whose account the AI uses, chosen per connection:
 
 1. Open `MCP Connections` in the OpenWork Cloud dashboard.
 2. Click `Add Connection`.
-3. Pick a preset (Notion, Linear, Stripe, Sentry, Context7) or enter any
+3. Pick a preset (Notion, Linear, Stripe, Sentry, Exa, Context7) or enter any
    MCP server URL.
 4. Choose the account mode: `Individual accounts` or `One org account`.
 5. Choose who can use it: the whole workspace, specific teams, or specific


### PR DESCRIPTION
## What

Adds **Exa** (exa.ai — AI web search / code search / research) to the cloud Connections quick-add presets, wired to its hosted MCP server `https://mcp.exa.ai/mcp` with **org API-key** auth. Zero dialog/server plumbing changes — the apikey preset path already existed; this is one preset entry + proof + a docs touch.

## Why API key and not OAuth (probed for real)

Exa advertises OAuth (RFC 9728 metadata + dynamic client registration), but its **anonymous free tier accepts MCP initialize without auth**, so den-api's OAuth path — which triggers only on an Unauthorized error — returns "connected" without ever producing an authorize URL. A per-member OAuth Exa preset would render a Connect button that can never mint a per-member credential (probed against the live service: `connect/start` → `{"status":"connected","authorizeUrl":null}`). Exa's keys are org/team-level in their product anyway (dashboard.exa.ai/api-keys), and the key is enforced at tool-call time (401 "Invalid API key" — also probed). Our client already sends apikey connections as `Authorization: Bearer`, which Exa accepts.

## Tests / proof

- `pnpm --dir ee/apps/den-api exec tsc --noEmit` — passed.
- New voiceover-scripted flow `exa-connection`, run **twice**:
  - **Locally** against a full stack — PASSED.
  - **On Daytona**: den stack (MySQL + den-api + den-web) running in a Daytona server sandbox from this branch (`openwork-server-…` via `.devcontainer/test-server-on-daytona.sh`), demo org seeded in the sandbox, a real browser driving the public preview URLs, and the sandbox's den-api reaching the **real mcp.exa.ai** — PASSED. Proof comment below is from a Daytona run.
- What the flow proves: the Exa quick-add card; the Add Exa dialog with the API key field; create-time validation against the real Exa server; ground truth that `search_capabilities` lists the real `mcp:<id>:web_search_exa` tool. Real search execution additionally runs when `OPENWORK_EVAL_EXA_API_KEY` is set (no shared key in CI, so the default run validates everything except a live search — stated in the flow).

Repro (Daytona):
```bash
bash .devcontainer/test-server-on-daytona.sh feat/exa-connection-preset
# seed demo org in the sandbox (pnpm --filter @openwork-ee/den-api seed:demo-org with the sandbox env)
OPENWORK_EVAL_DEN_API_URL=<den-api-url> OPENWORK_EVAL_DEN_WEB_URL=<den-web-url> \
  pnpm fraimz --flow exa-connection --cdp-url http://127.0.0.1:9333
```