### PR TITLE
fix(installer): avoid Windows server-worker path failure

### DIFF
--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -102,22 +102,22 @@ async function readJsonFile(targetPath, fallback) {
 }
 
 // The bootstrap CLI (packages/openwork-bootstrap) and this app must agree on
-// where desktop-bootstrap.json lives: %APPDATA% on Windows, XDG_CONFIG_HOME
+// where desktop-bootstrap.json lives: %LOCALAPPDATA% on Windows, XDG_CONFIG_HOME
 // (falling back to ~/.config) elsewhere. Resolved once at module load so a
 // mid-session process.env mutation (runtime.mjs buildChildEnv ->
 // Object.assign(process.env)) can never retarget reads to a different file.
 const DEFAULT_DESKTOP_BOOTSTRAP_PATH = (() => {
   // Same precedence as the CLI's configHomeDir(): XDG_CONFIG_HOME everywhere,
-  // then APPDATA on Windows, then ~/.config.
+  // then LOCALAPPDATA on Windows, then ~/.config.
   const configHome =
     process.env.XDG_CONFIG_HOME?.trim() ||
-    (process.platform === "win32" ? process.env.APPDATA?.trim() : "") ||
-    path.join(os.homedir(), process.platform === "win32" ? path.join("AppData", "Roaming") : ".config");
+    (process.platform === "win32" ? process.env.LOCALAPPDATA?.trim() : "") ||
+    path.join(os.homedir(), process.platform === "win32" ? path.join("AppData", "Local") : ".config");
   return path.join(configHome, "openwork", "desktop-bootstrap.json");
 })();
 
 // Older builds resolved the default as ~/.config on every OS, ignoring
-// APPDATA and XDG_CONFIG_HOME. Keep reading that file when the canonical one
+// LOCALAPPDATA and XDG_CONFIG_HOME. Keep reading that file when the canonical one
 // is missing so existing installs keep their deployment config.
 const LEGACY_DESKTOP_BOOTSTRAP_PATH = path.join(os.homedir(), ".config", "openwork", "desktop-bootstrap.json");
 

--- a/apps/installer/src/bootstrap-path.ts
+++ b/apps/installer/src/bootstrap-path.ts
@@ -5,7 +5,7 @@ import path from "node:path"
  * Where the desktop app reads its deployment config. Must agree byte-for-byte
  * with the Electron shell (apps/desktop/electron/workspace-store.mjs) and the
  * bootstrap CLI (packages/openwork-bootstrap/bin/openwork.mjs): XDG_CONFIG_HOME
