### PR TITLE
feat(den): org picker for multi-org cloud-local login

### DIFF
--- a/ee/apps/den-api/src/active-organization.ts
+++ b/ee/apps/den-api/src/active-organization.ts
@@ -19,7 +19,7 @@ export async function getInitialActiveOrganizationIdForUser(userId: string) {
     .from(MemberTable)
     .where(and(eq(MemberTable.userId, normalizedUserId), isNull(MemberTable.removedAt)))
     .orderBy(asc(MemberTable.createdAt))
-    .limit(1)
+    .limit(2)
 
-  return rows[0]?.organizationId ?? null
+  return rows.length === 1 ? rows[0].organizationId : null
 }

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -1014,7 +1014,9 @@ export async function resolveUserOrganizations(input: {
     }
   }
 
-  activeOrgId ??= orgs[0]?.id ?? null
+  if (!activeOrgId && orgs.length === 1) {
+    activeOrgId = orgs[0].id
+  }
 
   const activeOrg = orgs.find((org) => org.id === activeOrgId) ?? null
 

--- a/ee/apps/den-web/app/(den)/_lib/den-org.selection.test.mts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.selection.test.mts
@@ -1,0 +1,29 @@
+// Runnable check for the org-selection decision. No test framework in den-web,
+// so this is a plain assert script: `pnpm exec tsx den-org.selection.test.mts`.
+import assert from "node:assert/strict";
+import { shouldRequireOrgSelection, shouldShowOrgSelection } from "./den-org.ts";
+import type { DenOrgSummary } from "./den-org.ts";
+
+function org(id: string, isActive: boolean): DenOrgSummary {
+  return {
+    id, name: id, slug: id, logo: null, metadata: null, role: "member",
+    orgMemberId: `m-${id}`, membershipId: `ms-${id}`, memberCount: 1,
+    createdAt: null, updatedAt: null, isActive,
+  };
+}
+
+// multiple orgs + none active => picker
+assert.equal(shouldRequireOrgSelection([org("a", false), org("b", false)]), true);
+// multiple orgs + one active => no picker (dashboard loads active)
+assert.equal(shouldRequireOrgSelection([org("a", true), org("b", false)]), false);
+// explicit login selection request => picker even when a prior active org exists
+assert.equal(shouldShowOrgSelection([org("a", true), org("b", false)], true), true);
+// no explicit selection request + active org => dashboard loads active
+assert.equal(shouldShowOrgSelection([org("a", true), org("b", false)], false), false);
+// single org + not active => auto-select, no picker
+assert.equal(shouldRequireOrgSelection([org("a", false)]), false);
+assert.equal(shouldShowOrgSelection([org("a", false)], true), false);
+// no orgs => no picker (routes to create/join)
+assert.equal(shouldRequireOrgSelection([]), false);
+
+console.log("ok: den-org selection predicate");

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -338,6 +338,14 @@ export function getOrgAccessFlags(roleValue: string, isOwner: boolean, roleDefin
   };
 }
 
