### PR TITLE
Add connection-backed plugin imports

### DIFF
--- a/apps/app/src/app/cloud/import-state.ts
+++ b/apps/app/src/app/cloud/import-state.ts
@@ -29,6 +29,8 @@ export type CloudImportedMarketplace = {
 
 export type CloudImportedPluginFile = {
   configObjectId: string;
+  denSkillId?: string | null;
+  externalMcpConnectionId?: string | null;
   versionId: string | null;
   objectType: string;
   title: string;
@@ -155,10 +157,18 @@ export function readWorkspaceCloudImports(value: unknown): WorkspaceCloudImports
             const objectType = typeof file.objectType === "string" ? file.objectType.trim() : "";
             const title = typeof file.title === "string" ? file.title.trim() : configObjectId;
             const path = typeof file.path === "string" ? file.path.trim() : "";
+            const externalMcpConnectionId = typeof file.externalMcpConnectionId === "string"
+              ? file.externalMcpConnectionId.trim() || null
+              : null;
+            const denSkillId = typeof file.denSkillId === "string"
+              ? file.denSkillId.trim() || null
+              : null;
             if (!configObjectId || !objectType || !title || !path) return [];
             return [
               {
                 configObjectId,
+                denSkillId,
+                externalMcpConnectionId,
                 versionId: typeof file.versionId === "string" ? file.versionId.trim() || null : null,
                 objectType,
                 title,

--- a/apps/app/src/react-app/domains/settings/extension-items.ts
+++ b/apps/app/src/react-app/domains/settings/extension-items.ts
@@ -129,11 +129,15 @@ function resourceFromImportedFile(file: CloudImportedPluginFile): ExtensionResou
 
 function childKeysForPlugin(plugin: CloudImportedPlugin) {
   const mcpServerNames = new Set<string>();
+  const externalMcpConnectionIds = new Set<string>();
   const skillPaths = new Set<string>();
   const skillNames = new Set<string>();
   for (const file of plugin.files) {
     if (file.path.startsWith(MCP_IMPORT_PATH_PREFIX)) {
       mcpServerNames.add(file.path.slice(MCP_IMPORT_PATH_PREFIX.length));
+    }
+    if (file.externalMcpConnectionId) {
+      externalMcpConnectionIds.add(file.externalMcpConnectionId);
     }
     if (file.objectType === "skill") {
       skillPaths.add(file.path);
@@ -142,7 +146,7 @@ function childKeysForPlugin(plugin: CloudImportedPlugin) {
       skillNames.add(file.title);
     }
   }
-  return { mcpServerNames, skillPaths, skillNames };
+  return { externalMcpConnectionIds, mcpServerNames, skillPaths, skillNames };
 }
 
 export function buildExtensionItems(input: ExtensionItemBuildInput) {
@@ -176,14 +180,24 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
     const enablement = manifest?.enablement ? evaluateEnablement(manifest.enablement, input.enablementContext) : null;
     const pendingChange = input.pendingCloudPluginChanges?.[plugin.id];
     const installState = imported && pendingChange === "modified" ? "update_available" : cloudPluginStatus(imported, plugin);
+    const externalConnectionIds = new Set(imported?.files.flatMap((file) => file.externalMcpConnectionId ? [file.externalMcpConnectionId] : []) ?? []);
+    const connectionStates = [...externalConnectionIds].flatMap((id) => {
+      const connection = input.orgMcpConnections?.find((entry) => entry.id === id);
+      return connection ? [isOrgMcpConnectionReady(connection)] : [false];
+    });
+    const connectionSetupState = connectionStates.length === 0
+      ? null
+      : connectionStates.every(Boolean)
+        ? "ready"
+        : "needs_setup";
     return {
       id: `marketplace:${marketplace.marketplace.id}:${plugin.id}`,
       source: "marketplace",
       name: plugin.extension?.name ?? plugin.name,
       description: plugin.extension?.description ?? plugin.description,
       installState,
-      setupState: enablement ? setupStateFromEnablement(enablement) : installState === "available" ? "needs_setup" : "ready",
-      active: enablement?.active ?? installState !== "available",
+      setupState: enablement ? setupStateFromEnablement(enablement) : installState === "available" ? "needs_setup" : connectionSetupState ?? "ready",
+      active: enablement?.active ?? (installState !== "available" && connectionSetupState !== "needs_setup"),
       enablement,
       resources: imported?.files.map(resourceFromImportedFile) ?? Object.entries(plugin.componentCounts).flatMap(([type, count]) => count > 0 ? [{
         id: `${plugin.id}:${type}`,
@@ -240,10 +254,12 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
   };
 
   const groupedMcpServerNames = new Set<string>();
+  const groupedExternalMcpConnectionIds = new Set<string>();
   const groupedSkillPaths = new Set<string>();
   const groupedSkillNames = new Set<string>();
   for (const plugin of Object.values(input.importedCloudPlugins)) {
     const keys = childKeysForPlugin(plugin);
+    keys.externalMcpConnectionIds.forEach((value) => groupedExternalMcpConnectionIds.add(value));
     keys.mcpServerNames.forEach((value) => groupedMcpServerNames.add(value));
     keys.skillPaths.forEach((value) => groupedSkillPaths.add(value));
     keys.skillNames.forEach((value) => groupedSkillNames.add(value));
@@ -273,6 +289,9 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
     skill,
   }));
 
+  const visibleOrgMcpConnectionItems = orgMcpConnectionItems.filter((item) =>
+    !item.orgMcpConnection || !groupedExternalMcpConnectionIds.has(item.orgMcpConnection.id));
+
   return {
     // Org-managed MCP connections are beta, so keep them last in unified lists.
     items: [...builtInItems, ...cloudPluginItems, ...importedPluginItems, ...standaloneMcpEntries.map((entry): ExtensionItem => ({
@@ -286,10 +305,10 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
       enablement: null,
       resources: [{ id: getMcpServerName(entry), type: "mcp", title: entry.name }],
       mcpEntry: entry,
-    })), ...standaloneSkillItems, ...orgMcpConnectionItems],
+    })), ...standaloneSkillItems, ...visibleOrgMcpConnectionItems],
     builtInItems,
     cloudPluginItems: [...cloudPluginItems, ...importedPluginItems],
-    orgMcpConnectionItems,
+    orgMcpConnectionItems: visibleOrgMcpConnectionItems,
     installedMcpEntries: [
       ...builtInItems.flatMap((item) => item.active && item.builtInEntry ? [item.builtInEntry] : []),
       ...standaloneMcpEntries,

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -17,6 +17,7 @@ import { resolveMarketplaceDeliveryAction } from "@/react-app/domains/settings/c
 import { isDesktopInstallableMarketplacePlugin } from "@/react-app/domains/settings/connect-cloud-readiness";
 import {
   isOrgMcpConnectionItem,
+  isOrgMcpConnectionReady,
   isToggleControlledExtension,
   orgMcpConnectionActionLabel,
   type ExtensionItem,
@@ -69,6 +70,7 @@ type MarketplacePackageRow = {
   marketplaceName: string;
   plugin: DenOrgPlugin;
   imported: CloudImportedPlugin | null;
+  item: ExtensionItem | null;
   status: MarketplacePackageStatus;
   counts: string[];
   composition: Array<{ count: number; label: string; type: string }>;
@@ -113,6 +115,7 @@ export type CloudMarketplacesViewProps = {
   configSlotForBuiltIn?: (entry: McpDirectoryInfo) => React.ReactNode | null;
   isBuiltInConnected?: (entry: McpDirectoryInfo) => boolean;
   extensionItems?: ExtensionItem[];
+  orgMcpConnections?: DenExternalMcpConnection[];
   orgMcpConnectingId?: string | null;
   onConnectOrgMcp?: (connectionId: string) => void;
   refreshOrgMcpConnections?: () => Promise<unknown> | void;
@@ -200,6 +203,7 @@ export function CloudMarketplacesView({
   configSlotForBuiltIn,
   isBuiltInConnected,
   extensionItems = [],
+  orgMcpConnections = [],
   orgMcpConnectingId = null,
   onConnectOrgMcp,
   refreshOrgMcpConnections,
@@ -266,6 +270,7 @@ export function CloudMarketplacesView({
         marketplaceName: marketplace.marketplace.name,
         plugin,
         imported,
+        item: item ?? null,
         status,
         counts,
         composition,
@@ -657,7 +662,10 @@ export function CloudMarketplacesView({
           resolved={resolvedPlugins[detailRow.plugin.id] ?? null}
           resolving={detailLoadingId === detailRow.plugin.id}
           resolveError={detailError}
+          orgMcpConnections={orgMcpConnections}
+          orgMcpConnectingId={orgMcpConnectingId}
           onClose={() => setDetailRow(null)}
+          onConnectOrgMcp={onConnectOrgMcp}
           onImportPlugin={importPlugin}
           connectEnabled={connectEnabled}
           onRemovePlugin={removePlugin}
@@ -778,6 +786,7 @@ function MarketplaceCard(props: {
     importedLocally: Boolean(row.imported),
   });
   const cloudDelivery = deliveryAction !== "install";
+  const needsSetup = Boolean(row.imported && row.item?.setupState === "needs_setup");
 
   return (
     <div ref={highlightRef} className={`flex flex-col gap-2 ${highlightClass}`}>
@@ -787,10 +796,10 @@ function MarketplaceCard(props: {
         iconSlug={manifest?.icon?.simpleIconSlug}
         iconSrc={manifest?.icon?.src}
         kind="extension"
-        connected={cloudBuiltIn || cloudDelivery || Boolean(row.imported)}
-        connectedLabel={cloudDelivery ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : updateAvailable ? t("extensions.update_available") : "Installed"}
+        connected={cloudBuiltIn || (cloudDelivery && !needsSetup) || (Boolean(row.imported) && !needsSetup)}
+        connectedLabel={cloudDelivery && !needsSetup ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : updateAvailable ? t("extensions.update_available") : "Installed"}
         connecting={actionBusy}
-        actionLabel={cloudDelivery ? t("extensions.marketplace_runs_in_cloud") : cloudBuiltIn ? "View details" : actionBusy ? "Working..." : actionLabelForStatus(row.status)}
+        actionLabel={needsSetup ? "View setup" : cloudDelivery ? t("extensions.marketplace_runs_in_cloud") : cloudBuiltIn ? "View details" : actionBusy ? "Working..." : actionLabelForStatus(row.status)}
         onClick={() => onOpenDetail(row)}
       />
       {updateAvailable && !cloudDelivery ? (
@@ -894,11 +903,26 @@ function MarketplacePackageDetailModal(props: {
   resolving: boolean;
   resolveError: string | null;
   connectEnabled?: boolean;
+  orgMcpConnections: DenExternalMcpConnection[];
+  orgMcpConnectingId: string | null;
   onClose: () => void;
+  onConnectOrgMcp?: (connectionId: string) => void;
   onImportPlugin: (marketplaceId: string | null, plugin: DenOrgPlugin) => void | Promise<void>;
   onRemovePlugin: (pluginId: string, pluginName: string) => void | Promise<void>;
 }) {
-  const { actionId, row, resolved, resolving, resolveError, onClose, onImportPlugin, onRemovePlugin } = props;
+  const {
+    actionId,
+    row,
+    resolved,
+    resolving,
+    resolveError,
+    orgMcpConnections,
+    orgMcpConnectingId,
+    onClose,
+    onConnectOrgMcp,
+    onImportPlugin,
+    onRemovePlugin,
+  } = props;
   const actionBusy = actionId === row.plugin.id;
   const cloudBuiltIn = isCloudBuiltInPlugin(row.plugin);
   const manifest = row.plugin.extension?.manifest;
@@ -907,7 +931,14 @@ function MarketplacePackageDetailModal(props: {
     importedLocally: Boolean(row.imported),
   });
   const cloudDelivery = deliveryAction !== "install";
+  const needsSetup = Boolean(row.imported && row.item?.setupState === "needs_setup");
   const canAddOrUpdate = !cloudDelivery && !cloudBuiltIn && (row.status === "available" || row.status === "update_available");
+  const importedExternalConnectionIds = row.imported?.files.flatMap((file) => file.externalMcpConnectionId ? [file.externalMcpConnectionId] : []) ?? [];
+  const importedConnections = [...new Set(importedExternalConnectionIds)].flatMap((connectionId) => {
+    const connection = orgMcpConnections.find((entry) => entry.id === connectionId);
+    return connection ? [connection] : [];
+  });
+  const missingImportedConnectionCount = new Set(importedExternalConnectionIds).size - importedConnections.length;
 
   return (
     <ExtensionDetailModal
@@ -918,10 +949,11 @@ function MarketplacePackageDetailModal(props: {
       iconSlug={manifest?.icon?.simpleIconSlug}
       iconSrc={manifest?.icon?.src}
       kind="extension"
-      connected={cloudBuiltIn || cloudDelivery || Boolean(row.imported)}
-      connectedLabel={cloudDelivery ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : "Installed"}
+      connected={cloudBuiltIn || (cloudDelivery && !needsSetup) || (Boolean(row.imported) && !needsSetup)}
+      connectedLabel={cloudDelivery && !needsSetup ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : "Installed"}
+      disconnectedLabel={needsSetup ? "Needs setup" : undefined}
       connecting={actionBusy}
-      connectLabel={row.status === "update_available" ? "Update" : "Add"}
+      connectLabel={needsSetup ? "View setup" : row.status === "update_available" ? "Update" : "Add"}
       connectingLabel={row.status === "update_available" ? "Updating..." : "Adding..."}
       uninstallLabel="Remove"
       showEnablementCard={false}
@@ -933,8 +965,8 @@ function MarketplacePackageDetailModal(props: {
       configSlot={(
         <div className="space-y-4">
           <div className="flex flex-wrap gap-2">
-            <SettingsPill className={cloudDelivery ? "border-green-7/30 bg-green-3/20 text-green-11" : statusClass(row.status)}>
-              {cloudDelivery ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : statusLabel(row.status)}
+            <SettingsPill className={needsSetup ? "border-amber-7/30 bg-amber-3/20 text-amber-11" : statusClass(row.status)}>
+              {needsSetup ? "Needs setup" : cloudDelivery ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : statusLabel(row.status)}
             </SettingsPill>
             <SettingsPill>{row.marketplaceName}</SettingsPill>
             {row.counts.map((label) => <SettingsPill key={label}>{label}</SettingsPill>)}
@@ -955,6 +987,44 @@ function MarketplacePackageDetailModal(props: {
           ) : null}
           {resolving ? (
             <SettingsNotice>Loading extension contents...</SettingsNotice>
+          ) : null}
+          {missingImportedConnectionCount > 0 ? (
+            <SettingsNotice tone="error">
+              You do not have access to {missingImportedConnectionCount === 1 ? "one required MCP connection" : `${missingImportedConnectionCount} required MCP connections`}. Ask an admin to update the connection sharing settings.
+            </SettingsNotice>
+          ) : null}
+          {importedConnections.length > 0 ? (
+            <div className="rounded-xl border border-dls-border bg-dls-hover px-3 py-3">
+              <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Cloud MCP connections</div>
+              <div className="mt-3 grid gap-2">
+                {importedConnections.map((connection) => {
+                  const ready = isOrgMcpConnectionReady(connection);
+                  const needsMemberConnect = connection.credentialMode === "per_member" && !connection.connectedForMe;
+                  const connecting = orgMcpConnectingId === connection.id;
+                  return (
+                    <div key={connection.id} className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-dls-border bg-dls-surface px-3 py-2">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-card-foreground">{connection.name}</div>
+                        <div className="truncate text-xs text-muted-foreground">{connection.url}</div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <SettingsPill>{ready ? "Ready" : needsMemberConnect ? "Needs setup" : "Waiting for admin"}</SettingsPill>
+                        {needsMemberConnect && onConnectOrgMcp ? (
+                          <Button
+                            size="xs"
+                            variant="outline"
+                            disabled={connecting}
+                            onClick={() => onConnectOrgMcp(connection.id)}
+                          >
+                            {connecting ? "Waiting for browser..." : "Connect account"}
+                          </Button>
+                        ) : null}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
           ) : null}
           {resolved ? (
             <div className="space-y-2">

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -1061,6 +1061,39 @@ export function createExtensionsStore(options: {
     return warnings.length > 0 ? `${message} ${warnings.join(" ")}` : message;
   };
 
+  const externalMcpConnectionIdFromPayload = (
+    object: NonNullable<DenOrgPluginResolved["memberships"][number]["configObject"]>,
+  ): string | null => {
+    const version = object.latestVersion;
+    const payload = version?.normalizedPayloadJson ?? parseJsonRecord(version?.rawSourceText ?? null);
+    if (!payload) return null;
+    if (payload.openworkManaged === "den_external_mcp") {
+      const id = readNonEmptyString(payload.externalMcpConnectionId);
+      if (id) return id;
+    }
+    const containers = [
+      isRecord(payload.mcpServers) ? payload.mcpServers : null,
+      isRecord(payload.mcp) ? payload.mcp : null,
+    ].filter((entry): entry is Record<string, unknown> => Boolean(entry));
+    for (const container of containers) {
+      for (const config of Object.values(container)) {
+        if (!isRecord(config) || config.openworkManaged !== "den_external_mcp") continue;
+        const id = readNonEmptyString(config.externalMcpConnectionId);
+        if (id) return id;
+      }
+    }
+    return null;
+  };
+
+  const denSkillIdFromPayload = (
+    object: NonNullable<DenOrgPluginResolved["memberships"][number]["configObject"]>,
+  ): string | null => {
+    const version = object.latestVersion;
+    const payload = version?.normalizedPayloadJson ?? parseJsonRecord(version?.rawSourceText ?? null);
+    if (!payload || payload.openworkManaged !== "den_skill") return null;
+    return readNonEmptyString(payload.denSkillId);
+  };
+
   const upsertPluginMcpConfig = async (name: string, config: Record<string, unknown>) => {
     const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
@@ -1166,6 +1199,19 @@ export function createExtensionsStore(options: {
       }
 
       if (object.objectType === "mcp") {
+        const externalMcpConnectionId = externalMcpConnectionIdFromPayload(object);
+        if (externalMcpConnectionId) {
+          files.push({
+            configObjectId: object.id,
+            externalMcpConnectionId,
+            versionId: version?.id ?? null,
+            objectType: object.objectType,
+            title: object.title,
+            path: `den#mcp-connection.${externalMcpConnectionId}`,
+            updatedAt: object.updatedAt,
+          });
+          continue;
+        }
         const configs = pluginMcpConfigsFromPayload(object, namespace);
         if (configs.length === 0) warnings.push(mcpNoConfigWarning(object.title));
         for (const config of configs) {
@@ -1185,6 +1231,22 @@ export function createExtensionsStore(options: {
           });
         }
         continue;
+      }
+
+      if (object.objectType === "skill") {
+        const denSkillId = denSkillIdFromPayload(object);
+        if (denSkillId) {
+          files.push({
+            configObjectId: object.id,
+            denSkillId,
+            versionId: version?.id ?? null,
+            objectType: object.objectType,
+            title: object.title,
+            path: `den#skill.${denSkillId}`,
+            updatedAt: object.updatedAt,
+          });
+          continue;
+        }
       }
 
       if (version?.rawSourceText == null) continue;

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2120,6 +2120,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 configSlotForBuiltIn={extensionController.configSlotForEntry}
                 isBuiltInConnected={extensionController.isConnected}
                 extensionItems={extensionItemsForExtensions}
+                orgMcpConnections={orgMcpConnections.connections}
                 orgMcpConnectingId={orgMcpConnections.connectingId}
                 onConnectOrgMcp={(connectionId) => {
                   void orgMcpConnections.connect(connectionId);
@@ -2159,6 +2160,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             configSlotForBuiltIn={extensionController.configSlotForEntry}
             isBuiltInConnected={extensionController.isConnected}
             extensionItems={extensionItemsForExtensions}
+            orgMcpConnections={orgMcpConnections.connections}
             orgMcpConnectingId={orgMcpConnections.connectingId}
             onConnectOrgMcp={(connectionId) => {
               void orgMcpConnections.connect(connectionId);

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -14,6 +14,7 @@ import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities } from "./search.js"
 import { executeExternalCapability, parseExternalCapabilityName, resolveMcpMemberIdentity, searchExternalCapabilities } from "./external-capabilities.js"
 import { executeMarketplaceCapability, parseMarketplaceCapabilityName, searchMarketplaceCapabilities } from "./marketplace-capabilities.js"
+import { executeSkillCapability, parseSkillCapabilityName, searchSkillCapabilities } from "./skill-capabilities.js"
 import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { env } from "../env.js"
 
@@ -90,6 +91,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
           "Search for a capability by keyword. This connection only exposes this tool and execute_capability —",
           "there is no list of individually-named tools to browse. Always search first.",
           "Each match includes pathParams/queryParams/hasBody describing exactly what execute_capability needs.",
+          "Skill matches use method SKILL and return stored SKILL.md content when executed.",
         ].join(" "),
         inputSchema: z.object({
           query: z.string().min(1).describe("Keywords describing the capability you need, e.g. \"create organization\" or \"list workers\"."),
@@ -121,7 +123,13 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
             enabled: externalMcpConnectionsEnabled,
           })
           : []
-        const matches = [...restMatches, ...externalMatches, ...marketplaceMatches]
+        const skillMatches = await searchSkillCapabilities({
+          organizationId: principal.organizationId,
+          member: memberIdentity,
+          query,
+          limit: boundedLimit,
+        })
+        const matches = [...restMatches, ...externalMatches, ...marketplaceMatches, ...skillMatches]
           .sort((a, b) => b.score - a.score)
           .slice(0, boundedLimit)
         const text = matches.length > 0
@@ -138,6 +146,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         description: [
           "Call a capability found via search_capabilities, by its exact name.",
           "Pass path/query/body only as described by that match's pathParams/queryParams/hasBody.",
+          "For skill:<id> matches, this returns that skill's stored SKILL.md content.",
           "Returns unknown_capability if name doesn't match a current capability — call search_capabilities again.",
         ].join(" "),
         inputSchema: z.object({
@@ -208,6 +217,35 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
             }
           }
           return { content: textContent(JSON.stringify(result.result, null, 2)) }
+        }
+
+        const skillId = parseSkillCapabilityName(name)
+        if (skillId) {
+          const result = await executeSkillCapability({
+            organizationId: principal.organizationId,
+            member: memberIdentity,
+            skillId,
+          })
+          if (!result.ok) {
+            return {
+              isError: true,
+              content: [{ type: "text" as const, text: JSON.stringify({ error: result.error, message: result.message }) }],
+            }
+          }
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                skill: {
+                  id: result.skill.id,
+                  title: result.skill.title,
+                  description: result.skill.description,
+                  skillText: result.skill.skillText,
+                  updatedAt: result.skill.updatedAt,
+                },
+              }, null, 2),
+            }],
+          }
         }
 
         const operation = catalog.find((candidate) => candidate.name === name)

--- a/ee/apps/den-api/src/mcp/skill-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/skill-capabilities.ts
@@ -1,0 +1,214 @@
+import { and, desc, eq, inArray, or } from "@openwork-ee/den-db/drizzle"
+import { SkillHubMemberTable, SkillHubSkillTable, SkillHubTable, SkillTable } from "@openwork-ee/den-db/schema"
+import { normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
+import { db } from "../db.js"
+import { tokenize } from "./search.js"
+import type { CapabilityMatch } from "./search.js"
+import type { McpMemberIdentity } from "./external-capabilities.js"
+
+const SKILL_CAPABILITY_PREFIX = "skill:"
+
+type OrganizationId = DenTypeId<"organization">
+type SkillId = DenTypeId<"skill">
+
+type SkillSearchRow = {
+  id: SkillId
+  title: string
+  description: string | null
+  shared: "org" | "public" | null
+  createdByOrgMembershipId: DenTypeId<"member">
+  updatedAt: Date
+}
+
+type SkillReadRow = SkillSearchRow & {
+  skillText: string
+}
+
+export function buildSkillCapabilityName(skillId: string): string {
+  return `${SKILL_CAPABILITY_PREFIX}${skillId}`
+}
+
+export function parseSkillCapabilityName(name: string): string | null {
+  if (!name.startsWith(SKILL_CAPABILITY_PREFIX)) return null
+  const skillId = name.slice(SKILL_CAPABILITY_PREFIX.length)
+  return skillId.length > 0 ? skillId : null
+}
+
+function scoreText(nameTokens: string[], summaryTokens: string[], queryTokens: string[]): number {
+  let score = 0
+  for (const queryToken of queryTokens) {
+    if (nameTokens.includes(queryToken)) {
+      score += 5
+    } else if (nameTokens.some((token) => token.startsWith(queryToken) || queryToken.startsWith(token))) {
+      score += 3
+    }
+    if (summaryTokens.includes(queryToken)) {
+      score += 2
+    }
+  }
+  return score
+}
+
+async function listHubAccessibleSkillIds(input: {
+  organizationId: OrganizationId
+  member: McpMemberIdentity
+}): Promise<Set<SkillId>> {
+  const grantCondition = input.member.teamIds.length > 0
+    ? or(
+        eq(SkillHubMemberTable.orgMembershipId, input.member.orgMembershipId),
+        inArray(SkillHubMemberTable.teamId, input.member.teamIds),
+      )
+    : eq(SkillHubMemberTable.orgMembershipId, input.member.orgMembershipId)
+
+  const rows = await db
+    .select({ skillId: SkillHubSkillTable.skillId })
+    .from(SkillHubSkillTable)
+    .innerJoin(SkillHubTable, eq(SkillHubSkillTable.skillHubId, SkillHubTable.id))
+    .innerJoin(SkillHubMemberTable, eq(SkillHubMemberTable.skillHubId, SkillHubTable.id))
+    .where(and(
+      eq(SkillHubTable.organizationId, input.organizationId),
+      grantCondition,
+    ))
+
+  return new Set(rows.map((row) => row.skillId))
+}
+
+function canAccessSkill(input: {
+  member: McpMemberIdentity
+  skill: SkillSearchRow
+  hubAccessibleSkillIds: Set<SkillId>
+}) {
+  return input.skill.createdByOrgMembershipId === input.member.orgMembershipId
+    || input.skill.shared !== null
+    || input.hubAccessibleSkillIds.has(input.skill.id)
+}
+
+async function listAccessibleSkills(input: {
+  organizationId: string
+  member: McpMemberIdentity | null
+}): Promise<SkillSearchRow[]> {
+  if (!input.member) return []
+  const member = input.member
+  const organizationId = normalizeDenTypeId("organization", input.organizationId)
+  const hubAccessibleSkillIds = await listHubAccessibleSkillIds({
+    organizationId,
+    member,
+  })
+
+  const skills = await db
+    .select({
+      id: SkillTable.id,
+      title: SkillTable.title,
+      description: SkillTable.description,
+      shared: SkillTable.shared,
+      createdByOrgMembershipId: SkillTable.createdByOrgMembershipId,
+      updatedAt: SkillTable.updatedAt,
+    })
+    .from(SkillTable)
+    .where(eq(SkillTable.organizationId, organizationId))
+    .orderBy(desc(SkillTable.updatedAt))
+
+  return skills.filter((skill) => canAccessSkill({
+    member,
+    skill,
+    hubAccessibleSkillIds,
+  }))
+}
+
+async function getAccessibleSkill(input: {
+  organizationId: string
+  member: McpMemberIdentity | null
+  skillId: string
+}): Promise<SkillReadRow | null> {
+  if (!input.member) return null
+  const member = input.member
+  let organizationId: OrganizationId
+  let skillId: SkillId
+  try {
+    organizationId = normalizeDenTypeId("organization", input.organizationId)
+    skillId = normalizeDenTypeId("skill", input.skillId)
+  } catch {
+    return null
+  }
+
+  const hubAccessibleSkillIds = await listHubAccessibleSkillIds({
+    organizationId,
+    member,
+  })
+  const rows = await db
+    .select({
+      id: SkillTable.id,
+      title: SkillTable.title,
+      description: SkillTable.description,
+      shared: SkillTable.shared,
+      createdByOrgMembershipId: SkillTable.createdByOrgMembershipId,
+      updatedAt: SkillTable.updatedAt,
+      skillText: SkillTable.skillText,
+    })
+    .from(SkillTable)
+    .where(and(eq(SkillTable.id, skillId), eq(SkillTable.organizationId, organizationId)))
+    .limit(1)
+  const skill = rows[0]
+  if (!skill) return null
+  return canAccessSkill({ member, skill, hubAccessibleSkillIds }) ? skill : null
+}
+
+export async function searchSkillCapabilities(input: {
+  organizationId: string
+  member: McpMemberIdentity | null
+  query: string
+  limit?: number
+}): Promise<CapabilityMatch[]> {
+  const queryTokens = tokenize(input.query)
+  if (queryTokens.length === 0) return []
+  const skills = await listAccessibleSkills({
+    organizationId: input.organizationId,
+    member: input.member,
+  })
+  const matches = skills
+    .map((skill) => {
+      const summary = skill.description ?? skill.title
+      return {
+        name: buildSkillCapabilityName(skill.id),
+        method: "SKILL",
+        path: "SKILL.md",
+        score: scoreText(tokenize(skill.title), tokenize(summary), queryTokens),
+        summary: `[Skill] ${skill.title}${skill.description ? ` - ${skill.description}` : ""}`,
+        pathParams: [],
+        queryParams: [],
+        hasBody: false,
+      }
+    })
+    .filter((match) => match.score > 0)
+    .sort((a, b) => (b.score - a.score) || a.name.localeCompare(b.name))
+
+  return matches.slice(0, input.limit ?? 5)
+}
+
+export type SkillCapabilityExecuteResult =
+  | { ok: true; skill: { id: SkillId; title: string; description: string | null; skillText: string; updatedAt: Date } }
+  | { ok: false; error: "unknown_capability" | "forbidden"; message: string }
+
+export async function executeSkillCapability(input: {
+  organizationId: string
+  member: McpMemberIdentity | null
+  skillId: string
+}): Promise<SkillCapabilityExecuteResult> {
+  if (!input.member) {
+    return { ok: false, error: "forbidden", message: "No active org membership for this token." }
+  }
+  const skill = await getAccessibleSkill(input)
+  if (!skill) {
+    return { ok: false, error: "unknown_capability", message: `No accessible skill "${input.skillId}" in this organization.` }
+  }
+  return {
+    ok: true,
+    skill: {
+      id: skill.id,
+      title: skill.title,
+      description: skill.description,
+      skillText: skill.skillText,
+      updatedAt: skill.updatedAt,
+    },
+  }
+}

--- a/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
@@ -164,6 +164,8 @@ export const pluginArchRoutePaths = {
   pluginReleases: `${orgBasePath}/plugins/:pluginId/releases`,
   pluginAccess: `${orgBasePath}/plugins/:pluginId/access`,
   pluginAccessGrant: `${orgBasePath}/plugins/:pluginId/access/:grantId`,
+  pluginGithubMcpImportPreview: `${orgBasePath}/plugins/import-mcps-from-github-url/preview`,
+  pluginGithubMcpImport: `${orgBasePath}/plugins/import-mcps-from-github-url`,
   marketplaces: `${orgBasePath}/marketplaces`,
   marketplace: `${orgBasePath}/marketplaces/:marketplaceId`,
   marketplaceResolved: `${orgBasePath}/marketplaces/:marketplaceId/resolved`,

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -37,6 +37,10 @@ import {
   githubConnectorDiscoveryResponseSchema,
   githubDiscoveryApplyResponseSchema,
   githubDiscoveryApplySchema,
+  githubPluginMcpImportPreviewResponseSchema,
+  githubPluginMcpImportPreviewSchema,
+  githubPluginMcpImportResponseSchema,
+  githubPluginMcpImportSchema,
   githubDiscoveryTreeQuerySchema,
   githubDiscoveryTreeResponseSchema,
   connectorInstanceDetailResponseSchema,
@@ -150,6 +154,8 @@ import {
   getConnectorInstanceConfiguration,
   getGithubConnectorDiscovery,
   getGithubConnectorDiscoveryTree,
+  importGithubPluginMcps,
+  previewGithubPluginMcpImport,
   removeConnectorInstance,
   setConnectorInstanceAutoImport,
   queueConnectorTargetResync,
@@ -843,6 +849,65 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
       try {
         const params = validParam<any>(c)
         return c.json(await listPluginMemberships({ context: actorContext(c), includeConfigObjects: true, onlyActive: true, pluginId: params.pluginId }))
+      } catch (error) {
+        return routeErrorResponse(c, error)
+      }
+    })
+
+  withPluginArchOrgContext(app, "post", pluginArchRoutePaths.pluginGithubMcpImportPreview,
+    jsonValidator(githubPluginMcpImportPreviewSchema),
+    describeRoute({
+      tags: ["GitHub"],
+      summary: "Preview GitHub plugin MCP import",
+      description: "Reads a public GitHub plugin URL and returns remote MCP servers that can be imported as Den External MCP Connections.",
+      responses: {
+        200: jsonResponse("GitHub plugin MCP import preview returned successfully.", githubPluginMcpImportPreviewResponseSchema),
+        400: jsonResponse("The GitHub plugin MCP import preview request was invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to preview plugin MCP imports.", unauthorizedSchema),
+        404: jsonResponse("The GitHub plugin path could not be found.", notFoundSchema),
+      },
+    }),
+    async (c: OrgContext) => {
+      try {
+        const body = validJson<{
+          githubUrl: string
+        }>(c)
+        return c.json({ ok: true, item: await previewGithubPluginMcpImport({ githubUrl: body.githubUrl }) })
+      } catch (error) {
+        return routeErrorResponse(c, error)
+      }
+    })
+
+  withPluginArchOrgContext(app, "post", pluginArchRoutePaths.pluginGithubMcpImport,
+    jsonValidator(githubPluginMcpImportSchema),
+    describeRoute({
+      tags: ["GitHub"],
+      summary: "Import GitHub plugin MCPs",
+      description: "Creates/reuses Den External MCP Connections for selected remote MCP servers from a public GitHub plugin URL and publishes one marketplace plugin that references them.",
+      responses: {
+        200: jsonResponse("GitHub plugin MCPs imported successfully.", githubPluginMcpImportResponseSchema),
+        400: jsonResponse("The GitHub plugin MCP import request was invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to import plugin MCPs.", unauthorizedSchema),
+        403: jsonResponse("The caller lacks permission to import plugin MCPs.", forbiddenSchema),
+        404: jsonResponse("The GitHub plugin path or marketplace could not be found.", notFoundSchema),
+      },
+    }),
+    async (c: OrgContext) => {
+      try {
+        const context = actorContext(c)
+        await requirePluginArchCapability(context, "plugin.create")
+        const body = validJson<z.infer<typeof githubPluginMcpImportSchema>>(c)
+        return c.json({ ok: true, item: await importGithubPluginMcps({
+          access: body.access,
+          authType: body.authType,
+          context,
+          credentialMode: body.credentialMode,
+          githubUrl: body.githubUrl,
+          marketplaceId: body.marketplaceId,
+          selectedSkillKeys: body.selectedSkillKeys,
+          selectedServerKeys: body.selectedServerKeys,
+          selectedServerNames: body.selectedServerNames,
+        }) })
       } catch (error) {
         return routeErrorResponse(c, error)
       }

--- a/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
@@ -381,6 +381,34 @@ export const githubDiscoveryApplySchema = z.object({
   selectedKeys: z.array(z.string().trim().min(1).max(255)).max(200),
 })
 
+export const githubPluginMcpImportAccessSchema = z.object({
+  orgWide: z.boolean().optional().default(true),
+  memberIds: z.array(memberIdSchema).max(200).optional().default([]),
+  teamIds: z.array(teamIdSchema).max(200).optional().default([]),
+}).superRefine((value, ctx) => {
+  if (!value.orgWide && value.memberIds.length === 0 && value.teamIds.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Provide orgWide=true or at least one member/team grant.",
+      path: ["orgWide"],
+    })
+  }
+})
+
+export const githubPluginMcpImportPreviewSchema = z.object({
+  githubUrl: z.string().trim().url().max(2048),
+})
+
+export const githubPluginMcpImportSchema = githubPluginMcpImportPreviewSchema.extend({
+  access: githubPluginMcpImportAccessSchema.optional(),
+  authType: z.enum(["oauth", "none"]).optional().default("oauth"),
+  credentialMode: z.enum(["shared", "per_member"]).optional().default("per_member"),
+  marketplaceId: marketplaceIdSchema,
+  selectedSkillKeys: z.array(z.string().trim().min(1).max(1024)).max(200).optional(),
+  selectedServerKeys: z.array(z.string().trim().min(1).max(1024)).max(200).optional(),
+  selectedServerNames: z.array(z.string().trim().min(1).max(255)).max(200).optional(),
+})
+
 export const githubDiscoveryTreeQuerySchema = z.object({
   cursor: z.string().trim().min(1).max(255).optional(),
   limit: z.coerce.number().int().positive().max(500).optional(),
@@ -775,6 +803,84 @@ export const marketplaceResolvedResponseSchema = pluginArchMutationResponseSchem
       repositoryFullName: z.string().trim().min(1),
       branch: z.string().trim().min(1).nullable(),
     }).nullable(),
+  }),
+)
+
+const githubPluginMcpImportServerSchema = z.object({
+  authType: z.literal("oauth"),
+  connectionId: z.string().nullable(),
+  name: z.string(),
+  pluginKey: z.string(),
+  pluginName: z.string(),
+  serverKey: z.string(),
+  skippedReason: z.enum(["missing_url", "local_unsupported", "invalid_url", "unsupported_auth"]).nullable(),
+  sourcePath: z.string(),
+  supported: z.boolean(),
+  url: z.string().nullable(),
+}).meta({ ref: "GithubPluginMcpImportServer" })
+
+const githubPluginMcpImportPlanSchema = z.object({
+  branch: z.string(),
+  classification: z.enum(["claude_marketplace_repo", "claude_multi_plugin_repo", "claude_single_plugin_repo", "folder_inferred_repo", "unsupported"]),
+  marketplace: z.object({
+    description: z.string().nullable(),
+    name: z.string().nullable(),
+    owner: z.string().nullable(),
+    version: z.string().nullable(),
+  }).nullable(),
+  plugins: z.array(z.object({
+    description: z.string().nullable(),
+    key: z.string(),
+    mcpCount: z.number().int().nonnegative(),
+    name: z.string(),
+    skillCount: z.number().int().nonnegative(),
+  })),
+  repositoryFullName: z.string(),
+  rootPath: z.string(),
+  servers: z.array(githubPluginMcpImportServerSchema),
+  skills: z.array(z.object({
+    description: z.string().nullable(),
+    name: z.string(),
+    pluginKey: z.string(),
+    pluginName: z.string(),
+    skillKey: z.string(),
+    skippedReason: z.enum(["invalid_skill"]).nullable(),
+    sourcePath: z.string(),
+    supported: z.boolean(),
+  })),
+  sourceRevisionRef: z.string(),
+  warnings: z.array(z.string()),
+}).meta({ ref: "GithubPluginMcpImportPlan" })
+
+export const githubPluginMcpImportPreviewResponseSchema = pluginArchMutationResponseSchema(
+  "GithubPluginMcpImportPreviewResponse",
+  githubPluginMcpImportPlanSchema,
+)
+
+export const githubPluginMcpImportResponseSchema = pluginArchMutationResponseSchema(
+  "GithubPluginMcpImportResponse",
+  z.object({
+    imported: z.array(z.object({
+      connectionId: z.string(),
+      name: z.string(),
+      url: z.string(),
+    })),
+    importedSkills: z.array(z.object({
+      name: z.string(),
+      skillId: denTypeIdSchema("skill"),
+      sourcePath: z.string(),
+    })),
+    marketplaceId: marketplaceIdSchema,
+    plugin: pluginSchema,
+    skipped: z.array(z.object({
+      name: z.string(),
+      reason: z.enum(["missing_url", "local_unsupported", "invalid_url", "unsupported_auth"]),
+    })),
+    skippedSkills: z.array(z.object({
+      name: z.string(),
+      reason: z.enum(["invalid_skill"]),
+      sourcePath: z.string(),
+    })),
   }),
 )
 export const marketplacePluginListResponseSchema = pluginArchListResponseSchema("PluginArchMarketplacePluginListResponse", marketplacePluginSchema)

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -11,6 +11,7 @@ import {
   ConnectorSourceTombstoneTable,
   ConnectorSyncEventTable,
   ConnectorTargetTable,
+  ExternalMcpConnectionTable,
   MarketplaceAccessGrantTable,
   MarketplacePluginTable,
   MarketplaceTable,
@@ -19,9 +20,14 @@ import {
   PluginAccessGrantTable,
   PluginConfigObjectTable,
   PluginTable,
+  SkillHubMemberTable,
+  SkillHubSkillTable,
+  SkillHubTable,
+  SkillTable,
   TeamTable,
 } from "@openwork-ee/den-db/schema"
-import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { hasSkillFrontmatterName, parseSkillMarkdown } from "@openwork-ee/utils"
 import type { PluginArchActorContext, PluginArchResourceKind, PluginArchRole } from "./access.js"
 import { requirePluginArchResourceRole, resolvePluginArchResourceRole } from "./access.js"
 import {
@@ -64,6 +70,13 @@ import { env } from "../../../env.js"
 import { roleIncludesOwner } from "../../../orgs.js"
 import { memberFacingMcpConnectionsEnabled } from "../../../capability-sources/external-mcp-rollout.js"
 import { resolveMarketplacePluginCloudReadiness } from "../../../mcp/marketplace-capabilities.js"
+import { assertPublicUrl } from "../../../capability-sources/url-guard.js"
+import {
+  createExternalMcpConnection,
+  deleteExternalMcpConnection,
+  listExternalMcpConnectionAccess,
+  listExternalMcpConnections,
+} from "../../../capability-sources/external-mcp-connections.js"
 
 type OrganizationId = PluginArchActorContext["organizationContext"]["organization"]["id"]
 type MemberId = PluginArchActorContext["organizationContext"]["currentMember"]["id"]
@@ -80,6 +93,7 @@ type MarketplaceId = MarketplaceRow["id"]
 type MarketplaceMembershipId = MarketplaceMembershipRow["id"]
 type PluginId = PluginRow["id"]
 type PluginMembershipId = PluginMembershipRow["id"]
+type SkillId = typeof SkillTable.$inferSelect.id
 type AccessGrantRow =
   | typeof ConfigObjectAccessGrantTable.$inferSelect
   | typeof MarketplaceAccessGrantTable.$inferSelect
@@ -150,6 +164,74 @@ type GithubDiscoverySnapshot = GithubDiscoveryCacheEntry & {
   treeEntries: GithubDiscoveryTreeEntry[]
 }
 
+type PublicGithubPluginTarget = {
+  branch: string | null
+  repositoryFullName: string
+  rootPath: string
+}
+
+type PublicGithubTreeSnapshot = {
+  branch: string
+  fullPathByDiscoveryPath: Map<string, string>
+  headSha: string
+  repositoryFullName: string
+  rootPath: string
+  treeEntries: GithubDiscoveryTreeEntry[]
+  truncated: boolean
+}
+
+type GithubPluginMcpImportAccess = {
+  memberIds: MemberId[]
+  orgWide: boolean
+  teamIds: TeamId[]
+}
+
+type GithubPluginMcpImportServer = {
+  authType: "oauth"
+  connectionId: string | null
+  name: string
+  pluginKey: string
+  pluginName: string
+  serverKey: string
+  skippedReason: "missing_url" | "local_unsupported" | "invalid_url" | "unsupported_auth" | null
+  sourcePath: string
+  supported: boolean
+  url: string | null
+}
+
+type GithubPluginMcpImportPlugin = {
+  description: string | null
+  key: string
+  mcpCount: number
+  name: string
+  skillCount: number
+}
+
+type GithubPluginSkillImportSkill = {
+  description: string | null
+  name: string
+  pluginKey: string
+  pluginName: string
+  rawSourceText?: string
+  skillKey: string
+  skippedReason: "invalid_skill" | null
+  sourcePath: string
+  supported: boolean
+}
+
+type GithubPluginMcpImportPlan = {
+  branch: string
+  classification: GithubDiscoveryClassification
+  marketplace: GithubMarketplaceInfo | null
+  plugins: GithubPluginMcpImportPlugin[]
+  repositoryFullName: string
+  rootPath: string
+  servers: GithubPluginMcpImportServer[]
+  skills: GithubPluginSkillImportSkill[]
+  sourceRevisionRef: string
+  warnings: string[]
+}
+
 type ConfigObjectInput = {
   metadata?: Record<string, unknown>
   normalizedPayloadJson?: Record<string, unknown>
@@ -213,7 +295,7 @@ type GrantTarget = ConfigObjectGrantTarget | MarketplaceGrantTarget | PluginGran
 
 export class PluginArchRouteFailure extends Error {
   constructor(
-    readonly status: 400 | 404 | 409,
+    readonly status: 400 | 404 | 409 | 502,
     readonly error: string,
     message: string,
   ) {
@@ -241,6 +323,196 @@ function stripLineDecorators(value: string) {
     .replace(/^title\s*:\s*/i, "")
     .replace(/^description\s*:\s*/i, "")
     .trim()
+}
+
+function normalizeGithubPath(value: string) {
+  return value.trim().replace(/^\.\//, "").replace(/^\/+/, "").replace(/\/+$/, "")
+}
+
+function parsePublicGithubPluginUrl(rawUrl: string): PublicGithubPluginTarget {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    throw new PluginArchRouteFailure(400, "invalid_github_url", "Enter a valid GitHub URL.")
+  }
+
+  if (url.hostname !== "github.com" && url.hostname !== "www.github.com") {
+    throw new PluginArchRouteFailure(400, "invalid_github_url", "Only github.com plugin URLs are supported.")
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean)
+  const [owner, rawRepo] = segments
+  if (!owner || !rawRepo) {
+    throw new PluginArchRouteFailure(400, "invalid_github_url", "GitHub URL must include an owner and repository.")
+  }
+
+  const repo = rawRepo.replace(/\.git$/i, "")
+  if (!repo) {
+    throw new PluginArchRouteFailure(400, "invalid_github_url", "GitHub URL must include a repository.")
+  }
+
+  if (segments.length === 2) {
+    return {
+      branch: null,
+      repositoryFullName: `${owner}/${repo}`,
+      rootPath: "",
+    }
+  }
+
+  if (segments[2] !== "tree") {
+    throw new PluginArchRouteFailure(400, "invalid_github_url", "Use a GitHub repository or tree URL, for example /tree/main/sales.")
+  }
+
+  const branch = segments[3]
+  if (!branch) {
+    throw new PluginArchRouteFailure(400, "invalid_github_url", "GitHub tree URL must include a branch.")
+  }
+
+  return {
+    branch,
+    repositoryFullName: `${owner}/${repo}`,
+    rootPath: normalizeGithubPath(segments.slice(4).join("/")),
+  }
+}
+
+async function requestPublicGithubJson(input: { path: string; allowStatuses?: number[] }) {
+  const response = await fetch(`https://api.github.com${input.path}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "openwork-den-api",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  })
+  const text = await response.text()
+  const body: unknown = text ? JSON.parse(text) : null
+  if (!response.ok && !(input.allowStatuses ?? []).includes(response.status)) {
+    const message = isRecord(body) && typeof body.message === "string"
+      ? body.message
+      : `GitHub request failed with status ${response.status}.`
+    throw new PluginArchRouteFailure(response.status === 404 ? 404 : 502, "github_request_failed", message)
+  }
+  return { body, ok: response.ok, status: response.status }
+}
+
+function publicGithubRepoParts(repositoryFullName: string) {
+  const [owner, repo, ...rest] = repositoryFullName.split("/")
+  if (!owner || !repo || rest.length > 0) {
+    throw new PluginArchRouteFailure(400, "invalid_github_url", "GitHub repository name is invalid.")
+  }
+  return { owner, repo }
+}
+
+async function getPublicGithubDefaultBranch(repositoryFullName: string) {
+  const { owner, repo } = publicGithubRepoParts(repositoryFullName)
+  const response = await requestPublicGithubJson({
+    path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+  })
+  if (!isRecord(response.body) || typeof response.body.default_branch !== "string" || !response.body.default_branch.trim()) {
+    throw new PluginArchRouteFailure(502, "github_response_incomplete", "GitHub repository response was missing the default branch.")
+  }
+  if (response.body.private === true) {
+    throw new PluginArchRouteFailure(400, "private_github_repo", "Private GitHub repositories must be imported through the GitHub connector.")
+  }
+  return response.body.default_branch.trim()
+}
+
+async function getPublicGithubRepositoryTree(target: PublicGithubPluginTarget): Promise<PublicGithubTreeSnapshot> {
+  const { owner, repo } = publicGithubRepoParts(target.repositoryFullName)
+  const branch = target.branch ?? await getPublicGithubDefaultBranch(target.repositoryFullName)
+  const commitResponse = await requestPublicGithubJson({
+    path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits/${encodeURIComponent(branch)}`,
+  })
+  if (!isRecord(commitResponse.body)) {
+    throw new PluginArchRouteFailure(502, "github_response_incomplete", "GitHub commit response was invalid.")
+  }
+  const headSha = typeof commitResponse.body.sha === "string" ? commitResponse.body.sha : ""
+  const commit = isRecord(commitResponse.body.commit) ? commitResponse.body.commit : null
+  const tree = commit && isRecord(commit.tree) ? commit.tree : null
+  const treeSha = tree && typeof tree.sha === "string" ? tree.sha : ""
+  if (!headSha || !treeSha) {
+    throw new PluginArchRouteFailure(502, "github_response_incomplete", "GitHub commit response was missing the head or tree sha.")
+  }
+
+  const treeResponse = await requestPublicGithubJson({
+    path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/git/trees/${encodeURIComponent(treeSha)}?recursive=1`,
+  })
+  if (!isRecord(treeResponse.body) || !Array.isArray(treeResponse.body.tree)) {
+    throw new PluginArchRouteFailure(502, "github_response_incomplete", "GitHub tree response was invalid.")
+  }
+
+  const rootPath = normalizeGithubPath(target.rootPath)
+  const fullPathByDiscoveryPath = new Map<string, string>()
+  const treeEntries = treeResponse.body.tree.flatMap((entry): GithubDiscoveryTreeEntry[] => {
+    if (!isRecord(entry)) return []
+    const fullPath = typeof entry.path === "string" ? normalizeGithubPath(entry.path) : ""
+    const kind = entry.type === "blob" || entry.type === "tree" ? entry.type : null
+    if (!fullPath || !kind) return []
+    if (rootPath && fullPath !== rootPath && !fullPath.startsWith(`${rootPath}/`)) return []
+    const discoveryPath = rootPath
+      ? (fullPath === rootPath ? "" : fullPath.slice(rootPath.length + 1))
+      : fullPath
+    if (!discoveryPath) return []
+    fullPathByDiscoveryPath.set(discoveryPath, fullPath)
+    return [{
+      id: entry.sha === null || typeof entry.sha === "string" ? entry.sha ?? discoveryPath : discoveryPath,
+      kind,
+      path: discoveryPath,
+      sha: entry.sha === null || typeof entry.sha === "string" ? entry.sha : null,
+      size: typeof entry.size === "number" ? entry.size : null,
+    }]
+  })
+
+  if (treeEntries.length === 0) {
+    throw new PluginArchRouteFailure(404, "github_plugin_root_not_found", "No files were found at that GitHub plugin path.")
+  }
+
+  return {
+    branch,
+    fullPathByDiscoveryPath,
+    headSha,
+    repositoryFullName: target.repositoryFullName,
+    rootPath,
+    treeEntries,
+    truncated: isRecord(treeResponse.body) && treeResponse.body.truncated === true,
+  }
+}
+
+async function getPublicGithubTextFile(input: { branch: string; discoveryPath: string; snapshot: PublicGithubTreeSnapshot }) {
+  const fullPath = input.snapshot.fullPathByDiscoveryPath.get(input.discoveryPath) ?? input.discoveryPath
+  const { owner, repo } = publicGithubRepoParts(input.snapshot.repositoryFullName)
+  const response = await requestPublicGithubJson({
+    allowStatuses: [404],
+    path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${fullPath.split("/").map(encodeURIComponent).join("/")}?ref=${encodeURIComponent(input.branch)}`,
+  })
+  if (!response.ok) return null
+  if (!isRecord(response.body) || response.body.encoding !== "base64" || typeof response.body.content !== "string") {
+    throw new PluginArchRouteFailure(502, "github_response_incomplete", "GitHub file response was incomplete.")
+  }
+  return Buffer.from(response.body.content.replace(/\n/g, ""), "base64").toString("utf8")
+}
+
+async function getPublicGithubDiscoveryFileTexts(snapshot: PublicGithubTreeSnapshot) {
+  const interestingPaths = new Set<string>()
+  const knownPaths = new Set(snapshot.treeEntries.map((entry) => entry.path))
+  if (knownPaths.has(".claude-plugin/marketplace.json")) {
+    interestingPaths.add(".claude-plugin/marketplace.json")
+  }
+  for (const entry of snapshot.treeEntries) {
+    if (entry.path.endsWith(".claude-plugin/plugin.json") || entry.path.endsWith("/plugin.json") || entry.path === "plugin.json") {
+      interestingPaths.add(entry.path)
+    }
+  }
+
+  const fileTextByPath: Record<string, string | null> = {}
+  for (const path of interestingPaths) {
+    fileTextByPath[path] = await getPublicGithubTextFile({
+      branch: snapshot.branch,
+      discoveryPath: path,
+      snapshot,
+    })
+  }
+  return fileTextByPath
 }
 
 function deriveProjection(input: { objectType: ConfigObjectRow["objectType"]; value: ConfigObjectInput }) {
@@ -1658,6 +1930,100 @@ export async function updatePlugin(input: { context: PluginArchActorContext; des
   return getPluginDetail(input.context, row.id)
 }
 
+function externalMcpConnectionIdsFromPayload(payload: unknown, options?: { ownedOnly?: boolean }): string[] {
+  const ids = new Set<string>()
+  const collect = (value: unknown) => {
+    if (!isRecord(value) || value.openworkManaged !== "den_external_mcp") return
+    if (options?.ownedOnly === true && value.externalMcpConnectionOwnedByPlugin !== true) return
+    if (typeof value.externalMcpConnectionId === "string" && value.externalMcpConnectionId.trim()) {
+      ids.add(value.externalMcpConnectionId.trim())
+    }
+  }
+
+  collect(payload)
+  if (isRecord(payload)) {
+    const containers = [
+      isRecord(payload.mcpServers) ? payload.mcpServers : null,
+      isRecord(payload.mcp) ? payload.mcp : null,
+    ].filter((entry): entry is Record<string, unknown> => Boolean(entry))
+    for (const container of containers) {
+      for (const value of Object.values(container)) collect(value)
+    }
+  }
+  return [...ids]
+}
+
+async function pluginOwnedExternalMcpConnectionIds(input: {
+  context: PluginArchActorContext
+  pluginId: PluginId
+}) {
+  const memberships = await db
+    .select({ configObjectId: PluginConfigObjectTable.configObjectId })
+    .from(PluginConfigObjectTable)
+    .innerJoin(ConfigObjectTable, eq(PluginConfigObjectTable.configObjectId, ConfigObjectTable.id))
+    .where(and(
+      eq(PluginConfigObjectTable.pluginId, input.pluginId),
+      eq(PluginConfigObjectTable.organizationId, input.context.organizationContext.organization.id),
+      eq(ConfigObjectTable.objectType, "mcp"),
+      isNull(PluginConfigObjectTable.removedAt),
+    ))
+  const versions = await getLatestVersions(memberships.map((membership) => membership.configObjectId))
+  const ids = new Set<string>()
+  for (const membership of memberships) {
+    const payload = versions.get(membership.configObjectId)?.normalizedPayloadJson
+    for (const id of externalMcpConnectionIdsFromPayload(payload, { ownedOnly: true })) ids.add(id)
+  }
+  return [...ids]
+}
+
+async function activePluginReferencesExternalMcpConnection(input: {
+  connectionId: string
+  context: PluginArchActorContext
+  excludingPluginId: PluginId
+}) {
+  const memberships = await db
+    .select({
+      configObjectId: PluginConfigObjectTable.configObjectId,
+      pluginId: PluginConfigObjectTable.pluginId,
+    })
+    .from(PluginConfigObjectTable)
+    .innerJoin(ConfigObjectTable, eq(PluginConfigObjectTable.configObjectId, ConfigObjectTable.id))
+    .innerJoin(PluginTable, eq(PluginConfigObjectTable.pluginId, PluginTable.id))
+    .where(and(
+      eq(PluginConfigObjectTable.organizationId, input.context.organizationContext.organization.id),
+      eq(ConfigObjectTable.objectType, "mcp"),
+      eq(PluginTable.status, "active"),
+      isNull(PluginTable.deletedAt),
+      isNull(PluginConfigObjectTable.removedAt),
+    ))
+  const otherMemberships = memberships.filter((membership) => membership.pluginId !== input.excludingPluginId)
+  const versions = await getLatestVersions(otherMemberships.map((membership) => membership.configObjectId))
+  for (const membership of otherMemberships) {
+    const payload = versions.get(membership.configObjectId)?.normalizedPayloadJson
+    if (externalMcpConnectionIdsFromPayload(payload).includes(input.connectionId)) return true
+  }
+  return false
+}
+
+async function deletePluginOwnedExternalMcpConnections(input: {
+  context: PluginArchActorContext
+  pluginId: PluginId
+}) {
+  const connectionIds = await pluginOwnedExternalMcpConnectionIds(input)
+  for (const connectionId of connectionIds) {
+    const referencedElsewhere = await activePluginReferencesExternalMcpConnection({
+      connectionId,
+      context: input.context,
+      excludingPluginId: input.pluginId,
+    })
+    if (referencedElsewhere) continue
+    await deleteExternalMcpConnection({
+      connectionId: normalizeDenTypeId("externalMcpConnection", connectionId),
+      organizationId: input.context.organizationContext.organization.id,
+    })
+  }
+}
+
 export async function setPluginLifecycle(input: { action: "archive" | "restore"; context: PluginArchActorContext; pluginId: PluginId }) {
   const row = await ensureVisiblePlugin(input.context, input.pluginId)
   await requirePluginArchResourceRole({ context: input.context, resourceId: row.id, resourceKind: "plugin", role: "manager" })
@@ -1667,6 +2033,9 @@ export async function setPluginLifecycle(input: { action: "archive" | "restore";
     status: input.action === "archive" ? "archived" : "active",
     updatedAt,
   }).where(eq(PluginTable.id, row.id))
+  if (input.action === "archive") {
+    await deletePluginOwnedExternalMcpConnections({ context: input.context, pluginId: row.id })
+  }
   return getPluginDetail(input.context, row.id)
 }
 
@@ -2950,6 +3319,735 @@ function buildGithubDiscoveryImportPlans(input: { discoveredPlugins: GithubDisco
       } satisfies GithubDiscoveryImportPlan
     }),
   ])) satisfies Record<string, GithubDiscoveryImportPlan[]>
+}
+
+function slugifyPluginMcpName(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80) || "mcp"
+}
+
+function externalMcpConnectionName(input: { pluginName: string; serverName: string }) {
+  const serverName = input.serverName.trim()
+  const pluginName = input.pluginName.trim()
+  if (!pluginName) return serverName || "Imported MCP"
+  if (!serverName) return pluginName
+  return `${pluginName} / ${serverName}`
+}
+
+function githubPluginMcpServerKey(input: { name: string; pluginKey: string; sourcePath: string; url: string | null }) {
+  return [input.pluginKey, input.sourcePath, input.name, input.url ?? ""].map(encodeURIComponent).join(":")
+}
+
+function githubPluginMcpImportServer(input: Omit<GithubPluginMcpImportServer, "serverKey">): GithubPluginMcpImportServer {
+  return {
+    ...input,
+    serverKey: githubPluginMcpServerKey(input),
+  }
+}
+
+function mcpServerEntriesFromPayload(input: {
+  plugin: GithubDiscoveredPlugin
+  rawSourceText: string
+  sourcePath: string
+}): GithubPluginMcpImportServer[] {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(input.rawSourceText)
+  } catch {
+    return [githubPluginMcpImportServer({
+      authType: "oauth",
+      connectionId: null,
+      name: input.sourcePath,
+      pluginKey: input.plugin.key,
+      pluginName: input.plugin.displayName,
+      skippedReason: "invalid_url",
+      sourcePath: input.sourcePath,
+      supported: false,
+      url: null,
+    })]
+  }
+
+  const root = isRecord(parsed) ? parsed : {}
+  const containers = [
+    isRecord(root.mcpServers) ? root.mcpServers : null,
+    isRecord(root.mcp) ? root.mcp : null,
+  ].filter((entry): entry is Record<string, unknown> => Boolean(entry))
+  const entries = containers.flatMap((container) => Object.entries(container))
+  const fallbackEntries: Array<[string, unknown]> = entries.length > 0 ? entries : [[input.plugin.displayName, root]]
+
+  return fallbackEntries.map(([rawName, rawConfig]) => {
+    const config = isRecord(rawConfig) ? rawConfig : {}
+    const name = rawName.trim() || input.plugin.displayName
+    const url = typeof config.url === "string" ? config.url.trim() : ""
+    const type = typeof config.type === "string" ? config.type.trim().toLowerCase() : ""
+    const command = typeof config.command === "string"
+      ? config.command.trim()
+      : Array.isArray(config.command) && config.command.some((part) => typeof part === "string" && part.trim())
+        ? "local command"
+        : ""
+
+    if (!url) {
+      return githubPluginMcpImportServer({
+        authType: "oauth",
+        connectionId: null,
+        name,
+        pluginKey: input.plugin.key,
+        pluginName: input.plugin.displayName,
+        skippedReason: command ? "local_unsupported" : "missing_url",
+        sourcePath: input.sourcePath,
+        supported: false,
+        url: null,
+      })
+    }
+
+    let parsedUrl: URL
+    try {
+      parsedUrl = new URL(url)
+    } catch {
+      return githubPluginMcpImportServer({
+        authType: "oauth",
+        connectionId: null,
+        name,
+        pluginKey: input.plugin.key,
+        pluginName: input.plugin.displayName,
+        skippedReason: "invalid_url",
+        sourcePath: input.sourcePath,
+        supported: false,
+        url,
+      })
+    }
+
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      return githubPluginMcpImportServer({
+        authType: "oauth",
+        connectionId: null,
+        name,
+        pluginKey: input.plugin.key,
+        pluginName: input.plugin.displayName,
+        skippedReason: "invalid_url",
+        sourcePath: input.sourcePath,
+        supported: false,
+        url,
+      })
+    }
+
+    if (type && type !== "http" && type !== "remote" && type !== "streamable-http" && type !== "sse") {
+      return githubPluginMcpImportServer({
+        authType: "oauth",
+        connectionId: null,
+        name,
+        pluginKey: input.plugin.key,
+        pluginName: input.plugin.displayName,
+        skippedReason: "local_unsupported",
+        sourcePath: input.sourcePath,
+        supported: false,
+        url,
+      })
+    }
+
+    return githubPluginMcpImportServer({
+      authType: "oauth",
+      connectionId: null,
+      name,
+      pluginKey: input.plugin.key,
+      pluginName: input.plugin.displayName,
+      skippedReason: null,
+      sourcePath: input.sourcePath,
+      supported: true,
+      url,
+    })
+  })
+}
+
+function githubPluginSkillKey(input: { pluginKey: string; sourcePath: string }) {
+  return [input.pluginKey, input.sourcePath].map(encodeURIComponent).join(":")
+}
+
+function skillMetadataFromText(skillText: string) {
+  const parsed = parseSkillMarkdown(skillText)
+  if (parsed.hasFrontmatter) {
+    const title = parsed.name.trim() || "Untitled skill"
+    const description = parsed.description.trim() || null
+    return {
+      description: description ? description.slice(0, 65535) : null,
+      title: title.slice(0, 255),
+    }
+  }
+
+  const lines = skillText
+    .split(/\r?\n/g)
+    .map((line) => line.trim())
+    .filter(Boolean)
+
+  const cleanup = (value: string) => value
+    .replace(/^#{1,6}\s+/, "")
+    .replace(/^[-*+]\s+/, "")
+    .replace(/^title\s*:\s*/i, "")
+    .replace(/^description\s*:\s*/i, "")
+    .trim()
+
+  const title = cleanup(lines[0] ?? "") || "Untitled skill"
+  const description = lines.slice(1).map(cleanup).find(Boolean) ?? null
+
+  return {
+    description: description ? description.slice(0, 65535) : null,
+    title: title.slice(0, 255),
+  }
+}
+
+function skillEntryFromSource(input: {
+  includeRawSourceText: boolean
+  plugin: GithubDiscoveredPlugin
+  rawSourceText: string
+  sourcePath: string
+}): GithubPluginSkillImportSkill {
+  const metadata = skillMetadataFromText(input.rawSourceText)
+  const base = {
+    description: metadata.description,
+    name: metadata.title,
+    pluginKey: input.plugin.key,
+    pluginName: input.plugin.displayName,
+    skillKey: githubPluginSkillKey({ pluginKey: input.plugin.key, sourcePath: input.sourcePath }),
+    sourcePath: input.sourcePath,
+  }
+  if (!input.rawSourceText.trim() || !hasSkillFrontmatterName(input.rawSourceText)) {
+    return {
+      ...base,
+      skippedReason: "invalid_skill",
+      supported: false,
+    }
+  }
+  return {
+    ...base,
+    rawSourceText: input.includeRawSourceText ? input.rawSourceText : undefined,
+    skippedReason: null,
+    supported: true,
+  }
+}
+
+async function computeGithubPluginMcpImportPlan(input: { githubUrl: string; includeSkillText?: boolean }): Promise<GithubPluginMcpImportPlan> {
+  const target = parsePublicGithubPluginUrl(input.githubUrl)
+  const snapshot = await getPublicGithubRepositoryTree(target)
+  const fileTextByPath = await getPublicGithubDiscoveryFileTexts(snapshot)
+  const discovery = buildGithubRepoDiscovery({
+    entries: snapshot.treeEntries,
+    fileTextByPath,
+  })
+  const importPlansByPluginKey = buildGithubDiscoveryImportPlans({
+    discoveredPlugins: discovery.discoveredPlugins,
+    treeEntries: snapshot.treeEntries,
+  })
+
+  const servers: GithubPluginMcpImportServer[] = []
+  const skills: GithubPluginSkillImportSkill[] = []
+  for (const plugin of discovery.discoveredPlugins.filter((entry) => entry.supported)) {
+    const componentPlans = importPlansByPluginKey[plugin.key] ?? []
+    for (const plan of componentPlans.filter((entry) => entry.objectType === "mcp")) {
+      for (const path of plan.paths) {
+        const rawSourceText = await getPublicGithubTextFile({
+          branch: snapshot.branch,
+          discoveryPath: path,
+          snapshot,
+        })
+        if (!rawSourceText) continue
+        servers.push(...mcpServerEntriesFromPayload({
+          plugin,
+          rawSourceText,
+          sourcePath: path,
+        }))
+      }
+    }
+    for (const plan of componentPlans.filter((entry) => entry.objectType === "skill")) {
+      for (const path of plan.paths) {
+        const rawSourceText = await getPublicGithubTextFile({
+          branch: snapshot.branch,
+          discoveryPath: path,
+          snapshot,
+        })
+        if (!rawSourceText) continue
+        skills.push(skillEntryFromSource({
+          includeRawSourceText: input.includeSkillText === true,
+          plugin,
+          rawSourceText,
+          sourcePath: path,
+        }))
+      }
+    }
+  }
+
+  const plugins = discovery.discoveredPlugins
+    .filter((plugin) => plugin.supported)
+    .map((plugin) => ({
+      description: plugin.description,
+      key: plugin.key,
+      mcpCount: servers.filter((server) => server.pluginKey === plugin.key && server.supported).length,
+      name: plugin.displayName,
+      skillCount: skills.filter((skill) => skill.pluginKey === plugin.key && skill.supported).length,
+    } satisfies GithubPluginMcpImportPlugin))
+    .filter((plugin) => plugin.mcpCount > 0 || plugin.skillCount > 0)
+
+  return {
+    branch: snapshot.branch,
+    classification: discovery.classification,
+    marketplace: discovery.marketplace,
+    plugins,
+    repositoryFullName: snapshot.repositoryFullName,
+    rootPath: snapshot.rootPath,
+    servers,
+    skills,
+    sourceRevisionRef: snapshot.headSha,
+    warnings: [
+      ...discovery.warnings,
+      ...(snapshot.truncated ? ["GitHub truncated the repository tree; some MCP files may be missing."] : []),
+    ],
+  }
+}
+
+function normalizeConnectionUrl(value: string) {
+  try {
+    const url = new URL(value)
+    return `${url.protocol}//${url.host}${url.pathname}`.replace(/\/+$/, "").toLowerCase()
+  } catch {
+    return value.trim().replace(/\/+$/, "").toLowerCase()
+  }
+}
+
+function sortedUnique(values: string[]) {
+  return [...new Set(values)].sort()
+}
+
+function sameStringSet(left: string[], right: string[]) {
+  const normalizedLeft = sortedUnique(left)
+  const normalizedRight = sortedUnique(right)
+  return normalizedLeft.length === normalizedRight.length
+    && normalizedLeft.every((value, index) => value === normalizedRight[index])
+}
+
+async function requireExistingExternalMcpConnectionMatchesImport(input: {
+  access: GithubPluginMcpImportAccess
+  authType: "none" | "oauth"
+  connectionId: Parameters<typeof listExternalMcpConnectionAccess>[0]
+  credentialMode: "per_member" | "shared"
+  existingAuthType: "apikey" | "none" | "oauth"
+  existingCredentialMode: "per_member" | "shared"
+}) {
+  const expectedCredentialMode = input.authType === "none" ? "shared" : input.credentialMode
+  if (input.existingAuthType !== input.authType || input.existingCredentialMode !== expectedCredentialMode) {
+    throw new PluginArchRouteFailure(
+      409,
+      "external_mcp_connection_config_mismatch",
+      "An External MCP Connection already exists for this URL with different authentication or credential mode. Edit the existing connection or import with matching settings.",
+    )
+  }
+
+  const grants = await listExternalMcpConnectionAccess(input.connectionId)
+  const existingOrgWide = grants.some((grant) => grant.orgWide)
+  const existingMemberIds = grants.flatMap((grant) => grant.orgMembershipId ? [grant.orgMembershipId] : [])
+  const existingTeamIds = grants.flatMap((grant) => grant.teamId ? [grant.teamId] : [])
+  const accessMatches = existingOrgWide === input.access.orgWide
+    && sameStringSet(existingMemberIds, input.access.memberIds)
+    && sameStringSet(existingTeamIds, input.access.teamIds)
+
+  if (!accessMatches) {
+    throw new PluginArchRouteFailure(
+      409,
+      "external_mcp_connection_access_mismatch",
+      "An External MCP Connection already exists for this URL with different sharing settings. Edit the existing connection or choose an import audience that matches it.",
+    )
+  }
+}
+
+async function ensureImportedExternalMcpConnection(input: {
+  access: GithubPluginMcpImportAccess
+  authType: "none" | "oauth"
+  context: PluginArchActorContext
+  credentialMode: "per_member" | "shared"
+  server: GithubPluginMcpImportServer
+}): Promise<{ connection: Awaited<ReturnType<typeof createExternalMcpConnection>>; ownedByImportedPlugin: boolean }> {
+  if (!input.server.url) {
+    throw new PluginArchRouteFailure(400, "invalid_mcp_import", "MCP server URL is required.")
+  }
+
+  await assertPublicUrl(input.server.url)
+  const organizationId = input.context.organizationContext.organization.id
+  const normalizedUrl = normalizeConnectionUrl(input.server.url)
+  const existing = (await listExternalMcpConnections(organizationId))
+    .find((connection) => normalizeConnectionUrl(connection.url) === normalizedUrl)
+
+  const access = {
+    memberIds: input.access.memberIds,
+    orgWide: input.access.orgWide,
+    teamIds: input.access.teamIds,
+  }
+
+  if (existing) {
+    await requireExistingExternalMcpConnectionMatchesImport({
+      access,
+      connectionId: existing.id,
+      authType: input.authType,
+      credentialMode: input.credentialMode,
+      existingAuthType: existing.authType,
+      existingCredentialMode: existing.credentialMode,
+    })
+    if (input.authType === "none") {
+      await markImportedExternalMcpConnectionConnected(existing.id)
+    }
+    return { connection: existing, ownedByImportedPlugin: false }
+  }
+
+  const created = await createExternalMcpConnection({
+    access,
+    authType: input.authType,
+    createdByOrgMembershipId: input.context.organizationContext.currentMember.id,
+    credentialMode: input.authType === "none" ? "shared" : input.credentialMode,
+    name: externalMcpConnectionName({ pluginName: input.server.pluginName, serverName: input.server.name }),
+    organizationId,
+    url: input.server.url,
+  })
+  if (input.authType === "none") {
+    await markImportedExternalMcpConnectionConnected(created.id)
+  }
+  return { connection: created, ownedByImportedPlugin: true }
+}
+
+async function markImportedExternalMcpConnectionConnected(connectionId: typeof ExternalMcpConnectionTable.$inferSelect.id) {
+  await db
+    .update(ExternalMcpConnectionTable)
+    .set({ connectedAt: new Date() })
+    .where(eq(ExternalMcpConnectionTable.id, connectionId))
+}
+
+function importedConnectionBackedMcpPayload(input: {
+  connectionId: string
+  ownedByImportedPlugin: boolean
+  server: GithubPluginMcpImportServer
+}) {
+  const serverName = slugifyPluginMcpName(input.server.name)
+  return {
+    mcpServers: {
+      [serverName]: {
+        type: "remote",
+        url: input.server.url,
+        openworkManaged: "den_external_mcp",
+        externalMcpConnectionId: input.connectionId,
+        externalMcpConnectionOwnedByPlugin: input.ownedByImportedPlugin,
+      },
+    },
+    openworkManaged: "den_external_mcp",
+    externalMcpConnectionId: input.connectionId,
+    externalMcpConnectionOwnedByPlugin: input.ownedByImportedPlugin,
+  }
+}
+
+function importedDenSkillPayload(skillId: SkillId) {
+  return {
+    denSkillId: skillId,
+    openworkManaged: "den_skill",
+  }
+}
+
+async function createSkillHubForImportedSkills(input: {
+  access: GithubPluginMcpImportAccess
+  context: PluginArchActorContext
+  name: string
+}) {
+  if (input.access.orgWide) return null
+  const now = new Date()
+  const skillHubId = createDenTypeId("skillHub")
+  const createdByOrgMembershipId = input.context.organizationContext.currentMember.id
+  const organizationId = input.context.organizationContext.organization.id
+  const accessRows: (typeof SkillHubMemberTable.$inferInsert)[] = []
+  for (const memberId of new Set(input.access.memberIds)) {
+    accessRows.push({
+      id: createDenTypeId("skillHubMember"),
+      skillHubId,
+      orgMembershipId: memberId,
+      teamId: null,
+      createdAt: now,
+    })
+  }
+  for (const teamId of new Set(input.access.teamIds)) {
+    accessRows.push({
+      id: createDenTypeId("skillHubMember"),
+      skillHubId,
+      orgMembershipId: null,
+      teamId,
+      createdAt: now,
+    })
+  }
+
+  await db.transaction(async (tx) => {
+    await tx.insert(SkillHubTable).values({
+      id: skillHubId,
+      organizationId,
+      createdByOrgMembershipId,
+      name: input.name,
+      description: "Skills imported from a GitHub plugin.",
+      createdAt: now,
+      updatedAt: now,
+    })
+    if (accessRows.length > 0) {
+      await tx.insert(SkillHubMemberTable).values(accessRows)
+    }
+  })
+  return skillHubId
+}
+
+async function createImportedSkill(input: {
+  access: GithubPluginMcpImportAccess
+  context: PluginArchActorContext
+  skill: GithubPluginSkillImportSkill
+  skillHubId: typeof SkillHubTable.$inferSelect.id | null
+}) {
+  const skillText = input.skill.rawSourceText
+  if (!skillText) {
+    throw new PluginArchRouteFailure(400, "invalid_skill_import", "Selected skill content was unavailable.")
+  }
+  const metadata = skillMetadataFromText(skillText)
+  const now = new Date()
+  const skillId = createDenTypeId("skill")
+  const createdByOrgMembershipId = input.context.organizationContext.currentMember.id
+  const organizationId = input.context.organizationContext.organization.id
+  await db.transaction(async (tx) => {
+    await tx.insert(SkillTable).values({
+      id: skillId,
+      organizationId,
+      createdByOrgMembershipId,
+      title: metadata.title,
+      description: metadata.description,
+      skillText,
+      shared: input.access.orgWide ? "org" : null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    if (input.skillHubId) {
+      await tx.insert(SkillHubSkillTable).values({
+        id: createDenTypeId("skillHubSkill"),
+        skillHubId: input.skillHubId,
+        skillId,
+        addedByOrgMembershipId: createdByOrgMembershipId,
+        createdAt: now,
+      })
+    }
+  })
+  return {
+    description: metadata.description,
+    id: skillId,
+    skillText,
+    title: metadata.title,
+  }
+}
+
+function importedPluginName(plan: GithubPluginMcpImportPlan) {
+  if (plan.plugins.length === 1) return plan.plugins[0].name
+  return plan.marketplace?.name?.trim() || plan.rootPath.split("/").filter(Boolean).at(-1) || plan.repositoryFullName.split("/").at(-1) || "GitHub MCP Plugin"
+}
+
+export async function previewGithubPluginMcpImport(input: { githubUrl: string }) {
+  return computeGithubPluginMcpImportPlan({ githubUrl: input.githubUrl })
+}
+
+async function grantImportAccessToPluginArchResource(input: {
+  access: GithubPluginMcpImportAccess
+  context: PluginArchActorContext
+} & (
+  | { resourceId: ConfigObjectId; resourceKind: "config_object" }
+  | { resourceId: PluginId; resourceKind: "plugin" }
+)) {
+  const grant = async (value: AccessGrantWrite) => {
+    if (input.resourceKind === "plugin") {
+      await createResourceAccessGrant({
+        context: input.context,
+        resourceId: input.resourceId,
+        resourceKind: "plugin",
+        value,
+      })
+      return
+    }
+    await createResourceAccessGrant({
+      context: input.context,
+      resourceId: input.resourceId,
+      resourceKind: "config_object",
+      value,
+    })
+  }
+
+  if (input.access.orgWide) {
+    await grant({ orgWide: true, role: "viewer" })
+    return
+  }
+
+  for (const memberId of input.access.memberIds) {
+    await grant({ orgMembershipId: memberId, role: "viewer" })
+  }
+  for (const teamId of input.access.teamIds) {
+    await grant({ role: "viewer", teamId })
+  }
+}
+
+export async function importGithubPluginMcps(input: {
+  access?: GithubPluginMcpImportAccess
+  authType: "none" | "oauth"
+  context: PluginArchActorContext
+  credentialMode: "per_member" | "shared"
+  githubUrl: string
+  marketplaceId: MarketplaceId
+  selectedSkillKeys?: string[]
+  selectedServerKeys?: string[]
+  selectedServerNames?: string[]
+}) {
+  await ensureEditableMarketplace(input.context, input.marketplaceId)
+  const plan = await computeGithubPluginMcpImportPlan({ githubUrl: input.githubUrl, includeSkillText: true })
+  const selectedSkillKeys = new Set(input.selectedSkillKeys?.map((key) => key.trim()).filter(Boolean) ?? [])
+  const selectedServerKeys = new Set(input.selectedServerKeys?.map((key) => key.trim()).filter(Boolean) ?? [])
+  const selectedServerNames = new Set(input.selectedServerNames?.map((name) => name.trim()).filter(Boolean) ?? [])
+  const consideredServers = selectedServerKeys.size > 0
+    ? plan.servers.filter((server) => selectedServerKeys.has(server.serverKey))
+    : selectedServerNames.size > 0
+    ? plan.servers.filter((server) => selectedServerNames.has(server.name))
+    : plan.servers
+  const consideredSkills = selectedSkillKeys.size > 0
+    ? plan.skills.filter((skill) => selectedSkillKeys.has(skill.skillKey))
+    : []
+  const supportedServers = consideredServers.filter((server) => server.supported && server.url)
+  const supportedSkills = consideredSkills.filter((skill) => skill.supported && skill.rawSourceText)
+  if (supportedServers.length === 0 && supportedSkills.length === 0) {
+    throw new PluginArchRouteFailure(400, "no_supported_plugin_components", "No supported remote MCP servers or skills were selected from that plugin.")
+  }
+
+  const access = input.access ?? {
+    memberIds: [],
+    orgWide: true,
+    teamIds: [],
+  }
+  if (!access.orgWide && access.memberIds.length === 0 && access.teamIds.length === 0) {
+    throw new PluginArchRouteFailure(400, "missing_import_access", "Choose who can use the imported MCP connections.")
+  }
+
+  const plugin = await createPlugin({
+    context: input.context,
+    description: `Plugin components imported from ${plan.repositoryFullName}${plan.rootPath ? `/${plan.rootPath}` : ""}.`,
+    name: importedPluginName(plan),
+  })
+
+  await grantImportAccessToPluginArchResource({
+    access,
+    context: input.context,
+    resourceId: plugin.id,
+    resourceKind: "plugin",
+  })
+
+  const imported: Array<{ connectionId: string; name: string; url: string }> = []
+  const importedSkills: Array<{ name: string; skillId: SkillId; sourcePath: string }> = []
+  for (const server of supportedServers) {
+    const importedConnection = await ensureImportedExternalMcpConnection({
+      access,
+      authType: input.authType,
+      context: input.context,
+      credentialMode: input.credentialMode,
+      server,
+    })
+    const connection = importedConnection.connection
+    const payload = importedConnectionBackedMcpPayload({
+      connectionId: connection.id,
+      ownedByImportedPlugin: importedConnection.ownedByImportedPlugin,
+      server,
+    })
+    const configObject = await createConfigObject({
+      context: input.context,
+      objectType: "mcp",
+      pluginIds: [plugin.id],
+      sourceMode: "import",
+      value: {
+        metadata: {
+          description: `Den-hosted MCP connection imported from ${server.sourcePath}.`,
+          externalMcpConnectionId: connection.id,
+          externalMcpConnectionOwnedByPlugin: importedConnection.ownedByImportedPlugin,
+          githubUrl: input.githubUrl,
+          name: externalMcpConnectionName({ pluginName: server.pluginName, serverName: server.name }),
+          openworkManaged: "den_external_mcp",
+          repositoryFullName: plan.repositoryFullName,
+          sourcePath: server.sourcePath,
+        },
+        normalizedPayloadJson: payload,
+        schemaVersion: "openwork.den_external_mcp.v1",
+      },
+    })
+    await grantImportAccessToPluginArchResource({
+      access,
+      context: input.context,
+      resourceId: configObject.id,
+      resourceKind: "config_object",
+    })
+    imported.push({ connectionId: connection.id, name: server.name, url: server.url ?? "" })
+  }
+
+  const skillHubId = supportedSkills.length > 0
+    ? await createSkillHubForImportedSkills({
+      access,
+      context: input.context,
+      name: `${plugin.name} skills`,
+    })
+    : null
+  for (const skill of supportedSkills) {
+    const createdSkill = await createImportedSkill({
+      access,
+      context: input.context,
+      skill,
+      skillHubId,
+    })
+    const configObject = await createConfigObject({
+      context: input.context,
+      objectType: "skill",
+      pluginIds: [plugin.id],
+      sourceMode: "import",
+      value: {
+        metadata: {
+          description: createdSkill.description ?? `Den skill imported from ${skill.sourcePath}.`,
+          denSkillId: createdSkill.id,
+          githubUrl: input.githubUrl,
+          name: createdSkill.title,
+          openworkManaged: "den_skill",
+          repositoryFullName: plan.repositoryFullName,
+          sourcePath: skill.sourcePath,
+        },
+        normalizedPayloadJson: importedDenSkillPayload(createdSkill.id),
+        schemaVersion: "openwork.den_skill.v1",
+      },
+    })
+    await grantImportAccessToPluginArchResource({
+      access,
+      context: input.context,
+      resourceId: configObject.id,
+      resourceKind: "config_object",
+    })
+    importedSkills.push({ name: createdSkill.title, skillId: createdSkill.id, sourcePath: skill.sourcePath })
+  }
+
+  await attachPluginToMarketplace({
+    context: input.context,
+    marketplaceId: input.marketplaceId,
+    membershipSource: "api",
+    pluginId: plugin.id,
+  })
+
+  const skipped = consideredServers.flatMap((server) =>
+    server.supported || !server.skippedReason ? [] : [{ name: server.name, reason: server.skippedReason }])
+  const skippedSkills = consideredSkills.flatMap((skill) =>
+    skill.supported || !skill.skippedReason ? [] : [{ name: skill.name, reason: skill.skippedReason, sourcePath: skill.sourcePath }])
+
+  return {
+    imported,
+    importedSkills,
+    marketplaceId: input.marketplaceId,
+    plugin: await getPluginDetail(input.context, plugin.id),
+    skipped,
+    skippedSkills,
+  }
 }
 
 function readGithubDiscoveryCache(config: Record<string, unknown> | null) {

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -472,8 +472,12 @@ export function getGithubIntegrationRoute(orgSlug?: string | null): string {
   return `${getIntegrationsRoute(orgSlug)}/github`;
 }
 
+export function getConnectionsRoute(orgSlug?: string | null): string {
+  return `${getOrgDashboardRoute(orgSlug)}/connections`;
+}
+
 export function getMcpConnectionsRoute(orgSlug?: string | null): string {
-  return `${getOrgDashboardRoute(orgSlug)}/mcp-connections`;
+  return getConnectionsRoute(orgSlug);
 }
 
 export function getYourConnectionsRoute(orgSlug?: string | null): string {

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/connections/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/connections/page.tsx
@@ -1,0 +1,5 @@
+import { McpConnectionsScreen } from "../../_components/mcp-connections-screen";
+
+export default function ConnectionsPage() {
+  return <McpConnectionsScreen />;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/page.tsx
@@ -1,5 +1,6 @@
-import { McpConnectionsScreen } from "../../_components/mcp-connections-screen";
+import { redirect } from "next/navigation";
+import { getConnectionsRoute } from "../../../_lib/den-org";
 
 export default function McpConnectionsPage() {
-  return <McpConnectionsScreen />;
+  redirect(getConnectionsRoute());
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -1,13 +1,19 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Check, Loader2, Plug, Plus, Trash2, Users } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Check, Loader2, Plug, Puzzle, Server, Trash2, Users } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
+import { DenSelect } from "../../_components/ui/select";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { getPluginRoute } from "../../_lib/den-org";
+import { getRequestError, requestJson } from "../../_lib/den-flow";
 import { IntegrationIcon } from "./integration-icon";
 import { shouldShowMcpConnectionsStagingBanner } from "./mcp-connections-capability";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import { marketplaceQueryKeys, useMarketplaces } from "./marketplace-data";
 import {
   type CreatedMcpConnection,
   type CreateMcpConnectionInput,
@@ -17,6 +23,7 @@ import {
   type ExternalMcpPreset,
   type McpConnectionAccessInput,
   formatMcpConnectedTimestamp,
+  mcpConnectionQueryKeys,
   useCreateMcpConnection,
   useDeleteMcpConnection,
   useMcpConnectionPresets,
@@ -25,6 +32,7 @@ import {
   useSaveNativeProviderClient,
   useStartMcpConnectionOAuth,
 } from "./mcp-connections-data";
+import { getPluginPartsSummary, pluginQueryKeys, usePlugins } from "./plugin-data";
 
 const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
@@ -92,6 +100,92 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
   }
 }
 
+type GithubPluginImportSkippedReason = "missing_url" | "local_unsupported" | "invalid_url" | "unsupported_auth";
+
+type GithubPluginImportServer = {
+  name: string;
+  serverKey: string;
+  url: string | null;
+  supported: boolean;
+  skippedReason: GithubPluginImportSkippedReason | null;
+};
+
+type GithubPluginImportSkill = {
+  description: string | null;
+  name: string;
+  skillKey: string;
+  sourcePath: string;
+  supported: boolean;
+};
+
+type GithubPluginImportPreview = {
+  repositoryFullName: string;
+  rootPath: string;
+  servers: GithubPluginImportServer[];
+  skills: GithubPluginImportSkill[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parseSkippedReason(value: unknown): GithubPluginImportSkippedReason | null {
+  if (value === "missing_url" || value === "local_unsupported" || value === "invalid_url" || value === "unsupported_auth") {
+    return value;
+  }
+  return null;
+}
+
+function parseGithubPluginImportPreview(payload: unknown): GithubPluginImportPreview {
+  const item = isRecord(payload) && isRecord(payload.item) ? payload.item : null;
+  if (!item) throw new Error("GitHub plugin preview response was incomplete.");
+
+  return {
+    repositoryFullName: asString(item.repositoryFullName) ?? "",
+    rootPath: asString(item.rootPath) ?? "",
+    servers: Array.isArray(item.servers)
+      ? item.servers.flatMap((entry) => {
+          if (!isRecord(entry)) return [];
+          const name = asString(entry.name);
+          const serverKey = asString(entry.serverKey);
+          if (!name || !serverKey) return [];
+          return [{
+            name,
+            serverKey,
+            url: asString(entry.url),
+            supported: entry.supported === true,
+            skippedReason: parseSkippedReason(entry.skippedReason),
+          }];
+        })
+      : [],
+    skills: Array.isArray(item.skills)
+      ? item.skills.flatMap((entry) => {
+          if (!isRecord(entry)) return [];
+          const name = asString(entry.name);
+          const skillKey = asString(entry.skillKey);
+          if (!name || !skillKey) return [];
+          return [{
+            description: asString(entry.description),
+            name,
+            skillKey,
+            sourcePath: asString(entry.sourcePath) ?? "SKILL.md",
+            supported: entry.supported === true,
+          }];
+        })
+      : [],
+  };
+}
+
+function importServerStatus(server: GithubPluginImportServer): string {
+  if (server.supported) return "ready";
+  if (server.skippedReason === "missing_url") return "missing URL";
+  return "unsupported";
+}
+
 export function McpConnectionsScreen() {
   const { orgContext } = useOrgDashboard();
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections();
@@ -104,6 +198,7 @@ export function McpConnectionsScreen() {
 
   const [formOpen, setFormOpen] = useState(false);
   const [formPreset, setFormPreset] = useState<ExternalMcpPreset | null>(null);
+  const [pluginDialogOpen, setPluginDialogOpen] = useState(false);
   const [googleDialogOpen, setGoogleDialogOpen] = useState(false);
   const googleConfigured = usableConnections.some((connection) => connection.id === "google-workspace");
   const showStagingBanner = orgContext ? shouldShowMcpConnectionsStagingBanner(orgContext.capabilities) : false;
@@ -187,22 +282,44 @@ export function McpConnectionsScreen() {
         </div>
       ) : null}
 
-      <div className="mb-6 flex items-center justify-between rounded-2xl border border-gray-100 bg-white px-6 py-5">
+      <div className="mb-6 rounded-2xl border border-gray-100 bg-white px-6 py-5">
         <div>
-          <h2 className="text-[15px] font-semibold text-gray-900">Add a custom MCP server</h2>
-          <p className="mt-1 text-[13px] text-gray-500">Connect any MCP server by URL, with OAuth, an API key, or no auth.</p>
+          <h2 className="text-[15px] font-semibold text-gray-900">Add a connection</h2>
+          <p className="mt-1 text-[13px] text-gray-500">
+            Add a single MCP server, or import a plugin bundle so its MCPs and skills become available through capabilities.
+          </p>
         </div>
-        <DenButton
-          variant="primary"
-          size="sm"
-          icon={Plus}
-          onClick={() => {
-            setFormPreset(null);
-            setFormOpen(true);
-          }}
-        >
-          Add Custom
-        </DenButton>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <button
+            type="button"
+            onClick={() => {
+              setFormPreset(null);
+              setFormOpen(true);
+            }}
+            className="flex items-start gap-3 rounded-2xl border border-gray-100 px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
+          >
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gray-900 text-white">
+              <Server className="h-4 w-4" />
+            </span>
+            <span>
+              <span className="block text-[14px] font-semibold text-gray-900">MCP server</span>
+              <span className="mt-1 block text-[12px] leading-5 text-gray-500">Connect one remote MCP server by URL.</span>
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setPluginDialogOpen(true)}
+            className="flex items-start gap-3 rounded-2xl border border-gray-100 px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
+          >
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gray-900 text-white">
+              <Puzzle className="h-4 w-4" />
+            </span>
+            <span>
+              <span className="block text-[14px] font-semibold text-gray-900">Plugin bundle</span>
+              <span className="mt-1 block text-[12px] leading-5 text-gray-500">Import from GitHub or choose from your plugin library.</span>
+            </span>
+          </button>
+        </div>
       </div>
 
       <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Quick add</h3>
@@ -290,6 +407,12 @@ export function McpConnectionsScreen() {
         onSubmit={handleCreate}
       />
 
+      <ImportPluginConnectionDialog
+        open={pluginDialogOpen}
+        onClose={() => setPluginDialogOpen(false)}
+        onImported={() => void refetch()}
+      />
+
       <GoogleWorkspaceDialog
         open={googleDialogOpen}
         submitting={saveNativeClient.isPending}
@@ -301,6 +424,336 @@ export function McpConnectionsScreen() {
         }}
       />
     </DashboardPageTemplate>
+  );
+}
+
+function ImportPluginConnectionDialog({
+  open,
+  onClose,
+  onImported,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onImported: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { orgSlug, runReauthableAction } = useOrgDashboard();
+  const { data: marketplaces = [] } = useMarketplaces();
+  const { data: plugins = [], isLoading: pluginsLoading } = usePlugins();
+  const [githubUrl, setGithubUrl] = useState("");
+  const [marketplaceId, setMarketplaceId] = useState("");
+  const [authType, setAuthType] = useState<"oauth" | "none">("oauth");
+  const [credentialMode, setCredentialMode] = useState<ExternalMcpCredentialMode>("per_member");
+  const [preview, setPreview] = useState<GithubPluginImportPreview | null>(null);
+  const [selectedServerKeys, setSelectedServerKeys] = useState<string[]>([]);
+  const [selectedSkillKeys, setSelectedSkillKeys] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    if (!marketplaceId && marketplaces.length > 0) {
+      setMarketplaceId(marketplaces[0].id);
+    }
+  }, [marketplaceId, marketplaces, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setGithubUrl("");
+    setAuthType("oauth");
+    setCredentialMode("per_member");
+    setPreview(null);
+    setSelectedServerKeys([]);
+    setSelectedSkillKeys([]);
+    setError(null);
+  }, [open]);
+
+  const libraryPlugins = useMemo(
+    () => plugins.filter((plugin) => plugin.mcps.length > 0 || plugin.skills.length > 0),
+    [plugins],
+  );
+
+  async function previewGithubPlugin() {
+    if (!githubUrl.trim()) {
+      setError("Paste a GitHub plugin URL.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      let payload: unknown = null;
+      await runReauthableAction("preview-github-connection-plugin", async () => {
+        const result = await requestJson(
+          "/v1/plugins/import-mcps-from-github-url/preview",
+          { method: "POST", body: JSON.stringify({ githubUrl: githubUrl.trim() }) },
+          20000,
+        );
+        if (!result.response.ok) {
+          throw getRequestError(result.payload, result.response, "Failed to preview GitHub plugin.");
+        }
+        payload = result.payload;
+      });
+      const nextPreview = parseGithubPluginImportPreview(payload);
+      setPreview(nextPreview);
+      setSelectedServerKeys(nextPreview.servers.filter((server) => server.supported).map((server) => server.serverKey));
+      setSelectedSkillKeys(nextPreview.skills.filter((skill) => skill.supported).map((skill) => skill.skillKey));
+    } catch (previewError) {
+      setError(previewError instanceof Error ? previewError.message : "Failed to preview GitHub plugin.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function importGithubPlugin() {
+    if (!preview) {
+      setError("Preview the GitHub plugin first.");
+      return;
+    }
+    if (!marketplaceId) {
+      setError("Choose a marketplace.");
+      return;
+    }
+    if (selectedServerKeys.length === 0 && selectedSkillKeys.length === 0) {
+      setError("Select at least one MCP or skill.");
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      await runReauthableAction("import-github-connection-plugin", async () => {
+        const result = await requestJson(
+          "/v1/plugins/import-mcps-from-github-url",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              access: { orgWide: true, memberIds: [], teamIds: [] },
+              authType,
+              credentialMode: authType === "oauth" ? credentialMode : "shared",
+              githubUrl: githubUrl.trim(),
+              marketplaceId,
+              selectedServerKeys,
+              selectedSkillKeys,
+            }),
+          },
+          30000,
+        );
+        if (!result.response.ok) {
+          throw getRequestError(result.payload, result.response, "Failed to import GitHub plugin.");
+        }
+      });
+      await queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });
+      await queryClient.invalidateQueries({ queryKey: pluginQueryKeys.all });
+      await queryClient.invalidateQueries({ queryKey: marketplaceQueryKeys.all });
+      onImported();
+      onClose();
+    } catch (importError) {
+      setError(importError instanceof Error ? importError.message : "Failed to import GitHub plugin.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function toggleServer(serverKey: string, checked: boolean) {
+    setSelectedServerKeys((current) =>
+      checked ? [...new Set([...current, serverKey])] : current.filter((key) => key !== serverKey),
+    );
+  }
+
+  function toggleSkill(skillKey: string, checked: boolean) {
+    setSelectedSkillKeys((current) =>
+      checked ? [...new Set([...current, skillKey])] : current.filter((key) => key !== skillKey),
+    );
+  }
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={onClose}>
+      <div
+        className="max-h-[88vh] w-full max-w-2xl overflow-y-auto rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">Add plugin connection</h2>
+        <p className="mt-1 text-[13px] leading-6 text-gray-600">
+          Import a plugin from GitHub. Remote MCPs become Den-hosted org connections; imported skills are saved to Skill Hub storage and show up in capabilities.
+        </p>
+
+        <div className="mt-5 rounded-2xl border border-gray-100 bg-gray-50 p-4">
+          <label className="mb-1.5 block text-[12px] font-medium text-gray-700">GitHub plugin URL</label>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <DenInput
+              value={githubUrl}
+              onChange={(event) => {
+                setGithubUrl(event.target.value);
+                setPreview(null);
+                setSelectedServerKeys([]);
+                setSelectedSkillKeys([]);
+                setError(null);
+              }}
+              placeholder="https://github.com/anthropics/knowledge-work-plugins/tree/main/sales"
+              disabled={busy}
+            />
+            <DenButton variant="secondary" onClick={() => void previewGithubPlugin()} disabled={busy || !githubUrl.trim()}>
+              {busy && !preview ? "Previewing..." : "Preview"}
+            </DenButton>
+          </div>
+        </div>
+
+        {preview ? (
+          <div className="mt-4 space-y-4">
+            <div className="rounded-2xl border border-gray-100 bg-white px-4 py-3 text-[13px] text-gray-600">
+              Found {preview.servers.filter((server) => server.supported).length} MCPs and {preview.skills.filter((skill) => skill.supported).length} skills in{" "}
+              <span className="font-medium text-gray-900">{preview.repositoryFullName}{preview.rootPath ? `/${preview.rootPath}` : ""}</span>.
+            </div>
+
+            {preview.servers.length > 0 ? (
+              <div className="overflow-hidden rounded-2xl border border-gray-100">
+                <table className="w-full text-left text-[13px]">
+                  <thead className="bg-gray-50 text-[11px] uppercase tracking-[0.12em] text-gray-400">
+                    <tr>
+                      <th className="w-12 px-4 py-3">Use</th>
+                      <th className="px-4 py-3">MCP</th>
+                      <th className="px-4 py-3">URL</th>
+                      <th className="px-4 py-3">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 bg-white">
+                    {preview.servers.map((server) => (
+                      <tr key={server.serverKey}>
+                        <td className="px-4 py-3">
+                          <input
+                            type="checkbox"
+                            checked={selectedServerKeys.includes(server.serverKey)}
+                            disabled={!server.supported || busy}
+                            onChange={(event) => toggleServer(server.serverKey, event.target.checked)}
+                          />
+                        </td>
+                        <td className="px-4 py-3 font-medium text-gray-900">{server.name}</td>
+                        <td className="max-w-[240px] truncate px-4 py-3 font-mono text-[12px] text-gray-500">{server.url ?? "—"}</td>
+                        <td className="px-4 py-3 text-gray-500">{importServerStatus(server)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+
+            {preview.skills.length > 0 ? (
+              <div className="overflow-hidden rounded-2xl border border-gray-100">
+                <table className="w-full text-left text-[13px]">
+                  <thead className="bg-gray-50 text-[11px] uppercase tracking-[0.12em] text-gray-400">
+                    <tr>
+                      <th className="w-12 px-4 py-3">Use</th>
+                      <th className="px-4 py-3">Skill</th>
+                      <th className="px-4 py-3">Path</th>
+                      <th className="px-4 py-3">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 bg-white">
+                    {preview.skills.map((skill) => (
+                      <tr key={skill.skillKey}>
+                        <td className="px-4 py-3">
+                          <input
+                            type="checkbox"
+                            checked={selectedSkillKeys.includes(skill.skillKey)}
+                            disabled={!skill.supported || busy}
+                            onChange={(event) => toggleSkill(skill.skillKey, event.target.checked)}
+                          />
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="font-medium text-gray-900">{skill.name}</div>
+                          {skill.description ? <div className="mt-0.5 text-[12px] text-gray-500">{skill.description}</div> : null}
+                        </td>
+                        <td className="max-w-[240px] truncate px-4 py-3 font-mono text-[12px] text-gray-500">{skill.sourcePath}</td>
+                        <td className="px-4 py-3 text-gray-500">{skill.supported ? "ready" : "unsupported"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <label className="block">
+                <span className="mb-1.5 block text-[12px] font-medium text-gray-700">Authentication</span>
+                <DenSelect value={authType} onChange={(event) => setAuthType(event.target.value === "none" ? "none" : "oauth")} disabled={busy}>
+                  <option value="oauth">OAuth</option>
+                  <option value="none">No auth</option>
+                </DenSelect>
+              </label>
+              <label className="block">
+                <span className="mb-1.5 block text-[12px] font-medium text-gray-700">Account mode</span>
+                <DenSelect
+                  value={credentialMode}
+                  onChange={(event) => setCredentialMode(event.target.value === "shared" ? "shared" : "per_member")}
+                  disabled={busy || authType === "none"}
+                >
+                  <option value="per_member">Individual accounts</option>
+                  <option value="shared">Org account</option>
+                </DenSelect>
+              </label>
+              <label className="block">
+                <span className="mb-1.5 block text-[12px] font-medium text-gray-700">Marketplace</span>
+                <DenSelect value={marketplaceId} onChange={(event) => setMarketplaceId(event.target.value)} disabled={busy}>
+                  {marketplaces.map((marketplace) => (
+                    <option key={marketplace.id} value={marketplace.id}>
+                      {marketplace.name}
+                    </option>
+                  ))}
+                </DenSelect>
+              </label>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="mt-6">
+          <h3 className="text-[12px] font-semibold uppercase tracking-[0.14em] text-gray-400">Plugin library</h3>
+          <div className="mt-3 rounded-2xl border border-gray-100 bg-white">
+            {pluginsLoading ? (
+              <div className="px-4 py-5 text-[13px] text-gray-500">Loading plugin library...</div>
+            ) : libraryPlugins.length === 0 ? (
+              <div className="px-4 py-5 text-[13px] text-gray-500">No imported plugins with MCPs or skills yet.</div>
+            ) : (
+              <div className="divide-y divide-gray-100">
+                {libraryPlugins.slice(0, 6).map((plugin) => (
+                  <Link
+                    key={plugin.id}
+                    href={getPluginRoute(orgSlug, plugin.id)}
+                    className="flex items-center justify-between gap-3 px-4 py-3 transition hover:bg-gray-50"
+                    onClick={onClose}
+                  >
+                    <span className="min-w-0">
+                      <span className="block truncate text-[13px] font-semibold text-gray-900">{plugin.name}</span>
+                      <span className="mt-0.5 block truncate text-[12px] text-gray-500">{getPluginPartsSummary(plugin)}</span>
+                    </span>
+                    <span className="text-[12px] font-medium text-gray-500">Open</span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {error ? (
+          <p className="mt-3 text-[13px] text-red-600">{error}</p>
+        ) : null}
+
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <DenButton variant="secondary" onClick={onClose} disabled={busy}>
+            Cancel
+          </DenButton>
+          <DenButton
+            variant="primary"
+            loading={busy && Boolean(preview)}
+            disabled={!preview || !marketplaceId || (selectedServerKeys.length === 0 && selectedSkillKeys.length === 0)}
+            onClick={() => void importGithubPlugin()}
+          >
+            Import selected
+          </DenButton>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-editor-screen.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, FileText, Plus, Server, Terminal, Trash2 } from "lucide-react";
+import { ArrowLeft, FileText, Info, Plus, Server, Terminal, Trash2 } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenSelect } from "../../_components/ui/select";
@@ -24,6 +24,33 @@ type DraftComponent = {
   description: string;
   /** Markdown body for skills/commands; remote server URL for MCP. */
   content: string;
+};
+
+type GithubMcpImportSkippedReason = "missing_url" | "local_unsupported" | "invalid_url" | "unsupported_auth";
+
+type GithubMcpImportServer = {
+  name: string;
+  serverKey: string;
+  url: string | null;
+  supported: boolean;
+  skippedReason: GithubMcpImportSkippedReason | null;
+};
+
+type GithubSkillImportSkill = {
+  description: string | null;
+  name: string;
+  skillKey: string;
+  sourcePath: string;
+  supported: boolean;
+  skippedReason: "invalid_skill" | null;
+};
+
+type GithubMcpImportPreview = {
+  repositoryFullName: string;
+  rootPath: string;
+  servers: GithubMcpImportServer[];
+  skills: GithubSkillImportSkill[];
+  warnings: string[];
 };
 
 const COMPONENT_META: Record<ComponentKind, { label: string; icon: typeof FileText; hint: string }> = {
@@ -111,12 +138,71 @@ async function postJson(path: string, body: unknown, failureLabel: string): Prom
   return payload;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 function createdItemId(payload: unknown): string | null {
-  if (payload && typeof payload === "object" && "item" in payload) {
-    const item = (payload as { item?: { id?: unknown } }).item;
-    if (item && typeof item.id === "string") return item.id;
+  const item = isRecord(payload) && isRecord(payload.item) ? payload.item : null;
+  return typeof item?.id === "string" ? item.id : null;
+}
+
+function parseSkippedReason(value: unknown): GithubMcpImportSkippedReason | null {
+  if (value === "missing_url" || value === "local_unsupported" || value === "invalid_url" || value === "unsupported_auth") {
+    return value;
   }
   return null;
+}
+
+function parseGithubMcpImportPreview(payload: unknown): GithubMcpImportPreview {
+  const item = isRecord(payload) && isRecord(payload.item) ? payload.item : null;
+  if (!item) throw new Error("GitHub MCP import preview response was incomplete.");
+  return {
+    repositoryFullName: typeof item.repositoryFullName === "string" ? item.repositoryFullName : "",
+    rootPath: typeof item.rootPath === "string" ? item.rootPath : "",
+    servers: Array.isArray(item.servers)
+      ? item.servers.flatMap((entry) => {
+          if (!isRecord(entry) || typeof entry.name !== "string") return [];
+          return [{
+            name: entry.name,
+            serverKey: typeof entry.serverKey === "string" ? entry.serverKey : `${entry.name}:${typeof entry.url === "string" ? entry.url : ""}`,
+            url: typeof entry.url === "string" ? entry.url : null,
+            supported: entry.supported === true,
+            skippedReason: parseSkippedReason(entry.skippedReason),
+          }];
+        })
+      : [],
+    skills: Array.isArray(item.skills)
+      ? item.skills.flatMap((entry) => {
+          if (!isRecord(entry) || typeof entry.name !== "string" || typeof entry.skillKey !== "string") return [];
+          return [{
+            description: typeof entry.description === "string" ? entry.description : null,
+            name: entry.name,
+            skillKey: entry.skillKey,
+            sourcePath: typeof entry.sourcePath === "string" ? entry.sourcePath : "SKILL.md",
+            supported: entry.supported === true,
+            skippedReason: entry.skippedReason === "invalid_skill" ? "invalid_skill" : null,
+          }];
+        })
+      : [],
+    warnings: Array.isArray(item.warnings)
+      ? item.warnings.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+      : [],
+  };
+}
+
+function statusLabel(server: GithubMcpImportServer) {
+  if (server.supported) return "ready";
+  if (server.skippedReason === "missing_url") return "missing URL";
+  return "unsupported";
+}
+
+function skillTooltip(skill: GithubSkillImportSkill) {
+  return [
+    skill.description ? `Description: ${skill.description}` : null,
+    `Path: ${skill.sourcePath}`,
+    `Status: ${skill.supported ? "ready" : "unsupported"}`,
+  ].filter(Boolean).join("\n");
 }
 
 export function PluginEditorScreen() {
@@ -132,6 +218,15 @@ export function PluginEditorScreen() {
   const [marketplaceId, setMarketplaceId] = useState<string>("");
   const [marketplaceTouched, setMarketplaceTouched] = useState(false);
   const [shareOrgWide, setShareOrgWide] = useState(true);
+  const [githubImportUrl, setGithubImportUrl] = useState("");
+  const [githubImportMarketplaceId, setGithubImportMarketplaceId] = useState("");
+  const [githubImportAuthType, setGithubImportAuthType] = useState<"oauth" | "none">("oauth");
+  const [githubImportCredentialMode, setGithubImportCredentialMode] = useState<"per_member" | "shared">("per_member");
+  const [githubImportPreview, setGithubImportPreview] = useState<GithubMcpImportPreview | null>(null);
+  const [selectedGithubMcpKeys, setSelectedGithubMcpKeys] = useState<string[]>([]);
+  const [selectedGithubSkillKeys, setSelectedGithubSkillKeys] = useState<string[]>([]);
+  const [githubImportBusy, setGithubImportBusy] = useState(false);
+  const [githubImportError, setGithubImportError] = useState<string | null>(null);
 
   // Publishing is the happy path for non-technical creators: pre-select the
   // first marketplace once the list loads, unless the user chose otherwise.
@@ -139,9 +234,25 @@ export function PluginEditorScreen() {
     if (!marketplaceTouched && !marketplaceId && marketplaces.length > 0) {
       setMarketplaceId(marketplaces[0].id);
     }
-  }, [marketplaceId, marketplaceTouched, marketplaces]);
+    if (!githubImportMarketplaceId && marketplaces.length > 0) {
+      setGithubImportMarketplaceId(marketplaces[0].id);
+    }
+  }, [githubImportMarketplaceId, marketplaceId, marketplaceTouched, marketplaces]);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const githubImportHasUrl = githubImportUrl.trim().length > 0;
+  const primaryBusy = saving || githubImportBusy;
+  const primaryButtonLabel = githubImportHasUrl
+    ? githubImportBusy
+      ? githubImportPreview
+        ? "Importing..."
+        : "Previewing..."
+      : githubImportPreview
+        ? "Import selected"
+        : "Preview GitHub plugin"
+    : saving
+      ? "Creating..."
+      : "Create plugin";
 
   const addComponent = (kind: ComponentKind) => {
     setComponents((current) => [
@@ -215,6 +326,104 @@ export function PluginEditorScreen() {
     }
   }
 
+  async function previewGithubMcpImport() {
+    if (!githubImportUrl.trim()) {
+      setGithubImportError("Paste a GitHub plugin URL.");
+      return;
+    }
+
+    setGithubImportBusy(true);
+    setGithubImportError(null);
+    setSaveError(null);
+    try {
+      let payload: unknown = null;
+      await runReauthableAction("preview-github-plugin-mcps", async () => {
+        const result = await requestJson(
+          "/v1/plugins/import-mcps-from-github-url/preview",
+          { method: "POST", body: JSON.stringify({ githubUrl: githubImportUrl.trim() }) },
+          20000,
+        );
+        if (!result.response.ok) {
+          throw getRequestError(result.payload, result.response, "Failed to preview GitHub plugin components.");
+        }
+        payload = result.payload;
+      });
+      const preview = parseGithubMcpImportPreview(payload);
+      setGithubImportPreview(preview);
+      setSelectedGithubMcpKeys(preview.servers.filter((server) => server.supported).map((server) => server.serverKey));
+      setSelectedGithubSkillKeys(preview.skills.filter((skill) => skill.supported).map((skill) => skill.skillKey));
+    } catch (error) {
+      setGithubImportError(error instanceof Error ? error.message : "Failed to preview GitHub plugin components.");
+    } finally {
+      setGithubImportBusy(false);
+    }
+  }
+
+  async function importGithubMcpPlugin() {
+    if (!githubImportPreview) {
+      setGithubImportError("Preview the GitHub plugin first.");
+      return;
+    }
+    if (!githubImportMarketplaceId) {
+      setGithubImportError("Choose a marketplace.");
+      return;
+    }
+    if (selectedGithubMcpKeys.length === 0 && selectedGithubSkillKeys.length === 0) {
+      setGithubImportError("Select at least one supported MCP or skill.");
+      return;
+    }
+
+    setGithubImportBusy(true);
+    setGithubImportError(null);
+    setSaveError(null);
+    try {
+      let pluginId: string | null = null;
+      await runReauthableAction("import-github-plugin-mcps", async () => {
+        const result = await requestJson(
+          "/v1/plugins/import-mcps-from-github-url",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              access: { orgWide: true, memberIds: [], teamIds: [] },
+              authType: githubImportAuthType,
+              credentialMode: githubImportCredentialMode,
+              githubUrl: githubImportUrl.trim(),
+              marketplaceId: githubImportMarketplaceId,
+              selectedSkillKeys: selectedGithubSkillKeys,
+              selectedServerKeys: selectedGithubMcpKeys,
+            }),
+          },
+          30000,
+        );
+        if (!result.response.ok) {
+          throw getRequestError(result.payload, result.response, "Failed to import GitHub plugin components.");
+        }
+        const item = isRecord(result.payload) && isRecord(result.payload.item) ? result.payload.item : null;
+        const plugin = item && isRecord(item.plugin) ? item.plugin : null;
+        pluginId = plugin && typeof plugin.id === "string" ? plugin.id : null;
+      });
+      await queryClient.invalidateQueries({ queryKey: pluginQueryKeys.all });
+      router.push(pluginId ? getPluginRoute(orgSlug, pluginId) : getPluginsRoute(orgSlug));
+      router.refresh();
+    } catch (error) {
+      setGithubImportError(error instanceof Error ? error.message : "Failed to import GitHub plugin components.");
+    } finally {
+      setGithubImportBusy(false);
+    }
+  }
+
+  async function handlePrimarySubmit() {
+    if (githubImportHasUrl) {
+      if (!githubImportPreview) {
+        await previewGithubMcpImport();
+        return;
+      }
+      await importGithubMcpPlugin();
+      return;
+    }
+    await createPlugin();
+  }
+
   return (
     <div className="mx-auto w-full max-w-3xl px-6 py-10">
       <Link
@@ -229,6 +438,193 @@ export function PluginEditorScreen() {
       <p className="mt-1 text-[15px] text-gray-500">
         Bundle skills, commands, and MCP servers your team can install in OpenWork with one click.
       </p>
+
+      <div className="mt-8 rounded-[24px] border border-gray-200 bg-white p-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-[18px] font-semibold text-gray-900">Import MCPs and skills from GitHub URL</h2>
+            <p className="mt-1 text-[13px] leading-5 text-gray-500">
+              Paste a public plugin URL like <span className="font-mono text-[12px]">github.com/anthropics/knowledge-work-plugins/tree/main/sales</span>.
+            </p>
+          </div>
+          <DenButton
+            variant="secondary"
+            size="sm"
+            className="shrink-0 whitespace-nowrap"
+            disabled={githubImportBusy}
+            onClick={() => void previewGithubMcpImport()}
+          >
+            {githubImportBusy && !githubImportPreview ? "Previewing..." : "Preview first"}
+          </DenButton>
+        </div>
+
+        <div className="mt-4">
+          <label className="mb-1.5 block text-[13px] font-medium text-gray-700">GitHub plugin URL</label>
+          <DenInput
+            value={githubImportUrl}
+            onChange={(event) => {
+              setGithubImportUrl(event.target.value);
+              setGithubImportPreview(null);
+              setSelectedGithubMcpKeys([]);
+              setSelectedGithubSkillKeys([]);
+              setGithubImportError(null);
+              setSaveError(null);
+            }}
+            placeholder="https://github.com/anthropics/knowledge-work-plugins/tree/main/sales"
+            disabled={githubImportBusy}
+          />
+        </div>
+
+        {githubImportPreview ? (
+          <div className="mt-5 flex flex-col gap-4">
+            <div className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3 text-[13px] text-gray-600">
+              Found {githubImportPreview.servers.filter((server) => server.supported).length} importable MCPs and {githubImportPreview.skills.filter((skill) => skill.supported).length} importable skills in{" "}
+              <span className="font-medium text-gray-900">{githubImportPreview.repositoryFullName}{githubImportPreview.rootPath ? `/${githubImportPreview.rootPath}` : ""}</span>.
+            </div>
+
+            <div className="overflow-hidden rounded-2xl border border-gray-100">
+              <table className="w-full table-fixed text-left text-[13px]">
+                <thead className="bg-gray-50 text-[11px] uppercase tracking-[0.12em] text-gray-400">
+                  <tr>
+                    <th className="w-12 px-4 py-3">Use</th>
+                    <th className="w-[28%] px-4 py-3">Name</th>
+                    <th className="px-4 py-3">Server URL</th>
+                    <th className="w-24 px-4 py-3">Status</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100 bg-white">
+                  {githubImportPreview.servers.map((server) => (
+                    <tr key={server.serverKey}>
+                      <td className="px-4 py-3">
+                        <input
+                          type="checkbox"
+                          checked={selectedGithubMcpKeys.includes(server.serverKey)}
+                          disabled={!server.supported || githubImportBusy}
+                          onChange={(event) => {
+                            setSelectedGithubMcpKeys((current) =>
+                              event.target.checked
+                                ? [...new Set([...current, server.serverKey])]
+                                : current.filter((key) => key !== server.serverKey),
+                            );
+                          }}
+                        />
+                      </td>
+                      <td className="min-w-0 px-4 py-3">
+                        <div className="truncate font-medium text-gray-900" title={server.name}>{server.name}</div>
+                      </td>
+                      <td className="min-w-0 px-4 py-3">
+                        <div className="truncate font-mono text-[12px] text-gray-500" title={server.url ?? "No URL declared"}>
+                          {server.url ?? "—"}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-gray-500">
+                        <span className="whitespace-nowrap">{statusLabel(server)}</span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {githubImportPreview.skills.length > 0 ? (
+              <div className="overflow-hidden rounded-2xl border border-gray-100">
+                <table className="w-full table-fixed text-left text-[13px]">
+                  <thead className="bg-gray-50 text-[11px] uppercase tracking-[0.12em] text-gray-400">
+                    <tr>
+                      <th className="w-12 px-4 py-3">Use</th>
+                      <th className="px-4 py-3">Skill</th>
+                      <th className="w-28 px-4 py-3">Details</th>
+                      <th className="w-24 px-4 py-3">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 bg-white">
+                    {githubImportPreview.skills.map((skill) => (
+                      <tr key={skill.skillKey}>
+                        <td className="px-4 py-3">
+                          <input
+                            type="checkbox"
+                            checked={selectedGithubSkillKeys.includes(skill.skillKey)}
+                            disabled={!skill.supported || githubImportBusy}
+                            onChange={(event) => {
+                              setSelectedGithubSkillKeys((current) =>
+                                event.target.checked
+                                  ? [...new Set([...current, skill.skillKey])]
+                                  : current.filter((key) => key !== skill.skillKey),
+                              );
+                            }}
+                          />
+                        </td>
+                        <td className="min-w-0 px-4 py-3">
+                          <div className="truncate font-medium text-gray-900" title={skill.name}>{skill.name}</div>
+                          {skill.description ? (
+                            <div className="mt-0.5 truncate text-[12px] text-gray-500" title={skill.description}>{skill.description}</div>
+                          ) : null}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span
+                            className="inline-flex items-center gap-1 whitespace-nowrap text-[12px] font-medium text-gray-500"
+                            title={skillTooltip(skill)}
+                          >
+                            <Info size={13} aria-hidden />
+                            View info
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-gray-500">
+                          <span className="whitespace-nowrap">{skill.supported ? "ready" : "unsupported"}</span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <label className="block">
+                <span className="mb-1.5 block text-[13px] font-medium text-gray-700">Authentication</span>
+                <DenSelect value={githubImportAuthType} onChange={(event) => setGithubImportAuthType(event.target.value === "none" ? "none" : "oauth")} disabled={githubImportBusy}>
+                  <option value="oauth">OAuth</option>
+                  <option value="none">No auth</option>
+                </DenSelect>
+              </label>
+              <label className="block">
+                <span className="mb-1.5 block text-[13px] font-medium text-gray-700">Credential mode</span>
+                <DenSelect
+                  value={githubImportCredentialMode}
+                  onChange={(event) => setGithubImportCredentialMode(event.target.value === "shared" ? "shared" : "per_member")}
+                  disabled={githubImportBusy || githubImportAuthType === "none"}
+                >
+                  <option value="per_member">Individual accounts</option>
+                  <option value="shared">Org account</option>
+                </DenSelect>
+              </label>
+              <label className="block">
+                <span className="mb-1.5 block text-[13px] font-medium text-gray-700">Marketplace</span>
+                <DenSelect value={githubImportMarketplaceId} onChange={(event) => setGithubImportMarketplaceId(event.target.value)} disabled={githubImportBusy}>
+                  {marketplaces.map((marketplace) => (
+                    <option key={marketplace.id} value={marketplace.id}>
+                      {marketplace.name}
+                    </option>
+                  ))}
+                </DenSelect>
+              </label>
+            </div>
+
+            <div className="flex items-center justify-between gap-3 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
+              <p className="text-[13px] text-gray-500">Access defaults to everyone in the organization. Row-level overrides can be added later.</p>
+              <DenButton disabled={githubImportBusy || (selectedGithubMcpKeys.length === 0 && selectedGithubSkillKeys.length === 0) || !githubImportMarketplaceId} onClick={() => void importGithubMcpPlugin()}>
+                {githubImportBusy && githubImportPreview ? "Importing..." : "Import selected"}
+              </DenButton>
+            </div>
+          </div>
+        ) : null}
+
+        {githubImportError ? (
+          <div className="mt-4 rounded-[16px] border border-red-200 bg-red-50 px-4 py-3 text-[14px] text-red-700">
+            {githubImportError}
+          </div>
+        ) : null}
+      </div>
 
       <div className="mt-8 flex flex-col gap-5 rounded-[24px] border border-gray-200 bg-white p-6">
         <div>
@@ -391,8 +787,8 @@ export function PluginEditorScreen() {
       ) : null}
 
       <div className="mt-6 flex items-center gap-3">
-        <DenButton onClick={() => void createPlugin()} disabled={saving}>
-          {saving ? "Creating..." : "Create plugin"}
+        <DenButton onClick={() => void handlePrimarySubmit()} disabled={primaryBusy}>
+          {primaryButtonLabel}
         </DenButton>
         <Link href={getPluginsRoute(orgSlug)} className="text-[14px] text-gray-500 hover:text-gray-900">
           Cancel


### PR DESCRIPTION
## Goal

Make plugin-provided MCPs and skills usable through the same Den connection/capability path that already exposes org MCP tools.

Admins should be able to paste a public Claude-compatible GitHub plugin URL, preview the plugin's remote MCPs and skills, import selected components, and publish one marketplace plugin. Desktop members then install that plugin, while Den-hosted MCP tools and imported skills are discovered through:

- `search_capabilities`
- `execute_capability`

Example target URL:

```text
https://github.com/anthropics/knowledge-work-plugins/tree/main/sales
```

## End-to-End Flow Added

| Step | User/System | Behavior |
| --- | --- | --- |
| 1 | Admin | Opens Den Web Connections at `/dashboard/connections`. |
| 2 | Admin | Chooses `Plugin bundle` instead of `MCP server`. |
| 3 | Admin | Pastes a public GitHub plugin URL. |
| 4 | Den API | Resolves repo/ref/path and discovers plugin MCP/skill components. |
| 5 | Admin | Selects supported remote MCPs and skills, then imports. |
| 6 | Den API | Creates/reuses External MCP Connections for remote MCPs. |
| 7 | Den API | Persists selected `SKILL.md` content into org skill storage. |
| 8 | Den API | Publishes one marketplace plugin containing connection/skill references. |
| 9 | Desktop | Shows the plugin as a normal marketplace plugin. |
| 10 | Desktop | Installs the plugin without writing Den-hosted MCPs to local `mcpServers`. |
| 11 | Member | Uses `Connect account` for per-member OAuth when needed. |
| 12 | Den MCP | Returns imported MCP tools and skills through capability search/execute. |

## What Changed By Area

| Area | Files | What changed |
| --- | --- | --- |
| Den API: GitHub import | `ee/apps/den-api/src/routes/org/plugin-system/*` | Added preview/import routes for GitHub plugin MCPs and skills; parses repo/tree URLs; discovers `.mcp.json` and plugin manifests; imports selected supported components. |
| Den API: External MCP reuse | `store.ts`, `external-mcp-connections.ts` usage | Existing connections are reused by normalized URL only when access, auth type, and credential mode match. Reuse does not overwrite grants. |
| Den API: Skills as capabilities | `ee/apps/den-api/src/mcp/skill-capabilities.ts`, `agent.ts` | Imported org skills are searchable as `skill:<skillId>` and executable as stored `SKILL.md` content through `/mcp/agent`. |
| Den Web: Connections route | `den-org.ts`, `dashboard/(admin)/connections/page.tsx`, `dashboard/(admin)/mcp-connections/page.tsx` | Adds `/dashboard/connections` as the primary route and keeps `/dashboard/mcp-connections` as a compatibility redirect. |
| Den Web: Connections UI | `mcp-connections-screen.tsx` | Adds `Add a connection` chooser with `MCP server` and `Plugin bundle`; plugin bundle supports GitHub preview/import and plugin library links. |
| Den Web: Plugin editor | `plugin-editor-screen.tsx` | Pasted GitHub URL now drives preview/import instead of triggering the manual empty-component validation. |
| Desktop marketplace | `cloud-marketplaces-view.tsx`, `extension-items.ts`, `extensions-store.ts`, `import-state.ts`, `settings-route.tsx` | Connection-backed plugins render/install as marketplace plugins; Den-hosted MCPs are recorded without local `mcpServers`; Den skills are recorded without local skill files; setup state is shown correctly. |

## Data And Ownership Choices

| Decision | Choice made | Reason |
| --- | --- | --- |
| Credential ownership | External MCP Connections own OAuth/API key/no-auth connection state. Plugin imports may own the connection record lifecycle only when the import created that connection. | Keeps credentials in the existing security-sensitive connection tables and makes plugin removal clean for imported bundles. |
| Plugin object contents | Plugin/config objects store connection IDs, skill IDs, ownership markers, and metadata only. | Avoids plugin-hosted secrets, keeps plugin objects portable, and lets plugin archive clean up connections created by that import. |
| Existing connection reuse | Reuse only if normalized URL, access grants, auth type, and credential mode match. Reused connections are not marked plugin-owned. | Prevents imports from silently broadening/changing an existing connection and prevents plugin archive from deleting a pre-existing shared connection. |
| Selection identity | Import selection uses stable server/skill keys instead of display names. | Avoids collisions when plugin entries share names. |
| Local MCP materialization | Den-hosted org MCP connections are not written to local `mcpServers`. | Tools should run through Den MCP `search_capabilities` / `execute_capability`. |
| Skill materialization | Imported Den skills are stored in Den skill storage, not local skill files. | Skills become available through the org skill capability path and current access model. |
| Access default | Initial UI defaults to org-wide sharing. | Matches the current Connections UI default and keeps the first flow simple. |

## API Surface Added

| Endpoint | Purpose |
| --- | --- |
| `POST /v1/plugins/import-mcps-from-github-url/preview` | Resolve a public GitHub plugin URL and return previewable MCP/skill components. |
| `POST /v1/plugins/import-mcps-from-github-url` | Import selected remote MCPs/skills, create/reuse connections, create plugin resources, and publish to a marketplace. |

Selection now supports:

| Field | Use |
| --- | --- |
| `selectedServerKeys` | Stable MCP server selection. |
| `selectedSkillKeys` | Stable skill selection. |
| `selectedServerNames` | Backwards-compatible fallback for older callers. |

## Capability Behavior

| Capability source | Search result name | Execute behavior |
| --- | --- | --- |
| Native Den REST capability | Existing native names | Existing REST capability execution. |
| External MCP connection tool | `mcp:<connectionId>:<toolName>` | Executes through Den-hosted External MCP connection client. |
| Marketplace/plugin capability | Existing marketplace capability names | Preserved existing marketplace capability behavior. |
| Imported org skill | `skill:<skillId>` | Returns stored `SKILL.md` content as `skillText`. |

## Initial Scope

This first scoped pass is centered around:

| Included | Details |
| --- | --- |
| Public GitHub plugin URLs | Repo/tree URLs, including plugin roots below repo root. |
| Remote HTTP MCP servers | Supported MCP entries are imported as External MCP Connections. |
| Plugin skills | Primary `SKILL.md` content is imported into Den org skill storage. |
| Marketplace plugin publication | One plugin is published with MCP connection resources and imported skill references. |
| Desktop install path | Marketplace plugin installs without localizing Den-hosted MCPs or Den skills. |
| Per-member setup UX | Desktop shows `Needs setup` / `View setup` and keeps the `Connect account` path. |

## Follow-Up Scope

| Follow-up | Notes |
| --- | --- |
| Local/stdio MCP import | Not handled in this pass; local MCPs are skipped during GitHub import preview/import. |
| Private GitHub URLs | Should use or extend existing GitHub connector-backed flows. |
| Plugin-hosted secrets | Not introduced here; would need a separate credential ownership design. |
| Automatic access sync | Plugin access and connection grants are matched at import time, not continuously synced. |
| Full blocked-state projection | Desktop still does not fully solve every grant mismatch state. |
| Skill references/resources | Only primary `SKILL.md` is imported for now. |
| Row-level overrides | Current import applies shared auth/credential/access settings to selected rows. |


## Delete / Remove Semantics

| User action | What is removed | What is preserved |
| --- | --- | --- |
| Remove a standalone connection from `/dashboard/connections` | The External MCP Connection, grants, OAuth client, and connected accounts for that connection. | Plugin records/config objects are not cascade-deleted by the connection button. |
| Archive a plugin imported by this flow | Plugin-owned External MCP Connections created during that import, plus normal plugin archive behavior. | Pre-existing/reused connections are preserved. Connections still referenced by another active plugin are preserved. |
| Remove a plugin from Desktop Marketplace | Local installed plugin materialization only. | Den org connections and Den plugin records remain managed by Den Web/Admin flows. |

## Security / Trust Boundary

| Boundary | Handling |
| --- | --- |
| OAuth tokens | Stored only in existing External MCP Connection / connected account storage. |
| API keys | Not stored in plugin/config objects. |
| Plugin imports | Store references and metadata, not credentials. |
| Existing connections | Reuse refuses mismatched access/auth/credential mode instead of mutating grants. |
| Per-member OAuth | Members still connect their own account through the existing connection flow. |

## Validation

Ran from a clean worktree based on latest `upstream/dev`:

| Command | Result |
| --- | --- |
| `pnpm typecheck` | ✅ Passed |
| `pnpm --filter @openwork-ee/den-api build` | ✅ Passed |
| `pnpm --filter @openwork-ee/den-web build` | ✅ Passed |

## Proof Still Needed

I have not attached a fraimz/video proof yet. Recommended proof flow:

1. Admin opens `/dashboard/connections`.
2. Admin chooses `Plugin bundle`.
3. Admin imports `https://github.com/anthropics/knowledge-work-plugins/tree/main/sales`.
4. Den previews selected MCPs and skills.
5. Import creates/reuses External MCP Connections and creates SkillTable rows.
6. Member sees the plugin in Desktop Marketplace.
7. Member installs the plugin.
8. Per-member OAuth shows `Connect account` until connected.
9. `/mcp/agent` `search_capabilities` returns both `mcp:<connectionId>:<toolName>` and `skill:<skillId>`.
10. `/mcp/agent` `execute_capability` works for both an imported MCP tool and imported skill.