- * everywhere, then APPDATA on Windows, then the conventional per-OS default.
+ * everywhere, then LOCALAPPDATA on Windows, then the conventional per-OS default.
  */
 export function desktopBootstrapPath(
   env: NodeJS.ProcessEnv = process.env,
@@ -16,8 +16,8 @@ export function desktopBootstrapPath(
 
   const configHome =
     env.XDG_CONFIG_HOME?.trim() ||
-    (platform === "win32" ? env.APPDATA?.trim() : "") ||
-    path.join(os.homedir(), platform === "win32" ? path.join("AppData", "Roaming") : ".config")
+    (platform === "win32" ? env.LOCALAPPDATA?.trim() : "") ||
+    path.join(os.homedir(), platform === "win32" ? path.join("AppData", "Local") : ".config")
   return path.join(configHome, "openwork", "desktop-bootstrap.json")
 }
 

--- a/apps/installer/src/index.ts
+++ b/apps/installer/src/index.ts
@@ -1,10 +1,20 @@
-import { installerConfigSourceLabel, resolveInstallerConfig } from "./config"
+import { spawn } from "node:child_process"
+
+import { installerConfigSourceLabel, resolveInstallerConfig, resolveOptionalInstallerConfig } from "./config"
 import { runInstall } from "./install"
+import { startInstallerServer } from "./server"
 
 const rawArgs = Bun.argv.slice(2)
 const args = new Set(rawArgs)
 const headless = args.has("--headless") || process.env.OPENWORK_INSTALLER_HEADLESS === "1"
 const dryRun = args.has("--dry-run") || process.env.OPENWORK_INSTALLER_DRY_RUN === "1"
+
+type ReadyServer = {
+  url: string
+  token: string
+  onExit: (listener: () => void) => void
+  stop: () => void
+}
 
 function argValue(name: string) {
   const inline = rawArgs.find((entry) => entry.startsWith(`${name}=`))
@@ -13,6 +23,143 @@ function argValue(name: string) {
   }
   const index = rawArgs.indexOf(name)
   return index >= 0 ? rawArgs[index + 1]?.trim() ?? "" : ""
+}
+
+function isReadyMessage(value: unknown): value is { type: "ready"; url: string; token: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "ready" &&
+    "url" in value &&
+    typeof value.url === "string" &&
+    "token" in value &&
+    typeof value.token === "string"
+  )
+}
+
+function isExitMessage(value: unknown): value is { type: "exit" } {
+  return typeof value === "object" && value !== null && "type" in value && value.type === "exit"
+}
+
+async function runServerProcess(): Promise<never> {
+  try {
+    const resolution = await resolveOptionalInstallerConfig()
+    const server = startInstallerServer(resolution, () => console.log(JSON.stringify({ type: "exit" })))
+    console.log(JSON.stringify({ type: "ready", url: server.url, token: server.token }))
+  } catch (error) {
+    console.error(`[openwork-installer] ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(2)
+  }
+  return await new Promise<never>(() => undefined)
+}
+
+if (args.has("--server-worker")) {
+  await runServerProcess()
+}
+
+function selfCommand() {
+  const executable = Bun.argv[0] || process.execPath
+  const script = Bun.argv[1]
+  const virtualScript = script ? script.includes("$bunfs") || /[\\/]~BUN[\\/]/.test(script) : false
+  if (virtualScript) return { command: process.execPath, args: [] }
+  if (!script) return { command: executable, args: [] }
+  return { command: executable, args: [script] }
+}
+
+async function startChildInstallerServer(): Promise<ReadyServer> {
+  const command = selfCommand()
+  const child = spawn(command.command, [...command.args, "--server-worker"], {
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  })
+  const exitListeners = new Set<() => void>()
+  let settled = false
+  let stderr = ""
+  let stdout = ""
+
+  child.stderr.setEncoding("utf8")
+  child.stderr.on("data", (chunk) => {
+    stderr += String(chunk)
+  })
+
+  return await new Promise<ReadyServer>((resolve, reject) => {
+    function fail(error: Error) {
+      if (settled) return
+      settled = true
+      reject(error)
+    }
+
+    function handleLine(line: string) {
+      if (!line) return
+      let payload: unknown
+      try {
+        payload = JSON.parse(line)
+      } catch {
+        return
+      }
+      if (isExitMessage(payload)) {
+        for (const listener of exitListeners) listener()
+      }
+      if (!isReadyMessage(payload) || settled) return
+      settled = true
+      resolve({
+        url: payload.url,
+        token: payload.token,
+        onExit: (listener) => {
+          exitListeners.add(listener)
+        },
+        stop: () => {
+          child.kill()
+        },
+      })
+    }
+
+    child.stdout.setEncoding("utf8")
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk)
+      let newline = stdout.indexOf("\n")
+      while (newline >= 0) {
+        handleLine(stdout.slice(0, newline).trim())
+        stdout = stdout.slice(newline + 1)
+        newline = stdout.indexOf("\n")
+      }
+    })
+    child.on("error", (error) => fail(error))
+    child.on("exit", (code) => {
+      fail(new Error(`installer server exited before it was ready (${code ?? "signal"})${stderr.trim() ? `: ${stderr.trim()}` : ""}`))
+    })
+  })
+}
+
+async function startWorkerInstallerServer(): Promise<ReadyServer> {
+  // Referenced as .js (not .ts): Bun's compiled executables embed the worker
+  // entrypoint as server-worker.js, and its rewrite of .ts worker URLs breaks
+  // when the worker shares imports with the main entrypoint. Bun's resolver
+  // maps the .js specifier back to server-worker.ts when running from source.
+  const worker = new Worker(new URL("./server-worker.js", import.meta.url))
+  return await new Promise<ReadyServer>((resolve, reject) => {
+    worker.onmessage = (event: MessageEvent<{ type: string; url?: string; token?: string; error?: string }>) => {
+      if (event.data.type === "ready" && event.data.url && event.data.token) {
+        resolve({
+          url: event.data.url,
+          token: event.data.token,
+          onExit: (listener) => {
+            worker.addEventListener("message", (event: MessageEvent<{ type: string }>) => {
+              if (event.data.type === "exit") listener()
+            })
+          },
+          stop: () => {
+            worker.terminate()
+          },
+        })
+      } else if (event.data.type === "error") {
+        reject(new Error(event.data.error))
+      }
+    }
+    worker.onerror = (event) => reject(new Error(event.message))
+    worker.postMessage({ type: "start" })
+  })
 }
 
 if (headless) {
@@ -37,28 +184,17 @@ if (headless) {
   process.exit(0)
 }
 
-// UI mode. The HTTP server and install run live on a worker thread; the
-// native window must own the main thread (Cocoa requires it on macOS, and
-// Webview.run() blocks its thread until the window closes).
-// Referenced as .js (not .ts): Bun's compiled executables embed the worker
-// entrypoint as server-worker.js, and its rewrite of .ts worker URLs breaks
-// when the worker shares imports with the main entrypoint. Bun's resolver
-// maps the .js specifier back to server-worker.ts when running from source.
-const worker = new Worker(new URL("./server-worker.js", import.meta.url))
-const ready = await new Promise<{ url: string; token: string }>((resolve, reject) => {
-  worker.onmessage = (event: MessageEvent<{ type: string; url?: string; token?: string; error?: string }>) => {
-    if (event.data.type === "ready" && event.data.url && event.data.token) {
-      resolve({ url: event.data.url, token: event.data.token })
-    } else if (event.data.type === "error") {
-      reject(new Error(event.data.error))
-    }
-  }
-  worker.onerror = (event) => reject(new Error(event.message))
-  worker.postMessage({ type: "start" })
-}).catch((error) => {
+// UI mode. The HTTP server and install run away from the native window's main
+// thread because Webview.run() blocks until the window closes. Windows uses a
+// child copy of this executable instead of Bun Worker: compiled Worker URLs can
+// resolve to Bun's virtual B:/... filesystem there and fail before the server
+// starts.
+const uiServer = await (process.platform === "win32" ? startChildInstallerServer() : startWorkerInstallerServer()).catch((error) => {
   console.error(`[openwork-installer] ${error instanceof Error ? error.message : String(error)}`)
   process.exit(2)
 })
+const ready = { url: uiServer.url, token: uiServer.token }
+process.on("exit", () => uiServer.stop())
 
 async function installIsRunning(): Promise<boolean> {
   try {
@@ -75,6 +211,7 @@ async function exitWhenInstallSettles(): Promise<never> {
   while (await installIsRunning()) {
     await new Promise((resolve) => setTimeout(resolve, 500))
   }
+  uiServer.stop()
   process.exit(0)
 }
 
@@ -88,9 +225,7 @@ if (process.env.OPENWORK_INSTALLER_UI === "manual") {
   // browser (headless CI, remote debugging, UI evals). The URL is printed so
   // the operator can attach their own browser.
   console.log(`[openwork-installer] UI ready at ${ready.url}`)
-  worker.addEventListener("message", (event: MessageEvent<{ type: string }>) => {
-    if (event.data.type === "exit") void exitWhenInstallSettles()
-  })
+  uiServer.onExit(() => void exitWhenInstallSettles())
 } else {
 try {
   const { Webview, SizeHint } = await import("webview-bun")
@@ -106,8 +241,6 @@ try {
   // Native webview unavailable (e.g. no WebkitGTK): same UI in the browser.
   console.warn(`[openwork-installer] native window unavailable (${error instanceof Error ? error.message : String(error)}); opening browser UI`)
   openInBrowser(ready.url)
-  worker.addEventListener("message", (event: MessageEvent<{ type: string }>) => {
-    if (event.data.type === "exit") void exitWhenInstallSettles()
-  })
+  uiServer.onExit(() => void exitWhenInstallSettles())
 }
 }

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -20,9 +20,9 @@ describe("desktopBootstrapPath", () => {
     expect(desktopBootstrapPath({ XDG_CONFIG_HOME: "/xdg" }, "win32")).toBe(path.join("/xdg", "openwork", "desktop-bootstrap.json"))
   })
 
-  test("uses APPDATA on Windows and ~/.config elsewhere", () => {
-    expect(desktopBootstrapPath({ APPDATA: "C:\\Users\\u\\AppData\\Roaming" }, "win32")).toBe(
-      path.join("C:\\Users\\u\\AppData\\Roaming", "openwork", "desktop-bootstrap.json"),
+  test("uses LOCALAPPDATA on Windows and ~/.config elsewhere", () => {
+    expect(desktopBootstrapPath({ LOCALAPPDATA: "C:\\Users\\u\\AppData\\Local" }, "win32")).toBe(
+      path.join("C:\\Users\\u\\AppData\\Local", "openwork", "desktop-bootstrap.json"),
     )
     expect(desktopBootstrapPath({}, "darwin")).toBe(path.join(os.homedir(), ".config", "openwork", "desktop-bootstrap.json"))
   })

--- a/docs/org-install-links.md
+++ b/docs/org-install-links.md
@@ -80,7 +80,7 @@ installer and bootstrap CLI:
 
 | OS | Canonical path |
 |---|---|
-| Windows | `%APPDATA%\openwork\desktop-bootstrap.json` (`%XDG_CONFIG_HOME%\openwork\desktop-bootstrap.json` wins first if your environment sets it) |
+| Windows | `%LOCALAPPDATA%\openwork\desktop-bootstrap.json` (`%XDG_CONFIG_HOME%\openwork\desktop-bootstrap.json` wins first if your environment sets it) |
 | macOS/Linux | `$XDG_CONFIG_HOME/openwork/desktop-bootstrap.json`, falling back to `~/.config/openwork/desktop-bootstrap.json` |
 
 Older desktop builds also wrote `~/.config/openwork/desktop-bootstrap.json` on

--- a/packages/openwork-bootstrap/bin/openwork.mjs
+++ b/packages/openwork-bootstrap/bin/openwork.mjs
@@ -124,9 +124,9 @@ function configHomeDir() {
   if (process.env.XDG_CONFIG_HOME) return process.env.XDG_CONFIG_HOME
   if (process.platform === "win32") {
     // Match the Electron shell (apps/desktop/electron/workspace-store.mjs):
-    // APPDATA, then the conventional Roaming dir — never ~/.config on Windows.
-    if (process.env.APPDATA) return process.env.APPDATA
-    return join(process.env.USERPROFILE || process.env.HOME || process.cwd(), "AppData", "Roaming")
+    // LOCALAPPDATA, then the conventional Local dir — never ~/.config on Windows.
+    if (process.env.LOCALAPPDATA) return process.env.LOCALAPPDATA
+    return join(process.env.USERPROFILE || process.env.HOME || process.cwd(), "AppData", "Local")
   }
   return join(process.env.HOME || process.cwd(), ".config")
 }


### PR DESCRIPTION
## Summary
- avoid Bun Worker startup for the Windows installer UI by launching the loopback installer server in a child copy of the installer executable
- keep macOS/Linux on the existing Worker path
- move the Windows desktop bootstrap path from `%APPDATA%`/Roaming to `%LOCALAPPDATA%`/Local across installer, desktop reader, bootstrap CLI, tests, and docs

## Tests
- `pnpm --filter @openwork/installer test` ✅
- `pnpm --filter @openwork/desktop test -- electron/workspace-store.test.mjs` ✅
- `pnpm --filter openwork-bootstrap check` ✅
- `pnpm --filter openwork-bootstrap test` ✅
- `pnpm --filter @openwork/installer compile` ✅
- `bun build --compile --minify --target=bun-windows-x64 src/index.ts src/server-worker.ts --outfile dist/openwork-installer-win` ✅
- forced Windows UI-server path on macOS with `bun build --compile --minify --define process.platform='"win32"' src/index.ts src/server-worker.ts --outfile dist/openwork-installer-force-win && OPENWORK_INSTALLER_UI=manual ./dist/openwork-installer-force-win`; it printed `UI ready at http://127.0.0.1:...` ✅

## Fraimz / proof
- No fraimz artifact attached: I could not drive a real Windows installer UI in this local macOS worktree. The PR includes focused tests plus a Windows-target compile and a forced Windows server-start smoke check.