### PR TITLE
feat(den-api): delete imported plugin components

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
@@ -157,6 +157,7 @@ export const pluginArchRoutePaths = {
   plugins: `${orgBasePath}/plugins`,
   plugin: `${orgBasePath}/plugins/:pluginId`,
   pluginArchive: `${orgBasePath}/plugins/:pluginId/archive`,
+  pluginRemove: `${orgBasePath}/plugins/:pluginId/remove`,
   pluginRestore: `${orgBasePath}/plugins/:pluginId/restore`,
   pluginConfigObjects: `${orgBasePath}/plugins/:pluginId/config-objects`,
   pluginConfigObject: `${orgBasePath}/plugins/:pluginId/config-objects/:configObjectId`,
@@ -397,6 +398,15 @@ export const pluginArchEndpointContracts: Record<string, EndpointContract> = {
     path: pluginArchRoutePaths.pluginArchive,
     request: { params: pluginParamsSchema },
     response: { description: "Archived plugin detail.", schema: pluginMutationResponseSchema, status: 200 },
+    tag: "Plugins",
+  },
+  removePlugin: {
+    audience: "admin",
+    description: "Remove a plugin from active Den plugin surfaces and delete imported components owned only by that plugin.",
+    method: "POST",
+    path: pluginArchRoutePaths.pluginRemove,
+    request: { params: pluginParamsSchema },
+    response: { description: "Removed plugin detail.", schema: pluginMutationResponseSchema, status: 200 },
     tag: "Plugins",
   },
   restorePlugin: {

--- a/ee/apps/den-api/src/routes/org/plugin-system/managed-component-cleanup.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/managed-component-cleanup.ts
@@ -1,0 +1,95 @@
+import type { DenTypeId } from "@openwork-ee/utils/typeid"
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { uniqueIds } from "./connector-cleanup.js"
+
+export type ManagedCleanupObjectType = "mcp" | "skill"
+
+export type ManagedConfigObjectVersion = {
+  normalizedPayloadJson: unknown
+}
+
+type SkillId = DenTypeId<"skill">
+type ExternalMcpConnectionId = DenTypeId<"externalMcpConnection">
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function denSkillIdFromConfigObjectVersion(row: ManagedConfigObjectVersion | undefined): SkillId | null {
+  const payload = row?.normalizedPayloadJson
+  if (!isRecord(payload) || payload.openworkManaged !== "den_skill" || typeof payload.denSkillId !== "string") {
+    return null
+  }
+  try {
+    return normalizeDenTypeId("skill", payload.denSkillId)
+  } catch {
+    return null
+  }
+}
+
+export function externalMcpConnectionIdsFromPayload(payload: unknown, options?: { ownedOnly?: boolean }): string[] {
+  const ids = new Set<string>()
+  const collect = (value: unknown) => {
+    if (!isRecord(value) || value.openworkManaged !== "den_external_mcp") return
+    if (options?.ownedOnly === true && value.externalMcpConnectionOwnedByPlugin !== true) return
+    if (typeof value.externalMcpConnectionId === "string" && value.externalMcpConnectionId.trim()) {
+      ids.add(value.externalMcpConnectionId.trim())
+    }
+  }
+
+  collect(payload)
+  if (isRecord(payload)) {
+    const containers = [
+      isRecord(payload.mcpServers) ? payload.mcpServers : null,
+      isRecord(payload.mcp) ? payload.mcp : null,
+    ].filter((entry): entry is Record<string, unknown> => Boolean(entry))
+    for (const container of containers) {
+      for (const value of Object.values(container)) collect(value)
+    }
+  }
+  return [...ids]
+}
+
+function normalizedExternalMcpConnectionIdsFromPayload(payload: unknown, options?: { ownedOnly?: boolean }): ExternalMcpConnectionId[] {
+  const ids: ExternalMcpConnectionId[] = []
+  for (const value of externalMcpConnectionIdsFromPayload(payload, options)) {
+    try {
+      ids.push(normalizeDenTypeId("externalMcpConnection", value))
+    } catch {
+      // Ignore stale or malformed managed payload metadata.
+    }
+  }
+  return uniqueIds(ids)
+}
+
+function externalMcpConnectionIdsFromConfigObjectVersion(row: ManagedConfigObjectVersion | undefined, options?: { ownedOnly?: boolean }): ExternalMcpConnectionId[] {
+  return normalizedExternalMcpConnectionIdsFromPayload(row?.normalizedPayloadJson, options)
+}
+
+export function planManagedImportedConfigObjectCleanup(input: {
+  active: Array<{ latestVersion: ManagedConfigObjectVersion | undefined; objectType: ManagedCleanupObjectType }>
+  deleting: Array<{ latestVersion: ManagedConfigObjectVersion | undefined; objectType: ManagedCleanupObjectType }>
+}) {
+  const activeSkillIds = new Set(input.active.flatMap((entry) => {
+    if (entry.objectType !== "skill") return []
+    const skillId = denSkillIdFromConfigObjectVersion(entry.latestVersion)
+    return skillId ? [skillId] : []
+  }))
+  const activeExternalMcpConnectionIds = new Set(input.active.flatMap((entry) => {
+    if (entry.objectType !== "mcp") return []
+    return externalMcpConnectionIdsFromConfigObjectVersion(entry.latestVersion)
+  }))
+
+  return {
+    externalMcpConnectionIds: uniqueIds(input.deleting.flatMap((entry) => {
+      if (entry.objectType !== "mcp") return []
+      return externalMcpConnectionIdsFromConfigObjectVersion(entry.latestVersion, { ownedOnly: true })
+        .filter((connectionId) => !activeExternalMcpConnectionIds.has(connectionId))
+    })),
+    skillIds: uniqueIds(input.deleting.flatMap((entry) => {
+      if (entry.objectType !== "skill") return []
+      const skillId = denSkillIdFromConfigObjectVersion(entry.latestVersion)
+      return skillId && !activeSkillIds.has(skillId) ? [skillId] : []
+    })),
+  }
+}

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -736,13 +736,15 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
       }
     })
 
