### PR TITLE
fix(installer): survive macOS App Translocation — the stamped installer works on download → unzip → double-click

### DIFF
--- a/.github/workflows/release-generic-installer.yml
+++ b/.github/workflows/release-generic-installer.yml
@@ -18,9 +18,17 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Existing release tag to attach the installer assets to (e.g. v0.17.9)"
-        required: true
+        description: "Existing release tag to attach the installer assets to (required for publish_mode=release; e.g. v0.17.9)"
+        required: false
         type: string
+      publish_mode:
+        description: "Publish to a GitHub release or keep as workflow artifacts"
+        required: false
+        type: choice
+        default: "release"
+        options:
+          - "release"
+          - "artifact"
       platforms:
         description: "Platforms to build and publish"
         required: false
@@ -56,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.resolve.outputs.release_tag }}
+      publish_mode: ${{ steps.resolve.outputs.publish_mode }}
       sign_windows: ${{ steps.resolve.outputs.sign_windows }}
       matrix: ${{ steps.resolve.outputs.matrix }}
     steps:
@@ -66,6 +75,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          INPUT_PUBLISH_MODE: ${{ github.event.inputs.publish_mode }}
           INPUT_PLATFORMS: ${{ github.event.inputs.platforms }}
           INPUT_SIGN_WINDOWS: ${{ github.event.inputs.sign_windows }}
           RELEASE_EVENT_TAG: ${{ github.event.release.tag_name }}
@@ -74,17 +84,25 @@ jobs:
 
           if [ "$EVENT_NAME" = "release" ]; then
             RELEASE_TAG="$RELEASE_EVENT_TAG"
+            PUBLISH_MODE="release"
             PLATFORMS="mac-arm64,mac-x64,win-x64"
             SIGN_WINDOWS="false"
           else
             RELEASE_TAG="$INPUT_RELEASE_TAG"
+            PUBLISH_MODE="${INPUT_PUBLISH_MODE:-release}"
             PLATFORMS="${INPUT_PLATFORMS:-mac-arm64,mac-x64,win-x64}"
             SIGN_WINDOWS="${INPUT_SIGN_WINDOWS:-false}"
           fi
 
-          if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null; then
-            echo "Release $RELEASE_TAG does not exist on $GITHUB_REPOSITORY" >&2
-            exit 1
+          if [ "$PUBLISH_MODE" = "release" ]; then
+            if [ -z "$RELEASE_TAG" ]; then
+              echo "release_tag is required when publish_mode=release" >&2
+              exit 1
+            fi
+            if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null; then
+              echo "Release $RELEASE_TAG does not exist on $GITHUB_REPOSITORY" >&2
+              exit 1
+            fi
           fi
 
           ALL='[
@@ -101,6 +119,7 @@ jobs:
 
           {
             echo "release_tag=$RELEASE_TAG"
+            echo "publish_mode=$PUBLISH_MODE"
             echo "sign_windows=$SIGN_WINDOWS"
             echo "matrix=$MATRIX"
           } >> "$GITHUB_OUTPUT"
@@ -112,6 +131,7 @@ jobs:
     timeout-minutes: 90
     env:
       RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+      PUBLISH_MODE: ${{ needs.resolve.outputs.publish_mode }}
       SIGN_WINDOWS: ${{ needs.resolve.outputs.sign_windows }}
       SIGNPATH_ORGANIZATION_ID: ${{ secrets.SIGNPATH_ORGANIZATION_ID || vars.SIGNPATH_ORGANIZATION_ID }}
       SIGNPATH_PROJECT_SLUG: ${{ secrets.SIGNPATH_PROJECT_SLUG || vars.SIGNPATH_PROJECT_SLUG }}
@@ -372,6 +392,7 @@ jobs:
           fi
 
       - name: Upload release asset
+        if: env.PUBLISH_MODE == 'release'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -379,3 +400,12 @@ jobs:
           set -euo pipefail
           gh release upload "$RELEASE_TAG" "$RUNNER_TEMP/out/${{ matrix.asset }}" \
             --repo "$GITHUB_REPOSITORY" --clobber
+
+      - name: Upload workflow artifact
+        if: env.PUBLISH_MODE == 'artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: generic-installer-${{ matrix.platform_id }}
+          path: ${{ runner.temp }}/out/${{ matrix.asset }}
+          if-no-files-found: error
+          retention-days: 7

