### PR TITLE
feat(extensions): hide built-in OpenWork MCPs by default; UI-control preview surface becomes opt-in

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -170,6 +170,10 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     oauth: true,
     kind: "mcp",
     iconSrc: "/openwork-mark.svg",
+    // Auto-managed by the signed-in cloud reconciler (syncCloudControlMcp):
+    // configured + enabled while signed in to OpenWork Cloud. Hidden from the
+    // default catalog; "Show hidden" reveals it.
+    defaultHidden: true,
   },
   {
     get name() { return t("mcp.quick_connect_openwork_admin_title"); },
@@ -201,6 +205,9 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     oauth: false,
     kind: "ui-control",
     iconSrc: "/openwork-mark.svg",
+    // Internal UI-control surface for agents driving the desktop app. Hidden
+    // from the default catalog; "Show hidden" reveals it.
+    defaultHidden: true,
   },
   ...BUILT_IN_OPENWORK_EXTENSION_MANIFESTS.map(extensionManifestToDirectoryInfo),
 ];

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -400,6 +400,15 @@ export function McpView(props: McpViewProps) {
       );
     });
 
+  // Auto-configured built-ins like openwork-cloud remain active but hidden from
+  // Your apps until Show hidden reveals the row for disable/remove.
+  const visibleMcpServers = showHidden
+    ? props.mcpServers
+    : props.mcpServers.filter((entry) => {
+        const match = resolveQuickConnectMatch(entry.name);
+        return !match || !isOpenWorkExtensionHidden(match);
+      });
+
   const displayName = (name: string) => resolveQuickConnectMatch(name)?.name ?? name;
 
   const quickConnectStatus = (entry: McpDirectoryInfo) =>
@@ -640,7 +649,7 @@ export function McpView(props: McpViewProps) {
       />
 
       <McpConfiguredServersSection
-        servers={props.mcpServers}
+        servers={visibleMcpServers}
         statuses={props.mcpStatuses}
         lastUpdatedAt={props.mcpLastUpdatedAt}
         selectedMcp={props.selectedMcp}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1914,6 +1914,15 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     }
   };
 
