### PR TITLE
feat(plugins): add connection-backed plugin UX

### DIFF
--- a/apps/app/src/app/cloud/import-state.ts
+++ b/apps/app/src/app/cloud/import-state.ts
@@ -29,6 +29,8 @@ export type CloudImportedMarketplace = {
 
 export type CloudImportedPluginFile = {
   configObjectId: string;
+  denSkillId?: string | null;
+  externalMcpConnectionId?: string | null;
   versionId: string | null;
   objectType: string;
   title: string;
@@ -155,10 +157,18 @@ export function readWorkspaceCloudImports(value: unknown): WorkspaceCloudImports
             const objectType = typeof file.objectType === "string" ? file.objectType.trim() : "";
             const title = typeof file.title === "string" ? file.title.trim() : configObjectId;
             const path = typeof file.path === "string" ? file.path.trim() : "";
+            const externalMcpConnectionId = typeof file.externalMcpConnectionId === "string"
+              ? file.externalMcpConnectionId.trim() || null
+              : null;
+            const denSkillId = typeof file.denSkillId === "string"
+              ? file.denSkillId.trim() || null
+              : null;
             if (!configObjectId || !objectType || !title || !path) return [];
             return [
               {
                 configObjectId,
+                denSkillId,
+                externalMcpConnectionId,
                 versionId: typeof file.versionId === "string" ? file.versionId.trim() || null : null,
                 objectType,
                 title,

--- a/apps/app/src/react-app/domains/settings/extension-items.ts
+++ b/apps/app/src/react-app/domains/settings/extension-items.ts
@@ -129,11 +129,15 @@ function resourceFromImportedFile(file: CloudImportedPluginFile): ExtensionResou
 
 function childKeysForPlugin(plugin: CloudImportedPlugin) {
   const mcpServerNames = new Set<string>();
+  const externalMcpConnectionIds = new Set<string>();
   const skillPaths = new Set<string>();
   const skillNames = new Set<string>();
   for (const file of plugin.files) {
     if (file.path.startsWith(MCP_IMPORT_PATH_PREFIX)) {
       mcpServerNames.add(file.path.slice(MCP_IMPORT_PATH_PREFIX.length));
+    }
+    if (file.externalMcpConnectionId) {
+      externalMcpConnectionIds.add(file.externalMcpConnectionId);
     }
     if (file.objectType === "skill") {
       skillPaths.add(file.path);
@@ -142,7 +146,7 @@ function childKeysForPlugin(plugin: CloudImportedPlugin) {
       skillNames.add(file.title);
     }
   }
-  return { mcpServerNames, skillPaths, skillNames };
+  return { externalMcpConnectionIds, mcpServerNames, skillPaths, skillNames };
 }
 
 export function buildExtensionItems(input: ExtensionItemBuildInput) {
@@ -176,14 +180,24 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
     const enablement = manifest?.enablement ? evaluateEnablement(manifest.enablement, input.enablementContext) : null;
     const pendingChange = input.pendingCloudPluginChanges?.[plugin.id];
     const installState = imported && pendingChange === "modified" ? "update_available" : cloudPluginStatus(imported, plugin);
+    const externalConnectionIds = new Set(imported?.files.flatMap((file) => file.externalMcpConnectionId ? [file.externalMcpConnectionId] : []) ?? []);
+    const connectionStates = [...externalConnectionIds].flatMap((id) => {
+      const connection = input.orgMcpConnections?.find((entry) => entry.id === id);
+      return connection ? [isOrgMcpConnectionReady(connection)] : [false];
+    });
+    const connectionSetupState = connectionStates.length === 0
+      ? null
+      : connectionStates.every(Boolean)
+        ? "ready"
+        : "needs_setup";
     return {
       id: `marketplace:${marketplace.marketplace.id}:${plugin.id}`,
       source: "marketplace",
       name: plugin.extension?.name ?? plugin.name,
       description: plugin.extension?.description ?? plugin.description,
       installState,
-      setupState: enablement ? setupStateFromEnablement(enablement) : installState === "available" ? "needs_setup" : "ready",
-      active: enablement?.active ?? installState !== "available",
+      setupState: enablement ? setupStateFromEnablement(enablement) : installState === "available" ? "needs_setup" : connectionSetupState ?? "ready",
+      active: enablement?.active ?? (installState !== "available" && connectionSetupState !== "needs_setup"),
       enablement,
       resources: imported?.files.map(resourceFromImportedFile) ?? Object.entries(plugin.componentCounts).flatMap(([type, count]) => count > 0 ? [{
         id: `${plugin.id}:${type}`,
@@ -240,10 +254,12 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
   };
 
   const groupedMcpServerNames = new Set<string>();
+  const groupedExternalMcpConnectionIds = new Set<string>();
   const groupedSkillPaths = new Set<string>();
   const groupedSkillNames = new Set<string>();
   for (const plugin of Object.values(input.importedCloudPlugins)) {
     const keys = childKeysForPlugin(plugin);
+    keys.externalMcpConnectionIds.forEach((value) => groupedExternalMcpConnectionIds.add(value));
     keys.mcpServerNames.forEach((value) => groupedMcpServerNames.add(value));
     keys.skillPaths.forEach((value) => groupedSkillPaths.add(value));
     keys.skillNames.forEach((value) => groupedSkillNames.add(value));
@@ -273,6 +289,9 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
     skill,
   }));
 
+  const visibleOrgMcpConnectionItems = orgMcpConnectionItems.filter((item) =>
+    !item.orgMcpConnection || !groupedExternalMcpConnectionIds.has(item.orgMcpConnection.id));
+
   return {
     // Org-managed MCP connections are beta, so keep them last in unified lists.
     items: [...builtInItems, ...cloudPluginItems, ...importedPluginItems, ...standaloneMcpEntries.map((entry): ExtensionItem => ({
@@ -286,10 +305,10 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
       enablement: null,
       resources: [{ id: getMcpServerName(entry), type: "mcp", title: entry.name }],
       mcpEntry: entry,
-    })), ...standaloneSkillItems, ...orgMcpConnectionItems],
+    })), ...standaloneSkillItems, ...visibleOrgMcpConnectionItems],
     builtInItems,
     cloudPluginItems: [...cloudPluginItems, ...importedPluginItems],
-    orgMcpConnectionItems,
+    orgMcpConnectionItems: visibleOrgMcpConnectionItems,
     installedMcpEntries: [
       ...builtInItems.flatMap((item) => item.active && item.builtInEntry ? [item.builtInEntry] : []),
       ...standaloneMcpEntries,

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -17,6 +17,7 @@ import { resolveMarketplaceDeliveryAction } from "@/react-app/domains/settings/c
 import { isDesktopInstallableMarketplacePlugin } from "@/react-app/domains/settings/connect-cloud-readiness";
 import {
   isOrgMcpConnectionItem,
+  isOrgMcpConnectionReady,
   isToggleControlledExtension,
   orgMcpConnectionActionLabel,
   type ExtensionItem,
@@ -69,6 +70,7 @@ type MarketplacePackageRow = {
   marketplaceName: string;
   plugin: DenOrgPlugin;
   imported: CloudImportedPlugin | null;
+  item: ExtensionItem | null;
   status: MarketplacePackageStatus;
   counts: string[];
   composition: Array<{ count: number; label: string; type: string }>;
@@ -113,6 +115,7 @@ export type CloudMarketplacesViewProps = {
   configSlotForBuiltIn?: (entry: McpDirectoryInfo) => React.ReactNode | null;
   isBuiltInConnected?: (entry: McpDirectoryInfo) => boolean;
   extensionItems?: ExtensionItem[];
+  orgMcpConnections?: DenExternalMcpConnection[];
   orgMcpConnectingId?: string | null;
   onConnectOrgMcp?: (connectionId: string) => void;
   refreshOrgMcpConnections?: () => Promise<unknown> | void;
@@ -200,6 +203,7 @@ export function CloudMarketplacesView({
   configSlotForBuiltIn,
   isBuiltInConnected,
   extensionItems = [],
+  orgMcpConnections = [],
   orgMcpConnectingId = null,
   onConnectOrgMcp,
   refreshOrgMcpConnections,
@@ -266,6 +270,7 @@ export function CloudMarketplacesView({
         marketplaceName: marketplace.marketplace.name,
         plugin,
         imported,
+        item: item ?? null,
         status,
         counts,
         composition,
@@ -657,7 +662,10 @@ export function CloudMarketplacesView({
           resolved={resolvedPlugins[detailRow.plugin.id] ?? null}
           resolving={detailLoadingId === detailRow.plugin.id}
           resolveError={detailError}
+          orgMcpConnections={orgMcpConnections}
+          orgMcpConnectingId={orgMcpConnectingId}
           onClose={() => setDetailRow(null)}
+          onConnectOrgMcp={onConnectOrgMcp}
           onImportPlugin={importPlugin}
           connectEnabled={connectEnabled}
           onRemovePlugin={removePlugin}
@@ -778,6 +786,7 @@ function MarketplaceCard(props: {
     importedLocally: Boolean(row.imported),
   });
   const cloudDelivery = deliveryAction !== "install";
+  const needsSetup = Boolean(row.imported && row.item?.setupState === "needs_setup");
 
   return (
     <div ref={highlightRef} className={`flex flex-col gap-2 ${highlightClass}`}>
@@ -787,10 +796,10 @@ function MarketplaceCard(props: {
         iconSlug={manifest?.icon?.simpleIconSlug}
         iconSrc={manifest?.icon?.src}
         kind="extension"
-        connected={cloudBuiltIn || cloudDelivery || Boolean(row.imported)}
-        connectedLabel={cloudDelivery ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : updateAvailable ? t("extensions.update_available") : "Installed"}
+        connected={cloudBuiltIn || (cloudDelivery && !needsSetup) || (Boolean(row.imported) && !needsSetup)}
+        connectedLabel={cloudDelivery && !needsSetup ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : updateAvailable ? t("extensions.update_available") : "Installed"}
         connecting={actionBusy}
-        actionLabel={cloudDelivery ? t("extensions.marketplace_runs_in_cloud") : cloudBuiltIn ? "View details" : actionBusy ? "Working..." : actionLabelForStatus(row.status)}
+        actionLabel={needsSetup ? "View setup" : cloudDelivery ? t("extensions.marketplace_runs_in_cloud") : cloudBuiltIn ? "View details" : actionBusy ? "Working..." : actionLabelForStatus(row.status)}
         onClick={() => onOpenDetail(row)}
       />
       {updateAvailable && !cloudDelivery ? (
@@ -894,11 +903,26 @@ function MarketplacePackageDetailModal(props: {
   resolving: boolean;
   resolveError: string | null;
   connectEnabled?: boolean;
+  orgMcpConnections: DenExternalMcpConnection[];
+  orgMcpConnectingId: string | null;
   onClose: () => void;
+  onConnectOrgMcp?: (connectionId: string) => void;
   onImportPlugin: (marketplaceId: string | null, plugin: DenOrgPlugin) => void | Promise<void>;
   onRemovePlugin: (pluginId: string, pluginName: string) => void | Promise<void>;
 }) {
-  const { actionId, row, resolved, resolving, resolveError, onClose, onImportPlugin, onRemovePlugin } = props;
+  const {
+    actionId,
+    row,
+    resolved,
+    resolving,
+    resolveError,
+    orgMcpConnections,
+    orgMcpConnectingId,
+    onClose,
+    onConnectOrgMcp,
+    onImportPlugin,
+    onRemovePlugin,
+  } = props;
   const actionBusy = actionId === row.plugin.id;
   const cloudBuiltIn = isCloudBuiltInPlugin(row.plugin);
   const manifest = row.plugin.extension?.manifest;
@@ -907,7 +931,14 @@ function MarketplacePackageDetailModal(props: {
     importedLocally: Boolean(row.imported),
   });
   const cloudDelivery = deliveryAction !== "install";
+  const needsSetup = Boolean(row.imported && row.item?.setupState === "needs_setup");
   const canAddOrUpdate = !cloudDelivery && !cloudBuiltIn && (row.status === "available" || row.status === "update_available");
+  const importedExternalConnectionIds = row.imported?.files.flatMap((file) => file.externalMcpConnectionId ? [file.externalMcpConnectionId] : []) ?? [];
+  const importedConnections = [...new Set(importedExternalConnectionIds)].flatMap((connectionId) => {
+    const connection = orgMcpConnections.find((entry) => entry.id === connectionId);
+    return connection ? [connection] : [];
+  });
+  const missingImportedConnectionCount = new Set(importedExternalConnectionIds).size - importedConnections.length;
 
   return (
     <ExtensionDetailModal
@@ -918,10 +949,11 @@ function MarketplacePackageDetailModal(props: {
       iconSlug={manifest?.icon?.simpleIconSlug}
       iconSrc={manifest?.icon?.src}
       kind="extension"
-      connected={cloudBuiltIn || cloudDelivery || Boolean(row.imported)}
-      connectedLabel={cloudDelivery ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : "Installed"}
+      connected={cloudBuiltIn || (cloudDelivery && !needsSetup) || (Boolean(row.imported) && !needsSetup)}
+      connectedLabel={cloudDelivery && !needsSetup ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : "Installed"}
+      disconnectedLabel={needsSetup ? "Needs setup" : undefined}
       connecting={actionBusy}
-      connectLabel={row.status === "update_available" ? "Update" : "Add"}
+      connectLabel={needsSetup ? "View setup" : row.status === "update_available" ? "Update" : "Add"}
       connectingLabel={row.status === "update_available" ? "Updating..." : "Adding..."}
       uninstallLabel="Remove"
       showEnablementCard={false}
@@ -933,8 +965,8 @@ function MarketplacePackageDetailModal(props: {
       configSlot={(
         <div className="space-y-4">
           <div className="flex flex-wrap gap-2">
-            <SettingsPill className={cloudDelivery ? "border-green-7/30 bg-green-3/20 text-green-11" : statusClass(row.status)}>
-              {cloudDelivery ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : statusLabel(row.status)}
+            <SettingsPill className={needsSetup ? "border-amber-7/30 bg-amber-3/20 text-amber-11" : statusClass(row.status)}>
+              {needsSetup ? "Needs setup" : cloudDelivery ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : statusLabel(row.status)}
             </SettingsPill>
             <SettingsPill>{row.marketplaceName}</SettingsPill>
             {row.counts.map((label) => <SettingsPill key={label}>{label}</SettingsPill>)}
@@ -955,6 +987,44 @@ function MarketplacePackageDetailModal(props: {
           ) : null}
           {resolving ? (
             <SettingsNotice>Loading extension contents...</SettingsNotice>
+          ) : null}
+          {missingImportedConnectionCount > 0 ? (
+            <SettingsNotice tone="error">
+              You do not have access to {missingImportedConnectionCount === 1 ? "one required MCP connection" : `${missingImportedConnectionCount} required MCP connections`}. Ask an admin to update the connection sharing settings.
+            </SettingsNotice>
+          ) : null}
+          {importedConnections.length > 0 ? (
+            <div className="rounded-xl border border-dls-border bg-dls-hover px-3 py-3">
+              <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Cloud MCP connections</div>
+              <div className="mt-3 grid gap-2">
+                {importedConnections.map((connection) => {
+                  const ready = isOrgMcpConnectionReady(connection);
+                  const needsMemberConnect = connection.credentialMode === "per_member" && !connection.connectedForMe;
+                  const connecting = orgMcpConnectingId === connection.id;
+                  return (
+                    <div key={connection.id} className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-dls-border bg-dls-surface px-3 py-2">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-card-foreground">{connection.name}</div>
+                        <div className="truncate text-xs text-muted-foreground">{connection.url}</div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <SettingsPill>{ready ? "Ready" : needsMemberConnect ? "Needs setup" : "Waiting for admin"}</SettingsPill>
+                        {needsMemberConnect && onConnectOrgMcp ? (
+                          <Button
+                            size="xs"
+                            variant="outline"
+                            disabled={connecting}
+                            onClick={() => onConnectOrgMcp(connection.id)}
+                          >
+                            {connecting ? "Waiting for browser..." : "Connect account"}
+                          </Button>
+                        ) : null}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
           ) : null}
           {resolved ? (
             <div className="space-y-2">

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -1061,6 +1061,39 @@ export function createExtensionsStore(options: {
     return warnings.length > 0 ? `${message} ${warnings.join(" ")}` : message;
   };
 
+  const externalMcpConnectionIdFromPayload = (
+    object: NonNullable<DenOrgPluginResolved["memberships"][number]["configObject"]>,
+  ): string | null => {
+    const version = object.latestVersion;
+    const payload = version?.normalizedPayloadJson ?? parseJsonRecord(version?.rawSourceText ?? null);
+    if (!payload) return null;
+    if (payload.openworkManaged === "den_external_mcp") {
+      const id = readNonEmptyString(payload.externalMcpConnectionId);
+      if (id) return id;
+    }
+    const containers = [
+      isRecord(payload.mcpServers) ? payload.mcpServers : null,
+      isRecord(payload.mcp) ? payload.mcp : null,
+    ].filter((entry): entry is Record<string, unknown> => Boolean(entry));
+    for (const container of containers) {
+      for (const config of Object.values(container)) {
+        if (!isRecord(config) || config.openworkManaged !== "den_external_mcp") continue;
+        const id = readNonEmptyString(config.externalMcpConnectionId);
+        if (id) return id;
+      }
+    }
+    return null;
+  };
+
+  const denSkillIdFromPayload = (
+    object: NonNullable<DenOrgPluginResolved["memberships"][number]["configObject"]>,
+  ): string | null => {
+    const version = object.latestVersion;
+    const payload = version?.normalizedPayloadJson ?? parseJsonRecord(version?.rawSourceText ?? null);
+    if (!payload || payload.openworkManaged !== "den_skill") return null;
+    return readNonEmptyString(payload.denSkillId);
+  };
+
   const upsertPluginMcpConfig = async (name: string, config: Record<string, unknown>) => {
     const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
@@ -1166,6 +1199,19 @@ export function createExtensionsStore(options: {
       }
 
       if (object.objectType === "mcp") {
+        const externalMcpConnectionId = externalMcpConnectionIdFromPayload(object);
+        if (externalMcpConnectionId) {
+          files.push({
+            configObjectId: object.id,
+            externalMcpConnectionId,
+            versionId: version?.id ?? null,
+            objectType: object.objectType,
+            title: object.title,
+            path: `den#mcp-connection.${externalMcpConnectionId}`,
+            updatedAt: object.updatedAt,
+          });
+          continue;
+        }
         const configs = pluginMcpConfigsFromPayload(object, namespace);
         if (configs.length === 0) warnings.push(mcpNoConfigWarning(object.title));
         for (const config of configs) {
@@ -1185,6 +1231,22 @@ export function createExtensionsStore(options: {
           });
         }
         continue;
+      }
+
+      if (object.objectType === "skill") {
+        const denSkillId = denSkillIdFromPayload(object);
+        if (denSkillId) {
+          files.push({
+            configObjectId: object.id,
+            denSkillId,
+            versionId: version?.id ?? null,
+            objectType: object.objectType,
+            title: object.title,
+            path: `den#skill.${denSkillId}`,
+            updatedAt: object.updatedAt,
+          });
+          continue;
+        }
       }
 
       if (version?.rawSourceText == null) continue;

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2120,6 +2120,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 configSlotForBuiltIn={extensionController.configSlotForEntry}
                 isBuiltInConnected={extensionController.isConnected}
                 extensionItems={extensionItemsForExtensions}
+                orgMcpConnections={orgMcpConnections.connections}
                 orgMcpConnectingId={orgMcpConnections.connectingId}
                 onConnectOrgMcp={(connectionId) => {
                   void orgMcpConnections.connect(connectionId);
@@ -2159,6 +2160,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             configSlotForBuiltIn={extensionController.configSlotForEntry}
             isBuiltInConnected={extensionController.isConnected}
             extensionItems={extensionItemsForExtensions}
+            orgMcpConnections={orgMcpConnections.connections}
             orgMcpConnectingId={orgMcpConnections.connectingId}
             onConnectOrgMcp={(connectionId) => {
               void orgMcpConnections.connect(connectionId);

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -1,13 +1,19 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Check, Loader2, Plug, Plus, Trash2, Users } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Check, Loader2, Plug, Puzzle, Server, Trash2, Users } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
+import { DenSelect } from "../../_components/ui/select";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { getPluginRoute } from "../../_lib/den-org";
+import { getRequestError, requestJson } from "../../_lib/den-flow";
 import { IntegrationIcon } from "./integration-icon";
 import { shouldShowMcpConnectionsStagingBanner } from "./mcp-connections-capability";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import { marketplaceQueryKeys, useMarketplaces } from "./marketplace-data";
 import {
   type CreatedMcpConnection,
   type CreateMcpConnectionInput,
@@ -17,6 +23,7 @@ import {
   type ExternalMcpPreset,
   type McpConnectionAccessInput,
   formatMcpConnectedTimestamp,
+  mcpConnectionQueryKeys,
   useCreateMcpConnection,
   useDeleteMcpConnection,
   useMcpConnectionPresets,
@@ -25,6 +32,7 @@ import {
   useSaveNativeProviderClient,
   useStartMcpConnectionOAuth,
 } from "./mcp-connections-data";
+import { getPluginPartsSummary, pluginQueryKeys, usePlugins } from "./plugin-data";
 
 const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
@@ -92,6 +100,92 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
   }
 }
 
+type GithubPluginImportSkippedReason = "missing_url" | "local_unsupported" | "invalid_url" | "unsupported_auth";
+
+type GithubPluginImportServer = {
+  name: string;
+  serverKey: string;
+  url: string | null;
+  supported: boolean;
+  skippedReason: GithubPluginImportSkippedReason | null;
+};
+
+type GithubPluginImportSkill = {
+  description: string | null;
+  name: string;
+  skillKey: string;
+  sourcePath: string;
+  supported: boolean;
+};
+
+type GithubPluginImportPreview = {
+  repositoryFullName: string;
+  rootPath: string;
+  servers: GithubPluginImportServer[];
+  skills: GithubPluginImportSkill[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parseSkippedReason(value: unknown): GithubPluginImportSkippedReason | null {
+  if (value === "missing_url" || value === "local_unsupported" || value === "invalid_url" || value === "unsupported_auth") {
+    return value;
+  }
+  return null;
+}
+
+function parseGithubPluginImportPreview(payload: unknown): GithubPluginImportPreview {
+  const item = isRecord(payload) && isRecord(payload.item) ? payload.item : null;
+  if (!item) throw new Error("GitHub plugin preview response was incomplete.");
+
+  return {
+    repositoryFullName: asString(item.repositoryFullName) ?? "",
+    rootPath: asString(item.rootPath) ?? "",
+    servers: Array.isArray(item.servers)
+      ? item.servers.flatMap((entry) => {
+          if (!isRecord(entry)) return [];
+          const name = asString(entry.name);
+          const serverKey = asString(entry.serverKey);
+          if (!name || !serverKey) return [];
+          return [{
+            name,
+            serverKey,
+            url: asString(entry.url),
+            supported: entry.supported === true,
+            skippedReason: parseSkippedReason(entry.skippedReason),
+          }];
+        })
+      : [],
+    skills: Array.isArray(item.skills)
+      ? item.skills.flatMap((entry) => {
+          if (!isRecord(entry)) return [];
+          const name = asString(entry.name);
+          const skillKey = asString(entry.skillKey);
+          if (!name || !skillKey) return [];
+          return [{
+            description: asString(entry.description),
+            name,
+            skillKey,
+            sourcePath: asString(entry.sourcePath) ?? "SKILL.md",
+            supported: entry.supported === true,
+          }];
+        })
+      : [],
+  };
+}
+
+function importServerStatus(server: GithubPluginImportServer): string {
+  if (server.supported) return "ready";
+  if (server.skippedReason === "missing_url") return "missing URL";
+  return "unsupported";
+}
+
 export function McpConnectionsScreen() {
   const { orgContext } = useOrgDashboard();
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections();
@@ -104,6 +198,7 @@ export function McpConnectionsScreen() {
 
   const [formOpen, setFormOpen] = useState(false);
   const [formPreset, setFormPreset] = useState<ExternalMcpPreset | null>(null);
+  const [pluginDialogOpen, setPluginDialogOpen] = useState(false);
   const [googleDialogOpen, setGoogleDialogOpen] = useState(false);
   const googleConfigured = usableConnections.some((connection) => connection.id === "google-workspace");
   const showStagingBanner = orgContext ? shouldShowMcpConnectionsStagingBanner(orgContext.capabilities) : false;
@@ -187,22 +282,44 @@ export function McpConnectionsScreen() {
         </div>
       ) : null}
 
-      <div className="mb-6 flex items-center justify-between rounded-2xl border border-gray-100 bg-white px-6 py-5">
+      <div className="mb-6 rounded-2xl border border-gray-100 bg-white px-6 py-5">
         <div>
-          <h2 className="text-[15px] font-semibold text-gray-900">Add a custom MCP server</h2>
-          <p className="mt-1 text-[13px] text-gray-500">Connect any MCP server by URL, with OAuth, an API key, or no auth.</p>
+          <h2 className="text-[15px] font-semibold text-gray-900">Add a connection</h2>
+          <p className="mt-1 text-[13px] text-gray-500">
+            Add a single MCP server, or import a plugin bundle so its MCPs and skills become available through capabilities.
+          </p>
         </div>
-        <DenButton
-          variant="primary"
-          size="sm"
-          icon={Plus}
-          onClick={() => {
-            setFormPreset(null);
-            setFormOpen(true);
-          }}
-        >
-          Add Custom
-        </DenButton>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <button
+            type="button"
+            onClick={() => {
+              setFormPreset(null);
+              setFormOpen(true);
+            }}
+            className="flex items-start gap-3 rounded-2xl border border-gray-100 px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
+          >
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gray-900 text-white">
+              <Server className="h-4 w-4" />
+            </span>
+            <span>
+              <span className="block text-[14px] font-semibold text-gray-900">MCP server</span>
+              <span className="mt-1 block text-[12px] leading-5 text-gray-500">Connect one remote MCP server by URL.</span>
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setPluginDialogOpen(true)}
+            className="flex items-start gap-3 rounded-2xl border border-gray-100 px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
+          >
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gray-900 text-white">
+              <Puzzle className="h-4 w-4" />
+            </span>
+            <span>
+              <span className="block text-[14px] font-semibold text-gray-900">Plugin bundle</span>
+              <span className="mt-1 block text-[12px] leading-5 text-gray-500">Import from GitHub or choose from your plugin library.</span>
+            </span>
+          </button>
+        </div>
       </div>
 
       <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Quick add</h3>
@@ -290,6 +407,12 @@ export function McpConnectionsScreen() {
         onSubmit={handleCreate}
       />
 
+      <ImportPluginConnectionDialog
+        open={pluginDialogOpen}
+        onClose={() => setPluginDialogOpen(false)}
+        onImported={() => void refetch()}
+      />
+
       <GoogleWorkspaceDialog
         open={googleDialogOpen}
         submitting={saveNativeClient.isPending}
@@ -301,6 +424,336 @@ export function McpConnectionsScreen() {
         }}
       />
     </DashboardPageTemplate>
+  );
+}
+
+function ImportPluginConnectionDialog({
+  open,
+  onClose,
+  onImported,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onImported: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { orgSlug, runReauthableAction } = useOrgDashboard();
+  const { data: marketplaces = [] } = useMarketplaces();
+  const { data: plugins = [], isLoading: pluginsLoading } = usePlugins();
+  const [githubUrl, setGithubUrl] = useState("");
+  const [marketplaceId, setMarketplaceId] = useState("");
+  const [authType, setAuthType] = useState<"oauth" | "none">("oauth");
+  const [credentialMode, setCredentialMode] = useState<ExternalMcpCredentialMode>("per_member");
+  const [preview, setPreview] = useState<GithubPluginImportPreview | null>(null);
+  const [selectedServerKeys, setSelectedServerKeys] = useState<string[]>([]);
+  const [selectedSkillKeys, setSelectedSkillKeys] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    if (!marketplaceId && marketplaces.length > 0) {
+      setMarketplaceId(marketplaces[0].id);
+    }
+  }, [marketplaceId, marketplaces, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setGithubUrl("");
+    setAuthType("oauth");
+    setCredentialMode("per_member");
+    setPreview(null);
+    setSelectedServerKeys([]);
+    setSelectedSkillKeys([]);
+    setError(null);
+  }, [open]);
+
+  const libraryPlugins = useMemo(
+    () => plugins.filter((plugin) => plugin.mcps.length > 0 || plugin.skills.length > 0),
+    [plugins],
+  );
+
+  async function previewGithubPlugin() {
+    if (!githubUrl.trim()) {
+      setError("Paste a GitHub plugin URL.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      let payload: unknown = null;
+      await runReauthableAction("preview-github-connection-plugin", async () => {
+        const result = await requestJson(
+          "/v1/plugins/import-mcps-from-github-url/preview",
+          { method: "POST", body: JSON.stringify({ githubUrl: githubUrl.trim() }) },
+          20000,
+        );
+        if (!result.response.ok) {
+          throw getRequestError(result.payload, result.response, "Failed to preview GitHub plugin.");
+        }
+        payload = result.payload;
+      });
+      const nextPreview = parseGithubPluginImportPreview(payload);
+      setPreview(nextPreview);
+      setSelectedServerKeys(nextPreview.servers.filter((server) => server.supported).map((server) => server.serverKey));
+      setSelectedSkillKeys(nextPreview.skills.filter((skill) => skill.supported).map((skill) => skill.skillKey));
+    } catch (previewError) {
+      setError(previewError instanceof Error ? previewError.message : "Failed to preview GitHub plugin.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function importGithubPlugin() {
+    if (!preview) {
+      setError("Preview the GitHub plugin first.");
+      return;
+    }
+    if (!marketplaceId) {
+      setError("Choose a marketplace.");
+      return;
+    }
+    if (selectedServerKeys.length === 0 && selectedSkillKeys.length === 0) {
+      setError("Select at least one MCP or skill.");
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      await runReauthableAction("import-github-connection-plugin", async () => {
+        const result = await requestJson(
+          "/v1/plugins/import-mcps-from-github-url",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              access: { orgWide: true, memberIds: [], teamIds: [] },
+              authType,
+              credentialMode: authType === "oauth" ? credentialMode : "shared",
+              githubUrl: githubUrl.trim(),
+              marketplaceId,
+              selectedServerKeys,
+              selectedSkillKeys,
+            }),
+          },
+          30000,
+        );
+        if (!result.response.ok) {
+          throw getRequestError(result.payload, result.response, "Failed to import GitHub plugin.");
+        }
+      });
+      await queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });
+      await queryClient.invalidateQueries({ queryKey: pluginQueryKeys.all });
+      await queryClient.invalidateQueries({ queryKey: marketplaceQueryKeys.all });
+      onImported();
+      onClose();
+    } catch (importError) {
+      setError(importError instanceof Error ? importError.message : "Failed to import GitHub plugin.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function toggleServer(serverKey: string, checked: boolean) {
+    setSelectedServerKeys((current) =>
+      checked ? [...new Set([...current, serverKey])] : current.filter((key) => key !== serverKey),
+    );
+  }
+
+  function toggleSkill(skillKey: string, checked: boolean) {
+    setSelectedSkillKeys((current) =>
+      checked ? [...new Set([...current, skillKey])] : current.filter((key) => key !== skillKey),
+    );
+  }
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={onClose}>
+      <div
+        className="max-h-[88vh] w-full max-w-2xl overflow-y-auto rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">Add plugin connection</h2>
+        <p className="mt-1 text-[13px] leading-6 text-gray-600">
+          Import a plugin from GitHub. Remote MCPs become Den-hosted org connections; imported skills are saved to Skill Hub storage and show up in capabilities.
+        </p>
+
+        <div className="mt-5 rounded-2xl border border-gray-100 bg-gray-50 p-4">
+          <label className="mb-1.5 block text-[12px] font-medium text-gray-700">GitHub plugin URL</label>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <DenInput
+              value={githubUrl}
+              onChange={(event) => {
+                setGithubUrl(event.target.value);
+                setPreview(null);
+                setSelectedServerKeys([]);
+                setSelectedSkillKeys([]);
+                setError(null);
+              }}
+              placeholder="https://github.com/anthropics/knowledge-work-plugins/tree/main/sales"
+              disabled={busy}
+            />
+            <DenButton variant="secondary" onClick={() => void previewGithubPlugin()} disabled={busy || !githubUrl.trim()}>
+              {busy && !preview ? "Previewing..." : "Preview"}
+            </DenButton>
+          </div>
+        </div>
+
+        {preview ? (
+          <div className="mt-4 space-y-4">
+            <div className="rounded-2xl border border-gray-100 bg-white px-4 py-3 text-[13px] text-gray-600">
+              Found {preview.servers.filter((server) => server.supported).length} MCPs and {preview.skills.filter((skill) => skill.supported).length} skills in{" "}
+              <span className="font-medium text-gray-900">{preview.repositoryFullName}{preview.rootPath ? `/${preview.rootPath}` : ""}</span>.
+            </div>
+
+            {preview.servers.length > 0 ? (
+              <div className="overflow-hidden rounded-2xl border border-gray-100">
+                <table className="w-full text-left text-[13px]">
+                  <thead className="bg-gray-50 text-[11px] uppercase tracking-[0.12em] text-gray-400">
+                    <tr>
+                      <th className="w-12 px-4 py-3">Use</th>
+                      <th className="px-4 py-3">MCP</th>
+                      <th className="px-4 py-3">URL</th>
+                      <th className="px-4 py-3">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 bg-white">
+                    {preview.servers.map((server) => (
+                      <tr key={server.serverKey}>
+                        <td className="px-4 py-3">
+                          <input
+                            type="checkbox"
+                            checked={selectedServerKeys.includes(server.serverKey)}
+                            disabled={!server.supported || busy}
+                            onChange={(event) => toggleServer(server.serverKey, event.target.checked)}
+                          />
+                        </td>
+                        <td className="px-4 py-3 font-medium text-gray-900">{server.name}</td>
+                        <td className="max-w-[240px] truncate px-4 py-3 font-mono text-[12px] text-gray-500">{server.url ?? "—"}</td>
+                        <td className="px-4 py-3 text-gray-500">{importServerStatus(server)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+
+            {preview.skills.length > 0 ? (
+              <div className="overflow-hidden rounded-2xl border border-gray-100">
+                <table className="w-full text-left text-[13px]">
+                  <thead className="bg-gray-50 text-[11px] uppercase tracking-[0.12em] text-gray-400">
+                    <tr>
+                      <th className="w-12 px-4 py-3">Use</th>
+                      <th className="px-4 py-3">Skill</th>
+                      <th className="px-4 py-3">Path</th>
+                      <th className="px-4 py-3">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 bg-white">
+                    {preview.skills.map((skill) => (
+                      <tr key={skill.skillKey}>
+                        <td className="px-4 py-3">
+                          <input
+                            type="checkbox"
+                            checked={selectedSkillKeys.includes(skill.skillKey)}
+                            disabled={!skill.supported || busy}
+                            onChange={(event) => toggleSkill(skill.skillKey, event.target.checked)}
+                          />
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="font-medium text-gray-900">{skill.name}</div>
+                          {skill.description ? <div className="mt-0.5 text-[12px] text-gray-500">{skill.description}</div> : null}
+                        </td>
+                        <td className="max-w-[240px] truncate px-4 py-3 font-mono text-[12px] text-gray-500">{skill.sourcePath}</td>
+                        <td className="px-4 py-3 text-gray-500">{skill.supported ? "ready" : "unsupported"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <label className="block">
+                <span className="mb-1.5 block text-[12px] font-medium text-gray-700">Authentication</span>
+                <DenSelect value={authType} onChange={(event) => setAuthType(event.target.value === "none" ? "none" : "oauth")} disabled={busy}>
+                  <option value="oauth">OAuth</option>
+                  <option value="none">No auth</option>
+                </DenSelect>
+              </label>
+              <label className="block">
+                <span className="mb-1.5 block text-[12px] font-medium text-gray-700">Account mode</span>
+                <DenSelect
+                  value={credentialMode}
+                  onChange={(event) => setCredentialMode(event.target.value === "shared" ? "shared" : "per_member")}
+                  disabled={busy || authType === "none"}
+                >
+                  <option value="per_member">Individual accounts</option>
+                  <option value="shared">Org account</option>
+                </DenSelect>
+              </label>
+              <label className="block">
+                <span className="mb-1.5 block text-[12px] font-medium text-gray-700">Marketplace</span>
+                <DenSelect value={marketplaceId} onChange={(event) => setMarketplaceId(event.target.value)} disabled={busy}>
+                  {marketplaces.map((marketplace) => (
+                    <option key={marketplace.id} value={marketplace.id}>
+                      {marketplace.name}
+                    </option>
+                  ))}
+                </DenSelect>
+              </label>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="mt-6">
+          <h3 className="text-[12px] font-semibold uppercase tracking-[0.14em] text-gray-400">Plugin library</h3>
+          <div className="mt-3 rounded-2xl border border-gray-100 bg-white">
+            {pluginsLoading ? (
+              <div className="px-4 py-5 text-[13px] text-gray-500">Loading plugin library...</div>
+            ) : libraryPlugins.length === 0 ? (
+              <div className="px-4 py-5 text-[13px] text-gray-500">No imported plugins with MCPs or skills yet.</div>
+            ) : (
+              <div className="divide-y divide-gray-100">
+                {libraryPlugins.slice(0, 6).map((plugin) => (
+                  <Link
+                    key={plugin.id}
+                    href={getPluginRoute(orgSlug, plugin.id)}
+                    className="flex items-center justify-between gap-3 px-4 py-3 transition hover:bg-gray-50"
+                    onClick={onClose}
+                  >
+                    <span className="min-w-0">
+                      <span className="block truncate text-[13px] font-semibold text-gray-900">{plugin.name}</span>
+                      <span className="mt-0.5 block truncate text-[12px] text-gray-500">{getPluginPartsSummary(plugin)}</span>
+                    </span>
+                    <span className="text-[12px] font-medium text-gray-500">Open</span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {error ? (
+          <p className="mt-3 text-[13px] text-red-600">{error}</p>
+        ) : null}
+
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <DenButton variant="secondary" onClick={onClose} disabled={busy}>
+            Cancel
+          </DenButton>
+          <DenButton
+            variant="primary"
+            loading={busy && Boolean(preview)}
+            disabled={!preview || !marketplaceId || (selectedServerKeys.length === 0 && selectedSkillKeys.length === 0)}
+            onClick={() => void importGithubPlugin()}
+          >
+            Import selected
+          </DenButton>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-editor-screen.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, FileText, Plus, Server, Terminal, Trash2 } from "lucide-react";
+import { ArrowLeft, FileText, Info, Plus, Server, Terminal, Trash2 } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenSelect } from "../../_components/ui/select";
@@ -24,6 +24,33 @@ type DraftComponent = {
   description: string;
   /** Markdown body for skills/commands; remote server URL for MCP. */
   content: string;
+};
+
+type GithubMcpImportSkippedReason = "missing_url" | "local_unsupported" | "invalid_url" | "unsupported_auth";
+
+type GithubMcpImportServer = {
+  name: string;
+  serverKey: string;
+  url: string | null;
+  supported: boolean;
+  skippedReason: GithubMcpImportSkippedReason | null;
+};
+
+type GithubSkillImportSkill = {
+  description: string | null;
+  name: string;
+  skillKey: string;
+  sourcePath: string;
+  supported: boolean;
+  skippedReason: "invalid_skill" | null;
+};
+
+type GithubMcpImportPreview = {
+  repositoryFullName: string;
+  rootPath: string;
+  servers: GithubMcpImportServer[];
+  skills: GithubSkillImportSkill[];
+  warnings: string[];
 };
 
 const COMPONENT_META: Record<ComponentKind, { label: string; icon: typeof FileText; hint: string }> = {
@@ -111,12 +138,71 @@ async function postJson(path: string, body: unknown, failureLabel: string): Prom
   return payload;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 function createdItemId(payload: unknown): string | null {
-  if (payload && typeof payload === "object" && "item" in payload) {
-    const item = (payload as { item?: { id?: unknown } }).item;
-    if (item && typeof item.id === "string") return item.id;
+  const item = isRecord(payload) && isRecord(payload.item) ? payload.item : null;
+  return typeof item?.id === "string" ? item.id : null;
+}
+
+function parseSkippedReason(value: unknown): GithubMcpImportSkippedReason | null {
+  if (value === "missing_url" || value === "local_unsupported" || value === "invalid_url" || value === "unsupported_auth") {
+    return value;
   }
   return null;
+}
+
+function parseGithubMcpImportPreview(payload: unknown): GithubMcpImportPreview {
+  const item = isRecord(payload) && isRecord(payload.item) ? payload.item : null;
+  if (!item) throw new Error("GitHub MCP import preview response was incomplete.");
+  return {
+    repositoryFullName: typeof item.repositoryFullName === "string" ? item.repositoryFullName : "",
+    rootPath: typeof item.rootPath === "string" ? item.rootPath : "",
+    servers: Array.isArray(item.servers)
+      ? item.servers.flatMap((entry) => {
+          if (!isRecord(entry) || typeof entry.name !== "string") return [];
+          return [{
+            name: entry.name,
+            serverKey: typeof entry.serverKey === "string" ? entry.serverKey : `${entry.name}:${typeof entry.url === "string" ? entry.url : ""}`,
+            url: typeof entry.url === "string" ? entry.url : null,
+            supported: entry.supported === true,
+            skippedReason: parseSkippedReason(entry.skippedReason),
+          }];
+        })
+      : [],
+    skills: Array.isArray(item.skills)
+      ? item.skills.flatMap((entry) => {
+          if (!isRecord(entry) || typeof entry.name !== "string" || typeof entry.skillKey !== "string") return [];
+          return [{
+            description: typeof entry.description === "string" ? entry.description : null,
+            name: entry.name,
+            skillKey: entry.skillKey,
+            sourcePath: typeof entry.sourcePath === "string" ? entry.sourcePath : "SKILL.md",
+            supported: entry.supported === true,
+            skippedReason: entry.skippedReason === "invalid_skill" ? "invalid_skill" : null,
+          }];
+        })
+      : [],
+    warnings: Array.isArray(item.warnings)
+      ? item.warnings.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+      : [],
+  };
+}
+
+function statusLabel(server: GithubMcpImportServer) {
+  if (server.supported) return "ready";
+  if (server.skippedReason === "missing_url") return "missing URL";
+  return "unsupported";
+}
+
+function skillTooltip(skill: GithubSkillImportSkill) {
+  return [
+    skill.description ? `Description: ${skill.description}` : null,
+    `Path: ${skill.sourcePath}`,
+    `Status: ${skill.supported ? "ready" : "unsupported"}`,
+  ].filter(Boolean).join("\n");
 }
 
 export function PluginEditorScreen() {
@@ -132,6 +218,15 @@ export function PluginEditorScreen() {
   const [marketplaceId, setMarketplaceId] = useState<string>("");
   const [marketplaceTouched, setMarketplaceTouched] = useState(false);
   const [shareOrgWide, setShareOrgWide] = useState(true);
+  const [githubImportUrl, setGithubImportUrl] = useState("");
+  const [githubImportMarketplaceId, setGithubImportMarketplaceId] = useState("");
+  const [githubImportAuthType, setGithubImportAuthType] = useState<"oauth" | "none">("oauth");
+  const [githubImportCredentialMode, setGithubImportCredentialMode] = useState<"per_member" | "shared">("per_member");
+  const [githubImportPreview, setGithubImportPreview] = useState<GithubMcpImportPreview | null>(null);
+  const [selectedGithubMcpKeys, setSelectedGithubMcpKeys] = useState<string[]>([]);
+  const [selectedGithubSkillKeys, setSelectedGithubSkillKeys] = useState<string[]>([]);
+  const [githubImportBusy, setGithubImportBusy] = useState(false);
+  const [githubImportError, setGithubImportError] = useState<string | null>(null);
 
   // Publishing is the happy path for non-technical creators: pre-select the
   // first marketplace once the list loads, unless the user chose otherwise.
@@ -139,9 +234,25 @@ export function PluginEditorScreen() {
     if (!marketplaceTouched && !marketplaceId && marketplaces.length > 0) {
       setMarketplaceId(marketplaces[0].id);
     }
-  }, [marketplaceId, marketplaceTouched, marketplaces]);
+    if (!githubImportMarketplaceId && marketplaces.length > 0) {
+      setGithubImportMarketplaceId(marketplaces[0].id);
+    }
+  }, [githubImportMarketplaceId, marketplaceId, marketplaceTouched, marketplaces]);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const githubImportHasUrl = githubImportUrl.trim().length > 0;
+  const primaryBusy = saving || githubImportBusy;
+  const primaryButtonLabel = githubImportHasUrl
+    ? githubImportBusy
+      ? githubImportPreview
+        ? "Importing..."
+        : "Previewing..."
+      : githubImportPreview
+        ? "Import selected"
+        : "Preview GitHub plugin"
+    : saving
+      ? "Creating..."
+      : "Create plugin";
 
   const addComponent = (kind: ComponentKind) => {
     setComponents((current) => [
@@ -215,6 +326,104 @@ export function PluginEditorScreen() {
     }
   }
 
+  async function previewGithubMcpImport() {
+    if (!githubImportUrl.trim()) {
+      setGithubImportError("Paste a GitHub plugin URL.");
+      return;
+    }
+
+    setGithubImportBusy(true);
+    setGithubImportError(null);
+    setSaveError(null);
+    try {
+      let payload: unknown = null;
+      await runReauthableAction("preview-github-plugin-mcps", async () => {
+        const result = await requestJson(
+          "/v1/plugins/import-mcps-from-github-url/preview",
+          { method: "POST", body: JSON.stringify({ githubUrl: githubImportUrl.trim() }) },
+          20000,
+        );
+        if (!result.response.ok) {
+          throw getRequestError(result.payload, result.response, "Failed to preview GitHub plugin components.");
+        }
+        payload = result.payload;
+      });
+      const preview = parseGithubMcpImportPreview(payload);
+      setGithubImportPreview(preview);
+      setSelectedGithubMcpKeys(preview.servers.filter((server) => server.supported).map((server) => server.serverKey));
+      setSelectedGithubSkillKeys(preview.skills.filter((skill) => skill.supported).map((skill) => skill.skillKey));
+    } catch (error) {
+      setGithubImportError(error instanceof Error ? error.message : "Failed to preview GitHub plugin components.");
+    } finally {
+      setGithubImportBusy(false);
+    }
+  }
+
+  async function importGithubMcpPlugin() {
+    if (!githubImportPreview) {
+      setGithubImportError("Preview the GitHub plugin first.");
+      return;
+    }
+    if (!githubImportMarketplaceId) {
+      setGithubImportError("Choose a marketplace.");
+      return;
+    }
+    if (selectedGithubMcpKeys.length === 0 && selectedGithubSkillKeys.length === 0) {
+      setGithubImportError("Select at least one supported MCP or skill.");
+      return;
+    }
+
+    setGithubImportBusy(true);
+    setGithubImportError(null);
+    setSaveError(null);
+    try {
+      let pluginId: string | null = null;
+      await runReauthableAction("import-github-plugin-mcps", async () => {
+        const result = await requestJson(
+          "/v1/plugins/import-mcps-from-github-url",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              access: { orgWide: true, memberIds: [], teamIds: [] },
+              authType: githubImportAuthType,
+              credentialMode: githubImportCredentialMode,
+              githubUrl: githubImportUrl.trim(),
+              marketplaceId: githubImportMarketplaceId,
+              selectedSkillKeys: selectedGithubSkillKeys,
+              selectedServerKeys: selectedGithubMcpKeys,
+            }),
+          },
+          30000,
+        );
+        if (!result.response.ok) {
+          throw getRequestError(result.payload, result.response, "Failed to import GitHub plugin components.");
+        }
+        const item = isRecord(result.payload) && isRecord(result.payload.item) ? result.payload.item : null;
+        const plugin = item && isRecord(item.plugin) ? item.plugin : null;
+        pluginId = plugin && typeof plugin.id === "string" ? plugin.id : null;
+      });
+      await queryClient.invalidateQueries({ queryKey: pluginQueryKeys.all });
+      router.push(pluginId ? getPluginRoute(orgSlug, pluginId) : getPluginsRoute(orgSlug));
+      router.refresh();
+    } catch (error) {
+      setGithubImportError(error instanceof Error ? error.message : "Failed to import GitHub plugin components.");
+    } finally {
+      setGithubImportBusy(false);
+    }
+  }
+
+  async function handlePrimarySubmit() {
+    if (githubImportHasUrl) {
+      if (!githubImportPreview) {
+        await previewGithubMcpImport();
+        return;
+      }
+      await importGithubMcpPlugin();
+      return;
+    }
+    await createPlugin();
+  }
+
   return (
     <div className="mx-auto w-full max-w-3xl px-6 py-10">
       <Link
@@ -229,6 +438,193 @@ export function PluginEditorScreen() {
       <p className="mt-1 text-[15px] text-gray-500">
         Bundle skills, commands, and MCP servers your team can install in OpenWork with one click.
       </p>
+
+      <div className="mt-8 rounded-[24px] border border-gray-200 bg-white p-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-[18px] font-semibold text-gray-900">Import MCPs and skills from GitHub URL</h2>
+            <p className="mt-1 text-[13px] leading-5 text-gray-500">
+              Paste a public plugin URL like <span className="font-mono text-[12px]">github.com/anthropics/knowledge-work-plugins/tree/main/sales</span>.
+            </p>
+          </div>
+          <DenButton
+            variant="secondary"
+            size="sm"
+            className="shrink-0 whitespace-nowrap"
+            disabled={githubImportBusy}
+            onClick={() => void previewGithubMcpImport()}
+          >
+            {githubImportBusy && !githubImportPreview ? "Previewing..." : "Preview first"}
+          </DenButton>
+        </div>
+
+        <div className="mt-4">
+          <label className="mb-1.5 block text-[13px] font-medium text-gray-700">GitHub plugin URL</label>
+          <DenInput
+            value={githubImportUrl}
+            onChange={(event) => {
+              setGithubImportUrl(event.target.value);
+              setGithubImportPreview(null);
+              setSelectedGithubMcpKeys([]);
+              setSelectedGithubSkillKeys([]);
+              setGithubImportError(null);
+              setSaveError(null);
+            }}
+            placeholder="https://github.com/anthropics/knowledge-work-plugins/tree/main/sales"
+            disabled={githubImportBusy}
+          />
+        </div>
+
+        {githubImportPreview ? (
+          <div className="mt-5 flex flex-col gap-4">
+            <div className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3 text-[13px] text-gray-600">
+              Found {githubImportPreview.servers.filter((server) => server.supported).length} importable MCPs and {githubImportPreview.skills.filter((skill) => skill.supported).length} importable skills in{" "}
+              <span className="font-medium text-gray-900">{githubImportPreview.repositoryFullName}{githubImportPreview.rootPath ? `/${githubImportPreview.rootPath}` : ""}</span>.
+            </div>
+
+            <div className="overflow-hidden rounded-2xl border border-gray-100">
+              <table className="w-full table-fixed text-left text-[13px]">
+                <thead className="bg-gray-50 text-[11px] uppercase tracking-[0.12em] text-gray-400">
+                  <tr>
+                    <th className="w-12 px-4 py-3">Use</th>
+                    <th className="w-[28%] px-4 py-3">Name</th>
+                    <th className="px-4 py-3">Server URL</th>
+                    <th className="w-24 px-4 py-3">Status</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100 bg-white">
+                  {githubImportPreview.servers.map((server) => (
+                    <tr key={server.serverKey}>
+                      <td className="px-4 py-3">
+                        <input
+                          type="checkbox"
+                          checked={selectedGithubMcpKeys.includes(server.serverKey)}
+                          disabled={!server.supported || githubImportBusy}
+                          onChange={(event) => {
+                            setSelectedGithubMcpKeys((current) =>
+                              event.target.checked
+                                ? [...new Set([...current, server.serverKey])]
+                                : current.filter((key) => key !== server.serverKey),
+                            );
+                          }}
+                        />
+                      </td>
+                      <td className="min-w-0 px-4 py-3">
+                        <div className="truncate font-medium text-gray-900" title={server.name}>{server.name}</div>
+                      </td>
+                      <td className="min-w-0 px-4 py-3">
+                        <div className="truncate font-mono text-[12px] text-gray-500" title={server.url ?? "No URL declared"}>
+                          {server.url ?? "—"}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-gray-500">
+                        <span className="whitespace-nowrap">{statusLabel(server)}</span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {githubImportPreview.skills.length > 0 ? (
+              <div className="overflow-hidden rounded-2xl border border-gray-100">
+                <table className="w-full table-fixed text-left text-[13px]">
+                  <thead className="bg-gray-50 text-[11px] uppercase tracking-[0.12em] text-gray-400">
+                    <tr>
+                      <th className="w-12 px-4 py-3">Use</th>
+                      <th className="px-4 py-3">Skill</th>
+                      <th className="w-28 px-4 py-3">Details</th>
+                      <th className="w-24 px-4 py-3">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 bg-white">
+                    {githubImportPreview.skills.map((skill) => (
+                      <tr key={skill.skillKey}>
+                        <td className="px-4 py-3">
+                          <input
+                            type="checkbox"
+                            checked={selectedGithubSkillKeys.includes(skill.skillKey)}
+                            disabled={!skill.supported || githubImportBusy}
+                            onChange={(event) => {
+                              setSelectedGithubSkillKeys((current) =>
+                                event.target.checked
+                                  ? [...new Set([...current, skill.skillKey])]
+                                  : current.filter((key) => key !== skill.skillKey),
+                              );
+                            }}
+                          />
+                        </td>
+                        <td className="min-w-0 px-4 py-3">
+                          <div className="truncate font-medium text-gray-900" title={skill.name}>{skill.name}</div>
+                          {skill.description ? (
+                            <div className="mt-0.5 truncate text-[12px] text-gray-500" title={skill.description}>{skill.description}</div>
+                          ) : null}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span
+                            className="inline-flex items-center gap-1 whitespace-nowrap text-[12px] font-medium text-gray-500"
+                            title={skillTooltip(skill)}
+                          >
+                            <Info size={13} aria-hidden />
+                            View info
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-gray-500">
+                          <span className="whitespace-nowrap">{skill.supported ? "ready" : "unsupported"}</span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <label className="block">
+                <span className="mb-1.5 block text-[13px] font-medium text-gray-700">Authentication</span>
+                <DenSelect value={githubImportAuthType} onChange={(event) => setGithubImportAuthType(event.target.value === "none" ? "none" : "oauth")} disabled={githubImportBusy}>
+                  <option value="oauth">OAuth</option>
+                  <option value="none">No auth</option>
+                </DenSelect>
+              </label>
+              <label className="block">
+                <span className="mb-1.5 block text-[13px] font-medium text-gray-700">Credential mode</span>
+                <DenSelect
+                  value={githubImportCredentialMode}
+                  onChange={(event) => setGithubImportCredentialMode(event.target.value === "shared" ? "shared" : "per_member")}
+                  disabled={githubImportBusy || githubImportAuthType === "none"}
+                >
+                  <option value="per_member">Individual accounts</option>
+                  <option value="shared">Org account</option>
+                </DenSelect>
+              </label>
+              <label className="block">
+                <span className="mb-1.5 block text-[13px] font-medium text-gray-700">Marketplace</span>
+                <DenSelect value={githubImportMarketplaceId} onChange={(event) => setGithubImportMarketplaceId(event.target.value)} disabled={githubImportBusy}>
+                  {marketplaces.map((marketplace) => (
+                    <option key={marketplace.id} value={marketplace.id}>
+                      {marketplace.name}
+                    </option>
+                  ))}
+                </DenSelect>
+              </label>
+            </div>
+
+            <div className="flex items-center justify-between gap-3 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
+              <p className="text-[13px] text-gray-500">Access defaults to everyone in the organization. Row-level overrides can be added later.</p>
+              <DenButton disabled={githubImportBusy || (selectedGithubMcpKeys.length === 0 && selectedGithubSkillKeys.length === 0) || !githubImportMarketplaceId} onClick={() => void importGithubMcpPlugin()}>
+                {githubImportBusy && githubImportPreview ? "Importing..." : "Import selected"}
+              </DenButton>
+            </div>
+          </div>
+        ) : null}
+
+        {githubImportError ? (
+          <div className="mt-4 rounded-[16px] border border-red-200 bg-red-50 px-4 py-3 text-[14px] text-red-700">
+            {githubImportError}
+          </div>
+        ) : null}
+      </div>
 
       <div className="mt-8 flex flex-col gap-5 rounded-[24px] border border-gray-200 bg-white p-6">
         <div>
@@ -391,8 +787,8 @@ export function PluginEditorScreen() {
       ) : null}
 
       <div className="mt-6 flex items-center gap-3">
-        <DenButton onClick={() => void createPlugin()} disabled={saving}>
-          {saving ? "Creating..." : "Create plugin"}
+        <DenButton onClick={() => void handlePrimarySubmit()} disabled={primaryBusy}>
+          {primaryButtonLabel}
         </DenButton>
         <Link href={getPluginsRoute(orgSlug)} className="text-[14px] text-gray-500 hover:text-gray-900">
           Cancel


### PR DESCRIPTION
## Goal

Add the admin and desktop surfaces for connection-backed plugin imports while keeping the existing Connections route at `/dashboard/mcp-connections`.

This branch answers: "Can an admin start a GitHub plugin import from the existing MCP Connections surface, and can Desktop install connection-backed plugin resources without materializing Den-hosted MCPs locally?"

## What Changed

| Area | Added / Changed |
| --- | --- |
| Den Web entry point | Adds plugin import controls to the existing MCP Connections screen. |
| Plugin editor | Lets admins preview/select GitHub plugin MCP and skill resources from a URL. |
| Selection UX | Stores selections by stable server/skill keys instead of display names. |
| Desktop install | Records connection-backed plugin resources without writing local `mcpServers` entries for Den-hosted org MCP connections. |
| Desktop skills | Records Den-backed imported skills without writing local skill files. |
| Marketplace state | Shows setup-oriented state for installed connection-backed plugins that still need per-member connection setup. |
| Standalone connection rows | Hides standalone org MCP connection rows when that connection is bundled by a marketplace plugin. |

## Route Boundary

Since we intend to address the broader Connections direction more specifically, this split keeps the existing MCP Connections path as-is for now.

| Route | Status |
| --- | --- |
| `/dashboard/mcp-connections` | Kept as the current admin surface. |
| `/dashboard/connections` | Not added in this split. |
| Redirect from `/dashboard/mcp-connections` | Not added in this split. |

## File Boundary

| File | Purpose |
| --- | --- |
| `ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx` | Adds the import entry point on the existing MCP Connections screen. |
| `ee/apps/den-web/app/(den)/dashboard/_components/plugin-editor-screen.tsx` | Adds URL preview/selection UI for imported MCP and skill resources. |
| `apps/app/src/app/cloud/import-state.ts` | Tracks connection-backed plugin import/install state. |
| `apps/app/src/react-app/domains/settings/extension-items.ts` | Represents connection-backed plugin resources as extension items. |
| `apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx` | Updates marketplace card/install/setup behavior. |
| `apps/app/src/react-app/domains/settings/state/extensions-store.ts` | Avoids local materialization for Den-backed resources. |
| `apps/app/src/react-app/shell/settings-route.tsx` | Keeps settings navigation behavior aligned with the marketplace/plugin state. |

## Dependency Boundary

| Related branch | Relationship |
| --- | --- |
| `feature/github-plugin-import-backend` | Provides the backend preview/import endpoints this UI calls. |
| `feature/skill-capabilities` | Makes imported Den skills discoverable through `/mcp/agent` once persisted. |

The branches are based independently on `dev` so they can be reviewed as separate concerns. Functionally, this UX path expects the backend import API to be available.

## Not Included

| Not in this branch | Why |
| --- | --- |
| Backend import implementation | Separate backend branch. |
| Skill capability search/execution | Separate capability branch. |
| Full blocked grant-state projection | Existing broader gap; this branch only fixes the introduced needs-setup card UX. |
| Local/stdio MCP import | Not part of this flow. |
| Plugin-hosted secrets | Credentials remain owned by External MCP Connections. |

## Validation

| Command | Result |
| --- | --- |
| `pnpm typecheck` | Passed |

