### PR TITLE
fix(den): auto-trust the public API origin as an MCP resource (zero deploy config)

### DIFF
--- a/ee/apps/den-api/.env.example
+++ b/ee/apps/den-api/.env.example
@@ -15,7 +15,7 @@ DEN_API_PUBLIC_URL=http://localhost:8790
 DEN_DESKTOP_DEN_BASE_URL=http://localhost:3005/api/den
 DEN_MARKETING_URL=http://localhost:3005
 DEN_MCP_RESOURCE_URL=http://localhost:8790/mcp
-# Extra public MCP resource URLs this deployment serves, e.g. https://api.openworklabs.com/mcp — needed when den-api is reachable on more than one public origin
+# Extra public MCP resource URLs beyond the DEN_API_PUBLIC_URL API origin and web-app defaults.
 DEN_MCP_ADDITIONAL_RESOURCES=
 # Defaults to BETTER_AUTH_URL when blank. Set this to a stable hosted namespace
 # before issuing MCP tokens if you need claim URI compatibility across host moves.

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -86,14 +86,28 @@ function localMcpResourceAliases(resource: string) {
   return [];
 }
 
+function apiPublicMcpResource(apiPublicUrl: string | undefined) {
+  if (!apiPublicUrl) return [];
+
+  try {
+    return [`${new URL(apiPublicUrl).origin}/mcp`];
+  } catch {
+    return [];
+  }
+}
+
 export const DEN_MCP_RESOURCE = env.mcpResourceUrl ?? deriveDenMcpResource(env.betterAuthUrl, env.webAppHosts);
+const DEN_API_PUBLIC_MCP_RESOURCES = apiPublicMcpResource(env.apiPublicUrl);
 export const DEN_MCP_RESOURCES = Array.from(new Set([
   DEN_MCP_RESOURCE,
   // Audience compatibility: tokens issued before the proxied default carry
   // the bare-origin resource (`<betterAuthUrl>/mcp`); keep accepting them.
   `${env.betterAuthUrl}/mcp`,
+  // Auto-trust the public API origin so multi-origin clients work without extra config.
+  ...DEN_API_PUBLIC_MCP_RESOURCES,
   ...env.mcpAdditionalResources,
   ...localMcpResourceAliases(DEN_MCP_RESOURCE),
+  ...DEN_API_PUBLIC_MCP_RESOURCES.flatMap((resource) => localMcpResourceAliases(resource)),
   ...env.mcpAdditionalResources.flatMap((resource) => localMcpResourceAliases(resource)),
 ]));
 export const DEN_MCP_TOKEN_USE_CLAIM = `${env.mcpClaimNamespace}/token_use`;

