### PR TITLE
feat(connections): Granola + Render quick-add presets

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
@@ -44,6 +44,13 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
     authType: "oauth",
   },
   {
+    presetId: "granola",
+    displayName: "Granola",
+    description: "Search your meeting notes and transcripts.",
+    url: "https://mcp.granola.ai/mcp",
+    authType: "oauth",
+  },
+  {
     presetId: "slack",
     displayName: "Slack",
     description: "Channels, DMs, and search. Slack has no automatic app registration — paste your Slack app's OAuth client once; each person then connects their own account.",


### PR DESCRIPTION
## What

Adds two entries to the Den org-wide External MCP Connections quick-add presets (`ee/apps/den-api/src/capability-sources/external-mcp-presets.ts`, +14 lines total, nothing else touched):

**Granola** (granola.ai — AI meeting notes)
- URL: `https://mcp.granola.ai/mcp` — official hosted server ([Granola docs](https://docs.granola.ai/help-center/sharing/integrations/mcp))
- `authType: "oauth"`, no `requiresOAuthClient`: supports OAuth 2.0 dynamic client registration, so each member just approves in the browser — placed with the other plain-OAuth servers (after Sentry, before Slack).

**Render** (render.com — cloud hosting)
- URL: `https://mcp.render.com/mcp` — official hosted server ([Render docs](https://render.com/docs/mcp-server))
- `authType: "apikey"`: Render's MCP does not support OAuth; it authenticates via `Authorization: Bearer <RENDER_API_KEY>`, which is exactly what den-api's apikey path sends (`external-mcp-client.ts`). Placed with Exa in the API-key group; description tells admins to grab the key from dashboard.render.com.

Both follow the exact pattern of the Exa preset (#2498). Desktop app untouched — entries flow through the existing `GET /org/mcp-connections/presets` route (`presetResponseSchema` already matches) into the Den dashboard quick-add cards.

## Testing

- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit` — **pass** (clean, run after each entry).
- No unit tests exist for the preset catalog (`rg -ln 'presetId|EXTERNAL_MCP_PRESETS' ee --glob '*test*'` → none), so none needed updating.
- **No video/screenshot attached** — I did not spin up the local Den stack for this data-only catalog addition. Reviewer repro:
  1. `pnpm demo:den:reset && pnpm dev:den`
  2. Sign in as the seeded demo admin, open **Dashboard → Connections**
  3. **Granola** and **Render** cards appear in the quick-add presets; Granola's Add starts browser OAuth against `mcp.granola.ai`, Render's Add opens the API-key dialog.

Happy to follow up with a fraimz run (variant of `evals/flows/exa-connection.flow.mjs`) if wanted before merge.