### PR TITLE
feat(onboarding): agent-screen-first onboarding — land directly in a chat-ready workspace

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -151,6 +151,7 @@ declare global {
         initialDeepLinks?: string[];
         platform?: "darwin" | "linux" | "windows";
         version?: string;
+        disableWorkspaceRecovery?: boolean;
       };
     };
   }

--- a/apps/app/src/app/lib/runtime-env.ts
+++ b/apps/app/src/app/lib/runtime-env.ts
@@ -8,3 +8,14 @@ export function isElectronRuntime() {
 export function isDesktopRuntime() {
   return isElectronRuntime();
 }
+
+// True when the desktop was launched with OPENWORK_DESKTOP_DISABLE_WORKSPACE_RECOVERY=1.
+// Bridged synchronously via the preload meta so first-render code (e.g. the
+// first-run loader arming) can treat the profile as fresh even when stale
+// renderer localStorage still remembers a previous workspace.
+export function isDesktopWorkspaceRecoveryDisabled() {
+  return (
+    typeof window !== "undefined" &&
+    (window as Window).__OPENWORK_ELECTRON__?.meta?.disableWorkspaceRecovery === true
+  );
+}

--- a/apps/app/src/app/utils/index.ts
+++ b/apps/app/src/app/utils/index.ts
@@ -162,7 +162,7 @@ export function formatModelLabel(model: ModelRef, providers: ProviderListItem[] 
   return `${providerLabel} · ${modelLabel}`;
 }
 
-export { isDesktopRuntime, isElectronRuntime } from "../lib/runtime-env";
+export { isDesktopRuntime, isDesktopWorkspaceRecoveryDisabled, isElectronRuntime } from "../lib/runtime-env";
 
 export function isWindowsPlatform() {
   if (typeof navigator === "undefined") return false;

--- a/apps/app/src/index.react.tsx
+++ b/apps/app/src/index.react.tsx
@@ -8,7 +8,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { initializeDenBootstrapConfig } from "./app/lib/den";
 import { getOpenWorkDeployment } from "./app/lib/openwork-deployment";
 import { bootstrapTheme } from "./app/theme";
-import { isDesktopRuntime } from "./app/utils";
+import { isDesktopRuntime, isDesktopWorkspaceRecoveryDisabled } from "./app/utils";
+import { resetFirstRunClientState } from "./react-app/shell/session-memory";
 import { initLocale } from "./i18n";
 import { getReactQueryClient } from "./react-app/infra/query-client";
 import {
@@ -19,6 +20,14 @@ import { AppProviders } from "./react-app/shell/providers";
 import { AppRoot } from "./react-app/shell/app-root";
 import { startDeepLinkBridge } from "./react-app/shell/startup-deep-links";
 import "./app/index.css";
+
+// OPENWORK_DESKTOP_DISABLE_WORKSPACE_RECOVERY resets backend workspace state
+// but not the renderer's localStorage; wipe the renderer's first-run memory
+// here (before any provider/component reads it) so the flag actually produces a
+// fresh first run — loader, auto session, provider step — on every launch.
+if (isDesktopWorkspaceRecoveryDisabled()) {
+  resetFirstRunClientState();
+}
 
 bootstrapTheme();
 initLocale();

--- a/apps/app/src/react-app/domains/cloud/use-openwork-models-startup-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/use-openwork-models-startup-promo.ts
@@ -23,10 +23,16 @@ export type UseOpenWorkModelsStartupPromoInput = {
   clientReady: boolean;
   workspaceId: string;
   providerConnectedIds: string[];
+  /**
+   * Defers the auto-open while another onboarding surface (welcome modal,
+   * provider selection step) is showing, so the promo never overlaps them.
+   * The promo schedules normally once this flips back to false.
+   */
+  suppressed?: boolean;
 };
 
 export function useOpenWorkModelsStartupPromo(input: UseOpenWorkModelsStartupPromoInput) {
-  const { clientReady, workspaceId, providerConnectedIds } = input;
+  const { clientReady, workspaceId, providerConnectedIds, suppressed } = input;
   const navigate = useNavigate();
   const platform = usePlatform();
   const denAuth = useDenAuth();
@@ -48,6 +54,7 @@ export function useOpenWorkModelsStartupPromo(input: UseOpenWorkModelsStartupPro
   );
 
   useEffect(() => {
+    if (suppressed) return;
     if (!shellConfig.cloudSignin || promoHidden || hasOpenWorkModels) return;
     if (denAuth.status === "checking" || !clientReady || !workspaceId) return;
     if (wasOpenWorkModelsStartupPromoShown() || scheduledRef.current) return;
@@ -58,7 +65,7 @@ export function useOpenWorkModelsStartupPromo(input: UseOpenWorkModelsStartupPro
       setOpen(true);
     }, 900);
     return () => window.clearTimeout(timeout);
-  }, [clientReady, denAuth.status, hasOpenWorkModels, promoHidden, shellConfig.cloudSignin, workspaceId]);
+  }, [clientReady, denAuth.status, hasOpenWorkModels, promoHidden, shellConfig.cloudSignin, suppressed, workspaceId]);
 
   const subscribe = useCallback(() => {
     setOpen(false);

--- a/apps/app/src/react-app/domains/onboarding/first-run-loader.tsx
+++ b/apps/app/src/react-app/domains/onboarding/first-run-loader.tsx
@@ -1,0 +1,38 @@
+/** @jsxImportSource react */
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+
+const MESSAGES = [
+  "Warming things up…",
+  "Working the magic…",
+  "Talking to the gremlins…",
+  "Setting up your workspace…",
+  "Sharpening the pencils…",
+  "Untangling the wires…",
+  "Teaching the agent some manners…",
+  "Almost there…",
+];
+
+/**
+ * Full-screen loader shown on a brand-new install while the first session is
+ * being created, so the "select or create a session" page never flashes.
+ */
+export function FirstRunLoader() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setIndex((current) => (current + 1) % MESSAGES.length);
+    }, 1800);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-background">
+      <Loader2 className="size-8 animate-spin text-muted-foreground" />
+      <p className="text-sm text-muted-foreground" aria-live="polite">
+        {MESSAGES[index]}
+      </p>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/onboarding/first-run-loader.tsx
+++ b/apps/app/src/react-app/domains/onboarding/first-run-loader.tsx
@@ -1,6 +1,9 @@
 /** @jsxImportSource react */
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { Loader2 } from "lucide-react";
+import { PaperGrainGradient } from "@openwork/ui/react";
+
+import { getResolvedThemeMode, subscribeToTheme } from "../../../app/theme";
 
 const MESSAGES = [
   "Warming things up…",
@@ -13,11 +16,18 @@ const MESSAGES = [
   "Almost there…",
 ];
 
+// Silver-gray grain palette matching the landing page hero, per theme.
+const GRAIN = {
+  light: { back: "#f4f5f7", colors: ["#c8cdd4", "#9aa1ab", "#e9ebee", "#767d87"] },
+  dark: { back: "#0e0f11", colors: ["#2a2d33", "#42464e", "#191b1f", "#565b64"] },
+} as const;
+
 /**
  * Full-screen loader shown on a brand-new install while the first session is
  * being created, so the "select or create a session" page never flashes.
  */
 export function FirstRunLoader() {
+  const theme = useSyncExternalStore(subscribeToTheme, getResolvedThemeMode);
   const [index, setIndex] = useState(0);
 
   useEffect(() => {
@@ -27,12 +37,25 @@ export function FirstRunLoader() {
     return () => window.clearInterval(interval);
   }, []);
 
+  const grain = GRAIN[theme];
   return (
-    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-background">
-      <Loader2 className="size-8 animate-spin text-muted-foreground" />
-      <p className="text-sm text-muted-foreground" aria-live="polite">
-        {MESSAGES[index]}
-      </p>
+    <div className="fixed inset-0 z-50">
+      <PaperGrainGradient
+        speed={0.6}
+        softness={0.7}
+        intensity={0.4}
+        noise={0.35}
+        shape="corners"
+        colors={[...grain.colors]}
+        colorBack="#00000000"
+        style={{ backgroundColor: grain.back, width: "100%", height: "100%" }}
+      />
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-4">
+        <Loader2 className="size-8 animate-spin text-muted-foreground" />
+        <p className="text-sm text-muted-foreground" aria-live="polite">
+          {MESSAGES[index]}
+        </p>
+      </div>
     </div>
   );
 }

--- a/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
+++ b/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
@@ -39,6 +39,7 @@ import {
   safeStringify,
 } from "../../../../app/utils";
 import { t } from "../../../../i18n";
+import { resetFirstRunClientState } from "../../../shell/session-memory";
 import type { DebugViewProps } from "../pages/debug-view";
 import type { ReleaseChannel } from "../../../../app/types";
 import type { OpenworkServerStore, OpenworkServerStoreSnapshot } from "../../connections/openwork-server-store";
@@ -49,13 +50,6 @@ const ENGINE_CUSTOM_BIN_KEY = "openwork.engineCustomBinPath";
 const OPENCODE_ENABLE_EXA_KEY = "openwork.opencodeEnableExa";
 
 type ResetModalMode = "onboarding" | "all";
-
-const ONBOARDING_LOCAL_STORAGE_KEYS = [
-  "openwork.acknowledgedProviders",
-  "openwork.orgOnboardingSeen",
-  "openwork.reloadAfterOrgOnboarding",
-  "openwork.seenProviderIds",
-];
 
 type UseDebugViewModelOptions = {
   developerMode: boolean;
@@ -95,24 +89,18 @@ function clearStoredString(key: string): void {
 
 function clearOpenworkLocalStorageForReset(mode: ResetModalMode): void {
   if (typeof window === "undefined") return;
-  try {
-    if (mode === "all") {
+  if (mode === "all") {
+    try {
       window.localStorage.clear();
-      return;
+    } catch {
+      // ignore persistence failures
     }
-    for (const key of ONBOARDING_LOCAL_STORAGE_KEYS) {
-      window.localStorage.removeItem(key);
-    }
-    const raw = window.localStorage.getItem("openwork.preferences");
-    if (raw) {
-      const prefs = JSON.parse(raw);
-      prefs.hasCompletedOnboarding = false;
-      prefs.providerStepCompleted = false;
-      window.localStorage.setItem("openwork.preferences", JSON.stringify(prefs));
-    }
-  } catch {
-    // ignore persistence failures
+    return;
   }
+  // Single source of truth so this can't drift from the recovery-disabled boot
+  // reset (both must clear the workspace-memory keys or the first-run loader and
+  // auto-session-create stay silently suppressed).
+  resetFirstRunClientState();
 }
 
 function readEngineSource(): "path" | "sidecar" | "custom" {

--- a/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
+++ b/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
@@ -107,6 +107,7 @@ function clearOpenworkLocalStorageForReset(mode: ResetModalMode): void {
     if (raw) {
       const prefs = JSON.parse(raw);
       prefs.hasCompletedOnboarding = false;
+      prefs.providerStepCompleted = false;
       window.localStorage.setItem("openwork.preferences", JSON.stringify(prefs));
     }
   } catch {

--- a/apps/app/src/react-app/kernel/local-provider.tsx
+++ b/apps/app/src/react-app/kernel/local-provider.tsx
@@ -52,6 +52,11 @@ export type LocalPreferences = {
    */
   hasCompletedOnboarding: boolean;
   /**
+   * One-shot provider selection shown on the user's first send when no
+   * user-added provider is connected. True once completed or skipped.
+   */
+  providerStepCompleted: boolean;
+  /**
    * Anonymous product analytics (PostHog). On by default with a visible
    * opt-out in Settings -> Preferences. Never includes message content.
    */
@@ -81,6 +86,7 @@ const INITIAL_PREFS: LocalPreferences = {
   releaseChannel: "stable",
   featureFlags: { microsandboxCreateSandbox: true, memory: false },
   hasCompletedOnboarding: false,
+  providerStepCompleted: false,
   analyticsEnabled: true,
 };
 
@@ -118,6 +124,17 @@ export function LocalProvider({ children }: LocalProviderProps) {
   );
   const [prefs, setPrefsRaw] = useState<LocalPreferences>(() => {
     const persisted = readPersisted(PREFS_STORAGE_KEY, INITIAL_PREFS);
+    // Back-fill: users who onboarded before the agent-screen-first flow have
+    // already picked a provider path. Only fires while the new key is absent
+    // from storage (first write persists it).
+    try {
+      const raw = JSON.parse(window.localStorage.getItem(PREFS_STORAGE_KEY) ?? "{}") as Record<string, unknown>;
+      if (raw.hasCompletedOnboarding === true && raw.providerStepCompleted === undefined) {
+        persisted.providerStepCompleted = true;
+      }
+    } catch {
+      // ignore parse failures; defaults apply
+    }
     if (persisted.defaultModel) {
       return persisted;
     }

--- a/apps/app/src/react-app/shell/session-memory.ts
+++ b/apps/app/src/react-app/shell/session-memory.ts
@@ -155,6 +155,50 @@ export function writeWorkspaceProjectDimension(
   safeSet(WORKSPACE_PROJECT_DIMENSION_KEY, Object.keys(map).length ? JSON.stringify(map) : null);
 }
 
+// Provider/org onboarding flags owned elsewhere but cleared together with the
+// workspace-memory keys so a "reset onboarding" (Settings → Recovery) or a
+// recovery-disabled dev launch produces a genuinely fresh first run — the
+// first-run loader arms, the first session auto-creates, and the provider step
+// (not the OpenWork Models startup promo) shows on the first send.
+const ONBOARDING_FLAG_KEYS = [
+  "openwork.acknowledgedProviders",
+  "openwork.orgOnboardingSeen",
+  "openwork.reloadAfterOrgOnboarding",
+  "openwork.seenProviderIds",
+];
+const PREFERENCES_KEY = "openwork.preferences";
+
+/**
+ * Clear every renderer signal that marks this profile as "already onboarded".
+ * Non-`all` reset paths previously left ACTIVE_WORKSPACE_KEY and
+ * SESSION_BY_WORKSPACE_KEY behind, which silently suppressed the whole
+ * first-run flow (the loader keys off active-workspace memory; auto-create and
+ * the loader-dismiss check key off last-session memory).
+ */
+export function resetFirstRunClientState(): void {
+  if (typeof window === "undefined") return;
+  try {
+    for (const key of [
+      ACTIVE_WORKSPACE_KEY,
+      SESSION_BY_WORKSPACE_KEY,
+      WORKSPACE_ORDER_KEY,
+      WORKSPACE_PROJECT_DIMENSION_KEY,
+      ...ONBOARDING_FLAG_KEYS,
+    ]) {
+      window.localStorage.removeItem(key);
+    }
+    const raw = window.localStorage.getItem(PREFERENCES_KEY);
+    if (raw) {
+      const prefs = JSON.parse(raw) as Record<string, unknown>;
+      prefs.hasCompletedOnboarding = false;
+      prefs.providerStepCompleted = false;
+      window.localStorage.setItem(PREFERENCES_KEY, JSON.stringify(prefs));
+    }
+  } catch {
+    // ignore storage errors (quota, privacy modes, etc.)
+  }
+}
+
 export function forgetWorkspaceMemory(workspaceId: string): void {
   const wsId = workspaceId?.trim();
   if (!wsId) return;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -123,6 +123,7 @@ import {
   hideOpenWorkModelsPromo,
   markOpenWorkModelsStartupPromoShown,
 } from "@/react-app/domains/cloud/openwork-models-promo";
+import { FirstRunLoader } from "@/react-app/domains/onboarding/first-run-loader";
 import { ProviderSelectionStep } from "@/react-app/domains/onboarding/provider-selection-step";
 import { useOpenWorkModelsStartupPromo } from "@/react-app/domains/cloud/use-openwork-models-startup-promo";
 import {
@@ -1260,6 +1261,18 @@ export function SessionRoute() {
   // instead of the "select or create a session" page. Retries on the next
   // state change until a session is actually created — the create call bails
   // silently while the workspace endpoint/token is still resolving at boot.
+  // While pending, a full-screen loader covers the page; errors drop it so
+  // the retry toast stays reachable.
+  const firstRunSessionPending =
+    isDesktopRuntime() &&
+    Boolean(selectedWorkspaceId) &&
+    !selectedSessionId &&
+    workspaces.length > 0 &&
+    (sessionsByWorkspaceId[selectedWorkspaceId] ?? []).length === 0 &&
+    !readLastSessionFor(selectedWorkspaceId) &&
+    !routeError &&
+    !selectedWorkspaceError &&
+    !errorsByWorkspaceId[selectedWorkspaceId];
   useEffect(() => {
     if (!canCreateTask || !isDesktopRuntime()) return;
     if (selectedSessionId || firstRunSessionRef.current) return;
@@ -2134,6 +2147,7 @@ export function SessionRoute() {
       onSubscribe={openWorkModelsPromo.subscribe}
       onContinueWithout={openWorkModelsPromo.continueWithout}
     />
+    {firstRunSessionPending ? <FirstRunLoader /> : null}
     {providerStepOpen ? (
       <ProviderSelectionStep
         onOpenWorkModels={() => completeProviderStep("openwork-models")}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -322,6 +322,11 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
   return parts;
 }
 
+// Module-scoped so the first-run loader survives route remounts during boot
+// (component state would reset and flash the underlying page). Reset only on
+// app relaunch, matching BOOT_STARTED in desktop-runtime-boot.ts.
+let firstRunLoaderPhase: "unarmed" | "armed" | "done" = "unarmed";
+
 export function SessionRoute() {
   const navigate = useNavigate();
   const platform = usePlatform();
@@ -1256,23 +1261,59 @@ export function SessionRoute() {
     }
   }, [baseUrl, loading, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, token, workspaces]);
 
+  // Full-screen first-run loader. Armed once per app launch from the very
+  // first render of a brand-new profile (no active-workspace memory yet) and
+  // held through all boot-state churn AND route remounts — recomputing
+  // visibility from volatile route state made it flicker, and a remount
+  // would reset component state. It drops only when the first session is
+  // selected, on error (retry toast must be reachable), when state settles
+  // and this turns out not to be a first run, or after a safety timeout.
+  const [firstRunLoaderActive, setFirstRunLoaderActive] = useState(() => {
+    if (firstRunLoaderPhase === "unarmed") {
+      firstRunLoaderPhase = isDesktopRuntime() && !readActiveWorkspaceId() ? "armed" : "done";
+    }
+    return firstRunLoaderPhase === "armed";
+  });
+  const dismissFirstRunLoader = useCallback(() => {
+    firstRunLoaderPhase = "done";
+    setFirstRunLoaderActive(false);
+  }, []);
+  useEffect(() => {
+    if (!firstRunLoaderActive) return;
+    const timeout = window.setTimeout(dismissFirstRunLoader, 30_000);
+    return () => window.clearTimeout(timeout);
+  }, [firstRunLoaderActive, dismissFirstRunLoader]);
+  useEffect(() => {
+    if (!firstRunLoaderActive) return;
+    if (selectedSessionId) {
+      dismissFirstRunLoader();
+      return;
+    }
+    const workspaceError = selectedWorkspaceId ? errorsByWorkspaceId[selectedWorkspaceId] : null;
+    if (routeError || selectedWorkspaceError || workspaceError) {
+      dismissFirstRunLoader();
+      return;
+    }
+    // State settled and this profile already has sessions or last-session
+    // memory (not a first run): hand back to the normal UI. Skipped once the
+    // auto-create below has latched — our own just-created session briefly
+    // satisfies this before navigation lands.
+    if (
+      !loading &&
+      !firstRunSessionRef.current &&
+      selectedWorkspaceId &&
+      ((sessionsByWorkspaceId[selectedWorkspaceId] ?? []).length > 0 ||
+        Boolean(readLastSessionFor(selectedWorkspaceId)))
+    ) {
+      dismissFirstRunLoader();
+    }
+  }, [firstRunLoaderActive, dismissFirstRunLoader, selectedSessionId, routeError, selectedWorkspaceError, errorsByWorkspaceId, loading, selectedWorkspaceId, sessionsByWorkspaceId]);
+
   // Drop the user straight into a chat-ready session when they arrive at a
   // workspace they have never used (no sessions, no last-session memory),
   // instead of the "select or create a session" page. Retries on the next
   // state change until a session is actually created — the create call bails
   // silently while the workspace endpoint/token is still resolving at boot.
-  // While pending, a full-screen loader covers the page; errors drop it so
-  // the retry toast stays reachable.
-  const firstRunSessionPending =
-    isDesktopRuntime() &&
-    Boolean(selectedWorkspaceId) &&
-    !selectedSessionId &&
-    workspaces.length > 0 &&
-    (sessionsByWorkspaceId[selectedWorkspaceId] ?? []).length === 0 &&
-    !readLastSessionFor(selectedWorkspaceId) &&
-    !routeError &&
-    !selectedWorkspaceError &&
-    !errorsByWorkspaceId[selectedWorkspaceId];
   useEffect(() => {
     if (!canCreateTask || !isDesktopRuntime()) return;
     if (selectedSessionId || firstRunSessionRef.current) return;
@@ -2147,7 +2188,7 @@ export function SessionRoute() {
       onSubscribe={openWorkModelsPromo.subscribe}
       onContinueWithout={openWorkModelsPromo.continueWithout}
     />
-    {firstRunSessionPending ? <FirstRunLoader /> : null}
+    {firstRunLoaderActive ? <FirstRunLoader /> : null}
     {providerStepOpen ? (
       <ProviderSelectionStep
         onOpenWorkModels={() => completeProviderStep("openwork-models")}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -399,6 +399,7 @@ export function SessionRoute() {
   const [providerStepOpen, setProviderStepOpen] = useState(false);
   const pendingProviderDraftRef = useRef<{ draft: ComposerDraft; sessionId: string } | null>(null);
   const providerStepResendRef = useRef(false);
+  const firstRunSessionRef = useRef(false);
   const [createWorkspaceBusy, setCreateWorkspaceBusy] = useState(false);
   const [createWorkspaceError, setCreateWorkspaceError] = useState<string | null>(null);
   const [createWorkspaceRemoteBusy, setCreateWorkspaceRemoteBusy] = useState(false);
@@ -1251,6 +1252,20 @@ export function SessionRoute() {
       }
     }
   }, [baseUrl, loading, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, token, workspaces]);
+
+  // First run: drop the user straight into a new session so they can chat
+  // immediately, instead of the "select or create a session" page. One-shot —
+  // hasCompletedOnboarding flips so later launches respect the last-session
+  // memory, and deleting all sessions never auto-creates a new one.
+  useEffect(() => {
+    if (!canCreateTask || !isDesktopRuntime()) return;
+    if (local.prefs.hasCompletedOnboarding || firstRunSessionRef.current) return;
+    if (selectedSessionId) return;
+    if ((sessionsByWorkspaceId[selectedWorkspaceId] ?? []).length > 0) return;
+    firstRunSessionRef.current = true;
+    local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true }));
+    void handleCreateTaskInWorkspace(selectedWorkspaceId);
+  }, [canCreateTask, local, selectedSessionId, selectedWorkspaceId, sessionsByWorkspaceId, handleCreateTaskInWorkspace]);
 
   // Latest session-list state for prev/next session tab navigation. The
   // `options` field is updated by `onSessionTabsChange` from SessionPage so we

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -117,7 +117,13 @@ import { RenameWorkspaceModal } from "@/react-app/domains/workspace/rename-works
 import { useRemoteWorkspaceConnectionEditor } from "@/react-app/domains/workspace/use-remote-workspace-connection-editor";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
 import { OpenWorkModelsStartupDialog } from "@/react-app/domains/cloud/openwork-models-startup-dialog";
-import { OPENWORK_MODEL_PREVIEWS } from "@/react-app/domains/cloud/openwork-models-promo";
+import {
+  OPENWORK_MODEL_PREVIEWS,
+  getOpenWorkModelsActionUrl,
+  hideOpenWorkModelsPromo,
+  markOpenWorkModelsStartupPromoShown,
+} from "@/react-app/domains/cloud/openwork-models-promo";
+import { ProviderSelectionStep } from "@/react-app/domains/onboarding/provider-selection-step";
 import { useOpenWorkModelsStartupPromo } from "@/react-app/domains/cloud/use-openwork-models-startup-promo";
 import {
   diagnoseRemoteWorkspaceTaskLoadFailure,
@@ -388,6 +394,11 @@ export function SessionRoute() {
   // One-way latch for "a refreshRouteState is currently running"; prevents
   // overlapping route refreshes from queueing up when the user clicks fast.
   const [createWorkspaceOpen, setCreateWorkspaceOpen] = useState(false);
+  // Agent-screen-first onboarding: a one-shot provider selection intercepting
+  // the first send (the first-run default workspace is created further down).
+  const [providerStepOpen, setProviderStepOpen] = useState(false);
+  const pendingProviderDraftRef = useRef<{ draft: ComposerDraft; sessionId: string } | null>(null);
+  const providerStepResendRef = useRef(false);
   const [createWorkspaceBusy, setCreateWorkspaceBusy] = useState(false);
   const [createWorkspaceError, setCreateWorkspaceError] = useState<string | null>(null);
   const [createWorkspaceRemoteBusy, setCreateWorkspaceRemoteBusy] = useState(false);
@@ -626,6 +637,10 @@ export function SessionRoute() {
     clientReady: Boolean(opencodeClient),
     workspaceId: selectedWorkspaceId,
     providerConnectedIds,
+    // First-run users get the OpenWork Models pitch from the provider
+    // selection step on their first send, not a startup popup. Completing
+    // the step marks the promo as shown, so it never auto-pops for them.
+    suppressed: providerStepOpen || !local.prefs.providerStepCompleted,
   });
 
   const { store: sessionProviderAuthStore, snapshot: sessionProviderAuthSnapshot } =
@@ -826,6 +841,19 @@ export function SessionRoute() {
         if (!targetSessionId) return;
         const text = (draft.resolvedText ?? draft.text).trim();
         if (!text && draft.attachments.length === 0) return;
+        // One-shot provider selection on the first send: hold the draft,
+        // show the step, and resend automatically once the user chooses.
+        if (
+          !providerStepResendRef.current &&
+          !local.prefs.providerStepCompleted &&
+          !hasUsableModel &&
+          userProviderConnectedIds.length === 0 &&
+          draft.mode !== "shell"
+        ) {
+          pendingProviderDraftRef.current = { draft, sessionId: targetSessionId };
+          setProviderStepOpen(true);
+          return;
+        }
         if (selectedModelUnavailable) throw new Error("Selected model is unavailable. Choose another model before sending.");
 
         captureAnalyticsEvent("task_message_sent", {
@@ -976,6 +1004,7 @@ export function SessionRoute() {
     handleApplyEnvironmentChanges,
     environmentRuntimeKey,
     local,
+    userProviderConnectedIds,
     listAgents,
     listSlashCommands,
     modelBehaviorOptions,
@@ -995,6 +1024,40 @@ export function SessionRoute() {
     sessionsByWorkspaceId,
     token,
   ]);
+
+  // Latest surfaceProps for the provider-step resend below; the memoized
+  // onSendDraft closure is otherwise unreachable from callbacks.
+  const surfacePropsRef = useRef<typeof surfaceProps>(null);
+  useEffect(() => {
+    surfacePropsRef.current = surfaceProps;
+  });
+
+  const completeProviderStep = useCallback((action: "openwork-models" | "byok" | "skip") => {
+    setProviderStepOpen(false);
+    local.setPrefs((prev) => ({ ...prev, providerStepCompleted: true }));
+    // The step IS the OpenWork Models pitch — never auto-pop the startup
+    // promo on top of it afterwards.
+    markOpenWorkModelsStartupPromoShown();
+    if (action === "openwork-models") {
+      platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn, "sign-up"));
+    } else if (action === "byok") {
+      hideOpenWorkModelsPromo();
+      void sessionProviderAuthStore.openProviderAuthModal({ returnFocusTarget: "composer" });
+    }
+    // ponytail: the held draft is resent immediately on the free model for
+    // all three choices; a byok key applies from the next message onward.
+    const pending = pendingProviderDraftRef.current;
+    pendingProviderDraftRef.current = null;
+    const send = surfacePropsRef.current?.onSendDraft;
+    if (pending && send) {
+      providerStepResendRef.current = true;
+      void Promise.resolve(send(pending.draft, pending.sessionId))
+        .catch((error) => setRouteError(describeRouteError(error)))
+        .finally(() => {
+          providerStepResendRef.current = false;
+        });
+    }
+  }, [denAuth.isSignedIn, local, platform, sessionProviderAuthStore, setRouteError]);
 
   const handleOpenCreateWorkspace = useCallback(() => {
     // Respect the org-level `allowMultipleWorkspaces` restriction (dev
@@ -1615,18 +1678,42 @@ export function SessionRoute() {
         await workspaceSetSelected(createdId).catch(() => undefined);
         await workspaceSetRuntimeActive(createdId).catch(() => undefined);
       }
+      // First workspace on a fresh install: the OpenWork server was started
+      // engine-less (it only spawns OpenCode at boot when a workspace already
+      // exists), so sessions would hang forever. This boots the engine when
+      // it isn't running, same as the old /welcome flow did.
+      let sessionBaseUrl = baseUrl;
+      let sessionToken = token;
+      if (targetWorkspace && isDesktopRuntime()) {
+        await ensureDesktopLocalOpenworkConnection({
+          route: "session",
+          workspace: targetWorkspace,
+          allWorkspaces: list.workspaces,
+        }).catch(() => undefined);
+        // The engine boot can restart the server with fresh tokens; re-resolve
+        // so the first-session creation below doesn't use stale credentials.
+        const fresh = await resolveOpenworkConnection().catch(() => null);
+        if (fresh?.normalizedBaseUrl && fresh.resolvedToken) {
+          sessionBaseUrl = fresh.normalizedBaseUrl;
+          sessionToken = fresh.resolvedToken;
+        }
+      }
       setCreateWorkspaceOpen(false);
       // Mark onboarding complete so the /welcome redirect never fires again.
       local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true }));
       await refreshRouteState();
       if (targetWorkspaceId) {
         const workspacePath = targetWorkspace?.path?.trim() || folder;
-        const session = createdOnServer && baseUrl && token
-          ? unwrap(await createClient(
-              `${(buildOpenworkWorkspaceBaseUrl(baseUrl, targetWorkspaceId) ?? baseUrl).replace(/\/+$/, "")}/opencode`,
+        // Best-effort first task creation (mirrors the old welcome flow) — a
+        // failure here must not surface as a failed workspace creation.
+        const session = createdOnServer && sessionBaseUrl && sessionToken
+          ? await createClient(
+              `${(buildOpenworkWorkspaceBaseUrl(sessionBaseUrl, targetWorkspaceId) ?? sessionBaseUrl).replace(/\/+$/, "")}/opencode`,
               workspacePath || undefined,
-              { token, mode: "openwork" },
-            ).session.create({ directory: workspacePath || undefined }))
+              { token: sessionToken, mode: "openwork" },
+            ).session.create({ directory: workspacePath || undefined })
+              .then((result) => unwrap(result))
+              .catch(() => null)
           : null;
         setLegacySelectedWorkspaceId(targetWorkspaceId);
         writeActiveWorkspaceId(targetWorkspaceId);
@@ -2028,6 +2115,13 @@ export function SessionRoute() {
       onSubscribe={openWorkModelsPromo.subscribe}
       onContinueWithout={openWorkModelsPromo.continueWithout}
     />
+    {providerStepOpen ? (
+      <ProviderSelectionStep
+        onOpenWorkModels={() => completeProviderStep("openwork-models")}
+        onBringYourOwn={() => completeProviderStep("byok")}
+        onSkip={() => completeProviderStep("skip")}
+      />
+    ) : null}
     <CreateWorkspaceModal
       open={createWorkspaceOpen}
       onClose={() => {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1182,18 +1182,18 @@ export function SessionRoute() {
   );
 
 
-  const handleCreateTaskInWorkspace = useCallback(async (workspaceId: string) => {
+  const handleCreateTaskInWorkspace = useCallback(async (workspaceId: string): Promise<string | null> => {
     const workspace = workspaces.find((item) => item.id === workspaceId);
     if (
       !workspace ||
       loading ||
       retryingWorkspaceIds.includes(workspaceId)
     ) {
-      return;
+      return null;
     }
     const endpoint = resolveWorkspaceEndpoint(workspace, { baseUrl, token });
     if (!endpoint || !endpoint.token) {
-      return;
+      return null;
     }
     const workspaceClient = createClient(
       endpoint.opencodeBaseUrl,
@@ -1227,6 +1227,7 @@ export function SessionRoute() {
       navigateToWorkspaceSession(workspaceId, session.id);
       focusPromptSoon();
       void refreshRouteState();
+      return session.id;
     } catch (error) {
       const message = describeTaskCreateError(error);
       setRouteError(message);
@@ -1250,22 +1251,25 @@ export function SessionRoute() {
           }, 1_000);
         }
       }
+      return null;
     }
   }, [baseUrl, loading, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, token, workspaces]);
 
-  // First run: drop the user straight into a new session so they can chat
-  // immediately, instead of the "select or create a session" page. One-shot —
-  // hasCompletedOnboarding flips so later launches respect the last-session
-  // memory, and deleting all sessions never auto-creates a new one.
+  // Drop the user straight into a chat-ready session when they arrive at a
+  // workspace they have never used (no sessions, no last-session memory),
+  // instead of the "select or create a session" page. Retries on the next
+  // state change until a session is actually created — the create call bails
+  // silently while the workspace endpoint/token is still resolving at boot.
   useEffect(() => {
     if (!canCreateTask || !isDesktopRuntime()) return;
-    if (local.prefs.hasCompletedOnboarding || firstRunSessionRef.current) return;
-    if (selectedSessionId) return;
+    if (selectedSessionId || firstRunSessionRef.current) return;
     if ((sessionsByWorkspaceId[selectedWorkspaceId] ?? []).length > 0) return;
+    if (readLastSessionFor(selectedWorkspaceId)) return;
     firstRunSessionRef.current = true;
-    local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true }));
-    void handleCreateTaskInWorkspace(selectedWorkspaceId);
-  }, [canCreateTask, local, selectedSessionId, selectedWorkspaceId, sessionsByWorkspaceId, handleCreateTaskInWorkspace]);
+    void handleCreateTaskInWorkspace(selectedWorkspaceId).then((createdSessionId) => {
+      if (!createdSessionId) firstRunSessionRef.current = false;
+    });
+  }, [canCreateTask, selectedSessionId, selectedWorkspaceId, sessionsByWorkspaceId, handleCreateTaskInWorkspace]);
 
   // Latest session-list state for prev/next session tab navigation. The
   // `options` field is updated by `onSessionTabsChange` from SessionPage so we
@@ -1306,7 +1310,7 @@ export function SessionRoute() {
   } = useShellShortcuts({
     canCreateTask,
     workspaceId: selectedWorkspaceId,
-    onCreateTask: handleCreateTaskInWorkspace,
+    onCreateTask: (workspaceId: string) => void handleCreateTaskInWorkspace(workspaceId),
     onNextSessionTab: goToNextSessionTab,
     onPrevSessionTab: goToPrevSessionTab,
   });

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -670,8 +670,11 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   // Redirect to /welcome when no workspaces exist and the user hasn't
   // completed onboarding. This fires after the initial route refresh so
   // `loading` is false and we know for sure there are zero workspaces.
+  // Desktop skips it: first-run there lands on the chat with a default
+  // workspace and the welcome content as a modal (see session-route).
   useEffect(() => {
     if (loading) return;
+    if (isDesktopRuntime()) return;
     if (workspaces.length > 0) return;
     if (local.prefs.hasCompletedOnboarding) return;
     navigate("/welcome", { replace: true });

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -160,6 +160,10 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     initialDeepLinks: [],
     platform: normalizePlatform(process.platform),
     version: process.versions.electron,
+    // Mirror the main-process workspace-recovery flag so the renderer's
+    // first-run detection (which reads localStorage, not the desktop state
+    // file) stays consistent when recovery is deliberately disabled.
+    disableWorkspaceRecovery: process.env.OPENWORK_DESKTOP_DISABLE_WORKSPACE_RECOVERY === "1",
   },
 });
 

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -467,6 +467,32 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     return recoverWorkspacesFromTokenStore();
   }
 
+  function firstRunDefaultWorkspaceDir() {
+    // Dev mode sandboxes HOME under userData (see desktopBootstrapPath);
+    // mirror that so the dev default workspace never touches the real home.
+    if (process.env.OPENWORK_DEV_MODE === "1") {
+      return path.join(app.getPath("userData"), "openwork-dev-data", "home", "OpenWork");
+    }
+    return path.join(os.homedir(), "OpenWork");
+  }
+
+  // True first run: create the default "OpenWork" workspace under the user's
+  // home directory so the renderer lands directly in a ready workspace — no
+  // folder picker, no empty state. Cross-platform (os.homedir + path.join).
+  async function createDefaultFirstRunWorkspace() {
+    const folderPath = await normalizeLocalWorkspacePath(firstRunDefaultWorkspaceDir());
+    await mkdir(path.join(folderPath, ".opencode"), { recursive: true });
+    await writeWorkspaceOpenworkConfig(folderPath, defaultWorkspaceOpenworkConfig(folderPath, "starter"));
+    return normalizeWorkspaceEntry({
+      id: localWorkspaceId(folderPath),
+      name: "OpenWork",
+      displayName: "OpenWork",
+      path: folderPath,
+      preset: "starter",
+      workspaceType: "local",
+    });
+  }
+
   function stableWorkspaceId(value) {
     return `ws_${createHash("sha256").update(String(value)).digest("hex").slice(0, 12)}`;
   }
@@ -615,6 +641,7 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
   }
 
   async function readWorkspaceState() {
+    const stateFileExists = existsSync(workspaceStatePath());
     const state = await readJsonFile(workspaceStatePath(), EMPTY_WORKSPACE_LIST);
     let selectedId =
       typeof state?.selectedId === "string"
@@ -646,6 +673,28 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
         activeId = selectedWorkspace.id;
         workspaces = recoveredWorkspaces;
         changed = true;
+      }
+    }
+    // First run only (no persisted desktop state file, nothing recovered):
+    // create the default workspace before the renderer ever reads the list,
+    // so the UI never flashes an empty "create a workspace" state and the
+    // engine boots with a workspace from the start. Gated to packaged/dev
+    // runs so tests never mkdir into a real home directory.
+    if (
+      workspaces.length === 0 &&
+      !stateFileExists &&
+      (app.isPackaged || process.env.OPENWORK_DEV_MODE === "1")
+    ) {
+      try {
+        const defaultWorkspace = await createDefaultFirstRunWorkspace();
+        console.info("[first-run] created default workspace", { path: defaultWorkspace.path });
+        selectedId = defaultWorkspace.id;
+        watchedId = defaultWorkspace.id;
+        activeId = defaultWorkspace.id;
+        workspaces = [defaultWorkspace];
+        changed = true;
+      } catch (error) {
+        console.warn("[first-run] default workspace creation failed", error);
       }
     }
     const idMap = new Map();


### PR DESCRIPTION
## What

Replaces the full-screen `/welcome` onboarding on desktop with an agent-screen-first flow: a brand-new install boots straight into a ready workspace with a session open and the composer focused — no folder picker, no empty states, no startup popups.

## How it works

<img width="1164" height="811" alt="image" src="https://github.com/user-attachments/assets/cfb7a0b8-414e-483a-9a7c-281d9e45ba18" />


**First launch (desktop):**
1. The Electron main process creates a default `OpenWork` workspace under the user's home directory during the first workspace-state read (`workspace-store.mjs`) — before the renderer loads, so the UI never flashes an empty "create a workspace" state and the engine boots with the workspace from the start. Cross-platform (`os.homedir()` + `path.join`); dev mode uses the sandboxed dev-data home. Only fires on a true first run (no persisted state file, nothing recoverable); recovery from an existing install still takes priority.
2. The renderer auto-creates the first session for a never-used workspace (zero sessions, no last-session memory) and navigates into it, retrying until the workspace endpoint resolves.
3. While that happens, a full-screen loader (landing-page-style `PaperGrainGradient` background with light/dark palettes, rotating status messages) covers boot. It's a module-scoped latch so route remounts and boot-state churn can't flicker it; it drops on session selection, on error, or after a 30s safety timeout.

**First send:** a one-shot `ProviderSelectionStep` intercepts the first message when no user provider is connected (OpenWork Models / bring your own key / free model); the held message is sent automatically after the choice. Tracked via a new `providerStepCompleted` pref, back-filled for existing users and cleared by Debug → Reset onboarding.

**OpenWork Models startup promo:** no longer auto-pops at launch for new users — the provider step is the pitch; completing it marks the promo shown. Existing users keep current behavior.

## Fixes along the way

- `handleCreateWorkspace` now boots the engine via `ensureDesktopLocalOpenworkConnection` when it isn't running — the server only spawns OpenCode at startup when a workspace already exists, so creating the *first* workspace on a fresh install used to hang sessions forever ("Preparing workspace"). First-session creation is best-effort with re-resolved credentials after the engine boot.
- `handleCreateTaskInWorkspace` reports the created session id so callers can distinguish success from a silent bail.

## Sign-in / org flows

Verified untouched: the forced-signin gate wraps the route tree before the session route mounts; org onboarding and org resource sync key off auth token + org id (the default workspace is the sync target, not an obstacle); org-provisioned providers naturally skip the provider step. Web keeps the old `/welcome` flow.

## Testing

- `apps/app` typecheck clean; `apps/desktop` electron tests pass (21/21).
- Manual: fresh-profile first run on macOS (light + dark) — loader → new session with composer focused → provider step on first send → message sends. Windows/Linux/macOS builds green via `build-electron-desktop` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)