### PR TITLE
Add SMTP config to EE Helm docs

### DIFF
--- a/docs/aws-eks-helm.md
+++ b/docs/aws-eks-helm.md
@@ -215,6 +215,23 @@ Use the first value for `secret.values.betterAuthSecret` and the second for
 `secret.values.denDbEncryptionKey`. Do not reuse either value across
 environments.
 
+To send transactional email, configure SMTP in the same values file:
+
+```yaml
+secret:
+  values:
+    smtpHost: "smtp.example.com"
+    smtpPort: "587"
+    smtpUser: "openwork@example.com"
+    smtpPass: "REPLACE_SMTP_PASSWORD"
+    smtpSecure: "false"
+```
+
+These values become `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, and
+`SMTP_SECURE` in Den API. If you use `secret.create=false`, add those keys to
+the existing Kubernetes Secret referenced by `secret.existingSecret`. Leave
+`smtpHost` blank only when SMTP-backed transactional email should be disabled.
+
 Use a values file, not a long list of `--set` flags. Several OpenWork values are
 comma-separated strings, such as `config.public.corsOrigins`, and plain
 `--set` parsing commonly breaks them.
@@ -233,7 +250,7 @@ helm template openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
   --namespace openwork-ee \
   -f values.aws.yaml > /tmp/openwork-rendered.yaml
 
-grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN' /tmp/openwork-rendered.yaml
+grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN|SMTP_HOST|SMTP_PORT|SMTP_SECURE' /tmp/openwork-rendered.yaml
 ```
 
 Redact secrets before sharing rendered manifests or terminal output.

--- a/docs/azure-aks-helm.md
+++ b/docs/azure-aks-helm.md
@@ -184,6 +184,23 @@ Use the first value for `secret.values.betterAuthSecret` and the second for
 `secret.values.denDbEncryptionKey`. Do not reuse either value across
 environments.
 
+To send transactional email, configure SMTP in the same values file:
+
+```yaml
+secret:
+  values:
+    smtpHost: "smtp.example.com"
+    smtpPort: "587"
+    smtpUser: "openwork@example.com"
+    smtpPass: "REPLACE_SMTP_PASSWORD"
+    smtpSecure: "false"
+```
+
+These values become `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, and
+`SMTP_SECURE` in Den API. If you use `secret.create=false`, add those keys to
+the existing Kubernetes Secret referenced by `secret.existingSecret`. Leave
+`smtpHost` blank only when SMTP-backed transactional email should be disabled.
+
 Use a values file, not a long list of `--set` flags. Several OpenWork values are
 comma-separated strings, such as `config.public.corsOrigins`, and plain `--set`
 parsing commonly breaks them.
@@ -202,7 +219,7 @@ helm template openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
   --namespace openwork-ee \
   -f values.azure.yaml > /tmp/openwork-rendered.yaml
 
-grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN' /tmp/openwork-rendered.yaml
+grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN|SMTP_HOST|SMTP_PORT|SMTP_SECURE' /tmp/openwork-rendered.yaml
 ```
 
 Redact secrets before sharing rendered manifests or terminal output.

--- a/docs/gcp-gke-helm.md
+++ b/docs/gcp-gke-helm.md
@@ -273,6 +273,23 @@ Use the first value for `secret.values.betterAuthSecret` and the second for
 `secret.values.denDbEncryptionKey`. Do not reuse either value across
 environments.
 
+To send transactional email, configure SMTP in the same values file:
+
+```yaml
+secret:
+  values:
+    smtpHost: "smtp.example.com"
+    smtpPort: "587"
+    smtpUser: "openwork@example.com"
+    smtpPass: "REPLACE_SMTP_PASSWORD"
+    smtpSecure: "false"
+```
+
+These values become `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, and
+`SMTP_SECURE` in Den API. If you use `secret.create=false`, add those keys to
+the existing Kubernetes Secret referenced by `secret.existingSecret`. Leave
+`smtpHost` blank only when SMTP-backed transactional email should be disabled.
+
 Use a values file, not a long list of `--set` flags. Several OpenWork values are
 comma-separated strings, such as `config.public.corsOrigins`, and plain `--set`
 parsing commonly breaks them.
@@ -291,7 +308,7 @@ helm template openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
   --namespace openwork-ee \
   -f values.gcp.yaml > /tmp/openwork-rendered.yaml
 
-grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN' /tmp/openwork-rendered.yaml
+grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN|SMTP_HOST|SMTP_PORT|SMTP_SECURE' /tmp/openwork-rendered.yaml
 ```
 
 Redact secrets before sharing rendered manifests or terminal output.

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -54,6 +54,11 @@ secret:
     databaseUrl: "mysql://openwork:REPLACE_ME@mysql.example.internal:3306/openwork_den?sslaccept=accept"
     betterAuthSecret: "REPLACE_WITH_AT_LEAST_32_CHARACTERS"
     denDbEncryptionKey: "REPLACE_WITH_AT_LEAST_32_CHARACTERS"
