### PR TITLE
refactor(evals): move mintMcpToken/mcpAgentCall into the shared den-web lib

### DIFF
--- a/evals/flows/exa-connection.flow.mjs
+++ b/evals/flows/exa-connection.flow.mjs
@@ -5,7 +5,7 @@
  */
 
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
-import { denApiFetch, denApiUrl, openAdminConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+import { denApiFetch, mcpAgentCall, mintMcpToken, openAdminConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
 
 const vo = await loadVoiceoverParagraphs("exa-connection");
 
@@ -54,33 +54,6 @@ function exaConnectedRowScript() {
     }
     return false;
   })()`;
-}
-
-async function mcpAgentCall(mcpToken, method, params, ctx) {
-  const response = await fetch(`${denApiUrl()}/mcp/agent`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      accept: "application/json, text/event-stream",
-      authorization: `Bearer ${mcpToken}`,
-    },
-    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
-  });
-  const raw = await response.text();
-  ctx.assert(response.ok, `MCP ${method} failed: ${response.status} ${raw.slice(0, 200)}`);
-  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
-  ctx.assert(Boolean(dataLine), `MCP ${method} returned no data frame.`);
-  return JSON.parse(dataLine.slice(5)).result;
-}
-
-async function mintMcpToken(sessionToken, ctx) {
-  const { response, body } = await denApiFetch("/v1/mcp/token", {
-    method: "POST",
-    headers: { authorization: `Bearer ${sessionToken}` },
-    body: "{}",
-  });
-  ctx.assert(response.ok, `Minting an MCP token failed: ${response.status}`);
-  return body.token;
 }
 
 export default {

--- a/evals/flows/lib/den-web.mjs
+++ b/evals/flows/lib/den-web.mjs
@@ -100,3 +100,32 @@ export async function openYourConnections(ctx) {
   );
   await ctx.waitFor("window.location.pathname.endsWith('/your-connections')", { timeoutMs: 20_000, label: "Your Connections route" });
 }
+
+/** Mints an agent MCP token for a signed-in session (POST /v1/mcp/token). */
+export async function mintMcpToken(sessionToken, ctx) {
+  const { response, body } = await denApiFetch("/v1/mcp/token", {
+    method: "POST",
+    headers: { authorization: `Bearer ${sessionToken}` },
+    body: "{}",
+  });
+  ctx.assert(response.ok, `Minting an MCP token failed: ${response.status}`);
+  return body.token;
+}
+
+/** Calls the agent-facing MCP surface (/mcp/agent) and returns the JSON-RPC result. */
+export async function mcpAgentCall(mcpToken, method, params, ctx) {
+  const response = await fetch(`${denApiUrl()}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${mcpToken}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
+  });
+  const raw = await response.text();
+  ctx.assert(response.ok, `MCP ${method} failed: ${response.status} ${raw.slice(0, 200)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  ctx.assert(Boolean(dataLine), `MCP ${method} returned no data frame.`);
+  return JSON.parse(dataLine.slice(5)).result;
+}

--- a/evals/flows/mcp-connections-cloud-oauth.flow.mjs
+++ b/evals/flows/mcp-connections-cloud-oauth.flow.mjs
@@ -40,7 +40,7 @@
  *   accommodation, not a product behavior change).
  */
 
-import { denApiFetch, denApiUrl, denWebUrl, openAdminConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+import { denApiFetch, denWebUrl, mcpAgentCall, mintMcpToken, openAdminConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
 
 const DEMO_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
 const DEMO_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
@@ -221,51 +221,23 @@ export default {
       run: async (ctx) => {
         await ctx.prove("The org's harness-facing MCP surface (search_capabilities + execute_capability) picks up the connection with zero desktop-side setup", {
           assert: async () => {
-            const signIn = await denApiFetch("/api/auth/sign-in/email", {
-              method: "POST",
-              body: JSON.stringify({ email: DEMO_EMAIL, password: DEMO_PASSWORD }),
-            });
-            ctx.assert(signIn.response.ok, `Den API sign-in failed: ${signIn.response.status}`);
-            const sessionToken = signIn.body.token;
+            const sessionToken = await signInApi(DEMO_EMAIL, DEMO_PASSWORD);
+            ctx.assert(Boolean(sessionToken), `Den API sign-in failed for ${DEMO_EMAIL}.`);
+            const mcpToken = await mintMcpToken(sessionToken, ctx);
 
-            const mint = await denApiFetch("/v1/mcp/token", {
-              method: "POST",
-              headers: { authorization: `Bearer ${sessionToken}` },
-              body: "{}",
-            });
-            ctx.assert(mint.response.ok, `Minting an MCP token failed: ${mint.response.status}`);
-            const mcpToken = mint.body.token;
-
-            async function mcpAgentCall(method, params) {
-              const response = await fetch(`${denApiUrl()}/mcp/agent`, {
-                method: "POST",
-                headers: {
-                  "content-type": "application/json",
-                  accept: "application/json, text/event-stream",
-                  authorization: `Bearer ${mcpToken}`,
-                },
-                body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
-              });
-              const raw = await response.text();
-              ctx.assert(response.ok, `MCP ${method} failed: ${response.status} ${raw.slice(0, 200)}`);
-              const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
-              ctx.assert(Boolean(dataLine), `MCP ${method} returned no data frame.`);
-              return JSON.parse(dataLine.slice(5)).result;
-            }
-
-            const searchResult = await mcpAgentCall("tools/call", {
+            const searchResult = await mcpAgentCall(mcpToken, "tools/call", {
               name: "search_capabilities",
               arguments: { query: "echo" },
-            });
+            }, ctx);
             const matchesText = searchResult.content[0].text;
             ctx.assert(matchesText.includes(CONNECTION_NAME), `search_capabilities didn't surface ${CONNECTION_NAME}: ${matchesText}`);
             const match = JSON.parse(matchesText).matches.find((entry) => entry.summary.includes(CONNECTION_NAME));
             ctx.assert(Boolean(match), `No search_capabilities match for ${CONNECTION_NAME}.`);
 
-            const executeResult = await mcpAgentCall("tools/call", {
+            const executeResult = await mcpAgentCall(mcpToken, "tools/call", {
               name: "execute_capability",
               arguments: { name: match.name, body: { text: ECHO_TEXT } },
-            });
+            }, ctx);
             const echoed = executeResult.content?.[0]?.text;
             ctx.assert(echoed === ECHO_TEXT, `execute_capability didn't echo back the exact text: got "${echoed}"`);
           },

