### PR TITLE
fix(settings): stop engine reloads on settings open (MCP re-mint, provider-sync race, workspace re-select)

### DIFF
--- a/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.test.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.test.ts
@@ -1,0 +1,70 @@
+declare const afterEach: (fn: () => void) => void;
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toBe: (expected: unknown) => void;
+  toEqual: (expected: unknown) => void;
+};
+
+import {
+  __setCloudMcpUserStateStorageForTest,
+  clearCloudMcpUnhealthyRemintAttempt,
+  readCloudMcpUnhealthyRemintAttempt,
+  writeCloudMcpUnhealthyRemintAttempt,
+} from "./cloud-mcp-user-state";
+
+const UNHEALTHY_REMINT_ATTEMPT_KEY = "openwork.den.mcp.unhealthyRemintAttempt";
+
+function createStorageStub() {
+  const values = new Map<string, string>();
+  return {
+    values,
+    storage: {
+      getItem(key: string) {
+        return values.get(key) ?? null;
+      },
+      setItem(key: string, value: string) {
+        values.set(key, value);
+      },
+      removeItem(key: string) {
+        values.delete(key);
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  __setCloudMcpUserStateStorageForTest(null);
+});
+
+describe("cloud MCP unhealthy re-mint attempt marker", () => {
+  test("round-trips and clears the persisted marker", () => {
+    const { storage } = createStorageStub();
+    __setCloudMcpUserStateStorageForTest(storage);
+
+    expect(readCloudMcpUnhealthyRemintAttempt()).toBe(null);
+
+    writeCloudMcpUnhealthyRemintAttempt({ orgId: "org_1" });
+    expect(readCloudMcpUnhealthyRemintAttempt()).toEqual({ orgId: "org_1" });
+
+    clearCloudMcpUnhealthyRemintAttempt();
+    expect(readCloudMcpUnhealthyRemintAttempt()).toBe(null);
+  });
+
+  test("returns null for corrupt JSON", () => {
+    const { storage, values } = createStorageStub();
+    __setCloudMcpUserStateStorageForTest(storage);
+    values.set(UNHEALTHY_REMINT_ATTEMPT_KEY, "{");
+
+    expect(readCloudMcpUnhealthyRemintAttempt()).toBe(null);
+  });
+
+  test("returns the stored org so callers can compare org mismatches", () => {
+    const { storage } = createStorageStub();
+    __setCloudMcpUserStateStorageForTest(storage);
+
+    writeCloudMcpUnhealthyRemintAttempt({ orgId: "org_a" });
+
+    expect(readCloudMcpUnhealthyRemintAttempt()).toEqual({ orgId: "org_a" });
+  });
+});

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
@@ -14,8 +14,10 @@
 export const CLOUD_MCP_SERVER_NAME = "openwork-cloud";
 
 const CLOUD_MCP_USER_STATE_KEY = "openwork.den.mcp.cloudControlUserState";
+const CLOUD_MCP_UNHEALTHY_REMINT_ATTEMPT_KEY = "openwork.den.mcp.unhealthyRemintAttempt";
 
 export type CloudMcpUserState = "disabled" | "removed";
+export type CloudMcpUnhealthyRemintAttempt = { orgId: string };
 
 type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
@@ -61,6 +63,49 @@ export function writeCloudMcpUserState(state: CloudMcpUserState) {
 export function clearCloudMcpUserState() {
   try {
     getStorage()?.removeItem(CLOUD_MCP_USER_STATE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * One re-mint attempt per unhealthy Cloud Control MCP episode must survive
+ * store remounts: the settings route recreates the connections store per
+ * mount, which re-armed the re-mint and reloaded the engine on every settings
+ * open. The episode ends when the entry reports connected, or when the user
+ * forces a refresh.
+ */
+export function readCloudMcpUnhealthyRemintAttempt(): CloudMcpUnhealthyRemintAttempt | null {
+  try {
+    const raw = getStorage()?.getItem(CLOUD_MCP_UNHEALTHY_REMINT_ATTEMPT_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      "orgId" in parsed &&
+      typeof parsed.orgId === "string"
+    ) {
+      return { orgId: parsed.orgId };
+    }
+  } catch {
+    // Corrupt marker or storage unavailable — treat as no recorded attempt.
+  }
+  return null;
+}
+
+export function writeCloudMcpUnhealthyRemintAttempt(marker: CloudMcpUnhealthyRemintAttempt) {
+  try {
+    getStorage()?.setItem(CLOUD_MCP_UNHEALTHY_REMINT_ATTEMPT_KEY, JSON.stringify(marker));
+  } catch {
+    // Storage unavailable — the in-memory guard still suppresses same-store retries.
+  }
+}
+
+export function clearCloudMcpUnhealthyRemintAttempt() {
+  try {
+    getStorage()?.removeItem(CLOUD_MCP_UNHEALTHY_REMINT_ATTEMPT_KEY);
   } catch {
     // ignore
   }

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1526,6 +1526,15 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       return;
     }
 
+    // Imports, baseline reads, and persistence all go through the OpenWork
+    // server target (patchRuntimeProviders throws without it). Running before
+    // the target resolves made the baseline read fall back to an empty source
+    // and re-import every org provider — engine dispose churn on settings open.
+    const target = await resolveOpenworkConfigTarget("write");
+    if (!target.canUseOpenworkServer || !target.openworkClient || !target.openworkWorkspaceId) {
+      return;
+    }
+
     let importedProviders: Record<string, CloudImportedProvider>;
     try {
       importedProviders = await refreshImportedCloudProviders({ strict: true });

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -42,9 +42,12 @@ import type { OpenworkServerStore } from "./openwork-server-store";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
 import {
   CLOUD_MCP_SERVER_NAME,
+  clearCloudMcpUnhealthyRemintAttempt,
   clearCloudMcpUserState,
   isCloudMcpSyncMarkerFresh,
+  readCloudMcpUnhealthyRemintAttempt,
   readCloudMcpUserState,
+  writeCloudMcpUnhealthyRemintAttempt,
   writeCloudMcpUserState,
 } from "./cloud-mcp-user-state";
 
@@ -882,7 +885,8 @@ export function createConnectionsStore(options: {
     }
   }
 
-  // Guards the unhealthy-status self-heal in syncCloudControlMcp: each
+  // Guards the unhealthy-status self-heal in syncCloudControlMcp with a
+  // persisted marker that survives settings-route store remounts: each
   // re-mint writes a new token to config, which marks an engine reload as
   // required. Until that reload happens the status stays needs_auth, so
   // retrying on every sync tick produced an endless "MCP 'openwork-cloud'
@@ -917,6 +921,10 @@ export function createConnectionsStore(options: {
     if (readCloudMcpUserState() !== null) return "skipped";
     const configuredEntry = snapshot.mcpServers.find((server) => server.name === slug);
     if (configuredEntry?.config.enabled === false) return "skipped";
+    if (options?.force) {
+      cloudMcpUnhealthyRemintAttempted = false;
+      clearCloudMcpUnhealthyRemintAttempt();
+    }
 
     const marker = readCloudMcpSyncMarker();
     const markerFresh =
@@ -934,9 +942,11 @@ export function createConnectionsStore(options: {
     const entryStatus = snapshot.mcpStatuses[slug]?.status;
     if (entryStatus === "connected") {
       cloudMcpUnhealthyRemintAttempted = false;
+      clearCloudMcpUnhealthyRemintAttempt();
     }
     const entryUnhealthy = entryStatus === "needs_auth" || entryStatus === "failed";
-    const shouldRemintForHealth = entryUnhealthy && !cloudMcpUnhealthyRemintAttempted;
+    const attempted = cloudMcpUnhealthyRemintAttempted || readCloudMcpUnhealthyRemintAttempt()?.orgId === orgId;
+    const shouldRemintForHealth = entryUnhealthy && !attempted;
 
     // Builds before #2116's follow-up wrote the MCP URL against the bare
     // web-app origin (https://app.openworklabs.com/mcp), which 404s.
@@ -956,6 +966,7 @@ export function createConnectionsStore(options: {
     }
     if (shouldRemintForHealth) {
       cloudMcpUnhealthyRemintAttempted = true;
+      writeCloudMcpUnhealthyRemintAttempt({ orgId });
     }
 
     // Validate the session up front so a failed mint never reaches

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1743,6 +1743,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   };
 
   const handleSelectSettingsWorkspace = useCallback((workspaceId: string) => {
+    if (workspaceId === selectedWorkspaceId) return;
     setLegacySelectedWorkspaceId(workspaceId);
     writeActiveWorkspaceId(workspaceId);
     const workspace = workspaces.find((item) => item.id === workspaceId) ?? null;
@@ -1755,7 +1756,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       void workspaceSetRuntimeActive(workspaceId).catch(() => undefined);
     }
     navigate(workspaceSettingsRoute(workspaceId, settingsPathForRoute(route)), { state: location.state });
-  }, [baseUrl, location, navigate, route, token, workspaces]);
+  }, [baseUrl, location, navigate, route, selectedWorkspaceId, token, workspaces]);
 
   const handleOpenRenameWorkspace = useCallback((workspaceId: string) => {
     const workspace = workspaces.find((item) => item.id === workspaceId);

--- a/apps/server/src/routes/workspaces.ts
+++ b/apps/server/src/routes/workspaces.ts
@@ -456,6 +456,7 @@ export function registerWorkspaceRoutes(options: RegisterWorkspaceRoutesOptions)
     const body = queryPersist === undefined ? await readOptionalJsonBody(ctx.request) : {};
     const persist = queryPersist ?? (body.persist === true);
     if (persist) ensureWritable(config);
+    const wasActive = config.workspaces[0]?.id === workspace.id;
     config.workspaces = [
       workspace,
       ...config.workspaces.filter((entry) => entry.id !== workspace.id),
@@ -471,7 +472,8 @@ export function registerWorkspaceRoutes(options: RegisterWorkspaceRoutesOptions)
       summary: "Switched active workspace",
       timestamp: Date.now(),
     });
-    if (workspace.workspaceType === "local" && resolveWorkspaceOpencodeConnection(config, workspace).baseUrl?.trim()) {
+    // Re-activating the already-active workspace must not dispose its engine instance; switch reloads stay (#870).
+    if (!wasActive && workspace.workspaceType === "local" && resolveWorkspaceOpencodeConnection(config, workspace).baseUrl?.trim()) {
       await reloadOpencodeEngine(config, workspace);
     }
     return jsonResponse({ activeId: workspace.id, workspace: serializeWorkspace(workspace), persisted });

--- a/apps/server/src/workspace-activate.e2e.test.ts
+++ b/apps/server/src/workspace-activate.e2e.test.ts
@@ -68,13 +68,13 @@ async function readPersistedConfig(configPath: string): Promise<unknown> {
 }
 
 function startMockOpencode() {
-  const requests: Array<{ pathname: string; search: string }> = [];
+  const requests: Array<{ method: string; pathname: string; search: string }> = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
     fetch(request) {
       const url = new URL(request.url);
-      requests.push({ pathname: url.pathname, search: url.search });
+      requests.push({ method: request.method, pathname: url.pathname, search: url.search });
 
       if (url.pathname === "/instance/dispose") {
         return Response.json({ disposed: true });
@@ -113,37 +113,6 @@ function startMockRemoteOpenwork() {
   return { server, requests };
 }
 
-async function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl: string }) {
-  const config: ServerConfig = {
-    host: "127.0.0.1",
-    port: 0,
-    token: "owt_test_token",
-    hostToken: "owt_host_token",
-    approval: { mode: "auto", timeoutMs: 1000 },
-    corsOrigins: ["*"],
-    workspaces: [
-      {
-        id: "ws_1",
-        name: "Workspace",
-        path: input.workspaceRoot,
-        preset: "starter",
-        workspaceType: "local",
-        baseUrl: input.opencodeBaseUrl,
-      },
-    ],
-    authorizedRoots: [input.workspaceRoot],
-    readOnly: false,
-    startedAt: Date.now(),
-    tokenSource: "cli",
-    hostTokenSource: "cli",
-    logFormat: "pretty",
-    logRequests: false,
-  };
-  const server = await startServer(config) as Served;
-  stops.push(() => server.stop(true));
-  return { server, hostToken: config.hostToken };
-}
-
 async function startOpenworkServerWithWorkspaces(input: {
   configPath: string;
   workspaces: ServerConfig["workspaces"];
@@ -178,31 +147,65 @@ async function startOpenworkServerWithWorkspaces(input: {
 }
 
 describe("workspace activation", () => {
-  test("reloads the bound OpenCode engine on activate", async () => {
-    const workspaceRoot = await createWorkspaceRoot();
+  test("reloads the bound OpenCode engine on workspace switch only", async () => {
+    const firstRoot = await createWorkspaceRoot();
+    const secondRoot = await createWorkspaceRoot();
     const mock = startMockOpencode();
-    const openwork = await startOpenworkServer({
-      workspaceRoot,
-      opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
+    const opencodeBaseUrl = `http://127.0.0.1:${mock.server.port}`;
+    const workspaces: ServerConfig["workspaces"] = [
+      {
+        id: "ws_1",
+        name: "One",
+        path: firstRoot,
+        preset: "starter",
+        workspaceType: "local",
+        baseUrl: opencodeBaseUrl,
+      },
+      {
+        id: "ws_2",
+        name: "Two",
+        path: secondRoot,
+        preset: "starter",
+        workspaceType: "local",
+        baseUrl: opencodeBaseUrl,
+      },
+    ];
+    const openwork = await startOpenworkServerWithWorkspaces({
+      configPath: join(firstRoot, "server.json"),
+      workspaces,
+      authorizedRoots: [firstRoot, secondRoot],
     });
 
     const base = `http://127.0.0.1:${openwork.server.port}`;
-    const response = await fetch(`${base}/workspaces/ws_1/activate`, {
+    const disposeCount = () => mock.requests.filter(
+      (request) => request.method === "POST" && request.pathname === "/instance/dispose",
+    ).length;
+
+    const response = await fetch(`${base}/workspaces/ws_2/activate`, {
       method: "POST",
       headers: hostAuth(openwork.hostToken),
     });
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body.activeId).toBe("ws_1");
+    expect(body.activeId).toBe("ws_2");
+    expect(disposeCount()).toBe(1);
 
     const reloadRequest = mock.requests.find(
-      (request) => request.pathname === "/instance/dispose",
+      (request) => request.method === "POST" && request.pathname === "/instance/dispose",
     );
     expect(reloadRequest).toBeDefined();
     expect(reloadRequest?.search).toContain(
-      `directory=${encodeURIComponent(workspaceRoot)}`,
+      `directory=${encodeURIComponent(secondRoot)}`,
     );
+
+    const sameWorkspaceResponse = await fetch(`${base}/workspaces/ws_2/activate`, {
+      method: "POST",
+      headers: hostAuth(openwork.hostToken),
+    });
+
+    expect(sameWorkspaceResponse.status).toBe(200);
+    expect(disposeCount()).toBe(1);
   });
 
   test("persists activation order only when requested", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #2530 (the provider-sync engine dispose/create loop). This fixes the remaining family the same customer reported: **the OpenCode engine reloads when the Settings screen opens** (and when clicking the current workspace in the settings menu). All three paths were identified by code-tracing every settings-mount effect, then verified live on the same Daytona repro rig as #2530 (seeded Acme Robotics cloud, signed in as `alex@acme.test`, org provider imported, `openwork-cloud` MCP stuck `failed` — matching the customer's failing-MCP environment).

## The three paths

1. **Cloud MCP re-mint on every settings open** — `syncCloudControlMcp` (mounted only by the settings route) re-mints the `openwork-cloud` MCP token when the entry is unhealthy, guarded to once per unhealthy episode. But the guard (`cloudMcpUnhealthyRemintAttempted`) was a closure variable in a store **recreated on every settings mount**, so a persistently unhealthy cloud MCP (revoked org token, blocked URL) re-minted → `POST /workspace/:id/mcp` → runtime config write → `markReloadRequired("mcp")` → **engine reload on every settings open, forever**. Fix: persist the attempt marker (org-scoped, `openwork.den.mcp.unhealthyRemintAttempt`) with the module's existing storage pattern; cleared when the entry reports connected or when the user hits the user-facing Refresh (`force`).
2. **Provider sync racing target resolution** — a cloud-provider sync pass could start before the OpenWork server target resolved; the import-baseline read then silently fell back to an empty source, so the pass re-imported every org provider (observed live: auth PUT + 2× config PATCH + **3 engine disposes** with a byte-identical baseline). Fix: `performCloudProviderSync` now requires the resolved OpenWork server target up front — imports and persistence need it anyway (`patchRuntimeProviders` throws without it).
3. **Workspace re-select reload** — the settings workspace menu had no same-id guard (the session route has one), so clicking the **already-active** workspace POSTed `/workspaces/:id/activate`, and the server reloaded the engine **unconditionally** for local workspaces. Fix: same-id selections return early in the app, and the server skips the reload when the workspace is already first (workspace-switch reloads stay, per #870).

## Live verification (before → after, same environment)

| settings action | before (observed) | after (observed) |
| --- | --- | --- |
| open #1 | MCP re-mint + engine reload | MCP re-mint + engine reload — the one allowed per-episode attempt; marker persisted |
| open #2 | spurious full provider re-import: auth PUT + 2× `PATCH /config` + **3 reloads** | **no writes, no reloads** |
| open #3 | MCP re-mint + engine reload again (guard reset by remount) | **no writes, no reloads** |
| click current workspace in menu | `POST /workspaces/:id/activate` → engine reload | **no activate call, no reload** |

Engine instance create-count stayed flat (13 → 13) across opens #2/#3 and the workspace re-select, with the `openwork-cloud` MCP still genuinely `failed`. Full request-log evidence: https://github.com/different-ai/openwork/pull/2530#issuecomment-4906239951

## Tests

- `pnpm --filter openwork-server test -- src/workspace-activate.e2e.test.ts src/runtime-config-patch-reload.e2e.test.ts` — pass, 7 tests (new: engine stub counts `/instance/dispose` — activate reloads on switch only, re-activating the active workspace does not)
- `pnpm --filter @openwork/app exec bun test src/react-app/domains/connections/cloud-mcp-user-state.test.ts` — pass, 3 tests (episode marker helpers: round-trip, corrupt JSON, clear)
- `pnpm --filter @openwork/app typecheck` / `pnpm --filter openwork-server typecheck` — clean

Screen-recording note: verification was request-log + engine-log based (writes and dispose counts per settings open, tables above); the #2530 fraimz covers the surrounding user journey on this rig.
