### PR TITLE
fix(installer): make bootstrap cleanup test portable

### DIFF
--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -317,7 +317,7 @@ describe("writeBootstrapConfig", () => {
       }))
       const written = writeBootstrapConfig(
         { clientName: "Acme", webUrl: "https://openwork.acme.com", apiUrl: "https://openwork-api.acme.com", requireSignin: true, logoUrl: null },
-        { OPENWORK_DESKTOP_BOOTSTRAP_PATH: target, HOME: home },
+        { OPENWORK_DESKTOP_BOOTSTRAP_PATH: target, HOME: home, USERPROFILE: home },
       )
       expect(written).toBe(target)
       const parsed = JSON.parse(readFileSync(target, "utf8"))


### PR DESCRIPTION
## Summary
- Fix the Windows failure in `Build Client Installer` by making the `writeBootstrapConfig` test pass a fake `USERPROFILE` alongside fake `HOME`.
- The production code already uses `USERPROFILE` for the Windows legacy bootstrap path, so the test now creates and cleans up the same legacy path on Windows and macOS.

## Failed run diagnosed
- `Build Client Installer` run `28953413371` failed in the Windows matrix during `cd apps/installer && bun test`.
- Failure: `existsSync(legacy)` stayed true because the test-created legacy path used fake `HOME`, while Windows cleanup resolved legacy through `USERPROFILE`.

## Tests
- `pnpm --filter @openwork/installer test` ✅
- `pnpm --filter @openwork/installer compile` ✅
- `bun build --compile --minify --target=bun-windows-x64 src/index.ts src/server-worker.ts --outfile dist/openwork-installer-win` ✅

## Fraimz / proof
- Skipped: this is a CI portability test fix only; no user-facing runtime path changed.