### PR TITLE
Make client installer deployment smoke check opt-in

### DIFF
--- a/.github/workflows/build-client-installer.yml
+++ b/.github/workflows/build-client-installer.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: boolean
         default: false
+      smoke_check_deployment:
+        description: "Run the compiled installer against the deployment API (requires GitHub-hosted runners to reach api_url)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -164,7 +169,7 @@ jobs:
 
       - name: Smoke test (headless dry run against the client deployment)
         # Cross-compiled mac x64 output cannot run on the arm64 runner.
-        if: matrix.bun_target != 'bun-darwin-x64'
+        if: github.event.inputs.smoke_check_deployment == 'true' && matrix.bun_target != 'bun-darwin-x64'
         shell: bash
         env:
           OPENWORK_DESKTOP_BOOTSTRAP_PATH: ${{ runner.temp }}/smoke/desktop-bootstrap.json


### PR DESCRIPTION
## Summary
- add a smoke_check_deployment workflow input for Build Client Installer
- default the live deployment dry-run to off so private/unreachable client APIs do not block artifact builds
- keep the existing headless dry-run available when explicitly requested

## Failure investigated
- https://github.com/different-ai/openwork/actions/runs/28879948763
- install, tests, config generation, and compile all passed
- Linux, Windows, and macOS arm64 failed only when the compiled installer tried to reach the client deployment API during the smoke test

## Tests
- gh run view 28879948763 --repo different-ai/openwork --json name,status,conclusion,headBranch,headSha,event,createdAt,updatedAt,url,jobs
- gh run view 28879948763 --repo different-ai/openwork --log-failed
- cd packages/install-config && bun install && bun run build
- cd apps/installer && bun install && bun test
- git diff --check

No fraimz run: this is a GitHub Actions workflow gating fix, not an end-user UI/runtime change.