### PR TITLE
fix(cloud): stop the provider-sync engine dispose/create loop (active workspace reload churn)

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.test.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.test.ts
@@ -1,0 +1,83 @@
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => { toBe: (expected: unknown) => void };
+
+import type {
+  DenOrgLlmProvider,
+  DenOrgLlmProviderModel,
+} from "../../../../app/lib/den";
+import type { CloudImportedProvider } from "../../../../app/cloud/import-state";
+import {
+  getCloudManagedProviderId,
+  getProviderModelIds,
+  isCloudProviderOutOfSync,
+} from "./cloud-provider-config";
+
+const UPDATED_AT = "2024-02-01T00:00:00.000Z";
+
+const makeModel = (id: string): DenOrgLlmProviderModel => ({
+  id,
+  name: id,
+  config: {},
+  createdAt: null,
+});
+
+const makeProvider = (
+  models: DenOrgLlmProviderModel[],
+  updatedAt = UPDATED_AT,
+): DenOrgLlmProvider => ({
+  id: "lpr_openrouter",
+  source: "custom",
+  providerId: "openrouter",
+  name: "OpenRouter",
+  providerConfig: {},
+  hasApiKey: true,
+  models,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt,
+});
+
+const importedFrom = (provider: DenOrgLlmProvider): CloudImportedProvider => ({
+  cloudProviderId: provider.id,
+  providerId: getCloudManagedProviderId(provider),
+  sourceProviderId: provider.providerId,
+  name: provider.name,
+  source: provider.source,
+  updatedAt: provider.updatedAt,
+  modelIds: getProviderModelIds(provider),
+  importedAt: 1,
+});
+
+describe("isCloudProviderOutOfSync", () => {
+  test("returns false for an in-sync provider", () => {
+    const provider = makeProvider([makeModel("model-a"), makeModel("model-b")]);
+    expect(isCloudProviderOutOfSync(provider, importedFrom(provider))).toBe(false);
+  });
+
+  test("ignores whitespace and empty live model ids", () => {
+    const baselineProvider = makeProvider([makeModel("model-a")]);
+    const liveProvider = makeProvider([
+      makeModel("model-a "),
+      makeModel("   "),
+    ]);
+
+    expect(isCloudProviderOutOfSync(liveProvider, importedFrom(baselineProvider))).toBe(false);
+  });
+
+  test("returns true for a changed model list", () => {
+    const baselineProvider = makeProvider([makeModel("model-a")]);
+    const liveProvider = makeProvider([makeModel("model-a"), makeModel("model-b")]);
+
+    expect(isCloudProviderOutOfSync(liveProvider, importedFrom(baselineProvider))).toBe(true);
+  });
+
+  test("returns true for a changed updatedAt", () => {
+    const baselineProvider = makeProvider([makeModel("model-a")]);
+    const liveProvider = makeProvider(
+      [makeModel("model-a")],
+      "2024-03-01T00:00:00.000Z",
+    );
+
+    expect(isCloudProviderOutOfSync(liveProvider, importedFrom(baselineProvider))).toBe(true);
+  });
+});

--- a/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
@@ -21,8 +21,6 @@ const getStringList = (value: unknown): string[] =>
       )
     : [];
 
-const sortStrings = (values: string[]) => values.toSorted();
-
 const sameStringList = (a: string[], b: string[]) =>
   a.length === b.length && a.every((value, index) => value === b[index]);
 
@@ -103,7 +101,9 @@ export const isCloudProviderOutOfSync = (
   (importedProvider.updatedAt ?? null) !== (provider.updatedAt ?? null) ||
   !sameStringList(
     importedProvider.modelIds,
-    sortStrings(provider.models.map((model) => model.id)),
+    // Normalize both sides: raw Den ids can include whitespace/empty values,
+    // which otherwise made providers permanently out-of-sync.
+    getProviderModelIds(provider),
   );
 
 export const buildCloudProviderConfig = (

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -389,7 +389,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     return false;
   };
 
-  const refreshImportedCloudProviders = async () => {
+  const refreshImportedCloudProviders = async (refreshOptions?: { strict?: boolean }) => {
     try {
       const config = await readWorkspaceOpenworkConfigRecord();
       const cloudImports = readWorkspaceCloudImports(config);
@@ -403,7 +403,10 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         setStateField("importedCloudProviders", next);
       }
       return next;
-    } catch {
+    } catch (error) {
+      if (refreshOptions?.strict) {
+        throw error;
+      }
       // Preserve existing state on read failure to avoid losing import state.
       return state.importedCloudProviders;
     }
@@ -1523,10 +1526,14 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       return;
     }
 
-    const [importedProviders, liveProviders] = await Promise.all([
-      refreshImportedCloudProviders(),
-      refreshCloudOrgProviders({ force: true }),
-    ]);
+    let importedProviders: Record<string, CloudImportedProvider>;
+    try {
+      importedProviders = await refreshImportedCloudProviders({ strict: true });
+    } catch (error) {
+      logCloudProviderSyncError(reason, error);
+      return;
+    }
+    const liveProviders = await refreshCloudOrgProviders({ force: true });
     const liveProviderMap = new Map(liveProviders.map((provider) => [provider.id, provider]));
     const failures: string[] = [];
     const processedLiveProviderIds = new Set<string>();

--- a/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
@@ -54,6 +54,7 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
   } = input;
   const checkDesktopRestriction = useCheckDesktopRestriction();
   const reloadCoordinator = useReloadCoordinator();
