### PR TITLE
fix(server): skip command files with malformed frontmatter

### DIFF
--- a/apps/server/src/commands.test.ts
+++ b/apps/server/src/commands.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { listCommands, upsertCommand } from "./commands.js";
+import { listCommands, repairCommands, upsertCommand } from "./commands.js";
 
 describe("commands", () => {
   test("upsertCommand omits null model from frontmatter", async () => {
@@ -36,5 +36,27 @@ describe("commands", () => {
     const repaired = await readFile(commandPath, "utf8");
     expect(repaired).not.toContain("model: null");
     expect(repaired).not.toContain("model:");
+  });
+
+  test("listCommands skips files with malformed frontmatter instead of throwing", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "openwork-commands-"));
+    const commandsDir = join(workspace, ".opencode", "commands");
+
+    await mkdir(commandsDir, { recursive: true });
+    await writeFile(join(commandsDir, "broken.md"), "---\nname: broken\n  bad: [unclosed\n---\nBody\n", "utf8");
+    await writeFile(join(commandsDir, "good.md"), "---\nname: good\ndescription: Good\n---\nDo the thing\n", "utf8");
+
+    const commands = await listCommands(workspace, "workspace");
+    expect(commands.map((c) => c.name)).toEqual(["good"]);
+  });
+
+  test("repairCommands does not throw on malformed frontmatter", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "openwork-commands-"));
+    const commandsDir = join(workspace, ".opencode", "commands");
+
+    await mkdir(commandsDir, { recursive: true });
+    await writeFile(join(commandsDir, "broken.md"), "---\nname: broken\n  bad: [unclosed\n---\nBody\n", "utf8");
+
+    expect(await repairCommands(workspace)).toBe(false);
   });
 });

--- a/apps/server/src/commands.ts
+++ b/apps/server/src/commands.ts
@@ -14,8 +14,14 @@ function normalizeCommandFrontmatter(data: Record<string, unknown>): Record<stri
   );
 }
 
-async function repairLegacyCommandFile(filePath: string, content: string): Promise<{ data: Record<string, unknown>; body: string; changed: boolean }> {
-  const parsed = parseFrontmatter(content);
+async function repairLegacyCommandFile(filePath: string, content: string): Promise<{ data: Record<string, unknown>; body: string; changed: boolean } | null> {
+  let parsed: { data: Record<string, unknown>; body: string };
+  try {
+    parsed = parseFrontmatter(content);
+  } catch {
+    // Malformed YAML frontmatter: skip this file rather than crash the caller.
+    return null;
+  }
   if (parsed.data.model !== null) {
     return { ...parsed, changed: false };
   }
@@ -38,7 +44,9 @@ async function listCommandsInDir(dir: string, scope: "workspace" | "global"): Pr
     if (!entry.name.endsWith(".md")) continue;
     const filePath = join(dir, entry.name);
     const content = await readFile(filePath, "utf8");
-    const { data, body } = await repairLegacyCommandFile(filePath, content);
+    const repaired = await repairLegacyCommandFile(filePath, content);
+    if (!repaired) continue;
+    const { data, body } = repaired;
     const name = typeof data.name === "string" ? data.name : entry.name.replace(/\.md$/, "");
     try {
       validateCommandName(name);
@@ -114,6 +122,7 @@ export async function repairCommands(workspaceRoot: string): Promise<boolean> {
     const filePath = join(dir, entry.name);
     const content = await readFile(filePath, "utf8");
     const result = await repairLegacyCommandFile(filePath, content);
+    if (!result) continue;
     changed ||= result.changed;
   }
   return changed;


### PR DESCRIPTION
## Summary
- A command file with malformed YAML frontmatter no longer bricks the whole workspace. `repairLegacyCommandFile` now returns `null` when the frontmatter cannot be parsed, and both call sites (`listCommandsInDir` and `repairCommands`) skip that file.
- The try/catch wraps only `parseFrontmatter`, so real I/O errors (readFile/writeFile) still propagate.

## Issue
`resolveWorkspace` runs `repairCommands` on every proxied request (when not read-only). `repairCommands` -> `repairLegacyCommandFile` -> `parseFrontmatter` -> `yaml.parse()` threw an unhandled `YAMLParseError` on a single bad frontmatter block. The result was an opaque 500 "Unexpected server error" on `POST /workspaces/:id/activate` and every `/w/{id}/opencode/*` route, so one malformed command file took down the entire workspace. `listCommands` (`GET /commands`) had the same latent crash.

opencode's own `/config` returned 200 (opencode parses fine), but every request proxied through OpenWork 500'd, which pointed at the OpenWork layer rather than opencode.

## Test Evidence
- `cd apps/server && ./node_modules/.bin/tsc -p tsconfig.json --noEmit` -> pass (typecheck via tsc directly; the `pnpm typecheck` dep-status check fails on the `better-sqlite3` native build on Node > 24, unrelated to this change)
- `cd apps/server && bun test src/commands.test.ts` -> 4 pass, 0 fail, 8 expect()
  - added `listCommands skips files with malformed frontmatter instead of throwing`
  - added `repairCommands does not throw on malformed frontmatter`

## Evidence
N/A (server-side, no UI change).
