### PR TITLE
fix(den): OAuth error responses survive hono's global Response override

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { env } from "../env.js"
-import { createGuardedFetch } from "./url-guard.js"
+import { createGuardedFetch, createRealmSafeFetch } from "./url-guard.js"
 import {
   type OAuthClientProvider,
   UnauthorizedError,
@@ -229,7 +229,7 @@ function buildTransport(connection: ExternalMcpConnectionRow, redirectUri: strin
     // discovery documents and token endpoints the SDK follows to OTHER
     // hosts) is checked against private/reserved address ranges at request
     // time. Hosted-deployment protection; self-hosted/dev opt out via env.
-    fetch: env.allowPrivateMcpUrls ? undefined : createGuardedFetch(),
+    fetch: env.allowPrivateMcpUrls ? createRealmSafeFetch() : createGuardedFetch(),
     requestInit: connection.authType === "apikey" && connection.apiKey
       ? { headers: { authorization: `Bearer ${connection.apiKey}` } }
       : undefined,

--- a/ee/apps/den-api/src/capability-sources/url-guard.ts
+++ b/ee/apps/den-api/src/capability-sources/url-guard.ts
@@ -118,6 +118,29 @@ export async function assertPublicUrl(rawUrl: string): Promise<void> {
 
 type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>
 
+function isCurrentResponseRealm(res: Response): boolean {
+  return res instanceof globalThis.Response
+}
+
+/**
+ * @hono/node-server overrides globalThis.Response with its own Response2
+ * constructor when Den starts serving. Real undici fetch() error responses do
+ * not chain to that new prototype, so the MCP SDK's OAuth error parser sees
+ * `input instanceof Response` as false and stringifies the whole response — the
+ * production symptom was `Invalid OAuth error response: SyntaxError: ... Raw
+ * body: [object Response]`, hiding the upstream OAuth server's JSON error.
+ * Success responses pass through untouched so streaming/SSE bodies stay live.
+ */
+export async function normalizeResponseRealm(res: Response): Promise<Response> {
+  if (res.ok || isCurrentResponseRealm(res)) return res
+  const buffered = await res.arrayBuffer()
+  return new globalThis.Response(buffered, {
+    status: res.status,
+    statusText: res.statusText,
+    headers: res.headers,
+  })
+}
+
 /**
  * A fetch wrapper that re-applies assertPublicUrl to EVERY outbound request
  * — the MCP SDK follows discovery documents to other hosts (authorization
@@ -127,6 +150,10 @@ type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>
 export function createGuardedFetch(): FetchLike {
   return async (input, init) => {
     await assertPublicUrl(String(input))
-    return fetch(input, init)
+    return normalizeResponseRealm(await fetch(input, init))
   }
+}
+
+export function createRealmSafeFetch(): FetchLike {
+  return async (input, init) => normalizeResponseRealm(await fetch(input, init))
 }

--- a/ee/apps/den-api/test/oauth-response-realm.test.ts
+++ b/ee/apps/den-api/test/oauth-response-realm.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test"
+import { createServer, type Server } from "node:http"
+import { getRequestListener } from "@hono/node-server"
+import { parseErrorResponse } from "@modelcontextprotocol/sdk/client/auth.js"
+import { createRealmSafeFetch, normalizeResponseRealm } from "../src/capability-sources/url-guard.js"
+
+getRequestListener(async () => new globalThis.Response("ok"))
+
+const OAUTH_ERROR_BODY = JSON.stringify({
+  error: "invalid_client_metadata",
+  error_description: "redirect_uri not allowed",
+})
+
+function serverUrl(server: Server): string {
+  const address = server.address()
+  if (typeof address === "object" && address !== null) {
+    return `http://127.0.0.1:${address.port}`
+  }
+  throw new Error("Test server did not bind to a TCP port.")
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject)
+      resolve()
+    })
+  })
+  return serverUrl(server)
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+async function withLocalResponse(status: number, body: string, run: (url: string) => Promise<void>): Promise<void> {
+  const server = createServer((_request, response) => {
+    response.writeHead(status, { "content-type": "application/json" })
+    response.end(body)
+  })
+  const url = await listen(server)
+  try {
+    await run(url)
+  } finally {
+    await close(server)
+  }
+}
+
+describe("OAuth response realm normalization", () => {
+  test("precondition: hono's global Response override is active", async () => {
+    await withLocalResponse(400, OAUTH_ERROR_BODY, async (url) => {
+      const response = await fetch(url)
+
+      expect(new globalThis.Response("x").constructor).not.toBe(response.constructor)
+      expect(response instanceof globalThis.Response).toBe(false)
+    })
+  })
+
+  test("normalizes failing fetch responses into the current global Response realm", async () => {
+    await withLocalResponse(400, OAUTH_ERROR_BODY, async (url) => {
+      const response = await createRealmSafeFetch()(url)
+
+      expect(response instanceof globalThis.Response).toBe(true)
+      expect(response.status).toBe(400)
+      expect(response.ok).toBe(false)
+      expect(await response.text()).toBe(OAUTH_ERROR_BODY)
+    })
+  })
+
+  test("lets the SDK parse OAuth errors instead of stringifying Response objects", async () => {
+    await withLocalResponse(400, OAUTH_ERROR_BODY, async (url) => {
+      const original = await fetch(url)
+      const broken = await parseErrorResponse(original)
+
+      expect(broken.message).toContain("[object Response]")
+
+      const normalized = await createRealmSafeFetch()(url)
+      const parsed = await parseErrorResponse(normalized)
+
+      expect(parsed.message).toContain("redirect_uri not allowed")
+      expect(parsed.message).not.toContain("[object Response]")
+    })
+  })
+
+  test("leaves success responses untouched", async () => {
+    await withLocalResponse(200, "ok", async (url) => {
+      const response = await fetch(url)
+      const normalized = await normalizeResponseRealm(response)
+
+      expect(normalized).toBe(response)
+      expect(await normalized.text()).toBe("ok")
+    })
+  })
+})


### PR DESCRIPTION
## What / why

Production Notion connect failures were logging `Invalid OAuth error response: SyntaxError: ... Raw body: [object Response]` — the upstream OAuth server's real rejection was being destroyed before it could reach logs or the (now-mapped, #2543) 502 message.

Root cause, verified line-by-line: `@hono/node-server` **replaces `globalThis.Response`** with its own `Response2` class when den-api serves (its prototype chains to the real Response, but real undici fetch responses don't chain to *it*). The MCP SDK's `parseErrorResponse` checks `input instanceof Response` against the current global → false for genuine fetch responses → `statusCode` undefined and the Response object itself gets template-stringified into the error. Only OAuth **error** paths are affected (success paths duck-type), which is why the flow works locally (Notion DCR returns 201 here) but prod — where Notion rejects the registration — produced garbage.

Fix: `normalizeResponseRealm` in url-guard — non-ok responses are buffered and rebuilt via the *current* `globalThis.Response` (hono's class implements ok/status/text/json and chains to the real prototype, so every downstream check passes). Success responses pass through by identity (SSE/streaming untouched). Applied in `createGuardedFetch` and a new `createRealmSafeFetch` used when `allowPrivateMcpUrls` is on, so both modes are covered.

## Tests

New `test/oauth-response-realm.test.ts` (4 pass): activates hono's real global override via `getRequestListener`, spins a local 400-JSON OAuth-error server, and proves — (a) the unnormalized path reproduces the `[object Response]` bug through the real SDK `parseErrorResponse` (regression guard), (b) the normalized path yields the actual `redirect_uri not allowed`-style message, (c) realm/status/text contracts, (d) 200s pass through by identity.

tsc + build green. Full suite failure names unchanged (known pre-existing in-suite pollution class only: route-guard-policy, breached-password, me-desktop-config + cleanup, mcp JWT).

## Effect after deploy

The Connect banner (and Render logs) will finally show Notion's **actual** registration error — the last missing piece to diagnose the production connect failure.

## Proof note

fraimz: N/A — server-only; deterministic reproduction + fix are covered by the SDK-level test above.