### PR TITLE
fix(den-web): install-link copy falls back to a manual share row when the browser blocks the clipboard

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
@@ -163,6 +163,8 @@ export function ManageMembersScreen() {
   const [seatBillingDialogError, setSeatBillingDialogError] = useState<OrgPaymentRequiredError | null>(null);
   const [installLinkBusy, setInstallLinkBusy] = useState(false);
   const [installLinkCopied, setInstallLinkCopied] = useState(false);
+  const [installLinkShareUrl, setInstallLinkShareUrl] = useState<string | null>(null);
+  const [installLinkShareCopied, setInstallLinkShareCopied] = useState(false);
 
   const assignableRoles = useMemo(
     () => (orgContext?.roles ?? []).filter((role) => !role.protected),
@@ -252,13 +254,38 @@ export function ManageMembersScreen() {
       : null;
   }
 
+  function selectInstallLinkShareInput() {
+    const input = document.getElementById("install-link-share-url");
+    if (input instanceof HTMLInputElement) {
+      input.focus();
+      input.select();
+    }
+  }
+
+  async function handleInstallLinkShareCopy() {
+    if (!installLinkShareUrl) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(installLinkShareUrl);
+      setInstallLinkShareCopied(true);
+      window.setTimeout(() => setInstallLinkShareCopied(false), 1800);
+    } catch {
+      selectInstallLinkShareInput();
+    }
+  }
+
   async function handleCopyInstallLink() {
     if (!activeOrg) {
       return;
     }
 
+    let mintedInstallPageUrl: string | null = null;
     setPageError(null);
     setInstallLinkCopied(false);
+    setInstallLinkShareUrl(null);
+    setInstallLinkShareCopied(false);
     setInstallLinkBusy(true);
     try {
       await runReauthableAction("copy-install-link", async () => {
@@ -277,10 +304,26 @@ export function ManageMembersScreen() {
           throw new Error("The install link response was incomplete.");
         }
 
-        await navigator.clipboard.writeText(installPageUrl);
+        mintedInstallPageUrl = installPageUrl;
+      });
+
+      if (!mintedInstallPageUrl) {
+        throw new Error("The install link response was incomplete.");
+      }
+
+      // The clipboard write is best-effort presentation, kept outside the
+      // queued action: after a step-up verification the retry runs without
+      // transient user activation, and some browsers deniy programmatic
+      // clipboard access entirely. The mint already succeeded either way, so
+      // failure falls back to showing the link for a manual copy instead of
+      // surfacing a raw browser error.
+      try {
+        await navigator.clipboard.writeText(mintedInstallPageUrl);
         setInstallLinkCopied(true);
         window.setTimeout(() => setInstallLinkCopied(false), 1800);
-      });
+      } catch {
+        setInstallLinkShareUrl(mintedInstallPageUrl);
+      }
     } catch (error) {
       setPageError(error instanceof Error ? error.message : "Could not copy install link.");
     } finally {
@@ -745,6 +788,46 @@ export function ManageMembersScreen() {
               </div>
             ) : null}
           </div>
+
+          {installLinkShareUrl ? (
+            <div className="mb-6 rounded-[24px] border border-gray-200 bg-white px-5 py-4">
+              <p className="text-[13px] text-gray-500">
+                Copy blocked by the browser — copy the link manually:
+              </p>
+              <div className="mt-3 flex flex-col gap-3 lg:flex-row lg:items-center">
+                <DenInput
+                  id="install-link-share-url"
+                  data-testid="install-link-share-url"
+                  value={installLinkShareUrl}
+                  readOnly
+                  aria-label="Install link"
+                  className="font-mono text-[12px]"
+                  onFocus={(event) => event.currentTarget.select()}
+                  onClick={(event) => event.currentTarget.select()}
+                />
+                <div className="flex shrink-0 gap-2">
+                  <DenButton
+                    data-testid="install-link-share-copy"
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => void handleInstallLinkShareCopy()}
+                  >
+                    {installLinkShareCopied ? "Copied" : "Copy"}
+                  </DenButton>
+                  <DenButton
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => {
+                      setInstallLinkShareUrl(null);
+                      setInstallLinkShareCopied(false);
+                    }}
+                  >
+                    Done
+                  </DenButton>
+                </div>
+              </div>
+            </div>
+          ) : null}
 
           <div className="overflow-visible rounded-2xl border border-gray-100 bg-white">
             <div className="grid grid-cols-[minmax(0,1fr)_180px_140px_160px] gap-4 border-b border-gray-100 px-6 py-3 text-[11px] font-medium uppercase tracking-wide text-gray-400">

