### PR TITLE
feat(extensions): connect-aware system-prompt steering toward openwork-cloud capabilities

### DIFF
--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  composeOpenWorkExtensionDiscoveryInstruction,
+  OPENWORK_CLOUD_CONNECTION_INSTRUCTION,
+  OPENWORK_CONNECT_GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION,
+  OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION,
+  resetOpenWorkExtensionDiscoveryInstructionCacheForTests,
+  resolveOpenWorkExtensionDiscoveryInstruction,
+  type OpenWorkExtensionConnectState,
+} from "./openwork-extensions-preview.js";
+
+const originalServerUrl = process.env.OPENWORK_SERVER_URL;
+const originalServerToken = process.env.OPENWORK_SERVER_TOKEN;
+
+const UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION =
+  "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
+
+const CLOUD_CONNECTION_INSTRUCTION =
+  "The OpenWork Cloud connection is active. For email (Gmail), calendar, Google Drive, and org-connected services such as Notion, Linear, Slack, etc., FIRST call openwork-cloud_search_capabilities with 2-4 keyword variants, then call openwork-cloud_execute_capability with an exact returned name. Do not claim these are unavailable without searching. OpenWork extensions (openwork_extension_list_actions / openwork_extension_call) remain available for other local actions such as image generation, but do NOT use them for Google Workspace, and never direct the user to Settings > Extensions for Google Workspace; use Settings > Connect.";
+
+const GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION =
+  `${UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION} Google Workspace is not connected on this device; if the user asks for email, calendar, or Google Drive, tell them to connect their account in Settings > Connect (never Settings > Extensions).`;
+
+beforeEach(() => {
+  resetOpenWorkExtensionDiscoveryInstructionCacheForTests();
+});
+
+afterEach(() => {
+  resetOpenWorkExtensionDiscoveryInstructionCacheForTests();
+  if (originalServerUrl === undefined) delete process.env.OPENWORK_SERVER_URL;
+  else process.env.OPENWORK_SERVER_URL = originalServerUrl;
+  if (originalServerToken === undefined) delete process.env.OPENWORK_SERVER_TOKEN;
+  else process.env.OPENWORK_SERVER_TOKEN = originalServerToken;
+});
+
+describe("composeOpenWorkExtensionDiscoveryInstruction", () => {
+  test("keeps the fallback instruction byte-identical when state is unavailable", () => {
+    expect(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+    expect(composeOpenWorkExtensionDiscoveryInstruction(null)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+  });
+
+  test("keeps the fallback instruction byte-identical when Connect is disabled", () => {
+    const state: OpenWorkExtensionConnectState = {
+      connectEnabled: false,
+      cloudMcpPresent: true,
+      googleWorkspace: { legacyConfigured: false },
+    };
+
+    expect(composeOpenWorkExtensionDiscoveryInstruction(state)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+  });
+
+  test("keeps the fallback instruction byte-identical when legacy Google Workspace is configured", () => {
+    const state: OpenWorkExtensionConnectState = {
+      connectEnabled: true,
+      cloudMcpPresent: true,
+      googleWorkspace: { legacyConfigured: true },
+    };
+
+    expect(composeOpenWorkExtensionDiscoveryInstruction(state)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+  });
+
+  test("steers active Connect users to openwork-cloud capabilities first", () => {
+    const state: OpenWorkExtensionConnectState = {
+      connectEnabled: true,
+      cloudMcpPresent: true,
+      googleWorkspace: { legacyConfigured: false },
+    };
+
+    expect(OPENWORK_CLOUD_CONNECTION_INSTRUCTION).toBe(CLOUD_CONNECTION_INSTRUCTION);
+    expect(composeOpenWorkExtensionDiscoveryInstruction(state)).toBe(CLOUD_CONNECTION_INSTRUCTION);
+  });
+
+  test("steers missing cloud MCP Google Workspace requests to Settings > Connect", () => {
+    const state: OpenWorkExtensionConnectState = {
+      connectEnabled: true,
+      cloudMcpPresent: false,
+      googleWorkspace: { legacyConfigured: false },
+    };
+
+    expect(OPENWORK_CONNECT_GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION).toBe(GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION);
+    expect(composeOpenWorkExtensionDiscoveryInstruction(state)).toBe(GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION);
+  });
+});
+
+describe("resolveOpenWorkExtensionDiscoveryInstruction", () => {
+  test("fetches connect state with bearer auth and caches the instruction for 15 seconds", async () => {
+    process.env.OPENWORK_SERVER_URL = "http://openwork.test/";
+    process.env.OPENWORK_SERVER_TOKEN = "test-token";
+    let now = 1_000;
+    let calls = 0;
+    const urls: string[] = [];
+    const authorizations: Array<string | null> = [];
+    const fakeFetch = async (url: string, init?: RequestInit): Promise<Response> => {
+      calls += 1;
+      urls.push(url);
+      authorizations.push(new Headers(init?.headers).get("authorization"));
+      return Response.json({
+        ok: true,
+        schemaVersion: 1,
+        connectEnabled: true,
+        cloudMcpPresent: true,
+        googleWorkspace: { legacyConfigured: false },
+      });
+    };
+
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction(fakeFetch, () => now)).toBe(CLOUD_CONNECTION_INSTRUCTION);
+    now += 14_999;
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction(fakeFetch, () => now)).toBe(CLOUD_CONNECTION_INSTRUCTION);
+    expect(calls).toBe(1);
+
+    now += 2;
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction(fakeFetch, () => now)).toBe(CLOUD_CONNECTION_INSTRUCTION);
+    expect(calls).toBe(2);
+    expect(urls).toEqual([
+      "http://openwork.test/experimental/connect/state",
+      "http://openwork.test/experimental/connect/state",
+    ]);
+    expect(authorizations).toEqual(["Bearer test-token", "Bearer test-token"]);
+  });
+
+  test("fails open and caches the fallback instruction when fetching throws", async () => {
+    process.env.OPENWORK_SERVER_URL = "http://openwork.test";
+    process.env.OPENWORK_SERVER_TOKEN = "test-token";
+    let now = 2_000;
+    let calls = 0;
+    const failingFetch = async (): Promise<Response> => {
+      calls += 1;
+      throw new Error("network unavailable");
+    };
+
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction(failingFetch, () => now)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+    now += 1;
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction(failingFetch, () => now)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+    expect(calls).toBe(1);
+  });
+
+  test("fails open when connect state parsing fails", async () => {
+    process.env.OPENWORK_SERVER_URL = "http://openwork.test";
+    process.env.OPENWORK_SERVER_TOKEN = "test-token";
+    const invalidFetch = async (): Promise<Response> => Response.json({ ok: true });
+
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction(invalidFetch, () => 3_000)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+  });
+});

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -112,8 +112,76 @@ const sessionMessagesEnvelopeSchema = z.object({
   items: z.array(sessionMessageSchema),
 }).passthrough();
 
-const OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION =
+const connectStateResponseSchema = z.object({
+  ok: z.literal(true),
+  schemaVersion: z.number(),
+  connectEnabled: z.boolean(),
+  cloudMcpPresent: z.boolean(),
+  googleWorkspace: z.object({
+    legacyConfigured: z.boolean(),
+  }).passthrough(),
+}).passthrough();
+
+export type OpenWorkExtensionConnectState = {
+  connectEnabled: boolean;
+  cloudMcpPresent: boolean;
+  googleWorkspace: {
+    legacyConfigured: boolean;
+  };
+};
+
+export const OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION =
   "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
+
+export const OPENWORK_CLOUD_CONNECTION_INSTRUCTION =
+  "The OpenWork Cloud connection is active. For email (Gmail), calendar, Google Drive, and org-connected services such as Notion, Linear, Slack, etc., FIRST call openwork-cloud_search_capabilities with 2-4 keyword variants, then call openwork-cloud_execute_capability with an exact returned name. Do not claim these are unavailable without searching. OpenWork extensions (openwork_extension_list_actions / openwork_extension_call) remain available for other local actions such as image generation, but do NOT use them for Google Workspace, and never direct the user to Settings > Extensions for Google Workspace; use Settings > Connect.";
+
+export const OPENWORK_CONNECT_GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION =
+  `${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION} Google Workspace is not connected on this device; if the user asks for email, calendar, or Google Drive, tell them to connect their account in Settings > Connect (never Settings > Extensions).`;
+
+const CONNECT_STATE_CACHE_MS = 15_000;
+
+type OpenWorkFetch = (url: string, init?: RequestInit) => Promise<Response>;
+type Clock = () => number;
+type CachedOpenWorkExtensionDiscoveryInstruction = {
+  at: number;
+  instruction: string;
+};
+
+let cachedOpenWorkExtensionDiscoveryInstruction: CachedOpenWorkExtensionDiscoveryInstruction | null = null;
+
+export function composeOpenWorkExtensionDiscoveryInstruction(state: OpenWorkExtensionConnectState | null): string {
+  if (!state || !state.connectEnabled || state.googleWorkspace.legacyConfigured) {
+    return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
+  }
+  return state.cloudMcpPresent
+    ? OPENWORK_CLOUD_CONNECTION_INSTRUCTION
+    : OPENWORK_CONNECT_GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION;
+}
+
+export function resetOpenWorkExtensionDiscoveryInstructionCacheForTests(): void {
+  cachedOpenWorkExtensionDiscoveryInstruction = null;
+}
+
+export async function resolveOpenWorkExtensionDiscoveryInstruction(fetcher: OpenWorkFetch = fetch, now: Clock = Date.now): Promise<string> {
+  const currentTime = now();
+  if (
+    cachedOpenWorkExtensionDiscoveryInstruction &&
+    currentTime - cachedOpenWorkExtensionDiscoveryInstruction.at < CONNECT_STATE_CACHE_MS
+  ) {
+    return cachedOpenWorkExtensionDiscoveryInstruction.instruction;
+  }
+
+  let instruction = OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
+  try {
+    instruction = composeOpenWorkExtensionDiscoveryInstruction(await fetchOpenWorkConnectState(fetcher));
+  } catch {
+    instruction = OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
+  }
+
+  cachedOpenWorkExtensionDiscoveryInstruction = { at: currentTime, instruction };
+  return instruction;
+}
 
 const OPENWORK_UI_CONTROL_INSTRUCTION =
   `IMPORTANT: You are running inside the OpenWork desktop app. When the user asks you to open settings, navigate the app, add providers, or control the OpenWork UI in any way, ALWAYS use the openwork_ui_* tools — NOT the browser_* tools. The browser tools are for external websites only. The openwork_ui_* tools control the app directly and are instant (one tool call).
@@ -241,6 +309,23 @@ async function serverGet(path: string): Promise<unknown> {
   const payload = await parseResponse(response);
   if (!response.ok) throw new Error(errorMessage(payload, "OpenWork server request failed"));
   return payload;
+}
+
+async function fetchOpenWorkConnectState(fetcher: OpenWorkFetch): Promise<OpenWorkExtensionConnectState> {
+  const { url, token } = requireOpenWorkServer();
+  const response = await fetcher(`${url}/experimental/connect/state`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const payload = await parseResponse(response);
+  if (!response.ok) throw new Error(errorMessage(payload, "OpenWork connect state request failed"));
+  const parsed = connectStateResponseSchema.parse(payload);
+  return {
+    connectEnabled: parsed.connectEnabled,
+    cloudMcpPresent: parsed.cloudMcpPresent,
+    googleWorkspace: {
+      legacyConfigured: parsed.googleWorkspace.legacyConfigured,
+    },
+  };
 }
 
 function collapseWhitespace(value: string): string {
@@ -613,7 +698,7 @@ export const OpenWorkExtensionsPreview = async () => {
   const uiControlEnabled = uiControlToolsEnabled();
   return {
   "experimental.chat.system.transform": async (_input: unknown, output: { system: string[] }) => {
-    output.system.push(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
+    output.system.push(await resolveOpenWorkExtensionDiscoveryInstruction());
     output.system.push(OPENWORK_SESSION_MEMORY_INSTRUCTION);
     output.system.push(OPENWORK_BROWSER_INSTRUCTION);
     if (uiControlEnabled) output.system.push(OPENWORK_UI_CONTROL_INSTRUCTION);

--- a/evals/flows/connect-aware-extension-gating.flow.mjs
+++ b/evals/flows/connect-aware-extension-gating.flow.mjs
@@ -1,0 +1,230 @@
+/**
+ * Internal demo: connect-aware gating of the legacy Google Workspace
+ * extension surface behind the org-level `connectEnabled` flag.
+ *
+ * Protagonist: the OpenWork server surface the agent actually consumes
+ * (`/experimental/extensions/*`), driven through the real running app via
+ * CDP — every request runs in-page with the app's own port and tokens,
+ * exactly like the desktop client and the extensions-preview plugin do.
+ *
+ * Safety property under proof: gating only ever hides actions that would
+ * fail with `google_workspace_not_connected` anyway (legacy unconfigured),
+ * and the flag is a live kill switch.
+ */
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "connect-aware-extension-gating";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const GW = "google-workspace";
+const IMAGE_GEN = "openai-image-generation";
+const GW_NON_STATUS = [
+  "calendar_list_events",
+  "gmail_create_draft",
+  "gmail_create_reply_draft",
+  "gmail_list_messages",
+  "gmail_get_message",
+  "gmail_download_attachment",
+  "drive_search_files",
+  "drive_read_file",
+  "drive_update_file",
+  "calendar_create_event",
+  "chat_list_spaces",
+  "chat_list_messages",
+  "chat_send_message",
+];
+
+/**
+ * In-page request against the embedded OpenWork server using the app's own
+ * token (in the dev sandbox the client bearer carries host scope; the stored
+ * hostToken can be stale across restarts, so we deliberately avoid it).
+ */
+const serverExpr = (path, { method = "GET", body } = {}) => `(async () => {
+  const port = localStorage.getItem("openwork.server.port");
+  const token = localStorage.getItem("openwork.server.token");
+  if (!port || !token) return { transport: "missing port or token" };
+  const response = await fetch("http://127.0.0.1:" + port + ${JSON.stringify(path)}, {
+    method: ${JSON.stringify(method)},
+    headers: {
+      Authorization: "Bearer " + token,
+      ...(${JSON.stringify(Boolean(body))} ? { "Content-Type": "application/json" } : {}),
+    },
+    ...(${JSON.stringify(Boolean(body))} ? { body: ${JSON.stringify(JSON.stringify(body ?? null))} } : {}),
+  });
+  const payload = await response.json().catch(() => null);
+  return { status: response.status, payload };
+})()`;
+
+async function server(ctx, path, options) {
+  const result = await ctx.eval(serverExpr(path, options), { awaitPromise: true });
+  ctx.assert(result && typeof result.status === "number", `server request ${path} reached the app's embedded server (got: ${JSON.stringify(result)})`);
+  return result;
+}
+
+const actionKey = (item) => `${item.extensionId}:${item.action}`;
+
+async function listActions(ctx) {
+  const { status, payload } = await server(ctx, "/experimental/extensions/actions");
+  ctx.assert(status === 200 && payload?.ok === true, `actions list responds ok (status ${status})`);
+  return payload.actions.map(actionKey);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Connect flag gates dead legacy Google Workspace actions and redirects the agent to OpenWork Cloud",
+  kind: "internal",
+  spec: "evals/voiceovers/connect-aware-extension-gating.md",
+  steps: [
+    {
+      name: "Baseline: flag off, full legacy surface (today's behavior)",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "window.__openworkControl" });
+        await ctx.waitFor('Boolean(localStorage.getItem("openwork.server.port")) && Boolean(localStorage.getItem("openwork.server.token"))', {
+          timeoutMs: 60_000,
+          label: "embedded server port/token in localStorage",
+        });
+        await ctx.prove("With connectEnabled off, every legacy extension action is offered exactly as before", {
+          voiceover: vo[0],
+          action: async () => {
+            // Idempotence: force the flag off regardless of previous runs.
+            const put = await server(ctx, "/experimental/connect/state", { method: "PUT", body: { connectEnabled: false } });
+            ctx.assert(put.status === 200 && put.payload?.ok === true, `PUT connect/state off succeeds (status ${put.status})`);
+          },
+          assert: async () => {
+            const state = await server(ctx, "/experimental/connect/state");
+            ctx.assert(state.payload?.connectEnabled === false, "connect state reports connectEnabled=false");
+            ctx.assert(state.payload?.googleWorkspace?.legacyConfigured === false, "no legacy Google OAuth client configured on this device");
+            const keys = await listActions(ctx);
+            for (const action of GW_NON_STATUS) {
+              ctx.assert(keys.includes(`${GW}:${action}`), `baseline offers ${GW}:${action}`);
+            }
+            ctx.assert(keys.includes(`${GW}:status`), "baseline offers google-workspace:status");
+            ctx.assert(keys.includes(`${IMAGE_GEN}:image_generate`), "baseline offers image generation");
+            ctx.output("baseline-actions", JSON.stringify({ count: keys.length, actions: keys }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Org flips connectEnabled — the desktop push endpoint",
+      run: async (ctx) => {
+        await ctx.prove("PUT /experimental/connect/state {connectEnabled:true} persists and reports the device snapshot", {
+          voiceover: vo[1],
+          action: async () => {
+            const put = await server(ctx, "/experimental/connect/state", { method: "PUT", body: { connectEnabled: true } });
+            ctx.assert(put.status === 200 && put.payload?.ok === true, `PUT connect/state on succeeds (status ${put.status})`);
+          },
+          assert: async () => {
+            const state = await server(ctx, "/experimental/connect/state");
+            ctx.assert(state.payload?.connectEnabled === true, "connect state reports connectEnabled=true");
+            ctx.assert(typeof state.payload?.cloudMcpPresent === "boolean", "snapshot reports whether the openwork-cloud MCP is present");
+            ctx.output("connect-state-on", JSON.stringify(state.payload, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Tool surface transforms: dead GW actions vanish, status and image-gen stay",
+      run: async (ctx) => {
+        await ctx.prove("Gating hides exactly the 13 dead Google Workspace actions and nothing else", {
+          voiceover: vo[2],
+          assert: async () => {
+            const keys = await listActions(ctx);
+            for (const action of GW_NON_STATUS) {
+              ctx.assert(!keys.includes(`${GW}:${action}`), `gated list no longer offers ${GW}:${action}`);
+            }
+            ctx.assert(keys.includes(`${GW}:status`), "status probe survives gating");
+            ctx.assert(keys.includes(`${IMAGE_GEN}:image_generate`), "image generation is untouched by gating");
+            ctx.assert(keys.includes(`${IMAGE_GEN}:status`), "image generation status is untouched by gating");
+            ctx.output("gated-actions", JSON.stringify({ count: keys.length, actions: keys }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Calling a hidden action returns a redirect, not an OAuth dead-end",
+      run: async (ctx) => {
+        await ctx.prove("A gated call answers use_openwork_cloud with Settings > Connect guidance", {
+          voiceover: vo[3],
+          assert: async () => {
+            const call = await server(ctx, "/experimental/extensions/call", {
+              method: "POST",
+              body: { extensionId: GW, action: "gmail_list_messages", args: {} },
+            });
+            ctx.assert(call.status === 200, `gated call responds 200 with a structured payload (status ${call.status})`);
+            ctx.assert(call.payload?.ok === false, "gated call is not treated as success");
+            ctx.assert(call.payload?.error === "use_openwork_cloud", `gated call error is use_openwork_cloud (got ${call.payload?.error})`);
+            ctx.assert(String(call.payload?.message ?? "").includes("Settings > Connect"), "guidance points at Settings > Connect");
+            ctx.assert(!String(call.payload?.message ?? "").includes("client secret"), "guidance never mentions OAuth client secrets");
+            ctx.output("gated-call-redirect", JSON.stringify(call.payload, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Status carries the same guidance for status-only agents",
+      run: async (ctx) => {
+        await ctx.prove("GET google-workspace/status includes an additive connect block with guidance", {
+          voiceover: vo[4],
+          assert: async () => {
+            const status = await server(ctx, "/experimental/google-workspace/status");
+            ctx.assert(status.status === 200, `status responds 200 (status ${status.status})`);
+            ctx.assert(status.payload?.configured === false, "legacy fields are preserved for UI compatibility");
+            ctx.assert(status.payload?.connect?.enabled === true, "status carries connect.enabled=true");
+            ctx.assert(String(status.payload?.connect?.guidance ?? "").includes("Settings > Connect"), "status guidance points at Settings > Connect");
+            ctx.output("gw-status-gated", JSON.stringify(status.payload, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Kill switch: flag off restores the full surface on the next request",
+      run: async (ctx) => {
+        await ctx.prove("Disabling connectEnabled restores all legacy actions with no restart", {
+          voiceover: vo[5],
+          action: async () => {
+            const put = await server(ctx, "/experimental/connect/state", { method: "PUT", body: { connectEnabled: false } });
+            ctx.assert(put.status === 200 && put.payload?.connectEnabled === false, "PUT connect/state off succeeds");
+          },
+          assert: async () => {
+            const keys = await listActions(ctx);
+            for (const action of GW_NON_STATUS) {
+              ctx.assert(keys.includes(`${GW}:${action}`), `restored list offers ${GW}:${action}`);
+            }
+            const call = await server(ctx, "/experimental/extensions/call", {
+              method: "POST",
+              body: { extensionId: GW, action: "status", args: {} },
+            });
+            ctx.assert(call.payload?.ok === true, "status action call succeeds again");
+            ctx.assert(call.payload?.result?.connect === undefined, "connect block is absent when the flag is off");
+            ctx.output("restored-actions", JSON.stringify({ count: keys.length }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "The surface users are pointed to exists: Settings > Connect",
+      run: async (ctx) => {
+        await ctx.prove("Settings > Connect renders as the org connections surface", {
+          voiceover: vo[6],
+          action: async () => {
+            await ctx.navigateHash("#/settings/connect");
+            await ctx.waitFor("document.body.innerText.includes('cloud-managed MCP connections')", {
+              timeoutMs: 30_000,
+              label: "Connect settings surface",
+            });
+          },
+          assert: async () => {
+            await ctx.expectHashIncludes("/settings/connect");
+            await ctx.expectText("Connect for teams");
+          },
+          screenshot: {
+            name: "settings-connect-surface",
+            requireText: ["Connect for teams"],
+            hashIncludes: "/settings/connect",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/connect-aware-extension-gating.md
+++ b/evals/voiceovers/connect-aware-extension-gating.md
@@ -1,0 +1,24 @@
+# Connect-aware legacy extension gating — internal demo
+
+The collision: OpenWork ships two Google Workspace integrations. The legacy
+per-device "extensions" path always advertises 14 Google Workspace actions to
+the agent, even when the device has no OAuth client configured — so agents run
+`status`, read "missing OAuth client secret", and tell connected-via-Cloud
+users to reconnect in Settings > Extensions. This demo proves the fix: an
+org-level `connectEnabled` switch that removes the dead tools, redirects the
+agent to OpenWork Cloud, and never touches a device where the legacy path is
+actually configured.
+
+1. This is a fresh device: the org has not enabled Connect, and no legacy Google OAuth client is configured. The legacy extension surface offers every action it always has — Google Workspace and image generation side by side — byte-for-byte the behavior shipped today.
+
+2. Now the organization flips one switch: connect enabled. This is the exact endpoint the desktop app pushes when the org's cloud config arrives — one boolean, stored server-side, effective on the very next request.
+
+3. The tool surface transforms. The thirteen Google Workspace actions that could only fail on this device are gone; the safe status probe stays; and image generation — which has no cloud equivalent — is untouched. The agent can no longer stumble into a dead end.
+
+4. If an agent still calls a hidden Google Workspace action, it no longer gets an OAuth error to misread. It gets a redirect: use OpenWork Cloud's search and execute capabilities, and if the user needs to connect, send them to Settings > Connect — never Settings > Extensions.
+
+5. The status probe itself now carries the same guidance, so even an agent that only checks status walks away with the correct next step instead of a missing-client-secret diagnosis.
+
+6. And it is a real kill switch: flip the flag off and the full legacy surface is back on the next request — no restart, no reinstall, nothing lost for teams that are not ready.
+
+7. Behind it all is the surface users are actually pointed to: Settings > Connect, where Google Workspace and the rest of the org's connections live in the cloud, connected once per member.


### PR DESCRIPTION
## Why

Stacked on #2597 (auto-retargets to `dev` when it merges). Gating removes the dead tools; this PR fixes the **recruitment**: the extensions-preview plugin unconditionally injects a system-prompt instruction steering agents to `openwork_extension_list_actions` for anything unusual, with zero equivalent steering toward `openwork-cloud_search_capabilities`. That is why "check my email" walks into the legacy path in the first place.

## What

`apps/server/src/opencode-plugins/openwork-extensions-preview.ts`:
- At system-transform time the plugin fetches `GET /experimental/connect/state` (its existing server phone-home pattern), with a 15s TTL cache and **fail-open** to today's static instruction on any error — steering can never break a session.
- Pure, exported composition `composeOpenWorkExtensionDiscoveryInstruction(state)`:
  - state unavailable / flag off / legacy configured → **byte-identical** static instruction (zero change);
  - Connect active + cloud MCP present → steer Gmail/Calendar/Drive/org services to `openwork-cloud_search_capabilities` → `execute_capability` first; extensions stay for local actions (image generation); never direct users to Settings > Extensions for Google Workspace — use Settings > Connect;
  - Connect active + cloud MCP absent → static instruction + "connect in Settings > Connect (never Settings > Extensions)".

Also carries the fraimz flow + approved voiceover for the whole gating experience (`evals/flows/connect-aware-extension-gating.flow.mjs`).

## Tests

Run on Daytona (same sandbox as #2597):
- `apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts` — 8 tests: byte-identical fallback ×3, both steering variants, bearer-auth fetch + 15s TTL, fail-open on fetch error and on parse error. All pass.
- Full apps/server suite: 581 pass / 1 pre-existing fail (identical on base commit — see #2597).
- `pnpm --filter openwork-server typecheck` — pass.

## Evidence

Fraimz (7 frames, PASSED) against the real app on Daytona — comment below.

## Honest gap

Model-driven e2e (a live agent choosing the cloud tool from a natural prompt) is not covered here; the composition layer is unit-tested and the consumed state endpoint is fraimz-proven. A model-in-the-loop eval matrix is the natural follow-up.