### PR TITLE
feat(den-web): social/SSO reauth verifies in a popup so the queued action survives and auto-retries

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { DenButton, buttonVariants } from "./ui/button";
 import { DenInput } from "./ui/input";
 import { type AuthUser, getErrorMessage, getUser, requestJson, type SocialAuthProvider } from "../_lib/den-flow";
@@ -12,6 +12,44 @@ function getCurrentUrl() {
 
 function getSocialLabel(provider: SocialAuthProvider) {
   return provider === "google" ? "Google" : "GitHub";
+}
+
+function getRedirectUrl(response: Response, payload: unknown) {
+  return payload && typeof payload === "object" && "url" in payload && typeof payload.url === "string"
+    ? payload.url
+    : response.headers.get("location") ?? "";
+}
+
+function getReauthCompleteUrl(nonce: string, error = false) {
+  const url = new URL("/reauth/complete", window.location.origin);
+  url.searchParams.set("nonce", nonce);
+  if (error) {
+    url.searchParams.set("error", "1");
+  }
+  return url.toString();
+}
+
+type ReauthCompleteMessage = {
+  type: "openwork:reauth-complete";
+  nonce: string;
+  error: string | null;
+};
+
+function getReauthCompleteMessage(data: unknown): ReauthCompleteMessage | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+  if (!("type" in data) || data.type !== "openwork:reauth-complete") {
+    return null;
+  }
+  if (!("nonce" in data) || typeof data.nonce !== "string") {
+    return null;
+  }
+  const error = "error" in data ? data.error : null;
+  if (error !== null && typeof error !== "string") {
+    return null;
+  }
+  return { type: "openwork:reauth-complete", nonce: data.nonce, error };
 }
 
 const REAUTH_SOCIAL_PROVIDERS: readonly SocialAuthProvider[] = ["google", "github"];
