### PR TITLE
fix(desktop): give spawned runtimes the OS certificate store via NODE_EXTRA_CA_CERTS

### DIFF
--- a/apps/desktop/electron/runtime-ca.test.mjs
+++ b/apps/desktop/electron/runtime-ca.test.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { resolveSystemCaEnv } from "./runtime.mjs";
+import { mergeSystemCaChildEnv, resolveSystemCaEnv } from "./runtime.mjs";
 
 const CERT_ONE = "-----BEGIN CERTIFICATE-----\none\n-----END CERTIFICATE-----";
 const CERT_TWO = "-----BEGIN CERTIFICATE-----\ntwo\n-----END CERTIFICATE-----";
@@ -40,6 +40,19 @@ test("sets NODE_EXTRA_CA_CERTS for a child env merge", async () => {
   const childEnv = { PATH: "/bin", ...caEnv };
 
   assert.equal(childEnv.NODE_EXTRA_CA_CERTS, path.join(userDataDir, "system-ca-bundle.pem"));
+});
+
+test("keeps NODE_EXTRA_CA_CERTS from user env file over generated bundle", () => {
+  const userEnvFile = { NODE_EXTRA_CA_CERTS: "/user/file-ca.pem" };
+  const processEnv = {};
+  const baseEnv = {
+    ...userEnvFile,
+    ...processEnv,
+    BUN_CONFIG_DNS_RESULT_ORDER: "verbatim",
+  };
+  const childEnv = mergeSystemCaChildEnv(baseEnv, { NODE_EXTRA_CA_CERTS: "/generated/system-ca-bundle.pem" });
+
+  assert.equal(childEnv.NODE_EXTRA_CA_CERTS, "/user/file-ca.pem");
 });
 
 test("respects user-set NODE_EXTRA_CA_CERTS", async () => {

--- a/apps/desktop/electron/runtime-ca.test.mjs
+++ b/apps/desktop/electron/runtime-ca.test.mjs
@@ -37,6 +37,7 @@ test("sets NODE_EXTRA_CA_CERTS for a child env merge", async () => {
     parentEnv: {},
     logInfo: () => {},
   });
+  /** @type {NodeJS.ProcessEnv} */
   const childEnv = { PATH: "/bin", ...caEnv };
 
   assert.equal(childEnv.NODE_EXTRA_CA_CERTS, path.join(userDataDir, "system-ca-bundle.pem"));

--- a/apps/desktop/electron/runtime-ca.test.mjs
+++ b/apps/desktop/electron/runtime-ca.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { resolveSystemCaEnv } from "./runtime.mjs";
+
+const CERT_ONE = "-----BEGIN CERTIFICATE-----\none\n-----END CERTIFICATE-----";
+const CERT_TWO = "-----BEGIN CERTIFICATE-----\ntwo\n-----END CERTIFICATE-----";
+
+test("writes system CA bundle when certificates are available", async () => {
+  const userDataDir = await mkdtemp(path.join(tmpdir(), "openwork-runtime-ca-"));
+  const bundlePath = path.join(userDataDir, "system-ca-bundle.pem");
+
+  const env = await resolveSystemCaEnv({
+    tlsModule: {
+      getCACertificates(scope) {
+        assert.equal(scope, "system");
+        return [CERT_ONE, CERT_TWO];
+      },
+    },
+    userDataDir,
+    parentEnv: {},
+    logInfo: () => {},
+  });
+
+  assert.deepEqual(env, { NODE_EXTRA_CA_CERTS: bundlePath });
+  assert.equal(await readFile(bundlePath, "utf8"), `${CERT_ONE}\n${CERT_TWO}\n`);
+});
+
+test("sets NODE_EXTRA_CA_CERTS for a child env merge", async () => {
+  const userDataDir = await mkdtemp(path.join(tmpdir(), "openwork-runtime-ca-"));
+  const caEnv = await resolveSystemCaEnv({
+    tlsModule: { getCACertificates: () => [CERT_ONE] },
+    userDataDir,
+    parentEnv: {},
+    logInfo: () => {},
+  });
+  const childEnv = { PATH: "/bin", ...caEnv };
+
+  assert.equal(childEnv.NODE_EXTRA_CA_CERTS, path.join(userDataDir, "system-ca-bundle.pem"));
+});
+
+test("respects user-set NODE_EXTRA_CA_CERTS", async () => {
+  const userDataDir = await mkdtemp(path.join(tmpdir(), "openwork-runtime-ca-"));
+  let called = false;
+  let logged = false;
+
+  const env = await resolveSystemCaEnv({
+    tlsModule: {
+      getCACertificates() {
+        called = true;
+        return [CERT_ONE];
+      },
+    },
+    userDataDir,
+    parentEnv: { NODE_EXTRA_CA_CERTS: "/custom/ca.pem" },
+    logInfo(message) {
+      logged = String(message).includes("NODE_EXTRA_CA_CERTS is already set");
+    },
+  });
+
+  assert.deepEqual(env, {});
+  assert.equal(called, false);
+  assert.equal(logged, true);
+});
+
+test("no-ops when tls.getCACertificates is unavailable", async () => {
+  const userDataDir = await mkdtemp(path.join(tmpdir(), "openwork-runtime-ca-"));
+
+  const env = await resolveSystemCaEnv({
+    tlsModule: {},
+    userDataDir,
+    parentEnv: {},
+    logInfo: () => {},
+  });
+
+  assert.deepEqual(env, {});
+  await assert.rejects(readFile(path.join(userDataDir, "system-ca-bundle.pem"), "utf8"));
+});

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -5,6 +5,7 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import tls from "node:tls";
 import { fileURLToPath } from "node:url";
 import { pathToFileURL } from "node:url";
 
@@ -483,6 +484,35 @@ function loadUserEnvFile() {
   }
 }
 
+export async function resolveSystemCaEnv({
+  tlsModule = tls,
+  userDataDir,
+  parentEnv = process.env,
+  logInfo = console.info,
+} = {}) {
+  const env = parentEnv ?? {};
+  if (Object.prototype.hasOwnProperty.call(env, "NODE_EXTRA_CA_CERTS")) {
+    if (typeof logInfo === "function") {
+      logInfo("OpenWork runtime: NODE_EXTRA_CA_CERTS is already set; skipping system CA bundle export.");
+    }
+    return {};
+  }
+
+  try {
+    if (typeof tlsModule?.getCACertificates !== "function") return {};
+    const certs = tlsModule.getCACertificates("system");
+    if (!Array.isArray(certs) || certs.length === 0) return {};
+    const pem = certs.filter((cert) => typeof cert === "string" && cert.trim()).join("\n");
+    if (!pem) return {};
+    const bundlePath = path.join(userDataDir, "system-ca-bundle.pem");
+    await mkdir(path.dirname(bundlePath), { recursive: true });
+    await writeFile(bundlePath, `${pem}\n`, "utf8");
+    return { NODE_EXTRA_CA_CERTS: bundlePath };
+  } catch {
+    return {};
+  }
+}
+
 export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths }) {
   const engineState = createEngineState();
   const openworkServerState = createOpenworkServerState();
@@ -515,6 +545,12 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     process.resourcesPath ? path.join(process.resourcesPath, "sidecars") : null,
     path.join(path.dirname(app.getPath("exe")), "sidecars"),
   ].filter(Boolean);
