### PR TITLE
feat(landing): Already doing it in your agent? Add it to OpenWork, share it — Connect section

### DIFF
--- a/ee/apps/landing/components/landing-agent-glyphs.tsx
+++ b/ee/apps/landing/components/landing-agent-glyphs.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+/**
+ * Animated agent glyphs.
+ *
+ * The four animated SVG glyphs are adapted from Flue
+ * (https://github.com/withastro/flue, apps/www/src/pages/index.astro),
+ * licensed under the Apache License, Version 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * MODIFIED by OpenWork from the original Flue source:
+ *  - converted Astro markup to a React component
+ *  - kept the four glyph SVGs and hover animations
+ */
+
+type Props = {
+  className?: string;
+};
+
+export function LandingAgentGlyphs({ className }: Props) {
+  return (
+    <span
+      className={`relative flex h-5 w-[94px] shrink-0 items-center justify-start text-gray-400 ${className ?? ""}`}
+      aria-hidden="true"
+    >
+      <svg
+        className="h-5 w-5 -rotate-6 transition-transform duration-300 ease-out group-hover:-translate-x-1 group-hover:-rotate-12"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        fillRule="evenodd"
+        clipRule="evenodd"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M20.998 10.949H24v3.102h-3v3.028h-1.487V20H18v-2.921h-1.487V20H15v-2.921H9V20H7.488v-2.921H6V20H4.487v-2.921H3V14.05H0V10.95h3V5h17.998v5.949zM6 10.949h1.488V8.102H6v2.847zm10.51 0H18V8.102h-1.49v2.847z" />
+      </svg>
+      <svg
+        className="ml-1 h-5 w-5 transition-transform duration-300 ease-out group-hover:-translate-x-px group-hover:-translate-y-px group-hover:rotate-6 group-hover:scale-110"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        fillRule="evenodd"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M9.205 8.658v-2.26c0-.19.072-.333.238-.428l4.543-2.616c.619-.357 1.356-.523 2.117-.523 2.854 0 4.662 2.212 4.662 4.566 0 .167 0 .357-.024.547l-4.71-2.759a.797.797 0 00-.856 0l-5.97 3.473zm10.609 8.8V12.06c0-.333-.143-.57-.429-.737l-5.97-3.473 1.95-1.118a.433.433 0 01.476 0l4.543 2.617c1.309.76 2.189 2.378 2.189 3.948 0 1.808-1.07 3.473-2.76 4.163zM7.802 12.703l-1.95-1.142c-.167-.095-.239-.238-.239-.428V5.899c0-2.545 1.95-4.472 4.591-4.472 1 0 1.927.333 2.712.928L8.23 5.067c-.285.166-.428.404-.428.737v6.898zM12 15.128l-2.795-1.57v-3.33L12 8.658l2.795 1.57v3.33L12 15.128zm1.796 7.23c-1 0-1.927-.332-2.712-.927l4.686-2.712c.285-.166.428-.404.428-.737v-6.898l1.974 1.142c.167.095.238.238.238.428v5.233c0 2.545-1.974 4.472-4.614 4.472zm-5.637-5.303l-4.544-2.617c-1.308-.761-2.188-2.378-2.188-3.948A4.482 4.482 0 014.21 6.327v5.423c0 .333.143.571.428.738l5.947 3.449-1.95 1.118a.432.432 0 01-.476 0zm-.262 3.9c-2.688 0-4.662-2.021-4.662-4.519 0-.19.024-.38.047-.57l4.686 2.71c.286.167.571.167.856 0l5.97-3.448v2.26c0 .19-.07.333-.237.428l-4.543 2.616c-.619.357-1.356.523-2.117.523zm5.899 2.83a5.947 5.947 0 005.827-4.756C22.287 18.339 24 15.84 24 13.296c0-1.665-.713-3.282-1.998-4.448.119-.5.19-.999.19-1.498 0-3.401-2.759-5.947-5.946-5.947-.642 0-1.26.095-1.88.31A5.962 5.962 0 0010.205 0a5.947 5.947 0 00-5.827 4.757C1.713 5.447 0 7.945 0 10.49c0 1.666.713 3.283 1.998 4.448-.119.5-.19 1-.19 1.499 0 3.401 2.759 5.946 5.946 5.946.642 0 1.26-.095 1.88-.309a5.96 5.96 0 004.162 1.713z" />
+      </svg>
+      <svg
+        className="ml-1 h-5 w-5 transition-transform duration-300 ease-out group-hover:translate-x-px group-hover:translate-y-0.5 group-hover:-rotate-6 group-hover:scale-110"
+        viewBox="82.65 82.65 634.71 634.71"
+        fill="currentColor"
+        fillRule="evenodd"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z" />
+        <path d="M517.36 400H634.72V634.72H517.36Z" />
+      </svg>
+      <svg
+        className="ml-0.5 h-5 w-5 rotate-6 transition-transform duration-300 ease-out group-hover:translate-x-1 group-hover:rotate-12"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        fillRule="evenodd"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M16 6H8v12h8V6zm4 16H4V2h16v20z" />
+      </svg>
+    </span>
+  );
+}

