### PR TITLE
fix: payment_failed immediately sets expired, add precedence parens

### DIFF
--- a/ee/apps/den-api/src/inference.ts
+++ b/ee/apps/den-api/src/inference.ts
@@ -50,7 +50,7 @@ export function readInferenceMetadata(metadata: Record<string, unknown> | null):
   }
 
   const inference = metadata.inference
-  if (inference.enabled !== true || inference.tier !== "tier1" && inference.tier !== "tier2") {
+  if (inference.enabled !== true || (inference.tier !== "tier1" && inference.tier !== "tier2")) {
     return null
   }
 

--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -677,7 +677,7 @@ export async function handleStripeWebhook(input: { payload: string; signature: s
         if (row) {
           await db
             .update(OrgSubscriptionTable)
-            .set({ status: "expired", last_event_id: event.id, updated_at: new Date() })
+            .set({ status: "past_due", last_event_id: event.id, updated_at: new Date() })
             .where(eq(OrgSubscriptionTable.id, row.id))
           if (row.type === INFERENCE_SUBSCRIPTION_TYPE) {
             await setInferenceEnabled({ organizationId: row.organization_id, enabled: false })


### PR DESCRIPTION
Two issues in the billing code:

- The \`invoice.payment_failed\` webhook handler was setting the subscription status to \`"expired"\` on the very first failed payment. Stripe retries payments multiple times over days/weeks via its dunning cycle — immediately killing the subscription before Stripe even retries means a single transient card decline locks people out. Changed to \`"past_due"\` which is the standard status for a failed payment that's still being retried.

- Added explicit parentheses to the tier check in \`readInferenceMetadata\` — the \`&&\` vs \`||\` precedence was technically correct but ambiguous enough that a future edit could easily change the logic without realizing it.