### PR TITLE
Fix Entra SSO verification flow

### DIFF
--- a/docs/azure-aks-helm.md
+++ b/docs/azure-aks-helm.md
@@ -623,6 +623,9 @@ Use OIDC first for a smoke test because most IdPs provide discovery metadata.
 Auth0, Okta trial, and Microsoft Entra test tenants all work as realistic demo
 IdPs.
 
+For the full Microsoft Entra SAML and SCIM setup flow, use
+`docs/microsoft-entra-sso-scim.md`.
+
 Configure the IdP application with this callback URL:
 
 ```text

--- a/docs/microsoft-entra-sso-scim.md
+++ b/docs/microsoft-entra-sso-scim.md
@@ -1,0 +1,189 @@
+# Microsoft Entra SSO and SCIM
+
+This guide connects Microsoft Entra ID to an OpenWork organization for SAML
+single sign-on and SCIM user provisioning.
+
+## How OpenWork is wired
+
+OpenWork uses Better Auth for the underlying SSO and SCIM protocol handlers, then
+wraps them with organization-scoped OpenWork routes and policy:
+
+| Area | OpenWork surface | Runtime behavior |
+|---|---|---|
+| SSO management | `/dashboard/sso`, `/v1/sso`, `/v1/sso/saml`, `/v1/sso/oidc` | One SSO connection per organization. Owners and security admins can create or replace it. |
+| SAML callback | `/api/auth/sso/saml2/sp/acs/openwork-sso-<org-id>` | Better Auth consumes the response after OpenWork validates SAML response policy. |
+| SAML metadata | `/api/auth/sso/saml2/sp/metadata?providerId=openwork-sso-<org-id>` | Generated after the SAML connection is saved in OpenWork. |
+| SSO sign-in | `/sso/<org-slug>` | Starts SP-initiated SSO for the organization and redirects to Entra. |
+| SCIM management | `/dashboard/scim`, `/v1/scim`, `/v1/scim/token` | Owners and security admins create or rotate an org-scoped SCIM bearer token. |
+| SCIM provisioning | `/api/auth/scim/v2` | Supports SCIM user provisioning, updates, and deprovisioning. |
+
+OpenWork enforces these SAML security settings for organization SSO:
+
+- Signed SAML assertions are required.
+- IdP-initiated SAML is disabled.
+- SAML timestamps are required.
+- Deprecated SAML algorithms are rejected.
+- SSO login writes an external identity link and just-in-time organization
+  membership.
+- Email/password sign-in is rejected for users managed by an organization SSO or
+  SCIM connection.
+
+OpenWork does not currently support SCIM Group object provisioning. You can
+assign Entra users and groups to the enterprise application for scope, but keep
+the Entra group object mapping disabled.
+
+## Prerequisites
+
+- An OpenWork organization owner or admin with security configuration access.
+- A Microsoft Entra account with permission to manage Enterprise applications.
+  Microsoft documents this as Cloud Application Administrator, Application
+  Administrator, or owner of the service principal for SSO configuration.
+- The public OpenWork web and auth URLs must already be final HTTPS URLs. SAML
+  and browser auth cookies should not be validated against temporary HTTP
+  origins in production.
+- The OpenWork organization should have the expected email domain configured in
+  organization settings before requiring SSO for that domain.
+- The OpenWork organization must have the SSO/Enterprise entitlement enabled.
+  Without it, OpenWork keeps the form editable but rejects save attempts with
+  `SSO / SAML requires an Enterprise plan`.
+
+## Create or select the Entra enterprise application
+
+1. Open the Microsoft Entra admin center.
+2. Go to **Entra ID** -> **Enterprise apps** -> **All applications**.
+3. Select the existing OpenWork enterprise application, or create a new
+   non-gallery enterprise application for OpenWork.
+4. Assign at least one test user or test group under **Users and groups**.
+
+For the OpenWork Labs test tenant, use:
+
+- **Tenant ID**: `2b853de0-b14b-4433-90be-cced1b963647`
+- **OpenWork SSO domain**: `omaropenworklabs.onmicrosoft.com`
+- **Test users**:
+  - `omar2@omaropenworklabs.onmicrosoft.com`
+  - `omar_openworklabs.com#EXT#@omaropenworklabs.onmicrosoft.com`
+- **OpenWork organization**: `Omar Azure Test`
+
+As of July 7, 2026, both test users are assigned to the **OpenWork Labs**
+enterprise application in Entra, and the OpenWork Cloud org has the Enterprise
+entitlement needed to save SSO settings.
+
+## Configure SAML SSO
+
+There is a small handoff between Entra and OpenWork: OpenWork needs Entra's IdP
+values before it can save the connection, and Entra needs OpenWork's generated
+ACS URL before SAML can be fully tested.
+
+1. In the Entra enterprise application, open **Single sign-on** and choose
+   **SAML**.
+2. In the Entra SAML page, copy these IdP values:
+   - **Microsoft Entra Identifier**. Use this as OpenWork **Issuer URL**.
+   - **Login URL**. Use this as OpenWork **SAML Entry Point**.
+   - **Certificate (Base64)**. Paste the PEM certificate into OpenWork
+     **IdP Certificate**.
+3. In OpenWork, open **Dashboard** -> **SSO** and choose **SAML**.
+4. Fill the OpenWork fields:
+   - **Issuer URL**: the Entra **Microsoft Entra Identifier**.
+   - **Domain**: the email domain that should use this SSO connection, for
+     example `example.com`.
+   - **SAML Entry Point**: the Entra **Login URL**.
+   - **Audience URL**: leave blank to use the OpenWork auth URL, or enter a
+     stable Entity ID that you will also set as the Entra Identifier.
+   - **IdP Certificate**: the Entra Base64 certificate as PEM text.
+5. Save the SSO connection in OpenWork.
+   - For a custom domain such as `example.com`, request the domain verification
+     TXT token in OpenWork, publish it in DNS, then click **Verify domain**.
+   - For Microsoft tenant domains ending in `.onmicrosoft.com`, OpenWork
+     verifies the domain from the matching Entra tenant issuer and SAML entry
+     point. You do not need to publish DNS records under Microsoft's
+     `onmicrosoft.com` zone.
+6. Copy the generated OpenWork values:
+   - **ACS URL**.
+   - **Metadata URL**.
+   - **Sign-in URL**.
+7. Return to Entra **Single sign-on** -> **Basic SAML Configuration** and set:
+   - **Identifier (Entity ID)**: the OpenWork audience. If you left the
+     OpenWork audience blank, use the OpenWork auth URL shown by your deployment
+     docs or metadata.
+   - **Reply URL (Assertion Consumer Service URL)**: the OpenWork **ACS URL**.
+   - **Sign on URL**: the OpenWork **Sign-in URL**.
+8. Save the Entra SAML configuration.
+9. In Entra **Attributes & Claims**, make sure OpenWork receives:
+   - `email`: the user's email address, usually `user.mail` with fallback to
+     `user.userprincipalname` in tenants where `mail` is empty.
+   - `displayName`: the user's display name.
+   - Name ID: an email-like stable user identifier.
+10. Test with an assigned user from the OpenWork `/sso/<org-slug>` URL. This is
+    the supported SP-initiated path.
+
+For the OpenWork Labs test tenant, the OpenWork SAML fields are:
+
+- **Issuer URL**:
+  `https://sts.windows.net/2b853de0-b14b-4433-90be-cced1b963647/`
+- **Domain**: `omaropenworklabs.onmicrosoft.com`
+- **SAML Entry Point**:
+  `https://login.microsoftonline.com/2b853de0-b14b-4433-90be-cced1b963647/saml2`
+- **Audience URL**: leave blank unless you also set a custom Entra Identifier.
+- **IdP Certificate**: paste the active Entra SAML signing certificate.
+
+## Configure SCIM user provisioning
+
+1. In OpenWork, open **Dashboard** -> **SCIM**.
+2. Copy the **SCIM base URL**.
+3. Create or rotate the connector token and copy the bearer token immediately.
+   OpenWork only shows it after creation or rotation.
+4. In the Entra enterprise application, open **Provisioning**.
+5. Set **Provisioning Mode** to **Automatic**.
+6. Under **Admin Credentials**, set:
+   - **Tenant URL**: the OpenWork **SCIM base URL**.
+   - **Secret Token**: the OpenWork SCIM bearer token.
+7. Select **Test Connection**.
+8. Open **Mappings**:
+   - Keep user provisioning enabled.
+   - Disable group object provisioning. OpenWork currently returns `501` for
+     SCIM `/Groups`.
+   - Use a matching attribute that OpenWork can filter by, normally
+     `userName` mapped from `userPrincipalName` or `mail`.
+9. Under **Settings**, choose the scope. For a controlled rollout, sync only
+   assigned users and groups.
+10. Turn **Provisioning Status** on after the test connection and mappings are
+    correct.
+
+## Validation checklist
+
+- Entra SAML test redirects through OpenWork's `/sso/<org-slug>` URL.
+- The SAML response lands on OpenWork's generated ACS URL.
+- A first SSO login creates or updates an OpenWork user and organization member.
+- Email/password sign-in is rejected for managed users when SSO is required for
+  the organization domain.
+- Entra SCIM **Test Connection** succeeds.
+- Provisioning an assigned test user creates the OpenWork user and organization
+  membership.
+- Removing the assignment deprovisions organization access without deleting the
+  global OpenWork user record.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Entra says the reply URL is invalid | The Entra Reply URL does not match OpenWork's generated ACS URL | Copy the ACS URL from OpenWork after saving the SAML connection and paste it into Basic SAML Configuration. |
+| SAML login fails with audience or recipient errors | Entra Identifier, OpenWork Audience URL, or ACS URL do not match | Keep the Entra Identifier equal to the OpenWork audience and the Entra Reply URL equal to the OpenWork ACS URL. |
+| SAML login fails after changing certs | OpenWork still has the old IdP certificate | Paste the new Entra Base64 certificate into OpenWork and save the SAML connection again. |
+| IdP-initiated login fails | OpenWork only supports SP-initiated organization SAML | Start login from OpenWork's `/sso/<org-slug>` sign-in URL. |
+| SCIM test connection is unauthorized | The token was copied incorrectly or rotated after Entra was configured | Rotate the OpenWork SCIM token and update Entra's Secret Token. |
+| Entra group provisioning fails | OpenWork does not support SCIM Group objects yet | Disable the group object mapping and use group assignment only to scope user provisioning. |
+
+## References
+
+- Microsoft: Enable SAML single sign-on for an enterprise application:
+  https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/add-application-portal-setup-sso
+- Microsoft: Manage automatic user account provisioning:
+  https://learn.microsoft.com/en-us/entra/identity/app-provisioning/configure-automatic-user-provisioning-portal
+- Microsoft: Develop and plan provisioning for a SCIM endpoint:
+  https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups
+- Microsoft: Customize provisioning attribute mappings:
+  https://learn.microsoft.com/en-us/entra/identity/app-provisioning/customize-application-attributes
+- Better Auth SSO plugin:
+  https://better-auth.com/docs/plugins/sso
+- Better Auth SCIM plugin:
+  https://better-auth.com/docs/plugins/scim

