### PR TITLE
Remove duplicate settings panel notification bell

### DIFF
--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -73,7 +73,6 @@ export function SettingsShell(props: SettingsShellProps) {
             />
           </div>
           <div className="flex shrink-0 items-center gap-1 mac:titlebar-no-drag">
-            <NotificationBell />
             <Button
               variant="ghost"
               type="button"


### PR DESCRIPTION
## Summary
- remove the duplicate notification bell from the compact settings/extensions side panel header
- keep the main session header notification bell unchanged

## Validation
- `pnpm --filter @openwork/app typecheck`

## Note
The repository does not have a `main` branch; GitHub reports `dev` as the default branch, so this PR targets `dev`.
