### PR TITLE
fix(den): repair dev build — unsuspended useSearchParams from org picker (#2503 follow-up)

### DIFF
--- a/ee/apps/den-web/app/(den)/_lib/den-org.selection.test.mts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.selection.test.mts
@@ -1,7 +1,7 @@
 // Runnable check for the org-selection decision. No test framework in den-web,
 // so this is a plain assert script: `pnpm exec tsx den-org.selection.test.mts`.
 import assert from "node:assert/strict";
-import { shouldRequireOrgSelection, shouldShowOrgSelection } from "./den-org.ts";
+import { shouldRequireOrgSelection } from "./den-org.ts";
 import type { DenOrgSummary } from "./den-org.ts";
 
 function org(id: string, isActive: boolean): DenOrgSummary {
@@ -16,13 +16,8 @@ function org(id: string, isActive: boolean): DenOrgSummary {
 assert.equal(shouldRequireOrgSelection([org("a", false), org("b", false)]), true);
 // multiple orgs + one active => no picker (dashboard loads active)
 assert.equal(shouldRequireOrgSelection([org("a", true), org("b", false)]), false);
-// explicit login selection request => picker even when a prior active org exists
-assert.equal(shouldShowOrgSelection([org("a", true), org("b", false)], true), true);
-// no explicit selection request + active org => dashboard loads active
-assert.equal(shouldShowOrgSelection([org("a", true), org("b", false)], false), false);
 // single org + not active => auto-select, no picker
 assert.equal(shouldRequireOrgSelection([org("a", false)]), false);
-assert.equal(shouldShowOrgSelection([org("a", false)], true), false);
 // no orgs => no picker (routes to create/join)
 assert.equal(shouldRequireOrgSelection([]), false);
 

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -342,10 +342,6 @@ export function shouldRequireOrgSelection(orgs: readonly DenOrgSummary[]): boole
   return orgs.length > 1 && !orgs.some((org) => org.isActive);
 }
 
-export function shouldShowOrgSelection(orgs: readonly DenOrgSummary[], selectionRequested: boolean): boolean {
-  return shouldRequireOrgSelection(orgs) || (selectionRequested && orgs.length > 1);
-}
-
 export function formatRoleLabel(role: string): string {
   return role
     .split(/[-_\s]+/)
@@ -356,10 +352,6 @@ export function formatRoleLabel(role: string): string {
 
 export function getOrgDashboardRoute(_orgSlug?: string | null): string {
   return "/dashboard";
-}
-
-export function getOrgSelectionRoute(): string {
-  return `${getOrgDashboardRoute()}?selectOrg=1`;
 }
 
 export function getMarketplaceOnboardingRoute(_orgSlug?: string | null): string {

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -62,7 +62,6 @@ import {
   getInferenceRoute,
   getJoinOrgRoute,
   getOrgDashboardRoute,
-  getOrgSelectionRoute,
   getWorkspaceClaimRoute,
   parseOrgListPayload,
 } from "../_lib/den-org";
@@ -963,9 +962,6 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   async function resolveDashboardRoute() {
     const orgDirectory = await loadOrgDirectory();
     const activeOrgSlug = orgDirectory.activeOrgSlug ?? orgDirectory.orgs[0]?.slug ?? null;
-    if (orgDirectory.orgs.length > 1 && !orgDirectory.activeOrgSlug) {
-      return getOrgSelectionRoute();
-    }
     return activeOrgSlug ? getOrgDashboardRoute(activeOrgSlug) : null;
   }
 
@@ -1042,7 +1038,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     const dashboardRoute = await resolveDashboardRoute();
 
     if (dashboardRoute) {
-      if (getPendingAuthIntent() === "models" && dashboardRoute !== getOrgSelectionRoute()) {
+      if (getPendingAuthIntent() === "models") {
         clearPendingAuthIntent();
         return getInferenceRoute();
       }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-home-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-home-screen.tsx
@@ -6,16 +6,18 @@ import { DashboardOverviewScreen } from "./dashboard-overview-screen";
 import { MemberDashboardScreen } from "./member-dashboard-screen";
 
 export function DashboardHomeScreen() {
-  const { orgBusy, orgContext } = useOrgDashboard();
+  const { orgBusy, orgContext, mutationBusy } = useOrgDashboard();
   const access = getOrgAccessFlags(
     orgContext?.currentMember.role ?? "member",
     orgContext?.currentMember.isOwner ?? false,
     orgContext?.roles,
   );
 
-  if (orgBusy || !orgContext) {
+  // Switching keeps the old orgContext until the new one loads; route switches
+  // through the placeholder so admin/member home layouts don't hard-swap and jump.
+  if (orgBusy || mutationBusy === "switch-organization" || !orgContext) {
     return (
-      <div className="flex min-h-[320px] items-center justify-center px-6 text-[14px] text-gray-500">
+      <div className="flex min-h-[60vh] items-center justify-center px-6 text-[14px] text-gray-500">
         Loading your workspace...
       </div>
     );

--- a/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
@@ -7,7 +7,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import { getErrorMessage, getOrgLimitError, getOrgPaymentRequiredError, getRequestError, isReauthRequiredError, requestJson } from "../../_lib/den-flow";
 import { ReauthDialog } from "../../_components/reauth-dialog";
@@ -17,7 +17,7 @@ import {
   getOrgDashboardRoute,
   parseOrgContextPayload,
   parseOrgListPayload,
-  shouldShowOrgSelection,
+  shouldRequireOrgSelection,
 } from "../../_lib/den-org";
 
 type OrgDashboardContextValue = {
@@ -64,7 +64,6 @@ export function OrgDashboardProvider({
   children: React.ReactNode;
 }) {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { user, sessionHydrated, signOut, refreshWorkers, workersLoadedOnce, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
   const [orgDirectory, setOrgDirectory] = useState<DenOrgSummary[]>([]);
   const [orgContext, setOrgContext] = useState<DenOrgContext | null>(null);
@@ -84,7 +83,6 @@ export function OrgDashboardProvider({
 
   const activeOrgId = activeOrg?.id ?? orgContext?.organization.id ?? null;
   const isSingleOrgMode = runtimeConfigLoaded && runtimeConfig.orgMode === "single_org";
-  const orgSelectionRequested = searchParams.get("selectOrg") === "1";
 
   function ensureActiveOrganizationSelected() {
     if (!activeOrgId) {
@@ -154,7 +152,7 @@ export function OrgDashboardProvider({
         return;
       }
 
-      if (!isSingleOrgMode && shouldShowOrgSelection(directoryPayload.orgs, orgSelectionRequested)) {
+      if (!isSingleOrgMode && shouldRequireOrgSelection(directoryPayload.orgs)) {
         setOrgDirectory(directoryPayload.orgs);
         setOrgContext(null);
         setOrgSelectionRequired(true);
@@ -577,7 +575,7 @@ export function OrgDashboardProvider({
     }
 
     void refreshOrgData();
-  }, [router, sessionHydrated, user?.id, isSingleOrgMode, orgSelectionRequested]);
+  }, [router, sessionHydrated, user?.id, isSingleOrgMode]);
 
   const value: OrgDashboardContextValue = {
     orgSlug: activeOrg?.slug ?? null,


### PR DESCRIPTION
## Problem

`dev` build is currently broken. `pnpm build:web` fails:

```
⨯ useSearchParams() should be wrapped in a suspense boundary at page "/dashboard/org-settings".
Error occurred prerendering page "/dashboard/org-settings", exiting the build.
```

#2503 was squash-merged from an earlier snapshot that included the `?selectOrg=1` / `useSearchParams` path in `OrgDashboardProvider`, but not the two follow-up fixes on the branch. `useSearchParams()` in the always-mounted provider forces a CSR bailout that fails static prerender of the admin dashboard pages.

## Fix (cherry-picks of the two missing commits)

1. **Drop the redundant `?selectOrg=1` path.** The picker is already driven server-side (multi-org sessions get no active org) and the dashboard shell gates every route on selection, so `useSearchParams` / `getOrgSelectionRoute` / `shouldShowOrgSelection` were redundant. Collapse to `shouldRequireOrgSelection`. This removes the unsuspended `useSearchParams` and fixes prerender.
2. **Avoid the dashboard-home layout jump on org switch.** `switchOrganization` sets `mutationBusy` (not `orgBusy`) and keeps the previous `orgContext` until the new one loads, so `DashboardHomeScreen` hard-swapped the admin/member layouts — a downward content jump, worst on free/member orgs. Route switches through the loading placeholder + stable `min-h-[60vh]`.

## Verification

- `pnpm build:web` → **exit 0** (prerender passes).
- `den-org.selection.test.mts` predicate check passes.
- Behavior unchanged: multi-org no active → picker; active org → dashboard; org switch shows loading placeholder instead of a mismatched hard-swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)