### PR TITLE
Fix offline access for existing MCP clients

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -5,6 +5,7 @@ import { deriveDenMcpResource } from "./mcp/resource.js";
 import { getDenAuthIssuer, getDenJwtOptions } from "./mcp/jwt-policy.js";
 import {
   DEN_MCP_DEFAULT_CLIENT_SCOPES,
+  DEN_MCP_OFFLINE_SCOPE,
   DEN_MCP_SCOPES,
 } from "./mcp/scopes.js";
 import {
@@ -149,6 +150,12 @@ function maybeString(value: unknown) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+function stringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((entry: unknown): entry is string => typeof entry === "string")
+    : [];
+}
+
 function pickRemoteIdentity(userInfo: Record<string, unknown>) {
   return (
     maybeString(userInfo.sub) ??
@@ -287,6 +294,30 @@ export const auth = betterAuth({
   },
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
+      if (ctx.path === "/oauth2/authorize") {
+        const clientId = maybeString(ctx.query?.client_id);
+        const requestedScopes = maybeString(ctx.query?.scope)?.split(/\s+/).filter(Boolean) ?? [];
+
+        if (clientId && requestedScopes.includes(DEN_MCP_OFFLINE_SCOPE)) {
+          const client = await ctx.context.adapter.findOne<{ scopes?: unknown }>({
+            model: "oauthClient",
+            where: [{ field: "clientId", value: clientId }],
+          });
+          const clientScopes = stringArray(client?.scopes);
+
+          if (hasMcpScope(clientScopes) && !clientScopes.includes(DEN_MCP_OFFLINE_SCOPE)) {
+            await ctx.context.adapter.update({
+              model: "oauthClient",
+              where: [{ field: "clientId", value: clientId }],
+              update: {
+                scopes: [...clientScopes, DEN_MCP_OFFLINE_SCOPE],
+                updatedAt: new Date(),
+              },
+            });
+          }
+        }
+      }
+
       if (ctx.path !== "/sign-in/email" && ctx.path !== "/sign-up/email") {
         return;
       }

--- a/ee/apps/den-api/src/mcp/scopes.ts
+++ b/ee/apps/den-api/src/mcp/scopes.ts
@@ -1,5 +1,6 @@
 export const DEN_MCP_READ_SCOPE = "mcp:read"
 export const DEN_MCP_WRITE_SCOPE = "mcp:write"
+export const DEN_MCP_OFFLINE_SCOPE = "offline_access"
 
 export type DenMcpTokenScope = typeof DEN_MCP_READ_SCOPE | typeof DEN_MCP_WRITE_SCOPE
 
@@ -7,7 +8,7 @@ export const DEN_MCP_SCOPES = [
   "openid",
   "profile",
   "email",
-  "offline_access",
+  DEN_MCP_OFFLINE_SCOPE,
   DEN_MCP_READ_SCOPE,
   DEN_MCP_WRITE_SCOPE,
 ]

--- a/ee/apps/den-api/test/mcp-oauth-refresh-flow.test.ts
+++ b/ee/apps/den-api/test/mcp-oauth-refresh-flow.test.ts
@@ -112,7 +112,7 @@ afterAll(async () => {
   mock.restore()
 })
 
-test("standard MCP authorization receives and rotates a thirty-day refresh grant", async () => {
+test("legacy MCP registration gains offline access and rotates a thirty-day refresh grant", async () => {
   const metadataResponse = await app.fetch(new Request(`${API_ORIGIN}/mcp/.well-known/oauth-protected-resource`))
   expect(metadataResponse.status).toBe(200)
   const metadata: unknown = await metadataResponse.json()
@@ -123,6 +123,7 @@ test("standard MCP authorization receives and rotates a thirty-day refresh grant
   const scopes = metadata.scopes_supported.filter((scope): scope is string => typeof scope === "string")
   expect(scopes).toContain("offline_access")
   const scope = scopes.join(" ")
+  const legacyScope = scopes.filter((entry) => entry !== "offline_access").join(" ")
 
   const registrationResponse = await app.fetch(new Request(`${API_ORIGIN}/register`, {
     method: "POST",
@@ -136,13 +137,13 @@ test("standard MCP authorization receives and rotates a thirty-day refresh grant
       token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
-      scope,
+      scope: legacyScope,
     }),
   }))
   expect(registrationResponse.status).toBe(200)
   const registration: unknown = await registrationResponse.json()
   oauthClientId = requiredString(registration, "client_id")
-  expect(requiredString(registration, "scope").split(" ")).toEqual(scopes)
+  expect(requiredString(registration, "scope")).toBe(legacyScope)
 
   const verifier = `mcp-refresh-verifier-${createDenTypeId("verification")}`
   const authorizeUrl = new URL(`${API_ORIGIN}/api/auth/oauth2/authorize`)
@@ -277,4 +278,14 @@ test("standard MCP authorization receives and rotates a thirty-day refresh grant
     .from(schema.OAuthRefreshTokenTable)
     .where(drizzle.eq(schema.OAuthRefreshTokenTable.clientId, oauthClientId))
   expect(grantsAfterReplay).toEqual([])
+
+  const overbroadAuthorizeUrl = new URL(authorizeUrl)
+  overbroadAuthorizeUrl.searchParams.set("scope", `${scope} email`)
+  const overbroadResponse = await app.fetch(new Request(overbroadAuthorizeUrl, {
+    headers: { cookie: sessionCookie },
+  }))
+  expect(overbroadResponse.status).toBe(302)
+  const overbroadCallback = new URL(overbroadResponse.headers.get("location") ?? REDIRECT_URI)
+  expect(overbroadCallback.searchParams.get("error")).toBe("invalid_scope")
+  expect(overbroadCallback.searchParams.get("error_description")).toContain("email")
 })

--- a/evals/flows/durable-auth-mcp.flow.mjs
+++ b/evals/flows/durable-auth-mcp.flow.mjs
@@ -1,4 +1,5 @@
 import { execFile, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
@@ -17,6 +18,7 @@ const execFileAsync = promisify(execFile);
 
 const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
 const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_BROWSER_API_URL = DEN_API_URL.replace("://127.0.0.1", "://localhost");
 const DEMO_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
 const DEMO_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
 const MYSQL_CONTAINER = process.env.OPENWORK_EVAL_DEN_MYSQL_CONTAINER?.trim() || "openwork-web-local-mysql";
@@ -48,6 +50,7 @@ const state = {
   secondConsentStartedAt: null,
   secondConnectionSkippedReauth: false,
   engineRestarted: false,
+  legacyClientId: null,
 };
 
 let mockChild = null;
@@ -218,6 +221,10 @@ async function cleanupDesktopEvalWorkspaces(ctx) {
 async function prepareCloudState(ctx) {
   await cleanupEvalBrowserTargets(ctx);
   await cleanupDesktopEvalWorkspaces(ctx);
+  await runMysql(ctx, "DELETE FROM oauthAccessToken WHERE client_id IN (SELECT client_id FROM oauthClient WHERE name LIKE 'Legacy MCP client %');");
+  await runMysql(ctx, "DELETE FROM oauthRefreshToken WHERE client_id IN (SELECT client_id FROM oauthClient WHERE name LIKE 'Legacy MCP client %');");
+  await runMysql(ctx, "DELETE FROM oauthConsent WHERE client_id IN (SELECT client_id FROM oauthClient WHERE name LIKE 'Legacy MCP client %');");
+  await runMysql(ctx, "DELETE FROM oauthClient WHERE name LIKE 'Legacy MCP client %';");
   await startMock(ctx);
   state.adminSession = await signInApi(DEMO_EMAIL, DEMO_PASSWORD);
   ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${DEMO_EMAIL}.`);
@@ -605,6 +612,42 @@ async function revokedMcpResponse() {
   return { status: response.status, ok: response.ok, text: await response.text() };
 }
 
+async function openLegacyMcpAuthorization(ctx) {
+  const registered = await denApiFetch("/register", {
+    method: "POST",
+    body: JSON.stringify({
+      client_name: `Legacy MCP client ${RUN_TAG}`,
+      redirect_uris: ["http://127.0.0.1:49152/oauth/callback"],
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      scope: "mcp:read mcp:write",
+    }),
+  });
+  ctx.assert(registered.response.ok && typeof registered.body?.client_id === "string", `Legacy client registration failed: ${registered.response.status}`);
+  state.legacyClientId = registered.body.client_id;
+
+  await openDenWebTab(ctx);
+  const verifier = `durable-auth-legacy-client-${RUN_TAG}`;
+  const authorizeUrl = new URL("/api/auth/oauth2/authorize", DEN_BROWSER_API_URL);
+  authorizeUrl.searchParams.set("client_id", state.legacyClientId);
+  authorizeUrl.searchParams.set("response_type", "code");
+  authorizeUrl.searchParams.set("redirect_uri", "http://127.0.0.1:49152/oauth/callback");
+  authorizeUrl.searchParams.set("scope", "mcp:read mcp:write offline_access");
+  authorizeUrl.searchParams.set("resource", `${DEN_API_URL}/mcp`);
+  authorizeUrl.searchParams.set("code_challenge", createHash("sha256").update(verifier).digest("base64url"));
+  authorizeUrl.searchParams.set("code_challenge_method", "S256");
+  authorizeUrl.searchParams.set("prompt", "consent");
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(authorizeUrl.toString())}); return true; })()`);
+  await ctx.waitFor("location.pathname === '/mcp/select-organization'", { timeoutMs: 45_000, label: "legacy MCP workspace authorization redirect" });
+  await ctx.eval(`(() => {
+    if (location.origin === ${JSON.stringify(new URL(DEN_WEB_URL).origin)}) return true;
+    location.assign(${JSON.stringify(DEN_WEB_URL)} + location.pathname + location.search);
+    return true;
+  })()`);
+  await ctx.waitForText("Authorize and continue", { timeoutMs: 45_000 });
+}
+
 export default {
   id: FLOW_ID,
   title: "Active OpenWork and MCP sessions renew silently while real security boundaries still hold",
@@ -861,6 +904,35 @@ export default {
       },
     },
     {
+      name: "Frame 8",
+      run: async (ctx) => {
+        await ctx.prove("A legacy MCP client reaches workspace authorization when it adds offline access", {
+          voiceover: vo[7],
+          action: async () => {
+            await openLegacyMcpAuthorization(ctx);
+          },
+          assert: async () => {
+            const storedScopes = await runMysql(
+              ctx,
+              `SELECT scopes FROM oauthClient WHERE client_id = ${sqlString(state.legacyClientId)} LIMIT 1;`,
+            );
+            const currentUrl = await ctx.eval("location.href");
+            recordAssertion(ctx, "The legacy MCP client gained only the refresh-enabling scope it requested", storedScopes.includes("mcp:read") && storedScopes.includes("mcp:write") && storedScopes.includes("offline_access"), storedScopes);
+            recordAssertion(ctx, "Authorization reached workspace selection instead of an invalid-scope callback", !currentUrl.includes("invalid_scope"), currentUrl);
+            await ctx.expectText("Authorize and continue");
+            await ctx.expectNoText("The following scopes are invalid");
+          },
+          screenshot: {
+            name: "legacy-mcp-offline-access-authorizes",
+            claim: "A previously registered MCP client reaches OpenWork workspace authorization after requesting offline access.",
+            targetUrlIncludes: "/mcp/select-organization",
+            requireText: ["Where should this client work?", "OpenWork", "Authorize and continue"],
+            rejectText: ["The following scopes are invalid", "No authorization code received"],
+          },
+        });
+      },
+    },
+    {
       name: "Cleanup: remove eval connections and stop the OAuth MCP provider",
       run: async (ctx) => {
         const cleanupSession = await signInApi(DEMO_EMAIL, DEMO_PASSWORD);
@@ -868,6 +940,12 @@ export default {
           state.adminSession = cleanupSession;
           await selectAdminOrganization(ctx);
           await cleanupConnections(ctx, cleanupSession);
+        }
+        if (state.legacyClientId) {
+          await runMysql(ctx, `DELETE FROM oauthAccessToken WHERE client_id = ${sqlString(state.legacyClientId)};`);
+          await runMysql(ctx, `DELETE FROM oauthRefreshToken WHERE client_id = ${sqlString(state.legacyClientId)};`);
+          await runMysql(ctx, `DELETE FROM oauthConsent WHERE client_id = ${sqlString(state.legacyClientId)};`);
+          await runMysql(ctx, `DELETE FROM oauthClient WHERE client_id = ${sqlString(state.legacyClientId)};`);
         }
         await stopMock(ctx);
       },

--- a/evals/voiceovers/durable-auth-mcp.md
+++ b/evals/voiceovers/durable-auth-mcp.md
@@ -13,3 +13,5 @@
 6. Maya attempts a genuinely sensitive action, such as transferring ownership, rotating an API key, or changing SSO. OpenWork asks her to confirm her identity once and automatically resumes the pending action.
 
 7. When Maya explicitly signs out, an administrator removes her membership, or credentials are revoked, her OpenWork sessions and MCP access stop immediately.
+
+8. An MCP client connected before this update asks for offline access so it can refresh quietly. OpenWork upgrades that client's refresh permission and shows workspace authorization instead of returning an invalid-scope error.


### PR DESCRIPTION
## What changed

- Lazily add `offline_access` to an existing OAuth client when it already owns an `mcp:*` scope and explicitly requests offline access.
- Keep every existing MCP data scope unchanged; unrelated unregistered scopes remain rejected.
- Extend the database-backed OAuth flow to reproduce a client registered before `offline_access` was advertised.
- Add an eighth Fraimz frame showing that the legacy client reaches workspace authorization instead of an `invalid_scope` callback.

## Root cause

MCP clients registered before PR #2628 stored `mcp:read mcp:write` without `offline_access`. After the protected-resource metadata began advertising offline access, those existing clients requested it during authorization. Better Auth validates requested scopes against each client's stored registration, so it redirected to localhost with `error=invalid_scope` before issuing an authorization code.

## User impact

Existing MCP configurations self-heal on their next authorization attempt. Users reach OpenWork workspace authorization and receive rotating refresh grants without deleting and re-adding the MCP.

## Validation

- `pnpm --filter @openwork-ee/den-api build` — passed
- Focused MCP authorization, lifetime, and revocation suites — 11 passed, 46 assertions
- Legacy database-backed PKCE flow — authorization code, thirty-day refresh grant, rotation, replay rejection, and unrelated-scope rejection all passed
- `pnpm fraimz --flow durable-auth-mcp` — 8/8 frames passed
- Fraimz report: `evals/results/2026-07-10T01-08-47-858Z/fraimz.html`
- `git diff --check` — passed
