### PR TITLE
feat(cloud): Google Workspace desktop-parity scopes + admin-selected optional permissions

### DIFF
--- a/ee/apps/den-api/src/capability-sources/generic-oauth.ts
+++ b/ee/apps/den-api/src/capability-sources/generic-oauth.ts
@@ -1,6 +1,6 @@
 import { createHash, createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto"
 import type { DenTypeId } from "@openwork-ee/utils/typeid"
-import type { NativeOAuthProviderConfig } from "./provider-registry.js"
+import { clientSelectedFeatures, resolveProviderScopes, type NativeOAuthProviderConfig } from "./provider-registry.js"
 import {
   getConnectedAccount,
   getOrgOAuthClient,
@@ -115,7 +115,7 @@ export function buildAuthorizeUrl(input: {
   url.searchParams.set("client_id", input.client.clientId)
   url.searchParams.set("redirect_uri", input.redirectUri)
   url.searchParams.set("response_type", "code")
-  url.searchParams.set("scope", input.provider.defaultScopes.join(" "))
+  url.searchParams.set("scope", resolveProviderScopes(input.provider, clientSelectedFeatures(input.provider, input.client.extra)).join(" "))
   url.searchParams.set("state", input.state)
   if (input.provider.usesPkce && input.codeChallenge) {
     url.searchParams.set("code_challenge", input.codeChallenge)

--- a/ee/apps/den-api/src/capability-sources/provider-registry.ts
+++ b/ee/apps/den-api/src/capability-sources/provider-registry.ts
@@ -19,6 +19,7 @@ export type NativeOAuthProviderConfig = {
   /** Display-only endpoint shown on connection cards. */
   websiteUrl: string
   defaultScopes: string[]
+  optionalFeatures?: Record<string, string[]>
   /** Google (and most modern providers) support PKCE even for confidential clients; harmless to always send. */
   usesPkce: boolean
   /** Extra fixed authorize-url params beyond client_id/redirect_uri/response_type/scope/state/PKCE. */
@@ -34,9 +35,22 @@ export const NATIVE_OAUTH_PROVIDERS: Record<string, NativeOAuthProviderConfig> =
     websiteUrl: "https://workspace.google.com",
     defaultScopes: [
       "openid",
-      "email",
+      "https://www.googleapis.com/auth/userinfo.email",
+      "https://www.googleapis.com/auth/userinfo.profile",
+      "https://www.googleapis.com/auth/calendar.readonly",
       "https://www.googleapis.com/auth/gmail.compose",
+      "https://www.googleapis.com/auth/drive.file",
     ],
+    optionalFeatures: {
+      gmailRead: ["https://www.googleapis.com/auth/gmail.readonly"],
+      driveFull: ["https://www.googleapis.com/auth/drive"],
+      calendarWrite: ["https://www.googleapis.com/auth/calendar.events"],
+      chat: [
+        "https://www.googleapis.com/auth/chat.spaces.readonly",
+        "https://www.googleapis.com/auth/chat.messages.readonly",
+        "https://www.googleapis.com/auth/chat.messages.create",
+      ],
+    },
     usesPkce: true,
     extraAuthorizeParams: {
       access_type: "offline",
@@ -47,4 +61,37 @@ export const NATIVE_OAUTH_PROVIDERS: Record<string, NativeOAuthProviderConfig> =
 
 export function getNativeOAuthProvider(providerId: string): NativeOAuthProviderConfig | null {
   return NATIVE_OAUTH_PROVIDERS[providerId] ?? null
+}
+
+export function resolveProviderScopes(provider: NativeOAuthProviderConfig, features: string[]): string[] {
+  const scopes: string[] = []
+  for (const scope of provider.defaultScopes) {
+    if (!scopes.includes(scope)) scopes.push(scope)
+  }
+
+  const optionalFeatures = provider.optionalFeatures
+  if (!optionalFeatures) return scopes
+
+  for (const feature of features) {
+    const featureScopes = optionalFeatures[feature]
+    if (!featureScopes) continue
+    for (const scope of featureScopes) {
+      if (!scopes.includes(scope)) scopes.push(scope)
+    }
+  }
+
+  return scopes
+}
+
+export function clientSelectedFeatures(provider: NativeOAuthProviderConfig, extra: Record<string, unknown> | null): string[] {
+  const optionalFeatures = provider.optionalFeatures
+  if (!optionalFeatures || !extra || !Array.isArray(extra.features)) return []
+
+  const features: string[] = []
+  for (const feature of extra.features) {
+    if (typeof feature !== "string") continue
+    if (!Object.hasOwn(optionalFeatures, feature)) continue
+    if (!features.includes(feature)) features.push(feature)
+  }
+  return features
 }

--- a/ee/apps/den-api/src/routes/org/oauth-providers.ts
+++ b/ee/apps/den-api/src/routes/org/oauth-providers.ts
@@ -19,7 +19,13 @@ import {
   verifyOAuthStateToken,
 } from "../../capability-sources/generic-oauth.js"
 import { connectCallbackPage } from "../../capability-sources/oauth-callback-page.js"
-import { getNativeOAuthProvider, NATIVE_OAUTH_PROVIDERS, type NativeOAuthProviderConfig } from "../../capability-sources/provider-registry.js"
+import {
+  clientSelectedFeatures,
+  getNativeOAuthProvider,
+  NATIVE_OAUTH_PROVIDERS,
+  resolveProviderScopes,
+  type NativeOAuthProviderConfig,
+} from "../../capability-sources/provider-registry.js"
 import {
   disconnectAccount,
   getConnectedAccount,
@@ -35,8 +41,9 @@ const providerParamsSchema = z.object({
 })
 
 const saveClientBodySchema = z.object({
-  clientId: z.string().trim().min(1).max(512),
+  clientId: z.string().trim().min(1).max(512).optional(),
   clientSecret: z.string().trim().min(1).max(4096).optional(),
+  features: z.array(z.string().trim().min(1).max(128)).optional(),
 })
 
 const oauthNotFoundSchema = z.object({
@@ -48,7 +55,15 @@ const clientConfigResponseSchema = z.object({
   ok: z.literal(true),
   providerId: z.string(),
   clientId: z.string(),
+  features: z.array(z.string()),
 }).meta({ ref: "OAuthClientConfigResponse" })
+
+const clientConfigDetailResponseSchema = z.object({
+  providerId: z.string(),
+  clientId: z.string(),
+  features: z.array(z.string()),
+  scopes: z.array(z.string()),
+}).meta({ ref: "OAuthClientConfigDetailResponse" })
 
 const connectStartResponseSchema = z.object({
   authorizeUrl: z.string(),
@@ -58,6 +73,8 @@ const clientNotConfiguredSchema = z.object({
   error: z.literal("client_not_configured"),
   message: z.string(),
 }).meta({ ref: "OAuthClientNotConfiguredError" })
+
+const clientLookupNotFoundSchema = z.union([oauthNotFoundSchema, clientNotConfiguredSchema]).meta({ ref: "OAuthClientLookupNotFoundError" })
 
 const oauthStatusResponseSchema = z.object({
   providerId: z.string(),
@@ -153,15 +170,75 @@ export function registerOAuthProviderRoutes<T extends { Variables: OrgRouteVaria
       }
 
       const body = c.req.valid("json")
-      await upsertOrgOAuthClient({
+      const existing = await getOrgOAuthClient(payload.organization.id, providerId)
+      if (!existing && !body.clientId) {
+        return c.json({ error: "invalid_request", message: "clientId is required for first-time setup." }, 400)
+      }
+
+      if (body.features !== undefined) {
+        const optionalFeatures = provider.optionalFeatures ?? {}
+        const unknownFeatures = body.features.filter((feature) => !Object.hasOwn(optionalFeatures, feature))
+        if (unknownFeatures.length > 0) {
+          return c.json({ error: "invalid_request", message: `Unknown optional feature(s): ${unknownFeatures.join(", ")}.` }, 400)
+        }
+      }
+
+      const clientId = body.clientId ?? existing?.clientId
+      if (!clientId) {
+        return c.json({ error: "invalid_request", message: "clientId is required for first-time setup." }, 400)
+      }
+
+      const saved = await upsertOrgOAuthClient({
         organizationId: payload.organization.id,
         providerId,
-        clientId: body.clientId,
-        clientSecret: body.clientSecret,
+        clientId,
+        ...(body.clientSecret !== undefined ? { clientSecret: body.clientSecret } : {}),
+        ...(body.features !== undefined ? { extra: { ...(existing?.extra ?? {}), features: body.features } } : {}),
         createdByOrgMembershipId: payload.currentMember.id,
       })
 
-      return c.json({ ok: true as const, providerId, clientId: body.clientId })
+      return c.json({ ok: true, providerId, clientId: saved.clientId, features: clientSelectedFeatures(provider, saved.extra) })
+    },
+  )
+
+  app.get(
+    "/v1/oauth-providers/:providerId/client",
+    describeRoute({
+      tags: ["Authentication"],
+      summary: "Get an org's OAuth client configuration for a provider",
+      description: "Admin-only. Returns the saved OAuth client id, selected optional features, and the full scope list members will be asked to approve. Never returns the client secret.",
+      responses: {
+        200: jsonResponse("OAuth client configuration.", clientConfigDetailResponseSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        403: jsonResponse("Only workspace owners and admins can view an OAuth client configuration.", forbiddenSchema),
+        404: jsonResponse("Unknown providerId, or the org has not configured an OAuth client for this provider yet.", clientLookupNotFoundSchema),
+      },
+    }),
+    orgMemberRoute(),
+    paramValidator(providerParamsSchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const admin = ensureOrganizationAdmin(c, "Only workspace owners and admins can view an OAuth client configuration.")
+      if (!admin.ok) return c.json(admin.response, orgAccessFailureStatus(admin.response))
+
+      const { providerId } = c.req.valid("param")
+      const provider = getNativeOAuthProvider(providerId)
+      if (!provider) {
+        return c.json({ error: "unknown_oauth_provider", message: `"${providerId}" is not a known native OAuth provider.` }, 404)
+      }
+
+      const client = await getOrgOAuthClient(payload.organization.id, providerId)
+      if (!client) {
+        return c.json({ error: "client_not_configured", message: `Connect an OAuth client for "${providerId}" first.` }, 404)
+      }
+
+      const features = clientSelectedFeatures(provider, client.extra)
+      return c.json({
+        providerId,
+        clientId: client.clientId,
+        features,
+        scopes: resolveProviderScopes(provider, features),
+      })
     },
   )
 
@@ -297,7 +374,7 @@ export function registerOAuthProviderRoutes<T extends { Variables: OrgRouteVaria
           refreshToken: tokens.refresh_token ?? null,
           tokenType: tokens.token_type ?? null,
           expiresAt: tokens.expires_in ? new Date(Date.now() + tokens.expires_in * 1000) : null,
-          scopes: tokens.scope ? tokens.scope.split(" ") : provider.defaultScopes,
+          scopes: tokens.scope ? tokens.scope.split(" ") : resolveProviderScopes(provider, clientSelectedFeatures(provider, client.extra)),
           pendingCodeVerifier: null,
         })
       } catch (error) {

--- a/ee/apps/den-api/test/native-provider-scopes.test.ts
+++ b/ee/apps/den-api/test/native-provider-scopes.test.ts
@@ -1,0 +1,93 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, describe, expect, test } from "bun:test"
+
+import type { OrgOAuthClientRow } from "../src/capability-sources/oauth-credentials.js"
+
+const GOOGLE_WORKSPACE_BASE_SCOPES = [
+  "openid",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
+  "https://www.googleapis.com/auth/calendar.readonly",
+  "https://www.googleapis.com/auth/gmail.compose",
+  "https://www.googleapis.com/auth/drive.file",
+]
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+let registry: typeof import("../src/capability-sources/provider-registry.js")
+let oauth: typeof import("../src/capability-sources/generic-oauth.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  registry = await import("../src/capability-sources/provider-registry.js")
+  oauth = await import("../src/capability-sources/generic-oauth.js")
+})
+
+function googleWorkspaceProvider() {
+  const provider = registry.getNativeOAuthProvider("google-workspace")
+  if (!provider) {
+    throw new Error("google-workspace provider is missing")
+  }
+  return provider
+}
+
+describe("google-workspace native provider scopes", () => {
+  test("defaultScopes matches the desktop base set", () => {
+    expect(googleWorkspaceProvider().defaultScopes).toEqual(GOOGLE_WORKSPACE_BASE_SCOPES)
+  })
+
+  test("resolveProviderScopes adds selected feature scopes and dedupes", () => {
+    const scopes = registry.resolveProviderScopes(googleWorkspaceProvider(), ["gmailRead", "calendarWrite", "gmailRead"])
+
+    expect(scopes).toEqual([
+      ...GOOGLE_WORKSPACE_BASE_SCOPES,
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/calendar.events",
+    ])
+  })
+
+  test("clientSelectedFeatures ignores unknown keys, non-strings, and absent extra", () => {
+    const provider = googleWorkspaceProvider()
+
+    expect(registry.clientSelectedFeatures(provider, null)).toEqual([])
+    expect(registry.clientSelectedFeatures(provider, {})).toEqual([])
+    expect(registry.clientSelectedFeatures(provider, {
+      features: ["gmailRead", "unknown", 42, "calendarWrite", null],
+    })).toEqual(["gmailRead", "calendarWrite"])
+  })
+
+  test("buildAuthorizeUrl includes base scopes plus selected optional feature scopes", () => {
+    const client: OrgOAuthClientRow = {
+      id: createDenTypeId("orgOAuthClient"),
+      organizationId: createDenTypeId("organization"),
+      providerId: "google-workspace",
+      clientId: "google-client-id",
+      clientSecret: "google-client-secret",
+      extra: { features: ["gmailRead", "calendarWrite"] },
+      createdByOrgMembershipId: createDenTypeId("member"),
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    }
+
+    const authorizeUrl = oauth.buildAuthorizeUrl({
+      provider: googleWorkspaceProvider(),
+      client,
+      state: "state-token",
+      redirectUri: "http://127.0.0.1:8790/v1/oauth-providers/google-workspace/connect/callback",
+      codeChallenge: "pkce-challenge",
+    })
+    const scopes = new URL(authorizeUrl).searchParams.get("scope")?.split(" ") ?? []
+
+    expect(scopes).toEqual([
+      ...GOOGLE_WORKSPACE_BASE_SCOPES,
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/calendar.events",
+    ])
+  })
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -47,7 +47,17 @@ export const mcpConnectionQueryKeys = {
   list: (orgId?: string | null, scope?: ExternalMcpConnectionScope) =>
     [...mcpConnectionQueryKeys.all, "list", orgId ?? "none", scope ?? "usable"] as const,
   presets: () => [...mcpConnectionQueryKeys.all, "presets"] as const,
+  nativeProviderClient: (orgId?: string | null, providerId?: string | null) =>
+    [...mcpConnectionQueryKeys.all, "native-provider-client", orgId ?? "none", providerId ?? "none"],
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
 
 async function fetchConnections(scope: ExternalMcpConnectionScope): Promise<ExternalMcpConnection[]> {
   const { response, payload } = await requestJson(`/v1/mcp-connections?scope=${scope}`, {}, 15000);
@@ -199,9 +209,28 @@ export function useDeleteMcpConnection() {
 
 export type SaveNativeProviderClientInput = {
   providerId: string;
-  clientId: string;
-  clientSecret: string;
+  clientId?: string;
+  clientSecret?: string;
+  features: string[];
 };
+
+export type NativeProviderClient = {
+  providerId: string;
+  clientId: string;
+  features: string[];
+  scopes: string[];
+};
+
+function parseNativeProviderClient(payload: unknown): NativeProviderClient {
+  if (!isRecord(payload)) {
+    throw new Error("Native provider client response was incomplete.");
+  }
+  const { providerId, clientId, features, scopes } = payload;
+  if (typeof providerId !== "string" || typeof clientId !== "string" || !isStringArray(features) || !isStringArray(scopes)) {
+    throw new Error("Native provider client response was incomplete.");
+  }
+  return { providerId, clientId, features, scopes };
+}
 
 /**
  * Native providers (google-workspace) are configured with an org OAuth
@@ -215,9 +244,18 @@ export function useSaveNativeProviderClient() {
   return useMutation({
     mutationFn: async (input: SaveNativeProviderClientInput): Promise<void> => {
       await runReauthableAction("save-native-oauth-client", async () => {
+        const clientId = input.clientId?.trim();
+        const clientSecret = input.clientSecret?.trim();
         const { response, payload } = await requestJson(
           `/v1/oauth-providers/${encodeURIComponent(input.providerId)}/client`,
-          { method: "POST", body: JSON.stringify({ clientId: input.clientId, clientSecret: input.clientSecret }) },
+          {
+            method: "POST",
+            body: JSON.stringify({
+              ...(clientId ? { clientId } : {}),
+              ...(clientSecret ? { clientSecret } : {}),
+              features: input.features,
+            }),
+          },
           20000,
         );
         if (!response.ok) {
@@ -227,6 +265,29 @@ export function useSaveNativeProviderClient() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });
+    },
+  });
+}
+
+export function useNativeProviderClient(providerId: string, enabled: boolean) {
+  const { orgId } = useOrgDashboard();
+
+  return useQuery({
+    enabled: enabled && Boolean(orgId),
+    queryKey: mcpConnectionQueryKeys.nativeProviderClient(orgId, providerId),
+    queryFn: async (): Promise<NativeProviderClient | null> => {
+      const { response, payload } = await requestJson(
+        `/v1/oauth-providers/${encodeURIComponent(providerId)}/client`,
+        {},
+        15000,
+      );
+      if (response.status === 404) {
+        return null;
+      }
+      if (!response.ok) {
+        throw getRequestError(payload, response, `Failed to load the OAuth client (${response.status}).`);
+      }
+      return parseNativeProviderClient(payload);
     },
   });
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -30,10 +30,10 @@ const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
 
 const GOOGLE_WORKSPACE_OPTIONAL_PERMISSIONS = [
-  { key: "gmailRead", label: "Read Gmail (gmailRead)" },
-  { key: "driveFull", label: "Full Drive access (driveFull)" },
-  { key: "calendarWrite", label: "Create calendar events (calendarWrite)" },
-  { key: "chat", label: "Google Chat (chat)" },
+  { key: "gmailRead", label: "Read Gmail" },
+  { key: "driveFull", label: "Full Drive access" },
+  { key: "calendarWrite", label: "Create calendar events" },
+  { key: "chat", label: "Google Chat" },
 ];
 
 export function McpConnectionsScreen() {
@@ -265,18 +265,21 @@ function GoogleWorkspaceDialog({
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const [features, setFeatures] = useState<string[]>([]);
+  const featuresPrefilled = useRef(false);
 
   useEffect(() => {
     if (!open) return;
     setClientId("");
     setClientSecret("");
     setFeatures([]);
+    featuresPrefilled.current = false;
   }, [open]);
 
   useEffect(() => {
-    if (!open || clientConfig.isLoading) return;
+    if (!open || featuresPrefilled.current || !clientConfig.isSuccess || clientConfig.isFetching) return;
     setFeatures(clientConfig.data?.features ?? []);
-  }, [open, clientConfig.isLoading, clientConfig.data?.features]);
+    featuresPrefilled.current = true;
+  }, [open, clientConfig.isSuccess, clientConfig.isFetching, clientConfig.data?.features]);
 
   if (!open) {
     return null;
@@ -317,6 +320,7 @@ function GoogleWorkspaceDialog({
                 <label key={permission.key} className="flex items-center gap-2 text-[13px] text-gray-700">
                   <input
                     type="checkbox"
+                    data-feature={permission.key}
                     className="h-4 w-4 rounded border-gray-300 text-gray-900"
                     checked={features.includes(permission.key)}
                     disabled={loadingConfig}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -21,12 +21,20 @@ import {
   useDeleteMcpConnection,
   useMcpConnectionPresets,
   useMcpConnections,
+  useNativeProviderClient,
   useSaveNativeProviderClient,
   useStartMcpConnectionOAuth,
 } from "./mcp-connections-data";
 
 const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
+
+const GOOGLE_WORKSPACE_OPTIONAL_PERMISSIONS = [
+  { key: "gmailRead", label: "Read Gmail (gmailRead)" },
+  { key: "driveFull", label: "Full Drive access (driveFull)" },
+  { key: "calendarWrite", label: "Create calendar events (calendarWrite)" },
+  { key: "chat", label: "Google Chat (chat)" },
+];
 
 export function McpConnectionsScreen() {
   const { orgContext } = useOrgDashboard();
@@ -251,19 +259,38 @@ function GoogleWorkspaceDialog({
   submitting: boolean;
   error: unknown;
   onClose: () => void;
-  onSubmit: (input: { clientId: string; clientSecret: string }) => void;
+  onSubmit: (input: { clientId?: string; clientSecret?: string; features: string[] }) => void;
 }) {
+  const clientConfig = useNativeProviderClient("google-workspace", open);
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
+  const [features, setFeatures] = useState<string[]>([]);
 
   useEffect(() => {
     if (!open) return;
     setClientId("");
     setClientSecret("");
+    setFeatures([]);
   }, [open]);
+
+  useEffect(() => {
+    if (!open || clientConfig.isLoading) return;
+    setFeatures(clientConfig.data?.features ?? []);
+  }, [open, clientConfig.isLoading, clientConfig.data?.features]);
 
   if (!open) {
     return null;
+  }
+
+  const configured = Boolean(clientConfig.data);
+  const loadingConfig = clientConfig.isLoading;
+  const formError = error ?? clientConfig.error;
+  const trimmedClientId = clientId.trim();
+  const trimmedClientSecret = clientSecret.trim();
+  const saveDisabled = loadingConfig || (!configured && (!trimmedClientId || !trimmedClientSecret));
+
+  function toggleFeature(feature: string) {
+    setFeatures((current) => current.includes(feature) ? current.filter((entry) => entry !== feature) : [...current, feature]);
   }
 
   return (
@@ -277,14 +304,35 @@ function GoogleWorkspaceDialog({
           Paste the OAuth client from your company&apos;s Google Cloud project. Members then connect their own
           Google account from Your Connections — sign-ins stay in your org&apos;s cloud.
         </p>
+        <p className="mt-2 text-[12px] leading-5 text-gray-500">
+          Included permissions: calendar read, Gmail drafts, and selected Drive files.
+        </p>
 
         <div className="mt-5 space-y-4">
+          <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
+            <p className="text-[13px] font-semibold text-gray-900">Optional permissions</p>
+            <p className="mt-1 text-[12px] leading-5 text-gray-500">Only add these when your team needs the extra Google access.</p>
+            <div className="mt-3 space-y-2">
+              {GOOGLE_WORKSPACE_OPTIONAL_PERMISSIONS.map((permission) => (
+                <label key={permission.key} className="flex items-center gap-2 text-[13px] text-gray-700">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-gray-300 text-gray-900"
+                    checked={features.includes(permission.key)}
+                    disabled={loadingConfig}
+                    onChange={() => toggleFeature(permission.key)}
+                  />
+                  <span>{permission.label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
           <div>
             <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client ID</label>
             <DenInput
               value={clientId}
               onChange={(event) => setClientId(event.target.value)}
-              placeholder="1234567890-abc.apps.googleusercontent.com"
+              placeholder={configured ? "Saved client ID kept if left blank" : "1234567890-abc.apps.googleusercontent.com"}
             />
           </div>
           <div>
@@ -293,13 +341,13 @@ function GoogleWorkspaceDialog({
               type="password"
               value={clientSecret}
               onChange={(event) => setClientSecret(event.target.value)}
-              placeholder="GOCSPX-…"
+              placeholder={configured ? "Saved client secret kept if left blank" : "GOCSPX-…"}
             />
           </div>
         </div>
 
-        {error ? (
-          <p className="mt-3 text-[13px] text-red-600">{error instanceof Error ? error.message : "Failed to save the OAuth client."}</p>
+        {formError ? (
+          <p className="mt-3 text-[13px] text-red-600">{formError instanceof Error ? formError.message : "Failed to save the OAuth client."}</p>
         ) : null}
 
         <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
@@ -309,8 +357,12 @@ function GoogleWorkspaceDialog({
           <DenButton
             variant="primary"
             loading={submitting}
-            disabled={!clientId.trim() || !clientSecret.trim()}
-            onClick={() => onSubmit({ clientId: clientId.trim(), clientSecret: clientSecret.trim() })}
+            disabled={saveDisabled}
+            onClick={() => onSubmit({
+              ...(trimmedClientId ? { clientId: trimmedClientId } : {}),
+              ...(trimmedClientSecret ? { clientSecret: trimmedClientSecret } : {}),
+              features,
+            })}
           >
             Save
           </DenButton>

--- a/evals/flows/org-google-workspace-scopes.flow.mjs
+++ b/evals/flows/org-google-workspace-scopes.flow.mjs
@@ -34,6 +34,8 @@ const EXPECTED_MEMBER_SCOPES = [
 const state = {
   adminSession: null,
   memberSession: null,
+  orgId: null,
+  orgName: null,
   authorizeUrl: null,
   authorizeScopes: [],
   status: null,
@@ -59,6 +61,29 @@ function assertExactStringSet(ctx, actual, expected, label) {
   );
 }
 
+function orgHeaders(session) {
+  if (!session) throw new Error("Missing session for org-scoped API call.");
+  if (!state.orgId) throw new Error("Missing pinned organization id for org-scoped API call.");
+  return { authorization: `Bearer ${session}`, "x-openwork-legacy-org-id": state.orgId };
+}
+
+async function selectAdminOrganization(ctx) {
+  const listed = await denApiFetch("/v1/me/orgs", {
+    headers: { authorization: `Bearer ${state.adminSession}` },
+  });
+  ctx.assert(listed.response.ok, `Admin org list failed: ${listed.response.status} ${JSON.stringify(listed.body).slice(0, 200)}`);
+  const orgs = Array.isArray(listed.body.orgs) ? listed.body.orgs : [];
+  const acme = orgs.find((org) => org.slug === "acme-robotics-demo");
+  const adminOrg = orgs.find((org) => ["owner", "admin"].includes(String(org.role ?? "").toLowerCase()));
+  const selected = acme ?? adminOrg;
+  ctx.assert(
+    selected && typeof selected.id === "string",
+    `Admin ${ADMIN_EMAIL} is not in acme-robotics-demo and has no owner/admin org. Orgs: ${JSON.stringify(orgs)}`,
+  );
+  state.orgId = selected.id;
+  state.orgName = typeof selected.name === "string" && selected.name ? selected.name : selected.slug ?? selected.id;
+}
+
 async function ensureVerifiedUser(ctx, email, name, password) {
   let token = await signInApi(email, password);
   if (token) return token;
@@ -75,24 +100,38 @@ async function ensureVerifiedUser(ctx, email, name, password) {
   return token;
 }
 
+async function memberBelongsToPinnedOrg(ctx) {
+  const orgs = await denApiFetch("/v1/me/orgs", { headers: { authorization: `Bearer ${state.memberSession}` } });
+  ctx.assert(orgs.response.ok, `Member org list failed: ${orgs.response.status} ${JSON.stringify(orgs.body).slice(0, 200)}`);
+  return (orgs.body.orgs ?? []).some((org) => org.id === state.orgId);
+}
+
 async function ensureMember(ctx) {
   state.memberSession = await ensureVerifiedUser(ctx, MEMBER_EMAIL, "Jordan Demo", MEMBER_PASSWORD);
-  const orgs = await denApiFetch("/v1/me/orgs", { headers: { authorization: `Bearer ${state.memberSession}` } });
-  const inAcme = (orgs.body.orgs ?? []).some((org) => org.slug === "acme-robotics-demo");
-  if (inAcme) return;
+  if (await memberBelongsToPinnedOrg(ctx)) return;
 
   const invite = await denApiFetch("/v1/invitations", {
     method: "POST",
-    headers: { authorization: `Bearer ${state.adminSession}` },
+    headers: orgHeaders(state.adminSession),
     body: JSON.stringify({ email: MEMBER_EMAIL, role: "member" }),
   });
-  ctx.assert(invite.response.ok, `Invitation failed: ${invite.response.status}`);
+  if (!invite.response.ok && invite.body?.error === "member_exists") {
+    ctx.assert(await memberBelongsToPinnedOrg(ctx), `Invite returned member_exists, but ${MEMBER_EMAIL} is not in ${state.orgName} (${state.orgId}).`);
+    return;
+  }
+  ctx.assert(invite.response.ok, `Invitation failed: ${invite.response.status} ${JSON.stringify(invite.body).slice(0, 200)}`);
   const accept = await denApiFetch("/v1/orgs/invitations/accept", {
     method: "POST",
     headers: { authorization: `Bearer ${state.memberSession}` },
     body: JSON.stringify({ id: invite.body.inviteToken }),
   });
   ctx.assert(accept.response.ok && accept.body.accepted, "Invitation accept failed.");
+  ctx.assert(await memberBelongsToPinnedOrg(ctx), `${MEMBER_EMAIL} did not join ${state.orgName} (${state.orgId}) after accepting the invite.`);
+}
+
+async function setBrowserActiveOrg(ctx) {
+  const ok = await ctx.eval(`fetch('/api/auth/organization/set-active', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ organizationId: ${JSON.stringify(state.orgId)} }) }).then((r) => r.ok)`, { awaitPromise: true });
+  ctx.assert(ok, `Could not set the browser active org to ${state.orgName} (${state.orgId}).`);
 }
 
 function clickGoogleQuickAddScript() {
@@ -185,7 +224,7 @@ async function waitForSavedFeatures(ctx) {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     const config = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
-      headers: { authorization: `Bearer ${state.adminSession}` },
+      headers: orgHeaders(state.adminSession),
     });
     if (config.response.ok) {
       features = Array.isArray(config.body.features) ? config.body.features : [];
@@ -212,7 +251,7 @@ async function waitForMemberConnectedStatus(ctx) {
   const deadline = Date.now() + 45_000;
   while (Date.now() < deadline) {
     const result = await denApiFetch("/v1/oauth-providers/google-workspace/status", {
-      headers: { authorization: `Bearer ${state.memberSession}` },
+      headers: orgHeaders(state.memberSession),
     });
     if (result.response.ok) {
       status = result.body;
@@ -258,16 +297,17 @@ export default {
 
         state.adminSession = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
         ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+        await selectAdminOrganization(ctx);
         await ensureMember(ctx);
 
         await denApiFetch("/v1/oauth-providers/google-workspace/disconnect", {
           method: "POST",
-          headers: { authorization: `Bearer ${state.memberSession}` },
+          headers: orgHeaders(state.memberSession),
         }).catch(() => undefined);
 
         const cleanClient = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
           method: "POST",
-          headers: { authorization: `Bearer ${state.adminSession}` },
+          headers: orgHeaders(state.adminSession),
           body: JSON.stringify({
             clientId: `google-clean-client-${RUN_TAG}`,
             clientSecret: "google-clean-secret",
@@ -284,6 +324,7 @@ export default {
           voiceover: vo[0],
           action: async () => {
             await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+            await setBrowserActiveOrg(ctx);
             await openAdminConnections(ctx);
             const clicked = await ctx.eval(clickGoogleQuickAddScript());
             ctx.assert(clicked, "Google Workspace quick-add card was not found.");
@@ -364,7 +405,7 @@ export default {
           voiceover: vo[3],
           action: async () => {
             const started = await denApiFetch("/v1/mcp-connections/google-workspace/connect/start", {
-              headers: { authorization: `Bearer ${state.memberSession}` },
+              headers: orgHeaders(state.memberSession),
             });
             ctx.assert(started.response.ok, `Starting Google Workspace connect failed: ${started.response.status} ${JSON.stringify(started.body).slice(0, 200)}`);
             ctx.assert(started.body.status === "needs_auth" && typeof started.body.authorizeUrl === "string", "connect/start did not return an authorizeUrl.");
@@ -400,6 +441,7 @@ export default {
           action: async () => {
             state.status = await waitForMemberConnectedStatus(ctx);
             await signInViaBrowser(ctx, MEMBER_EMAIL, MEMBER_PASSWORD);
+            await setBrowserActiveOrg(ctx);
             await openYourConnections(ctx);
           },
           assert: async () => {

--- a/evals/flows/org-google-workspace-scopes.flow.mjs
+++ b/evals/flows/org-google-workspace-scopes.flow.mjs
@@ -120,16 +120,14 @@ function includedPermissionsScript() {
 
 function featureReadyScript(featureKey) {
   return `(() => {
-    const label = [...document.querySelectorAll('label')].find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(`(${featureKey})`)}));
-    const input = label?.querySelector('input[type="checkbox"]');
+    const input = [...document.querySelectorAll('input[type="checkbox"][data-feature]')].find((entry) => entry.dataset.feature === ${JSON.stringify(featureKey)});
     return Boolean(input && !input.disabled);
   })()`;
 }
 
 function setFeatureCheckedScript(featureKey, checked) {
   return `(() => {
-    const label = [...document.querySelectorAll('label')].find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(`(${featureKey})`)}));
-    const input = label?.querySelector('input[type="checkbox"]');
+    const input = [...document.querySelectorAll('input[type="checkbox"][data-feature]')].find((entry) => entry.dataset.feature === ${JSON.stringify(featureKey)});
     if (!input || input.disabled) return { ok: false, checked: false };
     input.scrollIntoView({ block: 'center' });
     if (input.checked !== ${JSON.stringify(checked)}) input.click();
@@ -141,8 +139,7 @@ function featureStatesScript() {
   return `(() => {
     const states = {};
     for (const featureKey of ${JSON.stringify(FEATURE_KEYS)}) {
-      const label = [...document.querySelectorAll('label')].find((entry) => (entry.textContent ?? '').includes('(' + featureKey + ')'));
-      const input = label?.querySelector('input[type="checkbox"]');
+      const input = [...document.querySelectorAll('input[type="checkbox"][data-feature]')].find((entry) => entry.dataset.feature === featureKey);
       states[featureKey] = input ? input.checked : null;
     }
     return states;

--- a/evals/flows/org-google-workspace-scopes.flow.mjs
+++ b/evals/flows/org-google-workspace-scopes.flow.mjs
@@ -1,0 +1,426 @@
+import { execSync } from "node:child_process";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, openAdminConnections, openYourConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/org-google-workspace-scopes.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("org-google-workspace-scopes");
+
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MEMBER_EMAIL = process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || "jordan.demo@acme.test";
+const MEMBER_PASSWORD = process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const MOCK_SERVER_URL = (process.env.MOCK_OAUTH_MCP_URL ?? "http://127.0.0.1:3978").trim().replace(/\/+$/, "");
+const RUN_TAG = Date.now();
+const GOOGLE_CLIENT_ID = "google-client-id";
+const GOOGLE_CLIENT_SECRET = "google-client-secret";
+const SELECTED_FEATURES = ["gmailRead", "calendarWrite"];
+const FEATURE_KEYS = ["gmailRead", "driveFull", "calendarWrite", "chat"];
+const BASE_GOOGLE_SCOPES = [
+  "openid",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
+  "https://www.googleapis.com/auth/calendar.readonly",
+  "https://www.googleapis.com/auth/gmail.compose",
+  "https://www.googleapis.com/auth/drive.file",
+];
+const EXPECTED_MEMBER_SCOPES = [
+  ...BASE_GOOGLE_SCOPES,
+  "https://www.googleapis.com/auth/gmail.readonly",
+  "https://www.googleapis.com/auth/calendar.events",
+];
+
+const state = {
+  adminSession: null,
+  memberSession: null,
+  authorizeUrl: null,
+  authorizeScopes: [],
+  status: null,
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function sameStringSet(actual, expected) {
+  if (!Array.isArray(actual) || actual.length !== expected.length) return false;
+  const actualSet = new Set(actual);
+  return actualSet.size === expected.length && expected.every((value) => actualSet.has(value));
+}
+
+function assertExactStringSet(ctx, actual, expected, label) {
+  const actualValues = Array.isArray(actual) ? actual : [];
+  const missing = expected.filter((value) => !actualValues.includes(value));
+  const extra = actualValues.filter((value) => !expected.includes(value));
+  ctx.assert(
+    missing.length === 0 && extra.length === 0 && actualValues.length === expected.length,
+    `${label} mismatch. Missing: ${missing.join(", ") || "none"}. Extra: ${extra.join(", ") || "none"}. Actual: ${JSON.stringify(actualValues)}`,
+  );
+}
+
+async function ensureVerifiedUser(ctx, email, name, password) {
+  let token = await signInApi(email, password);
+  if (token) return token;
+
+  const signUp = await denApiFetch("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ email, name, password }),
+  });
+  ctx.assert(signUp.response.ok, `Sign-up failed for ${email}: ${signUp.response.status}`);
+  ctx.assert(MARK_VERIFIED_CMD.length > 0, "Set OPENWORK_EVAL_MARK_VERIFIED_CMD to verify eval accounts.");
+  execSync(MARK_VERIFIED_CMD.replaceAll("{email}", email), { stdio: "ignore" });
+  token = await signInApi(email, password);
+  ctx.assert(Boolean(token), `Sign-in still failing for ${email} after sign-up.`);
+  return token;
+}
+
+async function ensureMember(ctx) {
+  state.memberSession = await ensureVerifiedUser(ctx, MEMBER_EMAIL, "Jordan Demo", MEMBER_PASSWORD);
+  const orgs = await denApiFetch("/v1/me/orgs", { headers: { authorization: `Bearer ${state.memberSession}` } });
+  const inAcme = (orgs.body.orgs ?? []).some((org) => org.slug === "acme-robotics-demo");
+  if (inAcme) return;
+
+  const invite = await denApiFetch("/v1/invitations", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.adminSession}` },
+    body: JSON.stringify({ email: MEMBER_EMAIL, role: "member" }),
+  });
+  ctx.assert(invite.response.ok, `Invitation failed: ${invite.response.status}`);
+  const accept = await denApiFetch("/v1/orgs/invitations/accept", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.memberSession}` },
+    body: JSON.stringify({ id: invite.body.inviteToken }),
+  });
+  ctx.assert(accept.response.ok && accept.body.accepted, "Invitation accept failed.");
+}
+
+function clickGoogleQuickAddScript() {
+  return `(() => {
+    const card = [...document.querySelectorAll('button')].find((button) => {
+      const text = button.textContent ?? '';
+      return text.includes('Google Workspace') && (text.includes('Tap to set up') || text.includes('Configured'));
+    });
+    card?.scrollIntoView({ block: 'center' });
+    card?.click();
+    return Boolean(card);
+  })()`;
+}
+
+function includedPermissionsScript() {
+  return `(() => {
+    const text = document.body.innerText;
+    const normalized = text.toLowerCase();
+    return text.includes('Included permissions')
+      && normalized.includes('calendar')
+      && normalized.includes('gmail')
+      && normalized.includes('drive');
+  })()`;
+}
+
+function featureReadyScript(featureKey) {
+  return `(() => {
+    const label = [...document.querySelectorAll('label')].find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(`(${featureKey})`)}));
+    const input = label?.querySelector('input[type="checkbox"]');
+    return Boolean(input && !input.disabled);
+  })()`;
+}
+
+function setFeatureCheckedScript(featureKey, checked) {
+  return `(() => {
+    const label = [...document.querySelectorAll('label')].find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(`(${featureKey})`)}));
+    const input = label?.querySelector('input[type="checkbox"]');
+    if (!input || input.disabled) return { ok: false, checked: false };
+    input.scrollIntoView({ block: 'center' });
+    if (input.checked !== ${JSON.stringify(checked)}) input.click();
+    return { ok: input.checked === ${JSON.stringify(checked)}, checked: input.checked };
+  })()`;
+}
+
+function featureStatesScript() {
+  return `(() => {
+    const states = {};
+    for (const featureKey of ${JSON.stringify(FEATURE_KEYS)}) {
+      const label = [...document.querySelectorAll('label')].find((entry) => (entry.textContent ?? '').includes('(' + featureKey + ')'));
+      const input = label?.querySelector('input[type="checkbox"]');
+      states[featureKey] = input ? input.checked : null;
+    }
+    return states;
+  })()`;
+}
+
+function fillInputByLabelScript(labelText, value) {
+  return `(() => {
+    const label = [...document.querySelectorAll('label')].find((entry) => (entry.textContent ?? '').trim() === ${JSON.stringify(labelText)});
+    const input = label?.parentElement?.querySelector('input');
+    if (!input) return false;
+    input.focus();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+    setter?.call(input, ${JSON.stringify(value)});
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    return input.value === ${JSON.stringify(value)};
+  })()`;
+}
+
+function saveButtonEnabledScript() {
+  return `(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === 'Save');
+    return Boolean(button && !button.disabled);
+  })()`;
+}
+
+function parseScopes(authorizeUrl) {
+  return (new URL(authorizeUrl).searchParams.get("scope") ?? "").split(" ").filter(Boolean);
+}
+
+function consentAuthorizeUrl(authorizeUrl) {
+  const url = new URL(authorizeUrl);
+  const mockOrigin = new URL(MOCK_SERVER_URL).origin;
+  if (url.origin === mockOrigin && url.pathname === "/authorize") {
+    url.searchParams.set("force_consent", "1");
+  }
+  return url.toString();
+}
+
+async function waitForSavedFeatures(ctx) {
+  let features = [];
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const config = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
+      headers: { authorization: `Bearer ${state.adminSession}` },
+    });
+    if (config.response.ok) {
+      features = Array.isArray(config.body.features) ? config.body.features : [];
+      if (sameStringSet(features, SELECTED_FEATURES)) return features;
+    }
+    await sleep(500);
+  }
+  ctx.assert(false, `Saved features never matched ${JSON.stringify(SELECTED_FEATURES)}; last seen ${JSON.stringify(features)}.`);
+  return features;
+}
+
+async function approveMockConsent(ctx) {
+  const clicked = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === 'Approve OpenWork');
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(clicked, "Mock OAuth consent page did not show an Approve OpenWork button.");
+  await ctx.waitForText("Connected", { timeoutMs: 30_000 });
+}
+
+async function waitForMemberConnectedStatus(ctx) {
+  let status = null;
+  const deadline = Date.now() + 45_000;
+  while (Date.now() < deadline) {
+    const result = await denApiFetch("/v1/oauth-providers/google-workspace/status", {
+      headers: { authorization: `Bearer ${state.memberSession}` },
+    });
+    if (result.response.ok) {
+      status = result.body;
+      const scopes = Array.isArray(status.scopes) ? status.scopes : [];
+      if (status.connected === true && EXPECTED_MEMBER_SCOPES.every((scope) => scopes.includes(scope))) return status;
+    }
+    await sleep(750);
+  }
+  ctx.assert(false, `Member Google Workspace status did not become connected with the selected scopes: ${JSON.stringify(status)}`);
+  return status;
+}
+
+function googleWorkspaceConnectedRowScript() {
+  return `(() => {
+    const leaves = [...document.querySelectorAll('*')].filter((el) => el.children.length === 0 && (el.textContent ?? '').trim() === 'Google Workspace');
+    for (const leaf of leaves) {
+      let el = leaf;
+      for (let index = 0; index < 6 && el; index += 1) {
+        const text = el.textContent ?? '';
+        if (text.includes('Connected as you')) {
+          el.scrollIntoView({ block: 'center' });
+          return true;
+        }
+        el = el.parentElement;
+      }
+    }
+    return false;
+  })()`;
+}
+
+export default {
+  id: "org-google-workspace-scopes",
+  title: "Org Google Workspace asks for desktop-parity scopes and admin-selected extras",
+  kind: "user-facing",
+  spec: "evals/voiceovers/org-google-workspace-scopes.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Setup: admin and member sessions are ready and Google Workspace starts clean",
+      run: async (ctx) => {
+        const health = await fetch(`${MOCK_SERVER_URL}/health`).then((response) => response.json()).catch(() => null);
+        ctx.assert(Boolean(health?.ok), `Mock Google IdP not reachable at ${MOCK_SERVER_URL}.`);
+
+        state.adminSession = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
+        ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+        await ensureMember(ctx);
+
+        await denApiFetch("/v1/oauth-providers/google-workspace/disconnect", {
+          method: "POST",
+          headers: { authorization: `Bearer ${state.memberSession}` },
+        }).catch(() => undefined);
+
+        const cleanClient = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
+          method: "POST",
+          headers: { authorization: `Bearer ${state.adminSession}` },
+          body: JSON.stringify({
+            clientId: `google-clean-client-${RUN_TAG}`,
+            clientSecret: "google-clean-secret",
+            features: [],
+          }),
+        });
+        ctx.assert(cleanClient.response.ok, `Saving clean Google client failed: ${cleanClient.response.status} ${JSON.stringify(cleanClient.body).slice(0, 200)}`);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The Google Workspace setup explains the desktop-parity included permissions", {
+          voiceover: vo[0],
+          action: async () => {
+            await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+            await openAdminConnections(ctx);
+            const clicked = await ctx.eval(clickGoogleQuickAddScript());
+            ctx.assert(clicked, "Google Workspace quick-add card was not found.");
+          },
+          assert: async () => {
+            await ctx.waitFor(includedPermissionsScript(), { timeoutMs: 20_000, label: "included permissions copy" });
+          },
+          screenshot: {
+            name: "org-google-workspace-included-permissions",
+            claim: "The setup dialog names the included calendar, Gmail, and Drive permissions.",
+            requireText: ["Included permissions", "calendar", "Gmail", "Drive"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The admin selects Read Gmail and Create calendar events and the API stores those features", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.waitFor(featureReadyScript("gmailRead"), { timeoutMs: 20_000, label: "optional permission checkboxes ready" });
+            for (const feature of SELECTED_FEATURES) {
+              const result = await ctx.eval(setFeatureCheckedScript(feature, true));
+              ctx.assert(result?.ok, `Could not check optional feature ${feature}.`);
+            }
+            const filledClientId = await ctx.eval(fillInputByLabelScript("Client ID", GOOGLE_CLIENT_ID));
+            const filledSecret = await ctx.eval(fillInputByLabelScript("Client secret", GOOGLE_CLIENT_SECRET));
+            ctx.assert(filledClientId, "Could not fill the Google client ID.");
+            ctx.assert(filledSecret, "Could not fill the Google client secret.");
+            await ctx.waitFor(saveButtonEnabledScript(), { timeoutMs: 10_000, label: "enabled Save button" });
+            await ctx.clickText("Save", { timeoutMs: 10_000 });
+          },
+          assert: async () => {
+            const features = await waitForSavedFeatures(ctx);
+            assertExactStringSet(ctx, features, SELECTED_FEATURES, "Saved optional features");
+          },
+          screenshot: {
+            name: "org-google-workspace-features-saved",
+            claim: "The admin's two selected optional permissions are saved on the org OAuth client.",
+            requireText: ["Google Workspace", "Configured"],
+            rejectText: ["Something went wrong", "Failed to save"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Reopening Google Workspace shows the selected optional permissions persisted", {
+          voiceover: vo[2],
+          action: async () => {
+            const clicked = await ctx.eval(clickGoogleQuickAddScript());
+            ctx.assert(clicked, "Google Workspace quick-add card was not found when reopening.");
+          },
+          assert: async () => {
+            await ctx.waitFor(featureReadyScript("gmailRead"), { timeoutMs: 20_000, label: "reopened optional permission checkboxes ready" });
+            const states = await ctx.eval(featureStatesScript());
+            ctx.assert(states.gmailRead === true, "Read Gmail should be checked after reopening.");
+            ctx.assert(states.calendarWrite === true, "Create calendar events should be checked after reopening.");
+            ctx.assert(states.driveFull === false, "Full Drive access should remain unchecked.");
+            ctx.assert(states.chat === false, "Google Chat should remain unchecked.");
+          },
+          screenshot: {
+            name: "org-google-workspace-features-persisted",
+            claim: "The saved Read Gmail and Create calendar events options are still checked.",
+            requireText: ["Optional permissions", "Read Gmail", "Create calendar events"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("The member authorize URL asks for exactly the base Google scopes plus the two selected extras", {
+          voiceover: vo[3],
+          action: async () => {
+            const started = await denApiFetch("/v1/mcp-connections/google-workspace/connect/start", {
+              headers: { authorization: `Bearer ${state.memberSession}` },
+            });
+            ctx.assert(started.response.ok, `Starting Google Workspace connect failed: ${started.response.status} ${JSON.stringify(started.body).slice(0, 200)}`);
+            ctx.assert(started.body.status === "needs_auth" && typeof started.body.authorizeUrl === "string", "connect/start did not return an authorizeUrl.");
+            state.authorizeUrl = started.body.authorizeUrl;
+            state.authorizeScopes = parseScopes(state.authorizeUrl);
+            assertExactStringSet(ctx, state.authorizeScopes, EXPECTED_MEMBER_SCOPES, "Authorize URL scopes");
+            await ctx.eval(`(() => { window.location.href = ${JSON.stringify(consentAuthorizeUrl(state.authorizeUrl))}; return true; })()`);
+            await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "mock consent page loaded" });
+          },
+          assert: async () => {
+            assertExactStringSet(ctx, state.authorizeScopes, EXPECTED_MEMBER_SCOPES, "Authorize URL scopes");
+            await ctx.waitFor("document.body.innerText.includes('Mock MCP OAuth') && document.body.innerText.includes('Approve OpenWork')", {
+              timeoutMs: 30_000,
+              label: "mock Google consent page",
+            });
+          },
+          screenshot: {
+            name: "org-google-workspace-scope-consent",
+            claim: "The member reaches the mock Google consent step after Den generated the exact selected scope set.",
+            requireText: ["Mock MCP OAuth", "Approve OpenWork"],
+            rejectText: ["Connection failed"],
+          },
+        });
+
+        await approveMockConsent(ctx);
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("After consent, the member is connected and the recorded scopes include the selected extras", {
+          voiceover: vo[4],
+          action: async () => {
+            state.status = await waitForMemberConnectedStatus(ctx);
+            await signInViaBrowser(ctx, MEMBER_EMAIL, MEMBER_PASSWORD);
+            await openYourConnections(ctx);
+          },
+          assert: async () => {
+            ctx.assert(state.status?.connected === true, "Member status should report connected: true.");
+            const scopes = Array.isArray(state.status?.scopes) ? state.status.scopes : [];
+            ctx.assert(scopes.includes("https://www.googleapis.com/auth/gmail.readonly"), "Connected scopes should include Gmail read.");
+            ctx.assert(scopes.includes("https://www.googleapis.com/auth/calendar.events"), "Connected scopes should include calendar events.");
+            await ctx.waitForText("Google Workspace", { timeoutMs: 30_000 });
+            await ctx.waitFor(googleWorkspaceConnectedRowScript(), { timeoutMs: 60_000, label: "Google Workspace connected row" });
+          },
+          screenshot: {
+            name: "org-google-workspace-member-connected",
+            claim: "The member-facing row shows Google Workspace connected after consent.",
+            requireText: ["Google Workspace", "Connected as you"],
+            rejectText: ["Something went wrong", "Connection failed"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/org-google-workspace-scopes.md
+++ b/evals/voiceovers/org-google-workspace-scopes.md
@@ -1,0 +1,19 @@
+# org-google-workspace-scopes — Org Google Workspace covers the desktop permission set, and admins can pick more
+
+The org-level Google Workspace connection in OpenWork Cloud previously
+requested only `openid email gmail.compose`. This feature brings its default
+scopes to parity with the desktop extension's base set (Calendar read, Gmail
+drafts, selected Drive files) and lets the org admin opt into the same
+optional permissions the desktop offers (read Gmail, full Drive, create
+calendar events, Google Chat). Picks are stored on the org's OAuth client row
+and reflected in the authorize URL members are sent to.
+
+1. As the workspace admin, I open Connections in the OpenWork Cloud dashboard and tap Google Workspace. The setup now spells out what my team's AI gets out of the box — reading calendars, drafting Gmail, and working with selected Drive files — the same permissions the desktop app asks for.
+
+2. Under "Optional permissions", I can grant more when my team needs it: reading Gmail, full Drive access, creating calendar events, and Google Chat. I check Read Gmail and Create calendar events, paste my client ID and secret, and save.
+
+3. Reopening the setup shows Google Workspace is configured with my two extra permissions still checked — I can adjust my picks any time without retyping the client.
+
+4. When a teammate connects their Google account, the Google consent screen asks for exactly the base permissions plus the two I picked — nothing more.
+
+5. After approving, their card flips to Connected and the connection records those granted permissions — ready for Gmail, Calendar, and Drive work through OpenWork.

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -161,7 +161,7 @@ function authorize(req, res, url) {
   if (!requirePreregisteredAuthorizeClient(res, url.searchParams)) {
     return;
   }
-  if (autoApprove) {
+  if (autoApprove && url.searchParams.get("force_consent") !== "1") {
     redirectWithCode(res, url.searchParams);
     return;
   }
@@ -204,6 +204,7 @@ async function registerClient(req, res) {
 async function issueToken(req, res) {
   const form = await readForm(req);
   const grantType = form.grant_type || "authorization_code";
+  let grantedScope = "mcp:read mcp:write";
 
   if (grantType === "authorization_code") {
     const grant = codes.get(form.code);
@@ -214,6 +215,7 @@ async function issueToken(req, res) {
     if (!requirePreregisteredTokenClient(req, res, form, grant)) {
       return;
     }
+    grantedScope = grant.scope;
     if (grant.codeChallenge) {
       const verifier = form.code_verifier || "";
       const expected =
@@ -237,7 +239,7 @@ async function issueToken(req, res) {
     refresh_token: `mock-refresh-${randomUUID()}`,
     token_type: "Bearer",
     expires_in: 3600,
-    scope: "mcp:read mcp:write",
+    scope: grantedScope,
   });
 }
 


### PR DESCRIPTION
> **Record note**: this PR merged the *first* iteration — desktop-parity base scopes (`openid`, `userinfo.email`, `userinfo.profile`, `calendar.readonly`, `gmail.compose`, `drive.file`) plus 4 opt-in features (Read Gmail, Full Drive, Create calendar events, Google Chat) stored on the org OAuth client. The follow-up that superseded it — the fully granular permission picker and the in-dialog OAuth setup guide — landed in #2558.

## What (as merged here)

- Cloud org-level Google Workspace connection scope parity with the desktop extension (was `openid email gmail.compose` / Gmail drafts only).
- Optional org-admin picks (Gmail read / full Drive / calendar write / Chat) in the two-field dialog, stored in the existing `extra` json column — no migration.
- New admin-only `GET /v1/oauth-providers/:providerId/client` (clientId + picks, never the secret); authorize URLs reflect the saved selection.

## Verification (at merge time)
- den-api `tsc` ✓, `bun test` 4/4 ✓, builds ✓; den-web `tsc` + `build` ✓
- `pnpm fraimz --flow org-google-workspace-scopes --stack den` — PASSED 5/5 frames (proof comment below refers to the superseding granular iteration; the merged iteration's proof was the earlier run).