### PR TITLE
feat(den): add email-first sign-in flow

### DIFF
--- a/ee/apps/den-api/src/auth-login-options.ts
+++ b/ee/apps/den-api/src/auth-login-options.ts
@@ -1,0 +1,46 @@
+export type LoginOptionKind = "sso" | "google" | "github" | "password" | "new_account"
+
+export type LoginOptionAccount = {
+  providerId: string
+  hasPassword: boolean
+}
+
+export function normalizeLoginEmail(email: string) {
+  return email.trim().toLowerCase()
+}
+
+function normalizeProviderId(providerId: string) {
+  return providerId.trim().toLowerCase()
+}
+
+function isPasswordAccount(account: LoginOptionAccount) {
+  const providerId = normalizeProviderId(account.providerId)
+  return account.hasPassword || providerId === "credential" || providerId === "email" || providerId === "email-password"
+}
+
+function hasProvider(accounts: readonly LoginOptionAccount[], providerId: string) {
+  return accounts.some((account) => normalizeProviderId(account.providerId) === providerId)
+}
+
+export function resolveLoginOptionKind(input: {
+  requireSso: boolean
+  accounts: readonly LoginOptionAccount[]
+}): LoginOptionKind {
+  if (input.requireSso) {
+    return "sso"
+  }
+
+  if (hasProvider(input.accounts, "google")) {
+    return "google"
+  }
+
+  if (input.accounts.some(isPasswordAccount)) {
+    return "password"
+  }
+
+  if (hasProvider(input.accounts, "github")) {
+    return "github"
+  }
+
+  return "new_account"
+}

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -1,8 +1,11 @@
 import { oauthProviderAuthServerMetadata, oauthProviderOpenIdConfigMetadata } from "@better-auth/oauth-provider"