+export function shouldRequireOrgSelection(orgs: readonly DenOrgSummary[]): boolean {
+  return orgs.length > 1 && !orgs.some((org) => org.isActive);
+}
+
+export function shouldShowOrgSelection(orgs: readonly DenOrgSummary[], selectionRequested: boolean): boolean {
+  return shouldRequireOrgSelection(orgs) || (selectionRequested && orgs.length > 1);
+}
+
 export function formatRoleLabel(role: string): string {
   return role
     .split(/[-_\s]+/)
@@ -348,6 +356,10 @@ export function formatRoleLabel(role: string): string {
 
 export function getOrgDashboardRoute(_orgSlug?: string | null): string {
   return "/dashboard";
+}
+
+export function getOrgSelectionRoute(): string {
+  return `${getOrgDashboardRoute()}?selectOrg=1`;
 }
 
 export function getMarketplaceOnboardingRoute(_orgSlug?: string | null): string {

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -62,6 +62,7 @@ import {
   getInferenceRoute,
   getJoinOrgRoute,
   getOrgDashboardRoute,
+  getOrgSelectionRoute,
   getWorkspaceClaimRoute,
   parseOrgListPayload,
 } from "../_lib/den-org";
@@ -962,6 +963,9 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   async function resolveDashboardRoute() {
     const orgDirectory = await loadOrgDirectory();
     const activeOrgSlug = orgDirectory.activeOrgSlug ?? orgDirectory.orgs[0]?.slug ?? null;
+    if (orgDirectory.orgs.length > 1 && !orgDirectory.activeOrgSlug) {
+      return getOrgSelectionRoute();
+    }
     return activeOrgSlug ? getOrgDashboardRoute(activeOrgSlug) : null;
   }
 
@@ -1038,7 +1042,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     const dashboardRoute = await resolveDashboardRoute();
 
     if (dashboardRoute) {
-      if (getPendingAuthIntent() === "models") {
+      if (getPendingAuthIntent() === "models" && dashboardRoute !== getOrgSelectionRoute()) {
         clearPendingAuthIntent();
         return getInferenceRoute();
       }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -44,6 +44,7 @@ import {
 } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { buildDenFeedbackUrl } from "../../_lib/feedback";
+import { OrgSelectionScreen } from "./org-selection-screen";
 
 const OPENWORK_DOCS_URL = "/docs";
 
@@ -185,12 +186,27 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
     activeOrg,
     orgDirectory,
     orgContext,
+    orgSelectionRequired,
     orgBusy,
     orgError,
+    mutationBusy,
     switchOrganization,
   } = useOrgDashboard();
   const [switcherOpen, setSwitcherOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   const isSingleOrgMode = runtimeConfigLoaded && runtimeConfig.orgMode === "single_org";
+
+  if (orgSelectionRequired) {
+    return (
+      <OrgSelectionScreen
+        orgs={orgDirectory}
+        onSelect={switchOrganization}
+        onSignOut={() => void signOut()}
+        busy={mutationBusy === "switch-organization"}
+        error={orgError}
+      />
+    );
+  }
 
   const access = getOrgAccessFlags(
     orgContext?.currentMember.role ?? "member",
@@ -403,8 +419,6 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
       ) : null}
     </div>
   );
-
-  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const sidebarContent = (
     <div className="flex flex-1 flex-col">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-selection-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-selection-screen.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import Link from "next/link";
+import { Building2, ChevronRight, LogOut, Plus } from "lucide-react";
+import { formatRoleLabel, type DenOrgSummary } from "../../_lib/den-org";
+
+export function OrgSelectionScreen({
+  orgs,
+  onSelect,
+  onSignOut,
+  busy,
+  error,
+}: {
+  orgs: DenOrgSummary[];
+  onSelect: (slug: string) => void;
+  onSignOut: () => void;
+  busy: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#fafafa] px-4 py-12">
+      <div className="w-full max-w-md">
+        <div className="mb-6 text-center">
+          <h1 className="text-[18px] font-semibold tracking-[-0.2px] text-gray-900">
+            Choose an organization
+          </h1>
+          <p className="mt-1 text-[13px] text-gray-500">
+            You belong to {orgs.length} organizations. Select one to continue.
+          </p>
+        </div>
+
+        <div className="grid gap-2 rounded-xl border border-gray-200 bg-white p-2 shadow-[0_12px_24px_-16px_rgba(0,0,0,0.15)]">
+          {orgs.map((org) => (
+            <button
+              key={org.id}
+              type="button"
+              disabled={busy}
+              onClick={() => onSelect(org.slug)}
+              className="flex items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <span className="flex min-w-0 items-center gap-3">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-500">
+                  <Building2 className="h-4 w-4" strokeWidth={1.8} />
+                </span>
+                <span className="min-w-0">
+                  <span className="block truncate text-[14px] font-medium text-gray-900">{org.name}</span>
+                  <span className="block truncate text-[12px] text-gray-500">
+                    {formatRoleLabel(org.role)} • {org.memberCount} {org.memberCount === 1 ? "member" : "members"}
+                  </span>
+                </span>
+              </span>
+              <ChevronRight className="h-4 w-4 shrink-0 text-gray-300" strokeWidth={2} />
+            </button>
+          ))}
+        </div>
+
+        {error ? (
+          <p className="mt-3 px-1 text-[12px] font-medium text-rose-600">{error}</p>
+        ) : null}
+
+        <div className="mt-4 flex items-center justify-between px-1">
+          <Link
+            href="/organization"
+            className="flex items-center gap-1.5 text-[13px] font-medium text-gray-600 transition-colors hover:text-gray-900"
+          >
+            <Plus className="h-4 w-4 text-gray-400" /> Create or join
+          </Link>
+          <button
+            type="button"
+            onClick={onSignOut}
+            className="flex items-center gap-1.5 text-[13px] font-medium text-gray-600 transition-colors hover:text-gray-900"
+          >
+            <LogOut className="h-4 w-4 text-gray-400" /> Sign out
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
@@ -7,7 +7,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import { getErrorMessage, getOrgLimitError, getOrgPaymentRequiredError, getRequestError, isReauthRequiredError, requestJson } from "../../_lib/den-flow";
 import { ReauthDialog } from "../../_components/reauth-dialog";
@@ -17,6 +17,7 @@ import {
   getOrgDashboardRoute,
   parseOrgContextPayload,
   parseOrgListPayload,
+  shouldShowOrgSelection,
 } from "../../_lib/den-org";
 
 type OrgDashboardContextValue = {
@@ -25,6 +26,7 @@ type OrgDashboardContextValue = {
   orgDirectory: DenOrgSummary[];
   activeOrg: DenOrgSummary | null;
   orgContext: DenOrgContext | null;
+  orgSelectionRequired: boolean;
   orgBusy: boolean;
   orgError: string | null;
   mutationBusy: string | null;
@@ -62,9 +64,11 @@ export function OrgDashboardProvider({
   children: React.ReactNode;
 }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { user, sessionHydrated, signOut, refreshWorkers, workersLoadedOnce, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
   const [orgDirectory, setOrgDirectory] = useState<DenOrgSummary[]>([]);
   const [orgContext, setOrgContext] = useState<DenOrgContext | null>(null);
+  const [orgSelectionRequired, setOrgSelectionRequired] = useState(false);
   const [orgBusy, setOrgBusy] = useState(false);
   const [orgError, setOrgError] = useState<string | null>(null);
   const [mutationBusy, setMutationBusy] = useState<string | null>(null);
@@ -80,6 +84,7 @@ export function OrgDashboardProvider({
 
   const activeOrgId = activeOrg?.id ?? orgContext?.organization.id ?? null;
   const isSingleOrgMode = runtimeConfigLoaded && runtimeConfig.orgMode === "single_org";
+  const orgSelectionRequested = searchParams.get("selectOrg") === "1";
 
   function ensureActiveOrganizationSelected() {
     if (!activeOrgId) {
@@ -129,11 +134,13 @@ export function OrgDashboardProvider({
     if (!user) {
       setOrgDirectory([]);
       setOrgContext(null);
+      setOrgSelectionRequired(false);
       setOrgError(null);
       return;
     }
 
     setOrgBusy(true);
+    setOrgSelectionRequired(false);
     setOrgError(null);
 
     try {
@@ -144,6 +151,13 @@ export function OrgDashboardProvider({
         setOrgDirectory([]);
         setOrgContext(null);
         router.replace("/organization");
+        return;
+      }
+
+      if (!isSingleOrgMode && shouldShowOrgSelection(directoryPayload.orgs, orgSelectionRequested)) {
+        setOrgDirectory(directoryPayload.orgs);
+        setOrgContext(null);
+        setOrgSelectionRequired(true);
         return;
       }
 
@@ -277,8 +291,10 @@ export function OrgDashboardProvider({
         const context = await loadOrgContext();
         setOrgDirectory((current) => current.map((entry) => ({ ...entry, isActive: entry.id === context.organization.id })));
         setOrgContext(context);
+        setOrgSelectionRequired(false);
         await refreshWorkers({ keepSelection: false, quiet: workersLoadedOnce });
 
+        router.replace(getOrgDashboardRoute(context.organization.slug));
         router.refresh();
       } catch (error) {
         setOrgError(error instanceof Error ? error.message : "Failed to switch organization.");
@@ -561,7 +577,7 @@ export function OrgDashboardProvider({
     }
 
     void refreshOrgData();
-  }, [router, sessionHydrated, user?.id]);
+  }, [router, sessionHydrated, user?.id, isSingleOrgMode, orgSelectionRequested]);
 
   const value: OrgDashboardContextValue = {
     orgSlug: activeOrg?.slug ?? null,
@@ -569,6 +585,7 @@ export function OrgDashboardProvider({
     orgDirectory,
     activeOrg,
     orgContext,
+    orgSelectionRequired,
     orgBusy,
     orgError,
     mutationBusy,


### PR DESCRIPTION
## What

Multi-org users with no active org now land on a center-screen **"Choose an organization"** picker instead of being silently dropped into their oldest org. Single-org users and `single_org` deploy mode auto-select unchanged.

## Screenshot

Multi-org login → center-screen org picker:

![Org selection picker](https://raw.githubusercontent.com/umgbhalla/openwork/pr-assets/org-picker.png)

## Why

`getInitialActiveOrganizationIdForUser` (login session hook) and `resolveUserOrganizations` both silently defaulted to the first/oldest org, so a multi-org user never saw a picker — they were always dropped into one org. This makes org selection explicit for multi-org users while preserving single-org behavior.

## Changes

- **den-api** — `getInitialActiveOrganizationIdForUser` + `resolveUserOrganizations` auto-select an org only when the user has exactly one; multiple orgs with no valid active selection leave the session active org `null` so the web app can prompt. `single_org` mode untouched.
- **den-web** — `OrgSelectionScreen` (new) rendered full-screen by the dashboard shell when selection is required; `resolveDashboardRoute` routes to the picker **only when no active org exists**, so returning users with an active org go straight to the dashboard.
- Adds a runnable predicate check (`den-org.selection.test.mts`).

## Verification

- `tsc --noEmit` clean for den-web + den-api; predicate test passes.
- Live e2e (`pnpm dev:web-local`, seeded multi-org user `alex@acme.test`):
  - fresh multi-org login → center picker (not first org)
  - select org → dashboard loads, sidebar switcher marks it active
  - switcher → switch org → dashboard + session persists
  - revisit `/` with an active org already set → dashboard, **not** the picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)