### PR TITLE
fix(den): surface capability save failures inline, fix dev boot crash

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -3,10 +3,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "pnpm run build:email && OPENWORK_DEV_MODE=1 tsx watch src/server.ts",
-    "dev:local": "pnpm run build:email && OPENWORK_DEV_MODE=1 PORT=${DEN_API_PORT:-8790} tsx watch src/server.ts",
+    "dev": "pnpm run build:email && pnpm run build:install-config && OPENWORK_DEV_MODE=1 tsx watch src/server.ts",
+    "dev:local": "pnpm run build:email && pnpm run build:install-config && OPENWORK_DEV_MODE=1 PORT=${DEN_API_PORT:-8790} tsx watch src/server.ts",
     "build": "node ./scripts/build.mjs",
     "build:email": "pnpm --filter @openwork/email build",
+    "build:install-config": "pnpm --filter @openwork/install-config build",
     "build:den-db": "pnpm --filter @openwork-ee/den-db build",
     "backfill:desktop-policies": "pnpm run build:den-db && tsx scripts/backfill-desktop-policies.ts",
     "seed:demo-org": "pnpm run build:den-db && OPENWORK_DEV_MODE=${OPENWORK_DEV_MODE:-1} DATABASE_URL=${DATABASE_URL:-mysql://root:password@127.0.0.1:3306/openwork_den} DEN_DB_ENCRYPTION_KEY=${DEN_DB_ENCRYPTION_KEY:-local-dev-db-encryption-key-please-change-1234567890} BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-local-dev-secret-not-for-production-use!!} BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:${DEN_WEB_PORT:-3005}} tsx scripts/seed-demo-org.ts",

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -833,6 +833,7 @@ export function DenAdminPanel() {
   const [freeSeatsDialog, setFreeSeatsDialog] = useState<{ org: AdminOrganization; totalFreeSeats: string } | null>(null);
   const [savingFreeSeatsOrgId, setSavingFreeSeatsOrgId] = useState<string | null>(null);
   const [savingCapabilityOrgId, setSavingCapabilityOrgId] = useState<string | null>(null);
+  const [capabilityError, setCapabilityError] = useState<{ orgId: string; message: string } | null>(null);
   const [deleteUserDialog, setDeleteUserDialog] = useState<AdminUser | null>(null);
   const [deletingUserId, setDeletingUserId] = useState<string | null>(null);
 
@@ -1118,6 +1119,7 @@ export function DenAdminPanel() {
   const saveOrganizationCapability = useCallback(async (org: AdminOrganization, key: keyof AdminOrganizationCapabilities, enabled: boolean) => {
     setSavingCapabilityOrgId(org.id);
     setError(null);
+    setCapabilityError(null);
     // Optimistic: flip the toggle immediately, roll back if the PUT fails.
     setOrganizationCapabilityLocally(org.id, key, enabled);
 
@@ -1128,11 +1130,15 @@ export function DenAdminPanel() {
 
       if (!response.ok) {
         setOrganizationCapabilityLocally(org.id, key, !enabled);
-        setError(getErrorMessage(nextPayload, `Could not update capabilities for ${org.name}.`));
+        const message = getErrorMessage(nextPayload, `Could not update capabilities for ${org.name}.`);
+        setError(message);
+        setCapabilityError({ orgId: org.id, message });
       }
     } catch (nextError) {
       setOrganizationCapabilityLocally(org.id, key, !enabled);
-      setError(nextError instanceof Error ? nextError.message : "Unknown network error");
+      const message = nextError instanceof Error ? nextError.message : "Unknown network error";
+      setError(message);
+      setCapabilityError({ orgId: org.id, message });
     } finally {
       setSavingCapabilityOrgId(null);
     }
@@ -1599,6 +1605,11 @@ export function DenAdminPanel() {
                         MCP connections
                       </label>
                     </div>
+                    {capabilityError?.orgId === org.id ? (
+                      <p data-testid="admin-capability-error" className="mt-2 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-xs leading-5 text-red-700">
+                        Save failed — the change was reverted. {capabilityError.message}
+                      </p>
+                    ) : null}
                     <p className="mt-1 text-xs text-slate-400">Off by default. Lets workspace admins mint desktop install links for this organization.</p>
                     <p className="mt-1 text-xs text-slate-400">Off by default. Lets members discover and use organization MCP connections.</p>
                   </div>


### PR DESCRIPTION
## Problem

Toggling an org's "Install links" or "MCP connections" capability checkbox in `/admin` would flip back off right after saving, with no visible explanation. Reported by a user as "each time I press save it disables the checkbox."

## Root cause

The PUT to `/v1/admin/organizations/:id/capabilities` was failing (e.g. den-api upstream down), and `saveOrganizationCapability` correctly rolls the checkbox back on failure — but the only error feedback was a banner at the very top of the page, far from the org card the admin is looking at. The checkbox silently reverting looked like a bug in the checkbox itself.

Backend persistence was verified correct end-to-end (PUT → DB → GET/overview, survives plan/seat updates too) — this is a UI feedback bug, not a data bug.

Also found and fixed a related dev-environment trap: on a fresh worktree, den-api's `dev`/`dev:local` scripts never built `@openwork/install-config`, so den-api crashes at boot (`ERR_MODULE_NOT_FOUND`). That leaves the admin UI pointed at a dead upstream, which is exactly what produces this symptom in practice.

## Fix

- `ee/apps/den-web/components/den-admin-panel.tsx`: capability save failures now render an inline message directly under the checkbox row ("Save failed — the change was reverted. \<reason\>"), in addition to the existing top banner. Rollback behavior is unchanged.
- `ee/apps/den-api/package.json`: `dev`/`dev:local` now build `@openwork/install-config` before starting (same pattern as the existing `build:email` step).

## Proof

Full local stack (MySQL + den-api + den-web), driven via CDP as a signed-in platform admin:

1. Toggled Acme's "MCP connections" on → persisted through a full page reload, DB confirmed `mcpConnections: true`.
2. Killed den-api mid-session (reproducing the reported bug) → toggling now rolls back **and shows the inline error**:

   ![inline capability save error](https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/admin-mcp-capability-fix/browser-screenshot-1783384794175-Jx7ZHJP2lvWKjXxtrZCU41DPCrFu9K.png)

3. Restarted den-api → toggle works again, inline error clears, DB updated to `false`.

## Tests run

- `pnpm --filter @openwork-ee/den-web exec tsc --noEmit` — passes.
- Manual end-to-end verification above (CDP-driven, real DB, real failure injection) rather than an automated fraimz flow — this is a small UI-feedback fix on an already-merged feature, verified by directly reproducing the reported bug and confirming the fix resolves it.
