### PR TITLE
feat(connections): Google Workspace member disconnect on desktop Connect and Your Connections

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -2219,6 +2219,14 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
       return result;
     },
 
+    async disconnectOauthProviderAccount(orgId: string, providerId: string): Promise<void> {
+      await requestJson<unknown>(
+        baseUrls,
+        `/v1/oauth-providers/${encodeURIComponent(providerId)}/disconnect`,
+        { method: "POST", token, organizationId: orgId },
+      );
+    },
+
     async listOrgMarketplaces(orgId: string): Promise<DenOrgMarketplace[]> {
       const payload = await requestJson<unknown>(
         baseUrls,

--- a/apps/app/src/i18n/locales/ca.ts
+++ b/apps/app/src/i18n/locales/ca.ts
@@ -433,6 +433,8 @@ export default {
   "mcp.no_apps_hint": "Connecta'n una a dalt per començar.",
   "mcp.no_apps_yet": "Encara no hi ha cap aplicació connectada",
   "mcp.oauth": "Inicia la sessió",
+  "mcp.org_connection_disconnect_action": "Desconnecta",
+  "mcp.org_connection_disconnecting_action": "Desconnectant...",
   "mcp.oauth_autodetect_hint": "Si aquesta aplicació requereix iniciar sessió, el navegador s'obrirà per connectar el vostre compte després d'afegir-la.",
   "mcp.one_click_connect": "Connecta amb un sol clic",
   "mcp.open_file": "Obre el fitxer",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -560,6 +560,8 @@ export default {
   "mcp.opening_label": "Opening...",
   "mcp.org_connection_connect_action": "Connect your account",
   "mcp.org_connection_connected_label": "Connected",
+  "mcp.org_connection_disconnect_action": "Disconnect",
+  "mcp.org_connection_disconnecting_action": "Disconnecting...",
   "mcp.org_connection_desc_per_member": "Available from your organization. Connect your own account to use it.",
   "mcp.org_connection_desc_per_member_connected": "Connected with your own account.",
   "mcp.org_connection_desc_shared": "One org account managed by your organization — the AI acts as it.",

--- a/apps/app/src/i18n/locales/es.ts
+++ b/apps/app/src/i18n/locales/es.ts
@@ -433,6 +433,8 @@ export default {
   "mcp.no_apps_hint": "Conecta una de las opciones de arriba para empezar.",
   "mcp.no_apps_yet": "Aún no hay aplicaciones conectadas",
   "mcp.oauth": "Iniciar sesión",
+  "mcp.org_connection_disconnect_action": "Desconectar",
+  "mcp.org_connection_disconnecting_action": "Desconectando...",
   "mcp.oauth_autodetect_hint": "Si esta app requiere iniciar sesión, el navegador se abrirá para conectar tu cuenta después de añadirla.",
   "mcp.one_click_connect": "Conexión con un clic",
   "mcp.open_file": "Abrir archivo",

--- a/apps/app/src/i18n/locales/fr.ts
+++ b/apps/app/src/i18n/locales/fr.ts
@@ -433,6 +433,8 @@ export default {
   "mcp.no_apps_hint": "Connectez-en une ci-dessus pour commencer.",
   "mcp.no_apps_yet": "Aucune application connectée pour le moment",
   "mcp.oauth": "Se connecter",
+  "mcp.org_connection_disconnect_action": "Déconnecter",
+  "mcp.org_connection_disconnecting_action": "Déconnexion...",
   "mcp.oauth_autodetect_hint": "Si cette application nécessite une connexion, votre navigateur s'ouvrira pour connecter votre compte après l'ajout.",
   "mcp.one_click_connect": "Connexion en un clic",
   "mcp.open_file": "Ouvrir le fichier",

--- a/apps/app/src/i18n/locales/ja.ts
+++ b/apps/app/src/i18n/locales/ja.ts
@@ -409,6 +409,8 @@ export default {
   "mcp.no_apps_hint": "上のアプリを接続して始めましょう。",
   "mcp.no_apps_yet": "まだアプリが接続されていません",
   "mcp.oauth": "サインイン",
+  "mcp.org_connection_disconnect_action": "切断",
+  "mcp.org_connection_disconnecting_action": "切断中...",
   "mcp.oauth_autodetect_hint": "このアプリでサインインが必要な場合は、追加後にブラウザが開いてアカウントを接続します。",
   "mcp.one_click_connect": "ワンクリック接続",
   "mcp.open_file": "ファイルを開く",

--- a/apps/app/src/i18n/locales/pt-BR.ts
+++ b/apps/app/src/i18n/locales/pt-BR.ts
@@ -415,6 +415,8 @@ export default {
   "mcp.no_apps_hint": "Conecte um acima para começar.",
   "mcp.no_apps_yet": "Nenhum app conectado ainda",
   "mcp.oauth": "Entrar",
+  "mcp.org_connection_disconnect_action": "Desconectar",
+  "mcp.org_connection_disconnecting_action": "Desconectando...",
   "mcp.oauth_autodetect_hint": "Se este app exigir login, o navegador será aberto para conectar sua conta depois de adicioná-lo.",
   "mcp.one_click_connect": "Conectar com um clique",
   "mcp.open_file": "Abrir arquivo",

--- a/apps/app/src/i18n/locales/ru.ts
+++ b/apps/app/src/i18n/locales/ru.ts
@@ -332,6 +332,8 @@ export default {
   "mcp.no_apps_hint": "Подключите одно из приложений выше, чтобы начать.",
   "mcp.no_apps_yet": "Пока нет подключенных приложений",
   "mcp.oauth": "Войти",
+  "mcp.org_connection_disconnect_action": "Отключить",
+  "mcp.org_connection_disconnecting_action": "Отключение...",
   "mcp.oauth_autodetect_hint": "Если приложению требуется вход, после добавления откроется браузер для подключения аккаунта.",
   "mcp.one_click_connect": "Подключение в один клик",
   "mcp.open_file": "Открыть файл",

--- a/apps/app/src/i18n/locales/th.ts
+++ b/apps/app/src/i18n/locales/th.ts
@@ -410,6 +410,8 @@ export default {
   "mcp.no_apps_hint": "เชื่อมต่อแอปด้านบนเพื่อเริ่มต้น",
   "mcp.no_apps_yet": "ยังไม่มีแอปที่เชื่อมต่อ",
   "mcp.oauth": "เข้าสู่ระบบ",
+  "mcp.org_connection_disconnect_action": "ตัดการเชื่อมต่อ",
+  "mcp.org_connection_disconnecting_action": "กำลังตัดการเชื่อมต่อ...",
   "mcp.oauth_autodetect_hint": "หากแอปนี้ต้องการการลงชื่อเข้าใช้ เบราว์เซอร์จะเปิดขึ้นเพื่อเชื่อมต่อบัญชีของคุณหลังจากเพิ่มแล้ว",
   "mcp.one_click_connect": "เชื่อมต่อด้วยคลิกเดียว",
   "mcp.open_file": "เปิดไฟล์",

--- a/apps/app/src/i18n/locales/vi.ts
+++ b/apps/app/src/i18n/locales/vi.ts
@@ -410,6 +410,8 @@ export default {
   "mcp.no_apps_hint": "Kết nối một ứng dụng ở trên để bắt đầu.",
   "mcp.no_apps_yet": "Chưa kết nối ứng dụng nào",
   "mcp.oauth": "Đăng nhập",
+  "mcp.org_connection_disconnect_action": "Ngắt kết nối",
+  "mcp.org_connection_disconnecting_action": "Đang ngắt kết nối...",
   "mcp.oauth_autodetect_hint": "Nếu ứng dụng này yêu cầu đăng nhập, trình duyệt sẽ mở để kết nối tài khoản của bạn sau khi thêm.",
   "mcp.one_click_connect": "Kết nối một chạm",
   "mcp.open_file": "Mở tệp",

--- a/apps/app/src/i18n/locales/zh.ts
+++ b/apps/app/src/i18n/locales/zh.ts
@@ -413,6 +413,8 @@ export default {
   "mcp.no_apps_hint": "连接上方的应用开始使用。",
   "mcp.no_apps_yet": "暂无已连接的应用",
   "mcp.oauth": "登录",
+  "mcp.org_connection_disconnect_action": "断开连接",
+  "mcp.org_connection_disconnecting_action": "正在断开...",
   "mcp.oauth_autodetect_hint": "如果此应用需要登录，添加后浏览器将打开以连接你的账户。",
   "mcp.one_click_connect": "一键连接",
   "mcp.open_file": "打开文件",

--- a/apps/app/src/react-app/domains/connections/native-provider-connections.test.ts
+++ b/apps/app/src/react-app/domains/connections/native-provider-connections.test.ts
@@ -1,0 +1,21 @@
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => { toBe: (expected: unknown) => void };
+
+import {
+  canDisconnectNativeProviderAccount,
+  isNativeProviderConnectionId,
+} from "./native-provider-connections";
+
+describe("native provider connections", () => {
+  test("recognizes the Google Workspace native provider id", () => {
+    expect(isNativeProviderConnectionId("google-workspace")).toBe(true);
+    expect(isNativeProviderConnectionId("emc_google_workspace")).toBe(false);
+  });
+
+  test("shows disconnect only for the connected calling member", () => {
+    expect(canDisconnectNativeProviderAccount({ id: "google-workspace", connectedForMe: true })).toBe(true);
+    expect(canDisconnectNativeProviderAccount({ id: "google-workspace", connectedForMe: false })).toBe(false);
+    expect(canDisconnectNativeProviderAccount({ id: "emc_google_workspace", connectedForMe: true })).toBe(false);
+  });
+});

--- a/apps/app/src/react-app/domains/connections/native-provider-connections.ts
+++ b/apps/app/src/react-app/domains/connections/native-provider-connections.ts
@@ -1,0 +1,13 @@
+export type NativeProviderDisconnectableConnection = {
+  id: string;
+  connectedForMe: boolean;
+};
+
+export function isNativeProviderConnectionId(id: string): boolean {
+  // Today google-workspace is the only native provider connection id; a follow-up generalizes this for external per-member connections.
+  return id === "google-workspace";
+}
+
+export function canDisconnectNativeProviderAccount(connection: NativeProviderDisconnectableConnection): boolean {
+  return connection.connectedForMe && isNativeProviderConnectionId(connection.id);
+}

--- a/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
+++ b/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createDenClient, readDenSettings, type DenExternalMcpConnection } from "@/app/lib/den";
 import { openDesktopUrl } from "@/app/lib/desktop";
 import { isDesktopRuntime } from "@/app/utils";
+import { isNativeProviderConnectionId } from "./native-provider-connections";
 
 // Mirrors the poll-until-connected pattern used for local MCP OAuth
 // (mcp-auth-modal.tsx) — the external server's redirect completes on a
@@ -78,6 +79,7 @@ export function useOrgMcpConnections() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [connectingId, setConnectingId] = useState<string | null>(null);
+  const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
   const pollRef = useRef<number | null>(null);
 
   const stopPolling = useCallback(() => {
@@ -170,10 +172,31 @@ export function useOrgMcpConnections() {
     }
   }, [refresh, stopPolling]);
 
+  const disconnect = useCallback(async (connectionId: string) => {
+    if (!isNativeProviderConnectionId(connectionId)) return;
+
+    const settings = readDenSettings();
+    const token = settings.authToken?.trim() ?? "";
+    const orgId = settings.activeOrgId?.trim() ?? "";
+    if (!token || !orgId) return;
+
+    setDisconnectingId(connectionId);
+    setError(null);
+    try {
+      const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
+      await client.disconnectOauthProviderAccount(orgId, connectionId);
+      await refresh();
+    } catch (disconnectError) {
+      setError(disconnectError instanceof Error ? disconnectError.message : "Failed to disconnect the account.");
+    } finally {
+      setDisconnectingId(null);
+    }
+  }, [refresh]);
+
   useEffect(() => {
     void refresh();
     return () => stopPolling();
   }, [refresh, stopPolling]);
 
-  return { connections, loading, error, connectingId, refresh, connect };
+  return { connections, loading, error, connectingId, disconnectingId, refresh, connect, disconnect };
 }

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -11,12 +11,14 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { t } from "@/i18n";
 import { useConnectEnabled } from "@/react-app/domains/cloud/desktop-config-provider";
+import { canDisconnectNativeProviderAccount } from "@/react-app/domains/connections/native-provider-connections";
 import { ExtensionCard } from "@/react-app/design-system/extension-card";
 import { ExtensionDetailModal } from "@/react-app/design-system/extension-detail-modal";
 import { resolveMarketplaceDeliveryAction } from "@/react-app/domains/settings/connect-delivery";
 import { isDesktopInstallableMarketplacePlugin } from "@/react-app/domains/settings/connect-cloud-readiness";
 import {
   isOrgMcpConnectionItem,
+  isOrgMcpConnectionReady,
   isToggleControlledExtension,
   orgMcpConnectionActionLabel,
   type ExtensionItem,
@@ -114,7 +116,9 @@ export type CloudMarketplacesViewProps = {
   isBuiltInConnected?: (entry: McpDirectoryInfo) => boolean;
   extensionItems?: ExtensionItem[];
   orgMcpConnectingId?: string | null;
+  orgMcpDisconnectingId?: string | null;
   onConnectOrgMcp?: (connectionId: string) => void;
+  onDisconnectOrgMcp?: (connectionId: string) => void;
   refreshOrgMcpConnections?: () => Promise<unknown> | void;
   setBuiltInEnabled?: (entry: McpDirectoryInfo, enabled: boolean) => void;
 };
@@ -201,7 +205,9 @@ export function CloudMarketplacesView({
   isBuiltInConnected,
   extensionItems = [],
   orgMcpConnectingId = null,
+  orgMcpDisconnectingId = null,
   onConnectOrgMcp,
+  onDisconnectOrgMcp,
   refreshOrgMcpConnections,
   setBuiltInEnabled,
 }: CloudMarketplacesViewProps) {
@@ -641,6 +647,8 @@ export function CloudMarketplacesView({
                 onUpdatePlugin={importPlugin}
                 connectEnabled={connectEnabled}
                 orgMcpConnectingId={orgMcpConnectingId}
+                orgMcpDisconnectingId={orgMcpDisconnectingId}
+                onDisconnectOrgMcp={onDisconnectOrgMcp}
                 builtInDisabled={builtInExtensionsDisabled}
                 builtInConnectingName={builtInConnectingName}
                 highlighted={isHighlighted}
@@ -675,8 +683,10 @@ export function CloudMarketplacesView({
         <OrgMcpConnectionDetailModal
           row={detailRow}
           connecting={orgMcpConnectingId === detailRow.connection.id}
+          disconnecting={orgMcpDisconnectingId === detailRow.connection.id}
           onClose={() => setDetailRow(null)}
           onConnect={onConnectOrgMcp}
+          onDisconnect={onDisconnectOrgMcp}
         />
       ) : null}
     </SettingsSection>
@@ -708,6 +718,8 @@ function MarketplaceCard(props: {
   onUpdatePlugin: (marketplaceId: string | null, plugin: DenOrgPlugin) => void | Promise<void>;
   connectEnabled?: boolean;
   orgMcpConnectingId: string | null;
+  orgMcpDisconnectingId: string | null;
+  onDisconnectOrgMcp?: (connectionId: string) => void;
   builtInDisabled: boolean;
   builtInConnectingName: string | null;
   highlighted?: boolean;
@@ -752,19 +764,34 @@ function MarketplaceCard(props: {
 
   if (row.source === "org-mcp") {
     const actionBusy = props.orgMcpConnectingId === row.connection.id;
+    const disconnecting = props.orgMcpDisconnectingId === row.connection.id;
+    const canDisconnect = canDisconnectNativeProviderAccount(row.connection);
+    const ready = isOrgMcpConnectionReady(row.connection);
     return (
-      <div ref={highlightRef} className={highlightClass}>
+      <div ref={highlightRef} className={`space-y-2 ${highlightClass}`}>
         <ExtensionCard
           name={row.item.name}
           description={row.item.description ?? "Available from your organization."}
           kind="mcp"
           url={row.connection.url}
-          connected={false}
+          connected={ready}
+          connectedLabel={orgMcpConnectionActionLabel(row.connection)}
           beta
           connecting={actionBusy}
-          actionLabel={actionBusy ? "Waiting for browser..." : orgMcpConnectionActionLabel(row.connection)}
+          actionLabel={actionBusy ? "Waiting for browser..." : disconnecting ? t("mcp.org_connection_disconnecting_action") : ready ? "View details" : orgMcpConnectionActionLabel(row.connection)}
           onClick={() => onOpenDetail(row)}
         />
+        {canDisconnect ? (
+          <Button
+            size="sm"
+            variant="destructive"
+            className="w-full"
+            disabled={disconnecting}
+            onClick={() => props.onDisconnectOrgMcp?.(row.connection.id)}
+          >
+            {disconnecting ? t("mcp.org_connection_disconnecting_action") : t("mcp.org_connection_disconnect_action")}
+          </Button>
+        ) : null}
       </div>
     );
   }
@@ -851,10 +878,14 @@ function BuiltInMarketplaceDetailModal(props: {
 function OrgMcpConnectionDetailModal(props: {
   row: OrgMcpMarketplaceRow;
   connecting: boolean;
+  disconnecting: boolean;
   onClose: () => void;
   onConnect?: (connectionId: string) => void;
+  onDisconnect?: (connectionId: string) => void;
 }) {
-  const { row, connecting, onClose, onConnect } = props;
+  const { row, connecting, onClose, onConnect, onDisconnect } = props;
+  const ready = isOrgMcpConnectionReady(row.connection);
+  const canDisconnect = canDisconnectNativeProviderAccount(row.connection);
   return (
     <ExtensionDetailModal
       open
@@ -862,15 +893,18 @@ function OrgMcpConnectionDetailModal(props: {
       name={row.item.name}
       description={row.item.description ?? "Available from your organization."}
       kind="mcp"
-      connected={false}
+      connected={ready}
+      connectedLabel={orgMcpConnectionActionLabel(row.connection)}
       beta
-      connecting={connecting}
+      connecting={connecting || props.disconnecting}
       connectLabel={orgMcpConnectionActionLabel(row.connection)}
       connectingLabel="Waiting for browser..."
+      uninstallLabel={t("mcp.org_connection_disconnect_action")}
       url={row.connection.url}
       oauth={row.connection.authType === "oauth"}
       showEnablementCard={false}
-      onConnect={onConnect ? () => onConnect(row.connection.id) : undefined}
+      onConnect={!ready && onConnect ? () => onConnect(row.connection.id) : undefined}
+      onUninstall={canDisconnect && onDisconnect ? () => onDisconnect(row.connection.id) : undefined}
       configSlot={(
         <div className="space-y-4">
           <div className="flex flex-wrap gap-2">

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { t } from "@/i18n";
 import { DenSignInSurface } from "@/react-app/domains/cloud/den-signin-surface";
 import { useDenAuth, type DenAuthStatus } from "@/react-app/domains/cloud/den-auth-provider";
+import { canDisconnectNativeProviderAccount } from "@/react-app/domains/connections/native-provider-connections";
 import { useOrgMcpConnections } from "@/react-app/domains/connections/use-org-mcp-connections";
 import {
   cloudReadinessConnectableConnectionId,
@@ -254,7 +255,9 @@ function buildConnectRows(input: {
 
 function ConnectOrganizationRow(props: {
   connectingId: string | null;
+  disconnectingId: string | null;
   onConnect: (connectionId: string) => void;
+  onDisconnect: (connectionId: string) => void;
   row: ConnectOrganizationRow;
 }) {
   const row = props.row;
@@ -266,6 +269,8 @@ function ConnectOrganizationRow(props: {
       : null;
   const setupNames = row.kind === "plugin" ? cloudReadinessMissingConnectionNames(row.plugin.cloudReadiness) : [];
   const connecting = connectableConnectionId ? props.connectingId === connectableConnectionId : false;
+  const disconnectableConnectionId = row.kind === "connection" && canDisconnectNativeProviderAccount(row.connection) ? row.connection.id : null;
+  const disconnecting = disconnectableConnectionId ? props.disconnectingId === disconnectableConnectionId : false;
 
   return (
     <div
@@ -291,6 +296,15 @@ function ConnectOrganizationRow(props: {
         <Button size="sm" variant="outline" onClick={() => void openDesktopUrl(denManageConnectionsUrl())} title={setupNames.join(t("connect.row_meta_list_separator"))}>
           {t("connect.row_action_set_up_connection")}
         </Button>
+      ) : disconnectableConnectionId ? (
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          <span className="rounded-md bg-green-3 px-2 py-1 text-xs font-medium text-green-11">
+            {t("connect.row_chip_ready")}
+          </span>
+          <Button size="sm" variant="destructive" disabled={disconnecting} onClick={() => props.onDisconnect(disconnectableConnectionId)}>
+            {disconnecting ? t("mcp.org_connection_disconnecting_action") : t("mcp.org_connection_disconnect_action")}
+          </Button>
+        </div>
       ) : (
         <span className="shrink-0 rounded-md bg-green-3 px-2 py-1 text-xs font-medium text-green-11">
           {t("connect.row_chip_ready")}
@@ -302,9 +316,11 @@ function ConnectOrganizationRow(props: {
 
 function ConnectOrganizationList(props: {
   connectingId: string | null;
+  disconnectingId: string | null;
   connections: DenExternalMcpConnection[];
   items: ExtensionItem[];
   onConnect: (connectionId: string) => void;
+  onDisconnect: (connectionId: string) => void;
   role: "owner" | "admin" | "member" | null | undefined;
 }) {
   const [search, setSearch] = useState("");
@@ -351,7 +367,14 @@ function ConnectOrganizationList(props: {
                 </div>
                 <div className="space-y-2">
                   {groupRows.map((row) => (
-                    <ConnectOrganizationRow key={`${row.kind}:${row.id}`} row={row} connectingId={props.connectingId} onConnect={props.onConnect} />
+                    <ConnectOrganizationRow
+                      key={`${row.kind}:${row.id}`}
+                      row={row}
+                      connectingId={props.connectingId}
+                      disconnectingId={props.disconnectingId}
+                      onConnect={props.onConnect}
+                      onDisconnect={props.onDisconnect}
+                    />
                   ))}
                 </div>
               </div>
@@ -369,7 +392,9 @@ function ConnectActivePanel(props: {
   loading: boolean;
   error: string | null;
   connectingId: string | null;
+  disconnectingId: string | null;
   onConnect: (connectionId: string) => void;
+  onDisconnect: (connectionId: string) => void;
 }) {
   const { activeOrganization } = useCloudSession();
   const activeOrgName = activeOrganization?.name.trim();
@@ -394,7 +419,9 @@ function ConnectActivePanel(props: {
         items={props.marketplaceItems}
         role={activeOrganization?.role}
         connectingId={props.connectingId}
+        disconnectingId={props.disconnectingId}
         onConnect={props.onConnect}
+        onDisconnect={props.onDisconnect}
       />
 
       <div className="flex justify-end">
@@ -456,7 +483,9 @@ export function ConnectView(props: ConnectViewProps) {
           loading={orgMcpConnections.loading}
           error={orgMcpConnections.error}
           connectingId={orgMcpConnections.connectingId}
+          disconnectingId={orgMcpConnections.disconnectingId}
           onConnect={orgMcpConnections.connect}
+          onDisconnect={orgMcpConnections.disconnect}
         />
       ) : null}
       {state === "pitch" ? <ConnectPitchPanel /> : null}

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -51,6 +51,7 @@ import { Button } from "@/components/ui/button";
 import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
 import { AddMcpModal } from "../../connections/modals/add-mcp-modal";
 import { ClaudePluginImportModal } from "../../connections/modals/claude-plugin-import-modal";
+import { canDisconnectNativeProviderAccount } from "../../connections/native-provider-connections";
 import type { OpenworkClaudePluginPreview } from "../../../../app/lib/openwork-server";
 import {
   isOpenWorkExtensionEnabled,
@@ -126,6 +127,8 @@ export type McpViewProps = {
   installClaudePlugin?: (url: string) => Promise<{ ok: boolean; message: string }>;
   /** Connected org-level External MCP Connections rendered in My Extensions. */
   installedOrgMcpItems?: ExtensionItem[];
+  orgMcpDisconnectingId?: string | null;
+  disconnectOrgMcp?: (connectionId: string) => void;
 };
 
 const builtInExtensionDisabledReason = "Disabled by organization";
@@ -632,6 +635,8 @@ export function McpView(props: McpViewProps) {
         }}
         onPluginDetail={setDetailPlugin}
         onOrgMcpDetail={setDetailOrgMcpItem}
+        orgMcpDisconnectingId={props.orgMcpDisconnectingId ?? null}
+        disconnectOrgMcp={props.disconnectOrgMcp}
       />
 
       <McpConfiguredServersSection
@@ -830,6 +835,7 @@ export function McpView(props: McpViewProps) {
 
       {detailOrgMcpItem && isOrgMcpConnectionItem(detailOrgMcpItem) ? (() => {
         const connection = detailOrgMcpItem.orgMcpConnection;
+        const canDisconnect = canDisconnectNativeProviderAccount(connection);
         return (
           <ExtensionDetailModal
             open={true}
@@ -842,6 +848,8 @@ export function McpView(props: McpViewProps) {
             beta
             url={connection.url}
             oauth={connection.authType === "oauth"}
+            onUninstall={canDisconnect && props.disconnectOrgMcp ? () => props.disconnectOrgMcp?.(connection.id) : undefined}
+            uninstallLabel={t("mcp.org_connection_disconnect_action")}
             showEnablementCard={false}
             configSlot={(
               <div className="flex flex-wrap gap-2">
@@ -917,6 +925,8 @@ function McpQuickConnectSection(props: {
   onSkillDetail?: (skill: SkillItem) => void;
   onPluginDetail?: (plugin: CloudImportedPlugin) => void;
   onOrgMcpDetail?: (item: ExtensionItem) => void;
+  orgMcpDisconnectingId: string | null;
+  disconnectOrgMcp?: (connectionId: string) => void;
 }) {
   return (
     <div className="space-y-4">
@@ -995,19 +1005,33 @@ function McpQuickConnectSection(props: {
 
         {(props.installedOrgMcpItems ?? []).filter(isOrgMcpConnectionItem).map((item) => {
           const connection = item.orgMcpConnection;
+          const canDisconnect = canDisconnectNativeProviderAccount(connection);
+          const disconnecting = props.orgMcpDisconnectingId === connection.id;
           return (
-            <ExtensionCard
-              key={item.id}
-              name={item.name}
-              description={item.description ?? "Shared by your organization."}
-              kind="mcp"
-              url={connection.url}
-              connected={true}
-              connectedLabel={orgMcpConnectionActionLabel(connection)}
-              beta
-              actionLabel="View details"
-              onClick={() => props.onOrgMcpDetail?.(item)}
-            />
+            <div key={item.id} className="space-y-2">
+              <ExtensionCard
+                name={item.name}
+                description={item.description ?? "Shared by your organization."}
+                kind="mcp"
+                url={connection.url}
+                connected={true}
+                connectedLabel={orgMcpConnectionActionLabel(connection)}
+                beta
+                actionLabel={disconnecting ? t("mcp.org_connection_disconnecting_action") : "View details"}
+                onClick={() => props.onOrgMcpDetail?.(item)}
+              />
+              {canDisconnect ? (
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  className="w-full"
+                  disabled={disconnecting}
+                  onClick={() => props.disconnectOrgMcp?.(connection.id)}
+                >
+                  {disconnecting ? t("mcp.org_connection_disconnecting_action") : t("mcp.org_connection_disconnect_action")}
+                </Button>
+              ) : null}
+            </div>
           );
         })}
 

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1665,6 +1665,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     () => extensionItems.items.filter((item) => item.source !== "org-connection"),
     [extensionItems.items],
   );
+  const installedOrgMcpConnectionItems = useMemo(
+    () => extensionItems.orgMcpConnectionItems.filter((item) => item.installState === "installed"),
+    [extensionItems.orgMcpConnectionItems],
+  );
   const routeOpenworkStatus = openworkClient ? "connected" : "disconnected";
   const notFoundRouteError = !loading && routeWorkspaceId && !selectedWorkspace
     ? "Workspace was not found. Select a new workspace from the sidebar."
@@ -2098,8 +2102,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 readConfigFile={(scope) => connectionsStore.readMcpConfigFile(scope)}
                 installedSkills={extensionItems.installedSkills}
                 installedPlugins={extensionItems.installedCloudPlugins}
+                installedOrgMcpItems={installedOrgMcpConnectionItems}
                 uninstallSkill={(name) => { void extensionsStore.uninstallSkill(name); }}
                 removeCloudPlugin={(pluginId) => { void extensionsStore.removeCloudOrgPlugin(pluginId); }}
+                orgMcpDisconnectingId={orgMcpConnections.disconnectingId}
+                disconnectOrgMcp={(connectionId) => { void orgMcpConnections.disconnect(connectionId); }}
                 readSkill={(name) => extensionsStore.readSkill(name)}
                 previewClaudePlugin={(url) => extensionsStore.previewClaudePlugin(url)}
                 installClaudePlugin={(url) => extensionsStore.installClaudePlugin(url)}
@@ -2121,8 +2128,12 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 isBuiltInConnected={extensionController.isConnected}
                 extensionItems={extensionItemsForExtensions}
                 orgMcpConnectingId={orgMcpConnections.connectingId}
+                orgMcpDisconnectingId={orgMcpConnections.disconnectingId}
                 onConnectOrgMcp={(connectionId) => {
                   void orgMcpConnections.connect(connectionId);
+                }}
+                onDisconnectOrgMcp={(connectionId) => {
+                  void orgMcpConnections.disconnect(connectionId);
                 }}
                 refreshOrgMcpConnections={orgMcpConnections.refresh}
                 setBuiltInEnabled={setOpenWorkExtensionEnabled}
@@ -2160,8 +2171,12 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             isBuiltInConnected={extensionController.isConnected}
             extensionItems={extensionItemsForExtensions}
             orgMcpConnectingId={orgMcpConnections.connectingId}
+            orgMcpDisconnectingId={orgMcpConnections.disconnectingId}
             onConnectOrgMcp={(connectionId) => {
               void orgMcpConnections.connect(connectionId);
+            }}
+            onDisconnectOrgMcp={(connectionId) => {
+              void orgMcpConnections.disconnect(connectionId);
             }}
             refreshOrgMcpConnections={orgMcpConnections.refresh}
             setBuiltInEnabled={setOpenWorkExtensionEnabled}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -55,6 +55,15 @@ export type CreatedMcpConnection = ExternalMcpConnection & {
   };
 };
 
+export function isNativeProviderConnectionId(id: string): boolean {
+  // Today google-workspace is the only native provider connection id; a follow-up generalizes this for external per-member connections.
+  return id === "google-workspace";
+}
+
+export function canDisconnectNativeProviderAccount(connection: Pick<ExternalMcpConnection, "id" | "connectedForMe">): boolean {
+  return connection.connectedForMe && isNativeProviderConnectionId(connection.id);
+}
+
 export const mcpConnectionQueryKeys = {
   all: ["mcp-connections"] as const,
   list: (orgId?: string | null, scope?: ExternalMcpConnectionScope) =>
@@ -195,6 +204,28 @@ export function useStartMcpConnectionOAuth() {
         throw getRequestError(payload, response, `Failed to start OAuth (${response.status}).`);
       }
       return payload as { status: "connected" | "needs_auth"; authorizeUrl: string | null };
+    },
+  });
+}
+
+export function useDisconnectMyProviderAccount() {
+  const queryClient = useQueryClient();
+  const { orgId } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (providerId: string): Promise<string> => {
+      const { response, payload } = await requestJson(
+        `/v1/oauth-providers/${encodeURIComponent(providerId)}/disconnect`,
+        { method: "POST", headers: getOrgScopeHeaders(requireOrgId(orgId)) },
+        15000,
+      );
+      if (!response.ok) {
+        throw getRequestError(payload, response, `Failed to disconnect account (${response.status}).`);
+      }
+      return providerId;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });
     },
   });
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -8,7 +8,9 @@ import { getOrgAccessFlags } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { IntegrationIcon } from "./integration-icon";
 import {
+  canDisconnectNativeProviderAccount,
   type ExternalMcpConnection,
+  useDisconnectMyProviderAccount,
   useMcpConnections,
   useStartMcpConnectionOAuth,
 } from "./mcp-connections-data";
@@ -34,7 +36,9 @@ export function YourConnectionsScreen() {
     orgContext?.roles,
   );
   const startOAuth = useStartMcpConnectionOAuth();
+  const disconnectProvider = useDisconnectMyProviderAccount();
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<{ connectionId: string; message: string } | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
@@ -64,6 +68,7 @@ export function YourConnectionsScreen() {
   }
 
   async function handleConnectMyAccount(connectionId: string) {
+    setRowError(null);
     const result = await startOAuth.mutateAsync(connectionId);
     if (result.status === "connected") {
       void refetch();
@@ -72,6 +77,19 @@ export function YourConnectionsScreen() {
     if (result.authorizeUrl) {
       window.open(result.authorizeUrl, "_blank", "noopener,noreferrer");
       pollUntilConnectedForMe(connectionId);
+    }
+  }
+
+  async function handleDisconnectMyAccount(connectionId: string) {
+    setRowError(null);
+    try {
+      await disconnectProvider.mutateAsync(connectionId);
+      void refetch();
+    } catch (disconnectError) {
+      setRowError({
+        connectionId,
+        message: disconnectError instanceof Error ? disconnectError.message : "Failed to disconnect account.",
+      });
     }
   }
 
@@ -106,7 +124,10 @@ export function YourConnectionsScreen() {
               isAdmin={access.isAdmin}
               polling={pollingConnectionId === connection.id}
               connecting={startOAuth.isPending && startOAuth.variables === connection.id}
+              disconnecting={disconnectProvider.isPending && disconnectProvider.variables === connection.id}
+              errorMessage={rowError?.connectionId === connection.id ? rowError.message : null}
               onConnect={() => void handleConnectMyAccount(connection.id)}
+              onDisconnect={() => void handleDisconnectMyAccount(connection.id)}
             />
           ))}
         </div>
@@ -120,17 +141,24 @@ function YourConnectionRow({
   isAdmin,
   polling,
   connecting,
+  disconnecting,
+  errorMessage,
   onConnect,
+  onDisconnect,
 }: {
   connection: ExternalMcpConnection;
   isAdmin: boolean;
   polling: boolean;
   connecting: boolean;
+  disconnecting: boolean;
+  errorMessage: string | null;
   onConnect: () => void;
+  onDisconnect: () => void;
 }) {
   const isPerMember = connection.credentialMode === "per_member";
   const needsMyConnect = isPerMember && !connection.connectedForMe;
   const needsAdminConnect = isAdmin && !isPerMember && connection.authType === "oauth" && !connection.connectedForMe;
+  const canDisconnect = canDisconnectNativeProviderAccount(connection);
 
   return (
     <div className="flex items-center justify-between gap-4 px-6 py-4">
@@ -164,10 +192,16 @@ function YourConnectionRow({
             )}
           </div>
           <p className="mt-0.5 truncate text-[12px] text-gray-500">{connection.url}</p>
+          {errorMessage ? <p className="mt-1 text-[12px] text-red-600">{errorMessage}</p> : null}
         </div>
       </div>
 
       <div className="flex shrink-0 items-center gap-2">
+        {canDisconnect ? (
+          <DenButton variant="destructive" size="sm" loading={disconnecting} onClick={onDisconnect}>
+            Disconnect
+          </DenButton>
+        ) : null}
         {needsMyConnect || needsAdminConnect ? (
           <DenButton variant="primary" size="sm" loading={connecting || polling} onClick={onConnect}>
             Connect


### PR DESCRIPTION
## Summary

The org **Google Workspace** connection (the native provider entry that rides the member-facing connections list) could be connected per member but **never disconnected** from either UI — rows only ever offered Connect / "Connected as you". This PR adds member-scoped Disconnect on both surfaces, wired to the existing endpoint `POST /v1/oauth-providers/:providerId/disconnect` (no server changes).

## What changed

**Den web — Your Connections** (`your-connections-screen.tsx`, `mcp-connections-data.tsx`)
- New `useDisconnectMyProviderAccount()` mutation (mirrors the start-OAuth hook; invalidates the connections query).
- Connected-as-you Google Workspace rows get a destructive **Disconnect** button with loading state and row-level error; on success the row flips back to "Connect your account".

**Desktop app**
- `den.ts`: `disconnectOauthProviderAccount(orgId, providerId)`.
- `useOrgMcpConnections`: guarded `disconnect()` + `disconnectingId`, refreshes after.
- Disconnect surfaced on: the Connect view org row, the installed org MCP card/detail modal (`mcp-view.tsx`), and the marketplace detail path (`cloud-marketplaces-view.tsx`).
- New shared predicate `canDisconnectNativeProviderAccount` (gated to native provider ids — `google-workspace` today; a follow-up PR generalizes to external per-member connections like Notion/Linear).
- New locale keys (`mcp.org_connection_disconnect_action` / `…_disconnecting_action`) added to **all** locales.

The local Google Workspace extension config (which already had per-account disconnect) is untouched.

## Validation (commands + results)

- `pnpm typecheck` ✅
- `node scripts/i18n-audit.mjs --ci` ✅ (exit 0)
- `pnpm --filter @openwork-ee/den-web build` ✅
- Unit tests for the new predicates: `pnpm --filter @openwork/app exec bun test src/react-app/domains/connections/native-provider-connections.test.ts` → 2 pass / 0 fail

## Not run

Evals/fraimz skipped at the requester's explicit instruction for this PR (the follow-up GWS PR will carry eval proof where feasible). Reviewer repro: Den dashboard → Your Connections → Google Workspace ("Connected as you") → Disconnect → row returns to "Connect your account"; same from the desktop Connect screen row.
