### PR TITLE
feat(extensions): connect-aware gating of legacy Google Workspace actions behind connectEnabled

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -390,6 +390,19 @@ export type GoogleWorkspaceAuthStatus = {
     driveFileName: string | null;
     gmailDraftId: string | null;
   } | null;
+  connect?: {
+    enabled: true;
+    cloudMcpPresent: boolean;
+    guidance: string;
+  };
+};
+
+export type OpenworkConnectState = {
+  ok: true;
+  schemaVersion: 1;
+  connectEnabled: boolean;
+  cloudMcpPresent: boolean;
+  googleWorkspace: { legacyConfigured: boolean };
 };
 
 export type GoogleWorkspaceConnectStart = {
@@ -413,13 +426,19 @@ export type OpenworkExtensionActionCall = {
   context?: Record<string, unknown>;
 };
 
-export type OpenworkExtensionActionResult = {
-  ok: boolean;
-  extensionId: string;
-  action: string;
-  result: unknown;
-  context?: Record<string, unknown>;
-};
+export type OpenworkExtensionActionResult =
+  | {
+    ok: true;
+    extensionId: string;
+    action: string;
+    result: unknown;
+    context?: Record<string, unknown>;
+  }
+  | {
+    ok: false;
+    error: string;
+    message: string;
+  };
 
 export type OpenworkResolvedArtifactTarget = {
   id: string;
@@ -1017,6 +1036,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     status: () => requestJson<OpenworkServerDiagnostics>(baseUrl, "/status", { token, hostToken, timeoutMs: timeouts.status }),
     capabilities: () => requestJson<OpenworkServerCapabilities>(baseUrl, "/capabilities", { token, hostToken, timeoutMs: timeouts.capabilities }),
     googleWorkspaceStatus: () => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/status", { token, hostToken, timeoutMs: timeouts.status }),
+    setConnectState: (connectEnabled: boolean) => requestJson<OpenworkConnectState>(baseUrl, "/experimental/connect/state", { token, hostToken, method: "PUT", body: { connectEnabled }, timeoutMs: timeouts.config }),
     googleWorkspaceConnectStart: (options?: { gmailRead?: boolean; features?: string[] }) => requestJson<GoogleWorkspaceConnectStart>(baseUrl, "/experimental/google-workspace/connect/start", { token, hostToken, method: "POST", body: { gmailRead: options?.gmailRead === true, features: options?.features ?? [] }, timeoutMs: timeouts.status }),
     googleWorkspaceConnectStatus: (flowId: string) => requestJson<GoogleWorkspaceConnectStatus>(baseUrl, `/experimental/google-workspace/connect/status/${encodeURIComponent(flowId)}`, { token, hostToken, timeoutMs: timeouts.status }),
     googleWorkspaceDisconnect: (accountId?: string | null) => requestJson<GoogleWorkspaceAuthStatus>(baseUrl, "/experimental/google-workspace/disconnect", { token, hostToken, method: "POST", body: accountId ? { accountId } : {}, timeoutMs: timeouts.status }),

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -25,10 +25,12 @@ import {
   type DenDesktopConfig,
 } from "../../../app/lib/den";
 import { applyBrandIcon } from "../../../app/lib/desktop";
+import { createOpenworkServerClient } from "../../../app/lib/openwork-server";
 import {
   denSessionUpdatedEvent,
   denSettingsChangedEvent,
 } from "../../../app/lib/den-session-events";
+import { resolveOpenworkConnection } from "../../shell/openwork-connection";
 import { useDenAuth } from "./den-auth-provider";
 
 export type DesktopConfigStore = {
@@ -148,13 +150,14 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
   const denAuth = useDenAuth();
   const [desktopConfigState, setDesktopConfigState] = useState<DesktopConfigState>({
     config: DEFAULT_DESKTOP_CONFIG,
-    loading: false,
+    loading: true,
   });
   const { config, loading } = desktopConfigState;
   // Bumped whenever the browser tells us the Den session or settings changed.
   const [settingsVersion, bumpSettingsVersion] = useReducer((value: number) => value + 1, 0);
   // Monotonic run id — same guard-against-stale-resolution pattern as DenAuthProvider.
   const refreshRunRef = useRef(0);
+  const lastPushedConnectEnabledRef = useRef<boolean | null>(null);
   // Safe in-memory copy of the last config we actually applied. State drives
   // rendering, while this ref lets the handler compare without stale closures.
   const currentDesktopConfigRef = useRef<DenDesktopConfig>(DEFAULT_DESKTOP_CONFIG);
@@ -282,6 +285,29 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
       window.clearInterval(interval);
     };
   }, [desktopConfigHandler, isSignedIn]);
