### PR TITLE
Use single Cloud base URL in desktop

### DIFF
--- a/apps/app/src/app/cloud/desktop-cloud-sync.ts
+++ b/apps/app/src/app/cloud/desktop-cloud-sync.ts
@@ -111,7 +111,6 @@ async function runDesktopCloudSync(input: {
 
   const snapshot = await createDenClient({
     baseUrl: settings.baseUrl,
-    apiBaseUrl: settings.apiBaseUrl,
     token,
   }).getResourceSnapshot(activeOrgId);
 

--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -163,7 +163,7 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
       try {
         return `${getDenMcpUrl()}/agent`;
       } catch {
-        return "https://api.openworklabs.com/mcp/agent";
+        return "https://app.openworklabs.com/api/den/mcp/agent";
       }
     },
     type: "remote",
@@ -182,7 +182,7 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
       try {
         return `${getDenMcpUrl()}/admin`;
       } catch {
-        return "https://api.openworklabs.com/mcp/admin";
+        return "https://app.openworklabs.com/api/den/mcp/admin";
       }
     },
     type: "remote",

--- a/apps/app/src/app/lib/den-endpoint-sources.test.ts
+++ b/apps/app/src/app/lib/den-endpoint-sources.test.ts
@@ -11,14 +11,14 @@ import {
 } from "./den-endpoint-sources";
 
 describe("Den endpoint sources", () => {
-  test("custom storage wins over bootstrap", () => {
+  test("bootstrap wins over stale storage", () => {
     expect(describeDenEndpointSource({
       storedValue: "https://custom.example.com/",
       bootstrapValue: "http://127.0.0.1:8788",
       buildDefault: "https://app.openworklabs.com",
     })).toEqual({
-      effective: "https://custom.example.com",
-      source: "custom",
+      effective: "http://127.0.0.1:8788",
+      source: "bootstrap",
     });
   });
 
@@ -57,7 +57,7 @@ describe("Den endpoint sources", () => {
   test("detects MCP targets that do not match the API origin", () => {
     const target = describeCloudMcpTarget({
       mcpUrl: "https://other.example.com/mcp/agent",
-      effectiveApiBaseUrl: "https://api.openworklabs.com/api/den",
+      effectiveApiBaseUrl: "https://app.openworklabs.com/api/den",
     });
 
     expect(target.url).toBe("https://other.example.com/mcp/agent");
@@ -68,7 +68,7 @@ describe("Den endpoint sources", () => {
   test("handles a missing MCP URL", () => {
     expect(describeCloudMcpTarget({
       mcpUrl: null,
-      effectiveApiBaseUrl: "https://api.openworklabs.com/api/den",
+      effectiveApiBaseUrl: "https://app.openworklabs.com/api/den",
     })).toEqual({
       url: null,
       isLocalhost: false,

--- a/apps/app/src/app/lib/den-endpoint-sources.ts
+++ b/apps/app/src/app/lib/den-endpoint-sources.ts
@@ -7,11 +7,6 @@ export function describeDenEndpointSource(input: {
   bootstrapValue: string | null;
   buildDefault: string;
 }): { effective: string; source: DenEndpointSource } {
-  const stored = normalizeDenBaseUrl(input.storedValue);
-  if (stored) {
-    return { effective: stored, source: "custom" };
-  }
-
   const bootstrap = normalizeDenBaseUrl(input.bootstrapValue);
   if (bootstrap) {
     return { effective: bootstrap, source: "bootstrap" };

--- a/apps/app/src/app/lib/den-handoff.ts
+++ b/apps/app/src/app/lib/den-handoff.ts
@@ -16,11 +16,7 @@ export type HandoffActiveOrg = {
 export type ExchangeHandoffOptions = {
   /** Den base URL to exchange against (and persist on success). */
   baseUrl: string;
-  /**
-   * Pre-built client to reuse. Callers that need to preserve a specific
-   * apiBaseUrl (e.g. same-control-plane deployments) build their own client and
-   * pass it here. When omitted, a default client for `baseUrl` is created.
-   */
+  /** Pre-built client to reuse. When omitted, a default client for `baseUrl` is created. */
   client?: DenClient;
   /** Optional active org to select on sign-in (bootstrap prepares this). */
   activeOrg?: HandoffActiveOrg | null;
@@ -29,7 +25,7 @@ export type ExchangeHandoffOptions = {
 };
 
 export type ExchangeHandoffResult =
-  | { ok: true; exchange: DenDesktopHandoffExchange; baseUrl: string; apiBaseUrl: string }
+  | { ok: true; exchange: DenDesktopHandoffExchange; baseUrl: string }
   | { ok: false; error: string };
 
 /**
@@ -54,10 +50,8 @@ export async function exchangeHandoffAndSignIn(
       throw new Error(fallback);
     }
 
-    const apiBaseUrl = client.baseUrls.apiBaseUrl;
     writeDenSettings({
       baseUrl: options.baseUrl,
-      apiBaseUrl,
       authToken: exchange.token,
       activeOrgId: options.activeOrg?.id ?? null,
       activeOrgSlug: options.activeOrg?.slug ?? null,
@@ -72,7 +66,7 @@ export async function exchangeHandoffAndSignIn(
       email: exchange.user?.email ?? null,
     });
 
-    return { ok: true, exchange, baseUrl: options.baseUrl, apiBaseUrl };
+    return { ok: true, exchange, baseUrl: options.baseUrl };
   } catch (error) {
     const message = error instanceof Error ? error.message : fallback;
     dispatchDenSessionUpdated({ status: "error", message });

--- a/apps/app/src/app/lib/den-skills.ts
+++ b/apps/app/src/app/lib/den-skills.ts
@@ -10,7 +10,7 @@ export async function saveInstalledSkillToOpenWorkOrg(input: {
     throw new Error("Sign in to OpenWork Cloud in Settings to share with your team.");
   }
 
-  const cloudClient = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
+  const cloudClient = createDenClient({ baseUrl: settings.baseUrl, token });
   let orgId = settings.activeOrgId?.trim() ?? "";
   let orgSlug = settings.activeOrgSlug?.trim() ?? "";
   let orgName = settings.activeOrgName?.trim() ?? "";

--- a/apps/app/src/app/lib/den-telemetry.ts
+++ b/apps/app/src/app/lib/den-telemetry.ts
@@ -45,7 +45,6 @@ function getResolvedIngestUrl(settings: DenSettings): string | null {
 
   const baseUrls = resolveDenBaseUrls({
     baseUrl: settings.baseUrl,
-    apiBaseUrl: settings.apiBaseUrl,
   });
 
   return `${baseUrls.apiBaseUrl}${INGEST_PATH}`;

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -36,7 +36,7 @@ import type {
 } from "../extensions";
 
 export const STORAGE_BASE_URL = "openwork.den.baseUrl";
-export const STORAGE_API_BASE_URL = "openwork.den.apiBaseUrl";
+const LEGACY_STORAGE_API_BASE_URL = "openwork.den.apiBaseUrl";
 const STORAGE_AUTH_TOKEN = "openwork.den.authToken";
 const STORAGE_ACTIVE_ORG_ID = "openwork.den.activeOrgId";
 const STORAGE_ACTIVE_ORG_SLUG = "openwork.den.activeOrgSlug";
@@ -49,15 +49,12 @@ const BUILD_DEN_BASE_URL =
   (typeof import.meta !== "undefined" && typeof import.meta.env?.VITE_DEN_BASE_URL === "string"
     ? import.meta.env.VITE_DEN_BASE_URL
     : "").trim() || "https://app.openworklabs.com";
-const BUILD_DEN_API_BASE_URL =
-  (typeof import.meta !== "undefined" && typeof import.meta.env?.VITE_DEN_API_BASE_URL === "string"
-    ? import.meta.env.VITE_DEN_API_BASE_URL
-    : "").trim() || undefined;
 const BUILD_DEN_REQUIRE_SIGNIN =
   (typeof import.meta !== "undefined" && typeof import.meta.env?.VITE_DEN_REQUIRE_SIGNIN === "string"
     ? /^(1|true|yes|on)$/i.test(import.meta.env.VITE_DEN_REQUIRE_SIGNIN.trim())
     : false);
 
+const HOSTED_DEFAULT_DEN_BASE_URL = "https://app.openworklabs.com";
 export const DEFAULT_DEN_BASE_URL = BUILD_DEN_BASE_URL;
 export const DEN_INFERENCE_PATH = "/dashboard/inference";
 
@@ -286,7 +283,6 @@ export type DenDesktopHandoffExchange = {
 
 const defaultBootstrapBaseUrls = resolveDenBaseUrls({
   baseUrl: BUILD_DEN_BASE_URL,
-  apiBaseUrl: BUILD_DEN_API_BASE_URL,
 });
 export const DEFAULT_DEN_API_BASE_URL = defaultBootstrapBaseUrls.apiBaseUrl;
 
@@ -465,74 +461,8 @@ export function getDenInferenceUrl(baseUrl?: string | null): string {
   return `${normalized}${DEN_INFERENCE_PATH}`;
 }
 
-function isWebAppHost(hostname: string): boolean {
-  const normalized = hostname.trim().toLowerCase();
-
-  if (
-    normalized === "localhost" ||
-    normalized === "0.0.0.0" ||
-    normalized === "::1" ||
-    normalized === "[::1]" ||
-    /^127(?:\.\d{1,3}){3}$/.test(normalized)
-  ) {
-    return true;
-  }
-
-  const ipv4Match = normalized.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (ipv4Match) {
-    const [first, second, third, fourth] = ipv4Match.slice(1).map(Number);
-    const octets = [first, second, third, fourth];
-    if (octets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255)) {
-      if (
-        first === 10 ||
-        first === 127 ||
-        (first === 172 && second >= 16 && second <= 31) ||
-        (first === 192 && second === 168) ||
-        (first === 169 && second === 254) ||
-        (first === 100 && second >= 64 && second <= 127)
-      ) {
-        return true;
-      }
-    }
-  }
-
-  return (
-    normalized === "app.openworklabs.com" ||
-    normalized === "app.openwork.software" ||
-    normalized.startsWith("app.") ||
-    // Cloud Run hostnames serve the den-web frontend, which only exposes the
-    // Den API behind its `/api/den` proxy path (see #1807/#1808).
-    normalized.endsWith(".run.app")
-  );
-}
-
-/**
- * Hosted web-app hosts (`app.openworklabs.com`, `app.openwork.software`,
- * `app.*`) never serve the Den API at their root — only behind the
- * `/api/den` proxy. Loopback/private hosts are excluded on purpose: in dev
- * an explicit apiBaseUrl may point directly at den-api.
- */
 function isHostedWebAppHost(hostname: string): boolean {
   return hostname.trim().toLowerCase().startsWith("app.");
-}
-
-/**
- * Older builds persisted the bare web-app origin as the API base URL
- * (bootstrap file and localStorage). Requests against that origin 404 —
- * notably the cloud MCP at `https://app.openworklabs.com/mcp`. Heal such
- * values by routing them through the web app's `/api/den` proxy.
- */
-function healWebAppApiBaseUrl(input: string | null): string | null {
-  if (!input) return null;
-  try {
-    const url = new URL(input);
-    if (isHostedWebAppHost(url.hostname)) {
-      return ensureDenApiBasePath(input);
-    }
-  } catch {
-    // Not a URL — leave untouched.
-  }
-  return input;
 }
 
 function stripDenApiBasePath(input: string | null | undefined): string | null {
@@ -572,44 +502,20 @@ function ensureDenApiBasePath(input: string | null | undefined): string | null {
   }
 }
 
-function deriveDenApiBaseUrl(input: string | null | undefined): string {
-  const normalized = normalizeDenBaseUrl(input) ?? DEFAULT_DEN_BASE_URL;
-
-  try {
-    const url = new URL(normalized);
-    const pathname = url.pathname.replace(/\/+$/, "");
-    if (pathname.toLowerCase().endsWith("/api/den")) {
-      return normalized;
-    }
-    if (isWebAppHost(url.hostname)) {
-      return ensureDenApiBasePath(normalized) ?? normalized;
-    }
-  } catch {
-    return normalized;
-  }
-
-  return normalized;
-}
-
 export function resolveDenBaseUrls(input: { baseUrl?: string | null; apiBaseUrl?: string | null } | string | null | undefined): DenBaseUrls {
   const rawBaseUrl = typeof input === "string" ? input : input?.baseUrl;
-  const rawApiBaseUrl = typeof input === "string" ? null : input?.apiBaseUrl;
   const normalizedBaseUrl = normalizeDenBaseUrl(rawBaseUrl);
-  const normalizedApiBaseUrl = normalizeDenBaseUrl(rawApiBaseUrl);
-  const seedUrl = normalizedBaseUrl ?? normalizedApiBaseUrl ?? DEFAULT_DEN_BASE_URL;
+  const legacyApiBaseUrl = typeof input === "string" ? null : normalizeDenBaseUrl(input?.apiBaseUrl);
+  const seedUrl = stripDenApiBasePath(normalizedBaseUrl ?? legacyApiBaseUrl) ?? DEFAULT_DEN_BASE_URL;
+  const baseUrl = stripDenApiBasePath(seedUrl) ?? DEFAULT_DEN_BASE_URL;
 
   return {
-    baseUrl: stripDenApiBasePath(normalizedBaseUrl ?? seedUrl) ?? DEFAULT_DEN_BASE_URL,
-    apiBaseUrl: healWebAppApiBaseUrl(normalizedApiBaseUrl) ?? deriveDenApiBaseUrl(seedUrl),
+    baseUrl,
+    apiBaseUrl: ensureDenApiBasePath(baseUrl) ?? baseUrl,
   };
 }
 
-/**
- * The MCP endpoint served by den-api, resolved from the bootstrap config.
- * On the hosted web app this goes through the `/api/den` proxy
- * (`https://app.openworklabs.com/api/den/mcp`); a direct API origin maps to
- * `<apiBaseUrl>/mcp` (canonically `https://api.openworklabs.com/mcp`).
- */
+/** The MCP endpoint served through the Den web proxy from the single base URL. */
 export function getDenMcpUrl(): string {
   const { apiBaseUrl } = resolveDenBaseUrls(readDenBootstrapConfig());
   return `${apiBaseUrl.replace(/\/+$/, "")}/mcp`;
@@ -670,31 +576,20 @@ function resolveDenBootstrapConfig(
   };
 }
 
-function syncBootstrapSettingsToLocalStorage(config: DenBootstrapConfig) {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  window.localStorage.setItem(STORAGE_BASE_URL, config.baseUrl);
-  window.localStorage.setItem(STORAGE_API_BASE_URL, config.apiBaseUrl);
-}
-
 function getPendingBootstrapConfig(next: DenSettings): DenBootstrapConfig | null {
-  if (next.baseUrl === undefined && next.apiBaseUrl === undefined) {
+  if (next.baseUrl === undefined) {
     return null;
   }
 
   const previous = readDenBootstrapConfig();
   return resolveDenBootstrapConfig({
     baseUrl: next.baseUrl ?? previous.baseUrl,
-    apiBaseUrl: next.apiBaseUrl ?? previous.apiBaseUrl,
     requireSignin: previous.requireSignin,
   });
 }
 
 function applyDesktopBootstrapConfig(config: DenBootstrapConfig) {
   desktopBootstrapConfig = config;
-  syncBootstrapSettingsToLocalStorage(config);
 }
 
 export function readDenBootstrapConfig(): DenBootstrapConfig {
@@ -705,7 +600,6 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
   if (!isDesktopRuntime()) {
     desktopBootstrapConfig = resolveDenBootstrapConfig({
       baseUrl: BUILD_DEN_BASE_URL,
-      apiBaseUrl: BUILD_DEN_API_BASE_URL,
       requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
     });
     return desktopBootstrapConfig;
@@ -735,8 +629,7 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
   // silently reverted custom/self-hosted control planes to the production
   // URL until a manual reload.
   desktopBootstrapConfig = resolveDenBootstrapConfig({
-    baseUrl: BUILD_DEN_BASE_URL,
-    apiBaseUrl: BUILD_DEN_API_BASE_URL,
+    baseUrl: HOSTED_DEFAULT_DEN_BASE_URL,
     requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
   });
 
@@ -767,7 +660,6 @@ export async function setDenBootstrapConfig(
   if (isDesktopRuntime()) {
     const persisted = await setDesktopBootstrapConfigInShell({
       baseUrl: normalized.baseUrl,
-      apiBaseUrl: normalized.apiBaseUrl,
       requireSignin: normalized.requireSignin,
       ...(normalized.handoff ? { handoff: normalized.handoff } : {}),
       ...(normalized.prepared ? { prepared: normalized.prepared } : {}),
@@ -811,8 +703,9 @@ export function readDenSettings(): DenSettings {
   }
 
   const baseUrls = resolveDenBaseUrls({
-    baseUrl: window.localStorage.getItem(STORAGE_BASE_URL) ?? readDenBootstrapConfig().baseUrl,
-    apiBaseUrl: window.localStorage.getItem(STORAGE_API_BASE_URL) ?? readDenBootstrapConfig().apiBaseUrl,
+    baseUrl: isDesktopRuntime()
+      ? readDenBootstrapConfig().baseUrl
+      : window.localStorage.getItem(STORAGE_BASE_URL) ?? readDenBootstrapConfig().baseUrl,
   });
 
   return {
@@ -832,13 +725,8 @@ export function writeDenSettings(next: DenSettings, options?: { persistBootstrap
   const pendingBootstrap = getPendingBootstrapConfig(next);
   const previous = readDenSettings();
   const resolved = resolveDenBaseUrls(next);
-  const previousResolved = resolveDenBaseUrls(previous);
   const baseUrl = resolved.baseUrl;
-  const apiBaseUrl = next.apiBaseUrl !== undefined
-    ? resolved.apiBaseUrl
-    : previousResolved.baseUrl === resolved.baseUrl
-      ? previous.apiBaseUrl ?? resolved.apiBaseUrl
-      : resolved.apiBaseUrl;
+  const apiBaseUrl = resolved.apiBaseUrl;
   const authToken = next.authToken?.trim() ?? "";
   const activeOrgId = next.activeOrgId?.trim() ?? "";
   const activeOrgSlug = next.activeOrgSlug?.trim() ?? "";
@@ -855,8 +743,12 @@ export function writeDenSettings(next: DenSettings, options?: { persistBootstrap
     return;
   }
 
-  window.localStorage.setItem(STORAGE_BASE_URL, baseUrl);
-  window.localStorage.setItem(STORAGE_API_BASE_URL, apiBaseUrl);
+  if (isDesktopRuntime()) {
+    window.localStorage.removeItem(STORAGE_BASE_URL);
+  } else {
+    window.localStorage.setItem(STORAGE_BASE_URL, baseUrl);
+  }
+  window.localStorage.removeItem(LEGACY_STORAGE_API_BASE_URL);
   if (authToken) {
     window.localStorage.setItem(STORAGE_AUTH_TOKEN, authToken);
   } else {
@@ -884,12 +776,10 @@ export function writeDenSettings(next: DenSettings, options?: { persistBootstrap
   if (options?.persistBootstrap !== false && pendingBootstrap) {
     const currentBootstrap = readDenBootstrapConfig();
     if (
-      pendingBootstrap.baseUrl !== currentBootstrap.baseUrl ||
-      pendingBootstrap.apiBaseUrl !== currentBootstrap.apiBaseUrl
+      pendingBootstrap.baseUrl !== currentBootstrap.baseUrl
     ) {
       void setDenBootstrapConfig({
         baseUrl: pendingBootstrap.baseUrl,
-        apiBaseUrl: pendingBootstrap.apiBaseUrl,
         requireSignin: currentBootstrap.requireSignin,
       }).catch(() => undefined);
     }
@@ -907,7 +797,7 @@ export function clearDenSession(options?: { includeBaseUrls?: boolean }) {
 
   if (options?.includeBaseUrls) {
     window.localStorage.removeItem(STORAGE_BASE_URL);
-    window.localStorage.removeItem(STORAGE_API_BASE_URL);
+    window.localStorage.removeItem(LEGACY_STORAGE_API_BASE_URL);
   }
 
   window.localStorage.removeItem(STORAGE_AUTH_TOKEN);
@@ -929,7 +819,6 @@ export async function ensureDenActiveOrganization(options?: { forceServerSync?: 
 
   const client = createDenClient({
     baseUrl: settings.baseUrl,
-    apiBaseUrl: settings.apiBaseUrl,
     token,
   });
 
@@ -1960,20 +1849,14 @@ async function ensureActiveOrganization(
   });
 }
 
-export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string | null; token?: string | null }) {
+export function createDenClient(options: { baseUrl: string; token?: string | null }) {
   const baseUrls = resolveDenBaseUrls({
     baseUrl: options.baseUrl,
-    apiBaseUrl: options.apiBaseUrl,
   });
   const token = options.token?.trim() ?? null;
 
   return {
-    /**
-     * The resolved URLs this client actually talks to. Call sites that
-     * persist Den settings after a successful auth flow should store
-     * `baseUrls.apiBaseUrl` so relaunches reuse the exact endpoint that
-     * worked instead of re-deriving it from the web URL (see #1808).
-     */
+    /** The resolved web base URL and its derived `/api/den` proxy URL. */
     baseUrls,
 
     async setActiveOrganization(input: { organizationId?: string | null; organizationSlug?: string | null }): Promise<void> {
@@ -2331,7 +2214,6 @@ export async function mintCloudControlMcpToken(): Promise<DenMcpToken | null> {
   }
   const client = createDenClient({
     baseUrl: settings.baseUrl,
-    apiBaseUrl: settings.apiBaseUrl ?? null,
     token,
   });
   return client.mintMcpToken(orgId);

--- a/apps/app/src/app/lib/version-gate.ts
+++ b/apps/app/src/app/lib/version-gate.ts
@@ -165,7 +165,6 @@ async function readDenLatestAppVersion(): Promise<string | null> {
     const token = settings.authToken?.trim() ?? "";
     const client = createDenClient({
       baseUrl: settings.baseUrl,
-      apiBaseUrl: settings.apiBaseUrl,
       ...(token ? { token } : {}),
     });
     const metadata = await client.getAppVersionMetadata();

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -15,7 +15,6 @@ import {
   createDenClient,
   DenApiError,
   ensureDenActiveOrganization,
-  denOriginComparisonKey,
   readDenBootstrapConfig,
   readDenSettings,
   setDenBootstrapConfig,
@@ -81,7 +80,6 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
     try {
       const nextUser = await createDenClient({
         baseUrl: settings.baseUrl,
-        apiBaseUrl: settings.apiBaseUrl,
         token,
       }).getSession();
 
@@ -133,10 +131,9 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
   // relaunch never re-exchanges it. Persisting is best-effort: a failure here
   // must NOT be reported as an auth failure, since the user is already signed
   // in at this point.
-  const clearConsumedBootstrapHandoff = useCallback((bootstrap: DenBootstrapConfig, denBaseUrl: string, apiBaseUrl: string) => {
+  const clearConsumedBootstrapHandoff = useCallback((bootstrap: DenBootstrapConfig, denBaseUrl: string) => {
     void setDenBootstrapConfig({
       baseUrl: denBaseUrl,
-      apiBaseUrl,
       requireSignin: bootstrap.requireSignin,
       ...(bootstrap.claimLinks ? { claimLinks: bootstrap.claimLinks } : {}),
       handoff: null,
@@ -154,14 +151,13 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
     // Already signed in: just drop the now-unused grant from disk.
     if (readDenSettings().authToken?.trim()) {
       handledGrantsRef.current.add(handoff.grant);
-      clearConsumedBootstrapHandoff(bootstrap, bootstrap.baseUrl, bootstrap.apiBaseUrl);
+      clearConsumedBootstrapHandoff(bootstrap, bootstrap.baseUrl);
       return;
     }
 
     handledGrantsRef.current.add(handoff.grant);
     const client = createDenClient({
       baseUrl: handoff.denBaseUrl,
-      apiBaseUrl: bootstrap.apiBaseUrl,
     });
 
     void exchangeHandoffAndSignIn(handoff.grant, {
@@ -174,7 +170,7 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
         return;
       }
       // Best-effort cleanup; not part of the auth success/failure path.
-      clearConsumedBootstrapHandoff(bootstrap, handoff.denBaseUrl, result.apiBaseUrl);
+      clearConsumedBootstrapHandoff(bootstrap, handoff.denBaseUrl);
     });
   }, [clearConsumedBootstrapHandoff]);
 
@@ -198,21 +194,9 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
         if (!parsed || handledGrantsRef.current.has(parsed.grant)) continue;
         handledGrantsRef.current.add(parsed.grant);
 
-        // Keep the configured apiBaseUrl when the deep link targets the
-        // control plane we are already pointed at; deriving from the link's
-        // base URL alone breaks deployments where the advertised proxy path
-        // does not match how this app actually reaches the Den API.
-        const settings = readDenSettings();
-        const targetKey = denOriginComparisonKey(parsed.denBaseUrl);
-        const sameControlPlane =
-          denOriginComparisonKey(settings.baseUrl) === targetKey ||
-          denOriginComparisonKey(settings.apiBaseUrl ?? null) === targetKey;
         const client = createDenClient({
           baseUrl: parsed.denBaseUrl,
-          apiBaseUrl: sameControlPlane ? settings.apiBaseUrl ?? null : null,
         });
-        // Persist the API base URL the exchange actually succeeds against; the
-        // helper reads it from the client (#1808).
         void exchangeHandoffAndSignIn(parsed.grant, {
           baseUrl: parsed.denBaseUrl,
           client,

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -199,7 +199,6 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     try {
       const nextConfig = await createDenClient({
         baseUrl: settings.baseUrl,
-        apiBaseUrl: settings.apiBaseUrl,
         token,
       }).getDesktopConfig();
 

--- a/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
@@ -126,8 +126,7 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
       const client = createDenClient({
         baseUrl: nextBaseUrl,
       });
-      // The helper exchanges, persists (incl. the working apiBaseUrl, #1808), and
-      // dispatches the success/error session events.
+      // The helper exchanges, persists, and dispatches the success/error session events.
       const result = await exchangeHandoffAndSignIn(parsed.grant, {
         baseUrl: nextBaseUrl,
         client,

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -75,10 +75,9 @@ function useDenClient() {
     () =>
       createDenClient({
         baseUrl: settings.baseUrl,
-        apiBaseUrl: settings.apiBaseUrl,
         token: settings.authToken,
       }),
-    [authToken, settings.apiBaseUrl, settings.baseUrl],
+    [authToken, settings.baseUrl],
   );
 
   return {
@@ -259,7 +258,7 @@ export function OrgOnboardingPage() {
   }, [authToken, navigate, prepared]);
 
   const { data, error, isPending } = useQuery({
-    queryKey: ["den-org-onboarding", settings.baseUrl, settings.apiBaseUrl, "orgs"],
+    queryKey: ["den-org-onboarding", settings.baseUrl, "orgs"],
     enabled: Boolean(authToken),
     queryFn: () => denClient.listOrgs(),
   });
@@ -358,12 +357,12 @@ export function ResourceSelectionPage() {
   const { providers, marketplaces, loading, error } = useQueries({
     queries: [
       {
-        queryKey: ["den-org-onboarding", settings.baseUrl, settings.apiBaseUrl, orgId, "providers"],
+        queryKey: ["den-org-onboarding", settings.baseUrl, orgId, "providers"],
         enabled: Boolean(authToken && orgId),
         queryFn: () => denClient.listOrgLlmProviders(orgId),
       },
       {
-        queryKey: ["den-org-onboarding", settings.baseUrl, settings.apiBaseUrl, orgId, "marketplaces"],
+        queryKey: ["den-org-onboarding", settings.baseUrl, orgId, "marketplaces"],
         enabled: Boolean(authToken && orgId),
         queryFn: () => denClient.listOrgMarketplaces(orgId),
       },

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -770,7 +770,6 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     const settings = readDenSettings();
     return [
       settings.baseUrl,
-      settings.apiBaseUrl ?? "",
       settings.activeOrgId?.trim() ?? "",
       settings.authToken?.trim() ?? "",
     ].join("::");
@@ -798,7 +797,6 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
     const client = createDenClient({
       baseUrl: settings.baseUrl,
-      apiBaseUrl: settings.apiBaseUrl,
       token,
     });
     const request = client
@@ -1347,7 +1345,6 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     try {
       const den = createDenClient({
         baseUrl: settings.baseUrl,
-        apiBaseUrl: settings.apiBaseUrl,
         token,
       });
       const provider = await den.getOrgLlmProviderConnection(orgId, cloudProviderId);
@@ -1499,7 +1496,6 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     const settings = readDenSettings();
     return [
       settings.baseUrl,
-      settings.apiBaseUrl ?? "",
       settings.activeOrgId?.trim() ?? "",
       settings.authToken?.trim() ?? "",
       options.selectedWorkspaceDisplay().workspaceType,

--- a/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
+++ b/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
@@ -111,7 +111,7 @@ export function useOrgMcpConnections() {
     setLoading(true);
     setError(null);
     try {
-      const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
+      const client = createDenClient({ baseUrl: settings.baseUrl, token });
       const result = await client.listMcpConnections(orgId, "usable");
       setConnections(result);
     } catch (fetchError) {
@@ -129,7 +129,7 @@ export function useOrgMcpConnections() {
 
     setConnectingId(connectionId);
     try {
-      const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
+      const client = createDenClient({ baseUrl: settings.baseUrl, token });
       const result = await client.startMcpConnectionConnect(orgId, connectionId);
       if (result.status === "connected") {
         await refresh();
@@ -162,7 +162,6 @@ export function useOrgMcpConnections() {
         try {
           const pollClient = createDenClient({
             baseUrl: refreshedSettings.baseUrl,
-            apiBaseUrl: refreshedSettings.apiBaseUrl,
             token: refreshedToken,
           });
           const polled = await pollClient.listMcpConnections(refreshedOrgId, "usable");
@@ -193,7 +192,7 @@ export function useOrgMcpConnections() {
     setDisconnectingId(connectionId);
     setError(null);
     try {
-      const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
+      const client = createDenClient({ baseUrl: settings.baseUrl, token });
       await client.disconnectOauthProviderAccount(orgId, connectionId);
       await refresh();
     } catch (disconnectError) {

--- a/apps/app/src/react-app/domains/settings/cloud/cloud-session-provider.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/cloud-session-provider.tsx
@@ -41,7 +41,6 @@ export function CloudSessionProvider({ children }: CloudSessionProviderProps) {
   const initial = React.useMemo(() => readDenSettings(), []);
 
   const [baseUrl, setBaseUrl] = React.useState(() => initial.baseUrl || DEFAULT_DEN_BASE_URL);
-  const [apiBaseUrl, setApiBaseUrl] = React.useState(() => initial.apiBaseUrl || "");
   const [authToken, setAuthToken] = React.useState(initial.authToken?.trim() || "");
   const [isSignedIn, setIsSignedIn] = React.useState(false);
   const [user, setUser] = React.useState<DenUser | null>(null);
@@ -65,7 +64,7 @@ export function CloudSessionProvider({ children }: CloudSessionProviderProps) {
     if (typeof window === "undefined") return;
 
     const handleSettingsChanged = () => {
-      setApiBaseUrl(readDenSettings().apiBaseUrl || "");
+      setBaseUrl(readDenSettings().baseUrl || DEFAULT_DEN_BASE_URL);
     };
 
     window.addEventListener(denSettingsChangedEvent, handleSettingsChanged);
@@ -73,8 +72,8 @@ export function CloudSessionProvider({ children }: CloudSessionProviderProps) {
   }, []);
 
   const client = React.useMemo(
-    () => createDenClient({ baseUrl, apiBaseUrl, token: authToken }),
-    [apiBaseUrl, authToken, baseUrl],
+    () => createDenClient({ baseUrl, token: authToken }),
+    [authToken, baseUrl],
   );
 
   const value = React.useMemo<CloudSessionContextValue>(

--- a/apps/app/src/react-app/domains/settings/cloud/control-plane-url.ts
+++ b/apps/app/src/react-app/domains/settings/cloud/control-plane-url.ts
@@ -40,14 +40,12 @@ export async function saveControlPlaneUrl(value: string) {
   const bootstrap = readDenBootstrapConfig();
   const persisted = await setDenBootstrapConfig({
     baseUrl: resolved.baseUrl,
-    apiBaseUrl: resolved.apiBaseUrl,
     requireSignin: bootstrap.requireSignin,
   });
 
   writeDenSettings(
     {
       baseUrl: persisted.baseUrl,
-      apiBaseUrl: persisted.apiBaseUrl,
       authToken: null,
       activeOrgId: null,
       activeOrgSlug: null,

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -10,7 +10,6 @@ import {
   DenApiError,
   ensureDenActiveOrganization,
   initializeDenBootstrapConfig,
-  denOriginComparisonKey,
   normalizeDenBaseUrl,
   readDenSettings,
   resolveDenBaseUrls,
@@ -124,14 +123,9 @@ export function useDenSession({
   }, [authError, isSignedIn, sessionBusy]);
 
   const syncCurrentDenSettings = React.useCallback(() => {
-    const currentSettings = readDenSettings();
-    const resolved = resolveDenBaseUrls({
-      baseUrl,
-      apiBaseUrl: currentSettings.apiBaseUrl,
-    });
+    const resolved = resolveDenBaseUrls(baseUrl);
     writeDenSettings({
       baseUrl: resolved.baseUrl,
-      apiBaseUrl: resolved.apiBaseUrl,
       authToken: authToken || null,
       activeOrgId: activeOrgId || null,
       activeOrgSlug: activeOrg?.slug ?? null,
@@ -289,7 +283,6 @@ export function useDenSession({
       writeDenSettings(
         {
           baseUrl: resolved.baseUrl,
-          apiBaseUrl: resolved.apiBaseUrl,
           authToken: null,
           activeOrgId: null,
           activeOrgSlug: null,
@@ -455,20 +448,8 @@ export function useDenSession({
     setStatusMessage(t("den.signing_in"));
 
     try {
-      // When the pasted link targets the control plane we are already
-      // configured for, keep the configured apiBaseUrl. Deriving it from the
-      // link's base URL alone breaks deployments where the advertised proxy
-      // path does not match how this app actually reaches the Den API.
-      const settings = readDenSettings();
-      const targetKey = denOriginComparisonKey(nextBaseUrl);
-      const configuredApiBaseUrl =
-        denOriginComparisonKey(settings.baseUrl) === targetKey ||
-        denOriginComparisonKey(settings.apiBaseUrl ?? null) === targetKey
-          ? settings.apiBaseUrl ?? null
-          : null;
-      const exchangeClient = createDenClient({ baseUrl: nextBaseUrl, apiBaseUrl: configuredApiBaseUrl });
-      // The helper exchanges, persists (incl. the working apiBaseUrl, #1808), and
-      // dispatches the success/error session events.
+      const exchangeClient = createDenClient({ baseUrl: nextBaseUrl });
+      // The helper exchanges, persists, and dispatches the success/error session events.
       const result = await exchangeHandoffAndSignIn(parsed.grant, {
         baseUrl: nextBaseUrl,
         client: exchangeClient,

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -14,8 +14,6 @@ import {
   DEFAULT_DEN_BASE_URL,
   readDenBootstrapConfig,
   readDenSettings,
-  STORAGE_API_BASE_URL,
-  STORAGE_BASE_URL,
 } from "@/app/lib/den";
 import {
   describeCloudMcpTarget,
@@ -50,16 +48,6 @@ import {
 type SettingsTone = ComponentProps<typeof SettingsStatusBadge>["tone"];
 
 const DESKTOP_BOOTSTRAP_PATH_HINT = "~/.config/openwork/desktop-bootstrap.json";
-
-function readEndpointStorageValue(key: string): string | null {
-  if (typeof window === "undefined") return null;
-
-  try {
-    return window.localStorage.getItem(key);
-  } catch {
-    return null;
-  }
-}
 
 function sourceBadgeLabel(source: DenEndpointSource): string {
   switch (source) {
@@ -129,12 +117,12 @@ function ServerEndpointsCard(props: { cloudMcpUrl: string | null }) {
   const effectiveApiBaseUrl = settings.apiBaseUrl ?? DEFAULT_DEN_API_BASE_URL;
   const bootstrap = readDenBootstrapConfig();
   const organizationServer = describeDenEndpointSource({
-    storedValue: readEndpointStorageValue(STORAGE_BASE_URL),
+    storedValue: null,
     bootstrapValue: bootstrapValueWhenNotDefault(bootstrap.baseUrl, DEFAULT_DEN_BASE_URL),
     buildDefault: DEFAULT_DEN_BASE_URL,
   });
   const apiEndpoint = describeDenEndpointSource({
-    storedValue: readEndpointStorageValue(STORAGE_API_BASE_URL),
+    storedValue: null,
     bootstrapValue: bootstrapValueWhenNotDefault(bootstrap.apiBaseUrl, DEFAULT_DEN_API_BASE_URL),
     buildDefault: DEFAULT_DEN_API_BASE_URL,
   });

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -1454,7 +1454,7 @@ export function createExtensionsStore(options: {
         return;
       }
 
-      const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
+      const client = createDenClient({ baseUrl: settings.baseUrl, token });
       const catalog = await fetchDenOrgSkillsCatalog(client, orgId);
       if (refreshCloudOrgSkillsAborted || getCurrentCloudOrgLoadKey() !== loadKey) return;
       mutateState((current) => ({
@@ -1518,7 +1518,7 @@ export function createExtensionsStore(options: {
         return;
       }
 
-      const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
+      const client = createDenClient({ baseUrl: settings.baseUrl, token });
       const marketplaces = await client.listOrgMarketplaces(orgId);
       const resolved = await Promise.all(
         marketplaces.map((marketplace) => client.getOrgMarketplaceResolved(orgId, marketplace.id)),
@@ -1594,7 +1594,7 @@ export function createExtensionsStore(options: {
       const token = settings.authToken?.trim() ?? "";
       const orgId = settings.activeOrgId?.trim() ?? "";
       if (!token || !orgId) throw new Error("Sign in to OpenWork Cloud and choose an organization first.");
-      const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
+      const client = createDenClient({ baseUrl: settings.baseUrl, token });
       const resolved = await client.getOrgPluginResolved(orgId, plugin);
       const target = await resolveWorkspaceServerTarget();
       if (target.openworkClient && target.openworkWorkspaceId) {

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -161,7 +161,7 @@ function DenAuthControlActions() {
       if (!grant?.trim()) return { ok: false, error: "grant is required" };
       const settings = readDenSettings();
       const targetBaseUrl = argBaseUrl?.trim() || settings.baseUrl;
-      const client = createDenClient({ baseUrl: targetBaseUrl, apiBaseUrl: settings.apiBaseUrl });
+      const client = createDenClient({ baseUrl: targetBaseUrl });
       const result = await exchangeHandoffAndSignIn(grant.trim(), {
         baseUrl: targetBaseUrl,
         client,

--- a/apps/app/tests/den-desktop-bootstrap-settings.test.ts
+++ b/apps/app/tests/den-desktop-bootstrap-settings.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  initializeDenBootstrapConfig,
+  readDenSettings,
+  setDenBootstrapConfig,
+  writeDenSettings,
+} from "../src/app/lib/den";
+
+const originalWindow = globalThis.window;
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+describe("desktop Den bootstrap settings", () => {
+  let bootstrapConfig: { baseUrl: string; requireSignin: boolean; writtenAt?: string };
+
+  beforeEach(() => {
+    bootstrapConfig = {
+      baseUrl: "https://bootstrap.example.com",
+      requireSignin: false,
+    };
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        localStorage: memoryStorage(),
+        dispatchEvent: () => true,
+        __OPENWORK_ELECTRON__: {
+          invokeDesktop: async (command: string, payload?: { baseUrl: string; requireSignin: boolean }) => {
+            if (command === "getDesktopBootstrapConfig") return bootstrapConfig;
+            if (command === "setDesktopBootstrapConfig" && payload) {
+              bootstrapConfig = {
+                baseUrl: payload.baseUrl,
+                requireSignin: payload.requireSignin,
+                writtenAt: "2026-07-08T00:00:00.000Z",
+              };
+              return bootstrapConfig;
+            }
+            throw new Error(`Unexpected desktop command: ${command}`);
+          },
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  test("reads the desktop base URL from bootstrap instead of stale localStorage", async () => {
+    window.localStorage.setItem("openwork.den.baseUrl", "https://stale.example.com");
+    window.localStorage.setItem("openwork.den.apiBaseUrl", "https://api.example.com");
+
+    await initializeDenBootstrapConfig();
+
+    const settings = readDenSettings();
+    expect(settings.baseUrl).toBe("https://bootstrap.example.com");
+    expect(settings.apiBaseUrl).toBe("https://bootstrap.example.com/api/den");
+  });
+
+  test("saves base URL changes to bootstrap and clears legacy endpoint storage", async () => {
+    await initializeDenBootstrapConfig();
+    window.localStorage.setItem("openwork.den.baseUrl", "https://stale.example.com");
+    window.localStorage.setItem("openwork.den.apiBaseUrl", "https://api.example.com");
+
+    await setDenBootstrapConfig({
+      baseUrl: "https://saved.example.com",
+      requireSignin: false,
+    });
+    writeDenSettings({
+      baseUrl: "https://saved.example.com",
+      authToken: "tok_test",
+      activeOrgId: null,
+      activeOrgSlug: null,
+      activeOrgName: null,
+    });
+
+    expect(bootstrapConfig.baseUrl).toBe("https://saved.example.com");
+    expect(window.localStorage.getItem("openwork.den.baseUrl")).toBeNull();
+    expect(window.localStorage.getItem("openwork.den.apiBaseUrl")).toBeNull();
+    expect(readDenSettings().baseUrl).toBe("https://saved.example.com");
+  });
+});

--- a/apps/app/tests/den-extension-projection.test.ts
+++ b/apps/app/tests/den-extension-projection.test.ts
@@ -88,7 +88,7 @@ describe("Den extension projections", () => {
     const resolved = await client.getOrgMarketplaceResolved("organization_test", "marketplace_test");
     const plugin = resolved.plugins[0];
 
-    expect(calls).toEqual(["http://den.local/v1/marketplaces/marketplace_test/resolved"]);
+    expect(calls).toEqual(["http://den.local/api/den/v1/marketplaces/marketplace_test/resolved"]);
     expect(plugin.extension?.sourceFormat).toBe("claude-plugin");
     expect(plugin.extension?.manifest?.resources).toEqual([{
       type: "command",

--- a/apps/app/tests/den-mcp-url.test.ts
+++ b/apps/app/tests/den-mcp-url.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../src/app/lib/den";
 
 describe("resolveDenBaseUrls", () => {
-  test("heals a stale bare web-app apiBaseUrl through the /api/den proxy", () => {
+  test("always derives the API proxy from the base URL", () => {
     const resolved = resolveDenBaseUrls({
       baseUrl: "https://app.openworklabs.com",
       apiBaseUrl: "https://app.openworklabs.com",
@@ -16,20 +16,20 @@ describe("resolveDenBaseUrls", () => {
     expect(resolved.apiBaseUrl).toBe("https://app.openworklabs.com/api/den");
   });
 
-  test("keeps an explicit API origin verbatim", () => {
+  test("ignores an explicit API origin when a base URL is present", () => {
     const resolved = resolveDenBaseUrls({
       baseUrl: "https://app.openworklabs.com",
-      apiBaseUrl: "https://api.openworklabs.com",
+      apiBaseUrl: "https://api.example.com",
     });
-    expect(resolved.apiBaseUrl).toBe("https://api.openworklabs.com");
+    expect(resolved.apiBaseUrl).toBe("https://app.openworklabs.com/api/den");
   });
 
-  test("keeps an explicit loopback apiBaseUrl verbatim (dev den-api)", () => {
+  test("ignores an explicit loopback API URL when a base URL is present", () => {
     const resolved = resolveDenBaseUrls({
       baseUrl: "http://localhost:3000",
       apiBaseUrl: "http://127.0.0.1:8787",
     });
-    expect(resolved.apiBaseUrl).toBe("http://127.0.0.1:8787");
+    expect(resolved.apiBaseUrl).toBe("http://localhost:3000/api/den");
   });
 
   test("derives the /api/den proxy from a web-app baseUrl when no apiBaseUrl is set", () => {
@@ -53,7 +53,6 @@ describe("isLegacyWebAppMcpUrl", () => {
   });
 
   test("accepts valid MCP URLs", () => {
-    expect(isLegacyWebAppMcpUrl("https://api.openworklabs.com/mcp")).toBe(false);
     expect(isLegacyWebAppMcpUrl("https://app.openworklabs.com/api/den/mcp")).toBe(false);
     expect(isLegacyWebAppMcpUrl("http://127.0.0.1:8787/mcp")).toBe(false);
   });
@@ -75,9 +74,6 @@ describe("resolveCloudMcpResourceUrl", () => {
   });
 
   test("keeps healthy resources verbatim", () => {
-    expect(resolveCloudMcpResourceUrl("https://api.openworklabs.com/mcp")).toBe(
-      "https://api.openworklabs.com/mcp",
-    );
     expect(resolveCloudMcpResourceUrl("https://app.openworklabs.com/api/den/mcp")).toBe(
       "https://app.openworklabs.com/api/den/mcp",
     );

--- a/apps/app/tests/memory-client.test.ts
+++ b/apps/app/tests/memory-client.test.ts
@@ -22,12 +22,12 @@ afterEach(() => {
 });
 
 const client = () =>
-  createDenClient({ baseUrl: "https://web.test", apiBaseUrl: "https://api.test", token: "tok_test" });
+  createDenClient({ baseUrl: "https://web.test", token: "tok_test" });
 
 describe("Den memory client", () => {
   test("listMemory normalizes memories, tags, and contexts and drops malformed rows", async () => {
     const calls = mockFetch((url) => {
-      expect(url).toContain("/v1/memory");
+      expect(url).toContain("/api/den/v1/memory");
       return new Response(
         JSON.stringify({
           memories: [

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -196,10 +196,6 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
       throw new Error("baseUrl is required");
     }
 
-    const apiBaseUrl =
-      typeof input?.apiBaseUrl === "string" && input.apiBaseUrl.trim().length > 0
-        ? input.apiBaseUrl.trim()
-        : null;
     // The handoff grant is a one-time, short-lived (~5 min) desktop sign-in
     // token written to this machine-local config by the bootstrap CLI. The app
     // exchanges it once on boot and then rewrites this file with `handoff: null`
@@ -252,7 +248,6 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
 
     return {
       baseUrl,
-      apiBaseUrl,
       requireSignin: forceRequireSignin || input?.requireSignin === true,
       ...(writtenAt ? { writtenAt } : {}),
       ...(claimLinks.length > 0 ? { claimLinks } : {}),
@@ -347,7 +342,6 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     });
     return {
       baseUrl: defaultDenBaseUrl,
-      apiBaseUrl: null,
       requireSignin: defaultRequireSignin,
     };
   }

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+const previousDenApiBase = process.env.DEN_API_BASE;
+
+describe("Den upstream proxy", () => {
+  let server;
+  let observed = null;
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        observed = {
+          method: request.method,
+          path: `${url.pathname}${url.search}`,
+          body: await request.text(),
+          cookie: request.headers.get("cookie"),
+          authorization: request.headers.get("authorization"),
+          custom: request.headers.get("x-custom-proxy-test"),
+        };
+        return new Response("proxied", {
+          status: 207,
+          headers: {
+            "content-type": "text/plain",
+            "set-cookie": "sid=abc; Path=/; HttpOnly",
+            "x-upstream-result": "ok",
+          },
+        });
+      },
+    });
+    process.env.DEN_API_BASE = `http://127.0.0.1:${server.port}`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+    if (previousDenApiBase === undefined) {
+      delete process.env.DEN_API_BASE;
+    } else {
+      process.env.DEN_API_BASE = previousDenApiBase;
+    }
+  });
+
+  test("passes method, path, query, body, cookies, auth, status, and headers through", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const request = new NextRequest("https://app.example.com/api/den/v1/me?include=org", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer tok_test",
+        cookie: "ow_session=sess_test",
+        "content-type": "application/json",
+        "x-custom-proxy-test": "kept",
+      },
+      body: JSON.stringify({ ok: true }),
+    });
+
+    const response = await proxyUpstream(request, [], { routePrefix: "/api/den" });
+
+    expect(observed).toEqual({
+      method: "POST",
+      path: "/v1/me?include=org",
+      body: JSON.stringify({ ok: true }),
+      cookie: "ow_session=sess_test",
+      authorization: "Bearer tok_test",
+      custom: "kept",
+    });
+    expect(response.status).toBe(207);
+    expect(response.headers.get("x-upstream-result")).toBe("ok");
+    expect(response.headers.get("set-cookie")).toContain("sid=abc");
+    expect(await response.text()).toBe("proxied");
+  });
+});

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -1,16 +1,20 @@
 import { NextRequest } from "next/server";
 
 const NO_BODY_STATUS = new Set([204, 205, 304]);
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+const REQUEST_ONLY_HEADERS = new Set(["host", "content-length"]);
+const RESPONSE_ONLY_HEADERS = new Set(["content-length"]);
 
 const apiBase = readBaseUrlEnv("DEN_API_BASE");
-const authOrigin = readBaseUrlEnv("DEN_AUTH_ORIGIN");
-const authFallbackBase = readBaseUrlEnv("DEN_AUTH_FALLBACK_BASE");
-const appPort = process.env.OPENWORK_APP_PORT?.trim() || process.env.PORT?.trim() || "5173";
-const configuredCorsOrigins = splitCsv(process.env.DEN_CORS_ORIGINS ?? process.env.CORS_ORIGINS);
-const localDevCorsOrigins = process.env.OPENWORK_DEV_MODE === "1"
-  ? [`http://localhost:${appPort}`, `http://127.0.0.1:${appPort}`]
-  : [];
-const corsOrigins = Array.from(new Set([...configuredCorsOrigins, ...localDevCorsOrigins]));
 
 type ProxyOptions = {
   routePrefix: string;
@@ -25,13 +29,6 @@ function normalizeBaseUrl(value: string): string {
 function readBaseUrlEnv(name: string): string | null {
   const value = process.env[name]?.trim();
   return value ? normalizeBaseUrl(value) : null;
-}
-
-function splitCsv(value: string | undefined): string[] {
-  return (value ?? "")
-    .split(",")
-    .map((entry) => entry.trim().replace(/\/+$/, ""))
-    .filter(Boolean);
 }
 
 function normalizePathPrefix(value: string): string {
@@ -67,50 +64,69 @@ function buildTargetUrl(
   return upstream.toString();
 }
 
-function isLikelyHtmlBody(body: ArrayBuffer): boolean {
-  if (body.byteLength === 0) {
-    return false;
-  }
-
-  const preview = new TextDecoder().decode(body.slice(0, 256)).trim().toLowerCase();
-  return preview.startsWith("<!doctype") || preview.startsWith("<html") || preview.includes("<body");
+function shouldSkipRequestHeader(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return HOP_BY_HOP_HEADERS.has(normalized) || REQUEST_ONLY_HEADERS.has(normalized);
 }
 
-function isLikelyCannotGetBody(body: ArrayBuffer): boolean {
-  if (body.byteLength === 0) {
-    return false;
-  }
-
-  const preview = new TextDecoder().decode(body.slice(0, 256)).trim().toLowerCase();
-  return preview.includes("cannot get ");
+function shouldSkipResponseHeader(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return HOP_BY_HOP_HEADERS.has(normalized) || RESPONSE_ONLY_HEADERS.has(normalized) || normalized === "set-cookie";
 }
 
-function isAdminTargetPath(targetPath: string): boolean {
-  return targetPath === "v1/admin" || targetPath.startsWith("v1/admin/");
-}
-
-function shouldFallbackToAuthBase(response: Response, body: ArrayBuffer, targetPath: string): boolean {
-  if (response.status === 502 || response.status === 503 || response.status === 504) {
-    return true;
-  }
-
-  if (response.status === 404 && isAdminTargetPath(targetPath)) {
-    const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
-    if (contentType.includes("text/html") || isLikelyHtmlBody(body) || isLikelyCannotGetBody(body)) {
-      return true;
+function cloneRequestHeaders(request: NextRequest): Headers {
+  const headers = new Headers();
+  request.headers.forEach((value, name) => {
+    if (!shouldSkipRequestHeader(name)) {
+      headers.append(name, value);
     }
+  });
+  return headers;
+}
+
+function copySetCookieHeaders(upstreamHeaders: Headers, responseHeaders: Headers): void {
+  for (const cookie of upstreamHeaders.getSetCookie()) {
+    if (cookie) responseHeaders.append("set-cookie", cookie);
+  }
+}
+
+function rewriteLocationHeader(location: string, request: NextRequest): string {
+  if (!apiBase) return location;
+
+  let parsedLocation: URL;
+  try {
+    parsedLocation = new URL(location);
+  } catch {
+    return location;
   }
 
-  if (response.status < 500) {
-    return false;
+  let apiOrigin: string;
+  try {
+    apiOrigin = new URL(apiBase).origin;
+  } catch {
+    return location;
   }
 
-  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
-  if (contentType.includes("text/html")) {
-    return true;
+  if (parsedLocation.origin !== apiOrigin || !parsedLocation.pathname.startsWith("/api/auth/")) {
+    return location;
   }
 
-  return isLikelyHtmlBody(body);
+  const requestOrigin = new URL(request.url).origin;
+  return `${requestOrigin}${parsedLocation.pathname}${parsedLocation.search}${parsedLocation.hash}`;
+}
+
+function cloneResponseHeaders(request: NextRequest, upstream: Response, options: ProxyOptions): Headers {
+  const headers = new Headers();
+  upstream.headers.forEach((value, name) => {
+    if (shouldSkipResponseHeader(name)) return;
+    if (name.toLowerCase() === "location" && options.rewriteAuthLocationsToRequestOrigin) {
+      headers.append(name, rewriteLocationHeader(value, request));
+      return;
+    }
+    headers.append(name, value);
+  });
+  copySetCookieHeaders(upstream.headers, headers);
+  return headers;
 }
 
 function buildUpstreamErrorResponse(status: number, error: string): Response {
@@ -122,211 +138,9 @@ function buildUpstreamErrorResponse(status: number, error: string): Response {
   });
 }
 
-function applyCorsHeaders(request: NextRequest, headers: Headers): void {
-  const origin = request.headers.get("origin")?.trim().replace(/\/+$/, "") ?? "";
-  if (!origin) {
-    return;
-  }
-
-  const allowOrigin = corsOrigins.includes("*") || corsOrigins.includes(origin) ? origin : "";
-  if (!allowOrigin) {
-    return;
-  }
-
-  headers.set("access-control-allow-origin", allowOrigin);
-  headers.set("access-control-allow-credentials", "true");
-  headers.set("access-control-allow-methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS");
-  headers.set("access-control-allow-headers", "Content-Type,Authorization,X-Api-Key,X-Request-Id,X-Requested-With,X-OpenWork-Org-Id,X-OpenWork-Legacy-Org-Id");
-  headers.append("vary", "Origin");
-}
-
-export function buildCorsPreflightResponse(request: NextRequest): Response {
-  const headers = new Headers();
-  applyCorsHeaders(request, headers);
-  return new Response(null, { status: 204, headers });
-}
-
-function getJsonRedirectUrl(body: ArrayBuffer): string | null {
-  try {
-    const payload = JSON.parse(new TextDecoder().decode(body)) as unknown;
-    if (
-      payload &&
-      typeof payload === "object" &&
-      "redirect" in payload &&
-      payload.redirect === true &&
-      "url" in payload &&
-      typeof payload.url === "string" &&
-      payload.url.trim()
-    ) {
-      return payload.url.trim();
-    }
-  } catch {}
-  return null;
-}
-
-function copySetCookieHeaders(upstreamHeaders: Headers, responseHeaders: Headers): void {
-  const getSetCookie = (upstreamHeaders as Headers & { getSetCookie?: () => string[] }).getSetCookie;
-  if (typeof getSetCookie === "function") {
-    const cookies = getSetCookie.call(upstreamHeaders);
-    for (const cookie of cookies) {
-      if (cookie) {
-        responseHeaders.append("set-cookie", cookie);
-      }
-    }
-    return;
-  }
-
-  const cookie = upstreamHeaders.get("set-cookie");
-  if (cookie) {
-    responseHeaders.append("set-cookie", cookie);
-  }
-}
-
-function buildHeaders(request: NextRequest, contentType: string | null): Headers {
-  const headers = new Headers();
-  const copyHeaders = [
-    "accept",
-    "authorization",
-    "cookie",
-    "user-agent",
-    "x-requested-with",
-    "x-api-key",
-    "x-openwork-org-id",
-    "x-openwork-legacy-org-id",
-    "origin",
-    "x-forwarded-for",
-  ];
-
-  for (const key of copyHeaders) {
-    const value = request.headers.get(key);
-    if (value) {
-      headers.set(key, value);
-    }
-  }
-
-  if (contentType) {
-    headers.set("content-type", contentType);
-  }
-
-  if (!headers.has("accept")) {
-    headers.set("accept", "application/json");
-  }
-
-  if (!headers.has("origin") && authOrigin) {
-    headers.set("origin", authOrigin);
-  }
-
-  const incoming = new URL(request.url);
-  headers.set("x-forwarded-host", request.headers.get("host") ?? incoming.host);
-  headers.set("x-forwarded-proto", incoming.protocol.replace(/:$/, ""));
-
-  return headers;
-}
-
-async function fetchUpstream(
-  request: NextRequest,
-  targetUrl: string,
-  contentType: string | null,
-  body: Uint8Array | null,
-): Promise<Response> {
-  const init: RequestInit = {
-    method: request.method,
-    headers: buildHeaders(request, contentType),
-    redirect: "manual",
-  };
-
-  if (body && request.method !== "GET" && request.method !== "HEAD") {
-    init.body = body;
-  }
-
-  return fetch(targetUrl, init);
-}
-
-async function readUpstreamBody(response: Response): Promise<ArrayBuffer> {
-  return response.arrayBuffer();
-}
-
-function isEventStreamRequest(request: NextRequest): boolean {
-  const accept = request.headers.get("accept")?.toLowerCase() ?? "";
-  return accept.includes("text/event-stream");
-}
-
-function isEventStreamResponse(response: Response): boolean {
-  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
-  return contentType.includes("text/event-stream");
-}
-
-function shouldFallbackToAuthBaseForStream(response: Response, targetPath: string): boolean {
-  if (response.status === 502 || response.status === 503 || response.status === 504) {
-    return true;
-  }
-
-  if (response.status === 404 && isAdminTargetPath(targetPath)) {
-    return true;
-  }
-
-  return false;
-}
-
-function rewriteLocationHeader(location: string, request: NextRequest): string {
-  let parsedLocation: URL;
-  try {
-    parsedLocation = new URL(location);
-  } catch {
-    return location;
-  }
-
-  const requestOrigin = new URL(request.url).origin;
-  const rewriteableOrigins = [apiBase, authFallbackBase]
-    .filter((value): value is string => Boolean(value))
-    .map((value) => {
-      try {
-        return new URL(value).origin;
-      } catch {
-        return null;
-      }
-    })
-    .filter((value): value is string => Boolean(value));
-
-  if (!rewriteableOrigins.includes(parsedLocation.origin) || !parsedLocation.pathname.startsWith("/api/auth/")) {
-    return location;
-  }
-
-  return `${requestOrigin}${parsedLocation.pathname}${parsedLocation.search}${parsedLocation.hash}`;
-}
-
-function buildProxyResponse(
-  request: NextRequest,
-  upstream: Response,
-  options: ProxyOptions,
-  body?: BodyInit | null,
-): Response {
-  const responseHeaders = new Headers();
-  const passThroughHeaders = ["content-type", "location", "cache-control"];
-
-  for (const key of passThroughHeaders) {
-    const value = upstream.headers.get(key);
-    if (!value) {
-      continue;
-    }
-
-    if (key === "location" && options.rewriteAuthLocationsToRequestOrigin) {
-      responseHeaders.set(key, rewriteLocationHeader(value, request));
-      continue;
-    }
-
-    responseHeaders.set(key, value);
-  }
-
-  copySetCookieHeaders(upstream.headers, responseHeaders);
-  applyCorsHeaders(request, responseHeaders);
-
-  const shouldDropBody = request.method === "HEAD" || NO_BODY_STATUS.has(upstream.status);
-
-  return new Response(shouldDropBody ? null : (body ?? upstream.body), {
-    status: upstream.status,
-    headers: responseHeaders,
-  });
+async function readRequestBody(request: NextRequest): Promise<Uint8Array | null> {
+  if (request.method === "GET" || request.method === "HEAD") return null;
+  return new Uint8Array(await request.arrayBuffer());
 }
 
 export async function proxyUpstream(
@@ -334,74 +148,22 @@ export async function proxyUpstream(
   segments: string[] = [],
   options: ProxyOptions,
 ): Promise<Response> {
-  if (!apiBase || !authOrigin) {
-    const response = buildUpstreamErrorResponse(503, "DEN_API_BASE and DEN_AUTH_ORIGIN must be configured.");
-    applyCorsHeaders(request, response.headers);
-    return response;
+  if (!apiBase) {
+    return buildUpstreamErrorResponse(503, "DEN_API_BASE must be configured.");
   }
 
   const targetPath = getTargetPath(request, segments, options.routePrefix);
-  const primaryTargetUrl = buildTargetUrl(apiBase, request, targetPath, options.upstreamPathPrefix);
-  const fallbackTargetUrl = authFallbackBase
-    ? buildTargetUrl(authFallbackBase, request, targetPath, options.upstreamPathPrefix)
-    : null;
-  const contentType = request.headers.get("content-type");
-  const requestBody = request.method !== "GET" && request.method !== "HEAD"
-    ? new Uint8Array(await request.arrayBuffer())
-    : null;
+  const targetUrl = buildTargetUrl(apiBase, request, targetPath, options.upstreamPathPrefix);
+  const upstream = await fetch(targetUrl, {
+    method: request.method,
+    headers: cloneRequestHeaders(request),
+    body: await readRequestBody(request),
+    redirect: "manual",
+  });
+  const shouldDropBody = request.method === "HEAD" || NO_BODY_STATUS.has(upstream.status);
 
-  let upstream: Response | null = null;
-
-  try {
-    upstream = await fetchUpstream(request, primaryTargetUrl, contentType, requestBody);
-  } catch {
-    if (fallbackTargetUrl && apiBase !== authFallbackBase) {
-      try {
-        upstream = await fetchUpstream(request, fallbackTargetUrl, contentType, requestBody);
-      } catch {}
-    }
-  }
-
-  if (!upstream) {
-    const response = buildUpstreamErrorResponse(502, "Upstream request failed.");
-    applyCorsHeaders(request, response.headers);
-    return response;
-  }
-
-  if (isEventStreamRequest(request) || isEventStreamResponse(upstream)) {
-    if (fallbackTargetUrl && apiBase !== authFallbackBase && shouldFallbackToAuthBaseForStream(upstream, targetPath)) {
-      try {
-        upstream = await fetchUpstream(request, fallbackTargetUrl, contentType, requestBody);
-      } catch {}
-    }
-    return buildProxyResponse(request, upstream, options);
-  }
-
-  let body = await readUpstreamBody(upstream);
-
-  if (fallbackTargetUrl && apiBase !== authFallbackBase && shouldFallbackToAuthBase(upstream, body, targetPath)) {
-    try {
-      upstream = await fetchUpstream(request, fallbackTargetUrl, contentType, requestBody);
-      body = await readUpstreamBody(upstream);
-    } catch {}
-  }
-
-  const responseContentType = upstream.headers.get("content-type")?.toLowerCase() ?? "";
-  if (upstream.status >= 500 && (responseContentType.includes("text/html") || isLikelyHtmlBody(body))) {
-    const response = buildUpstreamErrorResponse(upstream.status, "Upstream service unavailable.");
-    applyCorsHeaders(request, response.headers);
-    return response;
-  }
-
-  if (request.method === "GET" && targetPath === "oauth2/authorize") {
-    const redirectUrl = getJsonRedirectUrl(body);
-    if (redirectUrl) {
-      const incoming = new URL(request.url);
-      const host = request.headers.get("host") ?? incoming.host;
-      const origin = `${incoming.protocol}//${host}`;
-      return Response.redirect(new URL(redirectUrl, origin), 302);
-    }
-  }
-
-  return buildProxyResponse(request, upstream, options, body);
+  return new Response(shouldDropBody ? null : upstream.body, {
+    status: upstream.status,
+    headers: cloneResponseHeaders(request, upstream, options),
+  });
 }

--- a/ee/apps/den-web/app/api/den/[...path]/route.ts
+++ b/ee/apps/den-web/app/api/den/[...path]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { buildCorsPreflightResponse, proxyUpstream } from "../../_lib/upstream-proxy";
+import { proxyUpstream } from "../../_lib/upstream-proxy";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +10,10 @@ async function proxy(request: NextRequest, segments: string[] = []) {
 }
 
 export async function GET(request: NextRequest) {
+  return proxy(request);
+}
+
+export async function HEAD(request: NextRequest) {
   return proxy(request);
 }
 
@@ -30,5 +34,5 @@ export async function DELETE(request: NextRequest) {
 }
 
 export async function OPTIONS(request: NextRequest) {
-  return buildCorsPreflightResponse(request);
+  return proxy(request);
 }

--- a/packages/docs/cloud/get-started.mdx
+++ b/packages/docs/cloud/get-started.mdx
@@ -41,6 +41,23 @@ Next, you want to make sure you can sign in the desktop app.
 3. Finish sign-in in your browser.
 4. If the browser does not return to OpenWork automatically, click `Paste sign-in code`, paste the `openwork://den-auth?...` link or one-time code from OpenWork Cloud, then click `Finish sign-in`.
 
+## Cloud URL used by the desktop app
+
+The desktop app uses a single Cloud URL: the Den web `baseUrl`. The hosted
+default is `https://app.openworklabs.com`.
+
+All Cloud API and MCP traffic is derived from that one URL through the web app
+proxy:
+
+- Cloud API requests go to `<baseUrl>/api/den/v1/...`.
+- OpenWork Cloud MCP requests go to `<baseUrl>/api/den/mcp/...`.
+
+The desktop app does not store or read a separate API URL. On startup it reads
+the Cloud URL from `desktop-bootstrap.json`; if that file is missing, it falls
+back to `https://app.openworklabs.com`. When you change the Cloud URL in
+`Settings -> Cloud`, OpenWork writes the new `baseUrl` back to the bootstrap
+file so the next launch uses the same source of truth.
+
 ## Choose your organization
 
 After sign-in, pick your org in `Settings -> Cloud -> Active org`.

--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -3,7 +3,7 @@ title: "Connect OpenWork Cloud MCP"
 description: "Use the hosted OpenWork Cloud MCP server from OpenWork or another OAuth-capable MCP client"
 ---
 
-OpenWork Cloud exposes a hosted MCP server at `https://api.openworklabs.com/mcp`. Add it to an MCP client when you want agents to use your OpenWork Cloud organization, skills, plugins, marketplaces, workers, and other Cloud API resources through MCP tools.
+OpenWork Cloud exposes a hosted MCP server through the Den web URL at `https://app.openworklabs.com/api/den/mcp`. Add it to an MCP client when you want agents to use your OpenWork Cloud organization, skills, plugins, marketplaces, workers, and other Cloud API resources through MCP tools.
 
 The server uses OAuth. Your MCP client opens a browser, you sign in to OpenWork Cloud, choose the organization to authorize, and the client stores the returned token.
 
@@ -15,6 +15,11 @@ with a token scoped to your active organization — no browser OAuth round-trip.
 You can see it under **Settings → Extensions** as **OpenWork Cloud Control**
 with a Ready status. Switching organizations refreshes the token
 automatically.
+
+The desktop app derives the MCP URL from the single Cloud `baseUrl`. For the
+hosted service, that means `https://app.openworklabs.com/api/den/mcp`; for a
+self-hosted Den web deployment, use `<baseUrl>/api/den/mcp`. There is no
+separate desktop API URL to configure.
 
 ## What you can ask the agent
 
@@ -52,7 +57,7 @@ Add this server to your MCP config:
     "openwork-cloud": {
       "type": "remote",
       "enabled": true,
-      "url": "https://api.openworklabs.com/mcp",
+      "url": "https://app.openworklabs.com/api/den/mcp",
       "oauth": {}
     }
   }
@@ -66,7 +71,7 @@ If your client expects the server map directly, use just the server entry:
   "openwork-cloud": {
     "type": "remote",
     "enabled": true,
-    "url": "https://api.openworklabs.com/mcp",
+    "url": "https://app.openworklabs.com/api/den/mcp",
     "oauth": {}
   }
 }

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -90,6 +90,16 @@ OpenWork cloud is composed of two services:
 - NodeJS backend (Hono) with MySQL DB
 - Electron/React desktop app
 
+The desktop app should be pointed at the Den web URL only. It derives API and
+MCP traffic through the Den web proxy:
+
+- API: `<baseUrl>/api/den/v1/...`
+- MCP: `<baseUrl>/api/den/mcp/...`
+
+For self-hosted deployments, configure `baseUrl` to the public Den web origin
+and make sure that web app's `/api/den` route can reach your Den API backend.
+The desktop app no longer needs, reads, or writes a separate API URL.
+
 These three alone cover most feature but do not include:
 
 - Remote code execution through sandboxes

--- a/packages/docs/start-here/troubleshooting/diagnostic-prompts.mdx
+++ b/packages/docs/start-here/troubleshooting/diagnostic-prompts.mdx
@@ -24,7 +24,7 @@ Your agent's `openwork-cloud` MCP entry is a snapshot: it stores a server URL an
 ````text
 Debug and fix my OpenWork Cloud MCP connection. It may be pointed at a stale or local server instead of my real OpenWork Cloud server. Work through ALL phases, show your findings after each, and ask before anything destructive. Never print bearer tokens or Authorization headers — redact them.
 
-My expected cloud API host: https://api.openworklabs.com (replace with your self-hosted server URL if you run your own).
+My expected cloud web URL: https://app.openworklabs.com (replace with your self-hosted Den web URL if you run your own).
 
 ## Phase 1 — Evidence: what am I actually connected to?
 
@@ -41,9 +41,9 @@ My expected cloud API host: https://api.openworklabs.com (replace with your self
 
 ## Phase 2 — Probe both servers directly (no auth needed)
 
-4. The server from Phase 1:
-   `curl -s -m 5 <that-origin>/openapi.json | python3 -c "import json,sys; d=json.load(sys.stdin); ps=[p for p in d.get('paths',{}) if 'google-workspace' in p]; print(len(ps)); [print(p) for p in ps]"`
-5. The expected cloud host, same command. Compare the two lists.
+4. The server from Phase 1, through the Den web proxy:
+   `curl -s -m 5 <that-origin>/api/den/openapi.json | python3 -c "import json,sys; d=json.load(sys.stdin); ps=[p for p in d.get('paths',{}) if 'google-workspace' in p]; print(len(ps)); [print(p) for p in ps]"`
+5. The expected cloud web URL, same command. Compare the two lists.
 
 ## Phase 3 — Probe through your own MCP tools (in-band ground truth)
 
@@ -54,7 +54,7 @@ My expected cloud API host: https://api.openworklabs.com (replace with your self
 
 State which world you are in:
 - openwork-cloud url is localhost/127.0.0.1, OR search returned only gmail-drafts, OR execute returned unknown_capability → you are bound to a STALE server, not the expected cloud.
-- a desktop-bootstrap.json contains localhost URLs → that file is the root cause (it feeds the app's server URL when the Advanced settings field is empty).
+- a desktop-bootstrap.json contains localhost URLs → that file is the root cause (it is the desktop app's Cloud URL source of truth).
 
 ## Phase 5 — Fix (confirm with me before each destructive step)
 
@@ -74,7 +74,7 @@ State which world you are in:
 
 **Expected passing state**
 
-- The `openwork-cloud` entry's `url` points at your real server's `/mcp/agent`.
+- The `openwork-cloud` entry's `url` points at your real server's `/api/den/mcp/agent`.
 - `search_capabilities` reflects your server's current catalog.
 - `execute_capability` on a known capability returns data or an actionable connection message — never `unknown_capability`.
 


### PR DESCRIPTION
## Summary
- collapse desktop/app Cloud configuration to a single Den web `baseUrl`
- derive Den API and MCP traffic through `<baseUrl>/api/den` instead of direct API hosts
- simplify the den-web `/api/den` proxy into a cleaner pass-through and add proxy coverage
- document the single-URL behavior for hosted Cloud, self-hosted deployments, MCP config, and troubleshooting

## Tests
- `pnpm --dir apps/app exec bun test tests/den-mcp-url.test.ts tests/memory-client.test.ts tests/den-extension-projection.test.ts tests/den-desktop-bootstrap-settings.test.ts src/app/lib/den-endpoint-sources.test.ts` ✅
- `pnpm --dir apps/app typecheck` ✅
- `pnpm --dir ee/apps/den-web exec bun test app/api/_lib/upstream-proxy.test.mjs` ✅
- `pnpm --dir ee/apps/den-web exec tsc --noEmit` ✅
- `pnpm --dir apps/desktop exec node --test electron/workspace-store.test.mjs` ✅

## E2E proof
No video/fraimz captured for this PR because the changed behavior is URL routing/bootstrap/proxy plumbing and was verified with focused unit, typecheck, and route-level proxy tests rather than a visible UI flow. Reviewer repro: run the commands above, then verify `/api/den/v1/...` reaches the configured `DEN_API_BASE` with cookies/auth/body preserved.