### PR TITLE
feat(connections): Polar quick-add preset (OAuth)

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
@@ -51,6 +51,13 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
     authType: "oauth",
   },
   {
+    presetId: "polar",
+    displayName: "Polar",
+    description: "Products, subscriptions, orders, and customer billing.",
+    url: "https://mcp.polar.sh/mcp/polar-mcp",
+    authType: "oauth",
+  },
+  {
     presetId: "slack",
     displayName: "Slack",
     description: "Channels, DMs, and search. Slack has no automatic app registration — paste your Slack app's OAuth client once; each person then connects their own account.",


### PR DESCRIPTION
## What

Adds **Polar** (polar.sh — payments, subscriptions, and merchant-of-record billing for developers) to the Den org-wide External MCP Connections quick-add presets. Companion to Granola (#2555) and Render (#2583).

- `ee/apps/den-api/src/capability-sources/external-mcp-presets.ts`: one new entry (+7 lines), grouped with the plain-OAuth servers (after Granola, before Slack).
- URL: `https://mcp.polar.sh/mcp/polar-mcp` — Polar's official hosted production MCP server ([Polar docs](https://polar.sh/docs/integrate/mcp)). Their sandbox URL (`…/polar-sandbox`) is deliberately not included.
- `authType: "oauth"`, no `requiresOAuthClient`: Polar's server does standard browser OAuth with discovery — each member connects their own Polar account.

## Testing

- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit` — **pass** (clean).
- No unit tests exist for the preset catalog, so none needed updating.
- **No video/screenshot attached** — data-only catalog addition. Reviewer repro:
  1. `pnpm demo:den:reset && pnpm dev:den`
  2. Sign in as the seeded demo admin, open **Dashboard → Connections**
  3. The **Polar** card appears in the quick-add presets; Add starts browser OAuth against `mcp.polar.sh`.