--- a/evals/flows/den-reauth-pending-action.flow.mjs
+++ b/evals/flows/den-reauth-pending-action.flow.mjs
@@ -85,6 +85,29 @@ async function grantClipboardPermissions(ctx) {
   });
 }
 
+async function denyClipboardPermissions(ctx) {
+  if (!ctx.client?.send) {
+    ctx.log("Clipboard permission denial skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  const origin = new URL(ctx.env.OPENWORK_EVAL_DEN_WEB_URL).origin;
+  const permissions = [
+    { name: "clipboard-write", allowWithoutSanitization: false },
+    { name: "clipboard-read" },
+  ];
+
+  for (const permission of permissions) {
+    await ctx.client.send("Browser.setPermission", {
+      origin,
+      permission,
+      setting: "denied",
+    }).catch((error) => {
+      ctx.log(`Clipboard permission denial skipped: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }
+}
+
 async function navigateTo(ctx, path) {
   await ctx.eval(`(() => { location.assign(${JSON.stringify(routeUrl(ctx, path))}); return true; })()`);
   await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${path}` });
@@ -347,6 +370,75 @@ export default {
             requireText: ["Copied"],
           },
         });
+      },
+    },
+    {
+      name: "Even when the browser blocks copying, the link is still usable",
+      run: async (ctx) => {
+        try {
+          await ctx.prove("Even when the browser blocks copying, the link is still usable", {
+            voiceover: vo[3],
+            action: async () => {
+              await ctx.waitFor(`(() => {
+                const button = document.querySelector(${JSON.stringify(COPY_INSTALL_LINK_SELECTOR)});
+                return Boolean(button && !button.disabled && button.textContent.includes('Copy install link'));
+              })()`, { timeoutMs: 10_000, label: "copy install link button reset" });
+              await denyClipboardPermissions(ctx);
+              await clickSelectorWithMouse(ctx, COPY_INSTALL_LINK_SELECTOR, "copy install link button");
+              await ctx.waitFor(`(() => {
+                const input = document.querySelector('[data-testid="install-link-share-url"]');
+                return input instanceof HTMLInputElement && input.value.includes('/install?token=');
+              })()`, { timeoutMs: 45_000, label: "manual install link share row" });
+            },
+            assert: async () => {
+              const actual = await ctx.eval(`(() => {
+                const input = document.querySelector('[data-testid="install-link-share-url"]');
+                const shareUrl = input instanceof HTMLInputElement ? input.value : '';
+                const bodyText = document.body.innerText.toLowerCase();
+                const pageErrorTexts = [...document.querySelectorAll('div')]
+                  .filter((element) => element.className.includes('mb-6') && element.className.includes('border-red-200') && element.className.includes('bg-red-50'))
+                  .map((element) => (element.textContent ?? '').trim())
+                  .filter((text) => text.length > 0);
+                return {
+                  shareRowVisible: input instanceof HTMLInputElement,
+                  shareUrl,
+                  rawClipboardMessageVisible: bodyText.includes('not allowed by the user agent'),
+                  pageErrorTexts,
+                  pageErrorHasClipboardFailure: pageErrorTexts.some((text) => {
+                    const normalized = text.toLowerCase();
+                    return normalized.includes('not allowed by the user agent') ||
+                      normalized.includes('notallowederror') ||
+                      normalized.includes('could not copy install link');
+                  }),
+                };
+              })()`);
+              recordAssertion(
+                ctx,
+                "The inline manual copy row appears with an install-link token URL",
+                actual.shareRowVisible === true && /\/install[?]token=/.test(actual.shareUrl),
+                actual,
+              );
+              recordAssertion(
+                ctx,
+                "The raw browser clipboard error is not rendered anywhere on the page",
+                actual.rawClipboardMessageVisible === false,
+                actual,
+              );
+              recordAssertion(
+                ctx,
+                "The page error banner stays empty after clipboard denial",
+                actual.pageErrorTexts.length === 0 && actual.pageErrorHasClipboardFailure === false,
+                actual,
+              );
+            },
+            screenshot: {
+              name: "reauth-copy-blocked-manual-install-link",
+              requireText: ["Copy blocked by the browser — copy the link manually:"],
+            },
+          });
+        } finally {
+          await grantClipboardPermissions(ctx);
+        }
       },
     },
   ],