+  // Hooks must run unconditionally: this useCallback used to sit below the
+  // redirect returns, so the bare <-> workspace-scoped settings transition
+  // changed the hook count and crashed the whole settings surface
+  // ("Rendered more/fewer hooks than during the previous render").
+  const refreshConnectMarketplaceItems = useCallback(
+    () => extensionsStore.refreshCloudOrgMarketplaces({ force: true }),
+    [extensionsStore],
+  );
+
   if (route.redirectPath && !props.embedded) {
     const target = selectedWorkspaceId
       ? workspaceSettingsRoute(selectedWorkspaceId, route.redirectPath)
@@ -1928,10 +1937,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const openCloudAccountSettings = () => {
     navigateSettingsPath("cloud-account");
   };
-  const refreshConnectMarketplaceItems = useCallback(
-    () => extensionsStore.refreshCloudOrgMarketplaces({ force: true }),
-    [extensionsStore],
-  );
 
   const settingsView = (() => {
     switch (route.tab) {

--- a/apps/app/tests/builtin-mcp-visibility.test.ts
+++ b/apps/app/tests/builtin-mcp-visibility.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { MCP_QUICK_CONNECT } from "../src/app/constants";
+
+describe("built-in OpenWork MCP visibility", () => {
+  test("hides internal OpenWork MCPs by default", () => {
+    expect(MCP_QUICK_CONNECT.find((entry) => entry.serverName === "openwork-cloud")?.defaultHidden).toBe(true);
+    expect(MCP_QUICK_CONNECT.find((entry) => entry.serverName === "openwork-admin")?.defaultHidden).toBe(true);
+    expect(MCP_QUICK_CONNECT.find((entry) => entry.serverName === "openwork-ui")?.defaultHidden).toBe(true);
+  });
+
+  test("keeps directory apps visible by default", () => {
+    expect(MCP_QUICK_CONNECT.find((entry) => entry.serverName === "notion")?.defaultHidden).toBeUndefined();
+    expect(MCP_QUICK_CONNECT.find((entry) => entry.serverName === "linear")?.defaultHidden).toBeUndefined();
+  });
+});

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -5,6 +5,7 @@ import { OpenWorkExtensionsPreview } from "./openwork-extensions-preview.js";
 
 const originalServerUrl = process.env.OPENWORK_SERVER_URL;
 const originalServerToken = process.env.OPENWORK_SERVER_TOKEN;
+const originalUiControlTools = process.env.OPENWORK_UI_CONTROL_TOOLS;
 const stops: Array<() => void> = [];
 
 const searchResultSchema = z.object({
@@ -36,7 +37,15 @@ afterEach(() => {
   else process.env.OPENWORK_SERVER_URL = originalServerUrl;
   if (originalServerToken === undefined) delete process.env.OPENWORK_SERVER_TOKEN;
   else process.env.OPENWORK_SERVER_TOKEN = originalServerToken;
+  if (originalUiControlTools === undefined) delete process.env.OPENWORK_UI_CONTROL_TOOLS;
+  else process.env.OPENWORK_UI_CONTROL_TOOLS = originalUiControlTools;
 });
+
+async function transformedSystem(plugin: Awaited<ReturnType<typeof OpenWorkExtensionsPreview>>): Promise<string> {
+  const output: { system: string[] } = { system: [] };
+  await plugin["experimental.chat.system.transform"]({}, output);
+  return output.system.join("\n");
+}
 
 function startFakeOpenWorkServer() {
   const requests: Array<{ pathname: string; search: string; authorization: string | null }> = [];
@@ -164,5 +173,36 @@ describe("OpenWorkExtensionsPreview session tools", () => {
         text: "We decided to ship the archive importer first.",
       },
     ]);
+  });
+});
+
+describe("OpenWorkExtensionsPreview UI control tools", () => {
+  test("omits UI-control tools and steering by default", async () => {
+    delete process.env.OPENWORK_UI_CONTROL_TOOLS;
+    const plugin = await OpenWorkExtensionsPreview();
+    const tools = Object.keys(plugin.tool);
+
+    expect(tools).not.toContain("openwork_ui_snapshot");
+    expect(tools).not.toContain("openwork_ui_list_actions");
+    expect(tools).not.toContain("openwork_ui_execute_action");
+    expect(tools).toContain("openwork_session_search");
+    expect(tools).toContain("openwork_extension_list_actions");
+
+    const system = await transformedSystem(plugin);
+    expect(system).not.toContain("openwork_ui_");
+    expect(system).toContain("openwork_session_search");
+  });
+
+  test("registers UI-control tools and steering when opted in", async () => {
+    process.env.OPENWORK_UI_CONTROL_TOOLS = "1";
+    const plugin = await OpenWorkExtensionsPreview();
+    const tools = Object.keys(plugin.tool);
+
+    expect(tools).toContain("openwork_ui_snapshot");
+    expect(tools).toContain("openwork_ui_list_actions");
+    expect(tools).toContain("openwork_ui_execute_action");
+
+    const system = await transformedSystem(plugin);
+    expect(system).toContain("openwork_ui_execute_action");
   });
 });

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -122,14 +122,16 @@ To open settings: openwork_ui_execute_action with actionId "settings.panel.open"
 To add a provider: openwork_ui_execute_action with actionId "settings.provider.add" and optional args {providerId:"anthropic"}
 To see what the user sees: openwork_ui_snapshot
 To list all available actions: openwork_ui_list_actions
-To ask what OpenWork can do: openwork_ui_execute_action with actionId "help.capabilities"
+To ask what OpenWork can do: openwork_ui_execute_action with actionId "help.capabilities"`;
 
-## Cross-session memory
+const OPENWORK_SESSION_MEMORY_INSTRUCTION =
+  `## Cross-session memory
 When the user asks what they said, what happened, or what was decided in another OpenWork chat/session, treat it as a session-history lookup, not hidden model memory.
 Use openwork_session_search first to search session titles and message transcripts across workspaces. If there is one clear match, use openwork_session_read with the returned sessionId/workspaceId to retrieve transcript context without navigating the UI.
-Answer only from the returned search/read results. If multiple sessions match, ask a short clarifying question. If the returned transcript is limited or missing the older context needed, say so instead of guessing.
+Answer only from the returned search/read results. If multiple sessions match, ask a short clarifying question. If the returned transcript is limited or missing the older context needed, say so instead of guessing.`;
 
-Do NOT use browser_navigate, browser_click, or browser_snapshot to interact with the OpenWork app itself. Those are for browsing external websites.
+const OPENWORK_BROWSER_INSTRUCTION =
+  `Do NOT use browser_navigate, browser_click, or browser_snapshot to interact with the OpenWork app itself. Those are for browsing external websites.
 
 ## Built-in Browser (external websites)
 For web browsing tasks, ALWAYS start with openwork_browser_open_url. It creates/selects a built-in OpenWork browser tab and returns browser_url plus target_id. Use that exact browser_url and target_id for every later browser_snapshot, browser_click, browser_fill, browser_eval, and browser_screenshot call.
@@ -171,6 +173,16 @@ function userAppDataDir(): string {
   if (platform() === "darwin") return join(homedir(), "Library", "Application Support");
   if (platform() === "win32") return process.env.APPDATA || join(homedir(), "AppData", "Roaming");
   return process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+}
+
+// The agent-facing UI-control surface (system steering + openwork_ui_* tools)
+// is opt-in: it noises every session's prompt/tool list, and the supported way
+// to grant agents UI control is the hidden "OpenWork UI Control" MCP in
+// Settings -> Extensions. Set OPENWORK_UI_CONTROL_TOOLS=1 to re-enable the
+// built-in preview surface (used by internal tooling).
+function uiControlToolsEnabled(): boolean {
+  const raw = process.env.OPENWORK_UI_CONTROL_TOOLS?.trim().toLowerCase() ?? "";
+  return raw === "1" || raw === "true";
 }
 
 function uiControlDiscoveryPaths(): string[] {
@@ -597,10 +609,14 @@ function contextPayload(context: OpenCodeContext) {
   };
 }
 
-export const OpenWorkExtensionsPreview = async () => ({
+export const OpenWorkExtensionsPreview = async () => {
+  const uiControlEnabled = uiControlToolsEnabled();
+  return {
   "experimental.chat.system.transform": async (_input: unknown, output: { system: string[] }) => {
     output.system.push(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
-    output.system.push(OPENWORK_UI_CONTROL_INSTRUCTION);
+    output.system.push(OPENWORK_SESSION_MEMORY_INSTRUCTION);
+    output.system.push(OPENWORK_BROWSER_INSTRUCTION);
+    if (uiControlEnabled) output.system.push(OPENWORK_UI_CONTROL_INSTRUCTION);
   },
   tool: {
     openwork_extension_list_actions: {
@@ -632,6 +648,7 @@ export const OpenWorkExtensionsPreview = async () => ({
         return JSON.stringify(payload, null, 2);
       },
     },
+    ...(uiControlEnabled ? {
     openwork_ui_snapshot: {
       description: "Get a snapshot of the current OpenWork UI state: active route, narration, visible actions, and status. Use this to understand what the user sees before taking action.",
       args: {},
@@ -660,6 +677,7 @@ export const OpenWorkExtensionsPreview = async () => ({
         return JSON.stringify(result, null, 2);
       },
     },
+    } : {}),
     openwork_session_search: {
       description: "Search OpenWork past chat sessions by title and full message transcript text without navigating the UI. Use this when the user refers to another/past chat or asks what was said, decided, or done previously.",
       args: sessionSearchArgsSchema.shape,
@@ -727,4 +745,5 @@ export const OpenWorkExtensionsPreview = async () => ({
       },
     },
   },
-});
+  };
+};

--- a/docs/mcp-ui-control-profile.md
+++ b/docs/mcp-ui-control-profile.md
@@ -47,6 +47,10 @@ For requests like `What did I say in the customer migration session?` or `Remind
 
 This may navigate OpenWork away from the user's current session while the lookup runs. If multiple sessions match, ask which one to inspect.
 
+### OpenWork agents
+
+Inside OpenWork, the supported way to grant an agent this UI-control surface is **Settings -> Extensions -> Show hidden**, then connect the hidden **OpenWork UI Control** MCP. The built-in preview tools injected by the extensions-preview plugin (`openwork_ui_*`) are disabled by default to keep sessions uncluttered; set `OPENWORK_UI_CONTROL_TOOLS=1` only for internal tooling that still needs that preview surface.
+
 ## Install
 
 ```bash

--- a/evals/flows/builtin-mcps-hidden-by-default.flow.mjs
+++ b/evals/flows/builtin-mcps-hidden-by-default.flow.mjs
@@ -1,0 +1,91 @@
+/**
+ * Built-in OpenWork MCPs stay out of the default Extensions list but remain
+ * available behind Show hidden for inspection, disable, or removal.
+ */
+
+const revealHidden = async (ctx) => {
+  const showing = await ctx.eval("document.body.innerText.includes('Showing hidden')");
+  if (!showing) await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+};
+
+export default {
+  id: "builtin-mcps-hidden-by-default",
+  title: "Built-in OpenWork MCPs are hidden by default and revealed by Show hidden",
+  spec: "evals/browser-extension-flows.md",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000 });
+      },
+    },
+    {
+      name: "Navigate to Settings → Extensions → MCP",
+      run: async (ctx) => {
+        await ctx.navigateHash("/settings/extensions/mcp");
+        await ctx.expectHashIncludes("/settings/extensions/mcp");
+        await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+        await ctx.waitFor(
+          "document.body.innerText.toLowerCase().includes('available apps')",
+          { timeoutMs: 30_000, label: "available apps section" },
+        );
+      },
+    },
+    {
+      name: "Built-in OpenWork MCPs are hidden by default",
+      run: async (ctx) => {
+        const directoryEntry = await ctx.hasText("Notion") ? "Notion" : "Linear";
+        await ctx.prove("Built-in OpenWork MCPs are hidden from the default extensions list", {
+          voiceover: "The regular MCP directory still renders in Settings, but OpenWork's internal control entries are not listed by default.",
+          assert: async () => {
+            ctx.assert(await ctx.hasText(directoryEntry), "Expected Notion or Linear to prove the catalog rendered.");
+            await ctx.expectNoText("OpenWork Cloud Control");
+            await ctx.expectNoText("OpenWork UI Control");
+            const hasHiddenCount = await ctx.eval("document.body.innerText.includes('Show hidden (')");
+            ctx.assert(hasHiddenCount, "Expected Show hidden to advertise a hidden count.");
+          },
+          screenshot: {
+            name: "builtin-mcps-hidden-default",
+            claim: "OpenWork Cloud Control and OpenWork UI Control are hidden from the default extensions list while the rest of the catalog renders.",
+            requireText: ["Show hidden", directoryEntry],
+            rejectText: ["OpenWork Cloud Control", "OpenWork UI Control", "Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+    {
+      name: "Show hidden reveals both entries",
+      run: async (ctx) => {
+        await ctx.prove("Show hidden reveals both built-in OpenWork MCP entries", {
+          voiceover: "When the user asks to show hidden extensions, both built-in OpenWork MCP controls appear for inspection or management.",
+          action: async () => {
+            await revealHidden(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 30_000 });
+            await ctx.expectText("OpenWork UI Control", { timeoutMs: 30_000 });
+            await ctx.waitFor("document.body.innerText.includes('Showing hidden')", {
+              timeoutMs: 10_000,
+              label: "hidden entries revealed",
+            });
+            await ctx.eval(`(() => {
+              const buttons = [...document.querySelectorAll("button")];
+              const card = buttons.find((el) => (el.textContent ?? "").includes("OpenWork UI Control"));
+              card?.scrollIntoView({ block: "center" });
+              return Boolean(card);
+            })()`);
+          },
+          screenshot: {
+            name: "builtin-mcps-revealed",
+            claim: "Show hidden reveals OpenWork Cloud Control and OpenWork UI Control with hidden styling.",
+            requireText: ["OpenWork Cloud Control", "OpenWork UI Control", "Showing hidden"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions/mcp",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/cloud-mcp-auto-config.flow.mjs
+++ b/evals/flows/cloud-mcp-auto-config.flow.mjs
@@ -1,7 +1,8 @@
 /**
  * After cloud sign-in, the Den cloud MCP ("OpenWork Cloud Control") is
  * auto-configured with a first-party org-scoped token: no browser OAuth,
- * entry appears under YOUR APPS, sync marker persisted.
+ * entry is hidden by default until Show hidden reveals it, sync marker
+ * persisted.
  *
  * Requires the programmatic runner (evals/runner) and a reachable Den API:
  * - OPENWORK_EVAL_DEN_API_URL    Den API base, e.g. http://127.0.0.1:8790
@@ -11,6 +12,12 @@
  * plane (desktop-bootstrap.json) and signed out at start, or already signed
  * in to the same account.
  */
+
+const revealHidden = async (ctx) => {
+  const showing = await ctx.eval("document.body.innerText.includes('Showing hidden')");
+  if (!showing) await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+};
+
 export default {
   id: "cloud-mcp-auto-config",
   title: "Cloud MCP auto-configures with first-party token on sign-in",
@@ -76,14 +83,18 @@ export default {
       },
     },
     {
-      name: "OpenWork Cloud Control appears as a configured app",
+      name: "OpenWork Cloud Control is hidden by default and revealed as a configured app",
       run: async (ctx) => {
         await ctx.navigateHash("/settings/extensions/mcp");
         await ctx.expectHashIncludes("/settings/extensions/mcp");
+        await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+        await ctx.expectNoText("OpenWork Cloud Control");
+        await revealHidden(ctx);
         await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 30_000 });
         await ctx.screenshot("cloud-mcp-configured", {
-          claim: "OpenWork Cloud Control appears in MCP settings after cloud sign-in sync.",
-          requireText: ["OpenWork Cloud Control"],
+          claim: "OpenWork Cloud Control is auto-configured while hidden by default, then appears after Show hidden.",
+          voiceover: "After signing in to OpenWork Cloud the connection is already configured and enabled, and it only shows up once the user reveals hidden extensions.",
+          requireText: ["OpenWork Cloud Control", "Showing hidden"],
           rejectText: ["Something went wrong"],
           hashIncludes: "/settings/extensions/mcp",
         });

--- a/evals/flows/cloud-mcp-auto-config.flow.mjs
+++ b/evals/flows/cloud-mcp-auto-config.flow.mjs
@@ -61,6 +61,9 @@ export default {
           "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
           { timeoutMs: 30_000, label: "persisted den auth token" },
         );
+        // Post-sign-in org onboarding may appear; drive through it best-effort.
+        await ctx.clickText("Continue with organization", { timeoutMs: 10_000 }).catch(() => {});
+        await ctx.clickText("Continue to workspace", { timeoutMs: 10_000 }).catch(() => {});
       },
     },
     {

--- a/evals/flows/cloud-mcp-disable-sticks.flow.mjs
+++ b/evals/flows/cloud-mcp-disable-sticks.flow.mjs
@@ -14,10 +14,12 @@
  * (plus an enabled:false guard), and fixes the marker margin. This flow
  * drives the real app:
  *   1. Sign in to OpenWork Cloud via desktop handoff.
- *   2. Wait for the reconciler to auto-configure openwork-cloud.
+ *   2. Reveal hidden extensions and wait for the reconciler to auto-configure
+ *      openwork-cloud.
  *   3. Disable it via the Settings toggle.
  *   4. Remount settings (the exact trigger that used to resurrect it) and
- *      assert it is still Paused and the intent record persists.
+ *      reveal hidden again, then assert it is still Paused and the intent
+ *      record persists.
  *   5. Re-enable it and assert the intent record clears.
  *
  * Required env:
@@ -28,6 +30,11 @@
 const CLOUD_TITLE = "OpenWork Cloud Control";
 const USER_STATE_KEY = "openwork.den.mcp.cloudControlUserState";
 const CLICK_ANY = "button, [role=button], a, div, article, li, label";
+
+const revealHidden = async (ctx) => {
+  const showing = await ctx.eval("document.body.innerText.includes('Showing hidden')");
+  if (!showing) await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+};
 
 // The configured-server row shows the friendly status next to the title;
 // catalog cards do not. Use that to target the configured row.
@@ -137,6 +144,7 @@ export default {
         await ctx.navigateHash("/settings/extensions/mcp");
         await ctx.waitFor("window.location.hash.includes('/settings/extensions/mcp')", { timeoutMs: 30_000 });
         await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+        await revealHidden(ctx);
         await ctx.waitFor(cloudRowExpr(CONFIGURED_STATUSES), {
           timeoutMs: 90_000,
           label: "openwork-cloud configured row",
@@ -215,6 +223,7 @@ export default {
             await ctx.navigateHash("/settings/extensions/mcp");
             await ctx.waitFor("window.location.hash.includes('/settings/extensions/mcp')", { timeoutMs: 20_000 });
             await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+            await revealHidden(ctx);
             // Give the sync tick time to run (it fires on mount).
             await new Promise((resolve) => setTimeout(resolve, 6_000));
           },

--- a/evals/flows/desktop-org-mcp-demo.flow.mjs
+++ b/evals/flows/desktop-org-mcp-demo.flow.mjs
@@ -40,6 +40,11 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const revealHidden = async (ctx) => {
+  const showing = await ctx.eval("document.body.innerText.includes('Showing hidden')");
+  if (!showing) await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+};
+
 async function denApiFetch(path, options = {}) {
   const response = await fetch(`${DEN_API_URL}${path}`, {
     ...options,
@@ -472,6 +477,7 @@ export default {
       name: "OpenWork Cloud Control is ready",
       run: async (ctx) => {
         await openMcpSettings(ctx);
+        await revealHidden(ctx);
         await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 30_000 });
 
         const alreadyConnected = await ctx.eval(`(() => {

--- a/evals/flows/mcp-cloud-force-sync.flow.mjs
+++ b/evals/flows/mcp-cloud-force-sync.flow.mjs
@@ -12,6 +12,12 @@
  * with an active org and a workspace open — the state mcp-connections-
  * desktop-e2e.flow.mjs ends in. Fails fast with a clear message otherwise.
  */
+
+const revealHidden = async (ctx) => {
+  const showing = await ctx.eval("document.body.innerText.includes('Showing hidden')");
+  if (!showing) await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+};
+
 export default {
   id: "mcp-cloud-force-sync",
   title: "Refresh force-syncs the cloud MCP (marker bypassed, token re-minted)",
@@ -35,6 +41,7 @@ export default {
         const settingsPath = workspaceId ? `/workspace/${workspaceId}/settings/extensions/mcp` : "/settings/extensions/mcp";
         await ctx.navigateHash(settingsPath);
         await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+        await revealHidden(ctx);
         // Let the on-mount auto-sync fully settle first (it may legitimately
         // re-sync if the marker aged past the refresh margin). THEN take the
         // baseline: at this point the marker is maximally fresh, so without

--- a/evals/flows/mcp-connections-desktop-e2e.flow.mjs
+++ b/evals/flows/mcp-connections-desktop-e2e.flow.mjs
@@ -54,6 +54,11 @@ const state = {
   chatStartedAt: null,
 };
 
+const revealHidden = async (ctx) => {
+  const showing = await ctx.eval("document.body.innerText.includes('Showing hidden')");
+  if (!showing) await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+};
+
 async function denApiFetch(path, options = {}) {
   const response = await fetch(`${DEN_API_URL}${path}`, {
     ...options,
@@ -254,6 +259,8 @@ export default {
         const workspaceId = await ctx.eval("(window.location.hash.match(/\\/workspace\\/([^/]+)/) ?? [])[1] ?? null");
         ctx.assert(Boolean(workspaceId), "No workspace id in URL.");
         await ctx.navigateHash(`/workspace/${workspaceId}/settings/extensions/mcp`);
+        await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+        await revealHidden(ctx);
         await ctx.waitFor(
           "Boolean(localStorage.getItem('openwork.den.mcp.sync'))",
           { timeoutMs: 120_000, label: "openwork.den.mcp.sync marker" },

--- a/evals/flows/mcp-search-capabilities.flow.mjs
+++ b/evals/flows/mcp-search-capabilities.flow.mjs
@@ -18,6 +18,11 @@
  * - OPENWORK_EVAL_DEN_TOKEN      Bearer session token for the demo owner
  */
 
+const revealHidden = async (ctx) => {
+  const showing = await ctx.eval("document.body.innerText.includes('Showing hidden')");
+  if (!showing) await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+};
+
 async function denFetch(ctx, path, options = {}) {
   const base = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
   const response = await fetch(`${base}${path}`, {
@@ -160,6 +165,8 @@ export default {
           action: async () => {
             await ctx.navigateHash("/settings/extensions/mcp");
             await ctx.expectHashIncludes("/settings/extensions/mcp");
+            await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+            await revealHidden(ctx);
           },
           assert: async () => {
             await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 30_000 });

--- a/evals/flows/org-google-workspace-demo.flow.mjs
+++ b/evals/flows/org-google-workspace-demo.flow.mjs
@@ -51,6 +51,11 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const revealHidden = async (ctx) => {
+  const showing = await ctx.eval("document.body.innerText.includes('Showing hidden')");
+  if (!showing) await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+};
+
 async function denApiFetch(path, options = {}) {
   const response = await fetch(`${DEN_API_URL}${path}`, {
     ...options,
@@ -455,6 +460,7 @@ export default {
           voiceover: vo[4],
           action: async () => {
             await openMcpSettings(ctx);
+            await revealHidden(ctx);
             await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 30_000 });
             const alreadyConnected = await ctx.eval(`(() => {
               const card = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('OpenWork Cloud Control'));

--- a/evals/flows/settings-extensions-mcp.flow.mjs
+++ b/evals/flows/settings-extensions-mcp.flow.mjs
@@ -1,9 +1,16 @@
 /**
- * The MCP settings view renders: connected built-in apps, the custom-app
- * entry point, the My Extensions / Marketplace tabs, and — regression guard
- * for #2008 — the unconfigured quick-connect directory (Notion, OpenWork
- * Cloud Control, ...) so MCP discovery works without a cloud sign-in.
+ * The MCP settings view renders the custom-app entry point, the My Extensions /
+ * Marketplace tabs, and — regression guard
+ * for #2008 — the unconfigured quick-connect directory (Notion/Linear) so MCP
+ * discovery works without a cloud sign-in. Built-in OpenWork MCPs are hidden by
+ * default and revealed via Show hidden.
  */
+
+const revealHidden = async (ctx) => {
+  const showing = await ctx.eval("document.body.innerText.includes('Showing hidden')");
+  if (!showing) await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+};
+
 export default {
   id: "settings-extensions-mcp",
   title: "MCP settings view renders apps and entry points",
@@ -41,14 +48,32 @@ export default {
       },
     },
     {
-      name: "Unconfigured directory entries are discoverable",
+      name: "Default view keeps directory apps discoverable and hides built-in OpenWork MCPs",
       run: async (ctx) => {
-        await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 15_000 });
-        const hasDirectoryEntry = (await ctx.hasText("Notion")) || (await ctx.hasText("Linear"));
+        const directoryEntry = await ctx.hasText("Notion") ? "Notion" : "Linear";
+        const hasDirectoryEntry = await ctx.hasText(directoryEntry);
         ctx.assert(hasDirectoryEntry, "Expected at least one MCP directory entry (Notion/Linear) in quick connect.");
-        await ctx.screenshot("mcp-view", {
-          claim: "MCP settings shows the built-in cloud control app and directory entries.",
-          requireText: ["OpenWork Cloud Control"],
+        await ctx.expectNoText("OpenWork Cloud Control");
+        await ctx.expectNoText("OpenWork UI Control");
+        await ctx.screenshot("mcp-view-default-hidden", {
+          claim: "MCP settings shows public directory apps while built-in OpenWork MCPs are hidden by default.",
+          voiceover: "Settings shows the extension directory with the public apps, while OpenWork's internal control entries stay out of the default list.",
+          requireText: [directoryEntry],
+          rejectText: ["OpenWork Cloud Control", "OpenWork UI Control", "Something went wrong"],
+          hashIncludes: "/settings/extensions/mcp",
+        });
+      },
+    },
+    {
+      name: "Show hidden reveals built-in OpenWork MCPs",
+      run: async (ctx) => {
+        await revealHidden(ctx);
+        await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 15_000 });
+        await ctx.expectText("OpenWork UI Control", { timeoutMs: 15_000 });
+        await ctx.screenshot("mcp-view-built-ins-revealed", {
+          claim: "Show hidden reveals the built-in OpenWork MCP entries.",
+          voiceover: "Choosing Show hidden brings back OpenWork Cloud Control and OpenWork UI Control for anyone who wants to manage them.",
+          requireText: ["OpenWork Cloud Control", "OpenWork UI Control"],
           rejectText: ["Something went wrong"],
           hashIncludes: "/settings/extensions/mcp",
         });

--- a/evals/flows/ui-control-tools-opt-in.flow.mjs
+++ b/evals/flows/ui-control-tools-opt-in.flow.mjs
@@ -1,0 +1,94 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const PROBE_SCRIPT = `
+  const { OpenWorkExtensionsPreview } = await import("./apps/server/src/opencode-plugins/openwork-extensions-preview.ts");
+  const plugin = await OpenWorkExtensionsPreview();
+  const output = { system: [] };
+  await plugin["experimental.chat.system.transform"](undefined, output);
+  console.log(JSON.stringify({ tools: Object.keys(plugin.tool).sort(), system: output.system.join("\\n") }));
+`;
+
+function envWithUiControl(value) {
+  const env = { ...process.env };
+  if (value === null) delete env.OPENWORK_UI_CONTROL_TOOLS;
+  else env.OPENWORK_UI_CONTROL_TOOLS = value;
+  return env;
+}
+
+async function probeUiControlTools(value) {
+  const { stdout } = await execFile("bun", ["-e", PROBE_SCRIPT], {
+    cwd: ROOT,
+    env: envWithUiControl(value),
+    maxBuffer: 1024 * 1024,
+  });
+  return JSON.parse(stdout.trim());
+}
+
+function pretty(value) {
+  return JSON.stringify(value, null, 2);
+}
+
+function witness(ctx, condition, assertion, actual) {
+  const detail = actual === undefined ? undefined : String(actual);
+  if (!condition) {
+    ctx.recordEvidence({ type: "assertion", status: "failed", assertion, actual: detail });
+    ctx.assert(false, assertion + (detail ? ` (actual: ${detail})` : ""));
+  }
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion, actual: detail });
+}
+
+export default {
+  id: "ui-control-tools-opt-in",
+  title: "Built-in OpenWork UI-control preview tools are opt-in",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "UI-control tools are absent by default",
+      run: async (ctx) => {
+        let result = null;
+        await ctx.prove("The built-in UI-control preview tools do not clutter default sessions", {
+          voiceover: "With the environment flag unset, the plugin still exposes extension discovery and cross-session memory, but the openwork UI-control preview tools are gone from the tool list and the system prompt.",
+          action: async () => {
+            result = await probeUiControlTools(null);
+            ctx.output("OPENWORK_UI_CONTROL_TOOLS unset", pretty(result));
+          },
+          assert: async () => {
+            witness(ctx, Array.isArray(result?.tools), "The probe printed a tools array", result ? pretty(result.tools) : "null");
+            witness(ctx, !result.tools.includes("openwork_ui_snapshot"), "openwork_ui_snapshot is not registered by default", result.tools.join(", "));
+            witness(ctx, !result.tools.includes("openwork_ui_list_actions"), "openwork_ui_list_actions is not registered by default", result.tools.join(", "));
+            witness(ctx, !result.tools.includes("openwork_ui_execute_action"), "openwork_ui_execute_action is not registered by default", result.tools.join(", "));
+            witness(ctx, result.tools.includes("openwork_session_search"), "openwork_session_search remains registered", result.tools.join(", "));
+            witness(ctx, !result.system.includes("openwork_ui_"), "The default system prompt lacks openwork_ui_ steering", result.system);
+          },
+        });
+      },
+    },
+    {
+      name: "Setting OPENWORK_UI_CONTROL_TOOLS=1 restores the surface",
+      run: async (ctx) => {
+        let result = null;
+        await ctx.prove("The preview UI-control surface returns when explicitly opted in", {
+          voiceover: "When internal tooling sets OPENWORK_UI_CONTROL_TOOLS to one, the same plugin initialization registers all three openwork UI-control tools and restores the steering that tells agents how to use them.",
+          action: async () => {
+            result = await probeUiControlTools("1");
+            ctx.output("OPENWORK_UI_CONTROL_TOOLS=1", pretty(result));
+          },
+          assert: async () => {
+            witness(ctx, Array.isArray(result?.tools), "The opt-in probe printed a tools array", result ? pretty(result.tools) : "null");
+            witness(ctx, result.tools.includes("openwork_ui_snapshot"), "openwork_ui_snapshot is registered when opted in", result.tools.join(", "));
+            witness(ctx, result.tools.includes("openwork_ui_list_actions"), "openwork_ui_list_actions is registered when opted in", result.tools.join(", "));
+            witness(ctx, result.tools.includes("openwork_ui_execute_action"), "openwork_ui_execute_action is registered when opted in", result.tools.join(", "));
+            witness(ctx, result.system.includes("openwork_ui_execute_action"), "The opt-in system prompt includes UI-control steering", result.system);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/runner/den-proxy.mjs
+++ b/evals/runner/den-proxy.mjs
@@ -1,0 +1,59 @@
+/**
+ * Tiny eval-only Den proxy.
+ *
+ * The desktop app only speaks the den-web topology and derives Den API calls
+ * with ensureDenApiBasePath (`/api/den/*`). The local eval stack runs the bare
+ * den-api, so this proxy exposes both bare paths and `/api/den/*` by stripping
+ * that prefix before streaming requests upstream.
+ */
+import http from "node:http";
+
+const listenPort = Number(process.env.DEN_PROXY_LISTEN_PORT);
+const upstreamPort = Number(process.env.DEN_PROXY_UPSTREAM_PORT);
+const DEN_PREFIX = "/api/den";
+
+if (!Number.isInteger(listenPort) || listenPort <= 0) {
+  console.error("DEN_PROXY_LISTEN_PORT must be a positive integer.");
+  process.exit(1);
+}
+
+if (!Number.isInteger(upstreamPort) || upstreamPort <= 0) {
+  console.error("DEN_PROXY_UPSTREAM_PORT must be a positive integer.");
+  process.exit(1);
+}
+
+function rewritePath(rawUrl) {
+  const url = new URL(rawUrl ?? "/", "http://127.0.0.1");
+  if (url.pathname === DEN_PREFIX || url.pathname.startsWith(`${DEN_PREFIX}/`)) {
+    return `${url.pathname.slice(DEN_PREFIX.length) || "/"}${url.search}`;
+  }
+  return `${url.pathname}${url.search}`;
+}
+
+const server = http.createServer((req, res) => {
+  const upstreamReq = http.request({
+    hostname: "127.0.0.1",
+    port: upstreamPort,
+    path: rewritePath(req.url),
+    method: req.method,
+    headers: req.headers,
+  }, (upstreamRes) => {
+    res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+    upstreamRes.pipe(res);
+  });
+
+  upstreamReq.on("error", () => {
+    if (res.headersSent) {
+      res.destroy();
+      return;
+    }
+    res.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
+    res.end("Bad Gateway\n");
+  });
+
+  req.pipe(upstreamReq);
+});
+
+server.listen(listenPort, "127.0.0.1", () => {
+  console.log(`den proxy listening on :${listenPort} -> :${upstreamPort}`);
+});

--- a/evals/runner/den-stack.mjs
+++ b/evals/runner/den-stack.mjs
@@ -4,7 +4,8 @@
  * Brings up everything the cloud eval flows need, idempotently:
  *   1. MySQL (docker compose, reuses the dev:den compose project + volume)
  *   2. Schema push (only when the database is empty)
- *   3. den-api on :8790 (only when not already healthy)
+ *   3. den-api behind a local proxy on :8790: bare /* plus den-web
+ *      /api/den/* topology (only when not already healthy)
  *   4. Demo-org seed (only when the demo owner cannot sign in)
  *   5. Desktop bootstrap pointed at the local Den + dev Electron with CDP
  *      (only when no CDP endpoint is reachable)
@@ -28,7 +29,9 @@ const REPO_ROOT = resolve(RUNNER_DIR, "..", "..");
 const STATE_DIR = join(RUNNER_DIR, "..", "results", ".den-stack");
 
 const DEN_API_PORT = Number(process.env.OPENWORK_EVAL_DEN_PORT ?? 8790);
+const DEN_API_INTERNAL_PORT = DEN_API_PORT + 1;
 const DEN_API_URL = `http://127.0.0.1:${DEN_API_PORT}`;
+const DEN_API_INTERNAL_URL = `http://127.0.0.1:${DEN_API_INTERNAL_PORT}`;
 const DEN_BASE_URL = `http://localhost:${DEN_API_PORT}`;
 const DEMO_EMAIL = process.env.DEN_DEMO_OWNER_EMAIL ?? "alex@acme.test";
 const DEMO_PASSWORD = process.env.DEN_DEMO_OWNER_PASSWORD ?? "OpenWorkDemo123!";
@@ -37,7 +40,7 @@ const COMPOSE_ARGS = ["compose", "-p", "openwork-den-local", "-f", "packaging/do
 
 const DEN_ENV = {
   OPENWORK_DEV_MODE: "1",
-  PORT: String(DEN_API_PORT),
+  PORT: String(DEN_API_INTERNAL_PORT),
   DATABASE_URL: "mysql://root:password@127.0.0.1:3306/openwork_den",
   DEN_DB_ENCRYPTION_KEY: "local-dev-db-encryption-key-please-change-1234567890",
   BETTER_AUTH_SECRET: "local-dev-secret-not-for-production-use!!",
@@ -171,11 +174,20 @@ async function ensureSchema(log) {
 }
 
 async function ensureDenApi(log) {
-  if (await httpOk(`${DEN_API_URL}/health`)) {
-    log(`den-api already healthy on :${DEN_API_PORT}`);
+  const publicHealthOk = await httpOk(`${DEN_API_URL}/health`);
+  const denWebPathHealthOk = await httpOk(`${DEN_API_URL}/api/den/health`);
+  if (publicHealthOk && denWebPathHealthOk) {
+    log("den stack already healthy (with /api/den path)");
     return;
   }
-  log(`Starting den-api on :${DEN_API_PORT}...`);
+  if (publicHealthOk) {
+    throw new Error(
+      `A den-api is already healthy on :${DEN_API_PORT}, but it does not serve /api/den. ` +
+      "The desktop app cannot use a bare den-api there; rerun with OPENWORK_EVAL_DEN_PORT=<free port>.",
+    );
+  }
+
+  log(`Starting den-api on internal :${DEN_API_INTERNAL_PORT} (proxied on :${DEN_API_PORT})...`);
   const pid = spawnDetached("npx", ["tsx", "src/server.ts"], {
     logName: "den-api",
     cwd: join(REPO_ROOT, "ee", "apps", "den-api"),
@@ -183,13 +195,33 @@ async function ensureDenApi(log) {
   });
   await writePidState("den-api.pid", pid);
   for (let attempt = 0; attempt < 30; attempt += 1) {
-    if (await httpOk(`${DEN_API_URL}/health`)) {
+    if (await httpOk(`${DEN_API_INTERNAL_URL}/health`)) {
       log("den-api healthy");
-      return;
+      break;
     }
     await sleep(2_000);
   }
-  throw new Error("den-api did not become healthy within 60s.");
+  if (!(await httpOk(`${DEN_API_INTERNAL_URL}/health`))) {
+    throw new Error(`den-api did not become healthy on internal :${DEN_API_INTERNAL_PORT} within 60s.`);
+  }
+
+  log(`Starting den proxy on :${DEN_API_PORT} -> :${DEN_API_INTERNAL_PORT}...`);
+  const proxyPid = spawnDetached(process.execPath, [join(RUNNER_DIR, "den-proxy.mjs")], {
+    logName: "den-proxy",
+    env: {
+      DEN_PROXY_LISTEN_PORT: String(DEN_API_PORT),
+      DEN_PROXY_UPSTREAM_PORT: String(DEN_API_INTERNAL_PORT),
+    },
+  });
+  await writePidState("den-proxy.pid", proxyPid);
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (await httpOk(`${DEN_API_URL}/api/den/health`)) {
+      log("den proxy healthy");
+      return;
+    }
+    await sleep(1_000);
+  }
+  throw new Error("den proxy did not expose /api/den/health within 30s.");
 }
 
 async function ensureSeed(log) {
@@ -288,6 +320,10 @@ export async function ensureDenStack({ log, cdpCandidates, skipApp = false }) {
 }
 
 export async function denStackDown({ log }) {
+  const proxyPid = await readPidState("den-proxy.pid");
+  if (proxyPid) {
+    try { process.kill(Number(proxyPid)); log(`Stopped den-proxy (pid ${proxyPid})`); } catch { /* already gone */ }
+  }
   const apiPid = await readPidState("den-api.pid");
   if (apiPid) {
     try { process.kill(Number(apiPid)); log(`Stopped den-api (pid ${apiPid})`); } catch { /* already gone */ }

--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -12,9 +12,10 @@ The server uses OAuth. Your MCP client opens a browser, you sign in to OpenWork 
 If you use the OpenWork desktop app, there is nothing to configure. When you
 sign in to OpenWork Cloud, the app connects the `openwork-cloud` MCP for you
 with a token scoped to your active organization — no browser OAuth round-trip.
-You can see it under **Settings → Extensions** as **OpenWork Cloud Control**
-with a Ready status. Switching organizations refreshes the token
-automatically.
+It is enabled while you are signed in and hidden from the default **Settings →
+Extensions** list; use **Show hidden** on that page to reveal **OpenWork Cloud
+Control** when you want to inspect, disable, or remove it. Switching
+organizations refreshes the token automatically.
 
 The desktop app derives the MCP URL from the single Cloud `baseUrl`. For the
 hosted service, that means `https://app.openworklabs.com/api/den/mcp`; for a


### PR DESCRIPTION
## What

The built-in OpenWork control surfaces stop cluttering the product by default:

1. **OpenWork Cloud Control (`openwork-cloud`) and OpenWork UI Control (`openwork-ui`) are hidden by default** in Settings → Extensions (like `openwork-admin` already was) — both in the *Available apps* catalog and, when configured, in the *Your apps* list. **Show hidden** reveals them for inspect/disable/remove. The signed-in cloud reconciler still auto-configures and auto-enables `openwork-cloud` — hidden ≠ disabled.
2. **The agent-facing UI-control preview surface is now opt-in.** The extensions-preview plugin used to push a UI-control instruction into every session's system prompt and register `openwork_ui_snapshot` / `openwork_ui_list_actions` / `openwork_ui_execute_action` unconditionally — it was getting in the way of every session. It now registers only with `OPENWORK_UI_CONTROL_TOOLS=1`. Cross-session memory + browser guidance stay always-on. The supported path for agent UI control remains connecting the (hidden) OpenWork UI Control MCP explicitly.

## Also in this PR (found while proving it)

- **fix(settings): Rules-of-Hooks crash** — `SettingsRouteContent` called a `useCallback` *after* two early `return <Navigate/>` statements (from #2527), so any bare ↔ workspace-scoped settings redirect changed the hook count and blanked the entire settings surface ("Rendered more/fewer hooks than during the previous render"). Reproduced on vanilla origin/dev; the hook now runs before the redirects.
- **fix(evals): local Den stack now speaks the desktop topology** — the desktop app always calls `<base>/api/den/...`, but the eval harness booted the bare den-api, so desktop cloud sign-in 404ed (`not_found`). `--stack den` now fronts den-api with a tiny path-rewriting proxy (`evals/runner/den-proxy.mjs`), refuses to reuse a squatting bare den-api, and `cloud-mcp-auto-config` drives the post-sign-in org onboarding.

## Behavior

- Signed out: neither entry appears in Extensions; Notion/Linear/… stay discoverable; `Show hidden (3)` reveals Cloud Control, Admin Analytics, UI Control (with Hidden badges).
- Signed in to cloud: `openwork-cloud` is auto-configured + enabled (sync marker written) while staying invisible until *Show hidden*; the revealed row shows **Ready** and can be disabled/removed as before (`cloud-mcp-disable-sticks` semantics untouched).
- Sessions: no `openwork_ui_*` tools and no UI-control steering in the system prompt by default; `OPENWORK_UI_CONTROL_TOOLS=1` restores the preview surface; `openwork_session_search`/`read`, extension actions, and browser tools unchanged.

## Tests run

- `pnpm typecheck` — pass
- `pnpm --filter @openwork/app test` — 142 pass / 0 fail (includes new `builtin-mcp-visibility.test.ts`)
- `cd apps/server && bun test src/opencode-plugins/openwork-extensions-preview.test.ts` — 4 pass / 0 fail (new opt-in coverage)
- `pnpm --filter openwork-server test`: 3 pre-existing reload-watcher fs-watch tests fail on this machine **with the diff stashed too** (environment-sensitive; unrelated files) — please rely on CI here.
- Fraimz suite (local Electron, fresh profile, local Den stack via `--stack den`): `builtin-mcps-hidden-by-default`, `settings-extensions-mcp`, `cloud-mcp-auto-config`, `ui-control-tools-opt-in` — **4/4 passed**; proof comment follows via `pnpm fraimz --pr`.

Updated flows that interact with the now-hidden entries reveal them first: `cloud-mcp-disable-sticks`, `mcp-cloud-force-sync`, `mcp-connections-desktop-e2e`, `mcp-search-capabilities`, `desktop-org-mcp-demo`, `org-google-workspace-demo`.

Docs: `packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx`, `docs/mcp-ui-control-profile.md`.