### PR TITLE
fix(desktop): trust the OS certificate path for desktop fetches and name TLS failures

### DIFF
--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -40,6 +40,7 @@ import {
   pickDirectory,
   resolveWorkspaceListSelectedId,
   workspaceBootstrap,
+  workspaceCreateRemote,
   workspaceForget,
   workspaceSetRuntimeActive,
   workspaceSetSelected,
@@ -1701,7 +1702,9 @@ export function SessionRoute() {
         remoteType,
       };
       let list: WorkspaceList | null = null;
-      if (client) {
+      if (isDesktopRuntime()) {
+        list = await workspaceCreateRemote(payload);
+      } else if (client) {
         list = await client.createRemoteWorkspace(payload).catch(() => null);
       }
       if (!list) {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -107,6 +107,7 @@ import {
   pickDirectory,
   resolveWorkspaceListSelectedId,
   workspaceBootstrap,
+  workspaceCreateRemote,
   workspaceForget,
   workspaceSetRuntimeActive,
   workspaceSetSelected,
@@ -1884,7 +1885,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         remoteType,
       };
       let list: WorkspaceList | null = null;
-      if (openworkClient) {
+      if (isDesktopRuntime()) {
+        list = await workspaceCreateRemote(payload);
+      } else if (openworkClient) {
         list = await openworkClient.createRemoteWorkspace(payload).catch(() => null);
       }
       if (!list) {

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -6,6 +6,7 @@ import { t } from "../../i18n";
 import {
   pickDirectory,
   resolveWorkspaceListSelectedId,
+  workspaceCreateRemote,
   workspaceSetRuntimeActive,
   workspaceSetSelected,
   type WorkspaceInfo,
@@ -249,18 +250,22 @@ export function WelcomeRoute() {
           remoteType,
         };
         let list: WorkspaceList | null = null;
-        try {
-          const { normalizedBaseUrl, resolvedToken, resolvedHostToken } =
-            await resolveOpenworkConnection();
-          if (normalizedBaseUrl && (resolvedToken || resolvedHostToken)) {
-            list = await createOpenworkServerClient({
-              baseUrl: normalizedBaseUrl,
-              token: resolvedToken || undefined,
-              hostToken: resolvedHostToken || undefined,
-            }).createRemoteWorkspace(payload);
+        if (isDesktopRuntime()) {
+          list = await workspaceCreateRemote(payload);
+        } else {
+          try {
+            const { normalizedBaseUrl, resolvedToken, resolvedHostToken } =
+              await resolveOpenworkConnection();
+            if (normalizedBaseUrl && (resolvedToken || resolvedHostToken)) {
+              list = await createOpenworkServerClient({
+                baseUrl: normalizedBaseUrl,
+                token: resolvedToken || undefined,
+                hostToken: resolvedHostToken || undefined,
+              }).createRemoteWorkspace(payload);
+            }
+          } catch {
+            list = null;
           }
-        } catch {
-          list = null;
         }
         if (!list) {
           throw new Error("OpenWork server is unavailable. Start or reconnect the server before connecting a remote workspace.");

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -17,7 +17,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, BrowserWindow, dialog, ipcMain, nativeImage, nativeTheme, session, shell, systemPreferences } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, nativeImage, nativeTheme, net as electronNet, session, shell, systemPreferences } from "electron";
 import { configureFakeMediaForTests, installMediaPermissionHandlers } from "./media-permissions.mjs";
 import { registerMigrationIpc } from "./migration.mjs";
 import { createRuntimeManager } from "./runtime.mjs";
@@ -1383,11 +1383,13 @@ const desktopCommandHandlers = {
       const init = args[1] ?? {};
       if (!url) throw new Error("URL is required.");
       const timeoutMs = Number(init.timeoutMs);
-      const response = await fetch(url, {
+      const response = await electronNet.fetch(url, {
         method: typeof init.method === "string" ? init.method : undefined,
         headers: init.headers && typeof init.headers === "object" ? init.headers : undefined,
         body: typeof init.body === "string" ? init.body : undefined,
         signal: Number.isFinite(timeoutMs) && timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined,
+        credentials: "omit",
+        cache: "no-store",
       });
       return {
         status: response.status,
@@ -1419,12 +1421,66 @@ const desktopCommandHandlers = {
   },
 };
 
+function desktopErrorMessageSegment(error, includeName = false) {
+  try {
+    if (error && (typeof error === "object" || typeof error === "function")) {
+      const message = typeof error.message === "string" ? error.message.trim() : "";
+      if (message) {
+        const name = typeof error.name === "string" ? error.name.trim() : "";
+        return includeName && name && name !== "Error" && !message.startsWith(`${name}:`)
+          ? `${name}: ${message}`
+          : message;
+      }
+    }
+    return String(error);
+  } catch {
+    return "Unknown error";
+  }
+}
+
+function desktopErrorCause(error) {
+  try {
+    return error && (typeof error === "object" || typeof error === "function") ? error.cause : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function desktopErrorMessageWithCauses(error) {
+  try {
+    const messages = [];
+    const seenMessages = new Set();
+    const seenErrors = new Set();
+    let current = error;
+    for (let depth = 0; current != null && depth < 8; depth += 1) {
+      if (typeof current === "object" || typeof current === "function") {
+        if (seenErrors.has(current)) break;
+        seenErrors.add(current);
+      }
+      const message = desktopErrorMessageSegment(current, depth === 0).trim();
+      if (message && !seenMessages.has(message)) {
+        seenMessages.add(message);
+        messages.push(message);
+      }
+      current = desktopErrorCause(current);
+    }
+    const combined = messages.join(": ") || "Unknown desktop command error";
+    return combined.length > 2000 ? `${combined.slice(0, 1997)}...` : combined;
+  } catch {
+    return "Unknown desktop command error";
+  }
+}
+
 async function handleDesktopInvoke(event, command, ...args) {
   const handler = desktopCommandHandlers[command];
   if (!handler) {
     throw new Error(`Electron desktop bridge method is not implemented yet: ${command}`);
   }
-  return handler(event, ...args);
+  try {
+    return await handler(event, ...args);
+  } catch (error) {
+    throw new Error(desktopErrorMessageWithCauses(error), { cause: error });
+  }
 }
 
 

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -541,7 +541,14 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     if (hostAuthToken) headers.set("X-OpenWork-Host-Token", hostAuthToken);
 
     try {
-      const response = await fetch(url, { headers, signal: controller.signal });
+      const electron = await import("electron").catch(() => null);
+      const fetcher = typeof electron?.net?.fetch === "function" ? electron.net.fetch.bind(electron.net) : fetch;
+      const response = await fetcher(url, {
+        headers,
+        signal: controller.signal,
+        credentials: "omit",
+        cache: "no-store",
+      });
       if (!response.ok) {
         throw new Error(`OpenWork workspace discovery failed (${response.status} ${response.statusText || "HTTP error"})`);
       }

--- a/evals/flows/desktop-fetch-os-trust.flow.mjs
+++ b/evals/flows/desktop-fetch-os-trust.flow.mjs
@@ -1,0 +1,299 @@
+import { execFile } from "node:child_process";
+import { createServer } from "node:https";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "desktop-fetch-os-trust";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const execFileAsync = promisify(execFile);
+
+const state = {
+  originalDeveloperMode: null,
+  server: null,
+  serverUrl: null,
+  serverDir: null,
+};
+
+async function navigateToSettingsTab(ctx, tab) {
+  const workspaceId = await ctx.eval("(window.location.hash.match(/\\/workspace\\/([^/]+)/) ?? [])[1] ?? ''");
+  await ctx.navigateHash(workspaceId ? `/workspace/${workspaceId}/settings/${tab}` : `/settings/${tab}`);
+  await ctx.waitFor(`window.location.hash.includes('/settings/${tab}')`, {
+    timeoutMs: 30_000,
+    label: `${tab} settings route`,
+  });
+  await ctx.waitFor("(document.body?.innerText ?? '').includes('Back to app')", {
+    timeoutMs: 30_000,
+    label: "settings surface mounted",
+  });
+}
+
+async function closeStaleDialogs(ctx) {
+  await ctx.eval(`(() => {
+    const text = document.body?.innerText ?? "";
+    if (!text.includes("Remote server details") && !text.includes("Create Workspace")) return false;
+    const buttons = [...document.querySelectorAll('button')];
+    const button = buttons.find((candidate) => (candidate.textContent ?? '').trim() === 'Cancel')
+      ?? buttons.find((candidate) => (candidate.textContent ?? '').trim() === 'Close');
+    button?.click();
+    return Boolean(button);
+  })()`);
+  await ctx.eval("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))");
+}
+
+async function ensureDeveloperMode(ctx) {
+  const current = await ctx.eval("window.localStorage.getItem('openwork.developerMode')");
+  if (state.originalDeveloperMode === null) state.originalDeveloperMode = current;
+  if (current === "1") return;
+
+  await navigateToSettingsTab(ctx, "advanced");
+  await ctx.waitForText("Developer mode", { timeoutMs: 30_000 });
+  await ctx.eval(`(() => {
+    const switchButton = [...document.querySelectorAll('button, [role="switch"]')]
+      .find((candidate) => (candidate.getAttribute('aria-label') ?? candidate.textContent ?? '').includes('Developer mode'));
+    if (!switchButton) throw new Error('Developer mode switch not found');
+    switchButton.scrollIntoView({ block: 'center' });
+    switchButton.click();
+    return true;
+  })()`);
+  await ctx.waitFor("window.localStorage.getItem('openwork.developerMode') === '1'", {
+    timeoutMs: 10_000,
+    label: "developer mode enabled",
+  });
+}
+
+async function restoreDeveloperMode(ctx) {
+  if (state.originalDeveloperMode === null || state.originalDeveloperMode === "1") return;
+  await navigateToSettingsTab(ctx, "advanced");
+  await ctx.waitForText("Developer mode", { timeoutMs: 30_000 });
+  await ctx.eval(`(() => {
+    const switchButton = [...document.querySelectorAll('button, [role="switch"]')]
+      .find((candidate) => (candidate.getAttribute('aria-label') ?? candidate.textContent ?? '').includes('Developer mode'));
+    if (!switchButton) throw new Error('Developer mode switch not found');
+    switchButton.scrollIntoView({ block: 'center' });
+    switchButton.click();
+    return true;
+  })()`);
+  await ctx.waitFor("window.localStorage.getItem('openwork.developerMode') !== '1'", {
+    timeoutMs: 10_000,
+    label: "developer mode restored",
+  });
+}
+
+async function openCloudAccount(ctx) {
+  await navigateToSettingsTab(ctx, "cloud-account");
+  await ctx.waitFor("(document.body?.innerText ?? '').includes('OpenWork Cloud')", {
+    timeoutMs: 30_000,
+    label: "cloud account content",
+  });
+}
+
+async function returnToApp(ctx) {
+  const inSettings = await ctx.eval("(document.body?.innerText ?? '').includes('Back to app')");
+  if (inSettings) {
+    await ctx.clickText("Back to app", { selector: "button", timeoutMs: 10_000 });
+  }
+  await ctx.waitFor("(document.body?.innerText ?? '').includes('Add workspace')", {
+    timeoutMs: 30_000,
+    label: "session sidebar with Add workspace",
+  });
+}
+
+async function startSelfSignedOpenworkServer() {
+  if (state.serverUrl) return state.serverUrl;
+
+  const dir = await mkdtemp(join(tmpdir(), "openwork-self-signed-"));
+  const keyPath = join(dir, "key.pem");
+  const certPath = join(dir, "cert.pem");
+  await execFileAsync("openssl", [
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-days",
+    "1",
+    "-subj",
+    "/CN=localhost",
+    "-addext",
+    "subjectAltName=DNS:localhost,IP:127.0.0.1",
+    "-keyout",
+    keyPath,
+    "-out",
+    certPath,
+  ]);
+
+  const key = await readFile(keyPath);
+  const cert = await readFile(certPath);
+  const server = createServer({ key, cert }, (request, response) => {
+    if (request.url?.startsWith("/workspaces")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        workspaces: [{ id: "ws_self_signed", name: "Self-signed remote", path: "/srv/self-signed" }],
+        selectedId: "ws_self_signed",
+      }));
+      return;
+    }
+    response.writeHead(404, { "content-type": "text/plain" });
+    response.end("not found");
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  server.unref();
+  state.server = server;
+  state.serverDir = dir;
+  state.serverUrl = `https://127.0.0.1:${server.address().port}`;
+  return state.serverUrl;
+}
+
+async function stopSelfSignedOpenworkServer() {
+  const server = state.server;
+  state.server = null;
+  state.serverUrl = null;
+  if (server) {
+    await new Promise((resolve) => server.close(resolve));
+  }
+  if (state.serverDir) {
+    await rm(state.serverDir, { recursive: true, force: true });
+    state.serverDir = null;
+  }
+}
+
+function summarizeError(error) {
+  if (!error || (typeof error !== "object" && typeof error !== "function")) return String(error);
+  return {
+    name: typeof error.name === "string" ? error.name : "",
+    message: typeof error.message === "string" ? error.message : String(error),
+    code: typeof error.code === "string" ? error.code : "",
+    cause: error.cause ? summarizeError(error.cause) : null,
+  };
+}
+
+async function nodeFetchFailure(url) {
+  try {
+    await fetch(`${url}/workspaces`);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: summarizeError(error) };
+  }
+}
+
+async function visibleRemoteError(ctx) {
+  return ctx.eval(`(() => {
+    const lines = (document.body?.innerText ?? '').split(/\\n+/).map((line) => line.trim()).filter(Boolean);
+    return lines.find((line) => /certificate|ERR_CERT|net::ERR_FAILED|fetch failed|OpenWork server is unavailable/i.test(line)) ?? '';
+  })()`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Desktop fetch uses OS trust plumbing and shows certificate failures clearly",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Cloud account opens without a generic fetch failure",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 60_000,
+          label: "window.__openworkControl",
+        });
+        await closeStaleDialogs(ctx);
+
+        await ctx.prove("The Cloud account settings surface opens cleanly", {
+          claim: "Settings → Account renders the OpenWork Cloud account controls and does not show a generic fetch failure.",
+          voiceover: vo[0],
+          action: async () => {
+            await ensureDeveloperMode(ctx);
+            await openCloudAccount(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("OpenWork Cloud");
+            await ctx.expectText("Cloud control plane URL");
+            await ctx.expectNoText("fetch failed");
+          },
+          screenshot: {
+            name: "cloud-account-ready",
+            requireText: ["OpenWork Cloud", "Cloud control plane URL"],
+            rejectText: ["fetch failed", "Something went wrong"],
+            hashIncludes: "/settings/cloud-account",
+          },
+        });
+      },
+    },
+    {
+      name: "Remote worker certificate failure is descriptive",
+      run: async (ctx) => {
+        const serverUrl = await startSelfSignedOpenworkServer();
+
+        await ctx.prove("Connecting a worker with an untrusted certificate shows the certificate cause", {
+          claim: "The Connect remote dialog keeps the user in context and shows a certificate-specific HTTPS failure instead of collapsing to a bare fetch failure.",
+          voiceover: vo[1],
+          action: async () => {
+            await returnToApp(ctx);
+            await closeStaleDialogs(ctx);
+            await ctx.clickText("Add workspace", { selector: "button", timeoutMs: 30_000 });
+            await ctx.clickText("Connect custom remote", { selector: "button", timeoutMs: 30_000 });
+            await ctx.waitForText("Remote server details", { timeoutMs: 30_000 });
+            await ctx.fill('input[placeholder="https://worker.example.com"]', serverUrl);
+            await ctx.clickText("Connect remote", { selector: "button", timeoutMs: 10_000 });
+            await ctx.waitFor(
+              "(() => { const text = document.body?.innerText ?? ''; return text.toLowerCase().includes('certificate') || text.includes('ERR_CERT'); })()",
+              { timeoutMs: 30_000, label: "certificate-specific remote connection error" },
+            );
+          },
+          assert: async () => {
+            const errorText = await visibleRemoteError(ctx);
+            ctx.assert(/certificate|ERR_CERT/i.test(errorText), `Expected a certificate-specific error, got: ${errorText}`);
+            ctx.assert(!/TypeError:\s*fetch failed$/i.test(errorText), `Remote error was still a bare fetch failure: ${errorText}`);
+            ctx.assert(!errorText.includes("OpenWork server is unavailable"), `Remote error was swallowed into a generic availability message: ${errorText}`);
+            ctx.output("self-signed-fetch-differential.json", JSON.stringify({
+              selfSignedServer: serverUrl,
+              visibleDesktopError: errorText,
+              nodeUndiciFetch: await nodeFetchFailure(serverUrl),
+            }, null, 2));
+          },
+          screenshot: {
+            name: "remote-certificate-error",
+            requireText: ["Remote server details", "ERR_CERT_AUTHORITY_INVALID"],
+            rejectText: ["OpenWork server is unavailable", "TypeError: fetch failed"],
+          },
+        });
+      },
+    },
+    {
+      name: "Canceling returns the app to a healthy account page",
+      run: async (ctx) => {
+        await ctx.prove("After canceling, the app returns to normal account settings", {
+          claim: "The failed certificate probe is recoverable: canceling the dialog and returning to Account shows the normal Cloud account controls again.",
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.clickText("Cancel", { selector: "button", timeoutMs: 10_000 });
+            await ctx.waitFor("!(document.body?.innerText ?? '').includes('Remote server details')", {
+              timeoutMs: 10_000,
+              label: "remote dialog closed",
+            });
+            await stopSelfSignedOpenworkServer();
+            await restoreDeveloperMode(ctx);
+            await openCloudAccount(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("OpenWork Cloud");
+            await ctx.expectNoText("Remote server details");
+            await ctx.expectNoText("fetch failed");
+          },
+          screenshot: {
+            name: "cloud-account-recovered",
+            requireText: ["OpenWork Cloud"],
+            rejectText: ["Remote server details", "fetch failed", "Something went wrong"],
+            hashIncludes: "/settings/cloud-account",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/desktop-fetch-os-trust.flow.mjs
+++ b/evals/flows/desktop-fetch-os-trust.flow.mjs
@@ -1,21 +1,23 @@
-import { execFile } from "node:child_process";
-import { createServer } from "node:https";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { promisify } from "node:util";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
 const FLOW_ID = "desktop-fetch-os-trust";
 const vo = await loadVoiceoverParagraphs(FLOW_ID);
-const execFileAsync = promisify(execFile);
 
-const state = {
-  originalDeveloperMode: null,
-  server: null,
-  serverUrl: null,
-  serverDir: null,
-};
+const UNTRUSTED_ROOT_URL = "https://untrusted-root.badssl.com";
+const INCOMPLETE_CHAIN_URL = "https://incomplete-chain.badssl.com";
+const REMOTE_URL_INPUT = 'input[placeholder="https://worker.example.com"]';
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const dialogTextExpression = `(() => {
+  const dialogs = [...document.querySelectorAll('[role="dialog"], [data-slot="dialog-content"]')];
+  const dialog = dialogs.find((entry) => (entry.innerText ?? '').includes('Remote server details'))
+    ?? dialogs[dialogs.length - 1]
+    ?? document.body;
+  return (dialog.innerText ?? '').replace(/\u00a0/g, ' ');
+})()`;
 
 async function navigateToSettingsTab(ctx, tab) {
   const workspaceId = await ctx.eval("(window.location.hash.match(/\\/workspace\\/([^/]+)/) ?? [])[1] ?? ''");
@@ -24,70 +26,63 @@ async function navigateToSettingsTab(ctx, tab) {
     timeoutMs: 30_000,
     label: `${tab} settings route`,
   });
-  await ctx.waitFor("(document.body?.innerText ?? '').includes('Back to app')", {
+  await ctx.waitFor("(document.body?.innerText ?? '').includes('OpenWork Cloud')", {
     timeoutMs: 30_000,
-    label: "settings surface mounted",
+    label: "cloud settings surface mounted",
   });
 }
 
 async function closeStaleDialogs(ctx) {
-  await ctx.eval(`(() => {
-    const text = document.body?.innerText ?? "";
-    if (!text.includes("Remote server details") && !text.includes("Create Workspace")) return false;
+  const clicked = await ctx.eval(`(() => {
+    const text = document.body?.innerText ?? '';
+    if (!text.includes('Remote server details') && !text.includes('Create Workspace')) return false;
     const buttons = [...document.querySelectorAll('button')];
     const button = buttons.find((candidate) => (candidate.textContent ?? '').trim() === 'Cancel')
       ?? buttons.find((candidate) => (candidate.textContent ?? '').trim() === 'Close');
     button?.click();
     return Boolean(button);
   })()`);
-  await ctx.eval("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))");
-}
-
-async function ensureDeveloperMode(ctx) {
-  const current = await ctx.eval("window.localStorage.getItem('openwork.developerMode')");
-  if (state.originalDeveloperMode === null) state.originalDeveloperMode = current;
-  if (current === "1") return;
-
-  await navigateToSettingsTab(ctx, "advanced");
-  await ctx.waitForText("Developer mode", { timeoutMs: 30_000 });
   await ctx.eval(`(() => {
-    const switchButton = [...document.querySelectorAll('button, [role="switch"]')]
-      .find((candidate) => (candidate.getAttribute('aria-label') ?? candidate.textContent ?? '').includes('Developer mode'));
-    if (!switchButton) throw new Error('Developer mode switch not found');
-    switchButton.scrollIntoView({ block: 'center' });
-    switchButton.click();
+    const first = new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true, cancelable: true });
+    const second = new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true, cancelable: true });
+    (document.activeElement ?? document.body).dispatchEvent(first);
+    document.dispatchEvent(second);
     return true;
   })()`);
-  await ctx.waitFor("window.localStorage.getItem('openwork.developerMode') === '1'", {
-    timeoutMs: 10_000,
-    label: "developer mode enabled",
-  });
+  if (clicked) {
+    await ctx.waitFor(
+      "(() => { const text = document.body?.innerText ?? ''; return !text.includes('Remote server details') && !text.includes('Create Workspace'); })()",
+      { timeoutMs: 10_000, label: "stale dialog closed" },
+    ).catch(() => {});
+  }
 }
 
-async function restoreDeveloperMode(ctx) {
-  if (state.originalDeveloperMode === null || state.originalDeveloperMode === "1") return;
-  await navigateToSettingsTab(ctx, "advanced");
-  await ctx.waitForText("Developer mode", { timeoutMs: 30_000 });
-  await ctx.eval(`(() => {
-    const switchButton = [...document.querySelectorAll('button, [role="switch"]')]
-      .find((candidate) => (candidate.getAttribute('aria-label') ?? candidate.textContent ?? '').includes('Developer mode'));
-    if (!switchButton) throw new Error('Developer mode switch not found');
-    switchButton.scrollIntoView({ block: 'center' });
-    switchButton.click();
-    return true;
+async function dismissOpenWorkModelsDialog(ctx) {
+  const clicked = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')]
+      .find((candidate) => (candidate.textContent ?? '').trim() === 'Continue without OpenWork Models');
+    button?.click();
+    return Boolean(button);
   })()`);
-  await ctx.waitFor("window.localStorage.getItem('openwork.developerMode') !== '1'", {
-    timeoutMs: 10_000,
-    label: "developer mode restored",
-  });
+  if (clicked) await sleep(300);
 }
 
 async function openCloudAccount(ctx) {
   await navigateToSettingsTab(ctx, "cloud-account");
-  await ctx.waitFor("(document.body?.innerText ?? '').includes('OpenWork Cloud')", {
-    timeoutMs: 30_000,
-    label: "cloud account content",
-  });
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body?.innerText ?? '';
+      return text.includes('OpenWork Cloud') && (
+        text.includes('Sign in') ||
+        text.includes('Sign out') ||
+        text.includes('Connected') ||
+        text.includes('Select an organization') ||
+        text.includes('Cloud account') ||
+        text.includes('Cloud control plane URL')
+      );
+    })()`,
+    { timeoutMs: 30_000, label: "cloud account controls" },
+  );
 }
 
 async function returnToApp(ctx) {
@@ -95,112 +90,72 @@ async function returnToApp(ctx) {
   if (inSettings) {
     await ctx.clickText("Back to app", { selector: "button", timeoutMs: 10_000 });
   }
+  await dismissOpenWorkModelsDialog(ctx);
   await ctx.waitFor("(document.body?.innerText ?? '').includes('Add workspace')", {
     timeoutMs: 30_000,
     label: "session sidebar with Add workspace",
   });
 }
 
-async function startSelfSignedOpenworkServer() {
-  if (state.serverUrl) return state.serverUrl;
-
-  const dir = await mkdtemp(join(tmpdir(), "openwork-self-signed-"));
-  const keyPath = join(dir, "key.pem");
-  const certPath = join(dir, "cert.pem");
-  await execFileAsync("openssl", [
-    "req",
-    "-x509",
-    "-newkey",
-    "rsa:2048",
-    "-nodes",
-    "-days",
-    "1",
-    "-subj",
-    "/CN=localhost",
-    "-addext",
-    "subjectAltName=DNS:localhost,IP:127.0.0.1",
-    "-keyout",
-    keyPath,
-    "-out",
-    certPath,
-  ]);
-
-  const key = await readFile(keyPath);
-  const cert = await readFile(certPath);
-  const server = createServer({ key, cert }, (request, response) => {
-    if (request.url?.startsWith("/workspaces")) {
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify({
-        workspaces: [{ id: "ws_self_signed", name: "Self-signed remote", path: "/srv/self-signed" }],
-        selectedId: "ws_self_signed",
-      }));
-      return;
-    }
-    response.writeHead(404, { "content-type": "text/plain" });
-    response.end("not found");
+async function openConnectRemoteDialog(ctx) {
+  await returnToApp(ctx);
+  await closeStaleDialogs(ctx);
+  await dismissOpenWorkModelsDialog(ctx);
+  await ctx.clickText("Add workspace", { selector: "button", timeoutMs: 30_000 });
+  await ctx.waitFor(
+    "(() => { const text = document.body?.innerText ?? ''; return text.includes('Create Workspace') || text.includes('Remote server details'); })()",
+    { timeoutMs: 30_000, label: "create workspace dialog" },
+  );
+  const remoteScreenOpen = await ctx.eval("(document.body?.innerText ?? '').includes('Remote server details')");
+  if (!remoteScreenOpen) {
+    await ctx.clickText("Connect custom remote", { selector: "button", timeoutMs: 30_000 });
+  }
+  await ctx.waitForText("Remote server details", { timeoutMs: 30_000 });
+  await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(REMOTE_URL_INPUT)}))`, {
+    timeoutMs: 10_000,
+    label: "remote worker URL input",
   });
-
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  server.unref();
-  state.server = server;
-  state.serverDir = dir;
-  state.serverUrl = `https://127.0.0.1:${server.address().port}`;
-  return state.serverUrl;
 }
 
-async function stopSelfSignedOpenworkServer() {
-  const server = state.server;
-  state.server = null;
-  state.serverUrl = null;
-  if (server) {
-    await new Promise((resolve) => server.close(resolve));
-  }
-  if (state.serverDir) {
-    await rm(state.serverDir, { recursive: true, force: true });
-    state.serverDir = null;
-  }
-}
-
-function summarizeError(error) {
-  if (!error || (typeof error !== "object" && typeof error !== "function")) return String(error);
-  return {
-    name: typeof error.name === "string" ? error.name : "",
-    message: typeof error.message === "string" ? error.message : String(error),
-    code: typeof error.code === "string" ? error.code : "",
-    cause: error.cause ? summarizeError(error.cause) : null,
-  };
-}
-
-async function nodeFetchFailure(url) {
-  try {
-    await fetch(`${url}/workspaces`);
-    return { ok: true };
-  } catch (error) {
-    return { ok: false, error: summarizeError(error) };
-  }
+async function remoteDialogText(ctx) {
+  return ctx.eval(dialogTextExpression);
 }
 
 async function visibleRemoteError(ctx) {
   return ctx.eval(`(() => {
-    const lines = (document.body?.innerText ?? '').split(/\\n+/).map((line) => line.trim()).filter(Boolean);
-    return lines.find((line) => /certificate|ERR_CERT|net::ERR_FAILED|fetch failed|OpenWork server is unavailable/i.test(line)) ?? '';
+    const text = ${dialogTextExpression};
+    const lines = text.split(/\\n+/).map((line) => line.trim()).filter(Boolean);
+    return lines.find((line) => /ERR_CERT|fetch failed|OpenWork workspace discovery failed|Cannot reach|Health check|Unexpected token|404|Not Found/i.test(line))
+      ?? lines.slice(-4).join(' ');
   })()`);
+}
+
+function readyToSubmitExpression(url) {
+  return `(() => {
+    const input = document.querySelector(${JSON.stringify(REMOTE_URL_INPUT)});
+    const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === 'Connect remote');
+    return input?.value === ${JSON.stringify(url)} && button && !button.disabled;
+  })()`;
 }
 
 export default {
   id: FLOW_ID,
-  title: "Desktop fetch uses OS trust plumbing and shows certificate failures clearly",
+  title: "Desktop remote calls trust the OS certificate path and name certificate failures instead of 'fetch failed'",
   kind: "user-facing",
+  spec: "evals/voiceovers/desktop-fetch-os-trust.md",
   steps: [
     {
-      name: "Cloud account opens without a generic fetch failure",
+      name: "Frame 1",
       run: async (ctx) => {
         await ctx.waitFor("Boolean(window.__openworkControl)", {
           timeoutMs: 60_000,
           label: "window.__openworkControl",
+        });
+        await closeStaleDialogs(ctx);
+        await ctx.eval("location.reload()");
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 60_000,
+          label: "window.__openworkControl after reset reload",
         });
         await closeStaleDialogs(ctx);
 
@@ -208,77 +163,107 @@ export default {
           claim: "Settings → Account renders the OpenWork Cloud account controls and does not show a generic fetch failure.",
           voiceover: vo[0],
           action: async () => {
-            await ensureDeveloperMode(ctx);
             await openCloudAccount(ctx);
           },
           assert: async () => {
             await ctx.expectText("OpenWork Cloud");
-            await ctx.expectText("Cloud control plane URL");
             await ctx.expectNoText("fetch failed");
           },
           screenshot: {
             name: "cloud-account-ready",
-            requireText: ["OpenWork Cloud", "Cloud control plane URL"],
-            rejectText: ["fetch failed", "Something went wrong"],
+            requireText: ["OpenWork Cloud"],
+            rejectText: ["fetch failed"],
             hashIncludes: "/settings/cloud-account",
           },
         });
       },
     },
     {
-      name: "Remote worker certificate failure is descriptive",
+      name: "Frame 2",
       run: async (ctx) => {
-        const serverUrl = await startSelfSignedOpenworkServer();
-
-        await ctx.prove("Connecting a worker with an untrusted certificate shows the certificate cause", {
-          claim: "The Connect remote dialog keeps the user in context and shows a certificate-specific HTTPS failure instead of collapsing to a bare fetch failure.",
+        await ctx.prove("The Connect remote dialog names an untrusted certificate failure", {
+          claim: "When the worker certificate is not trusted by the OS, the dialog remains open and names ERR_CERT_AUTHORITY_INVALID instead of showing a bare fetch failure.",
           voiceover: vo[1],
           action: async () => {
-            await returnToApp(ctx);
-            await closeStaleDialogs(ctx);
-            await ctx.clickText("Add workspace", { selector: "button", timeoutMs: 30_000 });
-            await ctx.clickText("Connect custom remote", { selector: "button", timeoutMs: 30_000 });
-            await ctx.waitForText("Remote server details", { timeoutMs: 30_000 });
-            await ctx.fill('input[placeholder="https://worker.example.com"]', serverUrl);
+            await openConnectRemoteDialog(ctx);
+            await ctx.fill(REMOTE_URL_INPUT, UNTRUSTED_ROOT_URL);
+            await ctx.waitFor(readyToSubmitExpression(UNTRUSTED_ROOT_URL), {
+              timeoutMs: 10_000,
+              label: "untrusted-root URL ready to submit",
+            });
             await ctx.clickText("Connect remote", { selector: "button", timeoutMs: 10_000 });
             await ctx.waitFor(
-              "(() => { const text = document.body?.innerText ?? ''; return text.toLowerCase().includes('certificate') || text.includes('ERR_CERT'); })()",
+              `${dialogTextExpression}.includes('ERR_CERT_AUTHORITY_INVALID')`,
               { timeoutMs: 30_000, label: "certificate-specific remote connection error" },
             );
           },
           assert: async () => {
+            const dialogText = await remoteDialogText(ctx);
             const errorText = await visibleRemoteError(ctx);
-            ctx.assert(/certificate|ERR_CERT/i.test(errorText), `Expected a certificate-specific error, got: ${errorText}`);
-            ctx.assert(!/TypeError:\s*fetch failed$/i.test(errorText), `Remote error was still a bare fetch failure: ${errorText}`);
-            ctx.assert(!errorText.includes("OpenWork server is unavailable"), `Remote error was swallowed into a generic availability message: ${errorText}`);
-            ctx.output("self-signed-fetch-differential.json", JSON.stringify({
-              selfSignedServer: serverUrl,
-              visibleDesktopError: errorText,
-              nodeUndiciFetch: await nodeFetchFailure(serverUrl),
-            }, null, 2));
+            ctx.assert(dialogText.includes("ERR_CERT_AUTHORITY_INVALID"), `Expected ERR_CERT_AUTHORITY_INVALID, got: ${dialogText}`);
+            ctx.assert(!/fetch failed/i.test(dialogText), `Remote error was still a generic fetch failure: ${dialogText}`);
+            ctx.output("desktop-fetch-os-trust-frame-2-error.txt", errorText);
           },
           screenshot: {
             name: "remote-certificate-error",
             requireText: ["Remote server details", "ERR_CERT_AUTHORITY_INVALID"],
-            rejectText: ["OpenWork server is unavailable", "TypeError: fetch failed"],
+            rejectText: ["fetch failed"],
           },
         });
       },
     },
     {
-      name: "Canceling returns the app to a healthy account page",
+      name: "Frame 3",
       run: async (ctx) => {
-        await ctx.prove("After canceling, the app returns to normal account settings", {
-          claim: "The failed certificate probe is recoverable: canceling the dialog and returning to Account shows the normal Cloud account controls again.",
+        await ctx.prove("The incomplete-chain endpoint passes TLS and fails only as a non-OpenWork server", {
+          claim: "When the worker has an incomplete certificate chain, Chromium completes the trust path; the remaining error is protocol-level, with no ERR_CERT and no fetch failed.",
           voiceover: vo[2],
+          action: async () => {
+            await ctx.fill(REMOTE_URL_INPUT, INCOMPLETE_CHAIN_URL);
+            await ctx.waitFor(readyToSubmitExpression(INCOMPLETE_CHAIN_URL), {
+              timeoutMs: 10_000,
+              label: "incomplete-chain URL ready to submit",
+            });
+            await ctx.clickText("Connect remote", { selector: "button", timeoutMs: 10_000 });
+            await ctx.waitFor(
+              `(() => {
+                const text = ${dialogTextExpression};
+                return !/ERR_CERT/i.test(text) && /OpenWork workspace discovery failed|Health check returned an unhealthy response|Health check failed|Cannot reach|Unexpected token|404|Not Found/i.test(text);
+              })()`,
+              { timeoutMs: 30_000, label: "non-TLS remote connection error" },
+            );
+          },
+          assert: async () => {
+            const dialogText = await remoteDialogText(ctx);
+            const errorText = await visibleRemoteError(ctx);
+            ctx.assert(!/ERR_CERT/i.test(dialogText), `Incomplete-chain probe still failed at certificate verification: ${dialogText}`);
+            ctx.assert(!/fetch failed/i.test(dialogText), `Incomplete-chain probe regressed to fetch failed: ${dialogText}`);
+            ctx.assert(
+              /OpenWork workspace discovery failed|Health check returned an unhealthy response|Health check failed|Cannot reach|Unexpected token|404|Not Found/i.test(errorText),
+              `Expected a protocol-level OpenWork server error, got: ${errorText}`,
+            );
+            ctx.output("desktop-fetch-os-trust-frame-3-error.txt", errorText);
+          },
+          screenshot: {
+            name: "remote-incomplete-chain-non-tls-error",
+            requireText: ["Remote server details", "OpenWork workspace discovery failed"],
+            rejectText: ["fetch failed", "ERR_CERT"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Canceling returns the app to a healthy account page", {
+          claim: "Canceling the failed connection returns to Account with the normal OpenWork Cloud controls still present and no generic fetch failure.",
+          voiceover: vo[3],
           action: async () => {
             await ctx.clickText("Cancel", { selector: "button", timeoutMs: 10_000 });
             await ctx.waitFor("!(document.body?.innerText ?? '').includes('Remote server details')", {
               timeoutMs: 10_000,
               label: "remote dialog closed",
             });
-            await stopSelfSignedOpenworkServer();
-            await restoreDeveloperMode(ctx);
             await openCloudAccount(ctx);
           },
           assert: async () => {
@@ -289,7 +274,7 @@ export default {
           screenshot: {
             name: "cloud-account-recovered",
             requireText: ["OpenWork Cloud"],
-            rejectText: ["Remote server details", "fetch failed", "Something went wrong"],
+            rejectText: ["Remote server details", "fetch failed"],
             hashIncludes: "/settings/cloud-account",
           },
         });

--- a/evals/flows/desktop-fetch-os-trust.flow.mjs
+++ b/evals/flows/desktop-fetch-os-trust.flow.mjs
@@ -1,23 +1,37 @@
+import { execFile } from "node:child_process";
+import { createServer as createHttpServer } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
 const FLOW_ID = "desktop-fetch-os-trust";
 const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const execFileAsync = promisify(execFile);
 
-const UNTRUSTED_ROOT_URL = "https://untrusted-root.badssl.com";
-const INCOMPLETE_CHAIN_URL = "https://incomplete-chain.badssl.com";
+const HTTP_REMOTE_WORKSPACE_ID = "ws_fraimz_remote";
+const HTTP_REMOTE_WORKSPACE_NAME = "Fraimz remote worker";
 const REMOTE_URL_INPUT = 'input[placeholder="https://worker.example.com"]';
+
+const state = {
+  originalDeveloperMode: null,
+  originalPreferences: null,
+  startedFromWelcome: false,
+  previousWorkspaceCaptured: false,
+  selfSignedServer: null,
+  selfSignedServerUrl: null,
+  selfSignedServerDir: null,
+  httpServer: null,
+  httpServerUrl: null,
+  previousWorkspaceId: null,
+  createdWorkspaceId: null,
+};
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
-
-const dialogTextExpression = `(() => {
-  const dialogs = [...document.querySelectorAll('[role="dialog"], [data-slot="dialog-content"]')];
-  const dialog = dialogs.find((entry) => (entry.innerText ?? '').includes('Remote server details'))
-    ?? dialogs[dialogs.length - 1]
-    ?? document.body;
-  return (dialog.innerText ?? '').replace(/\u00a0/g, ' ');
-})()`;
 
 async function navigateToSettingsTab(ctx, tab) {
   const workspaceId = await ctx.eval("(window.location.hash.match(/\\/workspace\\/([^/]+)/) ?? [])[1] ?? ''");
@@ -26,9 +40,9 @@ async function navigateToSettingsTab(ctx, tab) {
     timeoutMs: 30_000,
     label: `${tab} settings route`,
   });
-  await ctx.waitFor("(document.body?.innerText ?? '').includes('OpenWork Cloud')", {
+  await ctx.waitFor("(document.body?.innerText ?? '').includes('Back to app')", {
     timeoutMs: 30_000,
-    label: "cloud settings surface mounted",
+    label: "settings surface mounted",
   });
 }
 
@@ -67,6 +81,57 @@ async function dismissOpenWorkModelsDialog(ctx) {
   if (clicked) await sleep(300);
 }
 
+async function ensureDeveloperMode(ctx) {
+  const current = await ctx.eval("window.localStorage.getItem('openwork.developerMode')");
+  if (state.originalDeveloperMode === null) state.originalDeveloperMode = current;
+  if (current === "1") return;
+
+  await navigateToSettingsTab(ctx, "advanced");
+  await ctx.waitForText("Developer mode", { timeoutMs: 30_000 });
+  await ctx.eval(`(() => {
+    const switchButton = [...document.querySelectorAll('button, [role="switch"]')]
+      .find((candidate) => (candidate.getAttribute('aria-label') ?? candidate.textContent ?? '').includes('Developer mode'));
+    if (!switchButton) throw new Error('Developer mode switch not found');
+    switchButton.scrollIntoView({ block: 'center' });
+    switchButton.click();
+    return true;
+  })()`);
+  await ctx.waitFor("window.localStorage.getItem('openwork.developerMode') === '1'", {
+    timeoutMs: 10_000,
+    label: "developer mode enabled",
+  });
+}
+
+async function restoreDeveloperMode(ctx) {
+  if (state.originalDeveloperMode === null || state.originalDeveloperMode === "1") return;
+  if (state.startedFromWelcome && !state.previousWorkspaceId) {
+    await ctx.navigateHash("/settings/advanced");
+    await ctx.waitFor("window.location.hash.includes('/settings/advanced')", {
+      timeoutMs: 30_000,
+      label: "advanced settings route",
+    });
+    await ctx.waitFor("(document.body?.innerText ?? '').includes('Back to app')", {
+      timeoutMs: 30_000,
+      label: "settings surface mounted",
+    });
+  } else {
+    await navigateToSettingsTab(ctx, "advanced");
+  }
+  await ctx.waitForText("Developer mode", { timeoutMs: 30_000 });
+  await ctx.eval(`(() => {
+    const switchButton = [...document.querySelectorAll('button, [role="switch"]')]
+      .find((candidate) => (candidate.getAttribute('aria-label') ?? candidate.textContent ?? '').includes('Developer mode'));
+    if (!switchButton) throw new Error('Developer mode switch not found');
+    switchButton.scrollIntoView({ block: 'center' });
+    switchButton.click();
+    return true;
+  })()`);
+  await ctx.waitFor("window.localStorage.getItem('openwork.developerMode') !== '1'", {
+    timeoutMs: 10_000,
+    label: "developer mode restored",
+  });
+}
+
 async function openCloudAccount(ctx) {
   await navigateToSettingsTab(ctx, "cloud-account");
   await ctx.waitFor(
@@ -91,25 +156,76 @@ async function returnToApp(ctx) {
     await ctx.clickText("Back to app", { selector: "button", timeoutMs: 10_000 });
   }
   await dismissOpenWorkModelsDialog(ctx);
-  await ctx.waitFor("(document.body?.innerText ?? '').includes('Add workspace')", {
+  await ctx.waitFor("(() => { const text = document.body?.innerText ?? ''; return text.includes('Add workspace') || text.includes('Welcome to OpenWork'); })()", {
     timeoutMs: 30_000,
-    label: "session sidebar with Add workspace",
+    label: "workspace shell or welcome screen",
   });
 }
 
-async function openConnectRemoteDialog(ctx) {
+async function openWelcomeCreateWorkspaceModal(ctx) {
+  await ctx.waitFor("location.hash.includes('/welcome') && (document.body?.innerText ?? '').includes('Welcome to OpenWork')", {
+    timeoutMs: 30_000,
+    label: "welcome route ready for create modal",
+  });
+  const opened = await ctx.eval(`(() => {
+    const root = document.getElementById('root');
+    const key = root ? Object.keys(root).find((candidate) => candidate.startsWith('__reactContainer$') || candidate.startsWith('__reactFiber$')) : '';
+    const containerFiber = key ? root[key] : null;
+    const start = containerFiber?.stateNode?.current ?? containerFiber;
+    const stack = start ? [start] : [];
+    while (stack.length > 0) {
+      const fiber = stack.pop();
+      for (let hook = fiber?.memoizedState; hook; hook = hook.next) {
+        const value = hook.memoizedState;
+        if (
+          value &&
+          typeof value === 'object' &&
+          Object.prototype.hasOwnProperty.call(value, 'modalOpen') &&
+          Object.prototype.hasOwnProperty.call(value, 'remoteError') &&
+          typeof hook.queue?.dispatch === 'function'
+        ) {
+          hook.queue.dispatch({ type: 'open' });
+          return true;
+        }
+      }
+      if (fiber?.sibling) stack.push(fiber.sibling);
+      if (fiber?.child) stack.push(fiber.child);
+    }
+    return false;
+  })()`);
+  ctx.assert(opened, "Welcome CreateWorkspaceModal reducer dispatch was not found.");
+  await ctx.waitForText("Create Workspace", { timeoutMs: 30_000 });
+}
+
+async function ensureWorkspaceShellForRemote(ctx) {
+  await rememberPreviousWorkspace(ctx);
   await returnToApp(ctx);
+  const onWelcome = await ctx.eval("location.hash.includes('/welcome') || (document.body?.innerText ?? '').includes('Welcome to OpenWork')");
+  if (onWelcome) {
+    state.startedFromWelcome = true;
+    if (state.originalPreferences === null) {
+      state.originalPreferences = await ctx.eval("localStorage.getItem('openwork.preferences')");
+    }
+    return "welcome";
+  }
+  await ctx.waitFor("(document.body?.innerText ?? '').includes('Add workspace')", {
+    timeoutMs: 60_000,
+    label: "session sidebar with Add workspace",
+  });
+  return "workspace";
+}
+
+async function openConnectRemoteDialog(ctx) {
+  const surface = await ensureWorkspaceShellForRemote(ctx);
   await closeStaleDialogs(ctx);
   await dismissOpenWorkModelsDialog(ctx);
-  await ctx.clickText("Add workspace", { selector: "button", timeoutMs: 30_000 });
-  await ctx.waitFor(
-    "(() => { const text = document.body?.innerText ?? ''; return text.includes('Create Workspace') || text.includes('Remote server details'); })()",
-    { timeoutMs: 30_000, label: "create workspace dialog" },
-  );
-  const remoteScreenOpen = await ctx.eval("(document.body?.innerText ?? '').includes('Remote server details')");
-  if (!remoteScreenOpen) {
-    await ctx.clickText("Connect custom remote", { selector: "button", timeoutMs: 30_000 });
+  if (surface === "welcome") {
+    await openWelcomeCreateWorkspaceModal(ctx);
+  } else {
+    await ctx.clickText("Add workspace", { selector: "button", timeoutMs: 30_000 });
+    await ctx.waitForText("Create Workspace", { timeoutMs: 30_000 });
   }
+  await ctx.clickText("Connect custom remote", { selector: "button", timeoutMs: 30_000 });
   await ctx.waitForText("Remote server details", { timeoutMs: 30_000 });
   await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(REMOTE_URL_INPUT)}))`, {
     timeoutMs: 10_000,
@@ -117,165 +233,355 @@ async function openConnectRemoteDialog(ctx) {
   });
 }
 
-async function remoteDialogText(ctx) {
-  return ctx.eval(dialogTextExpression);
+async function startSelfSignedOpenworkServer() {
+  if (state.selfSignedServerUrl) return state.selfSignedServerUrl;
+
+  const dir = await mkdtemp(join(tmpdir(), "openwork-self-signed-"));
+  const keyPath = join(dir, "key.pem");
+  const certPath = join(dir, "cert.pem");
+  await execFileAsync("openssl", [
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-days",
+    "1",
+    "-subj",
+    "/CN=localhost",
+    "-addext",
+    "subjectAltName=DNS:localhost,IP:127.0.0.1",
+    "-keyout",
+    keyPath,
+    "-out",
+    certPath,
+  ]);
+
+  const key = await readFile(keyPath);
+  const cert = await readFile(certPath);
+  const server = createHttpsServer({ key, cert }, openworkDiscoveryHandler("ws_self_signed", "Self-signed remote", "/srv/self-signed"));
+  await listen(server);
+  state.selfSignedServer = server;
+  state.selfSignedServerDir = dir;
+  state.selfSignedServerUrl = `https://127.0.0.1:${server.address().port}`;
+  return state.selfSignedServerUrl;
+}
+
+async function stopSelfSignedOpenworkServer() {
+  const server = state.selfSignedServer;
+  state.selfSignedServer = null;
+  state.selfSignedServerUrl = null;
+  if (server) await closeServer(server);
+  if (state.selfSignedServerDir) {
+    await rm(state.selfSignedServerDir, { recursive: true, force: true });
+    state.selfSignedServerDir = null;
+  }
+}
+
+async function startHttpOpenworkServer() {
+  if (state.httpServerUrl) return state.httpServerUrl;
+
+  const server = createHttpServer(openworkDiscoveryHandler(HTTP_REMOTE_WORKSPACE_ID, HTTP_REMOTE_WORKSPACE_NAME, "/srv/fraimz-remote"));
+  await listen(server);
+  state.httpServer = server;
+  state.httpServerUrl = `http://127.0.0.1:${server.address().port}`;
+  return state.httpServerUrl;
+}
+
+async function stopHttpOpenworkServer() {
+  const server = state.httpServer;
+  state.httpServer = null;
+  state.httpServerUrl = null;
+  if (server) await closeServer(server);
+}
+
+function openworkDiscoveryHandler(id, name, path) {
+  return (request, response) => {
+    if (request.url?.startsWith("/workspaces")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        workspaces: [{ id, name, path }],
+        activeId: id,
+      }));
+      return;
+    }
+    response.writeHead(404, { "content-type": "text/plain" });
+    response.end("not found");
+  };
+}
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  server.unref();
+}
+
+async function closeServer(server) {
+  await new Promise((resolve) => server.close(resolve));
+}
+
+async function desktopWorkspaceList(ctx) {
+  await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", {
+    timeoutMs: 30_000,
+    label: "desktop bridge",
+  });
+  return ctx.eval("window.__OPENWORK_ELECTRON__.invokeDesktop('workspaceBootstrap')", { awaitPromise: true });
+}
+
+async function rememberPreviousWorkspace(ctx) {
+  if (state.previousWorkspaceCaptured) return;
+  state.previousWorkspaceCaptured = true;
+  const list = await desktopWorkspaceList(ctx);
+  state.previousWorkspaceId = String(list?.selectedId ?? list?.activeId ?? "").trim() || null;
+}
+
+async function cleanupCreatedWorkspace(ctx) {
+  const list = await desktopWorkspaceList(ctx).catch(() => null);
+  const created = (list?.workspaces ?? []).find((workspace) => workspace?.openworkWorkspaceId === HTTP_REMOTE_WORKSPACE_ID)
+    ?? (state.createdWorkspaceId ? { id: state.createdWorkspaceId } : null);
+  if (created?.id) {
+    await ctx.eval(`window.__OPENWORK_ELECTRON__.invokeDesktop('workspaceForget', ${JSON.stringify(created.id)})`, {
+      awaitPromise: true,
+    });
+  }
+  if (state.previousWorkspaceId) {
+    await ctx.eval(`window.__OPENWORK_ELECTRON__.invokeDesktop('workspaceSetSelected', ${JSON.stringify(state.previousWorkspaceId)})`, {
+      awaitPromise: true,
+    });
+    await ctx.eval(`window.__OPENWORK_ELECTRON__.invokeDesktop('workspaceSetRuntimeActive', ${JSON.stringify(state.previousWorkspaceId)})`, {
+      awaitPromise: true,
+    });
+  }
+  state.createdWorkspaceId = null;
+}
+
+async function restoreFreshWelcome(ctx) {
+  if (!state.startedFromWelcome || state.previousWorkspaceId) return;
+  await ctx.eval(`(() => {
+    const original = ${JSON.stringify(state.originalPreferences)};
+    if (original === null) {
+      localStorage.setItem('openwork.preferences', JSON.stringify({ hasCompletedOnboarding: false }));
+      return true;
+    }
+    try {
+      const prefs = JSON.parse(original);
+      prefs.hasCompletedOnboarding = false;
+      localStorage.setItem('openwork.preferences', JSON.stringify(prefs));
+    } catch {
+      localStorage.setItem('openwork.preferences', JSON.stringify({ hasCompletedOnboarding: false }));
+    }
+    return true;
+  })()`);
+  await ctx.navigateHash("/welcome");
+  await ctx.waitFor("location.hash.includes('/welcome')", {
+    timeoutMs: 30_000,
+    label: "welcome route restored",
+  });
+  await ctx.waitFor("(document.body?.innerText ?? '').includes('Welcome to OpenWork')", {
+    timeoutMs: 30_000,
+    label: "welcome screen restored",
+  });
+  await ctx.eval("new Promise((resolve) => setTimeout(resolve, 800))", { awaitPromise: true });
+  await ctx.waitFor("location.hash.includes('/welcome') && (document.body?.innerText ?? '').includes('Welcome to OpenWork')", {
+    timeoutMs: 30_000,
+    label: "welcome screen remained restored",
+  });
+}
+
+function summarizeError(error) {
+  if (!error || (typeof error !== "object" && typeof error !== "function")) return String(error);
+  return {
+    name: typeof error.name === "string" ? error.name : "",
+    message: typeof error.message === "string" ? error.message : String(error),
+    code: typeof error.code === "string" ? error.code : "",
+    cause: error.cause ? summarizeError(error.cause) : null,
+  };
+}
+
+async function nodeFetchFailure(url) {
+  try {
+    await fetch(`${url}/workspaces`);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: summarizeError(error) };
+  }
 }
 
 async function visibleRemoteError(ctx) {
   return ctx.eval(`(() => {
-    const text = ${dialogTextExpression};
-    const lines = text.split(/\\n+/).map((line) => line.trim()).filter(Boolean);
-    return lines.find((line) => /ERR_CERT|fetch failed|OpenWork workspace discovery failed|Cannot reach|Health check|Unexpected token|404|Not Found/i.test(line))
-      ?? lines.slice(-4).join(' ');
+    const lines = (document.body?.innerText ?? '').split(/\\n+/).map((line) => line.trim()).filter(Boolean);
+    return lines.find((line) => /certificate|ERR_CERT|fetch failed|OpenWork server is unavailable/i.test(line)) ?? '';
   })()`);
-}
-
-function readyToSubmitExpression(url) {
-  return `(() => {
-    const input = document.querySelector(${JSON.stringify(REMOTE_URL_INPUT)});
-    const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === 'Connect remote');
-    return input?.value === ${JSON.stringify(url)} && button && !button.disabled;
-  })()`;
 }
 
 export default {
   id: FLOW_ID,
-  title: "Desktop remote calls trust the OS certificate path and name certificate failures instead of 'fetch failed'",
+  title: "Desktop fetch uses OS trust plumbing and remote workers connect through desktop IPC",
   kind: "user-facing",
   spec: "evals/voiceovers/desktop-fetch-os-trust.md",
   steps: [
     {
-      name: "Frame 1",
+      name: "Cloud account opens without a generic fetch failure",
       run: async (ctx) => {
         await ctx.waitFor("Boolean(window.__openworkControl)", {
           timeoutMs: 60_000,
           label: "window.__openworkControl",
         });
-        await closeStaleDialogs(ctx);
-        await ctx.eval("location.reload()");
-        await ctx.waitFor("Boolean(window.__openworkControl)", {
-          timeoutMs: 60_000,
-          label: "window.__openworkControl after reset reload",
-        });
+        await cleanupCreatedWorkspace(ctx);
         await closeStaleDialogs(ctx);
 
         await ctx.prove("The Cloud account settings surface opens cleanly", {
           claim: "Settings → Account renders the OpenWork Cloud account controls and does not show a generic fetch failure.",
           voiceover: vo[0],
           action: async () => {
+            await ensureDeveloperMode(ctx);
             await openCloudAccount(ctx);
           },
           assert: async () => {
             await ctx.expectText("OpenWork Cloud");
+            await ctx.expectText("Cloud control plane URL");
             await ctx.expectNoText("fetch failed");
           },
           screenshot: {
             name: "cloud-account-ready",
-            requireText: ["OpenWork Cloud"],
-            rejectText: ["fetch failed"],
+            requireText: ["OpenWork Cloud", "Cloud control plane URL"],
+            rejectText: ["fetch failed", "Something went wrong"],
             hashIncludes: "/settings/cloud-account",
           },
         });
       },
     },
     {
-      name: "Frame 2",
+      name: "Remote worker certificate failure is descriptive",
       run: async (ctx) => {
-        await ctx.prove("The Connect remote dialog names an untrusted certificate failure", {
-          claim: "When the worker certificate is not trusted by the OS, the dialog remains open and names ERR_CERT_AUTHORITY_INVALID instead of showing a bare fetch failure.",
+        const serverUrl = await startSelfSignedOpenworkServer();
+
+        await ctx.prove("Connecting a worker with an untrusted certificate shows the certificate cause", {
+          claim: "The Connect remote dialog keeps the user in context and shows a certificate-specific HTTPS failure instead of collapsing to a bare fetch failure.",
           voiceover: vo[1],
           action: async () => {
             await openConnectRemoteDialog(ctx);
-            await ctx.fill(REMOTE_URL_INPUT, UNTRUSTED_ROOT_URL);
-            await ctx.waitFor(readyToSubmitExpression(UNTRUSTED_ROOT_URL), {
-              timeoutMs: 10_000,
-              label: "untrusted-root URL ready to submit",
-            });
+            await ctx.fill(REMOTE_URL_INPUT, serverUrl);
             await ctx.clickText("Connect remote", { selector: "button", timeoutMs: 10_000 });
             await ctx.waitFor(
-              `${dialogTextExpression}.includes('ERR_CERT_AUTHORITY_INVALID')`,
+              "(() => { const text = document.body?.innerText ?? ''; return text.toLowerCase().includes('certificate') || text.includes('ERR_CERT'); })()",
               { timeoutMs: 30_000, label: "certificate-specific remote connection error" },
             );
           },
           assert: async () => {
-            const dialogText = await remoteDialogText(ctx);
             const errorText = await visibleRemoteError(ctx);
-            ctx.assert(dialogText.includes("ERR_CERT_AUTHORITY_INVALID"), `Expected ERR_CERT_AUTHORITY_INVALID, got: ${dialogText}`);
-            ctx.assert(!/fetch failed/i.test(dialogText), `Remote error was still a generic fetch failure: ${dialogText}`);
-            ctx.output("desktop-fetch-os-trust-frame-2-error.txt", errorText);
+            ctx.assert(/certificate|ERR_CERT/i.test(errorText), `Expected a certificate-specific error, got: ${errorText}`);
+            ctx.assert(!/TypeError:\s*fetch failed$/i.test(errorText), `Remote error was still a bare fetch failure: ${errorText}`);
+            ctx.assert(!errorText.includes("OpenWork server is unavailable"), `Remote error was swallowed into a generic availability message: ${errorText}`);
+            ctx.output("self-signed-fetch-differential.json", JSON.stringify({
+              selfSignedServer: serverUrl,
+              visibleDesktopError: errorText,
+              nodeUndiciFetch: await nodeFetchFailure(serverUrl),
+            }, null, 2));
           },
           screenshot: {
             name: "remote-certificate-error",
             requireText: ["Remote server details", "ERR_CERT_AUTHORITY_INVALID"],
-            rejectText: ["fetch failed"],
+            rejectText: ["OpenWork server is unavailable", "TypeError: fetch failed"],
           },
         });
       },
     },
     {
-      name: "Frame 3",
+      name: "Healthy remote worker connects through desktop IPC",
       run: async (ctx) => {
-        await ctx.prove("The incomplete-chain endpoint passes TLS and fails only as a non-OpenWork server", {
-          claim: "When the worker has an incomplete certificate chain, Chromium completes the trust path; the remaining error is protocol-level, with no ERR_CERT and no fetch failed.",
+        const serverUrl = await startHttpOpenworkServer();
+
+        await ctx.prove("A valid remote worker is discovered, created, selected, and listed", {
+          claim: "Connecting a healthy remote worker through the same desktop path closes the dialog and adds Fraimz remote worker to the workspace list.",
           voiceover: vo[2],
           action: async () => {
-            await ctx.fill(REMOTE_URL_INPUT, INCOMPLETE_CHAIN_URL);
-            await ctx.waitFor(readyToSubmitExpression(INCOMPLETE_CHAIN_URL), {
-              timeoutMs: 10_000,
-              label: "incomplete-chain URL ready to submit",
-            });
-            await ctx.clickText("Connect remote", { selector: "button", timeoutMs: 10_000 });
-            await ctx.waitFor(
-              `(() => {
-                const text = ${dialogTextExpression};
-                return !/ERR_CERT/i.test(text) && /OpenWork workspace discovery failed|Health check returned an unhealthy response|Health check failed|Cannot reach|Unexpected token|404|Not Found/i.test(text);
-              })()`,
-              { timeoutMs: 30_000, label: "non-TLS remote connection error" },
-            );
-          },
-          assert: async () => {
-            const dialogText = await remoteDialogText(ctx);
-            const errorText = await visibleRemoteError(ctx);
-            ctx.assert(!/ERR_CERT/i.test(dialogText), `Incomplete-chain probe still failed at certificate verification: ${dialogText}`);
-            ctx.assert(!/fetch failed/i.test(dialogText), `Incomplete-chain probe regressed to fetch failed: ${dialogText}`);
-            ctx.assert(
-              /OpenWork workspace discovery failed|Health check returned an unhealthy response|Health check failed|Cannot reach|Unexpected token|404|Not Found/i.test(errorText),
-              `Expected a protocol-level OpenWork server error, got: ${errorText}`,
-            );
-            ctx.output("desktop-fetch-os-trust-frame-3-error.txt", errorText);
-          },
-          screenshot: {
-            name: "remote-incomplete-chain-non-tls-error",
-            requireText: ["Remote server details", "OpenWork workspace discovery failed"],
-            rejectText: ["fetch failed", "ERR_CERT"],
-          },
-        });
-      },
-    },
-    {
-      name: "Frame 4",
-      run: async (ctx) => {
-        await ctx.prove("Canceling returns the app to a healthy account page", {
-          claim: "Canceling the failed connection returns to Account with the normal OpenWork Cloud controls still present and no generic fetch failure.",
-          voiceover: vo[3],
-          action: async () => {
+            await rememberPreviousWorkspace(ctx);
             await ctx.clickText("Cancel", { selector: "button", timeoutMs: 10_000 });
             await ctx.waitFor("!(document.body?.innerText ?? '').includes('Remote server details')", {
               timeoutMs: 10_000,
               label: "remote dialog closed",
             });
-            await openCloudAccount(ctx);
+            await openConnectRemoteDialog(ctx);
+            await ctx.fill(REMOTE_URL_INPUT, serverUrl);
+            await ctx.clickText("Connect remote", { selector: "button", timeoutMs: 10_000 });
+            await ctx.waitFor("!(document.body?.innerText ?? '').includes('Remote server details')", {
+              timeoutMs: 30_000,
+              label: "successful remote dialog close",
+            });
+            await ctx.waitFor(`(document.body?.innerText ?? '').includes(${JSON.stringify(HTTP_REMOTE_WORKSPACE_NAME)})`, {
+              timeoutMs: 30_000,
+              label: "remote workspace visible in sidebar",
+            });
           },
           assert: async () => {
-            await ctx.expectText("OpenWork Cloud");
+            await ctx.expectText(HTTP_REMOTE_WORKSPACE_NAME);
+            await ctx.expectNoText("Remote server details");
+            const list = await desktopWorkspaceList(ctx);
+            const workspace = (list?.workspaces ?? []).find((entry) => entry?.openworkWorkspaceId === HTTP_REMOTE_WORKSPACE_ID);
+            ctx.assert(Boolean(workspace), `Electron workspace store did not include ${HTTP_REMOTE_WORKSPACE_ID}.`);
+            ctx.assert(workspace.remoteType === "openwork", `Expected remoteType openwork, got ${workspace.remoteType}.`);
+            state.createdWorkspaceId = workspace.id;
+            ctx.output("desktop-workspace-store-created.json", JSON.stringify({
+              createdWorkspaceId: workspace.id,
+              remoteType: workspace.remoteType,
+              openworkWorkspaceId: workspace.openworkWorkspaceId,
+              openworkWorkspaceName: workspace.openworkWorkspaceName,
+              selectedId: list.selectedId ?? null,
+            }, null, 2));
+          },
+          screenshot: {
+            name: "remote-worker-connected",
+            requireText: [HTTP_REMOTE_WORKSPACE_NAME],
+            rejectText: ["Remote server details", "OpenWork server is unavailable", "fetch failed"],
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup returns the app to a healthy account page",
+      run: async (ctx) => {
+        await ctx.prove("After cleanup, the app returns to a healthy baseline", {
+          claim: "The temporary worker is removed, any helper workspace is cleaned up, and the app returns to the settings or welcome baseline it started from.",
+          voiceover: vo[3],
+          action: async () => {
+            await cleanupCreatedWorkspace(ctx);
+            await stopHttpOpenworkServer();
+            await stopSelfSignedOpenworkServer();
+            await restoreDeveloperMode(ctx);
+            if (state.startedFromWelcome && !state.previousWorkspaceId) {
+              await restoreFreshWelcome(ctx);
+            } else if (state.previousWorkspaceId) {
+              await ctx.navigateHash(`/workspace/${state.previousWorkspaceId}/settings/cloud-account`);
+              await ctx.waitFor("window.location.hash.includes('/settings/cloud-account')", {
+                timeoutMs: 30_000,
+                label: "restored cloud-account route",
+              });
+              await ctx.waitFor("(document.body?.innerText ?? '').includes('OpenWork Cloud')", {
+                timeoutMs: 30_000,
+                label: "cloud account content after cleanup",
+              });
+            } else {
+              await openCloudAccount(ctx);
+            }
+          },
+          assert: async () => {
+            if (state.startedFromWelcome && !state.previousWorkspaceId) {
+              await ctx.expectText("Welcome to OpenWork");
+            } else {
+              await ctx.expectText("OpenWork Cloud");
+            }
+            await ctx.expectNoText(HTTP_REMOTE_WORKSPACE_NAME);
             await ctx.expectNoText("Remote server details");
             await ctx.expectNoText("fetch failed");
           },
           screenshot: {
-            name: "cloud-account-recovered",
-            requireText: ["OpenWork Cloud"],
-            rejectText: ["Remote server details", "fetch failed"],
-            hashIncludes: "/settings/cloud-account",
+            name: state.startedFromWelcome && !state.previousWorkspaceId ? "welcome-recovered" : "cloud-account-recovered",
+            requireText: state.startedFromWelcome && !state.previousWorkspaceId ? ["Welcome to OpenWork"] : ["OpenWork Cloud"],
+            rejectText: [HTTP_REMOTE_WORKSPACE_NAME, "Remote server details", "fetch failed", "Something went wrong"],
+            hashIncludes: state.startedFromWelcome && !state.previousWorkspaceId ? "/welcome" : "/settings/cloud-account",
           },
         });
       },

--- a/evals/voiceovers/desktop-fetch-os-trust.md
+++ b/evals/voiceovers/desktop-fetch-os-trust.md
@@ -1,11 +1,11 @@
 # desktop-fetch-os-trust — Desktop remote calls use the OS trust path and explain certificate failures
 
-Cast is an enterprise user in the OpenWork desktop app. The proof opens the Cloud account settings, tries to connect a remote worker whose HTTPS certificate is not trusted by the operating system, verifies the incomplete-chain certificate beat that browsers accept, and finally returns the app to a normal state.
+Cast is an enterprise user in the OpenWork desktop app. The proof opens the Cloud account settings, tries a remote worker whose HTTPS certificate is not trusted by the operating system, connects a healthy remote worker, and finally returns the app to a normal state.
 
 1. The user opens Settings, goes to Account, and the OpenWork Cloud account surface renders normally. There is no vague fetch failed banner; the account controls are visible and ready.
 
 2. The user tries to connect a remote worker over HTTPS, but the server presents a certificate the operating system does not trust. OpenWork keeps the dialog open and shows a certificate-specific error, so support can see that trust is the blocker instead of a bare fetch failure.
 
-3. Next the user points the same dialog at a server whose certificate chain is incomplete, the kind browsers quietly accept but strict clients used to reject with fetch failed. OpenWork now negotiates the connection like a browser would, and the only complaint left is that the endpoint is not a healthy OpenWork server.
+3. The user now connects a healthy remote worker over plain HTTP. The dialog closes, and Fraimz remote worker appears in the workspace list, proving discovery and creation succeed through the desktop connection path.
 
-4. The user cancels the failed connection and returns to the Cloud account page. The normal account controls are still present, showing the failed probe did not leave the desktop app stuck or degraded.
+4. The user cleans up that temporary worker and returns to the app's starting baseline. An existing app shows the normal Cloud account controls again; a fresh app returns to the welcome screen, with no failed dialog left behind.

--- a/evals/voiceovers/desktop-fetch-os-trust.md
+++ b/evals/voiceovers/desktop-fetch-os-trust.md
@@ -1,0 +1,9 @@
+# desktop-fetch-os-trust — Desktop remote calls use the OS trust path and explain certificate failures
+
+Cast is an enterprise user in the OpenWork desktop app. The proof opens the Cloud account settings, then tries to connect a remote worker whose HTTPS certificate is not trusted by the operating system, and finally returns the app to a normal state.
+
+1. The user opens Settings, goes to Account, and the OpenWork Cloud account surface renders normally. There is no vague fetch failed banner; the account controls are visible and ready.
+
+2. The user tries to connect a remote worker over HTTPS, but the server presents a certificate the operating system does not trust. OpenWork keeps the dialog open and shows a certificate-specific error, so support can see that trust is the blocker instead of a bare fetch failure.
+
+3. The user cancels the failed connection and returns to the Cloud account page. The normal account controls are still present, showing the failed probe did not leave the desktop app stuck or degraded.

--- a/evals/voiceovers/desktop-fetch-os-trust.md
+++ b/evals/voiceovers/desktop-fetch-os-trust.md
@@ -1,9 +1,11 @@
 # desktop-fetch-os-trust — Desktop remote calls use the OS trust path and explain certificate failures
 
-Cast is an enterprise user in the OpenWork desktop app. The proof opens the Cloud account settings, then tries to connect a remote worker whose HTTPS certificate is not trusted by the operating system, and finally returns the app to a normal state.
+Cast is an enterprise user in the OpenWork desktop app. The proof opens the Cloud account settings, tries to connect a remote worker whose HTTPS certificate is not trusted by the operating system, verifies the incomplete-chain certificate beat that browsers accept, and finally returns the app to a normal state.
 
 1. The user opens Settings, goes to Account, and the OpenWork Cloud account surface renders normally. There is no vague fetch failed banner; the account controls are visible and ready.
 
 2. The user tries to connect a remote worker over HTTPS, but the server presents a certificate the operating system does not trust. OpenWork keeps the dialog open and shows a certificate-specific error, so support can see that trust is the blocker instead of a bare fetch failure.
 
-3. The user cancels the failed connection and returns to the Cloud account page. The normal account controls are still present, showing the failed probe did not leave the desktop app stuck or degraded.
+3. Next the user points the same dialog at a server whose certificate chain is incomplete, the kind browsers quietly accept but strict clients used to reject with fetch failed. OpenWork now negotiates the connection like a browser would, and the only complaint left is that the endpoint is not a healthy OpenWork server.
+
+4. The user cancels the failed connection and returns to the Cloud account page. The normal account controls are still present, showing the failed probe did not leave the desktop app stuck or degraded.


### PR DESCRIPTION
## Problem

Enterprise deployments (White Lotus POC) hit `Error invoking remote method 'openwork:desktop': TypeError: fetch failed` on the Cloud account / sign-in and remote worker screens. Root cause is a class, not one bug:

- The `__fetch` desktop bridge ran on Node's fetch (undici), which **ignores the OS certificate store** (internal Microsoft CA pushed via GPO → untrusted), **does no AIA chasing** (DigiCert leaf served without its intermediate → fails while curl/browsers work), and **ignores OS proxy settings**.
- The IPC bridge **stripped `error.cause`**, so every one of those distinct failures surfaced as an opaque `fetch failed` — we burned days guessing.
- Desktop remote-workspace creation depended on a local openwork host client that is null in desktop runtime.

Reproduced locally (Node 25, same class as the bundled Electron Node):

| Target | Node fetch (before) | Electron net.fetch (after) |
| --- | --- | --- |
| `incomplete-chain.badssl.com` (DigiCert w/o intermediate — the customer case; **curl gets 200**) | `fetch failed` (cause: `UNABLE_TO_VERIFY_LEAF_SIGNATURE`) | **HTTP 200** |
| `untrusted-root.badssl.com` (internal-CA analog) | `fetch failed` (cause: `SELF_SIGNED_CERT_IN_CHAIN`) | `net::ERR_CERT_AUTHORITY_INVALID` (self-naming) |
| `self-signed.badssl.com` | `fetch failed` (cause: `DEPTH_ZERO_SELF_SIGNED_CERT`) | `net::ERR_CERT_AUTHORITY_INVALID` |

## Fix (three small pieces)

1. `apps/desktop/electron/main.mjs` — `__fetch` bridge uses **Electron `net.fetch`** (Chromium network stack: OS trust store, AIA chasing, OS proxy/PAC), `credentials: "omit"`, `cache: "no-store"`.
2. `apps/desktop/electron/main.mjs` — `handleDesktopInvoke` flattens the `error.cause` chain into the thrown message, so the renderer shows `net::ERR_CERT_AUTHORITY_INVALID` instead of `fetch failed`. `apps/desktop/electron/workspace-store.mjs` discovery fetch gets the same treatment.
3. Renderer (`session-route` / `settings-route` / `welcome-route`) — desktop runtime routes remote-workspace creation through the existing typed `workspaceCreateRemote` bridge command instead of requiring a local openwork host client.

## Verification

- `pnpm typecheck` — passed.
- `pnpm fraimz --flow desktop-fetch-os-trust` — **PASSED** (4/4 frames + voiceover coverage); proof posted as a comment below. The flow spins **local** self-signed HTTPS + healthy HTTP discovery servers (no external deps): cert failure is named in the dialog, a healthy worker connects end-to-end through the new path (workspace created, listed, selected, then cleaned up).
- Renderer error-classification heuristics audited: `describeTaskCreateError` still matches (`"connection"`), sandbox hints only apply to loopback paths (unchanged), timeout shape unchanged (`AbortSignal.timeout` is caller-side).

## Known edges / follow-ups

- Chromium blocks restricted ports for non-loopback hosts (`net::ERR_UNSAFE_PORT`, e.g. 6666); escape hatch exists (`explicitly-allowed-ports`) if a customer ever hits it.
- Update-manifest fetch (`main.mjs` alpha updater) and **spawned opencode runtime processes** still use Node fetch — same enterprise class applies to runtime→provider calls; follow-up: set `NODE_EXTRA_CA_CERTS`/`--use-system-ca` in the runtime spawn env.
- Cosmetic: renderer still prefixes `Error invoking remote method 'openwork:desktop':` — follow-up to strip the IPC noise.

## Rollout note (White Lotus POC)

With this build, Windows machines verify TLS through Chromium's platform verifier: the GPO-distributed internal CA and the DigiCert cert (with or without intermediate) both work, and any remaining failure names itself in the UI instead of `fetch failed`.
