### PR TITLE
fix(cloud): Gmail draft capability silently dropped threadId and cc — thread reply drafts properly

### DIFF
--- a/ee/apps/den-api/src/capability-sources/gmail.ts
+++ b/ee/apps/den-api/src/capability-sources/gmail.ts
@@ -38,15 +38,18 @@ export function readGmailDraftIds(text: string): { draftId: string | null; messa
   }
 }
 
-export function buildGmailDraftRaw(input: { to: string; subject: string; body: string }): string {
+export function buildGmailDraftRaw(input: { to: string; cc?: string; bcc?: string; subject: string; body: string; headers?: { name: string; value: string }[] }): string {
   const message = [
     `To: ${input.to}`,
+    input.cc ? `Cc: ${input.cc}` : null,
+    input.bcc ? `Bcc: ${input.bcc}` : null,
     `Subject: ${encodeMimeHeaderValue(input.subject)}`,
+    ...(input.headers ?? []).map((header) => `${header.name}: ${header.value}`),
     "MIME-Version: 1.0",
     'Content-Type: text/plain; charset="UTF-8"',
     "Content-Transfer-Encoding: base64",
     "",
     Buffer.from(input.body, "utf8").toString("base64"),
-  ].join("\r\n")
+  ].filter((line) => typeof line === "string").join("\r\n")
   return Buffer.from(message, "utf8").toString("base64url")
 }

--- a/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
+++ b/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
@@ -139,6 +139,23 @@ function readGmailHeaders(payload: Record<string, unknown>) {
   return headers
 }
 
