### PR TITLE
Document Helm GitHub connector setup

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -45,7 +45,8 @@
           {
             "group": "Self-host",
             "pages": [
-              "start-here/self-host"
+              "start-here/self-host",
+              "start-here/github-connector-helm"
             ]
           },
           {

--- a/packages/docs/start-here/github-connector-helm.mdx
+++ b/packages/docs/start-here/github-connector-helm.mdx
@@ -1,0 +1,129 @@
+---
+title: "GitHub connector for Helm"
+description: "Create a GitHub App and configure the OpenWork EE Helm chart for repository connectors."
+---
+
+The GitHub connector lets a self-hosted OpenWork deployment install a GitHub App, list repositories the installation can read, discover plugin or marketplace manifests, import selected repositories, and keep imported content fresh from GitHub webhooks.
+
+This is separate from GitHub social sign-in. Social sign-in uses `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` for Better Auth. The repository connector uses the `GITHUB_CONNECTOR_APP_*` settings below.
+
+## Public URLs
+
+Use the same public hosts that you set in the Helm chart:
+
+```yaml
+config:
+  public:
+    webOrigin: "https://openwork.example.com"
+    apiOrigin: "https://api.openwork.example.com"
+```
+
+The GitHub App needs these OpenWork URLs:
+
+| GitHub App field | Value |
+| --- | --- |
+| Homepage URL | `https://openwork.example.com` |
+| Setup URL | `https://openwork.example.com/dashboard/integrations/github` |
+| Webhook URL | `https://api.openwork.example.com/v1/webhooks/connectors/github` |
+
+Enable **Redirect on update** for the setup URL. GitHub redirects back to the setup URL with `installation_id` and `state`; Den web completes the installation by calling Den API.
+
+No OAuth callback URL is required for the current repository connector flow. If you also enable GitHub user authorization later, treat that as a separate OAuth setup from this connector.
+
+## Create the GitHub App
+
+In GitHub, create a new GitHub App for the account that should own the connector.
+
+Use these settings:
+
+- **Webhook**: active.
+- **Webhook URL**: `https://api.openwork.example.com/v1/webhooks/connectors/github`.
+- **Webhook secret**: generate a strong random secret and keep it for Helm.
+- **Setup URL**: `https://openwork.example.com/dashboard/integrations/github`.
+- **Redirect on update**: enabled.
+- **Repository permissions**:
+  - **Contents**: read-only.
+  - **Metadata**: read-only. GitHub grants this automatically.
+- **Subscribe to events**:
+  - `push`
+  - `installation`
+  - `installation_repositories`
+  - `repository`
+
+After creating the app, copy:
+
+- **App ID**
+- **Client ID**
+- **Client secret** if you generated one
+- **Private key** (`.pem`)
+- **Webhook secret**
+
+The connector currently requires the App ID and private key for live GitHub App calls. The webhook secret is required for webhook ingestion. The client ID and client secret are exposed by the Helm chart because GitHub Apps have them, but the current install and repository sync path does not depend on them.
+
+## Configure Helm
+
+Add the GitHub App values to your production values file:
+
+```yaml
+config:
+  githubConnector:
+    appId: "123456"
+    clientId: "Iv1.example"
+
+secret:
+  values:
+    githubConnectorAppClientSecret: "github-app-client-secret-if-used"
+    githubConnectorAppPrivateKey: |-
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+    githubConnectorAppWebhookSecret: "replace-with-the-github-webhook-secret"
+```
+
+You can also paste the private key with escaped newlines (`\n`). Den normalizes escaped newlines before signing GitHub App JWTs.
+
+If you use an existing Kubernetes Secret instead of `secret.values`, keep `config.githubConnector.appId` in values and include these secret-backed keys in that Secret:
+
+```yaml
+secret:
+  create: false
+  existingSecret: openwork-ee-secrets
+```
+
+Required deployment values:
+
+- `GITHUB_CONNECTOR_APP_ID`
+- `GITHUB_CONNECTOR_APP_PRIVATE_KEY`
+- `GITHUB_CONNECTOR_APP_WEBHOOK_SECRET`
+
+Optional connector keys:
+
+- `GITHUB_CONNECTOR_APP_CLIENT_ID`
+- `GITHUB_CONNECTOR_APP_CLIENT_SECRET`
+
+The chart writes `GITHUB_CONNECTOR_APP_ID` and `GITHUB_CONNECTOR_APP_CLIENT_ID` through the shared ConfigMap, and writes `GITHUB_CONNECTOR_APP_PRIVATE_KEY`, `GITHUB_CONNECTOR_APP_WEBHOOK_SECRET`, and `GITHUB_CONNECTOR_APP_CLIENT_SECRET` through the shared Secret.
+
+## What OpenWork does with it
+
+When an admin clicks **Connect GitHub** in OpenWork:
+
+1. Den API calls `/v1/connectors/github/install/start`.
+2. Den API reads the GitHub App metadata with the app ID and private key.
+3. Den API sends the admin to the GitHub App installation URL with a signed `state`.
+4. GitHub redirects to `/dashboard/integrations/github?installation_id=...&state=...`.
+5. Den web calls `/v1/connectors/github/install/complete`.
+6. Den API stores the GitHub installation as a connector account and lists repositories visible to that installation.
+
+When GitHub sends a webhook to `/v1/webhooks/connectors/github`, Den API verifies the `x-hub-signature-256` header with `GITHUB_CONNECTOR_APP_WEBHOOK_SECRET` before enqueueing connector sync work.
+
+## Validate the setup
+
+After deploying the chart, sign in to Den web and open:
+
+```text
+https://openwork.example.com/dashboard/integrations
+```
+
+Choose GitHub, install the GitHub App on a test account or organization, select a repository, and start discovery. A working setup should return to OpenWork, show repositories visible to the installation, and allow discovery on a selected repository.
+
+For webhook validation, push to a connected repository and check Den API logs for an accepted or intentionally ignored GitHub webhook delivery. A `503` response from `/v1/webhooks/connectors/github` means the webhook secret is not configured in the Den API pod.

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -28,6 +28,8 @@ helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee
 
 The chart pulls the matching GHCR images for `openwork-den-api`, `openwork-den-web`, and optional `openwork-inference`.
 
+If you want self-hosted repository imports and sync from GitHub, configure the [GitHub connector for Helm](/start-here/github-connector-helm) after the core Den web and Den controller hosts are reachable.
+
 ## How we deploy hosted workers
 
 Our hosted deployment uses Render for long-running services and worker provisioning. Render gives us service deploys, env vars, health checks, logs, and worker builds without asking us to operate raw AWS services directly. If you want to run closer to AWS yourself, use the same service boundaries on ECS/Fargate, EC2, Kubernetes, or another container platform.
@@ -106,6 +108,7 @@ OpenWork does not require many third-party services for the core runtime. These 
 - Polar: optional billing/paywall for hosted cloud workers.
 - Loops: optional user sync and lifecycle messaging.
 - GitHub/Google OAuth: optional social sign-in providers for Better Auth.
+- GitHub connector app: optional repository connector for importing and syncing plugins or marketplaces from GitHub. For Helm installs, use the [GitHub connector setup guide](/start-here/github-connector-helm).
 
 ## Don't want to run infra?
 

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -48,6 +48,9 @@ config:
     webAppHosts: "openwork.example.com"
     bootstrapAdminEmails: "admin@example.com"
     authCallbackUrl: "https://openwork.example.com"
+  githubConnector:
+    appId: ""
+    clientId: ""
 
 secret:
   values:
@@ -60,6 +63,9 @@ secret:
     smtpUser: "openwork@example.com"
     smtpPass: "REPLACE_ME"
     smtpSecure: "false"
+    githubConnectorAppClientSecret: ""
+    githubConnectorAppPrivateKey: ""
+    githubConnectorAppWebhookSecret: ""
 
 ingress:
   enabled: true
@@ -135,6 +141,47 @@ The existing Secret must contain the keys listed under `secret.keys`, especially
 - `DEN_DB_ENCRYPTION_KEY`
 
 Set `DAYTONA_API_KEY` when `config.provisioner.mode` is `daytona`. Set `POLAR_ACCESS_TOKEN` when Polar feature gating is enabled. Set `OPENROUTER_MANAGEMENT_API_KEY` when enabling OpenWork Models management.
+
+## GitHub Connector
+
+The GitHub repository connector uses a GitHub App. It is separate from GitHub
+OAuth social sign-in. Follow the full setup guide in
+[`packages/docs/start-here/github-connector-helm.mdx`](../../../packages/docs/start-here/github-connector-helm.mdx).
+
+Use these public URLs when creating the GitHub App:
+
+- Setup URL: `https://openwork.example.com/dashboard/integrations/github`
+- Webhook URL: `https://api.openwork.example.com/v1/webhooks/connectors/github`
+
+Then set the chart values:
+
+```yaml
+config:
+  githubConnector:
+    appId: "123456"
+    clientId: "Iv1.example"
+
+secret:
+  values:
+    githubConnectorAppClientSecret: "github-app-client-secret-if-used"
+    githubConnectorAppPrivateKey: |-
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+    githubConnectorAppWebhookSecret: "replace-with-the-github-webhook-secret"
+```
+
+The chart exposes these to Den API as:
+
+- `GITHUB_CONNECTOR_APP_ID`
+- `GITHUB_CONNECTOR_APP_CLIENT_ID`
+- `GITHUB_CONNECTOR_APP_CLIENT_SECRET`
+- `GITHUB_CONNECTOR_APP_PRIVATE_KEY`
+- `GITHUB_CONNECTOR_APP_WEBHOOK_SECRET`
+
+If `secret.create=false`, add the three secret-backed keys to the existing
+Secret referenced by `secret.existingSecret`. The app ID and client ID come from
+the chart ConfigMap.
 
 ## Transactional Email
 

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -16,6 +16,8 @@ data:
   DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP: {{ .Values.config.tenancy.allowPublicSignup | quote }}
   DEN_REQUIRE_EMAIL_VERIFICATION: {{ .Values.config.tenancy.requireEmailVerification | quote }}
   DEN_PASSWORD_BREACH_SCREENING_ENABLED: {{ .Values.config.auth.passwordBreachScreeningEnabled | quote }}
+  GITHUB_CONNECTOR_APP_ID: {{ .Values.config.githubConnector.appId | quote }}
+  GITHUB_CONNECTOR_APP_CLIENT_ID: {{ .Values.config.githubConnector.clientId | quote }}
   BETTER_AUTH_URL: {{ .Values.config.public.webOrigin | quote }}
   DEN_MCP_RESOURCE_URL: {{ .Values.config.public.mcpResourceUrl | quote }}
   DEN_MCP_CLAIM_NAMESPACE: {{ .Values.config.public.mcpClaimNamespace | quote }}

--- a/packaging/helm/openwork-ee/templates/secret.yaml
+++ b/packaging/helm/openwork-ee/templates/secret.yaml
@@ -21,4 +21,7 @@ stringData:
   {{ .Values.secret.keys.smtpUser }}: {{ .Values.secret.values.smtpUser | quote }}
   {{ .Values.secret.keys.smtpPass }}: {{ .Values.secret.values.smtpPass | quote }}
   {{ .Values.secret.keys.smtpSecure }}: {{ .Values.secret.values.smtpSecure | quote }}
+  {{ .Values.secret.keys.githubConnectorAppClientSecret }}: {{ .Values.secret.values.githubConnectorAppClientSecret | quote }}
+  {{ .Values.secret.keys.githubConnectorAppPrivateKey }}: {{ .Values.secret.values.githubConnectorAppPrivateKey | quote }}
+  {{ .Values.secret.keys.githubConnectorAppWebhookSecret }}: {{ .Values.secret.values.githubConnectorAppWebhookSecret | quote }}
 {{- end }}

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -19,6 +19,9 @@ config:
     requireEmailVerification: "false"
   auth:
     passwordBreachScreeningEnabled: "false"
+  githubConnector:
+    appId: ""
+    clientId: ""
   public:
     webOrigin: https://openwork.example.com
     apiOrigin: https://api.openwork.example.com
@@ -103,6 +106,9 @@ secret:
     smtpUser: SMTP_USER
     smtpPass: SMTP_PASS
     smtpSecure: SMTP_SECURE
+    githubConnectorAppClientSecret: GITHUB_CONNECTOR_APP_CLIENT_SECRET
+    githubConnectorAppPrivateKey: GITHUB_CONNECTOR_APP_PRIVATE_KEY
+    githubConnectorAppWebhookSecret: GITHUB_CONNECTOR_APP_WEBHOOK_SECRET
   values:
     databaseUrl: mysql://openwork:change-me@mysql:3306/openwork_den
     betterAuthSecret: CHANGE_ME_32_CHARS_MINIMUM_BETTER_AUTH
@@ -118,6 +124,9 @@ secret:
     smtpUser: ""
     smtpPass: ""
     smtpSecure: "false"
+    githubConnectorAppClientSecret: ""
+    githubConnectorAppPrivateKey: ""
+    githubConnectorAppWebhookSecret: ""
 
 installerArtifacts:
   enabled: false


### PR DESCRIPTION
## Summary
- Add first-class Helm values for the GitHub repository connector app.
- Add a standalone self-host doc for creating/configuring the GitHub App, including setup URL, webhook URL, permissions, events, Helm values, and validation.
- Link the connector guide from the self-host docs and Helm chart README.

## Why
- Self-hosted Helm operators need a clear, supported path for configuring the GitHub connector without relying on `denApi.env` overrides.

## Issue
- Closes N/A

## Scope
- `packaging/helm/openwork-ee` values, ConfigMap, Secret, and README.
- `packages/docs/start-here/github-connector-helm.mdx`.
- Docs navigation and self-host cross-links.

## Out of scope
- Runtime connector behavior changes.
- Better Auth GitHub social sign-in setup.

## Testing
### Ran
- `helm lint ./packaging/helm/openwork-ee`
- `helm template openwork-ee ./packaging/helm/openwork-ee --set-string config.githubConnector.appId=123456 --set-string config.githubConnector.clientId=Iv1.example --set-string secret.values.githubConnectorAppPrivateKey=private-key --set-string secret.values.githubConnectorAppWebhookSecret=webhook-secret --set-string secret.values.githubConnectorAppClientSecret=client-secret | rg -n "GITHUB_CONNECTOR_APP|123456|Iv1.example|webhook-secret|client-secret|private-key"`
- `node -e "JSON.parse(require('fs').readFileSync('packages/docs/docs.json','utf8')); console.log('docs.json ok')"`

### Result
- pass: Helm lint succeeded with 0 chart failures.
- pass: Helm template rendered `GITHUB_CONNECTOR_APP_ID`, `GITHUB_CONNECTOR_APP_CLIENT_ID`, `GITHUB_CONNECTOR_APP_CLIENT_SECRET`, `GITHUB_CONNECTOR_APP_PRIVATE_KEY`, and `GITHUB_CONNECTOR_APP_WEBHOOK_SECRET`.
- pass: `packages/docs/docs.json` parsed successfully.

## CI status
- pass: not run yet, waiting for PR CI.
- code-related failures: none known.
- external/env/auth blockers: none.

## Manual verification
1. Confirmed rendered chart includes the new first-class GitHub connector env vars.
2. Confirmed docs navigation includes the new self-host GitHub connector page.
3. Confirmed the doc distinguishes GitHub connector setup from GitHub social sign-in.

## Evidence
- `N/A (docs and Helm manifest wiring; no interactive UI flow changed)`

## Risk
- Low. Adds default-empty chart values and docs. Existing installs continue rendering empty optional connector env vars unless operators configure them.

## Rollback
- Revert this PR to remove the Helm values and connector setup docs.
