### PR TITLE
feat(den): marketplace plugins join the search/execute capability rail (Connect rollout PR 3/5)

### DIFF
--- a/docs/marketplace-capabilities-architecture.md
+++ b/docs/marketplace-capabilities-architecture.md
@@ -1,0 +1,299 @@
+# Marketplace Capabilities — every published plugin searchable & executable through the rail
+
+Cross-references:
+
+- `evals/org-mcp-connections-ux.md`
+- `docs/memory-bank-architecture.md`
+- `ee/apps/den-api/src/mcp/README.md`
+
+Status: design note for a Den-only, additive Phase 1.
+
+---
+
+## 1. North star
+
+Every plugin published to an org marketplace is automatically discoverable via `search_capabilities` and reachable via `execute_capability` on the existing `openwork-cloud` connection — the same rail as External MCP Connections.
+
+Installation, meaning copying files into `.opencode/`, becomes an optimization for offline use and pinning, not a requirement for using org-published content.
+
+The marketplace is the FOURTH capability source on the rail, after Den's REST catalog, External MCP Connections, and native provider capabilities. Native provider capabilities already ride the REST catalog as routes tagged `Capability Sources`.
+
+Before:
+
+```text
+harness
+  └─ openwork-cloud /mcp/agent
+       ├─ REST catalog (incl. native provider capability routes)
+       └─ External MCP Connections
+```
+
+After:
+
+```text
+harness
+  └─ openwork-cloud /mcp/agent
+       ├─ REST catalog (incl. native provider capability routes)
+       ├─ External MCP Connections
+       └─ Marketplace plugin capabilities   ← new, DB-only
+```
+
+The MCP tool surface does not grow. The rail still exposes exactly two tools: `search_capabilities` and `execute_capability`.
+
+---
+
+## 2. Why this is the natural next step
+
+Three precedents already prove the pattern:
+
+1. External MCP Connections merge into `/mcp/agent` search results and execute through the same `execute_capability` tool, with namespaced names from `ee/apps/den-api/src/mcp/external-capabilities.ts` and `needs_connection` pseudo-matches when a member must connect.
+2. The memory bank in `docs/memory-bank-architecture.md` says memory is reached by executing a discovered capability, not by registering a bespoke `memory_save` tool.
+3. Google Workspace native capabilities are plain Den REST routes tagged `Capability Sources`, then auto-surfaced through the REST catalog.
+
+The marketplace source is the cheapest of the four: indexed DB rows, pre-derived `ConfigObjectTable.searchText` (`title\ndescription\nrawSource`), no live `tools/list`, no network, no new auth, and no new execution machinery for instructional content.
+
+---
+
+## 3. Capability classes
+
+A config object's `objectType` determines its execution semantics on the rail.
+
+| objectType | phase-1 search | phase-1 execute | notes |
+|---|---|---|---|
+| `skill` | searchable | instructional payload with latest version `rawSourceText` | Generalizes local skill progressive disclosure: the harness skill tool returns `SKILL.md` content on invoke, but this is org-wide with zero install. |
+| `context` | searchable | instructional payload with latest version `rawSourceText` | Content is framed as org marketplace context with provenance. |
+| `custom` | searchable | instructional payload with latest version `rawSourceText` | The rail does not interpret custom content beyond provenance and grants. |
+| `agent` | searchable | instructional payload with latest version `rawSourceText` | Served as instructions the primary agent can adopt; real spawn-subagent integration is out of scope. |
+| `command` | searchable | accepts `body: { arguments?: string }`, substitutes `$ARGUMENTS`, returns rendered template | Instructional with arguments. No command is run server-side. |
+| `mcp` | searchable | returns declared server spec plus `status`/`hint` guidance | If an External MCP Connection for the same URL exists, hint to search for that connection's tools. Otherwise hint that an org admin can add it in Cloud → Connections, or the user can install locally. No auto-provisioning in Phase 1. |
+| `tool` | searchable | returns source plus `status: "needs_install"` and a hint naming the plugin/marketplace | Local-only in Phase 1. A human, or the agent via the desktop install flow, can finish locally. Phase 3 option: sandboxed execution via Den Worker Runtime. |
+| `hook` | searchable metadata only | returns definition plus an unsupported hint | Hooks are not supported anywhere yet: `apps/server/src/claude-plugin-bundle.ts` warns that OpenWork does not support hooks, and local install skips loading them. |
+
+Instructional payloads include provenance framing: `Content from marketplace plugin <plugin> in your organization's library.` The agent sees where the text came from before deciding how to use it.
+
+Degraded states:
+
+1. `content_not_synced`: a config object exists, but no latest version exists yet. This is real for seeded starter catalogs whose content arrives later via the GitHub connector. Execute returns `status: "content_not_synced"` with a hint to connect or sync the source.
+2. Seeded plugins with no config objects: nothing is indexed, so they simply do not match. This is correct and honest because there is no executable content yet.
+
+---
+
+## 4. Naming & wire shape
+
+Namespace:
+
+```text
+plugin:<pluginId>:<configObjectId>
+```
+
+This mirrors `mcp:<connectionId>:<toolName>`. IDs are stable and org-scoped. `parseMarketplaceCapabilityName` distinguishes marketplace names from `mcp:` names and REST catalog operation names in the execute handler.
+
+These names are data in search results and execute arguments. They are not registered MCP tool names, so MCP tool-name length limits do not apply; this is the same pattern External MCP Connections use today.
+
+Base match type from `ee/apps/den-api/src/mcp/search.ts`:
+
+```ts
+export type CapabilityMatch = {
+  name: string
+  method: string
+  path: string
+  score: number
+  summary: string
+  pathParams: string[]
+  queryParams: string[]
+  hasBody: boolean
+}
+```
+
+Marketplace match shape:
+
+```ts
+type MarketplaceCapabilityMatch = CapabilityMatch & {
+  kind: ConfigObjectType
+  plugin: string
+  marketplace?: string
+  status?: "needs_install" | "content_not_synced"
+  hint?: string
+}
+```
+
+Required marketplace match fields:
+
+- `method: "PLUGIN"`.
+- `path: plugin://<plugin-slug>/<currentRelativePath>`.
+- `pathParams: []`.
+- `queryParams: []`.
+- `hasBody: true` only for `command`; otherwise `false`.
+
+Instructional execute result is structured JSON text content:
+
+```json
+{
+  "kind": "skill",
+  "plugin": "Plugin name",
+  "marketplace": "Marketplace name",
+  "name": "Config object title",
+  "description": "Config object description",
+  "content": "...latest rawSourceText...",
+  "provenance": "Content from marketplace plugin Plugin name in your organization's library."
+}
+```
+
+Bridged, local-only, and degraded classes return the same envelope plus `status` and `hint`.
+
+Errors mirror External MCP's contract: `unknown_capability`, `forbidden`, and `content_not_synced`. Gated-off orgs get `unknown_capability`; search returns no marketplace matches. Disabled is indistinguishable from nonexistence: the byte-identical principle.
+
+The tool surface stays EXACTLY two tools. `evals/flows/mcp-search-capabilities.flow.mjs` keeps passing unchanged with `[execute_capability, search_capabilities]`.
+
+---
+
+## 5. Search & visibility semantics
+
+New module: `ee/apps/den-api/src/mcp/marketplace-capabilities.ts`, mirroring `ee/apps/den-api/src/mcp/external-capabilities.ts`.
+
+Search entry point:
+
+```ts
+searchMarketplaceCapabilities({ organizationId, member, query, limit })
+```
+
+Visible set for a member = active config objects reachable through direct `ConfigObjectAccessGrantTable` grants, `PluginAccessGrantTable` grants cascading to config objects, or `MarketplaceAccessGrantTable` grants cascading to plugins and config objects.
+
+Grant targets are `orgWide`, `orgMembershipId`, or `teamId`; roles are `viewer | editor | manager`; `viewer` is sufficient to search and execute.
+
+Use the pure function `resolvePluginArchGrantRole({grants, memberId, teamIds})` from `ee/apps/den-api/src/routes/org/plugin-system/access.ts`. Do NOT call the HTTP-context-coupled `resolvePluginArchResourceRole`; `/mcp/agent` has `McpMemberIdentity` (`memberId` + `teamIds`), not a route session context. A small set-oriented adapter is needed.
+
+Org admins, resolved via `MemberTable` role / `isOwner`, see all active objects.
+
+Status filters are strict:
+
+- Marketplace, plugin, and config object must be active.
+- `MarketplacePluginTable` and `PluginConfigObjectTable` links must not be removed.
+
+Scoring reuses `tokenize` / `scoreText` from `ee/apps/den-api/src/mcp/search.ts`: title tokens `+5` exact / `+3` prefix, description `+2`, `searchText` `+1`.
+
+Marketplace matches are interleaved with the other sources by score in `ee/apps/den-api/src/mcp/agent.ts`, exactly like External MCP matches are today.
+
+Search is DB-only, bounded by `limit`, and makes no live network calls. This contrasts with External MCP Connections, where search may call `tools/list` through `ee/apps/den-api/src/capability-sources/external-mcp-client.ts`.
+
+Dedupe against locally installed copies is NOT server-side possible in Phase 1. Den does not know what a desktop copied into `.opencode/`. Defer dedupe; make duplicates distinguishable with marketplace/plugin provenance in summaries and execute payloads.
+
+---
+
+## 6. Execute semantics
+
+Add `executeMarketplaceCapability(...)` in `ee/apps/den-api/src/mcp/marketplace-capabilities.ts`.
+
+Add a branch in `ee/apps/den-api/src/mcp/agent.ts`'s execute handler between the `mcp:` External MCP branch and the REST catalog lookup.
+
+Steps:
+
+1. Parse `plugin:<pluginId>:<configObjectId>`.
+2. Gate check; see §7.
+3. Load the config object scoped to the calling org.
+4. Verify membership in the named plugin through `PluginConfigObjectTable`.
+5. Check grants through the cascade adapter; `viewer` suffices.
+6. Load the latest version using the same indexed pattern as `ee/apps/den-api/src/routes/org/plugin-system/store.ts`'s `getLatestVersions`, backed by `config_object_version_lookup_latest`.
+7. Let `encryptedTextColumn` decrypt `rawSourceText` and `normalizedPayloadJson` transparently.
+8. Apply the per-class behavior from §3.
+
+Scope note: these are `mcp:read`-class operations; nothing on this path writes; there is no new auth, no new policy file, and no new execution logic beyond the branch. This mirrors `ee/apps/den-api/src/mcp/agent.ts`'s philosophy.
+
+---
+
+## 7. Rollout gate
+
+New module: `ee/apps/den-api/src/capability-sources/marketplace-capabilities-rollout.ts`, mirroring `ee/apps/den-api/src/capability-sources/external-mcp-rollout.ts`.
+
+Function: `marketplaceCapabilitiesEnabled(metadata, { gatingEnabled })`.
+
+Environment variable: `DEN_MARKETPLACE_CAPABILITIES_GATING_ENABLED`, wired in `ee/apps/den-api/src/env.ts` like `mcpConnectionsGatingEnabled`.
+
+Org metadata opt-in key:
+
+```json
+{ "marketplaceCapabilitiesEnabled": true }
+```
+
+Gating is off by default, so local dev, self-hosted, and evals get the feature immediately. Hosted production deploys with gating ON, so no org sees any change until opted in.
+
+Check the gate in both paths: search returns an empty marketplace merge; execute returns `unknown_capability`. Gated-off is byte-identical to nonexistence.
+
+### Additive invariants
+
+1. Desktop users without the cloud connection: this code is unreachable; zero change.
+2. Cloud-connected users in non-opted orgs: byte-identical search results and execute behavior.
+3. Tool surface unchanged: still exactly `search_capabilities` + `execute_capability`.
+4. The desktop install flow (`apps/server/src/cloud-plugins.ts`) is untouched; installed plugins keep working identically; nothing migrates, nothing is deprecated in Phase 1.
+5. The rich `/mcp` endpoint and `/mcp/admin` are untouched. External connections also merged only into `/mcp/agent`.
+6. No schema changes, no migrations, no new tables in Phase 1; everything derives from existing plugin-arch tables in `ee/packages/den-db/src/schema/sharables/plugin-arch.ts`.
+7. No prompt changes and no tool-description changes in Phase 1; results are self-describing via `summary`, `status`, and `hint`.
+
+Kill switch uses the same two layers as connections: flip org metadata through an ops script following `ee/apps/den-api/scripts/mcp-connections-rollout.ts`, or flip the env gate at deploy time following `scripts/revert-org-mcp-connections.sh`.
+
+---
+
+## 8. Phase plan
+
+### Phase 1: this document's scope, Den-only, additive
+
+Build the marketplace search source, the execute branch for all classes with honest statuses, the rollout gate, tests, and eval flow. There are zero desktop changes and zero behavior changes for anyone until an org is opted in when hosted gating is enabled.
+
+Deliverables:
+
+- New: `ee/apps/den-api/src/mcp/marketplace-capabilities.ts`.
+- New: `ee/apps/den-api/src/capability-sources/marketplace-capabilities-rollout.ts`.
+- Touched: `ee/apps/den-api/src/mcp/agent.ts` at the two merge points.
+- Touched: `ee/apps/den-api/src/env.ts`.
+- New: `ee/apps/den-api/test/marketplace-capabilities.test.ts`.
+- New: `evals/flows/marketplace-capabilities.flow.mjs`.
+- New: `docs/marketplace-capabilities-architecture.md`.
+
+Not in Phase 1: desktop UI, prompt edits, tool-description edits, schema changes, local rail parity, MCP auto-provisioning, sandboxed tool execution, dedupe against local installs, or retiring copy-install.
+
+### Phase 2: make the bridge real, still no removal
+
+Provision an External MCP Connection from a plugin's `mcp` spec; add nullable `sourcePluginId` linkage column as the first schema change; add inline connect cards; add desktop provenance / "Available via Cloud — no install needed" states in the Extensions UI; add search-side hints for already-installed dedupe; add one-line teaching in the OpenWork agent prompt and `/mcp/agent` tool descriptions; add command argument schemas.
+
+### Phase 3: retire the requirement to copy
+
+Add sandboxed `tool` execution via Den Worker Runtime; add `tools/searchText` caching if scale demands; add LOCAL rail parity so the local OpenWork server (`apps/server`) grows the same search/execute surface over locally-known catalogs for signed-out users; reposition copy-install as "pin locally / offline".
+
+---
+
+## 9. Security & trust considerations
+
+1. Marketplace content is org-curated but still third-party text. Instructional payloads are prompt-injection surface. Mitigations: provenance framing in every payload; the existing desktop invariant that agents do not auto-open tool-output URLs; strict grants; org admins control what is published.
+2. Encrypted-at-rest payloads decrypt only inside den-api through existing `encryptedTextColumn` machinery. Nothing new leaves the org boundary.
+3. No secrets should live in config objects. The connections machinery remains the only credential store, and Phase 1 never touches it.
+4. SSRF risk is avoided in Phase 1 because this path makes zero outbound calls. The Phase 2 bridge inherits the existing guarded MCP client.
+
+---
+
+## 10. Test & proof plan
+
+Unit tests in `ee/apps/den-api/test/marketplace-capabilities.test.ts`:
+
+1. Grant cascade: org-wide marketplace grant ⇒ member finds plugin skill.
+2. No grant ⇒ no match and no allowed execute.
+3. Team grant visibility.
+4. Admin sees all active objects.
+5. Gating byte-identity: gated org gets empty marketplace search merge and `unknown_capability` execute.
+6. Name build/parse round-trip.
+7. Scoring sanity.
+8. Command `$ARGUMENTS` substitution.
+9. `content_not_synced`.
+10. `hook` / `tool` statuses and hints.
+
+Existing contract must keep passing untouched: `evals/flows/mcp-search-capabilities.flow.mjs` asserts exactly two tools.
+
+New eval flow `evals/flows/marketplace-capabilities.flow.mjs`: seed marketplace + plugin + skill config object via the plugin-system API → real chat turn → assert `search_capabilities` returns the `plugin:` match → `execute_capability` returns the skill content → the answer reflects the skill's instructions; control frame proves an opted-out org sees no `plugin:` matches.
+
+Fraimz proof follows `AGENTS.md`: `evals/results/<run-id>/fraimz.html` exists, and every claim is backed by an observable assertion and screenshot.
+
+---
+
+## 11. Deliberately open questions
+
+1. Whether `none`-auth remote MCP specs could be proxied directly in Phase 1 without a connection row. It is credential-safe, but adds live network to search. Decision for Phase 1: no; revisit in Phase 2 with the bridge.
+2. Whether search should read `normalizedPayloadJson` frontmatter, such as skill `description`, instead of raw `searchText` for cleaner summaries. Phase 1 uses stored `title`, `description`, and `searchText`.
+3. Slug-based display names versus raw IDs in `path`. This is cosmetic and cheap to change until Phase 2 freezes the contract.

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -13,10 +13,22 @@ import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./in
 import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities } from "./search.js"
 import { executeExternalCapability, parseExternalCapabilityName, resolveMcpMemberIdentity, searchExternalCapabilities } from "./external-capabilities.js"