+import { eq, sql } from "@openwork-ee/den-db/drizzle"
+import { AuthAccountTable, AuthUserTable } from "@openwork-ee/den-db/schema"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { auth } from "../../auth.js"
+import { normalizeLoginEmail, resolveLoginOptionKind } from "../../auth-login-options.js"
 import {
   getBreachedPasswordResponse,
   getEmailPasswordLockoutResponse,
@@ -10,10 +13,12 @@ import {
   readEmailPasswordSignInAttempt,
   recordEmailPasswordSignInResult,
 } from "../../auth-protection.js"
+import { db } from "../../db.js"
 import { env } from "../../env.js"
+import { findEnterpriseAuthRequirementForEmail } from "../../enterprise-auth-requirement.js"
 import { getInvalidMcpOAuthRedirectUris } from "../../mcp/oauth-client-policy.js"
 import { normalizeMcpOAuthClientScope } from "../../mcp/scopes.js"
-import { publicRoute, tokenRoute } from "../../middleware/index.js"
+import { publicRoute, queryValidator, tokenRoute } from "../../middleware/index.js"
 import { emptyResponse, jsonResponse } from "../../openapi.js"
 import { getSingletonSsoStatus } from "../../orgs.js"
 import { publicRequestUrl } from "../../request-url.js"
@@ -241,6 +246,42 @@ const authPasswordScreeningUnavailableSchema = z.object({
   message: z.string(),
 }).meta({ ref: "AuthPasswordScreeningUnavailableError" })
 
+const loginOptionsQuerySchema = z.object({
+  email: z.string().trim().email().transform(normalizeLoginEmail),
+})
+
+const loginOptionKindSchema = z.union([
+  z.literal("sso"),
+  z.literal("google"),
+  z.literal("github"),
+  z.literal("password"),
+  z.literal("new_account"),
+])
+
+const loginOptionsResponseSchema = z.object({
+  email: z.string().email(),
+  nextStep: loginOptionKindSchema,
+  organizationSlug: z.string().optional(),
+  signInPath: z.string().optional(),
+  signInUrl: z.string().url().optional(),
+}).meta({ ref: "AuthLoginOptionsResponse" })
+
+async function getLoginOptionAccounts(email: string) {
+  const rows = await db
+    .select({
+      providerId: AuthAccountTable.providerId,
+      password: AuthAccountTable.password,
+    })
+    .from(AuthUserTable)
+    .innerJoin(AuthAccountTable, eq(AuthUserTable.id, AuthAccountTable.userId))
+    .where(sql`lower(${AuthUserTable.email}) = ${email}`)
+
+  return rows.map((row) => ({
+    providerId: row.providerId,
+    hasPassword: Boolean(row.password),
+  }))
+}
+
 async function handleAuthRequest(request: Request) {
   const singleOrgAuthGuardResponse = await getSingleOrgAuthGuardResponse(request)
   if (singleOrgAuthGuardResponse) {
@@ -285,6 +326,46 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
   app.post("/register", publicRoute, async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
   app.post("/api/auth/oauth2/register", publicRoute, async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
   app.get("/api/auth/oauth2/authorize", tokenRoute, (c) => auth.handler(c.req.raw))
+
+  app.get(
+    "/v1/auth/login-options",
+    describeRoute({
+      tags: ["Authentication"],
+      summary: "Resolve deterministic login option",
+      description: "Returns the deterministic next authentication step for an email address. SSO is preferred before Google, password, GitHub compatibility, and new account creation.",
+      responses: {
+        200: jsonResponse("Login option resolved successfully.", loginOptionsResponseSchema),
+        400: jsonResponse("The login option query parameters were invalid.", z.object({ error: z.literal("invalid_request") })),
+      },
+    }),
+    publicRoute,
+    queryValidator(loginOptionsQuerySchema),
+    async (c) => {
+      const { email } = c.req.valid("query")
+      const singletonSsoStatus = env.orgMode === "single_org" ? await getSingletonSsoStatus() : null
+      const singletonSsoRequirement = singletonSsoStatus?.configured
+        ? {
+            organizationSlug: singletonSsoStatus.organizationSlug,
+            signInPath: singletonSsoStatus.signInPath,
+          }
+        : null
+      const requirement = singletonSsoRequirement ?? await findEnterpriseAuthRequirementForEmail(email)
+      const accounts = requirement ? [] : await getLoginOptionAccounts(email)
+      const nextStep = resolveLoginOptionKind({ requireSso: Boolean(requirement), accounts })
+
+      if (nextStep === "sso" && requirement) {
+        return c.json({
+          email,
+          nextStep,
+          organizationSlug: requirement.organizationSlug,
+          signInPath: requirement.signInPath,
+          signInUrl: new URL(requirement.signInPath, env.betterAuthTrustedOrigins[0] ?? env.betterAuthUrl).toString(),
+        })
+      }
+
+      return c.json({ email, nextStep })
+    },
+  )
 
   app.on(
     ["GET", "POST", "PUT", "PATCH", "DELETE"],

--- a/ee/apps/den-api/test/auth-login-options.test.ts
+++ b/ee/apps/den-api/test/auth-login-options.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { normalizeLoginEmail, resolveLoginOptionKind } from "../src/auth-login-options.js"
+
+test("login option resolution normalizes email input", () => {
+  expect(normalizeLoginEmail(" User@Example.COM ")).toBe("user@example.com")
+})
+
+test("login option resolution prioritizes SSO before account providers", () => {
+  expect(resolveLoginOptionKind({
+    requireSso: true,
+    accounts: [
+      { providerId: "google", hasPassword: false },
+      { providerId: "credential", hasPassword: true },
+    ],
+  })).toBe("sso")
+})
+
+test("login option resolution prefers Google, then password, then GitHub compatibility", () => {
+  expect(resolveLoginOptionKind({
+    requireSso: false,
+    accounts: [
+      { providerId: "credential", hasPassword: true },
+      { providerId: "google", hasPassword: false },
+    ],
+  })).toBe("google")
+
+  expect(resolveLoginOptionKind({
+    requireSso: false,
+    accounts: [
+      { providerId: "github", hasPassword: false },
+      { providerId: "credential", hasPassword: true },
+    ],
+  })).toBe("password")
+
+  expect(resolveLoginOptionKind({
+    requireSso: false,
+    accounts: [{ providerId: "github", hasPassword: false }],
+  })).toBe("github")
+})
+
+test("login option resolution returns new account when no existing auth method matches", () => {
+  expect(resolveLoginOptionKind({ requireSso: false, accounts: [] })).toBe("new_account")
+})

--- a/ee/apps/den-api/test/route-guard-policy.test.ts
+++ b/ee/apps/den-api/test/route-guard-policy.test.ts
@@ -21,6 +21,7 @@ const routeGuardExceptions = new Map<string, string>([
   ["POST /register", "MCP OAuth dynamic client registration policy validates the request"],
   ["POST /api/auth/oauth2/register", "MCP OAuth dynamic client registration policy validates the request"],
   ["GET /api/auth/oauth2/authorize", "Better Auth OAuth authorization endpoint"],
+  ["GET /v1/auth/login-options", "public deterministic auth method discovery"],
   ["ALL /api/auth/sso/saml2/callback/*", "SAML response policy validates callback responses before Better Auth"],
   ["ALL /api/auth/sso/saml2/sp/acs/*", "SAML response policy validates ACS responses before Better Auth"],
   ["GET /api/auth/*", "Better Auth route mount"],

--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -14,6 +14,35 @@ type PanelContent = {
   submitLabel: string;
 };
 
+type EmailFirstStep = "email" | "sso" | "google" | "github" | "password" | "new_account";
+type ResolvedLoginStep = Exclude<EmailFirstStep, "email">;
+
+type LoginOption = {
+  nextStep: ResolvedLoginStep;
+  signInPath: string | null;
+  signInUrl: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isResolvedLoginStep(value: unknown): value is ResolvedLoginStep {
+  return value === "sso" || value === "google" || value === "github" || value === "password" || value === "new_account";
+}
+
+function readLoginOption(payload: unknown): LoginOption | null {
+  if (!isRecord(payload) || !isResolvedLoginStep(payload.nextStep)) {
+    return null;
+  }
+
+  return {
+    nextStep: payload.nextStep,
+    signInPath: typeof payload.signInPath === "string" ? payload.signInPath : null,
+    signInUrl: typeof payload.signInUrl === "string" ? payload.signInUrl : null,
+  };
+}
+
 function getDesktopGrant(url: string | null) {
   if (!url) return null;
   try {
@@ -75,6 +104,7 @@ export function AuthPanel({
   lockEmail = false,
   hideSocialAuth = false,
   hideEmailField = false,
+  emailFirstFlow = false,
   eyebrow = "Account",
   bare = false,
   signUpContent,
@@ -87,6 +117,7 @@ export function AuthPanel({
   lockEmail?: boolean;
   hideSocialAuth?: boolean;
   hideEmailField?: boolean;
+  emailFirstFlow?: boolean;
   eyebrow?: string;
   // When true the panel renders without its own `den-frame`/padding, so a parent
   // (the unified split auth card) can own the surface. Defaults to a self-framed
@@ -104,11 +135,16 @@ export function AuthPanel({
   const [passwordResetBusy, setPasswordResetBusy] = useState(false);
   const [passwordResetInfo, setPasswordResetInfo] = useState("");
   const [passwordResetError, setPasswordResetError] = useState<string | null>(null);
+  const [loginOption, setLoginOption] = useState<LoginOption | null>(null);
+  const [loginOptionBusy, setLoginOptionBusy] = useState(false);
+  const [loginOptionError, setLoginOptionError] = useState<string | null>(null);
   const {
     authMode,
     setAuthMode,
     email,
     setEmail,
+    authName,
+    setAuthName,
     password,
     setPassword,
     verificationCode,
@@ -180,6 +216,45 @@ export function AuthPanel({
     submitLabel: "Send reset link",
   };
 
+  const emailFirstStep: EmailFirstStep = loginOption?.nextStep ?? "email";
+  const emailFirstEmail = email.trim();
+  const emailFirstContent: PanelContent =
+    emailFirstStep === "email"
+      ? {
+          title: "Continue to OpenWork.",
+          copy: "Enter your email and we'll send you to the right sign-in step.",
+          submitLabel: "Next",
+        }
+      : emailFirstStep === "sso"
+      ? {
+          title: "Sign in with SSO.",
+          copy: emailFirstEmail ? `${emailFirstEmail} is managed by your organization.` : "Your organization manages this account.",
+          submitLabel: "Sign in with SSO",
+        }
+      : emailFirstStep === "google"
+      ? {
+          title: "Welcome back.",
+          copy: "Use Google to continue with this account.",
+          submitLabel: "Sign in with Google",
+        }
+      : emailFirstStep === "github"
+      ? {
+          title: "Welcome back.",
+          copy: "Use GitHub to continue with this account.",
+          submitLabel: "Sign in with GitHub",
+        }
+      : emailFirstStep === "password"
+      ? {
+          title: "Enter your password.",
+          copy: emailFirstEmail ? `Sign in as ${emailFirstEmail}.` : "Sign in with your password.",
+          submitLabel: "Sign in",
+        }
+      : {
+          title: "Create your account.",
+          copy: "Set up your OpenWork Cloud account.",
+          submitLabel: "Sign up",
+        };
+
   const desktopGrant = getDesktopGrant(desktopRedirectUrl);
   const isPasswordResetRequest = authMode === "sign-in" && passwordResetRequested && !verificationRequired;
   const formBusy = !runtimeConfigLoaded || (isPasswordResetRequest ? passwordResetBusy : authBusy || desktopRedirectBusy);
@@ -187,6 +262,8 @@ export function AuthPanel({
     ? resolvedVerificationContent
     : isPasswordResetRequest
       ? passwordResetContent
+      : emailFirstFlow
+      ? emailFirstContent
       : isSingleOrgSsoMode
       ? singleOrgSsoContent
       : authMode === "sign-in"
@@ -198,7 +275,7 @@ export function AuthPanel({
   // The segmented tabs are the primary sign-in/sign-up switch. Hide them for the
   // focused sub-flows (email verification, password reset) where switching mode
   // mid-step would be confusing.
-  const showModeTabs = !isSingleOrgSsoMode && !verificationRequired && !isPasswordResetRequest;
+  const showModeTabs = !emailFirstFlow && !isSingleOrgSsoMode && !verificationRequired && !isPasswordResetRequest;
   const showSingleOrgSso = isSingleOrgMode && Boolean(singleOrgSlug) && !verificationRequired && !isPasswordResetRequest && (!hideSocialAuth || isSingleOrgSsoMode);
   const showSingleOrgSsoDivider = showSingleOrgSso && !isSingleOrgSsoMode;
   const showEmailPasswordAuth = !isSingleOrgSsoMode;
@@ -213,9 +290,10 @@ export function AuthPanel({
     prefillRef.current = key;
     setAuthMode(initialMode);
     setEmail(prefilledEmail?.trim() ?? "");
+    setAuthName("");
     setPassword("");
     setVerificationCode("");
-  }, [initialMode, prefillKey, prefilledEmail, setAuthMode, setEmail, setPassword, setVerificationCode]);
+  }, [initialMode, prefillKey, prefilledEmail, setAuthMode, setAuthName, setEmail, setPassword, setVerificationCode]);
 
   const switchMode = (mode: AuthMode) => {
     if (mode === authMode && !passwordResetRequested) {
@@ -245,6 +323,73 @@ export function AuthPanel({
       nextUrl.searchParams.set("loginHint", trimmedEmail);
     }
     window.location.assign(nextUrl.toString());
+  };
+
+  const startEmailFirstSso = () => {
+    const target = loginOption?.signInPath ?? loginOption?.signInUrl;
+    if (!target) {
+      setLoginOptionError("Could not find your organization SSO sign-in link. Try again.");
+      return;
+    }
+
+    const nextUrl = new URL(target, window.location.origin);
+    nextUrl.searchParams.set("callbackURL", getSocialCallbackUrl(runtimeConfig.openworkAuthCallbackUrl));
+    const trimmedEmail = email.trim();
+    if (trimmedEmail) {
+      nextUrl.searchParams.set("loginHint", trimmedEmail);
+    }
+    window.location.assign(nextUrl.toString());
+  };
+
+  const resolveEmailFirstStep = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      setLoginOptionError("Enter your email to continue.");
+      return;
+    }
+
+    setLoginOptionBusy(true);
+    setLoginOptionError(null);
+    setLoginOption(null);
+    setPassword("");
+    setAuthName("");
+
+    try {
+      const { response, payload } = await requestJson(`/v1/auth/login-options?email=${encodeURIComponent(trimmedEmail)}`, { method: "GET" }, 12000);
+      if (!response.ok) {
+        setLoginOptionError(getErrorMessage(payload, `Could not check sign-in options (${response.status}).`));
+        return;
+      }
+
+      const nextOption = readLoginOption(payload);
+      if (!nextOption) {
+        setLoginOptionError("The sign-in options response was incomplete. Try again.");
+        return;
+      }
+
+      setEmail(trimmedEmail);
+      setAuthMode(nextOption.nextStep === "new_account" ? "sign-up" : "sign-in");
+      setLoginOption(nextOption);
+    } catch (error) {
+      setLoginOptionError(error instanceof Error ? error.message : "Could not check sign-in options.");
+    } finally {
+      setLoginOptionBusy(false);
+    }
+  };
+
+  const handleAuthNavigation = async (next: Awaited<ReturnType<typeof submitAuth>>) => {
+    const oauthRoute = typeof window === "undefined" ? null : getMcpOAuthSelectOrganizationRoute(window.location.search);
+    if (next && oauthRoute) {
+      router.replace(oauthRoute);
+      return;
+    }
+    if (next === "dashboard" || next === "join-org") {
+      const target = await resolveUserLandingRoute();
+      if (target && !isSamePathname(pathname, target)) {
+        router.replace(target);
+      }
+    }
   };
 
   const submitPasswordResetRequest = async (event: FormEvent<HTMLFormElement>) => {
@@ -284,6 +429,8 @@ export function AuthPanel({
   /*  Already signed in + desktop handoff: simplified view               */
   /* ------------------------------------------------------------------ */
   const isSignedInWithDesktopHandoff = desktopAuthRequested && desktopRedirectUrl && showAuthFeedback && authInfo && !authError;
+  const emailFirstPanelActive = emailFirstFlow && !verificationRequired && !isPasswordResetRequest;
+  const emailFirstFormBusy = loginOptionBusy || authBusy || desktopRedirectBusy;
 
   if (isSignedInWithDesktopHandoff) {
     return (
@@ -341,6 +488,200 @@ export function AuthPanel({
             Go to dashboard &rarr;
           </button>
         </div>
+      </div>
+    );
+  }
+
+  if (emailFirstPanelActive) {
+    return (
+      <div className={shellClass("gap-4 sm:gap-5", "p-5 sm:p-6 md:p-7")}>
+        <div className="grid gap-3">
+          <p className="den-eyebrow">{eyebrow}</p>
+          <div className="grid gap-2">
+            <h2 className="den-title-lg">{activeContent.title}</h2>
+            <p className="den-copy">{activeContent.copy}</p>
+          </div>
+        </div>
+
+        {desktopAuthRequested && desktopRedirectUrl ? (
+          <div className="grid gap-3">
+            <button
+              type="button"
+              className="den-button-primary w-full"
+              onClick={() => window.location.assign(desktopRedirectUrl)}
+            >
+              Open OpenWork
+              <ArrowRight className="h-4 w-4" />
+            </button>
+            <p className="m-0 text-center text-xs text-[var(--dls-text-secondary)]">
+              Sign in below, then click above to return to the app.
+            </p>
+          </div>
+        ) : null}
+
+        {emailFirstStep === "email" ? (
+          <form className="grid gap-4" onSubmit={resolveEmailFirstStep}>
+            <label className="grid gap-2">
+              <span className="den-label">Email</span>
+              <input
+                className="den-input"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                autoComplete="email"
+                required
+              />
+            </label>
+            <button
+              type="submit"
+              className="den-button-primary w-full"
+              disabled={emailFirstFormBusy}
+            >
+              {loginOptionBusy ? "Checking..." : "Next"}
+              {!loginOptionBusy ? <ArrowRight className="h-4 w-4" /> : null}
+            </button>
+          </form>
+        ) : null}
+
+        {emailFirstStep === "sso" ? (
+          <button
+            type="button"
+            className="den-button-primary w-full"
+            onClick={startEmailFirstSso}
+            disabled={!runtimeConfigLoaded || authBusy || desktopRedirectBusy}
+          >
+            Sign in with SSO
+            <ArrowRight className="h-4 w-4" />
+          </button>
+        ) : null}
+
+        {emailFirstStep === "google" ? (
+          <SocialButton
+            onClick={() => void beginSocialAuth("google")}
+            disabled={!runtimeConfigLoaded || authBusy || desktopRedirectBusy}
+          >
+            <GoogleLogo />
+            <span>Sign in with Google</span>
+          </SocialButton>
+        ) : null}
+
+        {emailFirstStep === "github" ? (
+          <SocialButton
+            onClick={() => void beginSocialAuth("github")}
+            disabled={!runtimeConfigLoaded || authBusy || desktopRedirectBusy}
+          >
+            <GitHubLogo />
+            <span>Sign in with GitHub</span>
+          </SocialButton>
+        ) : null}
+
+        {emailFirstStep === "password" ? (
+          <form
+            className="grid gap-4"
+            onSubmit={async (event) => {
+              const next = await submitAuth(event);
+              await handleAuthNavigation(next);
+            }}
+          >
+            <label className="grid gap-2">
+              <span className="den-label">Password</span>
+              <input
+                className="den-input"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete="current-password"
+                required
+              />
+            </label>
+            <div className="-mt-2 flex justify-end">
+              <button
+                type="button"
+                className="text-sm font-medium text-[var(--dls-text-primary)] transition hover:opacity-70"
+                onClick={() => {
+                  setAuthMode("sign-in");
+                  setPasswordResetRequested(true);
+                  setPasswordResetInfo("");
+                  setPasswordResetError(null);
+                }}
+              >
+                Forgot password?
+              </button>
+            </div>
+            <button type="submit" className="den-button-primary w-full" disabled={formBusy}>
+              {formBusy ? "Working..." : "Sign in"}
+              {!formBusy ? <ArrowRight className="h-4 w-4" /> : null}
+            </button>
+          </form>
+        ) : null}
+
+        {emailFirstStep === "new_account" ? (
+          <form
+            className="grid gap-4"
+            onSubmit={async (event) => {
+              const next = await submitAuth(event);
+              await handleAuthNavigation(next);
+            }}
+          >
+            <label className="grid gap-2">
+              <span className="den-label">Email</span>
+              <input
+                className="den-input"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                autoComplete="email"
+                required
+              />
+            </label>
+            <label className="grid gap-2">
+              <span className="den-label">Name</span>
+              <input
+                className="den-input"
+                type="text"
+                value={authName}
+                onChange={(event) => setAuthName(event.target.value)}
+                autoComplete="name"
+                required
+              />
+            </label>
+            <div className="den-divider" aria-hidden="true">
+              <span>or</span>
+            </div>
+            <SocialButton
+              onClick={() => void beginSocialAuth("google")}
+              disabled={!runtimeConfigLoaded || authBusy || desktopRedirectBusy}
+            >
+              <GoogleLogo />
+              <span>Sign up with Google</span>
+            </SocialButton>
+            <label className="grid gap-2">
+              <span className="den-label">Password</span>
+              <input
+                className="den-input"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete="new-password"
+                required
+              />
+            </label>
+            <button type="submit" className="den-button-primary w-full" disabled={formBusy}>
+              {formBusy ? "Working..." : "Sign up"}
+              {!formBusy ? <ArrowRight className="h-4 w-4" /> : null}
+            </button>
+          </form>
+        ) : null}
+
+        {loginOptionError || showAuthFeedback ? (
+          <div
+            className="den-frame-inset grid gap-1 rounded-[1.5rem] px-4 py-3 text-center text-[13px] text-[var(--dls-text-secondary)]"
+            aria-live="polite"
+          >
+            {loginOptionError ? <p className="font-medium text-rose-600">{loginOptionError}</p> : <p>{authInfo}</p>}
+            {!loginOptionError && authError ? <p className="font-medium text-rose-600">{authError}</p> : null}
+          </div>
+        ) : null}
       </div>
     );
   }
@@ -415,17 +756,7 @@ export function AuthPanel({
           const next = verificationRequired
             ? await submitVerificationCode(event)
             : await submitAuth(event);
-          const oauthRoute = typeof window === "undefined" ? null : getMcpOAuthSelectOrganizationRoute(window.location.search);
-          if (next && oauthRoute) {
-            router.replace(oauthRoute);
-            return;
-          }
-          if (next === "dashboard" || next === "join-org") {
-            const target = await resolveUserLandingRoute();
-            if (target && !isSamePathname(pathname, target)) {
-              router.replace(target);
-            }
-          }
+          await handleAuthNavigation(next);
         }}
       >
         {showSingleOrgSso ? (

--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -178,7 +178,7 @@ export function AuthScreen() {
             ) : hasResolvedSession ? (
               <SessionStatusPanel mode="redirecting" />
             ) : (
-              <AuthPanel bare />
+              <AuthPanel bare emailFirstFlow />
             )}
           </div>
         </div>

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -76,6 +76,8 @@ type DenFlowContextValue = {
   setAuthMode: (mode: AuthMode) => void;
   email: string;
   setEmail: (value: string) => void;
+  authName: string;
+  setAuthName: (value: string) => void;
   password: string;
   setPassword: (value: string) => void;
   verificationCode: string;
@@ -191,6 +193,7 @@ function clearPendingAuthIntent() {
 export function DenFlowProvider({ children }: { children: ReactNode }) {
   const [authMode, setAuthModeState] = useState<AuthMode>("sign-up");
   const [email, setEmail] = useState("");
+  const [authName, setAuthName] = useState("");
   const [password, setPassword] = useState("");
   const [verificationCode, setVerificationCode] = useState("");
   const [verificationRequired, setVerificationRequired] = useState(false);
@@ -1074,7 +1077,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       const body =
         authMode === "sign-up"
           ? {
-              name: DEFAULT_AUTH_NAME,
+              name: authName.trim() || DEFAULT_AUTH_NAME,
               email: trimmedEmail,
               password
             }
@@ -1273,6 +1276,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     setDesktopRedirectAttempted(false);
     setAuthMode("sign-up");
     setEmail("");
+    setAuthName("");
     setPassword("");
     setAuthInfo(getAuthInfoForMode("sign-up"));
     setLaunchStatus("Choose a worker name and launch.");
@@ -2062,6 +2066,8 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     setAuthMode,
     email,
     setEmail,
+    authName,
+    setAuthName,
     password,
     setPassword,
     verificationCode,

--- a/evals/flows/new-signin-flow.flow.mjs
+++ b/evals/flows/new-signin-flow.flow.mjs
@@ -1,0 +1,255 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "new-signin-flow";
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "http://localhost:3005").replace(/\/+$/, "");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+export default {
+  id: FLOW_ID,
+  title: "Den Web resolves sign-in from email first",
+  kind: "user-facing",
+  preserveTheme: true,
+  steps: [
+    {
+      name: "Email-first start",
+      run: async (ctx) => {
+        await ctx.prove("The root auth page starts with only email and Next", {
+          voiceover: vo[0],
+          action: async () => {
+            await openSignedOutRoot(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("Continue to OpenWork.", { timeoutMs: 30_000 });
+            const actual = await readAuthSurface(ctx);
+            ctx.assert(actual.emailInputs === 1, `Expected one email field, got ${JSON.stringify(actual)}`);
+            ctx.assert(actual.passwordInputs === 0, `Expected no password field, got ${JSON.stringify(actual)}`);
+            ctx.assert(actual.buttons.length === 1 && actual.buttons[0] === "Next", `Expected only Next button, got ${JSON.stringify(actual.buttons)}`);
+            ctx.assert(!actual.text.includes("Create account"), "Create account should not appear before email lookup.");
+            ctx.assert(!actual.text.includes("Continue with Google"), "Google should not appear before email lookup.");
+          },
+          screenshot: {
+            name: "email-first-start",
+            requireText: ["Continue to OpenWork.", "EMAIL", "Next"],
+            rejectText: ["Password", "Continue with Google", "Create account"],
+          },
+        });
+      },
+    },
+    {
+      name: "Backend decides next step",
+      run: async (ctx) => {
+        await ctx.prove("Next calls login-options for the entered email and renders the returned step", {
+          voiceover: vo[1],
+          action: async () => {
+            await openSignedOutRoot(ctx);
+            await installLoginOptionsMock(ctx, { nextStep: "password" });
+            await fillEmailAndNext(ctx, "pat@acme.test");
+            await ctx.waitFor("document.body.innerText.includes('Enter your password.')", {
+              timeoutMs: 30_000,
+              label: "password step after login-options response",
+            });
+          },
+          assert: async () => {
+            const requests = await ctx.eval("window.__openworkLoginOptionRequests ?? []");
+            ctx.assert(requests.length === 1, `Expected one login-options request, got ${JSON.stringify(requests)}`);
+            ctx.assert(requests[0]?.endsWith("email=pat%40acme.test"), `Expected request to include the typed email, got ${JSON.stringify(requests)}`);
+            const actual = await readAuthSurface(ctx);
+            ctx.assert(actual.text.includes("Enter your password."), `Expected password step, got ${actual.text}`);
+          },
+          screenshot: {
+            name: "backend-routes-to-step",
+            requireText: ["Enter your password.", "Sign in as pat@acme.test.", "PASSWORD", "Sign in"],
+            rejectText: ["Sign in with Google", "Sign in with SSO", "Create your account."],
+          },
+        });
+      },
+    },
+    {
+      name: "SSO route",
+      run: async (ctx) => {
+        await ctx.prove("An SSO-managed account only sees Sign in with SSO", {
+          voiceover: vo[2],
+          action: async () => {
+            await openSignedOutRoot(ctx);
+            await installLoginOptionsMock(ctx, {
+              nextStep: "sso",
+              organizationSlug: "acme",
+              signInPath: "/sso/acme",
+              signInUrl: `${DEN_WEB_URL}/sso/acme`,
+            });
+            await fillEmailAndNext(ctx, "sso@acme.test");
+            await ctx.waitFor("document.body.innerText.includes('Sign in with SSO.')", {
+              timeoutMs: 30_000,
+              label: "SSO step",
+            });
+          },
+          assert: async () => {
+            const actual = await readAuthSurface(ctx);
+            ctx.assert(actual.buttons.length === 1 && actual.buttons[0] === "Sign in with SSO", `Expected only SSO button, got ${JSON.stringify(actual.buttons)}`);
+            ctx.assert(actual.passwordInputs === 0, `Expected no password field, got ${JSON.stringify(actual)}`);
+            ctx.assert(!actual.text.includes("Google"), "Google should not appear on SSO step.");
+          },
+          screenshot: {
+            name: "sso-only-step",
+            requireText: ["Sign in with SSO.", "sso@acme.test is managed by your organization.", "Sign in with SSO"],
+            rejectText: ["Sign in with Google", "PASSWORD", "Create your account."],
+          },
+        });
+      },
+    },
+    {
+      name: "Google route",
+      run: async (ctx) => {
+        await ctx.prove("A Google account only sees Sign in with Google", {
+          voiceover: vo[3],
+          action: async () => {
+            await openSignedOutRoot(ctx);
+            await installLoginOptionsMock(ctx, { nextStep: "google" });
+            await fillEmailAndNext(ctx, "google@acme.test");
+            await ctx.waitFor("document.body.innerText.includes('Sign in with Google')", {
+              timeoutMs: 30_000,
+              label: "Google step",
+            });
+          },
+          assert: async () => {
+            const actual = await readAuthSurface(ctx);
+            ctx.assert(actual.buttons.length === 1 && actual.buttons[0] === "Sign in with Google", `Expected only Google button, got ${JSON.stringify(actual.buttons)}`);
+            ctx.assert(actual.passwordInputs === 0, `Expected no password field, got ${JSON.stringify(actual)}`);
+            ctx.assert(!actual.text.includes("SSO"), "SSO should not appear on Google step.");
+          },
+          screenshot: {
+            name: "google-only-step",
+            requireText: ["Welcome back.", "Use Google to continue with this account.", "Sign in with Google"],
+            rejectText: ["Sign in with SSO", "PASSWORD", "Create your account."],
+          },
+        });
+      },
+    },
+    {
+      name: "Password route",
+      run: async (ctx) => {
+        await ctx.prove("A password account sees the password field and Sign in", {
+          voiceover: vo[4],
+          action: async () => {
+            await openSignedOutRoot(ctx);
+            await installLoginOptionsMock(ctx, { nextStep: "password" });
+            await fillEmailAndNext(ctx, "password@acme.test");
+            await ctx.waitFor("document.body.innerText.includes('Enter your password.')", {
+              timeoutMs: 30_000,
+              label: "password step",
+            });
+          },
+          assert: async () => {
+            const actual = await readAuthSurface(ctx);
+            ctx.assert(actual.passwordInputs === 1, `Expected one password field, got ${JSON.stringify(actual)}`);
+            ctx.assert(actual.buttons.includes("Sign in"), `Expected Sign in button, got ${JSON.stringify(actual.buttons)}`);
+            ctx.assert(!actual.text.includes("Sign in with Google"), "Google should not appear on password step.");
+          },
+          screenshot: {
+            name: "password-step",
+            requireText: ["Enter your password.", "Sign in as password@acme.test.", "PASSWORD", "Sign in"],
+            rejectText: ["Sign in with Google", "Sign in with SSO", "Create your account."],
+          },
+        });
+      },
+    },
+    {
+      name: "New account route",
+      run: async (ctx) => {
+        await ctx.prove("A new email sees the create-account form with name, Google, password, and Sign up", {
+          voiceover: vo[5],
+          action: async () => {
+            await openSignedOutRoot(ctx);
+            await installLoginOptionsMock(ctx, { nextStep: "new_account" });
+            await fillEmailAndNext(ctx, "new@acme.test");
+            await ctx.waitFor("document.body.innerText.includes('Create your account.')", {
+              timeoutMs: 30_000,
+              label: "new account step",
+            });
+          },
+          assert: async () => {
+            const actual = await readAuthSurface(ctx);
+            ctx.assert(actual.emailInputs === 1, `Expected one email field, got ${JSON.stringify(actual)}`);
+            ctx.assert(actual.passwordInputs === 1, `Expected one password field, got ${JSON.stringify(actual)}`);
+            ctx.assert(actual.text.includes("NAME"), "Expected Name field on new account form.");
+            ctx.assert(actual.buttons.includes("Sign up with Google"), `Expected Google sign-up button, got ${JSON.stringify(actual.buttons)}`);
+            ctx.assert(actual.buttons.includes("Sign up"), `Expected Sign up button, got ${JSON.stringify(actual.buttons)}`);
+          },
+          screenshot: {
+            name: "new-account-step",
+            requireText: ["Create your account.", "EMAIL", "NAME", "Sign up with Google", "PASSWORD", "Sign up"],
+            rejectText: ["Sign in with SSO", "Sign in with Google"],
+          },
+        });
+      },
+    },
+  ],
+};
+
+async function openSignedOutRoot(ctx) {
+  await ctx.eval(`(() => {
+    window.location.href = ${JSON.stringify(DEN_WEB_URL)};
+    return true;
+  })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "den-web loaded" });
+  await ctx.eval(`(() => {
+    window.localStorage.removeItem('openwork:web:auth-token');
+    window.sessionStorage.clear();
+    return fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' })
+      .then(() => true)
+      .catch(() => true);
+  })()`, { awaitPromise: true });
+  await ctx.eval(`(() => {
+    window.location.href = ${JSON.stringify(DEN_WEB_URL)};
+    return true;
+  })()`);
+  await ctx.waitFor(
+    `(() => document.body.innerText.includes('Continue to OpenWork.') && Boolean(document.querySelector('input[type="email"]')))()`,
+    { timeoutMs: 30_000, label: "email-first auth panel" },
+  );
+}
+
+async function installLoginOptionsMock(ctx, responsePayload) {
+  await ctx.eval(`((payload) => {
+    const originalFetch = window.fetch.bind(window);
+    window.__openworkLoginOptionRequests = [];
+    window.fetch = (input, init) => {
+      const rawUrl = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, window.location.origin);
+      if (url.pathname === '/v1/auth/login-options' || url.pathname === '/api/den/v1/auth/login-options') {
+        window.__openworkLoginOptionRequests.push(url.pathname + url.search);
+        return Promise.resolve(new Response(JSON.stringify({ email: url.searchParams.get('email') ?? '', ...payload }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }));
+      }
+      return originalFetch(input, init);
+    };
+    return true;
+  })(${JSON.stringify(responsePayload)})`);
+}
+
+async function fillEmailAndNext(ctx, email) {
+  await ctx.fill('input[type="email"]', email);
+  const clicked = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === 'Next');
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(clicked, "Could not find the Next button.");
+}
+
+async function readAuthSurface(ctx) {
+  return ctx.eval(`(() => {
+    const buttons = [...document.querySelectorAll('button')]
+      .filter((button) => button.getClientRects().length > 0)
+      .map((button) => (button.textContent ?? '').replace(/\s+/g, ' ').trim())
+      .filter(Boolean);
+    return {
+      text: document.body.innerText,
+      buttons,
+      emailInputs: document.querySelectorAll('input[type="email"]').length,
+      passwordInputs: document.querySelectorAll('input[type="password"]').length,
+    };
+  })()`);
+}

--- a/evals/voiceovers/new-signin-flow.md
+++ b/evals/voiceovers/new-signin-flow.md
@@ -1,0 +1,13 @@
+# new-signin-flow — Deterministic email-first sign-in
+
+1. The sign-in screen starts simple: one email address field and one **Next** button.
+
+2. After entering an email, OpenWork checks the backend and chooses the right next step.
+
+3. If the email belongs to an org with SSO, the next screen only shows **Sign in with SSO**.
+
+4. If the email uses Google, the next screen only shows **Sign in with Google**.
+
+5. If the email uses a password, the next screen shows the password field and sign-in button.
+
+6. If the email is new, the screen becomes **Create an account** with email, name, a separator, **Sign up with Google**, password, and **Sign up**.


### PR DESCRIPTION
## Summary
- Adds a public `GET /v1/auth/login-options` lookup for deterministic auth routing: SSO → Google → password → GitHub compatibility → new account.
- Changes the root Den Web auth screen to start with only email + Next, then render the resolved next step.
- Adds the approved voiceover and fraimz proof flow for the new sign-in experience.

## Verification
- ✅ `pnpm --filter @openwork-ee/den-api exec bun test test/auth-login-options.test.ts`
- ✅ `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json`
- ✅ `pnpm --filter @openwork-ee/den-web exec tsc -p tsconfig.json --noEmit`
- ✅ `git diff --check`
- ✅ `OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3005 pnpm fraimz --flow new-signin-flow --cdp-url http://127.0.0.1:9223`

Fraimz artifact: `evals/results/2026-07-09T16-32-30-282Z/fraimz.html`

Note: `pnpm --filter @openwork-ee/den-api exec bun test test/route-guard-policy.test.ts` currently fails on existing uncovered dev/MCP routes unrelated to this change; this PR adds the login-options public-route exception.