+  let systemCaEnvPromise = null;
+
+  function systemCaEnv() {
+    systemCaEnvPromise ??= resolveSystemCaEnv({ tlsModule: tls, userDataDir, parentEnv: process.env });
+    return systemCaEnvPromise;
+  }
 
   function openworkServerTokenStorePath() {
     return path.join(userDataDir, "openwork-server-tokens.json");
@@ -688,6 +724,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   }
 
   async function buildChildEnv(extra = {}) {
+    const caEnv = await systemCaEnv();
     /** @type {NodeJS.ProcessEnv} */
     // User env is layered first so process.env + any caller overrides always
     // win. See apps/server/src/env-file.ts and apps/orchestrator/src/cli.ts —
@@ -696,6 +733,9 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       ...loadUserEnvFile(),
       ...process.env,
       BUN_CONFIG_DNS_RESULT_ORDER: "verbatim",
+      // Bun honors Node's NODE_EXTRA_CA_CERTS, so bundled Bun sidecars inherit
+      // the exported OS trust store through the same child env variable.
+      ...caEnv,
       ...extra,
     };
     const pathKey =

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -484,12 +484,29 @@ function loadUserEnvFile() {
   }
 }
 
+/**
+ * @typedef {Object} RuntimeSystemCaTlsModule
+ * @property {(type?: string) => string[]} [getCACertificates]
+ */
+
+/**
+ * @typedef {Object} ResolveSystemCaEnvOptions
+ * @property {RuntimeSystemCaTlsModule} [tlsModule]
+ * @property {string} userDataDir
+ * @property {NodeJS.ProcessEnv} [parentEnv]
+ * @property {(...args: unknown[]) => void} [logInfo]
+ */
+
+/**
+ * @param {ResolveSystemCaEnvOptions} options
+ * @returns {Promise<NodeJS.ProcessEnv>}
+ */
 export async function resolveSystemCaEnv({
   tlsModule = tls,
   userDataDir,
   parentEnv = process.env,
   logInfo = console.info,
-} = {}) {
+}) {
   const env = parentEnv ?? {};
   if (Object.prototype.hasOwnProperty.call(env, "NODE_EXTRA_CA_CERTS")) {
     if (typeof logInfo === "function") {
@@ -513,6 +530,12 @@ export async function resolveSystemCaEnv({
   }
 }
 
+/**
+ * @param {NodeJS.ProcessEnv} [baseEnv]
+ * @param {NodeJS.ProcessEnv} [caEnv]
+ * @param {NodeJS.ProcessEnv} [extra]
+ * @returns {NodeJS.ProcessEnv}
+ */
 export function mergeSystemCaChildEnv(baseEnv = {}, caEnv = {}, extra = {}) {
   return {
     ...baseEnv,

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -513,6 +513,14 @@ export async function resolveSystemCaEnv({
   }
 }
 
+export function mergeSystemCaChildEnv(baseEnv = {}, caEnv = {}, extra = {}) {
+  return {
+    ...baseEnv,
+    ...(Object.prototype.hasOwnProperty.call(baseEnv, "NODE_EXTRA_CA_CERTS") ? {} : caEnv),
+    ...extra,
+  };
+}
+
 export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths }) {
   const engineState = createEngineState();
   const openworkServerState = createOpenworkServerState();
@@ -724,20 +732,19 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   }
 
   async function buildChildEnv(extra = {}) {
-    const caEnv = await systemCaEnv();
     /** @type {NodeJS.ProcessEnv} */
     // User env is layered first so process.env + any caller overrides always
     // win. See apps/server/src/env-file.ts and apps/orchestrator/src/cli.ts —
     // all loaders must agree on path + reserved-keys policy.
-    const env = {
+    const baseEnv = {
       ...loadUserEnvFile(),
       ...process.env,
       BUN_CONFIG_DNS_RESULT_ORDER: "verbatim",
-      // Bun honors Node's NODE_EXTRA_CA_CERTS, so bundled Bun sidecars inherit
-      // the exported OS trust store through the same child env variable.
-      ...caEnv,
-      ...extra,
     };
+    const caEnv = Object.prototype.hasOwnProperty.call(baseEnv, "NODE_EXTRA_CA_CERTS") ? {} : await systemCaEnv();
+    // Bun honors Node's NODE_EXTRA_CA_CERTS, so bundled Bun sidecars inherit
+    // the exported OS trust store through the same child env variable.
+    const env = mergeSystemCaChildEnv(baseEnv, caEnv, extra);
     const pathKey =
       Object.prototype.hasOwnProperty.call(env, "PATH") ||
       !Object.prototype.hasOwnProperty.call(env, "Path")

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/runtime.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.17.11",


### PR DESCRIPTION
## Problem

#2554 moved the desktop app's own fetches onto the OS trust store — but the **spawned runtime children** (bundled opencode sidecar, openwork server, orchestrator; Bun/Node binaries) still verify TLS against their bundled Mozilla roots. On enterprise machines (internal CA via GPO, TLS inspection), every runtime-originated HTTPS call — LLM providers behind a corporate gateway, self-hosted control plane, MCP servers — still dies with an opaque `fetch failed` one layer below the app.

## Fix

- `resolveSystemCaEnv()` exports the OS trust store (`tls.getCACertificates("system")`, available in Electron 35's Node 22.16) to `<userData>/system-ca-bundle.pem` — lazily, once, fail-closed (any error → no-op).
- `buildChildEnv()` sets `NODE_EXTRA_CA_CERTS` to that bundle for all runtime children. Bun honors the same variable, so Bun-compiled sidecars inherit it too.
- **User configuration always wins**: a `NODE_EXTRA_CA_CERTS` present in `process.env` *or* in OpenWork's user env file is never overridden (second commit hardens the env-file case).

`NODE_EXTRA_CA_CERTS` is additive (extends, never replaces, default roots) — worst case is a no-op, never a regression.

## Verification

- `bun test apps/desktop/electron/runtime-ca.test.mjs` — 5/5 (PEM write, env merge, process-env override, env-file override, missing-API no-op)
- `pnpm --filter @openwork/desktop test` — 26 pass, 1 skipped; `pnpm typecheck` — clean
- Electron probe: Node `22.16.0`, `tls.getCACertificates` is a function
- Functional red/green: local TLS server with a private CA — `fetch` fails without the env var and succeeds with it, for **both** `node` and `bun`
- Integration harness (real code + real sidecar, in Electron): `resolveSystemCaEnv` → `mergeSystemCaChildEnv` → spawn of the bundled `opencode` sidecar with the resulting env → exit 0. Output: `{"envHasCa":true,"envHasPath":true,"sidecarExit":0,"sidecarOutput":"1.17.11"}`

## Honest limits

- macOS `getCACertificates("system")` enumerates sparsely (1 cert on the test machine) — harmless (additive), and macOS is not the deployment target.
- **Windows is the target** (GPO-pushed CA in `LocalMachine\Root`, which Node's system-store reader consumes): full E2E lands via the Daytona Windows sandbox validation track using `scripts/support/setup-openwork-tls-repro.ps1` (companion PR).
- A UI core-flow fraimz was attempted but blocked by shared-machine Electron singleton-lock contention; the spawn-level harness above covers the changed surface (env construction + child launch). Happy to re-run the UI flow on a clean machine before merge if preferred.
