### PR TITLE
fix(installer): Windows segfault on Exit/Launch — don't destroy the webview inside its own FFI callback

### DIFF
--- a/apps/installer/src/index.ts
+++ b/apps/installer/src/index.ts
@@ -8,6 +8,7 @@ const rawArgs = Bun.argv.slice(2)
 const args = new Set(rawArgs)
 const headless = args.has("--headless") || process.env.OPENWORK_INSTALLER_HEADLESS === "1"
 const dryRun = args.has("--dry-run") || process.env.OPENWORK_INSTALLER_DRY_RUN === "1"
+const smokeExitMs = Number.parseInt(process.env.OPENWORK_INSTALLER_SMOKE_EXIT_MS ?? "", 10)
 
 type ReadyServer = {
   url: string
@@ -234,11 +235,20 @@ try {
   // The page's Exit button calls this bound global; terminating the run loop
   // is the only clean way to close the window from page JS.
   webview.bind("openworkInstallerExit", () => webview.destroy())
+  if (Number.isFinite(smokeExitMs) && smokeExitMs > 0) {
+    // Automated smoke: drive the exact production exit path (page JS -> bound
+    // FFI callback) without a human click.
+    webview.init(`setTimeout(() => { if (window.openworkInstallerExit) window.openworkInstallerExit(); }, ${smokeExitMs})`)
+  }
   webview.navigate(ready.url)
   webview.run()
   await exitWhenInstallSettles()
 } catch (error) {
   // Native webview unavailable (e.g. no WebkitGTK): same UI in the browser.
+  if (Number.isFinite(smokeExitMs) && smokeExitMs > 0) {
+    console.error("[openwork-installer] smoke mode: native webview unavailable")
+    process.exit(3)
+  }
   console.warn(`[openwork-installer] native window unavailable (${error instanceof Error ? error.message : String(error)}); opening browser UI`)
   openInBrowser(ready.url)
   uiServer.onExit(() => void exitWhenInstallSettles())

--- a/apps/installer/src/index.ts
+++ b/apps/installer/src/index.ts
@@ -230,11 +230,18 @@ if (process.env.OPENWORK_INSTALLER_UI === "manual") {
 } else {
 try {
   const { Webview, SizeHint } = await import("webview-bun")
+  const { lib } = await import("webview-bun/src/ffi")
   const webview = new Webview(false, { width: 420, height: 440, hint: SizeHint.FIXED })
   webview.title = "OpenWork Installer"
-  // The page's Exit button calls this bound global; terminating the run loop
-  // is the only clean way to close the window from page JS.
-  webview.bind("openworkInstallerExit", () => webview.destroy())
+  // The page's Exit button calls this bound global. Only terminate the native
+  // run loop here — run() destroys the webview after the loop exits.
+  // Destroying inside the callback frees the executing FFI trampoline and
+  // tears down the webview mid-dispatch (use-after-free; segfaults on
+  // Windows, where WebView2 dispatches bindings from the Win32 message pump).
+  webview.bind("openworkInstallerExit", () => {
+    const handle = webview.unsafeHandle
+    if (handle) lib.symbols.webview_terminate(handle)
+  })
   if (Number.isFinite(smokeExitMs) && smokeExitMs > 0) {
     // Automated smoke: drive the exact production exit path (page JS -> bound
     // FFI callback) without a human click.


### PR DESCRIPTION
## Problem

On Windows, the desktop installer segfaults when the user clicks **Exit** (or **Launch** after a successful install):

```
panic(main thread): Segmentation fault at address 0x1A57DC27B31
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

(Reported from a real Windows 11 x64 machine, installer built with Bun 1.3.9. The install itself typically completes — the crash fires at the very end, on the exit path.)

## Root cause

`index.ts` bound the page's exit hook as:

```ts
webview.bind("openworkInstallerExit", () => webview.destroy())
```

The bound function is a `bun:ffi` `JSCallback` invoked **synchronously from the webview's native message loop** (WebView2/Win32 dispatch). Calling `webview.destroy()` inside it:

1. `unbind()`s the binding, which `close()`s the JSCallback — **freeing the FFI trampoline currently executing on the stack**;
2. runs `webview_terminate` + `webview_destroy`, tearing down the webview whose dispatch frames are still on the stack;
3. afterwards webview-bun's `bind()` wrapper still calls `webview_return` on the nulled handle, and `Webview.run()` calls `destroy()` a second time.

Use-after-free → segfault on Windows; on macOS the same code wedges the run loop (process hangs after the window closes) instead of crashing.

## Fix

The bound callback now only posts a quit to the native run loop (`webview_terminate`); `webview.run()` returns and performs the single, orderly `destroy()` outside the callback:

```ts
webview.bind("openworkInstallerExit", () => {
  const handle = webview.unsafeHandle
  if (handle) lib.symbols.webview_terminate(handle)
})
```

Commit 1 also adds an env-gated smoke hook (`OPENWORK_INSTALLER_SMOKE_EXIT_MS`) that drives the exact production exit path (page JS → bound FFI callback) without a human click, so this path is machine-testable.

## Proof — real Windows, on a Daytona Windows sandbox

Daytona `windows-medium` VM (**`Windows v.win11_dt` build 26100**, Server 2025 Datacenter), WebView2 Evergreen 122, interactive console session via Task Scheduler, cross-compiled `--target=bun-windows-x64` binaries of both commits. Same lane, same trigger; the only delta is the fix commit:

| binary | result |
|---|---|
| pre-fix (`d7c1edb`) | **`panic(main thread): Segmentation fault at address 0x28104AA2B31`** — full Bun crash dump, `abort()` exit 3, fired exactly when the exit callback ran (8.6s = WebView2 startup + 6s auto-exit) |
| post-fix (`56988c6`) | **exit 0**, empty stderr, ~1s after the auto-exit — full clean exit path |

The pre-fix crash header matches the field report line-for-line (`Windows v.win11_dt`, `Features: jsc spawn standalone_executable`, `Builtins: "bun:ffi" "bun:main" "node:child_process" …`, main-thread segfault at a heap-range address).

Real window on the real Windows desktop, seconds before the pre-fix segfault / during the post-fix clean run:

<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/installer-exit-fix/win-prefix-screen.png" width="480"> <img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/installer-exit-fix/win-postfix-screen.png" width="480">

Side-finding from the Windows lane: on a machine **without the VC++ 2015+ x64 redistributable** the webview DLL can't load and the installer silently uses the browser-UI fallback (no crash). Client Win11 machines generally have it; bare Server images don't.

## Supporting lanes

**Daytona Linux sandbox (Debian 13, WebKitGTK 6.0, Xvfb, Bun 1.3.9 — same pin as client builds):** same pair — pre-fix `panic(main thread): Segmentation fault at address 0x5D6788FDAC5` at the auto-exit trigger; post-fix exit 0. Screenshot of the rendered webview UI:

<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/installer-exit-fix/smoke-prefix-fVgWU269JTjDVpTIyt8suuyylUaU5i.png" width="480">

**macOS (Apple silicon, local):** pre-fix hangs after window close (killed at 20s); post-fix exit 0 in ~4s.

**Windows exe under Wine 10:** `--headless --dry-run` against a mock Den API → exit 0 end-to-end (wrote `C:\users\...\AppData\Local\openwork\desktop-bootstrap.json`, resolved `latestAppVersion`, HEAD-verified the real GitHub asset `openwork-win-x64-0.17.15.exe`).

**Tests:** `cd apps/installer && bun test` → 25 pass, 0 fail (both commits).

## Repro (any machine)

```
bun build --compile --minify src/index.ts src/server-worker.ts --outfile dist/openwork-installer
OPENWORK_INSTALLER_CLIENT_NAME="Smoke Test" \
OPENWORK_INSTALLER_WEB_URL="https://smoke.openwork.invalid" \
OPENWORK_INSTALLER_API_URL="https://smoke-api.openwork.invalid" \
OPENWORK_INSTALLER_SMOKE_EXIT_MS=5000 ./dist/openwork-installer
# pre-fix: segfault (Windows/Linux) or hang (macOS) at ~5s; post-fix: window self-closes, exit 0
```

Note: `evals/` fraimz flows cover the desktop app, not `apps/installer`; the frame-style evidence above (claim → action → observable assertion → validated screenshot) is the equivalent proof for this surface, gathered on real OS targets via Daytona.
