### PR TITLE
Add lifecycle diagnostics for workspace reload loop

### DIFF
--- a/apps/app/src/app/lib/diagnostics-bundle.ts
+++ b/apps/app/src/app/lib/diagnostics-bundle.ts
@@ -10,7 +10,10 @@ import {
 } from "./desktop";
 import { readPerfLogs, type PerfLogRecord } from "./perf-log";
 import {
+  DEFAULT_OPENWORK_SERVER_PORT,
+  createOpenworkServerClient,
   readOpenworkServerSettings,
+  type OpenworkServerDiagnostics,
   type OpenworkServerSettings,
   type OpenworkServerStatus,
 } from "./openwork-server";
@@ -35,6 +38,7 @@ export type DiagnosticsBundleInputs = {
   appInfo: AppBuildInfo | null;
   engineInfo: EngineInfo | null;
   openworkServerSettings: OpenworkServerSettings;
+  openworkServerDiagnostics: OpenworkServerDiagnostics | null;
   hostInfo: OpenworkServerInfo | null;
   developerLogs: DevLogRecord[];
   perfLogs: PerfLogRecord[];
@@ -164,6 +168,7 @@ export function composeDiagnosticsBundleJson(input: DiagnosticsBundleInputs): st
         urlOverride: urlOverride || null,
         tokenPresent: Boolean(token),
       },
+      diagnosticLogPaths: input.openworkServerDiagnostics?.server.diagnosticLogPaths ?? null,
       host: pickHostInfo(input.hostInfo),
     },
     reload: {
@@ -212,19 +217,43 @@ async function readHostInfo(desktopRuntime: boolean) {
   }
 }
 
