### PR TITLE
fix(desktop): reload updated embedded server

### DIFF
--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -83,6 +83,18 @@ export function commandMatchesPackagedSidecar(command, sidecarDirs = []) {
     /(?:^|[/\\])opencode[^/\\\s]*\s+serve\b/.test(value);
 }
 
+export function embeddedServerImportUrl(embeddedPath) {
+  const url = pathToFileURL(embeddedPath);
+  try {
+    const stats = statSync(embeddedPath);
+    url.searchParams.set("mtimeMs", String(stats.mtimeMs));
+    url.searchParams.set("size", String(stats.size));
+  } catch {
+    // Fall back to the deterministic file URL if stat fails; startup can continue.
+  }
+  return url.href;
+}
+
 function nowMs() {
   return Date.now();
 }
@@ -1188,7 +1200,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     if (!embeddedPath) {
       throw new Error(`Cannot find OpenWork embedded server bundle. Checked: ${candidates.join(", ")}`);
     }
-    const { startEmbeddedServer } = await import(pathToFileURL(embeddedPath).href);
+    const { startEmbeddedServer } = await import(embeddedServerImportUrl(embeddedPath));
     // startEmbeddedServer falls back to an OS-assigned port if `port` races
     // into EADDRINUSE (see apps/server/src/serve-node.ts), so the bound port
     // below is authoritative.

--- a/apps/desktop/electron/runtime.test.mjs
+++ b/apps/desktop/electron/runtime.test.mjs
@@ -1,8 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   commandMatchesPackagedSidecar,
+  embeddedServerImportUrl,
   prioritizeWorkspacePaths,
   resolveOpenworkServerConfigPath,
   seedWorkspacePathsForEmbeddedServer,
@@ -76,6 +81,49 @@ describe("commandMatchesPackagedSidecar", () => {
       ),
       false,
     );
+  });
+});
+
+describe("embeddedServerImportUrl", () => {
+  it("returns the same file URL for unchanged metadata", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "openwork-runtime-"));
+    try {
+      const embeddedPath = path.join(dir, "embedded.js");
+      await writeFile(embeddedPath, "export const value = 1;\n");
+
+      const first = embeddedServerImportUrl(embeddedPath);
+      const second = embeddedServerImportUrl(embeddedPath);
+      const url = new URL(first);
+
+      assert.equal(first, second);
+      assert.equal(url.protocol, "file:");
+      assert.equal(fileURLToPath(url), embeddedPath);
+      assert.ok(url.searchParams.get("mtimeMs"));
+      assert.equal(url.searchParams.get("size"), String("export const value = 1;\n".length));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("changes when the file metadata changes", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "openwork-runtime-"));
+    try {
+      const embeddedPath = path.join(dir, "embedded.js");
+      await writeFile(embeddedPath, "export const value = 1;\n");
+      const first = embeddedServerImportUrl(embeddedPath);
+
+      await writeFile(embeddedPath, "export const value = 12;\n");
+
+      assert.notEqual(embeddedServerImportUrl(embeddedPath), first);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the plain file URL if stat fails", () => {
+    const missingPath = path.join(os.tmpdir(), "openwork-missing-embedded.js");
+
+    assert.equal(embeddedServerImportUrl(missingPath), pathToFileURL(missingPath).href);
   });
 });
 


### PR DESCRIPTION
## Summary\n- cache-bust the embedded OpenWork server ESM import using deterministic file metadata\n- keep normal restarts stable when the server bundle is unchanged\n- add desktop runtime tests for unchanged, changed, and stat-failure import URLs\n\n## Validation\n- pnpm --dir apps/desktop test ✅\n- pnpm --filter @openwork/desktop typecheck:electron ✅\n- Daytona Electron smoke ✅: modified apps/server/dist/embedded.js while Electron stayed alive, triggered openworkServerRestart through the Electron bridge, and verified /tmp/openwork-embedded-reload-marker was created by the reloaded module. Screenshot: https://8090-yiqq1gpby76zmlps.daytonaproxy01.net/screenshots/daytona-screenshot-20260709-005928.png