### PR TITLE
Add skill-only capability search filter

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -11,7 +11,7 @@ import { db } from "../db.js"
 import { getMcpResourceUrl, verifyMcpRequest } from "./auth.js"
 import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./invoke.js"
 import { getCatalog, protectedResourceMetadata } from "./index.js"
-import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities } from "./search.js"
+import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities, searchCapabilitySourceFilter } from "./search.js"
 import { executeExternalCapability, parseExternalCapabilityName, resolveMcpMemberIdentity, searchExternalCapabilities } from "./external-capabilities.js"
 import { executeMarketplaceCapability, parseMarketplaceCapabilityName, searchMarketplaceCapabilities } from "./marketplace-capabilities.js"
 import { executeSkillCapability, parseSkillCapabilityName, searchSkillCapabilities } from "./skill-capabilities.js"
@@ -19,6 +19,7 @@ import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { env } from "../env.js"
 
 export const EXECUTE_CAPABILITY_TOOL_NAME = "execute_capability"
+const searchCapabilityTypeSchema = z.enum(["all", "api", "mcp", "marketplace", "skills"])
 
 function textContent(text: string): { text: string; type: "text" }[] {
   return [{ type: "text", text }]
@@ -96,16 +97,18 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         inputSchema: z.object({
           query: z.string().min(1).describe("Keywords describing the capability you need, e.g. \"create organization\" or \"list workers\"."),
           limit: z.number().int().min(1).max(20).optional().describe("Max number of matches to return. Defaults to 5."),
+          type: searchCapabilityTypeSchema.optional().describe("Optional capability source filter. Use skills to search only stored organization skills. Defaults to all."),
         }),
       },
