### PR TITLE
fix(den): connect/start maps OAuth handshake failures to 502 with a real message

### DIFF
--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -148,6 +148,22 @@ const connectStartResponseSchema = z.object({
   authorizeUrl: z.string().nullable(),
 }).meta({ ref: "ExternalMcpConnectStartResponse" })
 
+const connectStartFailedSchema = z.object({
+  error: z.literal("oauth_handshake_failed"),
+  message: z.string(),
+}).meta({ ref: "ExternalMcpConnectStartFailedError" })
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function errorForLog(error: unknown) {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack }
+  }
+  return { message: String(error) }
+}
+
 function isConnectionConnected(row: ExternalMcpConnectionRow): boolean {
   if (row.credentialMode === "per_member") {
     // A per_member connection is "published" once created; individual
@@ -305,6 +321,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         400: jsonResponse("Invalid request.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
         403: jsonResponse("Only workspace owners and admins can add MCP connections.", forbiddenSchema),
+        502: jsonResponse("The upstream MCP server could not be reached.", connectStartFailedSchema),
       },
     }),
     orgMemberRoute(),
@@ -370,7 +387,17 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
 
       if (body.authType !== "oauth") {
         // No OAuth dance needed — validate the server is real and reachable now.
-        await connectExternalMcp(created, callbackRedirectUri(c.req.raw, created.id))
+        try {
+          await connectExternalMcp(created, callbackRedirectUri(c.req.raw, created.id))
+        } catch (error) {
+          console.error("external_mcp_connection_validation_failed", {
+            connectionId: created.id,
+            organizationId: payload.organization.id,
+            connectionUrl: created.url,
+            error: errorForLog(error),
+          })
+          return c.json({ error: "oauth_handshake_failed", message: `The OAuth handshake with "${created.name}" failed: ${errorMessage(error)}` }, 502)
+        }
       }
 
       const refreshed = await getExternalMcpConnection({ organizationId: payload.organization.id, connectionId: created.id })
@@ -495,6 +522,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         200: jsonResponse("Authorize URL, or already connected.", connectStartResponseSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
         404: jsonResponse("Unknown connection.", connectionNotFoundSchema),
+        502: jsonResponse("OAuth handshake failed.", connectStartFailedSchema),
       },
     }),
     orgMemberRoute(),
@@ -529,26 +557,36 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         }
       }
 
-      // Our own signed state token identifies which connection AND which
-      // member this is for once the external server redirects back. It MUST
-      // travel as the standard OAuth `state` param — a custom param would
-      // simply be dropped, since only `state` is guaranteed to round-trip on
-      // any spec-compliant authorization server (see ExternalMcpOAuthProvider.state()).
-      const signedState = createOAuthStateToken({
-        organizationId: payload.organization.id,
-        orgMembershipId: payload.currentMember.id,
-        providerId: connectionId,
-        secret: env.betterAuthSecret,
-      })
-      const redirectUri = callbackRedirectUri(c.req.raw, connectionId)
-      const member = connection.credentialMode === "per_member"
-        ? { orgMembershipId: payload.currentMember.id }
-        : undefined
-      const result = await connectExternalMcp(connection, redirectUri, signedState, member)
-      if (result.status === "connected") {
-        return c.json({ status: "connected" as const, authorizeUrl: null })
+      try {
+        // Our own signed state token identifies which connection AND which
+        // member this is for once the external server redirects back. It MUST
+        // travel as the standard OAuth `state` param — a custom param would
+        // simply be dropped, since only `state` is guaranteed to round-trip on
+        // any spec-compliant authorization server (see ExternalMcpOAuthProvider.state()).
+        const signedState = createOAuthStateToken({
+          organizationId: payload.organization.id,
+          orgMembershipId: payload.currentMember.id,
+          providerId: connectionId,
+          secret: env.betterAuthSecret,
+        })
+        const redirectUri = callbackRedirectUri(c.req.raw, connectionId)
+        const member = connection.credentialMode === "per_member"
+          ? { orgMembershipId: payload.currentMember.id }
+          : undefined
+        const result = await connectExternalMcp(connection, redirectUri, signedState, member)
+        if (result.status === "connected") {
+          return c.json({ status: "connected" as const, authorizeUrl: null })
+        }
+        return c.json({ status: "needs_auth" as const, authorizeUrl: result.authorizeUrl })
+      } catch (error) {
+        console.error("external_mcp_connect_start_oauth_handshake_failed", {
+          connectionId: connection.id,
+          organizationId: payload.organization.id,
+          connectionUrl: connection.url,
+          error: errorForLog(error),
+        })
+        return c.json({ error: "oauth_handshake_failed", message: `The OAuth handshake with "${connection.name}" failed: ${errorMessage(error)}` }, 502)
       }
-      return c.json({ status: "needs_auth" as const, authorizeUrl: result.authorizeUrl })
     },
   )
 

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -153,6 +153,11 @@ const connectStartFailedSchema = z.object({
   message: z.string(),
 }).meta({ ref: "ExternalMcpConnectStartFailedError" })
 