--- a/ee/apps/den-api/src/sso-entra-domain.ts
+++ b/ee/apps/den-api/src/sso-entra-domain.ts
@@ -1,0 +1,31 @@
+function getMicrosoftTenantId(value: string) {
+  try {
+    const url = new URL(value)
+    const host = url.hostname.toLowerCase()
+    if (host !== "sts.windows.net" && host !== "login.microsoftonline.com") {
+      return null
+    }
+
+    const tenantId = url.pathname.split("/").filter(Boolean)[0]
+    return tenantId && /^[0-9a-f-]{36}$/i.test(tenantId) ? tenantId.toLowerCase() : null
+  } catch {
+    return null
+  }
+}
+
+export function isMicrosoftEntraManagedDomain(input: { domain: string; issuer: string; entryPoint?: string | null }) {
+  if (!input.domain.toLowerCase().endsWith(".onmicrosoft.com")) {
+    return false
+  }
+
+  const issuerTenantId = getMicrosoftTenantId(input.issuer)
+  if (!issuerTenantId) {
+    return false
+  }
+
+  if (input.entryPoint) {
+    return getMicrosoftTenantId(input.entryPoint) === issuerTenantId
+  }
+
+  return true
+}

--- a/ee/apps/den-api/src/sso.ts
+++ b/ee/apps/den-api/src/sso.ts
@@ -5,6 +5,7 @@ import { z } from "zod"
 import { auth } from "./auth.js"
 import { db } from "./db.js"
 import { env } from "./env.js"
