### PR TITLE
fix(landing): land the hero prompt design iteration that never made it to dev

### DIFF
--- a/ee/apps/landing/components/landing-hero-prompt.tsx
+++ b/ee/apps/landing/components/landing-hero-prompt.tsx
@@ -32,11 +32,7 @@ type Props = {
   className?: string;
 };
 
-const executionPreviewItems = [
-  "Installs the OpenWork desktop app",
-  "Creates your first workspace and skill",
-  "Opens the app, ready for your first task"
-];
+const steps = ["Installs OpenWork", "Creates your workspace", "Opens ready to run"];
 
 export function LandingHeroPrompt({ className }: Props) {
   const [feedback, setFeedback] = useState(false);
@@ -72,7 +68,7 @@ export function LandingHeroPrompt({ className }: Props) {
     }
     setCopyError(!copied);
     setFeedback(true);
-    setRevealed(true);
+    if (copied) setRevealed(true);
     capturePosthogEvent("landing_copy_prompt_clicked", {
       copied,
       method,
@@ -92,15 +88,15 @@ export function LandingHeroPrompt({ className }: Props) {
       data-feedback={feedback ? "true" : "false"}
       data-copy-error={copyError ? "true" : "false"}
     >
-      <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-gray-600">
-        Already use an AI agent? Have it install OpenWork for you
-      </div>
       <div
         onClick={() => {
           void onClick();
         }}
         className="group cursor-pointer rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
       >
+        <div className="mb-2 text-[13px] text-gray-500">
+          Already use an AI agent? Paste this prompt — it installs OpenWork for you.
+        </div>
         <p className="text-[15px] leading-relaxed text-[#011627]">
           Install OpenWork on my computer, set up my first workspace, and open it
           ready to use. Follow the steps in{" "}
@@ -196,32 +192,45 @@ export function LandingHeroPrompt({ className }: Props) {
             )}
           </button>
         </div>
-      </div>
-      <AnimatePresence initial={false}>
-        {revealed ? (
-          <motion.div
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: "auto" }}
-            exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.25 }}
-            className="overflow-hidden"
-          >
-            <div className="mt-3 rounded-xl border border-gray-100 bg-white/70 p-3 shadow-sm">
-              <div className="flex flex-col gap-2">
-                {executionPreviewItems.map((item) => (
-                  <div key={item} className="flex items-center gap-2 text-xs text-gray-400">
-                    <ChevronRight size={10} className="text-gray-300" />
-                    <span>{item}</span>
-                  </div>
-                ))}
-                <div className="pt-1 text-xs font-medium text-[#011627]">
-                  Now paste it into Claude Code, Cursor, or ChatGPT.
+        <AnimatePresence initial={false}>
+          {revealed ? (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              transition={{ duration: 0.25 }}
+              className="overflow-hidden"
+            >
+              <div className="mt-3 border-t border-gray-100 pt-3">
+                <div className="flex items-center gap-2 text-[13px] font-medium text-[#011627]">
+                  <svg
+                    className="h-4 w-4 shrink-0 text-green-600"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M20 6 9 17l-5-5" />
+                  </svg>
+                  Copied — now paste it into Claude Code, Cursor, or ChatGPT:
+                </div>
+                <div className="mt-2.5 flex flex-wrap items-center gap-x-2 gap-y-2">
+                  {steps.map((label, index) => (
+                    <div key={label} className="flex items-center gap-2">
+                      {index > 0 ? <ChevronRight size={12} className="text-gray-300" /> : null}
+                      <span className="step-circle">{index + 1}</span>
+                      <span className="text-[13px] text-gray-600">{label}</span>
+                    </div>
+                  ))}
                 </div>
               </div>
-            </div>
-          </motion.div>
-        ) : null}
-      </AnimatePresence>
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </div>
       <span aria-live="polite" className="sr-only">
         {feedback ? (copyError ? "Couldn't copy the prompt" : "Prompt copied to clipboard") : ""}
       </span>

--- a/evals/flows/landing-copy-prompt-analytics.flow.mjs
+++ b/evals/flows/landing-copy-prompt-analytics.flow.mjs
@@ -138,17 +138,24 @@ export default {
           voiceover: vo[0],
           action: async () => {
             await applyDesktopViewport(ctx);
+            // Warm the route first: on a cold `next dev` the first request
+            // compiles the page on demand and the dev client can trigger a
+            // full reload right after hydration — which would wipe the capture
+            // stub armed below and strand the waitFor.
+            await fetch(routeUrl(ctx, "/")).catch(() => {});
             await ctx.eval(`location.href = ${JSON.stringify(routeUrl(ctx, "/"))}; true`);
             await ctx.waitFor(
               `Boolean(document.querySelector(${JSON.stringify(COPY_BUTTON_SELECTOR)})) && document.body.innerText.includes("Install OpenWork on my computer")`,
               { timeoutMs: 30_000, label: "hero prompt copy button" },
             );
+            // Let any post-compile dev-client refresh settle before arming.
+            await sleep(1_500);
             // Freeze the recording stub onto window.posthog: PostHog's async
             // array.js loader assigns window.posthog when it arrives, and on a
             // fresh navigation that write can land after this step. A frozen
             // property makes the late assignment a silent no-op, so captures
             // deterministically reach the stub (and never real PostHog).
-            await ctx.eval(`(() => {
+            const armCaptureStub = () => ctx.eval(`(() => {
               window.__capturedPosthogEvents = [];
               Object.defineProperty(window, "posthog", {
                 value: {
@@ -161,15 +168,32 @@ export default {
               });
               return true;
             })()`);
+            await armCaptureStub();
             await grantClipboardPermissions(ctx);
             await clickCopyButton(ctx);
-            await ctx.waitFor(
-              `(() => {
-                const events = window.__capturedPosthogEvents || [];
-                return events.some((entry) => entry.event === ${JSON.stringify(POSTHOG_CLIENT_EVENT)}) && Boolean(document.querySelector('[data-feedback="true"]'));
-              })()`,
-              { timeoutMs: 10_000, label: "client PostHog event and feedback state" },
-            );
+            const capturedAndFedBack = `(() => {
+              const events = window.__capturedPosthogEvents || [];
+              return events.some((entry) => entry.event === ${JSON.stringify(POSTHOG_CLIENT_EVENT)}) && Boolean(document.querySelector('[data-feedback="true"]'));
+            })()`;
+            try {
+              await ctx.waitFor(capturedAndFedBack, { timeoutMs: 10_000, label: "client PostHog event and feedback state" });
+            } catch (error) {
+              // If the dev client reloaded the page after arming, the stub is
+              // gone (fresh window). Re-arm and click once more; when the stub
+              // is still armed the original failure stands. Re-arming resets
+              // the capture array, so the exactly-one-event assertion below
+              // stays truthful.
+              const stubArmed = await ctx.eval(`Array.isArray(window.__capturedPosthogEvents)`);
+              if (stubArmed) throw error;
+              ctx.log("Dev client reloaded after arming the capture stub; re-arming and clicking again.");
+              await ctx.waitFor(
+                `Boolean(document.querySelector(${JSON.stringify(COPY_BUTTON_SELECTOR)}))`,
+                { timeoutMs: 30_000, label: "hero prompt copy button after dev reload" },
+              );
+              await armCaptureStub();
+              await clickCopyButton(ctx);
+              await ctx.waitFor(capturedAndFedBack, { timeoutMs: 10_000, label: "client PostHog event and feedback state (after re-arm)" });
+            }
             // Let the 200ms copy-feedback morph settle so the frame shows a
             // clean "Copied" state instead of overlapping transition labels.
             await sleep(400);

--- a/evals/flows/landing-copy-prompt-analytics.flow.mjs
+++ b/evals/flows/landing-copy-prompt-analytics.flow.mjs
@@ -215,7 +215,8 @@ export default {
               const headerLinks = Array.from(header ? header.querySelectorAll("a") : []);
               return {
                 heroPromptVisible: bodyText.includes("Install OpenWork on my computer") && bodyText.includes("start.md?v=hero"),
-                executionPreviewVisible: bodyText.includes("Now paste it into Claude Code") && bodyText.includes("Installs the OpenWork desktop app"),
+                headerVisible: bodyText.includes("Paste this prompt — it installs OpenWork for you"),
+                executionPreviewVisible: bodyText.includes("now paste it into Claude Code") && bodyText.includes("Installs OpenWork") && bodyText.includes("Opens ready to run"),
                 copyPromptNavButtons: headerButtons.filter((button) => button.innerText.includes("Copy Prompt")).length,
                 downloadLinkVisible: headerLinks.some((link) => link.textContent.includes("Download") && link.href.endsWith("/download")),
               };
@@ -223,7 +224,7 @@ export default {
             recordAssertion(
               ctx,
               "The hero renders the human-readable agent install prompt with the hero start guide URL",
-              pageScan.heroPromptVisible === true,
+              pageScan.heroPromptVisible === true && pageScan.headerVisible === true,
               pageScan,
             );
             recordAssertion(
@@ -241,7 +242,7 @@ export default {
           },
           screenshot: {
             name: "hero-prompt-copied",
-            requireText: ["Copied", "Now paste it into"],
+            requireText: ["Copied", "now paste it into Claude Code"],
           },
         });
       },

--- a/evals/voiceovers/landing-copy-prompt-analytics.md
+++ b/evals/voiceovers/landing-copy-prompt-analytics.md
@@ -2,6 +2,6 @@
 
 A visitor lands on openworklabs.com. The old cryptic "Copy Prompt" navbar button is gone; the hero now offers both paths openly — Download for free for humans, and the exact install prompt to hand your AI agent, shown in full inside an OpenWork-style composer.
 
-1. The visitor clicks the prompt, the pill flashes Copied, and the block reveals exactly what their agent will do next — install the app, create a workspace, open it ready to run — while a single anonymous analytics event records the copy.
+1. The visitor clicks the prompt, the pill flashes Copied, and the card itself answers with the next move — paste it into Claude Code, Cursor, or ChatGPT — plus a three-step preview of what the agent will do, while a single anonymous analytics event records the copy.
 
 2. When an agent follows the prompt, its first move is fetching the start guide — the guide comes back intact, and the server counts that read anonymously, so the copy-to-agent funnel is measurable end to end.


### PR DESCRIPTION
## What

Recovers two commits from `feat/landing-hero-prompt` (PR #2499) that were **pushed after that PR had already merged** and therefore never landed on `dev`, despite the PR showing green. `dev` currently ships the *first* design iteration of the hero prompt card — the one with the floating uppercase eyebrow and a separate faint-gray execution-preview panel that was called out as bad UX. This PR lands the approved fix.

### Design fix (`refactor(landing): fold the hero prompt reveal into the card as an action-first stepper`)
- Removes the floating uppercase-tracking eyebrow ("ALREADY USE AN AI AGENT?...") — folded into the card itself as sentence-case microcopy.
- The post-copy reveal is no longer a second floating panel with faint gray timeline lines. It now expands **inside** the same card behind a hairline separator, action-first: green ✓ **"Copied — now paste it into Claude Code, Cursor, or ChatGPT:"**, followed by a legible ① ② ③ stepper using the site's existing `.step-circle`.
- Reveal fires only on a successful copy (not on clipboard failure).

### Eval hardening (`test(evals): survive next-dev cold-start reload...`)
- The Daytona proof of the design fix flaked once on a cold `next dev`: the dev client's post-compile reload wiped the flow's PostHog capture stub right after it was armed, stranding the wait. Fixed by warming the route before navigating, letting the post-compile refresh settle, and re-arming + re-clicking once (only) if the stub was found wiped.
- Updated assertions/screenshot text for the new copy.

## Why this is a separate PR

The original PR #2499 is merged and closed; these commits target the same files with no other changes on `dev` in between (verified — no other commit touched `landing-hero-prompt.tsx` or the analytics flow since #2499 merged), so this is a clean, conflict-free cherry-pick of exactly the missing delta.

## Tests run

- `pnpm --dir ee/apps/landing exec tsc --noEmit` — passed
- `pnpm --dir ee/apps/landing build` — passed
- Local: `pnpm fraimz --flow landing-copy-prompt-analytics` against local dev + PostHog mock + headless Chrome — PASSED
- Daytona: pending, will post fraimz proof as a PR comment before merge.
