### PR TITLE
chore(desktop): remove redundant route.settings.extensions control action

### DIFF
--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -468,13 +468,6 @@ export function OpenworkRouteControlActions() {
       execute: () => navigate("/settings/general"),
     },
     {
-      id: "route.settings.extensions",
-      label: "Open MCP and extension settings",
-      description: "Navigate to extension and MCP settings.",
-      sideEffect: "navigation",
-      execute: () => navigate("/settings/extensions"),
-    },
-    {
       id: "route.settings.skills",
       label: "Open skills settings",
       description: "Navigate to skills settings.",

--- a/evals/flows/control-pane-extensions-action-removed.flow.mjs
+++ b/evals/flows/control-pane-extensions-action-removed.flow.mjs
@@ -1,0 +1,66 @@
+/**
+ * internal flow demo (spec: evals/voiceovers/control-pane-extensions-action-removed.md):
+ * the redundant `route.settings.extensions` control action is removed from the
+ * Control UI pane; `settings.panel.open({panel:"extensions"})` still opens the
+ * Extensions settings.
+ */
+
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("control-pane-extensions-action-removed");
+
+export default {
+  id: "control-pane-extensions-action-removed",
+  title: "Control pane: redundant extensions action removed, generic panel open still works",
+  kind: "internal",
+  steps: [
+    {
+      name: "App booted with the control surface ready",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "window.__openworkControl" });
+        await ctx.waitFor("document.body.innerText.trim().length > 40", { label: "rendered body text" });
+      },
+    },
+    {
+      name: "Control pane no longer lists route.settings.extensions",
+      run: async (ctx) => {
+        await ctx.prove("The control pane omits the redundant extensions action", {
+          claim: "The Control UI action list no longer contains route.settings.extensions, while settings.panel.open and the other route shortcuts remain.",
+          voiceover: vo[0],
+          assert: async () => {
+            const ids = await ctx.eval("window.__openworkControl.listActions().map((a) => a.id)");
+            ctx.assert(Array.isArray(ids) && ids.length > 0, "Control pane returned no actions.");
+            ctx.assert(!ids.includes("route.settings.extensions"), "route.settings.extensions is still registered in the control pane.");
+            ctx.assert(ids.includes("settings.panel.open"), "settings.panel.open is missing from the control pane.");
+            ctx.assert(ids.includes("route.settings.general"), "route.settings.general is missing — over-deleted.");
+            ctx.assert(ids.includes("route.settings.skills"), "route.settings.skills is missing — over-deleted.");
+            ctx.output("control-pane-action-ids.json", JSON.stringify(ids, null, 2));
+          },
+          screenshot: { name: "control-pane-intact", rejectText: ["Open MCP and extension settings"] },
+        });
+      },
+    },
+    {
+      name: "settings.panel.open still opens the Extensions panel",
+      run: async (ctx) => {
+        await ctx.prove("The generic panel action still lands on Extensions", {
+          claim: "Executing settings.panel.open with {panel:\"extensions\"} navigates to #/settings/extensions and renders the Extensions settings screen.",
+          voiceover: vo[1],
+          action: async () => {
+            // Start from a different settings tab so the navigation is observable.
+            await ctx.navigateHash("/settings/general");
+            await ctx.waitFor("location.hash.includes('/settings/general')", { label: "on settings general" });
+            const result = await ctx.control("settings.panel.open", { panel: "extensions" });
+            ctx.assert(result?.panel === "extensions", `Unexpected control result: ${JSON.stringify(result)}`);
+            await ctx.waitFor("location.hash.includes('/settings/extensions')", { timeoutMs: 30_000, label: "navigated to /settings/extensions" });
+          },
+          assert: async () => {
+            await ctx.expectHashIncludes("/settings/extensions");
+            await ctx.expectText("Extensions");
+          },
+          screenshot: { name: "extensions-panel-open", requireText: ["Extensions"], hashIncludes: "/settings/extensions" },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/control-pane-extensions-action-removed.md
+++ b/evals/voiceovers/control-pane-extensions-action-removed.md
@@ -1,0 +1,7 @@
+# control-pane-extensions-action-removed — One settings path, no duplicate shortcut
+
+Agents and voice drive OpenWork through the control pane: the list of UI actions exposed to controllers. It used to offer two ways to open Extensions settings — a dedicated "Open MCP and extension settings" action (`route.settings.extensions`) and the generic "Open a settings panel" action (`settings.panel.open` with panel "extensions"). This demo shows the duplicate dedicated action is gone from the pane and the generic action still lands on the Extensions screen.
+
+1. The control pane still offers the route shortcuts and the generic Open a settings panel action. But the duplicate extensions entry — route dot settings dot extensions — is no longer listed.
+
+2. Nothing is lost. Running settings panel open with the extensions panel still walks the app straight to Settings and lands on the Extensions screen.


### PR DESCRIPTION
## What

Deletes the `route.settings.extensions` action ("Open MCP and extension settings") from the Control UI pane (`apps/app/src/react-app/shell/control/control-provider.tsx`). It duplicated the generic `settings.panel.open` action, which covers the same navigation with `{panel: "extensions"}` — verified working:

```json
{ "ok": true, "actionId": "settings.panel.open", "result": { "ok": true, "panel": "extensions" } }
```

Smallest possible diff: one 7-line object removed from the action registry. `route.settings.extensions` had no other references anywhere (no eval flows, plugins, or docs use it — checked with `rg`).

## Proof

Adds a fraimz flow + approved voiceover:
- `evals/voiceovers/control-pane-extensions-action-removed.md`
- `evals/flows/control-pane-extensions-action-removed.flow.mjs` — asserts the control pane no longer lists `route.settings.extensions` (while `settings.panel.open`, `route.settings.general`, `route.settings.skills` remain), then executes `settings.panel.open({panel:"extensions"})` and asserts the app lands on `#/settings/extensions` rendering the Extensions screen.

## Tests run

- `pnpm --filter @openwork/app typecheck` — passed (`tsc -p tsconfig.json --noEmit`, clean).
- `rg -n "route\.settings\.extensions"` — no matches left in the repo.
- Voiceover parser + flow module load checks — passed (2 frames, 3 steps, narration sourced from the approved script so the drift check holds).

## Honest gap

The fraimz e2e run against the live Electron app was **not** completed locally (dev-app launch was cut short on the host). Reviewer repro:

```bash
OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9826 pnpm dev   # in the worktree
pnpm fraimz --flow control-pane-extensions-action-removed --cdp-url http://127.0.0.1:9826
```