+async function readOpenworkServerDiagnostics(
+  settings: OpenworkServerSettings,
+  context?: DiagnosticsBundleContext,
+): Promise<OpenworkServerDiagnostics | null> {
+  const baseUrl = (
+    context?.openworkServerUrl ??
+    settings.urlOverride ??
+    `http://127.0.0.1:${settings.portOverride ?? DEFAULT_OPENWORK_SERVER_PORT}`
+  ).trim();
+  if (!baseUrl) return null;
+  try {
+    return await createOpenworkServerClient({
+      baseUrl,
+      token: settings.token,
+      hostToken: settings.hostToken,
+    }).status();
+  } catch {
+    return null;
+  }
+}
+
 export async function buildDiagnosticsBundleJson(context?: DiagnosticsBundleContext): Promise<string> {
   const desktopRuntime = isDesktopRuntime();
   const hasContextHostInfo = context !== undefined && "hostInfo" in context;
+  const openworkServerSettings = readOpenworkServerSettings();
   const appInfo = await readAppInfo(desktopRuntime);
   const engine = await readEngineInfo(desktopRuntime);
   const fetchedHostInfo = hasContextHostInfo ? null : await readHostInfo(desktopRuntime);
   const hostInfo = hasContextHostInfo && context ? context.hostInfo ?? null : fetchedHostInfo;
+  const openworkServerDiagnostics = await readOpenworkServerDiagnostics(openworkServerSettings, context);
   return composeDiagnosticsBundleJson({
     capturedAt: new Date().toISOString(),
     desktopRuntime,
     appInfo,
     engineInfo: engine,
-    openworkServerSettings: readOpenworkServerSettings(),
+    openworkServerSettings,
+    openworkServerDiagnostics,
     hostInfo,
     developerLogs: readDevLogs(80),
     perfLogs: readPerfLogs(80),

--- a/apps/app/src/app/lib/lifecycle-diagnostics.ts
+++ b/apps/app/src/app/lib/lifecycle-diagnostics.ts
@@ -1,0 +1,66 @@
+import { recordInspectorEvent } from "./app-inspector";
+import {
+  DEFAULT_OPENWORK_SERVER_PORT,
+  normalizeOpenworkServerUrl,
+  readOpenworkServerSettings,
+} from "./openwork-server";
+
+let flushTimer: number | null = null;
+let queue: Array<Record<string, unknown>> = [];
+
+function resolveDiagnosticServerUrl(): string {
+  const settings = readOpenworkServerSettings();
+  const explicit = normalizeOpenworkServerUrl(settings.urlOverride ?? "");
+  if (explicit) return explicit;
+  const port = typeof settings.portOverride === "number" && Number.isFinite(settings.portOverride)
+    ? settings.portOverride
+    : DEFAULT_OPENWORK_SERVER_PORT;
+  return `http://127.0.0.1:${port}`;
+}
+
+function scheduleFlush(): void {
+  if (typeof window === "undefined") return;
+  if (flushTimer) return;
+  flushTimer = window.setTimeout(() => {
+    flushTimer = null;
+    void flushLifecycleDiagnostics();
+  }, 500);
+}
+
+async function flushLifecycleDiagnostics(): Promise<void> {
+  if (queue.length === 0) return;
+  const batch = queue;
+  queue = [];
+  try {
+    await fetch(`${resolveDiagnosticServerUrl()}/dev/log`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(batch),
+      keepalive: true,
+    });
+  } catch {
+    // Keep diagnostics best-effort; failed writes should not feed the reload loop.
+  }
+}
+
+export function recordLifecycleDiagnostic(event: string, details: Record<string, unknown> = {}): void {
+  const entry = {
+    at: new Date().toISOString(),
+    event,
+    ...details,
+  };
+  recordInspectorEvent(`lifecycle.${event}`, entry);
+  queue.push({
+    level: "info",
+    source: "lifecycle",
+    message: event,
+    extra: entry,
+  });
+  if (queue.length > 100) queue.splice(0, queue.length - 100);
+  scheduleFlush();
+  try {
+    console.info("[openwork-lifecycle]", entry);
+  } catch {
+    // Diagnostics must never affect the app path they are observing.
+  }
+}

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -50,7 +50,15 @@ export type OpenworkServerDiagnostics = {
   selectedWorkspaceId?: string | null;
   workspace: OpenworkWorkspaceInfo | null;
   authorizedRoots: string[];
-  server: { host: string; port: number; configPath?: string | null };
+  server: {
+    host: string;
+    port: number;
+    configPath?: string | null;
+    diagnosticLogPaths?: {
+      browser?: string | null;
+      lifecycle?: string | null;
+    };
+  };
   tokenSource: { client: string; host: string };
 };
 

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -21,6 +21,7 @@ import {
   workspaceOpenworkRead,
   workspaceOpenworkWrite,
 } from "../../../../app/lib/desktop";
+import { recordLifecycleDiagnostic } from "../../../../app/lib/lifecycle-diagnostics";
 import { OpenworkServerError } from "../../../../app/lib/openwork-server";
 import type {
   Client,
@@ -1158,13 +1159,20 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             "";
           if (workspaceId) {
             try {
+              recordLifecycleDiagnostic("provider_auth.reload_server_start", { workspaceId });
               await openworkClient.reloadEngine(workspaceId);
+              recordLifecycleDiagnostic("provider_auth.reload_server_success", { workspaceId });
             } catch (error) {
               const unreachable =
                 error instanceof OpenworkServerError && error.code === "opencode_engine_unreachable";
               if (!unreachable || !isDesktopRuntime()) {
+                recordLifecycleDiagnostic("provider_auth.reload_server_error", {
+                  workspaceId,
+                  message: error instanceof Error ? error.message : String(error),
+                });
                 throw error;
               }
+              recordLifecycleDiagnostic("provider_auth.reload_desktop_restart", { workspaceId });
               await engineRestart({});
             }
             reloaded = true;
@@ -1176,8 +1184,11 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
       if (!reloaded) {
         try {
+          recordLifecycleDiagnostic("provider_auth.direct_dispose_start");
           unwrap(await c.instance.dispose());
+          recordLifecycleDiagnostic("provider_auth.direct_dispose_success");
         } catch {
+          recordLifecycleDiagnostic("provider_auth.direct_dispose_error");
           // ignore dispose failures and try reading current state anyway
         }
       }

--- a/apps/app/src/react-app/kernel/system-state.ts
+++ b/apps/app/src/react-app/kernel/system-state.ts
@@ -11,6 +11,7 @@ import {
   isDesktopRuntime,
   safeStringify,
 } from "../../app/utils";
+import { recordLifecycleDiagnostic } from "../../app/lib/lifecycle-diagnostics";
 import { t } from "../../i18n";
 
 export type ReloadState = {
@@ -89,6 +90,10 @@ export function useSystemState(
 
   const markReloadRequired = useCallback(
     (reason: ReloadReason, trigger?: ReloadTrigger) => {
+      recordLifecycleDiagnostic("system.mark_reload_required", {
+        reason,
+        trigger: trigger ?? null,
+      });
       setReloadPending(true);
       setReloadLastTriggeredAt(Date.now());
       setReloadReasons((current) =>
@@ -145,11 +150,20 @@ export function useSystemState(
     !reloadBusy && options.canReloadWorkspaceEngine?.() !== false;
 
   const reloadWorkspaceEngine = useCallback(async () => {
-    if (reloadBusy) return;
+    if (reloadBusy) {
+      recordLifecycleDiagnostic("system.reload_ignored_busy");
+      return;
+    }
     if (options.canReloadWorkspaceEngine?.() === false) {
+      recordLifecycleDiagnostic("system.reload_unavailable");
       setReloadError(t("system.reload_unavailable"));
       return;
     }
+    recordLifecycleDiagnostic("system.reload_start", {
+      pending: reloadPending,
+      reasons: reloadReasons,
+      trigger: reloadTrigger,
+    });
     setReloadBusy(true);
     setReloadError(null);
     options.setError(null);
@@ -158,18 +172,32 @@ export function useSystemState(
         ? await options.reloadWorkspaceEngine()
         : false;
       if (ok === false) {
+        recordLifecycleDiagnostic("system.reload_failed_return", {
+          pending: reloadPending,
+          reasons: reloadReasons,
+          trigger: reloadTrigger,
+        });
         setReloadError(t("system.reload_failed"));
         return;
       }
       await options.onReloadComplete?.();
       clearReloadRequired();
+      recordLifecycleDiagnostic("system.reload_success", {
+        reasons: reloadReasons,
+        trigger: reloadTrigger,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : safeStringify(error);
+      recordLifecycleDiagnostic("system.reload_error", {
+        message,
+        reasons: reloadReasons,
+        trigger: reloadTrigger,
+      });
       setReloadError(message || t("system.reload_failed"));
     } finally {
       setReloadBusy(false);
     }
-  }, [clearReloadRequired, options, reloadBusy]);
+  }, [clearReloadRequired, options, reloadBusy, reloadPending, reloadReasons, reloadTrigger]);
 
   const openResetModal = useCallback(
     (mode: ResetOpenworkMode) => {

--- a/apps/app/src/react-app/shell/reload-coordinator.tsx
+++ b/apps/app/src/react-app/shell/reload-coordinator.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 
 import type { ReloadReason, ReloadTrigger } from "@/app/types";
+import { recordLifecycleDiagnostic } from "@/app/lib/lifecycle-diagnostics";
 import { t } from "@/i18n";
 import {
   useSessionActivityStore,
@@ -177,7 +178,11 @@ export function ReloadCoordinatorProvider({ children }: { children: ReactNode })
   );
   const reloadWorkspaceEngine = useCallback(async () => {
     const controls = controlsRef.current;
-    if (!controls?.reloadWorkspaceEngine) return false;
+    if (!controls?.reloadWorkspaceEngine) {
+      recordLifecycleDiagnostic("coordinator.reload_missing_controls");
+      return false;
+    }
+    recordLifecycleDiagnostic("coordinator.reload_call_controls");
     return controls.reloadWorkspaceEngine();
   }, []);
   const ignoreError = useCallback(() => {}, []);
@@ -227,6 +232,10 @@ export function ReloadCoordinatorProvider({ children }: { children: ReactNode })
   useEffect(() => {
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<{ reason?: ReloadReason; trigger?: ReloadTrigger }>).detail;
+      recordLifecycleDiagnostic("coordinator.window_reload_required", {
+        reason: detail?.reason ?? "config",
+        trigger: detail?.trigger ?? null,
+      });
       systemState.markReloadRequired(detail?.reason ?? "config", detail?.trigger);
     };
 
@@ -284,13 +293,25 @@ export function ReloadCoordinatorProvider({ children }: { children: ReactNode })
       AUTO_RELOAD_DEBOUNCE_MS,
       lastAutoReloadAtRef.current + AUTO_RELOAD_COOLDOWN_MS - Date.now(),
     );
+    recordLifecycleDiagnostic("coordinator.auto_reload_scheduled", {
+      delayMs: delay,
+      activeSessions: activeSessions.length,
+      activityBlocked,
+      trigger: systemState.reload.reloadTrigger,
+    });
     const timer = window.setTimeout(() => {
       // Re-check at fire time: a task may have started during the debounce
       // window. The effect re-runs when activity ends and reschedules.
       if (hasLiveSessionActivity(useSessionActivityStore.getState().statusesByWorkspaceId)) {
+        recordLifecycleDiagnostic("coordinator.auto_reload_skipped_activity", {
+          trigger: systemState.reload.reloadTrigger,
+        });
         return;
       }
       lastAutoReloadAtRef.current = Date.now();
+      recordLifecycleDiagnostic("coordinator.auto_reload_fire", {
+        trigger: systemState.reload.reloadTrigger,
+      });
       void systemState.reloadWorkspaceEngine();
     }, delay);
     return () => window.clearTimeout(timer);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -19,6 +19,7 @@ import { captureAnalyticsEvent, markTaskRunStart } from "@/app/lib/analytics";
 import { trackSessionActive, trackTaskStarted } from "@/app/lib/den-telemetry";
 import { buildDiagnosticsBundleJson } from "@/app/lib/diagnostics-bundle";
 import { downloadTextAsFile } from "@/app/lib/download";
+import { recordLifecycleDiagnostic } from "@/app/lib/lifecycle-diagnostics";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { abortSessionSafe, forkSession, listCommands, revertSession, setSessionArchived, shellInSession } from "@/app/lib/opencode-session";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
@@ -1846,7 +1847,27 @@ export function SessionRoute() {
             const workspace = workspaces.find((item) => item.id === workspaceId) ?? null;
             const endpoint = endpointForWorkspace(workspace);
             if (endpoint) {
-              void endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true }).catch(() => undefined);
+              recordLifecycleDiagnostic("session.activate_workspace_start", {
+                selectedWorkspaceId: workspaceId,
+                endpointWorkspaceId: endpoint.workspaceId,
+                persist: true,
+              });
+              void endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true })
+                .then(() => {
+                  recordLifecycleDiagnostic("session.activate_workspace_success", {
+                    selectedWorkspaceId: workspaceId,
+                    endpointWorkspaceId: endpoint.workspaceId,
+                    persist: true,
+                  });
+                })
+                .catch((error) => {
+                  recordLifecycleDiagnostic("session.activate_workspace_error", {
+                    selectedWorkspaceId: workspaceId,
+                    endpointWorkspaceId: endpoint.workspaceId,
+                    persist: true,
+                    message: error instanceof Error ? error.message : String(error),
+                  });
+                });
             }
           }
           // If we remember what the user last opened here and that session

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -5,6 +5,7 @@ import { toast } from "@/components/ui/sonner";
 
 import { SUGGESTED_PLUGINS } from "@/app/constants";
 import type { EnablementContext } from "@/app/enablement";
+import { recordLifecycleDiagnostic } from "@/app/lib/lifecycle-diagnostics";
 import { createClient } from "@/app/lib/opencode";
 import {
   createOpenworkServerClient,
@@ -180,13 +181,20 @@ async function reloadEngineOrRestartDesktop(
   afterRestart?: () => Promise<void>,
 ): Promise<void> {
   try {
+    recordLifecycleDiagnostic("settings.reload_server_start", { workspaceId });
     await client.reloadEngine(workspaceId);
+    recordLifecycleDiagnostic("settings.reload_server_success", { workspaceId });
   } catch (error) {
     const unreachable =
       error instanceof OpenworkServerError && error.code === "opencode_engine_unreachable";
     if (!unreachable || !isDesktopRuntime()) {
+      recordLifecycleDiagnostic("settings.reload_server_error", {
+        workspaceId,
+        message: error instanceof Error ? error.message : String(error),
+      });
       throw error;
     }
+    recordLifecycleDiagnostic("settings.reload_desktop_restart", { workspaceId });
     await engineRestart({});
     await afterRestart?.();
   }
@@ -1748,7 +1756,27 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     const workspace = workspaces.find((item) => item.id === workspaceId) ?? null;
     const endpoint = resolveWorkspaceEndpoint(workspace, { baseUrl, token });
     if (endpoint) {
-      void endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true }).catch(() => undefined);
+      recordLifecycleDiagnostic("settings.activate_workspace_start", {
+        selectedWorkspaceId: workspaceId,
+        endpointWorkspaceId: endpoint.workspaceId,
+        persist: true,
+      });
+      void endpoint.client.activateWorkspace(endpoint.workspaceId, { persist: true })
+        .then(() => {
+          recordLifecycleDiagnostic("settings.activate_workspace_success", {
+            selectedWorkspaceId: workspaceId,
+            endpointWorkspaceId: endpoint.workspaceId,
+            persist: true,
+          });
+        })
+        .catch((error) => {
+          recordLifecycleDiagnostic("settings.activate_workspace_error", {
+            selectedWorkspaceId: workspaceId,
+            endpointWorkspaceId: endpoint.workspaceId,
+            persist: true,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        });
     }
     if (isDesktopRuntime()) {
       void workspaceSetSelected(workspaceId).catch(() => undefined);

--- a/apps/app/src/react-app/shell/use-engine-reload.ts
+++ b/apps/app/src/react-app/shell/use-engine-reload.ts
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { engineInfo, engineRestart } from "@/app/lib/desktop";
 import type { EngineInfo } from "@/app/lib/desktop-types";
+import { recordLifecycleDiagnostic } from "@/app/lib/lifecycle-diagnostics";
 import { isDesktopRuntime } from "@/app/lib/runtime-env";
 import { OpenworkServerError, type OpenworkServerClient } from "@/app/lib/openwork-server";
 import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
@@ -52,23 +53,42 @@ export function useEngineReload(input: UseEngineReloadInput) {
 
   const reloadWorkspaceEngineFromUi = useCallback(async () => {
     if (!client || !workspaceId) {
+      recordLifecycleDiagnostic("ui.reload_missing_client", { workspaceId });
       onError(t("app.error_connect_first"));
       return false;
     }
     const endpoint = endpointForWorkspace(workspace);
     if (!endpoint) {
+      recordLifecycleDiagnostic("ui.reload_missing_endpoint", { workspaceId });
       onError(t("app.error_connect_first"));
       return false;
     }
     let restartedEngine = false;
     try {
+      recordLifecycleDiagnostic("ui.reload_server_start", {
+        workspaceId,
+        endpointWorkspaceId: endpoint.workspaceId,
+      });
       await endpoint.client.reloadEngine(endpoint.workspaceId);
+      recordLifecycleDiagnostic("ui.reload_server_success", {
+        workspaceId,
+        endpointWorkspaceId: endpoint.workspaceId,
+      });
     } catch (error) {
       const unreachable =
         error instanceof OpenworkServerError && error.code === "opencode_engine_unreachable";
       if (!unreachable || !isDesktopRuntime()) {
+        recordLifecycleDiagnostic("ui.reload_server_error", {
+          workspaceId,
+          endpointWorkspaceId: endpoint.workspaceId,
+          message: error instanceof Error ? error.message : String(error),
+        });
         throw error;
       }
+      recordLifecycleDiagnostic("ui.reload_fallback_engine_restart", {
+        workspaceId,
+        endpointWorkspaceId: endpoint.workspaceId,
+      });
       await engineRestart({});
       restartedEngine = true;
     }
@@ -89,6 +109,11 @@ export function useEngineReload(input: UseEngineReloadInput) {
     }
     toast.dismiss(taskCreateUnavailableToastId(workspaceId));
     toast.dismiss();
+    recordLifecycleDiagnostic("ui.reload_complete", {
+      workspaceId,
+      endpointWorkspaceId: endpoint.workspaceId,
+      restartedEngine,
+    });
     return true;
   }, [client, endpointForWorkspace, onError, refreshRouteState, workspace, workspaceId]);
 
@@ -109,6 +134,7 @@ export function useEngineReload(input: UseEngineReloadInput) {
       return;
     }
     // Marking is enough: the reload coordinator auto-reloads once idle.
+    recordLifecycleDiagnostic("ui.org_onboarding_reload_latch", { workspaceId });
     reloadCoordinator.markReloadRequired("config", {
       type: "config",
       name: "opencode.json",
@@ -140,6 +166,13 @@ export function useEngineReload(input: UseEngineReloadInput) {
         // agent while the session page is open.
         if (currentCursor === undefined || currentCursor === null) return;
         for (const event of response.items ?? []) {
+          recordLifecycleDiagnostic("ui.reload_event_polled", {
+            workspaceId,
+            endpointWorkspaceId: endpoint.workspaceId,
+            reason: event.reason,
+            trigger: event.trigger ?? null,
+            seq: event.seq,
+          });
           reloadCoordinator.markReloadRequired(event.reason, event.trigger);
         }
       } catch {

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { publishInspectorSlice, recordInspectorEvent } from "@/app/lib/app-inspector";
+import { recordLifecycleDiagnostic } from "@/app/lib/lifecycle-diagnostics";
 import {
   resolveWorkspaceListSelectedId,
   workspaceBootstrap,
@@ -426,7 +427,30 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         const nextWorkspace = nextWorkspaces.find((workspace) => workspace.id === nextWorkspaceId) ?? null;
         const nextEndpoint = endpointForWorkspace(nextWorkspace);
         if (nextEndpoint) {
-          void nextEndpoint.client.activateWorkspace(nextEndpoint.workspaceId).catch(() => undefined);
+          recordLifecycleDiagnostic("route.activate_workspace_start", {
+            selectedWorkspaceId: nextWorkspaceId,
+            serverActiveId: list.activeId,
+            endpointWorkspaceId: nextEndpoint.workspaceId,
+            persist: false,
+          });
+          void nextEndpoint.client.activateWorkspace(nextEndpoint.workspaceId)
+            .then(() => {
+              recordLifecycleDiagnostic("route.activate_workspace_success", {
+                selectedWorkspaceId: nextWorkspaceId,
+                serverActiveId: list.activeId,
+                endpointWorkspaceId: nextEndpoint.workspaceId,
+                persist: false,
+              });
+            })
+            .catch((error) => {
+              recordLifecycleDiagnostic("route.activate_workspace_error", {
+                selectedWorkspaceId: nextWorkspaceId,
+                serverActiveId: list.activeId,
+                endpointWorkspaceId: nextEndpoint.workspaceId,
+                persist: false,
+                message: error instanceof Error ? error.message : String(error),
+              });
+            });
         }
       }
       recordInspectorEvent("route.refresh.complete", {

--- a/apps/server/src/lifecycle-diagnostics.ts
+++ b/apps/server/src/lifecycle-diagnostics.ts
@@ -1,0 +1,107 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { runtimeStorageDir } from "./runtime-opencode-config-store.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+export type ReloadOpencodeEngineInput = {
+  reason?: string;
+  source?: string;
+  trigger?: unknown;
+};
+
+function envFlagEnabled(name: string): boolean {
+  const raw = (process.env[name] ?? "").trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(raw);
+}
+
+export function browserDiagnosticLogPath(config: ServerConfig): string | null {
+  const override = (process.env.OPENWORK_DEV_LOG_FILE ?? "").trim();
+  if (override) return override;
+  if (envFlagEnabled("OPENWORK_DISABLE_DEV_LOG_FILE") || envFlagEnabled("OPENWORK_DISABLE_DIAGNOSTIC_LOGS")) return null;
+  return join(runtimeStorageDir(config), "openwork-browser-diagnostics.jsonl");
+}
+
+export function lifecycleDiagnosticLogPath(config: ServerConfig): string | null {
+  const override = (process.env.OPENWORK_LIFECYCLE_LOG_FILE ?? "").trim();
+  if (override) return override;
+  if (envFlagEnabled("OPENWORK_DISABLE_LIFECYCLE_LOG_FILE") || envFlagEnabled("OPENWORK_DISABLE_DIAGNOSTIC_LOGS")) return null;
+  return join(runtimeStorageDir(config), "openwork-lifecycle-diagnostics.jsonl");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitizeDiagnosticValue(input: unknown, depth = 0): unknown {
+  if (depth > 4) return "[truncated]";
+  if (input === null || input === undefined) return input;
+  if (typeof input === "string" || typeof input === "number" || typeof input === "boolean") return input;
+  if (typeof input === "bigint" || typeof input === "symbol" || typeof input === "function") return String(input);
+  if (input instanceof Error) {
+    return { name: input.name, message: input.message, stack: input.stack };
+  }
+  if (Array.isArray(input)) {
+    return input.slice(0, 50).map((item) => sanitizeDiagnosticValue(item, depth + 1));
+  }
+  if (!isRecord(input)) return String(input);
+
+  const output: Record<string, unknown> = {};
+  let count = 0;
+  for (const [key, value] of Object.entries(input)) {
+    if (count > 50) {
+      output.__truncated = true;
+      break;
+    }
+    count += 1;
+    output[key] = sanitizeDiagnosticValue(value, depth + 1);
+  }
+  return output;
+}
+
+export function sanitizeDiagnosticUrl(input: string): string {
+  try {
+    const url = new URL(input);
+    url.username = "";
+    url.password = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return input.trim() ? "[invalid-url]" : "";
+  }
+}
+
+export function workspaceDiagnosticSummary(workspace: WorkspaceInfo): Record<string, unknown> {
+  return {
+    id: workspace.id,
+    path: workspace.path,
+    name: workspace.name ?? null,
+    workspaceType: workspace.workspaceType ?? null,
+    preset: workspace.preset ?? null,
+    hasBaseUrl: Boolean(workspace.baseUrl?.trim()),
+    hasDirectory: Boolean(workspace.directory?.trim()),
+  };
+}
+
+export async function recordLifecycleDiagnostic(
+  config: ServerConfig,
+  event: string,
+  details: Record<string, unknown> = {},
+): Promise<void> {
+  const target = lifecycleDiagnosticLogPath(config);
+  if (!target) return;
+
+  const entry = {
+    at: new Date().toISOString(),
+    event,
+    pid: process.pid,
+    uptimeMs: Date.now() - config.startedAt,
+    ...details,
+  };
+
+  try {
+    await mkdir(dirname(target), { recursive: true });
+    await appendFile(target, `${JSON.stringify(sanitizeDiagnosticValue(entry))}\n`, "utf8");
+  } catch (error) {
+    console.warn("[openwork-lifecycle] failed to write diagnostic log", error);
+  }
+}

--- a/apps/server/src/routes/core.ts
+++ b/apps/server/src/routes/core.ts
@@ -48,6 +48,7 @@ interface RegisterCoreRoutesOptions {
   serializeWorkspace: (workspace: ServerConfig["workspaces"][number]) => unknown;
   resolveToyUiEnabled: () => boolean;
   resolveDevLogPath: () => string | null;
+  resolveLifecycleLogPath: () => string | null;
   createOpenAiRealtimeVoiceSession: (env: EnvService, input: unknown) => Promise<unknown>;
 }
 
@@ -74,6 +75,7 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
     serializeWorkspace,
     resolveToyUiEnabled,
     resolveDevLogPath,
+    resolveLifecycleLogPath,
     createOpenAiRealtimeVoiceSession,
   } = options;
   const googleWorkspaceConnectFlows = createGoogleWorkspaceConnectFlowManager(config);
@@ -93,7 +95,8 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
   // Dev log sink: append browser console + error events to a file that an
   // operator (or an AI driver) can tail. Unauth on purpose because this is
   // scoped to the dev host and needs to work before clients finish wiring
-  // tokens; it is also a no-op when OPENWORK_DEV_LOG_FILE is unset.
+  // tokens. Alpha/support builds keep this on by default and can opt out with
+  // OPENWORK_DISABLE_DEV_LOG_FILE=1.
   addRoute(routes, "POST", "/dev/log", "none", async (ctx) => {
     const target = resolveDevLogPath();
     if (!target) {
@@ -190,6 +193,10 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
         host: config.host,
         port: config.port,
         configPath: config.configPath ?? null,
+        diagnosticLogPaths: {
+          browser: resolveDevLogPath(),
+          lifecycle: resolveLifecycleLogPath(),
+        },
       },
       tokenSource: {
         client: config.tokenSource,
@@ -225,6 +232,10 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
         host: config.host,
         port: config.port,
         configPath: config.configPath ?? null,
+        diagnosticLogPaths: {
+          browser: resolveDevLogPath(),
+          lifecycle: resolveLifecycleLogPath(),
+        },
       },
       tokenSource: {
         client: config.tokenSource,

--- a/apps/server/src/routes/operations.ts
+++ b/apps/server/src/routes/operations.ts
@@ -1,5 +1,6 @@
 import { recordAudit } from "../audit.js";
 import { ApiError } from "../errors.js";
+import type { ReloadOpencodeEngineInput } from "../lifecycle-diagnostics.js";
 import type { ServerConfig, TokenScope, WorkspaceInfo } from "../types.js";
 import { shortId } from "../utils.js";
 import { addRoute, type RequestContext, type Route } from "./registry.js";
@@ -14,7 +15,7 @@ interface RegisterOperationRoutesOptions {
   readJsonBody: ReadJsonBody;
   requireClientScope: (ctx: RequestContext, required: TokenScope) => void;
   resolveWorkspace: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
-  reloadOpencodeEngine: (config: ServerConfig, workspace: WorkspaceInfo) => Promise<void>;
+  reloadOpencodeEngine: (config: ServerConfig, workspace: WorkspaceInfo, input?: ReloadOpencodeEngineInput) => Promise<void>;
 }
 
 export function registerOperationRoutes(options: RegisterOperationRoutesOptions): void {
@@ -40,7 +41,11 @@ export function registerOperationRoutes(options: RegisterOperationRoutesOptions)
     const workspace = await resolveWorkspace(config, ctx.params.id);
     requireClientScope(ctx, "collaborator");
 
-    await reloadOpencodeEngine(config, workspace);
+    await reloadOpencodeEngine(config, workspace, {
+      reason: "workspace.engine_reload",
+      source: "POST /workspace/:id/engine/reload",
+      trigger: { route: ctx.url.pathname },
+    });
 
     await recordAudit(workspace.path, {
       id: shortId(),

--- a/apps/server/src/routes/workspaces.ts
+++ b/apps/server/src/routes/workspaces.ts
@@ -2,6 +2,7 @@ import { readFile, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
 import { recordAudit } from "../audit.js";
 import { ApiError } from "../errors.js";
+import type { ReloadOpencodeEngineInput } from "../lifecycle-diagnostics.js";
 import { inheritWorkspaceOpencodeConnection, resolveWorkspaceOpencodeConnection } from "../opencode-connection.js";
 import type { ServerConfig, WorkspaceInfo } from "../types.js";
 import { ensureDir, exists, shortId } from "../utils.js";
@@ -25,7 +26,7 @@ interface RegisterWorkspaceRoutesOptions {
   ensureWritable: (config: ServerConfig) => void;
   resolveWorkspace: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
   serializeWorkspace: (workspace: ServerConfig["workspaces"][number]) => unknown;
-  reloadOpencodeEngine: (config: ServerConfig, workspace: WorkspaceInfo) => Promise<void>;
+  reloadOpencodeEngine: (config: ServerConfig, workspace: WorkspaceInfo, input?: ReloadOpencodeEngineInput) => Promise<void>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -452,6 +453,7 @@ export function registerWorkspaceRoutes(options: RegisterWorkspaceRoutesOptions)
 
   addRoute(routes, "POST", "/workspaces/:id/activate", "host", async (ctx) => {
     const workspace = await resolveWorkspaceForRegistry(ctx.params.id);
+    const previousActiveId = config.workspaces[0]?.id ?? null;
     const queryPersist = parseOptionalBoolean(ctx.url.searchParams.get("persist"), "persist");
     const body = queryPersist === undefined ? await readOptionalJsonBody(ctx.request) : {};
     const persist = queryPersist ?? (body.persist === true);
@@ -472,7 +474,16 @@ export function registerWorkspaceRoutes(options: RegisterWorkspaceRoutesOptions)
       timestamp: Date.now(),
     });
     if (workspace.workspaceType === "local" && resolveWorkspaceOpencodeConnection(config, workspace).baseUrl?.trim()) {
-      await reloadOpencodeEngine(config, workspace);
+      await reloadOpencodeEngine(config, workspace, {
+        reason: "workspace.activate",
+        source: "POST /workspaces/:id/activate",
+        trigger: {
+          route: ctx.url.pathname,
+          persist,
+          previousActiveId,
+          requestedWorkspaceId: workspace.id,
+        },
+      });
     }
     return jsonResponse({ activeId: workspace.id, workspace: serializeWorkspace(workspace), persisted });
   });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -70,6 +70,14 @@ import {
   writeRuntimeOpencodeConfig,
 } from "./runtime-opencode-config-store.js";
 import {
+  browserDiagnosticLogPath,
+  lifecycleDiagnosticLogPath,
+  recordLifecycleDiagnostic,
+  sanitizeDiagnosticUrl,
+  workspaceDiagnosticSummary,
+  type ReloadOpencodeEngineInput,
+} from "./lifecycle-diagnostics.js";
+import {
   hasOpenworkWorkspaceConfig,
   mergeOpenworkWorkspaceConfigs,
   readOpenworkWorkspaceConfig,
@@ -1121,13 +1129,11 @@ function resolveToyUiEnabled(): boolean {
   return ["1", "true", "yes", "on"].includes(raw);
 }
 
-// Dev-only log sink target. When OPENWORK_DEV_LOG_FILE is set to a path, the
-// /dev/log endpoint accepts JSON payloads and appends them to that file so an
-// operator can `tail -f` the file to see live browser activity. Returning null
-// disables the endpoint entirely.
-function resolveDevLogPath(): string | null {
-  const raw = (process.env.OPENWORK_DEV_LOG_FILE ?? "").trim();
-  return raw.length > 0 ? raw : null;
+// Browser diagnostic log target. Alpha/support builds write browser console,
+// fetch, and lifecycle breadcrumbs by default so affected users can attach one
+// durable file without setting environment variables first.
+function resolveDevLogPath(config: ServerConfig): string | null {
+  return browserDiagnosticLogPath(config);
 }
 
 function resolveBrowserProvider(): Capabilities["toolProviders"]["browser"] {
@@ -1145,11 +1151,17 @@ function resolveBrowserProvider(): Capabilities["toolProviders"]["browser"] {
 }
 
 function emitReloadEvent(
+  config: ServerConfig,
   reloadEvents: ReloadEventStore,
   workspace: WorkspaceInfo,
   reason: ReloadReason,
   trigger?: ReloadTrigger,
 ) {
+  void recordLifecycleDiagnostic(config, "reload_event.record", {
+    reason,
+    trigger: trigger ?? null,
+    workspace: workspaceDiagnosticSummary(workspace),
+  });
   reloadEvents.recordDebounced(workspace.id, reason, trigger);
 }
 
@@ -1321,7 +1333,8 @@ function createRoutes(
     resolveWorkspace,
     serializeWorkspace,
     resolveToyUiEnabled,
-    resolveDevLogPath,
+    resolveDevLogPath: () => resolveDevLogPath(config),
+    resolveLifecycleLogPath: () => lifecycleDiagnosticLogPath(config),
     createOpenAiRealtimeVoiceSession,
   });
 
@@ -1452,7 +1465,7 @@ function createRoutes(
     });
 
     for (const file of imported.files) {
-      emitReloadEvent(ctx.reloadEvents, workspace, file.objectType === "mcp" ? "mcp" : file.objectType === "skill" ? "skills" : file.objectType === "agent" ? "agents" : file.objectType === "command" ? "commands" : "config", {
+      emitReloadEvent(config, ctx.reloadEvents, workspace, file.objectType === "mcp" ? "mcp" : file.objectType === "skill" ? "skills" : file.objectType === "agent" ? "agents" : file.objectType === "command" ? "commands" : "config", {
         type: file.objectType === "skill" || file.objectType === "agent" || file.objectType === "command" || file.objectType === "mcp" ? file.objectType : "config",
         name: file.title,
         action: "added",
@@ -1507,7 +1520,7 @@ function createRoutes(
     });
 
     for (const file of imported.files) {
-      emitReloadEvent(ctx.reloadEvents, workspace, file.objectType === "mcp" ? "mcp" : file.objectType === "skill" ? "skills" : file.objectType === "agent" ? "agents" : file.objectType === "command" ? "commands" : "config", {
+      emitReloadEvent(config, ctx.reloadEvents, workspace, file.objectType === "mcp" ? "mcp" : file.objectType === "skill" ? "skills" : file.objectType === "agent" ? "agents" : file.objectType === "command" ? "commands" : "config", {
         type: file.objectType === "skill" || file.objectType === "agent" || file.objectType === "command" || file.objectType === "mcp" ? file.objectType : "config",
         name: file.title,
         action: "added",
@@ -1551,7 +1564,7 @@ function createRoutes(
     });
 
     for (const file of removed.files) {
-      emitReloadEvent(ctx.reloadEvents, workspace, file.objectType === "mcp" ? "mcp" : file.objectType === "skill" ? "skills" : file.objectType === "agent" ? "agents" : file.objectType === "command" ? "commands" : "config", {
+      emitReloadEvent(config, ctx.reloadEvents, workspace, file.objectType === "mcp" ? "mcp" : file.objectType === "skill" ? "skills" : file.objectType === "agent" ? "agents" : file.objectType === "command" ? "commands" : "config", {
         type: file.objectType === "skill" || file.objectType === "agent" || file.objectType === "command" || file.objectType === "mcp" ? file.objectType : "config",
         name: file.title,
         action: "removed",
@@ -1614,7 +1627,7 @@ function createRoutes(
       timestamp: updatedAt,
     });
 
-    emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(configPath));
+    emitReloadEvent(config, ctx.reloadEvents, workspace, "config", buildConfigTrigger(configPath));
 
     const updatedFoldersConfig = readAuthorizedFoldersFromOpencodeConfig({
       permission: { external_directory: nextExternalDirectory ?? {} },
@@ -1680,7 +1693,7 @@ function createRoutes(
       summary: `Migrated runtime OpenCode config: ${keys.join(", ")}`,
       timestamp: updatedAt,
     });
-    emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(configPath));
+    emitReloadEvent(config, ctx.reloadEvents, workspace, "config", buildConfigTrigger(configPath));
 
     return jsonResponse({ migrated: true, keys, legacyKeys: legacy.keys, userOpencodeKeys: user.keys, updatedAt, legacyError: openworkError });
   });
@@ -1788,7 +1801,7 @@ function createRoutes(
     });
 
     if (scope === "project" && changed) {
-      emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(configPath));
+      emitReloadEvent(config, ctx.reloadEvents, workspace, "config", buildConfigTrigger(configPath));
     }
 
     return jsonResponse({
@@ -1888,7 +1901,7 @@ function createRoutes(
     });
 
     if (opencode) {
-      emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(openworkConfigPath(workspace.path)));
+      emitReloadEvent(config, ctx.reloadEvents, workspace, "config", buildConfigTrigger(openworkConfigPath(workspace.path)));
     }
 
     return jsonResponse({ updatedAt: Date.now() });
@@ -1950,7 +1963,7 @@ function createRoutes(
       timestamp: Date.now(),
     });
     if (changed) {
-      emitReloadEvent(ctx.reloadEvents, workspace, "plugins", {
+      emitReloadEvent(config, ctx.reloadEvents, workspace, "plugins", {
         type: "plugin",
         name: normalized,
         action: "added",
@@ -1983,7 +1996,7 @@ function createRoutes(
       timestamp: Date.now(),
     });
     if (removed) {
-      emitReloadEvent(ctx.reloadEvents, workspace, "plugins", {
+      emitReloadEvent(config, ctx.reloadEvents, workspace, "plugins", {
         type: "plugin",
         name: normalized,
         action: "removed",
@@ -2048,7 +2061,7 @@ function createRoutes(
       summary: `Installed hub skill ${name}`,
       timestamp: Date.now(),
     });
-    emitReloadEvent(ctx.reloadEvents, workspace, "skills", {
+    emitReloadEvent(config, ctx.reloadEvents, workspace, "skills", {
       type: "skill",
       name,
       action: result.action,
@@ -2098,7 +2111,7 @@ function createRoutes(
       summary: `Upserted skill ${name}`,
       timestamp: Date.now(),
     });
-    emitReloadEvent(ctx.reloadEvents, workspace, "skills", {
+    emitReloadEvent(config, ctx.reloadEvents, workspace, "skills", {
       type: "skill",
       name,
       action: result.action,
@@ -2131,7 +2144,7 @@ function createRoutes(
       summary: `Deleted skill ${name}`,
       timestamp: Date.now(),
     });
-    emitReloadEvent(ctx.reloadEvents, workspace, "skills", {
+    emitReloadEvent(config, ctx.reloadEvents, workspace, "skills", {
       type: "skill",
       name,
       action: "removed",
@@ -2201,7 +2214,7 @@ function createRoutes(
       summary: `Added MCP ${name}`,
       timestamp: Date.now(),
     });
-    emitReloadEvent(ctx.reloadEvents, workspace, "mcp", {
+    emitReloadEvent(config, ctx.reloadEvents, workspace, "mcp", {
       type: "mcp",
       name,
       action: result.action,
@@ -2233,7 +2246,7 @@ function createRoutes(
     });
     if (removed) {
       await disconnectMcpFromOpencodeEngine(config, workspace, name).catch(() => undefined);
-      emitReloadEvent(ctx.reloadEvents, workspace, "mcp", {
+      emitReloadEvent(config, ctx.reloadEvents, workspace, "mcp", {
         type: "mcp",
         name,
         action: "removed",
@@ -2278,7 +2291,7 @@ function createRoutes(
       timestamp: Date.now(),
     });
     // ReloadTrigger.action only allows added/removed/updated, so toggle => "updated".
-    emitReloadEvent(ctx.reloadEvents, workspace, "mcp", {
+    emitReloadEvent(config, ctx.reloadEvents, workspace, "mcp", {
       type: "mcp",
       name,
       action: "updated",
@@ -2383,7 +2396,7 @@ function createRoutes(
       timestamp: Date.now(),
     });
 
-    emitReloadEvent(ctx.reloadEvents, workspace, "commands", {
+    emitReloadEvent(config, ctx.reloadEvents, workspace, "commands", {
       type: "command",
       name: sanitizeCommandName(name),
       action: "updated",
@@ -2415,7 +2428,7 @@ function createRoutes(
       timestamp: Date.now(),
     });
 
-    emitReloadEvent(ctx.reloadEvents, workspace, "commands", {
+    emitReloadEvent(config, ctx.reloadEvents, workspace, "commands", {
       type: "command",
       name: sanitizeCommandName(name),
       action: "removed",
@@ -2502,7 +2515,7 @@ function createRoutes(
       timestamp: Date.now(),
     });
     if (configFingerprintBefore !== await computeReloadFingerprint(workspace.path, "config")) {
-      emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(opencodeConfigPath(workspace.path)));
+      emitReloadEvent(config, ctx.reloadEvents, workspace, "config", buildConfigTrigger(opencodeConfigPath(workspace.path)));
     }
     return jsonResponse({ ok: true, preview: publicWorkspaceImportPreview(latestPreview) });
   });
@@ -2551,16 +2564,24 @@ async function resolveWorkspace(config: ServerConfig, id: string): Promise<Works
     }
     if (bootstrapReloadReasons.size > 0) {
       await reloadBaselineRefreshers.get(config)?.(workspace.id, Array.from(bootstrapReloadReasons));
-      reloadOpencodeEngineAfterInternalBootstrap(config, { ...workspace, path: resolvedWorkspace });
+      reloadOpencodeEngineAfterInternalBootstrap(config, { ...workspace, path: resolvedWorkspace }, Array.from(bootstrapReloadReasons));
     }
   }
   return { ...workspace, path: resolvedWorkspace };
 }
 
-function reloadOpencodeEngineAfterInternalBootstrap(config: ServerConfig, workspace: WorkspaceInfo): void {
+function reloadOpencodeEngineAfterInternalBootstrap(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  reloadReasons: ReloadReason[],
+): void {
   const connection = resolveWorkspaceOpencodeConnection(config, workspace);
   if (!connection.baseUrl?.trim()) return;
-  void reloadOpencodeEngine(config, workspace).catch(() => undefined);
+  void reloadOpencodeEngine(config, workspace, {
+    reason: "internal.bootstrap",
+    source: "resolveWorkspace",
+    trigger: { reloadReasons },
+  }).catch(() => undefined);
 }
 
 async function isAuthorizedRoot(workspacePath: string, roots: string[]): Promise<boolean> {
@@ -2809,15 +2830,39 @@ function parseOpencodeErrorBody(input: string): unknown {
   }
 }
 
-async function reloadOpencodeEngine(config: ServerConfig, workspace: WorkspaceInfo): Promise<void> {
+async function reloadOpencodeEngine(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  input: ReloadOpencodeEngineInput = {},
+): Promise<void> {
   const connection = resolveWorkspaceOpencodeConnection(config, workspace);
   const baseUrl = connection.baseUrl?.trim() ?? "";
   if (!baseUrl) {
+    void recordLifecycleDiagnostic(config, "opencode.reload.unconfigured", {
+      reason: input.reason ?? null,
+      source: input.source ?? null,
+      trigger: input.trigger ?? null,
+      workspace: workspaceDiagnosticSummary(workspace),
+    });
     throw new ApiError(400, "opencode_unconfigured", "OpenCode base URL is missing for this workspace");
   }
 
   const directory = resolveOpencodeDirectory(workspace);
   const targetUrl = buildOpencodeReloadUrl(baseUrl, directory);
+  const startedAt = Date.now();
+  const commonDetails = {
+    reason: input.reason ?? null,
+    source: input.source ?? null,
+    trigger: input.trigger ?? null,
+    workspace: workspaceDiagnosticSummary(workspace),
+    activeWorkspaceId: config.workspaces[0]?.id ?? null,
+    workspaceOrderIds: config.workspaces.map((entry) => entry.id),
+    configPath: config.configPath ?? null,
+    baseUrl: sanitizeDiagnosticUrl(baseUrl),
+    targetUrl: sanitizeDiagnosticUrl(targetUrl),
+    directory: directory ?? null,
+  };
+  void recordLifecycleDiagnostic(config, "opencode.reload.request", commonDetails);
   const headers: Record<string, string> = {};
   const auth = connection.authHeader ?? null;
   if (auth) headers.Authorization = auth;
@@ -2826,6 +2871,11 @@ async function reloadOpencodeEngine(config: ServerConfig, workspace: WorkspaceIn
   try {
     response = await fetch(targetUrl, { method: "POST", headers });
   } catch (error) {
+    void recordLifecycleDiagnostic(config, "opencode.reload.unreachable", {
+      ...commonDetails,
+      durationMs: Date.now() - startedAt,
+      error: error instanceof Error ? error : String(error),
+    });
     throw new ApiError(
       503,
       "opencode_engine_unreachable",
@@ -2835,17 +2885,42 @@ async function reloadOpencodeEngine(config: ServerConfig, workspace: WorkspaceIn
   }
   if (!response.ok) {
     const body = parseOpencodeErrorBody(await response.text());
+    void recordLifecycleDiagnostic(config, "opencode.reload.failed", {
+      ...commonDetails,
+      durationMs: Date.now() - startedAt,
+      status: response.status,
+      body,
+    });
     throw new ApiError(502, "opencode_reload_failed", "OpenCode reload failed", {
       status: response.status,
       body,
     });
   }
+  void recordLifecycleDiagnostic(config, "opencode.reload.success", {
+    ...commonDetails,
+    durationMs: Date.now() - startedAt,
+    status: response.status,
+  });
 
   // Re-register runtime-DB MCPs: dispose rebuilds engine state from disk
   // configs (including the server-managed runtime config file for the
   // primary workspace), but other workspaces' runtime MCPs only reach the
   // engine through this dynamic push.
-  await syncRuntimeMcpToOpencodeEngine(config, workspace).catch(() => undefined);
+  const syncStartedAt = Date.now();
+  await syncRuntimeMcpToOpencodeEngine(config, workspace)
+    .then(() => {
+      void recordLifecycleDiagnostic(config, "opencode.reload.runtime_mcp_sync.success", {
+        ...commonDetails,
+        durationMs: Date.now() - syncStartedAt,
+      });
+    })
+    .catch((error) => {
+      void recordLifecycleDiagnostic(config, "opencode.reload.runtime_mcp_sync.failed", {
+        ...commonDetails,
+        durationMs: Date.now() - syncStartedAt,
+        error: error instanceof Error ? error : String(error),
+      });
+    });
 }
 
 // Push runtime-DB MCP entries into the running OpenCode engine via its dynamic


### PR DESCRIPTION
## Summary
- add default-on persistent lifecycle/browser diagnostic JSONL files for alpha/support builds
- log server reload/dispose requests with caller reason/source, workspace state, timing, status, and runtime MCP sync outcomes
- add renderer breadcrumbs for reload scheduling, activation calls, UI/settings reloads, reload-event polling, and provider-auth direct dispose fallback
- expose diagnostic log paths via server status and the diagnostics bundle

## Verification
- pnpm --filter @openwork/app typecheck
- pnpm --filter openwork-server typecheck
- pnpm --filter openwork-server build
- pnpm --filter @openwork/app build
- git diff --check

No fraimz/video attached because this is diagnostic instrumentation for an unreproduced customer-machine loop rather than a user-facing flow change.