### PR TITLE
test(evals): regression flow for bare settings route redirect

### DIFF
--- a/evals/flows/bare-settings-route-redirect.flow.mjs
+++ b/evals/flows/bare-settings-route-redirect.flow.mjs
@@ -1,0 +1,63 @@
+/**
+ * Regression guard: opening a bare /settings/* hash must not crash the renderer
+ * when the route redirects into a workspace-scoped settings URL.
+ */
+export default {
+  id: "bare-settings-route-redirect",
+  title: "Bare settings route redirects without crashing",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "App booted",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000 });
+      },
+    },
+    {
+      name: "Open settings via a bare (workspace-less) URL",
+      run: async (ctx) => {
+        await ctx.navigateHash("/settings/cloud-account");
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 30_000,
+          label: "control API after bare settings navigation",
+        });
+        await ctx.waitFor(
+          `(() => {
+            const text = document.body.innerText;
+            return text.includes("Settings") && (text.includes("Account") || text.includes("OpenWork Cloud"));
+          })()`,
+          { timeoutMs: 30_000, label: "cloud account settings content" },
+        );
+        const bodyTextLength = await ctx.eval("document.body.innerText.length");
+        ctx.assert(typeof bodyTextLength === "number" && bodyTextLength > 100, "Expected a non-blank settings page.");
+        const hash = await ctx.eval("window.location.hash");
+        ctx.assert(typeof hash === "string" && hash.includes("/settings/cloud-account"), "Expected hash to stay on cloud account settings.");
+        await ctx.screenshot("bare-settings-cloud-account", {
+          claim: "Opening settings from a bare workspace-less URL renders the Cloud Account page instead of crashing to a blank window.",
+          voiceover: "We open Cloud Account settings directly, without choosing a workspace first. The settings page stays visible and ready to use instead of going blank.",
+          requireText: ["Settings", "Account"],
+          hashIncludes: "/settings/cloud-account",
+        });
+      },
+    },
+    {
+      name: "Back to the app",
+      run: async (ctx) => {
+        await ctx.navigateHash("/");
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 30_000,
+          label: "control API after returning home",
+        });
+        await ctx.waitFor("document.body.innerText.trim().length > 40", {
+          timeoutMs: 30_000,
+          label: "session UI content after redirect",
+        });
+        await ctx.screenshot("back-to-app", {
+          claim: "The app stays fully alive after the redirect — back on the session view.",
+          voiceover: "After visiting settings, we return to the main app. The session view is still alive and rendering normally.",
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## What this is now

The renderer crash this PR originally fixed (hooks running conditionally across bare `/settings/*` redirects) **landed in `dev` via #2591** — the `refreshConnectMarketplaceItems` `useCallback` already sits above the redirect returns there, with a why-comment.

This PR is repurposed to carry the one thing not in `dev`: the **regression flow** `evals/flows/bare-settings-route-redirect.flow.mjs` (no env gate — runs in normal suites). It drives the real app to a bare workspace-less settings URL and asserts:

- the control API survives the redirect (this is exactly what died before the fix),
- the Cloud Account page renders (non-blank, correct hash),
- the app returns to the session view alive.

## Context

Navigating to any bare (workspace-less) settings URL — e.g. `#/settings/cloud-account` from a deep link, old bookmark, or programmatic `navigate("/settings/...")` — used to hard-crash the whole renderer (hooks-order violation, no error boundary above `Routes`). Found while validating #2592; fixed in #2591; this flow guards against the class of bug returning.

## Tests run

- `node --check evals/flows/bare-settings-route-redirect.flow.mjs` — pass
- `pnpm fraimz --flow bare-settings-route-redirect` — **PASSED** against the rebased branch (dev + flow); proof comment below

## Follow-ups worth separate issues (unchanged from original)

- `apps/app` has no eslint config, so `react-hooks/rules-of-hooks` never guards against this class of bug.
- There is no React error boundary above `Routes`; any render error in any route blanks the entire window with no recovery UI.