### PR TITLE
Improve Google and Slack OAuth setup UX

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
@@ -325,7 +325,7 @@ export function ReauthDialog({
           <div className="grid gap-2">
             <h2 className="text-[24px] font-semibold tracking-[-0.03em] text-gray-950">Confirm it's you to continue</h2>
             <p className="text-[15px] leading-7 text-gray-600">
-              Changing workspace settings requires a recent sign-in. After you confirm, OpenWork retries the action automatically.
+              Changing workspace settings requires a recent sign-in. Choose a sign-in method below; after you confirm, OpenWork retries the pending action automatically.
             </p>
           </div>
         </div>
@@ -349,17 +349,20 @@ export function ReauthDialog({
             </DenButton>
           ) : null}
 
-          {socialProviders.map((provider) => (
-            <button
-              key={provider}
-              type="button"
-              className={buttonVariants({ variant: "secondary", className: "w-full" })}
-              disabled={busy}
-              onClick={() => void continueSocial(provider)}
-            >
-              Continue with {getSocialLabel(provider)}
-            </button>
-          ))}
+          {socialProviders.map((provider) => {
+            const primarySocial = !hasManagedOrgSignIn && (provider === "google" || socialProviders.length === 1);
+            return (
+              <button
+                key={provider}
+                type="button"
+                className={buttonVariants({ variant: primarySocial ? "primary" : "secondary", className: "w-full" })}
+                disabled={busy}
+                onClick={() => void continueSocial(provider)}
+              >
+                Continue with {getSocialLabel(provider)}
+              </button>
+            );
+          })}
 
           {hasPassword ? (
             <form className="grid gap-3" onSubmit={submitPassword}>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -775,6 +775,7 @@ function GoogleWorkspaceDialog({
   const [clientSecret, setClientSecret] = useState("");
   const [features, setFeatures] = useState<string[]>([]);
   const [copiedRedirectUri, setCopiedRedirectUri] = useState(false);
+  const [replacingCredentials, setReplacingCredentials] = useState(false);
   const featuresPrefilled = useRef(false);
 
   useEffect(() => {
@@ -783,6 +784,7 @@ function GoogleWorkspaceDialog({
     setClientSecret("");
     setFeatures(GOOGLE_WORKSPACE_DEFAULT_FEATURES);
     setCopiedRedirectUri(false);
+    setReplacingCredentials(false);
     featuresPrefilled.current = false;
   }, [open]);
 
@@ -797,12 +799,14 @@ function GoogleWorkspaceDialog({
   }
 
   const configured = clientConfig.data?.configured ?? false;
+  const savedClientId = clientConfig.data?.clientId;
   const redirectUri = clientConfig.data?.redirectUri ?? "";
   const loadingConfig = clientConfig.isLoading;
   const formError = error ?? clientConfig.error;
   const trimmedClientId = clientId.trim();
   const trimmedClientSecret = clientSecret.trim();
-  const saveDisabled = loadingConfig || (!configured && (!trimmedClientId || !trimmedClientSecret));
+  const showCredentialFields = !loadingConfig && (!configured || replacingCredentials);
+  const saveDisabled = loadingConfig || (showCredentialFields && (!trimmedClientId || !trimmedClientSecret));
 
   function toggleFeature(feature: string) {
     setFeatures((current) => current.includes(feature) ? current.filter((entry) => entry !== feature) : [...current, feature]);
@@ -813,16 +817,23 @@ function GoogleWorkspaceDialog({
     if (await copyTextToClipboard(redirectUri)) setCopiedRedirectUri(true);
   }
 
+  function startReplacingCredentials() {
+    setClientId(savedClientId ?? "");
+    setClientSecret("");
+    setReplacingCredentials(true);
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={onClose}>
       <div
         className="max-h-[calc(100vh-3rem)] w-full max-w-lg overflow-y-auto rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
         onClick={(event) => event.stopPropagation()}
       >
-        <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">Set up Google Workspace</h2>
+        <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
+          {configured ? "Update Google Workspace" : "Set up Google Workspace"}
+        </h2>
         <p className="mt-1 text-[13px] leading-6 text-gray-600">
-          Paste the OAuth client from your company&apos;s Google Cloud project. Members then connect their own
-          Google account from Your Connections — sign-ins stay in your org&apos;s cloud.
+          Use one Google OAuth web app for your org. Members then connect their own Google account from Your Connections — sign-ins stay in your org&apos;s cloud.
         </p>
 
         <div className="mt-5 space-y-4">
@@ -830,13 +841,13 @@ function GoogleWorkspaceDialog({
             <p className="text-[13px] font-semibold text-gray-900">How to set it up</p>
             <ol className="mt-2 list-decimal space-y-2 pl-4 text-[12px] leading-5 text-gray-600">
               <li>
-                Create an OAuth client in Google Cloud Console (APIs &amp; Services → Credentials → Create credentials → OAuth client ID → Web application).{" "}
+                In Google Cloud Console, create an OAuth client ID for a Web application.{" "}
                 <a href="https://console.cloud.google.com/apis/credentials" target="_blank" rel="noopener" className="font-medium text-gray-900 underline decoration-gray-300 underline-offset-4">
                   Open Google Cloud Console
                 </a>
               </li>
               <li>
-                <p>Add this authorized redirect URI:</p>
+                <p>Add this exact authorized redirect URI:</p>
                 <div className="mt-1 flex items-center gap-2 rounded-xl border border-gray-200 bg-white p-2">
                   <p data-google-redirect-uri className="min-w-0 flex-1 break-all font-mono text-[11px] leading-5 text-gray-800">
                     {redirectUri || "Loading redirect URI…"}
@@ -852,7 +863,7 @@ function GoogleWorkspaceDialog({
                   Open API library
                 </a>
               </li>
-              <li>Paste the client ID and secret below.</li>
+              <li>Paste the client ID and secret here for first-time setup, or only when you choose to replace saved credentials.</li>
             </ol>
           </div>
           <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
@@ -883,23 +894,59 @@ function GoogleWorkspaceDialog({
               ))}
             </div>
           </div>
-          <div>
-            <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client ID</label>
-            <DenInput
-              value={clientId}
-              onChange={(event) => setClientId(event.target.value)}
-              placeholder={configured ? "Saved client ID kept if left blank" : "1234567890-abc.apps.googleusercontent.com"}
-            />
-          </div>
-          <div>
-            <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client secret</label>
-            <DenInput
-              type="password"
-              value={clientSecret}
-              onChange={(event) => setClientSecret(event.target.value)}
-              placeholder={configured ? "Saved client secret kept if left blank" : "GOCSPX-…"}
-            />
-          </div>
+          {loadingConfig ? (
+            <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4 text-[13px] text-gray-500">
+              Checking saved credentials…
+            </div>
+          ) : null}
+          {configured && !replacingCredentials ? (
+            <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-4">
+              <p className="text-[13px] font-semibold text-emerald-950">Credentials saved</p>
+              <p className="mt-1 text-[12px] leading-5 text-emerald-800">
+                OpenWork keeps the saved Google client ID and secret when you save permission changes. Replace them only if you are rotating credentials.
+              </p>
+              <div className="mt-3 rounded-xl border border-emerald-100 bg-white px-3 py-2 text-[12px] text-emerald-900">
+                Saved client ID: <span className="font-mono">{savedClientId ?? "stored in OpenWork"}</span>
+              </div>
+              <DenButton className="mt-3" variant="secondary" size="sm" onClick={startReplacingCredentials} disabled={submitting}>
+                Replace credentials
+              </DenButton>
+            </div>
+          ) : null}
+          {showCredentialFields ? (
+            <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
+              <p className="text-[13px] font-semibold text-gray-900">Google OAuth credentials</p>
+              <p className="mt-1 text-[12px] leading-5 text-gray-500">
+                {replacingCredentials
+                  ? "Paste the new client ID and client secret. Both are required to replace the saved credentials."
+                  : "Paste the client ID and client secret from the Google OAuth app. Both are required for first-time setup."}
+              </p>
+              <div className="mt-3 space-y-3">
+                <div>
+                  <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client ID</label>
+                  <DenInput
+                    value={clientId}
+                    onChange={(event) => setClientId(event.target.value)}
+                    placeholder="1234567890-abc.apps.googleusercontent.com"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client secret</label>
+                  <DenInput
+                    type="password"
+                    value={clientSecret}
+                    onChange={(event) => setClientSecret(event.target.value)}
+                    placeholder="GOCSPX-…"
+                  />
+                </div>
+              </div>
+              {replacingCredentials ? (
+                <DenButton className="mt-3" variant="secondary" size="sm" onClick={() => setReplacingCredentials(false)} disabled={submitting}>
+                  Keep saved credentials
+                </DenButton>
+              ) : null}
+            </div>
+          ) : null}
         </div>
 
         {formError ? (
@@ -915,12 +962,11 @@ function GoogleWorkspaceDialog({
             loading={submitting}
             disabled={saveDisabled}
             onClick={() => onSubmit({
-              ...(trimmedClientId ? { clientId: trimmedClientId } : {}),
-              ...(trimmedClientSecret ? { clientSecret: trimmedClientSecret } : {}),
+              ...(showCredentialFields ? { clientId: trimmedClientId, clientSecret: trimmedClientSecret } : {}),
               features,
             })}
           >
-            Save
+            {configured && !replacingCredentials ? "Save permissions" : replacingCredentials ? "Save new credentials" : "Save setup"}
           </DenButton>
         </div>
       </div>
@@ -1075,6 +1121,7 @@ function AddConnectionDialog({
 
   const showOAuthClientFields = authType === "oauth" && (Boolean(preset?.requiresOAuthClient) || showOAuthClient);
   const oauthClientRequired = authType === "oauth" && Boolean(preset?.requiresOAuthClient);
+  const isSlackPreset = preset?.presetId === "slack";
   const access: McpConnectionAccessInput = accessMode === "everyone"
     ? { orgWide: true, memberIds: [], teamIds: [] }
     : { orgWide: false, memberIds: accessMode === "people" ? selectedMemberIds : [], teamIds: accessMode === "teams" ? selectedTeamIds : [] };
@@ -1121,9 +1168,13 @@ function AddConnectionDialog({
       >
         {oauthCallback ? (
           <>
-            <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">Almost done — add this redirect URL to your app:</h2>
+            <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
+              {isSlackPreset ? "Almost done — add this redirect URL to your Slack app" : "Almost done — add this redirect URL to your app"}
+            </h2>
             <p className="mt-2 text-[13px] leading-6 text-gray-600">
-              Copy this into the OAuth redirect URLs for your pre-registered app before teammates connect.
+              {isSlackPreset
+                ? "Copy this exact URL into your Slack app's OAuth redirect URLs before teammates connect."
+                : "Copy this into the OAuth redirect URLs for your pre-registered app before teammates connect."}
             </p>
             <div className="mt-4 rounded-2xl border border-gray-200 bg-gray-50 p-3">
               <p className="break-all font-mono text-[12px] leading-5 text-gray-800">{oauthCallback}</p>
@@ -1143,7 +1194,11 @@ function AddConnectionDialog({
           {preset ? `Add ${preset.displayName}` : "Add a custom MCP server"}
         </h2>
         <p className="mt-1 text-[13px] leading-6 text-gray-600">
-          Connect an MCP server org-wide. If it requires OAuth, you&apos;ll authorize it in a new tab next.
+          {isSlackPreset ? (
+            <>
+              Slack MCP uses <span className="font-mono text-[12px]">{url}</span> and needs a pre-registered Slack app. Slack does not support automatic app registration, so paste the Slack app&apos;s OAuth client here; after creation OpenWork shows the exact redirect URL to add in Slack.
+            </>
+          ) : "Connect an MCP server org-wide. If it requires OAuth, you'll authorize it in a new tab next."}
         </p>
 
         <div className="mt-5 space-y-4">
@@ -1203,9 +1258,11 @@ function AddConnectionDialog({
 
           {showOAuthClientFields ? (
             <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
-              <p className="text-[13px] font-semibold text-gray-900">OAuth app</p>
+              <p className="text-[13px] font-semibold text-gray-900">{isSlackPreset ? "Slack OAuth app" : "OAuth app"}</p>
               <p className="mt-1 text-[12px] leading-5 text-gray-500">
-                Create an app for your workspace, then paste its OAuth client here. Each person connects their own account with it — sign-ins stay in your org&apos;s cloud.
+                {isSlackPreset
+                  ? "Create or use an internal or directory-published Slack app, then paste its Client ID and Client Secret. Slack does not support automatic app registration / DCR; after OpenWork creates the connection, copy the exact redirect URL it shows into that Slack app."
+                  : "Create an app for your workspace, then paste its OAuth client here. Each person connects their own account with it — sign-ins stay in your org's cloud."}
               </p>
               <div className="mt-3 space-y-3">
                 <div>
@@ -1332,10 +1389,10 @@ function AddConnectionDialog({
           <DenButton
             variant="primary"
             loading={submitting}
-            disabled={!name.trim() || !url.trim() || (authType === "apikey" && !apiKey.trim()) || (oauthClientRequired && !oauthClientId.trim()) || accessIncomplete}
+            disabled={!name.trim() || !url.trim() || (authType === "apikey" && !apiKey.trim()) || (oauthClientRequired && (!oauthClientId.trim() || !oauthClientSecret.trim())) || accessIncomplete}
             onClick={() => void submit()}
           >
-            Add connection
+            {showOAuthClientFields ? "Create and show redirect URL" : "Add connection"}
           </DenButton>
         </div>
           </>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -900,12 +900,15 @@ function GoogleWorkspaceDialog({
             </div>
           ) : null}
           {configured && !replacingCredentials ? (
-            <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-4">
-              <p className="text-[13px] font-semibold text-emerald-950">Credentials saved</p>
-              <p className="mt-1 text-[12px] leading-5 text-emerald-800">
+            <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
+              <div className="flex items-center gap-2">
+                <Check className="h-4 w-4 text-emerald-600" />
+                <p className="text-[13px] font-semibold text-gray-900">Credentials saved</p>
+              </div>
+              <p className="mt-1 text-[12px] leading-5 text-gray-500">
                 OpenWork keeps the saved Google client ID and secret when you save permission changes. Replace them only if you are rotating credentials.
               </p>
-              <div className="mt-3 rounded-xl border border-emerald-100 bg-white px-3 py-2 text-[12px] text-emerald-900">
+              <div className="mt-3 rounded-xl border border-gray-100 bg-white px-3 py-2 text-[12px] text-gray-800">
                 Saved client ID: <span className="font-mono">{savedClientId ?? "stored in OpenWork"}</span>
               </div>
               <DenButton className="mt-3" variant="secondary" size="sm" onClick={startReplacingCredentials} disabled={submitting}>
@@ -1062,6 +1065,62 @@ function ConnectionRow({
   );
 }
 
+type SegmentedControlOption<TValue extends string> = {
+  value: TValue;
+  label: string;
+};
+
+function SegmentedControl<TValue extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: SegmentedControlOption<TValue>[];
+  value: TValue;
+  onChange: (value: TValue) => void;
+}) {
+  const gridColumns = options.length === 2 ? "grid-cols-2" : "grid-cols-3";
+
+  return (
+    <div className={`grid ${gridColumns} gap-1 rounded-full border border-gray-200 bg-gray-50 p-1`} role="group">
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          aria-pressed={value === option.value}
+          onClick={() => onChange(option.value)}
+          className={`rounded-full px-3 py-1.5 text-[12px] font-medium transition ${
+            value === option.value
+              ? "bg-white text-gray-900 shadow-[0_1px_2px_rgba(15,23,42,0.08)]"
+              : "text-gray-500 hover:text-gray-900"
+          }`}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+type AddConnectionAccessMode = "everyone" | "teams" | "people";
+
+const AUTH_TYPE_OPTIONS: SegmentedControlOption<ExternalMcpAuthType>[] = [
+  { value: "oauth", label: "OAuth" },
+  { value: "apikey", label: "API key" },
+  { value: "none", label: "None" },
+];
+
+const CREDENTIAL_MODE_OPTIONS: SegmentedControlOption<ExternalMcpCredentialMode>[] = [
+  { value: "per_member", label: "Individual accounts" },
+  { value: "shared", label: "One org account" },
+];
+
+const ACCESS_MODE_OPTIONS: SegmentedControlOption<AddConnectionAccessMode>[] = [
+  { value: "everyone", label: "Everyone" },
+  { value: "teams", label: "Specific teams" },
+  { value: "people", label: "Specific people" },
+];
+
 function AddConnectionDialog({
   open,
   preset,
@@ -1088,7 +1147,7 @@ function AddConnectionDialog({
   const [oauthClientSecret, setOAuthClientSecret] = useState("");
   const [oauthCallback, setOAuthCallback] = useState<string | null>(null);
   const [copiedCallback, setCopiedCallback] = useState(false);
-  const [accessMode, setAccessMode] = useState<"everyone" | "teams" | "people">("everyone");
+  const [accessMode, setAccessMode] = useState<AddConnectionAccessMode>("everyone");
   const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
   const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
 
@@ -1196,7 +1255,7 @@ function AddConnectionDialog({
         <p className="mt-1 text-[13px] leading-6 text-gray-600">
           {isSlackPreset ? (
             <>
-              Slack MCP uses <span className="font-mono text-[12px]">{url}</span> and needs a pre-registered Slack app. Slack does not support automatic app registration, so paste the Slack app&apos;s OAuth client here; after creation OpenWork shows the exact redirect URL to add in Slack.
+              Slack MCP needs a pre-registered Slack app — Slack does not support automatic app registration. Paste your Slack app&apos;s OAuth client below.
             </>
           ) : "Connect an MCP server org-wide. If it requires OAuth, you'll authorize it in a new tab next."}
         </p>
@@ -1218,25 +1277,14 @@ function AddConnectionDialog({
           {!preset ? (
             <div>
               <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Authentication</label>
-              <div className="flex gap-2">
-                {(["oauth", "apikey", "none"] as const).map((option) => (
-                  <button
-                    key={option}
-                    type="button"
-                    onClick={() => {
-                      setAuthType(option);
-                      if (option !== "oauth") setShowOAuthClient(false);
-                    }}
-                    className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition ${
-                      authType === option
-                        ? "border-gray-900 bg-gray-900 text-white"
-                        : "border-gray-200 text-gray-600 hover:border-gray-300"
-                    }`}
-                  >
-                    {option === "oauth" ? "OAuth" : option === "apikey" ? "API key" : "None"}
-                  </button>
-                ))}
-              </div>
+              <SegmentedControl
+                options={AUTH_TYPE_OPTIONS}
+                value={authType}
+                onChange={(option) => {
+                  setAuthType(option);
+                  if (option !== "oauth") setShowOAuthClient(false);
+                }}
+              />
             </div>
           ) : null}
           {authType === "apikey" ? (
@@ -1261,7 +1309,7 @@ function AddConnectionDialog({
               <p className="text-[13px] font-semibold text-gray-900">{isSlackPreset ? "Slack OAuth app" : "OAuth app"}</p>
               <p className="mt-1 text-[12px] leading-5 text-gray-500">
                 {isSlackPreset
-                  ? "Create or use an internal or directory-published Slack app, then paste its Client ID and Client Secret. Slack does not support automatic app registration / DCR; after OpenWork creates the connection, copy the exact redirect URL it shows into that Slack app."
+                  ? "Create or use an internal or directory-published Slack app, then paste its Client ID and Client secret. After you create the connection, OpenWork shows the exact redirect URL to add to that Slack app."
                   : "Create an app for your workspace, then paste its OAuth client here. Each person connects their own account with it — sign-ins stay in your org's cloud."}
               </p>
               <div className="mt-3 space-y-3">
@@ -1289,26 +1337,7 @@ function AddConnectionDialog({
           {authType === "oauth" ? (
             <div>
               <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Whose account does the AI use?</label>
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => setCredentialMode("per_member")}
-                  className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition ${
-                    credentialMode === "per_member" ? "border-gray-900 bg-gray-900 text-white" : "border-gray-200 text-gray-600 hover:border-gray-300"
-                  }`}
-                >
-                  Individual accounts
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setCredentialMode("shared")}
-                  className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition ${
-                    credentialMode === "shared" ? "border-gray-900 bg-gray-900 text-white" : "border-gray-200 text-gray-600 hover:border-gray-300"
-                  }`}
-                >
-                  One org account
-                </button>
-              </div>
+              <SegmentedControl options={CREDENTIAL_MODE_OPTIONS} value={credentialMode} onChange={setCredentialMode} />
               <p className="mt-1.5 text-[12px] leading-5 text-gray-500">
                 {credentialMode === "per_member"
                   ? "Each person signs in with their own account from Your Connections. Their AI acts as them, with their permissions."
@@ -1319,20 +1348,7 @@ function AddConnectionDialog({
 
           <div>
             <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Who can use this?</label>
-            <div className="flex gap-2">
-              {(["everyone", "teams", "people"] as const).map((option) => (
-                <button
-                  key={option}
-                  type="button"
-                  onClick={() => setAccessMode(option)}
-                  className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition ${
-                    accessMode === option ? "border-gray-900 bg-gray-900 text-white" : "border-gray-200 text-gray-600 hover:border-gray-300"
-                  }`}
-                >
-                  {option === "everyone" ? "Everyone in the org" : option === "teams" ? "Specific teams" : "Specific people"}
-                </button>
-              ))}
-            </div>
+            <SegmentedControl options={ACCESS_MODE_OPTIONS} value={accessMode} onChange={setAccessMode} />
             {accessMode === "teams" ? (
               <div className="mt-2 max-h-40 space-y-1 overflow-y-auto rounded-xl border border-gray-100 p-2">
                 {teams.length === 0 ? (
@@ -1344,7 +1360,7 @@ function AddConnectionDialog({
                       type="button"
                       onClick={() => setSelectedTeamIds((current) => toggle(current, team.id))}
                       className={`flex w-full items-center justify-between rounded-lg px-2.5 py-1.5 text-left text-[13px] transition ${
-                        selectedTeamIds.includes(team.id) ? "bg-gray-900 text-white" : "text-gray-700 hover:bg-gray-50"
+                        selectedTeamIds.includes(team.id) ? "bg-gray-100 text-gray-900" : "text-gray-700 hover:bg-gray-50"
                       }`}
                     >
                       <span className="truncate">{team.name}</span>
@@ -1365,7 +1381,7 @@ function AddConnectionDialog({
                       type="button"
                       onClick={() => setSelectedMemberIds((current) => toggle(current, member.id))}
                       className={`flex w-full items-center justify-between rounded-lg px-2.5 py-1.5 text-left text-[13px] transition ${
-                        selectedMemberIds.includes(member.id) ? "bg-gray-900 text-white" : "text-gray-700 hover:bg-gray-50"
+                        selectedMemberIds.includes(member.id) ? "bg-gray-100 text-gray-900" : "text-gray-700 hover:bg-gray-50"
                       }`}
                     >
                       <span className="truncate">{member.user.name || member.user.email}</span>

--- a/evals/flows/google-slack-oauth-ux.flow.mjs
+++ b/evals/flows/google-slack-oauth-ux.flow.mjs
@@ -645,7 +645,8 @@ export default {
           },
           assert: async () => {
             await ctx.expectText("Slack MCP");
-            await ctx.expectText("https://mcp.slack.com/mcp");
+            const serverUrl = await ctx.eval(`document.querySelector('input[placeholder="https://mcp.example.com/mcp"]')?.value ?? [...document.querySelectorAll('input')].map((input) => input.value).find((value) => value.includes('mcp.slack.com')) ?? ''`);
+            ctx.assert(serverUrl.includes("https://mcp.slack.com/mcp"), `Slack MCP Server URL input should contain https://mcp.slack.com/mcp; saw ${JSON.stringify(serverUrl)}.`);
             await ctx.expectText("pre-registered Slack app");
             await ctx.expectText("automatic app registration");
             await ctx.expectText("Slack OAuth app");
@@ -655,7 +656,7 @@ export default {
           screenshot: {
             name: "slack-quick-add-preregistered-oauth-copy",
             claim: "Slack quick-add names Slack MCP, the Slack app requirement, and the client ID/secret fields up front.",
-            requireText: ["Add Slack", "Slack MCP", "https://mcp.slack.com/mcp", "pre-registered Slack app", "Slack OAuth app", "Client ID", "Client secret"],
+            requireText: ["Add Slack", "Slack MCP", "pre-registered Slack app", "automatic app registration", "Slack OAuth app", "Client ID", "Client secret"],
             rejectText: ["Something went wrong"],
           },
         });

--- a/evals/flows/google-slack-oauth-ux.flow.mjs
+++ b/evals/flows/google-slack-oauth-ux.flow.mjs
@@ -1,0 +1,723 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, openAdminConnections } from "./lib/den-web.mjs";
+
+const FLOW_ID = "google-slack-oauth-ux";
+
+// Narration is loaded from the approved script (evals/voiceovers/google-slack-oauth-ux.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const execFileAsync = promisify(execFile);
+
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const MOCK_SERVER_URL = (process.env.MOCK_DCRLESS_MCP_URL ?? "http://127.0.0.1:3979").trim().replace(/\/+$/, "");
+const MOCK_CLIENT_ID = process.env.MOCK_CLIENT_ID || "mock-preregistered-client";
+const MOCK_CLIENT_SECRET = process.env.MOCK_CLIENT_SECRET || "mock-preregistered-secret";
+const RUN_TAG = Date.now();
+const GOOGLE_CLIENT_ID = `google-oauth-ux-client-${RUN_TAG}.apps.googleusercontent.com`;
+const GOOGLE_CLIENT_SECRET = `google-oauth-ux-secret-${RUN_TAG}`;
+const DEFAULT_GOOGLE_FEATURES = ["calendarRead", "gmailDraft", "driveFile"];
+const PERMISSIONS_ONLY_FEATURES = ["calendarRead", "gmailDraft", "driveFile", "gmailRead"];
+const GOOGLE_WORKSPACE_CALLBACK_PATH = "/v1/oauth-providers/google-workspace/connect/callback";
+const CONNECTION_PREFIX = "slack-oauth-ux-";
+const CONNECTION_NAME = `${CONNECTION_PREFIX}${RUN_TAG}`;
+
+const state = {
+  adminSession: null,
+  orgId: null,
+  orgName: null,
+  authProviders: [],
+  browserSessionId: null,
+  callbackUrl: null,
+  connectionId: null,
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function sqlString(value) {
+  return `'${String(value).replaceAll("\\", "\\\\").replaceAll("'", "''")}'`;
+}
+
+function denWebUrl(ctx, path = "/") {
+  const base = ctx.env.OPENWORK_EVAL_DEN_WEB_URL.trim().replace(/\/+$/, "");
+  ctx.assert(base.length > 0, "OPENWORK_EVAL_DEN_WEB_URL was empty.");
+  if (path.startsWith("http")) return path;
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+function adminSessionToken(ctx) {
+  const token = ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim();
+  ctx.assert(token.length > 0, "OPENWORK_EVAL_DEN_TOKEN was empty.");
+  return token;
+}
+
+function mysqlContainer(ctx) {
+  return ctx.env.OPENWORK_EVAL_DEN_MYSQL_CONTAINER || "openwork-web-local-mysql";
+}
+
+function orgHeaders(session) {
+  if (!session) throw new Error("Missing session for org-scoped API call.");
+  if (!state.orgId) throw new Error("Missing pinned organization id for org-scoped API call.");
+  return { authorization: `Bearer ${session}`, "x-openwork-legacy-org-id": state.orgId };
+}
+
+async function runMysql(ctx, sql) {
+  const { stdout, stderr } = await execFileAsync("docker", [
+    "exec",
+    mysqlContainer(ctx),
+    "mysql",
+    "-uroot",
+    "-ppassword",
+    "openwork_den",
+    "-e",
+    sql,
+  ]);
+  if (stderr.trim()) ctx.log(`mysql stderr: ${stderr.trim()}`);
+  return stdout;
+}
+
+async function refreshAdminSession(ctx) {
+  state.adminSession = adminSessionToken(ctx);
+  return state.adminSession;
+}
+
+async function selectAdminOrganization(ctx) {
+  const listed = await denApiFetch("/v1/me/orgs", {
+    headers: { authorization: `Bearer ${state.adminSession}` },
+  });
+  ctx.assert(listed.response.ok, `Admin org list failed: ${listed.response.status} ${JSON.stringify(listed.body).slice(0, 200)}`);
+  const orgs = Array.isArray(listed.body.orgs) ? listed.body.orgs : [];
+  const acme = orgs.find((org) => org.slug === "acme-robotics-demo");
+  const adminOrg = orgs.find((org) => ["owner", "admin"].includes(String(org.role ?? "").toLowerCase()));
+  const selected = acme ?? adminOrg;
+  ctx.assert(
+    selected && typeof selected.id === "string",
+    `Admin ${ADMIN_EMAIL} is not in acme-robotics-demo and has no owner/admin org. Orgs: ${JSON.stringify(orgs)}`,
+  );
+  state.orgId = selected.id;
+  state.orgName = typeof selected.name === "string" && selected.name ? selected.name : selected.slug ?? selected.id;
+}
+
+async function setBrowserActiveOrg(ctx) {
+  const session = state.adminSession ?? (await refreshAdminSession(ctx));
+  const ok = await ctx.eval(`fetch('/api/den/v1/me/active-organization', { method: 'POST', credentials: 'include', headers: { 'content-type': 'application/json', authorization: ${JSON.stringify(`Bearer ${session}`)} }, body: JSON.stringify({ organizationId: ${JSON.stringify(state.orgId)} }) }).then((response) => response.ok)`, { awaitPromise: true });
+  ctx.assert(ok, `Could not set the browser active org to ${state.orgName} (${state.orgId}).`);
+}
+
+async function goToDenWeb(ctx, path) {
+  await ctx.eval(`(() => { window.location.assign(${JSON.stringify(denWebUrl(ctx, path))}); return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `den-web loaded ${path}` });
+}
+
+async function installDenWebBrowserAuthShim(ctx, token) {
+  if (!ctx.client?.send) return;
+  const bearer = `Bearer ${token}`;
+  await ctx.client.send("Network.enable");
+  await ctx.client.send("Network.setExtraHTTPHeaders", {
+    headers: { Authorization: bearer },
+  });
+  await ctx.client.send("Page.addScriptToEvaluateOnNewDocument", {
+    source: `(() => {
+      const bearer = ${JSON.stringify(bearer)};
+      const originalFetch = window.fetch;
+      const shouldAuthorize = (input) => {
+        try {
+          const rawUrl = input instanceof Request ? input.url : String(input);
+          const url = new URL(rawUrl, window.location.href);
+          return url.origin === window.location.origin && url.pathname.startsWith('/api/den');
+        } catch {
+          return false;
+        }
+      };
+      const headersWithAuth = (input, init) => {
+        const headers = new Headers(input instanceof Request ? input.headers : undefined);
+        if (init?.headers) {
+          new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+        }
+        if (!headers.has('authorization')) headers.set('authorization', bearer);
+        return headers;
+      };
+      window.fetch = (input, init) => {
+        if (!shouldAuthorize(input)) return originalFetch.call(window, input, init);
+        const headers = headersWithAuth(input, init);
+        if (input instanceof Request && init === undefined) {
+          return originalFetch.call(window, new Request(input, { headers }));
+        }
+        return originalFetch.call(window, input, init === undefined ? { headers } : { ...init, headers });
+      };
+    })();`,
+  });
+}
+
+async function waitForDenConnectionsUi(ctx) {
+  const loadedState = await ctx.waitFor(`(() => {
+    const text = document.body.innerText;
+    if (text.toLowerCase().includes('unauthorized')) return 'unauthorized';
+    return location.pathname.includes('/dashboard/mcp-connections')
+      && text.includes('Connections')
+      && text.toLowerCase().includes('quick add')
+      && text.includes('Google Workspace')
+      ? 'connections'
+      : '';
+  })()`, { timeoutMs: 45_000, label: "den-web Connections UI after CDP bearer auth" });
+  if (loadedState !== "connections") {
+    const bodyText = await ctx.eval("document.body.innerText");
+    ctx.assert(false, `Den-web Connections UI did not authenticate with the CDP Authorization header. Body: ${String(bodyText).slice(0, 1000)}`);
+  }
+}
+
+async function signInAdminBrowserWithToken(ctx) {
+  const token = await refreshAdminSession(ctx);
+  await installDenWebBrowserAuthShim(ctx, token);
+  await goToDenWeb(ctx, "/");
+  await ctx.eval(`(() => {
+    const token = ${JSON.stringify(token)};
+    document.cookie = 'better-auth.session_token=; Max-Age=0; Path=/; SameSite=Lax';
+    document.cookie = 'better-auth.session_token=' + token + '; Path=/; SameSite=Lax';
+    localStorage.setItem('openwork:web:auth-token', token);
+    sessionStorage.clear();
+    return true;
+  })()`);
+  await goToDenWeb(ctx, "/dashboard/mcp-connections");
+  await waitForDenConnectionsUi(ctx);
+}
+
+async function loadAuthProviders(ctx) {
+  const me = await denApiFetch("/v1/me", {
+    headers: { authorization: `Bearer ${state.adminSession}` },
+  });
+  ctx.assert(me.response.ok, `Loading current user failed: ${me.response.status} ${JSON.stringify(me.body).slice(0, 200)}`);
+  state.authProviders = Array.isArray(me.body.user?.authProviders) ? me.body.user.authProviders : [];
+}
+
+async function saveGoogleClient(ctx, features) {
+  await refreshAdminSession(ctx);
+  const saved = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
+    method: "POST",
+    headers: orgHeaders(state.adminSession),
+    body: JSON.stringify({
+      clientId: GOOGLE_CLIENT_ID,
+      clientSecret: GOOGLE_CLIENT_SECRET,
+      features,
+    }),
+  });
+  ctx.assert(saved.response.ok, `Saving Google Workspace client failed: ${saved.response.status} ${JSON.stringify(saved.body).slice(0, 200)}`);
+}
+
+async function loadGoogleClientConfig(ctx) {
+  let config = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
+    headers: orgHeaders(state.adminSession),
+  });
+  if (config.response.status === 403 && config.body?.error === "reauth") {
+    await refreshAdminSession(ctx);
+    config = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
+      headers: orgHeaders(state.adminSession),
+    });
+  }
+  ctx.assert(config.response.ok, `Google Workspace client config failed: ${config.response.status} ${JSON.stringify(config.body).slice(0, 200)}`);
+  return config.body;
+}
+
+async function waitForGoogleFeatures(ctx, expectedFeatures) {
+  let features = [];
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const config = await loadGoogleClientConfig(ctx);
+    features = Array.isArray(config.features) ? config.features : [];
+    const sameLength = features.length === expectedFeatures.length;
+    if (sameLength && expectedFeatures.every((feature) => features.includes(feature))) return features;
+    await sleep(500);
+  }
+  ctx.assert(false, `Google Workspace features never matched ${JSON.stringify(expectedFeatures)}. Last seen ${JSON.stringify(features)}.`);
+  return features;
+}
+
+async function cleanupTestConnections(ctx) {
+  const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+    headers: orgHeaders(state.adminSession),
+  });
+  ctx.assert(existing.response.ok, `Listing manageable connections failed: ${existing.response.status} ${JSON.stringify(existing.body).slice(0, 200)}`);
+  for (const connection of existing.body.connections ?? []) {
+    if (connection.name?.startsWith?.(CONNECTION_PREFIX) || connection.name?.startsWith?.("slack-style-")) {
+      const removed = await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+        method: "DELETE",
+        headers: orgHeaders(state.adminSession),
+      });
+      ctx.assert(removed.response.ok, `Cleanup delete failed for leftover ${connection.id}: ${removed.response.status}`);
+    }
+  }
+}
+
+function clickGoogleQuickAddScript() {
+  return `(() => {
+    const card = [...document.querySelectorAll('button')].find((button) => {
+      const text = button.textContent ?? '';
+      return text.includes('Google Workspace') && (text.includes('Tap to set up') || text.includes('Configured'));
+    });
+    card?.scrollIntoView({ block: 'center' });
+    card?.click();
+    return Boolean(card);
+  })()`;
+}
+
+function clickSlackCardScript() {
+  return `(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => {
+      const text = entry.textContent ?? '';
+      return text.includes('Slack') && text.includes('Tap to add');
+    });
+    button?.scrollIntoView({ block: 'center' });
+    button?.click();
+    return Boolean(button);
+  })()`;
+}
+
+function clickCustomMcpCardScript() {
+  return `(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => {
+      const text = entry.textContent ?? '';
+      return text.includes('MCP server') || text.includes('Add Custom') || text.includes('Connect one remote MCP server by URL');
+    });
+    button?.scrollIntoView({ block: 'center' });
+    button?.click();
+    return Boolean(button);
+  })()`;
+}
+
+function googleSetupVisibleScript() {
+  return `(() => {
+    const dialog = document.querySelector('[role="dialog"]') ?? document.querySelector('.fixed.inset-0 > div');
+    const text = dialog?.textContent ?? document.body.innerText;
+    const titleOk = text.includes('Set up Google Workspace') || text.includes('Update Google Workspace');
+    return titleOk
+      && text.includes('Add this exact authorized redirect URI')
+      && text.includes(${JSON.stringify(GOOGLE_WORKSPACE_CALLBACK_PATH)})
+      && text.includes('Copy')
+      && text.includes('Open Google Cloud Console')
+      && text.includes('Open API library');
+  })()`;
+}
+
+function displayedGoogleRedirectUriScript() {
+  return `(() => (document.querySelector('[data-google-redirect-uri]')?.textContent ?? '').trim())()`;
+}
+
+function setFeatureCheckedScript(featureKey, checked) {
+  return `(() => {
+    const input = [...document.querySelectorAll('input[type="checkbox"][data-feature]')].find((entry) => entry.dataset.feature === ${JSON.stringify(featureKey)});
+    if (!input || input.disabled) return { ok: false, checked: false };
+    input.scrollIntoView({ block: 'center' });
+    if (input.checked !== ${JSON.stringify(checked)}) input.click();
+    return { ok: input.checked === ${JSON.stringify(checked)}, checked: input.checked };
+  })()`;
+}
+
+function googleSavedCredentialsVisibleScript() {
+  return `(() => {
+    const dialog = document.querySelector('[role="dialog"]') ?? document.querySelector('.fixed.inset-0 > div');
+    const text = dialog?.textContent ?? '';
+    const exactCredentialInput = [...document.querySelectorAll('label')]
+      .some((label) => (label.textContent ?? '').trim() === 'Client ID' && Boolean(label.parentElement?.querySelector('input')));
+    return {
+      ok: text.includes('Credentials saved')
+        && text.includes('Saved client ID')
+        && text.includes(${JSON.stringify(GOOGLE_CLIENT_ID)})
+        && text.includes('Save permissions')
+        && !text.includes('Google OAuth credentials')
+        && exactCredentialInput === false,
+      text,
+      exactCredentialInput,
+    };
+  })()`;
+}
+
+function googleReplaceCredentialsVisibleScript() {
+  return `(() => {
+    const text = document.body.innerText;
+    const labels = [...document.querySelectorAll('label')].map((label) => (label.textContent ?? '').trim());
+    const saveButton = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === 'Save new credentials');
+    return {
+      text,
+      hasGoogleOAuthCredentials: text.includes('Google OAuth credentials'),
+      hasClientIdLabel: labels.includes('Client ID'),
+      hasClientSecretLabel: labels.includes('Client secret'),
+      saveDisabled: Boolean(saveButton?.disabled),
+      hasKeepSavedCredentials: text.includes('Keep saved credentials'),
+    };
+  })()`;
+}
+
+function exactEnabledButtonScript(text) {
+  return `(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === ${JSON.stringify(text)} && !entry.disabled);
+    button?.scrollIntoView({ block: 'center' });
+    button?.click();
+    return Boolean(button);
+  })()`;
+}
+
+function reauthReadyScript() {
+  const expectsGoogle = state.authProviders.includes("google");
+  return `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    const text = dialog?.textContent ?? '';
+    const helperOk = text.includes('Changing workspace settings requires a recent sign-in')
+      && text.includes('OpenWork retries the pending action automatically');
+    const hasGoogle = text.includes('Continue with Google');
+    const hasPassword = text.includes('Verify password');
+    const hasSso = text.includes('Continue with organization SSO');
+    return Boolean(dialog)
+      && text.includes("Confirm it's you to continue")
+      && helperOk
+      && (${JSON.stringify(expectsGoogle)} ? hasGoogle : (hasGoogle || hasPassword || hasSso));
+  })()`;
+}
+
+function reauthDialogStateScript() {
+  return `(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    const text = dialog?.textContent ?? '';
+    return {
+      visible: Boolean(dialog),
+      text,
+      hasGoogle: text.includes('Continue with Google'),
+      hasPassword: text.includes('Verify password'),
+      hasSso: text.includes('Continue with organization SSO'),
+      nonce: dialog?.getAttribute('data-reauth-nonce') ?? null,
+    };
+  })()`;
+}
+
+function callbackUrlScript() {
+  return `(() => {
+    const elements = [...document.querySelectorAll('*')];
+    return elements.find((entry) => (entry.textContent ?? '').includes('/connect/callback'))?.textContent?.trim() ?? null;
+  })()`;
+}
+
+async function rememberBrowserSession(ctx) {
+  const session = state.adminSession ?? (await refreshAdminSession(ctx));
+  const sessionId = await ctx.eval(`fetch('/api/den/v1/me', { credentials: 'include', headers: { authorization: ${JSON.stringify(`Bearer ${session}`)} } })
+    .then((response) => response.ok ? response.json() : null)
+    .then((payload) => payload?.session?.id ?? null)`, { awaitPromise: true });
+  if (typeof sessionId === "string" && sessionId.length > 0) {
+    state.browserSessionId = sessionId;
+    return;
+  }
+
+  const rows = await runMysql(ctx, `SELECT id FROM session WHERE token = ${sqlString(session)} LIMIT 1;`);
+  const dbSessionId = rows.split(/\r?\n/).map((line) => line.trim()).find((line) => line && line !== "id") ?? null;
+  ctx.assert(typeof dbSessionId === "string" && dbSessionId.length > 0, `Could not read browser session id from /api/den/v1/me or MySQL. API: ${sessionId}; MySQL: ${rows.slice(0, 200)}`);
+  state.browserSessionId = dbSessionId;
+}
+
+async function staleBrowserSession(ctx) {
+  await rememberBrowserSession(ctx);
+  await runMysql(ctx, `UPDATE session SET created_at = DATE_SUB(NOW(3), INTERVAL 1 HOUR) WHERE id = ${sqlString(state.browserSessionId)};`);
+}
+
+async function makeBrowserSessionFreshInDb(ctx) {
+  ctx.assert(typeof state.browserSessionId === "string" && state.browserSessionId.length > 0, "Missing browser session id to refresh.");
+  await runMysql(ctx, `UPDATE session SET created_at = NOW(3) WHERE id = ${sqlString(state.browserSessionId)};`);
+}
+
+async function completeVisibleReauth(ctx) {
+  const reauthState = await ctx.eval(reauthDialogStateScript());
+  ctx.assert(reauthState?.visible, "Reauth dialog was not visible before completing it.");
+  await makeBrowserSessionFreshInDb(ctx);
+  ctx.assert(typeof reauthState.nonce === "string" && reauthState.nonce.length > 0, "Reauth nonce was missing for the completion seam.");
+  await ctx.eval(`window.postMessage({ type: 'openwork:reauth-complete', nonce: ${JSON.stringify(reauthState.nonce)}, error: null }, window.location.origin); true`);
+}
+
+async function waitForNoModalCopy(ctx) {
+  await ctx.waitFor(`(() => {
+    const text = document.body.innerText;
+    return !text.includes('Use one Google OAuth web app')
+      && !text.includes('Add Slack')
+      && !text.includes('Add a custom MCP server')
+      && !text.includes('Almost done')
+      && !text.includes('Google OAuth credentials');
+  })()`, { timeoutMs: 30_000, label: "modal copy cleared" });
+}
+
+async function completeReauthAndWaitForGoogleSave(ctx) {
+  await completeVisibleReauth(ctx);
+  await ctx.waitFor(`(() => {
+    const text = document.body.innerText;
+    return !document.querySelector('[role="dialog"]')
+      && !text.includes('Use one Google OAuth web app')
+      && text.includes('Google Workspace')
+      && text.includes('Configured');
+  })()`, { timeoutMs: 45_000, label: "Google save retried and dialog closed" });
+  ctx.recordEvidence({
+    type: "assertion",
+    status: "passed",
+    assertion: "After reauth, the pending Google Workspace save retried and returned to the configured card.",
+  });
+}
+
+async function waitForDialogClosed(ctx) {
+  await waitForNoModalCopy(ctx);
+}
+
+async function openGoogleDialog(ctx) {
+  await openAdminConnections(ctx);
+  const clicked = await ctx.eval(clickGoogleQuickAddScript());
+  ctx.assert(clicked, "Google Workspace quick-add card was not found.");
+  await ctx.waitFor(googleSetupVisibleScript(), { timeoutMs: 20_000, label: "Google Workspace dialog" });
+}
+
+async function clickCreateConnectionAndHandleReauth(ctx) {
+  const clicked = await ctx.eval(exactEnabledButtonScript("Create and show redirect URL"));
+  ctx.assert(clicked, "Create and show redirect URL button was not enabled.");
+  const stateName = await ctx.waitFor(`(() => {
+    const text = document.body.innerText;
+    if (text.includes('Almost done')) return 'created';
+    if (text.includes("Confirm it's you to continue")) return 'reauth';
+    return '';
+  })()`, { timeoutMs: 30_000, label: "redirect handoff or reauth" });
+  if (stateName === "reauth") {
+    await completeVisibleReauth(ctx);
+    await ctx.waitForText("Almost done", { timeoutMs: 45_000 });
+  }
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Google and Slack OAuth setup tells admins exactly what to do next",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MYSQL_CONTAINER"],
+  spec: "evals/voiceovers/google-slack-oauth-ux.md",
+  steps: [
+    {
+      name: "Setup: admin session, Google client, and Slack-style cleanup are ready",
+      run: async (ctx) => {
+        const health = await fetch(`${MOCK_SERVER_URL}/health`).then((response) => response.json()).catch(() => null);
+        ctx.assert(Boolean(health?.ok), `DCR-less mock OAuth+MCP server not reachable at ${MOCK_SERVER_URL}.`);
+        ctx.assert(health.disableDcr === true, `Mock server at ${MOCK_SERVER_URL} must run with DISABLE_DCR=1.`);
+        const metadata = await fetch(`${MOCK_SERVER_URL}/.well-known/oauth-authorization-server`).then((response) => response.json());
+        ctx.assert(!("registration_endpoint" in metadata), "DCR-less mock metadata unexpectedly advertised registration_endpoint.");
+
+        await refreshAdminSession(ctx);
+        await selectAdminOrganization(ctx);
+        await loadAuthProviders(ctx);
+        await cleanupTestConnections(ctx);
+        await saveGoogleClient(ctx, DEFAULT_GOOGLE_FEATURES);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The Google Workspace dialog gives admins the exact OAuth setup instructions and redirect URI", {
+          voiceover: vo[0],
+          action: async () => {
+            await signInAdminBrowserWithToken(ctx);
+            await setBrowserActiveOrg(ctx);
+            await openGoogleDialog(ctx);
+          },
+          assert: async () => {
+            const config = await loadGoogleClientConfig(ctx);
+            const displayedRedirectUri = await ctx.eval(displayedGoogleRedirectUriScript());
+            ctx.assert(typeof config.redirectUri === "string" && config.redirectUri.includes(GOOGLE_WORKSPACE_CALLBACK_PATH), `API redirect URI was missing the Google callback path: ${JSON.stringify(config)}`);
+            ctx.assert(displayedRedirectUri === config.redirectUri, `Displayed redirect URI did not match API config. Displayed: ${displayedRedirectUri}. API: ${config.redirectUri}.`);
+            await ctx.waitFor(googleSetupVisibleScript(), { timeoutMs: 20_000, label: "Google setup copy" });
+          },
+          screenshot: {
+            name: "google-workspace-oauth-setup-guide",
+            claim: "The dialog includes the redirect URI, copy button, and Google Console/API instructions.",
+            requireText: ["Google Workspace", "Add this exact authorized redirect URI", GOOGLE_WORKSPACE_CALLBACK_PATH, "Copy", "Open Google Cloud Console", "Open API library"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("A stale Google Workspace save opens the security check with a clear retry path", {
+          voiceover: vo[1],
+          action: async () => {
+            await staleBrowserSession(ctx);
+            const clicked = await ctx.eval(exactEnabledButtonScript("Save permissions"));
+            ctx.assert(clicked, "Save permissions button was not enabled.");
+            await ctx.waitFor(reauthReadyScript(), { timeoutMs: 30_000, label: "reauth dialog with available method" });
+          },
+          assert: async () => {
+            const actual = await ctx.eval(reauthDialogStateScript());
+            ctx.assert(actual.visible === true, "Reauth dialog should be visible.");
+            ctx.assert(actual.text.includes("Confirm it's you to continue"), `Reauth title missing: ${actual.text}`);
+            ctx.assert(actual.text.includes("Changing workspace settings requires a recent sign-in"), `Reauth helper missing recent sign-in copy: ${actual.text}`);
+            ctx.assert(actual.text.includes("OpenWork retries the pending action automatically"), `Reauth helper missing automatic retry copy: ${actual.text}`);
+            if (state.authProviders.includes("google")) {
+              ctx.assert(actual.hasGoogle === true, `Seeded Google auth provider should expose Continue with Google. Providers: ${JSON.stringify(state.authProviders)}. Dialog: ${actual.text}`);
+            } else {
+              ctx.assert(actual.hasPassword || actual.hasSso || actual.hasGoogle, `Reauth dialog had no clear CTA. Providers: ${JSON.stringify(state.authProviders)}. Dialog: ${actual.text}`);
+            }
+          },
+          screenshot: {
+            name: "google-workspace-reauth-security-check",
+            claim: "The security check explains why it appeared and gives a clear way to continue before retrying the save.",
+            requireText: state.authProviders.includes("google")
+              ? ["Confirm it's you to continue", "SECURITY CHECK", "OpenWork retries the pending action automatically", "Continue with Google"]
+              : ["Confirm it's you to continue", "SECURITY CHECK", "OpenWork retries the pending action automatically"],
+            rejectText: ["For security, confirm it's you before changing workspace settings."],
+          },
+        });
+
+        await completeReauthAndWaitForGoogleSave(ctx);
+        await refreshAdminSession(ctx);
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Admins can make a permissions-only Google edit without re-entering saved credentials", {
+          voiceover: vo[2],
+          action: async () => {
+            const config = await loadGoogleClientConfig(ctx);
+            ctx.assert(config.configured === true, `Google Workspace should be configured before permissions-only edit: ${JSON.stringify(config)}`);
+            await openGoogleDialog(ctx);
+            const toggled = await ctx.eval(setFeatureCheckedScript("gmailRead", true));
+            ctx.assert(toggled?.ok, `Could not turn on the Read Gmail permission: ${JSON.stringify(toggled)}`);
+          },
+          assert: async () => {
+            const actual = await ctx.eval(googleSavedCredentialsVisibleScript());
+            ctx.assert(actual.ok === true, `Saved credentials panel was not shown without credential inputs: ${JSON.stringify(actual)}`);
+          },
+          screenshot: {
+            name: "google-workspace-permissions-only-save",
+            claim: "The dialog shows saved credentials and the permissions-only save button without blank credential fields.",
+            requireText: ["Credentials saved", "Saved client ID", GOOGLE_CLIENT_ID, "Save permissions", "Replace credentials"],
+            rejectText: ["Google OAuth credentials", "Failed to save"],
+          },
+        });
+
+        const clicked = await ctx.eval(exactEnabledButtonScript("Save permissions"));
+        ctx.assert(clicked, "Save permissions button was not enabled for the permissions-only edit.");
+        await waitForDialogClosed(ctx);
+        await waitForGoogleFeatures(ctx, PERMISSIONS_ONLY_FEATURES);
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Google credential fields only become editable when the admin chooses Replace credentials", {
+          voiceover: vo[3],
+          action: async () => {
+            await openGoogleDialog(ctx);
+            const clicked = await ctx.eval(exactEnabledButtonScript("Replace credentials"));
+            ctx.assert(clicked, "Replace credentials button was not available.");
+            await ctx.waitFor("document.body.innerText.includes('Google OAuth credentials')", { timeoutMs: 10_000, label: "replacement credentials section" });
+          },
+          assert: async () => {
+            const actual = await ctx.eval(googleReplaceCredentialsVisibleScript());
+            ctx.assert(actual.hasGoogleOAuthCredentials === true, "Google OAuth credentials section should be visible after Replace credentials.");
+            ctx.assert(actual.hasClientIdLabel === true, "Client ID field should be visible after Replace credentials.");
+            ctx.assert(actual.hasClientSecretLabel === true, "Client secret field should be visible after Replace credentials.");
+            ctx.assert(actual.saveDisabled === true, "Save new credentials should stay disabled until client ID and secret are present.");
+            ctx.assert(actual.hasKeepSavedCredentials === true, "Keep saved credentials button should be available while replacing credentials.");
+          },
+          screenshot: {
+            name: "google-workspace-replace-credentials",
+            claim: "Replace credentials reveals the credential form and keeps saving disabled until both fields are filled.",
+            requireText: ["Google OAuth credentials", "Client ID", "Client secret", "Save new credentials", "Keep saved credentials"],
+            rejectText: ["Failed to save"],
+          },
+        });
+
+        await ctx.clickText("Cancel", { timeoutMs: 10_000 });
+        await waitForDialogClosed(ctx);
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("The Slack quick-add explains the pre-registered Slack OAuth app requirement before creation", {
+          voiceover: vo[4],
+          action: async () => {
+            await openAdminConnections(ctx);
+            const clicked = await ctx.eval(clickSlackCardScript());
+            ctx.assert(clicked, "Slack quick-add card with Tap to add was not found.");
+            await ctx.waitForText("Add Slack", { timeoutMs: 10_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Slack MCP");
+            await ctx.expectText("https://mcp.slack.com/mcp");
+            await ctx.expectText("pre-registered Slack app");
+            await ctx.expectText("automatic app registration");
+            await ctx.expectText("Slack OAuth app");
+            await ctx.expectText("Client ID");
+            await ctx.expectText("Client secret");
+          },
+          screenshot: {
+            name: "slack-quick-add-preregistered-oauth-copy",
+            claim: "Slack quick-add names Slack MCP, the Slack app requirement, and the client ID/secret fields up front.",
+            requireText: ["Add Slack", "Slack MCP", "https://mcp.slack.com/mcp", "pre-registered Slack app", "Slack OAuth app", "Client ID", "Client secret"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+
+        await ctx.clickText("Cancel", { timeoutMs: 10_000 });
+        await waitForDialogClosed(ctx);
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("Creating a Slack-style OAuth-client connection shows the exact redirect URL handoff and Copy button", {
+          voiceover: vo[5],
+          action: async () => {
+            const clicked = await ctx.eval(clickCustomMcpCardScript());
+            ctx.assert(clicked, "Custom MCP server card was not found.");
+            await ctx.waitFor("Boolean(document.querySelector('input[placeholder=\"notion\"]'))", { timeoutMs: 10_000, label: "custom MCP dialog" });
+            await ctx.fill('input[placeholder="notion"]', CONNECTION_NAME);
+            await ctx.fill('input[placeholder="https://mcp.example.com/mcp"]', `${MOCK_SERVER_URL}/mcp`);
+            await ctx.clickText("This server needs a pre-registered OAuth app", { timeoutMs: 10_000 });
+            await ctx.fill('input[placeholder="1234567890.1234567890123"]', MOCK_CLIENT_ID);
+            await ctx.fill('input[placeholder="Client secret"]', MOCK_CLIENT_SECRET);
+            await clickCreateConnectionAndHandleReauth(ctx);
+            await ctx.waitForText("Almost done", { timeoutMs: 20_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("redirect URL");
+            await ctx.expectText("/connect/callback");
+            await ctx.expectText("Copy");
+            state.callbackUrl = await ctx.eval(callbackUrlScript());
+            ctx.assert(Boolean(state.callbackUrl), "The redirect URL handoff did not render a callback URL.");
+            ctx.assert(state.callbackUrl.includes("/v1/mcp-connections/"), `Callback URL did not include the connection route: ${state.callbackUrl}`);
+
+            await refreshAdminSession(ctx);
+            const list = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+              headers: orgHeaders(state.adminSession),
+            });
+            ctx.assert(list.response.ok, `Listing manageable connections failed: ${list.response.status} ${JSON.stringify(list.body).slice(0, 200)}`);
+            const connection = (list.body.connections ?? []).find((entry) => entry.name === CONNECTION_NAME);
+            ctx.assert(Boolean(connection), `Created Slack-style connection ${CONNECTION_NAME} not found via API.`);
+            state.connectionId = connection.id;
+          },
+          screenshot: {
+            name: "slack-style-redirect-url-copy-handoff",
+            claim: "After creation, OpenWork shows the exact redirect URL and a Copy button before teammates connect.",
+            requireText: ["Almost done", "redirect URL", "/connect/callback", "Copy"],
+            rejectText: ["Something went wrong", "Failed to add connection"],
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup: delete the Slack-style test connection",
+      run: async (ctx) => {
+        if (!state.connectionId) return;
+        await refreshAdminSession(ctx);
+        const removed = await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+          method: "DELETE",
+          headers: orgHeaders(state.adminSession),
+        });
+        ctx.assert(removed.response.ok, `Cleanup delete failed for ${state.connectionId}: ${removed.response.status}`);
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/google-slack-oauth-ux.md
+++ b/evals/voiceovers/google-slack-oauth-ux.md
@@ -1,0 +1,13 @@
+# google-slack-oauth-ux — Clear OAuth setup, reauth recovery, and safe credential edits
+
+1. “I open Connections and choose Google Workspace. OpenWork shows exactly how to create the Google OAuth app, including the redirect URI I need to copy, so I’m not guessing between Cloud Console tabs.”
+
+2. “When I save Google Workspace settings and OpenWork needs a fresh security check, the dialog gives me one obvious next step: Continue with Google. After I confirm, OpenWork retries the save automatically.”
+
+3. “Later I reopen Google Workspace to make a permissions-only edit. The app shows that credentials are already saved, and I can save the edit without pasting the client ID or secret again.”
+
+4. “If I really need to rotate the Google credentials, I choose Replace credentials. Only then do the client ID and client secret fields become editable and required again.”
+
+5. “I add Slack from quick add, and OpenWork explains Slack’s requirement up front: Slack MCP needs a pre-registered Slack app because Slack does not support automatic app registration.”
+
+6. “After I create the Slack connection, OpenWork shows the exact redirect URL to add to the Slack app and gives me a copy button. I know which URL to whitelist before teammates connect.”


### PR DESCRIPTION
## Summary
- clarify Google Workspace OAuth setup with the exact redirect URI and credential-preserving edits
- add a saved-credentials / replace-credentials flow for Google Workspace settings
- make Slack's pre-registered OAuth app requirement and redirect URL handoff explicit
- make workspace reauth copy/action clearer and add fraimz proof coverage

## Validation
- node --check evals/flows/google-slack-oauth-ux.flow.mjs
- git diff --check
- pnpm --filter @openwork-ee/den-web build
- pnpm --filter @openwork-ee/den-api build
- OPENWORK_EVAL_DEN_PORT=8895 OPENWORK_EVAL_DEN_WEB_URL=http://127.0.0.1:3015 OPENWORK_EVAL_DEN_MYSQL_CONTAINER=openwork-web-local-mysql pnpm fraimz --flow google-slack-oauth-ux --stack den

Fraimz: evals/results/2026-07-09T04-43-31-824Z/fraimz.html