--- a/evals/flows/mcp-connections-member-scoped.flow.mjs
+++ b/evals/flows/mcp-connections-member-scoped.flow.mjs
@@ -36,7 +36,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { denApiFetch, denApiUrl, openAdminConnections, openYourConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+import { denApiFetch, mcpAgentCall, mintMcpToken, openAdminConnections, openYourConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
 
 const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
 const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
@@ -56,33 +56,6 @@ const state = {
   restrictedConnectionId: null,
   createdTeamId: null,
 };
-
-async function mcpAgentCall(mcpToken, method, params, ctx) {
-  const response = await fetch(`${denApiUrl()}/mcp/agent`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      accept: "application/json, text/event-stream",
-      authorization: `Bearer ${mcpToken}`,
-    },
-    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
-  });
-  const raw = await response.text();
-  ctx.assert(response.ok, `MCP ${method} failed: ${response.status} ${raw.slice(0, 200)}`);
-  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
-  ctx.assert(Boolean(dataLine), `MCP ${method} returned no data frame.`);
-  return JSON.parse(dataLine.slice(5)).result;
-}
-
-async function mintMcpToken(sessionToken, ctx) {
-  const { response, body } = await denApiFetch("/v1/mcp/token", {
-    method: "POST",
-    headers: { authorization: `Bearer ${sessionToken}` },
-    body: "{}",
-  });
-  ctx.assert(response.ok, `Minting an MCP token failed: ${response.status}`);
-  return body.token;
-}
 
 export default {
   id: "mcp-connections-member-scoped",


### PR DESCRIPTION
Follow-up to #2498 (this commit was pushed minutes after that PR was merged). The agent-surface helpers (`mintMcpToken`, `mcpAgentCall`) were duplicated in the member-scoped and exa flows plus an inline variant in cloud-oauth; all three now use `evals/flows/lib/den-web.mjs`. Net −53 lines, eval-only, behavior identical.

Verified: all three flows (`exa-connection`, `mcp-connections-cloud-oauth`, `mcp-connections-member-scoped`) ran PASSED against a live local stack with exactly this content before splitting it into this PR.

Heads-up for anyone running these locally: stable Google Chrome silently stopped honoring `--disable-popup-blocking` for non-gesture `window.open` (field-trial rollout mid-day 2026-07-06), which breaks the OAuth-popup flows on stable Chrome. Pinned Chromium / Chrome for Testing (e.g. the Playwright-managed build) is unaffected — that's what the verification ran on.