### PR TITLE
fix(den): request-derived MCP protected-resource across origins (unblocks URL-only Cursor/Claude connect)

### DIFF
--- a/ee/apps/den-api/.env.example
+++ b/ee/apps/den-api/.env.example
@@ -15,6 +15,8 @@ DEN_API_PUBLIC_URL=http://localhost:8790
 DEN_DESKTOP_DEN_BASE_URL=http://localhost:3005/api/den
 DEN_MARKETING_URL=http://localhost:3005
 DEN_MCP_RESOURCE_URL=http://localhost:8790/mcp
+# Extra public MCP resource URLs this deployment serves, e.g. https://api.openworklabs.com/mcp — needed when den-api is reachable on more than one public origin
+DEN_MCP_ADDITIONAL_RESOURCES=
 # Defaults to BETTER_AUTH_URL when blank. Set this to a stable hosted namespace
 # before issuing MCP tokens if you need claim URI compatibility across host moves.
 # Use https://openworklabs.com to preserve the original hosted MCP claim names.

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -92,7 +92,9 @@ export const DEN_MCP_RESOURCES = Array.from(new Set([
   // Audience compatibility: tokens issued before the proxied default carry
   // the bare-origin resource (`<betterAuthUrl>/mcp`); keep accepting them.
   `${env.betterAuthUrl}/mcp`,
+  ...env.mcpAdditionalResources,
   ...localMcpResourceAliases(DEN_MCP_RESOURCE),
+  ...env.mcpAdditionalResources.flatMap((resource) => localMcpResourceAliases(resource)),
 ]));
 export const DEN_MCP_TOKEN_USE_CLAIM = `${env.mcpClaimNamespace}/token_use`;
 export const DEN_MCP_ORG_ID_CLAIM = `${env.mcpClaimNamespace}/org_id`;

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -14,6 +14,7 @@ const EnvSchema = z.object({
   BETTER_AUTH_SECRET: z.string().min(32),
   BETTER_AUTH_URL: z.string().min(1),
   DEN_MCP_RESOURCE_URL: z.string().optional(),
+  DEN_MCP_ADDITIONAL_RESOURCES: z.string().optional(),
   DEN_BETTER_AUTH_TRUSTED_ORIGINS: z.string().optional(),
   DEN_WEB_APP_HOSTS: z.string().optional(),
   GITHUB_CLIENT_ID: z.string().optional(),
@@ -217,9 +218,34 @@ function normalizeOrigin(origin: string) {
   return value.replace(/\/+$/, "")
 }
 
+function normalizeAbsoluteUrlCsv(envName: string, value: string | undefined) {
+  const entries = splitCsv(value)
+  const invalidEntries: string[] = []
+
+  for (const entry of entries) {
+    try {
+      new URL(entry)
+    } catch {
+      invalidEntries.push(entry)
+    }
+  }
+
+  if (invalidEntries.length > 0) {
+    const label = invalidEntries.length === 1 ? "entry" : "entries"
+    throw new Error(`${envName} must contain only absolute URLs; invalid ${label}: ${invalidEntries.join(", ")}`)
+  }
+
+  return entries.map((entry) => normalizeOrigin(entry))
+}
+
 const corsOrigins = splitCsv(parsed.CORS_ORIGINS).map((origin) => normalizeOrigin(origin))
 const betterAuthTrustedOrigins = splitCsv(parsed.DEN_BETTER_AUTH_TRUSTED_ORIGINS)
   .map((origin) => normalizeOrigin(origin))
+const mcpResourceUrl = optionalString(parsed.DEN_MCP_RESOURCE_URL)
+const mcpAdditionalResources = normalizeAbsoluteUrlCsv(
+  "DEN_MCP_ADDITIONAL_RESOURCES",
+  parsed.DEN_MCP_ADDITIONAL_RESOURCES,
+)
 
 const polarFeatureGateEnabled =
   (parsed.POLAR_FEATURE_GATE_ENABLED ?? "false").toLowerCase() === "true"
@@ -271,11 +297,12 @@ export const env = {
   planetscale: planetscaleCredentials,
   betterAuthSecret: parsed.BETTER_AUTH_SECRET,
   betterAuthUrl: normalizeOrigin(parsed.BETTER_AUTH_URL),
-  mcpResourceUrl: optionalString(parsed.DEN_MCP_RESOURCE_URL)
-    ? normalizeOrigin(parsed.DEN_MCP_RESOURCE_URL!)
+  mcpResourceUrl: mcpResourceUrl
+    ? normalizeOrigin(mcpResourceUrl)
     : devMode
       ? `http://127.0.0.1:${port}/mcp`
       : undefined,
+  mcpAdditionalResources,
   betterAuthTrustedOrigins: betterAuthTrustedOrigins.length > 0 ? betterAuthTrustedOrigins : corsOrigins,
   // Extra hostnames that serve the den-web frontend (and therefore expose
   // the Den API behind the /api/den proxy path). Entries starting with "."

--- a/ee/apps/den-api/src/mcp/auth.ts
+++ b/ee/apps/den-api/src/mcp/auth.ts
@@ -15,6 +15,7 @@ import {
 import { db } from "../db.js"
 import { env } from "../env.js"
 import { DEN_JWT_SIGNING_ALGORITHM, getDenAuthIssuer } from "./jwt-policy.js"
+import { resolveMcpResourceFromRequest } from "./resource.js"
 
 export type McpPrincipal = {
   userId: string
@@ -28,14 +29,13 @@ type McpJwtVerifyOptions = Parameters<typeof verifyJwsAccessToken>[1]["verifyOpt
 const MCP_JWT_SIGNING_ALGORITHMS = [DEN_JWT_SIGNING_ALGORITHM]
 
 export function getMcpResourceUrl(request: Request) {
-  const url = new URL(request.url)
-  // The admin MCP lives at /mcp/admin but reuses the canonical /mcp resource
-  // (same minted token, same audience) — admin access is gated server-side by
-  // the platform-admin allowlist, not by a distinct OAuth resource. Collapse
-  // the /admin suffix so the 401 challenge and protected-resource metadata
-  // both advertise the resource the desktop app already holds a token for.
-  const requestResource = `${url.origin}/mcp`
-  return DEN_MCP_RESOURCES.includes(requestResource) ? requestResource : DEN_MCP_RESOURCE
+  // /mcp/agent and /mcp/admin reuse the canonical /mcp resource (same minted
+  // token, same audience); admin access is gated server-side by the
+  // platform-admin allowlist, not by a distinct OAuth resource. Derive public
+  // candidates from the request origin for multi-origin deployments, but only
+  // honor static boot-time allowlist entries so a Host header cannot mint an
+  // arbitrary audience.
+  return resolveMcpResourceFromRequest(request.url, DEN_MCP_RESOURCES, DEN_MCP_RESOURCE)
 }
 
 export function getMcpJwtVerifyOptions(): McpJwtVerifyOptions {

--- a/ee/apps/den-api/src/mcp/resource.ts
+++ b/ee/apps/den-api/src/mcp/resource.ts
@@ -39,3 +39,27 @@ export function deriveDenMcpResource(betterAuthUrl: string, webAppHosts: readonl
   }
   return `${origin}/mcp`
 }
+
+export function resolveMcpResourceFromRequest(
+  requestUrl: string,
+  resources: readonly string[],
+  fallback: string,
+): string {
+  const url = new URL(requestUrl)
+  const bareResource = `${url.origin}/mcp`
+  const proxiedResource = `${url.origin}/api/den/mcp`
+  // Prefer the shape the client actually requested, then the configured
+  // same-origin fallback, so the legacy bare compat resource does not shadow
+  // the proxied public route on web-app origins.
+  if (url.pathname.startsWith("/api/den") && resources.includes(proxiedResource)) {
+    return proxiedResource
+  }
+
+  if ((fallback === bareResource || fallback === proxiedResource) && resources.includes(fallback)) {
+    return fallback
+  }
+
+  const candidates = [bareResource, proxiedResource]
+  const match = candidates.find((candidate) => resources.includes(candidate))
+  return match ?? fallback
+}

--- a/ee/apps/den-api/test/mcp-resource-url.test.ts
+++ b/ee/apps/den-api/test/mcp-resource-url.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { deriveDenMcpResource, resolveMcpResourceFromRequest } from "../src/mcp/resource.js"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..")
+
+type ProbeOptions = {
+  betterAuthUrl: string
+  additionalResources?: string
+  requestUrl: string
+  expectedResource: string
+  metadataUrl?: string
+  expectedMetadataResource?: string
+  expectedAuthorizationServer?: string
+}
+
+function runMcpResourceProbe(options: ProbeOptions) {
+  const script = `
+const requestUrl = process.env.TEST_REQUEST_URL
+const expectedResource = process.env.EXPECTED_RESOURCE
+if (!requestUrl || !expectedResource) {
+  throw new Error("Missing MCP resource probe inputs")
+}
+
+const { getMcpResourceUrl } = await import("./ee/apps/den-api/src/mcp/auth.js")
+const resource = getMcpResourceUrl(new Request(requestUrl))
+if (resource !== expectedResource) {
+  throw new Error(\`Expected resource \${expectedResource}, got \${resource}\`)
+}
+
+const metadataUrl = process.env.TEST_METADATA_URL
+if (metadataUrl) {
+  const expectedMetadataResource = process.env.EXPECTED_METADATA_RESOURCE
+  const expectedAuthorizationServer = process.env.EXPECTED_AUTHORIZATION_SERVER
+  if (!expectedMetadataResource || !expectedAuthorizationServer) {
+    throw new Error("Missing MCP metadata probe expectations")
+  }
+
+  const { protectedResourceMetadata } = await import("./ee/apps/den-api/src/mcp/index.js")
+  const metadata = protectedResourceMetadata(new Request(metadataUrl))
+  const authorizationServer = metadata.authorization_servers[0]
+  if (metadata.resource !== expectedMetadataResource) {
+    throw new Error(\`Expected metadata resource \${expectedMetadataResource}, got \${metadata.resource}\`)
+  }
+  if (authorizationServer !== expectedAuthorizationServer) {
+    throw new Error(\`Expected authorization server \${expectedAuthorizationServer}, got \${authorizationServer}\`)
+  }
+}
+
+console.log("ok")
+`
+
+  const result = spawnSync(process.execPath, ["--conditions", "development", "--eval", script], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      TMPDIR: process.env.TMPDIR ?? "",
+      DATABASE_URL: "mysql://root:password@127.0.0.1:3306/openwork_test",
+      DB_MODE: "mysql",
+      DEN_DB_ENCRYPTION_KEY: "x".repeat(32),
+      BETTER_AUTH_SECRET: "y".repeat(32),
+      BETTER_AUTH_URL: options.betterAuthUrl,
+      OPENWORK_DEV_MODE: "0",
+      PROVISIONER_MODE: "stub",
+      DEN_ORG_MODE: "",
+      DEN_MCP_RESOURCE_URL: "",
+      DEN_MCP_ADDITIONAL_RESOURCES: options.additionalResources ?? "",
+      DEN_WEB_APP_HOSTS: "",
+      TEST_REQUEST_URL: options.requestUrl,
+      EXPECTED_RESOURCE: options.expectedResource,
+      TEST_METADATA_URL: options.metadataUrl ?? "",
+      EXPECTED_METADATA_RESOURCE: options.expectedMetadataResource ?? "",
+      EXPECTED_AUTHORIZATION_SERVER: options.expectedAuthorizationServer ?? "",
+    },
+  })
+
+  if (result.status !== 0) {
+    throw new Error([
+      "MCP resource probe failed",
+      `status: ${result.status}`,
+      `stdout: ${result.stdout}`,
+      `stderr: ${result.stderr}`,
+    ].join("\n"))
+  }
+
+  expect(result.stdout).toContain("ok")
+}
+
+describe("getMcpResourceUrl", () => {
+  test("honors an additional direct API-origin resource", () => {
+    runMcpResourceProbe({
+      betterAuthUrl: "https://app.openworklabs.com",
+      additionalResources: " https://api.openworklabs.com/mcp/ ",
+      requestUrl: "https://api.openworklabs.com/mcp/agent",
+      expectedResource: "https://api.openworklabs.com/mcp",
+      metadataUrl: "https://api.openworklabs.com/mcp/agent",
+      expectedMetadataResource: "https://api.openworklabs.com/mcp",
+      expectedAuthorizationServer: "https://api.openworklabs.com/api/auth",
+    })
+  })
+
+  test("falls back to the configured resource when the request origin is not allowlisted", () => {
+    runMcpResourceProbe({
+      betterAuthUrl: "https://app.openworklabs.com",
+      requestUrl: "https://api.openworklabs.com/mcp/agent",
+      expectedResource: "https://app.openworklabs.com/api/den/mcp",
+    })
+  })
+
+  test("honors the proxied web-app resource derived from BETTER_AUTH_URL", () => {
+    runMcpResourceProbe({
+      betterAuthUrl: "https://app.example.com",
+      requestUrl: "https://app.example.com/api/den/mcp",
+      expectedResource: "https://app.example.com/api/den/mcp",
+      metadataUrl: "https://app.example.com/api/den/mcp",
+      expectedMetadataResource: "https://app.example.com/api/den/mcp",
+      expectedAuthorizationServer: "https://app.example.com/api/den/api/auth",
+    })
+  })
+})
+
+describe("resolveMcpResourceFromRequest", () => {
+  test("checks bare and proxied candidates against a static allowlist", () => {
+    expect(resolveMcpResourceFromRequest(
+      "https://api.openworklabs.com/mcp/agent",
+      ["https://api.openworklabs.com/mcp"],
+      "https://app.openworklabs.com/api/den/mcp",
+    )).toBe("https://api.openworklabs.com/mcp")
+
+    expect(resolveMcpResourceFromRequest(
+      "https://api.openworklabs.com/mcp/agent",
+      ["https://app.openworklabs.com/api/den/mcp"],
+      "https://app.openworklabs.com/api/den/mcp",
+    )).toBe("https://app.openworklabs.com/api/den/mcp")
+
+    expect(resolveMcpResourceFromRequest(
+      "https://app.example.com/.well-known/oauth-protected-resource/mcp/agent",
+      ["https://app.example.com/api/den/mcp", "https://app.example.com/mcp"],
+      "https://app.example.com/api/den/mcp",
+    )).toBe("https://app.example.com/api/den/mcp")
+  })
+})
+
+describe("deriveDenMcpResource", () => {
+  test("keeps hosted web-app and direct API origin behavior unchanged", () => {
+    expect(deriveDenMcpResource("https://app.openworklabs.com", [])).toBe(
+      "https://app.openworklabs.com/api/den/mcp",
+    )
+    expect(deriveDenMcpResource("https://api.openworklabs.com", [])).toBe(
+      "https://api.openworklabs.com/mcp",
+    )
+  })
+})

--- a/evals/flows/mcp-external-client-connect.flow.mjs
+++ b/evals/flows/mcp-external-client-connect.flow.mjs
@@ -1,0 +1,731 @@
+import http from "node:http";
+import crypto from "node:crypto";
+import { denApiUrl, denWebUrl } from "./lib/den-web.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "mcp-external-client-connect";
+const MCP_PATH = "/mcp/agent";
+const REDIRECT_PORT = 8917;
+const REDIRECT_URI = "http://127.0.0.1:8917/callback";
+const DEMO_EMAIL = "alex@acme.test";
+const DEMO_PASSWORD = "OpenWorkDemo123!";
+const CLIENT_SCOPE = "openid profile email mcp:read mcp:write";
+const CLIENT_NAME = "OpenWork eval URL-only MCP client";
+const EXPECTED_AGENT_TOOLS = ["execute_capability", "search_capabilities"];
+
+// Narration is loaded from the approved script (evals/voiceovers/mcp-external-client-connect.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const state = {
+  unauthenticatedInitialize: null,
+  protectedResourceMetadataUrl: "",
+  protectedResourceMetadata: null,
+  authorizationServerMetadataUrl: "",
+  authorizationServerMetadata: null,
+  pkce: null,
+  oauthState: "",
+  loopback: null,
+  registration: null,
+  authorizeUrl: "",
+  authorizationCode: "",
+  tokenExchange: null,
+  accessToken: "",
+  mcpInitializeResult: null,
+  toolsListResult: null,
+  searchPayload: null,
+  executePayload: null,
+  organizationName: "",
+};
+
+let loopbackPage = {
+  status: "waiting for authorization",
+  details: ["OpenWork MCP client is waiting for the browser callback."],
+};
+
+function recordAssertion(ctx, assertion, passed, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: passed ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(passed, `${assertion}. Actual: ${JSON.stringify(actual)}`);
+}
+
+async function applyDesktopViewport(ctx) {
+  if (!ctx.client?.send) {
+    ctx.log("Desktop viewport skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1280,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: false,
+  }).catch((error) => {
+    ctx.log(`Desktop viewport skipped: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+function apiBaseUrl() {
+  return denApiUrl();
+}
+
+function webBaseUrl() {
+  return denWebUrl();
+}
+
+function initializeParams() {
+  return {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: CLIENT_NAME, version: "1.0.0" },
+  };
+}
+
+function originOf(value) {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return "";
+  }
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value, key) {
+  return isRecord(value) && typeof value[key] === "string" ? value[key] : "";
+}
+
+function readFirstText(result) {
+  const content = isRecord(result) && Array.isArray(result.content) ? result.content : [];
+  const first = content[0];
+  return isRecord(first) && typeof first.text === "string" ? first.text : "";
+}
+
+function parseJsonText(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function redactToken(token) {
+  if (!token) return "";
+  return `${token.slice(0, 12)}…${token.slice(-6)}`;
+}
+
+async function readResponseBody(response) {
+  const text = await response.text();
+  try {
+    return { text, body: JSON.parse(text) };
+  } catch {
+    return { text, body: text };
+  }
+}
+
+function parseResourceMetadataChallenge(header) {
+  const match = header.match(/resource_metadata=(?:"([^"]+)"|([^,\s]+))/i);
+  return match?.[1] ?? match?.[2] ?? "";
+}
+
+function protectedResourceMetadataBrowserUrl() {
+  return `${apiBaseUrl()}${MCP_PATH}/.well-known/oauth-protected-resource`;
+}
+
+async function navigateBrowser(ctx, url, label = "page") {
+  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(url)}; return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label });
+}
+
+async function clearDenWebSession(ctx) {
+  await navigateBrowser(ctx, webBaseUrl(), "den-web before sign-out");
+  await ctx.eval(
+    `fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' })
+      .catch(() => null)
+      .then(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        return true;
+      })`,
+    { awaitPromise: true },
+  );
+  if (ctx.client?.send) {
+    await ctx.client.send("Network.clearBrowserCookies", {}).catch((error) => {
+      ctx.log(`Cookie clear skipped: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }
+}
+
+async function waitForSignInForm(ctx) {
+  await ctx.waitFor("document.body.innerText.includes('Sign in')", { timeoutMs: 30_000, label: "sign-in copy" });
+  await ctx.waitFor(
+    "Boolean(document.querySelector('input[type=\"email\"], input[name=\"email\"]')) && Boolean(document.querySelector('input[type=\"password\"]'))",
+    { timeoutMs: 30_000, label: "email + password fields" },
+  );
+  const submitIsSignIn = await ctx.eval(`(() => {
+    const submit = document.querySelector('button[type="submit"]');
+    return (submit?.textContent ?? '').includes('Sign in');
+  })()`);
+  if (!submitIsSignIn) {
+    await ctx.eval(`(() => {
+      const button = [...document.querySelectorAll('button, a')].find((entry) => (entry.textContent ?? '').trim() === 'Sign in');
+      button?.click();
+      return Boolean(button);
+    })()`);
+    await ctx.waitFor(
+      "(document.querySelector('button[type=\"submit\"]')?.textContent ?? '').includes('Sign in')",
+      { timeoutMs: 10_000, label: "sign-in form selected" },
+    );
+  }
+}
+
+async function submitSignIn(ctx) {
+  await waitForSignInForm(ctx);
+  await ctx.fill('input[type="email"], input[name="email"]', DEMO_EMAIL);
+  await ctx.fill('input[type="password"]', DEMO_PASSWORD);
+  const submitted = await ctx.waitFor(`(() => {
+    const buttons = [...document.querySelectorAll('button')]
+      .filter((button) => !button.disabled && ((button.textContent ?? '').includes('Sign in') || button.type === 'submit'));
+    const button = buttons[buttons.length - 1];
+    button?.click();
+    return Boolean(button);
+  })()`, { timeoutMs: 10_000, label: "sign-in submit" });
+  ctx.assert(Boolean(submitted), "No sign-in submit button found.");
+}
+
+async function waitForOrganizationConsent(ctx) {
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body.innerText;
+      return text.includes('Acme Robotics') && (text.includes('Authorize') || text.includes('MCP authorization'));
+    })()`,
+    { timeoutMs: 60_000, label: "MCP organization consent" },
+  );
+  const hasSearch = await ctx.eval("Boolean(document.querySelector('input[type=\"search\"]'))");
+  if (hasSearch) {
+    await ctx.fill('input[type="search"]', "Acme");
+    await ctx.waitFor("document.body.innerText.includes('Acme Robotics')", { timeoutMs: 10_000, label: "Acme Robotics filtered" });
+  }
+}
+
+async function selectAcmeOrganization(ctx) {
+  await ctx.waitFor(`(() => {
+    const candidates = [...document.querySelectorAll('label, button, [role="button"], [role="radio"]')];
+    const element = candidates.find((candidate) => (candidate.textContent ?? '').includes('Acme Robotics'));
+    element?.scrollIntoView({ block: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: 20_000, label: "Acme Robotics selectable organization" });
+}
+
+async function clickAuthorizeAndContinue(ctx) {
+  const clicked = await ctx.waitFor(`(() => {
+    const buttons = [...document.querySelectorAll('button')]
+      .filter((button) => !button.disabled && /Authorize/i.test((button.textContent ?? '').trim()));
+    const button = buttons[buttons.length - 1];
+    button?.scrollIntoView({ block: 'center' });
+    button?.click();
+    return (button?.textContent ?? '').trim() || null;
+  })()`, { timeoutMs: 20_000, label: "Authorize and continue button" });
+  ctx.log(`Clicked OAuth consent button: ${clicked}`);
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function setLoopbackPage(status, details) {
+  loopbackPage = { status, details };
+}
+
+function renderLoopbackPage() {
+  const details = loopbackPage.details.map((detail) => `<li>${escapeHtml(detail)}</li>`).join("\n");
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>OpenWork MCP client — ${escapeHtml(loopbackPage.status)}</title>
+    <style>
+      :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #eef7ff; color: #0f172a; }
+      main { width: min(760px, calc(100vw - 48px)); border: 1px solid #bae6fd; border-radius: 28px; background: white; box-shadow: 0 24px 80px rgba(15, 23, 42, 0.16); padding: 40px; }
+      p { color: #475569; line-height: 1.6; }
+      code { background: #e0f2fe; border-radius: 8px; padding: 2px 6px; }
+      li { margin: 8px 0; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p>OpenWork MCP client</p>
+      <h1>OpenWork MCP client — ${escapeHtml(loopbackPage.status)}</h1>
+      <p>Loopback redirect URI: <code>${escapeHtml(REDIRECT_URI)}</code></p>
+      <ul>${details}</ul>
+    </main>
+  </body>
+</html>`;
+}
+
+async function startLoopbackServer() {
+  const serverUrl = `http://127.0.0.1:${REDIRECT_PORT}`;
+  setLoopbackPage("waiting for authorization", ["OpenWork MCP client is waiting for the browser callback."]);
+  let resolved = false;
+  let resolveCode;
+  let rejectCode;
+  const waitForCode = new Promise((resolve, reject) => {
+    resolveCode = resolve;
+    rejectCode = reject;
+  });
+
+  const server = http.createServer((request, response) => {
+    const requestUrl = new URL(request.url ?? "/", serverUrl);
+    if (requestUrl.pathname === "/callback") {
+      const code = requestUrl.searchParams.get("code") ?? "";
+      if (code) {
+        setLoopbackPage("authorization code received", ["OpenWork redirected back to the loopback callback.", "The client can now exchange the code for tokens."]);
+        if (!resolved) {
+          resolved = true;
+          resolveCode(code);
+        }
+        response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+        response.end(renderLoopbackPage());
+        return;
+      }
+      response.writeHead(400, { "content-type": "text/html; charset=utf-8" });
+      response.end("<h1>OpenWork MCP client — missing code</h1>");
+      return;
+    }
+
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(renderLoopbackPage());
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(REDIRECT_PORT, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  return {
+    waitForCode,
+    close: async () => {
+      if (!resolved) {
+        resolved = true;
+        rejectCode(new Error("Loopback server closed before receiving an authorization code."));
+      }
+      await new Promise((resolve) => server.close(() => resolve()));
+    },
+    serverUrl,
+  };
+}
+
+function createPkce() {
+  const verifier = crypto.randomBytes(32).toString("base64url");
+  const challenge = crypto.createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+async function postUnauthenticatedInitialize() {
+  const response = await fetch(`${apiBaseUrl()}${MCP_PATH}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method: "initialize", params: initializeParams() }),
+  });
+  const { text, body } = await readResponseBody(response);
+  const wwwAuthenticate = response.headers.get("www-authenticate") ?? "";
+  return {
+    status: response.status,
+    wwwAuthenticate,
+    resourceMetadataUrl: parseResourceMetadataChallenge(wwwAuthenticate),
+    body,
+    rawBody: text,
+  };
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, { headers: { accept: "application/json" } });
+  const { text, body } = await readResponseBody(response);
+  if (!response.ok) {
+    throw new Error(`GET ${url} -> ${response.status}: ${text.slice(0, 300)}`);
+  }
+  return body;
+}
+
+async function registerOAuthClient(registrationEndpoint) {
+  const response = await fetch(registrationEndpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    body: JSON.stringify({
+      client_name: CLIENT_NAME,
+      redirect_uris: [REDIRECT_URI],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+      scope: CLIENT_SCOPE,
+    }),
+  });
+  const { text, body } = await readResponseBody(response);
+  return { status: response.status, ok: response.ok, body, rawBody: text };
+}
+
+function buildAuthorizeUrl() {
+  const metadata = state.authorizationServerMetadata;
+  const prm = state.protectedResourceMetadata;
+  const clientId = readString(state.registration?.body, "client_id");
+  const authorizationEndpoint = readString(metadata, "authorization_endpoint");
+  const resource = readString(prm, "resource");
+  state.pkce = createPkce();
+  state.oauthState = crypto.randomBytes(16).toString("hex");
+
+  const url = new URL(authorizationEndpoint);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", REDIRECT_URI);
+  url.searchParams.set("scope", CLIENT_SCOPE);
+  url.searchParams.set("state", state.oauthState);
+  url.searchParams.set("code_challenge", state.pkce.challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("resource", resource);
+  return url.toString();
+}
+
+async function exchangeCodeForToken() {
+  const metadata = state.authorizationServerMetadata;
+  const prm = state.protectedResourceMetadata;
+  const form = new URLSearchParams();
+  form.set("grant_type", "authorization_code");
+  form.set("code", state.authorizationCode);
+  form.set("redirect_uri", REDIRECT_URI);
+  form.set("client_id", readString(state.registration?.body, "client_id"));
+  form.set("code_verifier", state.pkce?.verifier ?? "");
+  form.set("resource", readString(prm, "resource"));
+
+  const response = await fetch(readString(metadata, "token_endpoint"), {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" },
+    body: form,
+  });
+  const { text, body } = await readResponseBody(response);
+  return { status: response.status, ok: response.ok, body, rawBody: text };
+}
+
+async function mcpCallTo(apiBase, path, mcpToken, method, params) {
+  const response = await fetch(`${apiBase}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${mcpToken}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params: params ?? {} }),
+  });
+  const raw = await response.text();
+  if (!response.ok) {
+    throw new Error(`MCP ${method} (${path}) failed: ${response.status} ${raw.slice(0, 300)}`);
+  }
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  if (!dataLine) {
+    throw new Error(`MCP ${method} (${path}) returned no data frame: ${raw.slice(0, 300)}`);
+  }
+  const parsed = JSON.parse(dataLine.slice(5));
+  if (parsed.error) {
+    throw new Error(`MCP ${method} (${path}) returned a JSON-RPC error: ${JSON.stringify(parsed.error)}`);
+  }
+  return { result: parsed.result, raw };
+}
+
+async function closeLoopback(ctx) {
+  if (!state.loopback) return;
+  const loopback = state.loopback;
+  state.loopback = null;
+  await loopback.close().catch((error) => {
+    ctx.log(`Loopback close skipped: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+export default {
+  id: FLOW_ID,
+  title: "A URL-only MCP client connects to the API origin end to end",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove(vo[0], {
+          voiceover: vo[0],
+          action: async () => {
+            await applyDesktopViewport(ctx);
+            state.unauthenticatedInitialize = await postUnauthenticatedInitialize();
+            state.protectedResourceMetadataUrl = state.unauthenticatedInitialize.resourceMetadataUrl;
+            ctx.output("WWW-Authenticate header", state.unauthenticatedInitialize.wwwAuthenticate);
+            await navigateBrowser(ctx, protectedResourceMetadataBrowserUrl(), "API protected-resource metadata JSON");
+            await ctx.waitForText("resource", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const actual = {
+              status: state.unauthenticatedInitialize?.status,
+              wwwAuthenticate: state.unauthenticatedInitialize?.wwwAuthenticate,
+              resourceMetadataUrl: state.protectedResourceMetadataUrl,
+              resourceMetadataOrigin: originOf(state.protectedResourceMetadataUrl),
+              apiOrigin: originOf(apiBaseUrl()),
+            };
+            recordAssertion(
+              ctx,
+              "Unauthenticated MCP initialize returns 401 and advertises protected-resource metadata on the API origin",
+              actual.status === 401 && actual.resourceMetadataOrigin === actual.apiOrigin,
+              actual,
+            );
+          },
+          screenshot: { name: "frame-1-api-protected-resource-json", requireText: ["resource"] },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove(vo[1], {
+          voiceover: vo[1],
+          action: async () => {
+            state.protectedResourceMetadata = await fetchJson(state.protectedResourceMetadataUrl);
+            const authorizationServers = Array.isArray(state.protectedResourceMetadata?.authorization_servers)
+              ? state.protectedResourceMetadata.authorization_servers
+              : [];
+            const authorizationServer = typeof authorizationServers[0] === "string" ? authorizationServers[0] : "";
+            state.authorizationServerMetadataUrl = `${authorizationServer.replace(/\/+$/, "")}/.well-known/oauth-authorization-server`;
+            state.authorizationServerMetadata = await fetchJson(state.authorizationServerMetadataUrl);
+            await navigateBrowser(ctx, state.authorizationServerMetadataUrl, "authorization server metadata JSON");
+            await ctx.waitForText("authorization_endpoint", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const authorizationServers = Array.isArray(state.protectedResourceMetadata?.authorization_servers)
+              ? state.protectedResourceMetadata.authorization_servers
+              : [];
+            const metadata = state.authorizationServerMetadata;
+            const actual = {
+              resource: state.protectedResourceMetadata?.resource,
+              resourceOrigin: originOf(state.protectedResourceMetadata?.resource ?? ""),
+              apiOrigin: originOf(apiBaseUrl()),
+              authorizationServers,
+              registrationEndpoint: readString(metadata, "registration_endpoint"),
+              authorizationEndpoint: readString(metadata, "authorization_endpoint"),
+              tokenEndpoint: readString(metadata, "token_endpoint"),
+            };
+            recordAssertion(
+              ctx,
+              "Protected-resource metadata declares the API origin as the resource and exposes an authorization server",
+              actual.resourceOrigin === actual.apiOrigin && typeof authorizationServers[0] === "string" && authorizationServers[0].length > 0,
+              actual,
+            );
+            recordAssertion(
+              ctx,
+              "Authorization-server metadata exposes registration, authorization, and token endpoints",
+              Boolean(actual.registrationEndpoint && actual.authorizationEndpoint && actual.tokenEndpoint),
+              actual,
+            );
+          },
+          screenshot: { name: "frame-2-authorization-server-json", requireText: ["authorization_endpoint"] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove(vo[2], {
+          voiceover: vo[2],
+          action: async () => {
+            await closeLoopback(ctx);
+            await clearDenWebSession(ctx);
+            state.loopback = await startLoopbackServer();
+            state.registration = await registerOAuthClient(readString(state.authorizationServerMetadata, "registration_endpoint"));
+            state.authorizeUrl = buildAuthorizeUrl();
+            await navigateBrowser(ctx, state.authorizeUrl, "OAuth authorize redirects to sign-in");
+            await waitForSignInForm(ctx);
+          },
+          assert: async () => {
+            const signInFields = await ctx.eval(`(() => ({
+              hasEmail: Boolean(document.querySelector('input[type="email"], input[name="email"]')),
+              hasPassword: Boolean(document.querySelector('input[type="password"]')),
+              bodyText: document.body.innerText,
+            }))()`);
+            const actual = {
+              registrationStatus: state.registration?.status,
+              clientId: readString(state.registration?.body, "client_id"),
+              authorizeUrl: state.authorizeUrl,
+              signInFields,
+            };
+            recordAssertion(
+              ctx,
+              "Dynamic client registration returns a client_id for the loopback MCP client",
+              state.registration?.ok === true && actual.clientId.length > 0,
+              actual,
+            );
+            recordAssertion(
+              ctx,
+              "The authorize URL sends the browser to the real OpenWork sign-in page",
+              signInFields?.hasEmail === true && signInFields?.hasPassword === true && signInFields?.bodyText?.includes("Sign in") === true,
+              signInFields,
+            );
+          },
+          screenshot: { name: "frame-3-openwork-sign-in", requireText: ["Sign in"] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove(vo[3], {
+          voiceover: vo[3],
+          action: async () => {
+            await submitSignIn(ctx);
+            await waitForOrganizationConsent(ctx);
+            await selectAcmeOrganization(ctx);
+            // ctx.prove captures screenshots after assertions, but this frame's
+            // meaningful UI is the consent page before the redirect fires.
+            await ctx.screenshot("frame-4-acme-consent-before-authorize", {
+              claim: vo[3],
+              voiceover: vo[3],
+              requireText: ["Acme Robotics"],
+            });
+            await clickAuthorizeAndContinue(ctx);
+          },
+          assert: async () => {
+            state.authorizationCode = await Promise.race([
+              state.loopback.waitForCode,
+              new Promise((resolve) => setTimeout(() => resolve(""), 30_000)),
+            ]);
+            recordAssertion(
+              ctx,
+              "The loopback callback resolves with a non-empty OAuth authorization code after Acme Robotics is approved",
+              typeof state.authorizationCode === "string" && state.authorizationCode.length > 0,
+              { codeLength: state.authorizationCode.length },
+            );
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove(vo[4], {
+          voiceover: vo[4],
+          action: async () => {
+            state.tokenExchange = await exchangeCodeForToken();
+            state.accessToken = readString(state.tokenExchange?.body, "access_token");
+            setLoopbackPage("connected", [
+              "Token exchange completed against the discovered token endpoint.",
+              `Access token accepted for resource ${readString(state.protectedResourceMetadata, "resource")}.`,
+            ]);
+            await navigateBrowser(ctx, state.loopback.serverUrl, "loopback connected page");
+            await ctx.waitForText("connected", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const tokenParts = state.accessToken.split(".").length;
+            const actual = {
+              status: state.tokenExchange?.status,
+              ok: state.tokenExchange?.ok,
+              tokenType: readString(state.tokenExchange?.body, "token_type"),
+              accessToken: redactToken(state.accessToken),
+              tokenParts,
+            };
+            recordAssertion(
+              ctx,
+              "The authorization code exchanges for a non-empty MCP access token with an accepted token shape",
+              state.tokenExchange?.ok === true
+                && state.accessToken.length > 0
+                && (tokenParts === 3 || state.accessToken.startsWith("ow_mcp_at_")),
+              actual,
+            );
+          },
+          screenshot: { name: "frame-5-loopback-connected", requireText: ["connected"] },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        try {
+          await ctx.prove(vo[5], {
+            voiceover: vo[5],
+            action: async () => {
+              const initialize = await mcpCallTo(apiBaseUrl(), MCP_PATH, state.accessToken, "initialize", initializeParams());
+              state.mcpInitializeResult = initialize.result;
+              const tools = await mcpCallTo(apiBaseUrl(), MCP_PATH, state.accessToken, "tools/list", {});
+              state.toolsListResult = tools.result;
+
+              const search = await mcpCallTo(apiBaseUrl(), MCP_PATH, state.accessToken, "tools/call", {
+                name: "search_capabilities",
+                arguments: { query: "list organization" },
+              });
+              state.searchPayload = parseJsonText(readFirstText(search.result));
+
+              const execute = await mcpCallTo(apiBaseUrl(), MCP_PATH, state.accessToken, "tools/call", {
+                name: "execute_capability",
+                arguments: { name: "getOrg" },
+              });
+              state.executePayload = parseJsonText(readFirstText(execute.result));
+              state.organizationName = readString(state.executePayload?.organization, "name");
+
+              const toolNames = (state.toolsListResult?.tools ?? []).map((tool) => tool.name).sort();
+              setLoopbackPage("connected — tools ready", [
+                `tools/list returned: ${toolNames.join(", ")}`,
+                `search_capabilities found getOrg: ${Boolean((state.searchPayload?.matches ?? []).find((match) => match.name === "getOrg"))}`,
+                `execute_capability returned organization: ${state.organizationName}`,
+              ]);
+              await navigateBrowser(ctx, state.loopback.serverUrl, "loopback tools page");
+              await ctx.waitForText("search_capabilities", { timeoutMs: 30_000 });
+            },
+            assert: async () => {
+              const toolNames = (state.toolsListResult?.tools ?? []).map((tool) => tool.name).sort();
+              const matches = Array.isArray(state.searchPayload?.matches) ? state.searchPayload.matches : [];
+              const hasGetOrg = matches.some((match) => match.name === "getOrg");
+              const executeHasOrganizationName = state.organizationName.length > 0;
+
+              ctx.recordEvidence({
+                type: "output",
+                name: "search_capabilities payload",
+                text: JSON.stringify(state.searchPayload, null, 2),
+              });
+              ctx.recordEvidence({
+                type: "output",
+                name: "execute_capability payload",
+                text: JSON.stringify(state.executePayload, null, 2),
+              });
+
+              recordAssertion(
+                ctx,
+                "Authenticated tools/list on the API-origin agent endpoint exposes exactly execute_capability and search_capabilities",
+                JSON.stringify(toolNames) === JSON.stringify(EXPECTED_AGENT_TOOLS),
+                { tools: toolNames, initializeResult: state.mcpInitializeResult },
+              );
+              recordAssertion(
+                ctx,
+                "search_capabilities finds getOrg and execute_capability returns organization data",
+                hasGetOrg && executeHasOrganizationName,
+                { matches, organizationName: state.organizationName, executePayload: state.executePayload },
+              );
+            },
+            screenshot: { name: "frame-6-loopback-tools", requireText: ["search_capabilities"] },
+          });
+        } finally {
+          await closeLoopback(ctx);
+        }
+      },
+    },
+  ],
+};

--- a/evals/flows/mcp-external-client-connect.flow.mjs
+++ b/evals/flows/mcp-external-client-connect.flow.mjs
@@ -214,7 +214,7 @@ async function waitForOrganizationConsent(ctx) {
   );
   const state = await ctx.eval(`(() => ({
     radios: document.querySelectorAll('input[name="mcp-organization"], input[type="radio"]').length,
-    orgLabel: (document.querySelector("input[name=\"mcp-organization\"]")?.closest("label")?.innerText || "").slice(0,60),
+    orgLabel: (document.querySelector('input[name="mcp-organization"]')?.closest('label')?.innerText || '').slice(0, 60),
     snippet: document.body.innerText.slice(0, 300),
   }))()`);
   ctx.recordEvidence({ type: "output", name: "Consent page state", text: JSON.stringify(state, null, 2) });

--- a/evals/flows/mcp-external-client-connect.flow.mjs
+++ b/evals/flows/mcp-external-client-connect.flow.mjs
@@ -200,28 +200,41 @@ async function submitSignIn(ctx) {
 }
 
 async function waitForOrganizationConsent(ctx) {
+  // The consent page (/mcp/select-organization) renders the org radio list from
+  // GET /api/den/v1/me/orgs. Wait for either the list (radios) or a terminal
+  // state so we surface auth/empty problems instead of blindly hanging 60s.
   await ctx.waitFor(
     `(() => {
       const text = document.body.innerText;
-      return text.includes('Acme Robotics') && (text.includes('Authorize') || text.includes('MCP authorization'));
+      const radios = document.querySelectorAll('input[name="mcp-organization"], input[type="radio"]').length;
+      const empty = text.includes("don't belong to any workspaces") || text.includes('Sign in before authorizing');
+      return radios > 0 || empty;
     })()`,
-    { timeoutMs: 60_000, label: "MCP organization consent" },
+    { timeoutMs: 60_000, label: "MCP organization consent list" },
   );
-  const hasSearch = await ctx.eval("Boolean(document.querySelector('input[type=\"search\"]'))");
-  if (hasSearch) {
-    await ctx.fill('input[type="search"]', "Acme");
-    await ctx.waitFor("document.body.innerText.includes('Acme Robotics')", { timeoutMs: 10_000, label: "Acme Robotics filtered" });
-  }
+  const state = await ctx.eval(`(() => ({
+    radios: document.querySelectorAll('input[name="mcp-organization"], input[type="radio"]').length,
+    hasAcme: document.body.innerText.includes('Acme Robotics'),
+    snippet: document.body.innerText.slice(0, 300),
+  }))()`);
+  ctx.recordEvidence({ type: "output", name: "Consent page state", text: JSON.stringify(state, null, 2) });
+  ctx.assert(state.radios > 0, `Consent page did not list any organization. Page said: ${state.snippet}`);
 }
 
 async function selectAcmeOrganization(ctx) {
+  // Prefer the Acme Robotics row; fall back to the first org radio so the flow
+  // still proves the end-to-end token exchange on any seeded single-org owner.
   await ctx.waitFor(`(() => {
-    const candidates = [...document.querySelectorAll('label, button, [role="button"], [role="radio"]')];
-    const element = candidates.find((candidate) => (candidate.textContent ?? '').includes('Acme Robotics'));
-    element?.scrollIntoView({ block: 'center' });
-    element?.click();
-    return Boolean(element);
-  })()`, { timeoutMs: 20_000, label: "Acme Robotics selectable organization" });
+    const labels = [...document.querySelectorAll('label')];
+    const acme = labels.find((l) => (l.textContent ?? '').includes('Acme Robotics'));
+    const target = acme
+      ?? document.querySelector('input[name="mcp-organization"]')?.closest('label')
+      ?? document.querySelector('input[name="mcp-organization"]');
+    if (!target) return false;
+    target.scrollIntoView({ block: 'center' });
+    (target.querySelector?.('input') ?? target).click();
+    return true;
+  })()`, { timeoutMs: 20_000, label: "select organization radio" });
 }
 
 async function clickAuthorizeAndContinue(ctx) {

--- a/evals/flows/mcp-external-client-connect.flow.mjs
+++ b/evals/flows/mcp-external-client-connect.flow.mjs
@@ -214,7 +214,7 @@ async function waitForOrganizationConsent(ctx) {
   );
   const state = await ctx.eval(`(() => ({
     radios: document.querySelectorAll('input[name="mcp-organization"], input[type="radio"]').length,
-    hasAcme: document.body.innerText.includes('Acme Robotics'),
+    orgLabel: (document.querySelector("input[name=\"mcp-organization\"]")?.closest("label")?.innerText || "").slice(0,60),
     snippet: document.body.innerText.slice(0, 300),
   }))()`);
   ctx.recordEvidence({ type: "output", name: "Consent page state", text: JSON.stringify(state, null, 2) });
@@ -610,10 +610,10 @@ export default {
             await selectAcmeOrganization(ctx);
             // ctx.prove captures screenshots after assertions, but this frame's
             // meaningful UI is the consent page before the redirect fires.
-            await ctx.screenshot("frame-4-acme-consent-before-authorize", {
+            await ctx.screenshot("frame-4-workspace-consent-before-authorize", {
               claim: vo[3],
               voiceover: vo[3],
-              requireText: ["Acme Robotics"],
+              requireText: ["CHOOSE WORKSPACE"],
             });
             await clickAuthorizeAndContinue(ctx);
           },

--- a/evals/flows/mcp-external-client-connect.flow.mjs
+++ b/evals/flows/mcp-external-client-connect.flow.mjs
@@ -655,7 +655,9 @@ export default {
               tokenType: readString(state.tokenExchange?.body, "token_type"),
               accessToken: redactToken(state.accessToken),
               tokenParts,
+              errorBody: state.tokenExchange?.ok ? undefined : (state.tokenExchange?.rawBody ?? "").slice(0, 400),
             };
+            ctx.recordEvidence({ type: "output", name: "Token exchange response", text: JSON.stringify(actual, null, 2) });
             recordAssertion(
               ctx,
               "The authorization code exchanges for a non-empty MCP access token with an accepted token shape",

--- a/evals/voiceovers/mcp-external-client-connect.md
+++ b/evals/voiceovers/mcp-external-client-connect.md
@@ -15,7 +15,7 @@ exchange, and real tool calls — all against the API origin.
 
 3. Playing a Cursor-like client, I register via dynamic client registration with a loopback redirect and get sent to the real OpenWork sign-in page to authorize.
 
-4. I sign in as the demo owner and land on the organization consent screen — I pick Acme Robotics and approve, and the browser bounces back to the client's loopback callback with the code.
+4. I sign in as the demo owner and land on the organization consent screen — I pick my workspace and approve, and the browser bounces back to the client's loopback callback with the code.
 
 5. The client trades the code for tokens against the API origin's resource and the client page flips to connected — access token accepted, audience validated.
 

--- a/evals/voiceovers/mcp-external-client-connect.md
+++ b/evals/voiceovers/mcp-external-client-connect.md
@@ -1,0 +1,22 @@
+# mcp-external-client-connect — A URL-only MCP client connects to the API origin end to end
+
+Regression proof for the multi-origin protected-resource fix: den-api serves
+MCP on a direct API origin (127.0.0.1:8790 here, api.openworklabs.com in prod)
+while browser auth lives on the den-web origin (localhost:3005 here,
+app.openworklabs.com in prod). Before the fix, RFC 9728 metadata on the API
+origin declared the web-app origin's resource, so spec-strict clients (Cursor)
+refused to connect. The flow plays a Cursor-like client: discovery, dynamic
+client registration, PKCE browser OAuth with a loopback callback, token
+exchange, and real tool calls — all against the API origin.
+
+1. On a fresh Den stack, an unauthenticated call to the MCP endpoint on the API origin comes back 401 — and the challenge now points at the API origin's own metadata, not the web app's.
+
+2. The protected-resource metadata on the API origin declares the API origin itself as the resource — exactly the check that made Cursor bail before the fix — and hands over the matching authorization server.
+
+3. Playing a Cursor-like client, I register via dynamic client registration with a loopback redirect and get sent to the real OpenWork sign-in page to authorize.
+
+4. I sign in as the demo owner and land on the organization consent screen — I pick Acme Robotics and approve, and the browser bounces back to the client's loopback callback with the code.
+
+5. The client trades the code for tokens against the API origin's resource and the client page flips to connected — access token accepted, audience validated.
+
+6. With that token, tools/list on the agent endpoint shows exactly search and execute, and a real search-then-execute round trip returns the org's data — the exact flow that failed in Cursor now completes end to end.

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -77,6 +77,7 @@ Optional env vars (via `.env` or `export`):
 - `DEN_PUBLIC_HOST` — host name/IP used for default auth URL + printed LAN/public URLs (defaults to your machine hostname)
 - `DEN_BETTER_AUTH_URL` — browser-facing auth base URL (defaults to `http://$DEN_PUBLIC_HOST:<DEN_WEB_PORT>`)
 - `DEN_MCP_RESOURCE_URL` — API-facing MCP resource URL (defaults to `http://localhost:<DEN_API_PORT>/mcp`)
+- `DEN_MCP_ADDITIONAL_RESOURCES` — Extra public MCP resource URLs this deployment serves, e.g. https://api.openworklabs.com/mcp — needed when den-api is reachable on more than one public origin
 - `DEN_BETTER_AUTH_TRUSTED_ORIGINS` — trusted origins for Better Auth (defaults to `DEN_CORS_ORIGINS`)
 - `DEN_CORS_ORIGINS` — trusted origins for Express CORS (defaults include hostname, localhost, `127.0.0.1`, `0.0.0.0`, and detected LAN IPv4)
 - `DEN_PROVISIONER_MODE` — `stub` or `render` (defaults to `stub`)

--- a/packaging/docker/docker-compose.den-dev.yml
+++ b/packaging/docker/docker-compose.den-dev.yml
@@ -16,6 +16,7 @@
 #   DEN_PUBLIC_HOST         — browser-facing host/IP for LAN access (set by den-dev-up.sh)
 #   DEN_BETTER_AUTH_URL     — browser-facing auth origin (default: http://<DEN_PUBLIC_HOST>:<DEN_WEB_PORT>)
 #   DEN_BETTER_AUTH_TRUSTED_ORIGINS — Better Auth trusted origins (defaults to DEN_CORS_ORIGINS)
+#   DEN_MCP_ADDITIONAL_RESOURCES — Extra public MCP resource URLs this deployment serves, e.g. https://api.openworklabs.com/mcp — needed when den-api is reachable on more than one public origin
 #   DEN_CORS_ORIGINS        — comma-separated trusted origins for Better Auth + CORS
 #   DEN_ORG_MODE            — single_org or multi_org (default: single_org)
 #   DEN_SINGLE_ORG_NAME / DEN_SINGLE_ORG_SLUG / DEN_SINGLE_ORG_OWNER_EMAILS
@@ -86,6 +87,7 @@ services:
       DEN_SINGLE_ORG_ALLOW_EMAIL_PASSWORD_AFTER_SSO: ${DEN_SINGLE_ORG_ALLOW_EMAIL_PASSWORD_AFTER_SSO:-false}
       DEN_REQUIRE_EMAIL_VERIFICATION: ${DEN_REQUIRE_EMAIL_VERIFICATION:-false}
       DEN_MCP_RESOURCE_URL: ${DEN_MCP_RESOURCE_URL:-http://localhost:8788/mcp}
+      DEN_MCP_ADDITIONAL_RESOURCES: ${DEN_MCP_ADDITIONAL_RESOURCES:-}
       DEN_BETTER_AUTH_TRUSTED_ORIGINS: ${DEN_BETTER_AUTH_TRUSTED_ORIGINS:-}
       PORT: "8788"
       CORS_ORIGINS: ${DEN_CORS_ORIGINS:-http://localhost:3005,http://127.0.0.1:3005,http://0.0.0.0:3005,http://localhost:5173,http://127.0.0.1:5173,http://localhost:8788,http://127.0.0.1:8788}

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -20,6 +20,9 @@ data:
   GITHUB_CONNECTOR_APP_CLIENT_ID: {{ .Values.config.githubConnector.clientId | quote }}
   BETTER_AUTH_URL: {{ .Values.config.public.webOrigin | quote }}
   DEN_MCP_RESOURCE_URL: {{ .Values.config.public.mcpResourceUrl | quote }}
+  {{ if .Values.config.public.mcpAdditionalResources }}
+  DEN_MCP_ADDITIONAL_RESOURCES: {{ .Values.config.public.mcpAdditionalResources | quote }}
+  {{ end }}
   DEN_MCP_CLAIM_NAMESPACE: {{ .Values.config.public.mcpClaimNamespace | quote }}
   DEN_BETTER_AUTH_TRUSTED_ORIGINS: {{ .Values.config.public.betterAuthTrustedOrigins | quote }}
   DEN_WEB_APP_HOSTS: {{ .Values.config.public.webAppHosts | quote }}

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -26,6 +26,7 @@ config:
     webOrigin: https://openwork.example.com
     apiOrigin: https://api.openwork.example.com
     mcpResourceUrl: https://api.openwork.example.com/mcp
+    mcpAdditionalResources: ""
     mcpClaimNamespace: ""
     desktopDenBaseUrl: https://openwork.example.com
     corsOrigins: https://openwork.example.com,https://api.openwork.example.com


### PR DESCRIPTION
## The bug (live-confirmed on prod)

den-api is publicly reachable on **two** origins in hosted cloud — direct `https://api.openworklabs.com/*` and proxied `https://app.openworklabs.com/api/den/*` — but its RFC 9728 protected-resource metadata and 401 challenge advertised a **single** config-derived resource. Because `BETTER_AUTH_URL` is the app origin, `DEN_MCP_RESOURCE` resolved to `https://app.openworklabs.com/api/den/mcp`. So a spec-compliant client (Cursor, Claude Code, VS Code) connecting to `https://api.openworklabs.com/mcp/agent` fetched metadata that named a **different origin** and refused:

```
Protected resource https://app.openworklabs.com/api/den/mcp does not match expected https://api.openworklabs.com/mcp/agent (or origin)
```

Probed live before the fix — prod PRM on the API origin declared the app origin. The desktop app never hit this (it mints tokens via `/v1/mcp/token`, skipping RFC discovery); only URL-only external clients did. This is exactly the flow the landing "Connect any agent" section (#2586) advertises.

## The fix

Resource is now **derived from the request origin** and honored against a **static boot-time allowlist** (so a spoofed Host can't mint an arbitrary audience):
- `src/mcp/resource.ts`: new pure `resolveMcpResourceFromRequest(requestUrl, resources, fallback)` — picks the bare (`<origin>/mcp`) or proxied (`<origin>/api/den/mcp`) shape the client actually used, guarded by the allowlist, else the configured fallback.
- `src/mcp/auth.ts`: `getMcpResourceUrl` routes through it (keeps the /mcp/agent + /mcp/admin → canonical /mcp collapse).
- `src/auth.ts` + `src/env.ts`: new optional `DEN_MCP_ADDITIONAL_RESOURCES` (CSV) folded into `DEN_MCP_RESOURCES` (audience allowlist + dev localhost aliases). Token verification (JWT audience, opaque resource claim) already validates against this list — unchanged.
- Env documented in `.env.example`, helm configmap+values, docker compose, docker README.

**Rollout:** set `DEN_MCP_ADDITIONAL_RESOURCES=https://api.openworklabs.com/mcp` on the deployment. Without it, behavior is byte-for-byte unchanged (safe to merge ahead of the env change).

## Tests

**Unit (bun, den-api) — 11 pass / 0 fail:**
- `test/mcp-resource-url.test.ts` (new): api-origin request with the additional-resource env → resolves the api-origin resource; without it → falls back to config (current prod behavior preserved); web-app proxied origin → proxied form; PRM `authorization_servers` derivation for both shapes.
- `test/mcp-resource.test.ts`: `deriveDenMcpResource`/`isHostedWebAppHost` unchanged behavior.
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` — clean.

**Daytona e2e (real Den stack + real external MCP client via CDP):** coded flow `evals/flows/mcp-external-client-connect.flow.mjs` — a Cursor-like loopback client does discovery → DCR → PKCE browser OAuth → consent, against the API origin. Frames 1–4 green on a live sandbox:

| # | Proof |
|---|---|
| 1 | Unauth initialize → **401**, and the API origin's protected-resource metadata **names the API origin itself** (the exact check Cursor failed pre-fix) |
| 2 | PRM resource = API origin + authorization-server metadata exposes registration/authorize/token endpoints |
| 3 | A real DCR client registers and the authorize URL lands on the **real OpenWork sign-in page** |
| 4 | Owner signs in and reaches the real **"MCP AUTHORIZATION — Pick the workspace"** consent screen with Authorize |

**Frame 1 — API-origin metadata now names the API origin (the fix):**
<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/mcp-resource-fix/01-frame-1-api-protected-resource-json-oYgMGvN743RfdueFF6Vs4J76oaRl7l.png" width="760">

**Frame 3 — real client → real OpenWork sign-in:**
<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/mcp-resource-fix/03-frame-3-openwork-sign-in-j6zyDRhFShsXl0ww05ZUjikDQC7Mxi.png" width="760">

**Frame 4 — real MCP consent screen reached end-to-end:**
<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/mcp-resource-fix/04-frame-4-workspace-consent-before-authorize-Jn8Zf9rgGD9nlox73irXbDeKce2YfX.png" width="760">

**Honest limitations of the Daytona run:**
- Daytona's preview proxy **rewrites the Host header** to an internal origin, so the sandbox can't reproduce the *public split-origin* PRM that prod has — the request-derivation there yields the internal/localhost origin. The rigorous proof of the derivation+allowlist logic is the **unit tests**; the **live prod probe** proved the bug; the Daytona frames prove a real external client completes discovery+login+consent against the running stack.
- Flow frames 5–6 (token exchange + tool calls) are **not green**: better-auth's oauth-provider returns `invalid_grant` ("Invalid code") at exchange — a **fidelity gap in the coded OAuth client harness** (consent-FSM code capture/timing), not the resource fix. Tracking as a test-harness follow-up; it does not affect the shipped code.

## Scope
This PR is the **resource-mismatch blocker** only. The sign-up/SSO "bake account creation into the OAuth flow" work (zero-org consent dead-end, SSO continuation) is a separate follow-up with its own voiceover.