### PR TITLE
fix(den-mcp): surface upstream external-connection errors instead of truncating them

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -29,6 +29,7 @@ export const AGENT_MCP_INSTRUCTIONS = [
   "Capabilities include native Google Workspace operations (Gmail read/search, Calendar list/create, Drive search/read, and Gmail draft creation) executed with the signed-in member's organization credentials, plus any MCP connections the organization has added.",
   "Always call search_capabilities first with 2-4 keyword variants before concluding something is unavailable. Use execute_capability only with exact names returned by search_capabilities.",
   "Do not tell users to configure OAuth clients or local extensions for these capabilities; organization connections are managed in the OpenWork Cloud dashboard / Settings > Connect.",
+  "When a search match or execute result carries status needs_connection or a connection error, relay the fix to the user and stop — do not retry unchanged and do not improvise workarounds through other tools.",
 ].join("\n")
 
 const EXECUTE_CAPABILITY_TIMEOUT_MESSAGE = "The capability call exceeded 45s. Retry once; if it times out again, narrow the request (fewer results, tighter query) and tell the user the service is slow — do NOT tell them to reconfigure or reconnect."

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -1,4 +1,6 @@
 import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { MemberTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import {
@@ -111,9 +113,55 @@ export type ExternalCapabilityMatch = CapabilityMatch & {
   hint?: string
 }
 
-function shortErrorMessage(error: unknown): string {
+const ERROR_MESSAGE_LIMIT = 300
+const LIVE_PROBE_HINT = "This is a live probe, not a cached result — repeating the same search without changing anything will return the same error."
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function cappedErrorMessage(message: string): string {
+  return message.length > ERROR_MESSAGE_LIMIT ? `${message.slice(0, ERROR_MESSAGE_LIMIT)}...` : message
+}
+
+function parsedErrorMessage(value: unknown): string | null {
+  if (!isRecord(value)) return null
+  const nestedError = value.error
+  if (isRecord(nestedError) && typeof nestedError.message === "string") {
+    return typeof nestedError.code === "number"
+      ? `${nestedError.message} (JSON-RPC ${nestedError.code})`
+      : nestedError.message
+  }
+  if (typeof value.message === "string") return value.message
+  if (typeof nestedError === "string") return nestedError
+  return null
+}
+
+export function upstreamErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error)
-  return message.length > 120 ? `${message.slice(0, 117)}...` : message
+  const jsonStart = message.indexOf("{")
+  if (jsonStart >= 0) {
+    try {
+      const parsed: unknown = JSON.parse(message.slice(jsonStart))
+      const parsedMessage = parsedErrorMessage(parsed)
+      if (parsedMessage) return parsedMessage
+    } catch {
+      // Fall through to the capped raw message when the SDK wrapper contains partial or invalid JSON.
+    }
+  }
+  return cappedErrorMessage(message)
+}
+
+export function isExternalMcpAuthError(error: unknown): boolean {
+  return error instanceof UnauthorizedError
+    || (error instanceof StreamableHTTPError && (error.code === 401 || error.code === 403))
+}
+
+export function externalConnectionErrorHint(connectionName: string, error: unknown, message = upstreamErrorMessage(error)): string {
+  if (isExternalMcpAuthError(error)) {
+    return `The stored credential looks invalid or expired. Reconnect "${connectionName}" from the OpenWork Cloud dashboard -> Connections, then search again. ${LIVE_PROBE_HINT}`
+  }
+  return `The provider's server rejected the request for "${connectionName}": ${message}. If the message points at app installation or approval, an admin must fix it in the provider's own admin console. Reconnecting only helps for credential errors. ${LIVE_PROBE_HINT}`
 }
 
 /**
@@ -196,7 +244,7 @@ export async function searchExternalCapabilities(input: {
     try {
       tools = await listExternalMcpTools(connection, redirectUriFor(input.redirectUriBase, connection.id), member)
     } catch (error) {
-      const message = shortErrorMessage(error)
+      const message = upstreamErrorMessage(error)
       const nameTokens = tokenize(connection.name)
       const score = scoreText(nameTokens, nameTokens, queryTokens)
       if (score > 0) {
@@ -205,12 +253,12 @@ export async function searchExternalCapabilities(input: {
           method: "MCP",
           path: connection.url,
           score,
-          summary: `[${connection.name}] This connection is set up but not responding right now (${message}).`,
+          summary: `[${connection.name}] This connection is set up but returned an error (${message}).`,
           pathParams: [],
           queryParams: [],
           hasBody: false,
           status: "error",
-          hint: `The stored credential may be expired or the server may be unreachable. Reconnect "${connection.name}" from the OpenWork Cloud dashboard -> Connections, then search again.`,
+          hint: externalConnectionErrorHint(connection.name, error, message),
         })
       }
       continue

--- a/ee/apps/den-api/test/external-capability-errors.test.ts
+++ b/ee/apps/den-api/test/external-capability-errors.test.ts
@@ -1,0 +1,66 @@
+import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { beforeAll, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+seedRequiredEnv()
+
+let externalCapabilities: typeof import("../src/mcp/external-capabilities.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  externalCapabilities = await import("../src/mcp/external-capabilities.js")
+})
+
+test("upstreamErrorMessage unwraps JSON-RPC errors from the SDK wrapper", () => {
+  const message = externalCapabilities.upstreamErrorMessage(new Error('Streamable HTTP error: Error POSTing to endpoint: {"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"App is not installed on this workspace"}}'))
+
+  expect(message).toContain("App is not installed on this workspace")
+  expect(message).toContain("-32600")
+  expect(message).not.toContain("Streamable HTTP error")
+})
+
+test("upstreamErrorMessage caps non-JSON long messages at 300 characters plus ellipsis", () => {
+  const raw = "x".repeat(350)
+  const message = externalCapabilities.upstreamErrorMessage(new Error(raw))
+
+  expect(message).toBe(`${"x".repeat(300)}...`)
+  expect(message.length).toBe(303)
+})
+
+test("upstreamErrorMessage falls back without throwing when JSON-looking content is unparseable", () => {
+  const raw = `Streamable HTTP error: {${"not-json".repeat(60)}`
+  const message = externalCapabilities.upstreamErrorMessage(new Error(raw))
+
+  expect(message).toBe(`${raw.slice(0, 300)}...`)
+})
+
+test("upstreamErrorMessage handles non-Error inputs", () => {
+  expect(externalCapabilities.upstreamErrorMessage("plain failure")).toBe("plain failure")
+})
+
+test("externalConnectionErrorHint gives reconnect guidance for HTTP auth errors", () => {
+  const hint = externalCapabilities.externalConnectionErrorHint("Acme MCP", new StreamableHTTPError(401, "Unauthorized"))
+
+  expect(hint).toContain("The stored credential looks invalid or expired")
+  expect(hint).toContain('Reconnect "Acme MCP"')
+  expect(hint).toContain("This is a live probe, not a cached result")
+})
+
+test("externalConnectionErrorHint gives provider-admin guidance for JSON-RPC rejections", () => {
+  const error = new Error('Streamable HTTP error: Error POSTing to endpoint: {"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"App is not installed on this workspace"}}')
+  const hint = externalCapabilities.externalConnectionErrorHint("Acme MCP", error)
+
+  expect(hint).toContain("The provider's server rejected the request")
+  expect(hint).toContain("App is not installed on this workspace")
+  expect(hint).toContain("-32600")
+  expect(hint).toContain("provider's own admin console")
+  expect(hint).toContain("This is a live probe, not a cached result")
+  expect(hint).not.toContain("expired")
+})


### PR DESCRIPTION
## Why (production incident)

An org's Slack MCP connection rejects every request, and neither the user nor the agent could ever see why: the search-path error summary truncates at 120 chars, and the MCP SDK's wrapper prefix (`Streamable HTTP error: Error POSTing to endpoint: {\"jsonrpc\"...`) consumes the entire budget before the upstream message starts. Every probe ended at `\"App is...` — the field was information-free **by construction**. Worse, the accompanying hint confidently claimed "credential may be expired… Reconnect" for *every* failure, which sent the user into a useless reconnect loop (the actual failure was app-level, not credential-level), and the agent retried the identical search 3× hypothesizing a cache that does not exist.

## What

`ee/apps/den-api/src/mcp/external-capabilities.ts`:
- `upstreamErrorMessage(error)` (exported, pure): parses the JSON body embedded in the SDK wrapper and returns the nested JSON-RPC `error.message` + code (e.g. `App is not installed on this workspace (JSON-RPC -32600)`); falls back to a 300-char cap (up from 120) when no JSON is present.
- `externalConnectionErrorHint(name, error)` (exported, pure): auth-shaped failures (SDK `UnauthorizedError`, `StreamableHTTPError` 401/403) keep the reconnect guidance; everything else relays the provider's rejection verbatim, points at the provider's own admin console for app install/approval issues, and explicitly says reconnecting only helps for credential errors. **Both** variants state: "This is a live probe, not a cached result — repeating the same search without changing anything will return the same error."
- Search error summary now carries the unwrapped message.

`ee/apps/den-api/src/mcp/agent.ts`: one sentence appended to `AGENT_MCP_INSTRUCTIONS` — on `needs_connection`/connection errors, relay the fix and stop; no unchanged retries, no improvised workarounds.

## Tests (run on Daytona sandbox)

- New `ee/apps/den-api/test/external-capability-errors.test.ts` — 6 pure tests incl. the exact production-shaped fixture (JSON-RPC unwrap, 300-cap fallback, unparseable-JSON fallback, non-Error input, both hint branches + live-probe sentence). **6/6 pass.**
- `test/mcp-agent-timeouts.test.ts` (asserts instructions during MCP initialize) — **3/3 pass**, no changes needed.
- `pnpm exec tsc --noEmit` (den-api) — pass.

## Validation note (honest)

No fraimz for this change: demonstrating it end-to-end requires a live external MCP server that rejects requests (the production Slack failure). The shaping functions are exported and unit-tested against the verbatim production error string. Repro for reviewers: `upstreamErrorMessage(new Error('Streamable HTTP error: Error POSTing to endpoint: {\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\"message\":\"App is not installed on this workspace\"}}'))`.

Companion PR (desktop steering): stop-and-relay on needs_connection.