+    smtpHost: "smtp.example.com"
+    smtpPort: "587"
+    smtpUser: "openwork@example.com"
+    smtpPass: "REPLACE_ME"
+    smtpSecure: "false"
 
 ingress:
   enabled: true
@@ -129,6 +134,33 @@ The existing Secret must contain the keys listed under `secret.keys`, especially
 - `DEN_DB_ENCRYPTION_KEY`
 
 Set `DAYTONA_API_KEY` when `config.provisioner.mode` is `daytona`. Set `POLAR_ACCESS_TOKEN` when Polar feature gating is enabled. Set `OPENROUTER_MANAGEMENT_API_KEY` when enabling OpenWork Models management.
+
+## Transactional Email
+
+Den API can send transactional email through SMTP. Configure the SMTP values in
+the chart Secret:
+
+```yaml
+secret:
+  values:
+    smtpHost: "smtp.example.com"
+    smtpPort: "587"
+    smtpUser: "openwork@example.com"
+    smtpPass: "REPLACE_ME"
+    smtpSecure: "false"
+```
+
+These values are exposed to Den API as:
+
+- `SMTP_HOST`
+- `SMTP_PORT`
+- `SMTP_USER`
+- `SMTP_PASS`
+- `SMTP_SECURE`
+
+If `secret.create=false`, add those keys to the existing Secret referenced by
+`secret.existingSecret`. `SMTP_HOST` enables SMTP delivery; leave it blank to
+disable SMTP-backed transactional email.
 
 ## Tenancy Mode
 

--- a/packaging/helm/openwork-ee/templates/secret.yaml
+++ b/packaging/helm/openwork-ee/templates/secret.yaml
@@ -15,4 +15,9 @@ stringData:
   {{ .Values.secret.keys.openRouterManagementApiKey }}: {{ .Values.secret.values.openRouterManagementApiKey | quote }}
   {{ .Values.secret.keys.inferenceAdminToken }}: {{ .Values.secret.values.inferenceAdminToken | quote }}
   {{ .Values.secret.keys.inferenceWebhookSecret }}: {{ .Values.secret.values.inferenceWebhookSecret | quote }}
+  {{ .Values.secret.keys.smtpHost }}: {{ .Values.secret.values.smtpHost | quote }}
+  {{ .Values.secret.keys.smtpPort }}: {{ .Values.secret.values.smtpPort | quote }}
+  {{ .Values.secret.keys.smtpUser }}: {{ .Values.secret.values.smtpUser | quote }}
+  {{ .Values.secret.keys.smtpPass }}: {{ .Values.secret.values.smtpPass | quote }}
+  {{ .Values.secret.keys.smtpSecure }}: {{ .Values.secret.values.smtpSecure | quote }}
 {{- end }}

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -97,6 +97,11 @@ secret:
     openRouterManagementApiKey: OPENROUTER_MANAGEMENT_API_KEY
     inferenceAdminToken: INFERENCE_ADMIN_TOKEN
     inferenceWebhookSecret: INFERENCE_WEBHOOK_SECRET
+    smtpHost: SMTP_HOST
+    smtpPort: SMTP_PORT
+    smtpUser: SMTP_USER
+    smtpPass: SMTP_PASS
+    smtpSecure: SMTP_SECURE
   values:
     databaseUrl: mysql://openwork:change-me@mysql:3306/openwork_den
     betterAuthSecret: CHANGE_ME_32_CHARS_MINIMUM_BETTER_AUTH
@@ -106,6 +111,11 @@ secret:
     openRouterManagementApiKey: ""
     inferenceAdminToken: ""
     inferenceWebhookSecret: ""
+    smtpHost: ""
+    smtpPort: "587"
+    smtpUser: ""
+    smtpPass: ""
+    smtpSecure: "false"
 
 installerArtifacts:
   enabled: false


### PR DESCRIPTION
## Summary
- add SMTP secret keys to the OpenWork EE Helm chart values and rendered Secret
- document SMTP-only transactional email setup in the chart README
- update AWS, Azure, and GCP Helm deployment guides to include SMTP values and render checks

## Validation
- Passed: `helm template openwork-ee ./packaging/helm/openwork-ee`
- Passed: `helm lint ./packaging/helm/openwork-ee` (existing info: chart icon is recommended)
- Passed: `git diff --check`

Fraimz not run: this is a Helm chart/docs change with no browser-visible product flow.