### PR TITLE
fix(onboarding): Windows-verified first-run — plain loader, reachable provider step, no empty-state flash

### DIFF
--- a/apps/app/src/react-app/domains/onboarding/first-run-loader.tsx
+++ b/apps/app/src/react-app/domains/onboarding/first-run-loader.tsx
@@ -1,60 +1,24 @@
 /** @jsxImportSource react */
-import { useEffect, useState, useSyncExternalStore } from "react";
-import { Loader2 } from "lucide-react";
-import { PaperGrainGradient } from "@openwork/ui/react";
 
-import { getResolvedThemeMode, subscribeToTheme } from "../../../app/theme";
-
-const MESSAGES = [
-  "Warming things up…",
-  "Working the magic…",
-  "Talking to the gremlins…",
-  "Setting up your workspace…",
-  "Sharpening the pencils…",
-  "Untangling the wires…",
-  "Teaching the agent some manners…",
-  "Almost there…",
-];
-
-// Silver-gray grain palette matching the landing page hero, per theme.
-const GRAIN = {
-  light: { back: "#f4f5f7", colors: ["#c8cdd4", "#9aa1ab", "#e9ebee", "#767d87"] },
-  dark: { back: "#0e0f11", colors: ["#2a2d33", "#42464e", "#191b1f", "#565b64"] },
-} as const;
+import { OwDotTicker } from "../../shell/dot-ticker";
 
 /**
- * Full-screen loader shown on a brand-new install while the first session is
- * being created, so the "select or create a session" page never flashes.
+ * First-run full-screen loader shown while the first session is created,
+ * styled to match the boot LoadingOverlay.
  */
 export function FirstRunLoader() {
-  const theme = useSyncExternalStore(subscribeToTheme, getResolvedThemeMode);
-  const [index, setIndex] = useState(0);
-
-  useEffect(() => {
-    const interval = window.setInterval(() => {
-      setIndex((current) => (current + 1) % MESSAGES.length);
-    }, 1800);
-    return () => window.clearInterval(interval);
-  }, []);
-
-  const grain = GRAIN[theme];
   return (
-    <div className="fixed inset-0 z-50">
-      <PaperGrainGradient
-        speed={0.6}
-        softness={0.7}
-        intensity={0.4}
-        noise={0.35}
-        shape="corners"
-        colors={[...grain.colors]}
-        colorBack="#00000000"
-        style={{ backgroundColor: grain.back, width: "100%", height: "100%" }}
-      />
-      <div className="absolute inset-0 flex flex-col items-center justify-center gap-4">
-        <Loader2 className="size-8 animate-spin text-muted-foreground" />
-        <p className="text-sm text-muted-foreground" aria-live="polite">
-          {MESSAGES[index]}
-        </p>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-dls-surface"
+      aria-live="polite"
+      aria-busy={true}
+      role="status"
+    >
+      <div className="flex w-full max-w-[320px] flex-col items-center gap-4 px-6 text-center">
+        <OwDotTicker size="md" />
+        <div className="text-[12px] leading-5 text-dls-secondary">
+          Preparing workspace
+        </div>
       </div>
     </div>
   );

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -849,12 +849,13 @@ export function SessionRoute() {
         if (!targetSessionId) return;
         const text = (draft.resolvedText ?? draft.text).trim();
         if (!text && draft.attachments.length === 0) return;
-        // One-shot provider selection on the first send: hold the draft,
-        // show the step, and resend automatically once the user chooses.
+        // One-shot provider selection on the first send whenever no user-added
+        // provider is connected. The free default model being usable is the
+        // normal case here, not a reason to skip the step.
         if (
           !providerStepResendRef.current &&
           !local.prefs.providerStepCompleted &&
-          !hasUsableModel &&
+          isDesktopRuntime() &&
           userProviderConnectedIds.length === 0 &&
           draft.mode !== "shell"
         ) {
@@ -1281,7 +1282,10 @@ export function SessionRoute() {
   }, []);
   useEffect(() => {
     if (!firstRunLoaderActive) return;
-    const timeout = window.setTimeout(dismissFirstRunLoader, 30_000);
+    // Safety cap only: a cold first engine boot measured 35–40s on a slow
+    // Windows VM, so 30s cut the loader early and flashed the empty session
+    // page. Errors and settled states still dismiss immediately below.
+    const timeout = window.setTimeout(dismissFirstRunLoader, 120_000);
     return () => window.clearTimeout(timeout);
   }, [firstRunLoaderActive, dismissFirstRunLoader]);
   useEffect(() => {
@@ -1774,7 +1778,10 @@ export function SessionRoute() {
       }
       setCreateWorkspaceOpen(false);
       // Mark onboarding complete so the /welcome redirect never fires again.
-      local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true }));
+      // Completing the classic flow also counts as the provider step so the
+      // OpenWork Models startup promo is not suppressed forever (its
+      // `suppressed` input keys off providerStepCompleted).
+      local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true, providerStepCompleted: true }));
       await refreshRouteState();
       if (targetWorkspaceId) {
         const workspacePath = targetWorkspace?.path?.trim() || folder;
@@ -1877,7 +1884,10 @@ export function SessionRoute() {
       }
       setCreateWorkspaceOpen(false);
       // Mark onboarding complete so the /welcome redirect never fires again.
-      local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true }));
+      // Completing the classic flow also counts as the provider step so the
+      // OpenWork Models startup promo is not suppressed forever (its
+      // `suppressed` input keys off providerStepCompleted).
+      local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true, providerStepCompleted: true }));
       await refreshRouteState();
       return true;
     } catch (error) {

--- a/evals/flows/win-first-run-onboarding.flow.mjs
+++ b/evals/flows/win-first-run-onboarding.flow.mjs
@@ -16,7 +16,7 @@ export default {
       name: "Frame 1 — first-run loader holds the boot surface",
       run: async (ctx) => {
         await ctx.prove("First launch shows the Preparing workspace loader instead of an empty session picker", {
-          claim: "A factory-reset Windows launch starts on the full-screen Preparing workspace loader while OpenWork creates the default workspace.",
+          claim: "A factory-reset Windows launch starts on the full-screen Preparing workspace loader as the topmost surface while OpenWork creates the default workspace.",
           voiceover: vo[0],
           // "The instant the app opens there is no welcome wizard and no empty picker — j"
           action: async () => {
@@ -24,12 +24,26 @@ export default {
           },
           assert: async () => {
             await ctx.expectText("Preparing workspace", { timeoutMs: 1_000 });
-            await ctx.expectNoText("Select or create a session");
+            const occlusion = await ctx.eval(`(() => {
+              const overlayTop = document.elementFromPoint(Math.floor(innerWidth / 2), Math.floor(innerHeight / 2));
+              const status = overlayTop ? overlayTop.closest('[role="status"]') : null;
+              const leaves = Array.from(document.querySelectorAll("*")).filter(
+                (el) => el.children.length === 0 && (el.textContent || "").includes("Select or create a session"),
+              );
+              const emptyStateVisible = leaves.some((el) => {
+                const rect = el.getBoundingClientRect();
+                if (rect.width === 0 || rect.height === 0) return false;
+                const top = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+                return Boolean(top && (el === top || el.contains(top) || top.contains(el)));
+              });
+              return { loaderOnTop: Boolean(status), emptyStateVisible };
+            })()`);
+            ctx.assert(occlusion.loaderOnTop, "The Preparing workspace loader overlay is not the topmost element at the viewport center.");
+            ctx.assert(!occlusion.emptyStateVisible, "The select-or-create empty state is visible to the user during first-run boot.");
           },
           screenshot: {
             name: "first-run-loader",
             requireText: ["Preparing workspace"],
-            rejectText: ["Select or create a session"],
           },
         });
       },

--- a/evals/flows/win-first-run-onboarding.flow.mjs
+++ b/evals/flows/win-first-run-onboarding.flow.mjs
@@ -1,0 +1,157 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/win-first-run-onboarding.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("win-first-run-onboarding");
+const MSG = "Reply with exactly: Windows onboarding OK";
+const EDITOR_SELECTOR = '[contenteditable="true"][data-lexical-editor="true"]';
+
+export default {
+  id: "win-first-run-onboarding",
+  title: "Windows first run: chat-ready landing, held first send, provider step, free-model reply",
+  kind: "user-facing",
+  preserveTheme: true,
+  steps: [
+    {
+      name: "Frame 1 — first-run loader holds the boot surface",
+      run: async (ctx) => {
+        await ctx.prove("First launch shows the Preparing workspace loader instead of an empty session picker", {
+          claim: "A factory-reset Windows launch starts on the full-screen Preparing workspace loader while OpenWork creates the default workspace.",
+          voiceover: vo[0],
+          // "The instant the app opens there is no welcome wizard and no empty picker — j"
+          action: async () => {
+            await ctx.waitForText("Preparing workspace", { timeoutMs: 60_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Preparing workspace", { timeoutMs: 1_000 });
+            await ctx.expectNoText("Select or create a session");
+          },
+          screenshot: {
+            name: "first-run-loader",
+            requireText: ["Preparing workspace"],
+            rejectText: ["Select or create a session"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2 — auto-created session is chat-ready",
+      run: async (ctx) => {
+        await ctx.prove("The loader hands off directly to a ready first session", {
+          claim: "When the engine is ready, OpenWork lands on an auto-created session with the composer and Ready for new tasks status visible, never the select-or-create empty state.",
+          voiceover: vo[1],
+          // "When the engine is ready the loader hands off straight into a live chat sess"
+          action: async () => {
+            await ctx.waitFor('location.hash.includes("/session/")', {
+              timeoutMs: 150_000,
+              label: "auto-created first session route",
+            });
+            await ctx.waitFor('!document.body.innerText.includes("Preparing workspace")', {
+              timeoutMs: 150_000,
+              label: "Preparing workspace loader dismissed",
+            });
+          },
+          assert: async () => {
+            await ctx.expectText("Describe your task", { timeoutMs: 30_000 });
+            await ctx.expectText("Ready for new tasks", { timeoutMs: 30_000 });
+            await ctx.expectHashIncludes("/session/");
+            await ctx.expectNoText("Select or create a session");
+          },
+          screenshot: {
+            name: "chat-ready-session",
+            requireText: ["Describe your task", "Ready for new tasks"],
+            rejectText: ["Select or create a session"],
+            hashIncludes: "/session/",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — first send is held for provider choice",
+      run: async (ctx) => {
+        await ctx.prove("Running the first task opens the provider choice step before sending", {
+          claim: "The first Run task click keeps the draft in place and asks whether to use OpenWork Models, bring an API key, or skip to the free model.",
+          voiceover: vo[2],
+          // "The user types their first message and presses Run task. Instead of sending "
+          action: async () => {
+            await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(EDITOR_SELECTOR)}))`, {
+              timeoutMs: 30_000,
+              label: "Lexical composer editor",
+            });
+            await ctx.eval(`(() => {
+              const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+              if (!editor) throw new Error("composer editor missing");
+              editor.focus();
+              const data = new DataTransfer();
+              data.setData("text/plain", ${JSON.stringify(MSG)});
+              editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
+              return true;
+            })()`);
+            await ctx.waitFor(`(() => {
+              const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+              return Boolean(editor && editor.innerText.includes(${JSON.stringify(MSG)}));
+            })()`, { timeoutMs: 30_000, label: "pasted draft in composer" });
+            await ctx.waitFor(`(() => {
+              const buttons = Array.from(document.querySelectorAll("button"));
+              return buttons.some((button) => (button.textContent ?? "").includes("Run task") && !button.disabled);
+            })()`, { timeoutMs: 30_000, label: "enabled Run task button" });
+            await ctx.clickText("Run task", { selector: "button", timeoutMs: 30_000 });
+            await ctx.waitForText("Power your first task", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Power your first task");
+            await ctx.expectText("Use OpenWork Models");
+            await ctx.expectText("Bring your own API key");
+            await ctx.expectText("Skip and use the free model");
+          },
+          screenshot: {
+            name: "provider-choice-step",
+            requireText: ["Power your first task", "Use OpenWork Models", "Skip and use the free model"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4 — skip free model sends held draft and completes setup",
+      run: async (ctx) => {
+        await ctx.prove("Skipping to the free model auto-sends the held draft and marks provider setup complete", {
+          claim: "After choosing the free model, the provider step disappears, the held Windows onboarding draft is answered, and the one-shot provider preference is persisted.",
+          voiceover: vo[3],
+          // "The user picks skip and use the free model. The held message sends itself im"
+          action: async () => {
+            await ctx.clickText("Skip and use the free model", { selector: "button", timeoutMs: 30_000 });
+            await ctx.waitFor('!document.body.innerText.includes("Power your first task")', {
+              timeoutMs: 30_000,
+              label: "provider step dismissed",
+            });
+            await ctx.waitFor(`(() => {
+              const text = document.body.innerText;
+              return text.split(${JSON.stringify("Windows onboarding OK")}).length > 2;
+            })()`, { timeoutMs: 120_000, label: "free model reply appears after held draft resend" });
+          },
+          assert: async () => {
+            const result = await ctx.eval(`(() => {
+              const rawPreferences = localStorage.getItem("openwork.preferences");
+              const preferences = rawPreferences ? JSON.parse(rawPreferences) : null;
+              const text = document.body.innerText;
+              return {
+                providerStepCompleted: preferences?.providerStepCompleted === true,
+                promoStartupShown: localStorage.getItem("openwork.openworkModelsPromo.startupShown"),
+                replyCount: text.split(${JSON.stringify("Windows onboarding OK")}).length - 1,
+              };
+            })()`);
+            ctx.assert(result.providerStepCompleted === true, "providerStepCompleted was not true in openwork.preferences.");
+            ctx.assert(result.promoStartupShown === "1", "openwork.openworkModelsPromo.startupShown was not set to 1.");
+            ctx.assert(result.replyCount > 1, "Windows onboarding OK did not appear in both the user draft and assistant reply.");
+            await ctx.expectNoText("Power your first task");
+          },
+          screenshot: {
+            name: "free-model-reply-complete",
+            requireText: ["Windows onboarding OK"],
+            rejectText: ["Power your first task"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/win-first-run-onboarding.md
+++ b/evals/voiceovers/win-first-run-onboarding.md
@@ -1,0 +1,11 @@
+# win-first-run-onboarding — Windows first launch lands in a chat-ready workspace and the first send offers a model choice
+
+Cast is a brand-new Windows user launching the packaged OpenWork desktop app for the very first time — no prior state anywhere on the machine. The proof was driven against a real packaged build inside a Daytona Windows 11 VM.
+
+1. The instant the app opens there is no welcome wizard and no empty picker — just a calm full-screen loader that says Preparing workspace, in the same quiet style as the boot overlay, while OpenWork creates a default workspace in the user's home folder and starts the engine.
+
+2. When the engine is ready the loader hands off straight into a live chat session inside the default OpenWork workspace. The composer is focused and ready with the free model preselected, and the select-or-create session page never appeared at any point.
+
+3. The user types their first message and presses Run task. Instead of sending silently, OpenWork holds the draft and asks one question first: power your first task with OpenWork Models, bring your own API key, or skip and use the free model.
+
+4. The user picks skip and use the free model. The held message sends itself immediately — no retyping — the agent answers in the same session, and the one-shot provider step is marked complete so it never interrupts again.


### PR DESCRIPTION
## What

Windows verification of #2547 (agent-screen-first onboarding) on a real Daytona Windows 11 VM, plus the fixes it surfaced:

1. **Plain first-run loader** — drops the `PaperGrainGradient` shader + rotating novelty messages; the loader now matches the boot overlay ("Preparing workspace", solid `dls-surface`, `OwDotTicker`), staying close to the existing prepare-workspace example.
2. **First-run loader safety cap 30s → 120s** — a cold first engine boot measured **35–40s** on a 2-vCPU Windows VM (first `GET /sessions` returned after 35364ms). The 30s cap dismissed the loader early and the "Select or create a session" page — which #2547 promises never flashes — was visible for ~7s. Error/settled dismissal paths unchanged.
3. **Provider selection step was unreachable** — the intercept required `!hasUsableModel`, but fresh installs always ship a usable free default model (`opencode/big-pickle`), so the step never fired, `providerStepCompleted` never flipped, and the OpenWork Models startup promo was **suppressed forever for every new user**. Now gated on desktop runtime + no user-added provider, exactly as the #2547 description states; the held draft resends on the free model.
4. **Classic-flow parity** — local/remote workspace creation (the old /welcome path) now also sets `providerStepCompleted`, so welcome-flow users keep getting the startup promo.
5. **New fraimz flow** `win-first-run-onboarding` proving the whole journey.

## What was verified on Windows (packaged build, factory-reset VM)

- Default "OpenWork" workspace created at `C:\Users\Administrator\OpenWork` (`[first-run] created default workspace` in the main-process log; `.opencode/openwork.json` with preset `starter`, correct Windows paths).
- No /welcome page; loader holds the whole boot; lands directly in an auto-created, chat-ready session.
- First send is intercepted by **Power your first task**; "Skip and use the free model" auto-resends the held draft; the free model replies in-session.
- `providerStepCompleted=true` + `openwork.openworkModelsPromo.startupShown="1"` after the step; no promo popup over the flow.
- Returning-profile regression check: with existing engine sessions, the loader dismisses via the settled path (no 120s hang) and the session picker shows as designed.

## Before (dev @ 1088479b4, Windows) — empty state flash at ~35s

<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/win-first-run-onboarding/boot-20-w757PRJ5GUUsxFC3tzcIAVF2gNV3N8.png" width="700">

## After (this branch, Windows desktop via VNC-session capture)

Loader (plain, matches boot overlay) → direct chat-ready landing:

<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/win-first-run-onboarding/fixed-05-ZmCaC7HIpIt6rpDne42HbLsLqXFYrr.png" width="700">
<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/win-first-run-onboarding/fixed-20-qDhxlzomWYz4w4p7ZGUM77Tdxtzcom.png" width="700">

First send held for the provider step → skip → held draft answered on the free model:

<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/win-first-run-onboarding/20-provider-step-XyS8lSkgGWWCvFno3zCikoMhbZ3fAT.png" width="700">
<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/win-first-run-onboarding/22-agent-reply-VlLdVFxX5C9GYNXaArSEbeQyMjrE08.png" width="700">

## Tests run

- `pnpm --filter @openwork/app typecheck` — passed.
- `pnpm fraimz --flow win-first-run-onboarding --cdp-url <tunnel>` against the packaged Windows build in a factory-reset Daytona `windows-medium` VM — **PASSED (4/4 frames + voiceover coverage)**; fraimz comment below.
- Windows build produced by the `Build Electron Desktop` workflow on this branch (runs 28979126065 pre-fix, 28981155851 post-fix).

## Revert consideration

Per the "revert if broken" instruction: not reverting #2547 — its core (default workspace, engine boot, chat-ready landing, fresh-install hang fix) works on Windows; the two defects above were surgical and reverting would reintroduce the fresh-install hang. 