+import { executeMarketplaceCapability, parseMarketplaceCapabilityName, searchMarketplaceCapabilities } from "./marketplace-capabilities.js"
 import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { env } from "../env.js"
 
 export const EXECUTE_CAPABILITY_TOOL_NAME = "execute_capability"
+
+function textContent(text: string): { text: string; type: "text" }[] {
+  return [{ type: "text", text }]
+}
+
+function unknownCapabilityText(name: string): string {
+  return JSON.stringify({
+    error: "unknown_capability",
+    message: `No capability named "${name}". Call search_capabilities to find a valid name.`,
+  })
+}
 
 /**
  * The minimal, harness-facing MCP surface: exactly two tools, full stop.
@@ -100,7 +112,16 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
             limit: boundedLimit,
           })
           : []
-        const matches = [...restMatches, ...externalMatches]
+        const marketplaceMatches = externalMcpConnectionsEnabled
+          ? await searchMarketplaceCapabilities({
+            organizationId: principal.organizationId,
+            member: memberIdentity,
+            query,
+            limit: boundedLimit,
+            enabled: externalMcpConnectionsEnabled,
+          })
+          : []
+        const matches = [...restMatches, ...externalMatches, ...marketplaceMatches]
           .sort((a, b) => b.score - a.score)
           .slice(0, boundedLimit)
         const text = matches.length > 0
@@ -168,17 +189,32 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
           return { content }
         }
 
+        const marketplace = parseMarketplaceCapabilityName(name)
+        if (marketplace) {
+          const result = await executeMarketplaceCapability({
+            organizationId: principal.organizationId,
+            member: memberIdentity,
+            pluginId: marketplace.pluginId,
+            configObjectId: marketplace.configObjectId,
+            body,
+            enabled: externalMcpConnectionsEnabled,
+          })
+          if (!result.ok) {
+            return {
+              isError: true,
+              content: textContent(result.error === "unknown_capability"
+                ? unknownCapabilityText(name)
+                : JSON.stringify({ error: result.error, message: result.message })),
+            }
+          }
+          return { content: textContent(JSON.stringify(result.result, null, 2)) }
+        }
+
         const operation = catalog.find((candidate) => candidate.name === name)
         if (!operation) {
           return {
             isError: true,
-            content: [{
-              type: "text" as const,
-              text: JSON.stringify({
-                error: "unknown_capability",
-                message: `No capability named "${name}". Call search_capabilities to find a valid name.`,
-              }),
-            }],
+            content: textContent(unknownCapabilityText(name)),
           }
         }
 

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -1,0 +1,638 @@
+import { and, desc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
+import {
+  ConfigObjectAccessGrantTable,
+  ConfigObjectTable,
+  ConfigObjectVersionTable,
+  MarketplaceAccessGrantTable,
+  MarketplacePluginTable,
+  MarketplaceTable,
+  MemberTable,
+  PluginAccessGrantTable,
+  PluginConfigObjectTable,
+  PluginTable,
+} from "@openwork-ee/den-db/schema"
+import { normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
+import { listUsableExternalMcpConnections } from "../capability-sources/external-mcp-connections.js"
+import { db } from "../db.js"
+import { resolvePluginArchGrantRole } from "../routes/org/plugin-system/access.js"
+import { scoreText, tokenize } from "./search.js"
+import type { McpMemberIdentity } from "./external-capabilities.js"
+import type { CapabilityMatch } from "./search.js"
+
+const MARKETPLACE_CAPABILITY_PREFIX = "plugin:"
+const PROVENANCE_SUFFIX = "in your organization's library."
+
+type OrganizationId = DenTypeId<"organization">
+type PluginId = DenTypeId<"plugin">
+type ConfigObjectId = DenTypeId<"configObject">
+type ConfigObjectRow = typeof ConfigObjectTable.$inferSelect
+type ConfigObjectType = ConfigObjectRow["objectType"]
+type MemberRow = Pick<typeof MemberTable.$inferSelect, "id" | "role">
+type MarketplaceCapabilityRow = {
+  configObject: ConfigObjectRow
+  marketplace: typeof MarketplaceTable.$inferSelect
+  plugin: typeof PluginTable.$inferSelect
+}
+type GrantRow = {
+  orgMembershipId: DenTypeId<"member"> | null
+  orgWide: boolean
+  removedAt: Date | null
+  role: "viewer" | "editor" | "manager"
+  teamId: DenTypeId<"team"> | null
+}
+type GrantWithResourceId = GrantRow & { resourceId: string }
+
+export type MarketplaceCapabilityMatch = CapabilityMatch & {
+  kind: ConfigObjectType
+  plugin: string
+  marketplace?: string
+  status?: "needs_install" | "content_not_synced"
+  hint?: string
+}
+
+type MarketplaceCapabilityStatus = "connection_available" | "content_not_synced" | "needs_connection" | "needs_install" | "unsupported"
+
+export type MarketplaceCapabilityExecutePayload = {
+  kind: ConfigObjectType
+  plugin: string
+  marketplace: string
+  name: string
+  description: string | null
+  provenance: string
+  content?: string
+  definition?: string | null
+  serverSpec?: Record<string, unknown>
+  source?: string | null
+  status?: MarketplaceCapabilityStatus
+  hint?: string
+}
+
+export type MarketplaceCapabilityExecuteResult =
+  | { ok: true; result: MarketplaceCapabilityExecutePayload }
+  | { ok: false; error: "unknown_capability" | "forbidden"; message: string }
+
+export function buildMarketplaceCapabilityName(pluginId: string, configObjectId: string): string {
+  return `${MARKETPLACE_CAPABILITY_PREFIX}${pluginId}:${configObjectId}`
+}
+
+export function parseMarketplaceCapabilityName(name: string): { configObjectId: string; pluginId: string } | null {
+  if (!name.startsWith(MARKETPLACE_CAPABILITY_PREFIX)) return null
+  const rest = name.slice(MARKETPLACE_CAPABILITY_PREFIX.length)
+  const separatorIndex = rest.indexOf(":")
+  if (separatorIndex <= 0 || separatorIndex >= rest.length - 1) return null
+  return {
+    pluginId: rest.slice(0, separatorIndex),
+    configObjectId: rest.slice(separatorIndex + 1),
+  }
+}
+
+function normalizeMarketplaceIds(input: { configObjectId: string; pluginId: string }): { configObjectId: ConfigObjectId; pluginId: PluginId } | null {
+  try {
+    return {
+      configObjectId: normalizeDenTypeId("configObject", input.configObjectId),
+      pluginId: normalizeDenTypeId("plugin", input.pluginId),
+    }
+  } catch {
+    return null
+  }
+}
+
+function roleIncludes(roleValue: string, role: string): boolean {
+  return roleValue
+    .split(",")
+    .map((entry) => entry.trim())
+    .includes(role)
+}
+
+function isOrgAdmin(member: MemberRow): boolean {
+  return roleIncludes(member.role, "owner") || roleIncludes(member.role, "admin")
+}
+
+function unique<T>(values: T[]): T[] {
+  return [...new Set(values)]
+}
+
+function groupGrants<TGrant extends GrantWithResourceId>(rows: TGrant[]): Map<string, TGrant[]> {
+  const grouped = new Map<string, TGrant[]>()
+  for (const row of rows) {
+    const existing = grouped.get(row.resourceId) ?? []
+    existing.push(row)
+    grouped.set(row.resourceId, existing)
+  }
+  return grouped
+}
+
+function grantRole(member: McpMemberIdentity, grants: GrantRow[]) {
+  return resolvePluginArchGrantRole({
+    grants,
+    memberId: member.orgMembershipId,
+    teamIds: member.teamIds,
+  })
+}
+
+function slugify(value: string, fallback: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return slug || fallback
+}
+
+function pluginPath(row: MarketplaceCapabilityRow): string {
+  const pluginSlug = slugify(row.plugin.name, row.plugin.id)
+  const relativePath = row.configObject.currentRelativePath?.trim()
+    || row.configObject.currentFileName?.trim()
+    || row.configObject.id
+  return `plugin://${pluginSlug}/${relativePath.replace(/^\/+/, "")}`
+}
+
+function provenance(pluginName: string): string {
+  return `Content from marketplace plugin ${pluginName} ${PROVENANCE_SUFFIX}`
+}
+
+function objectHint(row: MarketplaceCapabilityRow): string {
+  return `Install marketplace plugin "${row.plugin.name}" from "${row.marketplace.name}" locally to use "${row.configObject.title}".`
+}
+
+function contentNotSyncedHint(row: MarketplaceCapabilityRow): string {
+  return `Marketplace plugin "${row.plugin.name}" has not synced content for "${row.configObject.title}" yet. Connect or sync the source, then try again.`
+}
+
+function summaryFor(row: MarketplaceCapabilityRow): string {
+  const prefix = `[${row.marketplace.name} / ${row.plugin.name}] ${row.configObject.title}`
+  const description = row.configObject.description?.trim()
+  return description ? `${prefix}: ${description}` : prefix
+}
+
+function scoreMarketplaceRow(row: MarketplaceCapabilityRow, queryTokens: string[]): number {
+  return scoreText(
+    tokenize(row.configObject.title),
+    tokenize(row.configObject.description ?? ""),
+    queryTokens,
+    tokenize(row.configObject.searchText ?? ""),
+  )
+}
+
+function basePayload(row: MarketplaceCapabilityRow): MarketplaceCapabilityExecutePayload {
+  return {
+    kind: row.configObject.objectType,
+    plugin: row.plugin.name,
+    marketplace: row.marketplace.name,
+    name: row.configObject.title,
+    description: row.configObject.description,
+    provenance: provenance(row.plugin.name),
+  }
+}
+
+async function getActiveMember(organizationId: OrganizationId, member: McpMemberIdentity | null): Promise<MemberRow | null> {
+  if (!member) return null
+  const rows = await db
+    .select({ id: MemberTable.id, role: MemberTable.role })
+    .from(MemberTable)
+    .where(and(
+      eq(MemberTable.id, member.orgMembershipId),
+      eq(MemberTable.organizationId, organizationId),
+      isNull(MemberTable.removedAt),
+    ))
+    .limit(1)
+  return rows[0] ?? null
+}
+
+async function listActiveMarketplaceRows(organizationId: OrganizationId): Promise<MarketplaceCapabilityRow[]> {
+  const rows = await db
+    .select({
+      configObject: ConfigObjectTable,
+      marketplace: MarketplaceTable,
+      plugin: PluginTable,
+    })
+    .from(ConfigObjectTable)
+    .innerJoin(
+      PluginConfigObjectTable,
+      eq(PluginConfigObjectTable.configObjectId, ConfigObjectTable.id),
+    )
+    .innerJoin(
+      PluginTable,
+      eq(PluginTable.id, PluginConfigObjectTable.pluginId),
+    )
+    .innerJoin(
+      MarketplacePluginTable,
+      eq(MarketplacePluginTable.pluginId, PluginTable.id),
+    )
+    .innerJoin(
+      MarketplaceTable,
+      eq(MarketplaceTable.id, MarketplacePluginTable.marketplaceId),
+    )
+    .where(and(
+      eq(ConfigObjectTable.organizationId, organizationId),
+      eq(ConfigObjectTable.status, "active"),
+      isNull(ConfigObjectTable.deletedAt),
+      eq(PluginConfigObjectTable.organizationId, organizationId),
+      isNull(PluginConfigObjectTable.removedAt),
+      eq(PluginTable.organizationId, organizationId),
+      eq(PluginTable.status, "active"),
+      isNull(PluginTable.deletedAt),
+      eq(MarketplacePluginTable.organizationId, organizationId),
+      isNull(MarketplacePluginTable.removedAt),
+      eq(MarketplaceTable.organizationId, organizationId),
+      eq(MarketplaceTable.status, "active"),
+      isNull(MarketplaceTable.deletedAt),
+    ))
+    .orderBy(PluginTable.name, ConfigObjectTable.title, MarketplaceTable.name)
+  return rows
+}
+
+async function listActiveMarketplaceRowsForCapability(input: {
+  configObjectId: ConfigObjectId
+  organizationId: OrganizationId
+  pluginId: PluginId
+}): Promise<MarketplaceCapabilityRow[]> {
+  const rows = await db
+    .select({
+      configObject: ConfigObjectTable,
+      marketplace: MarketplaceTable,
+      plugin: PluginTable,
+    })
+    .from(ConfigObjectTable)
+    .innerJoin(
+      PluginConfigObjectTable,
+      eq(PluginConfigObjectTable.configObjectId, ConfigObjectTable.id),
+    )
+    .innerJoin(
+      PluginTable,
+      eq(PluginTable.id, PluginConfigObjectTable.pluginId),
+    )
+    .innerJoin(
+      MarketplacePluginTable,
+      eq(MarketplacePluginTable.pluginId, PluginTable.id),
+    )
+    .innerJoin(
+      MarketplaceTable,
+      eq(MarketplaceTable.id, MarketplacePluginTable.marketplaceId),
+    )
+    .where(and(
+      eq(ConfigObjectTable.id, input.configObjectId),
+      eq(ConfigObjectTable.organizationId, input.organizationId),
+      eq(ConfigObjectTable.status, "active"),
+      isNull(ConfigObjectTable.deletedAt),
+      eq(PluginConfigObjectTable.organizationId, input.organizationId),
+      eq(PluginConfigObjectTable.pluginId, input.pluginId),
+      isNull(PluginConfigObjectTable.removedAt),
+      eq(PluginTable.id, input.pluginId),
+      eq(PluginTable.organizationId, input.organizationId),
+      eq(PluginTable.status, "active"),
+      isNull(PluginTable.deletedAt),
+      eq(MarketplacePluginTable.organizationId, input.organizationId),
+      isNull(MarketplacePluginTable.removedAt),
+      eq(MarketplaceTable.organizationId, input.organizationId),
+      eq(MarketplaceTable.status, "active"),
+      isNull(MarketplaceTable.deletedAt),
+    ))
+    .orderBy(MarketplaceTable.name)
+  return rows
+}
+
+async function listConfigObjectGrants(organizationId: OrganizationId, configObjectIds: ConfigObjectId[]) {
+  if (configObjectIds.length === 0) return []
+  return db
+    .select({
+      resourceId: ConfigObjectAccessGrantTable.configObjectId,
+      orgMembershipId: ConfigObjectAccessGrantTable.orgMembershipId,
+      orgWide: ConfigObjectAccessGrantTable.orgWide,
+      removedAt: ConfigObjectAccessGrantTable.removedAt,
+      role: ConfigObjectAccessGrantTable.role,
+      teamId: ConfigObjectAccessGrantTable.teamId,
+    })
+    .from(ConfigObjectAccessGrantTable)
+    .where(and(
+      eq(ConfigObjectAccessGrantTable.organizationId, organizationId),
+      inArray(ConfigObjectAccessGrantTable.configObjectId, configObjectIds),
+    ))
+}
+
+async function listPluginGrants(organizationId: OrganizationId, pluginIds: PluginId[]) {
+  if (pluginIds.length === 0) return []
+  return db
+    .select({
+      resourceId: PluginAccessGrantTable.pluginId,
+      orgMembershipId: PluginAccessGrantTable.orgMembershipId,
+      orgWide: PluginAccessGrantTable.orgWide,
+      removedAt: PluginAccessGrantTable.removedAt,
+      role: PluginAccessGrantTable.role,
+      teamId: PluginAccessGrantTable.teamId,
+    })
+    .from(PluginAccessGrantTable)
+    .where(and(
+      eq(PluginAccessGrantTable.organizationId, organizationId),
+      inArray(PluginAccessGrantTable.pluginId, pluginIds),
+    ))
+}
+
+async function listMarketplaceGrants(organizationId: OrganizationId, marketplaceIds: DenTypeId<"marketplace">[]) {
+  if (marketplaceIds.length === 0) return []
+  return db
+    .select({
+      resourceId: MarketplaceAccessGrantTable.marketplaceId,
+      orgMembershipId: MarketplaceAccessGrantTable.orgMembershipId,
+      orgWide: MarketplaceAccessGrantTable.orgWide,
+      removedAt: MarketplaceAccessGrantTable.removedAt,
+      role: MarketplaceAccessGrantTable.role,
+      teamId: MarketplaceAccessGrantTable.teamId,
+    })
+    .from(MarketplaceAccessGrantTable)
+    .where(and(
+      eq(MarketplaceAccessGrantTable.organizationId, organizationId),
+      inArray(MarketplaceAccessGrantTable.marketplaceId, marketplaceIds),
+    ))
+}
+
+async function filterVisibleRows(input: {
+  member: McpMemberIdentity
+  memberRow: MemberRow
+  organizationId: OrganizationId
+  rows: MarketplaceCapabilityRow[]
+}): Promise<MarketplaceCapabilityRow[]> {
+  if (isOrgAdmin(input.memberRow)) return input.rows
+
+  const configObjectGrantRows = await listConfigObjectGrants(
+    input.organizationId,
+    unique(input.rows.map((row) => row.configObject.id)),
+  )
+  const pluginGrantRows = await listPluginGrants(
+    input.organizationId,
+    unique(input.rows.map((row) => row.plugin.id)),
+  )
+  const marketplaceGrantRows = await listMarketplaceGrants(
+    input.organizationId,
+    unique(input.rows.map((row) => row.marketplace.id)),
+  )
+  const configObjectGrants = groupGrants(configObjectGrantRows)
+  const pluginGrants = groupGrants(pluginGrantRows)
+  const marketplaceGrants = groupGrants(marketplaceGrantRows)
+
+  return input.rows.filter((row) => {
+    if (grantRole(input.member, configObjectGrants.get(row.configObject.id) ?? [])) return true
+    if (grantRole(input.member, pluginGrants.get(row.plugin.id) ?? [])) return true
+    return Boolean(grantRole(input.member, marketplaceGrants.get(row.marketplace.id) ?? []))
+  })
+}
+
+async function latestVersion(configObjectId: ConfigObjectId, organizationId: OrganizationId) {
+  const rows = await db
+    .select()
+    .from(ConfigObjectVersionTable)
+    .where(and(
+      eq(ConfigObjectVersionTable.configObjectId, configObjectId),
+      eq(ConfigObjectVersionTable.organizationId, organizationId),
+    ))
+    .orderBy(desc(ConfigObjectVersionTable.createdAt), desc(ConfigObjectVersionTable.id))
+    .limit(1)
+  return rows[0] ?? null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseJsonRecord(value: string | null): Record<string, unknown> | null {
+  if (!value) return null
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return isRecord(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value.trim() || null : null
+}
+
+function versionServerSpec(version: typeof ConfigObjectVersionTable.$inferSelect): Record<string, unknown> {
+  return version.normalizedPayloadJson ?? parseJsonRecord(version.rawSourceText) ?? {}
+}
+
+function mcpServerEntries(spec: Record<string, unknown>, fallbackName: string): { config: Record<string, unknown>; name: string }[] {
+  const entries: { config: Record<string, unknown>; name: string }[] = []
+  for (const key of ["mcp", "mcpServers"]) {
+    const container = spec[key]
+    if (!isRecord(container)) continue
+    for (const [name, config] of Object.entries(container)) {
+      if (isRecord(config)) entries.push({ name, config })
+    }
+  }
+  if (entries.length === 0 && (readString(spec.url) || readString(spec.command))) {
+    entries.push({ name: fallbackName, config: spec })
+  }
+  return entries
+}
+
+function comparableUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "")
+}
+
+async function mcpHint(input: {
+  member: McpMemberIdentity
+  organizationId: OrganizationId
+  row: MarketplaceCapabilityRow
+  serverSpec: Record<string, unknown>
+}): Promise<{ hint: string; status: "connection_available" | "needs_connection" }> {
+  const urls = unique(
+    mcpServerEntries(input.serverSpec, input.row.configObject.title)
+      .flatMap((entry) => {
+        const url = readString(entry.config.url)
+        return url ? [comparableUrl(url)] : []
+      }),
+  )
+  if (urls.length > 0) {
+    const visibleConnections = await listUsableExternalMcpConnections({
+      organizationId: input.organizationId,
+      orgMembershipId: input.member.orgMembershipId,
+      teamIds: input.member.teamIds,
+    })
+    const matching = visibleConnections.find((connection) => urls.includes(comparableUrl(connection.url)))
+    if (matching) {
+      return {
+        status: "connection_available",
+        hint: `An External MCP Connection named "${matching.name}" already points at this server. Search capabilities for "${matching.name}" to use its tools.`,
+      }
+    }
+  }
+
+  return {
+    status: "needs_connection",
+    hint: `This plugin declares an MCP server but OpenWork will not auto-provision it. Ask an org admin to add it in OpenWork Cloud -> Connections, or install "${input.row.plugin.name}" locally.`,
+  }
+}
+
+function commandArguments(body: unknown): string {
+  if (!isRecord(body)) return ""
+  return typeof body.arguments === "string" ? body.arguments : ""
+}
+
+export async function searchMarketplaceCapabilities(input: {
+  enabled?: boolean
+  limit?: number
+  member: McpMemberIdentity | null
+  organizationId: string
+  query: string
+}): Promise<MarketplaceCapabilityMatch[]> {
+  if (input.enabled === false || !input.member) return []
+  const queryTokens = tokenize(input.query)
+  if (queryTokens.length === 0) return []
+
+  const organizationId = normalizeDenTypeId("organization", input.organizationId)
+  const memberRow = await getActiveMember(organizationId, input.member)
+  if (!memberRow) return []
+
+  const rows = await filterVisibleRows({
+    organizationId,
+    member: input.member,
+    memberRow,
+    rows: await listActiveMarketplaceRows(organizationId),
+  })
+  const matchesByName = new Map<string, MarketplaceCapabilityMatch>()
+
+  for (const row of rows) {
+    const score = scoreMarketplaceRow(row, queryTokens)
+    if (score <= 0) continue
+    const name = buildMarketplaceCapabilityName(row.plugin.id, row.configObject.id)
+    if (matchesByName.has(name)) continue
+    const match: MarketplaceCapabilityMatch = {
+      name,
+      method: "PLUGIN",
+      path: pluginPath(row),
+      score,
+      summary: summaryFor(row),
+      pathParams: [],
+      queryParams: [],
+      hasBody: row.configObject.objectType === "command",
+      kind: row.configObject.objectType,
+      plugin: row.plugin.name,
+      marketplace: row.marketplace.name,
+    }
+    if (row.configObject.objectType === "tool") {
+      match.status = "needs_install"
+      match.hint = objectHint(row)
+    }
+    matchesByName.set(name, match)
+  }
+
+  return [...matchesByName.values()]
+    .sort((a, b) => (b.score - a.score) || a.name.localeCompare(b.name))
+    .slice(0, input.limit ?? 5)
+}
+
+export async function executeMarketplaceCapability(input: {
+  body?: unknown
+  configObjectId: string
+  enabled?: boolean
+  member: McpMemberIdentity | null
+  organizationId: string
+  pluginId: string
+}): Promise<MarketplaceCapabilityExecuteResult> {
+  if (input.enabled === false) {
+    return { ok: false, error: "unknown_capability", message: "No such capability." }
+  }
+  if (!input.member) {
+    return { ok: false, error: "forbidden", message: "No active org membership for this token." }
+  }
+
+  const normalizedIds = normalizeMarketplaceIds({ pluginId: input.pluginId, configObjectId: input.configObjectId })
+  if (!normalizedIds) {
+    return { ok: false, error: "unknown_capability", message: "No such capability." }
+  }
+
+  const organizationId = normalizeDenTypeId("organization", input.organizationId)
+  const rows = await listActiveMarketplaceRowsForCapability({
+    organizationId,
+    pluginId: normalizedIds.pluginId,
+    configObjectId: normalizedIds.configObjectId,
+  })
+  if (rows.length === 0) {
+    return { ok: false, error: "unknown_capability", message: "No such capability." }
+  }
+
+  const memberRow = await getActiveMember(organizationId, input.member)
+  if (!memberRow) {
+    return { ok: false, error: "forbidden", message: "No active org membership for this token." }
+  }
+  const visibleRows = await filterVisibleRows({ organizationId, member: input.member, memberRow, rows })
+  const row = visibleRows[0]
+  if (!row) {
+    return { ok: false, error: "forbidden", message: "You have not been granted access to this marketplace plugin capability." }
+  }
+
+  const version = await latestVersion(row.configObject.id, organizationId)
+  if (!version) {
+    return {
+      ok: true,
+      result: {
+        ...basePayload(row),
+        status: "content_not_synced",
+        hint: contentNotSyncedHint(row),
+      },
+    }
+  }
+
+  if (row.configObject.objectType === "command") {
+    return {
+      ok: true,
+      result: {
+        ...basePayload(row),
+        content: (version.rawSourceText ?? "").replaceAll("$ARGUMENTS", commandArguments(input.body)),
+      },
+    }
+  }
+
+  if (
+    row.configObject.objectType === "skill"
+    || row.configObject.objectType === "context"
+    || row.configObject.objectType === "custom"
+    || row.configObject.objectType === "agent"
+  ) {
+    return {
+      ok: true,
+      result: {
+        ...basePayload(row),
+        content: version.rawSourceText ?? "",
+      },
+    }
+  }
+
+  if (row.configObject.objectType === "mcp") {
+    const serverSpec = versionServerSpec(version)
+    const guidance = await mcpHint({ organizationId, member: input.member, row, serverSpec })
+    return {
+      ok: true,
+      result: {
+        ...basePayload(row),
+        serverSpec,
+        status: guidance.status,
+        hint: guidance.hint,
+      },
+    }
+  }
+
+  if (row.configObject.objectType === "tool") {
+    return {
+      ok: true,
+      result: {
+        ...basePayload(row),
+        source: version.rawSourceText,
+        status: "needs_install",
+        hint: objectHint(row),
+      },
+    }
+  }
+
+  return {
+    ok: true,
+    result: {
+      ...basePayload(row),
+      definition: version.rawSourceText,
+      status: "unsupported",
+      hint: "Marketplace plugin hooks are not supported on the OpenWork capability rail yet.",
+    },
+  }
+}

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -39,6 +39,29 @@ export function tokenize(value: string): string[] {
     .filter((token) => token.length > 0)
 }
 
+export function scoreText(
+  nameTokens: string[],
+  summaryTokens: string[],
+  queryTokens: string[],
+  extraTokens: string[] = [],
+): number {
+  let score = 0
+  for (const queryToken of queryTokens) {
+    if (nameTokens.includes(queryToken)) {
+      score += 5
+    } else if (nameTokens.some((token) => token.startsWith(queryToken) || queryToken.startsWith(token))) {
+      score += 3
+    }
+    if (summaryTokens.includes(queryToken)) {
+      score += 2
+    }
+    if (extraTokens.includes(queryToken)) {
+      score += 1
+    }
+  }
+  return score
+}
+
 /**
  * Splits a camelCase / PascalCase tool name into lowercase word tokens so a
  * query like "organization" matches a tool named `getOrganizations`.
@@ -60,22 +83,7 @@ function scoreOperation(operation: McpToolOperation, queryTokens: string[]): num
   const nameTokens = tokenizeToolName(operation.name)
   const summaryTokens = tokenize(summaryFor(operation))
   const pathTokens = tokenize(operation.path)
-
-  let score = 0
-  for (const queryToken of queryTokens) {
-    if (nameTokens.includes(queryToken)) {
-      score += 5
-    } else if (nameTokens.some((token) => token.startsWith(queryToken) || queryToken.startsWith(token))) {
-      score += 3
-    }
-    if (summaryTokens.includes(queryToken)) {
-      score += 2
-    }
-    if (pathTokens.includes(queryToken)) {
-      score += 1
-    }
-  }
-  return score
+  return scoreText(nameTokens, summaryTokens, queryTokens, pathTokens)
 }
 
 export function searchCapabilities(

--- a/ee/apps/den-api/test/marketplace-capabilities.test.ts
+++ b/ee/apps/den-api/test/marketplace-capabilities.test.ts
@@ -1,0 +1,544 @@
+import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test"
+import { inArray } from "@openwork-ee/den-db/drizzle"
+import {
+  AuthUserTable,
+  ConfigObjectAccessGrantTable,
+  ConfigObjectTable,
+  ConfigObjectVersionTable,
+  ExternalMcpConnectionAccessGrantTable,
+  ExternalMcpConnectionTable,
+  MarketplaceAccessGrantTable,
+  MarketplacePluginTable,
+  MarketplaceTable,
+  MemberTable,
+  PluginAccessGrantTable,
+  PluginConfigObjectTable,
+  PluginTable,
+  OrganizationTable,
+} from "@openwork-ee/den-db/schema"
+import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
+import { memberFacingMcpConnectionsEnabled } from "../src/capability-sources/external-mcp-rollout.js"
+import type { McpMemberIdentity } from "../src/mcp/external-capabilities.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_pr3"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+type Db = typeof import("../src/db.js").db
+type MarketplaceCapabilities = typeof import("../src/mcp/marketplace-capabilities.js")
+type ExternalCapabilities = typeof import("../src/mcp/external-capabilities.js")
+type ConfigObjectType = typeof ConfigObjectTable.$inferSelect.objectType
+
+type SeededMember = {
+  member: McpMemberIdentity
+  memberId: DenTypeId<"member">
+  organizationId: DenTypeId<"organization">
+  userId: DenTypeId<"user">
+}
+
+type SeededCapability = {
+  configObjectId: DenTypeId<"configObject">
+  name: string
+  pluginId: DenTypeId<"plugin">
+}
+
+let db: Db
+let marketplaceCapabilities: MarketplaceCapabilities
+let externalCapabilities: ExternalCapabilities
+
+const createdOrganizationIds: DenTypeId<"organization">[] = []
+const createdUserIds: DenTypeId<"user">[] = []
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.restore()
+  db = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL,
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db }))
+  marketplaceCapabilities = await import("../src/mcp/marketplace-capabilities.js")
+  externalCapabilities = await import("../src/mcp/external-capabilities.js")
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+afterEach(async () => {
+  if (createdOrganizationIds.length > 0) {
+    await db.delete(ExternalMcpConnectionAccessGrantTable).where(inArray(ExternalMcpConnectionAccessGrantTable.organizationId, createdOrganizationIds))
+    await db.delete(ExternalMcpConnectionTable).where(inArray(ExternalMcpConnectionTable.organizationId, createdOrganizationIds))
+    await db.delete(ConfigObjectVersionTable).where(inArray(ConfigObjectVersionTable.organizationId, createdOrganizationIds))
+    await db.delete(ConfigObjectAccessGrantTable).where(inArray(ConfigObjectAccessGrantTable.organizationId, createdOrganizationIds))
+    await db.delete(PluginConfigObjectTable).where(inArray(PluginConfigObjectTable.organizationId, createdOrganizationIds))
+    await db.delete(PluginAccessGrantTable).where(inArray(PluginAccessGrantTable.organizationId, createdOrganizationIds))
+    await db.delete(MarketplacePluginTable).where(inArray(MarketplacePluginTable.organizationId, createdOrganizationIds))
+    await db.delete(MarketplaceAccessGrantTable).where(inArray(MarketplaceAccessGrantTable.organizationId, createdOrganizationIds))
+    await db.delete(ConfigObjectTable).where(inArray(ConfigObjectTable.organizationId, createdOrganizationIds))
+    await db.delete(PluginTable).where(inArray(PluginTable.organizationId, createdOrganizationIds))
+    await db.delete(MarketplaceTable).where(inArray(MarketplaceTable.organizationId, createdOrganizationIds))
+    await db.delete(MemberTable).where(inArray(MemberTable.organizationId, createdOrganizationIds))
+    await db.delete(OrganizationTable).where(inArray(OrganizationTable.id, createdOrganizationIds))
+  }
+  if (createdUserIds.length > 0) {
+    await db.delete(AuthUserTable).where(inArray(AuthUserTable.id, createdUserIds))
+  }
+  createdOrganizationIds.length = 0
+  createdUserIds.length = 0
+})
+
+async function seedMember(input: { metadata?: Record<string, unknown> | null; role?: string } = {}): Promise<SeededMember> {
+  const organizationId = createDenTypeId("organization")
+  const userId = createDenTypeId("user")
+  const memberId = createDenTypeId("member")
+  createdOrganizationIds.push(organizationId)
+  createdUserIds.push(userId)
+
+  await db.insert(AuthUserTable).values({
+    id: userId,
+    name: "Marketplace Tester",
+    email: `${userId}@marketplace.test.local`,
+  })
+  await db.insert(OrganizationTable).values({
+    id: organizationId,
+    name: "Marketplace Test Org",
+    slug: `marketplace-${organizationId}`,
+    metadata: input.metadata ?? null,
+  })
+  await db.insert(MemberTable).values({
+    id: memberId,
+    organizationId,
+    userId,
+    role: input.role ?? "member",
+  })
+
+  return {
+    organizationId,
+    userId,
+    memberId,
+    member: { orgMembershipId: memberId, teamIds: [] },
+  }
+}
+
+async function seedCapability(input: {
+  description?: string | null
+  grant?: "config_object" | "marketplace" | "none" | "plugin"
+  normalizedPayloadJson?: Record<string, unknown> | null
+  objectType: ConfigObjectType
+  owner: SeededMember
+  rawSourceText?: string | null
+  title: string
+  withVersion?: boolean
+}): Promise<SeededCapability> {
+  const now = new Date()
+  const marketplaceId = createDenTypeId("marketplace")
+  const pluginId = createDenTypeId("plugin")
+  const configObjectId = createDenTypeId("configObject")
+  const description = input.description ?? null
+  const rawSourceText = input.rawSourceText ?? null
+
+  await db.insert(MarketplaceTable).values({
+    id: marketplaceId,
+    organizationId: input.owner.organizationId,
+    name: "Team Marketplace",
+    description: "Curated marketplace for tests",
+    logoUrl: null,
+    status: "active",
+    createdByOrgMembershipId: input.owner.memberId,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+  })
+  await db.insert(PluginTable).values({
+    id: pluginId,
+    organizationId: input.owner.organizationId,
+    name: "Revenue Ops Plugin",
+    description: "Helps with revenue work",
+    status: "active",
+    createdByOrgMembershipId: input.owner.memberId,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+  })
+  await db.insert(ConfigObjectTable).values({
+    id: configObjectId,
+    organizationId: input.owner.organizationId,
+    objectType: input.objectType,
+    sourceMode: "cloud",
+    title: input.title,
+    description,
+    searchText: [input.title, description, rawSourceText].filter(Boolean).join("\n"),
+    currentFileName: `${input.title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}.md`,
+    currentFileExtension: ".md",
+    currentRelativePath: `${input.objectType}s/${input.title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}.md`,
+    status: "active",
+    createdByOrgMembershipId: input.owner.memberId,
+    connectorInstanceId: null,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+  })
+  await db.insert(MarketplacePluginTable).values({
+    id: createDenTypeId("marketplacePlugin"),
+    organizationId: input.owner.organizationId,
+    marketplaceId,
+    pluginId,
+    membershipSource: "manual",
+    createdByOrgMembershipId: input.owner.memberId,
+    createdAt: now,
+    removedAt: null,
+  })
+  await db.insert(PluginConfigObjectTable).values({
+    id: createDenTypeId("pluginConfigObject"),
+    organizationId: input.owner.organizationId,
+    pluginId,
+    configObjectId,
+    membershipSource: "manual",
+    connectorMappingId: null,
+    createdByOrgMembershipId: input.owner.memberId,
+    createdAt: now,
+    removedAt: null,
+  })
+  if (input.withVersion !== false) {
+    await db.insert(ConfigObjectVersionTable).values({
+      id: createDenTypeId("configObjectVersion"),
+      organizationId: input.owner.organizationId,
+      configObjectId,
+      normalizedPayloadJson: input.normalizedPayloadJson ?? null,
+      rawSourceText,
+      schemaVersion: null,
+      createdVia: "cloud",
+      createdByOrgMembershipId: input.owner.memberId,
+      connectorSyncEventId: null,
+      sourceRevisionRef: null,
+      isDeletedVersion: false,
+      createdAt: now,
+    })
+  }
+
+  const grant = input.grant ?? "marketplace"
+  if (grant === "marketplace") {
+    await db.insert(MarketplaceAccessGrantTable).values({
+      id: createDenTypeId("marketplaceAccessGrant"),
+      organizationId: input.owner.organizationId,
+      marketplaceId,
+      orgMembershipId: null,
+      teamId: null,
+      orgWide: true,
+      role: "viewer",
+      createdByOrgMembershipId: input.owner.memberId,
+      createdAt: now,
+      removedAt: null,
+    })
+  }
+  if (grant === "plugin") {
+    await db.insert(PluginAccessGrantTable).values({
+      id: createDenTypeId("pluginAccessGrant"),
+      organizationId: input.owner.organizationId,
+      pluginId,
+      orgMembershipId: null,
+      teamId: null,
+      orgWide: true,
+      role: "viewer",
+      createdByOrgMembershipId: input.owner.memberId,
+      createdAt: now,
+      removedAt: null,
+    })
+  }
+  if (grant === "config_object") {
+    await db.insert(ConfigObjectAccessGrantTable).values({
+      id: createDenTypeId("configObjectAccessGrant"),
+      organizationId: input.owner.organizationId,
+      configObjectId,
+      orgMembershipId: null,
+      teamId: null,
+      orgWide: true,
+      role: "viewer",
+      createdByOrgMembershipId: input.owner.memberId,
+      createdAt: now,
+      removedAt: null,
+    })
+  }
+
+  return {
+    configObjectId,
+    pluginId,
+    name: marketplaceCapabilities.buildMarketplaceCapabilityName(pluginId, configObjectId),
+  }
+}
+
+async function execute(owner: SeededMember, seeded: SeededCapability, body?: unknown) {
+  return marketplaceCapabilities.executeMarketplaceCapability({
+    organizationId: owner.organizationId,
+    member: owner.member,
+    pluginId: seeded.pluginId,
+    configObjectId: seeded.configObjectId,
+    body,
+    enabled: true,
+  })
+}
+
+describe("marketplace capabilities source", () => {
+  test("search finds a published plugin skill and execute returns provenance-framed raw content", async () => {
+    const owner = await seedMember()
+    const seeded = await seedCapability({
+      owner,
+      objectType: "skill",
+      title: "Renewal Playbook",
+      description: "Use for enterprise renewal strategy",
+      rawSourceText: "# Renewal Playbook\n\nAlways mention expansion risk.",
+    })
+
+    const matches = await marketplaceCapabilities.searchMarketplaceCapabilities({
+      organizationId: owner.organizationId,
+      member: owner.member,
+      query: "renewal expansion",
+      limit: 5,
+      enabled: true,
+    })
+    const match = matches.find((candidate) => candidate.name === seeded.name)
+    expect(match?.method).toBe("PLUGIN")
+    expect(match?.kind).toBe("skill")
+    expect(match?.plugin).toBe("Revenue Ops Plugin")
+    expect(match?.marketplace).toBe("Team Marketplace")
+    expect(match?.hasBody).toBe(false)
+
+    const result = await execute(owner, seeded)
+    if (!result.ok) throw new Error(result.message)
+    expect(result.result).toMatchObject({
+      kind: "skill",
+      plugin: "Revenue Ops Plugin",
+      marketplace: "Team Marketplace",
+      name: "Renewal Playbook",
+      content: "# Renewal Playbook\n\nAlways mention expansion risk.",
+      provenance: "Content from marketplace plugin Revenue Ops Plugin in your organization's library.",
+    })
+  })
+
+  test("command execute substitutes $ARGUMENTS without running anything server-side", async () => {
+    const owner = await seedMember()
+    const seeded = await seedCapability({
+      owner,
+      objectType: "command",
+      title: "Draft Follow-up",
+      rawSourceText: "Create the follow-up for $ARGUMENTS.",
+    })
+
+    const result = await execute(owner, seeded, { arguments: "Acme renewal" })
+    if (!result.ok) throw new Error(result.message)
+    expect(result.result.kind).toBe("command")
+    expect(result.result.content).toBe("Create the follow-up for Acme renewal.")
+  })
+
+  test("mcp objects return server specs and existing-connection or admin-install hints", async () => {
+    const owner = await seedMember()
+    const url = "https://mcp.example.test/remote"
+    const serverSpec = { mcpServers: { brief: { url } } }
+    const seeded = await seedCapability({
+      owner,
+      objectType: "mcp",
+      title: "Brief MCP",
+      rawSourceText: JSON.stringify(serverSpec),
+      normalizedPayloadJson: serverSpec,
+    })
+
+    const missingConnection = await execute(owner, seeded)
+    if (!missingConnection.ok) throw new Error(missingConnection.message)
+    expect(missingConnection.result.serverSpec).toEqual(serverSpec)
+    expect(missingConnection.result.status).toBe("needs_connection")
+    expect(missingConnection.result.hint).toContain("OpenWork Cloud -> Connections")
+
+    const connectionId = createDenTypeId("externalMcpConnection")
+    await db.insert(ExternalMcpConnectionTable).values({
+      id: connectionId,
+      organizationId: owner.organizationId,
+      name: "Brief Remote",
+      url,
+      authType: "none",
+      credentialMode: "shared",
+      createdByOrgMembershipId: owner.memberId,
+    })
+    await db.insert(ExternalMcpConnectionAccessGrantTable).values({
+      id: createDenTypeId("externalMcpConnectionAccessGrant"),
+      organizationId: owner.organizationId,
+      externalMcpConnectionId: connectionId,
+      orgMembershipId: null,
+      teamId: null,
+      orgWide: true,
+      createdByOrgMembershipId: owner.memberId,
+    })
+
+    const matchingConnection = await execute(owner, seeded)
+    if (!matchingConnection.ok) throw new Error(matchingConnection.message)
+    expect(matchingConnection.result.status).toBe("connection_available")
+    expect(matchingConnection.result.hint).toContain("Brief Remote")
+  })
+
+  test("tool and hook objects return honest local-only and unsupported statuses", async () => {
+    const owner = await seedMember()
+    const tool = await seedCapability({
+      owner,
+      objectType: "tool",
+      title: "Local CSV Tool",
+      rawSourceText: "export function run() { return 'csv' }",
+    })
+    const hook = await seedCapability({
+      owner,
+      objectType: "hook",
+      title: "Preflight Hook",
+      rawSourceText: "hooks:\n  before: echo nope",
+    })
+
+    const toolResult = await execute(owner, tool)
+    if (!toolResult.ok) throw new Error(toolResult.message)
+    expect(toolResult.result.status).toBe("needs_install")
+    expect(toolResult.result.source).toContain("csv")
+    expect(toolResult.result.hint).toContain("Revenue Ops Plugin")
+
+    const hookResult = await execute(owner, hook)
+    if (!hookResult.ok) throw new Error(hookResult.message)
+    expect(hookResult.result.status).toBe("unsupported")
+    expect(hookResult.result.definition).toContain("before")
+    expect(hookResult.result.hint).toContain("not supported")
+  })
+
+  test("execute reports content_not_synced when a config object has no latest version", async () => {
+    const owner = await seedMember()
+    const seeded = await seedCapability({
+      owner,
+      objectType: "skill",
+      title: "Unsynced Skill",
+      rawSourceText: null,
+      withVersion: false,
+    })
+
+    const result = await execute(owner, seeded)
+    if (!result.ok) throw new Error(result.message)
+    expect(result.result.status).toBe("content_not_synced")
+    expect(result.result.hint).toContain("has not synced content")
+  })
+
+  test("rollout gating hides marketplace search and makes execute unknown until mcpConnections is enabled", async () => {
+    const gatedOff = await seedMember()
+    const gatedOffCapability = await seedCapability({
+      owner: gatedOff,
+      objectType: "skill",
+      title: "Hidden Capability",
+      rawSourceText: "Do not expose while gated.",
+    })
+    const disabled = memberFacingMcpConnectionsEnabled(null, { gatingEnabled: true })
+    expect(disabled).toBe(false)
+    expect(await marketplaceCapabilities.searchMarketplaceCapabilities({
+      organizationId: gatedOff.organizationId,
+      member: gatedOff.member,
+      query: "hidden",
+      enabled: disabled,
+    })).toEqual([])
+    const gatedExecute = await marketplaceCapabilities.executeMarketplaceCapability({
+      organizationId: gatedOff.organizationId,
+      member: gatedOff.member,
+      pluginId: gatedOffCapability.pluginId,
+      configObjectId: gatedOffCapability.configObjectId,
+      enabled: disabled,
+    })
+    expect(gatedExecute.ok).toBe(false)
+    if (gatedExecute.ok) throw new Error("expected gated execute to fail")
+    expect(gatedExecute.error).toBe("unknown_capability")
+
+    const metadata = { capabilities: { mcpConnections: true } }
+    const gatedOn = await seedMember({ metadata })
+    const visibleCapability = await seedCapability({
+      owner: gatedOn,
+      objectType: "skill",
+      title: "Visible Capability",
+      rawSourceText: "Expose while gated on.",
+    })
+    const enabled = memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled: true })
+    expect(enabled).toBe(true)
+    const matches = await marketplaceCapabilities.searchMarketplaceCapabilities({
+      organizationId: gatedOn.organizationId,
+      member: gatedOn.member,
+      query: "visible",
+      enabled,
+    })
+    expect(matches.some((match) => match.name === visibleCapability.name)).toBe(true)
+  })
+
+  test("members cannot search or execute marketplace content from another organization", async () => {
+    const orgA = await seedMember()
+    const orgB = await seedMember()
+    const orgBCapability = await seedCapability({
+      owner: orgB,
+      objectType: "skill",
+      title: "Org B Secret",
+      rawSourceText: "Only org B should see this.",
+    })
+
+    const orgBMatches = await marketplaceCapabilities.searchMarketplaceCapabilities({
+      organizationId: orgB.organizationId,
+      member: orgB.member,
+      query: "secret",
+      enabled: true,
+    })
+    expect(orgBMatches.some((match) => match.name === orgBCapability.name)).toBe(true)
+
+    const orgAMatches = await marketplaceCapabilities.searchMarketplaceCapabilities({
+      organizationId: orgA.organizationId,
+      member: orgA.member,
+      query: "secret",
+      enabled: true,
+    })
+    expect(orgAMatches.some((match) => match.name === orgBCapability.name)).toBe(false)
+
+    const orgAExecute = await marketplaceCapabilities.executeMarketplaceCapability({
+      organizationId: orgA.organizationId,
+      member: orgA.member,
+      pluginId: orgBCapability.pluginId,
+      configObjectId: orgBCapability.configObjectId,
+      enabled: true,
+    })
+    expect(orgAExecute.ok).toBe(false)
+    if (orgAExecute.ok) throw new Error("expected cross-org execute to fail")
+    expect(orgAExecute.error).toBe("unknown_capability")
+  })
+
+  test("existing external-connection capabilities still surface their needs_connection pseudo-match", async () => {
+    const owner = await seedMember()
+    const connectionId = createDenTypeId("externalMcpConnection")
+    await db.insert(ExternalMcpConnectionTable).values({
+      id: connectionId,
+      organizationId: owner.organizationId,
+      name: "Calendar Bridge",
+      url: "https://calendar.example.test/mcp",
+      authType: "oauth",
+      credentialMode: "per_member",
+      createdByOrgMembershipId: owner.memberId,
+    })
+    await db.insert(ExternalMcpConnectionAccessGrantTable).values({
+      id: createDenTypeId("externalMcpConnectionAccessGrant"),
+      organizationId: owner.organizationId,
+      externalMcpConnectionId: connectionId,
+      orgMembershipId: null,
+      teamId: null,
+      orgWide: true,
+      createdByOrgMembershipId: owner.memberId,
+    })
+
+    const matches = await externalCapabilities.searchExternalCapabilities({
+      organizationId: owner.organizationId,
+      member: owner.member,
+      query: "calendar",
+      redirectUriBase: "http://127.0.0.1:8790",
+      limit: 5,
+    })
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.name).toBe(externalCapabilities.buildExternalCapabilityName(connectionId, "*"))
+    expect(matches[0]?.method).toBe("MCP")
+    expect(matches[0]?.status).toBe("needs_connection")
+  })
+})


### PR DESCRIPTION
## What

PR 3 of the Connect rollout, implementing `docs/marketplace-capabilities-architecture.md` (design note committed in this PR): every plugin published to an org marketplace becomes discoverable via `search_capabilities` and reachable via `execute_capability` on the existing `openwork-cloud` rail — the same pattern as External MCP Connections. **The tool surface does not grow** (still exactly two tools).

- New `mcp/marketplace-capabilities.ts` — fourth capability source: DB-only, indexed rows, no live tools/list, member-scoped through the real plugin/marketplace access-grant system.
- Wire naming: `plugin:<pluginId>:<configObjectId>`; matches carry `kind`, `plugin`, `marketplace`, `status`, `hint`.
- Execution semantics by objectType (per design note §3): `skill|context|custom|agent` → instructional payload (latest version rawSourceText + provenance framing) · `command` → `$ARGUMENTS` substitution · `mcp` → declared server spec + status/hint (NO auto-provisioning; hints to an existing matching External MCP Connection when present) · `tool` → `needs_install` · `hook` → unsupported hint · missing content → `content_not_synced`.
- **Gating inherited**: marketplace capabilities ride the same `memberFacingMcpConnectionsEnabled` gate as external connections (org capability `mcpConnections` / `connectEnabled` aliases, deployment env `DEN_MCP_CONNECTIONS_GATING_ENABLED`). Gated-off orgs: absent from search, `unknown_capability` on execute — byte-identical to nothing-published.

## Tests (commands + results)

DB-backed contract tests (own database `openwork_test_pr3`), all following the existing suite harness:

- `bun test test/marketplace-capabilities.test.ts` → **8 pass / 0 fail**: skill search+execute w/ provenance · command $ARGUMENTS · mcp spec+hint (both hint variants) · tool needs_install + hook unsupported · content_not_synced · gating on/off · cross-org isolation · external-connection regression guard.
- Full den-api suite: failure set **byte-identical to origin/dev baseline** (sorted-name diff, exit 0) — the known pre-existing in-suite classes only (route-guard-policy; memory-*/desktop-config 401 auth-pollution class, all pass isolated). No growth.
- `pnpm --filter @openwork-ee/den-api build` + `tsc --noEmit` → pass.
- Note: CI does not run the den-api suite; the above is the local gate (same method as #2524).

## Proof note

fraimz: N/A — server-only rail extension behind the org gate; no app surface changes (the desktop's existing `/mcp/agent` bridge picks these up automatically once an org is opted in). Desktop-visible delivery switching lands in PR 4 with its own fraimz.