### PR TITLE
fix(den): adopt pending invitations in membership bootstrap paths

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -43,6 +43,7 @@ import {
 } from "./sso-saml-policy.js";
 import {
   getOrganizationContextForUser,
+  reconcilePendingInvitationsForUser,
   seedDefaultOrganizationRoles,
   validateOrganizationMemberRemovalForHook,
   validateOrganizationMemberRoleUpdate,
@@ -246,7 +247,15 @@ export const auth = betterAuth({
     session: {
       create: {
         before: async (session) => {
-          const activeOrganizationId = await getInitialActiveOrganizationIdForUser(session.userId);
+          const userId = normalizeDenTypeId("user", session.userId);
+          const activeOrganizationId = await getInitialActiveOrganizationIdForUser(userId);
+          try {
+            // SSO JIT creates the raw member row before the session row, so this
+            // chokepoint can merge any matching pending invitation without blocking sign-in.
+            await reconcilePendingInvitationsForUser(userId);
+          } catch (error) {
+            console.error("[auth][invitation_reconcile_failed]", { userId, error });
+          }
 
           return {
             data: {

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
+import { and, asc, count, eq, gt, inArray, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import {
   AuthSessionTable,
   AuthUserTable,
@@ -411,10 +411,10 @@ async function ensureDefaultDynamicRoles(orgId: OrgId) {
   }
 }
 
-function normalizeAssignableRole(input: string, availableRoles: Set<string>) {
+function normalizeAssignableRole(input: string, availableRoles: Set<string>, fallbackRole = "member") {
   const roles = splitRoles(input).filter((role) => availableRoles.has(role))
   if (roles.length === 0) {
-    return "member"
+    return fallbackRole
   }
   return roles.join(",")
 }
@@ -434,6 +434,7 @@ async function insertMemberIfMissing(input: {
   organizationId: OrgId
   userId: UserId
   role: string
+  email?: string | null
 }) {
   const existing = await db
     .select()
@@ -443,6 +444,16 @@ async function insertMemberIfMissing(input: {
 
   if (existing.length > 0) {
     return existing[0]
+  }
+
+  const invitedMember = await acceptPendingInvitationForBootstrapMembership({
+    organizationId: input.organizationId,
+    userId: input.userId,
+    email: input.email ?? null,
+    defaultRole: input.role,
+  })
+  if (invitedMember) {
+    return invitedMember
   }
 
   try {
@@ -468,9 +479,101 @@ async function insertMemberIfMissing(input: {
   return created[0]
 }
 
-async function acceptInvitation(invitation: InvitationRow, userId: UserId) {
+export async function ensureBootstrapMembershipForOrganization(input: {
+  organizationId: OrgId
+  userId: UserId
+  role: string
+  email?: string | null
+}) {
+  return insertMemberIfMissing(input)
+}
+
+export async function acceptPendingInvitationForBootstrapMembership(input: {
+  organizationId: OrgId
+  userId: UserId
+  email: string | null
+  defaultRole: string
+}) {
+  const email = input.email?.trim().toLowerCase()
+  if (!email) {
+    return null
+  }
+
+  const invitationRows = await db
+    .select()
+    .from(InvitationTable)
+    .where(and(
+      eq(InvitationTable.organizationId, input.organizationId),
+      eq(InvitationTable.status, "pending"),
+      gt(InvitationTable.expiresAt, new Date()),
+      sql`lower(${InvitationTable.email}) = ${email}`,
+    ))
+    .limit(1)
+
+  const invitation = invitationRows.find((row) => (
+    row.organizationId === input.organizationId
+    && row.status === "pending"
+    && row.expiresAt > new Date()
+    && row.email.trim().toLowerCase() === email
+  )) ?? null
+  if (!invitation) {
+    return null
+  }
+
+  // Bootstrap paths already grant same-org membership before email verification.
+  // organization-join-verification.ts keeps that gate on the explicit accept endpoint.
+  return acceptInvitation(invitation, input.userId, { fallbackRole: input.defaultRole })
+}
+
+export async function reconcilePendingInvitationsForUser(userId: UserId) {
+  const userRows = await db
+    .select({ email: AuthUserTable.email })
+    .from(AuthUserTable)
+    .where(eq(AuthUserTable.id, userId))
+    .limit(1)
+  const email = userRows[0]?.email.trim().toLowerCase()
+  if (!email) {
+    return 0
+  }
+
+  const now = new Date()
+  const invitations = await db
+    .select()
+    .from(InvitationTable)
+    .where(and(
+      eq(InvitationTable.status, "pending"),
+      gt(InvitationTable.expiresAt, now),
+      sql`lower(${InvitationTable.email}) = ${email}`,
+    ))
+    .limit(20)
+
+  let acceptedCount = 0
+  for (const invitation of invitations) {
+    if (invitation.status !== "pending" || invitation.expiresAt <= now || invitation.email.trim().toLowerCase() !== email) {
+      continue
+    }
+
+    const existingMemberRows = await db
+      .select({ id: MemberTable.id })
+      .from(MemberTable)
+      .where(and(eq(MemberTable.organizationId, invitation.organizationId), eq(MemberTable.userId, userId), isNull(MemberTable.removedAt)))
+      .limit(1)
+    if (!existingMemberRows[0]) {
+      // No cross-org auto-join here; organization-join-verification.ts keeps
+      // that email-verification boundary on the explicit accept endpoint.
+      continue
+    }
+
+    await acceptInvitation(invitation, userId)
+    acceptedCount += 1
+  }
+
+  return acceptedCount
+}
+
+async function acceptInvitation(invitation: InvitationRow, userId: UserId, options?: { fallbackRole?: string }) {
   const availableRoles = await listAssignableRoles(invitation.organizationId)
-  const role = normalizeAssignableRole(invitation.role, availableRoles)
+  const role = normalizeAssignableRole(invitation.role, availableRoles, options?.fallbackRole)
   const joinedAt = new Date()
 
   const existingMemberRows = await db
@@ -488,6 +591,19 @@ async function acceptInvitation(invitation: InvitationRow, userId: UserId) {
   const invitedMember = invitedMemberRows[0] ?? null
   const existingMember = existingMemberRows[0] ?? null
   let member = existingMember
+
+  if (existingMember && invitedMember) {
+    const existingJoinedAt = existingMember.joinedAt ?? joinedAt
+    const existingRole = roleIncludesOwner(existingMember.role) ? existingMember.role : role
+    await db
+      .update(MemberTable)
+      .set({ role: existingRole, joinedAt: existingJoinedAt })
+      .where(eq(MemberTable.id, existingMember.id))
+    if (invitedMember.id !== existingMember.id) {
+      await db.delete(MemberTable).where(eq(MemberTable.id, invitedMember.id))
+    }
+    member = { ...existingMember, role: existingRole, joinedAt: existingJoinedAt }
+  }
 
   if (!member && invitedMember) {
     await db
@@ -756,10 +872,11 @@ export async function ensureSingletonOrganizationForUser(userId: UserId) {
     return null
   }
 
-  const member = await insertMemberIfMissing({
+  const member = await ensureBootstrapMembershipForOrganization({
     organizationId: organization.id,
     userId,
     role,
+    email: userEmail,
   })
 
   await ensureDefaultDesktopPolicyForOrganization({

--- a/ee/apps/den-api/test/invite-duplicate-members.test.ts
+++ b/ee/apps/den-api/test/invite-duplicate-members.test.ts
@@ -1,0 +1,505 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, beforeAll, expect, test } from "bun:test"
+
+const singleOrgSlug = "invite-duplicates-test"
+const future = new Date(Date.now() + 1000 * 60 * 60)
+const past = new Date(Date.now() - 1000 * 60 * 60)
+
+const organizationId = createDenTypeId("organization")
+const otherOrganizationId = createDenTypeId("organization")
+const ownerUserId = createDenTypeId("user")
+const ownerMemberId = createDenTypeId("member")
+const otherOwnerMemberId = createDenTypeId("member")
+
+const invitedUserId = createDenTypeId("user")
+const ssoInviteUserId = createDenTypeId("user")
+const reconcileNoMembershipUserId = createDenTypeId("user")
+const reconcileOwnerUserId = createDenTypeId("user")
+const noPendingUserId = createDenTypeId("user")
+const noInviteUserId = createDenTypeId("user")
+const mergeUserId = createDenTypeId("user")
+const ownerMergeUserId = createDenTypeId("user")
+const expiredInviteUserId = createDenTypeId("user")
+const nonMatchingInviteUserId = createDenTypeId("user")
+const otherOrgInviteUserId = createDenTypeId("user")
+
+const ownerEmail = `owner+${ownerUserId}@invite-duplicates.test`
+const invitedEmail = `invited+${invitedUserId}@invite-duplicates.test`
+const ssoInviteEmail = `sso-invited+${ssoInviteUserId}@invite-duplicates.test`
+const reconcileNoMembershipEmail = `reconcile-no-member+${reconcileNoMembershipUserId}@invite-duplicates.test`
+const reconcileOwnerEmail = `reconcile-owner+${reconcileOwnerUserId}@invite-duplicates.test`
+const noPendingEmail = `no-pending+${noPendingUserId}@invite-duplicates.test`
+const noInviteEmail = `no-invite+${noInviteUserId}@invite-duplicates.test`
+const mergeEmail = `merge+${mergeUserId}@invite-duplicates.test`
+const ownerMergeEmail = `owner-merge+${ownerMergeUserId}@invite-duplicates.test`
+const expiredEmail = `expired+${expiredInviteUserId}@invite-duplicates.test`
+const nonMatchingEmail = `non-matching+${nonMatchingInviteUserId}@invite-duplicates.test`
+const otherOrgEmail = `other-org+${otherOrgInviteUserId}@invite-duplicates.test`
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.DEN_ORG_MODE = "single_org"
+  process.env.DEN_SINGLE_ORG_SLUG = singleOrgSlug
+  process.env.DEN_SINGLE_ORG_OWNER_EMAILS = ownerEmail
+}
+
+let db: typeof import("../src/db.js").db | null = null
+let schema: typeof import("@openwork-ee/den-db/schema") | null = null
+let drizzle: typeof import("@openwork-ee/den-db/drizzle") | null = null
+let orgs: typeof import("../src/orgs.js") | null = null
+
+const userIds = [
+  ownerUserId,
+  invitedUserId,
+  ssoInviteUserId,
+  reconcileNoMembershipUserId,
+  reconcileOwnerUserId,
+  noPendingUserId,
+  noInviteUserId,
+  mergeUserId,
+  ownerMergeUserId,
+  expiredInviteUserId,
+  nonMatchingInviteUserId,
+  otherOrgInviteUserId,
+]
+
+async function deleteOrganizations(organizationIds: string[]) {
+  if (!db || !schema || !drizzle || organizationIds.length === 0) {
+    return
+  }
+
+  await db.delete(schema.DesktopPolicyMemberTable).where(drizzle.inArray(schema.DesktopPolicyMemberTable.organizationId, organizationIds))
+  await db.delete(schema.DesktopPolicyTable).where(drizzle.inArray(schema.DesktopPolicyTable.organizationId, organizationIds))
+  await db.delete(schema.MemberTable).where(drizzle.inArray(schema.MemberTable.organizationId, organizationIds))
+  await db.delete(schema.InvitationTable).where(drizzle.inArray(schema.InvitationTable.organizationId, organizationIds))
+  await db.delete(schema.OrganizationRoleTable).where(drizzle.inArray(schema.OrganizationRoleTable.organizationId, organizationIds))
+  await db.delete(schema.OrganizationTable).where(drizzle.inArray(schema.OrganizationTable.id, organizationIds))
+}
+
+async function cleanup() {
+  if (!db || !schema || !drizzle) {
+    return
+  }
+
+  const staleOrgs = await db
+    .select({ id: schema.OrganizationTable.id })
+    .from(schema.OrganizationTable)
+    .where(drizzle.eq(schema.OrganizationTable.slug, singleOrgSlug))
+  await deleteOrganizations([...staleOrgs.map((row) => row.id), organizationId, otherOrganizationId])
+  await db.delete(schema.AuthUserTable).where(drizzle.inArray(schema.AuthUserTable.id, userIds))
+}
+
+async function createInvitation(input: {
+  invitationId: string
+  memberId: string
+  organizationId: string
+  email: string
+  role: string
+  expiresAt: Date
+  inviterMemberId: string
+}) {
+  if (!db || !schema) {
+    throw new Error("test database not initialized")
+  }
+
+  await db.insert(schema.InvitationTable).values({
+    id: input.invitationId,
+    organizationId: input.organizationId,
+    email: input.email,
+    role: input.role,
+    status: "pending",
+    inviterId: ownerUserId,
+    orgMemberId: input.inviterMemberId,
+    inviteToken: `token-${input.invitationId.slice(-20)}`,
+    expiresAt: input.expiresAt,
+  })
+  await db.insert(schema.MemberTable).values({
+    id: input.memberId,
+    organizationId: input.organizationId,
+    userId: null,
+    inviteId: input.invitationId,
+    invitedByOrgMember: input.inviterMemberId,
+    role: input.role,
+    joinedAt: null,
+  })
+}
+
+async function membersForOrganization(organizationIdToRead: string) {
+  if (!db || !schema || !drizzle) {
+    throw new Error("test database not initialized")
+  }
+
+  return db
+    .select()
+    .from(schema.MemberTable)
+    .where(drizzle.eq(schema.MemberTable.organizationId, organizationIdToRead))
+}
+
+async function invitationStatus(invitationId: string) {
+  if (!db || !schema || !drizzle) {
+    throw new Error("test database not initialized")
+  }
+
+  const rows = await db
+    .select({ status: schema.InvitationTable.status })
+    .from(schema.InvitationTable)
+    .where(drizzle.eq(schema.InvitationTable.id, invitationId))
+    .limit(1)
+  return rows[0]?.status ?? null
+}
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  const [dbModule, schemaModule, drizzleModule, orgsModule] = await Promise.all([
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+    import("../src/orgs.js"),
+  ])
+  db = dbModule.db
+  schema = schemaModule
+  drizzle = drizzleModule
+  orgs = orgsModule
+
+  await cleanup()
+
+  await db.insert(schema.AuthUserTable).values([
+    { id: ownerUserId, name: "Invite Owner", email: ownerEmail, emailVerified: true },
+    { id: invitedUserId, name: "Invited User", email: invitedEmail.toUpperCase(), emailVerified: false },
+    { id: ssoInviteUserId, name: "SSO Invited User", email: ssoInviteEmail.toUpperCase(), emailVerified: false },
+    { id: reconcileNoMembershipUserId, name: "Reconcile No Member", email: reconcileNoMembershipEmail.toUpperCase(), emailVerified: false },
+    { id: reconcileOwnerUserId, name: "Reconcile Owner", email: reconcileOwnerEmail.toUpperCase(), emailVerified: false },
+    { id: noPendingUserId, name: "No Pending", email: noPendingEmail, emailVerified: false },
+    { id: noInviteUserId, name: "No Invite", email: noInviteEmail, emailVerified: false },
+    { id: mergeUserId, name: "Merge User", email: mergeEmail, emailVerified: true },
+    { id: ownerMergeUserId, name: "Owner Merge", email: ownerMergeEmail, emailVerified: true },
+    { id: expiredInviteUserId, name: "Expired Invite", email: expiredEmail, emailVerified: false },
+    { id: nonMatchingInviteUserId, name: "Non Matching", email: nonMatchingEmail, emailVerified: false },
+    { id: otherOrgInviteUserId, name: "Other Org", email: otherOrgEmail, emailVerified: false },
+  ])
+  await db.insert(schema.OrganizationTable).values([
+    { id: organizationId, name: "Invite Duplicates Test", slug: singleOrgSlug },
+    { id: otherOrganizationId, name: "Invite Duplicates Other", slug: `invite-duplicates-other-${otherOrganizationId}` },
+  ])
+  await db.insert(schema.MemberTable).values([
+    { id: ownerMemberId, organizationId, userId: ownerUserId, role: "owner" },
+    { id: otherOwnerMemberId, organizationId: otherOrganizationId, userId: ownerUserId, role: "owner" },
+  ])
+})
+
+afterAll(async () => {
+  await cleanup()
+})
+
+test("single-org bootstrap adopts a pending invitation instead of creating a duplicate member", async () => {
+  if (!orgs) {
+    throw new Error("orgs module not initialized")
+  }
+  const invitationId = createDenTypeId("invitation")
+  const placeholderId = createDenTypeId("member")
+  await createInvitation({
+    invitationId,
+    memberId: placeholderId,
+    organizationId,
+    email: invitedEmail.toLowerCase(),
+    role: "admin",
+    expiresAt: future,
+    inviterMemberId: ownerMemberId,
+  })
+
+  const member = await orgs.ensureBootstrapMembershipForOrganization({
+    organizationId,
+    userId: invitedUserId,
+    role: "member",
+    email: invitedEmail.toUpperCase(),
+  })
+  expect(member.organizationId).toBe(organizationId)
+
+  const relatedMembers = (await membersForOrganization(organizationId))
+    .filter((member) => member.userId === invitedUserId || member.inviteId === invitationId)
+  expect(relatedMembers).toHaveLength(1)
+  expect(relatedMembers[0]?.id).toBe(placeholderId)
+  expect(relatedMembers[0]?.userId).toBe(invitedUserId)
+  expect(relatedMembers[0]?.role).toBe("admin")
+  expect(relatedMembers[0]?.joinedAt).toBeInstanceOf(Date)
+  await expect(invitationStatus(invitationId)).resolves.toBe("accepted")
+})
+
+test("single-org bootstrap without a pending invitation keeps the default member insert behavior", async () => {
+  if (!orgs) {
+    throw new Error("orgs module not initialized")
+  }
+
+  const member = await orgs.ensureBootstrapMembershipForOrganization({
+    organizationId,
+    userId: noInviteUserId,
+    role: "member",
+    email: noInviteEmail,
+  })
+  expect(member.organizationId).toBe(organizationId)
+
+  const rows = (await membersForOrganization(organizationId)).filter((member) => member.userId === noInviteUserId)
+  expect(rows).toHaveLength(1)
+  expect(rows[0]?.role).toBe("member")
+  expect(rows[0]?.inviteId).toBeNull()
+})
+
+test("reconcilePendingInvitationsForUser merges a raw SSO JIT membership with its pending invitation", async () => {
+  if (!db || !schema || !orgs) {
+    throw new Error("test modules not initialized")
+  }
+  const invitationId = createDenTypeId("invitation")
+  const placeholderId = createDenTypeId("member")
+  const rawSsoMemberId = createDenTypeId("member")
+  await createInvitation({
+    invitationId,
+    memberId: placeholderId,
+    organizationId,
+    email: ssoInviteEmail.toLowerCase(),
+    role: "admin",
+    expiresAt: future,
+    inviterMemberId: ownerMemberId,
+  })
+  await db.insert(schema.MemberTable).values({
+    id: rawSsoMemberId,
+    organizationId,
+    userId: ssoInviteUserId,
+    role: "member",
+    joinedAt: null,
+  })
+
+  await expect(orgs.reconcilePendingInvitationsForUser(ssoInviteUserId)).resolves.toBe(1)
+
+  const relatedMembers = (await membersForOrganization(organizationId))
+    .filter((row) => row.userId === ssoInviteUserId || row.inviteId === invitationId)
+  expect(relatedMembers).toHaveLength(1)
+  expect(relatedMembers[0]?.id).toBe(rawSsoMemberId)
+  expect(relatedMembers[0]?.role).toBe("admin")
+  expect(relatedMembers[0]?.joinedAt).toBeInstanceOf(Date)
+  await expect(invitationStatus(invitationId)).resolves.toBe("accepted")
+})
+
+test("reconcilePendingInvitationsForUser leaves invitations pending when no same-org membership exists", async () => {
+  if (!orgs) {
+    throw new Error("orgs module not initialized")
+  }
+  const invitationId = createDenTypeId("invitation")
+  const placeholderId = createDenTypeId("member")
+  await createInvitation({
+    invitationId,
+    memberId: placeholderId,
+    organizationId,
+    email: reconcileNoMembershipEmail.toLowerCase(),
+    role: "admin",
+    expiresAt: future,
+    inviterMemberId: ownerMemberId,
+  })
+
+  await expect(orgs.reconcilePendingInvitationsForUser(reconcileNoMembershipUserId)).resolves.toBe(0)
+
+  const relatedMembers = (await membersForOrganization(organizationId))
+    .filter((row) => row.userId === reconcileNoMembershipUserId || row.inviteId === invitationId)
+  expect(relatedMembers).toHaveLength(1)
+  expect(relatedMembers[0]?.id).toBe(placeholderId)
+  expect(relatedMembers[0]?.userId).toBeNull()
+  await expect(invitationStatus(invitationId)).resolves.toBe("pending")
+})
+
+test("reconcilePendingInvitationsForUser never downgrades an existing owner", async () => {
+  if (!db || !schema || !orgs) {
+    throw new Error("test modules not initialized")
+  }
+  const invitationId = createDenTypeId("invitation")
+  const ownerMemberToReconcileId = createDenTypeId("member")
+  const placeholderId = createDenTypeId("member")
+  await db.insert(schema.MemberTable).values({
+    id: ownerMemberToReconcileId,
+    organizationId,
+    userId: reconcileOwnerUserId,
+    role: "owner",
+    joinedAt: null,
+  })
+  await createInvitation({
+    invitationId,
+    memberId: placeholderId,
+    organizationId,
+    email: reconcileOwnerEmail.toLowerCase(),
+    role: "admin",
+    expiresAt: future,
+    inviterMemberId: ownerMemberId,
+  })
+
+  await expect(orgs.reconcilePendingInvitationsForUser(reconcileOwnerUserId)).resolves.toBe(1)
+
+  const relatedMembers = (await membersForOrganization(organizationId))
+    .filter((row) => row.userId === reconcileOwnerUserId || row.inviteId === invitationId)
+  expect(relatedMembers).toHaveLength(1)
+  expect(relatedMembers[0]?.id).toBe(ownerMemberToReconcileId)
+  expect(relatedMembers[0]?.role).toBe("owner")
+  expect(relatedMembers[0]?.joinedAt).toBeInstanceOf(Date)
+  await expect(invitationStatus(invitationId)).resolves.toBe("accepted")
+})
+
+test("reconcilePendingInvitationsForUser is a no-op when the user has no pending invitations", async () => {
+  if (!orgs) {
+    throw new Error("orgs module not initialized")
+  }
+
+  await expect(orgs.reconcilePendingInvitationsForUser(noPendingUserId)).resolves.toBe(0)
+  const rows = (await membersForOrganization(organizationId)).filter((member) => member.userId === noPendingUserId)
+  expect(rows).toHaveLength(0)
+})
+
+test("acceptInvitation merges an existing member with the invitation placeholder", async () => {
+  if (!db || !schema || !orgs) {
+    throw new Error("test modules not initialized")
+  }
+  const invitationId = createDenTypeId("invitation")
+  const existingMemberId = createDenTypeId("member")
+  const placeholderId = createDenTypeId("member")
+
+  await db.insert(schema.MemberTable).values({
+    id: existingMemberId,
+    organizationId,
+    userId: mergeUserId,
+    role: "member",
+    joinedAt: null,
+  })
+  await createInvitation({
+    invitationId,
+    memberId: placeholderId,
+    organizationId,
+    email: mergeEmail,
+    role: "admin",
+    expiresAt: future,
+    inviterMemberId: ownerMemberId,
+  })
+
+  const accepted = await orgs.acceptInvitationForUser({
+    userId: mergeUserId,
+    email: mergeEmail,
+    invitationId,
+  })
+
+  expect(accepted?.member.id).toBe(existingMemberId)
+  const relatedMembers = (await membersForOrganization(organizationId))
+    .filter((member) => member.userId === mergeUserId || member.inviteId === invitationId)
+  expect(relatedMembers).toHaveLength(1)
+  expect(relatedMembers[0]?.id).toBe(existingMemberId)
+  expect(relatedMembers[0]?.role).toBe("admin")
+  expect(relatedMembers[0]?.joinedAt).toBeInstanceOf(Date)
+  await expect(invitationStatus(invitationId)).resolves.toBe("accepted")
+})
+
+test("acceptInvitation does not downgrade an existing owner while removing the placeholder", async () => {
+  if (!db || !schema || !orgs) {
+    throw new Error("test modules not initialized")
+  }
+  const invitationId = createDenTypeId("invitation")
+  const ownerMemberToMergeId = createDenTypeId("member")
+  const placeholderId = createDenTypeId("member")
+
+  await db.insert(schema.MemberTable).values({
+    id: ownerMemberToMergeId,
+    organizationId,
+    userId: ownerMergeUserId,
+    role: "owner",
+    joinedAt: null,
+  })
+  await createInvitation({
+    invitationId,
+    memberId: placeholderId,
+    organizationId,
+    email: ownerMergeEmail,
+    role: "admin",
+    expiresAt: future,
+    inviterMemberId: ownerMemberId,
+  })
+
+  const accepted = await orgs.acceptInvitationForUser({
+    userId: ownerMergeUserId,
+    email: ownerMergeEmail,
+    invitationId,
+  })
+
+  expect(accepted?.member.id).toBe(ownerMemberToMergeId)
+  const relatedMembers = (await membersForOrganization(organizationId))
+    .filter((member) => member.userId === ownerMergeUserId || member.inviteId === invitationId)
+  expect(relatedMembers).toHaveLength(1)
+  expect(relatedMembers[0]?.role).toBe("owner")
+  expect(relatedMembers[0]?.joinedAt).toBeInstanceOf(Date)
+  await expect(invitationStatus(invitationId)).resolves.toBe("accepted")
+})
+
+test("bootstrap ignores expired, non-matching, and other-org invitations", async () => {
+  if (!orgs) {
+    throw new Error("orgs module not initialized")
+  }
+  const expiredInvitationId = createDenTypeId("invitation")
+  const nonMatchingInvitationId = createDenTypeId("invitation")
+  const otherOrgInvitationId = createDenTypeId("invitation")
+
+  await createInvitation({
+    invitationId: expiredInvitationId,
+    memberId: createDenTypeId("member"),
+    organizationId,
+    email: expiredEmail,
+    role: "admin",
+    expiresAt: past,
+    inviterMemberId: ownerMemberId,
+  })
+  await createInvitation({
+    invitationId: nonMatchingInvitationId,
+    memberId: createDenTypeId("member"),
+    organizationId,
+    email: `different-${nonMatchingEmail}`,
+    role: "admin",
+    expiresAt: future,
+    inviterMemberId: ownerMemberId,
+  })
+  await createInvitation({
+    invitationId: otherOrgInvitationId,
+    memberId: createDenTypeId("member"),
+    organizationId: otherOrganizationId,
+    email: otherOrgEmail,
+    role: "admin",
+    expiresAt: future,
+    inviterMemberId: otherOwnerMemberId,
+  })
+
+  await orgs.ensureBootstrapMembershipForOrganization({
+    organizationId,
+    userId: expiredInviteUserId,
+    role: "member",
+    email: expiredEmail,
+  })
+  await orgs.ensureBootstrapMembershipForOrganization({
+    organizationId,
+    userId: nonMatchingInviteUserId,
+    role: "member",
+    email: nonMatchingEmail,
+  })
+  await orgs.ensureBootstrapMembershipForOrganization({
+    organizationId,
+    userId: otherOrgInviteUserId,
+    role: "member",
+    email: otherOrgEmail,
+  })
+
+  const singletonMembers = await membersForOrganization(organizationId)
+  expect(singletonMembers.filter((member) => member.userId === expiredInviteUserId && member.role === "member")).toHaveLength(1)
+  expect(singletonMembers.filter((member) => member.inviteId === expiredInvitationId && member.userId === null)).toHaveLength(1)
+  expect(singletonMembers.filter((member) => member.userId === nonMatchingInviteUserId && member.role === "member")).toHaveLength(1)
+  expect(singletonMembers.filter((member) => member.inviteId === nonMatchingInvitationId && member.userId === null)).toHaveLength(1)
+
+  const otherOrgMembers = await membersForOrganization(otherOrganizationId)
+  expect(singletonMembers.filter((member) => member.userId === otherOrgInviteUserId && member.role === "member")).toHaveLength(1)
+  expect(otherOrgMembers.filter((member) => member.userId === otherOrgInviteUserId)).toHaveLength(0)
+  expect(otherOrgMembers.filter((member) => member.inviteId === otherOrgInvitationId && member.userId === null)).toHaveLength(1)
+  await expect(invitationStatus(expiredInvitationId)).resolves.toBe("pending")
+  await expect(invitationStatus(nonMatchingInvitationId)).resolves.toBe("pending")
+  await expect(invitationStatus(otherOrgInvitationId)).resolves.toBe("pending")
+})

--- a/evals/flows/invite-adoption-no-duplicates.flow.mjs
+++ b/evals/flows/invite-adoption-no-duplicates.flow.mjs
@@ -1,0 +1,436 @@
+import { execFileSync } from "node:child_process";
+import { randomBytes, randomUUID } from "node:crypto";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "invite-adoption-no-duplicates";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? DEN_API_URL.replace("127.0.0.1", "localhost")).trim().replace(/\/+$/, "");
+const MYSQL_CONTAINER = "openwork-web-local-mysql";
+const MYSQL_ARGS = ["exec", MYSQL_CONTAINER, "mysql", "-uroot", "-ppassword", "openwork_den", "-N", "-e"];
+const ADMIN_TOKEN = (process.env.OPENWORK_EVAL_DEN_TOKEN ?? "").trim();
+const TYPE_ID_ALPHABET = "0123456789abcdefghjkmnpqrstvwxyz";
+const TYPE_ID_PREFIXES = {
+  member: "om",
+  orgSubscription: "osub",
+};
+const RUN_TAG = `${Date.now().toString(36)}-${randomBytes(2).toString("hex")}`;
+const RASHMI_EMAIL = `rashmi+${RUN_TAG}@acme.test`;
+const RASHMI_JIT_EMAIL = `rashmi+jit-${RUN_TAG}@acme.test`;
+const RASHMI_PASSWORD = `OpenWork-${RUN_TAG}!`;
+
+const state = {
+  organization: null,
+  adminMemberId: null,
+  orgMode: null,
+  rashmiToken: null,
+  rashmiUserId: null,
+  reconcileEmail: null,
+  reconcileUserId: null,
+};
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : typeof actual === "string" ? actual : JSON.stringify(actual).slice(0, 900),
+  });
+  ctx.assert(condition, assertion + (actual === undefined ? "" : ` (actual: ${JSON.stringify(actual).slice(0, 500)})`));
+}
+
+function sqlString(value) {
+  return `'${String(value).replace(/\\/g, "\\\\").replace(/'/g, "''")}'`;
+}
+
+function createDenTypeId(name) {
+  const prefix = TYPE_ID_PREFIXES[name];
+  let value = BigInt(`0x${randomUUID().replace(/-/g, "")}`);
+  let suffix = "";
+  for (let index = 0; index < 26; index += 1) {
+    suffix = TYPE_ID_ALPHABET[Number(value % 32n)] + suffix;
+    value /= 32n;
+  }
+  return `${prefix}_${suffix}`;
+}
+
+function mysqlQuery(sql) {
+  return execFileSync("docker", [...MYSQL_ARGS, sql], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  }).trim();
+}
+
+function cleanupPriorEvalArtifacts() {
+  return mysqlQuery("DELETE FROM org_subscriptions WHERE last_event_id = 'invite-adoption-no-duplicates';");
+}
+
+async function denFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      origin: DEN_WEB_URL || DEN_API_URL,
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {}
+  return { response, body, text };
+}
+
+async function authed(path, options = {}) {
+  return denFetch(path, {
+    ...options,
+    headers: {
+      authorization: `Bearer ${ADMIN_TOKEN}`,
+      ...(options.headers ?? {}),
+    },
+  });
+}
+
+function redactAuthResult(result) {
+  const body = result.body && typeof result.body === "object" ? result.body : null;
+  return {
+    status: result.response.status,
+    ok: result.response.ok,
+    token: typeof body?.token === "string" ? "<present>" : undefined,
+    user: body?.user
+      ? {
+          id: body.user.id,
+          email: body.user.email,
+          name: body.user.name,
+          emailVerified: body.user.emailVerified,
+        }
+      : undefined,
+    session: body?.session
+      ? {
+          id: body.session.id,
+          activeOrganizationId: body.session.activeOrganizationId,
+        }
+      : undefined,
+    body: body && !body.token ? body : undefined,
+  };
+}
+
+function normalizeEmail(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function membersForEmail(org, email) {
+  const normalized = normalizeEmail(email);
+  return (org.members ?? []).filter((member) => normalizeEmail(member.user?.email) === normalized);
+}
+
+function invitationsForEmail(org, email) {
+  const normalized = normalizeEmail(email);
+  return (org.invitations ?? []).filter((invitation) => normalizeEmail(invitation.email) === normalized);
+}
+
+function activeMembersForEmail(org, email) {
+  return membersForEmail(org, email).filter((member) => typeof member.userId === "string" && member.userId.length > 0);
+}
+
+function invitedGhostsForEmail(org, email) {
+  return membersForEmail(org, email).filter((member) => !member.userId && typeof member.inviteId === "string" && member.inviteId.length > 0);
+}
+
+function compactMember(member) {
+  return {
+    id: member.id,
+    email: member.user?.email,
+    userId: member.userId,
+    inviteId: member.inviteId,
+    role: member.role,
+    joinedAt: member.joinedAt,
+  };
+}
+
+function compactInvitation(invitation) {
+  return {
+    id: invitation.id,
+    email: invitation.email,
+    role: invitation.role,
+    status: invitation.status,
+    expiresAt: invitation.expiresAt,
+  };
+}
+
+function summarizeOrg(org, emails) {
+  return {
+    organization: {
+      id: org.organization?.id,
+      name: org.organization?.name,
+      slug: org.organization?.slug,
+    },
+    currentMember: {
+      id: org.currentMember?.id,
+      role: org.currentMember?.role,
+    },
+    totalMembers: Array.isArray(org.members) ? org.members.length : null,
+    totalInvitations: Array.isArray(org.invitations) ? org.invitations.length : null,
+    focus: emails.map((email) => ({
+      email,
+      members: membersForEmail(org, email).map(compactMember),
+      activeMembers: activeMembersForEmail(org, email).map(compactMember),
+      invitedPlaceholders: invitedGhostsForEmail(org, email).map(compactMember),
+      invitations: invitationsForEmail(org, email).map(compactInvitation),
+    })),
+  };
+}
+
+async function loadOrg(ctx) {
+  const result = await authed("/v1/org");
+  witness(ctx, result.response.ok, "Admin token can load the active organization", { status: result.response.status, body: result.body });
+  state.organization = result.body.organization;
+  state.adminMemberId = result.body.currentMember?.id ?? null;
+  witness(ctx, typeof state.organization?.id === "string", "Organization id is present", state.organization);
+  witness(ctx, typeof state.adminMemberId === "string", "Admin member id is present", result.body.currentMember);
+  return result.body;
+}
+
+function ensureSeatSubscription(ctx) {
+  const orgId = state.organization?.id;
+  const memberId = state.adminMemberId;
+  witness(ctx, typeof orgId === "string" && typeof memberId === "string", "Seat setup has an organization and admin member id", { orgId, memberId });
+  const subscriptionId = createDenTypeId("orgSubscription");
+  const quantity = 100;
+  const sql = `INSERT INTO org_subscriptions (id, organization_id, created_by_org_membership_id, type, status, stripe_customer_id, stripe_subscription_id, stripe_price_id, stripe_subscription_item_id, quantity, current_period_start, current_period_end, cancel_at_period_end, canceled_at, ended_at, last_event_id, created_at, updated_at) VALUES (${sqlString(subscriptionId)}, ${sqlString(orgId)}, ${sqlString(memberId)}, 'seat', 'active', ${sqlString(`cus_eval_${orgId}`)}, ${sqlString(`sub_eval_seats_${orgId}`)}, 'price_eval_seats', NULL, ${quantity}, CURRENT_TIMESTAMP(3), DATE_ADD(CURRENT_TIMESTAMP(3), INTERVAL 30 DAY), false, NULL, NULL, 'invite-adoption-no-duplicates', CURRENT_TIMESTAMP(3), CURRENT_TIMESTAMP(3)) ON DUPLICATE KEY UPDATE status='active', quantity=VALUES(quantity), current_period_end=VALUES(current_period_end), cancel_at_period_end=false, canceled_at=NULL, ended_at=NULL, updated_at=CURRENT_TIMESTAMP(3);`;
+  mysqlQuery(sql);
+  return sql;
+}
+
+async function inviteAsAdmin(ctx, email) {
+  let result = await authed("/v1/invitations", {
+    method: "POST",
+    body: JSON.stringify({ email, role: "admin" }),
+  });
+  let seatSql = null;
+  if (result.response.status === 402 && result.body?.error === "payment_required") {
+    seatSql = ensureSeatSubscription(ctx);
+    result = await authed("/v1/invitations", {
+      method: "POST",
+      body: JSON.stringify({ email, role: "admin" }),
+    });
+  }
+  const persisted = result.response.ok || (result.response.status === 502 && result.body?.error === "invitation_email_failed");
+  witness(ctx, persisted, `Admin invitation is persisted for ${email}`, { status: result.response.status, body: result.body });
+  return { result, seatSql };
+}
+
+async function signUpEmail(ctx, email, name) {
+  const result = await denFetch("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ email, name, password: RASHMI_PASSWORD }),
+  });
+  witness(ctx, result.response.ok, `Sign-up succeeds for ${email}`, redactAuthResult(result));
+  return result;
+}
+
+async function signInEmail(ctx, email) {
+  const result = await denFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password: RASHMI_PASSWORD }),
+  });
+  witness(ctx, result.response.ok && typeof result.body?.token === "string", `Sign-in returns a session token for ${email}`, redactAuthResult(result));
+  return result;
+}
+
+async function loadMe(ctx, token, label) {
+  const result = await denFetch("/v1/me", {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  witness(ctx, result.response.ok && typeof result.body?.user?.id === "string", `${label} profile exposes a user id`, { status: result.response.status, body: result.body });
+  return result.body;
+}
+
+function userIdForEmail(ctx, email) {
+  const sql = `SELECT id FROM user WHERE email = ${sqlString(normalizeEmail(email))} LIMIT 1;`;
+  const userId = mysqlQuery(sql).split(/\s+/).filter(Boolean)[0] ?? "";
+  witness(ctx, userId.startsWith("usr_"), `User id exists for ${email}`, { sql, userId });
+  return userId;
+}
+
+function insertRawJitMember(ctx, input) {
+  const memberId = createDenTypeId("member");
+  const sql = `INSERT INTO member (id, organization_id, user_id, role, joined_at, created_at) VALUES (${sqlString(memberId)}, ${sqlString(input.organizationId)}, ${sqlString(input.userId)}, 'member', CURRENT_TIMESTAMP(3), CURRENT_TIMESTAMP(3));`;
+  const output = mysqlQuery(sql);
+  witness(ctx, true, `Raw SSO-style member row inserted for ${input.email}`, { memberId, output });
+  return { memberId, sql, output };
+}
+
+function assertPendingInviteAndGhost(ctx, org, email) {
+  const invitations = invitationsForEmail(org, email);
+  const ghosts = invitedGhostsForEmail(org, email);
+  witness(ctx, invitations.length === 1, `${email} has one invitation`, invitations.map(compactInvitation));
+  witness(ctx, invitations[0]?.status === "pending", `${email} invitation is pending`, invitations.map(compactInvitation));
+  witness(ctx, invitations[0]?.role === "admin", `${email} invitation carries admin role`, invitations.map(compactInvitation));
+  witness(ctx, ghosts.length === 1, `${email} has one invited placeholder member`, ghosts.map(compactMember));
+  witness(ctx, ghosts[0]?.role === "admin", `${email} invited placeholder carries admin role`, ghosts.map(compactMember));
+}
+
+function assertReconciled(ctx, org, email) {
+  const active = activeMembersForEmail(org, email);
+  const ghosts = invitedGhostsForEmail(org, email);
+  const invitations = invitationsForEmail(org, email);
+  witness(ctx, membersForEmail(org, email).length === 1, `${email} has exactly one visible member row`, membersForEmail(org, email).map(compactMember));
+  witness(ctx, active.length === 1, `${email} has one active member`, active.map(compactMember));
+  witness(ctx, active[0]?.role === "admin", `${email} active member has admin role`, active.map(compactMember));
+  witness(ctx, ghosts.length === 0, `${email} has no invited placeholder ghost`, ghosts.map(compactMember));
+  witness(ctx, invitations.length === 1, `${email} has one invitation record`, invitations.map(compactInvitation));
+  witness(ctx, invitations[0]?.status === "accepted", `${email} invitation is accepted`, invitations.map(compactInvitation));
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Pending invitations are adopted without duplicate organization members",
+  kind: "internal",
+  requiresApp: false,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  steps: [
+    {
+      name: "Frame 1 — The admin invites Rashmi as an admin",
+      run: async (ctx) => {
+        await ctx.prove("The admin invite creates one pending admin invitation and one invited placeholder", {
+          voiceover: vo[0],
+          assert: async () => {
+            await loadOrg(ctx);
+            const cleanupOutput = cleanupPriorEvalArtifacts();
+            const invite = await inviteAsAdmin(ctx, RASHMI_EMAIL);
+            const org = await loadOrg(ctx);
+            assertPendingInviteAndGhost(ctx, org, RASHMI_EMAIL);
+            ctx.output("invite-response-and-org-listing", JSON.stringify({
+              runTag: RUN_TAG,
+              email: RASHMI_EMAIL,
+              cleanup: cleanupOutput || "removed prior eval-only seat rows if present",
+              inviteResponse: { status: invite.result.response.status, body: invite.result.body },
+              seatSetupApplied: Boolean(invite.seatSql),
+              org: summarizeOrg(org, [RASHMI_EMAIL]),
+            }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2 — Rashmi signs up and the stack's org mode decides the first-sign-in boundary",
+      run: async (ctx) => {
+        await ctx.prove("Rashmi's first sign-in either stays outside the org or adopts the invite in single-org mode", {
+          voiceover: vo[1],
+          action: async () => {
+            state.rashmiSignUp = await signUpEmail(ctx, RASHMI_EMAIL, "Rashmi Shah");
+            const signedIn = await signInEmail(ctx, RASHMI_EMAIL);
+            state.rashmiToken = signedIn.body.token;
+            const me = await loadMe(ctx, state.rashmiToken, "Rashmi");
+            state.rashmiUserId = me.user.id;
+          },
+          assert: async () => {
+            const org = await loadOrg(ctx);
+            const active = activeMembersForEmail(org, RASHMI_EMAIL);
+            const invitations = invitationsForEmail(org, RASHMI_EMAIL);
+            const ghosts = invitedGhostsForEmail(org, RASHMI_EMAIL);
+            if (active.length === 1 && invitations[0]?.status === "accepted") {
+              state.orgMode = "single_org";
+              assertReconciled(ctx, org, RASHMI_EMAIL);
+            } else {
+              state.orgMode = "multi_org";
+              witness(ctx, active.length === 0, "Rashmi is not yet an active member of the invited organization", active.map(compactMember));
+              witness(ctx, invitations[0]?.status === "pending", "Rashmi's invitation is still pending", invitations.map(compactInvitation));
+              witness(ctx, ghosts.length === 1, "Rashmi's invited placeholder still exists", ghosts.map(compactMember));
+            }
+            ctx.output("rashmi-first-signin-and-org-mode", JSON.stringify({
+              runTag: RUN_TAG,
+              inferredOrgMode: state.orgMode,
+              auth: {
+                signUp: redactAuthResult(state.rashmiSignUp),
+                signInToken: state.rashmiToken ? "<present>" : null,
+                userId: state.rashmiUserId,
+              },
+              org: summarizeOrg(org, [RASHMI_EMAIL]),
+            }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — An SSO-style raw membership appears",
+      run: async (ctx) => {
+        await ctx.prove("The pre-fix duplicate state is observable before the next session is created", {
+          voiceover: vo[2],
+          action: async () => {
+            if (state.orgMode === "single_org") {
+              state.reconcileEmail = RASHMI_JIT_EMAIL;
+              const invite = await inviteAsAdmin(ctx, state.reconcileEmail);
+              const signUp = await signUpEmail(ctx, state.reconcileEmail, "Rashmi JIT");
+              state.reconcileUserId = userIdForEmail(ctx, state.reconcileEmail);
+              state.jitSetup = { invite, signUp };
+            } else {
+              state.reconcileEmail = RASHMI_EMAIL;
+              state.reconcileUserId = state.rashmiUserId;
+            }
+            const orgId = state.organization?.id;
+            witness(ctx, typeof orgId === "string", "Raw member insert has an organization id", state.organization);
+            witness(ctx, typeof state.reconcileUserId === "string" && state.reconcileUserId.startsWith("usr_"), "Raw member insert has a Rashmi user id", state.reconcileUserId);
+            state.rawInsert = insertRawJitMember(ctx, {
+              email: state.reconcileEmail,
+              organizationId: orgId,
+              userId: state.reconcileUserId,
+            });
+          },
+          assert: async () => {
+            const org = await loadOrg(ctx);
+            const active = activeMembersForEmail(org, state.reconcileEmail);
+            const ghosts = invitedGhostsForEmail(org, state.reconcileEmail);
+            const invitations = invitationsForEmail(org, state.reconcileEmail);
+            witness(ctx, active.length === 1, `${state.reconcileEmail} has one active raw member`, active.map(compactMember));
+            witness(ctx, active[0]?.role === "member", `${state.reconcileEmail} active raw member has the old wrong member role`, active.map(compactMember));
+            witness(ctx, ghosts.length === 1, `${state.reconcileEmail} still has one invited placeholder ghost`, ghosts.map(compactMember));
+            witness(ctx, invitations[0]?.status === "pending", `${state.reconcileEmail} invitation remains pending before reconcile`, invitations.map(compactInvitation));
+            ctx.output("raw-jit-duplicate-state", JSON.stringify({
+              inferredOrgMode: state.orgMode,
+              email: state.reconcileEmail,
+              singleOrgExtraInvite: state.orgMode === "single_org",
+              rawInsertSql: state.rawInsert.sql,
+              rawInsertOutput: state.rawInsert.output,
+              setupInviteResponse: state.jitSetup
+                ? { status: state.jitSetup.invite.result.response.status, body: state.jitSetup.invite.result.body }
+                : undefined,
+              setupSignUp: state.jitSetup ? redactAuthResult(state.jitSetup.signUp) : undefined,
+              org: summarizeOrg(org, [state.reconcileEmail]),
+            }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4 — Rashmi signs in again and the app reconciles",
+      run: async (ctx) => {
+        await ctx.prove("The next sign-in merges the active member with the invite and deletes the invited ghost", {
+          voiceover: vo[3],
+          action: async () => {
+            const signedIn = await signInEmail(ctx, state.reconcileEmail);
+            state.reconciledToken = signedIn.body.token;
+            state.reconciledMe = await loadMe(ctx, state.reconciledToken, "Reconciled Rashmi");
+          },
+          assert: async () => {
+            const org = await loadOrg(ctx);
+            assertReconciled(ctx, org, state.reconcileEmail);
+            ctx.output("reconciled-org-listing", JSON.stringify({
+              inferredOrgMode: state.orgMode,
+              email: state.reconcileEmail,
+              auth: {
+                token: state.reconciledToken ? "<present>" : null,
+                userId: state.reconciledMe?.user?.id,
+                sessionActiveOrganizationId: state.reconciledMe?.session?.activeOrganizationId,
+              },
+              org: summarizeOrg(org, [state.reconcileEmail]),
+            }, null, 2));
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/invite-adoption-no-duplicates.flow.mjs
+++ b/evals/flows/invite-adoption-no-duplicates.flow.mjs
@@ -1,15 +1,34 @@
+/**
+ * Internal + visual proof for PR #2548: pending invitations are adopted without
+ * duplicate organization members, and the den-web Members page shows the same
+ * states the customer reported.
+ *
+ * Local runbook:
+ *   1. pnpm evals --stack-down
+ *   2. OPENWORK_EVAL_DEN_WEB_URL=http://127.0.0.1:3005 OPENWORK_EVAL_WEB_CDP_ADMIN=http://127.0.0.1:9855 pnpm fraimz --flow invite-adoption-no-duplicates --stack den
+ *      (the stack exports OPENWORK_EVAL_DEN_API_URL and OPENWORK_EVAL_DEN_TOKEN)
+ *   3. In another shell, run den-web against the stack API:
+ *      DEN_WEB_PORT=3005 DEN_API_BASE=http://127.0.0.1:8790 DEN_AUTH_ORIGIN=http://127.0.0.1:3005 DEN_AUTH_FALLBACK_BASE=http://127.0.0.1:8790 pnpm --filter @openwork-ee/den-web dev:local
+ *   4. In another shell, run Chrome for screenshots:
+ *      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless=new --remote-debugging-port=9855 --user-data-dir="$(mktemp -d)" --window-size=1440,1100 about:blank
+ */
 import { execFileSync } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
+import { connect, debuggerUrlFor, listTargets } from "../runner/cdp.mjs";
+import { denWebUrl } from "./lib/den-web.mjs";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
 const FLOW_ID = "invite-adoption-no-duplicates";
 const vo = await loadVoiceoverParagraphs(FLOW_ID);
 
 const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
-const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? DEN_API_URL.replace("127.0.0.1", "localhost")).trim().replace(/\/+$/, "");
+const DEN_WEB_URL = denWebUrl();
+const ADMIN_CDP_URL = (process.env.OPENWORK_EVAL_WEB_CDP_ADMIN ?? "").trim().replace(/\/+$/, "");
 const MYSQL_CONTAINER = "openwork-web-local-mysql";
 const MYSQL_ARGS = ["exec", MYSQL_CONTAINER, "mysql", "-uroot", "-ppassword", "openwork_den", "-N", "-e"];
 const ADMIN_TOKEN = (process.env.OPENWORK_EVAL_DEN_TOKEN ?? "").trim();
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
 const TYPE_ID_ALPHABET = "0123456789abcdefghjkmnpqrstvwxyz";
 const TYPE_ID_PREFIXES = {
   member: "om",
@@ -24,6 +43,7 @@ const state = {
   organization: null,
   adminMemberId: null,
   orgMode: null,
+  adminBrowserSignedIn: false,
   rashmiToken: null,
   rashmiUserId: null,
   reconcileEmail: null,
@@ -66,6 +86,211 @@ function cleanupPriorEvalArtifacts() {
   return mysqlQuery("DELETE FROM org_subscriptions WHERE last_event_id = 'invite-adoption-no-duplicates';");
 }
 
+function adminAuthOrigins() {
+  const origins = [];
+  if (DEN_WEB_URL) {
+    origins.push(new URL(DEN_WEB_URL).origin);
+  }
+  if (DEN_API_URL) {
+    const apiUrl = new URL(DEN_API_URL);
+    if (apiUrl.hostname === "127.0.0.1") {
+      const localhostUrl = new URL(apiUrl.toString());
+      localhostUrl.hostname = "localhost";
+      origins.push(localhostUrl.origin);
+    }
+    origins.push(apiUrl.origin);
+  }
+  return [...new Set(origins)];
+}
+
+function sessionCookiePair(setCookie) {
+  const match = String(setCookie ?? "").match(/better-auth\.session_token=([^;,\s]+)/);
+  return match ? `better-auth.session_token=${match[1]}` : "";
+}
+
+async function createAdminBrowserSession(ctx) {
+  let last = null;
+  for (const origin of adminAuthOrigins()) {
+    const response = await fetch(`${DEN_API_URL}/api/auth/sign-in/email`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin },
+      body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }),
+    });
+    const text = await response.text();
+    let body = text;
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {}
+    const cookie = sessionCookiePair(response.headers.get("set-cookie"));
+    last = { origin, status: response.status, body, cookie: cookie ? "<present>" : null };
+    if (response.ok && typeof body?.token === "string" && cookie) {
+      witness(ctx, true, "Admin API sign-in minted a den-web browser session", { origin, status: response.status, token: "<present>", cookie: "<present>" });
+      return { token: body.token, cookie };
+    }
+  }
+  witness(ctx, false, "Admin API sign-in minted a den-web browser session", last);
+  return null;
+}
+
+async function withClient(ctx, cdpBaseUrl, fn) {
+  const previous = ctx.client;
+  const target = await firstPageTarget(cdpBaseUrl);
+  const client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+  ctx.client = client;
+  try {
+    return await fn();
+  } finally {
+    ctx.client = previous;
+    try {
+      client.close();
+    } catch {}
+  }
+}
+
+async function firstPageTarget(cdpBaseUrl) {
+  const existing = await listTargets(cdpBaseUrl);
+  const page = existing.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (page) {
+    return page;
+  }
+
+  const base = cdpBaseUrl.replace(/\/+$/, "");
+  let response = await fetch(`${base}/json/new?about:blank`, { method: "PUT" });
+  if (!response.ok) {
+    response = await fetch(`${base}/json/new?about:blank`);
+  }
+  if (!response.ok) {
+    throw new Error(`Could not create a page target at ${cdpBaseUrl}: ${response.status}`);
+  }
+
+  const created = await response.json();
+  if (created?.type === "page" && created.webSocketDebuggerUrl) {
+    return created;
+  }
+  const targets = await listTargets(cdpBaseUrl);
+  const nextPage = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (!nextPage) {
+    throw new Error(`No page target available at ${cdpBaseUrl}.`);
+  }
+  return nextPage;
+}
+
+async function goToDenWeb(ctx, path) {
+  const url = path.startsWith("http") ? path : `${DEN_WEB_URL}${path}`;
+  await ctx.eval(`location.assign(${JSON.stringify(url)})`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `den-web loaded ${path}` });
+}
+
+async function signInAdminBrowser(ctx) {
+  if (state.adminBrowserSignedIn) {
+    return;
+  }
+
+  const session = await createAdminBrowserSession(ctx);
+  await goToDenWeb(ctx, "/");
+  await ctx.eval(`(() => {
+    document.cookie = 'better-auth.session_token=; Max-Age=0; Path=/';
+    document.cookie = ${JSON.stringify(`${session.cookie}; Path=/; SameSite=Lax`)};
+    localStorage.setItem('openwork:web:auth-token', ${JSON.stringify(session.token)});
+    sessionStorage.clear();
+    return true;
+  })()`);
+  await goToDenWeb(ctx, "/");
+  await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 45_000, label: "den-web dashboard after admin sign-in" });
+  state.adminBrowserSignedIn = true;
+}
+
+async function openMembersPage(ctx) {
+  await signInAdminBrowser(ctx);
+  await goToDenWeb(ctx, "/dashboard/members");
+  await ctx.waitFor("location.pathname.includes('/dashboard/members')", { timeoutMs: 30_000, label: "members route" });
+  await ctx.waitForText("Invite teammates, adjust roles, and keep access clean.", { timeoutMs: 30_000 });
+}
+
+function memberRowsExpression(email) {
+  return `(() => {
+    const email = ${JSON.stringify(email)};
+    return [...document.querySelectorAll('div')]
+      .filter((el) => {
+        const style = getComputedStyle(el);
+        return style.display === 'grid' && style.gridTemplateColumns.includes('180px') && (el.innerText ?? '').includes(email);
+      })
+      .map((el) => {
+        const cells = [...el.children].map((child) => child.innerText.trim());
+        return {
+          text: el.innerText.trim(),
+          role: cells[1] ?? '',
+          joined: cells[2] ?? '',
+        };
+      });
+  })()`;
+}
+
+async function memberRows(ctx, email) {
+  return ctx.eval(memberRowsExpression(email));
+}
+
+async function waitForUiRows(ctx, email, predicateSource, label) {
+  await ctx.waitFor(`(() => {
+    const rows = ${memberRowsExpression(email)};
+    const predicate = ${predicateSource};
+    return predicate(rows);
+  })()`, { timeoutMs: 30_000, label });
+  return memberRows(ctx, email);
+}
+
+async function scrollMemberRowsIntoView(ctx, email) {
+  await ctx.eval(`(() => {
+    const rows = [...document.querySelectorAll('div')]
+      .filter((el) => {
+        const style = getComputedStyle(el);
+        return style.display === 'grid' && style.gridTemplateColumns.includes('180px') && (el.innerText ?? '').includes(${JSON.stringify(email)});
+      });
+    rows[0]?.scrollIntoView({ block: 'center' });
+    return rows.length;
+  })()`);
+  await ctx.eval("new Promise((resolve) => setTimeout(resolve, 250))", { awaitPromise: true });
+}
+
+async function assertPendingInviteUi(ctx, email) {
+  const rows = await waitForUiRows(
+    ctx,
+    email,
+    "(rows) => rows.length === 1 && rows[0].role.includes('Admin') && rows[0].joined.includes('Pending') && rows[0].text.toLowerCase().includes('invited')",
+    `pending invited admin row for ${email}`,
+  );
+  witness(ctx, rows.length === 1, `${email} is one pending row in den-web`, rows);
+  witness(ctx, rows[0]?.role.includes("Admin"), `${email} den-web row shows Admin role`, rows);
+  witness(ctx, rows[0]?.joined.includes("Pending"), `${email} den-web row shows Pending`, rows);
+  await scrollMemberRowsIntoView(ctx, email);
+}
+
+async function assertDuplicateUi(ctx, email) {
+  const rows = await waitForUiRows(
+    ctx,
+    email,
+    "(rows) => rows.length === 2 && rows.some((row) => row.role.includes('Member') && !row.joined.includes('Pending')) && rows.some((row) => row.role.includes('Admin') && row.joined.includes('Pending') && row.text.toLowerCase().includes('invited'))",
+    `duplicate raw member plus pending invite rows for ${email}`,
+  );
+  witness(ctx, rows.length === 2, `${email} has two visible den-web rows in the duplicate state`, rows);
+  witness(ctx, rows.some((row) => row.role.includes("Member") && !row.joined.includes("Pending")), `${email} den-web duplicate includes the active wrong member role`, rows);
+  witness(ctx, rows.some((row) => row.role.includes("Admin") && row.joined.includes("Pending") && row.text.toLowerCase().includes("invited")), `${email} den-web duplicate includes the pending invited admin record`, rows);
+  await scrollMemberRowsIntoView(ctx, email);
+}
+
+async function assertReconciledUi(ctx, email) {
+  const rows = await waitForUiRows(
+    ctx,
+    email,
+    "(rows) => rows.length === 1 && rows[0].role.includes('Admin') && !rows[0].joined.includes('Pending') && !rows[0].text.toLowerCase().includes('invited')",
+    `single reconciled admin row for ${email}`,
+  );
+  witness(ctx, rows.length === 1, `${email} has exactly one visible den-web row after reconcile`, rows);
+  witness(ctx, rows[0]?.role.includes("Admin"), `${email} den-web row shows Admin after reconcile`, rows);
+  witness(ctx, !rows[0]?.joined.includes("Pending") && !rows[0]?.text.toLowerCase().includes("invited"), `${email} den-web row has no pending/invited ghost after reconcile`, rows);
+  await scrollMemberRowsIntoView(ctx, email);
+}
+
 async function denFetch(path, options = {}) {
   const response = await fetch(`${DEN_API_URL}${path}`, {
     ...options,
@@ -81,6 +306,24 @@ async function denFetch(path, options = {}) {
     body = text ? JSON.parse(text) : null;
   } catch {}
   return { response, body, text };
+}
+
+async function denAuthFetch(path, options = {}) {
+  let last = null;
+  for (const origin of adminAuthOrigins()) {
+    const result = await denFetch(path, {
+      ...options,
+      headers: {
+        origin,
+        ...(options.headers ?? {}),
+      },
+    });
+    last = result;
+    if (!(result.response.status === 403 && result.body?.code === "INVALID_ORIGIN")) {
+      return result;
+    }
+  }
+  return last;
 }
 
 async function authed(path, options = {}) {
@@ -223,7 +466,7 @@ async function inviteAsAdmin(ctx, email) {
 }
 
 async function signUpEmail(ctx, email, name) {
-  const result = await denFetch("/api/auth/sign-up/email", {
+  const result = await denAuthFetch("/api/auth/sign-up/email", {
     method: "POST",
     body: JSON.stringify({ email, name, password: RASHMI_PASSWORD }),
   });
@@ -232,7 +475,7 @@ async function signUpEmail(ctx, email, name) {
 }
 
 async function signInEmail(ctx, email) {
-  const result = await denFetch("/api/auth/sign-in/email", {
+  const result = await denAuthFetch("/api/auth/sign-in/email", {
     method: "POST",
     body: JSON.stringify({ email, password: RASHMI_PASSWORD }),
   });
@@ -290,11 +533,12 @@ export default {
   title: "Pending invitations are adopted without duplicate organization members",
   kind: "internal",
   requiresApp: false,
-  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_WEB_CDP_ADMIN"],
   steps: [
     {
       name: "Frame 1 — The admin invites Rashmi as an admin",
       run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
         await ctx.prove("The admin invite creates one pending admin invitation and one invited placeholder", {
           voiceover: vo[0],
           assert: async () => {
@@ -311,7 +555,15 @@ export default {
               seatSetupApplied: Boolean(invite.seatSql),
               org: summarizeOrg(org, [RASHMI_EMAIL]),
             }, null, 2));
+            await openMembersPage(ctx);
+            await assertPendingInviteUi(ctx, RASHMI_EMAIL);
           },
+          screenshot: {
+            name: "rashmi-pending-admin-invite",
+            requireText: [RASHMI_EMAIL, "Pending", "Admin"],
+            rejectText: ["Something went wrong"],
+          },
+        });
         });
       },
     },
@@ -358,6 +610,7 @@ export default {
     {
       name: "Frame 3 — An SSO-style raw membership appears",
       run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
         await ctx.prove("The pre-fix duplicate state is observable before the next session is created", {
           voiceover: vo[2],
           action: async () => {
@@ -379,6 +632,7 @@ export default {
               organizationId: orgId,
               userId: state.reconcileUserId,
             });
+            await openMembersPage(ctx);
           },
           assert: async () => {
             const org = await loadOrg(ctx);
@@ -401,19 +655,28 @@ export default {
               setupSignUp: state.jitSetup ? redactAuthResult(state.jitSetup.signUp) : undefined,
               org: summarizeOrg(org, [state.reconcileEmail]),
             }, null, 2));
+            await assertDuplicateUi(ctx, state.reconcileEmail);
           },
+          screenshot: {
+            name: "rashmi-duplicate-raw-member-and-pending-invite",
+            requireText: ["Member", "Pending", "INVITED", "Admin"],
+            rejectText: ["Something went wrong"],
+          },
+        });
         });
       },
     },
     {
       name: "Frame 4 — Rashmi signs in again and the app reconciles",
       run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
         await ctx.prove("The next sign-in merges the active member with the invite and deletes the invited ghost", {
           voiceover: vo[3],
           action: async () => {
             const signedIn = await signInEmail(ctx, state.reconcileEmail);
             state.reconciledToken = signedIn.body.token;
             state.reconciledMe = await loadMe(ctx, state.reconciledToken, "Reconciled Rashmi");
+            await openMembersPage(ctx);
           },
           assert: async () => {
             const org = await loadOrg(ctx);
@@ -428,7 +691,14 @@ export default {
               },
               org: summarizeOrg(org, [state.reconcileEmail]),
             }, null, 2));
+            await assertReconciledUi(ctx, state.reconcileEmail);
           },
+          screenshot: {
+            name: "rashmi-reconciled-single-admin-row",
+            requireText: ["Admin"],
+            rejectText: ["Something went wrong"],
+          },
+        });
         });
       },
     },

--- a/evals/runner/den-stack.mjs
+++ b/evals/runner/den-stack.mjs
@@ -267,13 +267,17 @@ async function ensureApp(log, cdpCandidates) {
   throw new Error("Dev Electron CDP did not come up within 3 minutes.");
 }
 
-export async function ensureDenStack({ log, cdpCandidates }) {
+export async function ensureDenStack({ log, cdpCandidates, skipApp = false }) {
   await mkdir(STATE_DIR, { recursive: true });
   await ensureMysql(log);
   await ensureSchema(log);
   await ensureDenApi(log);
   await ensureSeed(log);
-  await ensureApp(log, cdpCandidates);
+  if (skipApp) {
+    log("Skipping dev Electron startup — selected eval flow is app-less");
+  } else {
+    await ensureApp(log, cdpCandidates);
+  }
 
   const token = await signInDemoOwner();
   if (!token) throw new Error("Could not obtain a demo-owner session token.");

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -18,7 +18,7 @@
  * http://127.0.0.1:9823 (local pnpm dev). Override with --cdp-url or
  * OPENWORK_EVAL_CDP_URL.
  */
-import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { connect, debuggerUrlFor, pickAppTarget, resolveCdpBaseUrl } from "./cdp.mjs";
@@ -75,6 +75,20 @@ async function loadFlows() {
     flows.push({ ...flow, file: entry });
   }
   return flows;
+}
+
+async function selectedStackNeedsApp(args) {
+  if (args.list) return false;
+  if (args.all || args.flows.length === 0) return true;
+  for (const flowId of args.flows) {
+    try {
+      const source = await readFile(join(FLOWS_DIR, `${flowId}.flow.mjs`), "utf8");
+      if (!/requiresApp\s*:\s*false/.test(source)) return true;
+    } catch {
+      return true;
+    }
+  }
+  return false;
 }
 
 function missingEnv(flow, env) {
@@ -431,6 +445,7 @@ async function main() {
     await ensureDenStack({
       log: (msg) => console.log(`▸ ${msg}`),
       cdpCandidates: args.cdpUrl ? [args.cdpUrl] : DEFAULT_CDP_CANDIDATES,
+      skipApp: !(await selectedStackNeedsApp(args)),
     });
   } else if (args.stack) {
     throw new Error(`Unknown stack: ${args.stack}. Supported: den`);

--- a/evals/voiceovers/invite-adoption-no-duplicates.md
+++ b/evals/voiceovers/invite-adoption-no-duplicates.md
@@ -1,0 +1,11 @@
+# invite-adoption-no-duplicates — Invites become one member, never a duplicate
+
+This internal proof follows the Den API outputs for a tagged Rashmi invite. The reviewer sees the invite, the sign-in boundary for the stack's org mode, the duplicate state that used to strand customers, and the final reconciled membership.
+
+1. The first output shows the admin's invite for Rashmi as an admin. The workspace listing now has a pending invitation and an invited placeholder for the same email, both carrying the admin role.
+
+2. The next output shows Rashmi's account creation and first sign-in, then names the org mode the local stack is running. In single-org mode the first sign-in already becomes the headline proof: one active Rashmi member with role admin, the invite accepted, and no invited ghost; in multi-org mode Rashmi is still outside the workspace and the admin invite remains pending.
+
+3. The third output recreates the customer-reported bad state. A signed-up Rashmi has an active workspace membership with the wrong member role while the admin invitation is still pending beside the invited placeholder.
+
+4. The final output is the repair after the next sign-in. The listing has exactly one Rashmi member, the role is admin, the invitation is accepted, and the invited placeholder is gone.

--- a/evals/voiceovers/invite-adoption-no-duplicates.md
+++ b/evals/voiceovers/invite-adoption-no-duplicates.md
@@ -1,11 +1,11 @@
 # invite-adoption-no-duplicates — Invites become one member, never a duplicate
 
-This internal proof follows the Den API outputs for a tagged Rashmi invite. The reviewer sees the invite, the sign-in boundary for the stack's org mode, the duplicate state that used to strand customers, and the final reconciled membership.
+This internal proof follows the Den API outputs and the den-web Members page for a tagged Rashmi invite. The reviewer sees the same table states an admin would see: pending invite, duplicate bug shape, and the final clean row.
 
-1. The first output shows the admin's invite for Rashmi as an admin. The workspace listing now has a pending invitation and an invited placeholder for the same email, both carrying the admin role.
+1. The first frame shows Alex's Members page after inviting Rashmi as an admin. Rashmi is visible as a pending invite, and the API output beside the screenshot confirms the invitation and invited placeholder both carry the admin role.
 
-2. The next output shows Rashmi's account creation and first sign-in, then names the org mode the local stack is running. In single-org mode the first sign-in already becomes the headline proof: one active Rashmi member with role admin, the invite accepted, and no invited ghost; in multi-org mode Rashmi is still outside the workspace and the admin invite remains pending.
+2. The next frame shows Rashmi's account creation and first sign-in, then names the org mode the local stack is running. In single-org mode the first sign-in already becomes the headline proof: one active Rashmi member with role admin, the invite accepted, and no invited ghost; in multi-org mode Rashmi is still outside the workspace and the admin invite remains pending.
 
-3. The third output recreates the customer-reported bad state. A signed-up Rashmi has an active workspace membership with the wrong member role while the admin invitation is still pending beside the invited placeholder.
+3. The third frame is the customer-reported bad state on the Members page. One Rashmi row is an active member with the wrong member role, while the pending invited admin row is still visible beside it.
 
-4. The final output is the repair after the next sign-in. The listing has exactly one Rashmi member, the role is admin, the invitation is accepted, and the invited placeholder is gone.
+4. The final frame is the repaired Members page after Rashmi signs in again. The duplicate is gone: there is one Rashmi row, the role is admin, and the API output confirms the invitation is accepted with no invited placeholder left behind.


### PR DESCRIPTION
## Problem (White Lotus POC tracker #3 — "Duplicates in Member")
Admin invites a user by email with a role (e.g. admin). The invitee signs up but membership gets created through an invitation-unaware path. Result: the admin sees BOTH the pending "invited" placeholder AND a separate active member for the same person, and the invited role is dropped to `member`.

## Root cause
- Single-org auto-join (`ensureSingletonOrganizationForUser` → `insertMemberIfMissing`, fired on every session create and `/v1/me/orgs`) inserts a fresh member row ignoring pending invitations; `resolveSingleOrgMembershipRole` hardcodes `member` once an owner exists.
- `@better-auth/sso` JIT provisioning creates member rows via the **raw adapter** (`ctx.context.adapter.create`), bypassing databaseHooks entirely — also invitation-unaware.
- `acceptInvitation` never merged an existing member row with the invitation placeholder, so the ghost "invited" record persisted forever.

## Fix
- Bootstrap insert path now adopts a matching pending, non-expired, **same-org** invitation (case-insensitive email): placeholder adopted, invited role applied, invitation marked accepted — instead of inserting a duplicate row.
- `acceptInvitation` merge case: existing member + placeholder → invitation role applied (an existing **owner is never downgraded**), placeholder deleted, invitation accepted.
- New `reconcilePendingInvitationsForUser(userId)` wired into the existing `session.create.before` hook — the one chokepoint that fires for **every** sign-in method incl. SSO, and runs after JIT creates the raw member row. Failure-isolated (catch + log): can never block sign-in.
- Deliberately NOT changed: the explicit accept endpoint's email-verification gate; no cross-org auto-join introduced (comment documents the boundary per `organization-join-verification.ts`).

## Tests (ran, all pass)
```
pnpm --filter @openwork-ee/den-api exec bun test \
  test/invite-duplicate-members.test.ts test/single-org-mode.test.ts \
  test/sso-jit.test.ts test/organization-join-verification.test.ts \
  test/org-invitations.test.ts        # 24 pass / 0 fail
pnpm --filter @openwork-ee/den-api build          # pass
pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json  # pass
```
New coverage includes an SSO JIT simulation: raw member row (role `member`) + pending admin invitation + placeholder → reconcile → exactly one member row, role admin, invitation accepted, ghost gone.

## Validation status
**Fraimz posted:** https://github.com/different-ai/openwork/pull/2548#issuecomment-4910240715 — frame proof with den-web Members page screenshots against a real den-api + MySQL stack (single_org): invite → sign-up boundary → simulated SSO JIT duplicate → sign-in reconcile (one member, role admin, invitation accepted, ghost gone). Reviewer repro: invite email X as admin → sign up as X without completing accept → open dashboard. Before: two records + wrong role. After: one member, invited role, invitation accepted.