+
+  const connectEnabled = config.connectEnabled === true;
+
+  useEffect(() => {
+    if (loading) return;
+    if (lastPushedConnectEnabledRef.current === connectEnabled) return;
+    let cancelled = false;
+
+    void (async () => {
+      const connection = await resolveOpenworkConnection();
+      if (cancelled || !connection.normalizedBaseUrl || !connection.resolvedHostToken) return;
+      lastPushedConnectEnabledRef.current = connectEnabled;
+      await createOpenworkServerClient({
+        baseUrl: connection.normalizedBaseUrl,
+        token: connection.resolvedToken,
+        hostToken: connection.resolvedHostToken,
+      }).setConnectState(connectEnabled);
+    })().catch(() => null);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [connectEnabled, loading]);
 
   // Dev-only: expose a bridge so evals can inject config directly without
   // requiring a cloud sign-in. This simply applies the config to React state.

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -952,6 +952,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         args: { prompt },
         context: { directory: selectedWorkspaceRoot || undefined },
       });
+      if (!response.ok) {
+        setImageGenerationError(response.message);
+        return;
+      }
       const result = response.result;
       const path = typeof result === "object" && result !== null && "path" in result && typeof result.path === "string"
         ? result.path

--- a/apps/server/src/connect-state.ts
+++ b/apps/server/src/connect-state.ts
@@ -1,0 +1,104 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { googleWorkspaceLegacyConfigured } from "./extensions/google-workspace.js";
+import {
+  readRuntimeOpencodeConfig,
+  runtimeMcpMap,
+  runtimeStorageDir,
+} from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+import { ensureDir } from "./utils.js";
+
+const CONNECT_STATE_FILE = "connect-state.json";
+const OPENWORK_CLOUD_MCP_NAME = "openwork-cloud";
+
+type PersistedConnectState = {
+  connectEnabled: boolean;
+  updatedAt: number;
+};
+
+export type ConnectSnapshot = {
+  connectEnabled: boolean;
+  cloudMcpPresent: boolean;
+  googleWorkspace: {
+    legacyConfigured: boolean;
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function connectStatePath(config: ServerConfig): string {
+  return join(runtimeStorageDir(config), CONNECT_STATE_FILE);
+}
+
+function normalizeConnectState(value: unknown): PersistedConnectState {
+  if (!isRecord(value) || typeof value.connectEnabled !== "boolean") {
+    return { connectEnabled: false, updatedAt: 0 };
+  }
+  return {
+    connectEnabled: value.connectEnabled,
+    updatedAt: typeof value.updatedAt === "number" ? value.updatedAt : 0,
+  };
+}
+
+export function googleWorkspaceConnectGuidance(cloudMcpPresent: boolean): string {
+  return cloudMcpPresent
+    ? "Google Workspace is available through the OpenWork Cloud connection: call search_capabilities to find the capability, then execute_capability to run it. Do not tell the user to reconfigure extensions; the relevant settings surface is Settings > Connect."
+    : "Google Workspace is not connected on this device. Direct the user to Settings > Connect to connect their account. Do not direct them to Settings > Extensions.";
+}
+
+export async function readConnectState(config: ServerConfig): Promise<PersistedConnectState> {
+  try {
+    const raw = await readFile(connectStatePath(config), "utf8");
+    return normalizeConnectState(JSON.parse(raw));
+  } catch {
+    return { connectEnabled: false, updatedAt: 0 };
+  }
+}
+
+export async function writeConnectState(config: ServerConfig, state: { connectEnabled: boolean }): Promise<PersistedConnectState> {
+  const next = { connectEnabled: state.connectEnabled, updatedAt: Date.now() };
+  const target = connectStatePath(config);
+  await ensureDir(runtimeStorageDir(config));
+  await writeFile(target, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  return next;
+}
+
+export async function getConnectSnapshot(config: ServerConfig): Promise<ConnectSnapshot> {
+  const state = await readConnectState(config);
+  let cloudMcpPresent = false;
+
+  for (const workspace of config.workspaces) {
+    const runtimeConfig = await readRuntimeOpencodeConfig(config, workspace.id);
+    if (Object.hasOwn(runtimeMcpMap(runtimeConfig), OPENWORK_CLOUD_MCP_NAME)) {
+      cloudMcpPresent = true;
+      break;
+    }
+  }
+
+  return {
+    connectEnabled: state.connectEnabled,
+    cloudMcpPresent,
+    googleWorkspace: {
+      legacyConfigured: googleWorkspaceLegacyConfigured(),
+    },
+  };
+}
+
+export function shouldGateLegacyGoogleWorkspace(snapshot: ConnectSnapshot): boolean {
+  return snapshot.connectEnabled && !snapshot.googleWorkspace.legacyConfigured;
+}
+
+export function googleWorkspaceStatusConnectExtra(snapshot: ConnectSnapshot): Record<string, unknown> {
+  if (!shouldGateLegacyGoogleWorkspace(snapshot)) return {};
+  return {
+    connect: {
+      enabled: true,
+      cloudMcpPresent: snapshot.cloudMcpPresent,
+      guidance: googleWorkspaceConnectGuidance(snapshot.cloudMcpPresent),
+    },
+  };
+}

--- a/apps/server/src/extensions-connect-gating.test.ts
+++ b/apps/server/src/extensions-connect-gating.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+
+import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const CLIENT_TOKEN = "owt_connect_client_token";
+const HOST_TOKEN = "owt_connect_host_token";
+
+const actionSchema = z.object({
+  extensionId: z.string(),
+  action: z.string(),
+}).passthrough();
+
+const actionsResponseSchema = z.object({
+  ok: z.literal(true),
+  schemaVersion: z.literal(1),
+  actions: z.array(actionSchema),
+}).passthrough();
+
+const apiErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+}).passthrough();
+
+const connectStateResponseSchema = z.object({
+  ok: z.literal(true),
+  schemaVersion: z.literal(1),
+  connectEnabled: z.boolean(),
+  cloudMcpPresent: z.boolean(),
+  googleWorkspace: z.object({ legacyConfigured: z.boolean() }),
+}).passthrough();
+
+const gatedCallSchema = z.object({
+  ok: z.literal(false),
+  error: z.literal("use_openwork_cloud"),
+  message: z.string(),
+}).passthrough();
+
+const googleWorkspaceStatusSchema = z.object({
+  configured: z.boolean(),
+  missing: z.array(z.string()),
+  connected: z.boolean(),
+  connect: z.object({
+    enabled: z.literal(true),
+    cloudMcpPresent: z.boolean(),
+    guidance: z.string(),
+  }).optional(),
+}).passthrough();
+
+const googleWorkspaceStatusActionSchema = z.object({
+  ok: z.literal(true),
+  extensionId: z.literal("google-workspace"),
+  action: z.literal("status"),
+  result: googleWorkspaceStatusSchema,
+}).passthrough();
+
+type ActionItem = z.infer<typeof actionSchema>;
+
+const previousEnv = {
+  runtimeDb: process.env.OPENWORK_RUNTIME_DB,
+  googleClientSecret: process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET,
+  legacyGoogleClientSecret: process.env.OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET,
+  tokenBrokerUrl: process.env.OPENWORK_GOOGLE_WORKSPACE_TOKEN_BROKER_URL,
+  legacyTokenBrokerUrl: process.env.GOOGLE_WORKSPACE_TOKEN_BROKER_URL,
+};
+
+const stops: Array<() => void | Promise<void>> = [];
+const dirs: string[] = [];
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (typeof value === "string") process.env[key] = value;
+  else delete process.env[key];
+}
+
+function clearLegacyGoogleWorkspaceEnv() {
+  delete process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET;
+  delete process.env.OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET;
+  delete process.env.OPENWORK_GOOGLE_WORKSPACE_TOKEN_BROKER_URL;
+  delete process.env.GOOGLE_WORKSPACE_TOKEN_BROKER_URL;
+}
+
+function serverConfig(root: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: CLIENT_TOKEN,
+    hostToken: HOST_TOKEN,
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Test", path: root, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+async function boot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-connect-gating-"));
+  dirs.push(root);
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  const config = serverConfig(root);
+  const server = await startServer(config);
+  stops.push(() => server.stop());
+  return { base: `http://127.0.0.1:${server.port}`, config };
+}
+
+function clientHeaders() {
+  return { authorization: `Bearer ${CLIENT_TOKEN}` };
+}
+
+function clientJsonHeaders() {
+  return { ...clientHeaders(), "content-type": "application/json" };
+}
+
+function hostJsonHeaders() {
+  return { "x-openwork-host-token": HOST_TOKEN, "content-type": "application/json" };
+}
+
+async function readSchema<T>(response: Response, schema: z.ZodType<T>): Promise<T> {
+  const body: unknown = await response.json();
+  return schema.parse(body);
+}
+
+async function listActions(base: string): Promise<ActionItem[]> {
+  const response = await fetch(`${base}/experimental/extensions/actions`, { headers: clientHeaders() });
+  expect(response.status).toBe(200);
+  return (await readSchema(response, actionsResponseSchema)).actions;
+}
+
+function actionKeys(actions: ActionItem[]): string[] {
+  return actions.map((action) => `${action.extensionId}/${action.action}`).sort();
+}
+
+async function putConnectState(base: string, body: unknown): Promise<Response> {
+  return fetch(`${base}/experimental/connect/state`, {
+    method: "PUT",
+    headers: hostJsonHeaders(),
+    body: JSON.stringify(body),
+  });
+}
+
+async function callCalendarListEvents(base: string): Promise<Response> {
+  return fetch(`${base}/experimental/extensions/call`, {
+    method: "POST",
+    headers: clientJsonHeaders(),
+    body: JSON.stringify({
+      extensionId: "google-workspace",
+      action: "calendar_list_events",
+      args: {
+        timeMin: "2026-01-01T00:00:00.000Z",
+        timeMax: "2026-01-02T00:00:00.000Z",
+      },
+      context: {},
+    }),
+  });
+}
+
+async function callGoogleWorkspaceStatus(base: string): Promise<Response> {
+  return fetch(`${base}/experimental/extensions/call`, {
+    method: "POST",
+    headers: clientJsonHeaders(),
+    body: JSON.stringify({
+      extensionId: "google-workspace",
+      action: "status",
+      args: {},
+      context: {},
+    }),
+  });
+}
+
+async function expectLegacyCallPassesThrough(base: string) {
+  const response = await callCalendarListEvents(base);
+  expect(response.status).toBe(400);
+  const body = await readSchema(response, apiErrorSchema);
+  expect(body.code).toBe("google_workspace_not_connected");
+}
+
+function expectAllActions(actions: ActionItem[]) {
+  expect(actions).toHaveLength(16);
+  expect(actions.filter((action) => action.extensionId === "google-workspace")).toHaveLength(14);
+  expect(actions.filter((action) => action.extensionId === "openai-image-generation")).toHaveLength(2);
+}
+
+beforeEach(() => {
+  clearLegacyGoogleWorkspaceEnv();
+});
+
+afterEach(async () => {
+  while (stops.length) {
+    await stops.pop()?.();
+  }
+  while (dirs.length) {
+    const dir = dirs.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+  restoreEnv("OPENWORK_RUNTIME_DB", previousEnv.runtimeDb);
+  restoreEnv("GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", previousEnv.googleClientSecret);
+  restoreEnv("OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", previousEnv.legacyGoogleClientSecret);
+  restoreEnv("OPENWORK_GOOGLE_WORKSPACE_TOKEN_BROKER_URL", previousEnv.tokenBrokerUrl);
+  restoreEnv("GOOGLE_WORKSPACE_TOKEN_BROKER_URL", previousEnv.legacyTokenBrokerUrl);
+});
+
+describe("Connect-aware legacy extension gating", () => {
+  test("defaults to unchanged legacy extension behavior when no connect state file exists", async () => {
+    const { base } = await boot();
+
+    expectAllActions(await listActions(base));
+    await expectLegacyCallPassesThrough(base);
+  });
+
+  test("keeps legacy extension behavior unchanged when connectEnabled is false", async () => {
+    const { base } = await boot();
+    const put = await putConnectState(base, { connectEnabled: false });
+    expect(put.status).toBe(200);
+
+    expectAllActions(await listActions(base));
+    await expectLegacyCallPassesThrough(base);
+    const status = await readSchema(
+      await fetch(`${base}/experimental/google-workspace/status`, { headers: clientHeaders() }),
+      googleWorkspaceStatusSchema,
+    );
+    expect(status.connect).toBeUndefined();
+  });
+
+  test("keeps legacy extension behavior unchanged when legacy Google Workspace is configured", async () => {
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "test-secret";
+    const { base } = await boot();
+    const put = await putConnectState(base, { connectEnabled: true });
+    expect(put.status).toBe(200);
+
+    expectAllActions(await listActions(base));
+    await expectLegacyCallPassesThrough(base);
+    const status = await readSchema(
+      await fetch(`${base}/experimental/google-workspace/status`, { headers: clientHeaders() }),
+      googleWorkspaceStatusSchema,
+    );
+    expect(status.connect).toBeUndefined();
+    const state = await readSchema(
+      await fetch(`${base}/experimental/connect/state`, { headers: clientHeaders() }),
+      connectStateResponseSchema,
+    );
+    expect(state.googleWorkspace.legacyConfigured).toBe(true);
+  });
+
+  test("gates only non-status Google Workspace actions when Connect is enabled without legacy config", async () => {
+    const { base, config } = await boot();
+    const put = await putConnectState(base, { connectEnabled: true });
+    expect(put.status).toBe(200);
+
+    const actions = await listActions(base);
+    expect(actionKeys(actions)).toEqual([
+      "google-workspace/status",
+      "openai-image-generation/image_generate",
+      "openai-image-generation/status",
+    ]);
+
+    const gated = await callCalendarListEvents(base);
+    expect(gated.status).toBe(200);
+    const gatedBody = await readSchema(gated, gatedCallSchema);
+    expect(gatedBody.message).toContain("Settings > Connect");
+    expect(gatedBody.message).toContain("Do not direct them to Settings > Extensions");
+
+    const status = await readSchema(
+      await fetch(`${base}/experimental/google-workspace/status`, { headers: clientHeaders() }),
+      googleWorkspaceStatusSchema,
+    );
+    expect(status.connect).toEqual({
+      enabled: true,
+      cloudMcpPresent: false,
+      guidance: gatedBody.message,
+    });
+
+    const statusAction = await readSchema(await callGoogleWorkspaceStatus(base), googleWorkspaceStatusActionSchema);
+    expect(statusAction.result.connect).toEqual(status.connect);
+
+    await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({
+      ...current,
+      mcp: {
+        ...current.mcp,
+        "openwork-cloud": { type: "remote", url: "https://cloud.example/mcp" },
+      },
+    }));
+
+    const cloudGated = await callCalendarListEvents(base);
+    const cloudBody = await readSchema(cloudGated, gatedCallSchema);
+    expect(cloudBody.message).toContain("call search_capabilities");
+    expect(cloudBody.message).toContain("execute_capability");
+    expect(cloudBody.message).toContain("Settings > Connect");
+
+    const cloudStatus = await readSchema(
+      await fetch(`${base}/experimental/google-workspace/status`, { headers: clientHeaders() }),
+      googleWorkspaceStatusSchema,
+    );
+    expect(cloudStatus.connect).toEqual({
+      enabled: true,
+      cloudMcpPresent: true,
+      guidance: cloudBody.message,
+    });
+  });
+
+  test("validates and round-trips the persisted connect state route", async () => {
+    const { base } = await boot();
+    const badType = await putConnectState(base, { connectEnabled: "true" });
+    expect(badType.status).toBe(400);
+    expect((await readSchema(badType, apiErrorSchema)).code).toBe("invalid_payload");
+
+    const extraKey = await putConnectState(base, { connectEnabled: true, extra: false });
+    expect(extraKey.status).toBe(400);
+
+    const put = await putConnectState(base, { connectEnabled: true });
+    expect(put.status).toBe(200);
+    const putState = await readSchema(put, connectStateResponseSchema);
+    expect(putState.connectEnabled).toBe(true);
+    expect(putState.cloudMcpPresent).toBe(false);
+    expect(putState.googleWorkspace.legacyConfigured).toBe(false);
+
+    const get = await fetch(`${base}/experimental/connect/state`, { headers: clientHeaders() });
+    expect(get.status).toBe(200);
+    const getState = await readSchema(get, connectStateResponseSchema);
+    expect(getState).toEqual(putState);
+  });
+});

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -307,6 +307,10 @@ function googleWorkspaceCredentials() {
   return { clientId, clientSecret, tokenBrokerUrl, missing, customClient };
 }
 