+  const { markReloadRequired } = reloadCoordinator;
   const onboardingProviderAuthPendingRef = useRef(false);
 
   const stateRef = useRef({
@@ -77,6 +78,10 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
     selectedWorkspaceRoot,
   };
 
+  // Depend on the stable callback, not the coordinator object: the context
+  // value identity changes on every reload flip, and recreating this store
+  // triggers a spurious cloud provider sync pass that amplified the
+  // dispose/create loop.
   const store = useMemo(
     () =>
       createProviderAuthStore({
@@ -111,14 +116,14 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
         setProviderConnectedIds,
         setDisabledProviders: setDisabledProviderIds,
         markOpencodeConfigReloadRequired: () => {
-          reloadCoordinator.markReloadRequired("config", {
+          markReloadRequired("config", {
             type: "config",
             name: "opencode.json",
             action: "updated",
           });
         },
       }),
-    [checkDesktopRestriction, reloadCoordinator],
+    [checkDesktopRestriction, markReloadRequired],
   );
 
   useEffect(() => {

--- a/apps/server/src/desktop-cloud-sync-preserves-imports.e2e.test.ts
+++ b/apps/server/src/desktop-cloud-sync-preserves-imports.e2e.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) {
+    const root = roots.pop();
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function expectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`Expected ${label}`);
+  return value;
+}
+
+function auth(token: string) {
+  return { authorization: `Bearer ${token}`, "content-type": "application/json" };
+}
+
+async function createWorkspaceRoot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-desktop-cloud-sync-"));
+  roots.push(root);
+  return root;
+}
+
+async function startOpenworkServer(workspaceRoot: string) {
+  const config = {
+    host: "127.0.0.1",
+    port: 0,
+    configPath: join(workspaceRoot, "server.json"),
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  } satisfies ServerConfig;
+  const server = await startServer(config);
+  stops.push(() => server.stop());
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+}
+
+describe("desktop cloud sync provider imports", () => {
+  test("preserves workspace provider import baseline while recording sync state", async () => {
+    const root = await createWorkspaceRoot();
+    const { base, token } = await startOpenworkServer(root);
+    const providerImport = {
+      cloudProviderId: "lpr_test",
+      providerId: "ow_lpr_test",
+      sourceProviderId: "openai",
+      name: "Test Provider",
+      source: "org",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+      modelIds: ["model-a"],
+      importedAt: 1780442400000,
+    };
+
+    const patchResponse = await fetch(`${base}/workspace/ws_1/config`, {
+      method: "PATCH",
+      headers: auth(token),
+      body: JSON.stringify({
+        openwork: {
+          cloudImports: {
+            providers: { lpr_test: providerImport },
+          },
+        },
+      }),
+    });
+    expect(patchResponse.status).toBe(200);
+
+    const syncResponse = await fetch(`${base}/workspace/ws_1/desktop-cloud-sync`, {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({
+        snapshot: {
+          organizationId: "org_1",
+          orgMemberId: "member_1",
+          teamIds: ["team_1"],
+          resources: {
+            llmProviders: { lpr_test: "2026-06-02T00:00:00.000Z" },
+            marketplaces: {},
+          },
+        },
+      }),
+    });
+    expect(syncResponse.status).toBe(200);
+    const syncBody = expectRecord(await syncResponse.json(), "desktop cloud sync response");
+    const responseState = expectRecord(syncBody.state, "desktop cloud sync response state");
+    expect(Object.keys(expectRecord(responseState.entries, "desktop cloud sync response entries"))).toContain(
+      "org_1::member_1",
+    );
+
+    const configResponse = await fetch(`${base}/workspace/ws_1/config`, { headers: auth(token) });
+    expect(configResponse.status).toBe(200);
+    const configBody = expectRecord(await configResponse.json(), "workspace config response");
+    const openwork = expectRecord(configBody.openwork, "workspace openwork config");
+    const cloudImports = expectRecord(openwork.cloudImports, "workspace cloud imports");
+    const providers = expectRecord(cloudImports.providers, "workspace imported providers");
+    const preservedProvider = expectRecord(providers.lpr_test, "preserved provider import baseline");
+    expect(preservedProvider).toEqual(providerImport);
+
+    const stateResponse = await fetch(`${base}/workspace/ws_1/desktop-cloud-sync`, { headers: auth(token) });
+    expect(stateResponse.status).toBe(200);
+    const stateBody = expectRecord(await stateResponse.json(), "desktop cloud sync state");
+    const entries = expectRecord(stateBody.entries, "desktop cloud sync entries");
+    const entry = expectRecord(entries["org_1::member_1"], "recorded desktop cloud sync entry");
+    expect(entry.organizationId).toBe("org_1");
+    expect(entry.orgMemberId).toBe("member_1");
+    expect(Array.isArray(entry.pendingChanges) ? entry.pendingChanges : []).toHaveLength(1);
+  });
+});

--- a/apps/server/src/desktop-cloud-sync.ts
+++ b/apps/server/src/desktop-cloud-sync.ts
@@ -237,7 +237,7 @@ function readImportedPlugins(value: unknown): Record<string, CloudImportedPlugin
   return plugins;
 }
 
-function readWorkspaceCloudImports(openwork: Record<string, unknown>): WorkspaceCloudImports {
+export function readWorkspaceCloudImports(openwork: Record<string, unknown>): WorkspaceCloudImports {
   const cloudImports = isRecord(openwork.cloudImports) ? openwork.cloudImports : {};
   return {
     providers: readImportedProviders(cloudImports.providers),

--- a/apps/server/src/runtime-config-patch-reload.e2e.test.ts
+++ b/apps/server/src/runtime-config-patch-reload.e2e.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ReloadEvent, ServerConfig } from "./types.js";
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) {
+    const root = roots.pop();
+    if (root) {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isReloadEvent(value: unknown): value is ReloadEvent {
+  return isRecord(value) && typeof value.reason === "string";
+}
+
+function auth(token: string) {
+  return { authorization: `Bearer ${token}`, "content-type": "application/json" };
+}
+
+async function createWorkspaceRoot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-runtime-patch-reload-"));
+  roots.push(root);
+  return root;
+}
+
+async function startOpenworkServer(workspaceRoot: string) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    configPath: join(workspaceRoot, "server.json"),
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config);
+  stops.push(() => server.stop());
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+}
+
+async function patchConfig(base: string, token: string, payload: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${base}/workspace/ws_1/config`, {
+    method: "PATCH",
+    headers: auth(token),
+    body: JSON.stringify(payload),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function readEvents(base: string, token: string): Promise<ReloadEvent[]> {
+  const response = await fetch(`${base}/workspace/ws_1/events`, { headers: auth(token) });
+  expect(response.status).toBe(200);
+  const body: unknown = await response.json();
+  if (!isRecord(body) || !Array.isArray(body.items)) {
+    throw new Error("Expected reload event response");
+  }
+  return body.items.filter(isReloadEvent);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("workspace config patch reload events", () => {
+  test("identical runtime provider patches do not emit another config reload event", async () => {
+    const root = await createWorkspaceRoot();
+    const { base, token } = await startOpenworkServer(root);
+    const payload = {
+      opencode: {
+        provider: {
+          p1: {
+            id: "openrouter",
+            name: "OpenRouter",
+            env: ["OPENROUTER_API_KEY"],
+            models: {
+              "model-a": { id: "model-a", name: "Model A" },
+            },
+          },
+        },
+      },
+    };
+
+    await patchConfig(base, token, payload);
+    const firstEvents = await readEvents(base, token);
+    expect(firstEvents).toHaveLength(1);
+    expect(firstEvents[0]?.reason).toBe("config");
+
+    await sleep(800);
+    await patchConfig(base, token, payload);
+
+    const secondEvents = await readEvents(base, token);
+    expect(secondEvents).toHaveLength(1);
+  });
+});

--- a/apps/server/src/runtime-opencode-config-store.test.ts
+++ b/apps/server/src/runtime-opencode-config-store.test.ts
@@ -6,7 +6,11 @@ import { addMcp, listMcp, setMcpEnabled } from "./mcp.js";
 import { buildOpenworkRuntimeConfig } from "./openwork-runtime-config.js";
 import { readOpenworkWorkspaceConfig } from "./openwork-workspace-config-store.js";
 import { addPlugin, listPlugins, removePlugin } from "./plugins.js";
-import { readRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import {
+  onRuntimeOpencodeConfigWrite,
+  readRuntimeOpencodeConfig,
+  writeRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
 import { startServer } from "./server.js";
 import type { ServerConfig } from "./types.js";
 
@@ -56,6 +60,43 @@ async function expectMissing(path: string): Promise<void> {
 }
 
 describe("runtime OpenCode config store", () => {
+  test("reports no-op writes without notifying listeners", async () => {
+    await withWorkspace(async ({ config }) => {
+      let writes = 0;
+      const unsubscribe = onRuntimeOpencodeConfigWrite((writtenConfig, workspaceId) => {
+        if (writtenConfig === config && workspaceId === WORKSPACE_ID) {
+          writes += 1;
+        }
+      });
+
+      try {
+        const first = await writeRuntimeOpencodeConfig(config, WORKSPACE_ID, (current) => ({
+          ...current,
+          mcp: { posthog: { type: "remote", url: "https://mcp.posthog.com/mcp", enabled: true } },
+        }));
+        expect(first.changed).toBe(true);
+        expect(writes).toBe(1);
+
+        const second = await writeRuntimeOpencodeConfig(config, WORKSPACE_ID, (current) => ({
+          ...current,
+          mcp: { posthog: { type: "remote", url: "https://mcp.posthog.com/mcp", enabled: true } },
+        }));
+        expect(second.changed).toBe(false);
+        expect(second.config).toEqual(first.config);
+        expect(writes).toBe(1);
+
+        const third = await writeRuntimeOpencodeConfig(config, WORKSPACE_ID, (current) => ({
+          ...current,
+          mcp: { posthog: { type: "remote", url: "https://mcp.posthog.com/mcp", enabled: false } },
+        }));
+        expect(third.changed).toBe(true);
+        expect(writes).toBe(2);
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
   test("stores MCP changes in the OpenWork runtime DB without rewriting workspace files", async () => {
     await withWorkspace(async ({ root, config }) => {
       const opencodePath = join(root, "opencode.jsonc");

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -52,6 +52,14 @@ function normalizeRuntimeOpencodeConfig(value: unknown): RuntimeOpencodeConfig {
   };
 }
 
+function parseRuntimeOpencodeConfig(configJson: string): RuntimeOpencodeConfig {
+  try {
+    return normalizeRuntimeOpencodeConfig(JSON.parse(configJson));
+  } catch {
+    return {};
+  }
+}
+
 function runtimeDbPath(config: ServerConfig): string {
   const override = process.env.OPENWORK_RUNTIME_DB?.trim();
   if (override) return resolve(override);
@@ -178,25 +186,26 @@ export async function readRuntimeOpencodeConfig(config: ServerConfig, workspaceI
   const db = await runtimeDb(config);
   const row = db.get(workspaceId);
   if (!row) return {};
-  try {
-    return normalizeRuntimeOpencodeConfig(JSON.parse(row.configJson));
-  } catch {
-    return {};
-  }
+  return parseRuntimeOpencodeConfig(row.configJson);
 }
 
 export async function writeRuntimeOpencodeConfig(
   config: ServerConfig,
   workspaceId: string,
   updater: (current: RuntimeOpencodeConfig) => RuntimeOpencodeConfig,
-): Promise<RuntimeOpencodeConfig> {
+): Promise<{ config: RuntimeOpencodeConfig; changed: boolean }> {
   const db = await runtimeDb(config);
-  const next = normalizeRuntimeOpencodeConfig(updater(await readRuntimeOpencodeConfig(config, workspaceId)));
+  const row = db.get(workspaceId);
+  const current = row ? parseRuntimeOpencodeConfig(row.configJson) : {};
+  const next = normalizeRuntimeOpencodeConfig(updater(current));
   const now = Date.now();
   const configJson = JSON.stringify(next);
+  if (row?.configJson === configJson) {
+    return { config: next, changed: false };
+  }
   db.upsert({ workspaceId, configJson, updatedAt: now });
   for (const listener of writeListeners) listener(config, workspaceId);
-  return next;
+  return { config: next, changed: true };
 }
 
 export function mergeOpencodeConfigs(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -27,6 +27,7 @@ import { EnvService } from "./env-file.js";
 import {
   normalizeResourceSnapshot,
   readDesktopCloudSyncState,
+  readWorkspaceCloudImports,
   syncDesktopCloudResources,
 } from "./desktop-cloud-sync.js";
 import { installCloudPlugin, readCloudPluginResolved, readInstalledCloudPlugins, removeCloudPlugin } from "./cloud-plugins.js";
@@ -1383,9 +1384,19 @@ function createRoutes(
 
     const result = await enqueueDesktopCloudSync(async () => {
       const openwork = await readOpenworkConfigForWorkspace(config, workspace);
-      const cloudImports = await readInstalledCloudPlugins(config, workspace.id);
+      const installed = await readInstalledCloudPlugins(config, workspace.id);
+      const cloudImports = {
+        ...installed,
+        providers: readWorkspaceCloudImports(openwork).providers,
+      };
       const next = syncDesktopCloudResources({ openwork: { ...openwork, cloudImports }, snapshot });
-      await writeOpenworkWorkspaceConfig(config, workspace.id, () => next.openwork);
+      // The plugin DB owns plugins/marketplaces, but provider import baselines live in
+      // the workspace config. Writing the merged cloudImports back erased providers
+      // and drove the provider-sync dispose/create loop.
+      await writeOpenworkWorkspaceConfig(config, workspace.id, (current) => ({
+        ...current,
+        desktopCloudSync: next.state,
+      }));
       await recordAudit(workspace.path, {
         id: shortId(),
         workspaceId: workspace.id,
@@ -1815,6 +1826,7 @@ function createRoutes(
     const body = await readJsonBody(ctx.request);
     const opencode = body.opencode as Record<string, unknown> | undefined;
     const openwork = body.openwork as Record<string, unknown> | undefined;
+    let runtimeChanged = false;
 
     if (!opencode && !openwork) {
       throw new ApiError(400, "invalid_payload", "opencode or openwork updates required");
@@ -1864,10 +1876,11 @@ function createRoutes(
       }
 
       if (Object.keys(logicalUpdates).length || Object.prototype.hasOwnProperty.call(logicalUpdates, "permission")) {
-        await writeRuntimeOpencodeConfig(config, workspace.id, (current) => ({
+        const result = await writeRuntimeOpencodeConfig(config, workspace.id, (current) => ({
           ...current,
           ...logicalUpdates,
         }));
+        runtimeChanged = result.changed;
       }
     }
     if (openwork) {
@@ -1887,7 +1900,9 @@ function createRoutes(
       timestamp: Date.now(),
     });
 
-    if (opencode) {
+    // A no-op provider patch (for example cloud sync reconciling an identical
+    // block) must not force an engine reload; that caused a dispose/create loop.
+    if (opencode && runtimeChanged) {
       emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(openworkConfigPath(workspace.path)));
     }
 

--- a/evals/flows/provider-sync-stable-engine.flow.mjs
+++ b/evals/flows/provider-sync-stable-engine.flow.mjs
@@ -1,0 +1,378 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/provider-sync-stable-engine.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("provider-sync-stable-engine");
+
+const PROVIDER_NAME = "Acme Azure Foundry";
+const RELOAD_TEXT = "Reloading OpenCode config";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function denRequest(ctx, path, init = {}) {
+  const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+  const response = await fetch(`${apiBase}${path}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+      "content-type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+  const body = await response.text();
+  ctx.assert(response.ok, `${init.method ?? "GET"} ${path} failed: ${response.status} ${body.slice(0, 200)}`);
+  return body ? JSON.parse(body) : null;
+}
+
+async function readRouteInfo(ctx) {
+  return await ctx.eval(`(() => {
+    const hash = location.hash;
+    const workspaceMatch = hash.match(/^#\\/workspace\\/(ws_[a-z0-9]+)\\//i);
+    const sessionMatch = hash.match(/^#(\\/workspace\\/ws_[a-z0-9]+\\/session\\/ses_[A-Za-z0-9]+)/);
+    return {
+      hash,
+      workspaceId: workspaceMatch ? workspaceMatch[1] : "",
+      sessionPath: sessionMatch ? sessionMatch[1] : "",
+    };
+  })()`);
+}
+
+async function rememberSessionRoute(ctx) {
+  const route = await readRouteInfo(ctx);
+  if (route?.workspaceId) ctx.workspaceId = route.workspaceId;
+  if (route?.sessionPath) ctx.sessionPath = route.sessionPath;
+  return route;
+}
+
+async function ensureSessionRoute(ctx) {
+  const hash = await ctx.eval("location.hash");
+  if (typeof hash === "string" && hash.includes("/session/")) {
+    await rememberSessionRoute(ctx);
+    return;
+  }
+  if (ctx.sessionPath) {
+    await ctx.navigateHash(ctx.sessionPath);
+  } else {
+    await ctx.navigateHash("/session");
+  }
+  await ctx.waitFor("window.location.hash.includes('/session/')", {
+    timeoutMs: 60_000,
+    label: "workspace session route",
+  });
+  await rememberSessionRoute(ctx);
+}
+
+async function clickAcmeOrganization(ctx) {
+  await ctx.clickText("Acme Robotics", {
+    selector: "label, button, [role=button], [role=radio]",
+    timeoutMs: 30_000,
+  });
+}
+
+async function chooseAcmeIfPickerVisible(ctx) {
+  if (!(await ctx.hasText("Choose your organization"))) return false;
+  await clickAcmeOrganization(ctx);
+  await ctx.clickText("Continue with organization", { timeoutMs: 30_000 });
+  return true;
+}
+
+const workspaceConfigStateExpr = (workspaceId) => `(async () => {
+  try {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    const workspaceId = ${JSON.stringify(workspaceId)};
+    if (!port || !token || !workspaceId) {
+      return JSON.stringify({ providers: [], runtimeProviders: [], error: "missing server port/token/workspace" });
+    }
+    const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + workspaceId + "/config", {
+      headers: { Authorization: "Bearer " + token },
+    });
+    if (!response.ok) {
+      return JSON.stringify({ providers: [], runtimeProviders: [], error: "config status " + response.status });
+    }
+    const config = await response.json();
+    return JSON.stringify({
+      providers: Object.keys(config.openwork?.cloudImports?.providers ?? {}),
+      runtimeProviders: Object.keys(config.opencode?.provider ?? {}),
+    });
+  } catch (error) {
+    return JSON.stringify({
+      providers: [],
+      runtimeProviders: [],
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+})()`;
+
+async function readWorkspaceConfigState(ctx) {
+  const raw = await ctx.eval(workspaceConfigStateExpr(ctx.workspaceId), { awaitPromise: true });
+  ctx.assert(typeof raw === "string", "Workspace config read returned no state.");
+  const parsed = JSON.parse(raw);
+  return {
+    providers: Array.isArray(parsed.providers) ? parsed.providers : [],
+    runtimeProviders: Array.isArray(parsed.runtimeProviders) ? parsed.runtimeProviders : [],
+    error: typeof parsed.error === "string" ? parsed.error : "",
+  };
+}
+
+function lprKeys(values) {
+  return values.filter((value) => typeof value === "string" && value.startsWith("lpr_"));
+}
+
+async function pollWorkspaceConfigState(ctx, predicate, timeoutMs, label) {
+  const startedAt = Date.now();
+  let lastState = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    lastState = await readWorkspaceConfigState(ctx).catch((error) => ({
+      providers: [],
+      runtimeProviders: [],
+      error: error instanceof Error ? error.message : String(error),
+    }));
+    if (predicate(lastState)) return lastState;
+    await sleep(2_000);
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}. Last state: ${JSON.stringify(lastState)}`);
+}
+
+async function openCloudProvidersView(ctx) {
+  await ctx.navigateHash("/settings/cloud-providers");
+  await ctx.waitFor("window.location.hash.includes('/settings/cloud-providers')", {
+    timeoutMs: 20_000,
+    label: "cloud providers settings route",
+  });
+  await ctx.clickText("Refresh", { selector: "button", timeoutMs: 30_000 }).catch(() => {
+    ctx.log("Cloud providers Refresh button was not available; waiting for current list.");
+  });
+  await ctx.waitForText(PROVIDER_NAME, { timeoutMs: 60_000 });
+}
+
+export default {
+  id: "provider-sync-stable-engine",
+  title: "Org cloud providers import once and the engine connection stays stable",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("A clean signed-out workspace boots to a quiet session surface", {
+          voiceover: vo[0],
+          // "Alex starts on a clean workspace, signed out of the cloud — the composer is "
+          action: async () => {
+            await ctx.waitFor("Boolean(window.__openworkControl)", {
+              timeoutMs: 60_000,
+              label: "control API",
+            });
+            const route = await rememberSessionRoute(ctx);
+            ctx.assert(Boolean(route?.workspaceId), `Could not parse workspace id from hash: ${route?.hash ?? ""}`);
+            ctx.assert(Boolean(route?.sessionPath), `Could not parse session route from hash: ${route?.hash ?? ""}`);
+          },
+          assert: async () => {
+            await ctx.expectText("Describe your task", { timeoutMs: 30_000 });
+            await ctx.expectNoText(RELOAD_TEXT);
+          },
+          screenshot: {
+            name: "signed-out-session",
+            requireText: ["Describe your task"],
+            rejectText: [RELOAD_TEXT],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("Desktop handoff sign-in lands on the org picker and Alex picks Acme Robotics", {
+          voiceover: vo[1],
+          // "He signs in to OpenWork Cloud with a pasted sign-in code and lands on the or"
+          action: async () => {
+            const payload = await denRequest(ctx, "/v1/auth/desktop-handoff", {
+              method: "POST",
+              body: JSON.stringify({ desktopScheme: "openwork" }),
+            });
+            ctx.assert(
+              typeof payload?.openworkUrl === "string" && payload.openworkUrl.length > 0,
+              "No openworkUrl in handoff response.",
+            );
+            ctx.handoffUrl = payload.openworkUrl;
+
+            await ctx.navigateHash("/settings/cloud-account");
+            await ctx.waitFor(
+              `(() => {
+                const text = document.body.innerText;
+                return text.includes("Paste sign-in code") || text.includes("Sign out");
+              })()`,
+              { timeoutMs: 30_000, label: "cloud account state" },
+            );
+
+            ctx.alreadySignedIn = await ctx.hasText("Sign out");
+            if (ctx.alreadySignedIn) {
+              ctx.log("Already signed in — skipping paste flow.");
+            } else {
+              await ctx.clickText("Paste sign-in code", { timeoutMs: 30_000 });
+              await ctx.fill("#den-signin-link", ctx.handoffUrl);
+              await ctx.clickText("Finish sign-in", { timeoutMs: 30_000 });
+              await ctx.waitFor(
+                "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+                { timeoutMs: 60_000, label: "persisted den auth token" },
+              );
+            }
+
+            await ctx.navigateHash("/onboarding");
+            const state = await ctx.waitFor(
+              `(() => {
+                const text = document.body.innerText;
+                if (text.includes("Choose your organization") && text.includes("Acme Robotics")) return "picker";
+                if (text.includes("You have access to the following resources") && text.includes("AI Providers")) return "resources";
+                if (window.location.hash.includes("/session/")) return "session";
+                return null;
+              })()`,
+              { timeoutMs: 60_000, label: "org picker or already-selected organization" },
+            );
+            ctx.orgPickerState = state;
+            ctx.orgPickerSkipped = state !== "picker";
+            if (ctx.orgPickerSkipped) {
+              ctx.log(`Org picker was already past this state (${state}); continuing idempotently.`);
+            }
+          },
+          assert: async () => {
+            if (ctx.orgPickerSkipped) {
+              ctx.recordEvidence({
+                type: "assertion",
+                status: "passed",
+                assertion: `Org picker was already completed (${ctx.orgPickerState}); continuing idempotently.`,
+              });
+              return;
+            }
+            await ctx.expectText("Acme Robotics", { timeoutMs: 5_000 });
+            await ctx.expectText("Continue with organization", { timeoutMs: 5_000 });
+          },
+          screenshot: {
+            name: "org-picker-acme",
+            get requireText() {
+              return ctx.orgPickerSkipped ? [] : ["Choose your organization", "Acme Robotics"];
+            },
+            get hashIncludes() {
+              return ctx.orgPickerSkipped ? undefined : "/onboarding";
+            },
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Org resources travel with the sign-in: AI provider models are visible before entering the workspace", {
+          voiceover: vo[2],
+          // "Acme's resources come with him: the onboarding summary shows the org's AI pr"
+          action: async () => {
+            if (ctx.orgPickerSkipped && (await ctx.eval("window.location.hash.includes('/session/')"))) {
+              await ctx.navigateHash("/onboarding");
+            }
+            await chooseAcmeIfPickerVisible(ctx);
+            await ctx.waitFor(
+              `(() => {
+                const text = document.body.innerText;
+                return text.includes("You have access to the following resources") && text.includes("AI Providers");
+              })()`,
+              { timeoutMs: 60_000, label: "org resources summary" },
+            );
+          },
+          assert: async () => {
+            await ctx.expectText("AI Providers", { timeoutMs: 5_000 });
+            await ctx.expectText("Continue to workspace", { timeoutMs: 5_000 });
+          },
+          screenshot: {
+            name: "org-resources",
+            requireText: ["AI Providers", "Continue to workspace"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("The org provider imported once and the import baseline is persisted in the workspace config", {
+          voiceover: vo[3],
+          // "The org provider imported exactly once — under the hood the workspace config"
+          action: async () => {
+            if (await ctx.hasText("Continue to workspace")) {
+              await ctx.clickText("Continue to workspace", { timeoutMs: 30_000 });
+            }
+            await ctx.waitFor("window.location.hash.includes('/session/')", {
+              timeoutMs: 60_000,
+              label: "workspace session route after onboarding",
+            });
+            await rememberSessionRoute(ctx);
+            ctx.configState = await pollWorkspaceConfigState(
+              ctx,
+              (state) => lprKeys(state.providers).length > 0 && lprKeys(state.runtimeProviders).length > 0,
+              120_000,
+              "cloud import baseline and runtime provider",
+            );
+            await openCloudProvidersView(ctx);
+          },
+          assert: async () => {
+            const state = await readWorkspaceConfigState(ctx);
+            const imported = lprKeys(state.providers);
+            const runtime = lprKeys(state.runtimeProviders);
+            ctx.assert(imported.length === 1, `Expected exactly one lpr_ cloud import, got ${imported.length}: ${imported.join(", ")}`);
+            ctx.assert(runtime.includes(imported[0]), `Runtime providers did not include imported provider ${imported[0]}: ${runtime.join(", ")}`);
+            ctx.recordEvidence({
+              type: "assertion",
+              status: "passed",
+              assertion: `Workspace config has one cloud import (${imported[0]}) and the runtime provider includes it.`,
+              actual: JSON.stringify(state),
+            });
+          },
+          screenshot: {
+            name: "provider-imported",
+            requireText: [PROVIDER_NAME],
+            hashIncludes: "/settings/cloud-providers",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("Sixty seconds in the session with zero 'Reloading OpenCode config' flashes — the reload loop is gone", {
+          voiceover: vo[4],
+          // "The proof is in the waiting: a full minute in the session and the status bar"
+          action: async () => {
+            await ensureSessionRoute(ctx);
+            await ctx.waitForText("Describe your task", { timeoutMs: 60_000 });
+            await sleep(15_000);
+            let positives = 0;
+            for (let i = 0; i < 30; i += 1) {
+              await sleep(2_000);
+              if (await ctx.eval(`document.body.innerText.includes(${JSON.stringify(RELOAD_TEXT)})`)) {
+                positives += 1;
+              }
+            }
+            ctx.reloadPositiveSamples = positives;
+          },
+          assert: async () => {
+            ctx.assert(
+              ctx.reloadPositiveSamples === 0,
+              `saw "${RELOAD_TEXT}" ${ctx.reloadPositiveSamples}/30 samples`,
+            );
+            ctx.recordEvidence({
+              type: "assertion",
+              status: "passed",
+              assertion: `No ${RELOAD_TEXT} flashes across 30 samples.`,
+            });
+            await ctx.expectText("Describe your task", { timeoutMs: 5_000 });
+            await ctx.expectNoText(RELOAD_TEXT);
+          },
+          screenshot: {
+            name: "engine-stable",
+            requireText: ["Describe your task"],
+            rejectText: [RELOAD_TEXT],
+            hashIncludes: "/session/",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/provider-sync-stable-engine.md
+++ b/evals/voiceovers/provider-sync-stable-engine.md
@@ -1,0 +1,20 @@
+# provider-sync-stable-engine — Org providers import once, the engine stays put
+
+Cast is Alex Chen, owner of Acme Robotics, on a fresh OpenWork desktop
+connected to OpenWork Cloud. His org ships a custom LLM provider (Acme Azure
+Foundry). Before this fix, signing in started an invisible fight: every cloud
+sync erased the provider import baseline, so the app re-imported the provider,
+forced an engine reload, and disposed/re-created the active workspace's
+OpenCode instance about once a second — the status bar flashed "Reloading
+OpenCode config" forever. This demo proves the loop is gone: the provider
+imports once, stays imported, and the engine stays quiet.
+
+1. Alex starts on a clean workspace, signed out of the cloud — the composer is idle and the status bar is quiet.
+
+2. He signs in to OpenWork Cloud with a pasted sign-in code and lands on the organization picker — he chooses Acme Robotics, the org whose provider used to trigger the loop.
+
+3. Acme's resources come with him: the onboarding summary shows the org's AI provider models, and he continues into the workspace.
+
+4. The org provider imported exactly once — under the hood the workspace config now remembers the import baseline, so cloud sync has nothing left to re-import.
+
+5. The proof is in the waiting: a full minute in the session and the status bar never flashes "Reloading OpenCode config" — no dispose and re-create churn, the engine connection stays stable.


### PR DESCRIPTION
## Summary

Fixes the customer-reported engine lifecycle loop where the **active workspace's OpenCode instance is disposed and re-created continuously (~1x/sec)**, with the status bar stuck flashing "Reloading OpenCode config" and the `/event` SSE cycling `connected → disconnected` at ~1 Hz. Matches the field report from Go Autonomous (0.17.8-alpha + 0.17.13) and the customer's hunch that it only happens when **org inference providers are configured**.

## Root cause (verified live on a Daytona repro)

The loop is a cloud-provider sync reconcile feedback cycle:

1. **`POST /workspace/:id/desktop-cloud-sync` erased the provider import baseline on every call** (primary): it injected `cloudImports` from the cloud-plugin DB — whose `providers` record is always empty — and wrote that whole object back into the workspace config, wiping `cloudImports.providers` that the provider import had just persisted. The app calls this endpoint right after every provider import, so the baseline was erased immediately after being written. Every sync pass then saw "never imported" and re-imported all org providers.
2. **`PATCH /workspace/:id/config` emitted a `config` reload event unconditionally** — even for a byte-identical no-op provider patch — so every re-import forced an engine reload (dispose→create of the active workspace instance).
3. **The session provider-auth store was recreated on every reload flip**: its `useMemo` depended on the `reloadCoordinator` context value, whose identity changes on each `reloadPending`/`reloadBusy` flip. Every fresh store immediately started another cloud sync pass (empty sync-context key) → goto 1. This is why the loop followed the *active* workspace and background workspaces stayed stable.
4. Contributing hardening gaps: `isCloudProviderOutOfSync` compared trimmed baseline model ids against raw live ids (whitespace/empty ids ⇒ permanently out-of-sync), and a failed baseline read was treated as "no imports" (re-import storm) instead of aborting the pass.

Diagnostic fingerprint on the repro box: `runtime_opencode_configs` had the provider, while `openwork_workspace_configs.cloudImports.providers` stayed `{}` forever, and den-api logs showed continuous `GET /v1/llm-providers/:id/connect` reconciles.

## Fixes

- **server / desktop-cloud-sync**: only persist `desktopCloudSync` state (via the merge updater); the provider import baseline in the workspace config is preserved, and providers now diff against the real baseline.
- **server / PATCH config**: `writeRuntimeOpencodeConfig` detects no-op writes (skips the upsert and the write listeners) and the route only emits a reload event when the runtime config actually changed.
- **app / session provider-auth**: depend on the stable `markReloadRequired` callback instead of the whole coordinator context value — the store is no longer recreated on reload flips (settings route already did this).
- **app / cloud-provider-config**: symmetric model-id comparison (trim/filter both sides).
- **app / provider sync**: abort the pass when the import baseline cannot be read instead of re-importing everything.

## Reproduction & proof (Daytona, seeded cloud, signed in as Alex/Acme)

Setup: seeded OpenWork Cloud (Acme Robotics demo org, `alex@acme.test`) on a Daytona server sandbox, one custom org LLM provider ("Acme Azure Foundry", 2 models — mirroring the customer's Azure Foundry custom provider), Electron desktop in a second Daytona sandbox connected to that Den.

| metric (same Den, same org, same provider, same flow) | `dev` (pre-fix) | this branch |
| --- | --- | --- |
| engine `creating instance` for the active workspace | **2001 in ~26.5 min (~1.26/sec, unbounded)** | **4 total** (workspace open + one legitimate import reload), then silent |
| den-api `GET /llm-providers/:id/connect` reconciles | continuous | 1 per import |
| workspace config `cloudImports.providers` | `{}` forever (erased each sync) | baseline persisted |
| status bar | "Reloading OpenCode config" churn | quiet — 30/30 samples over 60 s clean |

The pre-fix loop only stopped when the sandbox's Den connectivity was cut (sync pass fails before reconciling) — confirming the mechanism.

fraimz (frame-by-frame proof with the full user journey — handoff sign-in, org pick, provider auto-import witnessed in the workspace config, 60 s quiet window) is posted as a comment below.

## Tests

- `pnpm --filter openwork-server test -- src/runtime-opencode-config-store.test.ts src/runtime-config-patch-reload.e2e.test.ts src/desktop-cloud-sync-preserves-imports.e2e.test.ts src/desktop-cloud-sync.test.ts` — **12 pass, 0 fail** (includes new: no-op write skips listeners; identical provider PATCH emits no second reload event; desktop-cloud-sync preserves `cloudImports.providers`)
- `pnpm --filter @openwork/app exec bun test src/react-app/domains/connections/provider-auth/cloud-provider-config.test.ts` — **4 pass, 0 fail** (new: symmetric out-of-sync comparison incl. whitespace model ids)
- `pnpm --filter openwork-server typecheck` / `pnpm --filter @openwork/app typecheck` — clean
- `pnpm fraimz --flow provider-sync-stable-engine --cdp-url <daytona-electron>` — **PASSED** (5/5 frames)

## Follow-up

The settings-open engine reloads (cloud-MCP re-mint per settings mount, provider-sync target race, workspace re-select) are fixed in #2544.
