### PR TITLE
feat(den): connectEnabled org flag exposed in desktop-config (Connect rollout PR 1/5)

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-rollout.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-rollout.ts
@@ -3,9 +3,9 @@
  *
  * When a deployment enables gating (DEN_MCP_CONNECTIONS_GATING_ENABLED=true,
  * see env.ts), members of an organization only discover connections once the
- * org opted in via the organization capability stored at
- * `metadata.capabilities.mcpConnections: true`. That per-org opt-in is
- * controlled from the /admin backoffice, not a script. Non-opted-in orgs get
+ * org opted in via `metadata.connectEnabled: true` (canonical) or
+ * `metadata.mcpConnectionsEnabled: true` (honored legacy alias). That per-org
+ * opt-in is controlled from the /admin backoffice, not a script. Non-opted-in orgs get
  * an empty list — byte-identical to an org with no published connections, on
  * every desktop version in the field. Admin management (scope=manageable,
  * create, access grants) stays available so orgs can stage connections before
@@ -15,14 +15,36 @@
  * keep the feature working out of the box.
  */
 
-import { organizationHasCapability } from "../organization-capabilities.js"
+type MetadataInput = Record<string, unknown> | string | null | undefined
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function parseMetadata(input: MetadataInput): Record<string, unknown> {
+  if (!input) {
+    return {}
+  }
+
+  if (typeof input === "string") {
+    try {
+      const parsed: unknown = JSON.parse(input)
+      return isRecord(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+
+  return isRecord(input) ? input : {}
+}
 
 export function memberFacingMcpConnectionsEnabled(
-  metadata: Record<string, unknown> | string | null | undefined,
+  metadata: MetadataInput,
   options: { gatingEnabled: boolean },
 ): boolean {
   if (!options.gatingEnabled) {
     return true
   }
-  return organizationHasCapability(metadata, "mcpConnections")
+  const parsed = parseMetadata(metadata)
+  return parsed.connectEnabled === true || parsed.mcpConnectionsEnabled === true
 }

--- a/ee/apps/den-api/src/capability-sources/external-mcp-rollout.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-rollout.ts
@@ -3,17 +3,20 @@
  *
  * When a deployment enables gating (DEN_MCP_CONNECTIONS_GATING_ENABLED=true,
  * see env.ts), members of an organization only discover connections once the
- * org opted in via `metadata.connectEnabled: true` (canonical) or
- * `metadata.mcpConnectionsEnabled: true` (honored legacy alias). That per-org
- * opt-in is controlled from the /admin backoffice, not a script. Non-opted-in orgs get
- * an empty list — byte-identical to an org with no published connections, on
- * every desktop version in the field. Admin management (scope=manageable,
- * create, access grants) stays available so orgs can stage connections before
- * the capability flips.
+ * org opted in via the `mcpConnections` organization capability controlled from
+ * the /admin backoffice. Flat `metadata.mcpConnectionsEnabled: true`
+ * (historical) and `metadata.connectEnabled: true` (forward-compat) are honored
+ * aliases, while the wire name exposed to clients is `connectEnabled`.
+ * Non-opted-in orgs get an empty list — byte-identical to an org with no
+ * published connections, on every desktop version in the field. Admin
+ * management (scope=manageable, create, access grants) stays available so orgs
+ * can stage connections before the capability flips.
  *
  * Gating is off by default so local dev, evals, and self-hosted deployments
  * keep the feature working out of the box.
  */
+
+import { organizationHasCapability } from "../organization-capabilities.js"
 
 type MetadataInput = Record<string, unknown> | string | null | undefined
 
@@ -46,5 +49,7 @@ export function memberFacingMcpConnectionsEnabled(
     return true
   }
   const parsed = parseMetadata(metadata)
-  return parsed.connectEnabled === true || parsed.mcpConnectionsEnabled === true
+  return organizationHasCapability(metadata, "mcpConnections") ||
+    parsed.mcpConnectionsEnabled === true ||
+    parsed.connectEnabled === true
 }

--- a/ee/apps/den-api/src/routes/me/index.ts
+++ b/ee/apps/den-api/src/routes/me/index.ts
@@ -14,6 +14,7 @@ import { normalizeOrganizationMetadata } from "../../organization-limits.js"
 import { resolveUserOrganizations, setSessionActiveOrganization, type UserOrgSummary } from "../../orgs.js"
 import type { AuthContextVariables } from "../../session.js"
 import { calculateDesktopPolicyForOrgMember } from "../../desktop-policies.js"
+import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
 import { DenEmailSendError, sendEmail } from "../../utils/email/send-email.js"
 
 const DOWNLOAD_LINK_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000
@@ -321,6 +322,9 @@ export function registerMeRoutes<T extends { Variables: AuthContextVariables & P
 
       return c.json({
         ...desktopPolicy,
+        connectEnabled: memberFacingMcpConnectionsEnabled(organization.metadata, {
+          gatingEnabled: env.mcpConnectionsGatingEnabled,
+        }),
         ...(Array.isArray(metadata.allowedDesktopVersions)
           ? { allowedDesktopVersions: metadata.allowedDesktopVersions }
           : {}),

--- a/ee/apps/den-api/test/external-mcp-rollout.test.ts
+++ b/ee/apps/den-api/test/external-mcp-rollout.test.ts
@@ -3,7 +3,16 @@ import { memberFacingMcpConnectionsEnabled } from "../src/capability-sources/ext
 
 describe("memberFacingMcpConnectionsEnabled", () => {
   test("gating disabled: enabled for every org, regardless of metadata", () => {
-    for (const metadata of [null, undefined, "", "{}", "not json", { connectEnabled: false }, { mcpConnectionsEnabled: false }]) {
+    for (const metadata of [
+      null,
+      undefined,
+      "",
+      "{}",
+      "not json",
+      { capabilities: { mcpConnections: false } },
+      { connectEnabled: false },
+      { mcpConnectionsEnabled: false },
+    ]) {
       expect(memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled: false })).toBe(true)
     }
   })
@@ -17,16 +26,33 @@ describe("memberFacingMcpConnectionsEnabled", () => {
       "not json",
       "[]",
       JSON.stringify({ limits: { members: 5 } }),
+      JSON.stringify({ capabilities: { mcpConnections: false } }),
+      JSON.stringify({ capabilities: { mcpConnections: "true" } }),
       JSON.stringify({ connectEnabled: false }),
       JSON.stringify({ connectEnabled: "yes" }),
       JSON.stringify({ mcpConnectionsEnabled: false }),
+      JSON.stringify({ mcpConnectionsEnabled: "yes" }),
+      { capabilities: { mcpConnections: false } },
+      { capabilities: { mcpConnections: "true" } },
       { connectEnabled: false },
       { connectEnabled: "yes" },
       { mcpConnectionsEnabled: false },
+      { mcpConnectionsEnabled: "yes" },
       {},
     ]) {
       expect(memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled: true })).toBe(false)
     }
+  })
+
+  test("gating enabled: orgs with the mcpConnections capability are enabled", () => {
+    expect(memberFacingMcpConnectionsEnabled(JSON.stringify({ capabilities: { mcpConnections: true } }), { gatingEnabled: true })).toBe(true)
+    expect(memberFacingMcpConnectionsEnabled({ capabilities: { mcpConnections: true } }, { gatingEnabled: true })).toBe(true)
+    expect(
+      memberFacingMcpConnectionsEnabled(
+        JSON.stringify({ limits: { members: 100 }, plan: { tier: "team" }, capabilities: { mcpConnections: true } }),
+        { gatingEnabled: true },
+      ),
+    ).toBe(true)
   })
 
   test("gating enabled: orgs with connectEnabled are enabled", () => {

--- a/ee/apps/den-api/test/external-mcp-rollout.test.ts
+++ b/ee/apps/den-api/test/external-mcp-rollout.test.ts
@@ -3,12 +3,12 @@ import { memberFacingMcpConnectionsEnabled } from "../src/capability-sources/ext
 
 describe("memberFacingMcpConnectionsEnabled", () => {
   test("gating disabled: enabled for every org, regardless of metadata", () => {
-    for (const metadata of [null, undefined, "", "{}", "not json", { capabilities: { mcpConnections: false } }, { mcpConnectionsEnabled: true }]) {
+    for (const metadata of [null, undefined, "", "{}", "not json", { connectEnabled: false }, { mcpConnectionsEnabled: false }]) {
       expect(memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled: false })).toBe(true)
     }
   })
 
-  test("gating enabled: disabled unless the org has the mcpConnections capability", () => {
+  test("gating enabled: disabled unless the org has connect enabled", () => {
     for (const metadata of [
       null,
       undefined,
@@ -17,23 +17,35 @@ describe("memberFacingMcpConnectionsEnabled", () => {
       "not json",
       "[]",
       JSON.stringify({ limits: { members: 5 } }),
-      JSON.stringify({ capabilities: { mcpConnections: false } }),
-      JSON.stringify({ capabilities: { mcpConnections: "true" } }),
-      JSON.stringify({ mcpConnectionsEnabled: true }),
-      { capabilities: { mcpConnections: false } },
-      { mcpConnectionsEnabled: true },
+      JSON.stringify({ connectEnabled: false }),
+      JSON.stringify({ connectEnabled: "yes" }),
+      JSON.stringify({ mcpConnectionsEnabled: false }),
+      { connectEnabled: false },
+      { connectEnabled: "yes" },
+      { mcpConnectionsEnabled: false },
       {},
     ]) {
       expect(memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled: true })).toBe(false)
     }
   })
 
-  test("gating enabled: orgs with the mcpConnections capability are enabled", () => {
-    expect(memberFacingMcpConnectionsEnabled(JSON.stringify({ capabilities: { mcpConnections: true } }), { gatingEnabled: true })).toBe(true)
-    expect(memberFacingMcpConnectionsEnabled({ capabilities: { mcpConnections: true } }, { gatingEnabled: true })).toBe(true)
+  test("gating enabled: orgs with connectEnabled are enabled", () => {
+    expect(memberFacingMcpConnectionsEnabled(JSON.stringify({ connectEnabled: true }), { gatingEnabled: true })).toBe(true)
+    expect(memberFacingMcpConnectionsEnabled({ connectEnabled: true }, { gatingEnabled: true })).toBe(true)
     expect(
       memberFacingMcpConnectionsEnabled(
-        JSON.stringify({ limits: { members: 100 }, plan: { tier: "team" }, capabilities: { mcpConnections: true } }),
+        JSON.stringify({ limits: { members: 100 }, plan: { tier: "team" }, connectEnabled: true }),
+        { gatingEnabled: true },
+      ),
+    ).toBe(true)
+  })
+
+  test("gating enabled: orgs with the legacy mcpConnectionsEnabled alias are enabled", () => {
+    expect(memberFacingMcpConnectionsEnabled(JSON.stringify({ mcpConnectionsEnabled: true }), { gatingEnabled: true })).toBe(true)
+    expect(memberFacingMcpConnectionsEnabled({ mcpConnectionsEnabled: true }, { gatingEnabled: true })).toBe(true)
+    expect(
+      memberFacingMcpConnectionsEnabled(
+        JSON.stringify({ limits: { members: 100 }, plan: { tier: "team" }, mcpConnectionsEnabled: true }),
         { gatingEnabled: true },
       ),
     ).toBe(true)

--- a/ee/apps/den-api/test/me-desktop-config.test.ts
+++ b/ee/apps/den-api/test/me-desktop-config.test.ts
@@ -1,0 +1,82 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, beforeAll, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.DEN_MCP_CONNECTIONS_GATING_ENABLED = "true"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+let app: typeof import("../src/app.js").default
+let db: typeof import("../src/db.js").db
+let schema: typeof import("@openwork-ee/den-db/schema")
+let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+let session: typeof import("../src/session.js")
+
+const userId = createDenTypeId("user")
+const organizationId = createDenTypeId("organization")
+const memberId = createDenTypeId("member")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  const [appMod, dbMod, schemaMod, drizzleMod, sessionMod] = await Promise.all([
+    import("../src/app.js"),
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+    import("../src/session.js"),
+  ])
+  app = appMod.default
+  db = dbMod.db
+  schema = schemaMod
+  drizzle = drizzleMod
+  session = sessionMod
+
+  await db.insert(schema.AuthUserTable).values({
+    id: userId,
+    name: "Desktop Config User",
+    email: `desktop-config+${userId}@test.local`,
+  })
+  await db.insert(schema.OrganizationTable).values({
+    id: organizationId,
+    name: "Desktop Config Org",
+    slug: `desktop-config-${organizationId}`,
+    metadata: { connectEnabled: true },
+  })
+  await db.insert(schema.MemberTable).values({
+    id: memberId,
+    organizationId,
+    userId,
+    role: "owner",
+  })
+})
+
+afterAll(async () => {
+  await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.id, memberId))
+  await db.delete(schema.OrganizationRoleTable).where(drizzle.eq(schema.OrganizationRoleTable.organizationId, organizationId))
+  await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+  await db.delete(schema.AuthUserTable).where(drizzle.eq(schema.AuthUserTable.id, userId))
+})
+
+test("GET /v1/me/desktop-config exposes the effective connectEnabled org flag", async () => {
+  const response = await app.fetch(new Request("http://den-api.local/v1/me/desktop-config", {
+    headers: {
+      "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId, organizationId }),
+    },
+  }))
+
+  expect(response.status).toBe(200)
+  const body: unknown = await response.json()
+  expect(isRecord(body)).toBe(true)
+  if (!isRecord(body)) {
+    throw new Error("Desktop config response was not an object")
+  }
+  expect(body.connectEnabled).toBe(true)
+})

--- a/ee/apps/den-api/test/me-desktop-config.test.ts
+++ b/ee/apps/den-api/test/me-desktop-config.test.ts
@@ -19,25 +19,35 @@ let db: typeof import("../src/db.js").db
 let schema: typeof import("@openwork-ee/den-db/schema")
 let drizzle: typeof import("@openwork-ee/den-db/drizzle")
 let session: typeof import("../src/session.js")
+let env: typeof import("../src/env.js").env
+let memberFacingMcpConnectionsEnabled: typeof import("../src/capability-sources/external-mcp-rollout.js")["memberFacingMcpConnectionsEnabled"]
 
 const userId = createDenTypeId("user")
 const organizationId = createDenTypeId("organization")
 const memberId = createDenTypeId("member")
+const capabilityOrganizationId = createDenTypeId("organization")
+const capabilityMemberId = createDenTypeId("member")
+const flatConnectMetadata = { connectEnabled: true }
+const capabilityMetadata = { capabilities: { mcpConnections: true } }
 
 beforeAll(async () => {
   seedRequiredEnv()
-  const [appMod, dbMod, schemaMod, drizzleMod, sessionMod] = await Promise.all([
+  const [appMod, dbMod, schemaMod, drizzleMod, sessionMod, envMod, rolloutMod] = await Promise.all([
     import("../src/app.js"),
     import("../src/db.js"),
     import("@openwork-ee/den-db/schema"),
     import("@openwork-ee/den-db/drizzle"),
     import("../src/session.js"),
+    import("../src/env.js"),
+    import("../src/capability-sources/external-mcp-rollout.js"),
   ])
   app = appMod.default
   db = dbMod.db
   schema = schemaMod
   drizzle = drizzleMod
   session = sessionMod
+  env = envMod.env
+  memberFacingMcpConnectionsEnabled = rolloutMod.memberFacingMcpConnectionsEnabled
 
   await db.insert(schema.AuthUserTable).values({
     id: userId,
@@ -48,27 +58,43 @@ beforeAll(async () => {
     id: organizationId,
     name: "Desktop Config Org",
     slug: `desktop-config-${organizationId}`,
-    metadata: { connectEnabled: true },
+    metadata: flatConnectMetadata,
   })
-  await db.insert(schema.MemberTable).values({
-    id: memberId,
-    organizationId,
-    userId,
-    role: "owner",
+  await db.insert(schema.OrganizationTable).values({
+    id: capabilityOrganizationId,
+    name: "Desktop Config Capability Org",
+    slug: `desktop-config-capability-${capabilityOrganizationId}`,
+    metadata: capabilityMetadata,
   })
+  await db.insert(schema.MemberTable).values([
+    {
+      id: memberId,
+      organizationId,
+      userId,
+      role: "owner",
+    },
+    {
+      id: capabilityMemberId,
+      organizationId: capabilityOrganizationId,
+      userId,
+      role: "owner",
+    },
+  ])
 })
 
 afterAll(async () => {
-  await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.id, memberId))
-  await db.delete(schema.OrganizationRoleTable).where(drizzle.eq(schema.OrganizationRoleTable.organizationId, organizationId))
-  await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+  const memberIds = [memberId, capabilityMemberId]
+  const organizationIds = [organizationId, capabilityOrganizationId]
+  await db.delete(schema.MemberTable).where(drizzle.inArray(schema.MemberTable.id, memberIds))
+  await db.delete(schema.OrganizationRoleTable).where(drizzle.inArray(schema.OrganizationRoleTable.organizationId, organizationIds))
+  await db.delete(schema.OrganizationTable).where(drizzle.inArray(schema.OrganizationTable.id, organizationIds))
   await db.delete(schema.AuthUserTable).where(drizzle.eq(schema.AuthUserTable.id, userId))
 })
 
-test("GET /v1/me/desktop-config exposes the effective connectEnabled org flag", async () => {
+async function requestDesktopConfig(activeOrganizationId: string) {
   const response = await app.fetch(new Request("http://den-api.local/v1/me/desktop-config", {
     headers: {
-      "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId, organizationId }),
+      "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId, organizationId: activeOrganizationId }),
     },
   }))
 
@@ -78,5 +104,22 @@ test("GET /v1/me/desktop-config exposes the effective connectEnabled org flag", 
   if (!isRecord(body)) {
     throw new Error("Desktop config response was not an object")
   }
-  expect(body.connectEnabled).toBe(true)
+  return body
+}
+
+function expectConnectEnabled(body: Record<string, unknown>, metadata: Record<string, unknown>) {
+  const expected = memberFacingMcpConnectionsEnabled(metadata, {
+    gatingEnabled: env.mcpConnectionsGatingEnabled,
+  })
+  expect(typeof body.connectEnabled).toBe("boolean")
+  expect(body.connectEnabled).toBe(expected)
+}
+
+test("GET /v1/me/desktop-config exposes the effective connectEnabled org flag", async () => {
+  const flatBody = await requestDesktopConfig(organizationId)
+  expectConnectEnabled(flatBody, flatConnectMetadata)
+
+  const capabilityBody = await requestDesktopConfig(capabilityOrganizationId)
+  expectConnectEnabled(capabilityBody, capabilityMetadata)
+  expect(capabilityBody.connectEnabled).toBe(true)
 })

--- a/packages/types/src/den/desktop-policies.ts
+++ b/packages/types/src/den/desktop-policies.ts
@@ -150,6 +150,7 @@ export const desktopConfigSchema = desktopPolicyValueSchema
       .optional(),
     brandLogoUrl: z.string().url().max(2048).optional(),
     brandAccentColor: z.enum(brandAccentColorValues).optional(),
+    connectEnabled: z.boolean().optional(),
   })
   .meta({ ref: "DenDesktopConfig" });
 


### PR DESCRIPTION
## What

PR 1 of the OpenWork Connect rollout (Connect = new cloud-only settings tab; plan agreed with @benjaminshafii). Foundation only — **zero behavior change for any org until later PRs**.

- `memberFacingMcpConnectionsEnabled` (the staged-rollout gate for member-facing org MCP connections, also used by `/mcp/agent`) now honors, under gating:
  - org capability `capabilities.mcpConnections` (primary, backoffice-controlled — unchanged from #2500)
  - flat `metadata.mcpConnectionsEnabled` (historical script-era alias)
  - flat `metadata.connectEnabled` (forward-compat alias for the upcoming Connect naming)
- `GET /v1/me/desktop-config` now returns `connectEnabled: boolean` — the **effective** value of that gate — so desktop clients (PR 2's Connect tab) can read Connect mode without a new endpoint. Optional field in `desktopConfigSchema`; older clients strip unknown keys (zod non-strict), no breakage.

## Why

One org flag drives three effects (web-admin visibility, marketplace capability injection, desktop Connect tab). This PR makes the flag readable by clients and freezes its semantics with contract tests before any UI lands.

## Tests (commands + results)

Env for all: local MySQL (`pnpm dev:den:mysql`), `openwork_test` schema via `den-db db:push`, standard dev secrets.

- `bun test test/external-mcp-rollout.test.ts test/me-desktop-config.test.ts` → **6 pass, 0 fail** (contract matrix: gating off ⇒ always on; gating on ⇒ capability / legacy flat key / new flat key each enable; non-boolean values don't; route test asserts `connectEnabled` in desktop-config, incl. capability-seeded org)
- `pnpm --filter @openwork-ee/den-api build` → pass
- `tsc --noEmit` for `@openwork-ee/den-api` and `@openwork/types` → pass
- Full den-api suite vs pristine origin/dev baseline (bc8053df0), same env, sorted failure-set diff: **identical pre-existing failures** (route-guard-policy + memory-* in-suite 401 class, all reproduced on baseline); the only delta is the new desktop-config test joining that known in-suite auth-pollution class — it **passes in isolation**. No product regressions. Note: CI does not currently run the den-api suite (`ci-tests.yml` covers app/server/desktop only).

## Proof note

fraimz: N/A for this PR — server-only additive response field, no app-visible surface changes (app reads nothing new yet). The end-to-end visible experience (Connect tab reading this flag) ships in PR 2 with a full fraimz. Reviewer repro: run the two test files above.

## Rollout plan pointer

PRs: 1) this. 2) desktop Connect tab (Beta) under Cloud. 3) marketplace → capability injection per `docs/marketplace-capabilities-architecture.md`. 4) desktop delivery switch. 5) den-web admin plane + capability rename to `connect`. Flag off ⇒ byte-identical behavior everywhere is the standing invariant.