### PR TITLE
fix(den-api): verify Entra SSO domains by issuer

### DIFF
--- a/ee/apps/den-api/src/sso-entra-domain.ts
+++ b/ee/apps/den-api/src/sso-entra-domain.ts
@@ -14,18 +14,5 @@ function getMicrosoftTenantId(value: string) {
 }
 
 export function isMicrosoftEntraManagedDomain(input: { domain: string; issuer: string; entryPoint?: string | null }) {
-  if (!input.domain.toLowerCase().endsWith(".onmicrosoft.com")) {
-    return false
-  }
-
-  const issuerTenantId = getMicrosoftTenantId(input.issuer)
-  if (!issuerTenantId) {
-    return false
-  }
-
-  if (input.entryPoint) {
-    return getMicrosoftTenantId(input.entryPoint) === issuerTenantId
-  }
-
-  return true
+  return getMicrosoftTenantId(input.issuer) !== null
 }

--- a/ee/apps/den-api/test/sso-entra-domain.test.ts
+++ b/ee/apps/den-api/test/sso-entra-domain.test.ts
@@ -3,7 +3,7 @@ import { isMicrosoftEntraManagedDomain } from "../src/sso-entra-domain.js"
 
 const tenantId = "2b853de0-b14b-4433-90be-cced1b963647"
 
-test("recognizes Microsoft Entra managed onmicrosoft.com SAML domains", () => {
+test("recognizes Microsoft Entra issuer URLs", () => {
   expect(isMicrosoftEntraManagedDomain({
     domain: "omaropenworklabs.onmicrosoft.com",
     issuer: `https://sts.windows.net/${tenantId}/`,
@@ -11,18 +11,34 @@ test("recognizes Microsoft Entra managed onmicrosoft.com SAML domains", () => {
   })).toBe(true)
 })
 
-test("rejects mismatched Entra tenant URLs for managed domains", () => {
+test("ignores mismatched entry point tenant URLs", () => {
   expect(isMicrosoftEntraManagedDomain({
     domain: "omaropenworklabs.onmicrosoft.com",
     issuer: `https://sts.windows.net/${tenantId}/`,
     entryPoint: "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/saml2",
-  })).toBe(false)
+  })).toBe(true)
 })
 
-test("keeps custom domains on DNS verification", () => {
+test("ignores custom domains for Microsoft Entra issuer URLs", () => {
   expect(isMicrosoftEntraManagedDomain({
     domain: "openworklabs.com",
     issuer: `https://sts.windows.net/${tenantId}/`,
+    entryPoint: `https://login.microsoftonline.com/${tenantId}/saml2`,
+  })).toBe(true)
+})
+
+test("rejects non-Microsoft issuer URLs", () => {
+  expect(isMicrosoftEntraManagedDomain({
+    domain: "omaropenworklabs.onmicrosoft.com",
+    issuer: `https://idp.example.com/${tenantId}/`,
+    entryPoint: `https://login.microsoftonline.com/${tenantId}/saml2`,
+  })).toBe(false)
+})
+
+test("rejects Microsoft issuer URLs without tenant UUIDs", () => {
+  expect(isMicrosoftEntraManagedDomain({
+    domain: "omaropenworklabs.onmicrosoft.com",
+    issuer: "https://login.microsoftonline.com/common/v2.0",
     entryPoint: `https://login.microsoftonline.com/${tenantId}/saml2`,
   })).toBe(false)
 })


### PR DESCRIPTION
## Summary
- Auto-verify SSO domains when the issuer URL is a Microsoft Entra tenant URL.
- Ignore the configured domain and SAML entry point for this Entra bypass.
- Update Entra domain verification tests for issuer-only behavior.

## Tests
- `bun test ee/apps/den-api/test/sso-entra-domain.test.ts` — 5 pass, 0 fail

## Proof
- No screenshot/video captured: this is backend issuer parsing/domain-verification logic with focused unit test coverage and no UI flow changed.