+const connectionValidationFailedSchema = z.object({
+  error: z.literal("connection_validation_failed"),
+  message: z.string(),
+}).meta({ ref: "ExternalMcpConnectionValidationFailedError" })
+
 function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error)
 }
@@ -321,7 +326,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         400: jsonResponse("Invalid request.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
         403: jsonResponse("Only workspace owners and admins can add MCP connections.", forbiddenSchema),
-        502: jsonResponse("The upstream MCP server could not be reached.", connectStartFailedSchema),
+        502: jsonResponse("The upstream MCP server could not be reached.", connectionValidationFailedSchema),
       },
     }),
     orgMemberRoute(),
@@ -396,7 +401,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
             connectionUrl: created.url,
             error: errorForLog(error),
           })
-          return c.json({ error: "oauth_handshake_failed", message: `The OAuth handshake with "${created.name}" failed: ${errorMessage(error)}` }, 502)
+          return c.json({ error: "connection_validation_failed", message: `Could not reach "${created.name}" at its MCP URL: ${errorMessage(error)}` }, 502)
         }
       }
 

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -1,0 +1,138 @@
+import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_pr7"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "local-dev-secret-not-for-production-use!!"
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.DEN_ALLOW_PRIVATE_MCP_URLS = "1"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+let app: typeof import("../src/app.js").default
+let db: typeof import("../src/db.js").db
+let schema: typeof import("@openwork-ee/den-db/schema")
+let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+let session: typeof import("../src/session.js")
+let createExternalMcpConnection: typeof import("../src/capability-sources/external-mcp-connections.js").createExternalMcpConnection
+
+const userId = createDenTypeId("user")
+const organizationId = createDenTypeId("organization")
+const memberId = createDenTypeId("member")
+const connectionName = "Broken OAuth MCP"
+let connectionId: DenTypeId<"externalMcpConnection"> | undefined
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.restore()
+  const realDb = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL,
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db: realDb }))
+
+  const [appMod, dbMod, schemaMod, drizzleMod, sessionMod, connectionsMod] = await Promise.all([
+    import("../src/app.js"),
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+    import("../src/session.js"),
+    import("../src/capability-sources/external-mcp-connections.js"),
+  ])
+  app = appMod.default
+  db = dbMod.db
+  schema = schemaMod
+  drizzle = drizzleMod
+  session = sessionMod
+  createExternalMcpConnection = connectionsMod.createExternalMcpConnection
+
+  await db.insert(schema.AuthUserTable).values({
+    id: userId,
+    name: "MCP Connect Start User",
+    email: `mcp-connect-start+${userId}@test.local`,
+  })
+  await db.insert(schema.OrganizationTable).values({
+    id: organizationId,
+    name: "MCP Connect Start Org",
+    slug: `mcp-connect-start-${organizationId}`,
+  })
+  await db.insert(schema.MemberTable).values({
+    id: memberId,
+    organizationId,
+    userId,
+    role: "member",
+  })
+
+  const connection = await createExternalMcpConnection({
+    organizationId,
+    name: connectionName,
+    url: "http://127.0.0.1:9/mcp",
+    authType: "oauth",
+    credentialMode: "per_member",
+    createdByOrgMembershipId: memberId,
+    access: { orgWide: true, memberIds: [], teamIds: [] },
+  })
+  connectionId = connection.id
+})
+
+afterAll(async () => {
+  await db.delete(schema.ConnectedAccountTable).where(drizzle.eq(schema.ConnectedAccountTable.organizationId, organizationId))
+  await db.delete(schema.OrgOAuthClientTable).where(drizzle.eq(schema.OrgOAuthClientTable.organizationId, organizationId))
+  await db.delete(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.eq(schema.ExternalMcpConnectionAccessGrantTable.organizationId, organizationId))
+  await db.delete(schema.ExternalMcpConnectionTable).where(drizzle.eq(schema.ExternalMcpConnectionTable.organizationId, organizationId))
+  await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.organizationId, organizationId))
+  await db.delete(schema.OrganizationRoleTable).where(drizzle.eq(schema.OrganizationRoleTable.organizationId, organizationId))
+  await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+  await db.delete(schema.AuthUserTable).where(drizzle.eq(schema.AuthUserTable.id, userId))
+  mock.restore()
+})
+
+function seededConnectionId() {
+  if (!connectionId) {
+    throw new Error("External MCP connection was not seeded")
+  }
+  return connectionId
+}
+
+function request(path: string) {
+  return app.fetch(new Request(`http://den-api.local${path}`, {
+    headers: {
+      "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId, organizationId }),
+    },
+  }))
+}
+
+test("GET /v1/mcp-connections/:connectionId/connect/start maps OAuth handshake failures to 502 JSON", async () => {
+  const response = await request(`/v1/mcp-connections/${seededConnectionId()}/connect/start`)
+  expect(response.status).toBe(502)
+
+  const body: unknown = await response.json()
+  expect(isRecord(body)).toBe(true)
+  if (!isRecord(body)) {
+    throw new Error("connect/start response was not an object")
+  }
+  expect(body.error).toBe("oauth_handshake_failed")
+  expect(typeof body.message).toBe("string")
+  if (typeof body.message !== "string") {
+    throw new Error("connect/start response message was not a string")
+  }
+  expect(body.message.length).toBeGreaterThan(0)
+  expect(body.message).toContain(connectionName)
+})
+
+test("GET /v1/mcp-connections/:connectionId/connect/start still returns connection_not_found", async () => {
+  const response = await request(`/v1/mcp-connections/${createDenTypeId("externalMcpConnection")}/connect/start`)
+  expect(response.status).toBe(404)
+
+  const body: unknown = await response.json()
+  expect(isRecord(body)).toBe(true)
+  if (!isRecord(body)) {
+    throw new Error("connect/start 404 response was not an object")
+  }
+  expect(body.error).toBe("connection_not_found")
+})


