### PR TITLE
fix(evals): auto-fetch BLOB_READ_WRITE_TOKEN from Infisical for fraimz PR uploads

### DIFF
--- a/evals/runner/pr.mjs
+++ b/evals/runner/pr.mjs
@@ -6,7 +6,7 @@
  *
  * Frame screenshots are uploaded to Vercel Blob (see the `upload-photo`
  * skill) so they render inline in the PR comment. Requires
- * `BLOB_READ_WRITE_TOKEN` in the environment.
+ * `BLOB_READ_WRITE_TOKEN`, falling back to Infisical when unset.
  */
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
@@ -14,6 +14,18 @@ import { writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 
 const BLOB_API_BASE = "https://blob.vercel-storage.com";
+
+function resolveBlobToken() {
+  const fromEnv = process.env.BLOB_READ_WRITE_TOKEN;
+  if (fromEnv) return fromEnv;
+  const result = spawnSync(
+    "infisical",
+    ["secrets", "get", "BLOB_READ_WRITE_TOKEN", "--plain", "--silent"],
+    { encoding: "utf8" },
+  );
+  const token = result.status === 0 && !result.error ? result.stdout.trim() : "";
+  return token.length > 0 ? token : null;
+}
 
 function contentTypeFor(file) {
   const lower = file.toLowerCase();
@@ -121,10 +133,11 @@ export async function uploadRunImages(report, outDir) {
   }
   if (files.length === 0) return null;
 
-  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  const token = resolveBlobToken();
   if (!token) {
     throw new Error(
-      "BLOB_READ_WRITE_TOKEN is not set — fetch it with the get-env-var skill: " +
+      "BLOB_READ_WRITE_TOKEN is not set and could not be fetched from Infisical (`infisical secrets get BLOB_READ_WRITE_TOKEN --plain --silent`) — " +
+        "run `infisical login` once, or export it: " +
         'export BLOB_READ_WRITE_TOKEN="$(infisical secrets get BLOB_READ_WRITE_TOKEN --plain --silent)"',
     );
   }


### PR DESCRIPTION
## Why

Every `pnpm fraimz --flow <id> --pr` run from a fresh shell/agent session failed screenshot upload with:

> screenshot upload failed: BLOB_READ_WRITE_TOKEN is not set — fetch it with the get-env-var skill …

The token is a secret that lives only in Infisical (never persisted to shell profiles, per repo policy), so every new session started without it and the PR comment posted without inline images.

## What

`evals/runner/pr.mjs` (+16/−3, single file):

- New `resolveBlobToken()`: use `process.env.BLOB_READ_WRITE_TOKEN` when set; otherwise silently fall back to `infisical secrets get BLOB_READ_WRITE_TOKEN --plain --silent` (uses the already-imported `spawnSync`; the token value is never logged).
- `uploadRunImages` errors only when **both** sources fail, with an actionable message (`run infisical login once, or export it`).
- Header comment updated to mention the fallback.

On any machine where `infisical login` has been done once, fraimz PR uploads now just work in fresh sessions.

## Validation (commands run + results)

This changes the fraimz runner's own PR-upload tooling (no product/UI surface), so instead of a fraimz.html I exercised the exact changed code path against reality:

- `node --check evals/runner/pr.mjs` → passes (run on this branch's worktree).
- **Fallback success path** (the recurring failure case): with `BLOB_READ_WRITE_TOKEN` explicitly unset (`env -u`), called `uploadRunImages` with a real 1×1 PNG → token fetched from Infisical, real upload to Vercel Blob succeeded and returned a public URL:
  - https://b8tgacyg507ru26g.public.blob.vercel-storage.com/fraimz/token-fallback-pr-verify/frame-wt.png
- **Fallback failure path**: env var unset + a stub `infisical` that exits 1 shadowing the real one on PATH → throws `BLOB_READ_WRITE_TOKEN is not set and could not be fetched from Infisical (…) — run infisical login once, or export it: …` (verified the message, no secret content).
- **Env-var path**: unchanged first branch (returns the env value directly, as before).

No video: this is a headless tooling path with no UI; the blob URL above is the observable end-to-end proof. Reviewer repro: `env -u BLOB_READ_WRITE_TOKEN node -e "import('./evals/runner/pr.mjs').then(m => …uploadRunImages…)"` on a machine with `infisical login` done.
