### PR TITLE
chore(ci): add manual den-api redeploy workflow

### DIFF
--- a/.github/workflows/den-api-deploy.yml
+++ b/.github/workflows/den-api-deploy.yml
@@ -1,0 +1,76 @@
+name: Den API Deploy
+
+# Triggers a fresh deploy of the production den-api service (Render) from the
+# latest commit on its tracked branch. No env vars are changed — use
+# den-api-env.yml for that. Use this when production den-api has fallen
+# behind dev (e.g. after merges) and needs a manual redeploy.
+#
+# Required GitHub Actions secrets:
+#   RENDER_API_KEY                        Render API key
+#   RENDER_DEN_CONTROL_PLANE_SERVICE_ID   Render service id of den-api
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: den-api-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Trigger deploy and wait
+    if: github.repository == 'different-ai/openwork'
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+
+    env:
+      RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+      RENDER_SERVICE_ID: ${{ secrets.RENDER_DEN_CONTROL_PLANE_SERVICE_ID }}
+
+    steps:
+      - name: Verify Render secrets are configured
+        run: |
+          set -euo pipefail
+          missing=""
+          [ -z "$RENDER_API_KEY" ] && missing="$missing RENDER_API_KEY"
+          [ -z "$RENDER_SERVICE_ID" ] && missing="$missing RENDER_DEN_CONTROL_PLANE_SERVICE_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing GitHub Actions secrets:$missing."
+            exit 1
+          fi
+          echo "Render secrets present."
+
+      - name: Trigger deploy and wait
+        run: |
+          set -euo pipefail
+          response="$(curl -s -w '\n%{http_code}' -X POST "https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys" \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" -d '{}')"
+          http_code="$(printf '%s' "$response" | tail -1)"
+          body="$(printf '%s' "$response" | sed '$d')"
+          if [ "$http_code" -ge 400 ]; then
+            echo "::error::POST /deploys returned HTTP $http_code: $body"
+            exit 1
+          fi
+          deploy_id="$(printf '%s' "$body" | jq -r '.id')"
+          echo "Deploy triggered: $deploy_id"
+          for _ in $(seq 1 90); do
+            status="$(curl -sf "https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys/$deploy_id" \
+              -H "Authorization: Bearer $RENDER_API_KEY" | jq -r '.status')"
+            echo "deploy status: $status"
+            case "$status" in
+              live)
+                echo "Deploy is live."
+                exit 0
+                ;;
+              build_failed|update_failed|pre_deploy_failed|canceled|deactivated)
+                echo "::error::Deploy failed with status: $status"
+                exit 1
+                ;;
+            esac
+            sleep 10
+          done
+          echo "::error::Deploy did not go live within 15 minutes."
+          exit 1


### PR DESCRIPTION
## What

Adds `.github/workflows/den-api-deploy.yml` — a `workflow_dispatch`-only workflow that triggers a Render deploy for the production den-api service and polls until it's live, with no other side effects.

## Why

`den-api-env.yml` already triggers a deploy, but only as a side effect of setting an env var (it requires `key`/`value` inputs). Using it just to force a redeploy would mean mutating a production env var I don't intend to change. This adds a dedicated, minimal-diff workflow that reuses the exact same proven trigger-and-wait `curl`/Render API logic, with zero env var mutation.

## Context

Production den-api is currently running a build from before PR #2480 (org install-links) — confirmed via `/v1/app-version` reporting `0.17.9`, which predates that commit by 55 commits (verified with `git merge-base --is-ancestor`). This workflow lets us redeploy it to current `dev` without touching config.

## Tests run

- `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML.
- `actionlint` — clean except the expected unknown-custom-runner-label warning for `blacksmith-4vcpu-ubuntu-2204`, which is the same self-hosted runner label already used by `den-api-env.yml` in this repo.
- No app/runtime code touched — pure CI workflow addition. Real validation is running it for real against the actual Render service (planned right after merge).
