### PR TITLE
fix: expose EMAIL_FROM in EE Helm chart

### DIFF
--- a/docs/aws-eks-helm.md
+++ b/docs/aws-eks-helm.md
@@ -220,6 +220,7 @@ To send transactional email, configure SMTP in the same values file:
 ```yaml
 secret:
   values:
+    emailFrom: "OpenWork <no-reply@example.com>"
     smtpHost: "smtp.example.com"
     smtpPort: "587"
     smtpUser: "openwork@example.com"
@@ -227,10 +228,12 @@ secret:
     smtpSecure: "false"
 ```
 
-These values become `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, and
-`SMTP_SECURE` in Den API. If you use `secret.create=false`, add those keys to
-the existing Kubernetes Secret referenced by `secret.existingSecret`. Leave
-`smtpHost` blank only when SMTP-backed transactional email should be disabled.
+These values become `EMAIL_FROM`, `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`,
+`SMTP_PASS`, and `SMTP_SECURE` in Den API. If you use `secret.create=false`,
+add those keys to the existing Kubernetes Secret referenced by
+`secret.existingSecret`. SMTP delivery requires both `EMAIL_FROM` and
+`SMTP_HOST`; leave `smtpHost` blank only when SMTP-backed transactional email
+should be disabled.
 
 Use a values file, not a long list of `--set` flags. Several OpenWork values are
 comma-separated strings, such as `config.public.corsOrigins`, and plain
@@ -250,7 +253,7 @@ helm template openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
   --namespace openwork-ee \
   -f values.aws.yaml > /tmp/openwork-rendered.yaml
 
-grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN|SMTP_HOST|SMTP_PORT|SMTP_SECURE' /tmp/openwork-rendered.yaml
+grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN|EMAIL_FROM|SMTP_HOST|SMTP_PORT|SMTP_SECURE' /tmp/openwork-rendered.yaml
 ```
 
 Redact secrets before sharing rendered manifests or terminal output.

--- a/docs/azure-aks-helm.md
+++ b/docs/azure-aks-helm.md
@@ -189,6 +189,7 @@ To send transactional email, configure SMTP in the same values file:
 ```yaml
 secret:
   values:
+    emailFrom: "OpenWork <no-reply@example.com>"
     smtpHost: "smtp.example.com"
     smtpPort: "587"
     smtpUser: "openwork@example.com"
@@ -196,10 +197,12 @@ secret:
     smtpSecure: "false"
 ```
 
-These values become `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, and
-`SMTP_SECURE` in Den API. If you use `secret.create=false`, add those keys to
-the existing Kubernetes Secret referenced by `secret.existingSecret`. Leave
-`smtpHost` blank only when SMTP-backed transactional email should be disabled.
+These values become `EMAIL_FROM`, `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`,
+`SMTP_PASS`, and `SMTP_SECURE` in Den API. If you use `secret.create=false`,
+add those keys to the existing Kubernetes Secret referenced by
+`secret.existingSecret`. SMTP delivery requires both `EMAIL_FROM` and
+`SMTP_HOST`; leave `smtpHost` blank only when SMTP-backed transactional email
+should be disabled.
 
 Use a values file, not a long list of `--set` flags. Several OpenWork values are
 comma-separated strings, such as `config.public.corsOrigins`, and plain `--set`
@@ -219,7 +222,7 @@ helm template openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
   --namespace openwork-ee \
   -f values.azure.yaml > /tmp/openwork-rendered.yaml
 
-grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN|SMTP_HOST|SMTP_PORT|SMTP_SECURE' /tmp/openwork-rendered.yaml
+grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN|EMAIL_FROM|SMTP_HOST|SMTP_PORT|SMTP_SECURE' /tmp/openwork-rendered.yaml
 ```
 
 Redact secrets before sharing rendered manifests or terminal output.

--- a/docs/gcp-gke-helm.md
+++ b/docs/gcp-gke-helm.md
@@ -278,6 +278,7 @@ To send transactional email, configure SMTP in the same values file:
 ```yaml
 secret:
   values:
+    emailFrom: "OpenWork <no-reply@example.com>"
     smtpHost: "smtp.example.com"
     smtpPort: "587"
     smtpUser: "openwork@example.com"
@@ -285,10 +286,12 @@ secret:
     smtpSecure: "false"
 ```
 