-      async ({ query, limit }) => {
+      async ({ query, limit, type }) => {
         const boundedLimit = limit ?? 5
-        const restMatches = searchCapabilities(catalog, query, boundedLimit)
+        const sourceFilter = searchCapabilitySourceFilter(type)
+        const restMatches = sourceFilter.api ? searchCapabilities(catalog, query, boundedLimit) : []
         // Merged in from each connected External MCP Connection's live
         // tools/list (capability-sources/external-mcp-client.ts) — a
         // Notion/Linear/Stripe/... connection an admin added in Den shows
         // up here exactly like any native capability, ranked together.
-        const externalMatches = externalMcpConnectionsEnabled
+        const externalMatches = sourceFilter.mcp && externalMcpConnectionsEnabled
           ? await searchExternalCapabilities({
             organizationId: principal.organizationId,
             member: memberIdentity,
@@ -114,7 +117,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
             limit: boundedLimit,
           })
           : []
-        const marketplaceMatches = externalMcpConnectionsEnabled
+        const marketplaceMatches = sourceFilter.marketplace && externalMcpConnectionsEnabled
           ? await searchMarketplaceCapabilities({
             organizationId: principal.organizationId,
             member: memberIdentity,
@@ -123,12 +126,14 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
             enabled: externalMcpConnectionsEnabled,
           })
           : []
-        const skillMatches = await searchSkillCapabilities({
-          organizationId: principal.organizationId,
-          member: memberIdentity,
-          query,
-          limit: boundedLimit,
-        })
+        const skillMatches = sourceFilter.skills
+          ? await searchSkillCapabilities({
+            organizationId: principal.organizationId,
+            member: memberIdentity,
+            query,
+            limit: boundedLimit,
+          })
+          : []
         const matches = [...restMatches, ...externalMatches, ...marketplaceMatches, ...skillMatches]
           .sort((a, b) => b.score - a.score)
           .slice(0, boundedLimit)

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -17,6 +17,7 @@ import { getParameters, hasJsonRequestBody, pathParameterNamesFromTemplate, type
  */
 
 export const SEARCH_CAPABILITIES_TOOL_NAME = "search_capabilities"
+export type SearchCapabilityType = "all" | "api" | "mcp" | "marketplace" | "skills"
 
 export type CapabilityMatch = {
   name: string
@@ -30,6 +31,16 @@ export type CapabilityMatch = {
   queryParams: string[]
   /** Whether calling this tool requires a JSON `body`. */
   hasBody: boolean
+}
+
+export function searchCapabilitySourceFilter(type?: SearchCapabilityType) {
+  const capabilityType = type ?? "all"
+  return {
+    api: capabilityType === "all" || capabilityType === "api",
+    mcp: capabilityType === "all" || capabilityType === "mcp",
+    marketplace: capabilityType === "all" || capabilityType === "marketplace",
+    skills: capabilityType === "all" || capabilityType === "skills",
+  }
 }
 
 export function tokenize(value: string): string[] {

--- a/ee/apps/den-api/src/mcp/skill-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/skill-capabilities.ts
@@ -37,6 +37,10 @@ export function parseSkillCapabilityName(name: string): string | null {
 function scoreText(nameTokens: string[], summaryTokens: string[], queryTokens: string[]): number {
   let score = 0
   for (const queryToken of queryTokens) {
+    if (queryToken === "skill" || queryToken === "skills") {
+      score += 1
+      continue
+    }
     if (nameTokens.includes(queryToken)) {
       score += 5
     } else if (nameTokens.some((token) => token.startsWith(queryToken) || queryToken.startsWith(token))) {

--- a/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
@@ -17,6 +17,7 @@ let isAgentApiKeyConnection: typeof import("../src/routes/org/mcp-connections.js
 let isAgentOAuthClientConnection: typeof import("../src/routes/org/mcp-connections.js")["isAgentOAuthClientConnection"]
 let buildMcpCatalog: typeof import("../src/mcp/catalog.js")["buildMcpCatalog"]
 let searchCapabilities: typeof import("../src/mcp/search.js")["searchCapabilities"]
+let searchCapabilitySourceFilter: typeof import("../src/mcp/search.js")["searchCapabilitySourceFilter"]
 let document: OpenApiDocument
 
 function findOperation(operationId: string) {
@@ -40,6 +41,7 @@ beforeAll(async () => {
   isMcpOperationAllowed = (await import("../src/mcp/policy.js")).isMcpOperationAllowed
   buildMcpCatalog = (await import("../src/mcp/catalog.js")).buildMcpCatalog
   searchCapabilities = (await import("../src/mcp/search.js")).searchCapabilities
+  searchCapabilitySourceFilter = (await import("../src/mcp/search.js")).searchCapabilitySourceFilter
   const mcpConnections = await import("../src/routes/org/mcp-connections.js")
   isAgentApiKeyConnection = mcpConnections.isAgentApiKeyConnection
   isAgentOAuthClientConnection = mcpConnections.isAgentOAuthClientConnection
@@ -84,6 +86,21 @@ describe("agent-configurable org connections policy", () => {
       path: "/v1/mcp-connections",
       hasBody: true,
     }))
+  })
+
+  test("agent capability search source filter can restrict searches to skills", () => {
+    expect(searchCapabilitySourceFilter()).toEqual({
+      api: true,
+      mcp: true,
+      marketplace: true,
+      skills: true,
+    })
+    expect(searchCapabilitySourceFilter("skills")).toEqual({
+      api: false,
+      mcp: false,
+      marketplace: false,
+      skills: true,
+    })
   })
 
   test("API-key connections are blocked only for the internal agent principal", () => {


### PR DESCRIPTION
## Summary
- add an optional `type` filter to the agent `search_capabilities` tool: `all`, `api`, `mcp`, `marketplace`, or `skills`
- keep the default as `all` so existing callers continue searching API, MCP, marketplace, and skills together
- make `skill`/`skills` weak-match stored org skills so `type: "skills"` is discoverable even when individual skill titles do not contain the word skill

## Validation
- `pnpm --filter @openwork-ee/den-db build`
- `pnpm --filter @openwork/email build`
- `pnpm --filter @openwork/install-config build`
- `pnpm --filter @openwork-ee/den-api exec bun test test/mcp-agent-config-policy.test.ts` - 7 pass, 0 fail
- `pnpm --filter @openwork-ee/den-api build`
- live local Den DB smoke via `pnpm --filter @openwork-ee/den-api exec tsx -e ...`: searched `query: "skills"`, got 9 matches with only method `SKILL`, then executed one skill and confirmed `executeOk: true` and non-empty skill text
