### PR TITLE
feat(desktop): organization server option on the forced sign-in gate

### DIFF
--- a/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
@@ -13,6 +13,7 @@ import { t } from "../../../i18n";
 import { DEFAULT_DEN_BASE_URL } from "../../../app/lib/den";
 import { Button } from "@/components/ui/button";
 import { TextInput } from "../../design-system/text-input";
+import { OrganizationServerAffordance } from "../settings/cloud/organization-server-affordance";
 
 export type DenSignInSurfaceVariant = "panel" | "fullscreen";
 
@@ -29,7 +30,11 @@ export type DenSignInSurfaceProps = {
   sessionBusy: boolean;
   manualAuthOpen: boolean;
   manualAuthInput: string;
+  organizationServerBusy?: boolean;
+  organizationServerError?: string | null;
+  organizationServerUrl?: string;
   onBaseUrlDraftInput: (value: string) => void;
+  onOrganizationServerSave?: (url: string) => Promise<boolean>;
   onResetBaseUrl: () => void;
   onApplyBaseUrl: () => void;
   onOpenControlPlane: () => void;
@@ -328,6 +333,15 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
                 Sign in with OpenWork Cloud
                 <ArrowUpRight size={15} />
               </button>
+
+              {props.onOrganizationServerSave ? (
+                <OrganizationServerAffordance
+                  busy={props.organizationServerBusy === true}
+                  error={props.organizationServerError ?? null}
+                  onSave={props.onOrganizationServerSave}
+                  url={props.organizationServerUrl ?? props.baseUrl}
+                />
+              ) : null}
 
               {props.statusMessage && !props.authError ? (
                 <div className={softNoticeClass}>{props.statusMessage}</div>

--- a/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
@@ -8,11 +8,8 @@ import {
   createDenClient,
   DEFAULT_DEN_BASE_URL,
   normalizeDenBaseUrl,
-  readDenBootstrapConfig,
   readDenSettings,
   resolveDenBaseUrls,
-  setDenBootstrapConfig,
-  writeDenSettings,
 } from "../../../app/lib/den";
 import { exchangeHandoffAndSignIn } from "../../../app/lib/den-handoff";
 import {
@@ -24,6 +21,7 @@ import { useBootState } from "../../shell/boot-state";
 import { useDenAuth } from "./den-auth-provider";
 import { useDesktopConfig } from "./desktop-config-provider";
 import { DenSignInSurface } from "./den-signin-surface";
+import { saveControlPlaneUrl } from "../settings/cloud/control-plane-url";
 
 export type ForcedSigninPageProps = {
   developerMode: boolean;
@@ -152,51 +150,43 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
     }
   }, [authBusy, baseUrl, developerMode, manualAuthInput]);
 
-  const applyBaseUrl = useCallback(async () => {
-    const normalized = normalizeDenBaseUrl(baseUrlDraft);
+  const applyBaseUrl = useCallback(async (value?: string) => {
+    const normalized = normalizeDenBaseUrl(value ?? baseUrlDraft);
     if (!normalized) {
       setBaseUrlError(t("den.error_base_url"));
-      return;
+      return false;
     }
 
     const resolved = resolveDenBaseUrls(normalized);
     setBaseUrlBusy(true);
 
     try {
-      await setDenBootstrapConfig({
-        baseUrl: resolved.baseUrl,
-        apiBaseUrl: resolved.apiBaseUrl,
-        requireSignin: readDenBootstrapConfig().requireSignin,
-      });
+      const persisted = await saveControlPlaneUrl(resolved.baseUrl);
+      if (!persisted) {
+        setBaseUrlError(t("den.error_base_url"));
+        return false;
+      }
+
       setBaseUrlError(null);
-      setBaseUrl(resolved.baseUrl);
-      setBaseUrlDraft(resolved.baseUrl);
-      clearDenSession({ includeBaseUrls: !developerMode });
-      writeDenSettings(
-        {
-          baseUrl: resolved.baseUrl,
-          apiBaseUrl: resolved.apiBaseUrl,
-          authToken: null,
-          activeOrgId: null,
-          activeOrgSlug: null,
-          activeOrgName: null,
-        },
-        { persistBootstrap: false },
-      );
+      setBaseUrl(persisted.baseUrl);
+      setBaseUrlDraft(persisted.baseUrl);
+      clearDenSession({ includeBaseUrls: false });
       setAuthError(null);
       setStatusMessage(t("den.status_base_url_updated"));
       void desktopConfig.refresh();
       void denAuth.refresh();
+      return true;
     } catch (error) {
       setBaseUrlError(
         error instanceof Error
           ? error.message
           : t("den.error_base_url"),
       );
+      return false;
     } finally {
       setBaseUrlBusy(false);
     }
-  }, [baseUrlDraft, denAuth, desktopConfig, developerMode]);
+  }, [baseUrlDraft, denAuth, desktopConfig]);
 
   // Listen for Den session events broadcast from the Tauri deep-link handler,
   // a successful browser auth, or an org switch, and reflect the result in
@@ -256,7 +246,11 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
       sessionBusy={denAuth.status === "checking"}
       manualAuthOpen={manualAuthOpen}
       manualAuthInput={manualAuthInput}
+      organizationServerBusy={baseUrlBusy}
+      organizationServerError={baseUrlError}
+      organizationServerUrl={baseUrl}
       onBaseUrlDraftInput={setBaseUrlDraft}
+      onOrganizationServerSave={applyBaseUrl}
       onResetBaseUrl={() => setBaseUrlDraft(baseUrl)}
       onApplyBaseUrl={() => {
         void applyBaseUrl();

--- a/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
+++ b/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { ShareIcon, UserGroupIcon } from "@heroicons/react/24/solid";
 import { PaperGrainGradient } from "@openwork/ui/react";
 
@@ -13,22 +13,9 @@ import {
   PageTitlebarRegion,
 } from "@/components/page";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
-import { TextInput } from "../../design-system/text-input";
-import {
-  displayCustomControlPlaneUrl,
-  formatControlPlaneHost,
-  isValidControlPlaneUrl,
-} from "../settings/cloud/control-plane-url";
+import { OrganizationServerAffordance } from "../settings/cloud/organization-server-affordance";
 
 interface BrandIconProps {
   slug: string;
@@ -168,96 +155,6 @@ function OnboardingStep({ number, title, children }: OnboardingStepProps) {
   );
 }
 
-type OrganizationServerWelcomeProps = {
-  busy: boolean;
-  error: string | null;
-  onSave: (url: string) => Promise<boolean>;
-  url: string;
-};
-
-function OrganizationServerWelcome(props: OrganizationServerWelcomeProps) {
-  const [open, setOpen] = useState(false);
-  const [draft, setDraft] = useState("");
-  const customUrl = displayCustomControlPlaneUrl(props.url);
-  const connectedHost = customUrl ? formatControlPlaneHost(customUrl) : "";
-
-  useEffect(() => {
-    if (open) setDraft(customUrl);
-  }, [customUrl, open]);
-
-  const submit = async () => {
-    const ok = await props.onSave(draft);
-    if (ok) setOpen(false);
-  };
-
-  return (
-    <div className="flex justify-center">
-      {customUrl ? (
-        <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 rounded-lg border border-border bg-muted/40 px-3 py-2 text-center text-sm text-muted-foreground">
-          <span>{t("welcome.organization_server_connected", { host: connectedHost })}</span>
-          <Button
-            type="button"
-            variant="link"
-            className="h-auto p-0 text-sm"
-            onClick={() => setOpen(true)}
-          >
-            {t("welcome.organization_server_change")}
-          </Button>
-        </div>
-      ) : (
-        <Button
-          type="button"
-          variant="link"
-          className="h-auto p-0 text-sm text-muted-foreground"
-          onClick={() => setOpen(true)}
-        >
-          {t("welcome.organization_server_link")}
-        </Button>
-      )}
-
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t("welcome.organization_server_dialog_title")}</DialogTitle>
-            <DialogDescription>{t("welcome.organization_server_dialog_desc")}</DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-2">
-            <TextInput
-              label={t("welcome.organization_server_url_label")}
-              value={draft}
-              onChange={(event) => setDraft(event.currentTarget.value)}
-              placeholder={t("welcome.organization_server_url_placeholder")}
-              disabled={props.busy}
-            />
-            {props.error ? (
-              <p className="text-xs text-destructive">{props.error}</p>
-            ) : null}
-          </div>
-
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setOpen(false)}
-              disabled={props.busy}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button
-              type="button"
-              onClick={() => void submit()}
-              disabled={props.busy || !isValidControlPlaneUrl(draft)}
-            >
-              {t("common.save")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
-  );
-}
-
 export function WelcomePage({
   onGetStarted,
   getStartedLabel,
@@ -318,7 +215,7 @@ export function WelcomePage({
                   >
                     {busy ? t("welcome.creating_workspace") : (getStartedLabel || t("welcome.get_started"))}
                   </Button>
-                  <OrganizationServerWelcome
+                  <OrganizationServerAffordance
                     busy={organizationServerBusy}
                     error={organizationServerError}
                     onSave={onOrganizationServerSave}

--- a/apps/app/src/react-app/domains/settings/cloud/organization-server-affordance.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/organization-server-affordance.tsx
@@ -1,0 +1,109 @@
+/** @jsxImportSource react */
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { t } from "@/i18n";
+import { TextInput } from "../../../design-system/text-input";
+import {
+  displayCustomControlPlaneUrl,
+  formatControlPlaneHost,
+  isValidControlPlaneUrl,
+} from "./control-plane-url";
+
+type OrganizationServerAffordanceProps = {
+  busy: boolean;
+  error: string | null;
+  onSave: (url: string) => Promise<boolean>;
+  url: string;
+};
+
+export function OrganizationServerAffordance(props: OrganizationServerAffordanceProps) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+  const customUrl = displayCustomControlPlaneUrl(props.url);
+  const connectedHost = customUrl ? formatControlPlaneHost(customUrl) : "";
+
+  useEffect(() => {
+    if (open) setDraft(customUrl);
+  }, [customUrl, open]);
+
+  const submit = async () => {
+    const ok = await props.onSave(draft);
+    if (ok) setOpen(false);
+  };
+
+  return (
+    <div className="flex justify-center">
+      {customUrl ? (
+        <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 rounded-lg border border-border bg-muted/40 px-3 py-2 text-center text-sm text-muted-foreground">
+          <span>{t("welcome.organization_server_connected", { host: connectedHost })}</span>
+          <Button
+            type="button"
+            variant="link"
+            className="h-auto p-0 text-sm"
+            onClick={() => setOpen(true)}
+          >
+            {t("welcome.organization_server_change")}
+          </Button>
+        </div>
+      ) : (
+        <Button
+          type="button"
+          variant="link"
+          className="h-auto p-0 text-sm text-muted-foreground"
+          onClick={() => setOpen(true)}
+        >
+          {t("welcome.organization_server_link")}
+        </Button>
+      )}
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("welcome.organization_server_dialog_title")}</DialogTitle>
+            <DialogDescription>{t("welcome.organization_server_dialog_desc")}</DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <TextInput
+              label={t("welcome.organization_server_url_label")}
+              value={draft}
+              onChange={(event) => setDraft(event.currentTarget.value)}
+              placeholder={t("welcome.organization_server_url_placeholder")}
+              disabled={props.busy}
+            />
+            {props.error ? (
+              <p className="text-xs text-destructive">{props.error}</p>
+            ) : null}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={props.busy}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void submit()}
+              disabled={props.busy || !isValidControlPlaneUrl(draft)}
+            >
+              {t("common.save")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/evals/flows/onprem-server-url.flow.mjs
+++ b/evals/flows/onprem-server-url.flow.mjs
@@ -10,6 +10,33 @@ const DEFAULT_DEN_BASE_URL = "https://app.openworklabs.com";
 const DEFAULT_DEN_API_BASE_URL = "https://app.openworklabs.com/api/den";
 const PROJECT_DIR = process.cwd();
 
+async function setDesktopBootstrapConfig(ctx, config) {
+  await ctx.waitFor(`Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)`, {
+    timeoutMs: 60_000,
+    label: "desktop bridge",
+  });
+  await ctx.eval(`(async () => {
+    const config = ${JSON.stringify(config)};
+    const persisted = await window.__OPENWORK_ELECTRON__.invokeDesktop("setDesktopBootstrapConfig", config);
+    const baseUrl = persisted?.baseUrl || config.baseUrl;
+    const apiBaseUrl = persisted?.apiBaseUrl || config.apiBaseUrl;
+    localStorage.setItem("openwork.den.baseUrl", baseUrl);
+    localStorage.setItem("openwork.den.apiBaseUrl", apiBaseUrl);
+    localStorage.removeItem("openwork.den.authToken");
+    localStorage.removeItem("openwork.den.activeOrgId");
+    localStorage.removeItem("openwork.den.activeOrgSlug");
+    localStorage.removeItem("openwork.den.activeOrgName");
+    return persisted;
+  })()`, { awaitPromise: true });
+}
+
+async function currentDenBaseUrls(ctx) {
+  return ctx.eval(`(() => ({
+    baseUrl: localStorage.getItem("openwork.den.baseUrl") || ${JSON.stringify(DEFAULT_DEN_BASE_URL)},
+    apiBaseUrl: localStorage.getItem("openwork.den.apiBaseUrl") || ${JSON.stringify(DEFAULT_DEN_API_BASE_URL)},
+  }))()`);
+}
+
 async function closeDialogs(ctx) {
   await ctx.eval(`(() => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
@@ -37,22 +64,13 @@ function writeOnboardingPrefScript(completed) {
 
 async function resetToDefaultWelcome(ctx) {
   await closeDialogs(ctx);
+  await setDesktopBootstrapConfig(ctx, {
+    baseUrl: DEFAULT_DEN_BASE_URL,
+    apiBaseUrl: DEFAULT_DEN_API_BASE_URL,
+    requireSignin: false,
+  });
   await ctx.eval(`(async () => {
-    localStorage.setItem("openwork.den.baseUrl", ${JSON.stringify(DEFAULT_DEN_BASE_URL)});
-    localStorage.setItem("openwork.den.apiBaseUrl", ${JSON.stringify(DEFAULT_DEN_API_BASE_URL)});
-    localStorage.removeItem("openwork.den.authToken");
-    localStorage.removeItem("openwork.den.activeOrgId");
-    localStorage.removeItem("openwork.den.activeOrgSlug");
-    localStorage.removeItem("openwork.den.activeOrgName");
     ${writeOnboardingPrefScript(false)};
-    const invokeDesktop = window.__OPENWORK_ELECTRON__?.invokeDesktop;
-    if (invokeDesktop) {
-      await invokeDesktop("setDesktopBootstrapConfig", {
-        baseUrl: ${JSON.stringify(DEFAULT_DEN_BASE_URL)},
-        apiBaseUrl: ${JSON.stringify(DEFAULT_DEN_API_BASE_URL)},
-        requireSignin: false,
-      });
-    }
     location.hash = "#/welcome";
     location.reload();
     return true;
@@ -252,6 +270,66 @@ export default {
             rejectText: [`Connected to ${ORG_HOST}`, "Something went wrong"],
           },
         });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        try {
+          await ctx.prove("The forced sign-in gate exposes the same on-premises server option without developer mode", {
+            voiceover: vo[5],
+            action: async () => {
+              await closeDialogs(ctx);
+              const current = await currentDenBaseUrls(ctx);
+              await setDesktopBootstrapConfig(ctx, {
+                baseUrl: current.baseUrl,
+                apiBaseUrl: current.apiBaseUrl,
+                requireSignin: true,
+              });
+              await ctx.eval(`(() => {
+                location.hash = "#/signin";
+                location.reload();
+                return true;
+              })()`);
+              await ctx.waitForText("Sign in with OpenWork Cloud", { timeoutMs: 60_000 });
+              await ctx.expectNoText("Developer mode only");
+              await ctx.expectText("Using OpenWork on-premises?");
+              await ctx.clickText("Using OpenWork on-premises?");
+              await ctx.expectText("Connect to your organization's server");
+              await ctx.expectText("Paste the server URL your IT team shared.");
+              await ctx.fill('input[placeholder="https://openwork.yourcompany.com"]', ORG_URL);
+              await ctx.clickText("Save", { selector: '[role="dialog"] button' });
+              await ctx.waitForText(`Connected to ${ORG_HOST}`, { timeoutMs: 30_000 });
+              // The dialog closes with a fade animation; screenshotting while the
+              // ghost overlay is still fading produced a dirty frame. Wait for the
+              // dialog (and any [role="dialog"] remnant) to be fully unmounted.
+              await ctx.waitFor(
+                "!document.querySelector('[role=\\\"dialog\\\"]') && !(document.body?.innerText ?? '').includes('Connect to your organization')",
+                { timeoutMs: 10_000, label: "organization server dialog fully closed" },
+              );
+            },
+            assert: async () => {
+              await ctx.expectText(`Connected to ${ORG_HOST}`);
+              await ctx.expectText("Change");
+              await ctx.expectNoText("Developer mode only");
+              const stored = await ctx.eval(`localStorage.getItem("openwork.den.baseUrl")`);
+              ctx.assert(stored === ORG_URL, `Expected forced sign-in control plane URL to be ${ORG_URL}, got ${stored}`);
+              const bootstrap = await ctx.eval(`(async () => {
+                const config = await window.__OPENWORK_ELECTRON__.invokeDesktop("getDesktopBootstrapConfig");
+                return { baseUrl: config.baseUrl, requireSignin: config.requireSignin === true };
+              })()`, { awaitPromise: true });
+              ctx.assert(bootstrap.requireSignin === true, "Expected forced sign-in to remain enabled while proving the gate.");
+              ctx.assert(bootstrap.baseUrl === ORG_URL, `Expected desktop bootstrap URL to be ${ORG_URL}, got ${bootstrap.baseUrl}`);
+            },
+            screenshot: {
+              name: "frame-6",
+              requireText: [`Connected to ${ORG_HOST}`, "Change"],
+              rejectText: ["Developer mode only", "Something went wrong"],
+            },
+          });
+        } finally {
+          await resetToDefaultWelcome(ctx);
+        }
       },
     },
   ],

--- a/evals/voiceovers/onprem-server-url.md
+++ b/evals/voiceovers/onprem-server-url.md
@@ -15,3 +15,5 @@ the welcome screen and at the top of Advanced settings.
 4. Later, in Settings, Advanced shows an Organization server section right at the top with no developer mode required. The same address is visible there and can be changed with one copy-paste.
 
 5. One click on Reset returns the app to standard OpenWork Cloud, proving there is no hidden state left behind and the welcome flow and the settings field stay in agreement.
+
+6. When an organization requires sign-in before anything else, the same on-premises option sits right on the sign-in screen, so pointing the app at the company server never depends on developer mode.


### PR DESCRIPTION
## What

Follow-up to #2560: the "Using OpenWork on-premises?" affordance now also renders on the **forced sign-in gate** (`requireSignin: true`), without developer mode.

Why it matters: forced sign-in is exactly the enterprise state (org installers set it), and it's also the state you land in right after pointing the app at a `requireSignin` server. Before this, a user stuck at that gate — wrong org URL, or a vanilla install that needs to target the company server — had no way out without developer mode.

- Extracted the welcome dialog into a shared `organization-server-affordance.tsx` (welcome + gate use the same component, strings, and `control-plane-url.ts` persistence).
- On the gate: quiet link → same "Connect to your organization's server" dialog; when a custom server is set, shows "Connected to {host}" + Change. Saving preserves `requireSignin`, clears the session, re-hydrates — the gate immediately reflects the new host.
- Developer-mode editor untouched (same underlying state).

## Demo-driven development

Voiceover extended with frame 6 (`evals/voiceovers/onprem-server-url.md`); flow extended with a matching frame that enables forced sign-in for real via the desktop bridge, proves the affordance without dev mode, and restores state (idempotent).

## Tests run

- `pnpm typecheck` — passed
- `pnpm fraimz --flow onprem-server-url` — **PASSED locally** (fresh profile) and **PASSED on Daytona** (fresh Linux sandbox, real Electron; run `2026-07-08T05-12-37-479Z`), all 6 frames
- One screenshot-hygiene repair during verification: frame 6 initially captured the dialog mid-fade; the flow now waits for full dialog unmount before capturing.
- Frame-by-frame proof with screenshots posted below.
