### PR TITLE
fix(server): surface dropped MCP components and hot-sync engine on cloud plugin install

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -246,6 +246,7 @@ export type OpenworkDesktopCloudSyncResult = {
 
 export type OpenworkCloudPluginInstallResult = {
   item: CloudImportedPlugin;
+  warnings: string[];
 };
 
 export type OpenworkCloudPluginsResult = {

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -45,7 +45,7 @@ import {
   type OpenMarketplacePluginDetail,
 } from "@/react-app/shell/notifications";
 
-type AsyncResult = { ok: boolean; message: string };
+type AsyncResult = { ok: boolean; message: string; warnings?: string[] };
 type MarketplacePackageStatus = "available" | "installed" | "update_available";
 type MarketplaceStatusFilter = "all" | MarketplacePackageStatus;
 type CloudMarketplacesSession = Pick<
@@ -442,7 +442,8 @@ export function CloudMarketplacesView({
       try {
         const result = await extensions.importCloudOrgPlugin(marketplaceId, plugin);
         if (!result.ok) throw new Error(result.message);
-        toast.success(result.message);
+        if (result.warnings?.length) toast.warning(result.message);
+        else toast.success(result.message);
         setDetailRow(null);
       } catch (error) {
         setActionError(error instanceof Error ? error.message : `Failed to add ${plugin.name}.`);
@@ -490,16 +491,20 @@ export function CloudMarketplacesView({
     setActionError(null);
     const targets = [...updatableRows];
     let failed = 0;
+    const warnings: string[] = [];
     // Sequential on purpose: avoid hammering the install routes.
     for (let index = 0; index < targets.length; index += 1) {
       const target = targets[index];
       setUpdateAllProgress({ current: index + 1, total: targets.length });
       const result = await extensions.importCloudOrgPlugin(target.marketplaceId, target.plugin);
       if (!result.ok) failed += 1;
+      else warnings.push(...(result.warnings ?? []));
     }
     setUpdateAllProgress(null);
     if (failed > 0) {
       setActionError(`Failed to update ${failed} extension${failed === 1 ? "" : "s"}.`);
+    } else if (warnings.length > 0) {
+      toast.warning(`Updated ${targets.length} extension${targets.length === 1 ? "" : "s"}. ${warnings.join(" ")}`);
     } else if (targets.length > 0) {
       toast.success(`Updated ${targets.length} extension${targets.length === 1 ? "" : "s"}.`);
     }

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -1050,6 +1050,17 @@ export function createExtensionsStore(options: {
     return [...configs.values()];
   };
 
+  const mcpNoConfigWarning = (title: string) =>
+    `MCP component "${title}" could not be installed: no server config with a "url" or "command" was found.`;
+
+  const mcpInactiveWarning = (title: string) =>
+    `MCP component "${title}" could not be installed because it is not active.`;
+
+  const cloudPluginImportMessage = (pluginName: string, fileCount: number, warnings: string[]) => {
+    const message = `Imported ${pluginName} with ${fileCount} file${fileCount === 1 ? "" : "s"}.`;
+    return warnings.length > 0 ? `${message} ${warnings.join(" ")}` : message;
+  };
+
   const upsertPluginMcpConfig = async (name: string, config: Record<string, unknown>) => {
     const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
@@ -1139,18 +1150,24 @@ export function createExtensionsStore(options: {
   const applyCloudOrgPluginImport = async (
     marketplaceId: string | null,
     resolved: DenOrgPluginResolved,
-  ): Promise<CloudImportedPluginFile[]> => {
+  ): Promise<{ files: CloudImportedPluginFile[]; warnings: string[] }> => {
     const files: CloudImportedPluginFile[] = [];
+    const warnings: string[] = [];
     const existing = snapshot.importedCloudPlugins[resolved.plugin.id];
     const namespace = pluginNamespace(resolved.plugin.name, resolved.plugin.id);
 
     for (const membership of resolved.memberships) {
       const object = membership.configObject;
       const version = object?.latestVersion ?? null;
-      if (!object || object.status !== "active") continue;
+      if (!object) continue;
+      if (object.status !== "active") {
+        if (object.objectType === "mcp") warnings.push(mcpInactiveWarning(object.title));
+        continue;
+      }
 
       if (object.objectType === "mcp") {
         const configs = pluginMcpConfigsFromPayload(object, namespace);
+        if (configs.length === 0) warnings.push(mcpNoConfigWarning(object.title));
         for (const config of configs) {
           await upsertPluginMcpConfig(config.name, config.config);
           files.push({
@@ -1245,7 +1262,7 @@ export function createExtensionsStore(options: {
       });
     }
 
-    return files;
+    return { files, warnings };
   };
 
   const persistHubRepos = () => {
@@ -1567,7 +1584,7 @@ export function createExtensionsStore(options: {
   async function importCloudOrgPlugin(
     marketplaceId: string | null,
     plugin: DenOrgPlugin,
-  ): Promise<{ ok: boolean; message: string; files: CloudImportedPluginFile[] }> {
+  ): Promise<{ ok: boolean; message: string; warnings: string[]; files: CloudImportedPluginFile[] }> {
     options.setBusy(true);
     options.setError(null);
     setStateField("cloudOrgMarketplacesStatus", null);
@@ -1592,22 +1609,24 @@ export function createExtensionsStore(options: {
         void refreshPendingCloudPluginChanges();
         return {
           ok: true,
-          message: `Imported ${plugin.name} with ${result.item.files.length} file${result.item.files.length === 1 ? "" : "s"}.`,
+          message: cloudPluginImportMessage(plugin.name, result.item.files.length, result.warnings),
+          warnings: result.warnings,
           files: result.item.files,
         };
       }
-      const files = await applyCloudOrgPluginImport(marketplaceId, resolved);
+      const result = await applyCloudOrgPluginImport(marketplaceId, resolved);
       await refreshSkills({ force: true });
       await refreshCloudOrgMarketplaces({ force: true });
       return {
         ok: true,
-        message: `Imported ${plugin.name} with ${files.length} file${files.length === 1 ? "" : "s"}.`,
-        files,
+        message: cloudPluginImportMessage(plugin.name, result.files.length, result.warnings),
+        warnings: result.warnings,
+        files: result.files,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : t("skills.unknown_error");
       options.setError(addOpencodeCacheHint(message));
-      return { ok: false, message, files: [] };
+      return { ok: false, message, warnings: [], files: [] };
     } finally {
       options.setBusy(false);
     }

--- a/apps/server/src/cloud-plugins.test.ts
+++ b/apps/server/src/cloud-plugins.test.ts
@@ -48,7 +48,7 @@ async function expectMissing(path: string): Promise<void> {
 describe("cloud plugin installs", () => {
   test("stores installed plugin state in the server DB and projects runtime resources", async () => {
     await withWorkspace(async ({ root, config }) => {
-      const imported = await installCloudPlugin({
+      const result = await installCloudPlugin({
         serverConfig: config,
         workspaceId: WORKSPACE_ID,
         workspaceRoot: root,
@@ -99,8 +99,10 @@ describe("cloud plugin installs", () => {
           ],
         },
       });
+      const imported = result.item;
 
       expect(imported.pluginId).toBe("plugin_1");
+      expect(result.warnings).toEqual([]);
       expect(imported.files.map((file) => file.objectType).sort()).toEqual(["mcp", "skill"]);
 
       const installed = await readInstalledCloudPlugins(config, WORKSPACE_ID);
@@ -143,7 +145,7 @@ describe("cloud plugin installs", () => {
         "Summarize commits since the last tag.",
       ].join("\n");
 
-      const imported = await installCloudPlugin({
+      const result = await installCloudPlugin({
         serverConfig: config,
         workspaceId: WORKSPACE_ID,
         workspaceRoot: root,
@@ -198,6 +200,7 @@ describe("cloud plugin installs", () => {
           ],
         },
       });
+      const imported = result.item;
 
       const agentPath = join(root, ".opencode", "agents", "review-plugin", "fancy-code-reviewer.md");
       const commandPath = join(root, ".opencode", "commands", "review-plugin", "release-notes.md");
@@ -207,6 +210,7 @@ describe("cloud plugin installs", () => {
         ".opencode/commands/review-plugin/release-notes.md",
         ".opencode/context/review-plugin/style-guide.md",
       ]);
+      expect(result.warnings).toEqual([]);
 
       const agentContent = await readFile(agentPath, "utf8");
       expect(agentContent).toContain("description: Reviews pull requests");
@@ -247,7 +251,7 @@ describe("cloud plugin installs", () => {
         "Triage issues.",
       ].join("\n");
 
-      await installCloudPlugin({
+      const result = await installCloudPlugin({
         serverConfig: config,
         workspaceId: WORKSPACE_ID,
         workspaceRoot: root,
@@ -271,6 +275,7 @@ describe("cloud plugin installs", () => {
           ],
         },
       });
+      expect(result.warnings).toEqual([]);
 
       const agentPath = join(root, ".opencode", "agents", "triage-plugin", "triage.md");
       const agentContent = await readFile(agentPath, "utf8");

--- a/apps/server/src/cloud-plugins.ts
+++ b/apps/server/src/cloud-plugins.ts
@@ -66,6 +66,11 @@ export type CloudImportedPlugin = {
   importedAt: number | null;
 };
 
+export type CloudPluginInstallResult = {
+  item: CloudImportedPlugin;
+  warnings: string[];
+};
+
 type WorkspaceCloudImports = {
   skills: Record<string, unknown>;
   providers: Record<string, unknown>;
@@ -419,6 +424,14 @@ function pluginMcpConfigsFromPayload(object: CloudPluginConfigObject, namespace:
   return [...configs.values()];
 }
 
+function mcpNoConfigWarning(title: string): string {
+  return `MCP component "${title}" could not be installed: no server config with a "url" or "command" was found.`;
+}
+
+function mcpInactiveWarning(title: string): string {
+  return `MCP component "${title}" could not be installed because it is not active.`;
+}
+
 function readCloudImports(config: Record<string, unknown>): WorkspaceCloudImports {
   const root = isRecord(config.cloudImports) ? config.cloudImports : {};
   const marketplaces = isRecord(root.marketplaces) ? Object.fromEntries(Object.entries(root.marketplaces).flatMap(([key, value]) => {
@@ -600,19 +613,25 @@ export async function installCloudPlugin(input: {
   marketplaceId: string | null;
   marketplace?: { id: string; name: string; updatedAt: string | null } | null;
   resolved: CloudPluginResolved;
-}): Promise<CloudImportedPlugin> {
+}): Promise<CloudPluginInstallResult> {
   const namespace = pluginNamespace(input.resolved.plugin.name, input.resolved.plugin.id);
   const cloudImports = await readInstalledCloudPlugins(input.serverConfig, input.workspaceId);
   const existing = cloudImports.plugins[input.resolved.plugin.id];
   const files: CloudImportedPluginFile[] = [];
+  const warnings: string[] = [];
 
   for (const membership of input.resolved.memberships) {
     const object = membership.configObject;
     const version = object?.latestVersion ?? null;
-    if (!object || object.status !== "active") continue;
+    if (!object) continue;
+    if (object.status !== "active") {
+      if (object.objectType === "mcp") warnings.push(mcpInactiveWarning(object.title));
+      continue;
+    }
 
     if (object.objectType === "mcp") {
       const configs = pluginMcpConfigsFromPayload(object, namespace);
+      if (configs.length === 0) warnings.push(mcpNoConfigWarning(object.title));
       for (const config of configs) {
         await addMcp(input.serverConfig, input.workspaceId, config.name, config.config);
         files.push({
@@ -697,7 +716,7 @@ export async function installCloudPlugin(input: {
     plugins: nextPlugins,
   }));
 
-  return imported;
+  return { item: imported, warnings };
 }
 
 export async function removeCloudPlugin(input: {

--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { startServer, syncAllWorkspacesRuntimeMcpToEngine } from "./server.js";
-import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
 type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
@@ -87,11 +87,20 @@ async function startOpenworkServer(workspaceRoot: string, opencodeBaseUrl: strin
   };
   const server = await startServer(config) as Served;
   stops.push(() => server.stop(true));
-  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token, config };
 }
 
 function auth(token: string) {
   return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (isRecord(value)) return value;
+  throw new Error(`${label} was not an object`);
 }
 
 const POSTHOG_CONFIG = {
@@ -121,6 +130,153 @@ describe("runtime MCP engine sync", () => {
       expect(addRequest).toBeDefined();
       expect(addRequest?.body).toEqual({ name: "posthog", config: POSTHOG_CONFIG });
       expect(addRequest?.search).toContain(`directory=${encodeURIComponent(workspaceRoot)}`);
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("cloud plugin install writes a remote MCP and hot-syncs it into the engine", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    try {
+      const mock = startMockOpencode();
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+
+      const response = await fetch(`${openwork.base}/workspace/ws_1/cloud-plugins`, {
+        method: "POST",
+        headers: auth(openwork.token),
+        body: JSON.stringify({
+          marketplaceId: null,
+          resolved: {
+            plugin: {
+              id: "plugin_cloud_mcp",
+              name: "Cloud MCP Plugin",
+              description: null,
+              updatedAt: "2026-06-02T00:00:00.000Z",
+            },
+            memberships: [
+              {
+                configObjectId: "config_mcp_valid",
+                configObject: {
+                  id: "config_mcp_valid",
+                  objectType: "mcp",
+                  title: "Brief MCP",
+                  description: null,
+                  currentRelativePath: null,
+                  status: "active",
+                  updatedAt: "2026-06-02T00:00:00.000Z",
+                  latestVersion: {
+                    id: "version_mcp_valid",
+                    rawSourceText: JSON.stringify({ mcpServers: { brief: { url: "https://example.com/mcp" } } }),
+                    normalizedPayloadJson: { mcpServers: { brief: { url: "https://example.com/mcp" } } },
+                  },
+                },
+              },
+            ],
+          },
+        }),
+      });
+      expect(response.status).toBe(200);
+      const parsed: unknown = await response.json();
+      const body = requireRecord(parsed, "cloud plugin install response");
+      const item = requireRecord(body.item, "cloud plugin install item");
+      expect(item.pluginId).toBe("plugin_cloud_mcp");
+      expect(body.warnings).toEqual([]);
+
+      expect((await readRuntimeOpencodeConfig(openwork.config, "ws_1")).mcp?.brief).toMatchObject({
+        type: "remote",
+        url: "https://example.com/mcp",
+      });
+      const addRequest = mock.requests.find((entry) => entry.method === "POST" && entry.pathname === "/mcp");
+      expect(addRequest).toBeDefined();
+      expect(addRequest?.body).toEqual({
+        name: "brief",
+        config: { type: "remote", url: "https://example.com/mcp", enabled: true },
+      });
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("cloud plugin install warns for dropped MCP payloads while still installing skills", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    try {
+      const mock = startMockOpencode();
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+
+      const response = await fetch(`${openwork.base}/workspace/ws_1/cloud-plugins`, {
+        method: "POST",
+        headers: auth(openwork.token),
+        body: JSON.stringify({
+          marketplaceId: null,
+          resolved: {
+            plugin: {
+              id: "plugin_broken_mcp",
+              name: "Broken Plugin",
+              description: null,
+              updatedAt: "2026-06-02T00:00:00.000Z",
+            },
+            memberships: [
+              {
+                configObjectId: "config_skill_broken",
+                configObject: {
+                  id: "config_skill_broken",
+                  objectType: "skill",
+                  title: "Helpful Skill",
+                  description: "Skill still installs",
+                  currentRelativePath: null,
+                  status: "active",
+                  updatedAt: "2026-06-02T00:00:00.000Z",
+                  latestVersion: {
+                    id: "version_skill_broken",
+                    rawSourceText: "# Helpful Skill\n\nInstalled skill body.",
+                    normalizedPayloadJson: null,
+                  },
+                },
+              },
+              {
+                configObjectId: "config_mcp_broken",
+                configObject: {
+                  id: "config_mcp_broken",
+                  objectType: "mcp",
+                  title: "Broken MCP",
+                  description: null,
+                  currentRelativePath: null,
+                  status: "active",
+                  updatedAt: "2026-06-02T00:00:00.000Z",
+                  latestVersion: {
+                    id: "version_mcp_broken",
+                    rawSourceText: JSON.stringify({
+                      mcpServers: { broken: { type: "sse", serverUrl: "https://x.example/mcp" } },
+                    }),
+                    normalizedPayloadJson: {
+                      mcpServers: { broken: { type: "sse", serverUrl: "https://x.example/mcp" } },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        }),
+      });
+      expect(response.status).toBe(200);
+      const parsed: unknown = await response.json();
+      const body = requireRecord(parsed, "cloud plugin install response");
+      const item = requireRecord(body.item, "cloud plugin install item");
+      expect(item.pluginId).toBe("plugin_broken_mcp");
+      expect(body.warnings).toEqual([
+        'MCP component "Broken MCP" could not be installed: no server config with a "url" or "command" was found.',
+      ]);
+
+      const skillPath = join(workspaceRoot, ".opencode", "skills", "broken-plugin", "helpful-skill", "SKILL.md");
+      expect(await readFile(skillPath, "utf8")).toContain("Installed skill body.");
+      expect((await readRuntimeOpencodeConfig(openwork.config, "ws_1")).mcp?.broken).toBeUndefined();
+      expect(mock.requests.some((entry) => entry.method === "POST" && entry.pathname === "/mcp")).toBe(false);
     } finally {
       if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
       else process.env.OPENWORK_RUNTIME_DB = previousDb;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1437,7 +1437,7 @@ function createRoutes(
       paths: [openworkConfigPath(workspace.path), join(workspace.path, ".opencode")],
     });
 
-    const imported = await installCloudPlugin({
+    const result = await installCloudPlugin({
       serverConfig: config,
       workspaceId: workspace.id,
       workspaceRoot: workspace.path,
@@ -1451,6 +1451,7 @@ function createRoutes(
         : null,
       resolved,
     });
+    const imported = result.item;
 
     await recordAudit(workspace.path, {
       id: shortId(),
@@ -1470,7 +1471,10 @@ function createRoutes(
       });
     }
 
-    return jsonResponse({ item: imported });
+    // Hot-register any bundled MCP servers with the running engine.
+    await syncRuntimeMcpToOpencodeEngine(config, workspace).catch(() => undefined);
+
+    return jsonResponse({ item: imported, warnings: result.warnings });
   });
 
   // Claude Code plugin bundles (MCP + skills + commands + agents) installed
@@ -1499,13 +1503,14 @@ function createRoutes(
       paths: [openworkConfigPath(workspace.path), join(workspace.path, ".opencode")],
     });
 
-    const imported = await installCloudPlugin({
+    const result = await installCloudPlugin({
       serverConfig: config,
       workspaceId: workspace.id,
       workspaceRoot: workspace.path,
       marketplaceId: null,
       resolved: bundle.resolved,
     });
+    const imported = result.item;
 
     await recordAudit(workspace.path, {
       id: shortId(),
@@ -1528,7 +1533,7 @@ function createRoutes(
     // Hot-register any bundled MCP servers with the running engine.
     await syncRuntimeMcpToOpencodeEngine(config, workspace).catch(() => undefined);
 
-    return jsonResponse({ item: imported, preview: bundle.preview });
+    return jsonResponse({ item: imported, preview: bundle.preview, warnings: result.warnings });
   });
 
   addRoute(routes, "DELETE", "/workspace/:id/cloud-plugins/:pluginId", "client", async (ctx) => {
@@ -1569,7 +1574,7 @@ function createRoutes(
       });
     }
 
-    return jsonResponse({ item: removed });
+    return jsonResponse({ item: removed, warnings: [] });
   });
 
   addRoute(routes, "GET", "/workspace/:id/authorized-folders", "client", async (ctx) => {

--- a/evals/flows/cloud-plugin-mcp-warning.flow.mjs
+++ b/evals/flows/cloud-plugin-mcp-warning.flow.mjs
@@ -1,0 +1,545 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "cloud-plugin-mcp-warning";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const RUN_TAG = Date.now().toString(36);
+const MARKETPLACE_NAME = `MCP warning proof ${RUN_TAG}`;
+const BROKEN_PLUGIN_NAME = `Broken MCP Bundle ${RUN_TAG}`;
+const VALID_PLUGIN_NAME = `Valid MCP Bundle ${RUN_TAG}`;
+const BROKEN_SKILL_TITLE = `Broken bundle skill ${RUN_TAG}`;
+const VALID_SKILL_TITLE = `Valid bundle skill ${RUN_TAG}`;
+const BROKEN_SKILL_NAME = slugify(BROKEN_SKILL_TITLE);
+const VALID_WARNING = 'MCP component "Broken MCP" could not be installed: no server config with a "url" or "command" was found.';
+
+const state = {
+  marketplaceId: "",
+  brokenPluginId: "",
+  validPluginId: "",
+  workspacePath: "",
+};
+
+function slugify(value) {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "skill";
+}
+
+function baseWorkspacePath(ctx) {
+  return ctx.env.OPENWORK_EVAL_WORKSPACE_PATH.trim().replace(/\/+$/, "");
+}
+
+async function denJson(ctx, path, options = {}) {
+  const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+  const response = await fetch(`${apiBase}${path}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  ctx.assert(
+    response.ok,
+    `${options.method ?? "GET"} ${path} failed: ${response.status} ${typeof body === "string" ? body : JSON.stringify(body)}`,
+  );
+  return body;
+}
+
+async function createMarketplace(ctx) {
+  const body = await denJson(ctx, "/v1/marketplaces", {
+    method: "POST",
+    body: JSON.stringify({
+      name: MARKETPLACE_NAME,
+      description: "Eval-only marketplace for cloud plugin MCP warning proof.",
+    }),
+  });
+  ctx.assert(typeof body.item?.id === "string", "Marketplace create response was missing item.id.");
+  state.marketplaceId = body.item.id;
+}
+
+function skillSource(title, purpose) {
+  return `# ${title}\n\nUse this eval-only skill to verify that ${purpose}.`;
+}
+
+async function createPlugin(ctx, input) {
+  const body = await denJson(ctx, "/v1/plugins", {
+    method: "POST",
+    body: JSON.stringify({
+      name: input.name,
+      description: input.description,
+      orgWide: true,
+      marketplaceId: state.marketplaceId,
+      components: [
+        {
+          type: "skill",
+          input: {
+            rawSourceText: skillSource(input.skillTitle, input.skillPurpose),
+            metadata: {
+              name: input.skillTitle,
+              description: input.skillDescription,
+            },
+          },
+        },
+        {
+          type: "mcp",
+          input: {
+            normalizedPayloadJson: input.mcpPayload,
+            metadata: {
+              name: input.mcpTitle,
+              description: input.mcpDescription,
+            },
+          },
+        },
+      ],
+    }),
+  });
+  ctx.assert(typeof body.item?.id === "string", `Plugin create response for ${input.name} was missing item.id.`);
+  return body.item.id;
+}
+
+async function setupCloudPlugins(ctx) {
+  await createMarketplace(ctx);
+  state.brokenPluginId = await createPlugin(ctx, {
+    name: BROKEN_PLUGIN_NAME,
+    description: "A skill plus an intentionally malformed MCP payload.",
+    skillTitle: BROKEN_SKILL_TITLE,
+    skillDescription: "Installed even when the bundled MCP is malformed.",
+    skillPurpose: "a skill survives a malformed bundled MCP component",
+    mcpTitle: "Broken MCP",
+    mcpDescription: "Uses serverUrl instead of url so it should warn and skip MCP install.",
+    mcpPayload: {
+      mcpServers: {
+        broken: { type: "sse", serverUrl: "https://x.example/mcp" },
+      },
+    },
+  });
+  state.validPluginId = await createPlugin(ctx, {
+    name: VALID_PLUGIN_NAME,
+    description: "A skill plus a valid remote Linear MCP server.",
+    skillTitle: VALID_SKILL_TITLE,
+    skillDescription: "Installed with the valid Linear MCP bundle.",
+    skillPurpose: "a valid bundled remote MCP is installed and synced",
+    mcpTitle: "Linear MCP",
+    mcpDescription: "Valid remote Linear MCP server.",
+    mcpPayload: {
+      mcpServers: {
+        linear: { type: "remote", url: "https://mcp.linear.app/sse" },
+      },
+    },
+  });
+  ctx.log(`Created marketplace ${state.marketplaceId} with plugins ${state.brokenPluginId}, ${state.validPluginId}.`);
+}
+
+async function signInViaHandoff(ctx) {
+  const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+  const response = await fetch(`${apiBase}/v1/auth/desktop-handoff`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({}),
+  });
+  const payload = await response.json();
+  ctx.assert(response.ok && typeof payload.grant === "string", `Handoff create failed: ${response.status}`);
+  await ctx.control("auth.exchange-grant", { grant: payload.grant, baseUrl: apiBase });
+  await ctx.waitFor(
+    "window.__openworkControl.execute('auth.status').then(r => r.result?.status === 'signed_in')",
+    { timeoutMs: 30_000, label: "auth signed_in" },
+  );
+  await ctx.waitFor(
+    "Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())",
+    { timeoutMs: 60_000, label: "active org resolved" },
+  );
+}
+
+async function clickOptional(ctx, text, options = {}) {
+  await ctx.clickText(text, options).catch(() => {});
+}
+
+async function handleOnboarding(ctx) {
+  await clickOptional(ctx, "Continue with organization", { timeoutMs: 5_000 });
+  await clickOptional(ctx, "Continue to workspace", { timeoutMs: 5_000 });
+}
+
+async function useWelcomeFolder(ctx) {
+  await ctx.navigateHash("/welcome");
+  await ensureRenderedApp(ctx);
+  await ctx.waitForText("Use this folder", { timeoutMs: 20_000 });
+  await ctx.fill("input", state.workspacePath);
+  await ctx.waitFor(
+    `(() => [...document.querySelectorAll("button")].some((button) => (button.textContent ?? "").includes("Use this folder") && !button.disabled))()`,
+    { timeoutMs: 10_000, label: "welcome folder button enabled" },
+  );
+  await ctx.clickText("Use this folder", { timeoutMs: 10_000 });
+  await ctx.waitFor("location.hash.includes('/workspace/')", {
+    timeoutMs: 45_000,
+    label: "workspace route after welcome folder selection",
+  });
+}
+
+async function waitForNewWorkspaceRoute(ctx, previousWorkspaceId, label) {
+  await ctx.waitFor(
+    `(() => {
+      const workspaceId = (location.hash.match(/\\/workspace\\/([^/]+)/) || [])[1] || "";
+      return workspaceId && workspaceId !== ${JSON.stringify(previousWorkspaceId)};
+    })()`,
+    { timeoutMs: 60_000, label },
+  );
+}
+
+async function createFreshWorkspace(ctx) {
+  state.workspacePath = join(baseWorkspacePath(ctx), `${FLOW_ID}-${RUN_TAG}`);
+  await mkdir(state.workspacePath, { recursive: true });
+  await handleOnboarding(ctx);
+
+  const hasActiveWorkspace = await ctx.eval(
+    "location.hash.includes('/workspace/') || Boolean(localStorage.getItem('openwork.react.activeWorkspace'))",
+  );
+  if (!hasActiveWorkspace) {
+    await useWelcomeFolder(ctx);
+    return;
+  }
+
+  const onWelcome = await ctx.eval("location.hash.includes('/welcome')");
+  if (onWelcome) {
+    await useWelcomeFolder(ctx);
+    return;
+  }
+
+  const previousWorkspaceId = await activeWorkspaceId(ctx);
+  await ctx.navigateHash(`/workspace/${previousWorkspaceId}/session`);
+  await ctx.waitFor(
+    `location.hash.includes(${JSON.stringify(`/workspace/${previousWorkspaceId}/session`)})`,
+    { timeoutMs: 20_000, label: "current workspace session route" },
+  );
+  await ensureRenderedApp(ctx);
+  await ctx.waitFor(
+    "Boolean(window.__openworkControl?.listActions().find(a => a.id === 'workspace.create'))",
+    { timeoutMs: 20_000, label: "workspace.create control action on session route" },
+  );
+  await ctx.control("workspace.create", {
+    path: state.workspacePath,
+    projectLabel: "Cloud plugin MCP warning proof",
+  });
+  await waitForNewWorkspaceRoute(ctx, previousWorkspaceId, "workspace route after session workspace.create");
+}
+
+async function waitForWorkspaceReady(ctx) {
+  await ctx.waitFor(
+    "document.body.innerText.includes('Ready for new tasks') || document.body.innerText.includes('Run task') || location.hash.includes('/settings/')",
+    { timeoutMs: 60_000, label: "workspace shell ready" },
+  );
+}
+
+async function activeWorkspaceId(ctx) {
+  const workspaceId = await ctx.eval(
+    "(location.hash.match(/\\/workspace\\/([^/]+)/) || [])[1] || localStorage.getItem('openwork.react.activeWorkspace') || ''",
+  );
+  ctx.assert(typeof workspaceId === "string" && workspaceId.trim().length > 0, "No active workspace id for settings route.");
+  return workspaceId.trim();
+}
+
+async function openWorkspaceSettings(ctx, panel) {
+  const workspaceId = await activeWorkspaceId(ctx);
+  const hashPath = `/workspace/${workspaceId}/settings/${panel}`;
+  await ctx.navigateHash(hashPath);
+  await ctx.waitFor(
+    `location.hash.includes(${JSON.stringify(hashPath)})`,
+    { timeoutMs: 20_000, label: `workspace settings ${panel}` },
+  );
+  await ensureRenderedApp(ctx);
+}
+
+async function ensureRenderedApp(ctx) {
+  const ready = await ctx.waitFor(
+    "Boolean(window.__openworkControl) && document.body.innerText.trim().length > 20",
+    { timeoutMs: 8_000, label: "rendered app shell" },
+  ).then(() => true).catch(() => false);
+  if (ready) return;
+  await ctx.eval("location.reload()");
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API after app reload",
+  });
+  await ctx.waitFor("document.body.innerText.trim().length > 20", {
+    timeoutMs: 30_000,
+    label: "body rendered after app reload",
+  });
+}
+
+async function useMarketplaceImportMode(ctx) {
+  await ctx.waitFor(
+    `(() => {
+      const bridge = window.__openworkApplyDesktopConfig;
+      if (typeof bridge !== "function") return false;
+      bridge({ connectEnabled: false });
+      return document.body.innerText.includes("Extension Marketplace");
+    })()`,
+    { timeoutMs: 20_000, label: "marketplace import mode" },
+  );
+}
+
+async function openMarketplace(ctx) {
+  await ensureRenderedApp(ctx);
+  await openWorkspaceSettings(ctx, "cloud-marketplaces");
+  await useMarketplaceImportMode(ctx);
+  await ctx.waitForText("Marketplace", { timeoutMs: 30_000 });
+  const hasRefresh = await ctx.eval(
+    "Boolean(window.__openworkControl?.listActions().find(a => a.id === 'extensions.refresh-marketplace'))",
+  );
+  if (hasRefresh) {
+    await ctx.control("extensions.refresh-marketplace");
+  }
+  await useMarketplaceImportMode(ctx);
+  await ctx.waitForText(BROKEN_PLUGIN_NAME, { timeoutMs: 45_000 });
+  await ctx.waitForText(VALID_PLUGIN_NAME, { timeoutMs: 45_000 });
+}
+
+async function searchMarketplace(ctx, value) {
+  await ctx.fill('input[placeholder="Search marketplace extensions..."]', value);
+  await ctx.waitFor(
+    `document.body.innerText.includes(${JSON.stringify(value)})`,
+    { timeoutMs: 15_000, label: `marketplace search result ${value}` },
+  );
+}
+
+async function installMarketplacePlugin(ctx, pluginName) {
+  await searchMarketplace(ctx, pluginName);
+  await ctx.clickText(pluginName, { selector: "button", timeoutMs: 20_000 });
+  await ctx.waitForText("COMPOSITION", { timeoutMs: 20_000 });
+  await ctx.clickText("Add", { selector: '[role="dialog"] button', timeoutMs: 20_000 });
+}
+
+async function workspaceServerJson(ctx, path) {
+  return ctx.eval(`(async () => {
+    const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!bridge) throw new Error("Electron bridge unavailable");
+    const info = await bridge("openworkServerInfo");
+    const baseUrl = String(info?.baseUrl ?? "").replace(/\\/+$/, "");
+    const token = String(info?.ownerToken || info?.clientToken || "").trim();
+    const workspaceId = (location.hash.match(/\\/workspace\\/([^/]+)/) || [])[1] || localStorage.getItem("openwork.react.activeWorkspace") || "";
+    if (!baseUrl || !token || !workspaceId) throw new Error("Missing OpenWork server connection");
+    const response = await fetch(baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + ${JSON.stringify(path)}, {
+      headers: { authorization: "Bearer " + token },
+    });
+    const text = await response.text();
+    let body;
+    try { body = JSON.parse(text); } catch { body = text; }
+    if (!response.ok) throw new Error(${JSON.stringify(path)} + " -> " + response.status + " " + text.slice(0, 200));
+    return body;
+  })()`, { awaitPromise: true });
+}
+
+async function waitForSkill(ctx, skillName) {
+  await ctx.waitFor(
+    `window.__OPENWORK_ELECTRON__?.invokeDesktop ? true : false`,
+    { timeoutMs: 15_000, label: "Electron bridge for skill check" },
+  );
+  await ctx.waitFor(
+    `(async () => {
+      const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+      const info = await bridge("openworkServerInfo");
+      const baseUrl = String(info?.baseUrl ?? "").replace(/\\/+$/, "");
+      const token = String(info?.ownerToken || info?.clientToken || "").trim();
+      const workspaceId = (location.hash.match(/\\/workspace\\/([^/]+)/) || [])[1] || localStorage.getItem("openwork.react.activeWorkspace") || "";
+      if (!baseUrl || !token || !workspaceId) return false;
+      const response = await fetch(baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/skills", {
+        headers: { authorization: "Bearer " + token },
+      });
+      if (!response.ok) return false;
+      const body = await response.json();
+      return Array.isArray(body.items) && body.items.some((item) => item.name === ${JSON.stringify(skillName)});
+    })()`,
+    { timeoutMs: 45_000, label: `workspace skill ${skillName}` },
+  );
+}
+
+async function readMcpState(ctx) {
+  const body = await workspaceServerJson(ctx, "/mcp");
+  const names = Array.isArray(body.items) ? body.items.map((item) => item.name) : [];
+  return { names, engineSync: body.engineSync ?? null };
+}
+
+async function assertNoBrokenMcp(ctx) {
+  const mcp = await readMcpState(ctx);
+  ctx.assert(!mcp.names.includes("broken"), `Broken MCP was installed unexpectedly: ${JSON.stringify(mcp.names)}`);
+  ctx.log(`MCP servers after broken install: ${JSON.stringify(mcp.names)}`);
+}
+
+async function assertLinearMcpSynced(ctx) {
+  await ctx.waitFor(
+    `(async () => {
+      const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+      if (!bridge) return false;
+      const info = await bridge("openworkServerInfo");
+      const baseUrl = String(info?.baseUrl ?? "").replace(/\\/+$/, "");
+      const token = String(info?.ownerToken || info?.clientToken || "").trim();
+      const workspaceId = (location.hash.match(/\\/workspace\\/([^/]+)/) || [])[1] || localStorage.getItem("openwork.react.activeWorkspace") || "";
+      if (!baseUrl || !token || !workspaceId) return false;
+      const response = await fetch(baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/mcp", {
+        headers: { authorization: "Bearer " + token },
+      });
+      if (!response.ok) return false;
+      const body = await response.json();
+      return Array.isArray(body.items) && body.items.some((item) => item.name === "linear") && body.engineSync?.status === "ok";
+    })()`,
+    { timeoutMs: 45_000, label: "linear MCP in server list with ok engine sync" },
+  );
+  const mcp = await readMcpState(ctx);
+  ctx.assert(mcp.engineSync?.status === "ok", `Expected engine sync ok, got ${JSON.stringify(mcp.engineSync)}`);
+  ctx.log(`MCP servers after valid install: ${JSON.stringify(mcp)}`);
+}
+
+async function openMcpSettings(ctx) {
+  await ensureRenderedApp(ctx);
+  await openWorkspaceSettings(ctx, "extensions/mcp");
+  await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+  await ctx.clickText("MCPs", { selector: "button", timeoutMs: 10_000 }).catch(() => {});
+  await ctx.clickText("Refresh", { selector: "button", timeoutMs: 10_000 }).catch(() => {});
+}
+
+async function scrollConfiguredServer(ctx, text) {
+  await ctx.eval(`(() => {
+    const rows = [...document.querySelectorAll("button")];
+    const target = rows.find((button) => (button.textContent ?? "").toLowerCase().includes(${JSON.stringify(text.toLowerCase())}));
+    if (target) target.scrollIntoView({ block: "center" });
+    return Boolean(target);
+  })()`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Cloud marketplace plugins warn on malformed MCP payloads and hot-sync valid MCPs",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_WORKSPACE_PATH"],
+  steps: [
+    {
+      name: "Prepare Den plugins and desktop workspace",
+      run: async (ctx) => {
+        await ensureRenderedApp(ctx);
+        await setupCloudPlugins(ctx);
+        await signInViaHandoff(ctx);
+        await createFreshWorkspace(ctx);
+        await waitForWorkspaceReady(ctx);
+        await ensureRenderedApp(ctx);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("Signed-in user sees both org marketplace plugins", {
+          voiceover: vo[0],
+          action: async () => {
+            await openMarketplace(ctx);
+            await searchMarketplace(ctx, RUN_TAG);
+          },
+          assert: async () => {
+            await ctx.expectText(BROKEN_PLUGIN_NAME);
+            await ctx.expectText(VALID_PLUGIN_NAME);
+          },
+          screenshot: {
+            name: "marketplace-shows-bundles",
+            requireText: ["Marketplace", BROKEN_PLUGIN_NAME, VALID_PLUGIN_NAME],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/cloud-marketplaces",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("Broken MCP bundle imports the skill and surfaces a warning", {
+          voiceover: vo[1],
+          action: async () => {
+            await installMarketplacePlugin(ctx, BROKEN_PLUGIN_NAME);
+            await ctx.waitForText("could not be installed", { timeoutMs: 20_000 });
+          },
+          assert: async () => {
+            await ctx.expectText(VALID_WARNING, { timeoutMs: 5_000 });
+            await waitForSkill(ctx, BROKEN_SKILL_NAME);
+            await assertNoBrokenMcp(ctx);
+          },
+          screenshot: {
+            name: "broken-install-warning-toast",
+            requireText: ["could not be installed"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/cloud-marketplaces",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Persistent state shows skill installed and no broken MCP row", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.waitFor(
+              `!document.body.innerText.includes(${JSON.stringify("could not be installed")})`,
+              { timeoutMs: 15_000, label: "warning toast dismissed" },
+            );
+            await openWorkspaceSettings(ctx, "extensions/skills");
+            await ctx.waitForText(BROKEN_PLUGIN_NAME, { timeoutMs: 30_000 });
+            await openMcpSettings(ctx);
+          },
+          assert: async () => {
+            await waitForSkill(ctx, BROKEN_SKILL_NAME);
+            await assertNoBrokenMcp(ctx);
+          },
+          screenshot: {
+            name: "mcp-settings-no-broken-row",
+            requireText: ["Add Custom App", "MCPs", "YOUR APPS"],
+            rejectText: ["Something went wrong", BROKEN_PLUGIN_NAME, "Broken MCP"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Valid remote MCP installs and appears without manual reload", {
+          voiceover: vo[3],
+          action: async () => {
+            await openMarketplace(ctx);
+            await installMarketplacePlugin(ctx, VALID_PLUGIN_NAME);
+            await ctx.waitForText(`Imported ${VALID_PLUGIN_NAME}`, { timeoutMs: 30_000 });
+            await openMcpSettings(ctx);
+            await ctx.waitForText("linear", { timeoutMs: 45_000 });
+            await scrollConfiguredServer(ctx, "linear");
+          },
+          assert: async () => {
+            await waitForSkill(ctx, slugify(VALID_SKILL_TITLE));
+            await assertLinearMcpSynced(ctx);
+            const visible = await ctx.eval(`(() => {
+              const text = document.body.innerText.toLowerCase();
+              return text.includes("linear") && text.includes("your apps");
+            })()`);
+            ctx.assert(visible, "Linear MCP is not visible in the MCP settings view.");
+          },
+          screenshot: {
+            name: "linear-mcp-hot-synced",
+            requireText: ["Add Custom App", "linear"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/cloud-plugin-mcp-warning.md
+++ b/evals/voiceovers/cloud-plugin-mcp-warning.md
@@ -1,0 +1,11 @@
+# Cloud plugin MCP warnings
+
+This demo proves that marketplace plugins can bundle both skills and MCP servers, and that a bad MCP payload no longer disappears silently.
+
+1. I’m signed in to the local Acme cloud org and open the Extension Marketplace. Two fresh org plugins are visible side by side: one intentionally broken MCP bundle and one valid Linear MCP bundle.
+
+2. I install the broken bundle first. The skill still imports, but OpenWork now warns me that the Broken MCP component could not be installed because no server config with a url or command was found.
+
+3. I check the durable state after that warning. The skill is listed for this workspace, while the MCP settings page has no broken server row, so the app is honest about the partial install.
+
+4. I install the valid bundle next and return to MCP settings without reloading the engine. The Linear MCP appears in Your apps immediately, proving the valid remote server was installed and hot-synced.


### PR DESCRIPTION
## Problem (White Lotus POC tracker #8)
An org admin publishes a marketplace plugin bundling a skill + an MCP server. A member installs it: the skill arrives, the MCP silently doesn't, and the toast reports success.

## Root cause
- `pluginMcpConfigsFromPayload` (apps/server/src/cloud-plugins.ts) silently drops MCP payloads that don't normalize (no `url`/`command`, unparsable `rawSourceText`); non-active objects are skipped silently; the success message counts only survivors.
- `POST /workspace/:id/cloud-plugins` was the **only** MCP-writing route that never called `syncRuntimeMcpToOpencodeEngine` — even a correctly written MCP stayed unregistered with the running engine until an eventual reload (which can be unavailable on remote workers).

## Fix
- `installCloudPlugin` now returns `warnings`; dropped or inactive MCP components produce human-readable warnings (e.g. `MCP component "X" could not be installed: no server config with a "url" or "command" was found.`).
- Warnings propagate through the route responses and the desktop client; the marketplace import flow shows `toast.warning` (single + bulk installs). Mirrored in the no-server fallback install path.
- The cloud-plugins route now hot-registers runtime MCPs with the running engine (same best-effort pattern as the claude-plugins route), so valid MCPs connect without waiting for a reload.

## Tests (ran, all pass)
```
pnpm --filter openwork-server test src/cloud-plugins.test.ts src/mcp.engine-sync.e2e.test.ts   # 13 tests pass
pnpm --filter openwork-server typecheck    # pass
pnpm --filter @openwork/app typecheck      # pass
```
New e2e coverage: valid remote MCP → runtime config written AND engine sync invoked; broken payload (`serverUrl` instead of `url`) → install succeeds, skill installed, warning returned, no MCP written; clean installs → empty warnings.

## Validation status
**Fraimz posted:** https://github.com/different-ai/openwork/pull/2549#issuecomment-4909963695 — user-facing frame proof on a real den stack + desktop app: broken MCP bundle → warning toast + skill installed + no phantom MCP; valid bundle → MCP appears in Settings → MCP hot-synced without reload. Manual repro: publish a plugin with `{"mcpServers":{"broken":{"type":"sse","serverUrl":"https://x.example/mcp"}}}` → member install → warning toast instead of silent success; with a valid `url` → MCP appears in Settings → MCP and connects without an engine reload.
