### PR TITLE
fix(den): allow SSO account linking for unverified users

### DIFF
--- a/ee/apps/den-api/src/account-linking-policy.ts
+++ b/ee/apps/den-api/src/account-linking-policy.ts
@@ -1,0 +1,8 @@
+import type { BetterAuthOptions } from "better-auth"
+
+export const DEN_ACCOUNT_CONFIG = {
+  accountLinking: {
+    enabled: true,
+    requireLocalEmailVerified: false,
+  },
+} satisfies NonNullable<BetterAuthOptions["account"]>

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -15,6 +15,7 @@ import {
   DEN_SESSION_EXPIRES_IN_SECONDS,
   DEN_SESSION_UPDATE_AGE_IN_SECONDS,
 } from "./session-lifetime.js";
+import { DEN_ACCOUNT_CONFIG } from "./account-linking-policy.js";
 import { SCIM_TOKEN_STORAGE_STRATEGY } from "./scim-token-storage.js";
 import { syncDenSignupContact } from "./loops.js";
 import { sendEmail } from "./utils/email/send-email.js";
@@ -219,6 +220,7 @@ export const auth = betterAuth({
     provider: "mysql",
     schema,
   }),
+  account: DEN_ACCOUNT_CONFIG,
   session: {
     expiresIn: DEN_SESSION_EXPIRES_IN_SECONDS,
     updateAge: DEN_SESSION_UPDATE_AGE_IN_SECONDS,

--- a/ee/apps/den-api/test/sso-account-linking-policy.test.ts
+++ b/ee/apps/den-api/test/sso-account-linking-policy.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "bun:test"
+import { DEN_ACCOUNT_CONFIG } from "../src/account-linking-policy.js"
+
+test("SSO can implicitly link a verified-domain provider to an existing unverified Den user", () => {
+  expect(DEN_ACCOUNT_CONFIG.accountLinking.enabled).toBe(true)
+  expect(DEN_ACCOUNT_CONFIG.accountLinking.requireLocalEmailVerified).toBe(false)
+})


### PR DESCRIPTION
## Summary
- Configure Better Auth account linking so verified-domain SSO providers can link existing Den users even when the local email is unverified.
- Move the Den account-linking policy into a testable constant.
- Add regression coverage for the SSO account-linking policy.

## Validation
- Passed: pnpm --filter @openwork-ee/den-api exec bun test test/sso-account-linking-policy.test.ts
- Passed: pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json

## Proof
No fraimz/video captured: this is a backend auth policy change and I do not have a live SAML IdP scenario in this workspace. The focused regression test and TypeScript check above passed.