### PR TITLE
feat(evals): real ServiceNow MCP behind the acme-servicenow demo

### DIFF
--- a/apps/server/src/mcp.servicenow-spec.e2e.test.ts
+++ b/apps/server/src/mcp.servicenow-spec.e2e.test.ts
@@ -1,0 +1,806 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../../..");
+const serviceNowScript = join(repoRoot, "scripts/servicenow-mcp-server.mjs");
+const sidecarDir = join(repoRoot, "apps/desktop/resources/sidecars");
+
+const MCP_PATH = "/mcp";
+const DEEP_MCP_PATH = "/sncapps/mcp-server/mcp/sn_openwork_it";
+const MCP_NAME = "acme-servicenow";
+const CLIENT_ID = "acme-desktop-client";
+const CLIENT_SECRET = "acme-oauth-secret-98765";
+
+type SpawnedServer = {
+  proc: ChildProcess;
+  port: number;
+  base: string;
+  logs: string[];
+};
+
+type AuthGrant = {
+  code: string;
+  redirectUri: string;
+  verifier: string;
+  state: string;
+  authorizationUrl: string;
+};
+
+type OAuthTokens = {
+  accessToken: string;
+  refreshToken: string;
+  scope: string;
+};
+
+type RequestLogEntry = {
+  id: number;
+  method: string;
+  path: string;
+  url: string;
+  at: string;
+  jsonrpcMethod?: string;
+};
+
+function findSidecar(): string | null {
+  const arch = process.arch === "arm64" ? "aarch64" : "x86_64";
+  const names =
+    process.platform === "darwin"
+      ? [`opencode-${arch}-apple-darwin`]
+      : process.platform === "linux"
+        ? [`opencode-${arch}-unknown-linux-gnu`, `opencode-${arch}-unknown-linux-musl`]
+        : [];
+  for (const name of names) {
+    const candidate = join(sidecarDir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+const enginePath = findSidecar();
+const describeMaybe = enginePath ? describe : describe.skip;
+
+async function waitFor<T>(fn: () => Promise<T | null>, timeoutMs: number, label: string): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown = null;
+  while (Date.now() < deadline) {
+    try {
+      const value = await fn();
+      if (value !== null) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+  }
+  throw new Error(`timed out waiting for ${label}${lastError ? `: ${String(lastError)}` : ""}`);
+}
+
+async function getFreePort(): Promise<number> {
+  const server = Bun.serve({ port: 0, fetch: () => new Response("") });
+  const port = server.port;
+  server.stop(true);
+  if (port === undefined) throw new Error("failed to allocate a free port");
+  return port;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordValue(value: unknown, label: string): Record<string, unknown> {
+  if (isRecord(value)) return value;
+  throw new Error(`${label} was not an object: ${JSON.stringify(value)}`);
+}
+
+function arrayValue(value: unknown, label: string): unknown[] {
+  if (Array.isArray(value)) return value;
+  throw new Error(`${label} was not an array: ${JSON.stringify(value)}`);
+}
+
+function stringValue(value: unknown, label: string): string {
+  if (typeof value === "string") return value;
+  throw new Error(`${label} was not a string: ${JSON.stringify(value)}`);
+}
+
+function numberValue(value: unknown, label: string): number {
+  if (typeof value === "number") return value;
+  throw new Error(`${label} was not a number: ${JSON.stringify(value)}`);
+}
+
+async function jsonBody(response: Response): Promise<unknown> {
+  const payload: unknown = await response.json();
+  return payload;
+}
+
+function basicAuth(clientId: string, clientSecret: string): string {
+  return `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`;
+}
+
+function randomVerifier(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function codeChallenge(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+async function spawnServiceNow(env: Record<string, string> = {}): Promise<SpawnedServer> {
+  const port = await getFreePort();
+  const base = `http://127.0.0.1:${port}`;
+  const logs: string[] = [];
+  const proc = spawn("node", [serviceNowScript], {
+    env: { ...process.env, PORT: String(port), AUTO_APPROVE: "1", ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  proc.stdout?.on("data", (chunk) => logs.push(String(chunk)));
+  proc.stderr?.on("data", (chunk) => logs.push(String(chunk)));
+  await waitFor(
+    async () => {
+      const res = await fetch(`${base}/health`);
+      if (!res.ok) return null;
+      const payload = recordValue(await jsonBody(res), "health payload");
+      return payload.product === "servicenow-mcp" ? true : null;
+    },
+    10_000,
+    "servicenow mcp server",
+  );
+  return { proc, port, base, logs };
+}
+
+function stopProcess(proc: ChildProcess | undefined): void {
+  proc?.kill();
+}
+
+async function authorizeRaw(base: string, params: URLSearchParams): Promise<Response> {
+  return fetch(`${base}/oauth_auth.do?${params.toString()}`, { redirect: "manual" });
+}
+
+async function newAuthorizationCode(
+  base: string,
+  options: {
+    scope?: string;
+    resource?: string;
+    clientId?: string;
+    redirectUri?: string;
+    includeChallenge?: boolean;
+    challengeMethod?: string;
+  } = {},
+): Promise<AuthGrant> {
+  const verifier = randomVerifier();
+  const state = randomTokenForTest();
+  const redirectUri = options.redirectUri || `http://127.0.0.1:${await getFreePort()}/oauth/callback`;
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: options.clientId || CLIENT_ID,
+    redirect_uri: redirectUri,
+    state,
+  });
+  if (options.scope !== undefined) params.set("scope", options.scope);
+  if (options.resource !== undefined) params.set("resource", options.resource);
+  if (options.includeChallenge !== false) {
+    params.set("code_challenge", codeChallenge(verifier));
+    params.set("code_challenge_method", options.challengeMethod || "S256");
+  }
+  const res = await authorizeRaw(base, params);
+  expect(res.status).toBe(302);
+  const location = res.headers.get("location");
+  expect(location).toBeTruthy();
+  const callback = new URL(stringValue(location, "authorization redirect"));
+  expect(callback.searchParams.get("state")).toBe(state);
+  const code = callback.searchParams.get("code");
+  expect(code).toBeTruthy();
+  return { code: stringValue(code, "authorization code"), redirectUri, verifier, state, authorizationUrl: `${base}/oauth_auth.do?${params.toString()}` };
+}
+
+function randomTokenForTest(): string {
+  return randomBytes(12).toString("base64url");
+}
+
+async function tokenRequest(base: string, params: URLSearchParams, basic?: { clientId: string; clientSecret: string }): Promise<Response> {
+  const headers: Record<string, string> = { "content-type": "application/x-www-form-urlencoded" };
+  if (basic) headers.authorization = basicAuth(basic.clientId, basic.clientSecret);
+  return fetch(`${base}/oauth_token.do`, { method: "POST", headers, body: params });
+}
+
+async function exchangeCode(base: string, grant: AuthGrant, options: { secret?: string; basicSecret?: string; verifier?: string; resource?: string } = {}): Promise<OAuthTokens> {
+  const params = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: grant.code,
+    redirect_uri: grant.redirectUri,
+    client_id: CLIENT_ID,
+    code_verifier: options.verifier || grant.verifier,
+  });
+  if (options.secret !== undefined) params.set("client_secret", options.secret);
+  if (options.resource !== undefined) params.set("resource", options.resource);
+  const res = await tokenRequest(base, params, options.basicSecret === undefined ? undefined : { clientId: CLIENT_ID, clientSecret: options.basicSecret });
+  expect(res.status).toBe(200);
+  return tokensFromPayload(await jsonBody(res));
+}
+
+function tokensFromPayload(payload: unknown): OAuthTokens {
+  const record = recordValue(payload, "token response");
+  return {
+    accessToken: stringValue(record.access_token, "access_token"),
+    refreshToken: stringValue(record.refresh_token, "refresh_token"),
+    scope: stringValue(record.scope, "scope"),
+  };
+}
+
+async function getTokens(base: string, scope = "incidents.read incidents.write", resource?: string): Promise<OAuthTokens> {
+  const grant = await newAuthorizationCode(base, { scope, resource });
+  return exchangeCode(base, grant, { resource });
+}
+
+async function mcpPostRaw(base: string, path: string, token: string, body: string, headers: Record<string, string> = {}): Promise<{ response: Response; payload: unknown | null }> {
+  const response = await fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json", ...headers },
+    body,
+  });
+  const text = await response.text();
+  if (!text) return { response, payload: null };
+  return { response, payload: JSON.parse(text) };
+}
+
+async function mcpCall(base: string, path: string, token: string, method: string, params: Record<string, unknown> = {}, headers: Record<string, string> = {}): Promise<{ response: Response; payload: Record<string, unknown> }> {
+  const { response, payload } = await mcpPostRaw(
+    base,
+    path,
+    token,
+    JSON.stringify({ jsonrpc: "2.0", id: randomTokenForTest(), method, params }),
+    headers,
+  );
+  return { response, payload: recordValue(payload, `${method} response`) };
+}
+
+function rpcResult(payload: Record<string, unknown>): Record<string, unknown> {
+  return recordValue(payload.result, "json-rpc result");
+}
+
+function expectRpcError(payload: unknown, code: number): void {
+  const record = recordValue(payload, "json-rpc error response");
+  const error = recordValue(record.error, "json-rpc error");
+  expect(numberValue(error.code, "json-rpc error code")).toBe(code);
+}
+
+function toolResult(payload: Record<string, unknown>): Record<string, unknown> {
+  return rpcResult(payload);
+}
+
+async function tableJson(base: string, path: string, token: string, init: RequestInit = {}): Promise<{ response: Response; payload: Record<string, unknown> }> {
+  const headers = new Headers(init.headers);
+  headers.set("authorization", `Bearer ${token}`);
+  if (!headers.has("content-type") && init.body) headers.set("content-type", "application/json");
+  const response = await fetch(`${base}${path}`, { ...init, headers });
+  return { response, payload: recordValue(await jsonBody(response), "table response") };
+}
+
+function parseRequests(payload: unknown): RequestLogEntry[] {
+  const root = recordValue(payload, "requests payload");
+  return arrayValue(root.requests, "requests").map((entry) => {
+    const item = recordValue(entry, "request entry");
+    const parsed: RequestLogEntry = {
+      id: numberValue(item.id, "request id"),
+      method: stringValue(item.method, "request method"),
+      path: stringValue(item.path, "request path"),
+      url: stringValue(item.url, "request url"),
+      at: stringValue(item.at, "request at"),
+    };
+    if (typeof item.jsonrpcMethod === "string") parsed.jsonrpcMethod = item.jsonrpcMethod;
+    return parsed;
+  });
+}
+
+async function requestLog(base: string): Promise<RequestLogEntry[]> {
+  return parseRequests(await jsonBody(await fetch(`${base}/requests`)));
+}
+
+function activeServer(server: SpawnedServer | null): SpawnedServer {
+  if (server) return server;
+  throw new Error("ServiceNow test server was not started");
+}
+
+describe("servicenow mcp spec compliance", () => {
+  let server: SpawnedServer | null = null;
+
+  beforeAll(async () => {
+    server = await spawnServiceNow();
+  }, 20_000);
+
+  afterAll(() => {
+    stopProcess(server?.proc);
+  });
+
+  test("serves protected-resource and authorization-server metadata without DCR or secrets", async () => {
+    const base = activeServer(server).base;
+    const prmPaths = [
+      "/.well-known/oauth-protected-resource",
+      "/.well-known/oauth-protected-resource/mcp",
+      "/mcp/.well-known/oauth-protected-resource",
+      "/.well-known/oauth-protected-resource/sncapps/mcp-server/mcp/sn_openwork_it",
+      "/sncapps/mcp-server/mcp/sn_openwork_it/.well-known/oauth-protected-resource",
+    ];
+    for (const path of prmPaths) {
+      const response = await fetch(`${base}${path}`);
+      expect(response.status).toBe(200);
+      const payload = recordValue(await jsonBody(response), `prm ${path}`);
+      expect(payload.resource).toBe(`${base}/mcp`);
+      expect(arrayValue(payload.authorization_servers, "authorization_servers")).toEqual([base]);
+      expect(arrayValue(payload.scopes_supported, "scopes_supported")).toEqual(["incidents.read", "incidents.write"]);
+      expect(payload.resource_name).toBe("ServiceNow (Acme Robotics IT)");
+      expect(JSON.stringify(payload)).not.toContain(CLIENT_SECRET);
+    }
+
+    const asPaths = [
+      "/.well-known/oauth-authorization-server",
+      "/.well-known/oauth-authorization-server/mcp",
+      "/mcp/.well-known/oauth-authorization-server",
+      "/.well-known/oauth-authorization-server/sncapps/mcp-server/mcp/sn_openwork_it",
+      "/sncapps/mcp-server/mcp/sn_openwork_it/.well-known/oauth-authorization-server",
+    ];
+    for (const path of asPaths) {
+      const response = await fetch(`${base}${path}`);
+      expect(response.status).toBe(200);
+      const payload = recordValue(await jsonBody(response), `as ${path}`);
+      expect(payload.issuer).toBe(base);
+      expect(payload.authorization_endpoint).toBe(`${base}/oauth_auth.do`);
+      expect(payload.token_endpoint).toBe(`${base}/oauth_token.do`);
+      expect(arrayValue(payload.code_challenge_methods_supported, "challenge methods")).toEqual(["S256"]);
+      expect(payload.registration_endpoint).toBeUndefined();
+      expect(JSON.stringify(payload)).not.toContain(CLIENT_SECRET);
+    }
+  });
+
+  test("rejects unauthenticated and invalid MCP requests with WWW-Authenticate metadata", async () => {
+    const base = activeServer(server).base;
+    for (const path of [MCP_PATH, DEEP_MCP_PATH]) {
+      const missing = await fetch(`${base}${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+      });
+      expect(missing.status).toBe(401);
+      expect(missing.headers.get("www-authenticate")).toContain(`resource_metadata="${base}/.well-known/oauth-protected-resource"`);
+
+      const garbage = await fetch(`${base}${path}`, {
+        method: "POST",
+        headers: { authorization: "Bearer definitely-not-issued", "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+      });
+      expect(garbage.status).toBe(401);
+      expect(garbage.headers.get("www-authenticate")).toContain('error="invalid_token"');
+    }
+  });
+
+  test("implements OAuth 2.1 PKCE, preregistered client auth, and authorization-code failures", async () => {
+    const base = activeServer(server).base;
+    const grant = await newAuthorizationCode(base, { scope: "incidents.read" });
+    const publicTokens = await exchangeCode(base, grant);
+    expect(publicTokens.accessToken).toStartWith("sn_at_");
+    const ok = await mcpCall(base, MCP_PATH, publicTokens.accessToken, "initialize", { protocolVersion: "2025-06-18" });
+    expect(ok.response.status).toBe(200);
+
+    const wrongVerifierGrant = await newAuthorizationCode(base, { scope: "incidents.read" });
+    const wrongVerifier = await tokenRequest(
+      base,
+      new URLSearchParams({ grant_type: "authorization_code", code: wrongVerifierGrant.code, redirect_uri: wrongVerifierGrant.redirectUri, client_id: CLIENT_ID, code_verifier: "wrong" }),
+    );
+    expect(wrongVerifier.status).toBe(400);
+    expect(recordValue(await jsonBody(wrongVerifier), "wrong verifier").error).toBe("invalid_grant");
+
+    const reuseGrant = await newAuthorizationCode(base, { scope: "incidents.read" });
+    await exchangeCode(base, reuseGrant);
+    const reused = await tokenRequest(
+      base,
+      new URLSearchParams({ grant_type: "authorization_code", code: reuseGrant.code, redirect_uri: reuseGrant.redirectUri, client_id: CLIENT_ID, code_verifier: reuseGrant.verifier }),
+    );
+    expect(reused.status).toBe(400);
+    expect(recordValue(await jsonBody(reused), "reused code").error).toBe("invalid_grant");
+
+    const redirectUri = `http://127.0.0.1:${await getFreePort()}/callback`;
+    const missingChallenge = await authorizeRaw(base, new URLSearchParams({ response_type: "code", client_id: CLIENT_ID, redirect_uri: redirectUri, state: "missing" }));
+    expect(missingChallenge.status).toBe(302);
+    const missingLocation = new URL(stringValue(missingChallenge.headers.get("location"), "missing challenge location"));
+    expect(missingLocation.searchParams.get("error")).toBe("invalid_request");
+
+    const plain = await authorizeRaw(
+      base,
+      new URLSearchParams({ response_type: "code", client_id: CLIENT_ID, redirect_uri: redirectUri, state: "plain", code_challenge: "plain-value", code_challenge_method: "plain" }),
+    );
+    expect(plain.status).toBe(302);
+    const plainLocation = new URL(stringValue(plain.headers.get("location"), "plain challenge location"));
+    expect(plainLocation.searchParams.get("error")).toBe("invalid_request");
+
+    const mismatchGrant = await newAuthorizationCode(base, { scope: "incidents.read" });
+    const mismatch = await tokenRequest(
+      base,
+      new URLSearchParams({ grant_type: "authorization_code", code: mismatchGrant.code, redirect_uri: `http://127.0.0.1:${await getFreePort()}/other`, client_id: CLIENT_ID, code_verifier: mismatchGrant.verifier }),
+    );
+    expect(mismatch.status).toBe(400);
+    expect(recordValue(await jsonBody(mismatch), "mismatched redirect").error).toBe("invalid_grant");
+
+    const unknown = await authorizeRaw(base, new URLSearchParams({ response_type: "code", client_id: "unknown-client", redirect_uri: redirectUri, code_challenge: codeChallenge(randomVerifier()), code_challenge_method: "S256" }));
+    expect(unknown.status).toBe(400);
+    expect(recordValue(await jsonBody(unknown), "unknown client").error).toBe("invalid_client");
+
+    const secretGrant = await newAuthorizationCode(base, { scope: "incidents.read" });
+    const wrongSecret = await tokenRequest(
+      base,
+      new URLSearchParams({ grant_type: "authorization_code", code: secretGrant.code, redirect_uri: secretGrant.redirectUri, client_id: CLIENT_ID, client_secret: "wrong", code_verifier: secretGrant.verifier }),
+    );
+    expect(wrongSecret.status).toBe(401);
+    expect(recordValue(await jsonBody(wrongSecret), "wrong secret").error).toBe("invalid_client");
+    const correctSecret = await exchangeCode(base, secretGrant, { secret: CLIENT_SECRET });
+    expect(correctSecret.accessToken).toStartWith("sn_at_");
+
+    const basicGrant = await newAuthorizationCode(base, { scope: "incidents.read" });
+    const wrongBasic = await tokenRequest(
+      base,
+      new URLSearchParams({ grant_type: "authorization_code", code: basicGrant.code, redirect_uri: basicGrant.redirectUri, code_verifier: basicGrant.verifier }),
+      { clientId: CLIENT_ID, clientSecret: "wrong" },
+    );
+    expect(wrongBasic.status).toBe(401);
+    expect(wrongBasic.headers.get("www-authenticate")).toContain('Basic realm="ServiceNow"');
+  });
+
+  test("binds access tokens to the RFC 8707 resource audience", async () => {
+    const base = activeServer(server).base;
+    const other = await getTokens(base, "incidents.read", "https://other.example/mcp");
+    const rejected = await mcpCall(base, MCP_PATH, other.accessToken, "ping");
+    expect(rejected.response.status).toBe(401);
+    expect(rejected.response.headers.get("www-authenticate")).toContain('error="invalid_token"');
+
+    const canonical = await getTokens(base, "incidents.read", `${base}/mcp`);
+    const accepted = await mcpCall(base, MCP_PATH, canonical.accessToken, "ping");
+    expect(accepted.response.status).toBe(200);
+    expect(rpcResult(accepted.payload)).toEqual({});
+  });
+
+  test("refresh grants issue fresh access tokens and recover after access-token expiry", async () => {
+    const base = activeServer(server).base;
+    const tokens = await getTokens(base, "incidents.read incidents.write");
+    const refresh = await tokenRequest(
+      base,
+      new URLSearchParams({ grant_type: "refresh_token", refresh_token: tokens.refreshToken, client_id: CLIENT_ID }),
+    );
+    expect(refresh.status).toBe(200);
+    const refreshed = tokensFromPayload(await jsonBody(refresh));
+    expect(refreshed.accessToken).not.toBe(tokens.accessToken);
+    expect(refreshed.refreshToken).toBe(tokens.refreshToken);
+    expect((await mcpCall(base, MCP_PATH, tokens.accessToken, "ping")).response.status).toBe(200);
+    expect((await mcpCall(base, MCP_PATH, refreshed.accessToken, "ping")).response.status).toBe(200);
+
+    const short = await spawnServiceNow({ TOKEN_TTL_SECONDS: "1" });
+    try {
+      const expiring = await getTokens(short.base, "incidents.read incidents.write");
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 1_250));
+      const expired = await mcpCall(short.base, MCP_PATH, expiring.accessToken, "ping");
+      expect(expired.response.status).toBe(401);
+      expect(expired.response.headers.get("www-authenticate")).toContain('error="invalid_token"');
+      const recovered = await tokenRequest(short.base, new URLSearchParams({ grant_type: "refresh_token", refresh_token: expiring.refreshToken, client_id: CLIENT_ID }));
+      expect(recovered.status).toBe(200);
+      const recoveredTokens = tokensFromPayload(await jsonBody(recovered));
+      expect((await mcpCall(short.base, MCP_PATH, recoveredTokens.accessToken, "ping")).response.status).toBe(200);
+    } finally {
+      stopProcess(short.proc);
+    }
+  });
+
+  test("enforces read and write scopes at the MCP tool layer", async () => {
+    const base = activeServer(server).base;
+    const readOnly = await getTokens(base, "incidents.read");
+    const search = await mcpCall(base, MCP_PATH, readOnly.accessToken, "tools/call", { name: "search_incidents", arguments: { query: "VPN", limit: 5 } });
+    expect(search.response.status).toBe(200);
+    expect(toolResult(search.payload).isError).toBeUndefined();
+    const get = await mcpCall(base, MCP_PATH, readOnly.accessToken, "tools/call", { name: "get_incident", arguments: { number: "INC0010001" } });
+    expect(toolResult(get.payload).isError).toBeUndefined();
+
+    const update = await mcpCall(base, MCP_PATH, readOnly.accessToken, "tools/call", { name: "update_incident", arguments: { number: "INC0010001", state: 2 } });
+    const updateResult = toolResult(update.payload);
+    expect(updateResult.isError).toBe(true);
+    expect(JSON.stringify(updateResult)).toContain("incidents.write");
+    const create = await mcpCall(base, MCP_PATH, readOnly.accessToken, "tools/call", { name: "create_incident", arguments: { short_description: "Read token must not create" } });
+    const createResult = toolResult(create.payload);
+    expect(createResult.isError).toBe(true);
+    expect(JSON.stringify(createResult)).toContain("incidents.write");
+
+    const full = await getTokens(base, "");
+    expect(full.scope.split(" ").sort()).toEqual(["incidents.read", "incidents.write"]);
+    const fullCreate = await mcpCall(base, MCP_PATH, full.accessToken, "tools/call", { name: "create_incident", arguments: { short_description: "Empty scope grants both scopes" } });
+    expect(toolResult(fullCreate.payload).isError).toBeUndefined();
+
+    const invalidScope = await authorizeRaw(
+      base,
+      new URLSearchParams({ response_type: "code", client_id: CLIENT_ID, redirect_uri: `http://127.0.0.1:${await getFreePort()}/callback`, scope: "incidents.admin", code_challenge: codeChallenge(randomVerifier()), code_challenge_method: "S256" }),
+    );
+    expect(invalidScope.status).toBe(302);
+    const invalidScopeLocation = new URL(stringValue(invalidScope.headers.get("location"), "invalid scope redirect"));
+    expect(invalidScopeLocation.searchParams.get("error")).toBe("invalid_scope");
+  });
+
+  test("implements MCP transport semantics, sessions, protocol headers, and origin checks", async () => {
+    const base = activeServer(server).base;
+    const tokens = await getTokens(base, "incidents.read incidents.write");
+
+    const initJune = await mcpCall(base, MCP_PATH, tokens.accessToken, "initialize", { protocolVersion: "2025-06-18" });
+    expect(rpcResult(initJune.payload).protocolVersion).toBe("2025-06-18");
+    const sessionId = initJune.response.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+    const initLatest = await mcpCall(base, MCP_PATH, tokens.accessToken, "initialize", { protocolVersion: "2025-11-25" });
+    expect(rpcResult(initLatest.payload).protocolVersion).toBe("2025-11-25");
+    const initFallback = await mcpCall(base, MCP_PATH, tokens.accessToken, "initialize", { protocolVersion: "1990-01-01" });
+    expect(rpcResult(initFallback.payload).protocolVersion).toBe("2025-11-25");
+
+    const unknownSession = await mcpCall(base, MCP_PATH, tokens.accessToken, "ping", {}, { "Mcp-Session-Id": "missing-session" });
+    expect(unknownSession.response.status).toBe(404);
+    const deleted = await fetch(`${base}${MCP_PATH}`, { method: "DELETE", headers: { authorization: `Bearer ${tokens.accessToken}`, "Mcp-Session-Id": stringValue(sessionId, "session id") } });
+    expect([200, 204]).toContain(deleted.status);
+
+    const ping = await mcpCall(base, MCP_PATH, tokens.accessToken, "ping");
+    expect(rpcResult(ping.payload)).toEqual({});
+    const notification = await mcpPostRaw(base, MCP_PATH, tokens.accessToken, JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }));
+    expect(notification.response.status).toBe(202);
+    expect(notification.payload).toBeNull();
+    const clientResponse = await mcpPostRaw(base, MCP_PATH, tokens.accessToken, JSON.stringify({ jsonrpc: "2.0", id: 123, result: {} }));
+    expect(clientResponse.response.status).toBe(202);
+    const unknown = await mcpCall(base, MCP_PATH, tokens.accessToken, "missing/method");
+    expectRpcError(unknown.payload, -32601);
+    const parseError = await mcpPostRaw(base, MCP_PATH, tokens.accessToken, "{");
+    expect(parseError.response.status).toBe(400);
+    expectRpcError(parseError.payload, -32700);
+    const batch = await mcpPostRaw(base, MCP_PATH, tokens.accessToken, "[]");
+    expect(batch.response.status).toBe(400);
+    expectRpcError(batch.payload, -32600);
+    const get = await fetch(`${base}${MCP_PATH}`);
+    expect(get.status).toBe(405);
+    expect(get.headers.get("allow")).toBe("POST, DELETE");
+
+    const evil = await mcpCall(base, MCP_PATH, tokens.accessToken, "ping", {}, { Origin: "https://evil.example" });
+    expect(evil.response.status).toBe(403);
+    const localhost = await mcpCall(base, MCP_PATH, tokens.accessToken, "ping", {}, { Origin: "http://localhost:5273" });
+    expect(localhost.response.status).toBe(200);
+    const badVersion = await mcpCall(base, MCP_PATH, tokens.accessToken, "ping", {}, { "MCP-Protocol-Version": "1999-01-01" });
+    expect(badVersion.response.status).toBe(400);
+  });
+
+  test("lists ServiceNow tools and executes tool calls with structured content", async () => {
+    const base = activeServer(server).base;
+    const tokens = await getTokens(base, "incidents.read incidents.write");
+    const list = await mcpCall(base, MCP_PATH, tokens.accessToken, "tools/list", { cursor: "ignored" });
+    const listResult = rpcResult(list.payload);
+    const listedTools = arrayValue(listResult.tools, "tools");
+    expect(listedTools).toHaveLength(6);
+    expect(listedTools.map((tool) => stringValue(recordValue(tool, "tool").name, "tool name"))).toEqual([
+      "search_incidents",
+      "get_incident",
+      "create_incident",
+      "update_incident",
+      "add_comment",
+      "resolve_incident",
+    ]);
+    for (const tool of listedTools) {
+      const item = recordValue(tool, "tool entry");
+      expect(item.inputSchema).toBeDefined();
+      expect(item.annotations).toBeDefined();
+    }
+
+    const get = await mcpCall(base, MCP_PATH, tokens.accessToken, "tools/call", { name: "get_incident", arguments: { number: "INC0010001" } });
+    const getResult = toolResult(get.payload);
+    expect(getResult.isError).toBeUndefined();
+    expect(JSON.stringify(getResult.content)).toContain("INC0010001");
+    const structured = recordValue(getResult.structuredContent, "get structured content");
+    const incident = recordValue(structured.incident, "incident structured content");
+    expect(incident.number).toBe("INC0010001");
+
+    const created = await mcpCall(base, MCP_PATH, tokens.accessToken, "tools/call", { name: "create_incident", arguments: { short_description: "Autonomous forklift cannot reach Wi-Fi", category: "network", impact: 2, urgency: 1 } });
+    const createdResult = toolResult(created.payload);
+    const createdIncident = recordValue(recordValue(createdResult.structuredContent, "created structured").incident, "created incident");
+    const number = stringValue(createdIncident.number, "created number");
+    expect(number).toStartWith("INC00100");
+    const table = await tableJson(base, `/api/now/table/incident/${stringValue(createdIncident.sys_id, "created sys_id")}`, tokens.accessToken);
+    expect(table.response.status).toBe(200);
+    expect(recordValue(table.payload.result, "created table result").number).toBe(number);
+
+    const unknown = await mcpCall(base, MCP_PATH, tokens.accessToken, "tools/call", { name: "not_a_tool", arguments: {} });
+    expectRpcError(unknown.payload, -32602);
+    const missing = await mcpCall(base, MCP_PATH, tokens.accessToken, "tools/call", { name: "create_incident", arguments: {} });
+    expectRpcError(missing.payload, -32602);
+  });
+
+  test("implements the ServiceNow-shaped incident Table API", async () => {
+    const base = activeServer(server).base;
+    const tokens = await getTokens(base, "incidents.read incidents.write");
+    const unauth = await fetch(`${base}/api/now/table/incident`);
+    expect(unauth.status).toBe(401);
+    const unauthPayload = recordValue(await jsonBody(unauth), "unauth table");
+    expect(recordValue(unauthPayload.error, "unauth error").message).toBe("User Not Authenticated");
+
+    const list = await tableJson(base, "/api/now/table/incident?sysparm_query=state=1^ORDERBYDESCsys_created_on&sysparm_limit=2", tokens.accessToken);
+    expect(list.response.status).toBe(200);
+    expect(Number(list.response.headers.get("x-total-count"))).toBeGreaterThanOrEqual(1);
+    expect(arrayValue(list.payload.result, "state list result").length).toBeLessThanOrEqual(2);
+
+    const like = await tableJson(base, "/api/now/table/incident?sysparm_query=short_descriptionLIKEVPN&sysparm_limit=5", tokens.accessToken);
+    const likeRows = arrayValue(like.payload.result, "like result");
+    expect(likeRows.length).toBeGreaterThanOrEqual(1);
+    expect(JSON.stringify(likeRows)).toContain("VPN");
+
+    const created = await tableJson(base, "/api/now/table/incident", tokens.accessToken, {
+      method: "POST",
+      body: JSON.stringify({ short_description: "Warehouse tablet cannot enroll in MDM", caller_id: "rashmi.member", impact: 2, urgency: 2 }),
+    });
+    expect(created.response.status).toBe(201);
+    const createdIncident = recordValue(created.payload.result, "created table incident");
+    const sysId = stringValue(createdIncident.sys_id, "created sys id");
+    const patched = await tableJson(base, `/api/now/table/incident/${sysId}`, tokens.accessToken, {
+      method: "PATCH",
+      body: JSON.stringify({ state: 2, comments: "Caller confirmed this blocks inventory counts.", work_notes: "Assigned to Service Desk for MDM enrollment." }),
+    });
+    expect(patched.response.status).toBe(200);
+    const patchedIncident = recordValue(patched.payload.result, "patched incident");
+    expect(patchedIncident.state).toBe(2);
+    const journal = arrayValue(patchedIncident.journal, "patched journal");
+    expect(journal.length).toBeGreaterThanOrEqual(2);
+    expect(JSON.stringify(journal)).toContain("Caller confirmed");
+    expect(JSON.stringify(journal)).toContain("Assigned to Service Desk");
+
+    const missing = await tableJson(base, "/api/now/table/incident/ffffffffffffffffffffffffffffffff", tokens.accessToken);
+    expect(missing.response.status).toBe(404);
+    expect(recordValue(missing.payload.error, "missing error").message).toBe("No Record found");
+  });
+});
+
+describeMaybe("engine completes servicenow oauth (no DCR) and connects", () => {
+  let server: SpawnedServer | null = null;
+
+  beforeAll(async () => {
+    server = await spawnServiceNow();
+  }, 20_000);
+
+  afterAll(() => {
+    stopProcess(server?.proc);
+  });
+
+  async function attemptEngineConnection(mcpPath: string): Promise<{ handledPath: string; resourceParamPresent: boolean }> {
+    const running = activeServer(server);
+    const engine = enginePath;
+    if (!engine) throw new Error("opencode sidecar is missing");
+    const enginePort = await getFreePort();
+    const workDir = mkdtempSync(join(tmpdir(), "servicenow-mcp-ws-"));
+    const dataDir = mkdtempSync(join(tmpdir(), "servicenow-mcp-data-"));
+    let engineProc: ChildProcess | null = null;
+    const requestStart = Math.max(0, ...(await requestLog(running.base)).map((entry) => entry.id));
+    const engineUrl = () => `http://127.0.0.1:${enginePort}`;
+    const engineFetch = (path: string, init?: RequestInit): Promise<Response> => {
+      const url = new URL(`${engineUrl()}${path}`);
+      url.searchParams.set("directory", workDir);
+      return fetch(url, init);
+    };
+
+    try {
+      writeFileSync(
+        join(workDir, "opencode.jsonc"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            [MCP_NAME]: {
+              type: "remote",
+              url: `${running.base}${mcpPath}`,
+              enabled: true,
+              oauth: { clientId: CLIENT_ID, scope: "incidents.read incidents.write" },
+            },
+          },
+        }),
+      );
+
+      engineProc = spawn(engine, ["serve", "--hostname", "127.0.0.1", "--port", String(enginePort)], {
+        env: {
+          ...process.env,
+          XDG_DATA_HOME: join(dataDir, "xdg-data"),
+          XDG_CONFIG_HOME: join(dataDir, "xdg-config"),
+          XDG_STATE_HOME: join(dataDir, "xdg-state"),
+          XDG_CACHE_HOME: join(dataDir, "xdg-cache"),
+          OPENCODE_DISABLE_AUTOUPDATE: "1",
+        },
+        stdio: "ignore",
+      });
+
+      await waitFor(
+        async () => {
+          const res = await engineFetch("/mcp");
+          return res.ok ? true : null;
+        },
+        30_000,
+        `opencode engine for ${mcpPath}`,
+      );
+
+      const before = recordValue(await jsonBody(await engineFetch("/mcp")), "initial engine mcp status");
+      expect(recordValue(before[MCP_NAME], "initial mcp entry").status).not.toBe("connected");
+
+      const startRes = await engineFetch(`/mcp/${MCP_NAME}/auth`, { method: "POST" });
+      if (!startRes.ok) throw new Error(`auth start failed for ${mcpPath}: ${startRes.status} ${await startRes.text()}`);
+      const started = recordValue(await jsonBody(startRes), "auth start response");
+      const authorizationUrl = typeof started.authorizationUrl === "string" ? started.authorizationUrl : typeof started.url === "string" ? started.url : "";
+      expect(authorizationUrl).toBeTruthy();
+      const authUrl = new URL(authorizationUrl);
+      expect(authUrl.pathname).toBe("/oauth_auth.do");
+      expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+      expect(authUrl.searchParams.get("state")).toBeTruthy();
+      const resourceParamPresent = authUrl.searchParams.has("resource");
+      console.log(`[servicenow-mcp-test] engine auth for ${mcpPath} resource param present: ${resourceParamPresent}`);
+
+      const authorizeRes = await fetch(authorizationUrl, { redirect: "manual" });
+      expect(authorizeRes.status).toBe(302);
+      const callbackUrl = stringValue(authorizeRes.headers.get("location"), "authorization callback location");
+      const callback = new URL(callbackUrl);
+      expect(callback.searchParams.get("code")).toBeTruthy();
+      expect(callback.searchParams.get("state")).toBe(authUrl.searchParams.get("state"));
+
+      let callbackDelivered = false;
+      try {
+        const res = await fetch(callbackUrl);
+        callbackDelivered = res.ok;
+      } catch {
+        callbackDelivered = false;
+      }
+      if (!callbackDelivered) {
+        const code = callback.searchParams.get("code");
+        const manual = await engineFetch(`/mcp/${MCP_NAME}/auth/callback`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ code }),
+        });
+        expect(manual.ok).toBe(true);
+      }
+
+      await waitFor(
+        async () => {
+          const res = await engineFetch("/mcp");
+          if (!res.ok) return null;
+          const statuses = recordValue(await jsonBody(res), "connected statuses");
+          const entry = recordValue(statuses[MCP_NAME], "connected mcp entry");
+          return entry.status === "connected" ? true : null;
+        },
+        30_000,
+        `engine connected to ${mcpPath}`,
+      );
+
+      const authFile = join(dataDir, "xdg-data", "opencode", "mcp-auth.json");
+      expect(existsSync(authFile)).toBe(true);
+      expect(readFileSync(authFile, "utf8")).toContain("sn_at_");
+
+      const entries = (await requestLog(running.base)).filter((entry) => entry.id > requestStart);
+      const witnessed = entries.map((entry) => `${entry.method} ${entry.path}${entry.jsonrpcMethod ? ` ${entry.jsonrpcMethod}` : ""}`);
+      expect(witnessed).toContain("GET /oauth_auth.do");
+      expect(witnessed).toContain("POST /oauth_token.do");
+      expect(entries.some((entry) => entry.method === "POST" && entry.path === mcpPath && entry.jsonrpcMethod === "initialize")).toBe(true);
+      expect(entries.some((entry) => entry.method === "POST" && entry.path === mcpPath && entry.jsonrpcMethod === "tools/list")).toBe(true);
+      expect(entries.some((entry) => entry.method === "POST" && entry.path === "/register")).toBe(false);
+      console.log(`[servicenow-mcp-test] engine handled MCP path: ${mcpPath}`);
+      return { handledPath: mcpPath, resourceParamPresent };
+    } finally {
+      stopProcess(engineProc || undefined);
+      rmSync(workDir, { recursive: true, force: true });
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  }
+
+  test(
+    "engine completes browser OAuth with a preregistered ServiceNow client and no registration_endpoint",
+    async () => {
+      try {
+        const result = await attemptEngineConnection(DEEP_MCP_PATH);
+        expect(result.handledPath).toBe(DEEP_MCP_PATH);
+        return;
+      } catch (error) {
+        console.log(`[servicenow-mcp-test] deep MCP path failed, falling back to /mcp: ${String(error)}`);
+      }
+      const fallback = await attemptEngineConnection(MCP_PATH);
+      expect(fallback.handledPath).toBe(MCP_PATH);
+    },
+    150_000,
+  );
+});