--- a/apps/installer/src/config-sources.ts
+++ b/apps/installer/src/config-sources.ts
@@ -1,4 +1,5 @@
 import { installConfigSchema, installConfigUrlFor, INSTALL_SIDECAR_FILENAME, parseInstallerFilenameTag, type InstallConfig } from "@openwork/install-config"
+import { execFileSync } from "node:child_process"
 import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 import { BUILD_API_URL, BUILD_CLIENT_NAME, BUILD_LOGO_URL, BUILD_REQUIRE_SIGNIN, BUILD_WEB_URL } from "./generated/build-config"
@@ -15,6 +16,7 @@ type ConfigSourceOptions = {
   env?: NodeJS.ProcessEnv
   execPath?: string
   fetcher?: typeof fetch
+  readMountTable?: () => string
   warn?: (message: string) => void
 }
 
@@ -110,6 +112,42 @@ function appBundleSidecarPath(execPath: string) {
   return match ? path.join(match[1], INSTALL_SIDECAR_FILENAME) : null
 }
 
+export function parseMountTableLine(line: string): { source: string; mountPoint: string; options: string } | null {
+  const match = /^(.+) on (\/.+?) \(([^)]*)\)$/.exec(line)
+  return match ? { source: match[1], mountPoint: match[2], options: match[3] } : null
+}
+
+function hasNullfsOption(options: string) {
+  return options.split(",").some((option) => option.trim() === "nullfs")
+}
+
+function isPathPrefix(prefix: string, value: string) {
+  return value === prefix || value.startsWith(prefix.endsWith("/") ? prefix : `${prefix}/`)
+}
+
+export function resolveTranslocatedOriginalPath(execPath: string, mountTable: string): string | null {
+  for (const line of mountTable.split(/\r?\n/)) {
+    const mount = parseMountTableLine(line)
+    if (mount && hasNullfsOption(mount.options) && isPathPrefix(mount.mountPoint, execPath)) {
+      return mount.source
+    }
+  }
+  return null
+}
+
+export function isTranslocatedPath(execPath: string): boolean {
+  return /\/AppTranslocation\//.test(execPath)
+}
+
+function readMountTable(options: ConfigSourceOptions) {
+  try {
+    return options.readMountTable?.() ?? execFileSync("/sbin/mount", { encoding: "utf8" })
+  } catch (error) {
+    warn(options, `Could not read mount table: ${error instanceof Error ? error.message : String(error)}`)
+    return null
+  }
+}
+
 export function readSidecarConfig(options: ConfigSourceOptions = {}): InstallerConfig | null {
   const execPath = options.execPath ?? process.execPath
   const sidecarPaths = [
@@ -124,6 +162,20 @@ export function readSidecarConfig(options: ConfigSourceOptions = {}): InstallerC
     const config = readJsonConfigFile(sidecarPath, options)
     if (config) {
       return config
+    }
+  }
+
+  if (isTranslocatedPath(execPath)) {
+    const mountTable = readMountTable(options)
+    const originalAppPath = mountTable ? resolveTranslocatedOriginalPath(execPath, mountTable) : null
+    if (originalAppPath) {
+      warn(options, `translocated launch detected; origenal app at ${originalAppPath}`)
+      // The nullfs SOURCE for App Translocation is the original .app bundle, so
+      // the sidecar lives next to that bundle rather than next to its binary.
+      const sidecarPath = path.join(path.dirname(originalAppPath), INSTALL_SIDECAR_FILENAME)
+      if (existsSync(sidecarPath)) {
+        return readJsonConfigFile(sidecarPath, options)
+      }
     }
   }
 

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -6,6 +6,7 @@ import { installConfigUrlFor, parseInstallerFilenameTag } from "@openwork/instal
 
 import { desktopBootstrapPath } from "../src/bootstrap-path"
 import { parseInstallLinkInput, resolveInstallerConfig } from "../src/config"
+import { isTranslocatedPath, parseMountTableLine, readSidecarConfig, resolveTranslocatedOriginalPath } from "../src/config-sources"
 import { writeBootstrapConfig } from "../src/install"
 import { releaseAssetFor } from "../src/release-asset"
 
@@ -140,6 +141,119 @@ describe("resolveInstallerConfig", () => {
       const resolution = await resolveInstallerConfig({ env: {}, execPath })
       expect(resolution.source).toBe("sidecar")
       expect(resolution.config.clientName).toBe("Bundle Sidecar")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("macOS App Translocation helpers", () => {
+  test("parses a normal mount table line", () => {
+    expect(parseMountTableLine("/private/tmp/OpenWork Installer.app on /private/var/folders/abc/T/AppTranslocation/123 (nullfs, local, read-only)")).toEqual({
+      source: "/private/tmp/OpenWork Installer.app",
+      mountPoint: "/private/var/folders/abc/T/AppTranslocation/123",
+      options: "nullfs, local, read-only",
+    })
+  })
+
+  test("parses paths with spaces and on in the source", () => {
+    expect(parseMountTableLine("/private/tmp/folder with spaces/source on disk/OpenWork Installer.app on /private/var/folders/abc/T/AppTranslocation/UUID With Space (nullfs, local)")).toEqual({
+      source: "/private/tmp/folder with spaces/source on disk/OpenWork Installer.app",
+      mountPoint: "/private/var/folders/abc/T/AppTranslocation/UUID With Space",
+      options: "nullfs, local",
+    })
+  })
+
+  test("ignores junk mount table lines", () => {
+    expect(parseMountTableLine("not a mount table line")).toBeNull()
+    expect(parseMountTableLine("/private/tmp/OpenWork Installer.app on /private/var/folders/abc/T/AppTranslocation/123")).toBeNull()
+  })
+
+  test("resolves the original app through the translocated /d path", () => {
+    const mountPoint = "/private/var/folders/abc/T/AppTranslocation/123"
+    const source = "/private/tmp/OpenWork Installer.app"
+    const execPath = `${mountPoint}/d/OpenWork Installer.app/Contents/MacOS/openwork-installer`
+
+    expect(resolveTranslocatedOriginalPath(execPath, `${source} on ${mountPoint} (nullfs, local, nodev)\n`)).toBe(source)
+  })
+
+  test("skips non-nullfs mounts", () => {
+    const mountPoint = "/private/var/folders/abc/T/AppTranslocation/123"
+    const source = "/private/tmp/OpenWork Installer.app"
+    const execPath = `${mountPoint}/d/OpenWork Installer.app/Contents/MacOS/openwork-installer`
+
+    expect(resolveTranslocatedOriginalPath(execPath, `${source} on ${mountPoint} (apfs, local)\n`)).toBeNull()
+  })
+
+  test("requires a mountpoint path-prefix boundary", () => {
+    const mountPoint = "/private/var/folders/abc/T/AppTranslocation/123"
+    const source = "/private/tmp/OpenWork Installer.app"
+    const execPath = `${mountPoint}-suffix/d/OpenWork Installer.app/Contents/MacOS/openwork-installer`
+
+    expect(resolveTranslocatedOriginalPath(execPath, `${source} on ${mountPoint} (nullfs, local)\n`)).toBeNull()
+  })
+
+  test("returns null when no translocation mount matches", () => {
+    const execPath = "/private/var/folders/abc/T/AppTranslocation/123/d/OpenWork Installer.app/Contents/MacOS/openwork-installer"
+    const mountTable = "/private/tmp/OpenWork Installer.app on /private/var/folders/abc/T/AppTranslocation/other (nullfs, local)\n"
+
+    expect(resolveTranslocatedOriginalPath(execPath, mountTable)).toBeNull()
+  })
+
+  test("detects App Translocation paths", () => {
+    expect(isTranslocatedPath("/private/var/folders/abc/T/AppTranslocation/123/d/OpenWork Installer.app/Contents/MacOS/openwork-installer")).toBe(true)
+    expect(isTranslocatedPath("/Applications/OpenWork Installer.app/Contents/MacOS/openwork-installer")).toBe(false)
+  })
+
+  test("reads the sidecar next to the original translocated app", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-translocated-"))
+    try {
+      const originalAppPath = path.join(dir, "OpenWork Installer.app")
+      const mountPoint = "/private/var/folders/abc/T/AppTranslocation/123"
+      const execPath = `${mountPoint}/d/OpenWork Installer.app/Contents/MacOS/openwork-installer`
+      mkdirSync(originalAppPath, { recursive: true })
+      writeFileSync(path.join(dir, "openwork-installer.json"), JSON.stringify({
+        clientName: "Translocated Sidecar",
+        webUrl: "https://translocated.example.com",
+        apiUrl: "https://translocated-api.example.com",
+        requireSignin: true,
+        logoUrl: null,
+      }))
+
+      expect(readSidecarConfig({
+        execPath,
+        readMountTable: () => `${originalAppPath} on ${mountPoint} (nullfs, local, read-only)\n`,
+        warn: () => undefined,
+      })).toEqual({
+        clientName: "Translocated Sidecar",
+        webUrl: "https://translocated.example.com",
+        apiUrl: "https://translocated-api.example.com",
+        requireSignin: true,
+        logoUrl: null,
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("falls through when the translocation mount is missing", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-translocated-missing-"))
+    try {
+      const originalAppPath = path.join(dir, "OpenWork Installer.app")
+      const execPath = "/private/var/folders/abc/T/AppTranslocation/123/d/OpenWork Installer.app/Contents/MacOS/openwork-installer"
+      writeFileSync(path.join(dir, "openwork-installer.json"), JSON.stringify({
+        clientName: "Missing Mount Sidecar",
+        webUrl: "https://missing.example.com",
+        apiUrl: "https://missing-api.example.com",
+        requireSignin: false,
+        logoUrl: null,
+      }))
+
+      expect(readSidecarConfig({
+        execPath,
+        readMountTable: () => `${originalAppPath} on /private/var/folders/abc/T/AppTranslocation/other (nullfs, local)\n`,
+        warn: () => undefined,
+      })).toBeNull()
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## The bug (found by actually double-clicking a quarantined download)

The org-stamped macOS installer ships as a `.zip` containing `OpenWork Installer.app` + a sibling `openwork-installer.json`. On the single most mainline path — **download → unzip → double-click in place** — macOS **App Translocation** runs the quarantined `.app` from a randomized read-only nullfs mount. The sidecar is *not* copied into that mount, so config resolution missed and the user hit the **"Paste your OpenWork install link"** screen instead of "This sets up OpenWork for {org}".

Every prior proof missed it because none *launched a quarantined bundle*: the spike ran the naked binary, the fraimz `spawn()`ed the bare binary, and the Gatekeeper check only `spctl`-assessed (never executed).

## Why the obvious fixes don't work (verified, not assumed)
- **`kMDItemWhereFroms`** (download URL on the file): Archive Utility / `ditto` do **not** propagate it to the extracted `.app`.
- **Quarantine-DB lookup** (UUID → URL): `LSQuarantineDataURLString` is empty in **1,497/1,497** events on a real machine — modern Chrome/macOS stopped recording URLs.

## The fix (verified end-to-end against a real translocated launch)
Translocation is a **nullfs mount, and the mount table publicly exposes the source path**. When `execPath` is under `/AppTranslocation/` **and** both normal sidecar candidates already missed, read `/sbin/mount`, find the nullfs mount whose mountpoint prefixes `execPath`, and re-check the sidecar next to its **source** (the origenal `.app`).

Proven on a real quarantined, translocated launch:
```
execPath  = /private/var/folders/…/AppTranslocation/9D33…/d/OpenWork Installer.app/Contents/MacOS/openwork-installer
mount     → "/private/tmp/…/OpenWork Installer.app on /private/var/folders/…/AppTranslocation/9D33… (nullfs, read-only …)"
recovered → { "clientName": "Acme Robotics", …, "requireSignin": true }   ✓
```

## Why it can't break anything
- Pure **additive fallback**: fires **only** when both sidecar candidates miss **AND** `isTranslocatedPath(execPath)` (`/AppTranslocation/`) — a state impossible in normal/dev/eval runs. Non-translocated behavior byte-for-byte unchanged.
- Chain order (env → sidecar → filename → build → install-link) unchanged; the paste screen remains the last resort.
- `/sbin/mount` read is wrapped in try/catch → warn + null → clean fall-through.

## Also here
`release-generic-installer.yml` gains `publish_mode=artifact` (workflow artifacts instead of release uploads) so signed generic installers can be built for pre-merge verification. The `release: published` auto-attach path is unchanged (always release mode); the release upload stays gated to release mode, the artifact upload to artifact mode.

## Verification
- `apps/installer bun test` — **24 pass** (14 existing + 10 new: mount-line parsing incl. spaces in paths, nullfs/path-prefix resolution, translocation detection, end-to-end sidecar recovery).
- `bun run compile` — ok · `actionlint` — clean · rebased on latest `dev`, diff is **3 files, +201/−5**.
- **Real signed build**: dispatched the workflow in `artifact` mode off this branch → downloaded the signed+notarized generic installer → stamped it exactly like den-api → confirmed the fixed binary recovers Acme's config under translocation and runs clean.

## Scope note
This is the verified, minimal, non-breaking fix that makes the *existing* installer work on the mainline flow. The broader packaging ideas discussed (DMG, filename-tag, a tier-2 force-signin build variant, invite-CTA tier selection) are deliberately **not** in this PR — they touch the release pipeline and/or carry unverified assumptions; they belong in separate scoped work.