### PR TITLE
fix(app): show a check icon for completed workspace-creation steps

### DIFF
--- a/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
@@ -81,7 +81,7 @@ export type CreateWorkspaceLocalPanelProps = {
 
 function stepIcon(status: CreateWorkspaceProgressStep["status"]) {
   if (status === "done")
-    return <CircleCheck size={16} className="text-green-10" />;
+    return <CircleCheck size={16} className="text-emerald-10" />;
   if (status === "active")
     return <Loader2 size={16} className="animate-spin text-dls-accent" />;
   if (status === "error") return <XCircle size={16} className="text-red-10" />;

--- a/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
@@ -2,6 +2,7 @@
 import {
   ChartNoAxesColumnIncreasing,
   Check,
+  CircleCheck,
   FolderPlus,
   Loader2,
   XCircle,
@@ -80,7 +81,7 @@ export type CreateWorkspaceLocalPanelProps = {
 
 function stepIcon(status: CreateWorkspaceProgressStep["status"]) {
   if (status === "done")
-    return <XCircle size={16} className="text-emerald-10" />;
+    return <CircleCheck size={16} className="text-green-10" />;
   if (status === "active")
     return <Loader2 size={16} className="animate-spin text-dls-accent" />;
   if (status === "error") return <XCircle size={16} className="text-red-10" />;


### PR DESCRIPTION
## Summary

In the create-workspace progress list, `stepIcon` renders `XCircle` for the `done` state — the same glyph it uses for `error`. So every successfully completed step shows an ✕ instead of a check. On current `dev` it's compounded by the icon's `text-emerald-10` class, which doesn't exist in the app's Radix-only Tailwind palette (see #2341), so the ✕ also renders with no color of its own.

`apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx`:

- `done` now renders `CircleCheck` — the same success glyph the notification center uses — in `text-green-10`, which exists in the palette.
- `error` keeps `XCircle` in red, so the two states are finally distinguishable at a glance.

## Testing

- `pnpm typecheck` — clean
- `bun test tests/` — 142 pass, 0 fail
- Two-line change confined to the `stepIcon` helper; the reviewer can reproduce by creating a local workspace and expanding the progress details while steps complete.