### PR TITLE
perf(orgs): cap and search org lists so 10k organizations no longer crash the browser

### DIFF
--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -49,6 +49,7 @@ import {
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Empty,
   EmptyContent,
@@ -63,6 +64,7 @@ import {
   RadioGroup,
   RadioGroupItem,
 } from "@/components/ui/radio-group"
+import { useOrgListWindow } from "./use-org-list-window";
 
 const RELOAD_AFTER_ONBOARDING_KEY = "openwork.reloadAfterOrgOnboarding";
 
@@ -786,45 +788,76 @@ interface OrganizationListProps {
 }
 
 export function OrganizationList({ orgs, value, onValueChange }: OrganizationListProps) {
-  return (
-    <RadioGroup
-      value={value.id}
-      onValueChange={(nextOrgId) => {
-        const nextOrg = orgs.find((org) => org.id === nextOrgId);
-        if (nextOrg) onValueChange(nextOrg);
-      }}
-      aria-label="Organizations"
-    >
-      {orgs.map((org) => {
-        const fieldId = `organization-${org.id}`;
+  const { filtered, query, showMore, updateQuery, visible } = useOrgListWindow(orgs);
+  const hasMore = visible.length < filtered.length;
 
-        return (
-          <FieldLabel
-            key={org.id}
-            htmlFor={fieldId}
-            className="p-0! transition-colors hover:bg-input/10"
-          >
-            <Field orientation="horizontal">
-              <FieldTitle className="flex min-w-0 items-center gap-4">
-                <BuildingOffice2Icon className="size-6 shrink-0 text-muted-foreground" />
-                <div className="flex min-w-0 flex-col items-start">
-                  <span className="max-w-full truncate text-sm font-semibold">
-                    {org.name}
-                  </span>
-                  <span className="max-w-full truncate text-muted-foreground text-xs">
-                    {org.slug}
-                  </span>
-                </div>
-              </FieldTitle>
-              <RadioGroupItem
-                value={org.id}
-                id={fieldId}
-                className="group-hover/field-label:bg-foreground/25"
-              />
-            </Field>
-          </FieldLabel>
-        );
-      })}
-    </RadioGroup>
+  return (
+    <div className="flex flex-col gap-3">
+      {orgs.length > 10 ? (
+        <Input
+          aria-label="Search organizations"
+          placeholder="Search organizations..."
+          value={query}
+          onChange={(event) => updateQuery(event.target.value)}
+        />
+      ) : null}
+
+      <RadioGroup
+        value={value.id}
+        onValueChange={(nextOrgId) => {
+          const nextOrg = orgs.find((org) => org.id === nextOrgId);
+          if (nextOrg) onValueChange(nextOrg);
+        }}
+        aria-label="Organizations"
+      >
+        {visible.map((org) => {
+          const fieldId = `organization-${org.id}`;
+
+          return (
+            <FieldLabel
+              key={org.id}
+              htmlFor={fieldId}
+              className="p-0! transition-colors hover:bg-input/10"
+            >
+              <Field orientation="horizontal">
+                <FieldTitle className="flex min-w-0 items-center gap-4">
+                  <BuildingOffice2Icon className="size-6 shrink-0 text-muted-foreground" />
+                  <div className="flex min-w-0 flex-col items-start">
+                    <span className="max-w-full truncate text-sm font-semibold">
+                      {org.name}
+                    </span>
+                    <span className="max-w-full truncate text-muted-foreground text-xs">
+                      {org.slug}
+                    </span>
+                  </div>
+                </FieldTitle>
+                <RadioGroupItem
+                  value={org.id}
+                  id={fieldId}
+                  className="group-hover/field-label:bg-foreground/25"
+                />
+              </Field>
+            </FieldLabel>
+          );
+        })}
+      </RadioGroup>
+
+      {filtered.length === 0 && query.trim() ? (
+        <div className="text-sm text-muted-foreground">
+          No organizations match your search.
+        </div>
+      ) : null}
+
+      {hasMore ? (
+        <div className="flex flex-col items-start gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={showMore}>
+            Show more
+          </Button>
+          <div className="text-xs text-muted-foreground">
+            Showing {visible.length} of {filtered.length} organizations
+          </div>
+        </div>
+      ) : null}
+    </div>
   )
 }

--- a/apps/app/src/react-app/domains/cloud/use-org-list-window.ts
+++ b/apps/app/src/react-app/domains/cloud/use-org-list-window.ts
@@ -1,0 +1,47 @@
+import { useCallback, useMemo, useState } from "react";
+
+export const ORG_LIST_PAGE_SIZE = 50;
+
+type OrgListWindowItem = {
+  name: string;
+  slug: string;
+};
+
+export function useOrgListWindow<TOrg extends OrgListWindowItem>(orgs: TOrg[]) {
+  const [query, setQuery] = useState("");
+  const [visibleCount, setVisibleCount] = useState(ORG_LIST_PAGE_SIZE);
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filtered = useMemo(() => {
+    if (!normalizedQuery) return orgs;
+
+    return orgs.filter((org) => {
+      const name = org.name.toLowerCase();
+      const slug = org.slug.toLowerCase();
+
+      return name.includes(normalizedQuery) || slug.includes(normalizedQuery);
+    });
+  }, [normalizedQuery, orgs]);
+
+  const visible = useMemo(
+    () => filtered.slice(0, visibleCount),
+    [filtered, visibleCount],
+  );
+
+  const updateQuery = useCallback((nextQuery: string) => {
+    setQuery(nextQuery);
+    setVisibleCount(ORG_LIST_PAGE_SIZE);
+  }, []);
+
+  const showMore = useCallback(() => {
+    setVisibleCount((count) => count + ORG_LIST_PAGE_SIZE);
+  }, []);
+
+  return {
+    filtered,
+    query,
+    showMore,
+    updateQuery,
+    visible,
+  };
+}

--- a/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
@@ -3,12 +3,14 @@ import { Building2, Check, LogOut, Loader2 } from "lucide-react";
 
 import type { DenOrgSummary } from "../../../../app/lib/den";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   SettingsNotice,
   SettingsSectionHeaderDescription,
 } from "../settings-section";
 import { t } from "@/i18n";
 import { useCloudSession } from "./cloud-session-provider";
+import { useOrgListWindow } from "../../cloud/use-org-list-window";
 
 export interface CloudAccountSectionProps {
   activeOrgId: string;
@@ -129,6 +131,9 @@ function OrgPicker({
   onSelect: (orgId: string) => void | Promise<void>;
   onRefresh: () => void | Promise<void>;
 }) {
+  const { filtered, query, showMore, updateQuery, visible } = useOrgListWindow(orgs);
+  const hasMore = visible.length < filtered.length;
+
   if (orgsBusy) {
     return (
       <div className="flex flex-col items-center gap-3 py-6 text-sm text-dls-secondary">
@@ -161,8 +166,17 @@ function OrgPicker({
       <div className="text-xs text-dls-secondary">
         Choose the organization to use with this workspace. Sign out to switch later.
       </div>
+      {orgs.length > 10 ? (
+        <Input
+          aria-label="Search organizations"
+          placeholder="Search organizations..."
+          value={query}
+          className="h-auto rounded-xl border-dls-border bg-dls-surface px-4 py-2.5 text-sm text-dls-text shadow-none placeholder:text-dls-secondary focus-visible:border-dls-text/30 focus-visible:ring-0 dark:bg-dls-surface"
+          onChange={(event) => updateQuery(event.target.value)}
+        />
+      ) : null}
       <div className="flex flex-col gap-2">
-        {orgs.map((org) => (
+        {visible.map((org) => (
           <button
             key={org.id}
             type="button"
@@ -182,6 +196,27 @@ function OrgPicker({
           </button>
         ))}
       </div>
+      {filtered.length === 0 && query.trim() ? (
+        <div className="text-sm text-dls-secondary">
+          No organizations match your search.
+        </div>
+      ) : null}
+      {hasMore ? (
+        <div className="flex flex-col items-start gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="rounded-xl border-dls-border text-dls-text hover:bg-dls-hover"
+            onClick={showMore}
+          >
+            Show more
+          </Button>
+          <div className="text-xs text-dls-secondary">
+            Showing {visible.length} of {filtered.length} organizations
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { LogOut, Settings } from "lucide-react";
 import { getErrorMessage, normalizeAuthIntentParam, PENDING_AUTH_INTENT_STORAGE_KEY, requestJson } from "../_lib/den-flow";
 import { type DenOrgSummary, formatRoleLabel, getInferenceRoute, getMarketplaceOnboardingRoute, getOrgDashboardRoute, parseOrgListPayload } from "../_lib/den-org";
+import { useOrgListWindow } from "../_lib/use-org-list-window";
 import { useDenFlow } from "../_providers/den-flow-provider";
 
 type SettingsTab = "profile" | "organizations";
@@ -38,6 +39,15 @@ export function OrganizationScreen() {
   const singleOrgName = runtimeConfig.singleOrgName || "OpenWork";
   const singleOrgSlug = runtimeConfig.singleOrgSlug.trim();
   const showDirectCreateFlow = !isSingleOrgMode && orgs.length === 0;
+  const {
+    query: orgQuery,
+    setQuery: setOrgQuery,
+    visible: visibleOrgs,
+    filteredCount: orgFilteredCount,
+    hasMore: orgHasMore,
+    showMore: showMoreOrgs,
+    showSearch: showOrgSearch,
+  } = useOrgListWindow(orgs);
 
   useEffect(() => {
     if (!sessionHydrated || !runtimeConfigLoaded) return;
@@ -352,16 +362,27 @@ export function OrganizationScreen() {
               </section>
             ) : (
               <>
-                <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                   <p className="max-w-2xl text-sm text-gray-500">
                     Organizations are independent environments. In each organization you can collaborate with other members and manage your own resources.
                   </p>
-                  <button
-                    onClick={() => setShowCreate(true)}
-                    className="w-full shrink-0 rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 sm:w-auto"
-                  >
-                    + Create New Organization
-                  </button>
+                  <div className="flex w-full flex-col gap-3 sm:w-auto sm:min-w-[18rem]">
+                    {showOrgSearch ? (
+                      <input
+                        type="search"
+                        value={orgQuery}
+                        onChange={(event) => setOrgQuery(event.target.value)}
+                        placeholder="Search organizations"
+                        className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm text-gray-900 outline-none transition focus:border-gray-400 focus:ring-4 focus:ring-gray-900/5"
+                      />
+                    ) : null}
+                    <button
+                      onClick={() => setShowCreate(true)}
+                      className="w-full shrink-0 rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 sm:w-auto"
+                    >
+                      + Create New Organization
+                    </button>
+                  </div>
                 </div>
 
                 {showCreate ? (
@@ -408,7 +429,7 @@ export function OrganizationScreen() {
                 ) : null}
 
                 <div className="grid gap-3 md:hidden">
-                  {orgs.map((org) => (
+                  {visibleOrgs.map((org) => (
                     <section key={org.id} className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
                       <div className="flex items-start justify-between gap-3">
                         <div className="min-w-0">
@@ -453,7 +474,7 @@ export function OrganizationScreen() {
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-gray-100">
-                        {orgs.map((org) => (
+                        {visibleOrgs.map((org) => (
                           <tr key={org.id} className="transition-colors hover:bg-gray-50/50">
                             <td className="px-6 py-4">
                               <div className="font-medium text-gray-900">{org.name}</div>
@@ -491,6 +512,25 @@ export function OrganizationScreen() {
                     </table>
                   </div>
                 </div>
+
+                {orgFilteredCount === 0 && orgQuery ? (
+                  <p className="mt-4 text-sm text-gray-500">No organizations match your search.</p>
+                ) : null}
+
+                {orgHasMore ? (
+                  <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="text-sm text-gray-500">
+                      Showing {visibleOrgs.length} of {orgFilteredCount} organizations
+                    </p>
+                    <button
+                      type="button"
+                      onClick={showMoreOrgs}
+                      className="w-full rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-50 sm:w-auto"
+                    >
+                      Show more
+                    </button>
+                  </div>
+                ) : null}
 
                 <p className="mt-8 text-center text-sm text-gray-500">You have no pending organization invites.</p>
               </>

--- a/ee/apps/den-web/app/(den)/_lib/use-org-list-window.ts
+++ b/ee/apps/den-web/app/(den)/_lib/use-org-list-window.ts
@@ -1,0 +1,40 @@
+import { useMemo, useState } from "react";
+
+const DEFAULT_PAGE_SIZE = 50;
+
+export function useOrgListWindow<T extends { name?: string | null; slug?: string | null }>(
+  orgs: T[],
+  pageSize = DEFAULT_PAGE_SIZE,
+) {
+  const [query, setQueryState] = useState("");
+  const [visibleCount, setVisibleCount] = useState(pageSize);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return orgs;
+
+    return orgs.filter((org) => {
+      const name = org.name?.toLowerCase() ?? "";
+      const slug = org.slug?.toLowerCase() ?? "";
+      return name.includes(q) || slug.includes(q);
+    });
+  }, [orgs, query]);
+
+  const visible = filtered.slice(0, visibleCount);
+  const hiddenCount = filtered.length - visible.length;
+
+  return {
+    query,
+    setQuery: (next: string) => {
+      setQueryState(next);
+      setVisibleCount(pageSize);
+    },
+    visible,
+    filteredCount: filtered.length,
+    totalCount: orgs.length,
+    hiddenCount,
+    hasMore: hiddenCount > 0,
+    showMore: () => setVisibleCount((count) => count + pageSize),
+    showSearch: orgs.length > 10,
+  };
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -42,6 +42,7 @@ import {
   getSsoRoute,
   getScimRoute,
 } from "../../_lib/den-org";
+import { useOrgListWindow } from "../../_lib/use-org-list-window";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { buildDenFeedbackUrl } from "../../_lib/feedback";
 import { OrgSelectionScreen } from "./org-selection-screen";
@@ -195,6 +196,16 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   const [switcherOpen, setSwitcherOpen] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const isSingleOrgMode = runtimeConfigLoaded && runtimeConfig.orgMode === "single_org";
+  const {
+    query: switcherQuery,
+    setQuery: setSwitcherQuery,
+    visible: visibleOrgDirectory,
+    filteredCount: switcherFilteredCount,
+    hiddenCount: switcherHiddenCount,
+    hasMore: switcherHasMore,
+    showMore: showMoreOrgDirectory,
+    showSearch: showSwitcherSearch,
+  } = useOrgListWindow(orgDirectory, 20);
 
   if (orgSelectionRequired) {
     return (
@@ -360,9 +371,21 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
               Switch workspace
             </p>
           </div>
-          
-          <div className="grid gap-0.5 px-1.5">
-            {orgDirectory.map((org) => (
+
+          {showSwitcherSearch ? (
+            <div className="px-2 pb-1">
+              <input
+                type="search"
+                value={switcherQuery}
+                onChange={(event) => setSwitcherQuery(event.target.value)}
+                placeholder="Search workspaces"
+                className="w-full rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-[12px] text-gray-900 outline-none transition focus:border-gray-400"
+              />
+            </div>
+          ) : null}
+
+          <div className="grid max-h-64 gap-0.5 overflow-y-auto px-1.5">
+            {visibleOrgDirectory.map((org) => (
               <button
                 key={org.id}
                 type="button"
@@ -392,6 +415,22 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
               </button>
             ))}
           </div>
+
+          {switcherFilteredCount === 0 && switcherQuery ? (
+            <p className="px-3 py-1 text-[12px] text-gray-500">No organizations match your search.</p>
+          ) : null}
+
+          {switcherHasMore ? (
+            <div className="px-1.5">
+              <button
+                type="button"
+                onClick={showMoreOrgDirectory}
+                className="flex w-full items-center justify-center rounded-lg px-2 py-1.5 text-[12px] font-medium text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900"
+              >
+                Show more ({switcherHiddenCount})
+              </button>
+            </div>
+          ) : null}
 
           <div className="px-1.5 mt-0.5">
             <Link

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-selection-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-selection-screen.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Building2, ChevronRight, LogOut, Plus } from "lucide-react";
 import { formatRoleLabel, type DenOrgSummary } from "../../_lib/den-org";
+import { useOrgListWindow } from "../../_lib/use-org-list-window";
 
 export function OrgSelectionScreen({
   orgs,
@@ -17,6 +18,16 @@ export function OrgSelectionScreen({
   busy: boolean;
   error: string | null;
 }) {
+  const {
+    query,
+    setQuery,
+    visible,
+    filteredCount,
+    hasMore,
+    showMore,
+    showSearch,
+  } = useOrgListWindow(orgs);
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#fafafa] px-4 py-12">
       <div className="w-full max-w-md">
@@ -29,8 +40,18 @@ export function OrgSelectionScreen({
           </p>
         </div>
 
+        {showSearch ? (
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search organizations"
+            className="mb-3 w-full rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-[13px] text-gray-900 outline-none transition focus:border-gray-400 focus:ring-4 focus:ring-gray-900/5"
+          />
+        ) : null}
+
         <div className="grid gap-2 rounded-xl border border-gray-200 bg-white p-2 shadow-[0_12px_24px_-16px_rgba(0,0,0,0.15)]">
-          {orgs.map((org) => (
+          {visible.map((org) => (
             <button
               key={org.id}
               type="button"
@@ -53,6 +74,25 @@ export function OrgSelectionScreen({
             </button>
           ))}
         </div>
+
+        {filteredCount === 0 && query ? (
+          <p className="mt-3 px-1 text-[13px] text-gray-500">No organizations match your search.</p>
+        ) : null}
+
+        {hasMore ? (
+          <div className="mt-3 flex items-center justify-between gap-3 px-1">
+            <p className="text-[12px] text-gray-500">
+              Showing {visible.length} of {filteredCount} organizations
+            </p>
+            <button
+              type="button"
+              onClick={showMore}
+              className="shrink-0 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-[12px] font-medium text-gray-700 transition-colors hover:bg-gray-50"
+            >
+              Show more
+            </button>
+          </div>
+        ) : null}
 
         {error ? (
           <p className="mt-3 px-1 text-[12px] font-medium text-rose-600">{error}</p>

--- a/ee/apps/den-web/app/mcp/select-organization/page.tsx
+++ b/ee/apps/den-web/app/mcp/select-organization/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { useOrgListWindow } from "../../(den)/_lib/use-org-list-window";
 
 type Organization = {
   id: string;
@@ -105,6 +106,15 @@ export default function McpSelectOrganizationPage() {
     [orgs, selectedOrgId],
   );
   const isBusy = flowState === "submitting" || flowState === "redirecting";
+  const {
+    query: orgQuery,
+    setQuery: setOrgQuery,
+    visible: visibleOrgs,
+    filteredCount: orgFilteredCount,
+    hasMore: orgHasMore,
+    showMore: showMoreOrgs,
+    showSearch: showOrgSearch,
+  } = useOrgListWindow(orgs);
 
   useEffect(() => {
     let cancelled = false;
@@ -300,59 +310,90 @@ export default function McpSelectOrganizationPage() {
             (flowState === "ready" ||
               flowState === "submitting" ||
               flowState === "redirecting") ? (
-              <ul className="grid gap-2">
-                {orgs.map((org) => {
-                  const display = org.name || org.slug || org.id;
-                  const isSelected = selectedOrgId === org.id;
-                  return (
-                    <li key={org.id}>
-                      <label
-                        className={`flex cursor-pointer items-center gap-3 rounded-2xl border bg-white px-4 py-3 transition-colors ${
-                          isSelected
-                            ? "border-[var(--dls-accent)] shadow-[0_0_0_4px_rgba(15,23,42,0.06)]"
-                            : "border-[var(--dls-border)] hover:bg-[var(--dls-hover)]"
-                        } ${isBusy ? "pointer-events-none opacity-70" : ""}`}
-                      >
-                        <input
-                          type="radio"
-                          name="mcp-organization"
-                          checked={isSelected}
-                          onChange={() => setSelectedOrgId(org.id)}
-                          className="sr-only"
-                          disabled={isBusy}
-                        />
-                        <span
-                          aria-hidden
-                          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#011627] text-[12px] font-semibold uppercase tracking-[0.08em] text-white"
-                        >
-                          {getInitials(display)}
-                        </span>
-                        <span className="grid flex-1 gap-0.5">
-                          <span className="text-[15px] font-medium text-[var(--dls-text-primary)]">
-                            {display}
-                          </span>
-                          <span className="text-[12px] text-[var(--dls-text-secondary)]">
-                            {formatRole(org.role)}
-                            {org.isActive ? " · Current workspace" : ""}
-                          </span>
-                        </span>
-                        <span
-                          aria-hidden
-                          className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border ${
+              <div className="grid gap-3">
+                {showOrgSearch ? (
+                  <input
+                    type="search"
+                    value={orgQuery}
+                    onChange={(event) => setOrgQuery(event.target.value)}
+                    placeholder="Search organizations"
+                    className="rounded-2xl border border-[var(--dls-border)] px-4 py-3 text-[14px] text-[var(--dls-text-primary)] outline-none transition focus:border-[var(--dls-accent)]"
+                  />
+                ) : null}
+
+                <ul className="grid gap-2">
+                  {visibleOrgs.map((org) => {
+                    const display = org.name || org.slug || org.id;
+                    const isSelected = selectedOrgId === org.id;
+                    return (
+                      <li key={org.id}>
+                        <label
+                          className={`flex cursor-pointer items-center gap-3 rounded-2xl border bg-white px-4 py-3 transition-colors ${
                             isSelected
-                              ? "border-[var(--dls-accent)] bg-[var(--dls-accent)]"
-                              : "border-[var(--dls-border)] bg-white"
-                          }`}
+                              ? "border-[var(--dls-accent)] shadow-[0_0_0_4px_rgba(15,23,42,0.06)]"
+                              : "border-[var(--dls-border)] hover:bg-[var(--dls-hover)]"
+                          } ${isBusy ? "pointer-events-none opacity-70" : ""}`}
                         >
-                          {isSelected ? (
-                            <span className="h-2 w-2 rounded-full bg-white" />
-                          ) : null}
-                        </span>
-                      </label>
-                    </li>
-                  );
-                })}
-              </ul>
+                          <input
+                            type="radio"
+                            name="mcp-organization"
+                            checked={isSelected}
+                            onChange={() => setSelectedOrgId(org.id)}
+                            className="sr-only"
+                            disabled={isBusy}
+                          />
+                          <span
+                            aria-hidden
+                            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#011627] text-[12px] font-semibold uppercase tracking-[0.08em] text-white"
+                          >
+                            {getInitials(display)}
+                          </span>
+                          <span className="grid flex-1 gap-0.5">
+                            <span className="text-[15px] font-medium text-[var(--dls-text-primary)]">
+                              {display}
+                            </span>
+                            <span className="text-[12px] text-[var(--dls-text-secondary)]">
+                              {formatRole(org.role)}
+                              {org.isActive ? " · Current workspace" : ""}
+                            </span>
+                          </span>
+                          <span
+                            aria-hidden
+                            className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border ${
+                              isSelected
+                                ? "border-[var(--dls-accent)] bg-[var(--dls-accent)]"
+                                : "border-[var(--dls-border)] bg-white"
+                            }`}
+                          >
+                            {isSelected ? (
+                              <span className="h-2 w-2 rounded-full bg-white" />
+                            ) : null}
+                          </span>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+
+                {orgFilteredCount === 0 && orgQuery ? (
+                  <p className="text-[13px] text-[var(--dls-text-secondary)]">No organizations match your search.</p>
+                ) : null}
+
+                {orgHasMore ? (
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="text-[13px] text-[var(--dls-text-secondary)]">
+                      Showing {visibleOrgs.length} of {orgFilteredCount} organizations
+                    </p>
+                    <button
+                      type="button"
+                      onClick={showMoreOrgs}
+                      className="den-button-ghost w-full sm:w-auto"
+                    >
+                      Show more
+                    </button>
+                  </div>
+                ) : null}
+              </div>
             ) : null}
 
             {errorMessage ? (

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -833,6 +833,7 @@ export function DenAdminPanel() {
   const [savingCapabilityOrgId, setSavingCapabilityOrgId] = useState<string | null>(null);
   const [deleteUserDialog, setDeleteUserDialog] = useState<AdminUser | null>(null);
   const [deletingUserId, setDeletingUserId] = useState<string | null>(null);
+  const [orgRenderLimit, setOrgRenderLimit] = useState(200);
 
   const loadOverview = useCallback(async (loadBilling: boolean) => {
     setRefreshing(true);
@@ -1017,6 +1018,8 @@ export function DenAdminPanel() {
 
     return payload.organizations.filter((org) => `${org.name} ${org.slug} ${org.id}`.toLowerCase().includes(normalizedQuery));
   }, [payload, query]);
+  const renderedOrganizations = filteredOrganizations.slice(0, orgRenderLimit);
+  const remainingOrganizationCount = filteredOrganizations.length - renderedOrganizations.length;
 
   useEffect(() => {
     if (!payload) {
@@ -1516,7 +1519,9 @@ export function DenAdminPanel() {
 
         <div className="mt-6 grid gap-3">
           {viewMode === "organizations" ? (
-            filteredOrganizations.length > 0 ? filteredOrganizations.map((org) => {
+            filteredOrganizations.length > 0 ? (
+              <>
+                {renderedOrganizations.map((org) => {
               const draft = orgDrafts[org.id] ?? { tier: org.plan.tier, seatLimit: String(org.seatLimit) };
               const changed = draft.tier !== org.plan.tier || draft.seatLimit !== String(org.seatLimit);
 
@@ -1626,7 +1631,23 @@ export function DenAdminPanel() {
                   </div>
                 </div>
               );
-            }) : (
+                })}
+                {remainingOrganizationCount > 0 ? (
+                  <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="text-sm text-slate-500">
+                      Showing {renderedOrganizations.length} of {filteredOrganizations.length} organizations
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => setOrgRenderLimit((current) => current + 200)}
+                      className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-300"
+                    >
+                      Show more
+                    </button>
+                  </div>
+                ) : null}
+              </>
+            ) : (
               <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-5 py-10 text-center">
                 <p className="text-base font-semibold text-slate-950">No organizations match</p>
                 <p className="mt-2 text-sm leading-7 text-slate-500">Try a different search.</p>


### PR DESCRIPTION
## Problem

Users who belong to thousands of organizations (~10k) crash the browser tab: every org surface renders the **full** orgs array with a plain `.map(...)` — the Organizations settings screen even renders it twice (mobile cards + desktop table), producing hundreds of thousands of DOM nodes.

## Fix

Client-side windowing + search on every org list, via a tiny shared hook (`useOrgListWindow`: query filter on name/slug, render cap with "Show more", search box appears when >10 orgs):

**den-web** (`ee/apps/den-web`)
- `app/(den)/_lib/use-org-list-window.ts` — new shared hook
- Organizations settings screen — search input, both mobile/desktop lists capped at 50, "Showing X of Y" + Show more
- "Choose an organization" selection screen — search + cap 50
- Dashboard sidebar workspace switcher — search, cap 20, `max-h-64` scroll, "Show more (N)"
- MCP `select-organization` picker — search + cap 50
- Admin panel organizations view — render capped at 200 + Show more (search filter already existed)

**desktop app** (`apps/app`)
- `domains/cloud/use-org-list-window.ts` — new shared hook
- Cloud onboarding `OrganizationList` and Settings → Cloud `OrgPicker` — search + cap 50 + Show more

No server/API changes; behavior is unchanged for users with few orgs (search input only appears above 10). Follow-up worth considering separately: `/v1/me/orgs` has no limit/search params and materializes all rows per request.

## Validation (real browser, 10,000 orgs)

Ran den-web dev against a stub Den API returning **10,000 orgs** and drove it headless via CDP:

- **/organization (settings)**: page renders instantly; **50 rows rendered, ~1,256 total DOM nodes** (previously 10k rows × 2 lists); typing `Organization 999` filters to the 11 matches; Show more: 50 → 100 rows, "Showing 100 of 10000 organizations".
- **Choose an organization**: 50 of 10,000 rendered ("Showing 50 of 10000"); searching `acme` narrows to the single match.
- **Sidebar workspace switcher**: popover renders only 20 org buttons + "Show more (9980)"; searching `7777` narrows to `Organization 7777`.

| Organizations settings (10k orgs) | Search | Org selection | Switcher |
|---|---|---|---|
| <img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/org-list-perf/browser-screenshot-1783383403693-3jiZs8s9GLx6PgYFzSW2YR61LUPrXI.png" width="400"> | <img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/org-list-perf/browser-screenshot-1783383421287-mhwfirhgtAttGA8mWeewQVOgiKPrZA.png" width="400"> | <img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/org-list-perf/browser-screenshot-1783383604327-87OQGoKShnx1p1YoafFVbBNfnNH4J7.png" width="400"> | <img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/org-list-perf/browser-screenshot-1783383718995-FIsnhdcsCUm9Fb4LqwVSHAugrrC6KY.png" width="400"> |

## Tests / commands run

- `pnpm --filter @openwork/app typecheck` — **passed**
- `pnpm --filter @openwork-ee/den-web build` — compiles + TypeScript passes; the build then fails on a **pre-existing** prerender error (`useSearchParams()` missing Suspense at `/dashboard/org-settings`) — verified identical failure on clean `dev` (073a7cf93) with no changes.
- CDP-driven browser validation above (stubbed `/v1/me`, `/v1/me/orgs`, `/v1/org`, `/v1/workers` with 10k orgs; `DEN_API_BASE` pointed at the stub).

Not runtime-validated (logic identical, typechecked only): MCP select-organization page (requires a live OAuth flow), admin panel (requires admin session), and the two desktop pickers (require cloud login in Electron). A full `pnpm fraimz` run was not used because these den-web surfaces need a seeded 10k-org Den backend; the stub-API CDP validation above is the proof for the crash-site screens.