-  for (const [path, action] of [[pluginArchRoutePaths.pluginArchive, "archive"], [pluginArchRoutePaths.pluginRestore, "restore"]] as const) {
+  for (const [path, action, label] of [[pluginArchRoutePaths.pluginArchive, "archive", "archive"], [pluginArchRoutePaths.pluginRemove, "remove", "remove"], [pluginArchRoutePaths.pluginRestore, "restore", "restore"]] as const) {
     withPluginArchOrgContext(app, "post", path,
       paramValidator(pluginParamsSchema),
       describeRoute({
         tags: ["Plugins"],
-        summary: `${action} plugin`,
-        description: `${action} a plugin without touching its historical memberships.`,
+        summary: `${label} plugin`,
+        description: label === "remove"
+          ? "Remove a plugin and delete imported skill/MCP components owned only by that plugin."
+          : `${label} a plugin without touching its historical memberships.`,
         responses: {
           200: jsonResponse("Plugin lifecycle updated successfully.", pluginMutationResponseSchema),
           400: jsonResponse("The plugin lifecycle path parameters were invalid.", invalidRequestSchema),

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -3,6 +3,7 @@ import {
   ConfigObjectAccessGrantTable,
   ConfigObjectTable,
   ConfigObjectVersionTable,
+  ConnectedAccountTable,
   ConnectorAccountTable,
   ConnectorInstanceAccessGrantTable,
   ConnectorInstanceTable,
@@ -11,12 +12,14 @@ import {
   ConnectorSourceTombstoneTable,
   ConnectorSyncEventTable,
   ConnectorTargetTable,
+  ExternalMcpConnectionAccessGrantTable,
   ExternalMcpConnectionTable,
   MarketplaceAccessGrantTable,
   MarketplacePluginTable,
   MarketplaceTable,
   MemberTable,
   OrganizationTable,
+  OrgOAuthClientTable,
   PluginAccessGrantTable,
   PluginConfigObjectTable,
   PluginTable,
@@ -65,6 +68,7 @@ import {
   DEFAULT_OPENWORK_MARKETPLACE_NAME,
   type DefaultMarketplacePluginEntry,
 } from "./default-marketplaces.js"
+import { externalMcpConnectionIdsFromPayload, planManagedImportedConfigObjectCleanup } from "./managed-component-cleanup.js"
 import { db } from "../../../db.js"
 import { env } from "../../../env.js"
 import { roleIncludesOwner } from "../../../orgs.js"
@@ -116,6 +120,7 @@ type ConnectorSyncEventId = ConnectorSyncEventRow["id"]
 type MemberRow = typeof MemberTable.$inferSelect
 type OrganizationRow = typeof OrganizationTable.$inferSelect
 type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0]
+type DbReader = Pick<typeof db, "select">
 
 type CursorPage<TItem extends { id: string }> = {
   items: TItem[]
@@ -562,12 +567,12 @@ function pageItems<TItem extends { id: string }>(items: TItem[], cursor: string 
   return { items: sliced, nextCursor }
 }
 
-async function getLatestVersions(configObjectIds: ConfigObjectId[]) {
+async function getLatestVersions(configObjectIds: ConfigObjectId[], reader: DbReader = db) {
   if (configObjectIds.length === 0) {
     return new Map<string, ConfigObjectVersionRow>()
   }
 
-  const rows = await db
+  const rows = await reader
     .select()
     .from(ConfigObjectVersionTable)
     .where(inArray(ConfigObjectVersionTable.configObjectId, configObjectIds))
@@ -1663,7 +1668,12 @@ export async function setConfigObjectLifecycle(input: { context: PluginArchActor
       ? { deletedAt: now, status: "deleted" as const, updatedAt: now }
       : { deletedAt: null, status: "active" as const, updatedAt: now }
 
-  await db.update(ConfigObjectTable).set(patch).where(eq(ConfigObjectTable.id, row.id))
+  await db.transaction(async (tx) => {
+    await tx.update(ConfigObjectTable).set(patch).where(eq(ConfigObjectTable.id, row.id))
+    if (input.action === "delete") {
+      await cleanupDeletedImportedConfigObject({ configObject: row, tx })
+    }
+  })
   return getConfigObjectDetail(input.context, row.id)
 }
 
@@ -1930,27 +1940,228 @@ export async function updatePlugin(input: { context: PluginArchActorContext; des
   return getPluginDetail(input.context, row.id)
 }
 
-function externalMcpConnectionIdsFromPayload(payload: unknown, options?: { ownedOnly?: boolean }): string[] {
-  const ids = new Set<string>()
-  const collect = (value: unknown) => {
-    if (!isRecord(value) || value.openworkManaged !== "den_external_mcp") return
-    if (options?.ownedOnly === true && value.externalMcpConnectionOwnedByPlugin !== true) return
-    if (typeof value.externalMcpConnectionId === "string" && value.externalMcpConnectionId.trim()) {
-      ids.add(value.externalMcpConnectionId.trim())
-    }
+async function activeImportedConfigObjectIds(input: {
+  excludingConfigObjectIds?: ConfigObjectId[]
+  objectType: ConfigObjectRow["objectType"]
+  organizationId: OrganizationId
+  tx: DbTransaction
+}) {
+  const rows = await input.tx
+    .select({ id: ConfigObjectTable.id })
+    .from(ConfigObjectTable)
+    .where(and(
+      eq(ConfigObjectTable.organizationId, input.organizationId),
+      eq(ConfigObjectTable.objectType, input.objectType),
+      eq(ConfigObjectTable.sourceMode, "import"),
+      eq(ConfigObjectTable.status, "active"),
+    ))
+  const excluded = new Set(input.excludingConfigObjectIds ?? [])
+  return rows.flatMap((row) => excluded.has(row.id) ? [] : [row.id])
+}
+
+async function activePluginOwnedImportedConfigObjectIds(input: {
+  objectType: ConfigObjectRow["objectType"]
+  organizationId: OrganizationId
+  pluginId: PluginId
+  tx: DbTransaction
+}) {
+  const pluginConfigObjectRows = await input.tx
+    .select({ configObjectId: ConfigObjectTable.id })
+    .from(PluginConfigObjectTable)
+    .innerJoin(ConfigObjectTable, eq(ConfigObjectTable.id, PluginConfigObjectTable.configObjectId))
+    .where(and(
+      eq(PluginConfigObjectTable.organizationId, input.organizationId),
+      eq(PluginConfigObjectTable.pluginId, input.pluginId),
+      isNull(PluginConfigObjectTable.removedAt),
+      eq(ConfigObjectTable.objectType, input.objectType),
+      eq(ConfigObjectTable.sourceMode, "import"),
+      eq(ConfigObjectTable.status, "active"),
+    ))
+  const pluginConfigObjectIds = uniqueIds(pluginConfigObjectRows.map((row) => row.configObjectId))
+  if (pluginConfigObjectIds.length === 0) {
+    return []
   }
 
-  collect(payload)
-  if (isRecord(payload)) {
-    const containers = [
-      isRecord(payload.mcpServers) ? payload.mcpServers : null,
-      isRecord(payload.mcp) ? payload.mcp : null,
-    ].filter((entry): entry is Record<string, unknown> => Boolean(entry))
-    for (const container of containers) {
-      for (const value of Object.values(container)) collect(value)
-    }
+  const activeMembershipRows = await input.tx
+    .select({ configObjectId: PluginConfigObjectTable.configObjectId, pluginId: PluginConfigObjectTable.pluginId })
+    .from(PluginConfigObjectTable)
+    .where(and(
+      eq(PluginConfigObjectTable.organizationId, input.organizationId),
+      inArray(PluginConfigObjectTable.configObjectId, pluginConfigObjectIds),
+      isNull(PluginConfigObjectTable.removedAt),
+    ))
+  const configObjectsUsedByOtherPlugins = new Set(activeMembershipRows
+    .filter((row) => row.pluginId !== input.pluginId)
+    .map((row) => row.configObjectId))
+
+  return pluginConfigObjectIds.filter((configObjectId) => !configObjectsUsedByOtherPlugins.has(configObjectId))
+}
+
+async function markImportedConfigObjectsDeleted(input: {
+  configObjectIds: ConfigObjectId[]
+  organizationId: OrganizationId
+  tx: DbTransaction
+}) {
+  if (input.configObjectIds.length === 0) return
+  const now = new Date()
+  await input.tx.update(ConfigObjectTable).set({
+    deletedAt: now,
+    status: "deleted",
+    updatedAt: now,
+  }).where(and(
+    eq(ConfigObjectTable.organizationId, input.organizationId),
+    inArray(ConfigObjectTable.id, input.configObjectIds),
+  ))
+}
+
+async function cleanupDeletedImportedSkills(input: {
+  configObjectIds: ConfigObjectId[]
+  organizationId: OrganizationId
+  tx: DbTransaction
+}) {
+  if (input.configObjectIds.length === 0) return
+  const latestVersions = await getLatestVersions(input.configObjectIds, input.tx)
+  const activeSkillConfigObjectIds = await activeImportedConfigObjectIds({
+    excludingConfigObjectIds: input.configObjectIds,
+    objectType: "skill",
+    organizationId: input.organizationId,
+    tx: input.tx,
+  })
+  const activeSkillVersions = await getLatestVersions(activeSkillConfigObjectIds, input.tx)
+  const cleanupPlan = planManagedImportedConfigObjectCleanup({
+    active: activeSkillConfigObjectIds.map((configObjectId) => ({
+      latestVersion: activeSkillVersions.get(configObjectId),
+      objectType: "skill",
+    })),
+    deleting: input.configObjectIds.map((configObjectId) => ({
+      latestVersion: latestVersions.get(configObjectId),
+      objectType: "skill",
+    })),
+  })
+  const removableSkillIds = cleanupPlan.skillIds
+  if (removableSkillIds.length === 0) return
+
+  const skillHubRows = await input.tx
+    .select({ skillHubId: SkillHubSkillTable.skillHubId })
+    .from(SkillHubSkillTable)
+    .where(inArray(SkillHubSkillTable.skillId, removableSkillIds))
+  const skillHubIds = uniqueIds(skillHubRows.map((row) => row.skillHubId))
+
+  await input.tx.delete(SkillHubSkillTable).where(inArray(SkillHubSkillTable.skillId, removableSkillIds))
+  await input.tx.delete(SkillTable).where(and(
+    eq(SkillTable.organizationId, input.organizationId),
+    inArray(SkillTable.id, removableSkillIds),
+  ))
+
+  if (skillHubIds.length === 0) return
+  const remainingHubSkillRows = await input.tx
+    .select({ skillHubId: SkillHubSkillTable.skillHubId })
+    .from(SkillHubSkillTable)
+    .where(inArray(SkillHubSkillTable.skillHubId, skillHubIds))
+  const skillHubsStillInUse = new Set(remainingHubSkillRows.map((row) => row.skillHubId))
+  const emptySkillHubIds = skillHubIds.filter((skillHubId) => !skillHubsStillInUse.has(skillHubId))
+  if (emptySkillHubIds.length === 0) return
+
+  await input.tx.delete(SkillHubMemberTable).where(inArray(SkillHubMemberTable.skillHubId, emptySkillHubIds))
+  await input.tx.delete(SkillHubTable).where(and(
+    eq(SkillHubTable.organizationId, input.organizationId),
+    inArray(SkillHubTable.id, emptySkillHubIds),
+  ))
+}
+
+async function cleanupDeletedImportedMcps(input: {
+  configObjectIds: ConfigObjectId[]
+  organizationId: OrganizationId
+  tx: DbTransaction
+}) {
+  if (input.configObjectIds.length === 0) return
+  const latestVersions = await getLatestVersions(input.configObjectIds, input.tx)
+  const activeMcpConfigObjectIds = await activeImportedConfigObjectIds({
+    excludingConfigObjectIds: input.configObjectIds,
+    objectType: "mcp",
+    organizationId: input.organizationId,
+    tx: input.tx,
+  })
+  const activeMcpVersions = await getLatestVersions(activeMcpConfigObjectIds, input.tx)
+  const cleanupPlan = planManagedImportedConfigObjectCleanup({
+    active: activeMcpConfigObjectIds.map((configObjectId) => ({
+      latestVersion: activeMcpVersions.get(configObjectId),
+      objectType: "mcp",
+    })),
+    deleting: input.configObjectIds.map((configObjectId) => ({
+      latestVersion: latestVersions.get(configObjectId),
+      objectType: "mcp",
+    })),
+  })
+  const removableConnectionIds = cleanupPlan.externalMcpConnectionIds
+  if (removableConnectionIds.length === 0) return
+
+  await input.tx.delete(ExternalMcpConnectionAccessGrantTable).where(inArray(ExternalMcpConnectionAccessGrantTable.externalMcpConnectionId, removableConnectionIds))
+  await input.tx.delete(ConnectedAccountTable).where(and(
+    eq(ConnectedAccountTable.organizationId, input.organizationId),
+    inArray(ConnectedAccountTable.providerId, removableConnectionIds),
+  ))
+  await input.tx.delete(OrgOAuthClientTable).where(and(
+    eq(OrgOAuthClientTable.organizationId, input.organizationId),
+    inArray(OrgOAuthClientTable.providerId, removableConnectionIds),
+  ))
+  await input.tx.delete(ExternalMcpConnectionTable).where(and(
+    eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+    inArray(ExternalMcpConnectionTable.id, removableConnectionIds),
+  ))
+}
+
+async function cleanupDeletedImportedConfigObject(input: {
+  configObject: ConfigObjectRow
+  tx: DbTransaction
+}) {
+  if (input.configObject.sourceMode !== "import") return
+  if (input.configObject.objectType === "skill") {
+    await cleanupDeletedImportedSkills({
+      configObjectIds: [input.configObject.id],
+      organizationId: input.configObject.organizationId,
+      tx: input.tx,
+    })
   }
-  return [...ids]
+  if (input.configObject.objectType === "mcp") {
+    await cleanupDeletedImportedMcps({
+      configObjectIds: [input.configObject.id],
+      organizationId: input.configObject.organizationId,
+      tx: input.tx,
+    })
+  }
+}
+
+async function cleanupRemovedPluginSkills(input: {
+  context: PluginArchActorContext
+  pluginId: PluginId
+  tx: DbTransaction
+}) {
+  const organizationId = input.context.organizationContext.organization.id
+  const removableConfigObjectIds = await activePluginOwnedImportedConfigObjectIds({
+    objectType: "skill",
+    organizationId,
+    pluginId: input.pluginId,
+    tx: input.tx,
+  })
+  await markImportedConfigObjectsDeleted({ configObjectIds: removableConfigObjectIds, organizationId, tx: input.tx })
+  await cleanupDeletedImportedSkills({ configObjectIds: removableConfigObjectIds, organizationId, tx: input.tx })
+}
+
+async function cleanupRemovedPluginMcps(input: {
+  context: PluginArchActorContext
+  pluginId: PluginId
+  tx: DbTransaction
+}) {
+  const organizationId = input.context.organizationContext.organization.id
+  const removableConfigObjectIds = await activePluginOwnedImportedConfigObjectIds({
+    objectType: "mcp",
+    organizationId,
+    pluginId: input.pluginId,
+    tx: input.tx,
+  })
+  await markImportedConfigObjectsDeleted({ configObjectIds: removableConfigObjectIds, organizationId, tx: input.tx })
+  await cleanupDeletedImportedMcps({ configObjectIds: removableConfigObjectIds, organizationId, tx: input.tx })
 }
 
 async function pluginOwnedExternalMcpConnectionIds(input: {
@@ -2024,15 +2235,27 @@ async function deletePluginOwnedExternalMcpConnections(input: {
   }
 }
 
-export async function setPluginLifecycle(input: { action: "archive" | "restore"; context: PluginArchActorContext; pluginId: PluginId }) {
+export async function setPluginLifecycle(input: { action: "archive" | "remove" | "restore"; context: PluginArchActorContext; pluginId: PluginId }) {
   const row = await ensureVisiblePlugin(input.context, input.pluginId)
   await requirePluginArchResourceRole({ context: input.context, resourceId: row.id, resourceKind: "plugin", role: "manager" })
   const updatedAt = new Date()
-  await db.update(PluginTable).set({
-    deletedAt: input.action === "archive" ? row.deletedAt : null,
-    status: input.action === "archive" ? "archived" : "active",
-    updatedAt,
-  }).where(eq(PluginTable.id, row.id))
+  await db.transaction(async (tx) => {
+    await tx.update(PluginTable).set({
+      deletedAt: input.action === "restore" ? null : row.deletedAt,
+      status: input.action === "restore" ? "active" : "archived",
+      updatedAt,
+    }).where(eq(PluginTable.id, row.id))
+
+    if (input.action === "remove") {
+      await cleanupRemovedPluginSkills({ context: input.context, pluginId: row.id, tx })
+      await cleanupRemovedPluginMcps({ context: input.context, pluginId: row.id, tx })
+      await tx.update(PluginConfigObjectTable).set({ removedAt: updatedAt }).where(and(
+        eq(PluginConfigObjectTable.organizationId, row.organizationId),
+        eq(PluginConfigObjectTable.pluginId, row.id),
+        isNull(PluginConfigObjectTable.removedAt),
+      ))
+    }
+  })
   if (input.action === "archive") {
     await deletePluginOwnedExternalMcpConnections({ context: input.context, pluginId: row.id })
   }

--- a/ee/apps/den-api/test/plugin-system-lifecycle-cleanup.test.ts
+++ b/ee/apps/den-api/test/plugin-system-lifecycle-cleanup.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { planManagedImportedConfigObjectCleanup } from "../src/routes/org/plugin-system/managed-component-cleanup.js"
+
+function version(normalizedPayloadJson: Record<string, unknown> | null) {
+  return { normalizedPayloadJson }
+}
+
+describe("managed imported component cleanup planning", () => {
+  test("deletes plugin-owned imported skills and MCP connections with no active references", () => {
+    const skillId = createDenTypeId("skill")
+    const connectionId = createDenTypeId("externalMcpConnection")
+
+    const result = planManagedImportedConfigObjectCleanup({
+      active: [],
+      deleting: [{
+        latestVersion: version({ denSkillId: skillId, openworkManaged: "den_skill" }),
+        objectType: "skill",
+      }, {
+        latestVersion: version({
+          externalMcpConnectionId: connectionId,
+          externalMcpConnectionOwnedByPlugin: true,
+          openworkManaged: "den_external_mcp",
+        }),
+        objectType: "mcp",
+      }, {
+        latestVersion: version({
+          denSkillId: skillId,
+          openworkManaged: "den_skill",
+        }),
+        objectType: "skill",
+      }],
+    })
+
+    expect(result).toEqual({
+      externalMcpConnectionIds: [connectionId],
+      skillIds: [skillId],
+    })
+  })
+
+  test("keeps underlying skills and MCP connections referenced by other active imported config objects", () => {
+    const skillId = createDenTypeId("skill")
+    const connectionId = createDenTypeId("externalMcpConnection")
+
+    const result = planManagedImportedConfigObjectCleanup({
+      active: [{
+        latestVersion: version({ denSkillId: skillId, openworkManaged: "den_skill" }),
+        objectType: "skill",
+      }, {
+        latestVersion: version({
+          mcpServers: {
+            sales: {
+              externalMcpConnectionId: connectionId,
+              openworkManaged: "den_external_mcp",
+              url: "https://example.com/mcp",
+            },
+          },
+        }),
+        objectType: "mcp",
+      }],
+      deleting: [{
+        latestVersion: version({ denSkillId: skillId, openworkManaged: "den_skill" }),
+        objectType: "skill",
+      }, {
+        latestVersion: version({
+          externalMcpConnectionId: connectionId,
+          externalMcpConnectionOwnedByPlugin: true,
+          openworkManaged: "den_external_mcp",
+        }),
+        objectType: "mcp",
+      }],
+    })
+
+    expect(result).toEqual({
+      externalMcpConnectionIds: [],
+      skillIds: [],
+    })
+  })
+
+  test("does not delete external MCP connections the plugin import does not own", () => {
+    const ownedConnectionId = createDenTypeId("externalMcpConnection")
+    const sharedConnectionId = createDenTypeId("externalMcpConnection")
+
+    const result = planManagedImportedConfigObjectCleanup({
+      active: [],
+      deleting: [{
+        latestVersion: version({
+          externalMcpConnectionId: sharedConnectionId,
+          externalMcpConnectionOwnedByPlugin: false,
+          openworkManaged: "den_external_mcp",
+        }),
+        objectType: "mcp",
+      }, {
+        latestVersion: version({
+          externalMcpConnectionId: createDenTypeId("externalMcpConnection"),
+          openworkManaged: "den_external_mcp",
+        }),
+        objectType: "mcp",
+      }, {
+        latestVersion: version({
+          mcpServers: {
+            owned: {
+              externalMcpConnectionId: ownedConnectionId,
+              externalMcpConnectionOwnedByPlugin: true,
+              openworkManaged: "den_external_mcp",
+              url: "https://example.com/owned",
+            },
+            shared: {
+              externalMcpConnectionId: sharedConnectionId,
+              externalMcpConnectionOwnedByPlugin: false,
+              openworkManaged: "den_external_mcp",
+              url: "https://example.com/shared",
+            },
+          },
+        }),
+        objectType: "mcp",
+      }],
+    })
+
+    expect(result).toEqual({
+      externalMcpConnectionIds: [ownedConnectionId],
+      skillIds: [],
+    })
+  })
+
+  test("ignores malformed managed payload metadata", () => {
+    const result = planManagedImportedConfigObjectCleanup({
+      active: [],
+      deleting: [{
+        latestVersion: undefined,
+        objectType: "skill",
+      }, {
+        latestVersion: version(null),
+        objectType: "mcp",
+      }, {
+        latestVersion: version({
+          denSkillId: "not-a-skill-id",
+          openworkManaged: "den_skill",
+        }),
+        objectType: "skill",
+      }, {
+        latestVersion: version({
+          externalMcpConnectionId: "not-a-connection-id",
+          externalMcpConnectionOwnedByPlugin: true,
+          openworkManaged: "den_external_mcp",
+        }),
+        objectType: "mcp",
+      }, {
+        latestVersion: version({
+          denSkillId: createDenTypeId("skill"),
+          openworkManaged: "unknown",
+        }),
+        objectType: "skill",
+      }],
+    })
+
+    expect(result).toEqual({
+      externalMcpConnectionIds: [],
+      skillIds: [],
+    })
+  })
+})


### PR DESCRIPTION
## Intent

Delete paths deserve a little extra seatbelt, so this PR adds a dedicated plugin `remove` lifecycle path that cleans up imported plugin components without sweeping up shared resources.

When an imported plugin is removed, we want it gone from active Den plugin surfaces and we also want to clean up the Den-managed skill/MCP rows created by that import. The goal is boring-in-a-good-way cleanup: no orphaned Den skills, skill hubs, external MCP connections, access grants, connected accounts, or OAuth client rows, and no surprise deletion of things another active config object still uses.

## What changed

- Added `POST /v1/plugins/:pluginId/remove` for plugin removal.
- Removal archives the plugin, removes active plugin-component memberships, and deletes active imported skill/MCP config objects owned only by that plugin.
- Added a shared managed cleanup planner for imported skills and MCPs.
- Reused the managed MCP payload parser for both archive cleanup and remove cleanup, including root and nested `mcpServers` payload shapes.
- Added unit coverage for the delete edge cases: duplicate refs, active shared refs, non-owned MCPs, nested MCP payloads, and malformed managed metadata.

## Delete Safety

Since this is a delete flow, the PR intentionally keeps the cleanup narrow:

- Only active config objects with `sourceMode: "import"` and object type `skill`/`mcp` are considered for underlying component cleanup.
- If the same imported config object is attached to another active plugin, plugin removal does not delete that config object.
- Underlying Den skills are deleted only when no other active imported skill config object references the same `denSkillId`.
- External MCP connections are deleted only when the managed payload explicitly says `externalMcpConnectionOwnedByPlugin === true`.
- Shared/non-owned MCP connections, missing ownership markers, and malformed managed IDs are ignored rather than deleted.
- The plugin remove and config object delete paths run cleanup inside the lifecycle transaction so the state change and managed cleanup stay together.

## Reviewer Focus

The most important review target is the planner. This is the small gatekeeper that decides what underlying resources are actually safe to delete:

```ts
const activeExternalMcpConnectionIds = new Set(input.active.flatMap((entry) => {
  if (entry.objectType !== "mcp") return []
  return externalMcpConnectionIdsFromConfigObjectVersion(entry.latestVersion)
}))

return {
  externalMcpConnectionIds: uniqueIds(input.deleting.flatMap((entry) => {
    if (entry.objectType !== "mcp") return []
    return externalMcpConnectionIdsFromConfigObjectVersion(entry.latestVersion, { ownedOnly: true })
      .filter((connectionId) => !activeExternalMcpConnectionIds.has(connectionId))
  })),
  skillIds: uniqueIds(input.deleting.flatMap((entry) => {
    if (entry.objectType !== "skill") return []
    const skillId = denSkillIdFromConfigObjectVersion(entry.latestVersion)
    return skillId && !activeSkillIds.has(skillId) ? [skillId] : []
  })),
}
```

Worth double-checking: the `ownedOnly: true` MCP branch and the active reference checks. That is where the PR avoids turning a plugin delete into a tiny chaos button.

## Validation

- `pnpm --filter @openwork-ee/den-api exec bun test test/plugin-system-lifecycle-cleanup.test.ts` - passed, 4 tests
- `pnpm --filter @openwork-ee/den-api build` - passed

Fraimz/video not captured: this is a backend lifecycle cleanup path with focused unit coverage plus den-api build validation.
