### PR TITLE
feat(connections): Render quick-add preset (org API key)

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
@@ -66,6 +66,13 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
     authType: "apikey",
   },
   {
+    presetId: "render",
+    displayName: "Render",
+    description: "Deploy and manage services, databases, and logs. Paste your org's Render API key from dashboard.render.com.",
+    url: "https://mcp.render.com/mcp",
+    authType: "apikey",
+  },
+  {
     presetId: "context7",
     displayName: "Context7",
     description: "Search product docs with richer context.",


### PR DESCRIPTION
## What

Adds **Render** (render.com — cloud hosting) to the Den org-wide External MCP Connections quick-add presets. Follow-up to #2555 (Granola), which merged before the Render commit landed on its branch — this re-lands that single commit on a fresh branch off `dev`.

- `ee/apps/den-api/src/capability-sources/external-mcp-presets.ts`: one new entry (+7 lines), grouped with Exa in the API-key presets (after Exa, before Context7).
- URL: `https://mcp.render.com/mcp` — Render's official hosted MCP server ([Render docs](https://render.com/docs/mcp-server)).
- `authType: "apikey"`: Render's MCP does not support OAuth; it authenticates via `Authorization: Bearer <RENDER_API_KEY>`, which is exactly the header den-api's apikey path sends (`external-mcp-client.ts`). Description tells admins to grab the key from dashboard.render.com, matching the Exa preset's register (#2498).

## Testing

- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit` — **pass** (clean, re-run after cherry-pick onto latest `dev`).
- No unit tests exist for the preset catalog (`rg -ln 'presetId|EXTERNAL_MCP_PRESETS' ee --glob '*test*'` → none).
- **No video/screenshot attached** — data-only catalog addition; I did not spin up the local Den stack. Reviewer repro:
  1. `pnpm demo:den:reset && pnpm dev:den`
  2. Sign in as the seeded demo admin, open **Dashboard → Connections**
  3. The **Render** card appears in the quick-add presets next to Exa; Add opens the API-key dialog (key from dashboard.render.com).