### PR TITLE
chore: tidy test fixtures and support script defaults

### DIFF
--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -264,7 +264,7 @@ describe("Google Workspace extension", () => {
     process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
     const config = createTestConfig();
     const workspaceRoot = join(dirname(config.configPath ?? ""), "workspace");
-    const invoicePath = join(workspaceRoot, "invoices", "blue-yonder-invoice-ow-by-poc-2026-001.pdf");
+    const invoicePath = join(workspaceRoot, "invoices", "acme-invoice-2026-001.pdf");
     config.workspaces = [{ id: "workspace-1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }];
     config.authorizedRoots = [workspaceRoot];
     await mkdir(dirname(invoicePath), { recursive: true });
@@ -284,24 +284,24 @@ describe("Google Workspace extension", () => {
     );
 
     const result = await callGoogleWorkspaceExtensionAction(config, "gmail_create_draft", {
-      to: ["AccountsPayable@blueyonder.com"],
-      cc: ["Purchasing.Administrator@blueyonder.com", "Vickie.Trent@blueyonder.com"],
-      subject: "Invoice OW-BY-POC-2026-001 for PO-047766",
-      body: "Please find attached invoice OW-BY-POC-2026-001 for PO-047766.",
-      attachments: [{ path: "invoices/blue-yonder-invoice-ow-by-poc-2026-001.pdf" }],
+      to: ["accounts.payable@acme.test"],
+      cc: ["purchasing.admin@acme.test", "casey.jordan@acme.test"],
+      subject: "Invoice ACME-2026-001 for PO-000123",
+      body: "Please find attached invoice ACME-2026-001 for PO-000123.",
+      attachments: [{ path: "invoices/acme-invoice-2026-001.pdf" }],
     }, { directory: workspaceRoot });
     expect(result?.ok).toBe(true);
     expect(result?.result).toMatchObject({ id: "draft-1" });
     expect(requests[0]?.url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/drafts");
     const raw = requests[0]?.body.match(/"raw":"([^"]+)"/)?.[1] ?? "";
     const decoded = Buffer.from(raw.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
-    expect(decoded).toContain("To: AccountsPayable@blueyonder.com");
-    expect(decoded).toContain("Cc: Purchasing.Administrator@blueyonder.com, Vickie.Trent@blueyonder.com");
-    expect(decoded).toContain("Subject: Invoice OW-BY-POC-2026-001 for PO-047766");
+    expect(decoded).toContain("To: accounts.payable@acme.test");
+    expect(decoded).toContain("Cc: purchasing.admin@acme.test, casey.jordan@acme.test");
+    expect(decoded).toContain("Subject: Invoice ACME-2026-001 for PO-000123");
     expect(decoded).toContain("Content-Type: multipart/mixed;");
-    expect(decoded).toContain("Please find attached invoice OW-BY-POC-2026-001 for PO-047766.");
-    expect(decoded).toContain("Content-Type: application/pdf; name=\"blue-yonder-invoice-ow-by-poc-2026-001.pdf\"");
-    expect(decoded).toContain("Content-Disposition: attachment; filename=\"blue-yonder-invoice-ow-by-poc-2026-001.pdf\"");
+    expect(decoded).toContain("Please find attached invoice ACME-2026-001 for PO-000123.");
+    expect(decoded).toContain("Content-Type: application/pdf; name=\"acme-invoice-2026-001.pdf\"");
+    expect(decoded).toContain("Content-Disposition: attachment; filename=\"acme-invoice-2026-001.pdf\"");
     expect(decoded).toContain(Buffer.from("%PDF-1.4\ninvoice bytes\n", "utf8").toString("base64"));
   });
 

--- a/docs/support/enterprise-network-doctor.md
+++ b/docs/support/enterprise-network-doctor.md
@@ -1,15 +1,15 @@
 # Enterprise network doctor
 
-`scripts/support/openwork-doctor.ps1` is a Windows PowerShell 5.1-compatible, no-admin, read-only report for customer IT. It checks DNS, TCP 443, the live TLS certificate/chain with `SslStream`, served certificates with `openssl` when available, WinHTTP/.NET proxy settings, PowerShell/OS version, and `NODE_EXTRA_CA_CERTS`. Send this Teams-ready one-liner to Ira after the branch or file is available at the raw URL:
+`scripts/support/openwork-doctor.ps1` is a Windows PowerShell 5.1-compatible, no-admin, read-only report for customer IT. It checks DNS, TCP 443, the live TLS certificate/chain with `SslStream`, served certificates with `openssl` when available, WinHTTP/.NET proxy settings, PowerShell/OS version, and `NODE_EXTRA_CA_CERTS`. Send this Teams-ready one-liner to the customer's IT contact once the file is available at the raw URL:
 
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -Command "`$p=Join-Path `$env:TEMP 'openwork-doctor.ps1'; Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/different-ai/openwork/feat/enterprise-network-doctor/scripts/support/openwork-doctor.ps1' -OutFile `$p; & `$p -WebUrl 'https://openwork-poc.blueyonder.com' -ApiUrl 'https://api-openwork-poc.blueyonder.com' -ExpectedIssuerMatch 'DigiCert'"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "`$p=Join-Path `$env:TEMP 'openwork-doctor.ps1'; Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/different-ai/openwork/dev/scripts/support/openwork-doctor.ps1' -OutFile `$p; & `$p -WebUrl 'https://openwork.example.com' -ApiUrl 'https://api.openwork.example.com' -ExpectedIssuerMatch 'DigiCert'"
 ```
 
 If raw download is blocked, save `scripts/support/openwork-doctor.ps1` locally and run:
 
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\openwork-doctor.ps1 -WebUrl 'https://openwork-poc.blueyonder.com' -ApiUrl 'https://api-openwork-poc.blueyonder.com' -ExpectedIssuerMatch 'DigiCert'
+powershell -NoProfile -ExecutionPolicy Bypass -File .\openwork-doctor.ps1 -WebUrl 'https://openwork.example.com' -ApiUrl 'https://api.openwork.example.com' -ExpectedIssuerMatch 'DigiCert'
 ```
 
 Common outcome patterns:

--- a/ee/apps/den-api/test/llm-endpoint-probe.test.ts
+++ b/ee/apps/den-api/test/llm-endpoint-probe.test.ts
@@ -24,7 +24,7 @@ describe("buildCandidateBaseUrls", () => {
   test("strips known suffixes and trailing slashes", () => {
     expect(buildCandidateBaseUrls("https://x.example.com/v1/")[0]).toBe("https://x.example.com/v1")
     expect(buildCandidateBaseUrls("https://x.example.com/v1/chat/completions")[0]).toBe("https://x.example.com/v1")
-    // The exact mistake from the Blue Yonder session: /responses pasted from the portal.
+    // The exact mistake from a real onboarding session: /responses pasted from the portal.
     expect(
       buildCandidateBaseUrls("https://r.services.ai.azure.com/openai/v1/responses")[0],
     ).toBe("https://r.services.ai.azure.com/openai/v1")
@@ -136,7 +136,7 @@ describe("probeEndpoint", () => {
         if (url.includes("/openai/deployments")) {
           return jsonResponse(200, { data: [{ id: "gpt-5-mini", object: "deployment" }] })
         }
-        // The Blue Yonder resource answers /models with the full Azure catalog.
+        // Real Foundry resources answer /models with the full Azure catalog.
         return jsonResponse(200, modelsPayload(["gpt-5-mini-2025-08-07", "dall-e-3-3.0"]))
       },
     })

--- a/ee/apps/den-web/tests/llm-provider-guided.test.ts
+++ b/ee/apps/den-web/tests/llm-provider-guided.test.ts
@@ -152,14 +152,14 @@ describe("readGuidedCustomProviderFields", () => {
 
     test("round-trips a verification-adjusted (OpenAI package) config", () => {
         const generated = buildGuidedCustomProviderConfig({
-            providerId: "blueyonder-foundry",
-            name: "Blue Yonder Azure Foundry",
-            baseUrl: "https://blueyonder.services.ai.azure.com/openai/v1",
+            providerId: "acme-foundry",
+            name: "Acme Azure Foundry",
+            baseUrl: "https://acme.services.ai.azure.com/openai/v1",
             modelIds: ["gpt-5-mini"],
             npm: "@ai-sdk/openai",
         });
         expect(generated.npm).toBe("@ai-sdk/openai");
-        expect(generated.env).toEqual(["BLUEYONDER_FOUNDRY_API_KEY"]);
+        expect(generated.env).toEqual(["ACME_FOUNDRY_API_KEY"]);
         expect(readGuidedCustomProviderFields(generated)?.npm).toBe("@ai-sdk/openai");
     });
 

--- a/evals/flows/llm-provider-azure-catalog-deployments.flow.mjs
+++ b/evals/flows/llm-provider-azure-catalog-deployments.flow.mjs
@@ -17,11 +17,12 @@
  * - OPENWORK_EVAL_DEN_WEB_URL          Den web origin
  * - OPENWORK_EVAL_DEN_EMAIL            Seeded admin email
  * - OPENWORK_EVAL_DEN_PASSWORD         Seeded admin password
- * - OPENWORK_EVAL_BLUEYONDER_API_KEY   Azure AI Foundry key (throwaway)
+ * - OPENWORK_EVAL_AZURE_FOUNDRY_RESOURCE  Azure AI Foundry resource name
+ * - OPENWORK_EVAL_AZURE_FOUNDRY_API_KEY   Azure AI Foundry key (throwaway)
  */
 
-const RESOURCE_NAME = "blueyonder-openworklabs";
-const PROVIDER_NAME = "Blue Yonder Azure (Catalog)";
+const RESOURCE_NAME = process.env.OPENWORK_EVAL_AZURE_FOUNDRY_RESOURCE ?? "";
+const PROVIDER_NAME = "Acme Azure (Catalog)";
 const DEPLOYMENT = "gpt-5-mini";
 const CATALOG_NOISE = "gpt-4o";
 
@@ -54,7 +55,8 @@ export default {
     "OPENWORK_EVAL_DEN_WEB_URL",
     "OPENWORK_EVAL_DEN_EMAIL",
     "OPENWORK_EVAL_DEN_PASSWORD",
-    "OPENWORK_EVAL_BLUEYONDER_API_KEY",
+    "OPENWORK_EVAL_AZURE_FOUNDRY_RESOURCE",
+    "OPENWORK_EVAL_AZURE_FOUNDRY_API_KEY",
   ],
   steps: [
     {
@@ -155,7 +157,7 @@ export default {
               ));
               await ctx.eval(fillInputExpr(
                 `[...document.querySelectorAll('input[type="password"]')].find((el) => el.placeholder.includes("AZURE_API_KEY"))`,
-                ctx.env.OPENWORK_EVAL_BLUEYONDER_API_KEY,
+                ctx.env.OPENWORK_EVAL_AZURE_FOUNDRY_API_KEY,
               ));
             },
             assert: async () => {

--- a/evals/flows/llm-provider-azure-foundry.flow.mjs
+++ b/evals/flows/llm-provider-azure-foundry.flow.mjs
@@ -1,5 +1,5 @@
 /**
- * Blue Yonder Azure Foundry, end to end against the REAL Azure resource:
+ * Custom Azure Foundry provider, end to end against the REAL Azure resource:
  * an admin sets up a gpt-5 deployment with nothing but a name, a lazily
  * pasted base URL, and a key — no JSON, no custom fields.
  *
@@ -18,13 +18,14 @@
  * - OPENWORK_EVAL_DEN_WEB_URL          Den web origin
  * - OPENWORK_EVAL_DEN_EMAIL            Seeded admin email
  * - OPENWORK_EVAL_DEN_PASSWORD         Seeded admin password
- * - OPENWORK_EVAL_BLUEYONDER_API_KEY   Azure AI Foundry key (throwaway)
+ * - OPENWORK_EVAL_AZURE_FOUNDRY_RESOURCE  Azure AI Foundry resource name
+ * - OPENWORK_EVAL_AZURE_FOUNDRY_API_KEY   Azure AI Foundry key (throwaway)
  */
 
-const RESOURCE_ORIGIN = "https://blueyonder-openworklabs.services.ai.azure.com";
+const RESOURCE_ORIGIN = `https://${process.env.OPENWORK_EVAL_AZURE_FOUNDRY_RESOURCE ?? ""}.services.ai.azure.com`;
 const HEALED_API = `${RESOURCE_ORIGIN}/openai/v1`;
-const PROVIDER_NAME = "Blue Yonder Azure Foundry";
-const PROVIDER_ID = "blueyonder-foundry";
+const PROVIDER_NAME = "Acme Azure Foundry";
+const PROVIDER_ID = "acme-foundry";
 const DEPLOYMENT = "gpt-5-mini";
 const CATALOG_NOISE = "gpt-5-mini-2025-08-07";
 
@@ -50,14 +51,15 @@ async function denApiDelete(ctx, name) {
 }
 
 export default {
-  id: "llm-provider-blueyonder-foundry",
-  title: "Blue Yonder Azure Foundry sets up gpt-5-mini with only name + URL + key",
+  id: "llm-provider-azure-foundry",
+  title: "Azure Foundry sets up gpt-5-mini with only name + URL + key",
   spec: "evals/cloud-provider-sync-flows.md",
   requiredEnv: [
     "OPENWORK_EVAL_DEN_WEB_URL",
     "OPENWORK_EVAL_DEN_EMAIL",
     "OPENWORK_EVAL_DEN_PASSWORD",
-    "OPENWORK_EVAL_BLUEYONDER_API_KEY",
+    "OPENWORK_EVAL_AZURE_FOUNDRY_RESOURCE",
+    "OPENWORK_EVAL_AZURE_FOUNDRY_API_KEY",
   ],
   steps: [
     {
@@ -122,7 +124,7 @@ export default {
               ));
               await ctx.eval(fillInputExpr(
                 `document.querySelector('input[type="password"]')`,
-                ctx.env.OPENWORK_EVAL_BLUEYONDER_API_KEY,
+                ctx.env.OPENWORK_EVAL_AZURE_FOUNDRY_API_KEY,
               ));
             },
             assert: async () => {
@@ -206,7 +208,7 @@ export default {
               ctx.assert(config.npm === "@ai-sdk/openai", `Wrong npm package persisted: ${config?.npm}`);
               ctx.assert(config.api === HEALED_API, `Wrong api persisted: ${config?.api}`);
               ctx.assert(
-                JSON.stringify(config.env) === JSON.stringify(["BLUEYONDER_FOUNDRY_API_KEY"]),
+                JSON.stringify(config.env) === JSON.stringify(["ACME_FOUNDRY_API_KEY"]),
                 `Wrong env persisted: ${JSON.stringify(config?.env)}`,
               );
               ctx.assert(

--- a/scripts/support/openwork-doctor.ps1
+++ b/scripts/support/openwork-doctor.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$WebUrl = "https://openwork-poc.blueyonder.com",
+    [string]$WebUrl = "",
     [string]$ApiUrl = "",
     [string]$ExpectedIssuerMatch = "DigiCert"
 )
@@ -68,8 +68,6 @@ function Test-InternalIssuer {
         "proxy",
         "zscaler",
         "netskope",
-        "blue yonder",
-        "blueyonder",
         "microsoft",
         "active directory",
         "domain ca",
@@ -577,7 +575,12 @@ $emdash = [char]0x2014
 Write-Report ("OpenWork Network Doctor v1 {0} {1}" -f $emdash, $timestamp)
 Write-Report "This entire output is safe to copy/paste back to OpenWork support."
 Write-Report ("Expected issuer match: {0}" -f $ExpectedIssuerMatch)
-Write-Report ("WebUrl: {0}" -f $WebUrl)
+if ([string]::IsNullOrWhiteSpace($WebUrl)) {
+    Write-Report "WebUrl: (empty; skipped)"
+}
+else {
+    Write-Report ("WebUrl: {0}" -f $WebUrl)
+}
 if ([string]::IsNullOrWhiteSpace($ApiUrl)) {
     Write-Report "ApiUrl: (empty; skipped)"
 }

--- a/scripts/support/setup-openwork-tls-repro.ps1
+++ b/scripts/support/setup-openwork-tls-repro.ps1
@@ -6,8 +6,8 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$Marker = "OpenWork Blue Yonder Repro"
-$ReproDir = Join-Path (Get-Location).Path "bly-repro"
+$Marker = "OpenWork TLS Repro"
+$ReproDir = Join-Path (Get-Location).Path "tls-repro"
 $StatePath = Join-Path $ReproDir "state.txt"
 $HostsMarker = "# OpenWork TLS repro"
 $SslAppId = "{1f6c8f8b-6b57-4a0b-8a1c-8d7e3d8f0d31}"
@@ -307,9 +307,9 @@ Invoke-Cleanup -Quiet
 New-Item -ItemType Directory -Path $ReproDir -Force | Out-Null
 
 $notAfter = (Get-Date).AddYears(1)
-$rootSubject = "CN=OpenWork Blue Yonder Repro Root CA, O=$Marker"
-$healthyIntermediateSubject = "CN=OpenWork Blue Yonder Repro Healthy Intermediate CA, O=$Marker"
-$brokenIntermediateSubject = "CN=OpenWork Blue Yonder Repro Broken Intermediate CA, O=$Marker"
+$rootSubject = "CN=OpenWork TLS Repro Root CA, O=$Marker"
+$healthyIntermediateSubject = "CN=OpenWork TLS Repro Healthy Intermediate CA, O=$Marker"
+$brokenIntermediateSubject = "CN=OpenWork TLS Repro Broken Intermediate CA, O=$Marker"
 $healthyLeafSubject = "CN=$Hostname, O=$Marker"
 $brokenLeafSubject = "CN=$Hostname, O=$Marker"
 $leafExtensions = @(
@@ -370,7 +370,7 @@ Write-Step ("   curl.exe -v {0}" -f $healthyUrl)
 Write-Step "2. curl broken (expect certificate/chain failure on a fresh VM; if it succeeds, Windows found a cached intermediate):"
 Write-Step ("   curl.exe -v {0}" -f $brokenUrl)
 Write-Step "3. Doctor against both local endpoints:"
-Write-Step ("   powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\support\openwork-doctor.ps1 -WebUrl {0} -ApiUrl {1} -ExpectedIssuerMatch `"OpenWork Blue Yonder Repro`"" -f $healthyUrl, $brokenUrl)
+Write-Step ("   powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\support\openwork-doctor.ps1 -WebUrl {0} -ApiUrl {1} -ExpectedIssuerMatch `"OpenWork TLS Repro`"" -f $healthyUrl, $brokenUrl)
 
 $nodeCommand = Get-Command node -ErrorAction SilentlyContinue
 if ($nodeCommand -ne $null) {


### PR DESCRIPTION
Housekeeping across tests, eval flows, and the support scripts: fixture data now uses the standard `acme.test` conventions, and environment-specific values are parameterized instead of hardcoded.

## Changes
- `apps/server` gmail draft test: fixture invoice/recipients moved to the standard `acme.test` fixture style.
- `ee/apps/den-web` + `ee/apps/den-api` tests: generic provider fixture ids/comments.
- Eval flows: the Azure Foundry flows now read the resource from env — new required vars `OPENWORK_EVAL_AZURE_FOUNDRY_RESOURCE` and `OPENWORK_EVAL_AZURE_FOUNDRY_API_KEY` (flows are skipped, not failed, when unset). The eval secrets store needs these two names going forward. Flow file/id renamed to `llm-provider-azure-foundry`.
- `scripts/support/openwork-doctor.ps1`: no baked-in default `-WebUrl` (empty is now reported as skipped, same as `-ApiUrl`); issuer keyword list trimmed to generic vendors.
- `scripts/support/setup-openwork-tls-repro.ps1`: repro marker/cert subjects/dir renamed to `OpenWork TLS Repro` / `tls-repro`.
- `docs/support/enterprise-network-doctor.md`: example hosts use `openwork.example.com`, raw URL pinned to `dev` (the old feature branch is gone).

## Tests run
- `apps/server`: `bun test src/extensions/google-workspace.test.ts` — 16 pass, 0 fail
- `ee/apps/den-api`: `bun test test/llm-endpoint-probe.test.ts` — 18 pass, 0 fail
- `ee/apps/den-web`: `bun test tests/llm-provider-guided.test.ts` — 19 pass, 0 fail
- Both eval flow modules import cleanly with no env set and report the new `requiredEnv` gates (verified via `node --input-type=module -e "import(...)"`).

No runtime/product code path changes (tests, eval fixtures, support scripts, docs only), so no fraimz run; the PowerShell scripts were changed only in string constants/defaults and are Windows-only, exact repro steps are in `docs/support/enterprise-network-doctor.md`.