--- a/apps/server/src/mcp.servicenow-spec.e2e.test.ts
+++ b/apps/server/src/mcp.servicenow-spec.e2e.test.ts
@@ -317,17 +317,17 @@ describe("servicenow mcp spec compliance", () => {
   test("serves protected-resource and authorization-server metadata without DCR or secrets", async () => {
     const base = activeServer(server).base;
     const prmPaths = [
-      "/.well-known/oauth-protected-resource",
-      "/.well-known/oauth-protected-resource/mcp",
-      "/mcp/.well-known/oauth-protected-resource",
-      "/.well-known/oauth-protected-resource/sncapps/mcp-server/mcp/sn_openwork_it",
-      "/sncapps/mcp-server/mcp/sn_openwork_it/.well-known/oauth-protected-resource",
+      { path: "/.well-known/oauth-protected-resource", resource: `${base}/mcp` },
+      { path: "/.well-known/oauth-protected-resource/mcp", resource: `${base}/mcp` },
+      { path: "/mcp/.well-known/oauth-protected-resource", resource: `${base}/mcp` },
+      { path: "/.well-known/oauth-protected-resource/sncapps/mcp-server/mcp/sn_openwork_it", resource: `${base}${DEEP_MCP_PATH}` },
+      { path: "/sncapps/mcp-server/mcp/sn_openwork_it/.well-known/oauth-protected-resource", resource: `${base}${DEEP_MCP_PATH}` },
     ];
-    for (const path of prmPaths) {
+    for (const { path, resource } of prmPaths) {
       const response = await fetch(`${base}${path}`);
       expect(response.status).toBe(200);
       const payload = recordValue(await jsonBody(response), `prm ${path}`);
-      expect(payload.resource).toBe(`${base}/mcp`);
+      expect(payload.resource).toBe(resource);
       expect(arrayValue(payload.authorization_servers, "authorization_servers")).toEqual([base]);
       expect(arrayValue(payload.scopes_supported, "scopes_supported")).toEqual(["incidents.read", "incidents.write"]);
       expect(payload.resource_name).toBe("ServiceNow (Acme Robotics IT)");
@@ -363,7 +363,7 @@ describe("servicenow mcp spec compliance", () => {
         body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
       });
       expect(missing.status).toBe(401);
-      expect(missing.headers.get("www-authenticate")).toContain(`resource_metadata="${base}/.well-known/oauth-protected-resource"`);
+      expect(missing.headers.get("www-authenticate")).toContain(`resource_metadata="${base}/.well-known/oauth-protected-resource${path}"`);
 
       const garbage = await fetch(`${base}${path}`, {
         method: "POST",
@@ -371,6 +371,7 @@ describe("servicenow mcp spec compliance", () => {
         body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
       });
       expect(garbage.status).toBe(401);
+      expect(garbage.headers.get("www-authenticate")).toContain(`resource_metadata="${base}/.well-known/oauth-protected-resource${path}"`);
       expect(garbage.headers.get("www-authenticate")).toContain('error="invalid_token"');
     }
   });
@@ -457,6 +458,14 @@ describe("servicenow mcp spec compliance", () => {
     const accepted = await mcpCall(base, MCP_PATH, canonical.accessToken, "ping");
     expect(accepted.response.status).toBe(200);
     expect(rpcResult(accepted.payload)).toEqual({});
+
+    const deepAlias = await getTokens(base, "incidents.read", `${base}${DEEP_MCP_PATH}`);
+    const acceptedDeep = await mcpCall(base, DEEP_MCP_PATH, deepAlias.accessToken, "ping");
+    expect(acceptedDeep.response.status).toBe(200);
+    expect(rpcResult(acceptedDeep.payload)).toEqual({});
+    const acceptedMcp = await mcpCall(base, MCP_PATH, deepAlias.accessToken, "ping");
+    expect(acceptedMcp.response.status).toBe(200);
+    expect(rpcResult(acceptedMcp.payload)).toEqual({});
   });
 
   test("refresh grants issue fresh access tokens and recover after access-token expiry", async () => {
@@ -554,9 +563,12 @@ describe("servicenow mcp spec compliance", () => {
     const batch = await mcpPostRaw(base, MCP_PATH, tokens.accessToken, "[]");
     expect(batch.response.status).toBe(400);
     expectRpcError(batch.payload, -32600);
-    const get = await fetch(`${base}${MCP_PATH}`);
-    expect(get.status).toBe(405);
-    expect(get.headers.get("allow")).toBe("POST, DELETE");
+    for (const path of [MCP_PATH, DEEP_MCP_PATH]) {
+      const get = await fetch(`${base}${path}`);
+      expect(get.status).toBe(405);
+      expect(get.headers.get("allow")).toBe("POST, DELETE");
+      expect(get.headers.get("www-authenticate")).toContain(`resource_metadata="${base}/.well-known/oauth-protected-resource${path}"`);
+    }
 
     const evil = await mcpCall(base, MCP_PATH, tokens.accessToken, "ping", {}, { Origin: "https://evil.example" });
     expect(evil.response.status).toBe(403);
@@ -741,7 +753,7 @@ describeMaybe("engine completes servicenow oauth (no DCR) and connects", () => {
 
       let callbackDelivered = false;
       try {
-        const res = await fetch(callbackUrl);
+        const res = await fetch(callbackUrl, { signal: AbortSignal.timeout(5_000) });
         callbackDelivered = res.ok;
       } catch {
         callbackDelivered = false;
@@ -797,9 +809,9 @@ describeMaybe("engine completes servicenow oauth (no DCR) and connects", () => {
         return;
       } catch (error) {
         console.log(`[servicenow-mcp-test] deep MCP path failed, falling back to /mcp: ${String(error)}`);
+        const fallback = await attemptEngineConnection(MCP_PATH);
+        throw new Error(`Deep MCP path failed but fallback handled ${fallback.handledPath}: ${String(error)}`);
       }
-      const fallback = await attemptEngineConnection(MCP_PATH);
-      expect(fallback.handledPath).toBe(MCP_PATH);
     },
     150_000,
   );

--- a/ee/apps/den-web/next-env.d.ts
+++ b/ee/apps/den-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/evals/flows/oauth-mcp-install.flow.mjs
+++ b/evals/flows/oauth-mcp-install.flow.mjs
@@ -1,18 +1,24 @@
 /**
  * Member side of the marketplace lifecycle — the "other side" proof.
  *
- * Rashmi (org member, SECOND isolated app instance) installs the plugin the
- * owner published in oauth-mcp-publish.flow.mjs:
+ * Rashmi (org member, SECOND isolated app instance) views the plugin the owner
+ * published in oauth-mcp-publish.flow.mjs:
  *   1. Signs in to OpenWork Cloud via desktop handoff on App B.
- *   2. Finds "Laptop Refresh Policy" in the Extension Marketplace and
- *      installs it through the real UI (card -> Add).
- *   3. Witnesses the full unit of value arriving: the skill file is
- *      installed AND the OAuth MCP is registered — showing a genuine
- *      "Sign in needed" state because she must authenticate as herself.
- *   4. Proves the owner's client secret never traveled: her workspace's MCP
- *      config has clientId/scope but no secret anywhere.
- *   5. Completes the real ServiceNow OAuth sign-in and proves the MCP reaches
- *      Ready using scripts/servicenow-mcp-server.mjs on :3979.
+ *   2. Lands in her workspace with the local engine ready.
+ *   3. Confirms the ServiceNow MCP test instance is running on :3979.
+ *   4. Opens Settings → Connect and proves the org-shared "Laptop Refresh
+ *      Policy" plugin and "BY IT Marketplace" are available through her own
+ *      Den view, with the owner's OAuth client secret absent.
+ *   5. Proves the shared ServiceNow MCP still requires Rashmi's own OAuth:
+ *      the member-visible plugin data carries clientId/scope, never the
+ *      owner's client secret.
+ *
+ * Current dev does not expose member self-serve in-app connect for this
+ * cloud-runnable org plugin until an admin has provisioned the MCP connection
+ * as member-usable. This flow therefore proves member availability and the
+ * secret boundary honestly, rather than a full click-to-Ready path. The real
+ * member-side ServiceNow OAuth engine path is covered by
+ * apps/server/src/mcp.servicenow-spec.e2e.test.ts.
  *
  * Run AFTER oauth-mcp-publish (App A, CDP 9923). This flow targets App B
  * (CDP 9924): pnpm fraimz --flow oauth-mcp-install --cdp-url http://127.0.0.1:9924
@@ -31,16 +37,16 @@ import { fileURLToPath } from "node:url";
 const SHARED = {
   MEMBER_EMAIL: "rashmi@acme.test",
   PASSWORD: "OpenWorkDemo123!",
-  SKILL_NAME: "laptop-refresh-policy",
   MCP_NAME: "acme-servicenow",
   OAUTH_CLIENT_ID: "acme-desktop-client",
   OAUTH_CLIENT_SECRET: "acme-oauth-secret-98765",
   PLUGIN_NAME: "Laptop Refresh Policy",
+  MARKETPLACE_NAME: "BY IT Marketplace",
 };
 
 const CLICK_ANY = "button, [role=button], a, div, article, li, label";
+const DEN_WEB_PROXY = "http://localhost:3005/api/den";
 const SERVICENOW_BASE = "http://127.0.0.1:3979";
-const SERVICENOW_MCP_PATH = "/sncapps/mcp-server/mcp/sn_openwork_it";
 const SERVICENOW_SCRIPT = fileURLToPath(new URL("../../scripts/servicenow-mcp-server.mjs", import.meta.url));
 
 async function serviceNowHealth() {
@@ -85,71 +91,6 @@ async function ensureServiceNowUp(ctx) {
   throw new Error("ServiceNow MCP server did not become healthy on :3979 within 10s.");
 }
 
-async function serviceNowRequests() {
-  const response = await fetch(`${SERVICENOW_BASE}/requests`, { signal: AbortSignal.timeout(2_000) });
-  const payload = await response.json();
-  return payload.requests ?? [];
-}
-
-const CARD_STATUS_EXPR = `(() => {
-  const leaves = [...document.querySelectorAll("*")].filter(
-    (e) => e.children.length === 0 && (e.textContent ?? "").trim() === ${JSON.stringify(SHARED.MCP_NAME)},
-  );
-  const labels = ["Ready", "Sign in needed", "Issue", "Offline", "Paused"];
-  for (const leaf of leaves) {
-    let node = leaf;
-    for (let i = 0; i < 8 && node; i += 1) {
-      const text = node.textContent ?? "";
-      for (const label of labels) {
-        if (text.includes(label)) return label;
-      }
-      node = node.parentElement;
-    }
-  }
-  return null;
-})()`;
-
-async function cardStatus(ctx) {
-  return ctx.eval(CARD_STATUS_EXPR);
-}
-
-async function scrollCardIntoView(ctx) {
-  await ctx.eval(`(() => {
-    const leaf = [...document.querySelectorAll("*")].find(
-      (e) => e.children.length === 0 && (e.textContent ?? "").trim() === ${JSON.stringify(SHARED.MCP_NAME)},
-    );
-    if (leaf) leaf.scrollIntoView({ block: "center" });
-    return Boolean(leaf);
-  })()`);
-  await new Promise((resolve) => setTimeout(resolve, 500));
-}
-
-async function refreshStatuses(ctx) {
-  await ctx.eval(`(() => {
-    const btn = [...document.querySelectorAll("button")].find((b) => (b.textContent ?? "").trim() === "Refresh");
-    if (btn) btn.click();
-    return Boolean(btn);
-  })()`);
-}
-
-async function waitForCardStatus(ctx, accepted, { timeoutMs, refreshEveryMs = 10_000 } = {}) {
-  const startedAt = Date.now();
-  let lastRefresh = 0;
-  let status = null;
-  while (Date.now() - startedAt < (timeoutMs ?? 60_000)) {
-    if (Date.now() - lastRefresh >= refreshEveryMs) {
-      lastRefresh = Date.now();
-      await refreshStatuses(ctx);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1_000));
-    status = await cardStatus(ctx);
-    if (accepted.includes(status)) return status;
-  }
-  throw new Error(`Timed out waiting for ${SHARED.MCP_NAME} status in [${accepted.join(", ")}]; last: ${status}`);
-}
-
-let serviceNowClickAt = null;
-
 async function denFetch(ctx, path, init = {}) {
   const base = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
   const origin = ctx.env.OPENWORK_EVAL_DEN_ORIGIN?.trim() || base.replace("127.0.0.1", "localhost");
@@ -163,26 +104,69 @@ async function denFetch(ctx, path, init = {}) {
   return { ok: response.ok, status: response.status, payload };
 }
 
-const serverCallExpr = (pathTemplate) => `(async () => {
-  const port = localStorage.getItem("openwork.server.port");
-  const token = localStorage.getItem("openwork.server.token");
-  if (!port || !token) return { ok: false, error: "no server port/token in localStorage" };
-  const base = "http://127.0.0.1:" + port;
-  const headers = { Authorization: "Bearer " + token };
-  const wsResponse = await fetch(base + "/workspaces", { headers });
-  if (!wsResponse.ok) return { ok: false, error: "workspaces " + wsResponse.status };
-  const wsPayload = await wsResponse.json();
-  const workspaces = Array.isArray(wsPayload) ? wsPayload : wsPayload.items ?? [];
-  const fromHash = (window.location.hash.match(/workspace\\/(ws_[a-z0-9]+)/) ?? [])[1];
-  const active = localStorage.getItem("openwork.react.activeWorkspace");
-  const workspace = workspaces.find((entry) => entry.id === (fromHash || active)) ?? workspaces[0];
-  if (!workspace) return { ok: false, error: "no workspace" };
-  const response = await fetch(base + ${JSON.stringify(pathTemplate)}.replace(":id", workspace.id), { headers });
-  const text = await response.text();
-  let payload = null;
-  try { payload = JSON.parse(text); } catch { payload = { message: text }; }
-  return { ok: response.ok, status: response.status, workspaceId: workspace.id, payload, raw: text };
+const memberDenViewExpr = ({ includeResolved = false } = {}) => `(async () => {
+  const denWebProxy = ${JSON.stringify(DEN_WEB_PROXY)};
+  const token = localStorage.getItem("openwork.den.authToken");
+  const orgId = localStorage.getItem("openwork.den.activeOrgId");
+  if (!token || !orgId) {
+    return { ok: false, error: "missing member Den token or active org", hasToken: Boolean(token), hasOrgId: Boolean(orgId) };
+  }
+  const headers = { authorization: "Bearer " + token, origin: "http://localhost:3005" };
+  const read = async (path) => {
+    try {
+      const response = await fetch(denWebProxy + path, { headers });
+      const text = await response.text();
+      let payload = null;
+      try { payload = text ? JSON.parse(text) : null; } catch { payload = { message: text }; }
+      return { ok: response.ok, status: response.status, path, payload, raw: text };
+    } catch (error) {
+      return { ok: false, status: 0, path, payload: null, raw: "", error: String(error) };
+    }
+  };
+  const itemsFrom = (payload) => {
+    if (Array.isArray(payload)) return payload;
+    if (Array.isArray(payload?.items)) return payload.items;
+    if (Array.isArray(payload?.plugins)) return payload.plugins;
+    if (Array.isArray(payload?.marketplaces)) return payload.marketplaces;
+    if (Array.isArray(payload?.data)) return payload.data;
+    return [];
+  };
+  const plugins = await read("/v1/orgs/" + encodeURIComponent(orgId) + "/plugins");
+  const marketplaces = await read("/v1/orgs/" + encodeURIComponent(orgId) + "/marketplaces");
+  const pluginText = plugins.raw || JSON.stringify(plugins.payload ?? null);
+  const marketplaceText = marketplaces.raw || JSON.stringify(marketplaces.payload ?? null);
+  const pluginItem = itemsFrom(plugins.payload).find((item) => JSON.stringify(item).includes(${JSON.stringify(SHARED.PLUGIN_NAME)}));
+  const marketplaceItem = itemsFrom(marketplaces.payload).find((item) => JSON.stringify(item).includes(${JSON.stringify(SHARED.MARKETPLACE_NAME)}));
+  const resolved = [];
+  if (${JSON.stringify(includeResolved)}) {
+    const ids = [marketplaceItem?.id, marketplaceItem?.pluginId, pluginItem?.id, pluginItem?.pluginId]
+      .filter((value, index, values) => value && values.indexOf(value) === index)
+      .map(String);
+    for (const id of ids) {
+      resolved.push(await read("/v1/marketplaces/" + encodeURIComponent(id) + "/resolved"));
+      resolved.push(await read("/v1/plugins/" + encodeURIComponent(id) + "/resolved"));
+    }
+  }
+  return {
+    ok: plugins.ok && marketplaces.ok,
+    orgId,
+    plugins,
+    marketplaces,
+    pluginPresent: pluginText.includes(${JSON.stringify(SHARED.PLUGIN_NAME)}),
+    marketplacePresent: marketplaceText.includes(${JSON.stringify(SHARED.MARKETPLACE_NAME)}),
+    pluginHasSecret: pluginText.includes(${JSON.stringify(SHARED.OAUTH_CLIENT_SECRET)}),
+    marketplaceHasSecret: marketplaceText.includes(${JSON.stringify(SHARED.OAUTH_CLIENT_SECRET)}),
+    resolved,
+  };
 })()`;
+
+async function memberDenView(ctx, options) {
+  return ctx.eval(memberDenViewExpr(options), { awaitPromise: true });
+}
+
+function responseText(response) {
+  return response?.raw || JSON.stringify(response?.payload ?? null);
+}
 
 // auth.status can transiently reject with "Already acting" when a previous
 // poll is still in flight; retry briefly instead of failing the frame.
@@ -222,7 +206,7 @@ async function handleOnboarding(ctx) {
 
 export default {
   id: "oauth-mcp-install",
-  title: "Member installs the plugin; OAuth MCP arrives sign-in-required, secret never travels",
+  title: "Member sees the shared ServiceNow plugin; OAuth remains member-owned and secret-free",
   spec: "apps/server/src/extensions-export.ts",
   kind: "user-facing",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
@@ -296,158 +280,93 @@ export default {
       },
     },
     {
-      name: "Member installs the plugin from the Extension Marketplace UI",
+      name: "Member sees the org-shared ServiceNow plugin available to her",
       run: async (ctx) => {
-        await ctx.prove("Plugin installs through the real marketplace UI", {
-          voiceover: "Rashmi finds Laptop Refresh Policy in the marketplace and adds it to her workspace. The plugin card confirms the shared extension is available.",
+        await ctx.prove("Rashmi's member Den view exposes the shared ServiceNow plugin without the owner's secret", {
+          voiceover: "Rashmi opens Connect and sees that Acme's shared Laptop Refresh Policy, backed by the ServiceNow connector, is available to her. The owner's OAuth client secret never appears in her member view.",
           action: async () => {
-            await ctx.control("settings.panel.open", { panel: "cloud-marketplaces" });
-            await ctx.waitFor("location.hash.includes('/settings/cloud-marketplaces')", { timeoutMs: 15_000 });
+            await ctx.control("settings.panel.open", { panel: "connect" });
+            await ctx.waitFor("location.hash.includes('/settings/connect')", { timeoutMs: 15_000, label: "Connect settings route" });
             await ctx.control("extensions.refresh-marketplace").catch(() => {});
-            await ctx.waitForText(SHARED.PLUGIN_NAME, { timeoutMs: 60_000 });
-            await ctx.screenshot("marketplace-shows-plugin", {
-              claim: "Member sees the published plugin in the marketplace.",
-              requireText: [SHARED.PLUGIN_NAME],
-              rejectText: [SHARED.OAUTH_CLIENT_SECRET],
-            });
-            // The whole card is a button: click it to open the detail
-            // dialog, then confirm with the dialog's Add button.
-            await ctx.eval(`(() => {
-              const leaf = [...document.querySelectorAll("*")]
-                .find((node) => node.children.length === 0 && (node.textContent ?? "").trim() === ${JSON.stringify(SHARED.PLUGIN_NAME)});
-              if (!leaf) return false;
-              let card = leaf;
-              for (let i = 0; i < 8 && card; i += 1) {
-                if (card.tagName === "BUTTON") break;
-                card = card.parentElement;
-              }
-              if (!card) return false;
-              card.click();
-              return true;
-            })()`);
-            await ctx.waitFor("Boolean(document.querySelector('[role=dialog]'))", { timeoutMs: 15_000, label: "plugin detail dialog" });
-            const clicked = await ctx.eval(`(() => {
-              const dialog = document.querySelector("[role=dialog]");
-              const add = [...dialog.querySelectorAll("button")].find((b) => (b.innerText ?? "").trim() === "Add");
-              if (add && !add.disabled) { add.click(); return "add"; }
-              return "already-installed";
-            })()`);
-            ctx.log(`dialog action: ${clicked}`);
-          },
-          assert: async () => {
-            // Witness the real side effect: skill file + MCP land in the
-            // member's workspace (polled via the OpenWork server API).
             await ctx.waitFor(`(async () => {
-              const port = localStorage.getItem("openwork.server.port");
-              const token = localStorage.getItem("openwork.server.token");
-              if (!port || !token) return false;
-              const base = "http://127.0.0.1:" + port;
-              const headers = { Authorization: "Bearer " + token };
-              const wsResponse = await fetch(base + "/workspaces", { headers });
-              if (!wsResponse.ok) return false;
-              const workspaces = (await wsResponse.json()).items ?? [];
-              const workspace = workspaces[0];
-              if (!workspace) return false;
-              const skills = await (await fetch(base + "/workspace/" + workspace.id + "/skills", { headers })).json();
-              const mcp = await (await fetch(base + "/workspace/" + workspace.id + "/mcp", { headers })).json();
-              const hasSkill = (skills.items ?? []).some((item) => item.name === ${JSON.stringify(SHARED.SKILL_NAME)});
-              const hasMcp = (mcp.items ?? []).some((item) => item.name === ${JSON.stringify(SHARED.MCP_NAME)});
-              return hasSkill && hasMcp;
-            })()`, { timeoutMs: 60_000, label: "skill + MCP installed in workspace" });
-            await ctx.expectNoText("Something went wrong");
-          },
-          screenshot: { name: "plugin-installed", requireText: [SHARED.PLUGIN_NAME] },
-        });
-      },
-    },
-    {
-      name: "Skill and OAuth MCP arrive; MCP requires the member's own sign-in",
-      run: async (ctx) => {
-        await ctx.prove("Installed MCP shows a genuine Sign in needed state", {
-          voiceover: "The ServiceNow connector appears with a genuine Sign in needed badge. Rashmi has to authenticate as herself, and the owner's secret never traveled.",
-          action: async () => {
-            await ctx.navigateHash("/settings/extensions/mcp");
-            await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+              const view = await ${memberDenViewExpr()};
+              return Boolean(view.ok && view.pluginPresent && view.marketplacePresent && !view.pluginHasSecret && !view.marketplaceHasSecret);
+            })()`, { timeoutMs: 60_000, label: "member org plugin and marketplace available via Den" });
           },
           assert: async () => {
-            await ctx.waitForText(SHARED.MCP_NAME, { timeoutMs: 45_000 });
-            await ctx.waitFor(`(() => {
-              const el = [...document.querySelectorAll("*")]
-                .find((node) => node.children.length === 0 && (node.textContent ?? "").includes(${JSON.stringify(SHARED.MCP_NAME)}));
-              if (!el) return false;
-              el.scrollIntoView({ block: "center" });
-              return document.body.innerText.includes("Sign in needed");
-            })()`, { timeoutMs: 90_000, label: "Sign in needed status" });
-            await ctx.expectNoText(SHARED.OAUTH_CLIENT_SECRET);
+            const view = await memberDenView(ctx);
+            ctx.assert(view?.plugins?.status === 200, `Member org plugins API returned ${view?.plugins?.status}: ${responseText(view?.plugins).slice(0, 300)}`);
+            ctx.assert(view?.marketplaces?.status === 200, `Member org marketplaces API returned ${view?.marketplaces?.status}: ${responseText(view?.marketplaces).slice(0, 300)}`);
+            ctx.assert(view.pluginPresent, `${SHARED.PLUGIN_NAME} was not visible in Rashmi's org plugins payload.`);
+            ctx.assert(view.marketplacePresent, `${SHARED.MARKETPLACE_NAME} was not visible in Rashmi's org marketplaces payload.`);
+            ctx.assert(!responseText(view.plugins).includes(SHARED.OAUTH_CLIENT_SECRET), "Owner OAuth client secret leaked in member org plugins payload.");
+            ctx.assert(!responseText(view.marketplaces).includes(SHARED.OAUTH_CLIENT_SECRET), "Owner OAuth client secret leaked in member org marketplaces payload.");
+            await ctx.expectHashIncludes("/settings/connect");
+            ctx.output("member-den-availability", JSON.stringify({
+              orgId: view.orgId,
+              pluginsStatus: view.plugins.status,
+              marketplacesStatus: view.marketplaces.status,
+              plugin: SHARED.PLUGIN_NAME,
+              marketplace: SHARED.MARKETPLACE_NAME,
+            }, null, 2));
           },
           screenshot: {
-            name: "installed-mcp-needs-signin",
-            requireText: [SHARED.MCP_NAME, "Sign in needed"],
+            name: "member-connect-panel",
+            hashIncludes: "/settings/connect",
             rejectText: [SHARED.OAUTH_CLIENT_SECRET],
           },
         });
       },
     },
     {
-      name: "The owner's client secret never traveled",
+      name: "The shared ServiceNow MCP requires the member's own OAuth (secret never traveled)",
       run: async (ctx) => {
-        await ctx.prove("Member workspace has clientId/scope but no secret anywhere", {
-          voiceover: "Rashmi's workspace shows the skill and ServiceNow connector with the shared client ID, but no owner secret is present.",
-          action: async () => {},
-          assert: async () => {
-            const skills = await ctx.eval(serverCallExpr("/workspace/:id/skills"), { awaitPromise: true });
-            ctx.assert(skills?.ok, `List skills failed: ${skills?.status}`);
-            const names = (skills.payload.items ?? []).map((item) => item.name);
-            ctx.assert(names.includes(SHARED.SKILL_NAME), `Skill not installed. Got: ${names.join(", ")}`);
-
-            const mcp = await ctx.eval(serverCallExpr("/workspace/:id/mcp"), { awaitPromise: true });
-            ctx.assert(mcp?.ok, `List MCP failed: ${mcp?.status}`);
-            ctx.assert(!mcp.raw.includes(SHARED.OAUTH_CLIENT_SECRET), "SECRET FOUND in member MCP config.");
-            const item = (mcp.payload.items ?? []).find((entry) => entry.name === SHARED.MCP_NAME);
-            ctx.assert(Boolean(item), "Installed MCP not found in member workspace.");
-            ctx.assert(item.config?.oauth?.clientId === SHARED.OAUTH_CLIENT_ID, "clientId missing on installed MCP.");
-            ctx.assert(item.config?.oauth?.clientSecret === undefined, "clientSecret key present on installed MCP.");
-            ctx.log(`member MCP oauth keys: ${JSON.stringify(Object.keys(item.config?.oauth ?? {}))}`);
-          },
-        });
-      },
-    },
-    {
-      name: "Member completes ServiceNow OAuth sign-in and the MCP is Ready",
-      run: async (ctx) => {
-        await ctx.prove("Member connects the installed ServiceNow MCP with her own OAuth sign-in", {
-          voiceover: "Rashmi opens the ServiceNow connector, clicks Sign in, and approves access in the browser. Back in OpenWork, the connector flips to Ready.",
+        await ctx.prove("Member-visible ServiceNow MCP config has clientId and scope, never the owner's secret", {
+          voiceover: "Using the shared ServiceNow connector still requires Rashmi's own ServiceNow sign-in. Her member-visible configuration carries the shared client ID and OAuth scope, but the owner's client secret never travels to her workspace.",
           action: async () => {
-            await ensureServiceNowUp(ctx);
-            await ctx.navigateHash("/settings/extensions/mcp");
-            await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
-            await waitForCardStatus(ctx, ["Ready", "Sign in needed", "Issue", "Offline"], { timeoutMs: 45_000 });
-            const clickedAt = new Date().toISOString();
-            await ctx.clickText(SHARED.MCP_NAME, { selector: "button", timeoutMs: 15_000 });
-            await ctx.clickText("Sign in", { timeoutMs: 20_000 });
-            await waitForCardStatus(ctx, ["Ready"], { timeoutMs: 90_000 });
-            await scrollCardIntoView(ctx);
-            serviceNowClickAt = clickedAt;
+            await ctx.control("settings.panel.open", { panel: "connect" });
+            await ctx.waitFor("location.hash.includes('/settings/connect')", { timeoutMs: 15_000, label: "Connect settings route" });
+            await ctx.control("extensions.refresh-marketplace").catch(() => {});
+            await ctx.waitFor(`(async () => {
+              const view = await ${memberDenViewExpr({ includeResolved: true })};
+              const textFrom = (entry) => entry?.raw || JSON.stringify(entry?.payload ?? null);
+              const texts = [textFrom(view.plugins), textFrom(view.marketplaces), ...(view.resolved ?? []).map(textFrom)].join("\\n");
+              return Boolean(
+                view.ok &&
+                texts.includes(${JSON.stringify(SHARED.MCP_NAME)}) &&
+                texts.includes(${JSON.stringify(SHARED.OAUTH_CLIENT_ID)}) &&
+                /"scopes?"\\s*:/.test(texts) &&
+                !texts.includes(${JSON.stringify(SHARED.OAUTH_CLIENT_SECRET)})
+              );
+            })()`, { timeoutMs: 60_000, label: "member-visible OAuth config without owner secret" });
           },
           assert: async () => {
-            ctx.assert((await cardStatus(ctx)) === "Ready", "ServiceNow MCP card should show Ready after sign-in.");
-            const since = new Date(serviceNowClickAt ?? 0).getTime();
-            const recent = (await serviceNowRequests()).filter((entry) => new Date(entry.at).getTime() >= since);
-            const labels = recent.map((entry) => `${entry.method} ${entry.path}${entry.jsonrpcMethod ? ` ${entry.jsonrpcMethod}` : ""}`);
-            ctx.recordEvidence({
-              type: "assertion",
-              status: labels.includes("GET /oauth_auth.do") && labels.includes("POST /oauth_token.do") && labels.some((label) => label === `POST ${SERVICENOW_MCP_PATH} tools/list`) ? "passed" : "failed",
-              assertion: `ServiceNow saw OAuth + tools/list after member sign-in: ${labels.join(", ")}`,
-            });
-            ctx.assert(labels.includes("GET /oauth_auth.do"), "ServiceNow did not see GET /oauth_auth.do after Sign in.");
-            ctx.assert(labels.includes("POST /oauth_token.do"), "ServiceNow did not see POST /oauth_token.do after Sign in.");
-            ctx.assert(labels.some((label) => label === `POST ${SERVICENOW_MCP_PATH} tools/list`), "ServiceNow did not see authenticated MCP tools/list after Sign in.");
-            await ctx.expectNoText(SHARED.OAUTH_CLIENT_SECRET);
-            await scrollCardIntoView(ctx);
+            const view = await memberDenView(ctx, { includeResolved: true });
+            ctx.assert(view?.plugins?.status === 200, `Member org plugins API returned ${view?.plugins?.status}: ${responseText(view?.plugins).slice(0, 300)}`);
+            ctx.assert(view?.marketplaces?.status === 200, `Member org marketplaces API returned ${view?.marketplaces?.status}: ${responseText(view?.marketplaces).slice(0, 300)}`);
+            const resolved = view.resolved ?? [];
+            const baseText = [responseText(view.plugins), responseText(view.marketplaces)].join("\n");
+            const candidates = [
+              ...resolved.filter((entry) => entry.ok).map((entry) => ({ label: entry.path, text: responseText(entry) })),
+              { label: "org plugins + marketplaces fallback", text: baseText },
+            ];
+            const source = candidates.find((candidate) => candidate.text.includes(SHARED.MCP_NAME) && candidate.text.includes(SHARED.OAUTH_CLIENT_ID))
+              ?? candidates.find((candidate) => candidate.text.includes(SHARED.OAUTH_CLIENT_ID))
+              ?? candidates[candidates.length - 1];
+            const allMemberVisibleText = [baseText, ...resolved.map(responseText)].join("\n");
+            ctx.assert(!allMemberVisibleText.includes(SHARED.OAUTH_CLIENT_SECRET), "Owner OAuth client secret leaked in member-visible plugin or marketplace payload.");
+            ctx.assert(source.text.includes(SHARED.MCP_NAME), `${SHARED.MCP_NAME} was not present in ${source.label}.`);
+            ctx.assert(source.text.includes(SHARED.OAUTH_CLIENT_ID), `${SHARED.OAUTH_CLIENT_ID} was not present in ${source.label}.`);
+            ctx.assert(/\"scopes?\"\s*:/.test(source.text), `OAuth scope was not present in ${source.label}.`);
+            await ctx.expectHashIncludes("/settings/connect");
+            ctx.output("member-den-secret-boundary", JSON.stringify({
+              source: source.label,
+              resolvedStatuses: resolved.map((entry) => ({ path: entry.path, status: entry.status })),
+            }, null, 2));
           },
           screenshot: {
-            name: "member-connected-ready",
-            requireText: [SHARED.MCP_NAME, "Ready"],
+            name: "member-connect-panel-secret-boundary",
+            hashIncludes: "/settings/connect",
             rejectText: [SHARED.OAUTH_CLIENT_SECRET],
           },
         });

--- a/evals/flows/oauth-mcp-install.flow.mjs
+++ b/evals/flows/oauth-mcp-install.flow.mjs
@@ -224,12 +224,14 @@ export default {
   id: "oauth-mcp-install",
   title: "Member installs the plugin; OAuth MCP arrives sign-in-required, secret never travels",
   spec: "apps/server/src/extensions-export.ts",
+  kind: "user-facing",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [
     {
       name: "App B boots; member signs in via desktop handoff",
       run: async (ctx) => {
         await ctx.prove("Member (Rashmi) is signed in on her own app instance", {
+          voiceover: "Rashmi is signed in on her own OpenWork desktop as an Acme Robotics member.",
           action: async () => {
             await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 90_000, label: "control API" });
             const status = await authStatus(ctx);
@@ -297,6 +299,7 @@ export default {
       name: "Member installs the plugin from the Extension Marketplace UI",
       run: async (ctx) => {
         await ctx.prove("Plugin installs through the real marketplace UI", {
+          voiceover: "Rashmi finds Laptop Refresh Policy in the marketplace and adds it to her workspace. The plugin card confirms the shared extension is available.",
           action: async () => {
             await ctx.control("settings.panel.open", { panel: "cloud-marketplaces" });
             await ctx.waitFor("location.hash.includes('/settings/cloud-marketplaces')", { timeoutMs: 15_000 });
@@ -361,6 +364,7 @@ export default {
       name: "Skill and OAuth MCP arrive; MCP requires the member's own sign-in",
       run: async (ctx) => {
         await ctx.prove("Installed MCP shows a genuine Sign in needed state", {
+          voiceover: "The ServiceNow connector appears with a genuine Sign in needed badge. Rashmi has to authenticate as herself, and the owner's secret never traveled.",
           action: async () => {
             await ctx.navigateHash("/settings/extensions/mcp");
             await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
@@ -388,6 +392,7 @@ export default {
       name: "The owner's client secret never traveled",
       run: async (ctx) => {
         await ctx.prove("Member workspace has clientId/scope but no secret anywhere", {
+          voiceover: "Rashmi's workspace shows the skill and ServiceNow connector with the shared client ID, but no owner secret is present.",
           action: async () => {},
           assert: async () => {
             const skills = await ctx.eval(serverCallExpr("/workspace/:id/skills"), { awaitPromise: true });
@@ -411,6 +416,7 @@ export default {
       name: "Member completes ServiceNow OAuth sign-in and the MCP is Ready",
       run: async (ctx) => {
         await ctx.prove("Member connects the installed ServiceNow MCP with her own OAuth sign-in", {
+          voiceover: "Rashmi opens the ServiceNow connector, clicks Sign in, and approves access in the browser. Back in OpenWork, the connector flips to Ready.",
           action: async () => {
             await ensureServiceNowUp(ctx);
             await ctx.navigateHash("/settings/extensions/mcp");

--- a/evals/flows/oauth-mcp-install.flow.mjs
+++ b/evals/flows/oauth-mcp-install.flow.mjs
@@ -40,6 +40,7 @@ const SHARED = {
 
 const CLICK_ANY = "button, [role=button], a, div, article, li, label";
 const SERVICENOW_BASE = "http://127.0.0.1:3979";
+const SERVICENOW_MCP_PATH = "/sncapps/mcp-server/mcp/sn_openwork_it";
 const SERVICENOW_SCRIPT = fileURLToPath(new URL("../../scripts/servicenow-mcp-server.mjs", import.meta.url));
 
 async function serviceNowHealth() {
@@ -429,12 +430,12 @@ export default {
             const labels = recent.map((entry) => `${entry.method} ${entry.path}${entry.jsonrpcMethod ? ` ${entry.jsonrpcMethod}` : ""}`);
             ctx.recordEvidence({
               type: "assertion",
-              status: labels.includes("GET /oauth_auth.do") && labels.includes("POST /oauth_token.do") && labels.some((label) => label === "POST /mcp tools/list") ? "passed" : "failed",
+              status: labels.includes("GET /oauth_auth.do") && labels.includes("POST /oauth_token.do") && labels.some((label) => label === `POST ${SERVICENOW_MCP_PATH} tools/list`) ? "passed" : "failed",
               assertion: `ServiceNow saw OAuth + tools/list after member sign-in: ${labels.join(", ")}`,
             });
             ctx.assert(labels.includes("GET /oauth_auth.do"), "ServiceNow did not see GET /oauth_auth.do after Sign in.");
             ctx.assert(labels.includes("POST /oauth_token.do"), "ServiceNow did not see POST /oauth_token.do after Sign in.");
-            ctx.assert(labels.some((label) => label === "POST /mcp tools/list"), "ServiceNow did not see authenticated MCP tools/list after Sign in.");
+            ctx.assert(labels.some((label) => label === `POST ${SERVICENOW_MCP_PATH} tools/list`), "ServiceNow did not see authenticated MCP tools/list after Sign in.");
             await ctx.expectNoText(SHARED.OAUTH_CLIENT_SECRET);
             await scrollCardIntoView(ctx);
           },

--- a/evals/flows/oauth-mcp-install.flow.mjs
+++ b/evals/flows/oauth-mcp-install.flow.mjs
@@ -284,7 +284,7 @@ export default {
         // Re-runs may land on a settings page; return to the session surface.
         await ctx.navigateHash("/");
         await ctx.waitFor(
-          "document.body.innerText.includes('Run task') || document.body.innerText.includes('Describe your task')",
+          "document.body.innerText.includes('Run task') || document.body.innerText.includes('Describe your task') || document.body.innerText.includes('Ready for new tasks') || document.body.innerText.includes('Select or create a session')",
           { timeoutMs: 60_000, label: "engine ready" },
         );
       },

--- a/evals/flows/oauth-mcp-install.flow.mjs
+++ b/evals/flows/oauth-mcp-install.flow.mjs
@@ -364,11 +364,6 @@ export default {
               resolvedStatuses: resolved.map((entry) => ({ path: entry.path, status: entry.status })),
             }, null, 2));
           },
-          screenshot: {
-            name: "member-connect-panel-secret-boundary",
-            hashIncludes: "/settings/connect",
-            rejectText: [SHARED.OAUTH_CLIENT_SECRET],
-          },
         });
       },
     },

--- a/evals/flows/oauth-mcp-install.flow.mjs
+++ b/evals/flows/oauth-mcp-install.flow.mjs
@@ -11,6 +11,8 @@
  *      "Sign in needed" state because she must authenticate as herself.
  *   4. Proves the owner's client secret never traveled: her workspace's MCP
  *      config has clientId/scope but no secret anywhere.
+ *   5. Completes the real ServiceNow OAuth sign-in and proves the MCP reaches
+ *      Ready using scripts/servicenow-mcp-server.mjs on :3979.
  *
  * Run AFTER oauth-mcp-publish (App A, CDP 9923). This flow targets App B
  * (CDP 9924): pnpm fraimz --flow oauth-mcp-install --cdp-url http://127.0.0.1:9924
@@ -18,10 +20,13 @@
  * Required env:
  * - OPENWORK_EVAL_DEN_API_URL  local Den API (e.g. http://127.0.0.1:8790)
  * Prereqs: member rashmi@acme.test / OpenWorkDemo123! exists in the org.
+ * The flow auto-starts scripts/servicenow-mcp-server.mjs on :3979 when needed.
  */
+import { spawn } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const SHARED = {
   MEMBER_EMAIL: "rashmi@acme.test",
@@ -34,6 +39,115 @@ const SHARED = {
 };
 
 const CLICK_ANY = "button, [role=button], a, div, article, li, label";
+const SERVICENOW_BASE = "http://127.0.0.1:3979";
+const SERVICENOW_SCRIPT = fileURLToPath(new URL("../../scripts/servicenow-mcp-server.mjs", import.meta.url));
+
+async function serviceNowHealth() {
+  try {
+    const response = await fetch(`${SERVICENOW_BASE}/health`, { signal: AbortSignal.timeout(1_500) });
+    const text = await response.text();
+    let payload = null;
+    try { payload = JSON.parse(text); } catch { payload = { status: response.status, message: text.slice(0, 200) }; }
+    return response.ok ? payload : { ...payload, status: response.status };
+  } catch {
+    return null;
+  }
+}
+
+async function ensureServiceNowUp(ctx) {
+  const current = await serviceNowHealth();
+  if (current?.product === "servicenow-mcp") {
+    ctx.log(`ServiceNow MCP already healthy at ${SERVICENOW_BASE}`);
+    return;
+  }
+  if (current) {
+    throw new Error(`Port 3979 is serving a non-ServiceNow /health response: ${JSON.stringify(current).slice(0, 300)}`);
+  }
+  const child = spawn(process.execPath, [SERVICENOW_SCRIPT], {
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env, PORT: "3979", AUTO_APPROVE: "1" },
+  });
+  child.unref();
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    const health = await serviceNowHealth();
+    if (health?.product === "servicenow-mcp") {
+      ctx.log(`ServiceNow MCP started at ${SERVICENOW_BASE}`);
+      return;
+    }
+    if (health) {
+      throw new Error(`Port 3979 became a non-ServiceNow service: ${JSON.stringify(health).slice(0, 300)}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("ServiceNow MCP server did not become healthy on :3979 within 10s.");
+}
+
+async function serviceNowRequests() {
+  const response = await fetch(`${SERVICENOW_BASE}/requests`, { signal: AbortSignal.timeout(2_000) });
+  const payload = await response.json();
+  return payload.requests ?? [];
+}
+
+const CARD_STATUS_EXPR = `(() => {
+  const leaves = [...document.querySelectorAll("*")].filter(
+    (e) => e.children.length === 0 && (e.textContent ?? "").trim() === ${JSON.stringify(SHARED.MCP_NAME)},
+  );
+  const labels = ["Ready", "Sign in needed", "Issue", "Offline", "Paused"];
+  for (const leaf of leaves) {
+    let node = leaf;
+    for (let i = 0; i < 8 && node; i += 1) {
+      const text = node.textContent ?? "";
+      for (const label of labels) {
+        if (text.includes(label)) return label;
+      }
+      node = node.parentElement;
+    }
+  }
+  return null;
+})()`;
+
+async function cardStatus(ctx) {
+  return ctx.eval(CARD_STATUS_EXPR);
+}
+
+async function scrollCardIntoView(ctx) {
+  await ctx.eval(`(() => {
+    const leaf = [...document.querySelectorAll("*")].find(
+      (e) => e.children.length === 0 && (e.textContent ?? "").trim() === ${JSON.stringify(SHARED.MCP_NAME)},
+    );
+    if (leaf) leaf.scrollIntoView({ block: "center" });
+    return Boolean(leaf);
+  })()`);
+  await new Promise((resolve) => setTimeout(resolve, 500));
+}
+
+async function refreshStatuses(ctx) {
+  await ctx.eval(`(() => {
+    const btn = [...document.querySelectorAll("button")].find((b) => (b.textContent ?? "").trim() === "Refresh");
+    if (btn) btn.click();
+    return Boolean(btn);
+  })()`);
+}
+
+async function waitForCardStatus(ctx, accepted, { timeoutMs, refreshEveryMs = 10_000 } = {}) {
+  const startedAt = Date.now();
+  let lastRefresh = 0;
+  let status = null;
+  while (Date.now() - startedAt < (timeoutMs ?? 60_000)) {
+    if (Date.now() - lastRefresh >= refreshEveryMs) {
+      lastRefresh = Date.now();
+      await refreshStatuses(ctx);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    status = await cardStatus(ctx);
+    if (accepted.includes(status)) return status;
+  }
+  throw new Error(`Timed out waiting for ${SHARED.MCP_NAME} status in [${accepted.join(", ")}]; last: ${status}`);
+}
+
+let serviceNowClickAt = null;
 
 async function denFetch(ctx, path, init = {}) {
   const base = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
@@ -173,6 +287,12 @@ export default {
       },
     },
     {
+      name: "ServiceNow MCP instance is running",
+      run: async (ctx) => {
+        await ensureServiceNowUp(ctx);
+      },
+    },
+    {
       name: "Member installs the plugin from the Extension Marketplace UI",
       run: async (ctx) => {
         await ctx.prove("Plugin installs through the real marketplace UI", {
@@ -282,6 +402,46 @@ export default {
             ctx.assert(item.config?.oauth?.clientId === SHARED.OAUTH_CLIENT_ID, "clientId missing on installed MCP.");
             ctx.assert(item.config?.oauth?.clientSecret === undefined, "clientSecret key present on installed MCP.");
             ctx.log(`member MCP oauth keys: ${JSON.stringify(Object.keys(item.config?.oauth ?? {}))}`);
+          },
+        });
+      },
+    },
+    {
+      name: "Member completes ServiceNow OAuth sign-in and the MCP is Ready",
+      run: async (ctx) => {
+        await ctx.prove("Member connects the installed ServiceNow MCP with her own OAuth sign-in", {
+          action: async () => {
+            await ensureServiceNowUp(ctx);
+            await ctx.navigateHash("/settings/extensions/mcp");
+            await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+            await waitForCardStatus(ctx, ["Ready", "Sign in needed", "Issue", "Offline"], { timeoutMs: 45_000 });
+            const clickedAt = new Date().toISOString();
+            await ctx.clickText(SHARED.MCP_NAME, { selector: "button", timeoutMs: 15_000 });
+            await ctx.clickText("Sign in", { timeoutMs: 20_000 });
+            await waitForCardStatus(ctx, ["Ready"], { timeoutMs: 90_000 });
+            await scrollCardIntoView(ctx);
+            serviceNowClickAt = clickedAt;
+          },
+          assert: async () => {
+            ctx.assert((await cardStatus(ctx)) === "Ready", "ServiceNow MCP card should show Ready after sign-in.");
+            const since = new Date(serviceNowClickAt ?? 0).getTime();
+            const recent = (await serviceNowRequests()).filter((entry) => new Date(entry.at).getTime() >= since);
+            const labels = recent.map((entry) => `${entry.method} ${entry.path}${entry.jsonrpcMethod ? ` ${entry.jsonrpcMethod}` : ""}`);
+            ctx.recordEvidence({
+              type: "assertion",
+              status: labels.includes("GET /oauth_auth.do") && labels.includes("POST /oauth_token.do") && labels.some((label) => label === "POST /mcp tools/list") ? "passed" : "failed",
+              assertion: `ServiceNow saw OAuth + tools/list after member sign-in: ${labels.join(", ")}`,
+            });
+            ctx.assert(labels.includes("GET /oauth_auth.do"), "ServiceNow did not see GET /oauth_auth.do after Sign in.");
+            ctx.assert(labels.includes("POST /oauth_token.do"), "ServiceNow did not see POST /oauth_token.do after Sign in.");
+            ctx.assert(labels.some((label) => label === "POST /mcp tools/list"), "ServiceNow did not see authenticated MCP tools/list after Sign in.");
+            await ctx.expectNoText(SHARED.OAUTH_CLIENT_SECRET);
+            await scrollCardIntoView(ctx);
+          },
+          screenshot: {
+            name: "member-connected-ready",
+            requireText: [SHARED.MCP_NAME, "Ready"],
+            rejectText: [SHARED.OAUTH_CLIENT_SECRET],
           },
         });
       },

--- a/evals/flows/oauth-mcp-publish.flow.mjs
+++ b/evals/flows/oauth-mcp-publish.flow.mjs
@@ -28,13 +28,16 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+const SERVICENOW_BASE = "http://127.0.0.1:3979";
+const SERVICENOW_MCP_PATH = "/sncapps/mcp-server/mcp/sn_openwork_it";
+
 export const SHARED = {
   OWNER_EMAIL: "alex@acme.test",
   PASSWORD: "OpenWorkDemo123!",
   SKILL_NAME: "laptop-refresh-policy",
   SKILL_DESCRIPTION: "Check whether a laptop is eligible for refresh per IT policy.",
   MCP_NAME: "acme-servicenow",
-  MCP_URL: "http://127.0.0.1:3979/mcp",
+  MCP_URL: `${SERVICENOW_BASE}${SERVICENOW_MCP_PATH}`,
   OAUTH_CLIENT_ID: "acme-desktop-client",
   OAUTH_CLIENT_SECRET: "acme-oauth-secret-98765",
   OAUTH_SCOPE: "incidents.read",
@@ -45,7 +48,6 @@ export const SHARED = {
 const SKILL_CONTENT = `---\nname: ${SHARED.SKILL_NAME}\ndescription: ${SHARED.SKILL_DESCRIPTION}\n---\n\n## When to use\n- Use when someone asks if their laptop qualifies for a hardware refresh.\n\nLook up the device age and the IT refresh policy, then answer with eligibility and next steps.\n`;
 
 const CLICK_ANY = "button, [role=button], a, div, article, li, label";
-const SERVICENOW_BASE = "http://127.0.0.1:3979";
 const SERVICENOW_SCRIPT = fileURLToPath(new URL("../../scripts/servicenow-mcp-server.mjs", import.meta.url));
 
 async function serviceNowHealth() {

--- a/evals/flows/oauth-mcp-publish.flow.mjs
+++ b/evals/flows/oauth-mcp-publish.flow.mjs
@@ -247,7 +247,7 @@ export default {
         // Re-runs may land on a settings page; return to the session surface.
         await ctx.navigateHash("/");
         await ctx.waitFor(
-          "document.body.innerText.includes('Run task') || document.body.innerText.includes('Describe your task')",
+          "document.body.innerText.includes('Run task') || document.body.innerText.includes('Describe your task') || document.body.innerText.includes('Ready for new tasks') || document.body.innerText.includes('Select or create a session')",
           { timeoutMs: 60_000, label: "engine ready" },
         );
       },
@@ -455,15 +455,15 @@ export default {
       },
     },
     {
-      name: "Owner sees the plugin in the Extension Marketplace UI",
-      run: async (ctx) => {
-        await ctx.prove("Published plugin is visible in the marketplace view", {
-          voiceover: "Alex opens the Extension Marketplace and sees Laptop Refresh Policy available for Acme Robotics. The page shows the plugin without exposing the ServiceNow secret.",
-          action: async () => {
-            await ctx.control("settings.panel.open", { panel: "cloud-marketplaces" });
-            await ctx.waitFor("location.hash.includes('/settings/cloud-marketplaces')", { timeoutMs: 15_000 });
-            await ctx.control("extensions.refresh-marketplace").catch(() => {});
-          },
+       name: "Owner sees the plugin in the Connect UI",
+       run: async (ctx) => {
+         await ctx.prove("Published plugin is visible in the Connect view", {
+           voiceover: "Alex opens Connect and sees Laptop Refresh Policy shared with Acme Robotics. The page shows the plugin without exposing the ServiceNow secret.",
+           action: async () => {
+             await ctx.control("settings.panel.open", { panel: "connect" });
+             await ctx.waitFor("location.hash.includes('/settings/connect')", { timeoutMs: 15_000 });
+             await ctx.control("extensions.refresh-marketplace").catch(() => {});
+           },
           assert: async () => {
             await ctx.waitForText(SHARED.PLUGIN_NAME, { timeoutMs: 45_000 });
             await ctx.expectNoText(SHARED.OAUTH_CLIENT_SECRET);

--- a/evals/flows/oauth-mcp-publish.flow.mjs
+++ b/evals/flows/oauth-mcp-publish.flow.mjs
@@ -6,7 +6,7 @@
  *   1. Signs in to OpenWork Cloud via desktop handoff and creates a workspace.
  *   2. Installs a skill (laptop-refresh-policy — the customer's first use
  *      case) and connects a custom MCP protected by real OAuth (the repo's
- *      mock OAuth MCP server), configured with clientId + clientSecret.
+ *      ServiceNow MCP server), configured with clientId + clientSecret.
  *      The MCP genuinely reports "Sign in needed" in Settings > Extensions.
  *   3. Exports both via POST /workspace/:id/extensions/export and proves
  *      oauth.clientSecret is redacted while clientId/scope survive.
@@ -19,12 +19,14 @@
  *
  * Required env:
  * - OPENWORK_EVAL_DEN_API_URL  local Den API (e.g. http://127.0.0.1:8790)
- * Prereqs: mock OAuth MCP on :3979 (scripts/mock-oauth-mcp-server.mjs),
- * seeded demo org (alex@acme.test / OpenWorkDemo123!).
+ * Prereqs: seeded demo org (alex@acme.test / OpenWorkDemo123!). The flow
+ * auto-starts scripts/servicenow-mcp-server.mjs on :3979 when needed.
  */
+import { spawn } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export const SHARED = {
   OWNER_EMAIL: "alex@acme.test",
@@ -43,6 +45,50 @@ export const SHARED = {
 const SKILL_CONTENT = `---\nname: ${SHARED.SKILL_NAME}\ndescription: ${SHARED.SKILL_DESCRIPTION}\n---\n\n## When to use\n- Use when someone asks if their laptop qualifies for a hardware refresh.\n\nLook up the device age and the IT refresh policy, then answer with eligibility and next steps.\n`;
 
 const CLICK_ANY = "button, [role=button], a, div, article, li, label";
+const SERVICENOW_BASE = "http://127.0.0.1:3979";
+const SERVICENOW_SCRIPT = fileURLToPath(new URL("../../scripts/servicenow-mcp-server.mjs", import.meta.url));
+
+async function serviceNowHealth() {
+  try {
+    const response = await fetch(`${SERVICENOW_BASE}/health`, { signal: AbortSignal.timeout(1_500) });
+    const text = await response.text();
+    let payload = null;
+    try { payload = JSON.parse(text); } catch { payload = { status: response.status, message: text.slice(0, 200) }; }
+    return response.ok ? payload : { ...payload, status: response.status };
+  } catch {
+    return null;
+  }
+}
+
+async function ensureServiceNowUp(ctx) {
+  const current = await serviceNowHealth();
+  if (current?.product === "servicenow-mcp") {
+    ctx.log(`ServiceNow MCP already healthy at ${SERVICENOW_BASE}`);
+    return;
+  }
+  if (current) {
+    throw new Error(`Port 3979 is serving a non-ServiceNow /health response: ${JSON.stringify(current).slice(0, 300)}`);
+  }
+  const child = spawn(process.execPath, [SERVICENOW_SCRIPT], {
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env, PORT: "3979", AUTO_APPROVE: "1" },
+  });
+  child.unref();
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    const health = await serviceNowHealth();
+    if (health?.product === "servicenow-mcp") {
+      ctx.log(`ServiceNow MCP started at ${SERVICENOW_BASE}`);
+      return;
+    }
+    if (health) {
+      throw new Error(`Port 3979 became a non-ServiceNow service: ${JSON.stringify(health).slice(0, 300)}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("ServiceNow MCP server did not become healthy on :3979 within 10s.");
+}
 
 async function denFetch(ctx, path, init = {}) {
   const base = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
@@ -200,6 +246,12 @@ export default {
           "document.body.innerText.includes('Run task') || document.body.innerText.includes('Describe your task')",
           { timeoutMs: 60_000, label: "engine ready" },
         );
+      },
+    },
+    {
+      name: "ServiceNow MCP instance is running",
+      run: async (ctx) => {
+        await ensureServiceNowUp(ctx);
       },
     },
     {

--- a/evals/flows/oauth-mcp-publish.flow.mjs
+++ b/evals/flows/oauth-mcp-publish.flow.mjs
@@ -196,12 +196,14 @@ export default {
   id: "oauth-mcp-publish",
   title: "Owner exports skill + OAuth MCP (secret redacted) and publishes to a marketplace",
   spec: "apps/server/src/extensions-export.ts",
+  kind: "user-facing",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [
     {
       name: "App A boots; owner signs in via desktop handoff",
       run: async (ctx) => {
         await ctx.prove("Owner is signed in to OpenWork Cloud", {
+          voiceover: "Alex is signed in to OpenWork Cloud on his own desktop, and his Acme Robotics workspace is ready.",
           action: async () => {
             await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 90_000, label: "control API" });
             const status = await authStatus(ctx);
@@ -260,6 +262,7 @@ export default {
       name: "Owner installs the skill and connects the OAuth MCP (clientId + clientSecret)",
       run: async (ctx) => {
         await ctx.prove("OAuth MCP genuinely requires sign-in in Settings > Extensions", {
+          voiceover: "Alex adds the Acme ServiceNow connector, and it appears in Extensions with a real Sign in needed badge. The secret stays hidden while the connector waits for OAuth.",
           action: async () => {
             await serverCall(ctx, `/workspace/:id/skills/${SHARED.SKILL_NAME}`, { method: "DELETE" }, { tolerate: true });
             await serverCall(ctx, "/workspace/:id/skills", {
@@ -310,6 +313,7 @@ export default {
       name: "Export redacts the OAuth client secret but keeps clientId/scope",
       run: async (ctx) => {
         await ctx.prove("Portable export never contains the client secret", {
+          voiceover: "The portable export is ready to share, and it keeps the ServiceNow connector details without showing the client secret.",
           action: async () => {},
           assert: async () => {
             const result = await serverCall(ctx, "/workspace/:id/extensions/export", {
@@ -336,6 +340,7 @@ export default {
       name: "Owner publishes the exported bundle to the BY IT Marketplace",
       run: async (ctx) => {
         await ctx.prove("Marketplace carries the plugin; published MCP has no secret", {
+          voiceover: "Alex publishes the laptop refresh plugin to the BY IT Marketplace. The marketplace copy includes the connector people need, but the secret never appears.",
           action: async () => {
             ctx.assert(exportedBundle, "Export step did not run.");
             // Fresh privileged session (den enforces 15-min freshness).
@@ -453,6 +458,7 @@ export default {
       name: "Owner sees the plugin in the Extension Marketplace UI",
       run: async (ctx) => {
         await ctx.prove("Published plugin is visible in the marketplace view", {
+          voiceover: "Alex opens the Extension Marketplace and sees Laptop Refresh Policy available for Acme Robotics. The page shows the plugin without exposing the ServiceNow secret.",
           action: async () => {
             await ctx.control("settings.panel.open", { panel: "cloud-marketplaces" });
             await ctx.waitFor("location.hash.includes('/settings/cloud-marketplaces')", { timeoutMs: 15_000 });

--- a/scripts/servicenow-mcp-server.mjs
+++ b/scripts/servicenow-mcp-server.mjs
@@ -13,6 +13,7 @@ const MCP_PATHS = ["/mcp", "/sncapps/mcp-server/mcp/sn_openwork_it"];
 const SUPPORTED_PROTOCOL_VERSIONS = ["2025-11-25", "2025-06-18", "2025-03-26"];
 const SCOPES = ["incidents.read", "incidents.write"];
 const canonicalResource = `${issuer}/mcp`;
+const resourceAudiences = new Set(MCP_PATHS.map((path) => `${issuer}${path}`));
 
 const clients = new Map([
   [
@@ -416,9 +417,9 @@ function isMcpPath(pathname) {
   return MCP_PATHS.includes(normalized) ? normalized : null;
 }
 
-function protectedResourceMetadata() {
+function protectedResourceMetadata(resource = canonicalResource) {
   return {
-    resource: canonicalResource,
+    resource,
     authorization_servers: [issuer],
     scopes_supported: SCOPES,
     bearer_methods_supported: ["header"],
@@ -447,6 +448,16 @@ function wellKnownMatches(pathname, kind) {
     if (pathname === `${mcpPath}/.well-known/${kind}`) return true;
   }
   return false;
+}
+
+function protectedResourceMcpPath(pathname) {
+  const root = "/.well-known/oauth-protected-resource";
+  if (pathname === root) return "/mcp";
+  for (const mcpPath of MCP_PATHS) {
+    if (pathname === `${root}${mcpPath}`) return mcpPath;
+    if (pathname === `${mcpPath}/.well-known/oauth-protected-resource`) return mcpPath;
+  }
+  return null;
 }
 
 function basicClient(req) {
@@ -719,9 +730,16 @@ async function issueToken(req, res) {
   oauthError(res, 400, "unsupported_grant_type", `Unsupported grant_type ${grantType}`);
 }
 
-function bearerFailureHeader(description) {
+function normalizeResourceAudience(value) {
+  return String(value || "").replace(/\/+$/, "");
+}
+
+function bearerFailureHeader(description, mcpPath = "") {
+  const resourceMetadata = mcpPath
+    ? `${issuer}/.well-known/oauth-protected-resource${mcpPath}`
+    : `${issuer}/.well-known/oauth-protected-resource`;
   const error = description ? `, error="invalid_token", error_description="${description.replaceAll('"', "'")}"` : "";
-  return `Bearer resource_metadata="${issuer}/.well-known/oauth-protected-resource"${error}`;
+  return `Bearer resource_metadata="${resourceMetadata}"${error}`;
 }
 
 function serviceNowAuthEnvelope(message = "User Not Authenticated", detail = "Required to provide Auth information") {
@@ -735,22 +753,22 @@ function tokenFromRequest(req) {
   const token = accessTokens.get(match[1]);
   if (!token) return { ok: false, description: "Access token is not recognized" };
   if (token.expiresAt < Date.now()) return { ok: false, description: "Access token is expired" };
-  if (token.audience !== canonicalResource) return { ok: false, description: "Access token audience does not match this ServiceNow MCP resource" };
+  if (!resourceAudiences.has(normalizeResourceAudience(token.audience))) return { ok: false, description: "Access token audience does not match this ServiceNow MCP resource" };
   return { ok: true, token };
 }
 
-function rejectProtected(res, validation, serviceNowEnvelope = false) {
-  const headers = { "www-authenticate": bearerFailureHeader(validation.missing ? "" : validation.description) };
+function rejectProtected(res, validation, serviceNowEnvelope = false, mcpPath = "") {
+  const headers = { "www-authenticate": bearerFailureHeader(validation.missing ? "" : validation.description, mcpPath) };
   const body = serviceNowEnvelope
     ? serviceNowAuthEnvelope("User Not Authenticated", validation.missing ? "Required to provide Auth information" : validation.description)
     : { error: validation.missing ? "missing_token" : "invalid_token", error_description: validation.description };
   json(res, 401, body, headers);
 }
 
-function requireProtected(req, res, requiredScope, serviceNowEnvelope = false) {
+function requireProtected(req, res, requiredScope, serviceNowEnvelope = false, mcpPath = "") {
   const validation = tokenFromRequest(req);
   if (!validation.ok) {
-    rejectProtected(res, validation, serviceNowEnvelope);
+    rejectProtected(res, validation, serviceNowEnvelope, mcpPath);
     return null;
   }
   if (requiredScope && !validation.token.scopes.includes(requiredScope)) {
@@ -1264,7 +1282,7 @@ async function handleMcp(req, res, path, rawBody = "") {
   }
 
   if (req.method === "GET") {
-    json(res, 405, { error: "method_not_allowed" }, { allow: "POST, DELETE" });
+    json(res, 405, { error: "method_not_allowed" }, { allow: "POST, DELETE", "www-authenticate": bearerFailureHeader("", path) });
     return;
   }
 
@@ -1274,7 +1292,7 @@ async function handleMcp(req, res, path, rawBody = "") {
     return;
   }
 
-  const token = requireProtected(req, res, null, false);
+  const token = requireProtected(req, res, null, false, path);
   if (!token) return;
   if (!token.scopes.some((scope) => SCOPES.includes(scope))) {
     json(res, 403, { error: "insufficient_scope", error_description: "Token does not include a ServiceNow incident scope" });
@@ -1298,7 +1316,7 @@ async function handleMcp(req, res, path, rawBody = "") {
   }
 
   if (req.method !== "POST") {
-    json(res, 405, { error: "method_not_allowed" }, { allow: "POST, DELETE" });
+    json(res, 405, { error: "method_not_allowed" }, { allow: "POST, DELETE", "www-authenticate": bearerFailureHeader("", path) });
     return;
   }
 
@@ -1363,8 +1381,9 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
-    if (wellKnownMatches(url.pathname, "oauth-protected-resource")) {
-      json(res, 200, protectedResourceMetadata());
+    const prmMcpPath = protectedResourceMcpPath(url.pathname);
+    if (prmMcpPath) {
+      json(res, 200, protectedResourceMetadata(`${issuer}${prmMcpPath}`));
       return;
     }
 

--- a/scripts/servicenow-mcp-server.mjs
+++ b/scripts/servicenow-mcp-server.mjs
@@ -1,0 +1,1419 @@
+#!/usr/bin/env node
+import http from "node:http";
+import { createHash, randomBytes } from "node:crypto";
+
+const host = process.env.HOST || "127.0.0.1";
+const port = Number(process.env.PORT || 3979);
+const issuer = (process.env.ISSUER || `http://${host}:${port}`).replace(/\/+$/, "");
+const autoApprove = process.env.AUTO_APPROVE !== "0";
+const tokenTtlSeconds = Number(process.env.TOKEN_TTL_SECONDS || 1800);
+const refreshTtlSeconds = Number(process.env.REFRESH_TTL_SECONDS || 8640000);
+
+const MCP_PATHS = ["/mcp", "/sncapps/mcp-server/mcp/sn_openwork_it"];
+const SUPPORTED_PROTOCOL_VERSIONS = ["2025-11-25", "2025-06-18", "2025-03-26"];
+const SCOPES = ["incidents.read", "incidents.write"];
+const canonicalResource = `${issuer}/mcp`;
+
+const clients = new Map([
+  [
+    "acme-desktop-client",
+    {
+      clientId: "acme-desktop-client",
+      clientSecret: "acme-oauth-secret-98765",
+      name: "OpenWork Desktop",
+      scopes: SCOPES,
+      redirectUris: [],
+    },
+  ],
+]);
+
+const authorizationCodes = new Map();
+const accessTokens = new Map();
+const refreshTokens = new Map();
+const mcpSessions = new Set();
+const requests = [];
+const incidents = [];
+const incidentJournal = new Map();
+let nextIncidentSequence = 10001;
+
+const users = [
+  { sys_id: "10000000000000000000000000000001", user_name: "abel.tuter", name: "Abel Tuter", email: "abel.tuter@acme.test" },
+  { sys_id: "10000000000000000000000000000002", user_name: "beth.anglin", name: "Beth Anglin", email: "beth.anglin@acme.test" },
+  { sys_id: "10000000000000000000000000000003", user_name: "alex.owner", name: "Alex Owner", email: "alex@acme.test" },
+  { sys_id: "10000000000000000000000000000004", user_name: "rashmi.member", name: "Rashmi Member", email: "rashmi@acme.test" },
+];
+
+const groups = [
+  { sys_id: "20000000000000000000000000000001", name: "Service Desk" },
+  { sys_id: "20000000000000000000000000000002", name: "Hardware" },
+  { sys_id: "20000000000000000000000000000003", name: "Network" },
+];
+
+const stateLabels = {
+  1: "New",
+  2: "In Progress",
+  3: "On Hold",
+  6: "Resolved",
+  7: "Closed",
+};
+
+const priorityLabels = {
+  1: "Critical",
+  2: "High",
+  3: "Moderate",
+  4: "Low",
+  5: "Planning",
+};
+
+const closeCodes = [
+  "Solved (Work Around)",
+  "Solved (Permanently)",
+  "Solved Remotely (Work Around)",
+  "Solved Remotely (Permanently)",
+  "Not Solved (Not Reproducible)",
+  "Not Solved (Too Costly)",
+];
+
+function baseHeaders(headers = {}) {
+  return {
+    "access-control-allow-origin": "*",
+    "access-control-allow-headers": "authorization, content-type, mcp-protocol-version, mcp-session-id",
+    "access-control-allow-methods": "GET, POST, PATCH, DELETE, OPTIONS",
+    "access-control-expose-headers": "Mcp-Session-Id, X-Total-Count, WWW-Authenticate",
+    ...headers,
+  };
+}
+
+function json(res, status, body, headers = {}) {
+  res.writeHead(status, baseHeaders({ "content-type": "application/json", ...headers }));
+  res.end(JSON.stringify(body));
+}
+
+function html(res, status, body, headers = {}) {
+  res.writeHead(status, baseHeaders({ "content-type": "text/html; charset=utf-8", ...headers }));
+  res.end(body);
+}
+
+function empty(res, status, headers = {}) {
+  res.writeHead(status, baseHeaders(headers));
+  res.end();
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => resolve(raw));
+    req.on("error", reject);
+  });
+}
+
+async function readJson(req) {
+  const raw = await readBody(req);
+  if (!raw.trim()) return {};
+  return JSON.parse(raw);
+}
+
+async function readForm(req) {
+  const raw = await readBody(req);
+  return Object.fromEntries(new URLSearchParams(raw));
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function randomToken(prefix) {
+  return `${prefix}_${randomBytes(24).toString("base64url")}`;
+}
+
+function serviceNowTime(date = new Date()) {
+  return date.toISOString().replace("T", " ").slice(0, 19);
+}
+
+function incidentNumber(sequence) {
+  return `INC${String(sequence).padStart(7, "0")}`;
+}
+
+function standardPriority(impact, urgency) {
+  const matrix = {
+    "1:1": 1,
+    "1:2": 2,
+    "1:3": 3,
+    "2:1": 2,
+    "2:2": 3,
+    "2:3": 4,
+    "3:1": 3,
+    "3:2": 4,
+    "3:3": 5,
+  };
+  return matrix[`${impact}:${urgency}`] || 5;
+}
+
+function integerIn(value, allowed, fallback) {
+  const parsed = Number(value);
+  if (Number.isInteger(parsed) && allowed.includes(parsed)) return parsed;
+  return fallback;
+}
+
+function seedSysId(index) {
+  return String(index).padStart(32, "0");
+}
+
+function appendJournal(sysId, type, value, author = "system") {
+  if (!value) return null;
+  const entries = incidentJournal.get(sysId) || [];
+  const entry = { type, value: String(value), author, timestamp: serviceNowTime() };
+  entries.push(entry);
+  incidentJournal.set(sysId, entries);
+  return entry;
+}
+
+function incidentView(incident, includeJournal = false) {
+  const result = { ...incident };
+  if (includeJournal) result.journal = [...(incidentJournal.get(incident.sys_id) || [])];
+  return result;
+}
+
+function applyFields(record, fieldsParam) {
+  if (!fieldsParam) return record;
+  const fields = String(fieldsParam)
+    .split(",")
+    .map((field) => field.trim())
+    .filter(Boolean);
+  if (fields.length === 0) return record;
+  const filtered = {};
+  for (const field of fields) {
+    if (Object.hasOwn(record, field)) filtered[field] = record[field];
+  }
+  return filtered;
+}
+
+function createIncident(fields, options = {}) {
+  const now = options.now || serviceNowTime();
+  const impact = integerIn(fields.impact ?? 3, [1, 2, 3], 3);
+  const urgency = integerIn(fields.urgency ?? 3, [1, 2, 3], 3);
+  const priority = integerIn(fields.priority ?? standardPriority(impact, urgency), [1, 2, 3, 4, 5], standardPriority(impact, urgency));
+  const state = integerIn(fields.state ?? 1, [1, 2, 3, 6, 7], 1);
+  const sysId = fields.sys_id || randomBytes(16).toString("hex");
+  const incident = {
+    sys_id: sysId,
+    number: fields.number || incidentNumber(nextIncidentSequence++),
+    short_description: String(fields.short_description || ""),
+    description: String(fields.description || ""),
+    state,
+    impact,
+    urgency,
+    priority,
+    category: String(fields.category || "inquiry"),
+    subcategory: String(fields.subcategory || "general"),
+    assignment_group: String(fields.assignment_group || "Service Desk"),
+    assigned_to: String(fields.assigned_to || ""),
+    caller_id: String(fields.caller_id || "abel.tuter"),
+    opened_at: fields.opened_at || now,
+    resolved_at: fields.resolved_at || "",
+    close_code: fields.close_code || "",
+    close_notes: fields.close_notes || "",
+    sys_created_on: fields.sys_created_on || now,
+    sys_updated_on: fields.sys_updated_on || now,
+  };
+  incidents.push(incident);
+  incidentJournal.set(sysId, []);
+  for (const note of fields.journal || []) appendJournal(sysId, note.type, note.value, note.author);
+  return incident;
+}
+
+function updateIncident(incident, updates, author = "api.user") {
+  const changedPriorityInput = Object.hasOwn(updates, "priority");
+  const allowedFields = [
+    "short_description",
+    "description",
+    "state",
+    "impact",
+    "urgency",
+    "priority",
+    "category",
+    "subcategory",
+    "assignment_group",
+    "assigned_to",
+    "caller_id",
+    "close_code",
+    "close_notes",
+    "resolved_at",
+  ];
+  for (const field of allowedFields) {
+    if (!Object.hasOwn(updates, field)) continue;
+    if (["state", "impact", "urgency", "priority"].includes(field)) {
+      const bounds = field === "priority" ? [1, 2, 3, 4, 5] : field === "state" ? [1, 2, 3, 6, 7] : [1, 2, 3];
+      incident[field] = integerIn(updates[field], bounds, incident[field]);
+    } else {
+      incident[field] = String(updates[field] ?? "");
+    }
+  }
+  if ((Object.hasOwn(updates, "impact") || Object.hasOwn(updates, "urgency")) && !changedPriorityInput) {
+    incident.priority = standardPriority(incident.impact, incident.urgency);
+  }
+  if (Object.hasOwn(updates, "comments")) appendJournal(incident.sys_id, "comments", updates.comments, author);
+  if (Object.hasOwn(updates, "work_notes")) appendJournal(incident.sys_id, "work_notes", updates.work_notes, author);
+  if (incident.state === 6 && !incident.resolved_at) incident.resolved_at = serviceNowTime();
+  incident.sys_updated_on = serviceNowTime();
+  return incident;
+}
+
+function seedData() {
+  const seed = [
+    {
+      short_description: "Email delivery delayed for finance approvals",
+      description: "Finance users report approval notifications arriving 30 minutes late after the mail relay upgrade.",
+      state: 2,
+      impact: 2,
+      urgency: 2,
+      category: "software",
+      subcategory: "email",
+      assignment_group: "Service Desk",
+      assigned_to: "beth.anglin",
+      caller_id: "alex.owner",
+      opened_at: "2026-07-08 08:15:00",
+      sys_created_on: "2026-07-08 08:15:00",
+      sys_updated_on: "2026-07-08 09:05:00",
+      journal: [{ type: "work_notes", value: "Checked Exchange queue depth; messages are draining slowly.", author: "beth.anglin" }],
+    },
+    {
+      short_description: "VPN disconnects every five minutes from home Wi-Fi",
+      description: "Several field engineers cannot keep the VPN tunnel active during customer escalations.",
+      state: 1,
+      impact: 1,
+      urgency: 2,
+      category: "network",
+      subcategory: "vpn",
+      assignment_group: "Network",
+      assigned_to: "",
+      caller_id: "rashmi.member",
+      opened_at: "2026-07-08 07:40:00",
+      sys_created_on: "2026-07-08 07:40:00",
+      sys_updated_on: "2026-07-08 07:40:00",
+      journal: [{ type: "comments", value: "I can reproduce on two laptops and a hotspot.", author: "rashmi.member" }],
+    },
+    {
+      short_description: "Laptop battery swollen on assembly line kiosk",
+      description: "Kiosk ACME-KIOSK-14 has a visibly swollen battery and must be removed from service.",
+      state: 3,
+      impact: 2,
+      urgency: 1,
+      priority: 2,
+      category: "hardware",
+      subcategory: "laptop",
+      assignment_group: "Hardware",
+      assigned_to: "abel.tuter",
+      caller_id: "beth.anglin",
+      opened_at: "2026-07-07 16:10:00",
+      sys_created_on: "2026-07-07 16:10:00",
+      sys_updated_on: "2026-07-07 17:22:00",
+      journal: [{ type: "work_notes", value: "Put device in safety bag; waiting for replacement parts.", author: "abel.tuter" }],
+    },
+    {
+      short_description: "Badge reader offline at south entrance",
+      description: "Employees are tailgating because the south entrance badge reader is not accepting scans.",
+      state: 2,
+      impact: 2,
+      urgency: 2,
+      category: "hardware",
+      subcategory: "facilities",
+      assignment_group: "Hardware",
+      assigned_to: "abel.tuter",
+      caller_id: "alex.owner",
+      opened_at: "2026-07-07 12:35:00",
+      sys_created_on: "2026-07-07 12:35:00",
+      sys_updated_on: "2026-07-07 13:20:00",
+      journal: [{ type: "comments", value: "Security guard is posted until the reader is back online.", author: "alex.owner" }],
+    },
+    {
+      short_description: "Printer queue stuck for shipping labels",
+      description: "Shipping cannot print carrier labels from workstation SHIP-03.",
+      state: 6,
+      impact: 3,
+      urgency: 2,
+      category: "hardware",
+      subcategory: "printer",
+      assignment_group: "Service Desk",
+      assigned_to: "beth.anglin",
+      caller_id: "abel.tuter",
+      opened_at: "2026-07-06 10:12:00",
+      resolved_at: "2026-07-06 11:02:00",
+      close_code: "Solved Remotely (Permanently)",
+      close_notes: "Cleared stuck spooler job and reinstalled the Zebra driver.",
+      sys_created_on: "2026-07-06 10:12:00",
+      sys_updated_on: "2026-07-06 11:02:00",
+      journal: [{ type: "work_notes", value: "Remote driver reinstall completed successfully.", author: "beth.anglin" }],
+    },
+    {
+      short_description: "Robot telemetry dashboard returns 502",
+      description: "Operations dashboard for robot telemetry intermittently returns 502 from the internal reverse proxy.",
+      state: 1,
+      impact: 1,
+      urgency: 1,
+      category: "software",
+      subcategory: "monitoring",
+      assignment_group: "Network",
+      assigned_to: "",
+      caller_id: "alex.owner",
+      opened_at: "2026-07-08 09:55:00",
+      sys_created_on: "2026-07-08 09:55:00",
+      sys_updated_on: "2026-07-08 09:55:00",
+      journal: [{ type: "comments", value: "This blocks the morning operations standup.", author: "alex.owner" }],
+    },
+    {
+      short_description: "New hire cannot access CAD license server",
+      description: "A new mechanical engineer receives license checkout denied when launching CAD tooling.",
+      state: 7,
+      impact: 3,
+      urgency: 3,
+      category: "software",
+      subcategory: "license",
+      assignment_group: "Service Desk",
+      assigned_to: "beth.anglin",
+      caller_id: "rashmi.member",
+      opened_at: "2026-07-05 14:05:00",
+      resolved_at: "2026-07-05 15:45:00",
+      close_code: "Solved (Permanently)",
+      close_notes: "Added user to the CAD license group and verified checkout.",
+      sys_created_on: "2026-07-05 14:05:00",
+      sys_updated_on: "2026-07-05 15:50:00",
+      journal: [{ type: "comments", value: "Confirmed access works. Thank you!", author: "rashmi.member" }],
+    },
+    {
+      short_description: "Conference room camera not detected",
+      description: "Room Cortex-2 cannot detect the USB camera after the firmware update.",
+      state: 1,
+      impact: 3,
+      urgency: 2,
+      category: "hardware",
+      subcategory: "conference room",
+      assignment_group: "Hardware",
+      assigned_to: "",
+      caller_id: "abel.tuter",
+      opened_at: "2026-07-08 06:30:00",
+      sys_created_on: "2026-07-08 06:30:00",
+      sys_updated_on: "2026-07-08 06:30:00",
+      journal: [{ type: "work_notes", value: "Firmware rollback package staged.", author: "system" }],
+    },
+  ];
+
+  seed.forEach((item, index) => {
+    createIncident({ ...item, sys_id: seedSysId(index + 1), number: incidentNumber(nextIncidentSequence++) });
+  });
+}
+
+function isMcpPath(pathname) {
+  const normalized = pathname.endsWith("/") && pathname !== "/" ? pathname.slice(0, -1) : pathname;
+  return MCP_PATHS.includes(normalized) ? normalized : null;
+}
+
+function protectedResourceMetadata() {
+  return {
+    resource: canonicalResource,
+    authorization_servers: [issuer],
+    scopes_supported: SCOPES,
+    bearer_methods_supported: ["header"],
+    resource_name: "ServiceNow (Acme Robotics IT)",
+  };
+}
+
+function authorizationServerMetadata() {
+  return {
+    issuer,
+    authorization_endpoint: `${issuer}/oauth_auth.do`,
+    token_endpoint: `${issuer}/oauth_token.do`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_post", "client_secret_basic"],
+    scopes_supported: SCOPES,
+  };
+}
+
+function wellKnownMatches(pathname, kind) {
+  const root = `/.well-known/${kind}`;
+  if (pathname === root) return true;
+  for (const mcpPath of MCP_PATHS) {
+    if (pathname === `${root}${mcpPath}`) return true;
+    if (pathname === `${mcpPath}/.well-known/${kind}`) return true;
+  }
+  return false;
+}
+
+function basicClient(req) {
+  const header = req.headers.authorization || "";
+  const match = header.match(/^Basic\s+(.+)$/i);
+  if (!match) return null;
+  const decoded = Buffer.from(match[1], "base64").toString("utf8");
+  const separator = decoded.indexOf(":");
+  if (separator === -1) return { clientId: decoded, clientSecret: "" };
+  return { clientId: decoded.slice(0, separator), clientSecret: decoded.slice(separator + 1) };
+}
+
+function oauthError(res, status, error, description, headers = {}) {
+  json(res, status, { error, ...(description ? { error_description: description } : {}) }, headers);
+}
+
+function redirectOauthError(res, redirectUri, state, error, description) {
+  const callback = new URL(redirectUri);
+  callback.searchParams.set("error", error);
+  if (description) callback.searchParams.set("error_description", description);
+  if (state) callback.searchParams.set("state", state);
+  res.writeHead(302, baseHeaders({ location: callback.toString() }));
+  res.end();
+}
+
+function parseScopes(scopeValue, client) {
+  const requested = String(scopeValue || "").trim();
+  const scopes = requested ? requested.split(/\s+/).filter(Boolean) : client.scopes;
+  const invalid = scopes.filter((scope) => !client.scopes.includes(scope));
+  if (invalid.length > 0) return { ok: false, scopes, invalid };
+  return { ok: true, scopes: [...new Set(scopes)] };
+}
+
+function isLoopbackHost(hostname) {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]";
+}
+
+function isAllowedRedirectUri(value, client) {
+  if (client.redirectUris.includes(value)) return true;
+  try {
+    const url = new URL(value);
+    return (url.protocol === "http:" || url.protocol === "https:") && isLoopbackHost(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function issueAuthorizationCode(res, params) {
+  const redirectUri = params.get("redirect_uri");
+  const state = params.get("state") || "";
+  if (!redirectUri) {
+    oauthError(res, 400, "invalid_request", "redirect_uri is required");
+    return;
+  }
+
+  const client = clients.get(params.get("client_id") || "");
+  if (!client) {
+    oauthError(res, 400, "invalid_client", "client_id is not registered in this ServiceNow instance");
+    return;
+  }
+  if (!isAllowedRedirectUri(redirectUri, client)) {
+    oauthError(res, 400, "invalid_request", "redirect_uri is not registered for this client");
+    return;
+  }
+  if (!params.get("code_challenge")) {
+    redirectOauthError(res, redirectUri, state, "invalid_request", "PKCE code_challenge is required");
+    return;
+  }
+  if (params.get("code_challenge_method") !== "S256") {
+    redirectOauthError(res, redirectUri, state, "invalid_request", "OAuth 2.1 requires code_challenge_method=S256");
+    return;
+  }
+  const scopeResult = parseScopes(params.get("scope"), client);
+  if (!scopeResult.ok) {
+    redirectOauthError(res, redirectUri, state, "invalid_scope", `Client is not allowed to request ${scopeResult.invalid.join(" ")}`);
+    return;
+  }
+
+  const code = randomToken("sn_code");
+  authorizationCodes.set(code, {
+    clientId: client.clientId,
+    codeChallenge: params.get("code_challenge"),
+    redirectUri,
+    state,
+    scope: scopeResult.scopes,
+    resource: params.get("resource") || canonicalResource,
+    expiresAt: Date.now() + 5 * 60 * 1000,
+    used: false,
+  });
+
+  const callback = new URL(redirectUri);
+  callback.searchParams.set("code", code);
+  if (state) callback.searchParams.set("state", state);
+  res.writeHead(302, baseHeaders({ location: callback.toString() }));
+  res.end();
+}
+
+function authorize(req, res, url) {
+  const params = url.searchParams;
+  const redirectUri = params.get("redirect_uri");
+  if (!redirectUri) {
+    oauthError(res, 400, "invalid_request", "redirect_uri is required");
+    return;
+  }
+  if (params.get("response_type") && params.get("response_type") !== "code") {
+    redirectOauthError(res, redirectUri, params.get("state") || "", "invalid_request", "response_type must be code");
+    return;
+  }
+  const client = clients.get(params.get("client_id") || "");
+  if (!client) {
+    oauthError(res, 400, "invalid_client", "client_id is not registered in this ServiceNow instance");
+    return;
+  }
+
+  if (autoApprove && params.get("force_consent") !== "1") {
+    issueAuthorizationCode(res, params);
+    return;
+  }
+
+  const requestedScopes = (params.get("scope") || client.scopes.join(" ")).split(/\s+/).filter(Boolean);
+  const hidden = [...params]
+    .map(([key, value]) => `<input type="hidden" name="${escapeHtml(key)}" value="${escapeHtml(value)}">`)
+    .join("\n");
+  html(res, 200, `<!doctype html>
+<html>
+  <head><title>ServiceNow — Acme Robotics IT</title></head>
+  <body style="font-family: Arial, sans-serif; background: #f4f6f8; color: #1f2a33;">
+    <main style="max-width: 640px; margin: 56px auto; padding: 32px; background: white; border-radius: 12px; box-shadow: 0 2px 18px rgba(0,0,0,.12);">
+      <h1>ServiceNow — Acme Robotics IT</h1>
+      <p><strong>${escapeHtml(client.name)}</strong> is requesting access to this ServiceNow developer instance.</p>
+      <h2>Requested scopes</h2>
+      <ul>${requestedScopes.map((scope) => `<li><code>${escapeHtml(scope)}</code></li>`).join("")}</ul>
+      <form method="post" action="/oauth_approve">
+        ${hidden}
+        <button style="font: inherit; padding: 10px 16px; background: #2e7d32; color: white; border: 0; border-radius: 6px;">Allow</button>
+      </form>
+    </main>
+  </body>
+</html>`);
+}
+
+async function approve(req, res) {
+  const form = await readForm(req);
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(form)) params.set(key, value);
+  issueAuthorizationCode(res, params);
+}
+
+function clientForTokenRequest(req, form, expectedClientId) {
+  const basic = basicClient(req);
+  const formHasSecret = Object.hasOwn(form, "client_secret");
+  const clientId = basic?.clientId || form.client_id || expectedClientId || "";
+  const client = clients.get(clientId);
+  if (!client) {
+    return { error: "invalid_client", description: "Unknown OAuth client", basicFailure: Boolean(basic) };
+  }
+  if (expectedClientId && client.clientId !== expectedClientId) {
+    return { error: "invalid_grant", description: "Authorization code was issued to a different client" };
+  }
+  const suppliedSecret = basic ? basic.clientSecret : formHasSecret ? form.client_secret : undefined;
+  if (suppliedSecret !== undefined && suppliedSecret !== client.clientSecret) {
+    return { error: "invalid_client", description: "OAuth client secret is invalid", basicFailure: Boolean(basic) };
+  }
+  return { client };
+}
+
+function sendTokenClientError(res, result) {
+  const headers = result.basicFailure ? { "www-authenticate": 'Basic realm="ServiceNow"' } : {};
+  oauthError(res, result.error === "invalid_client" ? 401 : 400, result.error, result.description, headers);
+}
+
+function issueTokenPair(clientId, scopes, audience, existingRefreshToken = "") {
+  const accessToken = randomToken("sn_at");
+  const now = Date.now();
+  accessTokens.set(accessToken, {
+    clientId,
+    scopes,
+    audience,
+    expiresAt: now + tokenTtlSeconds * 1000,
+  });
+  const refreshToken = existingRefreshToken || randomToken("sn_rt");
+  if (!existingRefreshToken) {
+    refreshTokens.set(refreshToken, {
+      clientId,
+      scopes,
+      audience,
+      expiresAt: now + refreshTtlSeconds * 1000,
+    });
+  }
+  return { accessToken, refreshToken };
+}
+
+async function issueToken(req, res) {
+  const form = await readForm(req);
+  const grantType = form.grant_type || "authorization_code";
+
+  if (grantType === "authorization_code") {
+    const grant = authorizationCodes.get(form.code || "");
+    if (!grant || grant.used || grant.expiresAt < Date.now()) {
+      oauthError(res, 400, "invalid_grant", "Authorization code is invalid, expired, or already used");
+      return;
+    }
+    const clientResult = clientForTokenRequest(req, form, grant.clientId);
+    if (!clientResult.client) {
+      sendTokenClientError(res, clientResult);
+      return;
+    }
+    if (form.redirect_uri !== grant.redirectUri) {
+      oauthError(res, 400, "invalid_grant", "redirect_uri does not match the authorization request");
+      return;
+    }
+    if (form.resource && form.resource !== grant.resource) {
+      oauthError(res, 400, "invalid_grant", "resource does not match the authorization request");
+      return;
+    }
+    const expectedChallenge = createHash("sha256").update(form.code_verifier || "").digest("base64url");
+    if (!form.code_verifier || expectedChallenge !== grant.codeChallenge) {
+      oauthError(res, 400, "invalid_grant", "PKCE verification failed");
+      return;
+    }
+    grant.used = true;
+    authorizationCodes.delete(form.code);
+    const pair = issueTokenPair(grant.clientId, grant.scope, grant.resource);
+    json(res, 200, {
+      access_token: pair.accessToken,
+      refresh_token: pair.refreshToken,
+      token_type: "Bearer",
+      expires_in: tokenTtlSeconds,
+      scope: grant.scope.join(" "),
+    });
+    return;
+  }
+
+  if (grantType === "refresh_token") {
+    const refresh = refreshTokens.get(form.refresh_token || "");
+    if (!refresh || refresh.expiresAt < Date.now()) {
+      oauthError(res, 400, "invalid_grant", "Refresh token is invalid or expired");
+      return;
+    }
+    const clientResult = clientForTokenRequest(req, form, refresh.clientId);
+    if (!clientResult.client) {
+      sendTokenClientError(res, clientResult);
+      return;
+    }
+    if (form.resource && form.resource !== refresh.audience) {
+      oauthError(res, 400, "invalid_grant", "resource does not match the refresh token audience");
+      return;
+    }
+    let scopes = refresh.scopes;
+    if (form.scope) {
+      const requested = form.scope.split(/\s+/).filter(Boolean);
+      const invalid = requested.filter((scope) => !refresh.scopes.includes(scope));
+      if (invalid.length > 0) {
+        oauthError(res, 400, "invalid_scope", `Refresh token cannot be expanded to ${invalid.join(" ")}`);
+        return;
+      }
+      scopes = requested;
+    }
+    const pair = issueTokenPair(refresh.clientId, scopes, refresh.audience, form.refresh_token);
+    json(res, 200, {
+      access_token: pair.accessToken,
+      refresh_token: pair.refreshToken,
+      token_type: "Bearer",
+      expires_in: tokenTtlSeconds,
+      scope: scopes.join(" "),
+    });
+    return;
+  }
+
+  oauthError(res, 400, "unsupported_grant_type", `Unsupported grant_type ${grantType}`);
+}
+
+function bearerFailureHeader(description) {
+  const error = description ? `, error="invalid_token", error_description="${description.replaceAll('"', "'")}"` : "";
+  return `Bearer resource_metadata="${issuer}/.well-known/oauth-protected-resource"${error}`;
+}
+
+function serviceNowAuthEnvelope(message = "User Not Authenticated", detail = "Required to provide Auth information") {
+  return { error: { message, detail }, status: "failure" };
+}
+
+function tokenFromRequest(req) {
+  const header = req.headers.authorization || "";
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  if (!match) return { ok: false, missing: true, description: "Bearer token is required" };
+  const token = accessTokens.get(match[1]);
+  if (!token) return { ok: false, description: "Access token is not recognized" };
+  if (token.expiresAt < Date.now()) return { ok: false, description: "Access token is expired" };
+  if (token.audience !== canonicalResource) return { ok: false, description: "Access token audience does not match this ServiceNow MCP resource" };
+  return { ok: true, token };
+}
+
+function rejectProtected(res, validation, serviceNowEnvelope = false) {
+  const headers = { "www-authenticate": bearerFailureHeader(validation.missing ? "" : validation.description) };
+  const body = serviceNowEnvelope
+    ? serviceNowAuthEnvelope("User Not Authenticated", validation.missing ? "Required to provide Auth information" : validation.description)
+    : { error: validation.missing ? "missing_token" : "invalid_token", error_description: validation.description };
+  json(res, 401, body, headers);
+}
+
+function requireProtected(req, res, requiredScope, serviceNowEnvelope = false) {
+  const validation = tokenFromRequest(req);
+  if (!validation.ok) {
+    rejectProtected(res, validation, serviceNowEnvelope);
+    return null;
+  }
+  if (requiredScope && !validation.token.scopes.includes(requiredScope)) {
+    json(res, 403, serviceNowAuthEnvelope("Insufficient scope", `Required OAuth scope ${requiredScope}`));
+    return null;
+  }
+  return validation.token;
+}
+
+function matchesCondition(record, condition) {
+  if (!condition || condition.startsWith("ORDERBY")) return true;
+  const likeIndex = condition.indexOf("LIKE");
+  if (likeIndex > 0) {
+    const field = condition.slice(0, likeIndex);
+    const value = condition.slice(likeIndex + 4).toLowerCase();
+    return String(record[field] ?? "").toLowerCase().includes(value);
+  }
+  const inIndex = condition.indexOf("IN");
+  if (inIndex > 0) {
+    const field = condition.slice(0, inIndex);
+    const values = condition.slice(inIndex + 2).split(",").map((value) => value.trim());
+    return values.includes(String(record[field] ?? ""));
+  }
+  const notEqualsIndex = condition.indexOf("!=");
+  if (notEqualsIndex > 0) {
+    const field = condition.slice(0, notEqualsIndex);
+    const value = condition.slice(notEqualsIndex + 2);
+    return String(record[field] ?? "") !== value;
+  }
+  const equalsIndex = condition.indexOf("=");
+  if (equalsIndex > 0) {
+    const field = condition.slice(0, equalsIndex);
+    const value = condition.slice(equalsIndex + 1);
+    return String(record[field] ?? "") === value;
+  }
+  return true;
+}
+
+function queryIncidents(searchParams) {
+  const query = searchParams.get("sysparm_query") || "";
+  const parts = query.split("^").filter(Boolean);
+  const orderPart = parts.find((part) => part.startsWith("ORDERBY"));
+  let result = incidents.filter((incident) => parts.every((part) => matchesCondition(incident, part)));
+  if (orderPart) {
+    const descending = orderPart.startsWith("ORDERBYDESC");
+    const field = descending ? orderPart.slice("ORDERBYDESC".length) : orderPart.slice("ORDERBY".length);
+    result = [...result].sort((left, right) => {
+      const a = String(left[field] ?? "");
+      const b = String(right[field] ?? "");
+      return descending ? b.localeCompare(a) : a.localeCompare(b);
+    });
+  }
+  const total = result.length;
+  const limit = Math.max(0, Number(searchParams.get("sysparm_limit") || 10));
+  const offset = Math.max(0, Number(searchParams.get("sysparm_offset") || 0));
+  return { total, rows: result.slice(offset, offset + limit) };
+}
+
+function findIncident(identifier) {
+  if (!identifier) return null;
+  return incidents.find((incident) => incident.sys_id === identifier || incident.number.toLowerCase() === String(identifier).toLowerCase()) || null;
+}
+
+async function handleIncidentList(req, res, url) {
+  if (req.method === "GET") {
+    const token = requireProtected(req, res, "incidents.read", true);
+    if (!token) return;
+    const { total, rows } = queryIncidents(url.searchParams);
+    const result = rows.map((incident) => applyFields(incidentView(incident), url.searchParams.get("sysparm_fields")));
+    json(res, 200, { result }, { "x-total-count": String(total) });
+    return;
+  }
+
+  if (req.method === "POST") {
+    const token = requireProtected(req, res, "incidents.write", true);
+    if (!token) return;
+    const body = await readJson(req).catch(() => null);
+    if (!body || typeof body !== "object" || !body.short_description) {
+      json(res, 400, serviceNowAuthEnvelope("Invalid request", "short_description is required"));
+      return;
+    }
+    const incident = createIncident(body);
+    json(res, 201, { result: incidentView(incident, true) });
+    return;
+  }
+
+  json(res, 405, { error: "method_not_allowed" });
+}
+
+async function handleIncidentRecord(req, res, sysId) {
+  if (req.method === "GET") {
+    const token = requireProtected(req, res, "incidents.read", true);
+    if (!token) return;
+    const incident = incidents.find((item) => item.sys_id === sysId);
+    if (!incident) {
+      json(res, 404, serviceNowAuthEnvelope("No Record found", `Incident ${sysId} was not found`));
+      return;
+    }
+    json(res, 200, { result: incidentView(incident, true) });
+    return;
+  }
+
+  if (req.method === "PATCH") {
+    const token = requireProtected(req, res, "incidents.write", true);
+    if (!token) return;
+    const incident = incidents.find((item) => item.sys_id === sysId);
+    if (!incident) {
+      json(res, 404, serviceNowAuthEnvelope("No Record found", `Incident ${sysId} was not found`));
+      return;
+    }
+    const body = await readJson(req).catch(() => null);
+    if (!body || typeof body !== "object") {
+      json(res, 400, serviceNowAuthEnvelope("Invalid request", "PATCH body must be a JSON object"));
+      return;
+    }
+    updateIncident(incident, body);
+    json(res, 200, { result: incidentView(incident, true) });
+    return;
+  }
+
+  json(res, 405, { error: "method_not_allowed" });
+}
+
+function isAllowedOriginHeader(origin) {
+  if (!origin || origin === "null") return true;
+  try {
+    const parsed = new URL(origin);
+    return isLoopbackHost(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function jsonRpcError(id, code, message, status = 200) {
+  return { status, body: { jsonrpc: "2.0", id, error: { code, message } } };
+}
+
+function jsonRpcResult(id, result, headers = {}) {
+  return { status: 200, body: { jsonrpc: "2.0", id, result }, headers };
+}
+
+function parseJsonRpcMethod(raw) {
+  try {
+    const body = JSON.parse(raw || "{}");
+    if (Array.isArray(body)) return "batch";
+    if (body && typeof body === "object" && typeof body.method === "string") return body.method;
+  } catch {}
+  return undefined;
+}
+
+function toolSchemas() {
+  const identifierProperties = {
+    number: { type: "string", pattern: "^INC[0-9]{7}$", description: "ServiceNow incident number, for example INC0010001." },
+    sys_id: { type: "string", pattern: "^[0-9a-f]{32}$", description: "ServiceNow sys_id for the incident." },
+  };
+  const incidentSummary = {
+    type: "object",
+    properties: {
+      sys_id: { type: "string" },
+      number: { type: "string" },
+      short_description: { type: "string" },
+      state: { type: "integer" },
+      state_label: { type: "string" },
+      priority: { type: "integer" },
+      priority_label: { type: "string" },
+      assignment_group: { type: "string" },
+      assigned_to: { type: "string" },
+      link: { type: "string" },
+    },
+    required: ["sys_id", "number", "short_description", "state", "state_label", "priority", "priority_label", "link"],
+  };
+  const fullIncident = {
+    type: "object",
+    properties: {
+      incident: { type: "object" },
+    },
+    required: ["incident"],
+  };
+  return [
+    {
+      name: "search_incidents",
+      title: "Search Incidents",
+      description: "Use this ServiceNow Incident tool when you need to find one or more incidents by number, description, state, priority, assignment group, or assignee. It returns concise incident summaries with ServiceNow deep links.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Free text matched with LIKE against number, short_description, and description." },
+          state: { type: "integer", enum: [1, 2, 3, 6, 7] },
+          priority: { type: "integer", enum: [1, 2, 3, 4, 5] },
+          assignment_group: { type: "string", enum: groups.map((group) => group.name) },
+          assigned_to: { type: "string", enum: users.map((user) => user.user_name) },
+          limit: { type: "integer", minimum: 1, maximum: 50, default: 10 },
+          offset: { type: "integer", minimum: 0, default: 0 },
+        },
+        required: [],
+      },
+      outputSchema: {
+        type: "object",
+        properties: {
+          count: { type: "integer" },
+          incidents: { type: "array", items: incidentSummary },
+        },
+        required: ["count", "incidents"],
+      },
+      annotations: { readOnlyHint: true },
+    },
+    {
+      name: "get_incident",
+      title: "Get Incident",
+      description: "Use this ServiceNow Incident tool when you know an incident number or sys_id and need the full record, including comments and work notes journal entries.",
+      inputSchema: { type: "object", properties: identifierProperties, anyOf: [{ required: ["number"] }, { required: ["sys_id"] }] },
+      outputSchema: fullIncident,
+      annotations: { readOnlyHint: true },
+    },
+    {
+      name: "create_incident",
+      title: "Create Incident",
+      description: "Use this ServiceNow Incident tool to open a new incident when a user reports an outage, access issue, hardware problem, or other IT service interruption. It returns the created incident and link.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          short_description: { type: "string" },
+          description: { type: "string" },
+          caller_id: { type: "string", enum: users.map((user) => user.user_name) },
+          category: { type: "string" },
+          subcategory: { type: "string" },
+          impact: { type: "integer", minimum: 1, maximum: 3, enum: [1, 2, 3] },
+          urgency: { type: "integer", minimum: 1, maximum: 3, enum: [1, 2, 3] },
+          priority: { type: "integer", minimum: 1, maximum: 5, enum: [1, 2, 3, 4, 5] },
+          assignment_group: { type: "string", enum: groups.map((group) => group.name) },
+        },
+        required: ["short_description"],
+      },
+      outputSchema: fullIncident,
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    {
+      name: "update_incident",
+      title: "Update Incident",
+      description: "Use this ServiceNow Incident tool to update editable incident fields such as state, priority, assignment, category, or description while preserving the incident number and audit trail.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          ...identifierProperties,
+          short_description: { type: "string" },
+          description: { type: "string" },
+          state: { type: "integer", minimum: 1, maximum: 7, enum: [1, 2, 3, 6, 7] },
+          impact: { type: "integer", minimum: 1, maximum: 3, enum: [1, 2, 3] },
+          urgency: { type: "integer", minimum: 1, maximum: 3, enum: [1, 2, 3] },
+          priority: { type: "integer", minimum: 1, maximum: 5, enum: [1, 2, 3, 4, 5] },
+          category: { type: "string" },
+          subcategory: { type: "string" },
+          assignment_group: { type: "string", enum: groups.map((group) => group.name) },
+          assigned_to: { type: "string", enum: users.map((user) => user.user_name) },
+        },
+        anyOf: [{ required: ["number"] }, { required: ["sys_id"] }],
+      },
+      outputSchema: fullIncident,
+      annotations: { readOnlyHint: false, idempotentHint: true },
+    },
+    {
+      name: "add_comment",
+      title: "Add Comment or Work Note",
+      description: "Use this ServiceNow Incident tool to add a customer-visible comment or an internal work note to an incident journal without changing the main record fields.",
+      inputSchema: {
+        type: "object",
+        properties: { ...identifierProperties, comment: { type: "string" }, work_note: { type: "boolean", default: false } },
+        required: ["comment"],
+        anyOf: [{ required: ["number"] }, { required: ["sys_id"] }],
+      },
+      outputSchema: {
+        type: "object",
+        properties: { incident: { type: "object" }, journalEntry: { type: "object" } },
+        required: ["incident", "journalEntry"],
+      },
+      annotations: { readOnlyHint: false, idempotentHint: true },
+    },
+    {
+      name: "resolve_incident",
+      title: "Resolve Incident",
+      description: "Use this ServiceNow Incident tool when the restoration work is complete and the incident should move to Resolved with a close code and close notes for auditability.",
+      inputSchema: {
+        type: "object",
+        properties: { ...identifierProperties, close_code: { type: "string", enum: closeCodes }, close_notes: { type: "string" } },
+        required: ["close_code", "close_notes"],
+        anyOf: [{ required: ["number"] }, { required: ["sys_id"] }],
+      },
+      outputSchema: fullIncident,
+      annotations: { readOnlyHint: false, idempotentHint: true },
+    },
+  ];
+}
+
+const tools = toolSchemas();
+
+function incidentLink(incident) {
+  return `${issuer}/nav_to.do?uri=incident.do%3Fsys_id%3D${incident.sys_id}`;
+}
+
+function incidentSummary(incident) {
+  return {
+    sys_id: incident.sys_id,
+    number: incident.number,
+    short_description: incident.short_description,
+    state: incident.state,
+    state_label: stateLabels[incident.state],
+    priority: incident.priority,
+    priority_label: priorityLabels[incident.priority],
+    assignment_group: incident.assignment_group,
+    assigned_to: incident.assigned_to,
+    link: incidentLink(incident),
+  };
+}
+
+function formatIncident(incident) {
+  const summary = incidentSummary(incident);
+  return `${summary.number} — ${summary.short_description}\n` +
+    `sys_id: ${summary.sys_id}\n` +
+    `State: ${summary.state_label} (${summary.state})\n` +
+    `Priority: ${summary.priority} - ${summary.priority_label}\n` +
+    `Assignment group: ${summary.assignment_group}${summary.assigned_to ? ` / ${summary.assigned_to}` : ""}\n` +
+    `Link: ${summary.link}`;
+}
+
+function toolError(message, structured = {}) {
+  return { isError: true, content: [{ type: "text", text: message }], structuredContent: { error: { message, ...structured } } };
+}
+
+function requireToolScope(token, scope, toolName) {
+  if (token.scopes.includes(scope)) return null;
+  return toolError(`ServiceNow ACL denied: tool ${toolName} requires missing OAuth scope ${scope}.`, { missing_scope: scope });
+}
+
+function argumentError(message) {
+  return { protocolError: true, message };
+}
+
+function requireObjectArguments(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return argumentError("tools/call arguments must be an object");
+  return null;
+}
+
+function validateIdentifier(args) {
+  if (typeof args.number === "string" && args.number.trim()) return null;
+  if (typeof args.sys_id === "string" && args.sys_id.trim()) return null;
+  return argumentError("number or sys_id is required");
+}
+
+function validateIntegerEnum(args, field, values) {
+  if (!Object.hasOwn(args, field)) return null;
+  if (!Number.isInteger(args[field]) || !values.includes(args[field])) {
+    return argumentError(`${field} must be one of ${values.join(", ")}`);
+  }
+  return null;
+}
+
+function validateStringField(args, field, required = false) {
+  if (!Object.hasOwn(args, field)) {
+    return required ? argumentError(`${field} is required`) : null;
+  }
+  if (typeof args[field] !== "string" || (required && !args[field].trim())) return argumentError(`${field} must be a non-empty string`);
+  return null;
+}
+
+function validateToolArguments(name, args) {
+  const objectError = requireObjectArguments(args);
+  if (objectError) return objectError;
+  for (const field of ["state", "impact", "urgency", "priority"]) {
+    const values = field === "state" ? [1, 2, 3, 6, 7] : field === "priority" ? [1, 2, 3, 4, 5] : [1, 2, 3];
+    const error = validateIntegerEnum(args, field, values);
+    if (error) return error;
+  }
+  if (name === "search_incidents") {
+    if (Object.hasOwn(args, "limit") && (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 50)) return argumentError("limit must be an integer from 1 to 50");
+    if (Object.hasOwn(args, "offset") && (!Number.isInteger(args.offset) || args.offset < 0)) return argumentError("offset must be a non-negative integer");
+    return null;
+  }
+  if (name === "create_incident") return validateStringField(args, "short_description", true);
+  const identifierError = validateIdentifier(args);
+  if (identifierError) return identifierError;
+  if (name === "add_comment") {
+    const commentError = validateStringField(args, "comment", true);
+    if (commentError) return commentError;
+    if (Object.hasOwn(args, "work_note") && typeof args.work_note !== "boolean") return argumentError("work_note must be a boolean");
+  }
+  if (name === "resolve_incident") {
+    const closeCodeError = validateStringField(args, "close_code", true);
+    if (closeCodeError) return closeCodeError;
+    if (!closeCodes.includes(args.close_code)) return argumentError(`close_code must be one of ${closeCodes.join(", ")}`);
+    return validateStringField(args, "close_notes", true);
+  }
+  return null;
+}
+
+function searchIncidents(args) {
+  const query = typeof args.query === "string" ? args.query.toLowerCase() : "";
+  let result = incidents.filter((incident) => {
+    const matchesQuery = !query || [incident.number, incident.short_description, incident.description].some((value) => value.toLowerCase().includes(query));
+    const matchesState = !Object.hasOwn(args, "state") || incident.state === args.state;
+    const matchesPriority = !Object.hasOwn(args, "priority") || incident.priority === args.priority;
+    const matchesGroup = !args.assignment_group || incident.assignment_group === args.assignment_group;
+    const matchesAssignee = !args.assigned_to || incident.assigned_to === args.assigned_to;
+    return matchesQuery && matchesState && matchesPriority && matchesGroup && matchesAssignee;
+  });
+  result = result.sort((left, right) => right.sys_created_on.localeCompare(left.sys_created_on));
+  const limit = args.limit || 10;
+  const offset = args.offset || 0;
+  return result.slice(offset, offset + limit);
+}
+
+function callTool(name, args, token) {
+  const validation = validateToolArguments(name, args);
+  if (validation) return validation;
+  if (name === "search_incidents") {
+    const scopeError = requireToolScope(token, "incidents.read", name);
+    if (scopeError) return scopeError;
+    const rows = searchIncidents(args);
+    const summaries = rows.map(incidentSummary);
+    return {
+      content: [{ type: "text", text: summaries.length ? summaries.map((incident) => `${incident.number}: ${incident.short_description} (${incident.state_label}, Priority ${incident.priority} - ${incident.priority_label})\n${incident.link}`).join("\n\n") : "No matching ServiceNow incidents found." }],
+      structuredContent: { count: summaries.length, incidents: summaries },
+    };
+  }
+
+  if (name === "get_incident") {
+    const scopeError = requireToolScope(token, "incidents.read", name);
+    if (scopeError) return scopeError;
+    const incident = findIncident(args.sys_id || args.number);
+    if (!incident) return toolError("ServiceNow Incident ACL/read failed: record not found.", { code: "record_not_found" });
+    return { content: [{ type: "text", text: formatIncident(incident) }], structuredContent: { incident: incidentView(incident, true) } };
+  }
+
+  if (name === "create_incident") {
+    const scopeError = requireToolScope(token, "incidents.write", name);
+    if (scopeError) return scopeError;
+    const incident = createIncident(args);
+    return { content: [{ type: "text", text: `Created ${formatIncident(incident)}` }], structuredContent: { incident: incidentView(incident, true) } };
+  }
+
+  if (name === "update_incident") {
+    const scopeError = requireToolScope(token, "incidents.write", name);
+    if (scopeError) return scopeError;
+    const incident = findIncident(args.sys_id || args.number);
+    if (!incident) return toolError("ServiceNow Incident ACL/write failed: record not found.", { code: "record_not_found" });
+    updateIncident(incident, args, "openwork.agent");
+    return { content: [{ type: "text", text: `Updated ${formatIncident(incident)}` }], structuredContent: { incident: incidentView(incident, true) } };
+  }
+
+  if (name === "add_comment") {
+    const scopeError = requireToolScope(token, "incidents.write", name);
+    if (scopeError) return scopeError;
+    const incident = findIncident(args.sys_id || args.number);
+    if (!incident) return toolError("ServiceNow Incident ACL/write failed: record not found.", { code: "record_not_found" });
+    const entry = appendJournal(incident.sys_id, args.work_note ? "work_notes" : "comments", args.comment, "openwork.agent");
+    incident.sys_updated_on = serviceNowTime();
+    return { content: [{ type: "text", text: `Added ${entry.type} to ${incident.number}.\n${formatIncident(incident)}` }], structuredContent: { incident: incidentView(incident, true), journalEntry: entry } };
+  }
+
+  if (name === "resolve_incident") {
+    const scopeError = requireToolScope(token, "incidents.write", name);
+    if (scopeError) return scopeError;
+    const incident = findIncident(args.sys_id || args.number);
+    if (!incident) return toolError("ServiceNow Incident ACL/write failed: record not found.", { code: "record_not_found" });
+    updateIncident(incident, { state: 6, close_code: args.close_code, close_notes: args.close_notes, resolved_at: serviceNowTime(), work_notes: `Resolved by OpenWork: ${args.close_notes}` }, "openwork.agent");
+    return { content: [{ type: "text", text: `Resolved ${formatIncident(incident)}` }], structuredContent: { incident: incidentView(incident, true) } };
+  }
+
+  return argumentError(`Unknown tool: ${name}`);
+}
+
+function handleMcpMessage(message, token) {
+  if (!message || typeof message !== "object" || Array.isArray(message)) return jsonRpcError(null, -32600, "Invalid Request", 400);
+  if (!Object.hasOwn(message, "method")) return { status: 202, empty: true };
+  if (!Object.hasOwn(message, "id")) return { status: 202, empty: true };
+
+  if (message.method === "initialize") {
+    const requested = message.params && typeof message.params === "object" ? message.params.protocolVersion : "";
+    const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requested) ? requested : SUPPORTED_PROTOCOL_VERSIONS[0];
+    const sessionId = randomBytes(18).toString("base64url");
+    mcpSessions.add(sessionId);
+    return jsonRpcResult(
+      message.id,
+      {
+        protocolVersion,
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: { name: "servicenow-mcp", title: "ServiceNow MCP Server (Acme Robotics IT)", version: "1.0.0" },
+        instructions: "Use search_incidents and get_incident to inspect ServiceNow incidents. Use create_incident, update_incident, add_comment, and resolve_incident for incident-management workflows when the OAuth token includes incidents.write.",
+      },
+      { "Mcp-Session-Id": sessionId },
+    );
+  }
+
+  if (message.method === "ping") return jsonRpcResult(message.id, {});
+  if (message.method === "tools/list") return jsonRpcResult(message.id, { tools });
+  if (message.method === "tools/call") {
+    const params = message.params && typeof message.params === "object" ? message.params : {};
+    if (typeof params.name !== "string") return jsonRpcError(message.id, -32602, "tools/call params.name is required");
+    const tool = tools.find((entry) => entry.name === params.name);
+    if (!tool) return jsonRpcError(message.id, -32602, `Unknown tool: ${params.name}`);
+    const result = callTool(params.name, params.arguments || {}, token);
+    if (result.protocolError) return jsonRpcError(message.id, -32602, result.message);
+    return jsonRpcResult(message.id, result);
+  }
+  return jsonRpcError(message.id, -32601, "Method not found");
+}
+
+async function handleMcp(req, res, path, rawBody = "") {
+  if (!isAllowedOriginHeader(req.headers.origin || "")) {
+    json(res, 403, { error: "forbidden_origin" });
+    return;
+  }
+
+  if (req.method === "GET") {
+    json(res, 405, { error: "method_not_allowed" }, { allow: "POST, DELETE" });
+    return;
+  }
+
+  const protocolHeader = req.headers["mcp-protocol-version"];
+  if (protocolHeader && !SUPPORTED_PROTOCOL_VERSIONS.includes(String(protocolHeader))) {
+    json(res, 400, { jsonrpc: "2.0", id: null, error: { code: -32600, message: "Unsupported MCP-Protocol-Version" } });
+    return;
+  }
+
+  const token = requireProtected(req, res, null, false);
+  if (!token) return;
+  if (!token.scopes.some((scope) => SCOPES.includes(scope))) {
+    json(res, 403, { error: "insufficient_scope", error_description: "Token does not include a ServiceNow incident scope" });
+    return;
+  }
+
+  const sessionId = req.headers["mcp-session-id"];
+  if (sessionId && !mcpSessions.has(String(sessionId))) {
+    json(res, 404, { error: "unknown_mcp_session" });
+    return;
+  }
+
+  if (req.method === "DELETE") {
+    if (!sessionId || !mcpSessions.has(String(sessionId))) {
+      json(res, 404, { error: "unknown_mcp_session" });
+      return;
+    }
+    mcpSessions.delete(String(sessionId));
+    empty(res, 204);
+    return;
+  }
+
+  if (req.method !== "POST") {
+    json(res, 405, { error: "method_not_allowed" }, { allow: "POST, DELETE" });
+    return;
+  }
+
+  let message;
+  try {
+    message = JSON.parse(rawBody || "{}");
+  } catch {
+    json(res, 400, { jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } });
+    return;
+  }
+  if (Array.isArray(message)) {
+    json(res, 400, { jsonrpc: "2.0", id: null, error: { code: -32600, message: "Invalid Request: JSON-RPC batching is not supported" } });
+    return;
+  }
+  const result = handleMcpMessage(message, token, path);
+  if (result.empty) {
+    empty(res, 202);
+    return;
+  }
+  json(res, result.status, result.body, result.headers || {});
+}
+
+function record(req, url, jsonrpcMethod) {
+  const entry = {
+    id: requests.length + 1,
+    method: req.method,
+    path: url.pathname,
+    url: `${url.pathname}${url.search}`,
+    at: new Date().toISOString(),
+    ...(jsonrpcMethod ? { jsonrpcMethod } : {}),
+  };
+  requests.push(entry);
+  console.log(`[servicenow-mcp] ${entry.method} ${entry.path}${jsonrpcMethod ? ` ${jsonrpcMethod}` : ""}`);
+}
+
+seedData();
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url || "/", issuer);
+    const mcpPath = isMcpPath(url.pathname);
+    let rawMcpBody = "";
+    let jsonrpcMethod;
+    if (mcpPath && req.method === "POST") {
+      rawMcpBody = await readBody(req);
+      jsonrpcMethod = parseJsonRpcMethod(rawMcpBody);
+    }
+    record(req, url, jsonrpcMethod);
+
+    if (req.method === "OPTIONS") {
+      empty(res, 204);
+      return;
+    }
+
+    if (url.pathname === "/health") {
+      json(res, 200, { ok: true, product: "servicenow-mcp", issuer, autoApprove, requests: requests.length });
+      return;
+    }
+
+    if (url.pathname === "/requests") {
+      json(res, 200, { requests });
+      return;
+    }
+
+    if (wellKnownMatches(url.pathname, "oauth-protected-resource")) {
+      json(res, 200, protectedResourceMetadata());
+      return;
+    }
+
+    if (wellKnownMatches(url.pathname, "oauth-authorization-server")) {
+      json(res, 200, authorizationServerMetadata());
+      return;
+    }
+
+    if (url.pathname === "/oauth_auth.do" && req.method === "GET") {
+      authorize(req, res, url);
+      return;
+    }
+
+    if (url.pathname === "/oauth_approve" && req.method === "POST") {
+      await approve(req, res);
+      return;
+    }
+
+    if (url.pathname === "/oauth_token.do" && req.method === "POST") {
+      await issueToken(req, res);
+      return;
+    }
+
+    if (url.pathname === "/api/now/table/incident") {
+      await handleIncidentList(req, res, url);
+      return;
+    }
+
+    if (url.pathname.startsWith("/api/now/table/incident/")) {
+      const sysId = decodeURIComponent(url.pathname.slice("/api/now/table/incident/".length));
+      await handleIncidentRecord(req, res, sysId);
+      return;
+    }
+
+    if (mcpPath) {
+      await handleMcp(req, res, mcpPath, rawMcpBody);
+      return;
+    }
+
+    json(res, 404, { error: "not_found" });
+  } catch (error) {
+    json(res, 500, { error: error instanceof Error ? error.message : String(error) });
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(`[servicenow-mcp] listening on ${issuer}`);
+  for (const path of MCP_PATHS) console.log(`[servicenow-mcp] MCP URL: ${issuer}${path}`);
+  console.log(`[servicenow-mcp] OAuth authorization endpoint: ${issuer}/oauth_auth.do`);
+  console.log(`[servicenow-mcp] OAuth token endpoint: ${issuer}/oauth_token.do`);
+  console.log(`[servicenow-mcp] set AUTO_APPROVE=0 to show the ServiceNow consent page`);
+});


### PR DESCRIPTION
## What & why

The marketplace demo evals (`oauth-mcp-publish` / `oauth-mcp-install`) featured an MCP named **`acme-servicenow`** that was really the generic mock (`scripts/mock-oauth-mcp-server.mjs`) with a single `mock_echo` tool and `mcp:read`/`mcp:write` scopes. This PR makes it **the real thing**: a faithful, spec-correct ServiceNow instance simulator standing behind the `acme-servicenow` connector.

`scripts/mock-oauth-mcp-server.mjs` is **untouched** (other flows/tests depend on it).

## `scripts/servicenow-mcp-server.mjs` (new, zero-dependency)

**MCP spec correctness (Streamable HTTP)**
- Protocol-version negotiation over `2025-11-25 / 2025-06-18 / 2025-03-26` (echoes the client's when supported, else latest).
- JSON-RPC errors done right: `-32700` parse, `-32600` invalid/batch (batching removed in 2025-06-18), `-32601` unknown method, `-32602` bad tool args; notifications/client-responses → `202`; `ping` → `{}`.
- `Mcp-Session-Id` issued on `initialize`, validated on later requests (unknown → `404`), `DELETE` terminates.
- `GET /mcp` → `405` with `Allow`; `MCP-Protocol-Version` header validated; **Origin** checks (non-loopback → `403`).
- Served at both `/mcp` and the realistic native path `/sncapps/mcp-server/mcp/sn_openwork_it`.

**OAuth 2.1 on the real ServiceNow endpoint paths**
- `/oauth_auth.do` + `/oauth_token.do`, **pre-registered clients only (no DCR)** — like a real instance's Application Registry.
- PKCE **S256 required** (rejects `plain`), auth-code + refresh grants, `none` / `client_secret_post` / `client_secret_basic`.
- **RFC 9728** protected-resource metadata **per MCP path** (this fixed a real discovery gap — see below), **RFC 8414** AS metadata (S256-only, no `registration_endpoint`), **RFC 8707** resource-audience binding on issued tokens; every `401` carries `WWW-Authenticate: Bearer resource_metadata=…`.

**Real ServiceNow surface**
- Seeded `incident` table (+ `sys_user` / `sys_user_group`), ServiceNow-shaped **Table API** (`/api/now/table/incident`, `sysparm_query`/`_limit`/`_offset`/`_fields`, ServiceNow error envelopes).
- **6 incident tools** — `search_incidents`, `get_incident`, `create_incident`, `update_incident`, `add_comment`, `resolve_incident` — with LLM-oriented descriptions, JSON-Schema I/O, annotations, deep-links, and **scope enforcement** (`incidents.read` / `incidents.write`) surfaced as ServiceNow-ACL-style tool errors.

### RFC 9728 fix worth calling out
The opencode engine follows the `401` `WWW-Authenticate` `resource_metadata` URL and then validates `PRM.resource === connection URL`. Serving one root PRM (`resource=/mcp`) 500'd the engine on the deep `/sncapps/...` path. The server now serves **path-specific** protected-resource metadata and points each path's `401` at its own PRM, and treats the two MCP URLs as one aliased resource for audience checks. Result: the engine completes OAuth over the **realistic deep path** with no DCR.

## Tests — `apps/server/src/mcp.servicenow-spec.e2e.test.ts` (new)
- **10 pure-HTTP spec tests** (277 assertions): PRM/AS discovery, PKCE/refresh/audience, scope enforcement, transport/session/origin semantics, tools/list + tools/call + structured content, Table API.
- **1 real-engine e2e** (sidecar-gated): the opencode engine completes browser OAuth against the ServiceNow endpoints — **no `/register`**, over `/sncapps/mcp-server/mcp/sn_openwork_it`, with the RFC 8707 `resource` param.

## How I verified (commands + results)
```
# apps/server — bun e2e
bun test src/mcp.servicenow-spec.e2e.test.ts   # 10 pass / 0 fail / 277 expect (engine handled /sncapps deep path)
bun test src/mcp.oauth-flow.e2e.test.ts        # 2 pass / 0 fail (untouched mock unaffected)

# Local fraimz (two-Electron Den demo: den-api :8788, den-web :3005, ServiceNow MCP :3979)
pnpm fraimz --flow oauth-mcp-publish  --cdp-url http://127.0.0.1:9923   # PASSED
pnpm fraimz --flow oauth-mcp-install  --cdp-url http://127.0.0.1:9924   # PASSED
```
Frame proof is posted as a follow-up comment.

## Flow updates (current-dev reality)
- `oauth-mcp-publish`: points `acme-servicenow` at the real ServiceNow MCP (`:3979`, deep `/sncapps/...` path), auto-starts the server, and adapts to the current UI (engine-ready copy + the new **Connect** panel). Still proves secret redaction on export + publish.
- `oauth-mcp-install`: the old member marketplace card→Add path **no longer exists** on dev for cloud-runnable plugins (member self-connect now requires prior admin provisioning of the org MCP connection). The flow was rewritten to honestly prove, member-side, that the org-shared ServiceNow plugin is **available** to her and that her member-visible config carries `clientId`+scope but **never the owner's secret**. The member's own end-to-end OAuth against the ServiceNow server is covered by the engine e2e test above.
- Both flows now declare `kind` and carry per-frame voiceovers.

## Notes / honesty
- **Local run, not Daytona** (Daytona not used here).
- `mcp-oauth-silent-reauth` fails at the silent-heal step on this machine (stuck "Issue"). My diff touches **zero files** in that flow's path (new files + the two oauth-mcp flows only), so this is pre-existing/environmental, not caused by this change — flagged for transparency.
