### PR TITLE
feat(den-mcp): agent instructions and explicit timeouts with agent-steering errors

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
@@ -12,6 +12,7 @@ import type {
   OAuthClientInformationMixed,
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js"
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js"
 import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import type { ExternalMcpConnectionRow } from "./external-mcp-connections.js"
 import {
@@ -43,6 +44,11 @@ import {
  */
 
 const CLIENT_NAME = "OpenWork"
+const EXTERNAL_MCP_CALL_TIMEOUT_MS = 30_000
+const EXTERNAL_MCP_CALL_OPTIONS: RequestOptions = {
+  timeout: EXTERNAL_MCP_CALL_TIMEOUT_MS,
+  resetTimeoutOnProgress: true,
+}
 
 /**
  * Which member's credential this session should use, for connections with
@@ -299,7 +305,7 @@ export async function callExternalMcpTool(input: {
   const { transport } = buildTransport(input.connection, input.redirectUri, undefined, input.member)
   await client.connect(transport)
   try {
-    return await client.callTool({ name: input.toolName, arguments: input.args })
+    return await client.callTool({ name: input.toolName, arguments: input.args }, undefined, EXTERNAL_MCP_CALL_OPTIONS)
   } finally {
     await client.close()
   }

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
 import { StreamableHTTPTransport } from "@hono/mcp"
 import { eq } from "@openwork-ee/den-db/drizzle"
 import { OrganizationTable } from "@openwork-ee/den-db/schema"
@@ -19,6 +20,21 @@ import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { env } from "../env.js"
 
 export const EXECUTE_CAPABILITY_TOOL_NAME = "execute_capability"
+export const EXECUTE_CAPABILITY_TIMEOUT_MS = 45_000
+
+export const AGENT_MCP_INSTRUCTIONS = [
+  "This OpenWork Cloud connection intentionally exposes exactly two tools: search_capabilities and execute_capability.",
+  "Capabilities include native Google Workspace operations (Gmail read/search, Calendar list/create, Drive search/read, and Gmail draft creation) executed with the signed-in member's organization credentials, plus any MCP connections the organization has added.",
+  "Always call search_capabilities first with 2-4 keyword variants before concluding something is unavailable. Use execute_capability only with exact names returned by search_capabilities.",
+  "Do not tell users to configure OAuth clients or local extensions for these capabilities; organization connections are managed in the OpenWork Cloud dashboard / Settings > Connect.",
+].join("\n")
+
+const EXECUTE_CAPABILITY_TIMEOUT_MESSAGE = "The capability call exceeded 45s. Retry once; if it times out again, narrow the request (fewer results, tighter query) and tell the user the service is slow — do NOT tell them to reconfigure or reconnect."
+
+export type ExecuteCapabilityToolResult = {
+  isError?: boolean
+  content: { text: string; type: "text" }[]
+}
 
 function textContent(text: string): { text: string; type: "text" }[] {
   return [{ type: "text", text }]
@@ -28,6 +44,87 @@ function unknownCapabilityText(name: string): string {
   return JSON.stringify({
     error: "unknown_capability",
     message: `No capability named "${name}". Call search_capabilities to find a valid name.`,
+  })
+}
+
+function normalizedExternalArgs(body: unknown): Record<string, unknown> {
+  const normalizedBody = normalizeToolBody(body)
+  if (typeof normalizedBody !== "object" || normalizedBody === null || Array.isArray(normalizedBody)) {
+    return {}
+  }
+  const args: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(normalizedBody)) {
+    args[key] = value
+  }
+  return args
+}
+
+function isTextContent(value: unknown): value is { type: "text"; text: string } {
+  return typeof value === "object"
+    && value !== null
+    && "type" in value
+    && value.type === "text"
+    && "text" in value
+    && typeof value.text === "string"
+}
+
+function externalToolContent(result: unknown): { type: "text"; text: string }[] {
+  if (typeof result === "object" && result !== null && "content" in result && Array.isArray(result.content) && result.content.every(isTextContent)) {
+    return result.content
+  }
+  return textContent(JSON.stringify(result))
+}
+
+function capabilityTimeoutResult(capability: string): ExecuteCapabilityToolResult {
+  return {
+    isError: true,
+    content: textContent(JSON.stringify({
+      error: "capability_timeout",
+      capability,
+      message: EXECUTE_CAPABILITY_TIMEOUT_MESSAGE,
+    })),
+  }
+}
+
+function isTimeoutError(error: unknown): boolean {
+  if (error instanceof McpError && error.code === ErrorCode.RequestTimeout) {
+    return true
+  }
+  if (error instanceof DOMException && (error.name === "TimeoutError" || error.name === "AbortError")) {
+    return true
+  }
+  return error instanceof Error && /\b(time(?:d)? out|timeout)\b/i.test(error.message)
+}
+
+export async function executeCapabilityWithBudget<T extends ExecuteCapabilityToolResult>(input: {
+  capability: string
+  timeoutMs?: number
+  invoke: () => Promise<T>
+}): Promise<T | ExecuteCapabilityToolResult> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const timeoutResult = new Promise<ExecuteCapabilityToolResult>((resolve) => {
+    timeout = setTimeout(() => resolve(capabilityTimeoutResult(input.capability)), input.timeoutMs ?? EXECUTE_CAPABILITY_TIMEOUT_MS)
+  })
+  try {
+    const invocation = input.invoke()
+    void invocation.catch(() => undefined)
+    return await Promise.race([invocation, timeoutResult])
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      return capabilityTimeoutResult(input.capability)
+    }
+    throw error
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
+export function createAgentMcpServer(): McpServer {
+  return new McpServer({
+    name: "openwork-den-api-agent",
+    version: "1.0.0",
+  }, {
+    instructions: AGENT_MCP_INSTRUCTIONS,
   })
 }
 
@@ -78,10 +175,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
     const externalMcpConnectionsEnabled = memberFacingMcpConnectionsEnabled(organizationRows[0]?.metadata, {
       gatingEnabled: env.mcpConnectionsGatingEnabled,
     })
-    const server = new McpServer({
-      name: "openwork-den-api-agent",
-      version: "1.0.0",
-    })
+    const server = createAgentMcpServer()
 
     server.registerTool(
       SEARCH_CAPABILITIES_TOOL_NAME,
@@ -90,6 +184,8 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         description: [
           "Search for a capability by keyword. This connection only exposes this tool and execute_capability —",
           "there is no list of individually-named tools to browse. Always search first.",
+          "Search covers native Google Workspace capabilities (Gmail, Calendar, Drive, Gmail drafts) and org-connected external MCPs such as Notion, Linear, Slack, or other services added in the OpenWork Cloud dashboard / Settings > Connect.",
+          "Try 2-4 keyword variants before deciding a capability is unavailable.",
           "Each match includes pathParams/queryParams/hasBody describing exactly what execute_capability needs.",
           "Skill matches use method SKILL and return stored SKILL.md content when executed.",
         ].join(" "),
@@ -157,114 +253,106 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         }),
       },
       async ({ name, path, query, body }) => {
-        const external = parseExternalCapabilityName(name)
-        if (external) {
-          if (!externalMcpConnectionsEnabled) {
-            return {
-              isError: true,
-              content: [{
-                type: "text",
-                text: JSON.stringify({
-                  error: "unknown_capability",
-                  message: "No external MCP connection capabilities are available for this organization.",
-                }),
-              }],
+        return executeCapabilityWithBudget({
+          capability: name,
+          invoke: async (): Promise<ExecuteCapabilityToolResult> => {
+            const external = parseExternalCapabilityName(name)
+            if (external) {
+              if (!externalMcpConnectionsEnabled) {
+                return {
+                  isError: true,
+                  content: textContent(JSON.stringify({
+                    error: "unknown_capability",
+                    message: "No external MCP connection capabilities are available for this organization.",
+                  })),
+                }
+              }
+              const result = await executeExternalCapability({
+                organizationId: principal.organizationId,
+                member: memberIdentity,
+                connectionId: external.connectionId,
+                toolName: external.toolName,
+                args: normalizedExternalArgs(body),
+                redirectUriBase: resolvePublicOrigin(c.req.raw, env.apiPublicUrl),
+              })
+              if (!result.ok) {
+                return {
+                  isError: true,
+                  content: textContent(JSON.stringify({ error: result.error, message: result.message })),
+                }
+              }
+              // The SDK's callTool() can return either the standard {content:[...]}
+              // shape or a legacy-compatibility {toolResult} shape; normalize to
+              // what McpServer's own tool callback contract requires.
+              return { content: externalToolContent(result.result) }
             }
-          }
-          const normalizedBody = normalizeToolBody(body)
-          const args = (typeof normalizedBody === "object" && normalizedBody !== null && !Array.isArray(normalizedBody)
-            ? normalizedBody
-            : {}) as Record<string, unknown>
-          const result = await executeExternalCapability({
-            organizationId: principal.organizationId,
-            member: memberIdentity,
-            connectionId: external.connectionId,
-            toolName: external.toolName,
-            args,
-            redirectUriBase: resolvePublicOrigin(c.req.raw, env.apiPublicUrl),
-          })
-          if (!result.ok) {
-            return {
-              isError: true,
-              content: [{ type: "text" as const, text: JSON.stringify({ error: result.error, message: result.message }) }],
+
+            const marketplace = parseMarketplaceCapabilityName(name)
+            if (marketplace) {
+              const result = await executeMarketplaceCapability({
+                organizationId: principal.organizationId,
+                member: memberIdentity,
+                pluginId: marketplace.pluginId,
+                configObjectId: marketplace.configObjectId,
+                body,
+                enabled: externalMcpConnectionsEnabled,
+              })
+              if (!result.ok) {
+                return {
+                  isError: true,
+                  content: textContent(result.error === "unknown_capability"
+                    ? unknownCapabilityText(name)
+                    : JSON.stringify({ error: result.error, message: result.message })),
+                }
+              }
+              return { content: textContent(JSON.stringify(result.result, null, 2)) }
             }
-          }
-          // The SDK's callTool() can return either the standard {content:[...]}
-          // shape or a legacy-compatibility {toolResult} shape; normalize to
-          // what McpServer's own tool callback contract requires.
-          const content = Array.isArray((result.result as { content?: unknown[] }).content)
-            ? (result.result as { content: { type: "text"; text: string }[] }).content
-            : [{ type: "text" as const, text: JSON.stringify(result.result) }]
-          return { content }
-        }
 
-        const marketplace = parseMarketplaceCapabilityName(name)
-        if (marketplace) {
-          const result = await executeMarketplaceCapability({
-            organizationId: principal.organizationId,
-            member: memberIdentity,
-            pluginId: marketplace.pluginId,
-            configObjectId: marketplace.configObjectId,
-            body,
-            enabled: externalMcpConnectionsEnabled,
-          })
-          if (!result.ok) {
-            return {
-              isError: true,
-              content: textContent(result.error === "unknown_capability"
-                ? unknownCapabilityText(name)
-                : JSON.stringify({ error: result.error, message: result.message })),
+            const skillId = parseSkillCapabilityName(name)
+            if (skillId) {
+              const result = await executeSkillCapability({
+                organizationId: principal.organizationId,
+                member: memberIdentity,
+                skillId,
+              })
+              if (!result.ok) {
+                return {
+                  isError: true,
+                  content: textContent(JSON.stringify({ error: result.error, message: result.message })),
+                }
+              }
+              return {
+                content: textContent(JSON.stringify({
+                  skill: {
+                    id: result.skill.id,
+                    title: result.skill.title,
+                    description: result.skill.description,
+                    skillText: result.skill.skillText,
+                    updatedAt: result.skill.updatedAt,
+                  },
+                }, null, 2)),
+              }
             }
-          }
-          return { content: textContent(JSON.stringify(result.result, null, 2)) }
-        }
 
-        const skillId = parseSkillCapabilityName(name)
-        if (skillId) {
-          const result = await executeSkillCapability({
-            organizationId: principal.organizationId,
-            member: memberIdentity,
-            skillId,
-          })
-          if (!result.ok) {
-            return {
-              isError: true,
-              content: [{ type: "text" as const, text: JSON.stringify({ error: result.error, message: result.message }) }],
+            const operation = catalog.find((candidate) => candidate.name === name)
+            if (!operation) {
+              return {
+                isError: true,
+                content: textContent(unknownCapabilityText(name)),
+              }
             }
-          }
-          return {
-            content: [{
-              type: "text" as const,
-              text: JSON.stringify({
-                skill: {
-                  id: result.skill.id,
-                  title: result.skill.title,
-                  description: result.skill.description,
-                  skillText: result.skill.skillText,
-                  updatedAt: result.skill.updatedAt,
-                },
-              }, null, 2),
-            }],
-          }
-        }
 
-        const operation = catalog.find((candidate) => candidate.name === name)
-        if (!operation) {
-          return {
-            isError: true,
-            content: textContent(unknownCapabilityText(name)),
-          }
-        }
-
-        return invokeMcpOperation({
-          app: app as unknown as Hono,
-          env: c.env,
-          operation,
-          principal,
-          toolInput: {
-            path: normalizeToolRecord(path),
-            query: normalizeToolRecord(query),
-            body: normalizeToolBody(body),
+            return invokeMcpOperation({
+              app: app as unknown as Hono,
+              env: c.env,
+              operation,
+              principal,
+              toolInput: {
+                path: normalizeToolRecord(path),
+                query: normalizeToolRecord(query),
+                body: normalizeToolBody(body),
+              },
+            })
           },
         })
       },

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -25,8 +25,9 @@ const CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
 const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file"
 const DRIVE_READ_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
 const DRIVE_FULL_SCOPE = "https://www.googleapis.com/auth/drive"
+const GOOGLE_WORKSPACE_API_TIMEOUT_MS = 30_000
 
-const CONNECT_GOOGLE_ACCOUNT_MESSAGE = "Connect your Google account first: open Settings, then Extensions, and use Connect your account on the Google Workspace card."
+const CONNECT_GOOGLE_ACCOUNT_MESSAGE = "Connect your Google account first: open Settings > Connect and use Connect your account on the Google Workspace row, or connect from the OpenWork Cloud dashboard."
 
 const createDraftBodySchema = z.object({
   to: z.string().trim().min(3).max(320).describe("Recipient email address."),
@@ -232,6 +233,13 @@ async function googleApiError(operation: string, response: Response) {
   return { error: "google_api_error", message: `${operation} failed: ${response.status} ${text.slice(0, 300)}` }
 }
 
+async function googleWorkspaceApiFetch(input: Parameters<typeof fetch>[0], init?: RequestInit): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: AbortSignal.timeout(GOOGLE_WORKSPACE_API_TIMEOUT_MS),
+  })
+}
+
 async function readJson(response: Response): Promise<unknown> {
   const body: unknown = await response.json()
   return body
@@ -297,7 +305,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (query.q) listUrl.searchParams.set("q", query.q)
       listUrl.searchParams.set("maxResults", String(query.maxResults))
 
-      const listResponse = await fetch(listUrl, {
+      const listResponse = await googleWorkspaceApiFetch(listUrl, {
         headers: { authorization: `Bearer ${token.accessToken}` },
       })
       if (!listResponse.ok) {
@@ -313,7 +321,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         messageUrl.searchParams.append("metadataHeaders", "To")
         messageUrl.searchParams.append("metadataHeaders", "Subject")
         messageUrl.searchParams.append("metadataHeaders", "Date")
-        const messageResponse = await fetch(messageUrl, {
+        const messageResponse = await googleWorkspaceApiFetch(messageUrl, {
           headers: { authorization: `Bearer ${token.accessToken}` },
         })
         if (!messageResponse.ok) {
@@ -370,7 +378,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       const { messageId } = c.req.valid("param")
       const messageUrl = new URL(`${gmailApiBase()}/gmail/v1/users/me/messages/${encodeURIComponent(messageId)}`)
       messageUrl.searchParams.set("format", "full")
-      const response = await fetch(messageUrl, {
+      const response = await googleWorkspaceApiFetch(messageUrl, {
         headers: { authorization: `Bearer ${token.accessToken}` },
       })
       if (!response.ok) {
@@ -420,7 +428,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       url.searchParams.set("orderBy", "startTime")
       url.searchParams.set("maxResults", String(query.maxResults))
 
-      const response = await fetch(url, {
+      const response = await googleWorkspaceApiFetch(url, {
         headers: { authorization: `Bearer ${token.accessToken}` },
       })
       if (!response.ok) {
@@ -463,7 +471,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       }
 
       const input = c.req.valid("json")
-      const response = await fetch(`${calendarApiBase()}/calendar/v3/calendars/primary/events`, {
+      const response = await googleWorkspaceApiFetch(`${calendarApiBase()}/calendar/v3/calendars/primary/events`, {
         method: "POST",
         headers: {
           authorization: `Bearer ${token.accessToken}`,
@@ -528,7 +536,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       url.searchParams.set("pageSize", String(query.maxResults))
       url.searchParams.set("fields", "files(id,name,mimeType,modifiedTime,webViewLink,size)")
 
-      const response = await fetch(url, {
+      const response = await googleWorkspaceApiFetch(url, {
         headers: { authorization: `Bearer ${token.accessToken}` },
       })
       if (!response.ok) {
@@ -573,7 +581,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       const { fileId } = c.req.valid("param")
       const metadataUrl = new URL(`${driveApiBase()}/drive/v3/files/${encodeURIComponent(fileId)}`)
       metadataUrl.searchParams.set("fields", "id,name,mimeType,modifiedTime,webViewLink,size")
-      const metadataResponse = await fetch(metadataUrl, {
+      const metadataResponse = await googleWorkspaceApiFetch(metadataUrl, {
         headers: { authorization: `Bearer ${token.accessToken}` },
       })
       if (!metadataResponse.ok) {
@@ -594,7 +602,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         contentUrl.searchParams.set("alt", "media")
       }
 
-      const contentResponse = await fetch(contentUrl, {
+      const contentResponse = await googleWorkspaceApiFetch(contentUrl, {
         headers: { authorization: `Bearer ${token.accessToken}` },
       })
       if (!contentResponse.ok) {
@@ -642,7 +650,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       }
 
       const { to, subject, body } = c.req.valid("json")
-      const response = await fetch(`${gmailApiBase()}/gmail/v1/users/me/drafts`, {
+      const response = await googleWorkspaceApiFetch(`${gmailApiBase()}/gmail/v1/users/me/drafts`, {
         method: "POST",
         headers: {
           authorization: `Bearer ${token.accessToken}`,

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -364,7 +364,7 @@ test("no connected account returns needs_connection", async () => {
   const body: unknown = await response.json()
   expect(body).toEqual({
     error: "needs_connection",
-    message: "Connect your Google account first: open Settings, then Extensions, and use Connect your account on the Google Workspace card.",
+    message: "Connect your Google account first: open Settings > Connect and use Connect your account on the Google Workspace row, or connect from the OpenWork Cloud dashboard.",
   })
 })
 

--- a/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
@@ -1,0 +1,111 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js"
+import type { Transport, TransportSendOptions } from "@modelcontextprotocol/sdk/shared/transport.js"
+import { beforeAll, expect, test } from "bun:test"
+import type { ExecuteCapabilityToolResult } from "../src/mcp/agent.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+class MemoryTransport implements Transport {
+  private peer: MemoryTransport | undefined
+  onclose: (() => void) | undefined
+  onerror: ((error: Error) => void) | undefined
+  onmessage: (<T extends JSONRPCMessage>(message: T) => void) | undefined
+
+  connectPeer(peer: MemoryTransport) {
+    this.peer = peer
+  }
+
+  async start(): Promise<void> {}
+
+  async send(message: JSONRPCMessage, _options?: TransportSendOptions): Promise<void> {
+    this.peer?.onmessage?.(message)
+  }
+
+  async close(): Promise<void> {
+    this.onclose?.()
+  }
+}
+
+function createMemoryTransportPair() {
+  const client = new MemoryTransport()
+  const server = new MemoryTransport()
+  client.connectPeer(server)
+  server.connectPeer(client)
+  return { client, server }
+}
+
+let agentModule: typeof import("../src/mcp/agent.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  agentModule = await import("../src/mcp/agent.js")
+})
+
+test("executeCapabilityWithBudget returns a structured timeout result", async () => {
+  const result = await agentModule.executeCapabilityWithBudget({
+    capability: "gmail_search",
+    timeoutMs: 1,
+    invoke: () => new Promise<ExecuteCapabilityToolResult>(() => {}),
+  })
+
+  expect(result.isError).toBe(true)
+  expect(result.content[0]?.text).toBe(JSON.stringify({
+    error: "capability_timeout",
+    capability: "gmail_search",
+    message: "The capability call exceeded 45s. Retry once; if it times out again, narrow the request (fewer results, tighter query) and tell the user the service is slow — do NOT tell them to reconfigure or reconnect.",
+  }))
+})
+
+test("executeCapabilityWithBudget swallows late rejections after timeout", async () => {
+  const unhandled: unknown[] = []
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandled.push(reason)
+  }
+  process.on("unhandledRejection", onUnhandledRejection)
+
+  try {
+    const result = await agentModule.executeCapabilityWithBudget({
+      capability: "slow_google_workspace",
+      timeoutMs: 1,
+      invoke: () => new Promise<ExecuteCapabilityToolResult>((_resolve, reject) => {
+        setTimeout(() => reject(new Error("late capability failure")), 10)
+      }),
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0]?.text).toBe(JSON.stringify({
+      error: "capability_timeout",
+      capability: "slow_google_workspace",
+      message: "The capability call exceeded 45s. Retry once; if it times out again, narrow the request (fewer results, tighter query) and tell the user the service is slow — do NOT tell them to reconfigure or reconnect.",
+    }))
+
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    expect(unhandled).toEqual([])
+  } finally {
+    process.off("unhandledRejection", onUnhandledRejection)
+  }
+})
+
+test("agent MCP server exposes steering instructions during initialize", async () => {
+  const server = agentModule.createAgentMcpServer()
+  const client = new Client({ name: "test-client", version: "1.0.0" })
+  const transports = createMemoryTransportPair()
+
+  await server.connect(transports.server)
+  await client.connect(transports.client)
+
+  expect(client.getInstructions()).toBe(agentModule.AGENT_MCP_INSTRUCTIONS)
+  expect(client.getInstructions()).toContain("search_capabilities and execute_capability")
+  expect(client.getInstructions()).toContain("Gmail read/search")
+  expect(client.getInstructions()).toContain("Settings > Connect")
+
+  await client.close()
+  await server.close()
+})


### PR DESCRIPTION
## Why

Two live-demo failures on the OpenWork Cloud agent MCP (`/mcp/agent`):
1. The server passes no `instructions` and the tool descriptions don't say what's reachable — agents fall back to legacy tools or claim capabilities are missing.
2. A capability call timed out opaquely: **no explicit timeout existed anywhere on this path** (MCP SDK 60s default per hop; plain fetches to Google with no signal), vs a 30s budget on the legacy desktop path.

## What

- `ee/apps/den-api/src/mcp/agent.ts`: `McpServer` now ships `instructions` (two-tool contract, native Google Workspace + org MCP connections, search-first with 2–4 keyword variants, never tell users to configure OAuth clients/local extensions); `search_capabilities` description enriched the same way. `execute_capability` wrapped in an exported 45s budget (`executeCapabilityWithBudget`) returning a structured `capability_timeout` result that tells the agent to retry/narrow — **not** to tell users to reconfigure. Late rejections after timeout are swallowed (no unhandled rejection).
- `external-mcp-client.ts`: `callTool` gets `{ timeout: 30_000, resetTimeoutOnProgress: true }`.
- `routes/org/google-workspace.ts`: all outbound Google API fetches through a shared 30s `AbortSignal.timeout` helper; also fixes `CONNECT_GOOGLE_ACCOUNT_MESSAGE` which pointed users at the **legacy** surface ("Settings, then Extensions") — now Settings > Connect / the Cloud dashboard, the exact wrong-surface bug this series kills.

## Tests

Run on Daytona with a provisioned MariaDB + den-db schema push:
- `test/mcp-agent-timeouts.test.ts` — 3 tests (structured timeout result, late-rejection swallow after timeout, instructions exposed during MCP initialize) — all pass.
- `test/google-workspace-capabilities.test.ts` — same pass/fail profile as base commit 848f65a4c: the updated `needs_connection` message test **passes**; the one failing test (`missing Gmail read scope…`) **fails identically on base** (pre-existing, unrelated).
- `pnpm exec tsc --noEmit` (den-api) — pass.

## Notes

Dynamic per-org provider enumeration in instructions was deliberately skipped (would add a DB query at MCP construction); static wording + enriched search description covers it. Companion desktop-side PRs: #2597 + stacked steering PR.