-These values become `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, and
-`SMTP_SECURE` in Den API. If you use `secret.create=false`, add those keys to
-the existing Kubernetes Secret referenced by `secret.existingSecret`. Leave
-`smtpHost` blank only when SMTP-backed transactional email should be disabled.
+These values become `EMAIL_FROM`, `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`,
+`SMTP_PASS`, and `SMTP_SECURE` in Den API. If you use `secret.create=false`,
+add those keys to the existing Kubernetes Secret referenced by
+`secret.existingSecret`. SMTP delivery requires both `EMAIL_FROM` and
+`SMTP_HOST`; leave `smtpHost` blank only when SMTP-backed transactional email
+should be disabled.
 
 Use a values file, not a long list of `--set` flags. Several OpenWork values are
 comma-separated strings, such as `config.public.corsOrigins`, and plain `--set`
@@ -308,7 +311,7 @@ helm template openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
   --namespace openwork-ee \
   -f values.gcp.yaml > /tmp/openwork-rendered.yaml
 
-grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN|SMTP_HOST|SMTP_PORT|SMTP_SECURE' /tmp/openwork-rendered.yaml
+grep -E 'DATABASE_URL|BETTER_AUTH_URL|DEN_API_PUBLIC_URL|DEN_WEB_PUBLIC_ORIGIN|EMAIL_FROM|SMTP_HOST|SMTP_PORT|SMTP_SECURE' /tmp/openwork-rendered.yaml
 ```
 
 Redact secrets before sharing rendered manifests or terminal output.

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -54,6 +54,7 @@ secret:
     databaseUrl: "mysql://openwork:REPLACE_ME@mysql.example.internal:3306/openwork_den?sslaccept=accept"
     betterAuthSecret: "REPLACE_WITH_AT_LEAST_32_CHARACTERS"
     denDbEncryptionKey: "REPLACE_WITH_AT_LEAST_32_CHARACTERS"
+    emailFrom: "OpenWork <no-reply@example.com>"
     smtpHost: "smtp.example.com"
     smtpPort: "587"
     smtpUser: "openwork@example.com"
@@ -143,6 +144,7 @@ the chart Secret:
 ```yaml
 secret:
   values:
+    emailFrom: "OpenWork <no-reply@example.com>"
     smtpHost: "smtp.example.com"
     smtpPort: "587"
     smtpUser: "openwork@example.com"
@@ -152,6 +154,7 @@ secret:
 
 These values are exposed to Den API as:
 
+- `EMAIL_FROM`
 - `SMTP_HOST`
 - `SMTP_PORT`
 - `SMTP_USER`
@@ -159,8 +162,9 @@ These values are exposed to Den API as:
 - `SMTP_SECURE`
 
 If `secret.create=false`, add those keys to the existing Secret referenced by
-`secret.existingSecret`. `SMTP_HOST` enables SMTP delivery; leave it blank to
-disable SMTP-backed transactional email.
+`secret.existingSecret`. SMTP delivery requires both `EMAIL_FROM` and
+`SMTP_HOST`; leave `smtpHost` blank only when SMTP-backed transactional email
+should be disabled.
 
 ## Tenancy Mode
 

--- a/packaging/helm/openwork-ee/templates/secret.yaml
+++ b/packaging/helm/openwork-ee/templates/secret.yaml
@@ -15,6 +15,7 @@ stringData:
   {{ .Values.secret.keys.openRouterManagementApiKey }}: {{ .Values.secret.values.openRouterManagementApiKey | quote }}
   {{ .Values.secret.keys.inferenceAdminToken }}: {{ .Values.secret.values.inferenceAdminToken | quote }}
   {{ .Values.secret.keys.inferenceWebhookSecret }}: {{ .Values.secret.values.inferenceWebhookSecret | quote }}
+  {{ .Values.secret.keys.emailFrom }}: {{ .Values.secret.values.emailFrom | quote }}
   {{ .Values.secret.keys.smtpHost }}: {{ .Values.secret.values.smtpHost | quote }}
   {{ .Values.secret.keys.smtpPort }}: {{ .Values.secret.values.smtpPort | quote }}
   {{ .Values.secret.keys.smtpUser }}: {{ .Values.secret.values.smtpUser | quote }}

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -97,6 +97,7 @@ secret:
     openRouterManagementApiKey: OPENROUTER_MANAGEMENT_API_KEY
     inferenceAdminToken: INFERENCE_ADMIN_TOKEN
     inferenceWebhookSecret: INFERENCE_WEBHOOK_SECRET
+    emailFrom: EMAIL_FROM
     smtpHost: SMTP_HOST
     smtpPort: SMTP_PORT
     smtpUser: SMTP_USER
@@ -111,6 +112,7 @@ secret:
     openRouterManagementApiKey: ""
     inferenceAdminToken: ""
     inferenceWebhookSecret: ""
+    emailFrom: ""
     smtpHost: ""
     smtpPort: "587"
     smtpUser: ""


### PR DESCRIPTION
## Summary
- add first-class Helm value secret.values.emailFrom mapped to EMAIL_FROM
- document EMAIL_FROM alongside SMTP settings in the EE chart README
- update AWS, Azure, and GCP Helm guides to include emailFrom and render checks

## Validation
- helm template openwork-ee ./packaging/helm/openwork-ee --set secret.values.emailFrom='OpenWork <no-reply@example.com>' --set secret.values.smtpHost=smtp.example.com --set secret.values.smtpUser=openwork@example.com --set secret.values.smtpPass=secret --set secret.values.smtpSecure=false
- helm lint ./packaging/helm/openwork-ee
- git diff --check

Fraimz not run: chart/docs-only change with no directly runnable app UX path.