### PR TITLE
Expose admin tools through OpenWork Cloud capabilities

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -176,26 +176,6 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     defaultHidden: true,
   },
   {
-    get name() { return t("mcp.quick_connect_openwork_admin_title"); },
-    serverName: "openwork-admin",
-    get description() { return t("mcp.quick_connect_openwork_admin_desc"); },
-    get url() {
-      // den-api serves the admin MCP at /mcp/admin, next to the org-scoped
-      // /mcp endpoint. Access is enforced server-side via the platform-admin
-      // allowlist, so this entry stays hidden from the default catalog.
-      try {
-        return `${getDenMcpUrl()}/admin`;
-      } catch {
-        return "https://app.openworklabs.com/api/den/mcp/admin";
-      }
-    },
-    type: "remote",
-    oauth: true,
-    kind: "mcp",
-    iconSrc: "/openwork-mark.svg",
-    defaultHidden: true,
-  },
-  {
     get name() { return t("mcp.quick_connect_openwork_ui_title"); },
     serverName: "openwork-ui",
     get description() { return t("mcp.quick_connect_openwork_ui_desc"); },

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -583,8 +583,6 @@ export default {
   "mcp.quick_connect_linear_title": "Linear",
   "mcp.quick_connect_notion_desc": "Pages, databases, and project docs in sync.",
   "mcp.quick_connect_notion_title": "Notion",
-  "mcp.quick_connect_openwork_admin_desc": "Read-only Den analytics for OpenWork platform admins: growth, retention, company lookups, and ad-hoc queries. Requires an allowlisted admin account. Try: \"What's our weekly signup growth?\"",
-  "mcp.quick_connect_openwork_admin_title": "OpenWork Admin Analytics",
   "mcp.quick_connect_openwork_cloud_desc": "Manage your org, workers, skills, providers, and team config from chat. Try: \"List all workers in my org\" or \"Push this skill to the team.\"",
   "mcp.quick_connect_openwork_cloud_title": "OpenWork Cloud Control",
   "mcp.quick_connect_openwork_ui_desc": "Let agents see and drive the OpenWork app. Navigate sessions, type into the composer, open settings. Try: \"Take a snapshot of what I see\" or \"Create a new session and type hello.\"",

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -680,24 +680,22 @@ export function createConnectionsStore(options: {
 
       // Signed-in cloud users connect the Den MCPs with a first-party token —
       // no browser OAuth round-trip. Signed-out users fall back to OAuth.
-      // The same minted token works for /mcp/agent (openwork-cloud), /mcp,
-      // and /mcp/admin (openwork-admin); den-api enforces the platform-admin
-      // allowlist on the admin endpoint server-side.
-      if (entry.serverName === "openwork-cloud" || entry.serverName === "openwork-admin") {
+      // Use the signed-in member's first-party token for OpenWork Cloud.
+      // Allowlisted platform-admin tools are discovered through this same
+      // search_capabilities / execute_capability connection.
+      if (entry.serverName === "openwork-cloud") {
         try {
           const minted = await mintCloudControlMcpToken();
           if (minted) {
-            if (entry.serverName === "openwork-cloud") {
-              // Never trust `minted.resource` verbatim: older den-api builds
-              // mint the bare web-app origin (https://app.openworklabs.com/mcp)
-              // where MCP 404s. Heal it to the canonical /mcp origin, then
-              // route the desktop app to the minimal, harness-facing
-              // /mcp/agent surface (search_capabilities + execute_capability
-              // only) rather than the full catalog — falling back to the
-              // entry's bootstrap-derived URL (which already targets /agent).
-              const healed = resolveCloudMcpResourceUrl(minted.resource);
-              resolvedUrl = healed ? `${healed}/agent` : resolvedUrl;
-            }
+            // Never trust `minted.resource` verbatim: older den-api builds
+            // mint the bare web-app origin (https://app.openworklabs.com/mcp)
+            // where MCP 404s. Heal it to the canonical /mcp origin, then
+            // route the desktop app to the minimal, harness-facing
+            // /mcp/agent surface (search_capabilities + execute_capability
+            // only) rather than the full catalog — falling back to the
+            // entry's bootstrap-derived URL (which already targets /agent).
+            const healed = resolveCloudMcpResourceUrl(minted.resource);
+            resolvedUrl = healed ? `${healed}/agent` : resolvedUrl;
             resolvedHeaders = { Authorization: `Bearer ${minted.token}` };
           }
         } catch {

--- a/apps/app/tests/builtin-mcp-visibility.test.ts
+++ b/apps/app/tests/builtin-mcp-visibility.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, test } from "bun:test";
 import { MCP_QUICK_CONNECT } from "../src/app/constants";
 
 describe("built-in OpenWork MCP visibility", () => {
-  test("hides internal OpenWork MCPs by default", () => {
+  test("hides internal OpenWork MCPs and omits the retired admin connector", () => {
     expect(MCP_QUICK_CONNECT.find((entry) => entry.serverName === "openwork-cloud")?.defaultHidden).toBe(true);
-    expect(MCP_QUICK_CONNECT.find((entry) => entry.serverName === "openwork-admin")?.defaultHidden).toBe(true);
+    expect(MCP_QUICK_CONNECT.find((entry) => entry.serverName === "openwork-admin")).toBeUndefined();
     expect(MCP_QUICK_CONNECT.find((entry) => entry.serverName === "openwork-ui")?.defaultHidden).toBe(true);
   });
 

--- a/ee/apps/den-api/src/mcp/admin-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/admin-capabilities.ts
@@ -1,0 +1,129 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import type { CapabilityMatch } from "./search.js"
+import { scoreText, tokenize } from "./search.js"
+import { DEN_ADMIN_MCP_VERSION, registerAdminMcpTools } from "./admin-tools.js"
+
+export const ADMIN_CAPABILITY_PREFIX = "admin:"
+
+type AdminToolResult = {
+  isError?: boolean
+  content: { type: "text"; text: string }[]
+}
+
+async function withAdminClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
+  const server = new McpServer({ name: "den-admin-agent-bridge", version: DEN_ADMIN_MCP_VERSION })
+  registerAdminMcpTools(server)
+  const client = new Client({ name: "openwork-agent", version: "1.0.0" })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+  await server.connect(serverTransport)
+  await client.connect(clientTransport)
+  try {
+    return await run(client)
+  } finally {
+    await client.close().catch(() => undefined)
+    await server.close().catch(() => undefined)
+  }
+}
+
+export function parseAdminCapabilityName(name: string): string | null {
+  if (!name.startsWith(ADMIN_CAPABILITY_PREFIX)) return null
+  const toolName = name.slice(ADMIN_CAPABILITY_PREFIX.length)
+  return toolName.length > 0 ? toolName : null
+}
+
+export async function searchAdminCapabilities(query: string, limit = 5): Promise<CapabilityMatch[]> {
+  const queryTokens = tokenize(query)
+  const boundedLimit = Math.max(1, Math.min(20, Math.trunc(limit) || 5))
+  const { tools } = await withAdminClient((client) => client.listTools())
+
+  return tools
+    .map((tool) => ({
+      name: `${ADMIN_CAPABILITY_PREFIX}${tool.name}`,
+      method: "MCP",
+      path: "/mcp/admin",
+      score: scoreText(
+        tokenize(tool.name),
+        tokenize(tool.description ?? ""),
+        queryTokens,
+        ["admin", "platform"],
+      ),
+      summary: `[OpenWork Admin] ${tool.description ?? tool.name}`,
+      pathParams: [],
+      queryParams: [],
+      hasBody: Object.keys(tool.inputSchema.properties ?? {}).length > 0,
+    }))
+    .filter((match) => match.score > 0)
+    .sort((a, b) => (b.score - a.score) || a.name.localeCompare(b.name))
+    .slice(0, boundedLimit)
+}
+
+export async function searchAvailableAdminCapabilities(
+  platformAdmin: boolean,
+  query: string,
+  limit = 5,
+): Promise<CapabilityMatch[]> {
+  return platformAdmin ? searchAdminCapabilities(query, limit) : []
+}
+
+function normalizeArguments(body: unknown): Record<string, unknown> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) return {}
+  return Object.fromEntries(Object.entries(body))
+}
+
+function isTextContent(value: unknown): value is { type: "text"; text: string } {
+  return typeof value === "object"
+    && value !== null
+    && "type" in value
+    && value.type === "text"
+    && "text" in value
+    && typeof value.text === "string"
+}
+
+function resultTextContent(result: unknown): { type: "text"; text: string }[] {
+  if (typeof result !== "object" || result === null || !("content" in result) || !Array.isArray(result.content)) {
+    return []
+  }
+  return result.content.filter(isTextContent)
+}
+
+function resultIsError(result: unknown): boolean {
+  return typeof result === "object" && result !== null && "isError" in result && result.isError === true
+}
+
+export async function executeAdminCapability(name: string, body: unknown): Promise<AdminToolResult | null> {
+  const toolName = parseAdminCapabilityName(name)
+  if (!toolName) return null
+
+  return withAdminClient(async (client) => {
+    const result = await client.callTool({ name: toolName, arguments: normalizeArguments(body) })
+    const content = resultTextContent(result)
+    return {
+      ...(resultIsError(result) ? { isError: true } : {}),
+      content: content.length > 0 ? content : [{ type: "text", text: JSON.stringify(result) }],
+    }
+  })
+}
+
+export async function executeAvailableAdminCapability(
+  platformAdmin: boolean,
+  name: string,
+  body: unknown,
+): Promise<AdminToolResult | null> {
+  if (!parseAdminCapabilityName(name)) return null
+  if (!platformAdmin) {
+    return {
+      isError: true,
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          error: "unknown_capability",
+          message: `No capability named "${name}". Call search_capabilities to find a valid name.`,
+        }),
+      }],
+    }
+  }
+  return executeAdminCapability(name, body)
+}

--- a/ee/apps/den-api/src/mcp/admin.ts
+++ b/ee/apps/den-api/src/mcp/admin.ts
@@ -1,11 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StreamableHTTPTransport } from "@hono/mcp"
-import { eq } from "@openwork-ee/den-db/drizzle"
-import { AuthUserTable } from "@openwork-ee/den-db/schema"
-import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
-import { db } from "../db.js"
-import { isAdminEmailAllowed } from "../middleware/admin.js"
+import { isPlatformAdminUserId } from "../middleware/admin.js"
 import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { getMcpResourceUrl, verifyMcpRequest } from "./auth.js"
 import { protectedResourceMetadata } from "./index.js"
@@ -44,22 +40,7 @@ export function registerAdminMcpRoutes<T extends { Variables: Record<string, unk
       return principal
     }
 
-    let userId: ReturnType<typeof normalizeDenTypeId<"user">> | null = null
-    try {
-      userId = normalizeDenTypeId("user", principal.userId)
-    } catch {
-      userId = null
-    }
-
-    const user = userId
-      ? (await db
-          .select({ email: AuthUserTable.email })
-          .from(AuthUserTable)
-          .where(eq(AuthUserTable.id, userId))
-          .limit(1))[0]
-      : undefined
-
-    if (!user || !(await isAdminEmailAllowed(user.email))) {
+    if (!(await isPlatformAdminUserId(principal.userId))) {
       return c.json({
         error: "admin_required",
         message: "The den-admin MCP is restricted to allowlisted platform admins.",

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -18,15 +18,18 @@ import { executeMarketplaceCapability, parseMarketplaceCapabilityName, searchMar
 import { executeSkillCapability, parseSkillCapabilityName, searchSkillCapabilities } from "./skill-capabilities.js"
 import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { env } from "../env.js"
+import { isPlatformAdminUserId } from "../middleware/admin.js"
+import { executeAvailableAdminCapability, parseAdminCapabilityName, searchAvailableAdminCapabilities } from "./admin-capabilities.js"
 
 export const EXECUTE_CAPABILITY_TOOL_NAME = "execute_capability"
-const searchCapabilityTypeSchema = z.enum(["all", "api", "mcp", "marketplace", "skills"])
+const searchCapabilityTypeSchema = z.enum(["all", "api", "admin", "mcp", "marketplace", "skills"])
 const skillMarketplaceObjectTypes: MarketplaceCapabilityObjectType[] = ["skill"]
 export const EXECUTE_CAPABILITY_TIMEOUT_MS = 45_000
 
 export const AGENT_MCP_INSTRUCTIONS = [
   "This OpenWork Cloud connection intentionally exposes exactly two tools: search_capabilities and execute_capability.",
   "Capabilities include native Google Workspace operations (Gmail read/search, Calendar list/create, Drive search/read, and Gmail draft creation) executed with the signed-in member's organization credentials, plus any MCP connections the organization has added.",
+  "Allowlisted platform admins can also discover namespaced OpenWork Admin capabilities through this same connection; other members cannot discover or execute them.",
   "Always call search_capabilities first with 2-4 keyword variants before concluding something is unavailable. Use execute_capability only with exact names returned by search_capabilities.",
   "Do not tell users to configure OAuth clients or local extensions for these capabilities; organization connections are managed in the OpenWork Cloud dashboard / Settings > Connect.",
   "When a search match or execute result carries status needs_connection or a connection error, relay the fix to the user and stop — do not retry unchanged and do not improvise workarounds through other tools.",
@@ -169,6 +172,11 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
       userId: principal.userId,
       organizationId: principal.organizationId,
     })
+    let platformAdmin: Promise<boolean> | undefined
+    const resolvePlatformAdmin = () => {
+      platformAdmin ??= isPlatformAdminUserId(principal.userId)
+      return platformAdmin
+    }
     const organizationId = normalizeDenTypeId("organization", principal.organizationId)
     const organizationRows = await db
       .select({ metadata: OrganizationTable.metadata })
@@ -187,7 +195,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         description: [
           "Search for a capability by keyword. This connection only exposes this tool and execute_capability —",
           "there is no list of individually-named tools to browse. Always search first.",
-          "Search covers native Google Workspace capabilities (Gmail, Calendar, Drive, Gmail drafts) and org-connected external MCPs such as Notion, Linear, Slack, or other services added in the OpenWork Cloud dashboard / Settings > Connect.",
+          "Search covers native Google Workspace capabilities (Gmail, Calendar, Drive, Gmail drafts), org-connected external MCPs, and namespaced OpenWork Admin tools for allowlisted platform admins.",
           "Try 2-4 keyword variants before deciding a capability is unavailable.",
           "Each match includes pathParams/queryParams/hasBody describing exactly what execute_capability needs.",
           "Skill matches use method SKILL and return stored SKILL.md content when executed.",
@@ -195,7 +203,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         inputSchema: z.object({
           query: z.string().min(1).describe("Keywords describing the capability you need, e.g. \"create organization\" or \"list workers\"."),
           limit: z.number().int().min(1).max(20).optional().describe("Max number of matches to return. Defaults to 5."),
-          type: searchCapabilityTypeSchema.optional().describe("Optional source filter. all searches every source; api searches Den API capabilities; mcp searches connected external MCP tools; marketplace searches marketplace plugin capabilities; skills searches native skills and marketplace skill objects. Defaults to all."),
+          type: searchCapabilityTypeSchema.optional().describe("Optional source filter. all searches every available source; api searches Den API capabilities; admin searches allowlisted platform-admin tools; mcp searches connected external MCP tools; marketplace searches marketplace plugin capabilities; skills searches native skills and marketplace skill objects. Defaults to all."),
         }),
       },
       async ({ query, limit, type }) => {
@@ -203,6 +211,9 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         const sourceFilter = searchCapabilitySourceFilter(type)
         const marketplaceObjectTypes = type === "skills" ? skillMarketplaceObjectTypes : undefined
         const restMatches = sourceFilter.api ? searchCapabilities(catalog, query, boundedLimit) : []
+        const adminMatches = sourceFilter.admin
+          ? await searchAvailableAdminCapabilities(await resolvePlatformAdmin(), query, boundedLimit)
+          : []
         // Merged in from each connected External MCP Connection's live
         // tools/list (capability-sources/external-mcp-client.ts) — a
         // Notion/Linear/Stripe/... connection an admin added in Den shows
@@ -234,7 +245,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
             limit: boundedLimit,
           })
           : []
-        const matches = [...restMatches, ...externalMatches, ...marketplaceMatches, ...skillMatches]
+        const matches = [...restMatches, ...adminMatches, ...externalMatches, ...marketplaceMatches, ...skillMatches]
           .sort((a, b) => b.score - a.score)
           .slice(0, boundedLimit)
         const text = matches.length > 0
@@ -265,6 +276,11 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         return executeCapabilityWithBudget({
           capability: name,
           invoke: async (): Promise<ExecuteCapabilityToolResult> => {
+            const adminResult = parseAdminCapabilityName(name)
+              ? await executeAvailableAdminCapability(await resolvePlatformAdmin(), name, body)
+              : null
+            if (adminResult) return adminResult
+
             const external = parseExternalCapabilityName(name)
             if (external) {
               if (!externalMcpConnectionsEnabled) {

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -17,7 +17,7 @@ import { getParameters, hasJsonRequestBody, pathParameterNamesFromTemplate, type
  */
 
 export const SEARCH_CAPABILITIES_TOOL_NAME = "search_capabilities"
-export type SearchCapabilityType = "all" | "api" | "mcp" | "marketplace" | "skills"
+export type SearchCapabilityType = "all" | "api" | "admin" | "mcp" | "marketplace" | "skills"
 
 export type CapabilityMatch = {
   name: string
@@ -37,6 +37,7 @@ export function searchCapabilitySourceFilter(type?: SearchCapabilityType) {
   const capabilityType = type ?? "all"
   return {
     api: capabilityType === "all" || capabilityType === "api",
+    admin: capabilityType === "all" || capabilityType === "admin",
     mcp: capabilityType === "all" || capabilityType === "mcp",
     marketplace: capabilityType === "all" || capabilityType === "marketplace" || capabilityType === "skills",
     skills: capabilityType === "all" || capabilityType === "skills",

--- a/ee/apps/den-api/src/middleware/admin.ts
+++ b/ee/apps/den-api/src/middleware/admin.ts
@@ -1,5 +1,6 @@
 import { eq } from "@openwork-ee/den-db/drizzle"
-import { AdminAllowlistTable } from "@openwork-ee/den-db/schema"
+import { AdminAllowlistTable, AuthUserTable } from "@openwork-ee/den-db/schema"
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { MiddlewareHandler } from "hono"
 import { ensureAdminAllowlistSeeded } from "../admin-allowlist.js"
 import { db } from "../db.js"
@@ -25,6 +26,24 @@ export async function isAdminEmailAllowed(email: string | null | undefined): Pro
     .limit(1)
 
   return allowed.length > 0
+}
+
+/** Whether a Den user id belongs to an allowlisted platform admin. */
+export async function isPlatformAdminUserId(value: string): Promise<boolean> {
+  let userId: ReturnType<typeof normalizeDenTypeId<"user">>
+  try {
+    userId = normalizeDenTypeId("user", value)
+  } catch {
+    return false
+  }
+
+  const user = (await db
+    .select({ email: AuthUserTable.email })
+    .from(AuthUserTable)
+    .where(eq(AuthUserTable.id, userId))
+    .limit(1))[0]
+
+  return isAdminEmailAllowed(user?.email)
 }
 
 export const requireAdminMiddleware: MiddlewareHandler<{ Variables: AuthContextVariables }> = async (c, next) => {

--- a/ee/apps/den-api/test/mcp-admin-capabilities.test.ts
+++ b/ee/apps/den-api/test/mcp-admin-capabilities.test.ts
@@ -1,0 +1,51 @@
+import { beforeAll, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+let capabilities: typeof import("../src/mcp/admin-capabilities.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  capabilities = await import("../src/mcp/admin-capabilities.js")
+})
+
+test("admin capability search returns namespaced MCP tools", async () => {
+  const matches = await capabilities.searchAdminCapabilities("Den admin overview", 10)
+
+  expect(matches).toContainEqual(expect.objectContaining({
+    name: "admin:den_overview",
+    method: "MCP",
+    path: "/mcp/admin",
+  }))
+})
+
+test("admin capability execution reuses the existing admin toolset", async () => {
+  const result = await capabilities.executeAdminCapability("admin:den_admin_version", undefined)
+  const payload = JSON.parse(result?.content[0]?.text ?? "{}")
+
+  expect(payload.name).toBe("den-admin")
+  expect(payload.toolsetVersion).toBeString()
+})
+
+test("only namespaced admin capability names are parsed", () => {
+  expect(capabilities.parseAdminCapabilityName("admin:den_overview")).toBe("den_overview")
+  expect(capabilities.parseAdminCapabilityName("den_overview")).toBeNull()
+  expect(capabilities.parseAdminCapabilityName("admin:")).toBeNull()
+})
+
+test("ordinary members cannot discover or directly execute admin capabilities", async () => {
+  const matches = await capabilities.searchAvailableAdminCapabilities(false, "Den admin overview", 10)
+  const result = await capabilities.executeAvailableAdminCapability(false, "admin:den_overview", undefined)
+
+  expect(matches).toEqual([])
+  expect(result?.isError).toBe(true)
+  expect(JSON.parse(result?.content[0]?.text ?? "{}")).toEqual(expect.objectContaining({
+    error: "unknown_capability",
+  }))
+})

--- a/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
@@ -91,15 +91,24 @@ describe("agent-configurable org connections policy", () => {
   test("agent capability search source filter can restrict searches to skills", () => {
     expect(searchCapabilitySourceFilter()).toEqual({
       api: true,
+      admin: true,
       mcp: true,
       marketplace: true,
       skills: true,
     })
     expect(searchCapabilitySourceFilter("skills")).toEqual({
       api: false,
+      admin: false,
       mcp: false,
       marketplace: true,
       skills: true,
+    })
+    expect(searchCapabilitySourceFilter("admin")).toEqual({
+      api: false,
+      admin: true,
+      mcp: false,
+      marketplace: false,
+      skills: false,
     })
   })
 

--- a/evals/flows/cloud-admin-capabilities.flow.mjs
+++ b/evals/flows/cloud-admin-capabilities.flow.mjs
@@ -1,0 +1,93 @@
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "cloud-admin-capabilities";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const TEST_FILE = "ee/apps/den-api/test/mcp-admin-capabilities.test.ts";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function witness(ctx, condition, assertion, actual) {
+  if (!condition) {
+    ctx.recordEvidence({ type: "assertion", status: "failed", assertion, actual });
+    ctx.assert(false, `${assertion}${actual ? ` (actual: ${actual})` : ""}`);
+  }
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion, actual });
+}
+
+function runFocusedTest(name) {
+  return spawnSync("pnpm", ["exec", "bun", "test", TEST_FILE, "--test-name-pattern", name], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: process.env,
+  });
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Platform admins use Den admin tools through the existing OpenWork Cloud connection",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Admin tools are discoverable through Cloud capability search",
+      run: async (ctx) => {
+        await ctx.prove("An allowlisted admin search returns admin:den_overview", {
+          voiceover: vo[0],
+          assert: async () => {
+            const test = runFocusedTest("admin capability search returns namespaced MCP tools");
+            witness(ctx, test.status === 0, "The real admin capability search test passes", test.stderr.trim());
+            witness(ctx, test.stderr.includes("admin capability search returns namespaced MCP tools"), "The passing test exercised namespaced admin discovery");
+            ctx.output("$ pnpm exec bun test (admin discovery)", `${test.stdout}${test.stderr}`.trim());
+          },
+        });
+      },
+    },
+    {
+      name: "The Cloud rail executes the existing admin toolset",
+      run: async (ctx) => {
+        await ctx.prove("The namespaced admin version capability executes and identifies den-admin", {
+          voiceover: vo[1],
+          assert: async () => {
+            const test = runFocusedTest("admin capability execution reuses the existing admin toolset");
+            witness(ctx, test.status === 0, "The real admin capability execution test passes", test.stderr.trim());
+            witness(ctx, test.stderr.includes("admin capability execution reuses the existing admin toolset"), "The passing test executed the existing den-admin toolset");
+            ctx.output("$ pnpm exec bun test (admin execution)", `${test.stdout}${test.stderr}`.trim());
+          },
+        });
+      },
+    },
+    {
+      name: "Ordinary members cannot discover or execute admin tools",
+      run: async (ctx) => {
+        await ctx.prove("The same Cloud rail hides admin tools and rejects direct calls for non-admins", {
+          voiceover: vo[2],
+          assert: async () => {
+            const test = runFocusedTest("ordinary members cannot discover or directly execute admin capabilities");
+            witness(ctx, test.status === 0, "The ordinary-member security test passes", test.stderr.trim());
+            witness(ctx, test.stderr.includes("ordinary members cannot discover or directly execute admin capabilities"), "The passing test covered both nondiscovery and direct execution rejection");
+            ctx.output("$ pnpm exec bun test (ordinary-member boundary)", `${test.stdout}${test.stderr}`.trim());
+          },
+        });
+      },
+    },
+    {
+      name: "The desktop keeps Cloud and removes the separate admin connector",
+      run: async (ctx) => {
+        await ctx.prove("The desktop catalog contains openwork-cloud but no openwork-admin entry", {
+          voiceover: vo[3],
+          assert: async () => {
+            const constants = await readFile(join(ROOT, "apps/app/src/app/constants.ts"), "utf8");
+            const store = await readFile(join(ROOT, "apps/app/src/react-app/domains/connections/store.ts"), "utf8");
+            witness(ctx, constants.includes('serverName: "openwork-cloud"'), "OpenWork Cloud remains in the desktop catalog");
+            witness(ctx, !constants.includes('serverName: "openwork-admin"'), "The separate OpenWork Admin catalog entry is absent");
+            witness(ctx, !store.includes('entry.serverName === "openwork-admin"'), "Desktop token injection no longer special-cases a local admin connection");
+            ctx.output("Desktop connection catalog", "openwork-cloud: present\nopenwork-admin: absent\nadmin token special-case: absent");
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/cloud-admin-capabilities.md
+++ b/evals/voiceovers/cloud-admin-capabilities.md
@@ -1,0 +1,11 @@
+# Cloud admin capabilities from any MCP app
+
+This internal demo proves that platform admins can use Den admin capabilities through the existing OpenWork Cloud connection, without configuring a separate local admin MCP.
+
+1. I connect an MCP app to OpenWork Cloud and search for the Den admin overview. Because I am an allowlisted platform admin, the existing capability search returns the namespaced admin tool.
+
+2. I execute that exact capability through the same OpenWork Cloud connection. The response identifies the Den admin toolset, proving admin operations travel through the normal search-and-execute rail.
+
+3. I repeat the search as an ordinary member. No admin capability is discoverable, and a direct execution attempt is rejected as unknown, so the platform-admin boundary remains intact.
+
+4. I inspect the desktop connection catalog. OpenWork Cloud remains available, while the separate hidden OpenWork Admin connector is gone because no local admin connection is needed anymore.


### PR DESCRIPTION
## What changed

- exposes the existing Den admin MCP toolset through the OpenWork Cloud `search_capabilities` / `execute_capability` rail using `admin:` namespaced capabilities
- preserves the platform-admin allowlist for both discovery and direct execution
- removes the separate hidden `openwork-admin` connector from the desktop app
- keeps `/mcp/admin` available for backward compatibility
- adds focused tests plus an internal fraimz flow and approved voiceover

## Why

Platform admins should receive admin capabilities automatically anywhere the OpenWork Cloud MCP is connected, instead of configuring a second local connector.

## Validation

- `pnpm --filter @openwork-ee/den-api build` — passed
- `pnpm exec bun test ee/apps/den-api/test/mcp-admin-capabilities.test.ts ee/apps/den-api/test/mcp-agent-config-policy.test.ts ee/apps/den-api/test/mcp-agent-timeouts.test.ts` — 14 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork/app build` — passed
- `pnpm fraimz --flow cloud-admin-capabilities` — Passed, 4 frames