--- a/evals/voiceovers/den-reauth-pending-action.md
+++ b/evals/voiceovers/den-reauth-pending-action.md
@@ -5,3 +5,5 @@
 2. From Members, Alex clicks Copy install link. Instead of a dead error banner, OpenWork opens the security check and clearly asks Alex to confirm it is him before changing workspace settings.
 
 3. Alex enters his password once. The dialog closes, OpenWork retries the original copy action automatically, and the button flips to Copied with the install URL already on the clipboard.
+
+4. Even when the browser refuses programmatic copying, Alex is not stuck. The freshly minted install link appears right on the page with a manual copy affordance, and no scary browser error is shown.


### PR DESCRIPTION
## What

Follow-up to #2521/#2522, fixing the production report: *"The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission."* rendered as a members-page banner after using **Copy install link**.

That message is the browser's `NotAllowedError` from `navigator.clipboard.writeText`. The write ran **inside** the queued reauth action, so after a step-up verification the automatic retry executed it **without transient user activation** (the retry fires from a verify/message chain, not a click) — and browsers that deniy clipboard permission hit the same. The mint itself had succeeded (and `rotate: true` had already revoked older links), but the user got a raw browser error and no link.

## Fix

The clipboard write is now a best-effort presentation step **outside** the queued action (`manage-members-screen.tsx`):

- Success → identical to today: button flips to **Copied**.
- Blocked → the minted link renders inline: readonly select-all input + **Copy** button (a fresh user gesture, so the retry typically succeeds) + **Done** dismiss, under the helper line *"Copy blocked by the browser — copy the link manually:"*. Never an error banner.
- Mint failures (HTTP errors) still surface via the page error as before; reauth still queues via the dialog.

## Proof — `den-reauth-pending-action` extended to 4 steps (PASSED, frames on the comment below)

Steps 1–3 unchanged (stale session → dialog → password verify → auto-retry → Copied with the token URL on the clipboard). New step 4: deniy `clipboard-read`/`clipboard-write` via CDP `Browser.setPermission`, mint again, assert the manual share row appears with a `/install?token=…` value while the raw browser message ("not allowed by the user agent") is absent from the page; permissions re-granted for idempotency.

```
▶ den-reauth-pending-action — Den reauth keeps the pending install-link action alive
  ✓ Signing in and staging a stale session
  ✓ A privileged click opens the security check instead of a dead banner
  ✓ Verify password and the queued action completes on its own
  ✓ Even when the browser blocks copying, the link is still usable
  ✓ Voice-over script coverage
Result: PASSED — 1 passed, 0 failed, 0 skipped
```

Also run: `pnpm --dir ee/apps/den-web exec tsc --noEmit` (pass), `pnpm --dir ee/apps/den-web build` (pass). Repro identical to #2521.

Known follow-up (out of scope): a dozen other `writeText` call sites across den-web share the raw-error exposure on permission-denied browsers; they all run in direct click handlers so they don't hit the activation gap fixed here.