--- a/ee/apps/den-api/test/mcp-resource-url.test.ts
+++ b/ee/apps/den-api/test/mcp-resource-url.test.ts
@@ -8,6 +8,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../
 
 type ProbeOptions = {
   betterAuthUrl: string
+  apiPublicUrl?: string
   additionalResources?: string
   requestUrl: string
   expectedResource: string
@@ -64,6 +65,7 @@ console.log("ok")
       DEN_DB_ENCRYPTION_KEY: "x".repeat(32),
       BETTER_AUTH_SECRET: "y".repeat(32),
       BETTER_AUTH_URL: options.betterAuthUrl,
+      DEN_API_PUBLIC_URL: options.apiPublicUrl ?? "",
       OPENWORK_DEV_MODE: "0",
       PROVISIONER_MODE: "stub",
       DEN_ORG_MODE: "",
@@ -91,6 +93,18 @@ console.log("ok")
 }
 
 describe("getMcpResourceUrl", () => {
+  test("auto-trusts the public API origin resource", () => {
+    runMcpResourceProbe({
+      betterAuthUrl: "https://app.example.com",
+      apiPublicUrl: "https://api.example.com",
+      requestUrl: "https://api.example.com/mcp/agent",
+      expectedResource: "https://api.example.com/mcp",
+      metadataUrl: "https://api.example.com/mcp/agent",
+      expectedMetadataResource: "https://api.example.com/mcp",
+      expectedAuthorizationServer: "https://api.example.com/api/auth",
+    })
+  })
+
   test("honors an additional direct API-origin resource", () => {
     runMcpResourceProbe({
       betterAuthUrl: "https://app.openworklabs.com",
@@ -109,6 +123,17 @@ describe("getMcpResourceUrl", () => {
       requestUrl: "https://api.openworklabs.com/mcp/agent",
       expectedResource: "https://app.openworklabs.com/api/den/mcp",
     })
+  })
+
+  test("ignores malformed and empty public API URLs", () => {
+    for (const apiPublicUrl of ["not a url", ""]) {
+      runMcpResourceProbe({
+        betterAuthUrl: "https://app.example.com",
+        apiPublicUrl,
+        requestUrl: "https://api.example.com/mcp/agent",
+        expectedResource: "https://app.example.com/api/den/mcp",
+      })
+    }
   })
 
   test("honors the proxied web-app resource derived from BETTER_AUTH_URL", () => {

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -77,7 +77,7 @@ Optional env vars (via `.env` or `export`):
 - `DEN_PUBLIC_HOST` — host name/IP used for default auth URL + printed LAN/public URLs (defaults to your machine hostname)
 - `DEN_BETTER_AUTH_URL` — browser-facing auth base URL (defaults to `http://$DEN_PUBLIC_HOST:<DEN_WEB_PORT>`)
 - `DEN_MCP_RESOURCE_URL` — API-facing MCP resource URL (defaults to `http://localhost:<DEN_API_PORT>/mcp`)
-- `DEN_MCP_ADDITIONAL_RESOURCES` — Extra public MCP resource URLs this deployment serves, e.g. https://api.openworklabs.com/mcp — needed when den-api is reachable on more than one public origin
+- `DEN_MCP_ADDITIONAL_RESOURCES` — extra public MCP resource URLs beyond the `DEN_API_PUBLIC_URL` API origin and web-app defaults
 - `DEN_BETTER_AUTH_TRUSTED_ORIGINS` — trusted origins for Better Auth (defaults to `DEN_CORS_ORIGINS`)
 - `DEN_CORS_ORIGINS` — trusted origins for Express CORS (defaults include hostname, localhost, `127.0.0.1`, `0.0.0.0`, and detected LAN IPv4)
 - `DEN_PROVISIONER_MODE` — `stub` or `render` (defaults to `stub`)

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
   GITHUB_CONNECTOR_APP_CLIENT_ID: {{ .Values.config.githubConnector.clientId | quote }}
   BETTER_AUTH_URL: {{ .Values.config.public.webOrigin | quote }}
   DEN_MCP_RESOURCE_URL: {{ .Values.config.public.mcpResourceUrl | quote }}
+  # Extra MCP resource URLs beyond the DEN_API_PUBLIC_URL API origin and web-app defaults.
   {{ if .Values.config.public.mcpAdditionalResources }}
   DEN_MCP_ADDITIONAL_RESOURCES: {{ .Values.config.public.mcpAdditionalResources | quote }}
   {{ end }}


### PR DESCRIPTION
## Follow-up to #2603

#2603 fixed the multi-origin MCP protected-resource mismatch, but required operators to **manually** set `DEN_MCP_ADDITIONAL_RESOURCES` to the public API origin. Every real deploy already knows that origin: it's `DEN_API_PUBLIC_URL` (`env.apiPublicUrl`) — set in helm (`config.public.apiOrigin` → configmap), docker (`den-dev-up.sh`), and the Daytona server scripts, and already used by `resolvePublicOrigin` for MCP OAuth redirect bases (`mcp/agent.ts`), install links, and oauth-providers.

This auto-includes `${DEN_API_PUBLIC_URL origin}/mcp` in the MCP resource allowlist, so the multi-origin fix works with **no new deploy config**. `DEN_MCP_ADDITIONAL_RESOURCES` remains as an escape hatch for any *extra* origins beyond the API + web-app defaults.

### Change
- `ee/apps/den-api/src/auth.ts`: safe `apiPublicMcpResource(env.apiPublicUrl)` helper (parses the origin, never throws on unset/malformed) folded into `DEN_MCP_RESOURCES` (with dev localhost aliases, like the other entries).
- Docs clarified (`.env.example`, helm configmap comment, docker README): the API origin is auto-trusted; `DEN_MCP_ADDITIONAL_RESOURCES` is only for extra origins.

### Tests (bun, den-api) — 13 pass / 0 fail
- New: with `DEN_API_PUBLIC_URL=https://api.example.com` and a web-app `BETTER_AUTH_URL`, a request to `https://api.example.com/mcp/agent` resolves `https://api.example.com/mcp` **without** `DEN_MCP_ADDITIONAL_RESOURCES`.
- New: malformed/empty `DEN_API_PUBLIC_URL` doesn't throw and adds no entry.
- Existing multi-origin cases still pass.
- `tsc --noEmit` clean.

### Net effect on prod
Once this ships, `api.openworklabs.com` auto-advertises its own resource (because `DEN_API_PUBLIC_URL` is already set there) — URL-only Cursor/Claude/VS Code connect works with zero env changes. No behavior change where `DEN_API_PUBLIC_URL` is unset.