### PR TITLE
fix(den): honor forwarded MCP origins and OAuth redirects

### DIFF
--- a/ee/apps/den-api/src/capability-sources/generic-oauth.ts
+++ b/ee/apps/den-api/src/capability-sources/generic-oauth.ts
@@ -1,5 +1,6 @@
 import { createHash, createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto"
 import type { DenTypeId } from "@openwork-ee/utils/typeid"
+import { publicRequestUrl } from "../request-url.js"
 import { clientSelectedFeatures, resolveProviderScopes, type NativeOAuthProviderConfig } from "./provider-registry.js"
 import {
   getConnectedAccount,
@@ -28,14 +29,15 @@ function base64UrlEncode(input: Buffer | string) {
  * reverse proxy (e.g. Daytona's port-forwarding proxy), `request.url`
  * reflects the *internal* bind address (http://127.0.0.1:8788) rather than
  * the public URL the browser actually called, since the proxy doesn't
- * rewrite the request's own URL — only `DEN_API_PUBLIC_URL`, when set,
- * reliably gives the real public origin in that case.
+ * rewrite the request's own URL — `x-forwarded-proto` can correct the
+ * scheme, while `DEN_API_PUBLIC_URL`, when set, is still needed when the
+ * proxy does not preserve the public host.
  */
 export function resolvePublicOrigin(request: Request, apiPublicUrl: string | undefined): string {
   if (apiPublicUrl) {
     return new URL(apiPublicUrl).origin
   }
-  return new URL(request.url).origin
+  return publicRequestUrl(request).origin
 }
 
 export function createPkcePair() {

--- a/ee/apps/den-api/src/mcp/auth.ts
+++ b/ee/apps/den-api/src/mcp/auth.ts
@@ -14,6 +14,7 @@ import {
 } from "../auth.js"
 import { db } from "../db.js"
 import { env } from "../env.js"
+import { publicRequestUrl } from "../request-url.js"
 import { DEN_JWT_SIGNING_ALGORITHM, getDenAuthIssuer } from "./jwt-policy.js"
 import { resolveMcpResourceFromRequest } from "./resource.js"
 
@@ -35,7 +36,7 @@ export function getMcpResourceUrl(request: Request) {
   // candidates from the request origin for multi-origin deployments, but only
   // honor static boot-time allowlist entries so a Host header cannot mint an
   // arbitrary audience.
-  return resolveMcpResourceFromRequest(request.url, DEN_MCP_RESOURCES, DEN_MCP_RESOURCE)
+  return resolveMcpResourceFromRequest(publicRequestUrl(request).toString(), DEN_MCP_RESOURCES, DEN_MCP_RESOURCE)
 }
 
 export function getMcpJwtVerifyOptions(): McpJwtVerifyOptions {

--- a/ee/apps/den-api/src/mcp/oauth-client-policy.ts
+++ b/ee/apps/den-api/src/mcp/oauth-client-policy.ts
@@ -1,8 +1,8 @@
-const BLOCKED_CUSTOM_REDIRECT_PROTOCOLS = new Set([
-  "data:",
-  "file:",
-  "javascript:",
-  "vbscript:",
+const BLOCKED_CUSTOM_REDIRECT_SCHEMES = new Set([
+  "data",
+  "file",
+  "javascript",
+  "vbscript",
 ])
 
 function isIpv4Loopback(hostname: string) {
@@ -30,9 +30,9 @@ function isLoopbackHostname(hostname: string) {
     || isIpv4Loopback(normalized)
 }
 
-function isPrivateUseCustomScheme(protocol: string) {
+function isCustomAppScheme(protocol: string) {
   const scheme = protocol.endsWith(":") ? protocol.slice(0, -1) : protocol
-  return /^[a-z][a-z0-9+.-]*$/.test(scheme) && scheme.includes(".")
+  return /^[a-z][a-z0-9+.-]*$/.test(scheme) && !BLOCKED_CUSTOM_REDIRECT_SCHEMES.has(scheme)
 }
 
 export function isAllowedMcpOAuthRedirectUri(uri: string) {
@@ -43,15 +43,15 @@ export function isAllowedMcpOAuthRedirectUri(uri: string) {
     return false
   }
 
-  if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+  if (parsed.protocol === "https:") {
+    return true
+  }
+
+  if (parsed.protocol === "http:") {
     return isLoopbackHostname(parsed.hostname)
   }
 
-  if (BLOCKED_CUSTOM_REDIRECT_PROTOCOLS.has(parsed.protocol)) {
-    return false
-  }
-
-  return isPrivateUseCustomScheme(parsed.protocol)
+  return isCustomAppScheme(parsed.protocol)
 }
 
 export function getInvalidMcpOAuthRedirectUris(value: unknown) {

--- a/ee/apps/den-api/src/request-url.ts
+++ b/ee/apps/den-api/src/request-url.ts
@@ -1,0 +1,8 @@
+export function publicRequestUrl(request: Request): URL {
+  const url = new URL(request.url)
+  const proto = request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim().toLowerCase()
+  if (proto === "https" || proto === "http") {
+    url.protocol = `${proto}:`
+  }
+  return url
+}

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -16,6 +16,7 @@ import { normalizeMcpOAuthClientScope } from "../../mcp/scopes.js"
 import { publicRoute, tokenRoute } from "../../middleware/index.js"
 import { emptyResponse, jsonResponse } from "../../openapi.js"
 import { getSingletonSsoStatus } from "../../orgs.js"
+import { publicRequestUrl } from "../../request-url.js"
 import { samlResponsePolicyMiddleware } from "../../sso-saml-response-middleware.js"
 import type { AuthContextVariables } from "../../session.js"
 import { registerDesktopAuthRoutes } from "./desktop-handoff.js"
@@ -184,7 +185,7 @@ async function rewriteMcpClientRegistrationRequest(request: Request, path: strin
     return oauthRegistrationError(
       400,
       "invalid_redirect_uri",
-      "MCP OAuth redirect URIs must use loopback HTTP(S) or a private-use custom scheme.",
+      "MCP OAuth redirect URIs must use HTTPS, loopback HTTP, or a custom app scheme.",
     )
   }
 
@@ -227,7 +228,7 @@ async function rewriteMetadataOrigin(response: Response, origin: string) {
 }
 
 function requestOrigin(request: Request) {
-  return new URL(request.url).origin
+  return publicRequestUrl(request).origin
 }
 
 const authLoginLockedSchema = z.object({

--- a/ee/apps/den-api/test/mcp-oauth-client-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-oauth-client-policy.test.ts
@@ -4,24 +4,34 @@ import {
   isAllowedMcpOAuthRedirectUri,
 } from "../src/mcp/oauth-client-policy.js"
 
-test("MCP OAuth redirect policy allows loopback redirects", () => {
-  expect(isAllowedMcpOAuthRedirectUri("http://127.0.0.1:49321/callback")).toBe(true)
-  expect(isAllowedMcpOAuthRedirectUri("http://localhost:49321/callback")).toBe(true)
-  expect(isAllowedMcpOAuthRedirectUri("https://dev.localhost/callback")).toBe(true)
-  expect(isAllowedMcpOAuthRedirectUri("http://[::1]:49321/callback")).toBe(true)
+test("MCP OAuth redirect policy allows HTTPS, loopback HTTP, and custom schemes", () => {
+  for (const uri of [
+    "http://127.0.0.1:49321/callback",
+    "http://localhost:49321/callback",
+    "http://[::1]:49321/callback",
+    "https://dev.localhost/callback",
+    "com.openwork.desktop:/oauth/callback",
+    "cursor://anysphere.cursor-mcp/oauth/callback",
+    "openwork:/oauth/callback",
+    "https://www.cursor.com/agents/mcp/oauth/callback",
+    "https://claude.ai/api/mcp/auth_callback",
+    "https://example.com/oauth/callback",
+  ]) {
+    expect(isAllowedMcpOAuthRedirectUri(uri)).toBe(true)
+  }
 })
 
-test("MCP OAuth redirect policy allows private-use custom schemes", () => {
-  expect(isAllowedMcpOAuthRedirectUri("com.openwork.desktop:/oauth/callback")).toBe(true)
-  expect(isAllowedMcpOAuthRedirectUri("software.openwork.app://oauth/callback")).toBe(true)
-})
-
-test("MCP OAuth redirect policy rejects public web and dangerous redirects", () => {
-  expect(isAllowedMcpOAuthRedirectUri("https://example.com/oauth/callback")).toBe(false)
-  expect(isAllowedMcpOAuthRedirectUri("http://example.com/oauth/callback")).toBe(false)
-  expect(isAllowedMcpOAuthRedirectUri("javascript:alert(1)")).toBe(false)
-  expect(isAllowedMcpOAuthRedirectUri("file:///tmp/callback")).toBe(false)
-  expect(isAllowedMcpOAuthRedirectUri("openwork:/oauth/callback")).toBe(false)
+test("MCP OAuth redirect policy rejects non-loopback HTTP, blocked schemes, and non-URLs", () => {
+  for (const uri of [
+    "http://example.com/oauth/callback",
+    "javascript:alert(1)",
+    "file:///tmp/callback",
+    "data:text/plain,callback",
+    "vbscript:foo",
+    "not a url",
+  ]) {
+    expect(isAllowedMcpOAuthRedirectUri(uri)).toBe(false)
+  }
 })
 
 test("MCP OAuth redirect policy lists invalid registration redirect URIs", () => {
@@ -29,9 +39,16 @@ test("MCP OAuth redirect policy lists invalid registration redirect URIs", () =>
     "http://127.0.0.1:49321/callback",
     "https://example.com/oauth/callback",
     "com.openwork.desktop:/oauth/callback",
+    "openwork:/oauth/callback",
+    "http://example.com/oauth/callback",
     "data:text/plain,callback",
   ])).toEqual([
-    "https://example.com/oauth/callback",
+    "http://example.com/oauth/callback",
     "data:text/plain,callback",
   ])
+
+  expect(getInvalidMcpOAuthRedirectUris([
+    "cursor://anysphere.cursor-mcp/oauth/callback",
+    "https://www.cursor.com/agents/mcp/oauth/callback",
+  ])).toEqual([])
 })

--- a/ee/apps/den-api/test/mcp-resource-url.test.ts
+++ b/ee/apps/den-api/test/mcp-resource-url.test.ts
@@ -5,16 +5,20 @@ import { fileURLToPath } from "node:url"
 import { deriveDenMcpResource, resolveMcpResourceFromRequest } from "../src/mcp/resource.js"
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..")
+const denApiRoot = path.join(repoRoot, "ee/apps/den-api")
 
 type ProbeOptions = {
   betterAuthUrl: string
   apiPublicUrl?: string
   additionalResources?: string
+  headers?: Record<string, string>
   requestUrl: string
   expectedResource: string
   metadataUrl?: string
   expectedMetadataResource?: string
   expectedAuthorizationServer?: string
+  authMetadataUrl?: string
+  expectedAuthIssuer?: string
 }
 
 function runMcpResourceProbe(options: ProbeOptions) {
@@ -25,8 +29,10 @@ if (!requestUrl || !expectedResource) {
   throw new Error("Missing MCP resource probe inputs")
 }
 
-const { getMcpResourceUrl } = await import("./ee/apps/den-api/src/mcp/auth.js")
-const resource = getMcpResourceUrl(new Request(requestUrl))
+const { getMcpResourceUrl } = await import("./src/mcp/auth.js")
+const requestHeaders = JSON.parse(process.env.TEST_REQUEST_HEADERS ?? "{}")
+const requestInit = { headers: requestHeaders }
+const resource = getMcpResourceUrl(new Request(requestUrl, requestInit))
 if (resource !== expectedResource) {
   throw new Error(\`Expected resource \${expectedResource}, got \${resource}\`)
 }
@@ -39,8 +45,8 @@ if (metadataUrl) {
     throw new Error("Missing MCP metadata probe expectations")
   }
 
-  const { protectedResourceMetadata } = await import("./ee/apps/den-api/src/mcp/index.js")
-  const metadata = protectedResourceMetadata(new Request(metadataUrl))
+  const { protectedResourceMetadata } = await import("./src/mcp/index.js")
+  const metadata = protectedResourceMetadata(new Request(metadataUrl, requestInit))
   const authorizationServer = metadata.authorization_servers[0]
   if (metadata.resource !== expectedMetadataResource) {
     throw new Error(\`Expected metadata resource \${expectedMetadataResource}, got \${metadata.resource}\`)
@@ -50,11 +56,32 @@ if (metadataUrl) {
   }
 }
 
+const authMetadataUrl = process.env.TEST_AUTH_METADATA_URL
+if (authMetadataUrl) {
+  const expectedAuthIssuer = process.env.EXPECTED_AUTH_ISSUER
+  if (!expectedAuthIssuer) {
+    throw new Error("Missing auth metadata probe expectations")
+  }
+
+  const { Hono } = await import("hono")
+  const { registerAuthRoutes } = await import("./src/routes/auth/index.js")
+  const app = new Hono()
+  registerAuthRoutes(app)
+  const response = await app.request(new Request(authMetadataUrl, requestInit))
+  if (!response.ok) {
+    throw new Error(\`Expected auth metadata response to be ok, got \${response.status}: \${await response.text()}\`)
+  }
+  const metadata = await response.json()
+  if (metadata.issuer !== expectedAuthIssuer) {
+    throw new Error(\`Expected auth issuer \${expectedAuthIssuer}, got \${metadata.issuer}\`)
+  }
+}
+
 console.log("ok")
 `
 
   const result = spawnSync(process.execPath, ["--conditions", "development", "--eval", script], {
-    cwd: repoRoot,
+    cwd: denApiRoot,
     encoding: "utf8",
     env: {
       PATH: process.env.PATH ?? "",
@@ -72,11 +99,14 @@ console.log("ok")
       DEN_MCP_RESOURCE_URL: "",
       DEN_MCP_ADDITIONAL_RESOURCES: options.additionalResources ?? "",
       DEN_WEB_APP_HOSTS: "",
+      TEST_REQUEST_HEADERS: JSON.stringify(options.headers ?? {}),
       TEST_REQUEST_URL: options.requestUrl,
       EXPECTED_RESOURCE: options.expectedResource,
       TEST_METADATA_URL: options.metadataUrl ?? "",
       EXPECTED_METADATA_RESOURCE: options.expectedMetadataResource ?? "",
       EXPECTED_AUTHORIZATION_SERVER: options.expectedAuthorizationServer ?? "",
+      TEST_AUTH_METADATA_URL: options.authMetadataUrl ?? "",
+      EXPECTED_AUTH_ISSUER: options.expectedAuthIssuer ?? "",
     },
   })
 
@@ -102,6 +132,30 @@ describe("getMcpResourceUrl", () => {
       metadataUrl: "https://api.example.com/mcp/agent",
       expectedMetadataResource: "https://api.example.com/mcp",
       expectedAuthorizationServer: "https://api.example.com/api/auth",
+    })
+  })
+
+  test("selects the https public API resource behind a TLS-terminating proxy", () => {
+    runMcpResourceProbe({
+      betterAuthUrl: "https://app.example.com",
+      apiPublicUrl: "https://api.example.com",
+      headers: { "x-forwarded-proto": "https, http" },
+      requestUrl: "http://api.example.com/mcp/agent",
+      expectedResource: "https://api.example.com/mcp",
+      metadataUrl: "http://api.example.com/mcp/agent",
+      expectedMetadataResource: "https://api.example.com/mcp",
+      expectedAuthorizationServer: "https://api.example.com/api/auth",
+      authMetadataUrl: "http://api.example.com/api/auth/.well-known/oauth-authorization-server",
+      expectedAuthIssuer: "https://api.example.com/api/auth",
+    })
+  })
+
+  test("keeps plain-http origins when no forwarded proto", () => {
+    runMcpResourceProbe({
+      betterAuthUrl: "https://app.example.com",
+      apiPublicUrl: "https://api.example.com",
+      requestUrl: "http://api.example.com/mcp/agent",
+      expectedResource: "https://app.example.com/api/den/mcp",
     })
   })
 


### PR DESCRIPTION
## Summary\n- honor x-forwarded-proto when den-api derives public request origins for MCP resources, auth metadata, and generic OAuth fallback origins\n- relax MCP dynamic client registration redirect policy to allow HTTPS callbacks and non-blocked custom app schemes like Cursor\n- add regression coverage for TLS-terminating proxy resource metadata and Cursor redirect registration policy\n\n## Verification\n- pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/mcp-oauth-client-policy.test.ts test/mcp-resource-url.test.ts — pass (12 pass / 0 fail)\n- pnpm --filter @openwork-ee/den-api exec tsc --noEmit — pass\n- pnpm --filter @openwork-ee/den-api exec bun test --conditions development test — existing suite failures only; compared against pristine origin/dev and failure sets were identical (74 fail-lines both before and after)\n\n## Proof notes\nNo fraimz UI proof: server/auth behavior only. The in-process probe tests exercise the affected Hono routes and request metadata paths. Post-deploy smoke checks should confirm api.openworklabs.com advertises https://api.openworklabs.com/mcp and accepts Cursor redirect URIs.