### PR TITLE
feat(den-web): Connect (beta) admin plane — backoffice relabel, staging banner, agent discovery (Connect rollout PR 5/5)

### DIFF
--- a/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
@@ -15,6 +15,8 @@ type OpenApiDocument = {
 let isMcpOperationAllowed: typeof import("../src/mcp/policy.js")["isMcpOperationAllowed"]
 let isAgentApiKeyConnection: typeof import("../src/routes/org/mcp-connections.js")["isAgentApiKeyConnection"]
 let isAgentOAuthClientConnection: typeof import("../src/routes/org/mcp-connections.js")["isAgentOAuthClientConnection"]
+let buildMcpCatalog: typeof import("../src/mcp/catalog.js")["buildMcpCatalog"]
+let searchCapabilities: typeof import("../src/mcp/search.js")["searchCapabilities"]
 let document: OpenApiDocument
 
 function findOperation(operationId: string) {
@@ -36,6 +38,8 @@ function allowed(operationId: string) {
 beforeAll(async () => {
   seedRequiredEnv()
   isMcpOperationAllowed = (await import("../src/mcp/policy.js")).isMcpOperationAllowed
+  buildMcpCatalog = (await import("../src/mcp/catalog.js")).buildMcpCatalog
+  searchCapabilities = (await import("../src/mcp/search.js")).searchCapabilities
   const mcpConnections = await import("../src/routes/org/mcp-connections.js")
   isAgentApiKeyConnection = mcpConnections.isAgentApiKeyConnection
   isAgentOAuthClientConnection = mcpConnections.isAgentOAuthClientConnection
@@ -62,6 +66,24 @@ describe("agent-configurable org connections policy", () => {
   test("discovery surfaces the agent needs are readable", () => {
     expect(allowed("getV1McpConnections")).toBe(true)
     expect(allowed("getV1McpConnectionsPresets")).toBe(true)
+  })
+
+  test("agent catalog search discovers member list and admin create mcp-connection operations", () => {
+    const catalog = buildMcpCatalog(document)
+    const memberMatches = searchCapabilities(catalog, "list external mcp connections", 10)
+    const adminMatches = searchCapabilities(catalog, "register external mcp connection", 10)
+
+    expect(memberMatches).toContainEqual(expect.objectContaining({
+      name: "getMcpConnections",
+      method: "GET",
+      path: "/v1/mcp-connections",
+    }))
+    expect(adminMatches).toContainEqual(expect.objectContaining({
+      name: "postMcpConnections",
+      method: "POST",
+      path: "/v1/mcp-connections",
+      hasBody: true,
+    }))
   })
 
   test("API-key connections are blocked only for the internal agent principal", () => {

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/page.tsx
@@ -1,10 +1,5 @@
-import { McpConnectionsCapabilityGuard } from "../../_components/mcp-connections-capability-guard";
 import { McpConnectionsScreen } from "../../_components/mcp-connections-screen";
 
 export default function McpConnectionsPage() {
-  return (
-    <McpConnectionsCapabilityGuard>
-      <McpConnectionsScreen />
-    </McpConnectionsCapabilityGuard>
-  );
+  return <McpConnectionsScreen />;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-capability.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-capability.ts
@@ -1,0 +1,7 @@
+export type McpConnectionsCapabilityState = {
+  mcpConnections: boolean;
+};
+
+export function shouldShowMcpConnectionsStagingBanner(capabilities: McpConnectionsCapabilityState) {
+  return !capabilities.mcpConnections;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -6,6 +6,7 @@ import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { IntegrationIcon } from "./integration-icon";
+import { shouldShowMcpConnectionsStagingBanner } from "./mcp-connections-capability";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
   type CreatedMcpConnection,
@@ -28,6 +29,7 @@ const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
 
 export function McpConnectionsScreen() {
+  const { orgContext } = useOrgDashboard();
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections();
   const { data: usableConnections = [] } = useMcpConnections("usable");
   const { data: presets = [] } = useMcpConnectionPresets();
@@ -40,6 +42,7 @@ export function McpConnectionsScreen() {
   const [formPreset, setFormPreset] = useState<ExternalMcpPreset | null>(null);
   const [googleDialogOpen, setGoogleDialogOpen] = useState(false);
   const googleConfigured = usableConnections.some((connection) => connection.id === "google-workspace");
+  const showStagingBanner = orgContext ? shouldShowMcpConnectionsStagingBanner(orgContext.capabilities) : false;
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -105,6 +108,15 @@ export function McpConnectionsScreen() {
       description="Connect any MCP server — Notion, Linear, Stripe, or a custom URL — once for the whole org. search_capabilities and execute_capability pick these up automatically."
       colors={["#E2E8F0", "#020617", "#0F172A", "#94A3B8"]}
     >
+      {showStagingBanner ? (
+        <div data-testid="mcp-connections-staging-banner" className="mb-6 rounded-[24px] border border-amber-200 bg-amber-50 px-5 py-4 text-[14px] leading-6 text-amber-800">
+          <p className="font-semibold text-amber-900">OpenWork Connect (beta) is staged for this org.</p>
+          <p className="mt-1">
+            Connections and marketplace capabilities you set up here stay staged and invisible to members until a platform admin enables OpenWork Connect (beta) for this org. Admin management remains fully usable.
+          </p>
+        </div>
+      ) : null}
+
       {error ? (
         <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">
           {error instanceof Error ? error.message : "Failed to load MCP connections."}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -235,7 +235,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   // Top-level rows: Dashboard, optional Your Connections, Extensions, Models,
   // Members, Analytics, Settings. Everything tool-shaped groups under
   // Extensions (in pipeline order: Sources feed Plugins, share via
-  // Marketplaces, optional beta Connections last); model config groups under
+  // Marketplaces, beta Connections last); model config groups under
   // Models; set-once governance groups under Settings.
   const extensionsGroup: DashboardNavItem | null = access.isAdmin && activeOrg
     ? {
@@ -246,7 +246,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
           { href: getIntegrationsRoute(activeOrg.slug), label: "Sources" },
           { href: getPluginsRoute(activeOrg.slug), label: "Plugins" },
           { href: getMarketplacesRoute(activeOrg.slug), label: "Marketplaces" },
-          ...(mcpConnectionsEnabled ? [{ href: getMcpConnectionsRoute(activeOrg.slug), label: "Connections", badge: "Beta" }] : []),
+          { href: getMcpConnectionsRoute(activeOrg.slug), label: "Connections", badge: "Beta" },
         ],
       }
     : null;

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -1735,7 +1735,7 @@ export function DenAdminPanel() {
                           }}
                           className="h-4 w-4 rounded border-slate-300"
                         />
-                        MCP connections
+                        OpenWork Connect (beta)
                       </label>
                     </div>
                     {capabilityError?.orgId === org.id ? (
@@ -1744,7 +1744,7 @@ export function DenAdminPanel() {
                       </p>
                     ) : null}
                     <p className="mt-1 text-xs text-slate-400">Off by default. Lets workspace admins mint desktop install links for this organization.</p>
-                    <p className="mt-1 text-xs text-slate-400">Off by default. Lets members discover and use organization MCP connections.</p>
+                    <p className="mt-1 text-xs text-slate-400">Off by default. Enables member-facing org connections, marketplace capabilities on the agent rail, and the desktop Connect tab.</p>
                   </div>
 
                   <div className="mt-4 grid gap-3 border-t border-slate-200 pt-4 lg:grid-cols-[12rem_10rem_auto] lg:items-end">

--- a/ee/apps/den-web/tests/mcp-connections-capability.test.ts
+++ b/ee/apps/den-web/tests/mcp-connections-capability.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldShowMcpConnectionsStagingBanner } from "../app/(den)/dashboard/_components/mcp-connections-capability";
+
+describe("shouldShowMcpConnectionsStagingBanner", () => {
+  test("shows the staging banner when OpenWork Connect is disabled", () => {
+    expect(shouldShowMcpConnectionsStagingBanner({ mcpConnections: false })).toBe(true);
+  });
+
+  test("hides the staging banner when OpenWork Connect is enabled", () => {
+    expect(shouldShowMcpConnectionsStagingBanner({ mcpConnections: true })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

PR 5 (final) of the Connect rollout: the admin plane catches up with what the one org capability now controls.

- **Backoffice relabel** (`den-admin-panel.tsx`): the `mcpConnections` capability toggle presents as **"OpenWork Connect (beta)"** with a description covering all three effects (member-facing org connections · marketplace capabilities on the agent rail · the desktop Connect tab). Key unchanged — no data migration.
- **Staging-first connections dashboard**: the admin `Connections` page no longer redirect-guards on the capability; org admins can stage connections while dark (exactly the staging model den-api's gate was designed for). A non-blocking amber banner explains that staged content stays invisible to members until a platform admin enables Connect (beta). Member-facing "Your Connections" keeps its capability guard.
- Admin nav shows `Connections (Beta)` unconditionally for admins (staging entry point).
- **Agent control-plane discovery verified in code**: new den-api test proves the org mcp-connections list/create operations are discoverable through `search_capabilities` on `/mcp/agent` — the "manage Connect through the agent" story holds with **zero policy changes** (they were already exposed via the Capability Sources policy). Destructive/OAuth plumbing stays excluded as before.

## Tests (commands + results)

- den-api: `bun test test/mcp-agent-config-policy.test.ts` (own DB `openwork_test_pr5`) → **6 pass / 0 fail** (includes the new discovery contracts for `getMcpConnections` / `postMcpConnections`)
- den-web: `bun test tests/mcp-connections-capability.test.ts` → **2 pass** (banner condition helper)
- `tsc --noEmit` for den-web and den-api → pass

## Proof note (honest)

fraimz: not produced — the harness drives the Electron desktop app, not den-web pages, and standing up the den-web proxy topology locally exceeded the time-box. UI changes here are a label, a banner (helper unit-tested + `data-testid="mcp-connections-staging-banner"`), and a nav row. Reviewer repro: run the den web-local stack, open `/admin` (platform admin) → capability shows "OpenWork Connect (beta)"; open an org's Extensions → Connections with the capability off → amber staging banner above the (fully usable) management screen.