### PR TITLE
Guide Slack setup through the Agents & AI Apps MCP toggle (stacked on #2617)

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -1307,11 +1307,22 @@ function AddConnectionDialog({
           {showOAuthClientFields ? (
             <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
               <p className="text-[13px] font-semibold text-gray-900">{isSlackPreset ? "Slack OAuth app" : "OAuth app"}</p>
-              <p className="mt-1 text-[12px] leading-5 text-gray-500">
-                {isSlackPreset
-                  ? "Create or use an internal or directory-published Slack app, then paste its Client ID and Client secret. After you create the connection, OpenWork shows the exact redirect URL to add to that Slack app."
-                  : "Create an app for your workspace, then paste its OAuth client here. Each person connects their own account with it — sign-ins stay in your org's cloud."}
-              </p>
+              {isSlackPreset ? (
+                <ol className="mt-2 list-decimal space-y-2 pl-4 text-[12px] leading-5 text-gray-600">
+                  <li>
+                    Create or use an internal or directory-published Slack app.{" "}
+                    <a href="https://api.slack.com/apps" target="_blank" rel="noopener" className="font-medium text-gray-900 underline decoration-gray-300 underline-offset-4">
+                      Open Slack apps
+                    </a>
+                  </li>
+                  <li>In the app&apos;s settings, open Agents &amp; AI Apps and turn on Model Context Protocol — Slack MCP rejects connections until this is enabled.</li>
+                  <li>Paste the app&apos;s Client ID and Client secret below. After you create the connection, OpenWork shows the exact redirect URL to add to that Slack app.</li>
+                </ol>
+              ) : (
+                <p className="mt-1 text-[12px] leading-5 text-gray-500">
+                  {"Create an app for your workspace, then paste its OAuth client here. Each person connects their own account with it — sign-ins stay in your org's cloud."}
+                </p>
+              )}
               <div className="mt-3 space-y-3">
                 <div>
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client ID</label>

--- a/evals/flows/google-slack-oauth-ux.flow.mjs
+++ b/evals/flows/google-slack-oauth-ux.flow.mjs
@@ -650,13 +650,15 @@ export default {
             await ctx.expectText("pre-registered Slack app");
             await ctx.expectText("automatic app registration");
             await ctx.expectText("Slack OAuth app");
+            await ctx.expectText("Agents & AI Apps");
+            await ctx.expectText("Model Context Protocol");
             await ctx.expectText("Client ID");
             await ctx.expectText("Client secret");
           },
           screenshot: {
             name: "slack-quick-add-preregistered-oauth-copy",
             claim: "Slack quick-add names Slack MCP, the Slack app requirement, and the client ID/secret fields up front.",
-            requireText: ["Add Slack", "Slack MCP", "pre-registered Slack app", "automatic app registration", "Slack OAuth app", "Client ID", "Client secret"],
+            requireText: ["Add Slack", "Slack MCP", "pre-registered Slack app", "automatic app registration", "Slack OAuth app", "Agents & AI Apps", "Model Context Protocol", "Client ID", "Client secret"],
             rejectText: ["Something went wrong"],
           },
         });


### PR DESCRIPTION
## Summary
Stacked on #2617. Slack's MCP server rejects connections unless the Slack app has **Features → Agents & AI Apps → Model Context Protocol** toggled on (https://api.slack.com/apps/<APP_ID>/app-assistant) — users hit this as a runtime error ('app is not enabled for MCP') with no guidance from us.

- Slack OAuth app panel now uses the same numbered 'how to set it up' pattern as the Google Workspace dialog:
  1. create/use an internal or directory-published Slack app (link to api.slack.com/apps)
  2. open Agents & AI Apps and turn on Model Context Protocol — called out as required
  3. paste Client ID/secret; redirect URL comes after creation
- fraimz Frame 5 now asserts 'Agents & AI Apps' and 'Model Context Protocol' are visible before creation.

Ref: https://docs.slack.dev/ai/slack-mcp-server/developing/ ('Enable the app for MCP by navigating to the Agents & AI Apps sidebar section and toggling On the Model Context Protocol feature.')

## Validation
- pnpm --filter @openwork-ee/den-web build
- node --check evals/flows/google-slack-oauth-ux.flow.mjs
- git diff --check
- OPENWORK_EVAL_DEN_PORT=8895 OPENWORK_EVAL_DEN_WEB_URL=http://127.0.0.1:3015 OPENWORK_EVAL_DEN_MYSQL_CONTAINER=openwork-web-local-mysql pnpm fraimz --flow google-slack-oauth-ux --stack den — PASSED (all 6 frames)