+import { isMicrosoftEntraManagedDomain } from "./sso-entra-domain.js"
 import { SSO_IDENTITY_EXTRA_FIELDS } from "./sso-jit.js"
 import { ORGANIZATION_SAML_WANT_ASSERTIONS_SIGNED } from "./sso-saml-policy.js"
 
@@ -244,11 +245,22 @@ export async function deleteOrganizationSsoConnection(organizationId: Organizati
 export async function registerOrganizationSsoConnection(input: OrganizationSsoRegistrationInput) {
   const providerId = buildOrganizationSsoProviderId(input.organizationId)
   const existing = await getOrganizationSsoConnection(input.organizationId)
+  const domainVerified = isMicrosoftEntraManagedDomain({
+    domain: input.domain,
+    issuer: input.issuer,
+    entryPoint: input.kind === "saml" ? input.entryPoint : null,
+  })
 
   if (existing) {
     const existingProvider = await getSsoProviderByProviderId(providerId)
     if (!existingProvider) {
       await registerBetterAuthSsoProvider(input, providerId)
+      if (domainVerified) {
+        await db
+          .update(SsoProviderTable)
+          .set({ domainVerified: true })
+          .where(eq(SsoProviderTable.providerId, providerId))
+      }
       await db
         .update(SsoConnectionTable)
         .set({
@@ -286,7 +298,7 @@ export async function registerOrganizationSsoConnection(input: OrganizationSsoRe
           domain: draftProvider.domain,
           oidcConfig: draftProvider.oidcConfig,
           samlConfig: draftProvider.samlConfig,
-          domainVerified: false,
+          domainVerified,
         })
         .where(eq(SsoProviderTable.providerId, providerId))
 
@@ -317,6 +329,12 @@ export async function registerOrganizationSsoConnection(input: OrganizationSsoRe
   }
 
   await registerBetterAuthSsoProvider(input, providerId)
+  if (domainVerified) {
+    await db
+      .update(SsoProviderTable)
+      .set({ domainVerified: true })
+      .where(eq(SsoProviderTable.providerId, providerId))
+  }
 
   await db.insert(SsoConnectionTable).values({
     id: createDenTypeId("ssoConnection"),

--- a/ee/apps/den-api/test/sso-entra-domain.test.ts
+++ b/ee/apps/den-api/test/sso-entra-domain.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { isMicrosoftEntraManagedDomain } from "../src/sso-entra-domain.js"
+
+const tenantId = "2b853de0-b14b-4433-90be-cced1b963647"
+
+test("recognizes Microsoft Entra managed onmicrosoft.com SAML domains", () => {
+  expect(isMicrosoftEntraManagedDomain({
+    domain: "omaropenworklabs.onmicrosoft.com",
+    issuer: `https://sts.windows.net/${tenantId}/`,
+    entryPoint: `https://login.microsoftonline.com/${tenantId}/saml2`,
+  })).toBe(true)
+})
+
+test("rejects mismatched Entra tenant URLs for managed domains", () => {
+  expect(isMicrosoftEntraManagedDomain({
+    domain: "omaropenworklabs.onmicrosoft.com",
+    issuer: `https://sts.windows.net/${tenantId}/`,
+    entryPoint: "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/saml2",
+  })).toBe(false)
+})
+
+test("keeps custom domains on DNS verification", () => {
+  expect(isMicrosoftEntraManagedDomain({
+    domain: "openworklabs.com",
+    issuer: `https://sts.windows.net/${tenantId}/`,
+    entryPoint: `https://login.microsoftonline.com/${tenantId}/saml2`,
+  })).toBe(false)
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
@@ -29,13 +29,13 @@ export function SsoScreen() {
   const [domainVerificationToken, setDomainVerificationToken] = useState<string | null>(null);
   const [requestingDomainToken, setRequestingDomainToken] = useState(false);
   const [verifyingDomain, setVerifyingDomain] = useState(false);
+  const [editing, setEditing] = useState(false);
   const [formMode, setFormMode] = useState<FormMode>("saml");
   const [issuer, setIssuer] = useState("");
   const [domain, setDomain] = useState("");
   const [entryPoint, setEntryPoint] = useState("");
   const [cert, setCert] = useState("");
   const [audience, setAudience] = useState("");
-  const [wantAssertionsSigned, setWantAssertionsSigned] = useState(true);
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const [scopes, setScopes] = useState("openid email profile");
@@ -68,6 +68,7 @@ export function SsoScreen() {
       const parsed = parseOrgSsoPayload(payload);
       setConnection(parsed.connection);
       syncFormFromConnection(parsed.connection);
+      setEditing(false);
     } catch (nextError) {
       setError(nextError instanceof Error ? nextError.message : "Failed to load SSO settings.");
     } finally {
@@ -86,7 +87,6 @@ export function SsoScreen() {
     if (nextConnection.saml) {
       setEntryPoint(nextConnection.saml.entryPoint ?? "");
       setAudience(nextConnection.saml.audience ?? "");
-      setWantAssertionsSigned(nextConnection.saml.wantAssertionsSigned);
     }
     if (nextConnection.oidc) {
       setClientId(nextConnection.oidc.clientId ?? "");
@@ -139,7 +139,6 @@ export function SsoScreen() {
                 entryPoint,
                 cert,
                 audience: audience || undefined,
-                wantAssertionsSigned,
               }
             : {
                 issuer,
@@ -164,6 +163,7 @@ export function SsoScreen() {
           setConnection(parsed.connection);
           syncFormFromConnection(parsed.connection);
           setDomainVerificationToken(parsed.domainVerificationToken);
+          setEditing(false);
         } finally {
           setSaving(false);
         }
@@ -188,6 +188,7 @@ export function SsoScreen() {
             throw getRequestError(payload, response, `Failed to delete SSO settings (${response.status}).`);
           }
           setConnection(null);
+          setEditing(false);
           await loadSsoConfig();
         } finally {
           setDeleting(false);
@@ -248,6 +249,13 @@ export function SsoScreen() {
     }
   }
 
+  function handleCancelEdit() {
+    syncFormFromConnection(connection);
+    setEditing(false);
+  }
+
+  const showConnectionForm = !connection || editing;
+
   if (!orgContext) {
     return (
       <DashboardPageTemplate icon={Shield} badgeLabel="Admin" title="SSO" description="Set up enterprise single sign-on for this workspace." colors={["#F5F3FF", "#4C1D95", "#8B5CF6", "#DDD6FE"]}>
@@ -265,95 +273,99 @@ export function SsoScreen() {
           {!orgContext.entitlements.sso ? <EnterprisePlanNotice feature="SSO" /> : null}
           {error ? <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">{error}</div> : null}
 
-          <div className="mb-6 rounded-[30px] border border-gray-200 bg-white p-6 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.22)]">
-            <div className="flex flex-wrap items-center gap-3">
-              <DenButton variant={formMode === "saml" ? "primary" : "secondary"} onClick={() => setFormMode("saml")}>SAML</DenButton>
-              <DenButton variant={formMode === "oidc" ? "primary" : "secondary"} onClick={() => setFormMode("oidc")}>OIDC</DenButton>
-            </div>
+          {showConnectionForm ? (
+            <div className="mb-6 rounded-[30px] border border-gray-200 bg-white p-6 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.22)]">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex flex-wrap items-center gap-3">
+                  <DenButton variant={formMode === "saml" ? "primary" : "secondary"} onClick={() => setFormMode("saml")}>SAML</DenButton>
+                  <DenButton variant={formMode === "oidc" ? "primary" : "secondary"} onClick={() => setFormMode("oidc")}>OIDC</DenButton>
+                </div>
+                {connection ? <DenButton variant="secondary" onClick={handleCancelEdit}>Cancel edit</DenButton> : null}
+              </div>
 
-            <div className="mt-6 grid gap-4 md:grid-cols-2">
-              <label className="block text-[14px] text-gray-700">
-                <span className="mb-2 block font-medium">Issuer URL</span>
-                <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={issuer} onChange={(event) => setIssuer(event.target.value)} placeholder="https://idp.example.com" />
-              </label>
-              <label className="block text-[14px] text-gray-700">
-                <span className="mb-2 block font-medium">Domain</span>
-                <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={domain} onChange={(event) => setDomain(event.target.value)} placeholder="example.com" />
-              </label>
-              {formMode === "saml" ? (
-                <>
-                  <label className="block text-[14px] text-gray-700 md:col-span-2">
-                    <span className="mb-2 block font-medium">SAML Entry Point</span>
-                    <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={entryPoint} onChange={(event) => setEntryPoint(event.target.value)} placeholder="https://idp.example.com/sso" />
-                  </label>
-                  <label className="block text-[14px] text-gray-700 md:col-span-2">
-                    <span className="mb-2 block font-medium">Audience URL</span>
-                    <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={audience} onChange={(event) => setAudience(event.target.value)} placeholder="Defaults to the OpenWork auth URL" />
-                  </label>
-                  <label className="block text-[14px] text-gray-700 md:col-span-2">
-                    <span className="mb-2 block font-medium">IdP Certificate</span>
-                    <textarea className="min-h-[140px] w-full rounded-[18px] border border-gray-200 px-4 py-3" value={cert} onChange={(event) => setCert(event.target.value)} placeholder="-----BEGIN CERTIFICATE-----" />
-                  </label>
-                  <label className="flex items-center gap-3 rounded-[18px] border border-gray-200 px-4 py-3 text-[14px] text-gray-700 md:col-span-2">
-                    <input type="checkbox" checked={wantAssertionsSigned} onChange={(event) => setWantAssertionsSigned(event.target.checked)} />
-                    Require signed SAML assertions
-                  </label>
-                </>
-              ) : (
-                <>
-                  <label className="block text-[14px] text-gray-700">
-                    <span className="mb-2 block font-medium">Client ID</span>
-                    <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={clientId} onChange={(event) => setClientId(event.target.value)} />
-                  </label>
-                  <label className="block text-[14px] text-gray-700">
-                    <span className="mb-2 block font-medium">Client Secret</span>
-                    <input type="password" className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={clientSecret} onChange={(event) => setClientSecret(event.target.value)} />
-                  </label>
-                  <label className="block text-[14px] text-gray-700 md:col-span-2">
-                    <span className="mb-2 block font-medium">Scopes</span>
-                    <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={scopes} onChange={(event) => setScopes(event.target.value)} placeholder="openid email profile" />
-                  </label>
-                  <label className="block text-[14px] text-gray-700 md:col-span-2">
-                    <span className="mb-2 block font-medium">Token endpoint auth method</span>
-                    <select className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={tokenEndpointAuthentication} onChange={(event) => setTokenEndpointAuthentication(event.target.value === "client_secret_basic" || event.target.value === "client_secret_post" ? event.target.value : "")}>
-                      <option value="">Use provider default</option>
-                      <option value="client_secret_basic">client_secret_basic</option>
-                      <option value="client_secret_post">client_secret_post</option>
-                    </select>
-                  </label>
-                  <label className="flex items-center gap-3 rounded-[18px] border border-gray-200 px-4 py-3 text-[14px] text-gray-700 md:col-span-2">
-                    <input type="checkbox" checked={skipDiscovery} onChange={(event) => setSkipDiscovery(event.target.checked)} />
-                    Use manual OIDC endpoints instead of discovery
-                  </label>
-                  {skipDiscovery ? (
-                    <>
-                      <label className="block text-[14px] text-gray-700 md:col-span-2">
-                        <span className="mb-2 block font-medium">Authorization endpoint</span>
-                        <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={authorizationEndpoint} onChange={(event) => setAuthorizationEndpoint(event.target.value)} placeholder="https://idp.example.com/oauth2/v1/authorize" />
-                      </label>
-                      <label className="block text-[14px] text-gray-700 md:col-span-2">
-                        <span className="mb-2 block font-medium">Token endpoint</span>
-                        <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={tokenEndpoint} onChange={(event) => setTokenEndpoint(event.target.value)} placeholder="https://idp.example.com/oauth2/v1/token" />
-                      </label>
-                      <label className="block text-[14px] text-gray-700 md:col-span-2">
-                        <span className="mb-2 block font-medium">JWKS endpoint</span>
-                        <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={jwksEndpoint} onChange={(event) => setJwksEndpoint(event.target.value)} placeholder="https://idp.example.com/oauth2/v1/keys" />
-                      </label>
-                      <label className="block text-[14px] text-gray-700 md:col-span-2">
-                        <span className="mb-2 block font-medium">UserInfo endpoint</span>
-                        <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={userInfoEndpoint} onChange={(event) => setUserInfoEndpoint(event.target.value)} placeholder="Optional" />
-                      </label>
-                    </>
-                  ) : null}
-                </>
-              )}
-            </div>
+              <div className="mt-6 grid gap-4 md:grid-cols-2">
+                <label className="block text-[14px] text-gray-700">
+                  <span className="mb-2 block font-medium">Issuer URL</span>
+                  <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={issuer} onChange={(event) => setIssuer(event.target.value)} placeholder="https://idp.example.com" />
+                </label>
+                <label className="block text-[14px] text-gray-700">
+                  <span className="mb-2 block font-medium">Domain</span>
+                  <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={domain} onChange={(event) => setDomain(event.target.value)} placeholder="example.com" />
+                </label>
+                {formMode === "saml" ? (
+                  <>
+                    <label className="block text-[14px] text-gray-700 md:col-span-2">
+                      <span className="mb-2 block font-medium">SAML Entry Point</span>
+                      <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={entryPoint} onChange={(event) => setEntryPoint(event.target.value)} placeholder="https://idp.example.com/sso" />
+                    </label>
+                    <label className="block text-[14px] text-gray-700 md:col-span-2">
+                      <span className="mb-2 block font-medium">Audience URL</span>
+                      <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={audience} onChange={(event) => setAudience(event.target.value)} placeholder="Defaults to the OpenWork auth URL" />
+                    </label>
+                    <label className="block text-[14px] text-gray-700 md:col-span-2">
+                      <span className="mb-2 block font-medium">IdP Certificate</span>
+                      <textarea className="min-h-[140px] w-full rounded-[18px] border border-gray-200 px-4 py-3" value={cert} onChange={(event) => setCert(event.target.value)} placeholder="-----BEGIN CERTIFICATE-----" />
+                    </label>
+                    <div className="rounded-[18px] border border-gray-200 px-4 py-3 text-[14px] leading-6 text-gray-600 md:col-span-2">
+                      OpenWork always requires signed SAML assertions, timestamps, and SP-initiated responses for organization SAML connections.
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <label className="block text-[14px] text-gray-700">
+                      <span className="mb-2 block font-medium">Client ID</span>
+                      <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={clientId} onChange={(event) => setClientId(event.target.value)} />
+                    </label>
+                    <label className="block text-[14px] text-gray-700">
+                      <span className="mb-2 block font-medium">Client Secret</span>
+                      <input type="password" className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={clientSecret} onChange={(event) => setClientSecret(event.target.value)} />
+                    </label>
+                    <label className="block text-[14px] text-gray-700 md:col-span-2">
+                      <span className="mb-2 block font-medium">Scopes</span>
+                      <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={scopes} onChange={(event) => setScopes(event.target.value)} placeholder="openid email profile" />
+                    </label>
+                    <label className="block text-[14px] text-gray-700 md:col-span-2">
+                      <span className="mb-2 block font-medium">Token endpoint auth method</span>
+                      <select className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={tokenEndpointAuthentication} onChange={(event) => setTokenEndpointAuthentication(event.target.value === "client_secret_basic" || event.target.value === "client_secret_post" ? event.target.value : "")}>
+                        <option value="">Use provider default</option>
+                        <option value="client_secret_basic">client_secret_basic</option>
+                        <option value="client_secret_post">client_secret_post</option>
+                      </select>
+                    </label>
+                    <label className="flex items-center gap-3 rounded-[18px] border border-gray-200 px-4 py-3 text-[14px] text-gray-700 md:col-span-2">
+                      <input type="checkbox" checked={skipDiscovery} onChange={(event) => setSkipDiscovery(event.target.checked)} />
+                      Use manual OIDC endpoints instead of discovery
+                    </label>
+                    {skipDiscovery ? (
+                      <>
+                        <label className="block text-[14px] text-gray-700 md:col-span-2">
+                          <span className="mb-2 block font-medium">Authorization endpoint</span>
+                          <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={authorizationEndpoint} onChange={(event) => setAuthorizationEndpoint(event.target.value)} placeholder="https://idp.example.com/oauth2/v1/authorize" />
+                        </label>
+                        <label className="block text-[14px] text-gray-700 md:col-span-2">
+                          <span className="mb-2 block font-medium">Token endpoint</span>
+                          <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={tokenEndpoint} onChange={(event) => setTokenEndpoint(event.target.value)} placeholder="https://idp.example.com/oauth2/v1/token" />
+                        </label>
+                        <label className="block text-[14px] text-gray-700 md:col-span-2">
+                          <span className="mb-2 block font-medium">JWKS endpoint</span>
+                          <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={jwksEndpoint} onChange={(event) => setJwksEndpoint(event.target.value)} placeholder="https://idp.example.com/oauth2/v1/keys" />
+                        </label>
+                        <label className="block text-[14px] text-gray-700 md:col-span-2">
+                          <span className="mb-2 block font-medium">UserInfo endpoint</span>
+                          <input className="w-full rounded-[18px] border border-gray-200 px-4 py-3" value={userInfoEndpoint} onChange={(event) => setUserInfoEndpoint(event.target.value)} placeholder="Optional" />
+                        </label>
+                      </>
+                    ) : null}
+                  </>
+                )}
+              </div>
 
-            <div className="mt-6 flex flex-wrap gap-3">
-              <DenButton variant="primary" icon={RefreshCw} onClick={() => void handleSave()} disabled={saving}>{saving ? "Saving..." : "Save SSO connection"}</DenButton>
-              <DenButton variant="secondary" icon={Trash2} onClick={() => void handleDelete()} disabled={deleting || !connection}>{deleting ? "Deleting..." : "Delete connection"}</DenButton>
+              <div className="mt-6 flex flex-wrap gap-3">
+                <DenButton variant="primary" icon={RefreshCw} onClick={() => void handleSave()} disabled={saving || !orgContext.entitlements.sso}>{saving ? "Saving..." : "Save SSO connection"}</DenButton>
+                <DenButton variant="secondary" icon={Trash2} onClick={() => void handleDelete()} disabled={deleting || !connection}>{deleting ? "Deleting..." : "Delete connection"}</DenButton>
+              </div>
             </div>
-          </div>
+          ) : null}
 
           <div className="rounded-[30px] border border-gray-200 bg-white p-6 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.22)]">
             <div className="flex items-start justify-between gap-4">
@@ -361,6 +373,12 @@ export function SsoScreen() {
                 <p className="text-[16px] font-semibold tracking-[-0.03em] text-gray-900">Current connection</p>
                 <p className="mt-1 text-[14px] leading-6 text-gray-500">Use the generated sign-in and provider setup URLs below.</p>
               </div>
+              {connection && !editing ? (
+                <div className="flex flex-wrap gap-3">
+                  <DenButton variant="secondary" onClick={() => setEditing(true)}>Edit connection</DenButton>
+                  <DenButton variant="secondary" icon={Trash2} onClick={() => void handleDelete()} disabled={deleting}>{deleting ? "Deleting..." : "Delete connection"}</DenButton>
+                </div>
+              ) : null}
             </div>
 
             {!connection && !busy ? <p className="mt-4 text-[14px] text-gray-500">No SSO connection configured yet.</p> : null}


### PR DESCRIPTION
## Summary
- hide the SSO setup form after a connection is saved and expose Edit/Delete actions from the current connection view
- auto-verify Microsoft Entra managed .onmicrosoft.com domains when the issuer and SAML entry point match the same tenant
- add Microsoft Entra SAML/SCIM setup docs and a focused unit test for managed-domain detection

## Verification
- bun test ee/apps/den-api/test/sso-entra-domain.test.ts ee/apps/den-api/test/sso-saml-policy.test.ts
- pnpm --filter @openwork-ee/den-api exec tsc --noEmit
- pnpm --filter @openwork-ee/den-web exec tsc --noEmit
- DEN_WEB_PORT=3505 DEN_API_PORT=9090 DEN_WORKER_PROXY_PORT=9091 INFERENCE_PORT=9092 pnpm dev:web-local
- curl -I http://localhost:3505/dashboard/sso
- curl -sS http://127.0.0.1:9090/health

## Notes
- Local authenticated UI verification was limited because the local seeded deployment enforces single-org SSO and rejects email/password login with single_org_sso_required.
- No video captured.