### PR TITLE
feat(den-web): render LaTeX math in user message bubbles

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -669,11 +669,11 @@ const UserMessage = React.memo(
   ({ message, isStreaming }: UserMessageProps) => {
     const { onRevertToUserMessage, onForkAtMessage, onEditUserMessage, highlightQuery } = useMessageList()
     const messageText = React.useMemo(() => getMessagesText([message]), [message])
-    const inlineParts = React.useMemo(
-      () => message.parts.filter((part) => (part.type === "text" && Boolean(part.text)) || isFileUIPart(part)),
+    const userText = React.useMemo(
+      () => message.parts.map((part) => (part.type === "text" ? part.text : "")).join(""),
       [message.parts],
     )
-    const hasContent = inlineParts.length > 0
+    const hasSkillChips = USER_SKILL_TOKEN_RE.test(userText)
 
     return (
       <Message
@@ -690,32 +690,30 @@ const UserMessage = React.memo(
                 className="group flex w-full flex-col items-end gap-1 !select-text"
                 style={{ userSelect: "text" }}
               >
-                {hasContent ? (
-                  <MessageContent
-                    className="bg-muted text-foreground max-w-[85%] rounded-3xl px-4 py-2.5 leading-6 sm:max-w-[75%] !select-text not-prose"
-                    style={{ userSelect: "text" }}
-                  >
-                    {inlineParts.map((part, index) => {
-                      if (part.type === "text") {
-                        return (
-                          <span key={`text-${index}`} className="whitespace-pre-wrap">
-                            {renderUserTextWithSkillChips(part.text, highlightQuery)}
-                          </span>
-                        )
-                      }
-                      if (isFileUIPart(part)) {
-                        return (
-                          <span
-                            key={`file-${part.url}-${index}`}
-                            className="mx-1 inline-flex align-middle not-prose"
-                          >
-                            <FileMessage part={part} tone="user" />
-                          </span>
-                        )
-                      }
-                      return null
-                    })}
-                  </MessageContent>
+                {message.parts.filter(isFileUIPart).map((part, index) => (
+                  <FileMessage key={`${part.url}-${index}`} part={part} tone="user" />
+                ))}
+                {message.parts.some((part) => part.type === "text" && part.text) ? (
+                  // NOTE: when skill chips are present we fall back to plain-text rendering.
+                  // LaTeX won't render in that path. Known tradeoff — chips + math in the same
+                  // message is rare today, but worth revisiting if math skills are introduced.
+                  hasSkillChips ? (
+                    <MessageContent
+                      className="bg-muted text-foreground max-w-[85%] rounded-3xl px-4 py-2.5 leading-6 whitespace-pre-wrap sm:max-w-[75%] !select-text not-prose"
+                      style={{ userSelect: "text" }}
+                    >
+                      {renderUserTextWithSkillChips(userText, highlightQuery)}
+                    </MessageContent>
+                  ) : (
+                    <MessageContent
+                      className="bg-muted text-foreground max-w-[85%] rounded-3xl px-4 py-2.5 leading-6 whitespace-pre-wrap sm:max-w-[75%] !select-text not-prose"
+                      style={{ userSelect: "text" }}
+                      mathOnly
+                      highlightQuery={highlightQuery}
+                    >
+                      {userText}
+                    </MessageContent>
+                  )
                 ) : null}
                 {!isStreaming && (
                   <MessageActions

--- a/apps/app/src/components/markdown/markdown-primitive.ts
+++ b/apps/app/src/components/markdown/markdown-primitive.ts
@@ -1,5 +1,7 @@
 import DOMPurify from "dompurify";
 import emojiKeywords from "emojilib";
+import katex from "katex";
+import "katex/dist/katex.min.css";
 import { Marked, type MarkedExtension, type Token, type Tokens } from "marked";
 import { markedEmoji } from "marked-emoji";
 import {
@@ -535,4 +537,37 @@ export async function renderHighlightedMarkdownHtml(text: string, presentation: 
   const { highlightedMarkdownParser } = parsersForPresentation(presentation);
   const html = await highlightedMarkdownParser.parse(text, { async: true });
   return sanitizeMarkdownHtml(html);
+}
+
+const USER_MATH_RE = /\$\$([\s\S]+?)\$\$|\$(?![\d\s])([^$\n]+?)\$(?!\d)/g;
+
+export function renderUserMathHtml(text: string): string {
+  if (!text.trim()) {
+    return "";
+  }
+
+  const parts: string[] = [];
+  let last = 0;
+  let match: RegExpExecArray | null;
+  const re = new RegExp(USER_MATH_RE.source, "g");
+
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > last) {
+      parts.push(escapeHtml(text.slice(last, match.index)));
+    }
+    const isDisplay = match[1] !== undefined;
+    const mathContent = (isDisplay ? match[1] : match[2])!.trim();
+    try {
+      parts.push(katex.renderToString(mathContent, { displayMode: isDisplay, throwOnError: false }));
+    } catch {
+      parts.push(escapeHtml(match[0]));
+    }
+    last = re.lastIndex;
+  }
+
+  if (last < text.length) {
+    parts.push(escapeHtml(text.slice(last)));
+  }
+
+  return sanitizeMarkdownHtml(parts.join(""));
 }

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -16,6 +16,7 @@ import {
   hasFencedCodeBlock,
   renderHighlightedMarkdownHtml,
   renderMarkdownHtml,
+  renderUserMathHtml,
   setCodeCopyButtonState,
   setCodeWrapButtonState,
   syncMarkdownImagePreviews,
@@ -90,6 +91,7 @@ type MarkdownBlockInnerProps = {
   text: string;
   streaming?: boolean;
   highlightQuery?: string;
+  mathOnly?: boolean;
 } & Omit<
   React.ComponentProps<"div">,
   "ref" | "className" | "children" | "dangerouslySetInnerHTML"
@@ -100,6 +102,7 @@ function MarkdownBlockInner({
   text,
   streaming,
   highlightQuery,
+  mathOnly,
   ...props
 }: MarkdownBlockInnerProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -110,8 +113,11 @@ function MarkdownBlockInner({
   const [linkMenu, setLinkMenu] = useState<{ target: OpenTarget; rect: DOMRect } | null>(null);
   const [imagePreview, setImagePreview] = useState<{ src: string; alt: string } | null>(null);
   const syncHtml = useMemo(() => {
+    if (mathOnly) {
+      return renderUserMathHtml(text);
+    }
     return renderMarkdownHtml(text);
-  }, [text]);
+  }, [text, mathOnly]);
   const [highlightedHtml, setHighlightedHtml] = useState<{ text: string; html: string } | null>(null);
 
   const handleCodeBlockCopy = useCallback(async (button: HTMLButtonElement, code: string) => {
@@ -163,7 +169,8 @@ function MarkdownBlockInner({
   }, []);
 
   useEffect(() => {
-    if (streaming || !hasFencedCodeBlock(text)) {
+    // mathOnly renderer has no async shiki step — skip entirely.
+    if (mathOnly || streaming || !hasFencedCodeBlock(text)) {
       setHighlightedHtml(null);
       return;
     }
@@ -181,7 +188,7 @@ function MarkdownBlockInner({
     return () => {
       cancelled = true;
     };
-  }, [streaming, text]);
+  }, [streaming, text, mathOnly]);
 
   const candidateHtml = !streaming && highlightedHtml?.text === text ? highlightedHtml.html : syncHtml;
   const html = useSelectionStableValue(rootRef, candidateHtml);

--- a/apps/app/src/components/ui/message.tsx
+++ b/apps/app/src/components/ui/message.tsx
@@ -52,6 +52,7 @@ export type MessageContentProps = {
   isStreaming?: boolean
   highlightQuery?: string
   className?: string
+  mathOnly?: boolean
 } & React.ComponentProps<"div">
 
 const MessageContent = ({
@@ -60,15 +61,17 @@ const MessageContent = ({
   className,
   isStreaming,
   highlightQuery,
+  mathOnly,
   ...props
 }: MessageContentProps) => {
-  if (markdown) {
+  if (markdown || mathOnly) {
     return (
       <MarkdownBlock
         className={cn(messageContentClassName, className)}
         text={children as string}
         streaming={isStreaming}
         highlightQuery={highlightQuery}
+        mathOnly={mathOnly}
         {...props}
       />
     )


### PR DESCRIPTION
## Summary
- Replace the full markdown-parser approach with a dedicated math-only renderer for user message bubbles.
- Renderer handles $$...$$ display math and $...$ inline math. Inline $ requires the next character to be non-digit and non-whitespace; closer $ must not be followed by a digit — prevents "$5 and $10" pairing as a math span.
- Plain text is HTML-escaped verbatim with whitespace-pre-wrap, so formatting characters (#, *, _, >) are shown literally — no markdown surprises.
- Output runs through the same sanitizeMarkdownHtml DOMPurify config as assistant messages.
- Falls back to plain-text + skill-chip renderer when skill tokens are present.


## Why
KaTeX was already wired for assistant messages but user messages bypassed the markdown renderer entirely, causing LaTeX to appear as raw `$$...$$` text in user bubbles.

## Issue
Closes #2501

## Scope
- apps/app/src/components/markdown/markdown.tsx — renderUserMath function + mathOnly prop on MarkdownBlock
- apps/app/src/components/ui/message.tsx — propagate mathOnly through MessageContent
- apps/app/src/components/chat/message-list.tsx — use mathOnly for user bubbles


## Out of scope
Segment-based rendering to support LaTeX inside skill-chip messages.

## Testing
### Ran
- `pnpm typecheck` — pass

### Manual
1. Send `What is $E = mc^2$?` — inline math renders in user bubble ✓
2. Send `$$\int_0^\infty e^{-x^2}dx = \frac{\sqrt{\pi}}{2}$$` — display math renders ✓
3. Send `$$\begin{cases} x+y=1 \\ x-y=0 \end{cases}$$` — multi-line environment renders ✓ (this was the known failure case in the DevTools workaround from the issue)
4. Send plain multi-line text — line breaks preserved ✓
5. Ask assistant to show LaTeX — assistant rendering unaffected ✓

## Evidence
<img width="302" height="157" alt="Screenshot 2026-07-07 at 12 29 33 PM" src="https://github.com/user-attachments/assets/8bdb7e9b-fb95-4b3a-9437-27a99e9d14a7" />
<img width="234" height="158" alt="Screenshot 2026-07-07 at 12 30 56 PM" src="https://github.com/user-attachments/assets/60cbb317-0337-4569-b73f-9085f0814e8f" />

<img width="212" height="182" alt="Screenshot 2026-07-07 at 12 31 05 PM" src="https://github.com/user-attachments/assets/1a3eaee5-d2d2-458b-9491-59c23d554ac4" />
<img width="267" height="101" alt="Screenshot 2026-07-08 at 10 45 04 PM" src="https://github.com/user-attachments/assets/7f8d116a-9916-4aa6-b003-1ecff9f85607" />

<img width="195" height="59" alt="Screenshot 2026-07-08 at 10 46 56 PM" src="https://github.com/user-attachments/assets/d20b6bde-fa35-4755-8fbb-abdf179eb437" />
<img width="161" height="70" alt="Screenshot 2026-07-08 at 10 47 02 PM" src="https://github.com/user-attachments/assets/6fff67bf-519c-4975-8cc0-dd775ec61c70" />
