### PR TITLE
fix(den): show org picker after multi-org login

### DIFF
--- a/ee/apps/den-web/app/(den)/_lib/den-org.selection.test.mts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.selection.test.mts
@@ -1,7 +1,7 @@
 // Runnable check for the org-selection decision. No test framework in den-web,
 // so this is a plain assert script: `pnpm exec tsx den-org.selection.test.mts`.
 import assert from "node:assert/strict";
-import { shouldRequireOrgSelection } from "./den-org.ts";
+import { shouldOfferOrgSelection, shouldRequireOrgSelection } from "./den-org.ts";
 import type { DenOrgSummary } from "./den-org.ts";
 
 function org(id: string, isActive: boolean): DenOrgSummary {
@@ -16,8 +16,11 @@ function org(id: string, isActive: boolean): DenOrgSummary {
 assert.equal(shouldRequireOrgSelection([org("a", false), org("b", false)]), true);
 // multiple orgs + one active => no picker (dashboard loads active)
 assert.equal(shouldRequireOrgSelection([org("a", true), org("b", false)]), false);
+// multiple orgs + one active => post-login can still offer explicit selection
+assert.equal(shouldOfferOrgSelection([org("a", true), org("b", false)]), true);
 // single org + not active => auto-select, no picker
 assert.equal(shouldRequireOrgSelection([org("a", false)]), false);
+assert.equal(shouldOfferOrgSelection([org("a", false)]), false);
 // no orgs => no picker (routes to create/join)
 assert.equal(shouldRequireOrgSelection([]), false);
 

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -226,6 +226,7 @@ export const DEN_ROLE_PERMISSION_OPTIONS = {
 
 export const PENDING_ORG_INVITATION_STORAGE_KEY = "openwork:web:pending-org-invitation";
 export const PENDING_WORKSPACE_CLAIM_STORAGE_KEY = "openwork:web:pending-workspace-claim";
+export const PENDING_ORG_SELECTION_STORAGE_KEY = "openwork:web:pending-org-selection";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -340,6 +341,10 @@ export function getOrgAccessFlags(roleValue: string, isOwner: boolean, roleDefin
 
 export function shouldRequireOrgSelection(orgs: readonly DenOrgSummary[]): boolean {
   return orgs.length > 1 && !orgs.some((org) => org.isActive);
+}
+
+export function shouldOfferOrgSelection(orgs: readonly DenOrgSummary[]): boolean {
+  return orgs.length > 1;
 }
 
 export function formatRoleLabel(role: string): string {

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -58,12 +58,14 @@ import {
 import { EMPTY_RUNTIME_CONFIG, getRuntimeConfig, type DenWebRuntimeConfig } from "../_lib/runtime-config";
 import {
   PENDING_ORG_INVITATION_STORAGE_KEY,
+  PENDING_ORG_SELECTION_STORAGE_KEY,
   PENDING_WORKSPACE_CLAIM_STORAGE_KEY,
   getInferenceRoute,
   getJoinOrgRoute,
   getOrgDashboardRoute,
   getWorkspaceClaimRoute,
   parseOrgListPayload,
+  shouldOfferOrgSelection,
 } from "../_lib/den-org";
 
 type LaunchWorkerResult = "success" | "limit" | "error";
@@ -961,6 +963,10 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
   async function resolveDashboardRoute() {
     const orgDirectory = await loadOrgDirectory();
+    if (typeof window !== "undefined" && shouldOfferOrgSelection(orgDirectory.orgs)) {
+      window.sessionStorage.setItem(PENDING_ORG_SELECTION_STORAGE_KEY, "1");
+    }
+
     const activeOrgSlug = orgDirectory.activeOrgSlug ?? orgDirectory.orgs[0]?.slug ?? null;
     return activeOrgSlug ? getOrgDashboardRoute(activeOrgSlug) : null;
   }

--- a/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
@@ -12,11 +12,13 @@ import { useDenFlow } from "../../_providers/den-flow-provider";
 import { getErrorMessage, getOrgLimitError, getOrgPaymentRequiredError, getRequestError, isReauthRequiredError, requestJson } from "../../_lib/den-flow";
 import { ReauthDialog } from "../../_components/reauth-dialog";
 import {
+  PENDING_ORG_SELECTION_STORAGE_KEY,
   type DenOrgContext,
   type DenOrgSummary,
   getOrgDashboardRoute,
   parseOrgContextPayload,
   parseOrgListPayload,
+  shouldOfferOrgSelection,
   shouldRequireOrgSelection,
 } from "../../_lib/den-org";
 
@@ -57,6 +59,16 @@ type PendingReauthMutation = {
 };
 
 const OrgDashboardContext = createContext<OrgDashboardContextValue | null>(null);
+
+function consumePendingOrgSelectionRequest(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const pending = window.sessionStorage.getItem(PENDING_ORG_SELECTION_STORAGE_KEY) === "1";
+  window.sessionStorage.removeItem(PENDING_ORG_SELECTION_STORAGE_KEY);
+  return pending;
+}
 
 export function OrgDashboardProvider({
   children,
@@ -152,7 +164,14 @@ export function OrgDashboardProvider({
         return;
       }
 
-      if (!isSingleOrgMode && shouldRequireOrgSelection(directoryPayload.orgs)) {
+      const shouldShowOrgSelection =
+        !isSingleOrgMode &&
+        (
+          shouldRequireOrgSelection(directoryPayload.orgs) ||
+          (consumePendingOrgSelectionRequest() && shouldOfferOrgSelection(directoryPayload.orgs))
+        );
+
+      if (shouldShowOrgSelection) {
         setOrgDirectory(directoryPayload.orgs);
         setOrgContext(null);
         setOrgSelectionRequired(true);


### PR DESCRIPTION
## Problem

Prod is configured for multi-org mode, but users who already have an active Better Auth organization skip the org picker after login.

The current dev logic only requires the picker when a user has multiple orgs and no active org. Existing multi-org prod accounts with an active org therefore go straight to the dashboard even though we want them to choose the org after login.

## Fix

- Add a one-shot post-login org-selection marker in session storage when the user has multiple orgs.
- Consume that marker in the dashboard org provider and show the existing org picker even when an active org already exists.
- Keep the #2505 build-safe behavior: no useSearchParams hook, no query-param routing, no Suspense or prerender regression.

The marker is removed immediately when consumed, so normal dashboard reloads do not keep forcing the picker.

## Verification

- pnpm --filter @openwork-ee/den-web exec tsc --noEmit -> pass
- pnpm --filter @openwork-ee/den-web build -> pass, including the dashboard org-settings prerender path

No video attached: this is a production-auth routing state fix, and the critical regression was the Next production build and prerender path.