### PR TITLE
feat(cloud): Google Workspace read capabilities — Gmail, Calendar, Drive via search_capabilities

### DIFF
--- a/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
+++ b/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
@@ -1,0 +1,238 @@
+export type GoogleWorkspaceAttachment = {
+  attachmentId: string
+  filename: string
+  mimeType: string
+  size: number | null
+}
+
+export type GoogleWorkspaceGmailMessage = {
+  id: string
+  threadId: string
+  from: string
+  to: string
+  subject: string
+  date: string
+  snippet: string
+  body: string
+  attachments: GoogleWorkspaceAttachment[]
+}
+
+export type GoogleWorkspaceCalendarEvent = {
+  id: string
+  summary: string
+  description: string
+  location: string
+  start: string
+  end: string
+  status: string
+  htmlLink: string
+  attendees: string[]
+}
+
+export type GoogleWorkspaceDriveFile = {
+  id: string
+  name: string
+  mimeType: string
+  modifiedTime: string
+  webViewLink: string
+  size: string | null
+}
+
+type GmailBodyState = {
+  plain: string | null
+  html: string | null
+  attachments: GoogleWorkspaceAttachment[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readRecord(record: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const value = record[key]
+  return isRecord(value) ? value : null
+}
+
+function readArray(record: Record<string, unknown>, key: string): unknown[] {
+  const value = record[key]
+  return Array.isArray(value) ? value : []
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key]
+  return typeof value === "string" ? value : ""
+}
+
+function readNumber(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key]
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function decodeBase64Url(value: string): string {
+  try {
+    return Buffer.from(value, "base64url").toString("utf8")
+  } catch {
+    return ""
+  }
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/[ \t\f\v]+/g, " ")
+    .replace(/\n\s+/g, "\n")
+    .trim()
+}
+
+function collectGmailPart(part: Record<string, unknown>, state: GmailBodyState) {
+  const mimeType = readString(part, "mimeType")
+  const filename = readString(part, "filename")
+  const body = readRecord(part, "body")
+  if (body) {
+    const attachmentId = readString(body, "attachmentId")
+    if (filename && attachmentId) {
+      state.attachments.push({
+        attachmentId,
+        filename,
+        mimeType,
+        size: readNumber(body, "size"),
+      })
+    }
+
+    const data = readString(body, "data")
+    if (data && mimeType === "text/plain" && state.plain === null) {
+      state.plain = decodeBase64Url(data)
+    }
+    if (data && mimeType === "text/html" && state.html === null) {
+      state.html = stripHtml(decodeBase64Url(data))
+    }
+  }
+
+  for (const child of readArray(part, "parts")) {
+    if (isRecord(child)) {
+      collectGmailPart(child, state)
+    }
+  }
+}
+
+function readGmailHeaders(payload: Record<string, unknown>) {
+  const headers = new Map<string, string>()
+  for (const header of readArray(payload, "headers")) {
+    if (!isRecord(header)) continue
+    const name = readString(header, "name").toLowerCase()
+    const value = readString(header, "value")
+    if (name && value) {
+      headers.set(name, value)
+    }
+  }
+  return headers
+}
+
+export function truncateText(text: string, maxCharacters: number): { text: string; truncated: boolean } {
+  if (text.length <= maxCharacters) {
+    return { text, truncated: false }
+  }
+  return { text: text.slice(0, maxCharacters), truncated: true }
+}
+
+export function buildDriveSearchQuery(text: string): string {
+  const escaped = text.replace(/\\/g, "\\\\").replace(/'/g, "\\'")
+  return `trashed = false and (name contains '${escaped}' or fullText contains '${escaped}')`
+}
+
+export function extractGmailMessage(payloadJson: unknown): GoogleWorkspaceGmailMessage {
+  const message = isRecord(payloadJson) ? payloadJson : {}
+  const payload = readRecord(message, "payload") ?? {}
+  const headers = readGmailHeaders(payload)
+  const state: GmailBodyState = { plain: null, html: null, attachments: [] }
+  collectGmailPart(payload, state)
+  const snippet = readString(message, "snippet")
+  const body = truncateText(state.plain ?? state.html ?? snippet, 100_000).text
+
+  return {
+    id: readString(message, "id"),
+    threadId: readString(message, "threadId"),
+    from: headers.get("from") ?? "",
+    to: headers.get("to") ?? "",
+    subject: headers.get("subject") ?? "",
+    date: headers.get("date") ?? "",
+    snippet,
+    body,
+    attachments: state.attachments,
+  }
+}
+
+export function extractGmailMessageIds(json: unknown, limit: number): string[] {
+  const root = isRecord(json) ? json : {}
+  const ids: string[] = []
+  for (const item of readArray(root, "messages")) {
+    if (!isRecord(item)) continue
+    const id = readString(item, "id")
+    if (!id) continue
+    ids.push(id)
+    if (ids.length >= limit) break
+  }
+  return ids
+}
+
+function calendarEventTime(event: Record<string, unknown>, key: string): string {
+  const time = readRecord(event, key)
+  if (!time) return ""
+  const dateTime = readString(time, "dateTime")
+  if (dateTime) return dateTime
+  return readString(time, "date")
+}
+
+export function extractCalendarEvents(json: unknown): GoogleWorkspaceCalendarEvent[] {
+  const root = isRecord(json) ? json : {}
+  const events: GoogleWorkspaceCalendarEvent[] = []
+  for (const item of readArray(root, "items")) {
+    if (!isRecord(item)) continue
+    const attendees: string[] = []
+    for (const attendee of readArray(item, "attendees")) {
+      if (!isRecord(attendee)) continue
+      const email = readString(attendee, "email")
+      if (email) attendees.push(email)
+    }
+    events.push({
+      id: readString(item, "id"),
+      summary: readString(item, "summary"),
+      description: readString(item, "description"),
+      location: readString(item, "location"),
+      start: calendarEventTime(item, "start"),
+      end: calendarEventTime(item, "end"),
+      status: readString(item, "status"),
+      htmlLink: readString(item, "htmlLink"),
+      attendees,
+    })
+  }
+  return events
+}
+
+export function extractDriveFiles(json: unknown): GoogleWorkspaceDriveFile[] {
+  const root = isRecord(json) ? json : {}
+  const files: GoogleWorkspaceDriveFile[] = []
+  for (const item of readArray(root, "files")) {
+    if (!isRecord(item)) continue
+    const size = readString(item, "size")
+    files.push({
+      id: readString(item, "id"),
+      name: readString(item, "name"),
+      mimeType: readString(item, "mimeType"),
+      modifiedTime: readString(item, "modifiedTime"),
+      webViewLink: readString(item, "webViewLink"),
+      size: size || null,
+    })
+  }
+  return files
+}

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -1,13 +1,32 @@
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
+import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import { env } from "../../env.js"
-import { jsonValidator, orgMemberRoute } from "../../middleware/index.js"
+import { jsonValidator, orgMemberRoute, paramValidator, queryValidator } from "../../middleware/index.js"
 import { jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import { buildGmailDraftRaw, readGmailDraftIds } from "../../capability-sources/gmail.js"
 import { getValidAccessToken } from "../../capability-sources/generic-oauth.js"
+import {
+  buildDriveSearchQuery,
+  extractCalendarEvents,
+  extractDriveFiles,
+  extractGmailMessage,
+  extractGmailMessageIds,
+  truncateText,
+} from "../../capability-sources/google-workspace-api.js"
+import type { ConnectedAccountRow } from "../../capability-sources/oauth-credentials.js"
 import { getNativeOAuthProvider } from "../../capability-sources/provider-registry.js"
 import type { OrgRouteVariables } from "./shared.js"
+
+const GMAIL_READ_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
+const CALENDAR_READ_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
+const CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
+const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file"
+const DRIVE_READ_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
+const DRIVE_FULL_SCOPE = "https://www.googleapis.com/auth/drive"
+
+const CONNECT_GOOGLE_ACCOUNT_MESSAGE = "Connect your Google account first: open Settings, then Extensions, and use Connect your account on the Google Workspace card."
 
 const createDraftBodySchema = z.object({
   to: z.string().trim().min(3).max(320).describe("Recipient email address."),
@@ -33,8 +52,206 @@ const upstreamErrorSchema = z.object({
   message: z.string(),
 }).meta({ ref: "GoogleWorkspaceUpstreamError" })
 
+const gmailMessagesQuerySchema = z.object({
+  q: z.string().trim().min(1).max(1_000).optional().describe("Optional Gmail search query, using Gmail's search syntax."),
+  maxResults: z.coerce.number().int().min(1).max(25).default(10).describe("Maximum messages to return, capped at 25."),
+}).meta({ ref: "GoogleWorkspaceGmailMessagesQuery" })
+
+const gmailMessageParamSchema = z.object({
+  messageId: z.string().trim().min(1).max(512).describe("Gmail message id."),
+}).meta({ ref: "GoogleWorkspaceGmailMessageParams" })
+
+const gmailAttachmentSchema = z.object({
+  attachmentId: z.string(),
+  filename: z.string(),
+  mimeType: z.string(),
+  size: z.number().nullable(),
+}).meta({ ref: "GoogleWorkspaceGmailAttachment" })
+
+const gmailMessageSummarySchema = z.object({
+  id: z.string(),
+  threadId: z.string(),
+  from: z.string(),
+  to: z.string(),
+  subject: z.string(),
+  date: z.string(),
+  snippet: z.string(),
+}).meta({ ref: "GoogleWorkspaceGmailMessageSummary" })
+
+const gmailMessageSchema = gmailMessageSummarySchema.extend({
+  body: z.string(),
+  attachments: z.array(gmailAttachmentSchema),
+}).meta({ ref: "GoogleWorkspaceGmailMessage" })
+
+const gmailMessagesResponseSchema = z.object({
+  ok: z.literal(true),
+  messages: z.array(gmailMessageSummarySchema),
+}).meta({ ref: "GoogleWorkspaceGmailMessagesResponse" })
+
+const gmailMessageResponseSchema = z.object({
+  ok: z.literal(true),
+  message: gmailMessageSchema,
+}).meta({ ref: "GoogleWorkspaceGmailMessageResponse" })
+
+const calendarEventsQuerySchema = z.object({
+  timeMin: z.string().datetime().describe("Inclusive lower bound for event start time."),
+  timeMax: z.string().datetime().describe("Exclusive upper bound for event start time."),
+  maxResults: z.coerce.number().int().min(1).max(100).default(25).describe("Maximum events to return, capped at 100."),
+}).meta({ ref: "GoogleWorkspaceCalendarEventsQuery" })
+
+const calendarEventSchema = z.object({
+  id: z.string(),
+  summary: z.string(),
+  description: z.string(),
+  location: z.string(),
+  start: z.string(),
+  end: z.string(),
+  status: z.string(),
+  htmlLink: z.string(),
+  attendees: z.array(z.string()),
+}).meta({ ref: "GoogleWorkspaceCalendarEvent" })
+
+const calendarEventsResponseSchema = z.object({
+  ok: z.literal(true),
+  events: z.array(calendarEventSchema),
+}).meta({ ref: "GoogleWorkspaceCalendarEventsResponse" })
+
+const createCalendarEventBodySchema = z.object({
+  summary: z.string().trim().min(1).max(1_000).describe("Event title."),
+  description: z.string().max(20_000).optional().describe("Optional event description."),
+  location: z.string().max(1_000).optional().describe("Optional event location."),
+  start: z.string().datetime().describe("Event start date-time."),
+  end: z.string().datetime().describe("Event end date-time."),
+  timeZone: z.string().trim().min(1).max(128).optional().describe("Optional IANA time zone for start and end."),
+  attendees: z.array(z.string().email()).max(100).optional().describe("Optional attendee email addresses."),
+}).meta({ ref: "GoogleWorkspaceCreateCalendarEventBody" })
+
+const createCalendarEventResponseSchema = z.object({
+  ok: z.literal(true),
+  eventId: z.string(),
+  htmlLink: z.string(),
+  summary: z.string(),
+  start: z.string(),
+  end: z.string(),
+}).meta({ ref: "GoogleWorkspaceCreateCalendarEventResponse" })
+
+const driveFilesQuerySchema = z.object({
+  query: z.string().trim().min(1).max(500).describe("Text to search in Drive file names and full text."),
+  maxResults: z.coerce.number().int().min(1).max(25).default(10).describe("Maximum files to return, capped at 25."),
+}).meta({ ref: "GoogleWorkspaceDriveFilesQuery" })
+
+const driveFileParamSchema = z.object({
+  fileId: z.string().trim().min(1).max(512).describe("Google Drive file id."),
+}).meta({ ref: "GoogleWorkspaceDriveFileParams" })
+
+const driveFileSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  mimeType: z.string(),
+  modifiedTime: z.string(),
+  webViewLink: z.string(),
+  size: z.string().nullable(),
+}).meta({ ref: "GoogleWorkspaceDriveFileSummary" })
+
+const driveFilesResponseSchema = z.object({
+  ok: z.literal(true),
+  files: z.array(driveFileSummarySchema),
+}).meta({ ref: "GoogleWorkspaceDriveFilesResponse" })
+
+const driveFileResponseSchema = z.object({
+  ok: z.literal(true),
+  file: driveFileSummarySchema.extend({
+    content: z.string(),
+    truncated: z.boolean(),
+  }),
+}).meta({ ref: "GoogleWorkspaceDriveFileResponse" })
+
+type GoogleWorkspaceAccessToken =
+  | { kind: "ok"; accessToken: string; account: ConnectedAccountRow }
+  | { kind: "needs_connection"; message: string }
+  | { kind: "google_api_error"; message: string }
+
+type CalendarEventCreatePayload = {
+  summary: string
+  description?: string
+  location?: string
+  start: { dateTime: string; timeZone?: string }
+  end: { dateTime: string; timeZone?: string }
+  attendees?: { email: string }[]
+}
+
 function gmailApiBase(): string {
   return (env.googleApiBaseUrl ?? "https://gmail.googleapis.com").replace(/\/+$/, "")
+}
+
+function calendarApiBase(): string {
+  // Calendar and Drive normally share www.googleapis.com; one env knob keeps Google API tests simple.
+  return (env.googleApiBaseUrl ?? "https://www.googleapis.com").replace(/\/+$/, "")
+}
+
+function driveApiBase(): string {
+  // Calendar and Drive normally share www.googleapis.com; one env knob keeps Google API tests simple.
+  return (env.googleApiBaseUrl ?? "https://www.googleapis.com").replace(/\/+$/, "")
+}
+
+export function missingScope(account: ConnectedAccountRow, anyOf: string[]): boolean {
+  const scopes = account.scopes
+  if (!Array.isArray(scopes) || scopes.length === 0) {
+    return false
+  }
+  return !anyOf.some((scope) => scopes.includes(scope))
+}
+
+function missingPermissionMessage(label: string): string {
+  return `Your connected Google account is missing the ${label} permission. An admin can enable it on the Google Workspace connection in OpenWork Cloud -> Connections; then reconnect your account in Settings -> Extensions.`
+}
+
+async function googleWorkspaceToken(input: {
+  organizationId: DenTypeId<"organization">
+  orgMembershipId: DenTypeId<"member">
+}): Promise<GoogleWorkspaceAccessToken> {
+  const provider = getNativeOAuthProvider("google-workspace")
+  if (!provider) {
+    return { kind: "google_api_error", message: "google-workspace provider is not registered." }
+  }
+
+  const token = await getValidAccessToken({
+    provider,
+    organizationId: input.organizationId,
+    orgMembershipId: input.orgMembershipId,
+  })
+  if ("error" in token) {
+    return { kind: "needs_connection", message: CONNECT_GOOGLE_ACCOUNT_MESSAGE }
+  }
+
+  return { kind: "ok", accessToken: token.accessToken, account: token.account }
+}
+
+async function googleApiError(operation: string, response: Response) {
+  const text = await response.text()
+  return { error: "google_api_error", message: `${operation} failed: ${response.status} ${text.slice(0, 300)}` }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const body: unknown = await response.json()
+  return body
+}
+
+function buildCalendarEventPayload(input: z.infer<typeof createCalendarEventBodySchema>): CalendarEventCreatePayload {
+  const start: CalendarEventCreatePayload["start"] = { dateTime: input.start }
+  const end: CalendarEventCreatePayload["end"] = { dateTime: input.end }
+  if (input.timeZone) {
+    start.timeZone = input.timeZone
+    end.timeZone = input.timeZone
+  }
+
+  const payload: CalendarEventCreatePayload = { summary: input.summary, start, end }
+  if (input.description) payload.description = input.description
+  if (input.location) payload.location = input.location
+  if (input.attendees?.length) {
+    payload.attendees = input.attendees.map((email) => ({ email }))
+  }
+  return payload
 }
 
 /**
@@ -44,6 +261,358 @@ function gmailApiBase(): string {
  * them — the agent path needs no MCP server and no extra wiring.
  */
 export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVariables }>(app: Hono<T>) {
+  app.get(
+    "/v1/capabilities/google-workspace/gmail-messages",
+    describeRoute({
+      tags: ["Capability Sources"],
+      summary: "List or search Gmail messages as the calling member",
+      description: "Reads and searches inbox mail in the calling member's Gmail mailbox, using the Google account they connected through the org Google Workspace connection. Returns needs_connection when the member has not connected their Google account yet or the connection lacks Gmail read permission.",
+      responses: {
+        200: jsonResponse("Gmail messages returned.", gmailMessagesResponseSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
+        502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
+      },
+    }),
+    orgMemberRoute(),
+    queryValidator(gmailMessagesQuerySchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const token = await googleWorkspaceToken({
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+      })
+      if (token.kind === "google_api_error") {
+        return c.json({ error: "google_api_error", message: token.message }, 502)
+      }
+      if (token.kind === "needs_connection") {
+        return c.json({ error: "needs_connection", message: token.message }, 409)
+      }
+      if (missingScope(token.account, [GMAIL_READ_SCOPE])) {
+        return c.json({ error: "needs_connection", message: missingPermissionMessage("Gmail read") }, 409)
+      }
+
+      const query = c.req.valid("query")
+      const listUrl = new URL(`${gmailApiBase()}/gmail/v1/users/me/messages`)
+      if (query.q) listUrl.searchParams.set("q", query.q)
+      listUrl.searchParams.set("maxResults", String(query.maxResults))
+
+      const listResponse = await fetch(listUrl, {
+        headers: { authorization: `Bearer ${token.accessToken}` },
+      })
+      if (!listResponse.ok) {
+        return c.json(await googleApiError("Gmail messages list", listResponse), 502)
+      }
+
+      const ids = extractGmailMessageIds(await readJson(listResponse), 25)
+      const messages: z.infer<typeof gmailMessageSummarySchema>[] = []
+      for (const id of ids) {
+        const messageUrl = new URL(`${gmailApiBase()}/gmail/v1/users/me/messages/${encodeURIComponent(id)}`)
+        messageUrl.searchParams.set("format", "metadata")
+        messageUrl.searchParams.append("metadataHeaders", "From")
+        messageUrl.searchParams.append("metadataHeaders", "To")
+        messageUrl.searchParams.append("metadataHeaders", "Subject")
+        messageUrl.searchParams.append("metadataHeaders", "Date")
+        const messageResponse = await fetch(messageUrl, {
+          headers: { authorization: `Bearer ${token.accessToken}` },
+        })
+        if (!messageResponse.ok) {
+          return c.json(await googleApiError("Gmail message metadata", messageResponse), 502)
+        }
+        const message = extractGmailMessage(await readJson(messageResponse))
+        messages.push({
+          id: message.id,
+          threadId: message.threadId,
+          from: message.from,
+          to: message.to,
+          subject: message.subject,
+          date: message.date,
+          snippet: message.snippet,
+        })
+      }
+
+      return c.json({ ok: true, messages })
+    },
+  )
+
+  // Singular by-id route segments keep structuralShorten from colliding with the plural list tool names.
+  app.get(
+    "/v1/capabilities/google-workspace/gmail-message/:messageId",
+    describeRoute({
+      tags: ["Capability Sources"],
+      summary: "Read a Gmail message with its plain-text body as the calling member",
+      description: "Reads one Gmail message, including decoded plain-text body content and attachment metadata, using the calling member's connected Google Workspace account.",
+      responses: {
+        200: jsonResponse("Gmail message returned.", gmailMessageResponseSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
+        502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
+      },
+    }),
+    orgMemberRoute(),
+    paramValidator(gmailMessageParamSchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const token = await googleWorkspaceToken({
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+      })
+      if (token.kind === "google_api_error") {
+        return c.json({ error: "google_api_error", message: token.message }, 502)
+      }
+      if (token.kind === "needs_connection") {
+        return c.json({ error: "needs_connection", message: token.message }, 409)
+      }
+      if (missingScope(token.account, [GMAIL_READ_SCOPE])) {
+        return c.json({ error: "needs_connection", message: missingPermissionMessage("Gmail read") }, 409)
+      }
+
+      const { messageId } = c.req.valid("param")
+      const messageUrl = new URL(`${gmailApiBase()}/gmail/v1/users/me/messages/${encodeURIComponent(messageId)}`)
+      messageUrl.searchParams.set("format", "full")
+      const response = await fetch(messageUrl, {
+        headers: { authorization: `Bearer ${token.accessToken}` },
+      })
+      if (!response.ok) {
+        return c.json(await googleApiError("Gmail message read", response), 502)
+      }
+
+      return c.json({ ok: true, message: extractGmailMessage(await readJson(response)) })
+    },
+  )
+
+  app.get(
+    "/v1/capabilities/google-workspace/calendar-events",
+    describeRoute({
+      tags: ["Capability Sources"],
+      summary: "List Google Calendar events in a time range as the calling member",
+      description: "Lists primary-calendar events for the calling member in a requested ISO time range, using their connected Google Workspace account.",
+      responses: {
+        200: jsonResponse("Google Calendar events returned.", calendarEventsResponseSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
+        502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
+      },
+    }),
+    orgMemberRoute(),
+    queryValidator(calendarEventsQuerySchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const token = await googleWorkspaceToken({
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+      })
+      if (token.kind === "google_api_error") {
+        return c.json({ error: "google_api_error", message: token.message }, 502)
+      }
+      if (token.kind === "needs_connection") {
+        return c.json({ error: "needs_connection", message: token.message }, 409)
+      }
+      if (missingScope(token.account, [CALENDAR_READ_SCOPE, CALENDAR_EVENTS_SCOPE])) {
+        return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Calendar read") }, 409)
+      }
+
+      const query = c.req.valid("query")
+      const url = new URL(`${calendarApiBase()}/calendar/v3/calendars/primary/events`)
+      url.searchParams.set("timeMin", query.timeMin)
+      url.searchParams.set("timeMax", query.timeMax)
+      url.searchParams.set("singleEvents", "true")
+      url.searchParams.set("orderBy", "startTime")
+      url.searchParams.set("maxResults", String(query.maxResults))
+
+      const response = await fetch(url, {
+        headers: { authorization: `Bearer ${token.accessToken}` },
+      })
+      if (!response.ok) {
+        return c.json(await googleApiError("Google Calendar events list", response), 502)
+      }
+
+      return c.json({ ok: true, events: extractCalendarEvents(await readJson(response)) })
+    },
+  )
+
+  app.post(
+    "/v1/capabilities/google-workspace/calendar-events",
+    describeRoute({
+      tags: ["Capability Sources"],
+      summary: "Create a Google Calendar event as the calling member",
+      description: "Creates an event on the calling member's primary Google Calendar, using their connected Google Workspace account.",
+      responses: {
+        200: jsonResponse("Google Calendar event created.", createCalendarEventResponseSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
+        502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
+      },
+    }),
+    orgMemberRoute(),
+    jsonValidator(createCalendarEventBodySchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const token = await googleWorkspaceToken({
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+      })
+      if (token.kind === "google_api_error") {
+        return c.json({ error: "google_api_error", message: token.message }, 502)
+      }
+      if (token.kind === "needs_connection") {
+        return c.json({ error: "needs_connection", message: token.message }, 409)
+      }
+      if (missingScope(token.account, [CALENDAR_EVENTS_SCOPE])) {
+        return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Calendar write") }, 409)
+      }
+
+      const input = c.req.valid("json")
+      const response = await fetch(`${calendarApiBase()}/calendar/v3/calendars/primary/events`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token.accessToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(buildCalendarEventPayload(input)),
+      })
+      if (!response.ok) {
+        return c.json(await googleApiError("Google Calendar event create", response), 502)
+      }
+
+      const event = extractCalendarEvents({ items: [await readJson(response)] })[0]
+      if (!event?.id) {
+        return c.json({ error: "google_api_error", message: "Google Calendar returned no event id." }, 502)
+      }
+
+      return c.json({
+        ok: true,
+        eventId: event.id,
+        htmlLink: event.htmlLink,
+        summary: event.summary,
+        start: event.start,
+        end: event.end,
+      })
+    },
+  )
+
+  app.get(
+    "/v1/capabilities/google-workspace/drive-files",
+    describeRoute({
+      tags: ["Capability Sources"],
+      summary: "Search Google Drive files as the calling member",
+      description: "Searches the calling member's Google Drive files by name and full text, using their connected Google Workspace account.",
+      responses: {
+        200: jsonResponse("Google Drive files returned.", driveFilesResponseSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
+        502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
+      },
+    }),
+    orgMemberRoute(),
+    queryValidator(driveFilesQuerySchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const token = await googleWorkspaceToken({
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+      })
+      if (token.kind === "google_api_error") {
+        return c.json({ error: "google_api_error", message: token.message }, 502)
+      }
+      if (token.kind === "needs_connection") {
+        return c.json({ error: "needs_connection", message: token.message }, 409)
+      }
+      if (missingScope(token.account, [DRIVE_READ_SCOPE, DRIVE_FULL_SCOPE, DRIVE_FILE_SCOPE])) {
+        return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Drive read") }, 409)
+      }
+
+      const query = c.req.valid("query")
+      const url = new URL(`${driveApiBase()}/drive/v3/files`)
+      url.searchParams.set("q", buildDriveSearchQuery(query.query))
+      url.searchParams.set("pageSize", String(query.maxResults))
+      url.searchParams.set("fields", "files(id,name,mimeType,modifiedTime,webViewLink,size)")
+
+      const response = await fetch(url, {
+        headers: { authorization: `Bearer ${token.accessToken}` },
+      })
+      if (!response.ok) {
+        return c.json(await googleApiError("Google Drive files search", response), 502)
+      }
+
+      return c.json({ ok: true, files: extractDriveFiles(await readJson(response)) })
+    },
+  )
+
+  app.get(
+    "/v1/capabilities/google-workspace/drive-file/:fileId",
+    describeRoute({
+      tags: ["Capability Sources"],
+      summary: "Read a Google Drive file's text content as the calling member",
+      description: "Reads text from one Google Drive file, exporting Google Docs editors files as plain text and downloading other files as UTF-8 text with truncation.",
+      responses: {
+        200: jsonResponse("Google Drive file returned.", driveFileResponseSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
+        502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
+      },
+    }),
+    orgMemberRoute(),
+    paramValidator(driveFileParamSchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const token = await googleWorkspaceToken({
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+      })
+      if (token.kind === "google_api_error") {
+        return c.json({ error: "google_api_error", message: token.message }, 502)
+      }
+      if (token.kind === "needs_connection") {
+        return c.json({ error: "needs_connection", message: token.message }, 409)
+      }
+      if (missingScope(token.account, [DRIVE_READ_SCOPE, DRIVE_FULL_SCOPE, DRIVE_FILE_SCOPE])) {
+        return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Drive read") }, 409)
+      }
+
+      const { fileId } = c.req.valid("param")
+      const metadataUrl = new URL(`${driveApiBase()}/drive/v3/files/${encodeURIComponent(fileId)}`)
+      metadataUrl.searchParams.set("fields", "id,name,mimeType,modifiedTime,webViewLink,size")
+      const metadataResponse = await fetch(metadataUrl, {
+        headers: { authorization: `Bearer ${token.accessToken}` },
+      })
+      if (!metadataResponse.ok) {
+        return c.json(await googleApiError("Google Drive file metadata", metadataResponse), 502)
+      }
+
+      const file = extractDriveFiles({ files: [await readJson(metadataResponse)] })[0]
+      if (!file?.id) {
+        return c.json({ error: "google_api_error", message: "Google Drive returned no file id." }, 502)
+      }
+
+      const contentUrl = file.mimeType.startsWith("application/vnd.google-apps")
+        ? new URL(`${driveApiBase()}/drive/v3/files/${encodeURIComponent(fileId)}/export`)
+        : new URL(`${driveApiBase()}/drive/v3/files/${encodeURIComponent(fileId)}`)
+      if (file.mimeType.startsWith("application/vnd.google-apps")) {
+        contentUrl.searchParams.set("mimeType", "text/plain")
+      } else {
+        contentUrl.searchParams.set("alt", "media")
+      }
+
+      const contentResponse = await fetch(contentUrl, {
+        headers: { authorization: `Bearer ${token.accessToken}` },
+      })
+      if (!contentResponse.ok) {
+        return c.json(await googleApiError("Google Drive file content", contentResponse), 502)
+      }
+
+      const content = truncateText(await contentResponse.text(), 200_000)
+      return c.json({
+        ok: true,
+        file: {
+          ...file,
+          content: content.text,
+          truncated: content.truncated,
+        },
+      })
+    },
+  )
+
   app.post(
     "/v1/capabilities/google-workspace/gmail-drafts",
     describeRoute({
@@ -61,21 +630,15 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     jsonValidator(createDraftBodySchema),
     async (c) => {
       const payload = c.get("organizationContext")
-      const provider = getNativeOAuthProvider("google-workspace")
-      if (!provider) {
-        return c.json({ error: "google_api_error" as const, message: "google-workspace provider is not registered." }, 502)
-      }
-
-      const token = await getValidAccessToken({
-        provider,
+      const token = await googleWorkspaceToken({
         organizationId: payload.organization.id,
         orgMembershipId: payload.currentMember.id,
       })
-      if ("error" in token) {
-        return c.json({
-          error: "needs_connection" as const,
-          message: "Connect your Google account first: open Settings, then Extensions, and use Connect your account on the Google Workspace card.",
-        }, 409)
+      if (token.kind === "google_api_error") {
+        return c.json({ error: "google_api_error", message: token.message }, 502)
+      }
+      if (token.kind === "needs_connection") {
+        return c.json({ error: "needs_connection", message: token.message }, 409)
       }
 
       const { to, subject, body } = c.req.valid("json")
@@ -89,15 +652,15 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       })
       const text = await response.text()
       if (!response.ok) {
-        return c.json({ error: "google_api_error" as const, message: `Gmail draft create failed: ${response.status} ${text.slice(0, 300)}` }, 502)
+        return c.json({ error: "google_api_error", message: `Gmail draft create failed: ${response.status} ${text.slice(0, 300)}` }, 502)
       }
 
       const { draftId, messageId } = readGmailDraftIds(text)
       if (!draftId) {
-        return c.json({ error: "google_api_error" as const, message: "Gmail returned no draft id." }, 502)
+        return c.json({ error: "google_api_error", message: "Gmail returned no draft id." }, 502)
       }
 
-      return c.json({ ok: true as const, draftId, messageId, to, subject })
+      return c.json({ ok: true, draftId, messageId, to, subject })
     },
   )
 }

--- a/ee/apps/den-api/test/google-workspace-api.test.ts
+++ b/ee/apps/den-api/test/google-workspace-api.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test"
+import {
+  buildDriveSearchQuery,
+  extractCalendarEvents,
+  extractDriveFiles,
+  extractGmailMessage,
+  truncateText,
+} from "../src/capability-sources/google-workspace-api.js"
+
+function base64Url(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64url")
+}
+
+describe("extractGmailMessage", () => {
+  test("reads headers, nested plain-text body, and attachment metadata", () => {
+    const message = extractGmailMessage({
+      id: "msg_1",
+      threadId: "thread_1",
+      snippet: "Snippet fallback",
+      payload: {
+        mimeType: "multipart/mixed",
+        headers: [
+          { name: "From", value: "Ada <ada@example.com>" },
+          { name: "To", value: "Ben <ben@example.com>" },
+          { name: "Subject", value: "Nested body" },
+          { name: "Date", value: "Tue, 07 Jul 2026 10:00:00 +0000" },
+        ],
+        parts: [
+          {
+            mimeType: "multipart/alternative",
+            parts: [
+              { mimeType: "text/html", body: { data: base64Url("<p>HTML <strong>fallback</strong></p>") } },
+              { mimeType: "text/plain", body: { data: base64Url("Plain body from Gmail") } },
+            ],
+          },
+          {
+            filename: "report.pdf",
+            mimeType: "application/pdf",
+            body: { attachmentId: "att_1", size: 1234 },
+          },
+        ],
+      },
+    })
+
+    expect(message).toEqual({
+      id: "msg_1",
+      threadId: "thread_1",
+      from: "Ada <ada@example.com>",
+      to: "Ben <ben@example.com>",
+      subject: "Nested body",
+      date: "Tue, 07 Jul 2026 10:00:00 +0000",
+      snippet: "Snippet fallback",
+      body: "Plain body from Gmail",
+      attachments: [{ attachmentId: "att_1", filename: "report.pdf", mimeType: "application/pdf", size: 1234 }],
+    })
+  })
+
+  test("falls back from stripped html to snippet", () => {
+    expect(extractGmailMessage({
+      snippet: "Snippet text",
+      payload: { mimeType: "text/html", body: { data: base64Url("<div>Hello <b>HTML</b></div>") } },
+    }).body).toBe("Hello HTML")
+
+    expect(extractGmailMessage({ snippet: "Snippet text", payload: {} }).body).toBe("Snippet text")
+  })
+
+  test("truncates long bodies to Gmail's route budget", () => {
+    const message = extractGmailMessage({
+      snippet: "short",
+      payload: { mimeType: "text/plain", body: { data: base64Url("x".repeat(100_010)) } },
+    })
+    expect(message.body.length).toBe(100_000)
+  })
+})
+
+describe("extractCalendarEvents", () => {
+  test("maps dateTime and all-day date events", () => {
+    expect(extractCalendarEvents({
+      items: [
+        {
+          id: "event_1",
+          summary: "Planning",
+          description: "Discuss launch",
+          location: "Room 1",
+          start: { dateTime: "2026-07-08T10:00:00Z" },
+          end: { dateTime: "2026-07-08T10:30:00Z" },
+          status: "confirmed",
+          htmlLink: "https://calendar.google.com/event?eid=event_1",
+          attendees: [{ email: "ada@example.com" }, { email: "ben@example.com" }],
+        },
+        {
+          id: "event_2",
+          summary: "Offsite",
+          start: { date: "2026-07-09" },
+          end: { date: "2026-07-10" },
+        },
+      ],
+    })).toEqual([
+      {
+        id: "event_1",
+        summary: "Planning",
+        description: "Discuss launch",
+        location: "Room 1",
+        start: "2026-07-08T10:00:00Z",
+        end: "2026-07-08T10:30:00Z",
+        status: "confirmed",
+        htmlLink: "https://calendar.google.com/event?eid=event_1",
+        attendees: ["ada@example.com", "ben@example.com"],
+      },
+      {
+        id: "event_2",
+        summary: "Offsite",
+        description: "",
+        location: "",
+        start: "2026-07-09",
+        end: "2026-07-10",
+        status: "",
+        htmlLink: "",
+        attendees: [],
+      },
+    ])
+  })
+})
+
+describe("Drive helpers", () => {
+  test("buildDriveSearchQuery escapes quotes and backslashes", () => {
+    expect(buildDriveSearchQuery("it's \\ tricky")).toBe("trashed = false and (name contains 'it\\'s \\\\ tricky' or fullText contains 'it\\'s \\\\ tricky')")
+  })
+
+  test("extractDriveFiles maps file metadata and preserves absent size as null", () => {
+    expect(extractDriveFiles({
+      files: [
+        {
+          id: "file_1",
+          name: "Notes.txt",
+          mimeType: "text/plain",
+          modifiedTime: "2026-07-08T11:00:00Z",
+          webViewLink: "https://drive.google.com/file/d/file_1/view",
+          size: "42",
+        },
+        {
+          id: "doc_1",
+          name: "Doc",
+          mimeType: "application/vnd.google-apps.document",
+          modifiedTime: "2026-07-08T12:00:00Z",
+          webViewLink: "https://docs.google.com/document/d/doc_1/edit",
+        },
+      ],
+    })).toEqual([
+      {
+        id: "file_1",
+        name: "Notes.txt",
+        mimeType: "text/plain",
+        modifiedTime: "2026-07-08T11:00:00Z",
+        webViewLink: "https://drive.google.com/file/d/file_1/view",
+        size: "42",
+      },
+      {
+        id: "doc_1",
+        name: "Doc",
+        mimeType: "application/vnd.google-apps.document",
+        modifiedTime: "2026-07-08T12:00:00Z",
+        webViewLink: "https://docs.google.com/document/d/doc_1/edit",
+        size: null,
+      },
+    ])
+  })
+})
+
+describe("truncateText", () => {
+  test("reports whether content was truncated", () => {
+    expect(truncateText("short", 10)).toEqual({ text: "short", truncated: false })
+    expect(truncateText("abcdef", 3)).toEqual({ text: "abc", truncated: true })
+  })
+})

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -1,0 +1,419 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, beforeAll, beforeEach, expect, mock, test } from "bun:test"
+import type { OpenApiOperation } from "../src/mcp/policy.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_gwscaps"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "local-dev-secret-not-for-production-use!!"
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+function base64Url(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64url")
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+type TestOpenApiDocument = {
+  paths?: Record<string, Record<string, OpenApiOperation>>
+}
+
+function isOpenApiDocument(value: unknown): value is TestOpenApiDocument {
+  if (!isRecord(value)) return false
+  return value.paths === undefined || isRecord(value.paths)
+}
+
+function expectMessage(body: unknown): string {
+  if (!isRecord(body) || typeof body.message !== "string") {
+    throw new Error("Expected response body with a message string")
+  }
+  return body.message
+}
+
+const GMAIL_READ_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
+const CALENDAR_READ_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
+const CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
+const DRIVE_READ_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
+const FULL_SCOPES = [GMAIL_READ_SCOPE, CALENDAR_READ_SCOPE, CALENDAR_EVENTS_SCOPE, DRIVE_READ_SCOPE]
+
+let lastAuthorization: string | null = null
+let googleCallCount = 0
+let forceGoogleError = false
+let lastDriveQuery: string | null = null
+
+function resetFakeGoogle() {
+  lastAuthorization = null
+  googleCallCount = 0
+  forceGoogleError = false
+  lastDriveQuery = null
+}
+
+function gmailMessagePayload() {
+  return {
+    id: "msg_1",
+    threadId: "thread_1",
+    snippet: "Gmail snippet",
+    payload: {
+      mimeType: "multipart/mixed",
+      headers: [
+        { name: "From", value: "Ada <ada@example.com>" },
+        { name: "To", value: "Ben <ben@example.com>" },
+        { name: "Subject", value: "Quarterly plan" },
+        { name: "Date", value: "Tue, 07 Jul 2026 10:00:00 +0000" },
+      ],
+      parts: [
+        { mimeType: "text/plain", body: { data: base64Url("Plain Gmail body") } },
+        { filename: "plan.pdf", mimeType: "application/pdf", body: { attachmentId: "att_1", size: 123 } },
+      ],
+    },
+  }
+}
+
+const fakeGoogleServer = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  async fetch(request) {
+    const url = new URL(request.url)
+    googleCallCount += 1
+    lastAuthorization = request.headers.get("authorization")
+
+    if (forceGoogleError && url.pathname === "/calendar/v3/calendars/primary/events") {
+      return new Response("calendar exploded", { status: 500 })
+    }
+
+    if (url.pathname === "/gmail/v1/users/me/messages") {
+      return json({ messages: [{ id: "msg_1", threadId: "thread_1" }] })
+    }
+    if (url.pathname === "/gmail/v1/users/me/messages/msg_1") {
+      return json(gmailMessagePayload())
+    }
+
+    if (url.pathname === "/calendar/v3/calendars/primary/events" && request.method === "GET") {
+      return json({
+        items: [
+          {
+            id: "event_1",
+            summary: "Planning",
+            description: "Discuss launch",
+            location: "Room 1",
+            start: { dateTime: "2026-07-08T10:00:00Z" },
+            end: { dateTime: "2026-07-08T10:30:00Z" },
+            status: "confirmed",
+            htmlLink: "https://calendar.google.com/event?eid=event_1",
+            attendees: [{ email: "ada@example.com" }, { email: "ben@example.com" }],
+          },
+          {
+            id: "event_2",
+            summary: "Offsite",
+            start: { date: "2026-07-09" },
+            end: { date: "2026-07-10" },
+          },
+        ],
+      })
+    }
+    if (url.pathname === "/calendar/v3/calendars/primary/events" && request.method === "POST") {
+      return json({
+        id: "created_event_1",
+        summary: "Created event",
+        start: { dateTime: "2026-07-08T12:00:00Z" },
+        end: { dateTime: "2026-07-08T12:30:00Z" },
+        htmlLink: "https://calendar.google.com/event?eid=created_event_1",
+      })
+    }
+
+    if (url.pathname === "/drive/v3/files") {
+      lastDriveQuery = url.searchParams.get("q")
+      return json({
+        files: [
+          {
+            id: "file_1",
+            name: "Quarterly Plan.txt",
+            mimeType: "text/plain",
+            modifiedTime: "2026-07-08T11:00:00Z",
+            webViewLink: "https://drive.google.com/file/d/file_1/view",
+            size: "42",
+          },
+        ],
+      })
+    }
+    if (url.pathname === "/drive/v3/files/file_1" && url.searchParams.get("alt") === "media") {
+      return new Response("Drive file text", { headers: { "content-type": "text/plain" } })
+    }
+    if (url.pathname === "/drive/v3/files/file_1") {
+      return json({
+        id: "file_1",
+        name: "Quarterly Plan.txt",
+        mimeType: "text/plain",
+        modifiedTime: "2026-07-08T11:00:00Z",
+        webViewLink: "https://drive.google.com/file/d/file_1/view",
+        size: "42",
+      })
+    }
+    if (url.pathname === "/drive/v3/files/doc_1/export") {
+      return new Response("Exported doc text", { headers: { "content-type": "text/plain" } })
+    }
+
+    return new Response(`Unhandled fake Google route: ${url.pathname}`, { status: 404 })
+  },
+})
+
+seedRequiredEnv()
+process.env.DEN_GOOGLE_API_BASE_URL = fakeGoogleServer.url.origin
+
+let app: typeof import("../src/app.js").default
+let db: typeof import("../src/db.js").db
+let schema: typeof import("@openwork-ee/den-db/schema")
+let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+let session: typeof import("../src/session.js")
+let upsertConnectedAccount: typeof import("../src/capability-sources/oauth-credentials.js").upsertConnectedAccount
+let buildMcpCatalog: typeof import("../src/mcp/catalog.js").buildMcpCatalog
+let searchCapabilities: typeof import("../src/mcp/search.js").searchCapabilities
+
+const userId = createDenTypeId("user")
+const organizationId = createDenTypeId("organization")
+const memberId = createDenTypeId("member")
+
+async function seedConnectedAccount(scopes: string[] | null = FULL_SCOPES) {
+  await upsertConnectedAccount({
+    organizationId,
+    orgMembershipId: memberId,
+    providerId: "google-workspace",
+    externalAccountId: "google-user-1",
+    scopes,
+    accessToken: "gws-token",
+    refreshToken: "gws-refresh-token",
+    tokenType: "Bearer",
+    expiresAt: new Date("2037-01-01T00:00:00Z"),
+    pendingCodeVerifier: null,
+  })
+}
+
+function authHeaders(): Headers {
+  return new Headers({
+    "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId, organizationId }),
+  })
+}
+
+function request(path: string, init?: { method?: string; body?: unknown }) {
+  const headers = authHeaders()
+  const body = init?.body
+  if (body !== undefined) {
+    headers.set("content-type", "application/json")
+  }
+
+  return app.request(`http://den-api.local${path}`, {
+    method: init?.method ?? "GET",
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+}
+
+beforeAll(async () => {
+  mock.restore()
+  const realDb = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL,
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db: realDb }))
+
+  const [appMod, dbMod, schemaMod, drizzleMod, sessionMod, credentialsMod, catalogMod, searchMod] = await Promise.all([
+    import("../src/app.js"),
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+    import("../src/session.js"),
+    import("../src/capability-sources/oauth-credentials.js"),
+    import("../src/mcp/catalog.js"),
+    import("../src/mcp/search.js"),
+  ])
+  app = appMod.default
+  db = dbMod.db
+  schema = schemaMod
+  drizzle = drizzleMod
+  session = sessionMod
+  upsertConnectedAccount = credentialsMod.upsertConnectedAccount
+  buildMcpCatalog = catalogMod.buildMcpCatalog
+  searchCapabilities = searchMod.searchCapabilities
+
+  await db.insert(schema.AuthUserTable).values({
+    id: userId,
+    name: "Google Workspace Capabilities User",
+    email: `gws-caps+${userId}@test.local`,
+  })
+  await db.insert(schema.OrganizationTable).values({
+    id: organizationId,
+    name: "Google Workspace Capabilities Org",
+    slug: `gws-caps-${organizationId}`,
+  })
+  await db.insert(schema.MemberTable).values({
+    id: memberId,
+    organizationId,
+    userId,
+    role: "member",
+  })
+})
+
+beforeEach(async () => {
+  resetFakeGoogle()
+  await db.delete(schema.ConnectedAccountTable).where(drizzle.eq(schema.ConnectedAccountTable.organizationId, organizationId))
+  await seedConnectedAccount()
+})
+
+afterAll(async () => {
+  await db.delete(schema.ConnectedAccountTable).where(drizzle.eq(schema.ConnectedAccountTable.organizationId, organizationId))
+  await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.organizationId, organizationId))
+  await db.delete(schema.OrganizationRoleTable).where(drizzle.eq(schema.OrganizationRoleTable.organizationId, organizationId))
+  await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+  await db.delete(schema.AuthUserTable).where(drizzle.eq(schema.AuthUserTable.id, userId))
+  fakeGoogleServer.stop(true)
+  mock.restore()
+})
+
+test("calendar list returns mapped events and sends the member token", async () => {
+  const response = await request("/v1/capabilities/google-workspace/calendar-events?timeMin=2026-07-08T00%3A00%3A00Z&timeMax=2026-07-11T00%3A00%3A00Z")
+  expect(response.status).toBe(200)
+  expect(lastAuthorization).toBe("Bearer gws-token")
+  const body: unknown = await response.json()
+  expect(body).toEqual({
+    ok: true,
+    events: [
+      {
+        id: "event_1",
+        summary: "Planning",
+        description: "Discuss launch",
+        location: "Room 1",
+        start: "2026-07-08T10:00:00Z",
+        end: "2026-07-08T10:30:00Z",
+        status: "confirmed",
+        htmlLink: "https://calendar.google.com/event?eid=event_1",
+        attendees: ["ada@example.com", "ben@example.com"],
+      },
+      {
+        id: "event_2",
+        summary: "Offsite",
+        description: "",
+        location: "",
+        start: "2026-07-09",
+        end: "2026-07-10",
+        status: "",
+        htmlLink: "",
+        attendees: [],
+      },
+    ],
+  })
+})
+
+test("gmail list returns metadata-mapped messages", async () => {
+  const response = await request("/v1/capabilities/google-workspace/gmail-messages?q=from%3Aada&maxResults=5")
+  expect(response.status).toBe(200)
+  expect(lastAuthorization).toBe("Bearer gws-token")
+  const body: unknown = await response.json()
+  expect(body).toEqual({
+    ok: true,
+    messages: [
+      {
+        id: "msg_1",
+        threadId: "thread_1",
+        from: "Ada <ada@example.com>",
+        to: "Ben <ben@example.com>",
+        subject: "Quarterly plan",
+        date: "Tue, 07 Jul 2026 10:00:00 +0000",
+        snippet: "Gmail snippet",
+      },
+    ],
+  })
+})
+
+test("drive search returns mapped files", async () => {
+  const response = await request("/v1/capabilities/google-workspace/drive-files?query=quarterly&maxResults=3")
+  expect(response.status).toBe(200)
+  expect(lastAuthorization).toBe("Bearer gws-token")
+  expect(lastDriveQuery).toBe("trashed = false and (name contains 'quarterly' or fullText contains 'quarterly')")
+  const body: unknown = await response.json()
+  expect(body).toEqual({
+    ok: true,
+    files: [
+      {
+        id: "file_1",
+        name: "Quarterly Plan.txt",
+        mimeType: "text/plain",
+        modifiedTime: "2026-07-08T11:00:00Z",
+        webViewLink: "https://drive.google.com/file/d/file_1/view",
+        size: "42",
+      },
+    ],
+  })
+})
+
+test("no connected account returns needs_connection", async () => {
+  await db.delete(schema.ConnectedAccountTable).where(drizzle.eq(schema.ConnectedAccountTable.organizationId, organizationId))
+  const response = await request("/v1/capabilities/google-workspace/calendar-events?timeMin=2026-07-08T00%3A00%3A00Z&timeMax=2026-07-11T00%3A00%3A00Z")
+  expect(response.status).toBe(409)
+  expect(googleCallCount).toBe(0)
+  const body: unknown = await response.json()
+  expect(body).toEqual({
+    error: "needs_connection",
+    message: "Connect your Google account first: open Settings, then Extensions, and use Connect your account on the Google Workspace card.",
+  })
+})
+
+test("missing Gmail read scope returns needs_connection without calling Google", async () => {
+  await seedConnectedAccount([CALENDAR_READ_SCOPE, CALENDAR_EVENTS_SCOPE, DRIVE_READ_SCOPE])
+  resetFakeGoogle()
+  const response = await request("/v1/capabilities/google-workspace/gmail-messages")
+  expect(response.status).toBe(409)
+  expect(googleCallCount).toBe(0)
+  const body: unknown = await response.json()
+  expect(expectMessage(body)).toContain("missing the Gmail read permission")
+})
+
+test("Google errors become 502 google_api_error", async () => {
+  forceGoogleError = true
+  const response = await request("/v1/capabilities/google-workspace/calendar-events?timeMin=2026-07-08T00%3A00%3A00Z&timeMax=2026-07-11T00%3A00%3A00Z")
+  expect(response.status).toBe(502)
+  const body: unknown = await response.json()
+  expect(body).toEqual({
+    error: "google_api_error",
+    message: "Google Calendar events list failed: 500 calendar exploded",
+  })
+})
+
+test("Google Workspace capability tools are discoverable and keep readable names", async () => {
+  const openApiResponse = await app.request("http://den-api.local/openapi.json")
+  expect(openApiResponse.status).toBe(200)
+  const document: unknown = await openApiResponse.json()
+  if (!isOpenApiDocument(document)) {
+    throw new Error("openapi.json did not look like an OpenAPI document")
+  }
+
+  const catalog = buildMcpCatalog(document)
+  expect(searchCapabilities(catalog, "calendar events list", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceCalendarEvents")
+  expect(searchCapabilities(catalog, "drive files", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceDriveFiles")
+  expect(searchCapabilities(catalog, "gmail search read messages", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceGmailMessages")
+
+  const expectedNames = [
+    "getCapabilitiesGoogleWorkspaceGmailMessages",
+    "getCapabilitiesGoogleWorkspaceGmailMessage",
+    "getCapabilitiesGoogleWorkspaceCalendarEvents",
+    "postCapabilitiesGoogleWorkspaceCalendarEvents",
+    "getCapabilitiesGoogleWorkspaceDriveFiles",
+    "getCapabilitiesGoogleWorkspaceDriveFile",
+  ]
+  const catalogNames = new Set(catalog.map((tool) => tool.name))
+  for (const name of expectedNames) {
+    expect(catalogNames.has(name)).toBe(true)
+    expect(name.length).toBeLessThanOrEqual(49)
+    expect(name).not.toMatch(/_[a-z0-9]{7}/)
+  }
+})


### PR DESCRIPTION
## Summary

PR #2558 made the org Google Workspace connection's permissions granular (gmailRead, calendarRead/Write, driveRead/File/Full, chat) — but the capability surface never grew past the single `gmail-drafts` route from #2455. Agents searching the cloud catalog got noise or nothing:

- `"gmail search read messages"` → `getMemorySearch` tied with gmail-drafts (score 8)
- `"calendar events list"` → `getConnectorSyncEvents` (score 10) — zero calendar capabilities existed
- `"drive files"` → `[]`

This PR builds the missing half: six read/write capabilities riding the exact gmail-drafts pattern (tags `Capability Sources`, `orgMemberRoute`, member-brokered `getValidAccessToken`, 409 `needs_connection`, 502 `google_api_error`).

## New capabilities

| Tool name | Route |
|---|---|
| `getCapabilitiesGoogleWorkspaceGmailMessages` | `GET /v1/capabilities/google-workspace/gmail-messages` (list/search) |
| `getCapabilitiesGoogleWorkspaceGmailMessage` | `GET …/gmail-message/{messageId}` (plain-text body + attachments) |
| `getCapabilitiesGoogleWorkspaceCalendarEvents` | `GET …/calendar-events?timeMin&timeMax` |
| `postCapabilitiesGoogleWorkspaceCalendarEvents` | `POST …/calendar-events` |
| `getCapabilitiesGoogleWorkspaceDriveFiles` | `GET …/drive-files?query=` |
| `getCapabilitiesGoogleWorkspaceDriveFile` | `GET …/drive-file/{fileId}` (text content, Google-Docs export aware) |

Notes:
- Singular by-id path segments keep `structuralShorten` tool names collision-free (no hash suffixes; all ≤ 49 chars).
- Proactive scope gating: if the member's connected account is missing the required scope (e.g. `gmail.readonly`), the route returns 409 with "an admin can enable it on the Google Workspace connection… then reconnect" — without calling Google. Unknown scopes fall through to Google's own error.
- Pure response parsing/query building lives in `capability-sources/google-workspace-api.ts` (no `any`, `unknown` + narrowing), mirroring `gmail.ts`.
- Calendar/Drive share the existing `DEN_GOOGLE_API_BASE_URL` test knob; real defaults differ per host.

## Validation (commands + results)

```
cd ee/apps/den-api
bun test test/google-workspace-api.test.ts                                  # 7 pass / 0 fail (pure helpers)
DATABASE_URL=…openwork_test_gwscaps bun test test/google-workspace-capabilities.test.ts   # 7 pass / 0 fail, twice (deterministic)
```

Integration tests drive the real routes via `app.request` with a real session + ConnectedAccount against a stubbed Google API (Bun.serve): happy paths assert `Bearer` forwarding and the built Drive query; 409 when no account; 409 + **zero Google calls** when scope missing; 502 mapping on Google 500.

Catalog payoff (the reported bug, now pinned):

```
searchCapabilities(catalog, "calendar events list")[0]  === getCapabilitiesGoogleWorkspaceCalendarEvents  (outranks getConnectorSyncEvents)
searchCapabilities(catalog, "drive files")[0]           === getCapabilitiesGoogleWorkspaceDriveFiles      (was zero matches)
searchCapabilities(catalog, "gmail search read messages")[0] === getCapabilitiesGoogleWorkspaceGmailMessages (outranks getMemorySearch)
```

Guard suites: `gmail-draft`, `mcp-tool-name-length`, `route-access-policy`, `mcp-agent-config-policy`, `native-provider-scopes` — 26 pass / 0 fail. `route-guard-policy.test.ts` fails identically on origin/dev with this change stashed (pre-existing, unrelated; its uncovered-routes list contains no google-workspace routes). `pnpm --filter @openwork-ee/den-api build` passes.

## Not run

Evals/fraimz skipped at the requester's explicit instruction. Interactive repro for a reviewer: connect a Google account on the org connection, then in chat ask "what's on my calendar this week?" — the agent's `search_capabilities("calendar events list")` now returns the calendar capability first and `execute_capability` returns real events (or a 409 with actionable guidance when not connected / missing a scope).