+export function googleWorkspaceLegacyConfigured(): boolean {
+  return googleWorkspaceCredentials().missing.length === 0;
+}
+
 function googleWorkspaceDir(config: ServerConfig): string {
   return join(configDir(config), "extensions", GOOGLE_WORKSPACE_EXTENSION_ID);
 }
@@ -1174,13 +1178,13 @@ async function googleWorkspaceSendChatMessage(config: ServerConfig, args: Record
   });
 }
 
-export async function callGoogleWorkspaceExtensionAction(config: ServerConfig, action: string, args: Record<string, unknown>, context: Record<string, unknown>) {
+export async function callGoogleWorkspaceExtensionAction(config: ServerConfig, action: string, args: Record<string, unknown>, context: Record<string, unknown>, statusExtra: Record<string, unknown> = {}) {
   if (action === "status") {
     return {
       ok: true,
       extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
       action,
-      result: await googleWorkspaceStatus(config),
+      result: await googleWorkspaceStatus(config, statusExtra),
       context,
     };
   }
@@ -1200,12 +1204,12 @@ export async function callGoogleWorkspaceExtensionAction(config: ServerConfig, a
   return null;
 }
 
-export async function googleWorkspaceStatus(config: ServerConfig) {
+export async function googleWorkspaceStatus(config: ServerConfig, extra: Record<string, unknown> = {}) {
   try {
     const record = await readGoogleWorkspaceVault(config);
-    return googleWorkspaceStatusPayload(record);
+    return googleWorkspaceStatusPayload(record, extra);
   } catch (error) {
-    return googleWorkspaceStatusPayload(null, { error: error instanceof Error ? error.message : String(error) });
+    return googleWorkspaceStatusPayload(null, { ...extra, error: error instanceof Error ? error.message : String(error) });
   }
 }
 

--- a/apps/server/src/extensions/index.ts
+++ b/apps/server/src/extensions/index.ts
@@ -1,5 +1,11 @@
 import { ApiError } from "../errors.js";
 import type { EnvService } from "../env-file.js";
+import {
+  googleWorkspaceConnectGuidance,
+  googleWorkspaceStatusConnectExtra,
+  shouldGateLegacyGoogleWorkspace,
+  type ConnectSnapshot,
+} from "../connect-state.js";
 import type { ServerConfig } from "../types.js";
 import {
   callGoogleWorkspaceExtensionAction,
@@ -27,14 +33,16 @@ function readStringField(value: unknown, key: string): string {
   return typeof field === "string" ? field.trim() : "";
 }
 
-export function listExperimentalExtensionActions(extensionId: string) {
+export function listExperimentalExtensionActions(extensionId: string, connectSnapshot?: ConnectSnapshot) {
   const filter = extensionId.trim();
-  return filter
+  const actions = filter
     ? OPENWORK_EXPERIMENTAL_EXTENSION_ACTIONS.filter((action) => action.extensionId === filter)
     : OPENWORK_EXPERIMENTAL_EXTENSION_ACTIONS;
+  if (!connectSnapshot || !shouldGateLegacyGoogleWorkspace(connectSnapshot)) return actions;
+  return actions.filter((action) => action.extensionId !== GOOGLE_WORKSPACE_EXTENSION_ID || action.action === "status");
 }
 
-export async function callExperimentalExtensionAction(config: ServerConfig, env: EnvService, input: unknown) {
+export async function callExperimentalExtensionAction(config: ServerConfig, env: EnvService, input: unknown, connectSnapshot?: ConnectSnapshot) {
   if (!isRecord(input)) {
     throw new ApiError(400, "invalid_payload", "Expected extension action call payload");
   }
@@ -50,8 +58,21 @@ export async function callExperimentalExtensionAction(config: ServerConfig, env:
     throw new ApiError(404, "extension_action_not_found", "OpenWork extension action not found");
   }
 
+  if (
+    extensionId === GOOGLE_WORKSPACE_EXTENSION_ID &&
+    action !== "status" &&
+    connectSnapshot &&
+    shouldGateLegacyGoogleWorkspace(connectSnapshot)
+  ) {
+    return {
+      ok: false,
+      error: "use_openwork_cloud",
+      message: googleWorkspaceConnectGuidance(connectSnapshot.cloudMcpPresent),
+    };
+  }
+
   if (extensionId === GOOGLE_WORKSPACE_EXTENSION_ID) {
-    const result = await callGoogleWorkspaceExtensionAction(config, action, args, context);
+    const result = await callGoogleWorkspaceExtensionAction(config, action, args, context, connectSnapshot ? googleWorkspaceStatusConnectExtra(connectSnapshot) : {});
     if (result) return result;
   }
 

--- a/apps/server/src/routes/core.ts
+++ b/apps/server/src/routes/core.ts
@@ -1,5 +1,10 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
+import {
+  getConnectSnapshot,
+  googleWorkspaceStatusConnectExtra,
+  writeConnectState,
+} from "../connect-state.js";
 import { EnvStoreReadError, InvalidEnvKeyError, isValidEnvKey, type EnvService } from "../env-file.js";
 import { ApiError } from "../errors.js";
 import {
@@ -263,12 +268,27 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
     return jsonResponse(buildCapabilities(config));
   });
 
+  addRoute(routes, "GET", "/experimental/connect/state", "client", async () => {
+    return jsonResponse({ ok: true, schemaVersion: 1, ...(await getConnectSnapshot(config)) });
+  });
+
+  addRoute(routes, "PUT", "/experimental/connect/state", "host", async (ctx) => {
+    ensureWritable(config);
+    const body = await readJsonBody(ctx.request);
+    if (typeof body.connectEnabled !== "boolean" || Object.keys(body).some((key) => key !== "connectEnabled")) {
+      throw new ApiError(400, "invalid_payload", "connectEnabled must be a boolean");
+    }
+    await writeConnectState(config, { connectEnabled: body.connectEnabled });
+    return jsonResponse({ ok: true, schemaVersion: 1, ...(await getConnectSnapshot(config)) });
+  });
+
   addRoute(routes, "GET", "/experimental/extensions/actions", "client", async (ctx) => {
     const extensionId = ctx.url.searchParams.get("extensionId") ?? "";
+    const connectSnapshot = await getConnectSnapshot(config);
     return jsonResponse({
       ok: true,
       schemaVersion: 1,
-      actions: listExperimentalExtensionActions(extensionId),
+      actions: listExperimentalExtensionActions(extensionId, connectSnapshot),
     });
   });
 
@@ -277,11 +297,12 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
       throw new ApiError(403, "forbidden", "Viewer tokens cannot call extension actions");
     }
     const body = await readJsonBody(ctx.request);
-    return jsonResponse(await callExperimentalExtensionAction(config, env, body));
+    return jsonResponse(await callExperimentalExtensionAction(config, env, body, await getConnectSnapshot(config)));
   });
 
   addRoute(routes, "GET", "/experimental/google-workspace/status", "client", async () => {
-    return jsonResponse(await googleWorkspaceStatus(config));
+    const connectSnapshot = await getConnectSnapshot(config);
+    return jsonResponse(await googleWorkspaceStatus(config, googleWorkspaceStatusConnectExtra(connectSnapshot)));
   });
 
   addRoute(routes, "POST", "/experimental/google-workspace/connect/start", "client", async (ctx) => {


### PR DESCRIPTION
## Why

Enterprise sessions hit a collision between the two Google Workspace integrations: the legacy per-device extensions surface always advertises 14 GW actions, so on cloud-connected devices the agent runs `status`, reads "missing OAuth client secret", and tells users to reconnect in **Settings > Extensions** — even though they are connected via Connect. Seen live on an enterprise demo call.

## What

Adds an org-level `connectEnabled` switch to the openwork-server, with a hard safety rule: **gating only ever hides actions that would fail with `google_workspace_not_connected` anyway.**

| Legacy configured? | connectEnabled | Behavior |
|---|---|---|
| yes | any | untouched (all 14 GW actions) |
| no | off | untouched (today's behavior) |
| no | on | 13 dead GW actions hidden; `status` stays; calls to hidden actions return a structured `use_openwork_cloud` redirect; status gains an additive `connect` guidance block. Image generation and every other extension untouched |

- `apps/server/src/connect-state.ts` — persisted `connect-state.json` next to `runtime.sqlite`, request-time snapshot (flag + openwork-cloud MCP presence + legacy GW credentials).
- `GET/PUT /experimental/connect/state` (client/host scope) in `routes/core.ts`.
- Gating + redirect in `extensions/index.ts`; additive `connect` block in GW status.
- Desktop pushes the org desktop-config `connectEnabled` to the server on change (fire-and-forget, gated on config load; harmless 404 on older servers).

Flag default is **off** → zero behavior change until an org opts in. Effective on the next request — no engine restart.

## Tests

Run on a Daytona sandbox (`openwork-test-20260708-151032`, branch stack incl. this PR):
- `bun test` (apps/server, full suite): **581 pass / 4 skip / 1 fail** — the 1 failure (`ensureWorkspaceFiles > uses shipped extension preview plugin`) **also fails on the base commit 848f65a4c** (pre-existing test-order pollution; passes in isolation on this branch).
- New matrix tests: `apps/server/src/extensions-connect-gating.test.ts` (5 tests — default/off/legacy-configured/gated+redirect+status/PUT validation+roundtrip) — all pass.
- `pnpm --filter openwork-server typecheck`, `pnpm --filter @openwork/app typecheck` — pass.

## Evidence

Fraimz (7 frames, PASSED) driven against the real Electron app + embedded server on Daytona — posted as a comment below (flow `connect-aware-extension-gating`, committed on the stacked steering PR).

## Notes for reviewers

- Stacked follow-up PR: connect-aware system-prompt steering (consumes `GET /experimental/connect/state`).
- Repro: `PUT /experimental/connect/state {"connectEnabled":true}` (host token) then `GET /experimental/extensions/actions`.