### PR TITLE
fix(den): pin org-scoped Connections requests — explicit org scope wins over drifted sessions

### DIFF
--- a/ee/apps/den-api/src/middleware/organization-context.ts
+++ b/ee/apps/den-api/src/middleware/organization-context.ts
@@ -3,7 +3,7 @@ import type { MiddlewareHandler } from "hono"
 import { getApiKeyScopedOrganizationId, isScopedApiKeyForOrganization } from "../api-keys.js"
 import { getOrganizationContextForUser, resolveUserOrganizations, type OrganizationContext } from "../orgs.js"
 import type { AuthContextVariables } from "../session.js"
-import { getLegacyProxyOrganizationId, hydrateSessionActiveOrganization, shouldHydrateSessionActiveOrganization, type UserOrganizationsContext } from "./user-organizations.js"
+import { getRequestScopedOrganizationId, hydrateSessionActiveOrganization, shouldHydrateSessionActiveOrganization, type UserOrganizationsContext } from "./user-organizations.js"
 
 export type OrganizationContextVariables = {
   organizationContext: OrganizationContext
@@ -19,28 +19,27 @@ export const resolveOrganizationContextMiddleware: MiddlewareHandler<{
 
   const apiKey = c.get("apiKey")
   const apiKeyScopedOrganizationId = getApiKeyScopedOrganizationId(apiKey)
-  const legacyProxyOrganizationId = getLegacyProxyOrganizationId(c.req.raw.headers)
-  const scopedOrganizationId = apiKeyScopedOrganizationId ?? legacyProxyOrganizationId
+  const headerOrganizationId = getRequestScopedOrganizationId(c.req.raw.headers)
+  const scopedOrganizationId = apiKeyScopedOrganizationId ?? headerOrganizationId
+  const session = c.get("session")
+  const userId = normalizeDenTypeId("user", user.id)
 
-  let organizationId = c.get("activeOrganizationId") ?? null
-  let organizationSlug = c.get("activeOrganizationSlug") ?? null
+  let organizationId = scopedOrganizationId ?? c.get("activeOrganizationId") ?? null
+  let organizationSlug = scopedOrganizationId ? null : c.get("activeOrganizationSlug") ?? null
 
   if (!organizationId) {
-    const session = c.get("session")
     const resolved = await resolveUserOrganizations({
-      activeOrganizationId: scopedOrganizationId ?? session?.activeOrganizationId ?? null,
-      userId: normalizeDenTypeId("user", user.id),
+      activeOrganizationId: session?.activeOrganizationId ?? null,
+      userId,
     })
 
-    const scopedOrgs = scopedOrganizationId
-      ? resolved.orgs.filter((org) => org.id === scopedOrganizationId)
-      : resolved.orgs
+    const scopedOrgs = resolved.orgs
 
-    organizationId = scopedOrganizationId ? scopedOrgs[0]?.id ?? null : resolved.activeOrgId
-    organizationSlug = scopedOrganizationId ? scopedOrgs[0]?.slug ?? null : resolved.activeOrgSlug
+    organizationId = resolved.activeOrgId
+    organizationSlug = resolved.activeOrgSlug
 
     if (shouldHydrateSessionActiveOrganization({
-      scopedOrganizationId: apiKeyScopedOrganizationId,
+      scopedOrganizationId,
       sessionActiveOrganizationId: session?.activeOrganizationId,
       resolvedActiveOrganizationId: organizationId,
     })) {
@@ -59,12 +58,38 @@ export const resolveOrganizationContextMiddleware: MiddlewareHandler<{
     return c.json({ error: "organization_not_found" }, 404) as never
   }
 
-  const normalizedOrganizationId = normalizeDenTypeId("organization", organizationId)
+  let normalizedOrganizationId = normalizeDenTypeId("organization", organizationId)
 
-  const context = await getOrganizationContextForUser({
-    userId: normalizeDenTypeId("user", user.id),
+  let context = await getOrganizationContextForUser({
+    userId,
     organizationId: normalizedOrganizationId,
   })
+
+  if (!context && !scopedOrganizationId) {
+    const resolved = await resolveUserOrganizations({
+      activeOrganizationId: null,
+      userId,
+    })
+
+    c.set("userOrganizations", resolved.orgs)
+    c.set("activeOrganizationId", resolved.activeOrgId)
+    c.set("activeOrganizationSlug", resolved.activeOrgSlug)
+
+    if (resolved.activeOrgId) {
+      normalizedOrganizationId = normalizeDenTypeId("organization", resolved.activeOrgId)
+      context = await getOrganizationContextForUser({
+        userId,
+        organizationId: normalizedOrganizationId,
+      })
+
+      if (context) {
+        await hydrateSessionActiveOrganization(session, resolved.activeOrgId)
+        if (session) {
+          c.set("session", { ...session, activeOrganizationId: resolved.activeOrgId })
+        }
+      }
+    }
+  }
 
   if (!context) {
     return c.json({ error: "organization_not_found" }, 404) as never

--- a/ee/apps/den-api/src/middleware/user-organizations.ts
+++ b/ee/apps/den-api/src/middleware/user-organizations.ts
@@ -5,6 +5,7 @@ import { resolveUserOrganizations, setSessionActiveOrganization, type UserOrgSum
 import type { AuthContextVariables } from "../session.js"
 
 export const LEGACY_ORG_PROXY_HEADER = "x-openwork-legacy-org-id"
+export const ORG_SCOPE_HEADER = "x-openwork-org-id"
 
 export type UserOrganizationsContext = {
   userOrganizations: UserOrgSummary[]
@@ -14,8 +15,8 @@ export type UserOrganizationsContext = {
 
 type SessionLike = AuthContextVariables["session"]
 
-export function getLegacyProxyOrganizationId(headers: Headers) {
-  const rawOrganizationId = headers.get(LEGACY_ORG_PROXY_HEADER)?.trim()
+function getHeaderOrganizationId(headers: Headers, headerName: string) {
+  const rawOrganizationId = headers.get(headerName)?.trim()
   if (!rawOrganizationId) {
     return null
   }
@@ -25,6 +26,14 @@ export function getLegacyProxyOrganizationId(headers: Headers) {
   } catch {
     return null
   }
+}
+
+export function getLegacyProxyOrganizationId(headers: Headers) {
+  return getHeaderOrganizationId(headers, LEGACY_ORG_PROXY_HEADER)
+}
+
+export function getRequestScopedOrganizationId(headers: Headers) {
+  return getHeaderOrganizationId(headers, ORG_SCOPE_HEADER) ?? getLegacyProxyOrganizationId(headers)
 }
 
 export function shouldHydrateSessionActiveOrganization(input: {
@@ -60,8 +69,8 @@ export const resolveUserOrganizationsMiddleware: MiddlewareHandler<{
   const session = c.get("session")
   const apiKey = c.get("apiKey")
   const apiKeyScopedOrganizationId = getApiKeyScopedOrganizationId(apiKey)
-  const legacyProxyOrganizationId = getLegacyProxyOrganizationId(c.req.raw.headers)
-  const scopedOrganizationId = apiKeyScopedOrganizationId ?? legacyProxyOrganizationId
+  const headerOrganizationId = getRequestScopedOrganizationId(c.req.raw.headers)
+  const scopedOrganizationId = apiKeyScopedOrganizationId ?? headerOrganizationId
   const resolved = await resolveUserOrganizations({
     activeOrganizationId: scopedOrganizationId ?? session?.activeOrganizationId ?? null,
     userId: normalizeDenTypeId("user", user.id),
@@ -77,7 +86,7 @@ export const resolveUserOrganizationsMiddleware: MiddlewareHandler<{
     : resolved.activeOrgSlug
 
   if (shouldHydrateSessionActiveOrganization({
-    scopedOrganizationId: apiKeyScopedOrganizationId,
+    scopedOrganizationId,
     sessionActiveOrganizationId: session?.activeOrganizationId,
     resolvedActiveOrganizationId: activeOrganizationId,
   })) {

--- a/ee/apps/den-api/test/organization-context.test.ts
+++ b/ee/apps/den-api/test/organization-context.test.ts
@@ -1,0 +1,312 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+type TestOrg = {
+  id: string
+  slug: string
+}
+
+type TestApiKey = {
+  id: string
+  configId: string
+  referenceId: string
+  metadata: {
+    organizationId: string
+    orgMembershipId: string
+    issuedByUserId: string
+    issuedByOrgMembershipId: string
+  } | null
+}
+
+type TestContext = {
+  organization: TestOrg
+  currentMember: { id: string; role: string; isOwner: boolean }
+  currentMemberTeams: unknown[]
+  members: unknown[]
+  teams: unknown[]
+  roles: unknown[]
+}
+
+type TestState = {
+  userId: string
+  visibleOrgs: TestOrg[]
+  contextByOrgId: Map<string, TestContext>
+  resolveUserOrganizationsCalls: Array<{ activeOrganizationId?: string | null; userId: string }>
+  setSessionActiveOrganizationCalls: Array<{ sessionId: string; organizationId: string | null }>
+}
+
+const stateByUserId = new Map<string, TestState>()
+const stateBySessionId = new Map<string, TestState>()
+let organizationContextModule: typeof import("../src/middleware/organization-context.js")
+
+mock.module("../src/orgs.js", () => ({
+  getOrganizationContextForUser: (input: { organizationId: string; userId: string }) => {
+    const state = stateByUserId.get(input.userId)
+    return Promise.resolve(state?.contextByOrgId.get(input.organizationId) ?? null)
+  },
+  resolveUserOrganizations: (input: { activeOrganizationId?: string | null; userId: string }) => {
+    const state = stateByUserId.get(input.userId)
+    if (!state) {
+      return Promise.resolve({ orgs: [], activeOrgId: null, activeOrgSlug: null })
+    }
+
+    state.resolveUserOrganizationsCalls.push(input)
+    const requestedOrg = input.activeOrganizationId
+      ? state.visibleOrgs.find((org) => org.id === input.activeOrganizationId) ?? null
+      : null
+    const activeOrg = requestedOrg ?? (state.visibleOrgs.length === 1 ? state.visibleOrgs[0] : null)
+    return Promise.resolve({
+      orgs: state.visibleOrgs,
+      activeOrgId: activeOrg?.id ?? null,
+      activeOrgSlug: activeOrg?.slug ?? null,
+    })
+  },
+  setSessionActiveOrganization: (sessionId: string, organizationId: string | null) => {
+    stateBySessionId.get(sessionId)?.setSessionActiveOrganizationCalls.push({ sessionId, organizationId })
+    return Promise.resolve()
+  },
+}))
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  organizationContextModule = await import("../src/middleware/organization-context.js")
+})
+
+function createTestState(userId: string): TestState {
+  const state: TestState = {
+    userId,
+    visibleOrgs: [],
+    contextByOrgId: new Map(),
+    resolveUserOrganizationsCalls: [],
+    setSessionActiveOrganizationCalls: [],
+  }
+  stateByUserId.set(userId, state)
+  return state
+}
+
+function addVisibleOrg(state: TestState, slug: string) {
+  const org = { id: createDenTypeId("organization"), slug }
+  const memberId = createDenTypeId("member")
+  state.visibleOrgs.push(org)
+  state.contextByOrgId.set(org.id, {
+    organization: org,
+    currentMember: { id: memberId, role: "owner", isOwner: true },
+    currentMemberTeams: [],
+    members: [],
+    teams: [],
+    roles: [],
+  })
+  return { org, memberId }
+}
+
+function createApiKey(input: { organizationId: string; memberId: string; userId: string }): TestApiKey {
+  return {
+    id: createDenTypeId("apiKey"),
+    configId: "den-api-key",
+    referenceId: input.userId,
+    metadata: {
+      organizationId: input.organizationId,
+      orgMembershipId: input.memberId,
+      issuedByUserId: input.userId,
+      issuedByOrgMembershipId: input.memberId,
+    },
+  }
+}
+
+function createOrgContextApp(state: TestState, input: {
+  apiKey?: TestApiKey | null
+  sessionActiveOrganizationId: string | null
+}) {
+  const app = new Hono()
+  const sessionId = createDenTypeId("session")
+  stateBySessionId.set(sessionId, state)
+  app.use("*", async (c, next) => {
+    c.set("user", {
+      id: state.userId,
+      name: "Org Context User",
+      email: "user@example.com",
+      emailVerified: true,
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    c.set("session", {
+      id: sessionId,
+      activeOrganizationId: input.sessionActiveOrganizationId,
+    })
+    c.set("apiKey", input.apiKey ?? null)
+    if (input.sessionActiveOrganizationId) {
+      c.set("activeOrganizationId", input.sessionActiveOrganizationId)
+    }
+    await next()
+  })
+  app.get("/v1/org", organizationContextModule.resolveOrganizationContextMiddleware, (c) => {
+    const context = c.get("organizationContext")
+    const session = c.get("session")
+    return c.json({
+      organizationId: context.organization.id,
+      activeOrganizationId: c.get("activeOrganizationId") ?? null,
+      sessionActiveOrganizationId: session?.activeOrganizationId ?? null,
+    })
+  })
+  return app
+}
+
+test("canonical organization scope header wins over a different active session org", async () => {
+  const userId = createDenTypeId("user")
+  const state = createTestState(userId)
+  const sessionOrg = addVisibleOrg(state, "session-org").org
+  const headerOrg = addVisibleOrg(state, "header-org").org
+  const app = createOrgContextApp(state, { sessionActiveOrganizationId: sessionOrg.id })
+
+  const response = await app.request("http://den.local/v1/org", {
+    headers: { "x-openwork-org-id": headerOrg.id },
+  })
+
+  expect(response.status).toBe(200)
+  await expect(response.json()).resolves.toEqual({
+    organizationId: headerOrg.id,
+    activeOrganizationId: headerOrg.id,
+    sessionActiveOrganizationId: sessionOrg.id,
+  })
+  expect(state.resolveUserOrganizationsCalls).toHaveLength(0)
+})
+
+test("legacy organization scope header remains an alias", async () => {
+  const userId = createDenTypeId("user")
+  const state = createTestState(userId)
+  const sessionOrg = addVisibleOrg(state, "session-org").org
+  const headerOrg = addVisibleOrg(state, "legacy-header-org").org
+  const app = createOrgContextApp(state, { sessionActiveOrganizationId: sessionOrg.id })
+
+  const response = await app.request("http://den.local/v1/org", {
+    headers: { "x-openwork-legacy-org-id": headerOrg.id },
+  })
+
+  expect(response.status).toBe(200)
+  await expect(response.json()).resolves.toEqual({
+    organizationId: headerOrg.id,
+    activeOrganizationId: headerOrg.id,
+    sessionActiveOrganizationId: sessionOrg.id,
+  })
+  expect(state.resolveUserOrganizationsCalls).toHaveLength(0)
+})
+
+test("a valid active session org resolves without re-resolving organizations", async () => {
+  const userId = createDenTypeId("user")
+  const state = createTestState(userId)
+  const sessionOrg = addVisibleOrg(state, "session-org").org
+  const app = createOrgContextApp(state, { sessionActiveOrganizationId: sessionOrg.id })
+
+  const response = await app.request("http://den.local/v1/org")
+
+  expect(response.status).toBe(200)
+  await expect(response.json()).resolves.toEqual({
+    organizationId: sessionOrg.id,
+    activeOrganizationId: sessionOrg.id,
+    sessionActiveOrganizationId: sessionOrg.id,
+  })
+  expect(state.resolveUserOrganizationsCalls).toHaveLength(0)
+})
+
+test("an explicit header for a non-member org hard fails instead of falling back", async () => {
+  const userId = createDenTypeId("user")
+  const state = createTestState(userId)
+  const sessionOrg = addVisibleOrg(state, "session-org").org
+  const nonMemberOrgId = createDenTypeId("organization")
+  const app = createOrgContextApp(state, { sessionActiveOrganizationId: sessionOrg.id })
+
+  const response = await app.request("http://den.local/v1/org", {
+    headers: { "x-openwork-org-id": nonMemberOrgId },
+  })
+
+  expect(response.status).toBe(404)
+  await expect(response.json()).resolves.toEqual({ error: "organization_not_found" })
+  expect(state.resolveUserOrganizationsCalls).toHaveLength(0)
+})
+
+test("a stale session self-heals when the user has exactly one org", async () => {
+  const userId = createDenTypeId("user")
+  const state = createTestState(userId)
+  const staleOrgId = createDenTypeId("organization")
+  const fallbackOrg = addVisibleOrg(state, "only-org").org
+  const app = createOrgContextApp(state, { sessionActiveOrganizationId: staleOrgId })
+
+  const response = await app.request("http://den.local/v1/org")
+
+  expect(response.status).toBe(200)
+  await expect(response.json()).resolves.toEqual({
+    organizationId: fallbackOrg.id,
+    activeOrganizationId: fallbackOrg.id,
+    sessionActiveOrganizationId: fallbackOrg.id,
+  })
+  expect(state.resolveUserOrganizationsCalls).toEqual([{ activeOrganizationId: null, userId }])
+  expect(state.setSessionActiveOrganizationCalls).toHaveLength(1)
+  expect(state.setSessionActiveOrganizationCalls[0]?.organizationId).toBe(fallbackOrg.id)
+})
+
+test("a stale session with multiple orgs still requires an explicit org signal", async () => {
+  const userId = createDenTypeId("user")
+  const state = createTestState(userId)
+  const staleOrgId = createDenTypeId("organization")
+  addVisibleOrg(state, "first-org")
+  addVisibleOrg(state, "second-org")
+  const app = createOrgContextApp(state, { sessionActiveOrganizationId: staleOrgId })
+
+  const response = await app.request("http://den.local/v1/org")
+
+  expect(response.status).toBe(404)
+  await expect(response.json()).resolves.toEqual({ error: "organization_not_found" })
+  expect(state.resolveUserOrganizationsCalls).toEqual([{ activeOrganizationId: null, userId }])
+  expect(state.setSessionActiveOrganizationCalls).toHaveLength(0)
+})
+
+test("a canonical header fixes a stale session even when the user has multiple orgs", async () => {
+  const userId = createDenTypeId("user")
+  const state = createTestState(userId)
+  const staleOrgId = createDenTypeId("organization")
+  const headerOrg = addVisibleOrg(state, "header-org").org
+  addVisibleOrg(state, "other-org")
+  const app = createOrgContextApp(state, { sessionActiveOrganizationId: staleOrgId })
+
+  const response = await app.request("http://den.local/v1/org", {
+    headers: { "x-openwork-org-id": headerOrg.id },
+  })
+
+  expect(response.status).toBe(200)
+  await expect(response.json()).resolves.toEqual({
+    organizationId: headerOrg.id,
+    activeOrganizationId: headerOrg.id,
+    sessionActiveOrganizationId: staleOrgId,
+  })
+  expect(state.resolveUserOrganizationsCalls).toHaveLength(0)
+})
+
+test("an API-key scoped org wins over a conflicting request header", async () => {
+  const userId = createDenTypeId("user")
+  const state = createTestState(userId)
+  const apiOrg = addVisibleOrg(state, "api-key-org")
+  const headerOrg = addVisibleOrg(state, "header-org").org
+  const apiKey = createApiKey({ organizationId: apiOrg.org.id, memberId: apiOrg.memberId, userId })
+  const app = createOrgContextApp(state, { apiKey, sessionActiveOrganizationId: headerOrg.id })
+
+  const response = await app.request("http://den.local/v1/org", {
+    headers: { "x-openwork-org-id": headerOrg.id },
+  })
+
+  expect(response.status).toBe(200)
+  await expect(response.json()).resolves.toEqual({
+    organizationId: apiOrg.org.id,
+    activeOrganizationId: apiOrg.org.id,
+    sessionActiveOrganizationId: headerOrg.id,
+  })
+  expect(state.resolveUserOrganizationsCalls).toHaveLength(0)
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -4,6 +4,19 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getRequestError, requestJson } from "../../_lib/den-flow";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 
+const ORG_SCOPE_HEADER = "x-openwork-org-id";
+
+function getOrgScopeHeaders(orgId: string) {
+  return { [ORG_SCOPE_HEADER]: orgId };
+}
+
+function requireOrgId(orgId: string | null) {
+  if (!orgId) {
+    throw new Error("Select an organization before managing connections.");
+  }
+  return orgId;
+}
+
 export type ExternalMcpAuthType = "oauth" | "apikey" | "none";
 export type ExternalMcpCredentialMode = "shared" | "per_member";
 export type ExternalMcpConnectionScope = "usable" | "manageable";
@@ -59,8 +72,12 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string");
 }
 
-async function fetchConnections(scope: ExternalMcpConnectionScope): Promise<ExternalMcpConnection[]> {
-  const { response, payload } = await requestJson(`/v1/mcp-connections?scope=${scope}`, {}, 15000);
+async function fetchConnections(scope: ExternalMcpConnectionScope, orgId: string): Promise<ExternalMcpConnection[]> {
+  const { response, payload } = await requestJson(
+    `/v1/mcp-connections?scope=${scope}`,
+    { headers: getOrgScopeHeaders(orgId) },
+    15000,
+  );
   if (!response.ok) {
     throw getRequestError(payload, response, `Failed to load MCP connections (${response.status}).`);
   }
@@ -73,7 +90,7 @@ export function useMcpConnections(scope: ExternalMcpConnectionScope = "manageabl
   return useQuery({
     enabled: Boolean(orgId),
     queryKey: mcpConnectionQueryKeys.list(orgId, scope),
-    queryFn: () => fetchConnections(scope),
+    queryFn: () => fetchConnections(scope, requireOrgId(orgId)),
   });
 }
 
@@ -120,7 +137,7 @@ export function useCreateMcpConnection() {
       await runReauthableAction("create-mcp-connection", async () => {
         const { response, payload } = await requestJson(
           "/v1/mcp-connections",
-          { method: "POST", body: JSON.stringify(input) },
+          { method: "POST", headers: getOrgScopeHeaders(requireOrgId(orgId)), body: JSON.stringify(input) },
           20000,
         );
         if (!response.ok) {
@@ -139,7 +156,7 @@ export function useCreateMcpConnection() {
 
 export function useReplaceMcpConnectionAccess() {
   const queryClient = useQueryClient();
-  const { runReauthableAction } = useOrgDashboard();
+  const { orgId, runReauthableAction } = useOrgDashboard();
 
   return useMutation({
     mutationFn: async (input: { connectionId: string; access: McpConnectionAccessInput }): Promise<string> => {
@@ -147,7 +164,7 @@ export function useReplaceMcpConnectionAccess() {
       await runReauthableAction("replace-mcp-connection-access", async () => {
         const { response, payload } = await requestJson(
           `/v1/mcp-connections/${encodeURIComponent(input.connectionId)}/access`,
-          { method: "PUT", body: JSON.stringify({ access: input.access }) },
+          { method: "PUT", headers: getOrgScopeHeaders(requireOrgId(orgId)), body: JSON.stringify({ access: input.access }) },
           15000,
         );
         if (!response.ok) {
@@ -165,11 +182,13 @@ export function useReplaceMcpConnectionAccess() {
 }
 
 export function useStartMcpConnectionOAuth() {
+  const { orgId } = useOrgDashboard();
+
   return useMutation({
     mutationFn: async (connectionId: string): Promise<{ status: "connected" | "needs_auth"; authorizeUrl: string | null }> => {
       const { response, payload } = await requestJson(
         `/v1/mcp-connections/${encodeURIComponent(connectionId)}/connect/start`,
-        {},
+        { headers: getOrgScopeHeaders(requireOrgId(orgId)) },
         20000,
       );
       if (!response.ok) {
@@ -190,7 +209,7 @@ export function useDeleteMcpConnection() {
       await runReauthableAction("delete-mcp-connection", async () => {
         const { response, payload } = await requestJson(
           `/v1/mcp-connections/${encodeURIComponent(connectionId)}`,
-          { method: "DELETE" },
+          { method: "DELETE", headers: getOrgScopeHeaders(requireOrgId(orgId)) },
           15000,
         );
         if (!response.ok) {
@@ -239,7 +258,7 @@ function parseNativeProviderClient(payload: unknown): NativeProviderClient {
  */
 export function useSaveNativeProviderClient() {
   const queryClient = useQueryClient();
-  const { runReauthableAction } = useOrgDashboard();
+  const { orgId, runReauthableAction } = useOrgDashboard();
 
   return useMutation({
     mutationFn: async (input: SaveNativeProviderClientInput): Promise<void> => {
@@ -250,6 +269,7 @@ export function useSaveNativeProviderClient() {
           `/v1/oauth-providers/${encodeURIComponent(input.providerId)}/client`,
           {
             method: "POST",
+            headers: getOrgScopeHeaders(requireOrgId(orgId)),
             body: JSON.stringify({
               ...(clientId ? { clientId } : {}),
               ...(clientSecret ? { clientSecret } : {}),
@@ -278,7 +298,7 @@ export function useNativeProviderClient(providerId: string, enabled: boolean) {
     queryFn: async (): Promise<NativeProviderClient | null> => {
       const { response, payload } = await requestJson(
         `/v1/oauth-providers/${encodeURIComponent(providerId)}/client`,
-        {},
+        { headers: getOrgScopeHeaders(requireOrgId(orgId)) },
         15000,
       );
       if (response.status === 404) {

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -136,7 +136,7 @@ function applyCorsHeaders(request: NextRequest, headers: Headers): void {
   headers.set("access-control-allow-origin", allowOrigin);
   headers.set("access-control-allow-credentials", "true");
   headers.set("access-control-allow-methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS");
-  headers.set("access-control-allow-headers", "Content-Type,Authorization,X-Api-Key,X-Request-Id,X-Requested-With,X-OpenWork-Legacy-Org-Id");
+  headers.set("access-control-allow-headers", "Content-Type,Authorization,X-Api-Key,X-Request-Id,X-Requested-With,X-OpenWork-Org-Id,X-OpenWork-Legacy-Org-Id");
   headers.append("vary", "Origin");
 }
 
@@ -191,6 +191,7 @@ function buildHeaders(request: NextRequest, contentType: string | null): Headers
     "user-agent",
     "x-requested-with",
     "x-api-key",
+    "x-openwork-org-id",
     "x-openwork-legacy-org-id",
     "origin",
     "x-forwarded-for",

--- a/evals/flows/org-scope-pinning.flow.mjs
+++ b/evals/flows/org-scope-pinning.flow.mjs
@@ -1,0 +1,309 @@
+/**
+ * Regression proof for multi-org active-org drift on the Connections surface.
+ *
+ * Bug class: den-web relied on the session's global active organization for
+ * org-scoped calls. With multiple orgs, a mid-flow active-org change (another
+ * tab, the desktop app, a stale session) made POST /v1/mcp-connections either
+ * fail with organization_not_found or silently write into the wrong org.
+ *
+ * Fix under test: den-web pins Connections requests with x-openwork-org-id,
+ * and den-api gives that explicit scope precedence over the session value.
+ *
+ * Requires a multi-org Den deployment (DEN_ORG_MODE=multi_org); gate with
+ * OPENWORK_EVAL_DEN_MULTI_ORG so single-org CI setups skip instead of fail.
+ */
+
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, openAdminConnections as openConnections, signInApi as signIn } from "./lib/den-web.mjs";
+
+const vo = await loadVoiceoverParagraphs("org-scope-pinning");
+
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MOCK_SERVER_URL = (process.env.MOCK_DCRLESS_MCP_URL ?? "http://127.0.0.1:3979").trim().replace(/\/+$/, "");
+const MOCK_CLIENT_ID = process.env.MOCK_CLIENT_ID || "mock-preregistered-client";
+const MOCK_CLIENT_SECRET = process.env.MOCK_CLIENT_SECRET || "mock-preregistered-secret";
+const DRIFT_ORG_NAME = "Drift Probe Org";
+const ORG_SCOPE_HEADER = "x-openwork-org-id";
+const CONNECTION_NAME = `pin-probe-${Date.now()}`;
+
+function denWebUrl() {
+  return (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+}
+
+const state = {
+  adminToken: null,
+  orgA: null,
+  orgB: null,
+  connectionId: null,
+};
+
+function orgScopedHeaders(orgId, extra = {}) {
+  return { authorization: `Bearer ${state.adminToken}`, [ORG_SCOPE_HEADER]: orgId, ...extra };
+}
+
+async function listConnections(orgId) {
+  const { response, body } = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+    headers: orgScopedHeaders(orgId),
+  });
+  return { response, connections: body.connections ?? [] };
+}
+
+async function cleanupProbeConnections(ctx, orgId) {
+  const { response, connections } = await listConnections(orgId);
+  ctx.assert(response.ok, `Listing connections for cleanup failed in ${orgId}: ${response.status}`);
+  for (const connection of connections) {
+    if (connection.name.startsWith("pin-probe-")) {
+      const removed = await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+        method: "DELETE",
+        headers: orgScopedHeaders(orgId),
+      });
+      ctx.assert(removed.response.ok, `Cleanup delete failed for leftover ${connection.id} in ${orgId}.`);
+    }
+  }
+}
+
+async function browserJson(ctx, script) {
+  const raw = await ctx.eval(script, { awaitPromise: true });
+  if (typeof raw !== "string") return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+async function browserSetActiveOrg(ctx, organizationId) {
+  return browserJson(
+    ctx,
+    `fetch('/api/auth/organization/set-active', { method: 'POST', headers: { 'content-type': 'application/json' }, body: ${JSON.stringify(JSON.stringify({ organizationId }))} }).then((response) => response.status)`,
+  );
+}
+
+async function browserActiveOrgId(ctx) {
+  return browserJson(
+    ctx,
+    `fetch('/api/den/v1/me/orgs').then((response) => response.json()).then((data) => JSON.stringify(data.activeOrgId ?? null))`,
+  );
+}
+
+export default {
+  id: "org-scope-pinning",
+  title: "Connections requests stay pinned to the org on screen when the session's active org drifts",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MULTI_ORG"],
+  spec: "evals/org-mcp-connections-ux.md",
+  steps: [
+    {
+      name: "Setup: admin signs in, has (or gets) a second org, and leftover probe connections are removed",
+      run: async (ctx) => {
+        state.adminToken = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+        ctx.assert(Boolean(state.adminToken), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+
+        const orgsFirst = await denApiFetch("/v1/me/orgs", {
+          headers: { authorization: `Bearer ${state.adminToken}` },
+        });
+        ctx.assert(orgsFirst.response.ok, `Listing orgs failed: ${orgsFirst.response.status}`);
+        let orgs = orgsFirst.body.orgs ?? [];
+        ctx.assert(orgs.length >= 1, "Admin has no organizations.");
+
+        state.orgB = orgs.find((org) => org.name === DRIFT_ORG_NAME) ?? null;
+        if (!state.orgB) {
+          const created = await denApiFetch("/v1/org", {
+            method: "POST",
+            headers: { authorization: `Bearer ${state.adminToken}` },
+            body: JSON.stringify({ name: DRIFT_ORG_NAME }),
+          });
+          ctx.assert(
+            created.response.ok,
+            `Creating the drift org failed (${created.response.status}): ${JSON.stringify(created.body)} — this flow needs DEN_ORG_MODE=multi_org.`,
+          );
+          const refreshed = await denApiFetch("/v1/me/orgs", {
+            headers: { authorization: `Bearer ${state.adminToken}` },
+          });
+          ctx.assert(refreshed.response.ok, `Re-listing orgs failed: ${refreshed.response.status}`);
+          orgs = refreshed.body.orgs ?? [];
+          state.orgB = orgs.find((org) => org.name === DRIFT_ORG_NAME) ?? null;
+        }
+        ctx.assert(Boolean(state.orgB), "Drift org missing after create.");
+
+        state.orgA = orgs.find((org) => org.id !== state.orgB.id && org.slug === "default")
+          ?? orgs.find((org) => org.id !== state.orgB.id);
+        ctx.assert(Boolean(state.orgA), "No primary org distinct from the drift org.");
+
+        await cleanupProbeConnections(ctx, state.orgA.id);
+        await cleanupProbeConnections(ctx, state.orgB.id);
+      },
+    },
+    {
+      name: "Multi-org admin picks an org and lands on its Connections screen",
+      run: async (ctx) => {
+        await ctx.prove("The admin is unmistakably operating in the chosen org's Connections screen", {
+          voiceover: vo[0],
+          action: async () => {
+            await ctx.eval(`(() => { window.location.href = ${JSON.stringify(denWebUrl())}; return true; })()`);
+            await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
+            await ctx.eval(
+              `fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`,
+              { awaitPromise: true },
+            );
+            await ctx.eval(`(() => { window.location.href = ${JSON.stringify(denWebUrl())}; return true; })()`);
+            await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
+            await ctx.waitFor(
+              "Boolean(document.querySelector('input[type=\"email\"]')) && Boolean(document.querySelector('input[type=\"password\"]'))",
+              { timeoutMs: 30_000, label: "email + password fields" },
+            );
+            await ctx.fill('input[type="email"]', ADMIN_EMAIL);
+            await ctx.fill('input[type="password"]', ADMIN_PASSWORD);
+            const submitted = await ctx.eval(`(() => {
+              const button = document.querySelector('button[type="submit"]');
+              if (!button) return false;
+              button.click();
+              return true;
+            })()`);
+            ctx.assert(submitted, "No submit button found on the sign-in card.");
+            await ctx.waitFor(
+              "!document.querySelector('input[type=\"password\"]')",
+              { timeoutMs: 30_000, label: "sign-in card dismissed" },
+            );
+
+            // A fresh multi-org session has no active org, so the org chooser
+            // appears; pick the primary org explicitly (that IS the feature).
+            await ctx.waitFor(
+              `(() => {
+                const text = document.body?.innerText ?? '';
+                return text.includes('Choose an organization') || text.includes('Dashboard');
+              })()`,
+              { timeoutMs: 30_000, label: "org chooser or dashboard" },
+            );
+            const chooserVisible = await ctx.eval(`(document.body?.innerText ?? '').includes('Choose an organization')`);
+            if (chooserVisible) {
+              const picked = await ctx.eval(`(() => {
+                const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(state.orgA.name)}));
+                button?.click();
+                return Boolean(button);
+              })()`);
+              ctx.assert(picked, `Org chooser did not list ${state.orgA.name}.`);
+            }
+            await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
+
+            // Pin the starting state deterministically: whatever org the
+            // session landed on, make org A active and boot fresh on it.
+            const status = await browserSetActiveOrg(ctx, state.orgA.id);
+            ctx.assert(status === 200, `Selecting the primary org failed with status ${status}.`);
+            await ctx.eval(`(() => { window.location.href = ${JSON.stringify(denWebUrl())}; return true; })()`);
+            await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
+            await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
+            await openConnections(ctx);
+          },
+          assert: async () => {
+            await ctx.waitForText("Slack", { timeoutMs: 20_000 });
+            await ctx.expectText("Add Custom");
+            // The screen chrome doesn't print the org name; the session's
+            // active org is the ground truth for which org is on screen.
+            const active = await browserActiveOrgId(ctx);
+            ctx.assert(active === state.orgA.id, `Browser session active org is ${active}, expected ${state.orgA.id}.`);
+          },
+          screenshot: {
+            name: "connections-in-chosen-org",
+            claim: "The Connections screen is open in the org the admin chose.",
+            requireText: ["Connections", "Add Custom", "Slack"],
+            rejectText: ["Something went wrong", "organization_not_found"],
+          },
+        });
+      },
+    },
+    {
+      name: "Active org drifts mid-flow; the open dialog still creates the connection without organization_not_found",
+      run: async (ctx) => {
+        await ctx.prove("Creating a connection survives an active-org drift because requests are pinned to the on-screen org", {
+          voiceover: vo[1],
+          action: async () => {
+            // Simulate the drift: another tab / the desktop app flips the
+            // session's active organization while this screen stays open.
+            const status = await browserSetActiveOrg(ctx, state.orgB.id);
+            ctx.assert(status === 200, `set-active drift call failed with status ${status}.`);
+            const active = await browserActiveOrgId(ctx);
+            ctx.assert(active === state.orgB.id, `Session did not drift (active org ${active}).`);
+
+            await ctx.clickText("Add Custom", { timeoutMs: 20_000 });
+            await ctx.waitFor("Boolean(document.querySelector('input[placeholder=\"notion\"]'))", { timeoutMs: 10_000, label: "Add Custom dialog" });
+            await ctx.fill('input[placeholder="notion"]', CONNECTION_NAME);
+            await ctx.fill('input[placeholder="https://mcp.example.com/mcp"]', `${MOCK_SERVER_URL}/mcp`);
+            await ctx.clickText("This server needs a pre-registered OAuth app", { timeoutMs: 10_000 });
+            await ctx.fill('input[placeholder="1234567890.1234567890123"]', MOCK_CLIENT_ID);
+            await ctx.fill('input[placeholder="Client secret"]', MOCK_CLIENT_SECRET);
+            await ctx.clickText("Add connection", { timeoutMs: 15_000 });
+          },
+          assert: async () => {
+            await ctx.waitForText("Almost done", { timeoutMs: 20_000 });
+            await ctx.expectText("/connect/callback");
+            await ctx.expectNoText("organization_not_found");
+            await ctx.expectNoText("Something went wrong");
+
+            // The session is still drifted; only the explicit org scope can
+            // have routed this write into the org on screen.
+            const active = await browserActiveOrgId(ctx);
+            ctx.assert(active === state.orgB.id, `Drift ended early (active org ${active}); the proof needs the drifted session.`);
+
+            const inOrgA = await listConnections(state.orgA.id);
+            ctx.assert(inOrgA.response.ok, `Listing org A connections failed: ${inOrgA.response.status}`);
+            const created = inOrgA.connections.find((entry) => entry.name === CONNECTION_NAME);
+            ctx.assert(Boolean(created), "Connection was not created in the org shown on screen.");
+            state.connectionId = created.id;
+
+            const inOrgB = await listConnections(state.orgB.id);
+            ctx.assert(inOrgB.response.ok, `Listing org B connections failed: ${inOrgB.response.status}`);
+            const strayWrite = inOrgB.connections.find((entry) => entry.name === CONNECTION_NAME);
+            ctx.assert(!strayWrite, "Connection leaked into the drifted org — the write was not pinned.");
+          },
+          screenshot: {
+            name: "create-survives-org-drift",
+            claim: "The connection is created and the redirect-URL handoff renders even though the session's active org drifted mid-dialog.",
+            requireText: ["Almost done", "/connect/callback"],
+            rejectText: ["organization_not_found", "Something went wrong"],
+          },
+        });
+        await ctx.clickText("Done", { timeoutMs: 10_000 });
+      },
+    },
+    {
+      name: "The connection lives in the org the admin saw, and the screen still shows it after the drift is undone",
+      run: async (ctx) => {
+        await ctx.prove("The org on screen owns the connection; the drifted org never saw the write", {
+          voiceover: vo[2],
+          action: async () => {
+            const status = await browserSetActiveOrg(ctx, state.orgA.id);
+            ctx.assert(status === 200, `Restoring the active org failed with status ${status}.`);
+            await ctx.eval(`(() => { window.location.reload(); return true; })()`);
+            await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000 });
+            await openConnections(ctx);
+          },
+          assert: async () => {
+            await ctx.waitForText(CONNECTION_NAME, { timeoutMs: 20_000 });
+            const active = await browserActiveOrgId(ctx);
+            ctx.assert(active === state.orgA.id, `Browser session active org is ${active}, expected ${state.orgA.id}.`);
+          },
+          screenshot: {
+            name: "connection-listed-in-correct-org",
+            claim: "After the drift is undone, the org's Connections list shows the probe connection exactly where the admin created it.",
+            requireText: [CONNECTION_NAME],
+            rejectText: ["Something went wrong", "organization_not_found"],
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup: delete the probe connection",
+      run: async (ctx) => {
+        if (!state.connectionId) return;
+        const removed = await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+          method: "DELETE",
+          headers: orgScopedHeaders(state.orgA.id),
+        });
+        ctx.assert(removed.response.ok, `Cleanup delete failed for ${state.connectionId}.`);
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/org-scope-pinning.md
+++ b/evals/voiceovers/org-scope-pinning.md
@@ -1,0 +1,7 @@
+# org-scope-pinning
+
+1. An admin who belongs to several organizations signs in, picks one in the organization chooser, and lands on that org's Connections screen — the dashboard is now clearly operating in the org they chose.
+
+2. While the add-connection dialog is open, the account's active organization flips to a different org behind the scenes — the same drift a second tab or the desktop app can cause. The admin finishes the dialog anyway, and the connection is created without any organization-not-found error, because every Connections request now carries the org the admin is actually looking at.
+
+3. Back on the same org's Connections list, the new connection is right there — and the API confirms it lives in the org the admin saw on screen, not in the org the session had drifted to. The stray write and the confusing 404 are both gone.


### PR DESCRIPTION
## Problem

Multi-org accounts hit `organization_not_found` (404) on the cloud Connections surface — e.g. creating the Slack MCP connection — whenever the session's active org was stale or drifted mid-flow (second tab, desktop app, reseeded instance). Worse, a *valid but different* session org silently routed writes into the wrong org.

Root cause chain:
- `sessionMiddleware` eagerly sets `activeOrganizationId` from the session, and `resolveOrganizationContextMiddleware` short-circuited on it — ignoring the explicit org header (which the desktop already sends, and the internal legacy `/v1/orgs/:orgId/*` proxy sets) and skipping the multi-org re-resolution fallback entirely.
- den-web never pinned org-scoped calls at all; the org shown in the UI lived only in client state while requests rode the session-global active org.

## Fix

**den-api**
- Canonical `x-openwork-org-id` header (the legacy `x-openwork-legacy-org-id` stays as an alias; API-key scope still wins over both).
- Explicit scope now takes precedence over the session-derived active org; membership is verified and a pin to a non-member org stays a hard 404.
- A stale session org self-heals by re-resolving (single-org auto-pick + session rehydration) instead of hard-404ing before the fallback ever ran.
- Explicit scopes no longer mutate the session's active org.

**den-web**
- Connections-surface requests (list / create / access / delete / connect-start / native provider client GET+POST) carry `x-openwork-org-id` for the org on screen; the proxy whitelists the header.

## Evidence

- `bun test` (den-api middleware/org/api-key/internal-principal/route-policy suites): **31 pass / 0 fail**, incl. new `test/organization-context.test.ts` covering precedence, alias, non-member 404, stale-session heal, multi-org 404, drift+header, API-key-over-header, and the happy path staying resolution-free.
- `tsc --noEmit` clean for den-api and den-web.
- fraimz `org-scope-pinning` (new, gated by `OPENWORK_EVAL_DEN_MULTI_ORG`; skips on single-org stacks): **PASSED** — session drifts to another org mid-dialog, create still succeeds, the connection lands in the on-screen org and *not* the drifted org (API-witnessed both ways). **Falsification: the same flow fails with `organization_not_found` on unpatched code.**
- fraimz `slack-org-connection` (canonical surface flow): **PASSED** on the patched single-org stack.
- Proof comment with validated screenshots follows below.

Known pre-existing (untouched): `pnpm -C ee/apps/den-web build` fails on clean dev (`useSearchParams()` without Suspense in `org-dashboard-provider.tsx`, introduced by #2503).