### PR TITLE
fix(den): production den-api crash-loops since #2480 — build install-config in build.mjs

### DIFF
--- a/ee/apps/den-api/scripts/build.mjs
+++ b/ee/apps/den-api/scripts/build.mjs
@@ -56,5 +56,6 @@ process.env.DEN_API_LATEST_APP_VERSION = process.env.DEN_API_LATEST_APP_VERSION 
 writeGeneratedVersionFile(process.env.DEN_API_LATEST_APP_VERSION)
 
 run(pnpmCommand, ["run", "build:email"])
+run(pnpmCommand, ["run", "build:install-config"])
 run(pnpmCommand, ["run", "build:den-db"])
 run(pnpmCommand, ["exec", "tsc", "-p", "tsconfig.json"])


### PR DESCRIPTION
## What

One line: den-api's production build (`scripts/build.mjs`) now builds `@openwork/install-config`, alongside the existing `build:email` / `build:den-db` steps.

## Why — production den-api is crash-looping on every deploy

Since #2480 landed, every Render auto-deploy of den-api dies on boot:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'.../ee/apps/den-api/node_modules/@openwork/install-config/dist/index.js'
imported from .../ee/apps/den-api/dist/routes/org/install-links.js
```

Render therefore keeps serving the last healthy build — from **v0.17.9, ~55 commits behind dev** — which is why "Copy install link" in production returns `404 {"error":"not_found"}` (the running build predates the route entirely; verified via prod `/v1/app-version` = 0.17.9 and prod `openapi.json` containing zero install-link paths).

Root cause chain:
- `@openwork/install-config` exports `default → ./dist/index.js`, `development → ./src/index.ts`, `types → ./src/index.ts`.
- Production (`node dist/server.js`) resolves `default` → needs `dist/` — but nothing in the Render build chain builds it: `build.mjs` runs `build:email`, `build:den-db` (which transitively builds `@openwork-ee/utils`), then `tsc`.
- `tsc` stays green because the `types` condition points at `src/` — green build, dead runtime.
- Dev/CI never hit it because tsx/vitest use the `development` condition. #2517 fixed exactly this for the **dev scripts only**; `packaging/docker/Dockerfile.den` already builds it (line 28). Render's path (`build.mjs`) was the one left behind.

## Verification (simulated fresh Render checkout)

```
rm -rf packages/install-config/dist ee/packages/utils/dist ee/packages/den-db/dist packages/email/dist ee/apps/den-api/dist
pnpm --dir ee/apps/den-api run build   # BUILD_OK, but packages/install-config/dist: No such file or directory
pnpm --dir ee/apps/den-api run start   # => exact production ERR_MODULE_NOT_FOUND reproduced
```

With this fix (same clean-slate rebuild):

```
pnpm --dir ee/apps/den-api run build   # BUILD_OK, install-config dist present
node dist/server.js                    # "den-api listening on 8791"
curl :8791/health                      # {"ok":true,"service":"den-api"}
```

(The SCIM/worker reconcile warnings in the boot log are local-MySQL-absent noise — they prove the process is far past module resolution.)

No fraimz for this one: it's a build-pipeline fix with terminal evidence above; the real end-to-end validation is Render auto-deploying `dev` after merge — I'll verify prod `/v1/app-version` moves off 0.17.9 and `openapi.json` gains the install-links paths, then that the Members page "Copy install link" button works.