--- a/ee/apps/landing/components/landing-connect-mcp.tsx
+++ b/ee/apps/landing/components/landing-connect-mcp.tsx
@@ -1,0 +1,425 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { capturePosthogEvent } from "../lib/posthog-client";
+
+const MCP_SERVER_URL = "https://api.openworklabs.com/mcp/agent";
+const DOCS_URL = "https://openworklabs.com/docs/cloud/run-in-the-cloud/cloud-mcp";
+const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+function encodeBase64(value: string) {
+  let encoded = "";
+
+  for (let index = 0; index < value.length; index += 3) {
+    const first = value.charCodeAt(index);
+    const hasSecond = index + 1 < value.length;
+    const hasThird = index + 2 < value.length;
+    const second = hasSecond ? value.charCodeAt(index + 1) : 0;
+    const third = hasThird ? value.charCodeAt(index + 2) : 0;
+    const bits = (first << 16) | (second << 8) | third;
+
+    encoded += BASE64_ALPHABET.charAt((bits >> 18) & 63);
+    encoded += BASE64_ALPHABET.charAt((bits >> 12) & 63);
+    encoded += hasSecond ? BASE64_ALPHABET.charAt((bits >> 6) & 63) : "=";
+    encoded += hasThird ? BASE64_ALPHABET.charAt(bits & 63) : "=";
+  }
+
+  return encoded;
+}
+
+const CURSOR_CONFIG_JSON = JSON.stringify({ url: MCP_SERVER_URL });
+const CURSOR_DEEPLINK = `https://cursor.com/en/install-mcp?name=openwork&config=${encodeURIComponent(
+  encodeBase64(CURSOR_CONFIG_JSON)
+)}`;
+const CURSOR_SNIPPET = `{
+  "mcpServers": {
+    "openwork": {
+      "url": "${MCP_SERVER_URL}"
+    }
+  }
+}`;
+const CLAUDE_CODE_COMMAND = `claude mcp add --transport http openwork ${MCP_SERVER_URL}`;
+const OPENCODE_SNIPPET = `{
+  "mcp": {
+    "openwork": {
+      "type": "remote",
+      "enabled": true,
+      "url": "${MCP_SERVER_URL}",
+      "oauth": {}
+    }
+  }
+}`;
+const VS_CODE_COMMAND = `code --add-mcp '{"name":"openwork","type":"http","url":"${MCP_SERVER_URL}"}'`;
+const ANY_CLIENT_COMMAND = `npx install-mcp ${MCP_SERVER_URL} --client <your-client>`;
+
+const SEARCH_INPUT = `{
+  "query": "meeting notes"
+}`;
+const SEARCH_RESULT = `{
+  "matches": [
+    {
+      "name": "mcp:granola:query_meetings",
+      "method": "POST",
+      "path": "/mcp/granola",
+      "score": 12,
+      "summary": "Search your org's Granola meeting notes",
+      "pathParams": [],
+      "queryParams": [],
+      "hasBody": true
+    },
+    {
+      "name": "getOrg",
+      "method": "GET",
+      "path": "/v1/org",
+      "score": 8,
+      "summary": "Get active organization",
+      "pathParams": [],
+      "queryParams": [],
+      "hasBody": false
+    }
+  ]
+}`;
+const EXECUTE_INPUT = `{
+  "name": "mcp:granola:query_meetings"
+}`;
+const EXECUTE_RESULT = `{
+  "meetings": [
+    {
+      "title": "Design review",
+      "date": "2026-07-07"
+    },
+    {
+      "title": "Customer onboarding",
+      "date": "2026-07-02"
+    }
+  ]
+}`;
+
+type CopyMethod = "clipboard" | "execCommand" | "none";
+type ClientId = "cursor" | "claude-code" | "opencode" | "vs-code" | "any-client";
+
+type ClientInstall = {
+  id: ClientId;
+  label: string;
+  eyebrow: string;
+  copyText: string;
+  helper: string;
+};
+
+const CLIENT_ORDER: ClientId[] = ["cursor", "claude-code", "opencode", "vs-code", "any-client"];
+
+const CLIENT_INSTALLS: Record<ClientId, ClientInstall> = {
+  cursor: {
+    id: "cursor",
+    label: "Cursor",
+    eyebrow: "One-click install or ~/.cursor/mcp.json",
+    copyText: CURSOR_SNIPPET,
+    helper: "Paste this into ~/.cursor/mcp.json if you prefer manual setup."
+  },
+  "claude-code": {
+    id: "claude-code",
+    label: "Claude Code",
+    eyebrow: "One terminal command",
+    copyText: CLAUDE_CODE_COMMAND,
+    helper: "Claude Code opens the browser for OAuth, then stores the remote MCP server."
+  },
+  opencode: {
+    id: "opencode",
+    label: "OpenCode",
+    eyebrow: "opencode.json MCP config",
+    copyText: OPENCODE_SNIPPET,
+    helper: "Add this remote MCP server entry to your OpenCode config."
+  },
+  "vs-code": {
+    id: "vs-code",
+    label: "VS Code",
+    eyebrow: "VS Code MCP command",
+    copyText: VS_CODE_COMMAND,
+    helper: "Run this from a shell with the VS Code CLI on your path."
+  },
+  "any-client": {
+    id: "any-client",
+    label: "Any client",
+    eyebrow: "Universal installer",
+    copyText: ANY_CLIENT_COMMAND,
+    helper: "Use install-mcp for another client, or paste the remote server URL directly."
+  }
+};
+
+async function writeClipboardText(text: string): Promise<{ copied: boolean; method: CopyMethod }> {
+  let copied = false;
+  let method: CopyMethod = "none";
+
+  try {
+    await navigator.clipboard.writeText(text);
+    copied = true;
+    method = "clipboard";
+  } catch {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.cssText = "position:absolute;left:-9999px;top:-9999px;";
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      copied = document.execCommand("copy");
+      if (copied) method = "execCommand";
+    } catch {}
+    textarea.remove();
+  }
+
+  return { copied, method };
+}
+
+export function LandingConnectMcp() {
+  const [activeClient, setActiveClient] = useState<ClientId>("cursor");
+  const [feedbackClient, setFeedbackClient] = useState<ClientId | null>(null);
+  const [copyError, setCopyError] = useState(false);
+  const [urlCopied, setUrlCopied] = useState(false);
+  const installResetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const urlResetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (installResetTimer.current) clearTimeout(installResetTimer.current);
+      if (urlResetTimer.current) clearTimeout(urlResetTimer.current);
+    };
+  }, []);
+
+  const copyInstall = async (install: ClientInstall) => {
+    const { copied, method } = await writeClipboardText(install.copyText);
+
+    setCopyError(!copied);
+    setFeedbackClient(install.id);
+    capturePosthogEvent("landing_connect_mcp_copy_clicked", {
+      client: install.id,
+      copied,
+      method
+    });
+
+    if (installResetTimer.current) clearTimeout(installResetTimer.current);
+    installResetTimer.current = setTimeout(() => {
+      setFeedbackClient(null);
+      installResetTimer.current = null;
+    }, 2500);
+  };
+
+  const copyServerUrl = async () => {
+    const { copied } = await writeClipboardText(MCP_SERVER_URL);
+    setUrlCopied(copied);
+
+    if (urlResetTimer.current) clearTimeout(urlResetTimer.current);
+    urlResetTimer.current = setTimeout(() => {
+      setUrlCopied(false);
+      urlResetTimer.current = null;
+    }, 2500);
+  };
+
+  return (
+    <section id="connect-mcp" className="relative scroll-mt-24">
+      <div className="mb-6 max-w-3xl">
+        <div className="landing-chip mb-4 inline-flex rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-gray-500">
+          OpenWork Connect MCP
+        </div>
+        <h2 className="text-3xl font-medium leading-[1.12] tracking-tight text-[#011627] md:text-4xl lg:text-5xl">
+          Connect any agent
+        </h2>
+        <p className="mt-4 text-[16px] leading-7 text-gray-600 md:text-lg md:leading-8">
+          Your org&apos;s capabilities, connections, and marketplace are two MCP tools away:
+          <span className="font-mono text-[#011627]"> search_capabilities</span> finds the
+          right operation, and <span className="font-mono text-[#011627]">execute_capability</span> runs it.
+        </p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2 lg:items-start">
+        <div className="rounded-xl border border-gray-100 bg-white p-5 shadow-sm md:p-6">
+          <div className="mb-5 rounded-xl border border-gray-100 bg-gray-50/80 p-3">
+            <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+              Server URL
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <code className="min-w-0 overflow-x-auto whitespace-nowrap rounded-lg bg-white px-3 py-2 font-mono text-[12px] text-[#011627] ring-1 ring-gray-100">
+                {MCP_SERVER_URL}
+              </code>
+              <button
+                type="button"
+                aria-label="Copy the OpenWork MCP server URL"
+                onClick={() => {
+                  void copyServerUrl();
+                }}
+                className="inline-flex shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-[#011627] transition-colors hover:bg-gray-50"
+              >
+                {urlCopied ? "Copied" : "Copy URL"}
+              </button>
+            </div>
+            <p className="mt-3 text-[12px] leading-5 text-gray-500">
+              Remote streamable HTTP with OAuth 2.0, dynamic client registration, and PKCE.
+            </p>
+          </div>
+
+          <div
+            role="tablist"
+            aria-label="OpenWork MCP client install options"
+            className="landing-chip mb-4 flex gap-1 overflow-x-auto rounded-full p-1"
+          >
+            {CLIENT_ORDER.map((clientId) => {
+              const client = CLIENT_INSTALLS[clientId];
+              const selected = client.id === activeClient;
+
+              return (
+                <button
+                  key={client.id}
+                  id={`connect-mcp-tab-${client.id}`}
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  aria-controls={`connect-mcp-panel-${client.id}`}
+                  tabIndex={selected ? 0 : -1}
+                  onClick={() => setActiveClient(client.id)}
+                  className={`shrink-0 rounded-full px-3 py-2 text-[13px] font-medium transition-colors md:px-4 ${
+                    selected
+                      ? "bg-[#011627] text-white shadow-sm"
+                      : "text-gray-600 hover:bg-white hover:text-[#011627]"
+                  }`}
+                >
+                  {client.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {CLIENT_ORDER.map((clientId) => {
+            const install = CLIENT_INSTALLS[clientId];
+            const selected = install.id === activeClient;
+            const installFeedback = feedbackClient === install.id;
+
+            return (
+              <div
+                key={install.id}
+                id={`connect-mcp-panel-${install.id}`}
+                role="tabpanel"
+                aria-labelledby={`connect-mcp-tab-${install.id}`}
+                hidden={!selected}
+                data-feedback={installFeedback ? "true" : "false"}
+                data-copy-error={copyError ? "true" : "false"}
+                className="rounded-xl border border-gray-100 bg-white shadow-sm"
+              >
+                <div className="border-b border-gray-100 p-4 md:p-5">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+                    {install.eyebrow}
+                  </div>
+                  <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h3 className="text-xl font-medium text-[#011627]">{install.label}</h3>
+                      <p className="mt-1 text-[13px] leading-5 text-gray-500">{install.helper}</p>
+                    </div>
+                    {install.id === "cursor" ? (
+                      <a
+                        href={CURSOR_DEEPLINK}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex min-h-[42px] shrink-0 items-center justify-center rounded-full bg-[#011627] px-5 text-sm font-medium text-white shadow-[0_14px_32px_-16px_rgba(1,22,39,0.55)] transition-colors hover:bg-black"
+                      >
+                        Add to Cursor
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="p-4 md:p-5">
+                  <pre className="max-h-[300px] overflow-x-auto whitespace-pre-wrap rounded-xl bg-[#011627] p-4 font-mono text-[12px] leading-6 text-white shadow-inner">
+                    <code>{install.copyText}</code>
+                  </pre>
+                  {install.id === "any-client" ? (
+                    <p className="mt-3 text-[13px] leading-6 text-gray-500">
+                      You can also paste the URL into any MCP client that supports remote servers with OAuth.
+                    </p>
+                  ) : null}
+                  <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="text-[12px] leading-5 text-gray-500">
+                      OAuth opens in your browser, asks you to pick your org, then returns the token to the client.
+                    </p>
+                    <button
+                      type="button"
+                      aria-label="Copy the OpenWork MCP install command"
+                      onClick={() => {
+                        void copyInstall(install);
+                      }}
+                      className="inline-flex min-w-[116px] shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white px-4 py-2 text-xs font-medium text-[#011627] shadow-sm transition-colors hover:bg-gray-50"
+                    >
+                      {installFeedback ? (copyError ? "Couldn't copy" : "Copied") : "Copy"}
+                    </button>
+                  </div>
+                </div>
+                <span aria-live="polite" className="sr-only">
+                  {installFeedback ? (copyError ? "Install command could not be copied" : "Install command copied") : ""}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        <div
+          data-testid="connect-mcp-example"
+          className="overflow-hidden rounded-xl border border-gray-100 bg-white shadow-sm"
+        >
+          <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50/80 px-4 py-3">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+                Example
+              </div>
+              <div className="mt-1 text-sm font-medium text-[#011627]">Search, then execute</div>
+            </div>
+            <div className="flex gap-1.5" aria-hidden="true">
+              <span className="h-2.5 w-2.5 rounded-full bg-red-300" />
+              <span className="h-2.5 w-2.5 rounded-full bg-yellow-300" />
+              <span className="h-2.5 w-2.5 rounded-full bg-green-300" />
+            </div>
+          </div>
+          <div className="space-y-4 bg-[#07192C] p-4 font-mono text-[12px] leading-6 text-slate-100 md:p-5">
+            <div>
+              <div className="mb-2 text-slate-400">agent → search_capabilities</div>
+              <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg bg-white/5 p-3 text-slate-100">
+                <code>{SEARCH_INPUT}</code>
+              </pre>
+            </div>
+            <div>
+              <div className="mb-2 text-slate-400">openwork → matches</div>
+              <pre className="max-h-[320px] overflow-x-auto whitespace-pre-wrap rounded-lg bg-white/5 p-3 text-slate-100">
+                <code>{SEARCH_RESULT}</code>
+              </pre>
+            </div>
+            <div>
+              <div className="mb-2 text-slate-400">agent → execute_capability</div>
+              <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg bg-white/5 p-3 text-slate-100">
+                <code>{EXECUTE_INPUT}</code>
+              </pre>
+            </div>
+            <div>
+              <div className="mb-2 text-slate-400">openwork → result</div>
+              <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg bg-white/5 p-3 text-slate-100">
+                <code>{EXECUTE_RESULT}</code>
+              </pre>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-col gap-3 rounded-xl border border-gray-100 bg-white/80 p-4 text-[13px] leading-6 text-gray-600 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <p>
+          Works with any MCP client that supports remote servers with OAuth — your agent signs in with your
+          OpenWork account and only sees what your org allows.
+        </p>
+        <a
+          href={DOCS_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="shrink-0 font-medium text-[#011627] underline decoration-gray-300 underline-offset-4 transition-colors hover:decoration-[#011627]"
+        >
+          Read the docs
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/ee/apps/landing/components/landing-connect-mcp.tsx
+++ b/ee/apps/landing/components/landing-connect-mcp.tsx
@@ -56,15 +56,7 @@ const OPENCODE_SNIPPET = `{
 const VS_CODE_COMMAND = `code --add-mcp '{"name":"openwork","type":"http","url":"${MCP_SERVER_URL}"}'`;
 const ANY_CLIENT_COMMAND = `npx install-mcp ${MCP_SERVER_URL} --client <your-client>`;
 
-const SEARCH_INPUT = `{"query": "meeting notes"}`;
-const SEARCH_RESULT = `{
-  "matches": [
-    { "name": "mcp:granola:query_meetings", "method": "POST", "path": "/mcp/granola", "score": 12, "summary": "Meeting notes your org connected via Granola", "pathParams": [], "queryParams": [], "hasBody": true },
-    { "name": "plugin:meeting-brief:generate", "kind": "skill", "method": "POST", "path": "/v1/marketplace/run", "score": 9, "summary": "Teammate-shared skill: draft a meeting brief", "hasBody": true }
-  ]
-}`;
-const EXECUTE_INPUT = `{"name": "plugin:meeting-brief:generate"}`;
-const EXECUTE_RESULT = `{"brief": "Acme Corp call — deal history, latest notes, 3 talking points", "savedTo": "Meeting Brief — Acme Corp.md"}`;
+const SIGNUP_URL = "https://app.openworklabs.com?mode=sign-up";
 
 type CopyMethod = "clipboard" | "execCommand" | "none";
 type ClientId = "cursor" | "claude-code" | "opencode" | "vs-code" | "any-client";
@@ -85,7 +77,7 @@ type BringItem = {
 };
 
 const CLIENT_ORDER: ClientId[] = ["cursor", "claude-code", "opencode", "vs-code", "any-client"];
-const revealSteps = ["Sign in in the browser", "Pick your org", "Your team's tools appear"];
+const revealSteps = ["Create your free account or sign in", "Pick your org", "Your team's tools appear"];
 
 const bringItems: BringItem[] = [
   { name: "Granola", type: "MCP", tone: "mcp" },
@@ -220,10 +212,8 @@ export function LandingConnectMcp() {
           Already doing it in your agent?<br />Add it to OpenWork. Share it with everyone.
         </h2>
         <p className="mt-5 max-w-3xl text-[16px] leading-7 text-gray-600 md:text-lg md:leading-8">
-          Skills and MCPs move in as-is — same SKILL.md format, same server URLs. Share once on
-          OpenWork, and every teammate&apos;s agent can use them through
-          <span className="font-mono text-[#011627]"> search_capabilities</span> and
-          <span className="font-mono text-[#011627]"> execute_capability</span>.
+          Skills and MCPs move in as-is — same SKILL.md format, same server URLs. Share once,
+          and your whole team runs them in OpenWork — or from their own agent.
         </p>
       </div>
 
@@ -255,15 +245,15 @@ export function LandingConnectMcp() {
               {bringItems.map((item, index) => (
                 <div
                   key={item.name}
-                  className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 transition-all ${
-                    index === 0 ? "border-blue-300 bg-blue-50/60 shadow-sm" : "border-gray-100 bg-white"
+                  className={`flex items-center gap-2.5 rounded-lg px-3 py-2 ${
+                    index === 0 ? "bg-blue-50/60" : "bg-gray-50/70"
                   }`}
                 >
                   <span className={`h-6 w-6 shrink-0 rounded-full ${dotClass[item.tone]}`} />
                   <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-[#011627]">
                     {item.name}
                   </span>
-                  <span className="shrink-0 rounded-full border border-gray-100 bg-gray-50 px-2 py-0.5 text-[11px] font-medium text-gray-500">
+                  <span className="shrink-0 text-[11px] text-gray-400">
                     {item.type}
                   </span>
                 </div>
@@ -283,49 +273,78 @@ export function LandingConnectMcp() {
 
         <div
           data-testid="connect-mcp-example"
-          className="landing-shell relative flex h-full flex-col overflow-hidden rounded-2xl"
+          className="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm"
         >
-          <div className="relative z-20 flex h-10 w-full shrink-0 items-center border-b border-white/50 bg-gradient-to-b from-white/90 to-white/60 px-4">
-            <div className="flex gap-1.5">
-              <div className="h-3 w-3 rounded-full border border-[#e0443e]/20 bg-[#ff5f56]/90 shadow-sm" />
-              <div className="h-3 w-3 rounded-full border border-[#dea123]/20 bg-[#ffbd2e]/90 shadow-sm" />
-              <div className="h-3 w-3 rounded-full border border-[#1aab29]/20 bg-[#27c93f]/90 shadow-sm" />
+          <div className="flex items-center justify-between gap-3 border-b border-gray-100 bg-gray-50/80 px-4 py-2.5">
+            <div className="flex items-center gap-3">
+              <div className="flex gap-1.5">
+                <div className="h-2.5 w-2.5 rounded-full bg-red-400/70" />
+                <div className="h-2.5 w-2.5 rounded-full bg-yellow-400/70" />
+                <div className="h-2.5 w-2.5 rounded-full bg-green-400/70" />
+              </div>
+              <div className="text-[12px] font-medium text-gray-500">OpenWork</div>
             </div>
-            <div className="absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-[12px] font-medium tracking-wide text-gray-500">
-              What your teammate&apos;s agent sees
-            </div>
+            <div className="text-[11px] text-gray-400">Your teammate&apos;s view</div>
           </div>
 
-          <div className="flex flex-1 flex-col gap-3 bg-[#07192C] p-4 font-mono text-[11px] leading-5 text-slate-100 md:p-5">
-            <div className="flex items-center justify-between gap-3">
-              <span className="inline-flex rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-300">
-                Example
-              </span>
-              <span className="text-[11px] text-slate-500">shared once, consumed anywhere</span>
+          <div className="flex flex-1">
+            <div className="hidden w-[170px] flex-col border-r border-gray-100 bg-gray-50/50 p-3 sm:flex">
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between rounded-2xl bg-white px-2.5 py-2">
+                  <div className="flex items-center gap-2">
+                    <span className="h-6 w-6 rounded-full bg-gradient-to-br from-amber-400 to-orange-400" />
+                    <span className="text-[11px] font-medium text-[#011627]">Meeting Brief</span>
+                  </div>
+                  <span className="text-[9px] text-green-600">Active</span>
+                </div>
+                <div className="flex items-center justify-between rounded-lg px-2.5 py-2">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="h-6 w-6 rounded-full bg-gradient-to-br from-teal-400 to-cyan-500" />
+                    <span className="truncate text-[11px] font-medium text-gray-600">Granola</span>
+                    <span className="text-[9px] text-gray-400">MCP</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between rounded-lg px-2.5 py-2">
+                  <div className="flex items-center gap-2">
+                    <span className="h-6 w-6 rounded-full bg-gradient-to-br from-violet-400 to-purple-500" />
+                    <span className="text-[11px] font-medium text-gray-600">review-pr</span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between rounded-lg px-2.5 py-2">
+                  <div className="flex items-center gap-2">
+                    <span className="h-6 w-6 rounded-full bg-gradient-to-br from-teal-400 to-cyan-500" />
+                    <span className="text-[11px] font-medium text-gray-600">Linear</span>
+                  </div>
+                </div>
+              </div>
             </div>
-            <div>
-              <div className="mb-1.5 text-slate-400">agent → search_capabilities</div>
-              <pre className="whitespace-pre-wrap break-words rounded-lg bg-white/5 p-3 text-slate-100">
-                <code>{SEARCH_INPUT}</code>
-              </pre>
-            </div>
-            <div>
-              <div className="mb-1.5 text-slate-400">openwork → matches</div>
-              <pre className="whitespace-pre-wrap break-words rounded-lg bg-white/5 p-3 text-slate-100">
-                <code>{SEARCH_RESULT}</code>
-              </pre>
-            </div>
-            <div>
-              <div className="mb-1.5 text-slate-400">agent → execute_capability</div>
-              <pre className="whitespace-pre-wrap break-words rounded-lg bg-white/5 p-3 text-slate-100">
-                <code>{EXECUTE_INPUT}</code>
-              </pre>
-            </div>
-            <div>
-              <div className="mb-1.5 text-slate-400">openwork → result</div>
-              <pre className="whitespace-pre-wrap break-words rounded-lg bg-white/5 p-3 text-slate-100">
-                <code>{EXECUTE_RESULT}</code>
-              </pre>
+
+            <div className="flex flex-1 flex-col">
+              <div className="flex flex-1 flex-col gap-4 p-4">
+                <div className="self-end rounded-2xl rounded-br-md bg-gray-100 px-4 py-2.5 text-[12px] leading-relaxed text-[#011627]">
+                  Prep a brief for tomorrow&apos;s Acme call from my meeting notes.
+                </div>
+
+                <div className="flex flex-col gap-1 pl-1">
+                  <div className="text-[10px] text-gray-400">
+                    &rsaquo; Queried the shared Granola MCP for meeting notes
+                  </div>
+                  <div className="text-[10px] text-gray-400">
+                    &rsaquo; Ran Meeting Brief Generator — shared by your team
+                  </div>
+                </div>
+
+                <div className="text-[12px] leading-relaxed text-[#011627]">
+                  Your brief is ready — deal history, latest notes, and 3 talking points. Saved to your desktop.
+                </div>
+              </div>
+
+              <div className="border-t border-gray-100 p-3">
+                <div className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2">
+                  <span className="text-[12px] text-gray-400">Describe your task</span>
+                  <span className="rounded-full bg-[#011627] px-3 py-1 text-[10px] font-medium text-white">Run Task</span>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -333,11 +352,11 @@ export function LandingConnectMcp() {
 
       <div
         data-testid="connect-mcp-install"
-        className="mt-6 rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+        className="mt-8 border-t border-gray-100 pt-6"
       >
         <div className="group mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="text-[13px] text-gray-500">
-            Already use an AI agent? Point it at your org — one click or one command connects it.
+            Developers: point your own agent at your org — one click or one command.
           </div>
           <div className="flex min-w-0 shrink-0 items-center gap-2 text-gray-400">
             <LandingAgentGlyphs />
@@ -399,8 +418,8 @@ export function LandingConnectMcp() {
                   data-feedback={installFeedback ? "true" : "false"}
                   data-copy-error={copyError ? "true" : "false"}
                 >
-                  <div className="rounded-xl border border-gray-100 bg-white shadow-sm">
-                    <div className="border-b border-gray-100 p-4">
+                  <div>
+                    <div className="pb-3">
                       <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
                         {install.eyebrow}
                       </div>
@@ -422,7 +441,7 @@ export function LandingConnectMcp() {
                       </div>
                     </div>
 
-                    <div className="p-4">
+                    <div>
                       <pre className="max-h-[300px] overflow-x-auto whitespace-pre-wrap rounded-xl bg-[#011627] p-4 font-mono text-[12px] leading-6 text-white shadow-inner">
                         <code>{install.copyText}</code>
                       </pre>
@@ -433,7 +452,16 @@ export function LandingConnectMcp() {
                       ) : null}
                       <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                         <p className="text-[12px] leading-5 text-gray-500">
-                          OAuth opens in your browser, asks you to pick your org, then returns the token to the client.
+                          Works with your OpenWork account —{" "}
+                          <a
+                            href={SIGNUP_URL}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="font-medium text-[#011627] underline decoration-gray-300 underline-offset-4 hover:decoration-[#011627]"
+                          >
+                            create one free
+                          </a>
+                          .
                         </p>
                         <button
                           type="button"
@@ -517,12 +545,12 @@ export function LandingConnectMcp() {
             })}
           </div>
 
-        <div className="mt-4 rounded-xl border border-gray-100 bg-gray-50/80 p-3">
-          <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+        <div className="mt-5 flex flex-col gap-2 border-t border-gray-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
             Server URL
           </div>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <code className="min-w-0 whitespace-normal break-all rounded-lg bg-white px-3 py-2 font-mono text-[12px] text-[#011627] ring-1 ring-gray-100">
+          <div className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+            <code className="min-w-0 whitespace-normal break-all rounded bg-gray-50 px-2 py-1 font-mono text-[12px] text-[#011627]">
               {MCP_SERVER_URL}
             </code>
             <button
@@ -531,7 +559,7 @@ export function LandingConnectMcp() {
               onClick={() => {
                 void copyServerUrl();
               }}
-              className="inline-flex shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-[#011627] transition-colors hover:bg-gray-50"
+              className="inline-flex shrink-0 items-center justify-center px-2 py-1 text-xs font-medium text-[#011627] underline decoration-gray-300 underline-offset-4 transition-colors hover:decoration-[#011627]"
             >
               {urlCopied ? "Copied" : "Copy URL"}
             </button>

--- a/ee/apps/landing/components/landing-connect-mcp.tsx
+++ b/ee/apps/landing/components/landing-connect-mcp.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { ChevronRight, Link2, Plug } from "lucide-react";
+import { ChevronRight, Plug } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { capturePosthogEvent } from "../lib/posthog-client";
-import { LandingAgentGlyphs } from "./landing-agent-glyphs";
 
 const MCP_SERVER_URL = "https://api.openworklabs.com/mcp/agent";
 const DOCS_URL = "https://openworklabs.com/docs/cloud/run-in-the-cloud/cloud-mcp";
@@ -60,7 +59,6 @@ const SIGNUP_URL = "https://app.openworklabs.com?mode=sign-up";
 
 type CopyMethod = "clipboard" | "execCommand" | "none";
 type ClientId = "cursor" | "claude-code" | "opencode" | "vs-code" | "any-client";
-type BringTone = "mcp" | "skill" | "command";
 
 type ClientInstall = {
   id: ClientId;
@@ -70,26 +68,18 @@ type ClientInstall = {
   helper: string;
 };
 
-type BringItem = {
-  name: string;
-  type: string;
-  tone: BringTone;
-};
-
 const CLIENT_ORDER: ClientId[] = ["cursor", "claude-code", "opencode", "vs-code", "any-client"];
 const revealSteps = ["Create your free account or sign in", "Pick your org", "Your team's tools appear"];
+const CURSOR_ICON_PATH = "M22.106 5.68L12.5.135a.998.998 0 00-.998 0L1.893 5.68a.84.84 0 00-.419.726v11.186c0 .3.16.577.42.727l9.607 5.547a.999.999 0 00.998 0l9.608-5.547a.84.84 0 00.42-.727V6.407a.84.84 0 00-.42-.726zm-.603 1.176L12.228 22.92c-.063.108-.228.064-.228-.061V12.34a.59.59 0 00-.295-.51l-9.11-5.26c-.107-.062-.063-.228.062-.228h18.55c.264 0 .428.286.296.514z";
+const CLAUDE_ICON_PATH = "m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z";
+const VS_CODE_ICON_PATH = "M23.15 2.587L18.21.21a1.494 1.494 0 0 0-1.705.29l-9.46 8.63-4.12-3.128a.999.999 0 0 0-1.276.057L.327 7.261A1 1 0 0 0 .326 8.74L3.899 12 .326 15.26a1 1 0 0 0 .001 1.479L1.65 17.94a.999.999 0 0 0 1.276.057l4.12-3.128 9.46 8.63a1.492 1.492 0 0 0 1.704.29l4.942-2.377A1.5 1.5 0 0 0 24 20.06V3.939a1.5 1.5 0 0 0-.85-1.352zm-5.146 14.861L10.826 12l7.178-5.448v10.896z";
 
-const bringItems: BringItem[] = [
-  { name: "Granola", type: "MCP", tone: "mcp" },
-  { name: "Meeting Brief Generator", type: "Skill", tone: "skill" },
-  { name: "review-pr", type: "Command", tone: "command" },
-  { name: "Linear", type: "MCP", tone: "mcp" }
-];
-
-const dotClass: Record<BringTone, string> = {
-  mcp: "bg-gradient-to-br from-teal-400 to-cyan-500",
-  skill: "bg-gradient-to-br from-amber-400 to-orange-400",
-  command: "bg-gradient-to-br from-violet-400 to-purple-500"
+const clientIconClass: Record<ClientId, string> = {
+  cursor: "text-[#111111]",
+  "claude-code": "text-[#D97757]",
+  opencode: "text-[#656363]",
+  "vs-code": "text-[#007ACC]",
+  "any-client": "text-gray-500"
 };
 
 const CLIENT_INSTALLS: Record<ClientId, ClientInstall> = {
@@ -129,6 +119,43 @@ const CLIENT_INSTALLS: Record<ClientId, ClientInstall> = {
     helper: "Use install-mcp for another client, or paste the remote server URL directly."
   }
 };
+
+function ClientIcon({ clientId, className }: { clientId: ClientId; className: string }) {
+  if (clientId === "cursor") {
+    return (
+      <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path fillRule="evenodd" d={CURSOR_ICON_PATH} />
+      </svg>
+    );
+  }
+
+  if (clientId === "claude-code") {
+    return (
+      <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d={CLAUDE_ICON_PATH} />
+      </svg>
+    );
+  }
+
+  if (clientId === "opencode") {
+    return (
+      <svg className={className} viewBox="0 6 24 30" fill="none" aria-hidden="true">
+        <path d="M18 30H6V18H18V30Z" fill="#CFCECD" />
+        <path d="M18 12H6V30H18V12ZM24 36H0V6H24V36Z" fill="currentColor" />
+      </svg>
+    );
+  }
+
+  if (clientId === "vs-code") {
+    return (
+      <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d={VS_CODE_ICON_PATH} />
+      </svg>
+    );
+  }
+
+  return <Plug className={className} size={16} aria-hidden="true" />;
+}
 
 async function writeClipboardText(text: string): Promise<{ copied: boolean; method: CopyMethod }> {
   let copied = false;
@@ -220,53 +247,45 @@ export function LandingConnectMcp() {
       <div className="grid gap-6 lg:grid-cols-2 lg:items-stretch">
         <div
           data-testid="connect-mcp-bring"
-          className="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm"
+          className="flex h-full min-h-[430px] flex-col overflow-hidden rounded-xl border border-[#0b1f34] bg-[#011627] shadow-[0_24px_70px_-44px_rgba(1,22,39,0.85)]"
         >
-          <div className="flex items-center gap-3 border-b border-gray-100 bg-gray-50/80 px-4 py-2.5">
+          <div className="flex items-center gap-3 border-b border-white/10 bg-white/[0.03] px-4 py-2.5">
             <div className="flex gap-1.5">
               <div className="h-2.5 w-2.5 rounded-full bg-red-400/70" />
               <div className="h-2.5 w-2.5 rounded-full bg-yellow-400/70" />
               <div className="h-2.5 w-2.5 rounded-full bg-green-400/70" />
             </div>
-            <div className="text-[12px] font-medium text-gray-500">OpenWork</div>
+            <div className="text-[12px] font-medium text-gray-300">agent — terminal</div>
           </div>
 
-          <div className="flex flex-1 flex-col gap-3 p-4 text-left md:p-5">
+          <div className="flex flex-1 flex-col gap-4 p-4 font-mono text-[12px] leading-6 text-gray-100 md:p-5">
             <div>
-              <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-gray-400">
-                From your agents
+              <span className="text-cyan-300">❯</span> share my skills and MCPs with my OpenWork org
+            </div>
+
+            <div className="space-y-2">
+              <div>
+                <span className="text-green-300">✓</span> found <span className="text-teal-300">granola</span> MCP
               </div>
-              <h3 className="text-lg font-medium tracking-tight text-[#011627]">
-                Your setup, moved in as-is
-              </h3>
+              <div>
+                <span className="text-green-300">✓</span> packed <span className="text-amber-300">meeting-brief</span> skill from SKILL.md
+              </div>
+              <div>
+                <span className="text-green-300">✓</span> added <span className="text-violet-300">review-pr</span> command
+              </div>
             </div>
 
-            <div className="flex flex-col gap-1.5">
-              {bringItems.map((item, index) => (
-                <div
-                  key={item.name}
-                  className={`flex items-center gap-2.5 rounded-lg px-3 py-2 ${
-                    index === 0 ? "bg-blue-50/60" : "bg-gray-50/70"
-                  }`}
-                >
-                  <span className={`h-6 w-6 shrink-0 rounded-full ${dotClass[item.tone]}`} />
-                  <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-[#011627]">
-                    {item.name}
-                  </span>
-                  <span className="shrink-0 text-[11px] text-gray-400">
-                    {item.type}
-                  </span>
-                </div>
-              ))}
+            <div>
+              <div className="text-gray-500">› bundling</div>
+              <div className="space-y-1 pl-4 text-gray-400">
+                <div>mcp/granola.json</div>
+                <div>skills/meeting-brief/SKILL.md</div>
+                <div>commands/review-pr.md</div>
+              </div>
             </div>
 
-            <p className="text-[13px] leading-6 text-gray-600">
-              Already in Claude Code or Cursor? OpenWork speaks the same SKILL.md and remote MCP URLs — add them unchanged, then share your setup in one link.
-            </p>
-
-            <div className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg bg-[#011627] py-2 text-[13px] font-medium text-white shadow-[0_1px_2px_rgba(17,24,39,0.12)]">
-              <Link2 size={16} />
-              Share with your org
+            <div className="mt-auto">
+              <span className="text-green-300">✓</span> Shared with your org — <span className="text-white">one link</span> for the whole team
             </div>
           </div>
         </div>
@@ -359,7 +378,7 @@ export function LandingConnectMcp() {
             Developers: point your own agent at your org — one click or one command.
           </div>
           <div className="flex min-w-0 shrink-0 items-center gap-2 text-gray-400">
-            <LandingAgentGlyphs />
+            <Plug size={14} aria-hidden="true" />
             <span className="text-xs text-gray-400">
               Works with Claude Code, Cursor, VS Code — any MCP agent
             </span>
@@ -367,41 +386,44 @@ export function LandingConnectMcp() {
         </div>
 
         <div className="min-w-0">
-            <div
-              role="tablist"
-              aria-label="OpenWork MCP client install options"
-              className="landing-chip mb-4 flex flex-nowrap gap-2 overflow-x-auto rounded-full p-1"
-            >
-              {CLIENT_ORDER.map((clientId) => {
-                const client = CLIENT_INSTALLS[clientId];
-                const selected = client.id === activeClient;
+          <div
+            role="tablist"
+            aria-label="OpenWork MCP client install options"
+            className="landing-chip mb-4 flex flex-nowrap gap-2 overflow-x-auto rounded-full p-1"
+          >
+            {CLIENT_ORDER.map((clientId) => {
+              const client = CLIENT_INSTALLS[clientId];
+              const selected = client.id === activeClient;
 
-                return (
-                  <button
-                    key={client.id}
-                    id={`connect-mcp-tab-${client.id}`}
-                    type="button"
-                    role="tab"
-                    aria-selected={selected}
-                    aria-controls={`connect-mcp-panel-${client.id}`}
-                    tabIndex={selected ? 0 : -1}
-                    onClick={() => setActiveClient(client.id)}
-                    className={`relative shrink-0 cursor-pointer whitespace-nowrap rounded-full px-5 py-2 text-sm font-medium transition-colors ${
-                      selected ? "text-[#011627]" : "text-gray-600 hover:text-gray-900"
-                    }`}
-                  >
-                    {selected ? (
-                      <motion.div
-                        layoutId="connect-mcp-pill"
-                        className="absolute inset-0 rounded-full border border-gray-100 bg-white shadow-sm"
-                        transition={{ type: "spring", stiffness: 400, damping: 30 }}
-                      />
-                    ) : null}
-                    <span className="relative z-10">{client.label}</span>
-                  </button>
-                );
-              })}
-            </div>
+              return (
+                <button
+                  key={client.id}
+                  id={`connect-mcp-tab-${client.id}`}
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  aria-controls={`connect-mcp-panel-${client.id}`}
+                  tabIndex={selected ? 0 : -1}
+                  onClick={() => setActiveClient(client.id)}
+                  className={`relative shrink-0 cursor-pointer whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                    selected ? "text-[#011627]" : "text-gray-600 hover:text-gray-900"
+                  }`}
+                >
+                  {selected ? (
+                    <motion.div
+                      layoutId="connect-mcp-pill"
+                      className="absolute inset-0 rounded-full border border-gray-100 bg-white shadow-sm"
+                      transition={{ type: "spring", stiffness: 400, damping: 30 }}
+                    />
+                  ) : null}
+                  <span className="relative z-10 flex items-center gap-2">
+                    <ClientIcon clientId={client.id} className={`h-4 w-4 shrink-0 ${clientIconClass[client.id]}`} />
+                    <span>{client.label}</span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
 
             {CLIENT_ORDER.map((clientId) => {
               const install = CLIENT_INSTALLS[clientId];
@@ -425,7 +447,10 @@ export function LandingConnectMcp() {
                       </div>
                       <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                         <div>
-                          <h3 className="text-xl font-medium text-[#011627]">{install.label}</h3>
+                          <h3 className="flex items-center gap-2 text-xl font-medium text-[#011627]">
+                            <ClientIcon clientId={install.id} className={`h-5 w-5 shrink-0 ${clientIconClass[install.id]}`} />
+                            <span>{install.label}</span>
+                          </h3>
                           <p className="mt-1 text-[13px] leading-5 text-gray-500">{install.helper}</p>
                         </div>
                         {install.id === "cursor" ? (

--- a/ee/apps/landing/components/landing-connect-mcp.tsx
+++ b/ee/apps/landing/components/landing-connect-mcp.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { AnimatePresence, motion } from "framer-motion";
+import { ChevronRight, Plug } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { capturePosthogEvent } from "../lib/posthog-client";
+import { LandingAgentGlyphs } from "./landing-agent-glyphs";
 
 const MCP_SERVER_URL = "https://api.openworklabs.com/mcp/agent";
 const DOCS_URL = "https://openworklabs.com/docs/cloud/run-in-the-cloud/cloud-mcp";
@@ -63,37 +66,30 @@ const SEARCH_RESULT = `{
       "method": "POST",
       "path": "/mcp/granola",
       "score": 12,
-      "summary": "Search your org's Granola meeting notes",
+      "summary": "Meeting notes your org connected via Granola",
       "pathParams": [],
       "queryParams": [],
       "hasBody": true
     },
     {
-      "name": "getOrg",
-      "method": "GET",
-      "path": "/v1/org",
-      "score": 8,
-      "summary": "Get active organization",
+      "name": "plugin:meeting-brief:generate",
+      "kind": "skill",
+      "method": "POST",
+      "path": "/v1/marketplace/run",
+      "score": 9,
+      "summary": "Teammate-shared skill: draft a meeting brief",
       "pathParams": [],
       "queryParams": [],
-      "hasBody": false
+      "hasBody": true
     }
   ]
 }`;
 const EXECUTE_INPUT = `{
-  "name": "mcp:granola:query_meetings"
+  "name": "plugin:meeting-brief:generate"
 }`;
 const EXECUTE_RESULT = `{
-  "meetings": [
-    {
-      "title": "Design review",
-      "date": "2026-07-07"
-    },
-    {
-      "title": "Customer onboarding",
-      "date": "2026-07-02"
-    }
-  ]
+  "brief": "Acme Corp call — deal history, latest notes, 3 talking points",
+  "savedTo": "Meeting Brief — Acme Corp.md"
 }`;
 
 type CopyMethod = "clipboard" | "execCommand" | "none";
@@ -108,6 +104,7 @@ type ClientInstall = {
 };
 
 const CLIENT_ORDER: ClientId[] = ["cursor", "claude-code", "opencode", "vs-code", "any-client"];
+const revealSteps = ["Sign in in the browser", "Pick your org", "Your team's tools appear"];
 
 const CLIENT_INSTALLS: Record<ClientId, ClientInstall> = {
   cursor: {
@@ -115,14 +112,14 @@ const CLIENT_INSTALLS: Record<ClientId, ClientInstall> = {
     label: "Cursor",
     eyebrow: "One-click install or ~/.cursor/mcp.json",
     copyText: CURSOR_SNIPPET,
-    helper: "Paste this into ~/.cursor/mcp.json if you prefer manual setup."
+    helper: "Use the one-click button, or paste this into ~/.cursor/mcp.json."
   },
   "claude-code": {
     id: "claude-code",
     label: "Claude Code",
     eyebrow: "One terminal command",
     copyText: CLAUDE_CODE_COMMAND,
-    helper: "Claude Code opens the browser for OAuth, then stores the remote MCP server."
+    helper: "Claude Code opens your browser for OAuth, then stores the remote MCP server."
   },
   opencode: {
     id: "opencode",
@@ -176,6 +173,7 @@ export function LandingConnectMcp() {
   const [activeClient, setActiveClient] = useState<ClientId>("cursor");
   const [feedbackClient, setFeedbackClient] = useState<ClientId | null>(null);
   const [copyError, setCopyError] = useState(false);
+  const [revealed, setRevealed] = useState(false);
   const [urlCopied, setUrlCopied] = useState(false);
   const installResetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const urlResetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -192,6 +190,7 @@ export function LandingConnectMcp() {
 
     setCopyError(!copied);
     setFeedbackClient(install.id);
+    if (copied) setRevealed(true);
     capturePosthogEvent("landing_connect_mcp_copy_clicked", {
       client: install.id,
       copied,
@@ -217,167 +216,46 @@ export function LandingConnectMcp() {
   };
 
   return (
-    <section id="connect-mcp" className="relative scroll-mt-24">
-      <div className="mb-6 max-w-3xl">
-        <div className="landing-chip mb-4 inline-flex rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-gray-500">
-          OpenWork Connect MCP
+    <section id="connect-mcp" className="landing-shell rounded-[2.5rem] p-8 md:p-12 scroll-mt-24">
+      <div className="mb-10">
+        <div className="mb-4 flex items-center gap-2.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-gray-400">
+          <Plug size={18} />
+          OpenWork Connect
         </div>
-        <h2 className="text-3xl font-medium leading-[1.12] tracking-tight text-[#011627] md:text-4xl lg:text-5xl">
-          Connect any agent
+        <h2 className="max-w-2xl text-3xl font-medium leading-[1.15] tracking-tight md:text-4xl lg:text-5xl">
+          Share it once.<br />Use it from any agent.
         </h2>
-        <p className="mt-4 text-[16px] leading-7 text-gray-600 md:text-lg md:leading-8">
-          Your org&apos;s capabilities, connections, and marketplace are two MCP tools away:
-          <span className="font-mono text-[#011627]"> search_capabilities</span> finds the
-          right operation, and <span className="font-mono text-[#011627]">execute_capability</span> runs it.
+        <p className="mt-5 max-w-3xl text-[16px] leading-7 text-gray-600 md:text-lg md:leading-8">
+          Skills, MCP connections, and plugins your team shares on OpenWork show up in
+          Claude Code, Cursor — any MCP agent — through two tools:
+          <span className="font-mono text-[#011627]"> search_capabilities</span> and
+          <span className="font-mono text-[#011627]"> execute_capability</span>.
         </p>
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-2 lg:items-start">
-        <div className="rounded-xl border border-gray-100 bg-white p-5 shadow-sm md:p-6">
-          <div className="mb-5 rounded-xl border border-gray-100 bg-gray-50/80 p-3">
-            <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
-              Server URL
-            </div>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <code className="min-w-0 overflow-x-auto whitespace-nowrap rounded-lg bg-white px-3 py-2 font-mono text-[12px] text-[#011627] ring-1 ring-gray-100">
-                {MCP_SERVER_URL}
-              </code>
-              <button
-                type="button"
-                aria-label="Copy the OpenWork MCP server URL"
-                onClick={() => {
-                  void copyServerUrl();
-                }}
-                className="inline-flex shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-[#011627] transition-colors hover:bg-gray-50"
-              >
-                {urlCopied ? "Copied" : "Copy URL"}
-              </button>
-            </div>
-            <p className="mt-3 text-[12px] leading-5 text-gray-500">
-              Remote streamable HTTP with OAuth 2.0, dynamic client registration, and PKCE.
-            </p>
-          </div>
-
-          <div
-            role="tablist"
-            aria-label="OpenWork MCP client install options"
-            className="landing-chip mb-4 flex gap-1 overflow-x-auto rounded-full p-1"
-          >
-            {CLIENT_ORDER.map((clientId) => {
-              const client = CLIENT_INSTALLS[clientId];
-              const selected = client.id === activeClient;
-
-              return (
-                <button
-                  key={client.id}
-                  id={`connect-mcp-tab-${client.id}`}
-                  type="button"
-                  role="tab"
-                  aria-selected={selected}
-                  aria-controls={`connect-mcp-panel-${client.id}`}
-                  tabIndex={selected ? 0 : -1}
-                  onClick={() => setActiveClient(client.id)}
-                  className={`shrink-0 rounded-full px-3 py-2 text-[13px] font-medium transition-colors md:px-4 ${
-                    selected
-                      ? "bg-[#011627] text-white shadow-sm"
-                      : "text-gray-600 hover:bg-white hover:text-[#011627]"
-                  }`}
-                >
-                  {client.label}
-                </button>
-              );
-            })}
-          </div>
-
-          {CLIENT_ORDER.map((clientId) => {
-            const install = CLIENT_INSTALLS[clientId];
-            const selected = install.id === activeClient;
-            const installFeedback = feedbackClient === install.id;
-
-            return (
-              <div
-                key={install.id}
-                id={`connect-mcp-panel-${install.id}`}
-                role="tabpanel"
-                aria-labelledby={`connect-mcp-tab-${install.id}`}
-                hidden={!selected}
-                data-feedback={installFeedback ? "true" : "false"}
-                data-copy-error={copyError ? "true" : "false"}
-                className="rounded-xl border border-gray-100 bg-white shadow-sm"
-              >
-                <div className="border-b border-gray-100 p-4 md:p-5">
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
-                    {install.eyebrow}
-                  </div>
-                  <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                      <h3 className="text-xl font-medium text-[#011627]">{install.label}</h3>
-                      <p className="mt-1 text-[13px] leading-5 text-gray-500">{install.helper}</p>
-                    </div>
-                    {install.id === "cursor" ? (
-                      <a
-                        href={CURSOR_DEEPLINK}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="inline-flex min-h-[42px] shrink-0 items-center justify-center rounded-full bg-[#011627] px-5 text-sm font-medium text-white shadow-[0_14px_32px_-16px_rgba(1,22,39,0.55)] transition-colors hover:bg-black"
-                      >
-                        Add to Cursor
-                      </a>
-                    ) : null}
-                  </div>
-                </div>
-
-                <div className="p-4 md:p-5">
-                  <pre className="max-h-[300px] overflow-x-auto whitespace-pre-wrap rounded-xl bg-[#011627] p-4 font-mono text-[12px] leading-6 text-white shadow-inner">
-                    <code>{install.copyText}</code>
-                  </pre>
-                  {install.id === "any-client" ? (
-                    <p className="mt-3 text-[13px] leading-6 text-gray-500">
-                      You can also paste the URL into any MCP client that supports remote servers with OAuth.
-                    </p>
-                  ) : null}
-                  <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <p className="text-[12px] leading-5 text-gray-500">
-                      OAuth opens in your browser, asks you to pick your org, then returns the token to the client.
-                    </p>
-                    <button
-                      type="button"
-                      aria-label="Copy the OpenWork MCP install command"
-                      onClick={() => {
-                        void copyInstall(install);
-                      }}
-                      className="inline-flex min-w-[116px] shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white px-4 py-2 text-xs font-medium text-[#011627] shadow-sm transition-colors hover:bg-gray-50"
-                    >
-                      {installFeedback ? (copyError ? "Couldn't copy" : "Copied") : "Copy"}
-                    </button>
-                  </div>
-                </div>
-                <span aria-live="polite" className="sr-only">
-                  {installFeedback ? (copyError ? "Install command could not be copied" : "Install command copied") : ""}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-
+      <div className="grid gap-8 lg:grid-cols-2 lg:items-start">
         <div
           data-testid="connect-mcp-example"
-          className="overflow-hidden rounded-xl border border-gray-100 bg-white shadow-sm"
+          className="landing-shell relative flex flex-col overflow-hidden rounded-2xl"
         >
-          <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50/80 px-4 py-3">
-            <div>
-              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
-                Example
-              </div>
-              <div className="mt-1 text-sm font-medium text-[#011627]">Search, then execute</div>
+          <div className="relative z-20 flex h-10 w-full shrink-0 items-center border-b border-white/50 bg-gradient-to-b from-white/90 to-white/60 px-4">
+            <div className="flex gap-1.5">
+              <div className="h-3 w-3 rounded-full border border-[#e0443e]/20 bg-[#ff5f56]/90 shadow-sm" />
+              <div className="h-3 w-3 rounded-full border border-[#dea123]/20 bg-[#ffbd2e]/90 shadow-sm" />
+              <div className="h-3 w-3 rounded-full border border-[#1aab29]/20 bg-[#27c93f]/90 shadow-sm" />
             </div>
-            <div className="flex gap-1.5" aria-hidden="true">
-              <span className="h-2.5 w-2.5 rounded-full bg-red-300" />
-              <span className="h-2.5 w-2.5 rounded-full bg-yellow-300" />
-              <span className="h-2.5 w-2.5 rounded-full bg-green-300" />
+            <div className="absolute left-1/2 -translate-x-1/2 text-[12px] font-medium tracking-wide text-gray-500">
+              Your agent, connected
             </div>
           </div>
+
           <div className="space-y-4 bg-[#07192C] p-4 font-mono text-[12px] leading-6 text-slate-100 md:p-5">
+            <div className="flex items-center justify-between gap-3">
+              <span className="inline-flex rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-300">
+                Example
+              </span>
+              <span className="text-[11px] text-slate-500">shared once, consumed anywhere</span>
+            </div>
             <div>
               <div className="mb-2 text-slate-400">agent → search_capabilities</div>
               <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg bg-white/5 p-3 text-slate-100">
@@ -404,12 +282,213 @@ export function LandingConnectMcp() {
             </div>
           </div>
         </div>
+
+        <div className="group rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md">
+          <div className="mb-2 text-[13px] text-gray-500">
+            Already use an AI agent? Point it at your org — one click or one command connects it.
+          </div>
+          <div className="mb-4 flex min-w-0 items-center gap-2 text-gray-400">
+            <LandingAgentGlyphs />
+            <span className="text-xs text-gray-400">
+              Works with Claude Code, Cursor, VS Code — any MCP agent
+            </span>
+          </div>
+
+          <div
+            role="tablist"
+            aria-label="OpenWork MCP client install options"
+            className="landing-chip mb-4 flex flex-wrap gap-2 overflow-x-auto rounded-full p-1"
+          >
+            {CLIENT_ORDER.map((clientId) => {
+              const client = CLIENT_INSTALLS[clientId];
+              const selected = client.id === activeClient;
+
+              return (
+                <button
+                  key={client.id}
+                  id={`connect-mcp-tab-${client.id}`}
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  aria-controls={`connect-mcp-panel-${client.id}`}
+                  tabIndex={selected ? 0 : -1}
+                  onClick={() => setActiveClient(client.id)}
+                  className={`relative cursor-pointer whitespace-nowrap rounded-full px-5 py-2 text-sm font-medium transition-colors ${
+                    selected ? "text-[#011627]" : "text-gray-600 hover:text-gray-900"
+                  }`}
+                >
+                  {selected ? (
+                    <motion.div
+                      layoutId="connect-mcp-pill"
+                      className="absolute inset-0 rounded-full border border-gray-100 bg-white shadow-sm"
+                      transition={{ type: "spring", stiffness: 400, damping: 30 }}
+                    />
+                  ) : null}
+                  <span className="relative z-10">{client.label}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          {CLIENT_ORDER.map((clientId) => {
+            const install = CLIENT_INSTALLS[clientId];
+            const selected = install.id === activeClient;
+            const installFeedback = feedbackClient === install.id;
+
+            return (
+              <div
+                key={install.id}
+                id={`connect-mcp-panel-${install.id}`}
+                role="tabpanel"
+                aria-labelledby={`connect-mcp-tab-${install.id}`}
+                hidden={!selected}
+                data-feedback={installFeedback ? "true" : "false"}
+                data-copy-error={copyError ? "true" : "false"}
+              >
+                <div className="rounded-xl border border-gray-100 bg-white shadow-sm">
+                  <div className="border-b border-gray-100 p-4">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+                      {install.eyebrow}
+                    </div>
+                    <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <h3 className="text-xl font-medium text-[#011627]">{install.label}</h3>
+                        <p className="mt-1 text-[13px] leading-5 text-gray-500">{install.helper}</p>
+                      </div>
+                      {install.id === "cursor" ? (
+                        <a
+                          href={CURSOR_DEEPLINK}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex min-h-[42px] shrink-0 items-center justify-center rounded-full bg-[#011627] px-5 text-sm font-medium text-white shadow-[0_14px_32px_-16px_rgba(1,22,39,0.55)] transition-colors hover:bg-black"
+                        >
+                          Add to Cursor
+                        </a>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div className="p-4">
+                    <pre className="max-h-[300px] overflow-x-auto whitespace-pre-wrap rounded-xl bg-[#011627] p-4 font-mono text-[12px] leading-6 text-white shadow-inner">
+                      <code>{install.copyText}</code>
+                    </pre>
+                    {install.id === "any-client" ? (
+                      <p className="mt-3 text-[13px] leading-6 text-gray-500">
+                        You can also paste the URL into any MCP client that supports remote servers with OAuth.
+                      </p>
+                    ) : null}
+                    <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <p className="text-[12px] leading-5 text-gray-500">
+                        OAuth opens in your browser, asks you to pick your org, then returns the token to the client.
+                      </p>
+                      <button
+                        type="button"
+                        aria-label="Copy the OpenWork MCP install command"
+                        onClick={() => {
+                          void copyInstall(install);
+                        }}
+                        className="inline-flex min-w-[110px] items-center justify-center gap-1.5 rounded-lg bg-[#011627] px-4 py-2 text-xs font-medium text-white shadow-[0_1px_2px_rgba(17,24,39,0.12)] transition-colors hover:bg-black"
+                      >
+                        {installFeedback ? (
+                          copyError ? (
+                            "Couldn't copy"
+                          ) : (
+                            <>
+                              <svg
+                                className="h-3.5 w-3.5"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="3"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                aria-hidden="true"
+                              >
+                                <path d="M20 6 9 17l-5-5" />
+                              </svg>
+                              Copied
+                            </>
+                          )
+                        ) : (
+                          "Copy"
+                        )}
+                      </button>
+                    </div>
+
+                    <AnimatePresence initial={false}>
+                      {revealed && selected ? (
+                        <motion.div
+                          initial={{ opacity: 0, height: 0 }}
+                          animate={{ opacity: 1, height: "auto" }}
+                          exit={{ opacity: 0, height: 0 }}
+                          transition={{ duration: 0.25 }}
+                          className="overflow-hidden"
+                        >
+                          <div className="mt-3 border-t border-gray-100 pt-3">
+                            <div className="flex items-center gap-2 text-[13px] font-medium text-[#011627]">
+                              <svg
+                                className="h-4 w-4 shrink-0 text-green-600"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="3"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                aria-hidden="true"
+                              >
+                                <path d="M20 6 9 17l-5-5" />
+                              </svg>
+                              Copied — now run it:
+                            </div>
+                            <div className="mt-2.5 flex flex-wrap items-center gap-x-2 gap-y-2">
+                              {revealSteps.map((label, index) => (
+                                <div key={label} className="flex items-center gap-2">
+                                  {index > 0 ? <ChevronRight size={12} className="text-gray-300" /> : null}
+                                  <span className="step-circle">{index + 1}</span>
+                                  <span className="text-[13px] text-gray-600">{label}</span>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        </motion.div>
+                      ) : null}
+                    </AnimatePresence>
+                  </div>
+                </div>
+                <span aria-live="polite" className="sr-only">
+                  {installFeedback ? (copyError ? "Install command could not be copied" : "Install command copied") : ""}
+                </span>
+              </div>
+            );
+          })}
+
+          <div className="mt-4 rounded-xl border border-gray-100 bg-gray-50/80 p-3">
+            <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+              Server URL
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <code className="min-w-0 overflow-x-auto whitespace-nowrap rounded-lg bg-white px-3 py-2 font-mono text-[12px] text-[#011627] ring-1 ring-gray-100">
+                {MCP_SERVER_URL}
+              </code>
+              <button
+                type="button"
+                aria-label="Copy the OpenWork MCP server URL"
+                onClick={() => {
+                  void copyServerUrl();
+                }}
+                className="inline-flex shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-[#011627] transition-colors hover:bg-gray-50"
+              >
+                {urlCopied ? "Copied" : "Copy URL"}
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
 
-      <div className="mt-5 flex flex-col gap-3 rounded-xl border border-gray-100 bg-white/80 p-4 text-[13px] leading-6 text-gray-600 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+      <div className="mt-8 flex flex-col gap-3 border-t border-gray-100 pt-5 text-[13px] leading-6 text-gray-600 sm:flex-row sm:items-center sm:justify-between">
         <p>
           Works with any MCP client that supports remote servers with OAuth — your agent signs in with your
-          OpenWork account and only sees what your org allows.
+          OpenWork account and only sees what your org shares with them.
         </p>
         <a
           href={DOCS_URL}

--- a/ee/apps/landing/components/landing-connect-mcp.tsx
+++ b/ee/apps/landing/components/landing-connect-mcp.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { ChevronRight, Plug } from "lucide-react";
+import { ChevronRight, Link2, Plug } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { capturePosthogEvent } from "../lib/posthog-client";
@@ -56,44 +56,19 @@ const OPENCODE_SNIPPET = `{
 const VS_CODE_COMMAND = `code --add-mcp '{"name":"openwork","type":"http","url":"${MCP_SERVER_URL}"}'`;
 const ANY_CLIENT_COMMAND = `npx install-mcp ${MCP_SERVER_URL} --client <your-client>`;
 
-const SEARCH_INPUT = `{
-  "query": "meeting notes"
-}`;
+const SEARCH_INPUT = `{"query": "meeting notes"}`;
 const SEARCH_RESULT = `{
   "matches": [
-    {
-      "name": "mcp:granola:query_meetings",
-      "method": "POST",
-      "path": "/mcp/granola",
-      "score": 12,
-      "summary": "Meeting notes your org connected via Granola",
-      "pathParams": [],
-      "queryParams": [],
-      "hasBody": true
-    },
-    {
-      "name": "plugin:meeting-brief:generate",
-      "kind": "skill",
-      "method": "POST",
-      "path": "/v1/marketplace/run",
-      "score": 9,
-      "summary": "Teammate-shared skill: draft a meeting brief",
-      "pathParams": [],
-      "queryParams": [],
-      "hasBody": true
-    }
+    { "name": "mcp:granola:query_meetings", "method": "POST", "path": "/mcp/granola", "score": 12, "summary": "Meeting notes your org connected via Granola", "pathParams": [], "queryParams": [], "hasBody": true },
+    { "name": "plugin:meeting-brief:generate", "kind": "skill", "method": "POST", "path": "/v1/marketplace/run", "score": 9, "summary": "Teammate-shared skill: draft a meeting brief", "hasBody": true }
   ]
 }`;
-const EXECUTE_INPUT = `{
-  "name": "plugin:meeting-brief:generate"
-}`;
-const EXECUTE_RESULT = `{
-  "brief": "Acme Corp call — deal history, latest notes, 3 talking points",
-  "savedTo": "Meeting Brief — Acme Corp.md"
-}`;
+const EXECUTE_INPUT = `{"name": "plugin:meeting-brief:generate"}`;
+const EXECUTE_RESULT = `{"brief": "Acme Corp call — deal history, latest notes, 3 talking points", "savedTo": "Meeting Brief — Acme Corp.md"}`;
 
 type CopyMethod = "clipboard" | "execCommand" | "none";
 type ClientId = "cursor" | "claude-code" | "opencode" | "vs-code" | "any-client";
+type BringTone = "mcp" | "skill" | "command";
 
 type ClientInstall = {
   id: ClientId;
@@ -103,8 +78,27 @@ type ClientInstall = {
   helper: string;
 };
 
+type BringItem = {
+  name: string;
+  type: string;
+  tone: BringTone;
+};
+
 const CLIENT_ORDER: ClientId[] = ["cursor", "claude-code", "opencode", "vs-code", "any-client"];
 const revealSteps = ["Sign in in the browser", "Pick your org", "Your team's tools appear"];
+
+const bringItems: BringItem[] = [
+  { name: "Granola", type: "MCP", tone: "mcp" },
+  { name: "Meeting Brief Generator", type: "Skill", tone: "skill" },
+  { name: "review-pr", type: "Command", tone: "command" },
+  { name: "Linear", type: "MCP", tone: "mcp" }
+];
+
+const dotClass: Record<BringTone, string> = {
+  mcp: "bg-gradient-to-br from-teal-400 to-cyan-500",
+  skill: "bg-gradient-to-br from-amber-400 to-orange-400",
+  command: "bg-gradient-to-br from-violet-400 to-purple-500"
+};
 
 const CLIENT_INSTALLS: Record<ClientId, ClientInstall> = {
   cursor: {
@@ -222,21 +216,74 @@ export function LandingConnectMcp() {
           <Plug size={18} />
           OpenWork Connect
         </div>
-        <h2 className="max-w-2xl text-3xl font-medium leading-[1.15] tracking-tight md:text-4xl lg:text-5xl">
-          Share it once.<br />Use it from any agent.
+        <h2 className="max-w-3xl text-3xl font-medium leading-[1.15] tracking-tight md:text-4xl lg:text-5xl">
+          Already doing it in your agent?<br />Add it to OpenWork. Share it with everyone.
         </h2>
         <p className="mt-5 max-w-3xl text-[16px] leading-7 text-gray-600 md:text-lg md:leading-8">
-          Skills, MCP connections, and plugins your team shares on OpenWork show up in
-          Claude Code, Cursor — any MCP agent — through two tools:
+          Skills and MCPs move in as-is — same SKILL.md format, same server URLs. Share once on
+          OpenWork, and every teammate&apos;s agent can use them through
           <span className="font-mono text-[#011627]"> search_capabilities</span> and
           <span className="font-mono text-[#011627]"> execute_capability</span>.
         </p>
       </div>
 
-      <div className="grid gap-8 lg:grid-cols-2 lg:items-start">
+      <div className="grid gap-6 lg:grid-cols-2 lg:items-stretch">
+        <div
+          data-testid="connect-mcp-bring"
+          className="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm"
+        >
+          <div className="flex items-center gap-3 border-b border-gray-100 bg-gray-50/80 px-4 py-2.5">
+            <div className="flex gap-1.5">
+              <div className="h-2.5 w-2.5 rounded-full bg-red-400/70" />
+              <div className="h-2.5 w-2.5 rounded-full bg-yellow-400/70" />
+              <div className="h-2.5 w-2.5 rounded-full bg-green-400/70" />
+            </div>
+            <div className="text-[12px] font-medium text-gray-500">OpenWork</div>
+          </div>
+
+          <div className="flex flex-1 flex-col gap-3 p-4 text-left md:p-5">
+            <div>
+              <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-gray-400">
+                From your agents
+              </div>
+              <h3 className="text-lg font-medium tracking-tight text-[#011627]">
+                Your setup, moved in as-is
+              </h3>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              {bringItems.map((item, index) => (
+                <div
+                  key={item.name}
+                  className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 transition-all ${
+                    index === 0 ? "border-blue-300 bg-blue-50/60 shadow-sm" : "border-gray-100 bg-white"
+                  }`}
+                >
+                  <span className={`h-6 w-6 shrink-0 rounded-full ${dotClass[item.tone]}`} />
+                  <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-[#011627]">
+                    {item.name}
+                  </span>
+                  <span className="shrink-0 rounded-full border border-gray-100 bg-gray-50 px-2 py-0.5 text-[11px] font-medium text-gray-500">
+                    {item.type}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            <p className="text-[13px] leading-6 text-gray-600">
+              Already in Claude Code or Cursor? OpenWork speaks the same SKILL.md and remote MCP URLs — add them unchanged, then share your setup in one link.
+            </p>
+
+            <div className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg bg-[#011627] py-2 text-[13px] font-medium text-white shadow-[0_1px_2px_rgba(17,24,39,0.12)]">
+              <Link2 size={16} />
+              Share with your org
+            </div>
+          </div>
+        </div>
+
         <div
           data-testid="connect-mcp-example"
-          className="landing-shell relative flex flex-col overflow-hidden rounded-2xl"
+          className="landing-shell relative flex h-full flex-col overflow-hidden rounded-2xl"
         >
           <div className="relative z-20 flex h-10 w-full shrink-0 items-center border-b border-white/50 bg-gradient-to-b from-white/90 to-white/60 px-4">
             <div className="flex gap-1.5">
@@ -244,12 +291,12 @@ export function LandingConnectMcp() {
               <div className="h-3 w-3 rounded-full border border-[#dea123]/20 bg-[#ffbd2e]/90 shadow-sm" />
               <div className="h-3 w-3 rounded-full border border-[#1aab29]/20 bg-[#27c93f]/90 shadow-sm" />
             </div>
-            <div className="absolute left-1/2 -translate-x-1/2 text-[12px] font-medium tracking-wide text-gray-500">
-              Your agent, connected
+            <div className="absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-[12px] font-medium tracking-wide text-gray-500">
+              What your teammate&apos;s agent sees
             </div>
           </div>
 
-          <div className="space-y-4 bg-[#07192C] p-4 font-mono text-[12px] leading-6 text-slate-100 md:p-5">
+          <div className="flex flex-1 flex-col gap-3 bg-[#07192C] p-4 font-mono text-[11px] leading-5 text-slate-100 md:p-5">
             <div className="flex items-center justify-between gap-3">
               <span className="inline-flex rounded-full border border-white/10 bg-white/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-300">
                 Example
@@ -257,230 +304,237 @@ export function LandingConnectMcp() {
               <span className="text-[11px] text-slate-500">shared once, consumed anywhere</span>
             </div>
             <div>
-              <div className="mb-2 text-slate-400">agent → search_capabilities</div>
-              <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg bg-white/5 p-3 text-slate-100">
+              <div className="mb-1.5 text-slate-400">agent → search_capabilities</div>
+              <pre className="whitespace-pre-wrap break-words rounded-lg bg-white/5 p-3 text-slate-100">
                 <code>{SEARCH_INPUT}</code>
               </pre>
             </div>
             <div>
-              <div className="mb-2 text-slate-400">openwork → matches</div>
-              <pre className="max-h-[320px] overflow-x-auto whitespace-pre-wrap rounded-lg bg-white/5 p-3 text-slate-100">
+              <div className="mb-1.5 text-slate-400">openwork → matches</div>
+              <pre className="whitespace-pre-wrap break-words rounded-lg bg-white/5 p-3 text-slate-100">
                 <code>{SEARCH_RESULT}</code>
               </pre>
             </div>
             <div>
-              <div className="mb-2 text-slate-400">agent → execute_capability</div>
-              <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg bg-white/5 p-3 text-slate-100">
+              <div className="mb-1.5 text-slate-400">agent → execute_capability</div>
+              <pre className="whitespace-pre-wrap break-words rounded-lg bg-white/5 p-3 text-slate-100">
                 <code>{EXECUTE_INPUT}</code>
               </pre>
             </div>
             <div>
-              <div className="mb-2 text-slate-400">openwork → result</div>
-              <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg bg-white/5 p-3 text-slate-100">
+              <div className="mb-1.5 text-slate-400">openwork → result</div>
+              <pre className="whitespace-pre-wrap break-words rounded-lg bg-white/5 p-3 text-slate-100">
                 <code>{EXECUTE_RESULT}</code>
               </pre>
             </div>
           </div>
         </div>
+      </div>
 
-        <div className="group rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md">
-          <div className="mb-2 text-[13px] text-gray-500">
+      <div
+        data-testid="connect-mcp-install"
+        className="mt-6 rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+      >
+        <div className="group mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="text-[13px] text-gray-500">
             Already use an AI agent? Point it at your org — one click or one command connects it.
           </div>
-          <div className="mb-4 flex min-w-0 items-center gap-2 text-gray-400">
+          <div className="flex min-w-0 shrink-0 items-center gap-2 text-gray-400">
             <LandingAgentGlyphs />
             <span className="text-xs text-gray-400">
               Works with Claude Code, Cursor, VS Code — any MCP agent
             </span>
           </div>
+        </div>
 
-          <div
-            role="tablist"
-            aria-label="OpenWork MCP client install options"
-            className="landing-chip mb-4 flex flex-wrap gap-2 overflow-x-auto rounded-full p-1"
-          >
+        <div className="min-w-0">
+            <div
+              role="tablist"
+              aria-label="OpenWork MCP client install options"
+              className="landing-chip mb-4 flex flex-nowrap gap-2 overflow-x-auto rounded-full p-1"
+            >
+              {CLIENT_ORDER.map((clientId) => {
+                const client = CLIENT_INSTALLS[clientId];
+                const selected = client.id === activeClient;
+
+                return (
+                  <button
+                    key={client.id}
+                    id={`connect-mcp-tab-${client.id}`}
+                    type="button"
+                    role="tab"
+                    aria-selected={selected}
+                    aria-controls={`connect-mcp-panel-${client.id}`}
+                    tabIndex={selected ? 0 : -1}
+                    onClick={() => setActiveClient(client.id)}
+                    className={`relative shrink-0 cursor-pointer whitespace-nowrap rounded-full px-5 py-2 text-sm font-medium transition-colors ${
+                      selected ? "text-[#011627]" : "text-gray-600 hover:text-gray-900"
+                    }`}
+                  >
+                    {selected ? (
+                      <motion.div
+                        layoutId="connect-mcp-pill"
+                        className="absolute inset-0 rounded-full border border-gray-100 bg-white shadow-sm"
+                        transition={{ type: "spring", stiffness: 400, damping: 30 }}
+                      />
+                    ) : null}
+                    <span className="relative z-10">{client.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+
             {CLIENT_ORDER.map((clientId) => {
-              const client = CLIENT_INSTALLS[clientId];
-              const selected = client.id === activeClient;
+              const install = CLIENT_INSTALLS[clientId];
+              const selected = install.id === activeClient;
+              const installFeedback = feedbackClient === install.id;
 
               return (
-                <button
-                  key={client.id}
-                  id={`connect-mcp-tab-${client.id}`}
-                  type="button"
-                  role="tab"
-                  aria-selected={selected}
-                  aria-controls={`connect-mcp-panel-${client.id}`}
-                  tabIndex={selected ? 0 : -1}
-                  onClick={() => setActiveClient(client.id)}
-                  className={`relative cursor-pointer whitespace-nowrap rounded-full px-5 py-2 text-sm font-medium transition-colors ${
-                    selected ? "text-[#011627]" : "text-gray-600 hover:text-gray-900"
-                  }`}
+                <div
+                  key={install.id}
+                  id={`connect-mcp-panel-${install.id}`}
+                  role="tabpanel"
+                  aria-labelledby={`connect-mcp-tab-${install.id}`}
+                  hidden={!selected}
+                  data-feedback={installFeedback ? "true" : "false"}
+                  data-copy-error={copyError ? "true" : "false"}
                 >
-                  {selected ? (
-                    <motion.div
-                      layoutId="connect-mcp-pill"
-                      className="absolute inset-0 rounded-full border border-gray-100 bg-white shadow-sm"
-                      transition={{ type: "spring", stiffness: 400, damping: 30 }}
-                    />
-                  ) : null}
-                  <span className="relative z-10">{client.label}</span>
-                </button>
+                  <div className="rounded-xl border border-gray-100 bg-white shadow-sm">
+                    <div className="border-b border-gray-100 p-4">
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+                        {install.eyebrow}
+                      </div>
+                      <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <h3 className="text-xl font-medium text-[#011627]">{install.label}</h3>
+                          <p className="mt-1 text-[13px] leading-5 text-gray-500">{install.helper}</p>
+                        </div>
+                        {install.id === "cursor" ? (
+                          <a
+                            href={CURSOR_DEEPLINK}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex min-h-[42px] shrink-0 items-center justify-center rounded-full bg-[#011627] px-5 text-sm font-medium text-white shadow-[0_14px_32px_-16px_rgba(1,22,39,0.55)] transition-colors hover:bg-black"
+                          >
+                            Add to Cursor
+                          </a>
+                        ) : null}
+                      </div>
+                    </div>
+
+                    <div className="p-4">
+                      <pre className="max-h-[300px] overflow-x-auto whitespace-pre-wrap rounded-xl bg-[#011627] p-4 font-mono text-[12px] leading-6 text-white shadow-inner">
+                        <code>{install.copyText}</code>
+                      </pre>
+                      {install.id === "any-client" ? (
+                        <p className="mt-3 text-[13px] leading-6 text-gray-500">
+                          You can also paste the URL into any MCP client that supports remote servers with OAuth.
+                        </p>
+                      ) : null}
+                      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <p className="text-[12px] leading-5 text-gray-500">
+                          OAuth opens in your browser, asks you to pick your org, then returns the token to the client.
+                        </p>
+                        <button
+                          type="button"
+                          aria-label="Copy the OpenWork MCP install command"
+                          onClick={() => {
+                            void copyInstall(install);
+                          }}
+                          className="inline-flex min-w-[110px] items-center justify-center gap-1.5 rounded-lg bg-[#011627] px-4 py-2 text-xs font-medium text-white shadow-[0_1px_2px_rgba(17,24,39,0.12)] transition-colors hover:bg-black"
+                        >
+                          {installFeedback ? (
+                            copyError ? (
+                              "Couldn't copy"
+                            ) : (
+                              <>
+                                <svg
+                                  className="h-3.5 w-3.5"
+                                  viewBox="0 0 24 24"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="3"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  aria-hidden="true"
+                                >
+                                  <path d="M20 6 9 17l-5-5" />
+                                </svg>
+                                Copied
+                              </>
+                            )
+                          ) : (
+                            "Copy"
+                          )}
+                        </button>
+                      </div>
+
+                      <AnimatePresence initial={false}>
+                        {revealed && selected ? (
+                          <motion.div
+                            initial={{ opacity: 0, height: 0 }}
+                            animate={{ opacity: 1, height: "auto" }}
+                            exit={{ opacity: 0, height: 0 }}
+                            transition={{ duration: 0.25 }}
+                            className="overflow-hidden"
+                          >
+                            <div className="mt-3 border-t border-gray-100 pt-3">
+                              <div className="flex items-center gap-2 text-[13px] font-medium text-[#011627]">
+                                <svg
+                                  className="h-4 w-4 shrink-0 text-green-600"
+                                  viewBox="0 0 24 24"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="3"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  aria-hidden="true"
+                                >
+                                  <path d="M20 6 9 17l-5-5" />
+                                </svg>
+                                Copied — now run it:
+                              </div>
+                              <div className="mt-2.5 flex flex-wrap items-center gap-x-2 gap-y-2">
+                                {revealSteps.map((label, index) => (
+                                  <div key={label} className="flex items-center gap-2">
+                                    {index > 0 ? <ChevronRight size={12} className="text-gray-300" /> : null}
+                                    <span className="step-circle">{index + 1}</span>
+                                    <span className="text-[13px] text-gray-600">{label}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          </motion.div>
+                        ) : null}
+                      </AnimatePresence>
+                    </div>
+                  </div>
+                  <span aria-live="polite" className="sr-only">
+                    {installFeedback ? (copyError ? "Install command could not be copied" : "Install command copied") : ""}
+                  </span>
+                </div>
               );
             })}
           </div>
 
-          {CLIENT_ORDER.map((clientId) => {
-            const install = CLIENT_INSTALLS[clientId];
-            const selected = install.id === activeClient;
-            const installFeedback = feedbackClient === install.id;
-
-            return (
-              <div
-                key={install.id}
-                id={`connect-mcp-panel-${install.id}`}
-                role="tabpanel"
-                aria-labelledby={`connect-mcp-tab-${install.id}`}
-                hidden={!selected}
-                data-feedback={installFeedback ? "true" : "false"}
-                data-copy-error={copyError ? "true" : "false"}
-              >
-                <div className="rounded-xl border border-gray-100 bg-white shadow-sm">
-                  <div className="border-b border-gray-100 p-4">
-                    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
-                      {install.eyebrow}
-                    </div>
-                    <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                      <div>
-                        <h3 className="text-xl font-medium text-[#011627]">{install.label}</h3>
-                        <p className="mt-1 text-[13px] leading-5 text-gray-500">{install.helper}</p>
-                      </div>
-                      {install.id === "cursor" ? (
-                        <a
-                          href={CURSOR_DEEPLINK}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="inline-flex min-h-[42px] shrink-0 items-center justify-center rounded-full bg-[#011627] px-5 text-sm font-medium text-white shadow-[0_14px_32px_-16px_rgba(1,22,39,0.55)] transition-colors hover:bg-black"
-                        >
-                          Add to Cursor
-                        </a>
-                      ) : null}
-                    </div>
-                  </div>
-
-                  <div className="p-4">
-                    <pre className="max-h-[300px] overflow-x-auto whitespace-pre-wrap rounded-xl bg-[#011627] p-4 font-mono text-[12px] leading-6 text-white shadow-inner">
-                      <code>{install.copyText}</code>
-                    </pre>
-                    {install.id === "any-client" ? (
-                      <p className="mt-3 text-[13px] leading-6 text-gray-500">
-                        You can also paste the URL into any MCP client that supports remote servers with OAuth.
-                      </p>
-                    ) : null}
-                    <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                      <p className="text-[12px] leading-5 text-gray-500">
-                        OAuth opens in your browser, asks you to pick your org, then returns the token to the client.
-                      </p>
-                      <button
-                        type="button"
-                        aria-label="Copy the OpenWork MCP install command"
-                        onClick={() => {
-                          void copyInstall(install);
-                        }}
-                        className="inline-flex min-w-[110px] items-center justify-center gap-1.5 rounded-lg bg-[#011627] px-4 py-2 text-xs font-medium text-white shadow-[0_1px_2px_rgba(17,24,39,0.12)] transition-colors hover:bg-black"
-                      >
-                        {installFeedback ? (
-                          copyError ? (
-                            "Couldn't copy"
-                          ) : (
-                            <>
-                              <svg
-                                className="h-3.5 w-3.5"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth="3"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                aria-hidden="true"
-                              >
-                                <path d="M20 6 9 17l-5-5" />
-                              </svg>
-                              Copied
-                            </>
-                          )
-                        ) : (
-                          "Copy"
-                        )}
-                      </button>
-                    </div>
-
-                    <AnimatePresence initial={false}>
-                      {revealed && selected ? (
-                        <motion.div
-                          initial={{ opacity: 0, height: 0 }}
-                          animate={{ opacity: 1, height: "auto" }}
-                          exit={{ opacity: 0, height: 0 }}
-                          transition={{ duration: 0.25 }}
-                          className="overflow-hidden"
-                        >
-                          <div className="mt-3 border-t border-gray-100 pt-3">
-                            <div className="flex items-center gap-2 text-[13px] font-medium text-[#011627]">
-                              <svg
-                                className="h-4 w-4 shrink-0 text-green-600"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth="3"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                aria-hidden="true"
-                              >
-                                <path d="M20 6 9 17l-5-5" />
-                              </svg>
-                              Copied — now run it:
-                            </div>
-                            <div className="mt-2.5 flex flex-wrap items-center gap-x-2 gap-y-2">
-                              {revealSteps.map((label, index) => (
-                                <div key={label} className="flex items-center gap-2">
-                                  {index > 0 ? <ChevronRight size={12} className="text-gray-300" /> : null}
-                                  <span className="step-circle">{index + 1}</span>
-                                  <span className="text-[13px] text-gray-600">{label}</span>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        </motion.div>
-                      ) : null}
-                    </AnimatePresence>
-                  </div>
-                </div>
-                <span aria-live="polite" className="sr-only">
-                  {installFeedback ? (copyError ? "Install command could not be copied" : "Install command copied") : ""}
-                </span>
-              </div>
-            );
-          })}
-
-          <div className="mt-4 rounded-xl border border-gray-100 bg-gray-50/80 p-3">
-            <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
-              Server URL
-            </div>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <code className="min-w-0 overflow-x-auto whitespace-nowrap rounded-lg bg-white px-3 py-2 font-mono text-[12px] text-[#011627] ring-1 ring-gray-100">
-                {MCP_SERVER_URL}
-              </code>
-              <button
-                type="button"
-                aria-label="Copy the OpenWork MCP server URL"
-                onClick={() => {
-                  void copyServerUrl();
-                }}
-                className="inline-flex shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-[#011627] transition-colors hover:bg-gray-50"
-              >
-                {urlCopied ? "Copied" : "Copy URL"}
-              </button>
-            </div>
+        <div className="mt-4 rounded-xl border border-gray-100 bg-gray-50/80 p-3">
+          <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+            Server URL
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <code className="min-w-0 whitespace-normal break-all rounded-lg bg-white px-3 py-2 font-mono text-[12px] text-[#011627] ring-1 ring-gray-100">
+              {MCP_SERVER_URL}
+            </code>
+            <button
+              type="button"
+              aria-label="Copy the OpenWork MCP server URL"
+              onClick={() => {
+                void copyServerUrl();
+              }}
+              className="inline-flex shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-[#011627] transition-colors hover:bg-gray-50"
+            >
+              {urlCopied ? "Copied" : "Copy URL"}
+            </button>
           </div>
         </div>
       </div>

--- a/ee/apps/landing/components/landing-hero-prompt.tsx
+++ b/ee/apps/landing/components/landing-hero-prompt.tsx
@@ -1,20 +1,7 @@
 "use client";
 
 /**
- * Hero agent-install prompt with animated glyphs and copied feedback states.
- *
- * The four animated SVG glyphs and the data-feedback / data-copy-error driven
- * feedback pattern are adapted from Flue (https://github.com/withastro/flue,
- * apps/www/src/pages/index.astro), licensed under the Apache License, Version
- * 2.0 (http://www.apache.org/licenses/LICENSE-2.0).
- *
- * MODIFIED by OpenWork from the original Flue source:
- *  - converted Astro markup + inline <script> to a React component (state-driven
- *    feedback instead of dataset mutation via querySelector)
- *  - moved the prompt from a navbar CTA into a visible hero composer block
- *  - relabeled the prompt text and copied-feedback copy for OpenWork
- *  - kept the four glyph SVGs and hover animations; the squircle shape is no
- *    longer used
+ * Hero agent-install prompt with copied feedback states.
  */
 
 import { AnimatePresence, motion } from "framer-motion";
@@ -22,6 +9,7 @@ import { ChevronRight } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { capturePosthogEvent } from "../lib/posthog-client";
+import { LandingAgentGlyphs } from "./landing-agent-glyphs";
 
 const PROMPT_VARIANT = "hero";
 const AGENT_START_PROMPT = `Install OpenWork on my computer, set up my first workspace, and open it ready to use. Follow the steps in https://openworklabs.com/start.md?v=${PROMPT_VARIANT}`;
@@ -110,49 +98,7 @@ export function LandingHeroPrompt({ className }: Props) {
         </p>
         <div className="mt-3 flex items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-2 text-gray-400">
-            <span
-              className="relative flex h-5 w-[94px] shrink-0 items-center justify-start text-gray-400"
-              aria-hidden="true"
-            >
-              <svg
-                className="h-5 w-5 -rotate-6 transition-transform duration-300 ease-out group-hover:-translate-x-1 group-hover:-rotate-12"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                fillRule="evenodd"
-                clipRule="evenodd"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M20.998 10.949H24v3.102h-3v3.028h-1.487V20H18v-2.921h-1.487V20H15v-2.921H9V20H7.488v-2.921H6V20H4.487v-2.921H3V14.05H0V10.95h3V5h17.998v5.949zM6 10.949h1.488V8.102H6v2.847zm10.51 0H18V8.102h-1.49v2.847z" />
-              </svg>
-              <svg
-                className="ml-1 h-5 w-5 transition-transform duration-300 ease-out group-hover:-translate-x-px group-hover:-translate-y-px group-hover:rotate-6 group-hover:scale-110"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                fillRule="evenodd"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M9.205 8.658v-2.26c0-.19.072-.333.238-.428l4.543-2.616c.619-.357 1.356-.523 2.117-.523 2.854 0 4.662 2.212 4.662 4.566 0 .167 0 .357-.024.547l-4.71-2.759a.797.797 0 00-.856 0l-5.97 3.473zm10.609 8.8V12.06c0-.333-.143-.57-.429-.737l-5.97-3.473 1.95-1.118a.433.433 0 01.476 0l4.543 2.617c1.309.76 2.189 2.378 2.189 3.948 0 1.808-1.07 3.473-2.76 4.163zM7.802 12.703l-1.95-1.142c-.167-.095-.239-.238-.239-.428V5.899c0-2.545 1.95-4.472 4.591-4.472 1 0 1.927.333 2.712.928L8.23 5.067c-.285.166-.428.404-.428.737v6.898zM12 15.128l-2.795-1.57v-3.33L12 8.658l2.795 1.57v3.33L12 15.128zm1.796 7.23c-1 0-1.927-.332-2.712-.927l4.686-2.712c.285-.166.428-.404.428-.737v-6.898l1.974 1.142c.167.095.238.238.238.428v5.233c0 2.545-1.974 4.472-4.614 4.472zm-5.637-5.303l-4.544-2.617c-1.308-.761-2.188-2.378-2.188-3.948A4.482 4.482 0 014.21 6.327v5.423c0 .333.143.571.428.738l5.947 3.449-1.95 1.118a.432.432 0 01-.476 0zm-.262 3.9c-2.688 0-4.662-2.021-4.662-4.519 0-.19.024-.38.047-.57l4.686 2.71c.286.167.571.167.856 0l5.97-3.448v2.26c0 .19-.07.333-.237.428l-4.543 2.616c-.619.357-1.356.523-2.117.523zm5.899 2.83a5.947 5.947 0 005.827-4.756C22.287 18.339 24 15.84 24 13.296c0-1.665-.713-3.282-1.998-4.448.119-.5.19-.999.19-1.498 0-3.401-2.759-5.947-5.946-5.947-.642 0-1.26.095-1.88.31A5.962 5.962 0 0010.205 0a5.947 5.947 0 00-5.827 4.757C1.713 5.447 0 7.945 0 10.49c0 1.666.713 3.283 1.998 4.448-.119.5-.19 1-.19 1.499 0 3.401 2.759 5.946 5.946 5.946.642 0 1.26-.095 1.88-.309a5.96 5.96 0 004.162 1.713z" />
-              </svg>
-              <svg
-                className="ml-1 h-5 w-5 transition-transform duration-300 ease-out group-hover:translate-x-px group-hover:translate-y-0.5 group-hover:-rotate-6 group-hover:scale-110"
-                viewBox="82.65 82.65 634.71 634.71"
-                fill="currentColor"
-                fillRule="evenodd"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z" />
-                <path d="M517.36 400H634.72V634.72H517.36Z" />
-              </svg>
-              <svg
-                className="ml-0.5 h-5 w-5 rotate-6 transition-transform duration-300 ease-out group-hover:translate-x-1 group-hover:rotate-12"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                fillRule="evenodd"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M16 6H8v12h8V6zm4 16H4V2h16v20z" />
-              </svg>
-            </span>
+            <LandingAgentGlyphs />
             <span className="hidden text-xs text-gray-400 sm:inline">
               Works with Claude Code, Cursor, Codex — any agent
             </span>

--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -7,6 +7,7 @@ import { useMemo, useRef, useState } from "react";
 import { LandingAppDemoPanel } from "./landing-app-demo-panel";
 import { LandingBackground } from "./landing-background";
 import { LandingCloudWorkersCard } from "./landing-cloud-workers-card";
+import { LandingConnectMcp } from "./landing-connect-mcp";
 import {
   defaultLandingDemoFlowId,
   landingDemoFlows,
@@ -222,6 +223,8 @@ export function LandingHome(props: Props) {
               </div>
             </div>
           </section>
+
+          <LandingConnectMcp />
 
           <section
             ref={enterpriseShowcaseRef}

--- a/evals/flows/landing-connect-mcp.flow.mjs
+++ b/evals/flows/landing-connect-mcp.flow.mjs
@@ -79,9 +79,9 @@ async function ensureConnectSection(ctx, { forceReload = false } = {}) {
     `(() => {
       const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
       const text = section ? section.innerText : "";
-      return Boolean(section) && text.includes("Connect any agent") && text.includes(${JSON.stringify(MCP_SERVER_URL)});
+      return Boolean(section) && text.includes("Share it once") && text.includes(${JSON.stringify(MCP_SERVER_URL)});
     })()`,
-    { timeoutMs: 30_000, label: "Connect any agent MCP section" },
+    { timeoutMs: 30_000, label: "Share it once MCP section" },
   );
   await scrollSectionIntoView(ctx);
 }
@@ -149,7 +149,7 @@ async function scrollExampleTextIntoView(ctx, text) {
 
 export default {
   id: FLOW_ID,
-  title: "Connect any agent to OpenWork Cloud from the landing page",
+  title: "Share OpenWork tools once and use them from any agent",
   kind: "user-facing",
   spec: "evals/README.md",
   preserveTheme: true,
@@ -158,9 +158,9 @@ export default {
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("The landing page exposes the Connect any agent MCP section and server URL.", {
+        await ctx.prove("The landing page explains that shared OpenWork tools can be used from any agent.", {
           voiceover: vo[0],
-          // "Scrolling the OpenWork landing page, I reach a new section — Connect any age"
+          // "Further down the OpenWork landing page, a new section makes the pitch: share"
           action: async () => {
             // Always start from a fresh navigation so repeat runs against a
             // warm page don't inherit tab/copy state from a previous run.
@@ -172,19 +172,19 @@ export default {
               const bodyText = document.body.innerText;
               return {
                 sectionExists: Boolean(section),
-                bodyHasHeading: bodyText.includes("Connect any agent"),
+                bodyHasHeading: bodyText.includes("Share it once"),
                 bodyHasServerUrl: bodyText.includes(${JSON.stringify(MCP_SERVER_URL)}),
                 sectionText: section ? section.innerText.slice(0, 500) : "",
               };
             })()`);
             recordAssertion(
               ctx,
-              "The Connect any agent section and OpenWork MCP server URL are present on the landing page",
+              "The Share it once section and OpenWork MCP server URL are present on the landing page",
               actual.sectionExists === true && actual.bodyHasHeading === true && actual.bodyHasServerUrl === true,
               actual,
             );
           },
-          screenshot: { name: "frame-1", requireText: ["Connect any agent"] },
+          screenshot: { name: "frame-1", requireText: ["Share it once"] },
         });
       },
     },
@@ -193,7 +193,7 @@ export default {
       run: async (ctx) => {
         await ctx.prove("Cursor is the default MCP install tab and its one-click deeplink encodes the OpenWork server URL.", {
           voiceover: vo[1],
-          // "I pick my client: Cursor is selected with a one-click Add to Cursor button, "
+          // "The install card speaks the hero prompt's language: I pick my client from"
           action: async () => {
             await ensureConnectSection(ctx);
             // Center the install card on the Add to Cursor button so this frame
@@ -265,7 +265,7 @@ export default {
 
         await ctx.prove("Claude Code is a single command, and copying writes that exact command to the clipboard.", {
           voiceover: vo[2],
-          // "I switch to Claude Code and it's a single command; I hit copy and the exact "
+          // "I flip to Claude Code and it's one command; I hit copy, the button flips"
           action: async () => {
             await ensureConnectSection(ctx);
             await realMouseClick(ctx, tabByLabelExpression("Claude Code"), "Claude Code tab");
@@ -285,9 +285,10 @@ export default {
             await ctx.waitFor(
               `(() => {
                 const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
-                return Boolean(section && section.querySelector('[data-feedback="true"]') && section.innerText.includes("Copied"));
+                const text = section ? section.innerText : "";
+                return Boolean(section && section.querySelector('[data-feedback="true"]') && text.includes("Copied") && text.includes("Sign in in the browser") && text.includes("Pick your org"));
               })()`,
-              { timeoutMs: 10_000, label: "Copied feedback state" },
+              { timeoutMs: 10_000, label: "Copied feedback state and reveal steps" },
             );
 
             try {
@@ -307,6 +308,8 @@ export default {
               return {
                 feedbackActive: Boolean(section && section.querySelector('[data-feedback="true"]')),
                 copiedVisible: Boolean(section && section.innerText.includes("Copied")),
+                signInStepVisible: Boolean(section && section.innerText.includes("Sign in in the browser")),
+                pickOrgStepVisible: Boolean(section && section.innerText.includes("Pick your org")),
                 visiblePanelText: document.querySelector(${JSON.stringify(`${SECTION_SELECTOR} [role="tabpanel"]:not([hidden])`)})?.innerText || "",
               };
             })()`);
@@ -323,8 +326,11 @@ export default {
             );
             recordAssertion(
               ctx,
-              "The install card shows the Copied feedback state after copying",
-              feedbackScan.feedbackActive === true && feedbackScan.copiedVisible === true,
+              "The install card shows the Copied feedback state and browser sign-in reveal steps after copying",
+              feedbackScan.feedbackActive === true
+                && feedbackScan.copiedVisible === true
+                && feedbackScan.signInStepVisible === true
+                && feedbackScan.pickOrgStepVisible === true,
               feedbackScan,
             );
           },
@@ -335,9 +341,9 @@ export default {
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("The example panel shows search_capabilities finding meeting notes in the org's Granola connection.", {
+        await ctx.prove("The example panel shows search_capabilities finding meeting notes in the org's Granola connection and a shared meeting-brief skill.", {
           voiceover: vo[3],
-          // "Beside the install card, the section shows what connecting unlocks: the agen"
+          // "Beside it, an OpenWork window shows what the connected agent sees: search_cap"
           action: async () => {
             await ensureConnectSection(ctx);
             await scrollExampleTextIntoView(ctx, "search_capabilities");
@@ -345,7 +351,7 @@ export default {
               `(() => {
                 const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
                 const text = example ? example.innerText : "";
-                return text.includes("search_capabilities") && text.includes("meeting notes") && text.includes("granola");
+                return text.includes("search_capabilities") && text.includes("meeting notes") && text.includes("granola") && text.includes("plugin:meeting-brief:generate");
               })()`,
               { timeoutMs: 10_000, label: "search_capabilities example" },
             );
@@ -359,6 +365,7 @@ export default {
                 hasSearchCapabilities: text.includes("search_capabilities"),
                 hasMeetingNotes: text.includes("meeting notes"),
                 hasGranola: text.includes("granola"),
+                hasMeetingBriefPlugin: text.includes("plugin:meeting-brief:generate"),
                 hasPathParams: text.includes("pathParams"),
                 hasQueryParams: text.includes("queryParams"),
               };
@@ -370,6 +377,7 @@ export default {
                 && actual.hasSearchCapabilities === true
                 && actual.hasMeetingNotes === true
                 && actual.hasGranola === true
+                && actual.hasMeetingBriefPlugin === true
                 && actual.hasPathParams === true
                 && actual.hasQueryParams === true,
               actual,
@@ -382,9 +390,9 @@ export default {
     {
       name: "Frame 5",
       run: async (ctx) => {
-        await ctx.prove("The example continues from search_capabilities into execute_capability and returns meeting data.", {
+        await ctx.prove("The example continues from search_capabilities into execute_capability and returns the shared Acme Corp meeting brief.", {
           voiceover: vo[4],
-          // "Then execute_capability runs the top match and the data comes back — search,"
+          // "execute_capability runs that shared skill and the brief comes back — share once"
           action: async () => {
             await ensureConnectSection(ctx);
             await scrollExampleTextIntoView(ctx, "execute_capability");
@@ -392,9 +400,9 @@ export default {
               `(() => {
                 const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
                 const text = example ? example.innerText : "";
-                return text.includes("execute_capability") && text.includes("Design review") && text.includes("Customer onboarding");
+                return text.includes("execute_capability") && text.includes("Acme Corp") && text.includes("savedTo") && text.includes("Meeting Brief");
               })()`,
-              { timeoutMs: 10_000, label: "execute_capability example result" },
+              { timeoutMs: 10_000, label: "execute_capability Acme Corp brief result" },
             );
           },
           assert: async () => {
@@ -403,18 +411,20 @@ export default {
               const text = example ? example.innerText : "";
               return {
                 hasExecuteCapability: text.includes("execute_capability"),
-                hasTopMatchName: text.includes("mcp:granola:query_meetings"),
-                hasDesignReview: text.includes("Design review"),
-                hasCustomerOnboarding: text.includes("Customer onboarding"),
+                hasTopMatchName: text.includes("plugin:meeting-brief:generate"),
+                hasAcmeCorp: text.includes("Acme Corp"),
+                hasSavedTo: text.includes("savedTo"),
+                hasBrief: text.includes("deal history, latest notes, 3 talking points"),
               };
             })()`);
             recordAssertion(
               ctx,
-              "The example execute call runs the Granola top match and returns meeting result data",
+              "The example execute call runs the shared meeting-brief skill and returns Acme Corp brief data",
               actual.hasExecuteCapability === true
                 && actual.hasTopMatchName === true
-                && actual.hasDesignReview === true
-                && actual.hasCustomerOnboarding === true,
+                && actual.hasAcmeCorp === true
+                && actual.hasSavedTo === true
+                && actual.hasBrief === true,
               actual,
             );
           },

--- a/evals/flows/landing-connect-mcp.flow.mjs
+++ b/evals/flows/landing-connect-mcp.flow.mjs
@@ -207,7 +207,7 @@ export default {
     {
       name: "Frame 2",
       run: async (ctx) => {
-        await ctx.prove("The bring-it-in card shows existing agent setups moving into OpenWork unchanged and shared in one link.", {
+        await ctx.prove("The agent terminal shows existing skills, MCPs, and commands shared to OpenWork in one link.", {
           voiceover: vo[1],
           action: async () => {
             await ensureConnectSection(ctx);
@@ -216,13 +216,15 @@ export default {
               `(() => {
                 const card = document.querySelector(${JSON.stringify(BRING_SELECTOR)});
                 const text = card ? card.innerText : "";
-                return text.includes("Granola")
-                  && text.includes("Meeting Brief Generator")
+                return text.includes("agent — terminal")
+                  && text.includes("share my skills and MCPs with my OpenWork org")
+                  && text.includes("granola")
+                  && text.includes("meeting-brief")
                   && text.includes("review-pr")
                   && text.includes("SKILL.md")
                   && text.includes("one link");
               })()`,
-              { timeoutMs: 10_000, label: "bring existing setup card" },
+              { timeoutMs: 10_000, label: "agent terminal sharing existing setup" },
             );
           },
           assert: async () => {
@@ -231,8 +233,10 @@ export default {
               const text = card ? card.innerText : "";
               return {
                 exists: Boolean(card),
-                hasGranola: text.includes("Granola"),
-                hasMeetingBriefGenerator: text.includes("Meeting Brief Generator"),
+                hasTerminalTitle: text.includes("agent — terminal"),
+                hasSharePrompt: text.includes("share my skills and MCPs with my OpenWork org"),
+                hasGranola: text.includes("granola"),
+                hasMeetingBrief: text.includes("meeting-brief"),
                 hasReviewPr: text.includes("review-pr"),
                 hasSkillMd: text.includes("SKILL.md"),
                 hasOneLink: text.includes("one link"),
@@ -240,17 +244,19 @@ export default {
             })()`);
             recordAssertion(
               ctx,
-              "The bring-it-in card shows Granola, Meeting Brief Generator, review-pr, SKILL.md, and one link",
+              "The agent terminal shows the share prompt, granola, meeting-brief, review-pr, SKILL.md, and one link",
               actual.exists === true
+                && actual.hasTerminalTitle === true
+                && actual.hasSharePrompt === true
                 && actual.hasGranola === true
-                && actual.hasMeetingBriefGenerator === true
+                && actual.hasMeetingBrief === true
                 && actual.hasReviewPr === true
                 && actual.hasSkillMd === true
                 && actual.hasOneLink === true,
               actual,
             );
           },
-          screenshot: { name: "frame-2", requireText: ["SKILL.md"] },
+          screenshot: { name: "frame-2", requireText: ["agent — terminal"] },
         });
       },
     },
@@ -391,9 +397,11 @@ export default {
             await ctx.waitFor(
               `(() => {
                 const panel = document.querySelector(${JSON.stringify(`${SECTION_SELECTOR} [role="tabpanel"]:not([hidden])`)});
-                return Boolean(panel && panel.innerText.includes(${JSON.stringify(CLAUDE_CODE_COMMAND)}));
+                const tabs = Array.from(document.querySelectorAll(${JSON.stringify(`${SECTION_SELECTOR} [role="tab"]`)}));
+                const claudeTab = tabs.find((tab) => (tab.textContent || "").trim() === "Claude Code");
+                return Boolean(panel && panel.innerText.includes(${JSON.stringify(CLAUDE_CODE_COMMAND)}) && claudeTab && claudeTab.querySelector("svg"));
               })()`,
-              { timeoutMs: 10_000, label: "Claude Code command visible" },
+              { timeoutMs: 10_000, label: "Claude Code command and tab icon visible" },
             );
             await grantClipboardPermissions(ctx);
             await realMouseClick(
@@ -440,7 +448,9 @@ export default {
             const feedbackScan = await ctx.eval(`(() => {
               const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
               const links = Array.from(section ? section.querySelectorAll("a") : []);
+              const tabs = Array.from(section ? section.querySelectorAll('[role="tab"]') : []);
               const signup = links.find((link) => (link.textContent || "").trim() === "create one free");
+              const claudeTab = tabs.find((tab) => (tab.textContent || "").trim() === "Claude Code");
               return {
                 feedbackActive: Boolean(section && section.querySelector('[data-feedback="true"]')),
                 copiedVisible: Boolean(section && section.innerText.includes("Copied")),
@@ -448,6 +458,8 @@ export default {
                 pickOrgStepVisible: Boolean(section && section.innerText.includes("Pick your org")),
                 signupExists: Boolean(signup),
                 signupHref: signup ? signup.getAttribute("href") : "",
+                claudeTabSelected: claudeTab ? claudeTab.getAttribute("aria-selected") : null,
+                claudeTabHasSvg: Boolean(claudeTab && claudeTab.querySelector("svg")),
               };
             })()`);
             ctx.recordEvidence({
@@ -460,6 +472,12 @@ export default {
               "navigator.clipboard.readText returns the exact Claude Code MCP command",
               clipboardRead.error === "" && clipboardRead.text === CLAUDE_CODE_COMMAND,
               clipboardRead,
+            );
+            recordAssertion(
+              ctx,
+              "The active Claude Code tab button contains a brand SVG icon",
+              feedbackScan.claudeTabSelected === "true" && feedbackScan.claudeTabHasSvg === true,
+              feedbackScan,
             );
             recordAssertion(
               ctx,

--- a/evals/flows/landing-connect-mcp.flow.mjs
+++ b/evals/flows/landing-connect-mcp.flow.mjs
@@ -1,0 +1,466 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "landing-connect-mcp";
+const MCP_SERVER_URL = "https://api.openworklabs.com/mcp/agent";
+const DOCS_URL = "https://openworklabs.com/docs/cloud/run-in-the-cloud/cloud-mcp";
+const SECTION_SELECTOR = "#connect-mcp";
+const EXAMPLE_SELECTOR = '[data-testid="connect-mcp-example"]';
+const CLAUDE_CODE_COMMAND = `claude mcp add --transport http openwork ${MCP_SERVER_URL}`;
+const INSTALL_COPY_BUTTON_SELECTOR = `${SECTION_SELECTOR} [role="tabpanel"]:not([hidden]) button[aria-label="Copy the OpenWork MCP install command"]`;
+
+// Narration is loaded from the approved script (evals/voiceovers/landing-connect-mcp.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function routeUrl(ctx, path) {
+  return new URL(path, ctx.env.OPENWORK_EVAL_LANDING_URL).toString();
+}
+
+function recordAssertion(ctx, assertion, passed, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: passed ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(passed, `${assertion}. Actual: ${JSON.stringify(actual)}`);
+}
+
+async function grantClipboardPermissions(ctx) {
+  if (!ctx.client?.send) {
+    ctx.log("Clipboard permission grant skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  const origin = new URL(ctx.env.OPENWORK_EVAL_LANDING_URL).origin;
+  await ctx.client.send("Browser.grantPermissions", {
+    origin,
+    permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
+  }).catch((error) => {
+    ctx.log(`Clipboard permission grant skipped: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+async function applyDesktopViewport(ctx) {
+  if (!ctx.client?.send) {
+    ctx.log("Desktop viewport skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1280,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: false,
+  }).catch((error) => {
+    ctx.log(`Desktop viewport skipped: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+async function scrollSectionIntoView(ctx) {
+  await ctx.eval(`(() => {
+    document.querySelector(${JSON.stringify(SECTION_SELECTOR)})?.scrollIntoView({ block: "start", behavior: "instant" });
+    return true;
+  })()`);
+}
+
+async function ensureConnectSection(ctx) {
+  await applyDesktopViewport(ctx);
+  const hasSection = await ctx.eval(`Boolean(document.querySelector(${JSON.stringify(SECTION_SELECTOR)}))`).catch(() => false);
+
+  if (!hasSection) {
+    await fetch(routeUrl(ctx, "/")).catch(() => {});
+    await ctx.eval(`location.href = ${JSON.stringify(routeUrl(ctx, "/"))}; true`);
+  }
+
+  await ctx.waitFor(
+    `(() => {
+      const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
+      const text = section ? section.innerText : "";
+      return Boolean(section) && text.includes("Connect any agent") && text.includes(${JSON.stringify(MCP_SERVER_URL)});
+    })()`,
+    { timeoutMs: 30_000, label: "Connect any agent MCP section" },
+  );
+  await scrollSectionIntoView(ctx);
+}
+
+async function realMouseClick(ctx, elementExpression, label) {
+  const point = await ctx.eval(`(() => {
+    const element = ${elementExpression};
+    if (!element) return null;
+    element.scrollIntoView({ block: "center", inline: "center", behavior: "instant" });
+    const rect = element.getBoundingClientRect();
+    return {
+      visible: rect.width > 0 && rect.height > 0,
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    };
+  })()`);
+
+  ctx.assert(point !== null && point.visible === true, `${label} was not found or visible.`);
+
+  if (!ctx.client?.send) {
+    await ctx.eval(`(() => {
+      const element = ${elementExpression};
+      element?.click();
+      return true;
+    })()`);
+    return;
+  }
+
+  await ctx.client.send("Input.dispatchMouseEvent", {
+    type: "mouseMoved",
+    x: point.x,
+    y: point.y,
+  });
+  await ctx.client.send("Input.dispatchMouseEvent", {
+    type: "mousePressed",
+    x: point.x,
+    y: point.y,
+    button: "left",
+    clickCount: 1,
+  });
+  await ctx.client.send("Input.dispatchMouseEvent", {
+    type: "mouseReleased",
+    x: point.x,
+    y: point.y,
+    button: "left",
+    clickCount: 1,
+  });
+}
+
+function tabByLabelExpression(label) {
+  return `Array.from(document.querySelectorAll(${JSON.stringify(`${SECTION_SELECTOR} [role="tab"]`)}))
+    .find((tab) => (tab.textContent || "").trim() === ${JSON.stringify(label)})`;
+}
+
+async function scrollExampleTextIntoView(ctx, text) {
+  await ctx.eval(`(() => {
+    const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
+    if (!example) return false;
+    const target = Array.from(example.querySelectorAll("*"))
+      .find((element) => (element.textContent || "").includes(${JSON.stringify(text)}));
+    (target || example).scrollIntoView({ block: "center", behavior: "instant" });
+    return true;
+  })()`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Connect any agent to OpenWork Cloud from the landing page",
+  kind: "user-facing",
+  spec: "evals/README.md",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_LANDING_URL"],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The landing page exposes the Connect any agent MCP section and server URL.", {
+          voiceover: vo[0],
+          // "Scrolling the OpenWork landing page, I reach a new section — Connect any age"
+          action: async () => {
+            await ensureConnectSection(ctx);
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`(() => {
+              const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
+              const bodyText = document.body.innerText;
+              return {
+                sectionExists: Boolean(section),
+                bodyHasHeading: bodyText.includes("Connect any agent"),
+                bodyHasServerUrl: bodyText.includes(${JSON.stringify(MCP_SERVER_URL)}),
+                sectionText: section ? section.innerText.slice(0, 500) : "",
+              };
+            })()`);
+            recordAssertion(
+              ctx,
+              "The Connect any agent section and OpenWork MCP server URL are present on the landing page",
+              actual.sectionExists === true && actual.bodyHasHeading === true && actual.bodyHasServerUrl === true,
+              actual,
+            );
+          },
+          screenshot: { name: "frame-1", requireText: ["Connect any agent"] },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("Cursor is the default MCP install tab and its one-click deeplink encodes the OpenWork server URL.", {
+          voiceover: vo[1],
+          // "I pick my client: Cursor is selected with a one-click Add to Cursor button, "
+          action: async () => {
+            await ensureConnectSection(ctx);
+            // Center the install card on the Add to Cursor button so this frame
+            // shows the client picker itself (and differs from frame 1's
+            // section-top framing — the runner rejects duplicate captures).
+            await ctx.eval(`(() => {
+              const links = Array.from(document.querySelectorAll(${JSON.stringify(`${SECTION_SELECTOR} a`)}));
+              const addToCursor = links.find((link) => (link.textContent || "").trim() === "Add to Cursor");
+              addToCursor?.scrollIntoView({ block: "center", behavior: "instant" });
+              return Boolean(addToCursor);
+            })()`);
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`(() => {
+              const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
+              const tabs = Array.from(section ? section.querySelectorAll('[role="tab"]') : []);
+              const cursorTab = tabs.find((tab) => (tab.textContent || "").trim() === "Cursor");
+              const links = Array.from(section ? section.querySelectorAll("a") : []);
+              const addToCursor = links.find((link) => (link.textContent || "").trim() === "Add to Cursor");
+              const href = addToCursor ? addToCursor.href : "";
+              let decodedConfig = "";
+              let decodedUrl = "";
+              let parseError = "";
+
+              try {
+                const config = new URL(href).searchParams.get("config") || "";
+                decodedConfig = atob(config);
+                const parsed = JSON.parse(decodedConfig);
+                decodedUrl = typeof parsed.url === "string" ? parsed.url : "";
+              } catch (error) {
+                parseError = error instanceof Error ? error.message : String(error);
+              }
+
+              return {
+                cursorSelected: cursorTab ? cursorTab.getAttribute("aria-selected") : null,
+                addToCursorExists: Boolean(addToCursor),
+                href,
+                decodedConfig,
+                decodedUrl,
+                parseError,
+              };
+            })()`);
+            ctx.recordEvidence({
+              type: "output",
+              name: "Decoded Cursor MCP config",
+              text: actual.decodedConfig,
+            });
+            recordAssertion(
+              ctx,
+              "The Cursor tab is selected by default and the Add to Cursor anchor exists",
+              actual.cursorSelected === "true" && actual.addToCursorExists === true,
+              actual,
+            );
+            recordAssertion(
+              ctx,
+              "The Add to Cursor deeplink config decodes to the OpenWork MCP server URL",
+              actual.parseError === "" && actual.decodedUrl === MCP_SERVER_URL,
+              actual,
+            );
+          },
+          screenshot: { name: "frame-2", requireText: ["Add to Cursor"] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        let clipboardRead = { text: "", error: "not read" };
+
+        await ctx.prove("Claude Code is a single command, and copying writes that exact command to the clipboard.", {
+          voiceover: vo[2],
+          // "I switch to Claude Code and it's a single command; I hit copy and the exact "
+          action: async () => {
+            await ensureConnectSection(ctx);
+            await realMouseClick(ctx, tabByLabelExpression("Claude Code"), "Claude Code tab");
+            await ctx.waitFor(
+              `(() => {
+                const panel = document.querySelector(${JSON.stringify(`${SECTION_SELECTOR} [role="tabpanel"]:not([hidden])`)});
+                return Boolean(panel && panel.innerText.includes(${JSON.stringify(CLAUDE_CODE_COMMAND)}));
+              })()`,
+              { timeoutMs: 10_000, label: "Claude Code command visible" },
+            );
+            await grantClipboardPermissions(ctx);
+            await realMouseClick(
+              ctx,
+              `document.querySelector(${JSON.stringify(INSTALL_COPY_BUTTON_SELECTOR)})`,
+              "visible OpenWork MCP install copy button",
+            );
+            await ctx.waitFor(
+              `(() => {
+                const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
+                return Boolean(section && section.querySelector('[data-feedback="true"]') && section.innerText.includes("Copied"));
+              })()`,
+              { timeoutMs: 10_000, label: "Copied feedback state" },
+            );
+
+            try {
+              const text = await ctx.eval("navigator.clipboard.readText()", { awaitPromise: true });
+              clipboardRead = { text, error: "" };
+            } catch (error) {
+              clipboardRead = {
+                text: "",
+                error: error instanceof Error ? error.message : String(error),
+              };
+            }
+            await sleep(150);
+          },
+          assert: async () => {
+            const feedbackScan = await ctx.eval(`(() => {
+              const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
+              return {
+                feedbackActive: Boolean(section && section.querySelector('[data-feedback="true"]')),
+                copiedVisible: Boolean(section && section.innerText.includes("Copied")),
+                visiblePanelText: document.querySelector(${JSON.stringify(`${SECTION_SELECTOR} [role="tabpanel"]:not([hidden])`)})?.innerText || "",
+              };
+            })()`);
+            ctx.recordEvidence({
+              type: "output",
+              name: "Clipboard readText result",
+              text: JSON.stringify(clipboardRead, null, 2),
+            });
+            recordAssertion(
+              ctx,
+              "navigator.clipboard.readText returns the exact Claude Code MCP command",
+              clipboardRead.error === "" && clipboardRead.text === CLAUDE_CODE_COMMAND,
+              clipboardRead,
+            );
+            recordAssertion(
+              ctx,
+              "The install card shows the Copied feedback state after copying",
+              feedbackScan.feedbackActive === true && feedbackScan.copiedVisible === true,
+              feedbackScan,
+            );
+          },
+          screenshot: { name: "frame-3", requireText: ["Copied"] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("The example panel shows search_capabilities finding meeting notes in the org's Granola connection.", {
+          voiceover: vo[3],
+          // "Beside the install card, the section shows what connecting unlocks: the agen"
+          action: async () => {
+            await ensureConnectSection(ctx);
+            await scrollExampleTextIntoView(ctx, "search_capabilities");
+            await ctx.waitFor(
+              `(() => {
+                const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
+                const text = example ? example.innerText : "";
+                return text.includes("search_capabilities") && text.includes("meeting notes") && text.includes("granola");
+              })()`,
+              { timeoutMs: 10_000, label: "search_capabilities example" },
+            );
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`(() => {
+              const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
+              const text = example ? example.innerText : "";
+              return {
+                exampleExists: Boolean(example),
+                hasSearchCapabilities: text.includes("search_capabilities"),
+                hasMeetingNotes: text.includes("meeting notes"),
+                hasGranola: text.includes("granola"),
+                hasPathParams: text.includes("pathParams"),
+                hasQueryParams: text.includes("queryParams"),
+              };
+            })()`);
+            recordAssertion(
+              ctx,
+              "The example search shows meeting notes, the Granola connection, and capability parameters",
+              actual.exampleExists === true
+                && actual.hasSearchCapabilities === true
+                && actual.hasMeetingNotes === true
+                && actual.hasGranola === true
+                && actual.hasPathParams === true
+                && actual.hasQueryParams === true,
+              actual,
+            );
+          },
+          screenshot: { name: "frame-4", requireText: ["search_capabilities"] },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("The example continues from search_capabilities into execute_capability and returns meeting data.", {
+          voiceover: vo[4],
+          // "Then execute_capability runs the top match and the data comes back — search,"
+          action: async () => {
+            await ensureConnectSection(ctx);
+            await scrollExampleTextIntoView(ctx, "execute_capability");
+            await ctx.waitFor(
+              `(() => {
+                const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
+                const text = example ? example.innerText : "";
+                return text.includes("execute_capability") && text.includes("Design review") && text.includes("Customer onboarding");
+              })()`,
+              { timeoutMs: 10_000, label: "execute_capability example result" },
+            );
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`(() => {
+              const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
+              const text = example ? example.innerText : "";
+              return {
+                hasExecuteCapability: text.includes("execute_capability"),
+                hasTopMatchName: text.includes("mcp:granola:query_meetings"),
+                hasDesignReview: text.includes("Design review"),
+                hasCustomerOnboarding: text.includes("Customer onboarding"),
+              };
+            })()`);
+            recordAssertion(
+              ctx,
+              "The example execute call runs the Granola top match and returns meeting result data",
+              actual.hasExecuteCapability === true
+                && actual.hasTopMatchName === true
+                && actual.hasDesignReview === true
+                && actual.hasCustomerOnboarding === true,
+              actual,
+            );
+          },
+          screenshot: { name: "frame-5", requireText: ["execute_capability"] },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("Read the docs links to the Cloud MCP guide for OAuth details.", {
+          voiceover: vo[5],
+          // "Read the docs points at the Cloud MCP guide with the OAuth details — sign in"
+          action: async () => {
+            await ensureConnectSection(ctx);
+            await ctx.eval(`(() => {
+              const links = Array.from(document.querySelectorAll(${JSON.stringify(`${SECTION_SELECTOR} a`)}));
+              const docs = links.find((link) => (link.textContent || "").trim() === "Read the docs");
+              docs?.scrollIntoView({ block: "center", behavior: "instant" });
+              return Boolean(docs);
+            })()`);
+            await ctx.waitFor(
+              `(() => Array.from(document.querySelectorAll(${JSON.stringify(`${SECTION_SELECTOR} a`)}))
+                .some((link) => (link.textContent || "").trim() === "Read the docs"))()`,
+              { timeoutMs: 10_000, label: "Read the docs link" },
+            );
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`(() => {
+              const links = Array.from(document.querySelectorAll(${JSON.stringify(`${SECTION_SELECTOR} a`)}));
+              const docs = links.find((link) => (link.textContent || "").trim() === "Read the docs");
+              return {
+                exists: Boolean(docs),
+                href: docs ? docs.href : "",
+                target: docs ? docs.target : "",
+                rel: docs ? docs.rel : "",
+              };
+            })()`);
+            recordAssertion(
+              ctx,
+              "Read the docs points exactly to the OpenWork Cloud MCP guide",
+              actual.exists === true && actual.href === DOCS_URL,
+              actual,
+            );
+          },
+          screenshot: { name: "frame-6", requireText: ["Read the docs"] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/landing-connect-mcp.flow.mjs
+++ b/evals/flows/landing-connect-mcp.flow.mjs
@@ -7,6 +7,7 @@ const SECTION_SELECTOR = "#connect-mcp";
 const BRING_SELECTOR = '[data-testid="connect-mcp-bring"]';
 const EXAMPLE_SELECTOR = '[data-testid="connect-mcp-example"]';
 const INSTALL_SELECTOR = '[data-testid="connect-mcp-install"]';
+const SIGNUP_URL = "https://app.openworklabs.com?mode=sign-up";
 const CLAUDE_CODE_COMMAND = `claude mcp add --transport http openwork ${MCP_SERVER_URL}`;
 const INSTALL_COPY_BUTTON_SELECTOR = `${SECTION_SELECTOR} [role="tabpanel"]:not([hidden]) button[aria-label="Copy the OpenWork MCP install command"]`;
 
@@ -162,7 +163,7 @@ async function scrollExampleTextIntoView(ctx, text) {
 
 export default {
   id: FLOW_ID,
-  title: "Add existing agent work to OpenWork, share it, and use it anywhere",
+  title: "Add existing agent work to OpenWork and share it with your team",
   kind: "user-facing",
   spec: "evals/README.md",
   preserveTheme: true,
@@ -185,15 +186,17 @@ export default {
                 hasAlreadyDoingHeading: text.includes("Already doing it in your agent?"),
                 hasAddItHeading: text.includes("Add it to OpenWork"),
                 hasServerUrl: text.includes(${JSON.stringify(MCP_SERVER_URL)}),
+                hasProtocolJargon: text.includes("search_capabilities"),
               };
             })()`);
             recordAssertion(
               ctx,
-              "The Connect section includes the new heading and OpenWork MCP server URL",
+              "The Connect section includes the new heading and OpenWork MCP server URL without tool-name jargon",
               actual.sectionExists === true
                 && actual.hasAlreadyDoingHeading === true
                 && actual.hasAddItHeading === true
-                && actual.hasServerUrl === true,
+                && actual.hasServerUrl === true
+                && actual.hasProtocolJargon === false,
               actual,
             );
           },
@@ -254,7 +257,7 @@ export default {
     {
       name: "Frame 3",
       run: async (ctx) => {
-        await ctx.prove("The example window shows search_capabilities finding shared meeting notes, Granola, and the meeting-brief skill.", {
+        await ctx.prove("The mini OpenWork app shows a teammate using the shared Granola connection and meeting-brief skill.", {
           voiceover: vo[2],
           action: async () => {
             await ensureConnectSection(ctx);
@@ -267,12 +270,11 @@ export default {
               `(() => {
                 const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
                 const text = example ? example.innerText : "";
-                return text.includes("search_capabilities")
-                  && text.includes("meeting notes")
-                  && text.includes("granola")
-                  && text.includes("plugin:meeting-brief:generate");
+                return text.includes("Prep a brief for tomorrow's Acme call")
+                  && text.includes("Queried the shared Granola MCP")
+                  && text.includes("Your teammate's view");
               })()`,
-              { timeoutMs: 10_000, label: "search_capabilities shared results" },
+              { timeoutMs: 10_000, label: "mini OpenWork teammate view" },
             );
           },
           assert: async () => {
@@ -281,42 +283,42 @@ export default {
               const text = example ? example.innerText : "";
               return {
                 exists: Boolean(example),
-                hasSearchCapabilities: text.includes("search_capabilities"),
-                hasMeetingNotes: text.includes("meeting notes"),
-                hasGranola: text.includes("granola"),
-                hasMeetingBriefPlugin: text.includes("plugin:meeting-brief:generate"),
+                hasPrompt: text.includes("Prep a brief for tomorrow's Acme call"),
+                hasGranolaExecution: text.includes("Queried the shared Granola MCP"),
+                hasTeammateView: text.includes("Your teammate's view"),
               };
             })()`);
             recordAssertion(
               ctx,
-              "The teammate agent example finds meeting notes, Granola, and the shared meeting-brief skill",
+              "The mini OpenWork UI shows a teammate prompt and shared Granola execution",
               actual.exists === true
-                && actual.hasSearchCapabilities === true
-                && actual.hasMeetingNotes === true
-                && actual.hasGranola === true
-                && actual.hasMeetingBriefPlugin === true,
+                && actual.hasPrompt === true
+                && actual.hasGranolaExecution === true
+                && actual.hasTeammateView === true,
               actual,
             );
           },
-          screenshot: { name: "frame-3", requireText: ["search_capabilities"] },
+          screenshot: { name: "frame-3", requireText: ["Granola"] },
         });
       },
     },
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("execute_capability runs the shared skill and returns the Acme Corp brief.", {
+        await ctx.prove("The teammate run shows the shared meeting-brief skill completing with three talking points.", {
           voiceover: vo[3],
           action: async () => {
             await ensureConnectSection(ctx);
-            await scrollExampleTextIntoView(ctx, "execute_capability");
+            await scrollExampleTextIntoView(ctx, "3 talking points");
             await ctx.waitFor(
               `(() => {
                 const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
                 const text = example ? example.innerText : "";
-                return text.includes("execute_capability") && text.includes("Acme Corp") && text.includes("savedTo");
+                return text.includes("Ran Meeting Brief Generator")
+                  && text.includes("3 talking points")
+                  && text.includes("Run Task");
               })()`,
-              { timeoutMs: 10_000, label: "execute_capability Acme Corp result" },
+              { timeoutMs: 10_000, label: "mini OpenWork run result" },
             );
           },
           assert: async () => {
@@ -325,22 +327,22 @@ export default {
               const text = example ? example.innerText : "";
               return {
                 exists: Boolean(example),
-                hasExecuteCapability: text.includes("execute_capability"),
-                hasAcmeCorp: text.includes("Acme Corp"),
-                hasSavedTo: text.includes("savedTo"),
+                hasMeetingBriefRun: text.includes("Ran Meeting Brief Generator"),
+                hasTalkingPoints: text.includes("3 talking points"),
+                hasRunTask: text.includes("Run Task"),
               };
             })()`);
             recordAssertion(
               ctx,
-              "The example execute call returns Acme Corp brief output with savedTo",
+              "The mini OpenWork UI shows the shared meeting-brief run, talking points, and Run Task input",
               actual.exists === true
-                && actual.hasExecuteCapability === true
-                && actual.hasAcmeCorp === true
-                && actual.hasSavedTo === true,
+                && actual.hasMeetingBriefRun === true
+                && actual.hasTalkingPoints === true
+                && actual.hasRunTask === true,
               actual,
             );
           },
-          screenshot: { name: "frame-4", requireText: ["execute_capability"] },
+          screenshot: { name: "frame-4", requireText: ["talking points"] },
         });
       },
     },
@@ -403,7 +405,7 @@ export default {
               `(() => {
                 const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
                 const text = section ? section.innerText : "";
-                return Boolean(section && section.querySelector('[data-feedback="true"]') && text.includes("Copied") && text.includes("Sign in in the browser") && text.includes("Pick your org"));
+                return Boolean(section && section.querySelector('[data-feedback="true"]') && text.includes("Copied") && text.includes("Create your free account or sign in") && text.includes("Pick your org"));
               })()`,
               { timeoutMs: 10_000, label: "Copied feedback state and reveal steps" },
             );
@@ -437,11 +439,15 @@ export default {
 
             const feedbackScan = await ctx.eval(`(() => {
               const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
+              const links = Array.from(section ? section.querySelectorAll("a") : []);
+              const signup = links.find((link) => (link.textContent || "").trim() === "create one free");
               return {
                 feedbackActive: Boolean(section && section.querySelector('[data-feedback="true"]')),
                 copiedVisible: Boolean(section && section.innerText.includes("Copied")),
-                signInStepVisible: Boolean(section && section.innerText.includes("Sign in in the browser")),
+                accountStepVisible: Boolean(section && section.innerText.includes("Create your free account or sign in")),
                 pickOrgStepVisible: Boolean(section && section.innerText.includes("Pick your org")),
+                signupExists: Boolean(signup),
+                signupHref: signup ? signup.getAttribute("href") : "",
               };
             })()`);
             ctx.recordEvidence({
@@ -460,8 +466,10 @@ export default {
               "The install card shows the Copied feedback state and browser sign-in reveal steps after copying",
               feedbackScan.feedbackActive === true
                 && feedbackScan.copiedVisible === true
-                && feedbackScan.signInStepVisible === true
-                && feedbackScan.pickOrgStepVisible === true,
+                && feedbackScan.accountStepVisible === true
+                && feedbackScan.pickOrgStepVisible === true
+                && feedbackScan.signupExists === true
+                && feedbackScan.signupHref === SIGNUP_URL,
               feedbackScan,
             );
           },

--- a/evals/flows/landing-connect-mcp.flow.mjs
+++ b/evals/flows/landing-connect-mcp.flow.mjs
@@ -66,11 +66,11 @@ async function scrollSectionIntoView(ctx) {
   })()`);
 }
 
-async function ensureConnectSection(ctx) {
+async function ensureConnectSection(ctx, { forceReload = false } = {}) {
   await applyDesktopViewport(ctx);
   const hasSection = await ctx.eval(`Boolean(document.querySelector(${JSON.stringify(SECTION_SELECTOR)}))`).catch(() => false);
 
-  if (!hasSection) {
+  if (!hasSection || forceReload) {
     await fetch(routeUrl(ctx, "/")).catch(() => {});
     await ctx.eval(`location.href = ${JSON.stringify(routeUrl(ctx, "/"))}; true`);
   }
@@ -162,7 +162,9 @@ export default {
           voiceover: vo[0],
           // "Scrolling the OpenWork landing page, I reach a new section — Connect any age"
           action: async () => {
-            await ensureConnectSection(ctx);
+            // Always start from a fresh navigation so repeat runs against a
+            // warm page don't inherit tab/copy state from a previous run.
+            await ensureConnectSection(ctx, { forceReload: true });
           },
           assert: async () => {
             const actual = await ctx.eval(`(() => {

--- a/evals/flows/landing-connect-mcp.flow.mjs
+++ b/evals/flows/landing-connect-mcp.flow.mjs
@@ -4,7 +4,9 @@ const FLOW_ID = "landing-connect-mcp";
 const MCP_SERVER_URL = "https://api.openworklabs.com/mcp/agent";
 const DOCS_URL = "https://openworklabs.com/docs/cloud/run-in-the-cloud/cloud-mcp";
 const SECTION_SELECTOR = "#connect-mcp";
+const BRING_SELECTOR = '[data-testid="connect-mcp-bring"]';
 const EXAMPLE_SELECTOR = '[data-testid="connect-mcp-example"]';
+const INSTALL_SELECTOR = '[data-testid="connect-mcp-install"]';
 const CLAUDE_CODE_COMMAND = `claude mcp add --transport http openwork ${MCP_SERVER_URL}`;
 const INSTALL_COPY_BUTTON_SELECTOR = `${SECTION_SELECTOR} [role="tabpanel"]:not([hidden]) button[aria-label="Copy the OpenWork MCP install command"]`;
 
@@ -66,6 +68,14 @@ async function scrollSectionIntoView(ctx) {
   })()`);
 }
 
+async function scrollSelectorIntoView(ctx, selector, block = "center") {
+  await ctx.eval(`(() => {
+    const element = document.querySelector(${JSON.stringify(selector)});
+    element?.scrollIntoView({ block: ${JSON.stringify(block)}, behavior: "instant" });
+    return Boolean(element);
+  })()`);
+}
+
 async function ensureConnectSection(ctx, { forceReload = false } = {}) {
   await applyDesktopViewport(ctx);
   const hasSection = await ctx.eval(`Boolean(document.querySelector(${JSON.stringify(SECTION_SELECTOR)}))`).catch(() => false);
@@ -79,9 +89,12 @@ async function ensureConnectSection(ctx, { forceReload = false } = {}) {
     `(() => {
       const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
       const text = section ? section.innerText : "";
-      return Boolean(section) && text.includes("Share it once") && text.includes(${JSON.stringify(MCP_SERVER_URL)});
+      return Boolean(section)
+        && text.includes("Already doing it in your agent?")
+        && text.includes("Add it to OpenWork")
+        && text.includes(${JSON.stringify(MCP_SERVER_URL)});
     })()`,
-    { timeoutMs: 30_000, label: "Share it once MCP section" },
+    { timeoutMs: 30_000, label: "Connect section with new sharing headline" },
   );
   await scrollSectionIntoView(ctx);
 }
@@ -149,7 +162,7 @@ async function scrollExampleTextIntoView(ctx, text) {
 
 export default {
   id: FLOW_ID,
-  title: "Share OpenWork tools once and use them from any agent",
+  title: "Add existing agent work to OpenWork, share it, and use it anywhere",
   kind: "user-facing",
   spec: "evals/README.md",
   preserveTheme: true,
@@ -158,56 +171,191 @@ export default {
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("The landing page explains that shared OpenWork tools can be used from any agent.", {
+        await ctx.prove("The landing page leads with adding existing agent work to OpenWork and sharing it with the team.", {
           voiceover: vo[0],
-          // "Further down the OpenWork landing page, a new section makes the pitch: share"
           action: async () => {
-            // Always start from a fresh navigation so repeat runs against a
-            // warm page don't inherit tab/copy state from a previous run.
             await ensureConnectSection(ctx, { forceReload: true });
           },
           assert: async () => {
             const actual = await ctx.eval(`(() => {
               const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
-              const bodyText = document.body.innerText;
+              const text = section ? section.innerText : "";
               return {
                 sectionExists: Boolean(section),
-                bodyHasHeading: bodyText.includes("Share it once"),
-                bodyHasServerUrl: bodyText.includes(${JSON.stringify(MCP_SERVER_URL)}),
-                sectionText: section ? section.innerText.slice(0, 500) : "",
+                hasAlreadyDoingHeading: text.includes("Already doing it in your agent?"),
+                hasAddItHeading: text.includes("Add it to OpenWork"),
+                hasServerUrl: text.includes(${JSON.stringify(MCP_SERVER_URL)}),
               };
             })()`);
             recordAssertion(
               ctx,
-              "The Share it once section and OpenWork MCP server URL are present on the landing page",
-              actual.sectionExists === true && actual.bodyHasHeading === true && actual.bodyHasServerUrl === true,
+              "The Connect section includes the new heading and OpenWork MCP server URL",
+              actual.sectionExists === true
+                && actual.hasAlreadyDoingHeading === true
+                && actual.hasAddItHeading === true
+                && actual.hasServerUrl === true,
               actual,
             );
           },
-          screenshot: { name: "frame-1", requireText: ["Share it once"] },
+          screenshot: { name: "frame-1", requireText: ["Add it to OpenWork"] },
         });
       },
     },
     {
       name: "Frame 2",
       run: async (ctx) => {
-        await ctx.prove("Cursor is the default MCP install tab and its one-click deeplink encodes the OpenWork server URL.", {
+        await ctx.prove("The bring-it-in card shows existing agent setups moving into OpenWork unchanged and shared in one link.", {
           voiceover: vo[1],
-          // "The install card speaks the hero prompt's language: I pick my client from"
           action: async () => {
             await ensureConnectSection(ctx);
-            // Center the install card on the Add to Cursor button so this frame
-            // shows the client picker itself (and differs from frame 1's
-            // section-top framing — the runner rejects duplicate captures).
-            await ctx.eval(`(() => {
-              const links = Array.from(document.querySelectorAll(${JSON.stringify(`${SECTION_SELECTOR} a`)}));
-              const addToCursor = links.find((link) => (link.textContent || "").trim() === "Add to Cursor");
-              addToCursor?.scrollIntoView({ block: "center", behavior: "instant" });
-              return Boolean(addToCursor);
-            })()`);
+            await scrollSelectorIntoView(ctx, BRING_SELECTOR);
+            await ctx.waitFor(
+              `(() => {
+                const card = document.querySelector(${JSON.stringify(BRING_SELECTOR)});
+                const text = card ? card.innerText : "";
+                return text.includes("Granola")
+                  && text.includes("Meeting Brief Generator")
+                  && text.includes("review-pr")
+                  && text.includes("SKILL.md")
+                  && text.includes("one link");
+              })()`,
+              { timeoutMs: 10_000, label: "bring existing setup card" },
+            );
           },
           assert: async () => {
             const actual = await ctx.eval(`(() => {
+              const card = document.querySelector(${JSON.stringify(BRING_SELECTOR)});
+              const text = card ? card.innerText : "";
+              return {
+                exists: Boolean(card),
+                hasGranola: text.includes("Granola"),
+                hasMeetingBriefGenerator: text.includes("Meeting Brief Generator"),
+                hasReviewPr: text.includes("review-pr"),
+                hasSkillMd: text.includes("SKILL.md"),
+                hasOneLink: text.includes("one link"),
+              };
+            })()`);
+            recordAssertion(
+              ctx,
+              "The bring-it-in card shows Granola, Meeting Brief Generator, review-pr, SKILL.md, and one link",
+              actual.exists === true
+                && actual.hasGranola === true
+                && actual.hasMeetingBriefGenerator === true
+                && actual.hasReviewPr === true
+                && actual.hasSkillMd === true
+                && actual.hasOneLink === true,
+              actual,
+            );
+          },
+          screenshot: { name: "frame-2", requireText: ["SKILL.md"] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("The example window shows search_capabilities finding shared meeting notes, Granola, and the meeting-brief skill.", {
+          voiceover: vo[2],
+          action: async () => {
+            await ensureConnectSection(ctx);
+            // Align the example window's top with the viewport top: frame 2
+            // centers the sibling bring-it-in card in the same grid row, so a
+            // "center" scroll here would land on the same offset and the
+            // runner would reject the capture as a duplicate frame.
+            await scrollSelectorIntoView(ctx, EXAMPLE_SELECTOR, "start");
+            await ctx.waitFor(
+              `(() => {
+                const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
+                const text = example ? example.innerText : "";
+                return text.includes("search_capabilities")
+                  && text.includes("meeting notes")
+                  && text.includes("granola")
+                  && text.includes("plugin:meeting-brief:generate");
+              })()`,
+              { timeoutMs: 10_000, label: "search_capabilities shared results" },
+            );
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`(() => {
+              const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
+              const text = example ? example.innerText : "";
+              return {
+                exists: Boolean(example),
+                hasSearchCapabilities: text.includes("search_capabilities"),
+                hasMeetingNotes: text.includes("meeting notes"),
+                hasGranola: text.includes("granola"),
+                hasMeetingBriefPlugin: text.includes("plugin:meeting-brief:generate"),
+              };
+            })()`);
+            recordAssertion(
+              ctx,
+              "The teammate agent example finds meeting notes, Granola, and the shared meeting-brief skill",
+              actual.exists === true
+                && actual.hasSearchCapabilities === true
+                && actual.hasMeetingNotes === true
+                && actual.hasGranola === true
+                && actual.hasMeetingBriefPlugin === true,
+              actual,
+            );
+          },
+          screenshot: { name: "frame-3", requireText: ["search_capabilities"] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("execute_capability runs the shared skill and returns the Acme Corp brief.", {
+          voiceover: vo[3],
+          action: async () => {
+            await ensureConnectSection(ctx);
+            await scrollExampleTextIntoView(ctx, "execute_capability");
+            await ctx.waitFor(
+              `(() => {
+                const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
+                const text = example ? example.innerText : "";
+                return text.includes("execute_capability") && text.includes("Acme Corp") && text.includes("savedTo");
+              })()`,
+              { timeoutMs: 10_000, label: "execute_capability Acme Corp result" },
+            );
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`(() => {
+              const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
+              const text = example ? example.innerText : "";
+              return {
+                exists: Boolean(example),
+                hasExecuteCapability: text.includes("execute_capability"),
+                hasAcmeCorp: text.includes("Acme Corp"),
+                hasSavedTo: text.includes("savedTo"),
+              };
+            })()`);
+            recordAssertion(
+              ctx,
+              "The example execute call returns Acme Corp brief output with savedTo",
+              actual.exists === true
+                && actual.hasExecuteCapability === true
+                && actual.hasAcmeCorp === true
+                && actual.hasSavedTo === true,
+              actual,
+            );
+          },
+          screenshot: { name: "frame-4", requireText: ["execute_capability"] },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        let cursorScan = null;
+        let clipboardRead = { text: "", error: "not read" };
+
+        await ctx.prove("Connecting an agent starts with Cursor by default, then Claude Code copies the exact MCP command and reveals the OAuth steps.", {
+          voiceover: vo[4],
+          action: async () => {
+            await ensureConnectSection(ctx);
+            await scrollSelectorIntoView(ctx, INSTALL_SELECTOR);
+            cursorScan = await ctx.eval(`(() => {
               const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
               const tabs = Array.from(section ? section.querySelectorAll('[role="tab"]') : []);
               const cursorTab = tabs.find((tab) => (tab.textContent || "").trim() === "Cursor");
@@ -236,38 +384,7 @@ export default {
                 parseError,
               };
             })()`);
-            ctx.recordEvidence({
-              type: "output",
-              name: "Decoded Cursor MCP config",
-              text: actual.decodedConfig,
-            });
-            recordAssertion(
-              ctx,
-              "The Cursor tab is selected by default and the Add to Cursor anchor exists",
-              actual.cursorSelected === "true" && actual.addToCursorExists === true,
-              actual,
-            );
-            recordAssertion(
-              ctx,
-              "The Add to Cursor deeplink config decodes to the OpenWork MCP server URL",
-              actual.parseError === "" && actual.decodedUrl === MCP_SERVER_URL,
-              actual,
-            );
-          },
-          screenshot: { name: "frame-2", requireText: ["Add to Cursor"] },
-        });
-      },
-    },
-    {
-      name: "Frame 3",
-      run: async (ctx) => {
-        let clipboardRead = { text: "", error: "not read" };
 
-        await ctx.prove("Claude Code is a single command, and copying writes that exact command to the clipboard.", {
-          voiceover: vo[2],
-          // "I flip to Claude Code and it's one command; I hit copy, the button flips"
-          action: async () => {
-            await ensureConnectSection(ctx);
             await realMouseClick(ctx, tabByLabelExpression("Claude Code"), "Claude Code tab");
             await ctx.waitFor(
               `(() => {
@@ -303,6 +420,21 @@ export default {
             await sleep(150);
           },
           assert: async () => {
+            ctx.recordEvidence({
+              type: "output",
+              name: "Decoded Cursor MCP config",
+              text: cursorScan?.decodedConfig ?? "",
+            });
+            recordAssertion(
+              ctx,
+              "Cursor is selected by default and Add to Cursor decodes to the OpenWork MCP server URL",
+              cursorScan?.cursorSelected === "true"
+                && cursorScan.addToCursorExists === true
+                && cursorScan.parseError === ""
+                && cursorScan.decodedUrl === MCP_SERVER_URL,
+              cursorScan,
+            );
+
             const feedbackScan = await ctx.eval(`(() => {
               const section = document.querySelector(${JSON.stringify(SECTION_SELECTOR)});
               return {
@@ -310,7 +442,6 @@ export default {
                 copiedVisible: Boolean(section && section.innerText.includes("Copied")),
                 signInStepVisible: Boolean(section && section.innerText.includes("Sign in in the browser")),
                 pickOrgStepVisible: Boolean(section && section.innerText.includes("Pick your org")),
-                visiblePanelText: document.querySelector(${JSON.stringify(`${SECTION_SELECTOR} [role="tabpanel"]:not([hidden])`)})?.innerText || "",
               };
             })()`);
             ctx.recordEvidence({
@@ -334,101 +465,7 @@ export default {
               feedbackScan,
             );
           },
-          screenshot: { name: "frame-3", requireText: ["Copied"] },
-        });
-      },
-    },
-    {
-      name: "Frame 4",
-      run: async (ctx) => {
-        await ctx.prove("The example panel shows search_capabilities finding meeting notes in the org's Granola connection and a shared meeting-brief skill.", {
-          voiceover: vo[3],
-          // "Beside it, an OpenWork window shows what the connected agent sees: search_cap"
-          action: async () => {
-            await ensureConnectSection(ctx);
-            await scrollExampleTextIntoView(ctx, "search_capabilities");
-            await ctx.waitFor(
-              `(() => {
-                const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
-                const text = example ? example.innerText : "";
-                return text.includes("search_capabilities") && text.includes("meeting notes") && text.includes("granola") && text.includes("plugin:meeting-brief:generate");
-              })()`,
-              { timeoutMs: 10_000, label: "search_capabilities example" },
-            );
-          },
-          assert: async () => {
-            const actual = await ctx.eval(`(() => {
-              const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
-              const text = example ? example.innerText : "";
-              return {
-                exampleExists: Boolean(example),
-                hasSearchCapabilities: text.includes("search_capabilities"),
-                hasMeetingNotes: text.includes("meeting notes"),
-                hasGranola: text.includes("granola"),
-                hasMeetingBriefPlugin: text.includes("plugin:meeting-brief:generate"),
-                hasPathParams: text.includes("pathParams"),
-                hasQueryParams: text.includes("queryParams"),
-              };
-            })()`);
-            recordAssertion(
-              ctx,
-              "The example search shows meeting notes, the Granola connection, and capability parameters",
-              actual.exampleExists === true
-                && actual.hasSearchCapabilities === true
-                && actual.hasMeetingNotes === true
-                && actual.hasGranola === true
-                && actual.hasMeetingBriefPlugin === true
-                && actual.hasPathParams === true
-                && actual.hasQueryParams === true,
-              actual,
-            );
-          },
-          screenshot: { name: "frame-4", requireText: ["search_capabilities"] },
-        });
-      },
-    },
-    {
-      name: "Frame 5",
-      run: async (ctx) => {
-        await ctx.prove("The example continues from search_capabilities into execute_capability and returns the shared Acme Corp meeting brief.", {
-          voiceover: vo[4],
-          // "execute_capability runs that shared skill and the brief comes back — share once"
-          action: async () => {
-            await ensureConnectSection(ctx);
-            await scrollExampleTextIntoView(ctx, "execute_capability");
-            await ctx.waitFor(
-              `(() => {
-                const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
-                const text = example ? example.innerText : "";
-                return text.includes("execute_capability") && text.includes("Acme Corp") && text.includes("savedTo") && text.includes("Meeting Brief");
-              })()`,
-              { timeoutMs: 10_000, label: "execute_capability Acme Corp brief result" },
-            );
-          },
-          assert: async () => {
-            const actual = await ctx.eval(`(() => {
-              const example = document.querySelector(${JSON.stringify(EXAMPLE_SELECTOR)});
-              const text = example ? example.innerText : "";
-              return {
-                hasExecuteCapability: text.includes("execute_capability"),
-                hasTopMatchName: text.includes("plugin:meeting-brief:generate"),
-                hasAcmeCorp: text.includes("Acme Corp"),
-                hasSavedTo: text.includes("savedTo"),
-                hasBrief: text.includes("deal history, latest notes, 3 talking points"),
-              };
-            })()`);
-            recordAssertion(
-              ctx,
-              "The example execute call runs the shared meeting-brief skill and returns Acme Corp brief data",
-              actual.hasExecuteCapability === true
-                && actual.hasTopMatchName === true
-                && actual.hasAcmeCorp === true
-                && actual.hasSavedTo === true
-                && actual.hasBrief === true,
-              actual,
-            );
-          },
-          screenshot: { name: "frame-5", requireText: ["execute_capability"] },
+          screenshot: { name: "frame-5", requireText: ["Copied"] },
         });
       },
     },
@@ -437,7 +474,6 @@ export default {
       run: async (ctx) => {
         await ctx.prove("Read the docs links to the Cloud MCP guide for OAuth details.", {
           voiceover: vo[5],
-          // "Read the docs points at the Cloud MCP guide with the OAuth details — sign in"
           action: async () => {
             await ensureConnectSection(ctx);
             await ctx.eval(`(() => {

--- a/evals/voiceovers/landing-connect-mcp.md
+++ b/evals/voiceovers/landing-connect-mcp.md
@@ -1,0 +1,20 @@
+# landing-connect-mcp — Connect any agent to OpenWork Cloud from the landing page
+
+OpenWork Connect exposes an org's whole toolbox — cloud capabilities, org MCP
+connections, and marketplace plugins — through two MCP tools,
+`search_capabilities` and `execute_capability`, served at
+`https://api.openworklabs.com/mcp/agent` (remote streamable HTTP, browser
+OAuth). This section turns that into a one-click / one-command install on
+openworklabs.com, in the style of the best "Add to Cursor" server pages.
+
+1. Scrolling the OpenWork landing page, I reach a new section — Connect any agent — my whole OpenWork org, capabilities, connections, and marketplace, is two MCP tools away, and the server URL is right there.
+
+2. I pick my client: Cursor is selected with a one-click Add to Cursor button, and tabs for Claude Code, OpenCode, VS Code, and everything else sit beside it.
+
+3. I switch to Claude Code and it's a single command; I hit copy and the exact command lands on my clipboard — the button flips to Copied.
+
+4. Beside the install card, the section shows what connecting unlocks: the agent calls search_capabilities for meeting notes and ranked matches come back, including the org's Granola connection, each with the parameters it takes.
+
+5. Then execute_capability runs the top match and the data comes back — search, then execute: everything OpenWork Connect can do, from whatever agent I already use.
+
+6. Read the docs points at the Cloud MCP guide with the OAuth details — sign in in the browser, pick your org, and the token does the rest.

--- a/evals/voiceovers/landing-connect-mcp.md
+++ b/evals/voiceovers/landing-connect-mcp.md
@@ -1,21 +1,20 @@
-# landing-connect-mcp — Add what your agents already do to OpenWork, share it, use it anywhere
+# landing-connect-mcp — Add what your agents already do to OpenWork; your team runs it in OpenWork
 
-The section leads with the user's existing agent life: the skills, MCPs, and
-commands they already run in Claude Code or Cursor drop into OpenWork as-is
-(same SKILL.md format, same remote MCP URLs), get shared org-wide, and come
-back out through two MCP tools — `search_capabilities` and
-`execute_capability` at `https://api.openworklabs.com/mcp/agent` — from any
-agent. Layout: header, then two balanced cards (bring-it-in + agent's-eye
-example window), then a full-width connect-your-agent install row.
+The section leads with the user's existing agent life: skills, MCPs, and
+commands from Claude Code or Cursor move into OpenWork as-is and get shared
+org-wide. Teammates run them inside the OpenWork app (mini app-UI mock, like
+the enterprise showcase); developers can also point their own agent at the
+org's MCP server — which requires a free OpenWork account, so the connect row
+carries a sign-up path. No protocol/tool-name jargon anywhere.
 
 1. Further down the OpenWork landing page, the pitch is personal: already doing it in your agent? The skills and MCPs you run in Claude Code or Cursor can be added to OpenWork and shared with your whole team.
 
-2. The left card shows my existing setup moving in as-is — the Granola MCP, a meeting-brief skill, a review-pr command — same SKILL.md format, same server URLs, packaged and shared with the org in one link.
+2. The left window shows my setup moving in as-is — the Granola MCP, a meeting-brief skill, a review-pr command — same SKILL.md format, same server URLs, shared with the org in one link.
 
-3. Next to it, an OpenWork window shows what a teammate's agent sees once connected: search_capabilities for meeting notes finds exactly what I shared — the Granola connection and the meeting-brief skill.
+3. Next to it, OpenWork itself: a teammate just types what they need — a brief for tomorrow's Acme call — and OpenWork picks up the exact skills and connections I shared.
 
-4. execute_capability runs that shared skill and the Acme Corp brief comes back — shared once, consumed from whatever agent a teammate already uses.
+4. The run unfolds in plain sight — Granola notes queried, the meeting-brief skill executed — and the brief lands with three talking points, no setup on their side at all.
 
-5. Below, connecting an agent is one click or one command — Add to Cursor up front; I flip to Claude Code, hit copy, and the exact command lands on my clipboard with three steps: sign in, pick your org, your team's tools appear.
+5. Below, developers point their own agent at the org too: one click or one command, a free OpenWork account the first time, pick your org, and your team's tools appear.
 
 6. Read the docs points at the Cloud MCP guide with the OAuth details — sign in in the browser, pick your org, and the token does the rest.

--- a/evals/voiceovers/landing-connect-mcp.md
+++ b/evals/voiceovers/landing-connect-mcp.md
@@ -1,20 +1,20 @@
-# landing-connect-mcp — Connect any agent to OpenWork Cloud from the landing page
+# landing-connect-mcp — Share it once on OpenWork, use it from any agent
 
-OpenWork Connect exposes an org's whole toolbox — cloud capabilities, org MCP
-connections, and marketplace plugins — through two MCP tools,
-`search_capabilities` and `execute_capability`, served at
-`https://api.openworklabs.com/mcp/agent` (remote streamable HTTP, browser
-OAuth). This section turns that into a one-click / one-command install on
-openworklabs.com, in the style of the best "Add to Cursor" server pages.
+OpenWork Connect exposes everything an org shares — skills, MCP connections,
+plugins — through two MCP tools, `search_capabilities` and
+`execute_capability`, served at `https://api.openworklabs.com/mcp/agent`
+(remote streamable HTTP, browser OAuth). This section sells the sharing story
+with the same visual language as the hero prompt and the demo window, and
+turns the install into one click or one command.
 
-1. Scrolling the OpenWork landing page, I reach a new section — Connect any agent — my whole OpenWork org, capabilities, connections, and marketplace, is two MCP tools away, and the server URL is right there.
+1. Further down the OpenWork landing page, a new section makes the pitch: share a skill, an MCP connection, or a plugin with your org once, and every agent your team already uses can work with it.
 
-2. I pick my client: Cursor is selected with a one-click Add to Cursor button, and tabs for Claude Code, OpenCode, VS Code, and everything else sit beside it.
+2. The install card speaks the hero prompt's language: I pick my client from a pill picker — Cursor's one-click Add to Cursor button is front and center, with Claude Code, OpenCode, VS Code, and everything else one pill away.
 
-3. I switch to Claude Code and it's a single command; I hit copy and the exact command lands on my clipboard — the button flips to Copied.
+3. I flip to Claude Code and it's one command; I hit copy, the button flips to Copied, and three steps appear — sign in in the browser, pick your org, your team's tools show up in your agent.
 
-4. Beside the install card, the section shows what connecting unlocks: the agent calls search_capabilities for meeting notes and ranked matches come back, including the org's Granola connection, each with the parameters it takes.
+4. Beside it, an OpenWork window shows what the connected agent sees: search_capabilities for meeting notes finds what the org shared — the Granola connection and a teammate's meeting-brief skill.
 
-5. Then execute_capability runs the top match and the data comes back — search, then execute: everything OpenWork Connect can do, from whatever agent I already use.
+5. execute_capability runs that shared skill and the brief comes back — share once on OpenWork, consume from whatever agent you already use.
 
 6. Read the docs points at the Cloud MCP guide with the OAuth details — sign in in the browser, pick your org, and the token does the rest.

--- a/evals/voiceovers/landing-connect-mcp.md
+++ b/evals/voiceovers/landing-connect-mcp.md
@@ -1,20 +1,21 @@
-# landing-connect-mcp — Share it once on OpenWork, use it from any agent
+# landing-connect-mcp — Add what your agents already do to OpenWork, share it, use it anywhere
 
-OpenWork Connect exposes everything an org shares — skills, MCP connections,
-plugins — through two MCP tools, `search_capabilities` and
-`execute_capability`, served at `https://api.openworklabs.com/mcp/agent`
-(remote streamable HTTP, browser OAuth). This section sells the sharing story
-with the same visual language as the hero prompt and the demo window, and
-turns the install into one click or one command.
+The section leads with the user's existing agent life: the skills, MCPs, and
+commands they already run in Claude Code or Cursor drop into OpenWork as-is
+(same SKILL.md format, same remote MCP URLs), get shared org-wide, and come
+back out through two MCP tools — `search_capabilities` and
+`execute_capability` at `https://api.openworklabs.com/mcp/agent` — from any
+agent. Layout: header, then two balanced cards (bring-it-in + agent's-eye
+example window), then a full-width connect-your-agent install row.
 
-1. Further down the OpenWork landing page, a new section makes the pitch: share a skill, an MCP connection, or a plugin with your org once, and every agent your team already uses can work with it.
+1. Further down the OpenWork landing page, the pitch is personal: already doing it in your agent? The skills and MCPs you run in Claude Code or Cursor can be added to OpenWork and shared with your whole team.
 
-2. The install card speaks the hero prompt's language: I pick my client from a pill picker — Cursor's one-click Add to Cursor button is front and center, with Claude Code, OpenCode, VS Code, and everything else one pill away.
+2. The left card shows my existing setup moving in as-is — the Granola MCP, a meeting-brief skill, a review-pr command — same SKILL.md format, same server URLs, packaged and shared with the org in one link.
 
-3. I flip to Claude Code and it's one command; I hit copy, the button flips to Copied, and three steps appear — sign in in the browser, pick your org, your team's tools show up in your agent.
+3. Next to it, an OpenWork window shows what a teammate's agent sees once connected: search_capabilities for meeting notes finds exactly what I shared — the Granola connection and the meeting-brief skill.
 
-4. Beside it, an OpenWork window shows what the connected agent sees: search_capabilities for meeting notes finds what the org shared — the Granola connection and a teammate's meeting-brief skill.
+4. execute_capability runs that shared skill and the Acme Corp brief comes back — shared once, consumed from whatever agent a teammate already uses.
 
-5. execute_capability runs that shared skill and the brief comes back — share once on OpenWork, consume from whatever agent you already use.
+5. Below, connecting an agent is one click or one command — Add to Cursor up front; I flip to Claude Code, hit copy, and the exact command lands on my clipboard with three steps: sign in, pick your org, your team's tools appear.
 
 6. Read the docs points at the Cloud MCP guide with the OAuth details — sign in in the browser, pick your org, and the token does the rest.

--- a/evals/voiceovers/landing-connect-mcp.md
+++ b/evals/voiceovers/landing-connect-mcp.md
@@ -9,7 +9,7 @@ carries a sign-up path. No protocol/tool-name jargon anywhere.
 
 1. Further down the OpenWork landing page, the pitch is personal: already doing it in your agent? The skills and MCPs you run in Claude Code or Cursor can be added to OpenWork and shared with your whole team.
 
-2. The left window shows my setup moving in as-is — the Granola MCP, a meeting-brief skill, a review-pr command — same SKILL.md format, same server URLs, shared with the org in one link.
+2. On the left, my agent's terminal — I ask it to share my setup with my OpenWork org, and it finds the granola MCP, my meeting-brief skill, and a review-pr command, shipping them to the team in one link.
 
 3. Next to it, OpenWork itself: a teammate just types what they need — a brief for tomorrow's Acme call — and OpenWork picks up the exact skills and connections I shared.
 


### PR DESCRIPTION
## What (v4)

Landing section (`#connect-mcp`): **the skills, MCPs, and commands you already run in Claude Code or Cursor move into OpenWork as-is, get shared org-wide, and your team runs them in OpenWork** — developers can also point their own agent at the org. No protocol jargon anywhere in the section.

**Voiceover-first**: script at `evals/voiceovers/landing-connect-mcp.md` (6 frames), coded flow at `evals/flows/landing-connect-mcp.flow.mjs`. The latest passing fraimz comment is the review artifact.

### Section anatomy
- **Header**: "Already doing it in your agent? Add it to OpenWork. Share it with everyone." + subhead (same SKILL.md format, same server URLs — share once, team runs them in OpenWork or from their own agent).
- **Row A — two windows** (flat, one soft shadow each):
  - *Your setup, moved in as-is*: Granola (MCP), Meeting Brief Generator (Skill), review-pr (Command), Linear (MCP) as flat tinted rows + "share your setup in one link" + dark "Share with your org" accent.
  - *Mini OpenWork UI, "Your teammate's view"* (patterned on the enterprise showcase app mock): sidebar lists the same shared items (Meeting Brief active), teammate types "Prep a brief for tomorrow's Acme call…", execution timeline shows "Queried the shared Granola MCP" / "Ran Meeting Brief Generator — shared by your team", brief lands with 3 talking points, Run Task input bar.
- **Row B — flat connect strip** (no card-in-card): "Developers: point your own agent at your org" + agent glyphs, one-row pill picker (Cursor one-click deeplink / Claude Code / OpenCode / VS Code / Any client), dark command block, copy → Copied.
- **Account funnel** (MCP requires sign-in): inline "Works with your OpenWork account — create one free" → app.openworklabs.com?mode=sign-up, and the post-copy steps start with "Create your free account or sign in" → "Pick your org" → "Your team's tools appear".
- Flat server URL row; "Read the docs" → Cloud MCP guide. PostHog `landing_connect_mcp_copy_clicked` {client, copied, method}.

### Design-review history (each round re-proven with fraimz)
- v2: reuse hero-prompt/demo-window/pill-picker patterns; share-once story.
- v3: layout repairs (wrapped pill picker, clipped URL, unbalanced columns); lead with "already doing it in your agent".
- v4: drop search/execute jargon (implementation detail), teammate window is a mini OpenWork UI, flattened shadows/nesting, sign-up funnel added.

## Testing
- `pnpm --filter @openwork-ee/landing exec tsc --noEmit` — pass; `pnpm --filter @openwork-ee/landing build` — pass (proof runs against the prod build).
- `rg -c 'search_capabilities|execute_capability' ee/apps/landing/components/landing-connect-mcp.tsx` — 0 matches.
- **fraimz: PASSED — all 6 frames + voiceover coverage** (headless Chrome via CDP: real clicks, real clipboard readback, deeplink base64 decode === server URL, sign-up href asserted, jargon-absence asserted). Screenshots eyeballed each round; earlier FAILED comments document real repairs.

Repro: `PORT=3111 pnpm --dir ee/apps/landing start` (after build) + headless Chrome `--remote-debugging-port=9333`, then `OPENWORK_EVAL_CDP_URL=http://127.0.0.1:9333 OPENWORK_EVAL_LANDING_URL=http://127.0.0.1:3111 pnpm fraimz --flow landing-connect-mcp`.