### PR TITLE
perf(admin): instant Den admin first paint (skeleton shell + stale-while-revalidate cache, bounded activity queries)

### DIFF
--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -548,13 +548,15 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
           userId: AuthAccountTable.userId,
           providerId: AuthAccountTable.providerId,
         })
-        .from(AuthAccountTable),
+        .from(AuthAccountTable)
+        .groupBy(AuthAccountTable.userId, AuthAccountTable.providerId),
       db
         .select({
           userId: AuthSessionTable.userId,
           day: sessionDayExpr,
         })
         .from(AuthSessionTable)
+        .where(gte(AuthSessionTable.createdAt, activityWindowStart))
         .groupBy(AuthSessionTable.userId, sessionDayExpr),
       // Non-fatal: telemetry_event may be missing in environments that never
       // ran its migration; activity then degrades to sign-in days only.

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -11,6 +11,9 @@ type ActivityFilter = "all" | "active-7d" | "active-30d" | "recurring" | "inacti
 type SortMode = "newest" | "recently-active" | "most-sign-ins" | "most-active-days" | "fastest-invite";
 
 const DEFAULT_FREE_SEAT_COUNT = 5;
+const ADMIN_OVERVIEW_CACHE_KEY = "den-admin-overview-cache";
+
+let cachedAdminOverviewPayload: unknown = null;
 
 type AdminBillingStatus = {
   status: "paid" | "unpaid" | "unavailable";
@@ -342,6 +345,74 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
     organizations,
     generatedAt: toStringValue(payload.generatedAt)
   };
+}
+
+function clearPersistedAdminOverviewCache() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.removeItem(ADMIN_OVERVIEW_CACHE_KEY);
+  } catch {
+    // Ignore storage failures: the cache is only a best-effort fast path.
+  }
+}
+
+function clearAdminOverviewCache() {
+  cachedAdminOverviewPayload = null;
+  clearPersistedAdminOverviewCache();
+}
+
+function storeAdminOverviewCache(payload: unknown) {
+  cachedAdminOverviewPayload = payload;
+
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    const serialized = JSON.stringify(payload);
+    if (serialized === undefined) {
+      window.sessionStorage.removeItem(ADMIN_OVERVIEW_CACHE_KEY);
+      return;
+    }
+
+    window.sessionStorage.setItem(ADMIN_OVERVIEW_CACHE_KEY, serialized);
+  } catch {
+    clearPersistedAdminOverviewCache();
+  }
+}
+
+function readAdminOverviewCache(): AdminPayload | null {
+  const parsedCachedPayload = parseAdminPayload(cachedAdminOverviewPayload);
+  if (parsedCachedPayload) {
+    return parsedCachedPayload;
+  }
+
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const persistedPayload = window.sessionStorage.getItem(ADMIN_OVERVIEW_CACHE_KEY);
+    if (!persistedPayload) {
+      return null;
+    }
+
+    const storedPayload: unknown = JSON.parse(persistedPayload);
+    const parsedStoredPayload = parseAdminPayload(storedPayload);
+    if (!parsedStoredPayload) {
+      window.sessionStorage.removeItem(ADMIN_OVERVIEW_CACHE_KEY);
+      return null;
+    }
+
+    cachedAdminOverviewPayload = storedPayload;
+    return parsedStoredPayload;
+  } catch {
+    clearPersistedAdminOverviewCache();
+    return null;
+  }
 }
 
 function getFriendlyHtmlError(value: string): string | null {
@@ -813,6 +884,57 @@ function PlanPill({ tier }: { tier: AdminOrganization["plan"]["tier"] }) {
   );
 }
 
