### PR TITLE
feat(cloud): granular Google Workspace permissions + in-dialog OAuth setup guide

### DIFF
--- a/ee/apps/den-api/src/capability-sources/provider-registry.ts
+++ b/ee/apps/den-api/src/capability-sources/provider-registry.ts
@@ -19,6 +19,7 @@ export type NativeOAuthProviderConfig = {
   /** Display-only endpoint shown on connection cards. */
   websiteUrl: string
   defaultScopes: string[]
+  defaultFeatures?: string[]
   optionalFeatures?: Record<string, string[]>
   /** Google (and most modern providers) support PKCE even for confidential clients; harmless to always send. */
   usesPkce: boolean
@@ -37,14 +38,16 @@ export const NATIVE_OAUTH_PROVIDERS: Record<string, NativeOAuthProviderConfig> =
       "openid",
       "https://www.googleapis.com/auth/userinfo.email",
       "https://www.googleapis.com/auth/userinfo.profile",
-      "https://www.googleapis.com/auth/calendar.readonly",
-      "https://www.googleapis.com/auth/gmail.compose",
-      "https://www.googleapis.com/auth/drive.file",
     ],
+    defaultFeatures: ["calendarRead", "gmailDraft", "driveFile"],
     optionalFeatures: {
-      gmailRead: ["https://www.googleapis.com/auth/gmail.readonly"],
-      driveFull: ["https://www.googleapis.com/auth/drive"],
+      calendarRead: ["https://www.googleapis.com/auth/calendar.readonly"],
       calendarWrite: ["https://www.googleapis.com/auth/calendar.events"],
+      gmailDraft: ["https://www.googleapis.com/auth/gmail.compose"],
+      gmailRead: ["https://www.googleapis.com/auth/gmail.readonly"],
+      driveFile: ["https://www.googleapis.com/auth/drive.file"],
+      driveRead: ["https://www.googleapis.com/auth/drive.readonly"],
+      driveFull: ["https://www.googleapis.com/auth/drive"],
       chat: [
         "https://www.googleapis.com/auth/chat.spaces.readonly",
         "https://www.googleapis.com/auth/chat.messages.readonly",
@@ -83,9 +86,16 @@ export function resolveProviderScopes(provider: NativeOAuthProviderConfig, featu
   return scopes
 }
 
+function providerDefaultFeatures(provider: NativeOAuthProviderConfig): string[] {
+  const optionalFeatures = provider.optionalFeatures
+  if (!optionalFeatures) return []
+  return (provider.defaultFeatures ?? []).filter((feature) => Object.hasOwn(optionalFeatures, feature))
+}
+
 export function clientSelectedFeatures(provider: NativeOAuthProviderConfig, extra: Record<string, unknown> | null): string[] {
   const optionalFeatures = provider.optionalFeatures
-  if (!optionalFeatures || !extra || !Array.isArray(extra.features)) return []
+  if (!optionalFeatures) return []
+  if (!extra || !Object.hasOwn(extra, "features") || !Array.isArray(extra.features)) return providerDefaultFeatures(provider)
 
   const features: string[] = []
   for (const feature of extra.features) {

--- a/ee/apps/den-api/src/routes/org/oauth-providers.ts
+++ b/ee/apps/den-api/src/routes/org/oauth-providers.ts
@@ -60,9 +60,11 @@ const clientConfigResponseSchema = z.object({
 
 const clientConfigDetailResponseSchema = z.object({
   providerId: z.string(),
-  clientId: z.string(),
+  configured: z.boolean(),
+  clientId: z.string().nullable(),
   features: z.array(z.string()),
   scopes: z.array(z.string()),
+  redirectUri: z.string(),
 }).meta({ ref: "OAuthClientConfigDetailResponse" })
 
 const connectStartResponseSchema = z.object({
@@ -73,8 +75,6 @@ const clientNotConfiguredSchema = z.object({
   error: z.literal("client_not_configured"),
   message: z.string(),
 }).meta({ ref: "OAuthClientNotConfiguredError" })
-
-const clientLookupNotFoundSchema = z.union([oauthNotFoundSchema, clientNotConfiguredSchema]).meta({ ref: "OAuthClientLookupNotFoundError" })
 
 const oauthStatusResponseSchema = z.object({
   providerId: z.string(),
@@ -206,12 +206,12 @@ export function registerOAuthProviderRoutes<T extends { Variables: OrgRouteVaria
     describeRoute({
       tags: ["Authentication"],
       summary: "Get an org's OAuth client configuration for a provider",
-      description: "Admin-only. Returns the saved OAuth client id, selected permission features, and the full scope list members will be asked to approve. Never returns the client secret.",
+      description: "Admin-only. Returns setup status, the saved OAuth client id when configured, selected permission features, the callback redirect URI, and the full scope list members will be asked to approve. Never returns the client secret.",
       responses: {
         200: jsonResponse("OAuth client configuration.", clientConfigDetailResponseSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
         403: jsonResponse("Only workspace owners and admins can view an OAuth client configuration.", forbiddenSchema),
-        404: jsonResponse("Unknown providerId, or the org has not configured an OAuth client for this provider yet.", clientLookupNotFoundSchema),
+        404: jsonResponse("Unknown providerId.", oauthNotFoundSchema),
       },
     }),
     orgMemberRoute(),
@@ -228,16 +228,14 @@ export function registerOAuthProviderRoutes<T extends { Variables: OrgRouteVaria
       }
 
       const client = await getOrgOAuthClient(payload.organization.id, providerId)
-      if (!client) {
-        return c.json({ error: "client_not_configured", message: `Connect an OAuth client for "${providerId}" first.` }, 404)
-      }
-
-      const features = clientSelectedFeatures(provider, client.extra)
+      const features = clientSelectedFeatures(provider, client?.extra ?? null)
       return c.json({
         providerId,
-        clientId: client.clientId,
+        configured: Boolean(client),
+        clientId: client?.clientId ?? null,
         features,
         scopes: resolveProviderScopes(provider, features),
+        redirectUri: callbackRedirectUri(c.req.raw, providerId),
       })
     },
   )

--- a/ee/apps/den-api/src/routes/org/oauth-providers.ts
+++ b/ee/apps/den-api/src/routes/org/oauth-providers.ts
@@ -206,7 +206,7 @@ export function registerOAuthProviderRoutes<T extends { Variables: OrgRouteVaria
     describeRoute({
       tags: ["Authentication"],
       summary: "Get an org's OAuth client configuration for a provider",
-      description: "Admin-only. Returns the saved OAuth client id, selected optional features, and the full scope list members will be asked to approve. Never returns the client secret.",
+      description: "Admin-only. Returns the saved OAuth client id, selected permission features, and the full scope list members will be asked to approve. Never returns the client secret.",
       responses: {
         200: jsonResponse("OAuth client configuration.", clientConfigDetailResponseSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),

--- a/ee/apps/den-api/test/native-provider-scopes.test.ts
+++ b/ee/apps/den-api/test/native-provider-scopes.test.ts
@@ -3,10 +3,14 @@ import { beforeAll, describe, expect, test } from "bun:test"
 
 import type { OrgOAuthClientRow } from "../src/capability-sources/oauth-credentials.js"
 
-const GOOGLE_WORKSPACE_BASE_SCOPES = [
+const GOOGLE_WORKSPACE_IDENTITY_SCOPES = [
   "openid",
   "https://www.googleapis.com/auth/userinfo.email",
   "https://www.googleapis.com/auth/userinfo.profile",
+]
+
+const GOOGLE_WORKSPACE_LEGACY_BASE_SCOPES = [
+  ...GOOGLE_WORKSPACE_IDENTITY_SCOPES,
   "https://www.googleapis.com/auth/calendar.readonly",
   "https://www.googleapis.com/auth/gmail.compose",
   "https://www.googleapis.com/auth/drive.file",
@@ -38,38 +42,61 @@ function googleWorkspaceProvider() {
 }
 
 describe("google-workspace native provider scopes", () => {
-  test("defaultScopes matches the desktop base set", () => {
-    expect(googleWorkspaceProvider().defaultScopes).toEqual(GOOGLE_WORKSPACE_BASE_SCOPES)
+  test("defaultScopes is only the identity trio", () => {
+    expect(googleWorkspaceProvider().defaultScopes).toEqual(GOOGLE_WORKSPACE_IDENTITY_SCOPES)
   })
 
-  test("resolveProviderScopes adds selected feature scopes and dedupes", () => {
-    const scopes = registry.resolveProviderScopes(googleWorkspaceProvider(), ["gmailRead", "calendarWrite", "gmailRead"])
+  test("missing features keeps legacy rows on the old desktop base behavior", () => {
+    const provider = googleWorkspaceProvider()
+    const features = registry.clientSelectedFeatures(provider, {})
+    const scopes = registry.resolveProviderScopes(provider, features)
+
+    expect(registry.clientSelectedFeatures(provider, null)).toEqual(["calendarRead", "gmailDraft", "driveFile"])
+    expect(features).toEqual(["calendarRead", "gmailDraft", "driveFile"])
+    expect(scopes).toEqual(GOOGLE_WORKSPACE_LEGACY_BASE_SCOPES)
+  })
+
+  test("features empty array means identity-only", () => {
+    const provider = googleWorkspaceProvider()
+    const features = registry.clientSelectedFeatures(provider, { features: [] })
+    const scopes = registry.resolveProviderScopes(provider, features)
+
+    expect(features).toEqual([])
+    expect(scopes).toEqual(GOOGLE_WORKSPACE_IDENTITY_SCOPES)
+  })
+
+  test("selected features are the complete capability set", () => {
+    const provider = googleWorkspaceProvider()
+    const features = registry.clientSelectedFeatures(provider, {
+      features: ["calendarRead", "calendarWrite", "gmailDraft", "gmailRead"],
+    })
+    const scopes = registry.resolveProviderScopes(provider, features)
 
     expect(scopes).toEqual([
-      ...GOOGLE_WORKSPACE_BASE_SCOPES,
-      "https://www.googleapis.com/auth/gmail.readonly",
+      ...GOOGLE_WORKSPACE_IDENTITY_SCOPES,
+      "https://www.googleapis.com/auth/calendar.readonly",
       "https://www.googleapis.com/auth/calendar.events",
+      "https://www.googleapis.com/auth/gmail.compose",
+      "https://www.googleapis.com/auth/gmail.readonly",
     ])
   })
 
-  test("clientSelectedFeatures ignores unknown keys, non-strings, and absent extra", () => {
+  test("clientSelectedFeatures ignores unknown keys and non-strings", () => {
     const provider = googleWorkspaceProvider()
 
-    expect(registry.clientSelectedFeatures(provider, null)).toEqual([])
-    expect(registry.clientSelectedFeatures(provider, {})).toEqual([])
     expect(registry.clientSelectedFeatures(provider, {
-      features: ["gmailRead", "unknown", 42, "calendarWrite", null],
-    })).toEqual(["gmailRead", "calendarWrite"])
+      features: ["calendarRead", "unknown", 42, "gmailRead", null],
+    })).toEqual(["calendarRead", "gmailRead"])
   })
 
-  test("buildAuthorizeUrl includes base scopes plus selected optional feature scopes", () => {
+  test("buildAuthorizeUrl includes identity plus the complete selected feature scopes", () => {
     const client: OrgOAuthClientRow = {
       id: createDenTypeId("orgOAuthClient"),
       organizationId: createDenTypeId("organization"),
       providerId: "google-workspace",
       clientId: "google-client-id",
       clientSecret: "google-client-secret",
-      extra: { features: ["gmailRead", "calendarWrite"] },
+      extra: { features: ["calendarRead", "gmailDraft", "driveFile", "gmailRead", "calendarWrite"] },
       createdByOrgMembershipId: createDenTypeId("member"),
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -85,7 +112,10 @@ describe("google-workspace native provider scopes", () => {
     const scopes = new URL(authorizeUrl).searchParams.get("scope")?.split(" ") ?? []
 
     expect(scopes).toEqual([
-      ...GOOGLE_WORKSPACE_BASE_SCOPES,
+      ...GOOGLE_WORKSPACE_IDENTITY_SCOPES,
+      "https://www.googleapis.com/auth/calendar.readonly",
+      "https://www.googleapis.com/auth/gmail.compose",
+      "https://www.googleapis.com/auth/drive.file",
       "https://www.googleapis.com/auth/gmail.readonly",
       "https://www.googleapis.com/auth/calendar.events",
     ])

--- a/ee/apps/den-api/test/native-provider-scopes.test.ts
+++ b/ee/apps/den-api/test/native-provider-scopes.test.ts
@@ -51,6 +51,7 @@ describe("google-workspace native provider scopes", () => {
     const features = registry.clientSelectedFeatures(provider, {})
     const scopes = registry.resolveProviderScopes(provider, features)
 
+    // Legacy rows without a features key preserve the old base-6 scope behavior.
     expect(registry.clientSelectedFeatures(provider, null)).toEqual(["calendarRead", "gmailDraft", "driveFile"])
     expect(features).toEqual(["calendarRead", "gmailDraft", "driveFile"])
     expect(scopes).toEqual(GOOGLE_WORKSPACE_LEGACY_BASE_SCOPES)
@@ -119,5 +120,6 @@ describe("google-workspace native provider scopes", () => {
       "https://www.googleapis.com/auth/gmail.readonly",
       "https://www.googleapis.com/auth/calendar.events",
     ])
+    expect(scopes).toHaveLength(8)
   })
 })

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -235,20 +235,29 @@ export type SaveNativeProviderClientInput = {
 
 export type NativeProviderClient = {
   providerId: string;
-  clientId: string;
+  configured: boolean;
+  clientId: string | null;
   features: string[];
   scopes: string[];
+  redirectUri: string;
 };
 
 function parseNativeProviderClient(payload: unknown): NativeProviderClient {
   if (!isRecord(payload)) {
     throw new Error("Native provider client response was incomplete.");
   }
-  const { providerId, clientId, features, scopes } = payload;
-  if (typeof providerId !== "string" || typeof clientId !== "string" || !isStringArray(features) || !isStringArray(scopes)) {
+  const { providerId, configured, clientId, features, scopes, redirectUri } = payload;
+  if (
+    typeof providerId !== "string"
+    || typeof configured !== "boolean"
+    || (typeof clientId !== "string" && clientId !== null)
+    || !isStringArray(features)
+    || !isStringArray(scopes)
+    || typeof redirectUri !== "string"
+  ) {
     throw new Error("Native provider client response was incomplete.");
   }
-  return { providerId, clientId, features, scopes };
+  return { providerId, configured, clientId, features, scopes, redirectUri };
 }
 
 /**
@@ -295,15 +304,12 @@ export function useNativeProviderClient(providerId: string, enabled: boolean) {
   return useQuery({
     enabled: enabled && Boolean(orgId),
     queryKey: mcpConnectionQueryKeys.nativeProviderClient(orgId, providerId),
-    queryFn: async (): Promise<NativeProviderClient | null> => {
+    queryFn: async (): Promise<NativeProviderClient> => {
       const { response, payload } = await requestJson(
         `/v1/oauth-providers/${encodeURIComponent(providerId)}/client`,
         { headers: getOrgScopeHeaders(requireOrgId(orgId)) },
         15000,
       );
-      if (response.status === 404) {
-        return null;
-      }
       if (!response.ok) {
         throw getRequestError(payload, response, `Failed to load the OAuth client (${response.status}).`);
       }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -291,19 +291,21 @@ function GoogleWorkspaceDialog({
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const [features, setFeatures] = useState<string[]>([]);
+  const [copiedRedirectUri, setCopiedRedirectUri] = useState(false);
   const featuresPrefilled = useRef(false);
 
   useEffect(() => {
     if (!open) return;
     setClientId("");
     setClientSecret("");
-    setFeatures([]);
+    setFeatures(GOOGLE_WORKSPACE_DEFAULT_FEATURES);
+    setCopiedRedirectUri(false);
     featuresPrefilled.current = false;
   }, [open]);
 
   useEffect(() => {
     if (!open || featuresPrefilled.current || !clientConfig.isSuccess || clientConfig.isFetching) return;
-    setFeatures(clientConfig.data?.features ?? GOOGLE_WORKSPACE_DEFAULT_FEATURES);
+    setFeatures(clientConfig.data.features);
     featuresPrefilled.current = true;
   }, [open, clientConfig.isSuccess, clientConfig.isFetching, clientConfig.data?.features]);
 
@@ -311,7 +313,8 @@ function GoogleWorkspaceDialog({
     return null;
   }
 
-  const configured = Boolean(clientConfig.data);
+  const configured = clientConfig.data?.configured ?? false;
+  const redirectUri = clientConfig.data?.redirectUri ?? "";
   const loadingConfig = clientConfig.isLoading;
   const formError = error ?? clientConfig.error;
   const trimmedClientId = clientId.trim();
@@ -322,10 +325,15 @@ function GoogleWorkspaceDialog({
     setFeatures((current) => current.includes(feature) ? current.filter((entry) => entry !== feature) : [...current, feature]);
   }
 
+  function copyRedirectUri() {
+    if (!redirectUri) return;
+    void navigator.clipboard.writeText(redirectUri).then(() => setCopiedRedirectUri(true));
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={onClose}>
       <div
-        className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
+        className="max-h-[calc(100vh-3rem)] w-full max-w-lg overflow-y-auto rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
         onClick={(event) => event.stopPropagation()}
       >
         <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">Set up Google Workspace</h2>
@@ -335,6 +343,35 @@ function GoogleWorkspaceDialog({
         </p>
 
         <div className="mt-5 space-y-4">
+          <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
+            <p className="text-[13px] font-semibold text-gray-900">How to set it up</p>
+            <ol className="mt-2 list-decimal space-y-2 pl-4 text-[12px] leading-5 text-gray-600">
+              <li>
+                Create an OAuth client in Google Cloud Console (APIs &amp; Services → Credentials → Create credentials → OAuth client ID → Web application).{" "}
+                <a href="https://console.cloud.google.com/apis/credentials" target="_blank" rel="noopener" className="font-medium text-gray-900 underline decoration-gray-300 underline-offset-4">
+                  Open Google Cloud Console
+                </a>
+              </li>
+              <li>
+                <p>Add this authorized redirect URI:</p>
+                <div className="mt-1 flex items-center gap-2 rounded-xl border border-gray-200 bg-white p-2">
+                  <p data-google-redirect-uri className="min-w-0 flex-1 break-all font-mono text-[11px] leading-5 text-gray-800">
+                    {redirectUri || "Loading redirect URI…"}
+                  </p>
+                  <DenButton variant="secondary" size="sm" onClick={copyRedirectUri} disabled={!redirectUri}>
+                    {copiedRedirectUri ? "Copied" : "Copy"}
+                  </DenButton>
+                </div>
+              </li>
+              <li>
+                Enable the Google APIs for the permissions you pick (Gmail, Calendar, Drive).{" "}
+                <a href="https://console.cloud.google.com/apis/library" target="_blank" rel="noopener" className="font-medium text-gray-900 underline decoration-gray-300 underline-offset-4">
+                  Open API library
+                </a>
+              </li>
+              <li>Paste the client ID and secret below.</li>
+            </ol>
+          </div>
           <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
             <p className="text-[13px] font-semibold text-gray-900">Permissions</p>
             <p className="mt-1 text-[12px] leading-5 text-gray-500">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -62,6 +62,36 @@ const GOOGLE_WORKSPACE_PERMISSION_GROUPS = [
   },
 ];
 
+async function copyTextToClipboard(text: string): Promise<boolean> {
+  try {
+    const clipboard = navigator.clipboard;
+    if (clipboard) {
+      await clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to the textarea fallback.
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "0";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+  }
+}
+
 export function McpConnectionsScreen() {
   const { orgContext } = useOrgDashboard();
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections();
@@ -325,9 +355,9 @@ function GoogleWorkspaceDialog({
     setFeatures((current) => current.includes(feature) ? current.filter((entry) => entry !== feature) : [...current, feature]);
   }
 
-  function copyRedirectUri() {
+  async function copyRedirectUri() {
     if (!redirectUri) return;
-    void navigator.clipboard.writeText(redirectUri).then(() => setCopiedRedirectUri(true));
+    if (await copyTextToClipboard(redirectUri)) setCopiedRedirectUri(true);
   }
 
   return (
@@ -358,7 +388,7 @@ function GoogleWorkspaceDialog({
                   <p data-google-redirect-uri className="min-w-0 flex-1 break-all font-mono text-[11px] leading-5 text-gray-800">
                     {redirectUri || "Loading redirect URI…"}
                   </p>
-                  <DenButton variant="secondary" size="sm" onClick={copyRedirectUri} disabled={!redirectUri}>
+                  <DenButton variant="secondary" size="sm" data-testid="copy-redirect-uri" onClick={copyRedirectUri} disabled={!redirectUri}>
                     {copiedRedirectUri ? "Copied" : "Copy"}
                   </DenButton>
                 </div>
@@ -621,9 +651,9 @@ function AddConnectionDialog({
     }
   }
 
-  function copyOAuthCallback() {
+  async function copyOAuthCallback() {
     if (!oauthCallback) return;
-    void navigator.clipboard.writeText(oauthCallback).then(() => setCopiedCallback(true));
+    if (await copyTextToClipboard(oauthCallback)) setCopiedCallback(true);
   }
 
   if (!open) {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -29,11 +29,37 @@ import {
 const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
 
-const GOOGLE_WORKSPACE_OPTIONAL_PERMISSIONS = [
-  { key: "gmailRead", label: "Read Gmail" },
-  { key: "driveFull", label: "Full Drive access" },
-  { key: "calendarWrite", label: "Create calendar events" },
-  { key: "chat", label: "Google Chat" },
+const GOOGLE_WORKSPACE_DEFAULT_FEATURES = ["calendarRead", "gmailDraft", "driveFile"];
+
+const GOOGLE_WORKSPACE_PERMISSION_GROUPS = [
+  {
+    name: "Calendar",
+    permissions: [
+      { key: "calendarRead", label: "Read calendar" },
+      { key: "calendarWrite", label: "Create calendar events" },
+    ],
+  },
+  {
+    name: "Gmail",
+    permissions: [
+      { key: "gmailDraft", label: "Draft emails" },
+      { key: "gmailRead", label: "Read Gmail" },
+    ],
+  },
+  {
+    name: "Drive",
+    permissions: [
+      { key: "driveFile", label: "Work with selected Drive files" },
+      { key: "driveRead", label: "Read all Drive files" },
+      { key: "driveFull", label: "Full Drive access" },
+    ],
+  },
+  {
+    name: "Chat",
+    permissions: [
+      { key: "chat", label: "Google Chat" },
+    ],
+  },
 ];
 
 export function McpConnectionsScreen() {
@@ -277,7 +303,7 @@ function GoogleWorkspaceDialog({
 
   useEffect(() => {
     if (!open || featuresPrefilled.current || !clientConfig.isSuccess || clientConfig.isFetching) return;
-    setFeatures(clientConfig.data?.features ?? []);
+    setFeatures(clientConfig.data?.features ?? GOOGLE_WORKSPACE_DEFAULT_FEATURES);
     featuresPrefilled.current = true;
   }, [open, clientConfig.isSuccess, clientConfig.isFetching, clientConfig.data?.features]);
 
@@ -307,27 +333,33 @@ function GoogleWorkspaceDialog({
           Paste the OAuth client from your company&apos;s Google Cloud project. Members then connect their own
           Google account from Your Connections — sign-ins stay in your org&apos;s cloud.
         </p>
-        <p className="mt-2 text-[12px] leading-5 text-gray-500">
-          Included permissions: calendar read, Gmail drafts, and selected Drive files.
-        </p>
 
         <div className="mt-5 space-y-4">
           <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
-            <p className="text-[13px] font-semibold text-gray-900">Optional permissions</p>
-            <p className="mt-1 text-[12px] leading-5 text-gray-500">Only add these when your team needs the extra Google access.</p>
-            <div className="mt-3 space-y-2">
-              {GOOGLE_WORKSPACE_OPTIONAL_PERMISSIONS.map((permission) => (
-                <label key={permission.key} className="flex items-center gap-2 text-[13px] text-gray-700">
-                  <input
-                    type="checkbox"
-                    data-feature={permission.key}
-                    className="h-4 w-4 rounded border-gray-300 text-gray-900"
-                    checked={features.includes(permission.key)}
-                    disabled={loadingConfig}
-                    onChange={() => toggleFeature(permission.key)}
-                  />
-                  <span>{permission.label}</span>
-                </label>
+            <p className="text-[13px] font-semibold text-gray-900">Permissions</p>
+            <p className="mt-1 text-[12px] leading-5 text-gray-500">
+              Pick what your team&apos;s AI can do across Calendar, Gmail, and Drive. Signing in always shares the member&apos;s name and email.
+            </p>
+            <div className="mt-3 space-y-3">
+              {GOOGLE_WORKSPACE_PERMISSION_GROUPS.map((group) => (
+                <div key={group.name}>
+                  <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-400">{group.name}</p>
+                  <div className="space-y-2">
+                    {group.permissions.map((permission) => (
+                      <label key={permission.key} className="flex items-center gap-2 text-[13px] text-gray-700">
+                        <input
+                          type="checkbox"
+                          data-feature={permission.key}
+                          className="h-4 w-4 rounded border-gray-300 text-gray-900"
+                          checked={features.includes(permission.key)}
+                          disabled={loadingConfig}
+                          onChange={() => toggleFeature(permission.key)}
+                        />
+                        <span>{permission.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
               ))}
             </div>
           </div>

--- a/evals/flows/org-google-workspace-scopes.flow.mjs
+++ b/evals/flows/org-google-workspace-scopes.flow.mjs
@@ -15,18 +15,20 @@ const MOCK_SERVER_URL = (process.env.MOCK_OAUTH_MCP_URL ?? "http://127.0.0.1:397
 const RUN_TAG = Date.now();
 const GOOGLE_CLIENT_ID = "google-client-id";
 const GOOGLE_CLIENT_SECRET = "google-client-secret";
-const SELECTED_FEATURES = ["gmailRead", "calendarWrite"];
-const FEATURE_KEYS = ["gmailRead", "driveFull", "calendarWrite", "chat"];
-const BASE_GOOGLE_SCOPES = [
+const DEFAULT_FEATURES = ["calendarRead", "gmailDraft", "driveFile"];
+const EXTRA_FEATURES = ["gmailRead", "calendarWrite"];
+const SAVED_FEATURES = ["calendarRead", "gmailDraft", "driveFile", "gmailRead", "calendarWrite"];
+const FEATURE_KEYS = ["calendarRead", "calendarWrite", "gmailDraft", "gmailRead", "driveFile", "driveRead", "driveFull", "chat"];
+const IDENTITY_SCOPES = [
   "openid",
   "https://www.googleapis.com/auth/userinfo.email",
   "https://www.googleapis.com/auth/userinfo.profile",
+];
+const EXPECTED_MEMBER_SCOPES = [
+  ...IDENTITY_SCOPES,
   "https://www.googleapis.com/auth/calendar.readonly",
   "https://www.googleapis.com/auth/gmail.compose",
   "https://www.googleapis.com/auth/drive.file",
-];
-const EXPECTED_MEMBER_SCOPES = [
-  ...BASE_GOOGLE_SCOPES,
   "https://www.googleapis.com/auth/gmail.readonly",
   "https://www.googleapis.com/auth/calendar.events",
 ];
@@ -150,11 +152,20 @@ function includedPermissionsScript() {
   return `(() => {
     const text = document.body.innerText;
     const normalized = text.toLowerCase();
-    return text.includes('Included permissions')
+    return text.includes('Permissions')
       && normalized.includes('calendar')
       && normalized.includes('gmail')
       && normalized.includes('drive');
   })()`;
+}
+
+function assertFeatureStates(ctx, states, checkedFeatures, uncheckedFeatures) {
+  for (const feature of checkedFeatures) {
+    ctx.assert(states[feature] === true, `${feature} should be checked.`);
+  }
+  for (const feature of uncheckedFeatures) {
+    ctx.assert(states[feature] === false, `${feature} should be unchecked.`);
+  }
 }
 
 function featureReadyScript(featureKey) {
@@ -228,11 +239,11 @@ async function waitForSavedFeatures(ctx) {
     });
     if (config.response.ok) {
       features = Array.isArray(config.body.features) ? config.body.features : [];
-      if (sameStringSet(features, SELECTED_FEATURES)) return features;
+      if (sameStringSet(features, SAVED_FEATURES)) return features;
     }
     await sleep(500);
   }
-  ctx.assert(false, `Saved features never matched ${JSON.stringify(SELECTED_FEATURES)}; last seen ${JSON.stringify(features)}.`);
+  ctx.assert(false, `Saved features never matched ${JSON.stringify(SAVED_FEATURES)}; last seen ${JSON.stringify(features)}.`);
   return features;
 }
 
@@ -311,7 +322,7 @@ export default {
           body: JSON.stringify({
             clientId: `google-clean-client-${RUN_TAG}`,
             clientSecret: "google-clean-secret",
-            features: [],
+            features: DEFAULT_FEATURES,
           }),
         });
         ctx.assert(cleanClient.response.ok, `Saving clean Google client failed: ${cleanClient.response.status} ${JSON.stringify(cleanClient.body).slice(0, 200)}`);
@@ -320,7 +331,7 @@ export default {
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("The Google Workspace setup explains the desktop-parity included permissions", {
+        await ctx.prove("The Google Workspace setup shows granular permissions with desktop defaults checked", {
           voiceover: vo[0],
           action: async () => {
             await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
@@ -330,12 +341,15 @@ export default {
             ctx.assert(clicked, "Google Workspace quick-add card was not found.");
           },
           assert: async () => {
-            await ctx.waitFor(includedPermissionsScript(), { timeoutMs: 20_000, label: "included permissions copy" });
+            await ctx.waitFor(includedPermissionsScript(), { timeoutMs: 20_000, label: "permissions copy" });
+            await ctx.waitFor(featureReadyScript("calendarRead"), { timeoutMs: 20_000, label: "default permission checkboxes ready" });
+            const states = await ctx.eval(featureStatesScript());
+            assertFeatureStates(ctx, states, DEFAULT_FEATURES, ["calendarWrite", "gmailRead", "driveRead", "driveFull", "chat"]);
           },
           screenshot: {
             name: "org-google-workspace-included-permissions",
-            claim: "The setup dialog names the included calendar, Gmail, and Drive permissions.",
-            requireText: ["Included permissions", "calendar", "Gmail", "Drive"],
+            claim: "The setup dialog shows granular Calendar, Gmail, and Drive permissions with the default picks checked.",
+            requireText: ["Permissions", "Calendar", "Gmail", "Drive", "Read calendar", "Draft emails"],
             rejectText: ["Something went wrong"],
           },
         });
@@ -348,7 +362,7 @@ export default {
           voiceover: vo[1],
           action: async () => {
             await ctx.waitFor(featureReadyScript("gmailRead"), { timeoutMs: 20_000, label: "optional permission checkboxes ready" });
-            for (const feature of SELECTED_FEATURES) {
+            for (const feature of EXTRA_FEATURES) {
               const result = await ctx.eval(setFeatureCheckedScript(feature, true));
               ctx.assert(result?.ok, `Could not check optional feature ${feature}.`);
             }
@@ -361,7 +375,7 @@ export default {
           },
           assert: async () => {
             const features = await waitForSavedFeatures(ctx);
-            assertExactStringSet(ctx, features, SELECTED_FEATURES, "Saved optional features");
+            assertExactStringSet(ctx, features, SAVED_FEATURES, "Saved permission features");
           },
           screenshot: {
             name: "org-google-workspace-features-saved",
@@ -384,15 +398,12 @@ export default {
           assert: async () => {
             await ctx.waitFor(featureReadyScript("gmailRead"), { timeoutMs: 20_000, label: "reopened optional permission checkboxes ready" });
             const states = await ctx.eval(featureStatesScript());
-            ctx.assert(states.gmailRead === true, "Read Gmail should be checked after reopening.");
-            ctx.assert(states.calendarWrite === true, "Create calendar events should be checked after reopening.");
-            ctx.assert(states.driveFull === false, "Full Drive access should remain unchecked.");
-            ctx.assert(states.chat === false, "Google Chat should remain unchecked.");
+            assertFeatureStates(ctx, states, SAVED_FEATURES, ["driveRead", "driveFull", "chat"]);
           },
           screenshot: {
             name: "org-google-workspace-features-persisted",
             claim: "The saved Read Gmail and Create calendar events options are still checked.",
-            requireText: ["Optional permissions", "Read Gmail", "Create calendar events"],
+            requireText: ["Permissions", "Read calendar", "Draft emails", "Read Gmail", "Create calendar events"],
             rejectText: ["Something went wrong"],
           },
         });
@@ -401,7 +412,7 @@ export default {
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("The member authorize URL asks for exactly the base Google scopes plus the two selected extras", {
+        await ctx.prove("The member authorize URL asks for exactly the defaults plus the two selected additions", {
           voiceover: vo[3],
           action: async () => {
             const started = await denApiFetch("/v1/mcp-connections/google-workspace/connect/start", {

--- a/evals/flows/org-google-workspace-scopes.flow.mjs
+++ b/evals/flows/org-google-workspace-scopes.flow.mjs
@@ -38,6 +38,7 @@ const state = {
   memberSession: null,
   orgId: null,
   orgName: null,
+  redirectUri: null,
   authorizeUrl: null,
   authorizeScopes: [],
   status: null,
@@ -153,10 +154,22 @@ function includedPermissionsScript() {
     const text = document.body.innerText;
     const normalized = text.toLowerCase();
     return text.includes('Permissions')
+      && text.includes('Add this authorized redirect URI')
       && normalized.includes('calendar')
       && normalized.includes('gmail')
       && normalized.includes('drive');
   })()`;
+}
+
+function redirectUriVisibleScript() {
+  return `(() => {
+    const element = document.querySelector('[data-google-redirect-uri]');
+    return Boolean(element && (element.textContent ?? '').includes('/v1/oauth-providers/google-workspace/connect/callback'));
+  })()`;
+}
+
+function displayedRedirectUriScript() {
+  return `(() => (document.querySelector('[data-google-redirect-uri]')?.textContent ?? '').trim())()`;
 }
 
 function assertFeatureStates(ctx, states, checkedFeatures, uncheckedFeatures) {
@@ -219,6 +232,18 @@ function saveButtonEnabledScript() {
 
 function parseScopes(authorizeUrl) {
   return (new URL(authorizeUrl).searchParams.get("scope") ?? "").split(" ").filter(Boolean);
+}
+
+function parseRedirectUri(authorizeUrl) {
+  return new URL(authorizeUrl).searchParams.get("redirect_uri");
+}
+
+async function loadGoogleClientConfig(ctx) {
+  const config = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
+    headers: orgHeaders(state.adminSession),
+  });
+  ctx.assert(config.response.ok, `Google Workspace client config failed: ${config.response.status} ${JSON.stringify(config.body).slice(0, 200)}`);
+  return config.body;
 }
 
 function consentAuthorizeUrl(authorizeUrl) {
@@ -331,7 +356,7 @@ export default {
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("The Google Workspace setup shows granular permissions with desktop defaults checked", {
+        await ctx.prove("The Google Workspace setup explains the Google Cloud app, redirect URL, and default granular permissions", {
           voiceover: vo[0],
           action: async () => {
             await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
@@ -343,13 +368,20 @@ export default {
           assert: async () => {
             await ctx.waitFor(includedPermissionsScript(), { timeoutMs: 20_000, label: "permissions copy" });
             await ctx.waitFor(featureReadyScript("calendarRead"), { timeoutMs: 20_000, label: "default permission checkboxes ready" });
+            await ctx.waitFor(redirectUriVisibleScript(), { timeoutMs: 20_000, label: "Google redirect URI" });
+            const config = await loadGoogleClientConfig(ctx);
+            state.redirectUri = typeof config.redirectUri === "string" ? config.redirectUri : null;
+            ctx.assert(Boolean(state.redirectUri), `Client config did not include a redirectUri: ${JSON.stringify(config)}`);
+            ctx.assert(state.redirectUri.includes("/v1/oauth-providers/google-workspace/connect/callback"), `Unexpected redirectUri: ${state.redirectUri}`);
+            const displayedRedirectUri = await ctx.eval(displayedRedirectUriScript());
+            ctx.assert(displayedRedirectUri === state.redirectUri, `Displayed redirect URI ${displayedRedirectUri} did not equal API redirectUri ${state.redirectUri}.`);
             const states = await ctx.eval(featureStatesScript());
             assertFeatureStates(ctx, states, DEFAULT_FEATURES, ["calendarWrite", "gmailRead", "driveRead", "driveFull", "chat"]);
           },
           screenshot: {
             name: "org-google-workspace-included-permissions",
-            claim: "The setup dialog shows granular Calendar, Gmail, and Drive permissions with the default picks checked.",
-            requireText: ["Permissions", "Calendar", "Gmail", "Drive", "Read calendar", "Draft emails"],
+            claim: "The setup dialog shows Google Cloud instructions, the redirect URI, and granular Calendar, Gmail, and Drive permissions with the default picks checked.",
+            requireText: ["How to set it up", "Add this authorized redirect URI", "Permissions", "Read calendar", "Draft emails"],
             rejectText: ["Something went wrong"],
           },
         });
@@ -412,7 +444,7 @@ export default {
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("The member authorize URL asks for exactly the defaults plus the two selected additions", {
+        await ctx.prove("The member authorize URL uses the setup redirect URI and exactly the defaults plus the two selected additions", {
           voiceover: vo[3],
           action: async () => {
             const started = await denApiFetch("/v1/mcp-connections/google-workspace/connect/start", {
@@ -422,12 +454,15 @@ export default {
             ctx.assert(started.body.status === "needs_auth" && typeof started.body.authorizeUrl === "string", "connect/start did not return an authorizeUrl.");
             state.authorizeUrl = started.body.authorizeUrl;
             state.authorizeScopes = parseScopes(state.authorizeUrl);
+            ctx.assert(Boolean(state.redirectUri), "Frame 1 did not capture the setup redirect URI.");
+            ctx.assert(parseRedirectUri(state.authorizeUrl) === state.redirectUri, `Authorize URL redirect_uri ${parseRedirectUri(state.authorizeUrl)} did not equal setup redirectUri ${state.redirectUri}.`);
             assertExactStringSet(ctx, state.authorizeScopes, EXPECTED_MEMBER_SCOPES, "Authorize URL scopes");
             await ctx.eval(`(() => { window.location.href = ${JSON.stringify(consentAuthorizeUrl(state.authorizeUrl))}; return true; })()`);
             await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "mock consent page loaded" });
           },
           assert: async () => {
             assertExactStringSet(ctx, state.authorizeScopes, EXPECTED_MEMBER_SCOPES, "Authorize URL scopes");
+            ctx.assert(parseRedirectUri(state.authorizeUrl) === state.redirectUri, `Authorize URL redirect_uri ${parseRedirectUri(state.authorizeUrl)} did not equal setup redirectUri ${state.redirectUri}.`);
             await ctx.waitFor("document.body.innerText.includes('Mock MCP OAuth') && document.body.innerText.includes('Approve OpenWork')", {
               timeoutMs: 30_000,
               label: "mock Google consent page",

--- a/evals/flows/org-google-workspace-scopes.flow.mjs
+++ b/evals/flows/org-google-workspace-scopes.flow.mjs
@@ -38,7 +38,6 @@ const state = {
   memberSession: null,
   orgId: null,
   orgName: null,
-  redirectUri: null,
   authorizeUrl: null,
   authorizeScopes: [],
   status: null,
@@ -154,22 +153,10 @@ function includedPermissionsScript() {
     const text = document.body.innerText;
     const normalized = text.toLowerCase();
     return text.includes('Permissions')
-      && text.includes('Add this authorized redirect URI')
       && normalized.includes('calendar')
       && normalized.includes('gmail')
       && normalized.includes('drive');
   })()`;
-}
-
-function redirectUriVisibleScript() {
-  return `(() => {
-    const element = document.querySelector('[data-google-redirect-uri]');
-    return Boolean(element && (element.textContent ?? '').includes('/v1/oauth-providers/google-workspace/connect/callback'));
-  })()`;
-}
-
-function displayedRedirectUriScript() {
-  return `(() => (document.querySelector('[data-google-redirect-uri]')?.textContent ?? '').trim())()`;
 }
 
 function assertFeatureStates(ctx, states, checkedFeatures, uncheckedFeatures) {
@@ -232,18 +219,6 @@ function saveButtonEnabledScript() {
 
 function parseScopes(authorizeUrl) {
   return (new URL(authorizeUrl).searchParams.get("scope") ?? "").split(" ").filter(Boolean);
-}
-
-function parseRedirectUri(authorizeUrl) {
-  return new URL(authorizeUrl).searchParams.get("redirect_uri");
-}
-
-async function loadGoogleClientConfig(ctx) {
-  const config = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
-    headers: orgHeaders(state.adminSession),
-  });
-  ctx.assert(config.response.ok, `Google Workspace client config failed: ${config.response.status} ${JSON.stringify(config.body).slice(0, 200)}`);
-  return config.body;
 }
 
 function consentAuthorizeUrl(authorizeUrl) {
@@ -356,7 +331,7 @@ export default {
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("The Google Workspace setup explains the Google Cloud app, redirect URL, and default granular permissions", {
+        await ctx.prove("The Google Workspace setup shows granular permissions with desktop defaults checked", {
           voiceover: vo[0],
           action: async () => {
             await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
@@ -368,20 +343,13 @@ export default {
           assert: async () => {
             await ctx.waitFor(includedPermissionsScript(), { timeoutMs: 20_000, label: "permissions copy" });
             await ctx.waitFor(featureReadyScript("calendarRead"), { timeoutMs: 20_000, label: "default permission checkboxes ready" });
-            await ctx.waitFor(redirectUriVisibleScript(), { timeoutMs: 20_000, label: "Google redirect URI" });
-            const config = await loadGoogleClientConfig(ctx);
-            state.redirectUri = typeof config.redirectUri === "string" ? config.redirectUri : null;
-            ctx.assert(Boolean(state.redirectUri), `Client config did not include a redirectUri: ${JSON.stringify(config)}`);
-            ctx.assert(state.redirectUri.includes("/v1/oauth-providers/google-workspace/connect/callback"), `Unexpected redirectUri: ${state.redirectUri}`);
-            const displayedRedirectUri = await ctx.eval(displayedRedirectUriScript());
-            ctx.assert(displayedRedirectUri === state.redirectUri, `Displayed redirect URI ${displayedRedirectUri} did not equal API redirectUri ${state.redirectUri}.`);
             const states = await ctx.eval(featureStatesScript());
             assertFeatureStates(ctx, states, DEFAULT_FEATURES, ["calendarWrite", "gmailRead", "driveRead", "driveFull", "chat"]);
           },
           screenshot: {
             name: "org-google-workspace-included-permissions",
-            claim: "The setup dialog shows Google Cloud instructions, the redirect URI, and granular Calendar, Gmail, and Drive permissions with the default picks checked.",
-            requireText: ["How to set it up", "Add this authorized redirect URI", "Permissions", "Read calendar", "Draft emails"],
+            claim: "The setup dialog shows granular Calendar, Gmail, and Drive permissions with the default picks checked.",
+            requireText: ["Permissions", "Calendar", "Gmail", "Drive", "Read calendar", "Draft emails"],
             rejectText: ["Something went wrong"],
           },
         });
@@ -444,7 +412,7 @@ export default {
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("The member authorize URL uses the setup redirect URI and exactly the defaults plus the two selected additions", {
+        await ctx.prove("The member authorize URL asks for exactly the defaults plus the two selected additions", {
           voiceover: vo[3],
           action: async () => {
             const started = await denApiFetch("/v1/mcp-connections/google-workspace/connect/start", {
@@ -454,15 +422,12 @@ export default {
             ctx.assert(started.body.status === "needs_auth" && typeof started.body.authorizeUrl === "string", "connect/start did not return an authorizeUrl.");
             state.authorizeUrl = started.body.authorizeUrl;
             state.authorizeScopes = parseScopes(state.authorizeUrl);
-            ctx.assert(Boolean(state.redirectUri), "Frame 1 did not capture the setup redirect URI.");
-            ctx.assert(parseRedirectUri(state.authorizeUrl) === state.redirectUri, `Authorize URL redirect_uri ${parseRedirectUri(state.authorizeUrl)} did not equal setup redirectUri ${state.redirectUri}.`);
             assertExactStringSet(ctx, state.authorizeScopes, EXPECTED_MEMBER_SCOPES, "Authorize URL scopes");
             await ctx.eval(`(() => { window.location.href = ${JSON.stringify(consentAuthorizeUrl(state.authorizeUrl))}; return true; })()`);
             await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "mock consent page loaded" });
           },
           assert: async () => {
             assertExactStringSet(ctx, state.authorizeScopes, EXPECTED_MEMBER_SCOPES, "Authorize URL scopes");
-            ctx.assert(parseRedirectUri(state.authorizeUrl) === state.redirectUri, `Authorize URL redirect_uri ${parseRedirectUri(state.authorizeUrl)} did not equal setup redirectUri ${state.redirectUri}.`);
             await ctx.waitFor("document.body.innerText.includes('Mock MCP OAuth') && document.body.innerText.includes('Approve OpenWork')", {
               timeoutMs: 30_000,
               label: "mock Google consent page",

--- a/evals/flows/org-google-workspace-setup-guide.flow.mjs
+++ b/evals/flows/org-google-workspace-setup-guide.flow.mjs
@@ -1,0 +1,314 @@
+import { execSync } from "node:child_process";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, openAdminConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/org-google-workspace-setup-guide.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("org-google-workspace-setup-guide");
+
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MEMBER_EMAIL = process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || "jordan.demo@acme.test";
+const MEMBER_PASSWORD = process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const MOCK_SERVER_URL = (process.env.MOCK_OAUTH_MCP_URL ?? "http://127.0.0.1:3978").trim().replace(/\/+$/, "");
+const RUN_TAG = Date.now();
+const DEFAULT_FEATURES = ["calendarRead", "gmailDraft", "driveFile"];
+
+const state = {
+  adminSession: null,
+  memberSession: null,
+  orgId: null,
+  orgName: null,
+  redirectUri: null,
+  authorizeUrl: null,
+};
+
+function orgHeaders(session) {
+  if (!session) throw new Error("Missing session for org-scoped API call.");
+  if (!state.orgId) throw new Error("Missing pinned organization id for org-scoped API call.");
+  return { authorization: `Bearer ${session}`, "x-openwork-legacy-org-id": state.orgId };
+}
+
+async function selectAdminOrganization(ctx) {
+  const listed = await denApiFetch("/v1/me/orgs", {
+    headers: { authorization: `Bearer ${state.adminSession}` },
+  });
+  ctx.assert(listed.response.ok, `Admin org list failed: ${listed.response.status} ${JSON.stringify(listed.body).slice(0, 200)}`);
+  const orgs = Array.isArray(listed.body.orgs) ? listed.body.orgs : [];
+  const acme = orgs.find((org) => org.slug === "acme-robotics-demo");
+  const adminOrg = orgs.find((org) => ["owner", "admin"].includes(String(org.role ?? "").toLowerCase()));
+  const selected = acme ?? adminOrg;
+  ctx.assert(
+    selected && typeof selected.id === "string",
+    `Admin ${ADMIN_EMAIL} is not in acme-robotics-demo and has no owner/admin org. Orgs: ${JSON.stringify(orgs)}`,
+  );
+  state.orgId = selected.id;
+  state.orgName = typeof selected.name === "string" && selected.name ? selected.name : selected.slug ?? selected.id;
+}
+
+async function ensureVerifiedUser(ctx, email, name, password) {
+  let token = await signInApi(email, password);
+  if (token) return token;
+
+  const signUp = await denApiFetch("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ email, name, password }),
+  });
+  ctx.assert(signUp.response.ok, `Sign-up failed for ${email}: ${signUp.response.status}`);
+  ctx.assert(MARK_VERIFIED_CMD.length > 0, "Set OPENWORK_EVAL_MARK_VERIFIED_CMD to verify eval accounts.");
+  execSync(MARK_VERIFIED_CMD.replaceAll("{email}", email), { stdio: "ignore" });
+  token = await signInApi(email, password);
+  ctx.assert(Boolean(token), `Sign-in still failing for ${email} after sign-up.`);
+  return token;
+}
+
+async function memberBelongsToPinnedOrg(ctx) {
+  const orgs = await denApiFetch("/v1/me/orgs", { headers: { authorization: `Bearer ${state.memberSession}` } });
+  ctx.assert(orgs.response.ok, `Member org list failed: ${orgs.response.status} ${JSON.stringify(orgs.body).slice(0, 200)}`);
+  return (orgs.body.orgs ?? []).some((org) => org.id === state.orgId);
+}
+
+async function ensureMember(ctx) {
+  state.memberSession = await ensureVerifiedUser(ctx, MEMBER_EMAIL, "Jordan Demo", MEMBER_PASSWORD);
+  if (await memberBelongsToPinnedOrg(ctx)) return;
+
+  const invite = await denApiFetch("/v1/invitations", {
+    method: "POST",
+    headers: orgHeaders(state.adminSession),
+    body: JSON.stringify({ email: MEMBER_EMAIL, role: "member" }),
+  });
+  if (!invite.response.ok && invite.body?.error === "member_exists") {
+    ctx.assert(await memberBelongsToPinnedOrg(ctx), `Invite returned member_exists, but ${MEMBER_EMAIL} is not in ${state.orgName} (${state.orgId}).`);
+    return;
+  }
+  ctx.assert(invite.response.ok, `Invitation failed: ${invite.response.status} ${JSON.stringify(invite.body).slice(0, 200)}`);
+  const accept = await denApiFetch("/v1/orgs/invitations/accept", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.memberSession}` },
+    body: JSON.stringify({ id: invite.body.inviteToken }),
+  });
+  ctx.assert(accept.response.ok && accept.body.accepted, "Invitation accept failed.");
+  ctx.assert(await memberBelongsToPinnedOrg(ctx), `${MEMBER_EMAIL} did not join ${state.orgName} (${state.orgId}) after accepting the invite.`);
+}
+
+async function setBrowserActiveOrg(ctx) {
+  const ok = await ctx.eval(`fetch('/api/auth/organization/set-active', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ organizationId: ${JSON.stringify(state.orgId)} }) }).then((r) => r.ok)`, { awaitPromise: true });
+  ctx.assert(ok, `Could not set the browser active org to ${state.orgName} (${state.orgId}).`);
+}
+
+function clickGoogleQuickAddScript() {
+  return `(() => {
+    const card = [...document.querySelectorAll('button')].find((button) => {
+      const text = button.textContent ?? '';
+      return text.includes('Google Workspace') && (text.includes('Tap to set up') || text.includes('Configured'));
+    });
+    card?.scrollIntoView({ block: 'center' });
+    card?.click();
+    return Boolean(card);
+  })()`;
+}
+
+function setupInstructionsVisibleScript() {
+  return `(() => {
+    const text = document.body.innerText;
+    const normalized = text.toLowerCase();
+    return text.includes('How to set it up')
+      && text.includes('Open Google Cloud Console')
+      && text.includes('Open API library')
+      && text.includes('Add this authorized redirect URI')
+      && normalized.includes('google cloud console')
+      && normalized.includes('gmail')
+      && normalized.includes('calendar')
+      && normalized.includes('drive');
+  })()`;
+}
+
+function redirectUriVisibleScript() {
+  return `(() => {
+    const element = document.querySelector('[data-google-redirect-uri]');
+    return Boolean(element && (element.textContent ?? '').includes('/v1/oauth-providers/google-workspace/connect/callback'));
+  })()`;
+}
+
+function displayedRedirectUriScript() {
+  return `(() => (document.querySelector('[data-google-redirect-uri]')?.textContent ?? '').trim())()`;
+}
+
+function copyButtonCopiedScript() {
+  return `(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === 'Copied');
+    return Boolean(button);
+  })()`;
+}
+
+function consoleLinksScript() {
+  return `(() => [...document.querySelectorAll('a')].map((link) => ({ text: (link.textContent ?? '').trim(), href: link.href })).filter((link) => link.href.includes('console.cloud.google.com')))()`;
+}
+
+function parseRedirectUri(authorizeUrl) {
+  return new URL(authorizeUrl).searchParams.get("redirect_uri");
+}
+
+function consentAuthorizeUrl(authorizeUrl) {
+  const url = new URL(authorizeUrl);
+  const mockOrigin = new URL(MOCK_SERVER_URL).origin;
+  if (url.origin === mockOrigin && url.pathname === "/authorize") {
+    url.searchParams.set("force_consent", "1");
+  }
+  return url.toString();
+}
+
+async function loadGoogleClientConfig(ctx) {
+  const config = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
+    headers: orgHeaders(state.adminSession),
+  });
+  ctx.assert(config.response.ok, `Google Workspace client config failed: ${config.response.status} ${JSON.stringify(config.body).slice(0, 200)}`);
+  ctx.assert(typeof config.body.redirectUri === "string", `Google Workspace client config did not include redirectUri: ${JSON.stringify(config.body)}`);
+  return config.body;
+}
+
+export default {
+  id: "org-google-workspace-setup-guide",
+  title: "Google Workspace setup guides admins through OAuth client registration",
+  kind: "user-facing",
+  spec: "evals/voiceovers/org-google-workspace-setup-guide.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Setup: admin and member sessions are ready and Google Workspace can start OAuth",
+      run: async (ctx) => {
+        const health = await fetch(`${MOCK_SERVER_URL}/health`).then((response) => response.json()).catch(() => null);
+        ctx.assert(Boolean(health?.ok), `Mock Google IdP not reachable at ${MOCK_SERVER_URL}.`);
+
+        state.adminSession = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
+        ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+        await selectAdminOrganization(ctx);
+        await ensureMember(ctx);
+
+        await denApiFetch("/v1/oauth-providers/google-workspace/disconnect", {
+          method: "POST",
+          headers: orgHeaders(state.memberSession),
+        }).catch(() => undefined);
+
+        const saved = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
+          method: "POST",
+          headers: orgHeaders(state.adminSession),
+          body: JSON.stringify({
+            clientId: `google-setup-guide-client-${RUN_TAG}`,
+            clientSecret: "google-setup-guide-secret",
+            features: DEFAULT_FEATURES,
+          }),
+        });
+        ctx.assert(saved.response.ok, `Saving Google Workspace client failed: ${saved.response.status} ${JSON.stringify(saved.body).slice(0, 200)}`);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The Google Workspace dialog explains where to create the OAuth client and which APIs to enable", {
+          voiceover: vo[0],
+          action: async () => {
+            await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+            await setBrowserActiveOrg(ctx);
+            await openAdminConnections(ctx);
+            const clicked = await ctx.eval(clickGoogleQuickAddScript());
+            ctx.assert(clicked, "Google Workspace quick-add card was not found.");
+          },
+          assert: async () => {
+            await ctx.waitFor(setupInstructionsVisibleScript(), { timeoutMs: 20_000, label: "Google Workspace setup guide" });
+          },
+          screenshot: {
+            name: "org-google-workspace-setup-guide-instructions",
+            claim: "The setup dialog walks the admin through Google Cloud OAuth client creation and API enablement.",
+            requireText: ["How to set it up", "Open Google Cloud Console", "Open API library", "Add this authorized redirect URI"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The setup dialog shows the exact API redirect URI and the Copy button confirms it copied", {
+          voiceover: vo[1],
+          action: async () => {
+            const config = await loadGoogleClientConfig(ctx);
+            state.redirectUri = config.redirectUri;
+            await ctx.waitFor(redirectUriVisibleScript(), { timeoutMs: 20_000, label: "rendered redirect URI" });
+            await ctx.clickText("Copy", { timeoutMs: 10_000 });
+          },
+          assert: async () => {
+            const displayedRedirectUri = await ctx.eval(displayedRedirectUriScript());
+            ctx.assert(displayedRedirectUri === state.redirectUri, `Displayed redirect URI ${displayedRedirectUri} did not equal API redirectUri ${state.redirectUri}.`);
+            await ctx.waitFor(copyButtonCopiedScript(), { timeoutMs: 10_000, label: "Copied button state" });
+          },
+          screenshot: {
+            name: "org-google-workspace-setup-guide-copy-redirect",
+            claim: "The redirect URI matches the API response and the copy control confirms success.",
+            requireText: ["Add this authorized redirect URI", "/v1/oauth-providers/google-workspace/connect/callback", "Copied"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("The setup guide links point directly to the Google Console credential and API pages", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.waitFor(setupInstructionsVisibleScript(), { timeoutMs: 20_000, label: "Google Console setup links" });
+          },
+          assert: async () => {
+            const links = await ctx.eval(consoleLinksScript());
+            const credentialsLink = links.find((link) => link.text === "Open Google Cloud Console" && link.href.includes("/apis/credentials"));
+            const apiLibraryLink = links.find((link) => link.text === "Open API library" && link.href.includes("/apis/library"));
+            ctx.assert(Boolean(credentialsLink), `Credentials console link was missing or wrong: ${JSON.stringify(links)}`);
+            ctx.assert(Boolean(apiLibraryLink), `API library console link was missing or wrong: ${JSON.stringify(links)}`);
+          },
+          screenshot: {
+            name: "org-google-workspace-setup-guide-console-links",
+            claim: "The setup guide includes direct links to Google Cloud credentials and API library pages.",
+            requireText: ["Open Google Cloud Console", "Open API library"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("The member Google sign-in uses the same redirect URI shown in setup", {
+          voiceover: vo[3],
+          action: async () => {
+            const config = await loadGoogleClientConfig(ctx);
+            state.redirectUri = config.redirectUri;
+            const started = await denApiFetch("/v1/mcp-connections/google-workspace/connect/start", {
+              headers: orgHeaders(state.memberSession),
+            });
+            ctx.assert(started.response.ok, `Starting Google Workspace connect failed: ${started.response.status} ${JSON.stringify(started.body).slice(0, 200)}`);
+            ctx.assert(started.body.status === "needs_auth" && typeof started.body.authorizeUrl === "string", "connect/start did not return an authorizeUrl.");
+            state.authorizeUrl = started.body.authorizeUrl;
+            ctx.assert(parseRedirectUri(state.authorizeUrl) === state.redirectUri, `Authorize URL redirect_uri ${parseRedirectUri(state.authorizeUrl)} did not equal API redirectUri ${state.redirectUri}.`);
+            await ctx.eval(`(() => { window.location.href = ${JSON.stringify(consentAuthorizeUrl(state.authorizeUrl))}; return true; })()`);
+            await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "mock consent page loaded" });
+          },
+          assert: async () => {
+            ctx.assert(parseRedirectUri(state.authorizeUrl) === state.redirectUri, `Authorize URL redirect_uri ${parseRedirectUri(state.authorizeUrl)} did not equal API redirectUri ${state.redirectUri}.`);
+            await ctx.waitFor("document.body.innerText.includes('Mock MCP OAuth') && document.body.innerText.includes('Approve OpenWork')", {
+              timeoutMs: 30_000,
+              label: "mock Google consent page",
+            });
+          },
+          screenshot: {
+            name: "org-google-workspace-setup-guide-consent-redirect",
+            claim: "The member reaches Google consent after Den generated an authorize URL with the exact setup redirect URI.",
+            requireText: ["Mock MCP OAuth", "Approve OpenWork"],
+            rejectText: ["Connection failed"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/org-google-workspace-setup-guide.flow.mjs
+++ b/evals/flows/org-google-workspace-setup-guide.flow.mjs
@@ -14,6 +14,7 @@ const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() ||
 const MOCK_SERVER_URL = (process.env.MOCK_OAUTH_MCP_URL ?? "http://127.0.0.1:3978").trim().replace(/\/+$/, "");
 const RUN_TAG = Date.now();
 const DEFAULT_FEATURES = ["calendarRead", "gmailDraft", "driveFile"];
+const GOOGLE_WORKSPACE_CALLBACK_PATH = "/v1/oauth-providers/google-workspace/connect/callback";
 
 const state = {
   adminSession: null,
@@ -150,6 +151,22 @@ function parseRedirectUri(authorizeUrl) {
   return new URL(authorizeUrl).searchParams.get("redirect_uri");
 }
 
+function normalizeLoopback(url) {
+  const parsed = new URL(url);
+  if (parsed.hostname === "127.0.0.1") parsed.hostname = "localhost";
+  return parsed.toString();
+}
+
+function assertRedirectUriMatch(ctx, actual, expected, label) {
+  ctx.assert(typeof actual === "string" && typeof expected === "string", `${label} redirect URI was missing. Actual: ${actual}. Expected: ${expected}.`);
+  const actualUrl = new URL(actual);
+  const expectedUrl = new URL(expected);
+  ctx.assert(actualUrl.pathname === GOOGLE_WORKSPACE_CALLBACK_PATH, `${label} actual path ${actualUrl.pathname} did not match ${GOOGLE_WORKSPACE_CALLBACK_PATH}.`);
+  ctx.assert(expectedUrl.pathname === GOOGLE_WORKSPACE_CALLBACK_PATH, `${label} expected path ${expectedUrl.pathname} did not match ${GOOGLE_WORKSPACE_CALLBACK_PATH}.`);
+  // Local den-web proxy may use localhost while direct API fetch uses 127.0.0.1; production pins DEN_API_PUBLIC_URL.
+  ctx.assert(normalizeLoopback(actual) === normalizeLoopback(expected), `${label} redirect URI mismatch. Actual: ${actual}. Expected: ${expected}.`);
+}
+
 function consentAuthorizeUrl(authorizeUrl) {
   const url = new URL(authorizeUrl);
   const mockOrigin = new URL(MOCK_SERVER_URL).origin;
@@ -240,7 +257,7 @@ export default {
           },
           assert: async () => {
             const displayedRedirectUri = await ctx.eval(displayedRedirectUriScript());
-            ctx.assert(displayedRedirectUri === state.redirectUri, `Displayed redirect URI ${displayedRedirectUri} did not equal API redirectUri ${state.redirectUri}.`);
+            assertRedirectUriMatch(ctx, displayedRedirectUri, state.redirectUri, "Displayed/API");
             await ctx.waitFor(copyButtonCopiedScript(), { timeoutMs: 10_000, label: "Copied button state" });
           },
           screenshot: {
@@ -290,12 +307,12 @@ export default {
             ctx.assert(started.response.ok, `Starting Google Workspace connect failed: ${started.response.status} ${JSON.stringify(started.body).slice(0, 200)}`);
             ctx.assert(started.body.status === "needs_auth" && typeof started.body.authorizeUrl === "string", "connect/start did not return an authorizeUrl.");
             state.authorizeUrl = started.body.authorizeUrl;
-            ctx.assert(parseRedirectUri(state.authorizeUrl) === state.redirectUri, `Authorize URL redirect_uri ${parseRedirectUri(state.authorizeUrl)} did not equal API redirectUri ${state.redirectUri}.`);
+            assertRedirectUriMatch(ctx, parseRedirectUri(state.authorizeUrl), state.redirectUri, "Authorize/API");
             await ctx.eval(`(() => { window.location.href = ${JSON.stringify(consentAuthorizeUrl(state.authorizeUrl))}; return true; })()`);
             await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "mock consent page loaded" });
           },
           assert: async () => {
-            ctx.assert(parseRedirectUri(state.authorizeUrl) === state.redirectUri, `Authorize URL redirect_uri ${parseRedirectUri(state.authorizeUrl)} did not equal API redirectUri ${state.redirectUri}.`);
+            assertRedirectUriMatch(ctx, parseRedirectUri(state.authorizeUrl), state.redirectUri, "Authorize/API");
             await ctx.waitFor("document.body.innerText.includes('Mock MCP OAuth') && document.body.innerText.includes('Approve OpenWork')", {
               timeoutMs: 30_000,
               label: "mock Google consent page",

--- a/evals/flows/org-google-workspace-setup-guide.flow.mjs
+++ b/evals/flows/org-google-workspace-setup-guide.flow.mjs
@@ -253,7 +253,7 @@ export default {
             const config = await loadGoogleClientConfig(ctx);
             state.redirectUri = config.redirectUri;
             await ctx.waitFor(redirectUriVisibleScript(), { timeoutMs: 20_000, label: "rendered redirect URI" });
-            await ctx.clickText("Copy", { timeoutMs: 10_000 });
+            await ctx.trustedClick('[data-testid="copy-redirect-uri"]', { timeoutMs: 10_000 });
           },
           assert: async () => {
             const displayedRedirectUri = await ctx.eval(displayedRedirectUriScript());

--- a/evals/runner/context.mjs
+++ b/evals/runner/context.mjs
@@ -268,6 +268,34 @@ export class EvalContext {
   }
 
   /**
+   * Dispatch a real browser click via CDP input events. Use this when a flow
+   * needs transient user activation (clipboard, popup, etc.).
+   */
+  async trustedClick(selector, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+    const point = await this.waitFor(`(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return null;
+      if (el instanceof HTMLButtonElement && el.disabled) return null;
+      el.scrollIntoView({ block: "center", inline: "center" });
+      const rect = el.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return null;
+      const style = window.getComputedStyle(el);
+      if (style.visibility === "hidden" || style.display === "none") return null;
+      return {
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
+        label: (el.textContent ?? "").trim(),
+      };
+    })()`, { timeoutMs, label: `trusted clickable element ${selector}` });
+
+    await this.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
+    await this.client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "left", clickCount: 1 });
+    await this.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: "left", clickCount: 1 });
+    this.log(`Trusted clicked ${selector}${point.label ? `: ${point.label}` : ""}`);
+    return point.label;
+  }
+
+  /**
    * Fill a controlled React input via the native value setter + input event.
    */
   async fill(selector, value, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {

--- a/evals/voiceovers/org-google-workspace-scopes.md
+++ b/evals/voiceovers/org-google-workspace-scopes.md
@@ -1,19 +1,19 @@
 # org-google-workspace-scopes — Org Google Workspace covers the desktop permission set, and admins can pick more
 
 The org-level Google Workspace connection in OpenWork Cloud previously
-requested only `openid email gmail.compose`. This feature brings its default
-scopes to parity with the desktop extension's base set (Calendar read, Gmail
-drafts, selected Drive files) and lets the org admin opt into the same
-optional permissions the desktop offers (read Gmail, full Drive, create
-calendar events, Google Chat). Picks are stored on the org's OAuth client row
-and reflected in the authorize URL members are sent to.
+requested only `openid email gmail.compose`. Identity is now fixed, while each
+Calendar, Gmail, Drive, and Chat capability is a granular permission pick. The
+desktop-parity defaults (Calendar read, Gmail drafts, selected Drive files)
+start checked, and admins can add or remove individual capabilities. Picks are
+stored on the org's OAuth client row and reflected in the authorize URL members
+are sent to.
 
-1. As the workspace admin, I open Connections in the OpenWork Cloud dashboard and tap Google Workspace. The setup now spells out what my team's AI gets out of the box — reading calendars, drafting Gmail, and working with selected Drive files — the same permissions the desktop app asks for.
+1. As the workspace admin, I open Connections in the OpenWork Cloud dashboard and tap Google Workspace. I now see every permission my team's AI could use across Calendar, Gmail, and Drive — with the desktop app's defaults already checked.
 
-2. Under "Optional permissions", I can grant more when my team needs it: reading Gmail, full Drive access, creating calendar events, and Google Chat. I check Read Gmail and Create calendar events, paste my client ID and secret, and save.
+2. I add Read Gmail and Create calendar events on top of the defaults, paste my client ID and secret, and save.
 
-3. Reopening the setup shows Google Workspace is configured with my two extra permissions still checked — I can adjust my picks any time without retyping the client.
+3. Reopening the setup shows Google Workspace is configured with my extra permissions still checked — I can adjust my picks any time without retyping the client.
 
-4. When a teammate connects their Google account, the Google consent screen asks for exactly the base permissions plus the two I picked — nothing more.
+4. When a teammate connects their Google account, the Google consent screen asks for exactly the defaults plus my two additions — nothing more.
 
 5. After approving, their card flips to Connected and the connection records those granted permissions — ready for Gmail, Calendar, and Drive work through OpenWork.

--- a/evals/voiceovers/org-google-workspace-scopes.md
+++ b/evals/voiceovers/org-google-workspace-scopes.md
@@ -1,19 +1,20 @@
 # org-google-workspace-scopes — Org Google Workspace covers the desktop permission set, and admins can pick more
 
-The org-level Google Workspace connection in OpenWork Cloud previously
-requested only `openid email gmail.compose`. Identity is now fixed, while each
-Calendar, Gmail, Drive, and Chat capability is a granular permission pick. The
-desktop-parity defaults (Calendar read, Gmail drafts, selected Drive files)
-start checked, and admins can add or remove individual capabilities. Picks are
-stored on the org's OAuth client row and reflected in the authorize URL members
-are sent to.
+The org-level Google Workspace connection in OpenWork Cloud now gives admins a
+guided setup path for bringing their own Google OAuth client. Identity scopes
+are fixed, each Calendar, Gmail, Drive, and Chat capability is a granular
+permission pick, and the setup screen shows the exact redirect URL to register
+in Google Cloud. Desktop-parity defaults (Calendar read, Gmail drafts, selected
+Drive files) start checked, and admins can add or remove individual
+capabilities. Picks are stored on the org's OAuth client row and reflected in
+the authorize URL members are sent to.
 
-1. As the workspace admin, I open Connections in the OpenWork Cloud dashboard and tap Google Workspace. I now see every permission my team's AI could use across Calendar, Gmail, and Drive — with the desktop app's defaults already checked.
+1. As the workspace admin, I open Connections in the OpenWork Cloud dashboard and tap Google Workspace. The setup walks me through it — where to create the OAuth client in Google Cloud, the exact redirect URL to register, and every permission my team's AI could use across Calendar, Gmail, and Drive, with the desktop app's defaults already checked.
 
 2. I add Read Gmail and Create calendar events on top of the defaults, paste my client ID and secret, and save.
 
 3. Reopening the setup shows Google Workspace is configured with my extra permissions still checked — I can adjust my picks any time without retyping the client.
 
-4. When a teammate connects their Google account, the Google consent screen asks for exactly the defaults plus my two additions — nothing more.
+4. When a teammate connects their Google account, Google receives the exact redirect URL from my setup screen and asks for exactly the defaults plus my two additions — nothing more.
 
 5. After approving, their card flips to Connected and the connection records those granted permissions — ready for Gmail, Calendar, and Drive work through OpenWork.

--- a/evals/voiceovers/org-google-workspace-scopes.md
+++ b/evals/voiceovers/org-google-workspace-scopes.md
@@ -1,20 +1,19 @@
 # org-google-workspace-scopes — Org Google Workspace covers the desktop permission set, and admins can pick more
 
-The org-level Google Workspace connection in OpenWork Cloud now gives admins a
-guided setup path for bringing their own Google OAuth client. Identity scopes
-are fixed, each Calendar, Gmail, Drive, and Chat capability is a granular
-permission pick, and the setup screen shows the exact redirect URL to register
-in Google Cloud. Desktop-parity defaults (Calendar read, Gmail drafts, selected
-Drive files) start checked, and admins can add or remove individual
-capabilities. Picks are stored on the org's OAuth client row and reflected in
-the authorize URL members are sent to.
+The org-level Google Workspace connection in OpenWork Cloud previously
+requested only `openid email gmail.compose`. Identity is now fixed, while each
+Calendar, Gmail, Drive, and Chat capability is a granular permission pick. The
+desktop-parity defaults (Calendar read, Gmail drafts, selected Drive files)
+start checked, and admins can add or remove individual capabilities. Picks are
+stored on the org's OAuth client row and reflected in the authorize URL members
+are sent to.
 
-1. As the workspace admin, I open Connections in the OpenWork Cloud dashboard and tap Google Workspace. The setup walks me through it — where to create the OAuth client in Google Cloud, the exact redirect URL to register, and every permission my team's AI could use across Calendar, Gmail, and Drive, with the desktop app's defaults already checked.
+1. As the workspace admin, I open Connections in the OpenWork Cloud dashboard and tap Google Workspace. I now see every permission my team's AI could use across Calendar, Gmail, and Drive — with the desktop app's defaults already checked.
 
 2. I add Read Gmail and Create calendar events on top of the defaults, paste my client ID and secret, and save.
 
 3. Reopening the setup shows Google Workspace is configured with my extra permissions still checked — I can adjust my picks any time without retyping the client.
 
-4. When a teammate connects their Google account, Google receives the exact redirect URL from my setup screen and asks for exactly the defaults plus my two additions — nothing more.
+4. When a teammate connects their Google account, the Google consent screen asks for exactly the defaults plus my two additions — nothing more.
 
 5. After approving, their card flips to Connected and the connection records those granted permissions — ready for Gmail, Calendar, and Drive work through OpenWork.

--- a/evals/voiceovers/org-google-workspace-setup-guide.md
+++ b/evals/voiceovers/org-google-workspace-setup-guide.md
@@ -1,0 +1,16 @@
+# org-google-workspace-setup-guide — The Google Workspace setup walks admins through creating the OAuth client
+
+Setting up the org Google Workspace connection requires a Google Cloud OAuth
+client. The setup dialog now teaches the admin exactly how to create one:
+which console pages to visit, which APIs to enable, and the exact authorized
+redirect URI to register — with one-tap copy. The same redirect URI is
+available through the API even before anything is configured, and it is
+exactly where member sign-ins return.
+
+1. As the workspace admin, I open the Google Workspace setup and the dialog now walks me through creating the OAuth client — where to go in the Google Cloud console and which APIs to enable.
+
+2. The exact redirect URL my org needs is right there — one tap copies it, ready to paste into my Google OAuth client's authorized redirect URIs.
+
+3. The setup links take me straight to the right Google console pages, so I never hunt through Google's settings.
+
+4. The redirect URL shown is exactly where my teammates' sign-ins will return — the API reports the same URL, and a member's Google sign-in round trip uses it verbatim.


### PR DESCRIPTION
> Note: #2546 merged the first iteration (base scopes + 4 opt-ins). This PR carries the two follow-up layers that superseded it before they could land there: the fully granular permission model and the in-dialog setup guide.

## What

### 1. Fully granular permissions (desktop-parity defaults)
- Identity (`openid`, `userinfo.email`, `userinfo.profile`) always on; **every capability is an individual pick**, grouped for non-technical admins:
  - Calendar: Read calendar (`calendar.readonly`) · Create calendar events (`calendar.events`)
  - Gmail: Draft emails (`gmail.compose`) · Read Gmail (`gmail.readonly`)
  - Drive: Work with selected Drive files (`drive.file`) · Read all Drive files (`drive.readonly`) · Full Drive access (`drive`)
  - Chat: Google Chat (spaces + messages read, message create)
- Defaults pre-checked = desktop base behavior (Read calendar, Draft emails, selected Drive files). Rows saved without `features` resolve to those defaults (legacy-safe). Picks stored in the existing `extra` json (**no migration**) and reflected verbatim in members' authorize URLs.

### 2. In-dialog OAuth setup guide
- "How to set it up": create a **Web application** client (APIs & Services → Credentials) with a direct **Open Google Cloud Console** link, the org's exact **authorized redirect URI with one-tap copy**, an **Open API library** link, then paste client ID + secret.
- `GET /v1/oauth-providers/:providerId/client` now returns 200 pre-configuration with `configured`, nullable `clientId`, default `features`, resolved `scopes`, `redirectUri` (never the secret).
- Hardened `copyTextToClipboard` (fallback + no crash on insecure origins) for both copy buttons.
- Eval infra: `ctx.trustedClick()` (real CDP mouse events → transient activation for clipboard assertions).

## Tests / verification (commands + results)
- den-api: `tsc --noEmit` ✓, `bun test test/native-provider-scopes.test.ts` 6/6 ✓, `build` ✓
- den-web: `tsc --noEmit` ✓, `build` ✓ (`next lint` broken on dev pre-existing)
- `pnpm fraimz --flow org-google-workspace-scopes --flow org-google-workspace-setup-guide --stack den` on the rebased branch — **PASSED 2/2 flows (5/5 + 4/4 frames)** against a real local Den stack (mysql, den-api multi_org, den-web, mock Google IdP, Electron CDP). Frame-by-frame proofs in comments below.
- Rebased onto dev cleanly; upstream #2552 org-scope pinning and #2555 Granola preset verified intact.