+export function extractGmailThreadReplyContext(json: unknown): { lastMessageId: string; references: string } | null {
+  const root = isRecord(json) ? json : {}
+  const messages = readArray(root, "messages")
+  const lastMessage = messages.at(-1)
+  if (!isRecord(lastMessage)) return null
+
+  const payload = readRecord(lastMessage, "payload")
+  if (!payload) return null
+
+  const headers = readGmailHeaders(payload)
+  const lastMessageId = headers.get("message-id")?.trim() ?? ""
+  if (!lastMessageId) return null
+
+  const references = `${headers.get("references")?.trim() ?? ""} ${lastMessageId}`.trim()
+  return { lastMessageId, references }
+}
+
 export function truncateText(text: string, maxCharacters: number): { text: string; truncated: boolean } {
   if (text.length <= maxCharacters) {
     return { text, truncated: false }

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -14,6 +14,7 @@ import {
   extractDriveFiles,
   extractGmailMessage,
   extractGmailMessageIds,
+  extractGmailThreadReplyContext,
   truncateText,
 } from "../../capability-sources/google-workspace-api.js"
 import type { ConnectedAccountRow } from "../../capability-sources/oauth-credentials.js"
@@ -32,9 +33,12 @@ const CONNECT_GOOGLE_ACCOUNT_MESSAGE = "Connect your Google account first: open 
 
 const createDraftBodySchema = z.object({
   to: z.string().trim().min(3).max(320).describe("Recipient email address."),
+  cc: z.string().trim().min(3).max(1_000).optional().describe("Optional comma-separated Cc email addresses."),
+  bcc: z.string().trim().min(3).max(1_000).optional().describe("Optional comma-separated Bcc email addresses."),
   subject: z.string().trim().min(1).max(500).describe("Draft subject line."),
   body: z.string().min(1).max(50_000).describe("Plain-text draft body."),
-})
+  threadId: z.string().trim().min(1).max(512).optional().describe("Optional Gmail thread id to reply on. Get it from the gmail-messages capability. When set, the draft is attached to that thread as a reply — keep the thread's subject (e.g. 'Re: …')."),
+}).strict()
 
 const createDraftResponseSchema = z.object({
   ok: z.literal(true),
@@ -42,6 +46,7 @@ const createDraftResponseSchema = z.object({
   messageId: z.string().nullable(),
   to: z.string(),
   subject: z.string(),
+  threadId: z.string().nullable(),
 }).meta({ ref: "GoogleWorkspaceDraftResponse" })
 
 const needsConnectionSchema = z.object({
@@ -736,12 +741,12 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     "/v1/capabilities/google-workspace/gmail-drafts",
     describeRoute({
       tags: ["Capability Sources"],
-      summary: "Create a Gmail draft as the calling member",
-      description: "Creates a plain-text Gmail draft in the calling member own mailbox, using the Google account they connected through the org Google Workspace connection. Returns needs_connection when the member has not connected their Google account yet.",
+      summary: "Create a Gmail draft or threaded reply draft as the calling member",
+      description: "Creates a plain-text Gmail draft in the calling member own mailbox, with optional Cc/Bcc recipients. Set threadId to attach the draft to an existing Gmail thread as a reply using the thread's matching subject. Returns needs_connection when the member has not connected their Google account yet or when a threaded reply needs Gmail read permission.",
       responses: {
         200: jsonResponse("Draft created.", createDraftResponseSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
-        409: jsonResponse("The calling member has not connected their Google account.", needsConnectionSchema),
+        409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
         502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
       },
     }),
@@ -760,14 +765,46 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         return c.json({ error: "needs_connection", message: token.message }, 409)
       }
 
-      const { to, subject, body } = c.req.valid("json")
+      const { to, cc, bcc, subject, body, threadId } = c.req.valid("json")
+      const headers: { name: string; value: string }[] = []
+      if (threadId) {
+        if (missingScope(token.account, [GMAIL_READ_SCOPE])) {
+          return c.json({ error: "needs_connection", message: missingPermissionMessage("Gmail read") }, 409)
+        }
+
+        const threadUrl = new URL(`${gmailApiBase()}/gmail/v1/users/me/threads/${encodeURIComponent(threadId)}`)
+        threadUrl.searchParams.set("format", "metadata")
+        threadUrl.searchParams.append("metadataHeaders", "Message-ID")
+        threadUrl.searchParams.append("metadataHeaders", "References")
+        threadUrl.searchParams.append("metadataHeaders", "Subject")
+        const threadResponse = await googleWorkspaceApiFetch(threadUrl, {
+          headers: { authorization: `Bearer ${token.accessToken}` },
+        })
+        if (!threadResponse.ok) {
+          return c.json(await googleApiError("Gmail thread read", threadResponse), 502)
+        }
+
+        const replyContext = extractGmailThreadReplyContext(await readJson(threadResponse))
+        if (!replyContext) {
+          return c.json({ error: "google_api_error", message: "Gmail thread has no Message-ID metadata; cannot build a threaded reply draft." }, 502)
+        }
+        headers.push(
+          { name: "In-Reply-To", value: replyContext.lastMessageId },
+          { name: "References", value: replyContext.references },
+        )
+      }
+
+      const message: { raw: string; threadId?: string } = { raw: buildGmailDraftRaw({ to, cc, bcc, subject, body, headers }) }
+      if (threadId) {
+        message.threadId = threadId
+      }
       const response = await googleWorkspaceApiFetch(`${gmailApiBase()}/gmail/v1/users/me/drafts`, {
         method: "POST",
         headers: {
           authorization: `Bearer ${token.accessToken}`,
           "content-type": "application/json",
         },
-        body: JSON.stringify({ message: { raw: buildGmailDraftRaw({ to, subject, body }) } }),
+        body: JSON.stringify({ message }),
       })
       const text = await response.text()
       if (!response.ok) {
@@ -779,7 +816,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         return c.json({ error: "google_api_error", message: "Gmail returned no draft id." }, 502)
       }
 
-      return c.json({ ok: true, draftId, messageId, to, subject })
+      return c.json({ ok: true, draftId, messageId, to, subject, threadId: threadId ?? null })
     },
   )
 }

--- a/ee/apps/den-api/test/gmail-draft.test.ts
+++ b/ee/apps/den-api/test/gmail-draft.test.ts
@@ -9,11 +9,17 @@ function seedRequiredEnv() {
 }
 
 let gmail: typeof import("../src/capability-sources/gmail.js")
+let googleWorkspaceApi: typeof import("../src/capability-sources/google-workspace-api.js")
 
 beforeAll(async () => {
   seedRequiredEnv()
   gmail = await import("../src/capability-sources/gmail.js")
+  googleWorkspaceApi = await import("../src/capability-sources/google-workspace-api.js")
 })
+
+function decodeRaw(raw: string): string {
+  return Buffer.from(raw, "base64url").toString("utf8")
+}
 
 describe("buildGmailDraftRaw", () => {
   test("encodes a plain-ASCII draft as base64url RFC 822 with the body base64-encoded", () => {
@@ -30,12 +36,119 @@ describe("buildGmailDraftRaw", () => {
 
   test("non-ASCII subjects get RFC 2047 B-encoding, bodies survive UTF-8 round trips", () => {
     const raw = gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Résumé — próxima reunión", body: "Grüße aus Zürich ✅" })
-    const decoded = Buffer.from(raw, "base64url").toString("utf8")
+    const decoded = decodeRaw(raw)
     const subjectLine = decoded.split("\r\n").find((line) => line.startsWith("Subject: "))
     expect(subjectLine).toMatch(/^Subject: =\?UTF-8\?B\?[A-Za-z0-9+/=]+\?=$/)
     expect(Buffer.from(subjectLine!.slice("Subject: =?UTF-8?B?".length, -2), "base64").toString("utf8")).toBe("Résumé — próxima reunión")
     const bodyPart = decoded.split("\r\n\r\n")[1]
     expect(Buffer.from(bodyPart, "base64").toString("utf8")).toBe("Grüße aus Zürich ✅")
+  })
+
+  test("keeps legacy draft output unchanged when optional fields are absent", () => {
+    const raw = gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Follow up", body: "Hello Sam" })
+    expect(decodeRaw(raw)).toBe([
+      "To: sam@acme.test",
+      "Subject: Follow up",
+      "MIME-Version: 1.0",
+      'Content-Type: text/plain; charset="UTF-8"',
+      "Content-Transfer-Encoding: base64",
+      "",
+      Buffer.from("Hello Sam", "utf8").toString("base64"),
+    ].join("\r\n"))
+  })
+
+  test("emits Cc and Bcc header lines exactly when provided", () => {
+    const decoded = decodeRaw(gmail.buildGmailDraftRaw({
+      to: "sam@acme.test",
+      cc: "ada@acme.test, grace@acme.test",
+      bcc: "hidden@acme.test",
+      subject: "Follow up",
+      body: "Hello Sam",
+    }))
+    expect(decoded.split("\r\n").slice(0, 4)).toEqual([
+      "To: sam@acme.test",
+      "Cc: ada@acme.test, grace@acme.test",
+      "Bcc: hidden@acme.test",
+      "Subject: Follow up",
+    ])
+
+    const ccOnly = decodeRaw(gmail.buildGmailDraftRaw({
+      to: "sam@acme.test",
+      cc: "ada@acme.test",
+      subject: "Follow up",
+      body: "Hello Sam",
+    }))
+    expect(ccOnly.split("\r\n").slice(0, 3)).toEqual([
+      "To: sam@acme.test",
+      "Cc: ada@acme.test",
+      "Subject: Follow up",
+    ])
+    expect(ccOnly).not.toContain("Bcc:")
+  })
+
+  test("emits extra headers before MIME headers", () => {
+    const decoded = decodeRaw(gmail.buildGmailDraftRaw({
+      to: "sam@acme.test",
+      subject: "Re: Follow up",
+      body: "Hello Sam",
+      headers: [
+        { name: "In-Reply-To", value: "<orig-2@mail.gmail.com>" },
+        { name: "References", value: "<orig-1@mail.gmail.com> <orig-2@mail.gmail.com>" },
+      ],
+    }))
+    expect(decoded.split("\r\n").slice(0, 5)).toEqual([
+      "To: sam@acme.test",
+      "Subject: Re: Follow up",
+      "In-Reply-To: <orig-2@mail.gmail.com>",
+      "References: <orig-1@mail.gmail.com> <orig-2@mail.gmail.com>",
+      "MIME-Version: 1.0",
+    ])
+  })
+})
+
+describe("extractGmailThreadReplyContext", () => {
+  test("uses the last message Message-ID and appends it to prior References", () => {
+    expect(googleWorkspaceApi.extractGmailThreadReplyContext({
+      messages: [
+        { payload: { headers: [{ name: "Message-ID", value: "<orig-1@mail.gmail.com>" }] } },
+        {
+          payload: {
+            headers: [
+              { name: "Message-ID", value: "<orig-2@mail.gmail.com>" },
+              { name: "References", value: "<orig-1@mail.gmail.com>" },
+            ],
+          },
+        },
+      ],
+    })).toEqual({
+      lastMessageId: "<orig-2@mail.gmail.com>",
+      references: "<orig-1@mail.gmail.com> <orig-2@mail.gmail.com>",
+    })
+  })
+
+  test("uses only Message-ID when the last message has no References", () => {
+    expect(googleWorkspaceApi.extractGmailThreadReplyContext({
+      messages: [
+        {
+          payload: {
+            headers: [{ name: "message-id", value: "<orig-2@mail.gmail.com>" }],
+          },
+        },
+      ],
+    })).toEqual({
+      lastMessageId: "<orig-2@mail.gmail.com>",
+      references: "<orig-2@mail.gmail.com>",
+    })
+  })
+
+  test("returns null for an empty thread", () => {
+    expect(googleWorkspaceApi.extractGmailThreadReplyContext({ messages: [] })).toBeNull()
+  })
+
+  test("returns null when the last message has no Message-ID", () => {
+    expect(googleWorkspaceApi.extractGmailThreadReplyContext({
+      messages: [{ payload: { headers: [{ name: "References", value: "<orig-1@mail.gmail.com>" }] } }],
+    })).toBeNull()
   })
 })
 

--- a/ee/apps/den-api/test/google-workspace-api.test.ts
+++ b/ee/apps/den-api/test/google-workspace-api.test.ts
@@ -106,6 +106,7 @@ describe("extractCalendarEvents", () => {
         status: "confirmed",
         htmlLink: "https://calendar.google.com/event?eid=event_1",
         attendees: ["ada@example.com", "ben@example.com"],
+        meetLink: null,
       },
       {
         id: "event_2",
@@ -117,6 +118,7 @@ describe("extractCalendarEvents", () => {
         status: "",
         htmlLink: "",
         attendees: [],
+        meetLink: null,
       },
     ])
   })

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -48,6 +48,24 @@ function expectRecord(value: unknown, label: string): Record<string, unknown> {
   return value
 }
 
+function expectString(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`Expected ${label} to be a string`)
+  }
+  return value
+}
+
+function expectDraftMessage(): Record<string, unknown> {
+  const payload = expectRecord(lastDraftPayload, "Gmail draft payload")
+  return expectRecord(payload.message, "Gmail draft message")
+}
+
+function decodeDraftRaw(): string {
+  const message = expectDraftMessage()
+  const raw = expectString(message.raw, "Gmail draft raw")
+  return Buffer.from(raw, "base64url").toString("utf8")
+}
+
 const GMAIL_READ_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
 const CALENDAR_READ_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
 const CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
@@ -56,22 +74,30 @@ const FULL_SCOPES = [GMAIL_READ_SCOPE, CALENDAR_READ_SCOPE, CALENDAR_EVENTS_SCOP
 
 let lastAuthorization: string | null = null
 let googleCallCount = 0
+let googleCallUrls: string[] = []
 let forceGoogleError = false
+let forceGmailThreadError = false
 let lastDriveQuery: string | null = null
 let lastCalendarEventPayload: unknown = null
 let lastCalendarUrl: string | null = null
 let lastCalendarMethod: string | null = null
 let calendarCreateCount = 0
+let lastDraftPayload: unknown = null
+let lastGmailThreadUrl: string | null = null
 
 function resetFakeGoogle() {
   lastAuthorization = null
   googleCallCount = 0
+  googleCallUrls = []
   forceGoogleError = false
+  forceGmailThreadError = false
   lastDriveQuery = null
   lastCalendarEventPayload = null
   lastCalendarUrl = null
   lastCalendarMethod = null
   calendarCreateCount = 0
+  lastDraftPayload = null
+  lastGmailThreadUrl = null
 }
 
 function gmailMessagePayload() {
@@ -101,6 +127,7 @@ const fakeGoogleServer = Bun.serve({
   async fetch(request) {
     const url = new URL(request.url)
     googleCallCount += 1
+    googleCallUrls.push(request.url)
     lastAuthorization = request.headers.get("authorization")
 
     if (url.pathname.startsWith("/calendar/v3/calendars/primary/events")) {
@@ -117,6 +144,40 @@ const fakeGoogleServer = Bun.serve({
     }
     if (url.pathname === "/gmail/v1/users/me/messages/msg_1") {
       return json(gmailMessagePayload())
+    }
+    if (url.pathname === "/gmail/v1/users/me/threads/thread_1") {
+      lastGmailThreadUrl = request.url
+      if (forceGmailThreadError) {
+        return new Response("thread exploded", { status: 500 })
+      }
+      return json({
+        messages: [
+          {
+            id: "msg_1",
+            payload: {
+              headers: [
+                { name: "Message-ID", value: "<orig-1@mail.gmail.com>" },
+                { name: "Subject", value: "Quarterly plan" },
+              ],
+            },
+          },
+          {
+            id: "msg_2",
+            payload: {
+              headers: [
+                { name: "Message-ID", value: "<orig-2@mail.gmail.com>" },
+                { name: "References", value: "<orig-1@mail.gmail.com>" },
+                { name: "Subject", value: "Quarterly plan" },
+              ],
+            },
+          },
+        ],
+      })
+    }
+    if (url.pathname === "/gmail/v1/users/me/drafts" && request.method === "POST") {
+      const body: unknown = await request.json()
+      lastDraftPayload = body
+      return json({ id: "draft_1", message: { id: "draft_msg_1", threadId: "thread_1" } })
     }
 
     if (url.pathname === "/calendar/v3/calendars/primary/events" && request.method === "GET") {
@@ -457,6 +518,128 @@ test("gmail list returns metadata-mapped messages", async () => {
       },
     ],
   })
+})
+
+test("gmail plain draft supports cc without requiring a thread", async () => {
+  const to = "sam@acme.test"
+  const subject = "Quarterly plan"
+  const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+    method: "POST",
+    body: {
+      to,
+      cc: "ada@acme.test, grace@acme.test",
+      subject,
+      body: "Draft body",
+    },
+  })
+  expect(response.status).toBe(200)
+  expect(googleCallCount).toBe(1)
+  const message = expectDraftMessage()
+  expect("threadId" in message).toBe(false)
+  const decoded = decodeDraftRaw()
+  expect(decoded).toContain("To: sam@acme.test\r\n")
+  expect(decoded).toContain("Cc: ada@acme.test, grace@acme.test\r\n")
+  expect(decoded).toContain("Subject: Quarterly plan\r\n")
+  const body: unknown = await response.json()
+  expect(body).toEqual({ ok: true, draftId: "draft_1", messageId: "draft_msg_1", to, subject, threadId: null })
+})
+
+test("gmail threaded reply draft reads thread metadata and sends reply headers", async () => {
+  const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+    method: "POST",
+    body: {
+      to: "sam@acme.test",
+      cc: "ada@acme.test",
+      subject: "Quarterly plan",
+      threadId: "thread_1",
+      body: "Reply body",
+    },
+  })
+  expect(response.status).toBe(200)
+  expect(googleCallCount).toBe(2)
+  const firstUrl = new URL(expectString(googleCallUrls[0], "first Google URL"))
+  expect(firstUrl.pathname).toBe("/gmail/v1/users/me/threads/thread_1")
+  expect(firstUrl.searchParams.get("format")).toBe("metadata")
+  expect(firstUrl.searchParams.getAll("metadataHeaders")).toEqual(["Message-ID", "References", "Subject"])
+  const secondUrl = new URL(expectString(googleCallUrls[1], "second Google URL"))
+  expect(secondUrl.pathname).toBe("/gmail/v1/users/me/drafts")
+  expect(lastGmailThreadUrl).toBe(expectString(googleCallUrls[0], "first Google URL"))
+  const message = expectDraftMessage()
+  expect(message.threadId).toBe("thread_1")
+  const decoded = decodeDraftRaw()
+  expect(decoded).toContain("In-Reply-To: <orig-2@mail.gmail.com>\r\n")
+  expect(decoded).toContain("References: <orig-1@mail.gmail.com> <orig-2@mail.gmail.com>\r\n")
+  const body: unknown = await response.json()
+  const responseBody = expectRecord(body, "threaded draft response")
+  expect(responseBody.threadId).toBe("thread_1")
+})
+
+test("gmail threaded reply draft requires Gmail read scope before calling Google", async () => {
+  await seedConnectedAccount([CALENDAR_READ_SCOPE, CALENDAR_EVENTS_SCOPE, DRIVE_READ_SCOPE])
+  resetFakeGoogle()
+  const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+    method: "POST",
+    body: {
+      to: "sam@acme.test",
+      subject: "Quarterly plan",
+      threadId: "thread_1",
+      body: "Reply body",
+    },
+  })
+  expect(response.status).toBe(409)
+  expect(googleCallCount).toBe(0)
+  const body: unknown = await response.json()
+  expect(expectMessage(body)).toContain("missing the Gmail read permission")
+})
+
+test("gmail plain draft still works without Gmail read scope", async () => {
+  await seedConnectedAccount([CALENDAR_READ_SCOPE, CALENDAR_EVENTS_SCOPE, DRIVE_READ_SCOPE])
+  resetFakeGoogle()
+  const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+    method: "POST",
+    body: {
+      to: "sam@acme.test",
+      subject: "Quarterly plan",
+      body: "Draft body",
+    },
+  })
+  expect(response.status).toBe(200)
+  expect(googleCallCount).toBe(1)
+})
+
+test("gmail draft rejects unknown body keys without calling Google", async () => {
+  const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+    method: "POST",
+    body: {
+      to: "sam@acme.test",
+      subject: "Quarterly plan",
+      body: "Draft body",
+      replyTo: "x@y.z",
+    },
+  })
+  expect(response.status).toBe(400)
+  expect(googleCallCount).toBe(0)
+  const body: unknown = await response.json()
+  expect(expectRecord(body, "invalid request response").error).toBe("invalid_request")
+})
+
+test("gmail threaded reply draft returns google_api_error when thread metadata fetch fails", async () => {
+  forceGmailThreadError = true
+  const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+    method: "POST",
+    body: {
+      to: "sam@acme.test",
+      subject: "Quarterly plan",
+      threadId: "thread_1",
+      body: "Reply body",
+    },
+  })
+  expect(response.status).toBe(502)
+  expect(googleCallCount).toBe(1)
+  const body: unknown = await response.json()
+  const responseBody = expectRecord(body, "thread error response")
+  expect(responseBody.error).toBe("google_api_error")
+  expect(expectMessage(body).startsWith("Gmail thread read failed: 500")).toBe(true)
 })
 
 test("drive search returns mapped files", async () => {


### PR DESCRIPTION
## Summary

Real incident: an agent called `postCapabilitiesGoogleWorkspaceGmailDrafts` with `threadId` (reply on an existing thread) and `cc`. The route's zod body schema only declared `to`/`subject`/`body`, and zod strips unknown keys — so **`threadId` and `cc` were silently discarded**. Gmail created a standalone draft (not attached to the thread) with no Cc recipients, while the capability still returned `ok: true`, so the agent confidently told the user the reply draft was on the thread. It wasn't.

## What changed (`ee/apps/den-api`)

- **`routes/org/google-workspace.ts`** — the gmail-drafts capability now supports real reply drafts, mirroring the proven local-server mechanics (`apps/server/src/extensions/google-workspace.ts` `createReplyDraft`):
  - Body schema gains optional `cc`, `bcc`, `threadId` — and is now `.strict()`, so unknown keys fail loudly with 400 `invalid_request` instead of silently vanishing (the class-of-bug fix; `.strict()` matches existing den-api usage in `mcp/catalog.ts`).
  - When `threadId` is set: require the Gmail read scope (409 `needs_connection` with the actionable message, zero Google calls otherwise), fetch `users/me/threads/{id}?format=metadata` (Message-ID/References/Subject), then create the draft with `message.threadId` **and** RFC 2822 `In-Reply-To` + `References` headers — the three things Gmail needs to attach a draft to a thread. Thread fetch failures map to 502 `google_api_error`; a thread with no Message-ID metadata hard-fails rather than silently creating an unthreaded draft.
  - Plain drafts (no `threadId`) behave exactly as before and still don't require the read scope.
  - Response now echoes `threadId` (nullable) so callers can verify threading took effect.
- **`capability-sources/gmail.ts`** — `buildGmailDraftRaw` accepts optional `cc`, `bcc`, and extra headers; output is byte-identical for the legacy input shape (pinned by a new unit test).
- **`capability-sources/google-workspace-api.ts`** — new pure `extractGmailThreadReplyContext` (last message's Message-ID + References chain, case-insensitive headers, `unknown` + narrowing, no `any`/`as`).

Route path is unchanged, so the tool name `postCapabilitiesGoogleWorkspaceGmailDrafts` stays stable; the OpenAPI-derived tool schema now advertises `threadId`/`cc`/`bcc` with `additionalProperties: false`.

## Validation (commands + results)

From `ee/apps/den-api` (fake Google API via `DEN_GOOGLE_API_BASE_URL`, real MySQL):

```
bun test test/gmail-draft.test.ts test/google-workspace-api.test.ts test/google-workspace-capabilities.test.ts
# 34 pass / 0 fail — run twice, deterministic
bun test test/mcp-tool-name-length.test.ts test/route-access-policy.test.ts test/route-guard-policy.test.ts test/marketplace-capabilities.test.ts
# 18 pass / 1 fail — the route-guard-policy failure reproduces identically on clean origin/dev (pre-existing, unrelated)
pnpm --filter @openwork-ee/den-api build   # passes
```

New integration coverage drives the real route via `app.request` and asserts against the stubbed Google API:
- threaded reply: thread metadata GET (`format=metadata` + the 3 `metadataHeaders`), then drafts POST with `message.threadId === "thread_1"` and decoded RFC-822 raw containing `In-Reply-To: <orig-2@…>` / `References: <orig-1@…> <orig-2@…>` (last-message-wins pinned by a two-message thread)
- plain draft with `cc`: `Cc:` header present, **no** `threadId` key sent to Gmail, response `threadId: null`
- `threadId` without read scope: 409 + zero Google calls; plain draft without read scope still 200 (no regression)
- unknown body key (`replyTo`): 400 `invalid_request`, zero Google calls
- thread fetch 500: 502 `Gmail thread read failed: 500 …`

Also verified the generated `/openapi.json` request schema directly: properties `[to, cc, bcc, subject, body, threadId]`, `required [to, subject, body]`, `additionalProperties: false`.

Note: `test/google-workspace-api.test.ts` was already failing on clean `origin/dev` (calendar events grew `meetLink` without the unit test being updated) — verified on a pristine origin/dev worktree. This PR aligns those two expectations (`meetLink: null`) so the suite is green.

## Not run

No fraimz/video: this is a cloud den-api capability change with no UI surface; end-to-end proof against real Gmail needs a Den org with a connected Google Workspace account (same validation standard as #2571, which introduced this test harness). Reviewer repro: connect a Google account, ask the agent to "reply on this thread" with a Gmail thread id from `gmail-messages` — the draft now lands on the thread in Gmail with Cc intact, and the draft's raw source shows `In-Reply-To`/`References`.
