### PR TITLE
Fix client installer workflow dependency setup

### DIFF
--- a/.github/workflows/build-client-installer.yml
+++ b/.github/workflows/build-client-installer.yml
@@ -134,7 +134,21 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: bun install --cwd apps/installer
+        run: |
+          set -euo pipefail
+          # Build the workspace dependency's dist first: @openwork/install-config's
+          # "default" export points at dist/, which a fresh checkout lacks.
+          (cd packages/install-config && bun install && bun run build)
+          # bun 1.3.9 on Windows can fail to create the parent-relative
+          # workspace symlink (ENOENT) after installing every other package;
+          # the copy fallback below repairs exactly that case.
+          (cd apps/installer && bun install) || [ "${{ matrix.os_type }}" = "windows" ]
+          if [ ! -e "apps/installer/node_modules/@openwork/install-config/package.json" ]; then
+            rm -rf "apps/installer/node_modules/@openwork/install-config"
+            mkdir -p "apps/installer/node_modules/@openwork"
+            cp -R "packages/install-config" "apps/installer/node_modules/@openwork/install-config"
+          fi
+          test -e "apps/installer/node_modules/@openwork/install-config/package.json"
 
       - name: Test
         shell: bash


### PR DESCRIPTION
## Summary
- build the @openwork/install-config workspace dependency before installing apps/installer in the client installer workflow
- repair Bun's Windows workspace symlink failure by copying the package when the symlink is missing
- keep the workflow aligned with the generic installer dependency setup

## Failure investigated
- https://github.com/different-ai/openwork/actions/runs/28875977266
- Windows failed in Install dependencies with Bun ENOENT while symlinking @openwork/install-config
- macOS/Linux failed in Test because @openwork/install-config could not be resolved

## Tests
- gh run view 28875977266 --repo different-ai/openwork --log-failed
- cd packages/install-config && bun install && bun run build
- cd apps/installer && bun install && bun test
- git diff --check

No fraimz run: this is a GitHub Actions dependency/install fix, not an end-user UI/runtime flow.