### PR DESCRIPTION
## What / why

Clicking "Connect your account" on a Notion (per-member) connection in the desktop Connect tab surfaced **"Request failed with 500."** against hosted Den. Root cause of the *bad UX* (and the diagnostic dead end): `GET /v1/mcp-connections/:id/connect/start` ran the whole OAuth dance (RFC 9728 discovery → dynamic client registration → authorize URL) with **no try/catch** — any upstream failure became a naked 500 with no JSON body, so the desktop fell back to its generic message (it renders server `message` verbatim when present).

Notably: the identical flow **succeeds on current dev code against real `mcp.notion.com`** (local repro: 200 `needs_auth`, fresh DCR client, 771ms) — so the production failure is environment-specific (prime suspects: stale stored OAuth client on that connection row, prod-origen redirect_uri rejected at registration, or egress/url-guard). This PR makes the failure *name itself*.

- connect/start: handshake failures → **502 `{ error: "oauth_handshake_failed", message: 'The OAuth handshake with "<name>" failed: <upstream error>' }`** + structured `console.error` (connection id, org, URL, stack) for prod logs.
- create-route reachability validation (apikey/none): same hardening with its own code `connection_validation_failed` and accurate copy.
- OpenAPI response schemas registered for both 502s.

## Tests

- New `test/mcp-connections-connect-start.test.ts` (own DB): unreachable upstream ⇒ deterministic 502 JSON with non-empty message (no unhandled 500), bogus id ⇒ existing `connection_not_found`. **2 pass / 0 fail**; tsc + build green.
- Full den-api suite: failure names within the documented pre-existing in-suite pollution class only (route-guard-policy, breached-password, desktop-config + cleanup, mcp JWT) — all pass isolated; no growth.

## Proof note

fraimz: N/A — server-only error mapping; the desktop already renders server `message` verbatim (that pathway is exercised by the existing connect flows). After deploy, the Connect banner will show the actual upstream failure instead of "Request failed with 500." — which is also how we find the production root cause.