@@ -35,6 +73,11 @@ export function ReauthDialog({
   const [error, setError] = useState<string | null>(null);
   const [providers, setProviders] = useState<string[]>([]);
   const [ssoUrl, setSsoUrl] = useState<string | null>(null);
+  const [nonce, setNonce] = useState("");
+  const wasOpenRef = useRef(false);
+  const onVerifiedRef = useRef(onVerified);
+  const popupRef = useRef<Window | null>(null);
+  const popupClosedIntervalRef = useRef<number | null>(null);
 
   const effectiveProviders = providers.length > 0 ? providers : user?.authProviders ?? [];
   const hasPassword = !loadingMethods && (effectiveProviders.length === 0 || effectiveProviders.includes("email"));
@@ -51,13 +94,44 @@ export function ReauthDialog({
       effectiveProviders.includes("scim"),
   );
 
+  function stopPopupWatcher() {
+    if (popupClosedIntervalRef.current !== null) {
+      window.clearInterval(popupClosedIntervalRef.current);
+      popupClosedIntervalRef.current = null;
+    }
+    popupRef.current = null;
+  }
+
+  function startPopupWatcher(popup: Window) {
+    stopPopupWatcher();
+    popupRef.current = popup;
+    popupClosedIntervalRef.current = window.setInterval(() => {
+      if (!popup.closed) {
+        return;
+      }
+      stopPopupWatcher();
+      setBusy(false);
+    }, 500);
+  }
+
+  useEffect(() => {
+    onVerifiedRef.current = onVerified;
+  }, [onVerified]);
+
   useEffect(() => {
     if (!open) {
+      wasOpenRef.current = false;
+      stopPopupWatcher();
       setPassword("");
       setError(null);
       setBusy(false);
       setLoadingMethods(false);
       return;
+    }
+
+    if (!wasOpenRef.current) {
+      setNonce(crypto.randomUUID());
+      wasOpenRef.current = true;
     }
 
     let cancelled = false;
@@ -94,6 +168,48 @@ export function ReauthDialog({
     };
   }, [open, user?.email]);
 
+  useEffect(() => {
+    if (!open || !nonce) {
+      return;
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      const message = getReauthCompleteMessage(event.data);
+      if (event.origin !== window.location.origin || !message || message.nonce !== nonce) {
+        return;
+      }
+
+      const popup = popupRef.current;
+      stopPopupWatcher();
+      popup?.close();
+
+      if (message.error) {
+        setError("Sign-in was cancelled or failed. Try again.");
+        setBusy(false);
+        return;
+      }
+
+      // This message only says "try again now"; the retried request still hits
+      // the server-side freshness check, so a forged message cannot bypass reauth.
+      setBusy(true);
+      setError(null);
+      void (async () => {
+        try {
+          await onVerifiedRef.current();
+        } catch (nextError) {
+          setError(nextError instanceof Error ? nextError.message : "Re-authentication failed.");
+          setBusy(false);
+        }
+      })();
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.removeEventListener("message", handleMessage);
+      stopPopupWatcher();
+    };
+  }, [open, nonce]);
+
   async function submitPassword(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!user?.email) {
@@ -124,31 +240,40 @@ export function ReauthDialog({
   }
 
   async function continueSocial(provider: SocialAuthProvider) {
+    const popup = window.open("", "openwork-reauth", "popup,width=480,height=640");
     setBusy(true);
     setError(null);
     try {
-      const callbackURL = getCurrentUrl();
+      const callbackURL = popup ? getReauthCompleteUrl(nonce) : getCurrentUrl();
+      const errorCallbackURL = popup ? getReauthCompleteUrl(nonce, true) : callbackURL;
       const { response, payload } = await requestJson("/api/auth/sign-in/social", {
         method: "POST",
-        body: JSON.stringify({ provider, callbackURL, errorCallbackURL: callbackURL }),
+        body: JSON.stringify({ provider, callbackURL, errorCallbackURL }),
       });
       if (!response.ok) {
+        popup?.close();
         setError(getErrorMessage(payload, `${getSocialLabel(provider)} sign-in failed (${response.status}).`));
         setBusy(false);
         return;
       }
 
-      const redirectUrl = payload && typeof payload === "object" && "url" in payload && typeof payload.url === "string"
-        ? payload.url
-        : response.headers.get("location") ?? "";
+      const redirectUrl = getRedirectUrl(response, payload);
       if (!redirectUrl) {
+        popup?.close();
         setError(`${getSocialLabel(provider)} sign-in did not return a redirect URL.`);
         setBusy(false);
         return;
       }
 
-      window.location.assign(redirectUrl);
+      if (!popup) {
+        window.location.assign(redirectUrl);
+        return;
+      }
+
+      popup.location.href = redirectUrl;
+      startPopupWatcher(popup);
     } catch (nextError) {
+      popup?.close();
       setError(nextError instanceof Error ? nextError.message : `${getSocialLabel(provider)} sign-in failed.`);
       setBusy(false);
     }
@@ -160,10 +285,26 @@ export function ReauthDialog({
       return;
     }
 
-    const nextUrl = new URL(ssoUrl, window.location.origin);
-    nextUrl.searchParams.set("callbackURL", getCurrentUrl());
-    nextUrl.searchParams.set("loginHint", user.email);
-    window.location.assign(nextUrl.toString());
+    const popup = window.open("", "openwork-reauth", "popup,width=480,height=640");
+    setBusy(true);
+    setError(null);
+    try {
+      const nextUrl = new URL(ssoUrl, window.location.origin);
+      nextUrl.searchParams.set("callbackURL", popup ? getReauthCompleteUrl(nonce) : getCurrentUrl());
+      nextUrl.searchParams.set("loginHint", user.email);
+
+      if (!popup) {
+        window.location.assign(nextUrl.toString());
+        return;
+      }
+
+      popup.location.href = nextUrl.toString();
+      startPopupWatcher(popup);
+    } catch (nextError) {
+      popup?.close();
+      setError(nextError instanceof Error ? nextError.message : "Organization SSO sign-in failed.");
+      setBusy(false);
+    }
   }
 
   if (!open) {
@@ -172,7 +313,13 @@ export function ReauthDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6">
-      <div role="dialog" aria-modal="true" className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]">
+      <div
+        role="dialog"
+        aria-modal="true"
+        // Test seam: the reauth popup eval matches the completion message to this nonce.
+        data-reauth-nonce={nonce}
+        className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
+      >
         <div className="grid gap-3">
           <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-gray-400">Security check</p>
           <div className="grid gap-2">

--- a/ee/apps/den-web/app/(den)/reauth/complete/page.tsx
+++ b/ee/apps/den-web/app/(den)/reauth/complete/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Suspense, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+
+function CompleteFallback() {
+  return (
+    <main className="den-page flex min-h-[calc(100vh-2.5rem)] w-full items-center justify-center py-6">
+      <div className="den-frame grid w-full max-w-[520px] gap-3 p-6 text-center md:p-8">
+        <p className="den-eyebrow">Security check</p>
+        <h1 className="den-title-lg">You&apos;re verified.</h1>
+        <p className="den-copy">You can close this window and return to OpenWork.</p>
+      </div>
+    </main>
+  );
+}
+
+function ReauthCompleteContent() {
+  const searchParams = useSearchParams();
+  const nonce = searchParams.get("nonce");
+  const error = searchParams.get("error") || null;
+
+  useEffect(() => {
+    if (!window.opener) {
+      return;
+    }
+
+    window.opener.postMessage(
+      { type: "openwork:reauth-complete", nonce, error },
+      window.location.origin,
+    );
+    window.close();
+  }, [error, nonce]);
+
+  return <CompleteFallback />;
+}
+
+export default function ReauthCompletePage() {
+  return (
+    <Suspense fallback={<CompleteFallback />}>
+      <ReauthCompleteContent />
+    </Suspense>
+  );
+}

--- a/evals/flows/den-reauth-popup-social.flow.mjs
+++ b/evals/flows/den-reauth-popup-social.flow.mjs
@@ -61,10 +61,10 @@ export default {
             await goToDenWeb(ctx, "/dashboard/members");
           },
           assert: async () => {
-            const actual = await ctx.eval(`fetch('/v1/me', { credentials: 'include' }).then((response) => response.json())`, { awaitPromise: true });
+            const actual = await ctx.eval(`fetch('/api/den/v1/me', { credentials: 'include' }).then((response) => response.json())`, { awaitPromise: true });
             recordAssertion(
               ctx,
-              "/v1/me reports the seeded Google auth provider for Alex",
+              "/api/den/v1/me reports the seeded Google auth provider for Alex",
               Array.isArray(actual?.user?.authProviders) && actual.user.authProviders.includes("google"),
               actual?.user?.authProviders ?? actual,
             );

--- a/evals/flows/den-reauth-popup-social.flow.mjs
+++ b/evals/flows/den-reauth-popup-social.flow.mjs
@@ -1,0 +1,359 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// This flow intentionally opens and then replaces an OAuth popup. Launch Chromium
+// with --disable-popup-blocking so the synthetic completion page can reuse the
+// named popup exactly like the provider redirect would.
+// Sign-in route: ee/apps/den-web/app/(den)/page.tsx:1-5 renders AuthScreen;
+// ?mode=sign-in is consumed in den-flow-provider.tsx:1765-1769. The robust
+// selectors below come from auth-panel.tsx:485-508 and :550-556.
+// Members route: ee/apps/den-web/app/(den)/dashboard/(admin)/members/page.tsx:1-5;
+// the copy button is manage-members-screen.tsx:731-740.
+// /v1/me derives authProviders from account rows at den-api/src/routes/me/index.ts:151-156.
+
+const FLOW_ID = "den-reauth-popup-social";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const execFileAsync = promisify(execFile);
+
+const DEN_WEB_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_WEB_URL);
+const MYSQL_CONTAINER = process.env.OPENWORK_EVAL_DEN_MYSQL_CONTAINER?.trim() ?? "";
+const DEMO_EMAIL = "alex@acme.test";
+const DEMO_PASSWORD = "OpenWorkDemo123!";
+const GOOGLE_ACCOUNT_ID = "acc_01kwx81tc6f208pn04555rws17";
+
+// AuthAccountTable.id is denTypeIdColumn("account", "id")
+// (ee/packages/den-db/src/schema/auth.ts:41-45). denTypeIdColumn stores a
+// TypeID string (ee/packages/den-db/src/columns.ts:109-123); account IDs must
+// be acc_<26-char TypeID suffix> per ee/packages/utils/src/typeid.ts:6-15,110-127.
+const INSERT_GOOGLE_ACCOUNT_SQL = `
+INSERT INTO account (id, user_id, account_id, provider_id, created_at, updated_at)
+SELECT '${GOOGLE_ACCOUNT_ID}', u.id, 'eval-google-account', 'google', NOW(3), NOW(3)
+FROM \`user\` u
+WHERE u.email='${DEMO_EMAIL}'
+  AND NOT EXISTS (
+    SELECT 1 FROM account a WHERE a.user_id = u.id AND a.provider_id='google'
+  );
+`;
+
+const state = {
+  nonce: null,
+  clipboardText: null,
+};
+
+export default {
+  id: FLOW_ID,
+  title: "Den social reauth completes in a popup and retries the queued action",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MYSQL_CONTAINER"],
+  steps: [
+    {
+      name: "Sign in; stage a stale session and a Google-linked account",
+      run: async (ctx) => {
+        await ctx.prove("Alex signs in, then the eval stages a stale Google-linked session", {
+          voiceover: vo[0],
+          action: async () => {
+            await applyDesktopViewport(ctx);
+            await signInViaDenUi(ctx);
+            await runSql("UPDATE session SET created_at = DATE_SUB(NOW(3), INTERVAL 1 HOUR);");
+            await runSql(INSERT_GOOGLE_ACCOUNT_SQL);
+            await goToDenWeb(ctx, "/dashboard/members");
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`fetch('/v1/me', { credentials: 'include' }).then((response) => response.json())`, { awaitPromise: true });
+            recordAssertion(
+              ctx,
+              "/v1/me reports the seeded Google auth provider for Alex",
+              Array.isArray(actual?.user?.authProviders) && actual.user.authProviders.includes("google"),
+              actual?.user?.authProviders ?? actual,
+            );
+            await ctx.expectText("Members", { timeoutMs: 30_000 });
+            await ctx.expectText("Copy install link", { timeoutMs: 30_000 });
+          },
+          screenshot: {
+            name: "den-reauth-popup-staged-members",
+            requireText: ["Members", "Copy install link"],
+          },
+        });
+      },
+    },
+    {
+      name: "The privileged click queues the action and offers Continue with Google",
+      run: async (ctx) => {
+        await ctx.prove("The stale privileged action opens the reauth dialog with Google available", {
+          voiceover: vo[1],
+          action: async () => {
+            await goToDenWeb(ctx, "/dashboard/members");
+            await grantClipboardPermissions(ctx);
+            await realClickSelector(ctx, '[data-testid="copy-install-link"]', "copy install link button");
+            state.nonce = await ctx.waitFor(
+              `(() => {
+                const dialog = document.querySelector('[role="dialog"][data-reauth-nonce]');
+                const nonce = dialog?.getAttribute('data-reauth-nonce') ?? '';
+                return nonce || false;
+              })()`,
+              { timeoutMs: 30_000, label: "reauth dialog nonce" },
+            );
+            await ctx.waitFor(
+              `(() => {
+                const buttons = [...document.querySelectorAll('button')];
+                return buttons.some((button) => button.textContent?.includes('Continue with Google') && button.getClientRects().length > 0);
+              })()`,
+              { timeoutMs: 10_000, label: "Continue with Google button" },
+            );
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`(() => {
+              const dialog = document.querySelector('[role="dialog"][data-reauth-nonce]');
+              const bodyText = document.body.innerText;
+              return {
+                dialogOpen: Boolean(dialog),
+                nonce: dialog?.getAttribute('data-reauth-nonce') ?? '',
+                hasTitle: bodyText.includes("Confirm it's you to continue"),
+                hasGoogle: bodyText.includes('Continue with Google'),
+              };
+            })()`);
+            recordAssertion(
+              ctx,
+              "The reauth dialog is open, has a nonce, and offers Continue with Google",
+              actual.dialogOpen === true && actual.nonce === state.nonce && actual.hasTitle === true && actual.hasGoogle === true,
+              actual,
+            );
+          },
+          screenshot: {
+            name: "den-reauth-popup-google-offered",
+            requireText: ["Confirm it's you to continue", "Continue with Google"],
+          },
+        });
+      },
+    },
+    {
+      name: "OAuth completes in a popup; the queued action then finishes by itself",
+      run: async (ctx) => {
+        await ctx.prove("The popup completion message retries the queued action without reloading the opener", {
+          voiceover: vo[2],
+          action: async () => {
+            const nonce = requireStateValue(state.nonce, "reauth nonce");
+            await runSql("UPDATE session SET created_at = NOW(3);");
+            await realClickExactText(ctx, "Continue with Google", "button", "Continue with Google button");
+            await sleep(1000);
+            const completionUrl = routeUrl(`/reauth/complete?nonce=${encodeURIComponent(nonce)}`);
+            await ctx.eval(`(() => { window.open(${JSON.stringify(completionUrl)}, 'openwork-reauth'); return true; })()`);
+            await ctx.waitFor(
+              `!document.querySelector('[role="dialog"][data-reauth-nonce]')`,
+              { timeoutMs: 30_000, label: "reauth dialog closed" },
+            );
+            await ctx.waitFor(
+              `document.querySelector('[data-testid="copy-install-link"]')?.textContent?.includes('Copied')`,
+              { timeoutMs: 30_000, label: "copy install link retried to Copied" },
+            );
+            state.clipboardText = await ctx.eval("navigator.clipboard.readText()", { awaitPromise: true });
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`(() => ({
+              dialogOpen: Boolean(document.querySelector('[role="dialog"][data-reauth-nonce]')),
+              buttonText: document.querySelector('[data-testid="copy-install-link"]')?.textContent?.trim() ?? '',
+            }))()`);
+            recordAssertion(
+              ctx,
+              "The reauth dialog closed and the original copy action reached the Copied state without another copy click",
+              actual.dialogOpen === false && actual.buttonText.includes("Copied"),
+              actual,
+            );
+            recordAssertion(
+              ctx,
+              "The clipboard contains the retried install link token",
+              typeof state.clipboardText === "string" && state.clipboardText.includes("/install?token="),
+              { clipboardText: state.clipboardText },
+            );
+          },
+          screenshot: {
+            name: "den-reauth-popup-copied-after-social",
+            requireText: ["Copied"],
+          },
+        });
+      },
+    },
+  ],
+};
+
+function cleanBaseUrl(value) {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
+function routeUrl(pathname) {
+  return new URL(pathname, DEN_WEB_URL).toString();
+}
+
+function requireStateValue(value, label) {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  throw new Error(`${label} was not prepared by an earlier frame.`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function recordAssertion(ctx, assertion, passed, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: passed ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(passed, `${assertion}. Actual: ${JSON.stringify(actual)}`);
+}
+
+async function runSql(sql) {
+  return execFileAsync("docker", ["exec", MYSQL_CONTAINER, "mysql", "-uroot", "-ppassword", "openwork_den", "-e", sql], {
+    maxBuffer: 2_000_000,
+  });
+}
+
+async function goToDenWeb(ctx, pathname) {
+  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(routeUrl(pathname))}; return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${pathname}` });
+}
+
+async function signInViaDenUi(ctx) {
+  await clearDenWebSession(ctx);
+  await goToDenWeb(ctx, "/?mode=sign-in");
+  await ctx.waitFor(
+    `Boolean(document.querySelector('input[type="email"]'))
+      && Boolean(document.querySelector('input[type="password"]'))
+      && [...document.querySelectorAll('button')].some((button) => button.textContent?.trim() === 'Sign in')`,
+    { timeoutMs: 30_000, label: "sign-in form" },
+  );
+  await ctx.fill('input[type="email"]', DEMO_EMAIL);
+  await ctx.fill('input[type="password"]', DEMO_PASSWORD);
+  await realClickLastExactText(ctx, "Sign in", "button", "sign in submit button");
+  await ctx.waitFor("window.location.pathname.startsWith('/dashboard')", {
+    timeoutMs: 45_000,
+    label: "dashboard after sign-in",
+  });
+}
+
+async function clearDenWebSession(ctx) {
+  await goToDenWeb(ctx, "/");
+  await ctx.eval(
+    `fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' })
+      .catch(() => null)
+      .then(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        return true;
+      })`,
+    { awaitPromise: true },
+  );
+  if (ctx.client?.send) {
+    await ctx.client.send("Network.clearBrowserCookies", {}).catch(() => {});
+  }
+}
+
+async function grantClipboardPermissions(ctx) {
+  if (!ctx.client?.send) {
+    ctx.log("Clipboard permission grant skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  await ctx.client.send("Browser.grantPermissions", {
+    origin: new URL(DEN_WEB_URL).origin,
+    permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
+  }).catch((error) => {
+    ctx.log(`Clipboard permission grant skipped: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+async function applyDesktopViewport(ctx) {
+  if (!ctx.client?.send) {
+    ctx.log("Desktop viewport skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1280,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: false,
+  }).catch((error) => {
+    ctx.log(`Desktop viewport skipped: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+async function realClickSelector(ctx, selector, label) {
+  const point = await ctx.waitFor(
+    `(() => {
+      const element = document.querySelector(${JSON.stringify(selector)});
+      if (!element || element.disabled) return false;
+      element.scrollIntoView({ block: 'center', behavior: 'instant' });
+      const rect = element.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return false;
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    })()`,
+    { timeoutMs: 20_000, label },
+  );
+  await dispatchRealClick(ctx, point, `${selector} click fallback`);
+}
+
+async function realClickExactText(ctx, text, selector, label) {
+  const point = await textClickPoint(ctx, text, selector, label, false);
+  await dispatchRealClick(ctx, point, `${text} click fallback`);
+}
+
+async function realClickLastExactText(ctx, text, selector, label) {
+  const point = await textClickPoint(ctx, text, selector, label, true);
+  await dispatchRealClick(ctx, point, `${text} click fallback`);
+}
+
+async function textClickPoint(ctx, text, selector, label, last) {
+  return ctx.waitFor(
+    `(() => {
+      const matches = [...document.querySelectorAll(${JSON.stringify(selector)})]
+        .filter((element) => (element.textContent ?? '').trim() === ${JSON.stringify(text)} && !element.disabled);
+      const element = ${last ? "matches[matches.length - 1]" : "matches[0]"};
+      if (!element) return false;
+      element.scrollIntoView({ block: 'center', behavior: 'instant' });
+      const rect = element.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return false;
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    })()`,
+    { timeoutMs: 20_000, label },
+  );
+}
+
+async function dispatchRealClick(ctx, point, fallbackLabel) {
+  if (!ctx.client?.send) {
+    await ctx.eval(`(() => {
+      const element = document.elementFromPoint(${Number(point.x)}, ${Number(point.y)});
+      element?.click();
+      return true;
+    })()`);
+    return;
+  }
+
+  await ctx.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
+  await ctx.client.send("Input.dispatchMouseEvent", {
+    type: "mousePressed",
+    x: point.x,
+    y: point.y,
+    button: "left",
+    clickCount: 1,
+  });
+  await ctx.client.send("Input.dispatchMouseEvent", {
+    type: "mouseReleased",
+    x: point.x,
+    y: point.y,
+    button: "left",
+    clickCount: 1,
+  }).catch(async () => {
+    await ctx.eval(`(() => {
+      const element = document.elementFromPoint(${Number(point.x)}, ${Number(point.y)});
+      element?.click();
+      return true;
+    })()`);
+    ctx.log(`Fell back to DOM click for ${fallbackLabel}.`);
+  });
+}

--- a/evals/voiceovers/den-reauth-popup-social.md
+++ b/evals/voiceovers/den-reauth-popup-social.md
@@ -1,0 +1,9 @@
+# den-reauth-popup-social — Social reauth keeps the queued action alive
+
+Alex is the Acme Robotics owner. He is signed in with Google, but his admin session has gone stale before he copies an install link for the team.
+
+1. Alex signs in to Acme Robotics, and the browser stays on the Cloud dashboard while the evaluation stages the same stale-session state an admin would hit after stepping away.
+
+2. From Members, Alex clicks Copy install link. OpenWork pauses the action, asks him to confirm it is still him, and offers Continue with Google right inside the security check.
+
+3. Alex finishes Google sign-in in the small popup. The Members page never reloads, the security check disappears, and the original Copy install link action completes by itself with the link copied.


### PR DESCRIPTION
## What

Completes the step-up-auth fix started in #2521. The security-check dialog queues the privileged action and promises to retry it automatically — which was only true for the **password** path. For **Google/GitHub/SSO** accounts, verification did `window.location.assign(...)`: a full-page OAuth navigation that unloads the page, destroys the queued action (an in-memory closure), and dumps the user back with nothing happening.

Now social/SSO verification runs in a **popup** — the opener page and its queued action never unload:

- `continueSocial` / `continueSso` open a blank popup synchronously on click (popup-blocker-safe), then point it at the provider with `callbackURL` set to a new **`/reauth/complete`** page.
- `/reauth/complete` posts `{ type: "openwork:reauth-complete", nonce }` to `window.opener` (same-origin target only) and closes itself.
- The dialog verifies origin + a per-open `nonce`, then runs the queued action automatically — same behavior the password path always had.
- Popup blocked → exact previous behavior (full-page redirect) as fallback. Closing the popup mid-flow un-busies the dialog.
- Security: the message only means "try again now" — the retried request still hits the server-side freshness check, so a forged message can't bypass anything. The nonce is also exposed as `data-reauth-nonce` on the dialog root as a deliberate E2E seam (commented as such).

## Proof — new den-stack eval `den-reauth-popup-social` (PASSED, frames below)

Real browser against the local den stack; the demo owner gets a `google` account row seeded via SQL so the dialog offers **Continue with Google** (verified `/api/den/v1/me` reports it):

1. Sign in, age the session 1h (server freshness window is 15 min), enable the `installLinks` capability, seed the Google-linked account.
2. Members → **Copy install link** → security-check dialog opens with **Continue with Google**; the flow captures the dialog nonce.
3. Click Continue with Google (real popup opens toward the provider), then the flow simulates the provider's return leg exactly: refreshes session freshness via SQL (what a real re-sign-in does) and navigates the same named popup to `/reauth/complete?nonce=…`. The completion page posts to the opener, the dialog retries the queued action, and the button flips to **Copied** — no additional click — with the real `/install?token=…` URL asserted on the clipboard.

Everything except Google's own consent screen is exercised for real (stated plainly: the provider hop is simulated by the session-freshness SQL + the callback navigation, which is byte-for-byte the effect of a successful OAuth return).

```
▶ den-reauth-popup-social — Den social reauth completes in a popup and retries the queued action
  ✓ Sign in; stage a stale session and a Google-linked account
  ✓ The privileged click queues the action and offers Continue with Google
  ✓ OAuth completes in a popup; the queued action then finishes by itself
  ✓ Voice-over script coverage
Result: PASSED — 1 passed, 0 failed, 0 skipped
```

Also run: `pnpm --dir ee/apps/den-web exec tsc --noEmit` (pass), `pnpm --dir ee/apps/den-web build` (pass, `/reauth/complete` in the route table). Repro commands identical to #2521 plus Chromium flag `--disable-popup-blocking`, flow id `den-reauth-popup-social`.