+function DenAdminLoadingShell() {
+  return (
+    <section className="mx-auto w-full max-w-6xl rounded-3xl border border-slate-200 bg-white shadow-sm" aria-busy="true">
+      <div className="border-b border-slate-200 px-6 py-6 sm:px-8">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-slate-500">Den admin</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-[-0.04em] text-slate-950">User backoffice</h1>
+            <p className="mt-2 max-w-3xl text-sm leading-7 text-slate-600">
+              Loading the latest signup, worker, and activity summaries.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 animate-pulse">
+            <div className="h-10 w-48 rounded-full bg-slate-100" />
+            <div className="h-10 w-24 rounded-full border border-slate-200 bg-slate-50" />
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-6 animate-pulse">
+          {[0, 1, 2, 3, 4, 5].map((index) => (
+            <div key={index} className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <div className="h-3 w-20 rounded-full bg-slate-200" />
+              <div className="mt-3 h-8 w-16 rounded-lg bg-slate-200" />
+              <div className="mt-3 h-3 w-full rounded-full bg-slate-200" />
+              <div className="mt-2 h-3 w-2/3 rounded-full bg-slate-200" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="px-6 py-6 sm:px-8">
+        <div className="flex flex-wrap items-center justify-between gap-3 animate-pulse">
+          <div className="h-11 w-80 rounded-full border border-slate-200 bg-slate-50" />
+          <div className="h-10 w-28 rounded-full border border-slate-200 bg-slate-50" />
+        </div>
+
+        <div className="mt-6 rounded-2xl border border-slate-200 bg-white p-4 animate-pulse">
+          <div className="h-4 w-56 rounded-full bg-slate-200" />
+          <div className="mt-4 grid gap-3 md:grid-cols-2">
+            <div className="h-24 rounded-2xl bg-slate-100" />
+            <div className="h-24 rounded-2xl bg-slate-100" />
+          </div>
+          <div className="mt-4 h-3 w-full rounded-full bg-slate-200" />
+          <div className="mt-2 h-3 w-5/6 rounded-full bg-slate-200" />
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export function DenAdminPanel() {
   const [accessState, setAccessState] = useState<AccessState>("loading");
   const [payload, setPayload] = useState<AdminPayload | null>(null);
@@ -846,12 +968,14 @@ export function DenAdminPanel() {
       const { response, payload: nextPayload } = await requestJson(`/v1/admin/overview${suffix}`);
 
       if (response.status === 401) {
+        clearAdminOverviewCache();
         setAccessState("signed-out");
         setPayload(null);
         return;
       }
 
       if (response.status === 403) {
+        clearAdminOverviewCache();
         setAccessState("forbidden");
         setPayload(null);
         return;
@@ -872,6 +996,7 @@ export function DenAdminPanel() {
         return;
       }
 
+      storeAdminOverviewCache(nextPayload);
       setIncludeBilling(parsed.summary.billingLoaded);
       setAccessState("ready");
       setPayload(parsed);
@@ -885,6 +1010,13 @@ export function DenAdminPanel() {
   }, []);
 
   useEffect(() => {
+    const cachedPayload = readAdminOverviewCache();
+    if (cachedPayload) {
+      setPayload(cachedPayload);
+      setIncludeBilling(cachedPayload.summary.billingLoaded);
+      setAccessState("ready");
+    }
+
     void loadOverview(false);
   }, [loadOverview]);
 
@@ -1248,11 +1380,7 @@ export function DenAdminPanel() {
   }, [filteredUsers, selectedUserId]);
 
   if (accessState === "loading") {
-    return (
-      <section className="mx-auto w-full max-w-6xl rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
-        <p className="text-sm text-slate-500">Loading Den admin...</p>
-      </section>
-    );
+    return <DenAdminLoadingShell />;
   }
 
   if (accessState === "signed-out" || accessState === "forbidden" || accessState === "error") {


### PR DESCRIPTION
## Problem

Opening the Den admin backoffice (`/admin`) shows a blank "Loading Den admin..." for 3-10 seconds. Everything is gated on one monolithic `GET /v1/admin/overview` (multi-MB payload: every user + every org + activity aggregates), with zero caching — every visit refetches everything before anything renders. Server-side, two of the 12 overview queries scan unbounded tables.

## Fix

**den-web — `den-admin-panel.tsx`**
- **Stale-while-revalidate cache**: the last successful overview payload is kept in a module-level cache + `sessionStorage` (quota-guarded try/catch). On mount, cached data renders **immediately** and the overview refetches in the background (existing `Refreshing...` state on the Refresh button indicates it). On 401/403 both caches are cleared before flipping to the signed-out/forbidden screen.
- **Skeleton shell** on cold load: the blank "Loading Den admin..." text is replaced with the panel shell (heading + pulsing stat-card/list placeholders), so the page structure paints instantly.

**den-api — `routes/admin/index.ts` (overview handler)**
- Session-day activity query now bounded to the 90-day `activityWindowStart` (previously grouped `date_format(createdAt)` over **all sessions ever**; telemetry queries were already 90-day bounded, so this aligns semantics: activity day-sets feed the 90-day activity stats and 30-day series).
- `AuthAccountTable` scan now `GROUP BY (userId, providerId)` instead of selecting every row (consumed as a per-user provider set, so dedup is lossless).
- "Last seen" / session counts untouched (still all-time). Billing/Stripe untouched (already opt-in).

## Validation (real browser, stubbed Den API with 3,000 users / 2,000 orgs / ~2.5MB payload, overview delayed 15s)

Drove the production build (`next start`) headless via CDP with `DEN_API_BASE` pointed at a stub:

1. **Cold load**: skeleton shell (aria-busy section, pulsing cards) renders immediately instead of blank text while the 15s request is in flight.
2. **Warm revisit (reload)**: full backoffice — stat cards + user list — rendered from the sessionStorage cache within ~1s while the button showed `Refreshing...` and the 15s network refetch was still pending (stub confirmed the background request fired). Cache measured at 2,573,654 bytes without hitting quota.
3. **Auth invalidation**: with the server returning 401, the panel drops cached data, clears `sessionStorage`, and shows "Sign in required".

| Cold load (skeleton, instant) | Warm revisit (cached data + background refresh) | Loaded state |
|---|---|---|
| <img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/den-admin-fast-paint/browser-screenshot-1783385373434-KSPyfMkVFhJ1756XInhYuicMvs3De9.png" width="400"> | <img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/den-admin-fast-paint/browser-screenshot-1783385426519-O5pSfdA5sMkIPKUoc7sFYJplFujcjY.png" width="400"> | <img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/den-admin-fast-paint/browser-screenshot-1783385298418-nCMy4bhq047wCSD999fjXXWyQ1HKa2.png" width="400"> |

Note the warm screenshot's Refresh button reads **"Refreshing..."** — data on screen, refetch still in flight.

## Tests / commands run

- `pnpm --filter @openwork-ee/den-web build` — **passed** (incl. TypeScript; the old `/dashboard/org-settings` prerender failure no longer occurs on dev)
- `pnpm --filter @openwork-ee/den-api build` — **passed**
- CDP browser validation above (production `next start` + stub API)

Not runtime-validated: the two SQL changes against a real MySQL (no local DB in this environment) — they are build/typecheck-verified and semantically reviewed (`gte` bound matches the existing telemetry queries' `activityWindowStart`; the account dedup feeds a Set). Follow-ups worth considering separately: a counts-only summary endpoint for fast cold loads, and pagination for the users/orgs arrays.
