### PR TITLE
feat(enterprise): serve desktop releases without public egress

### DIFF
--- a/apps/desktop/electron/desktop-release.mjs
+++ b/apps/desktop/electron/desktop-release.mjs
@@ -1,0 +1,79 @@
+function cleanHttpUrl(value) {
+  if (typeof value !== "string" || !value.trim()) return null;
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
+export function denApiBaseUrlFromBootstrap(config) {
+  const explicit = cleanHttpUrl(config?.apiBaseUrl);
+  if (explicit) return explicit;
+  const webBaseUrl = cleanHttpUrl(config?.baseUrl);
+  if (!webBaseUrl) throw new Error("Desktop bootstrap config is missing a valid Den URL.");
+  return new URL("/api", `${webBaseUrl}/`).toString().replace(/\/+$/, "");
+}
+
+export function parseDesktopReleaseMetadata(payload) {
+  if (!payload || typeof payload !== "object") return null;
+  const desktopRelease = payload.desktopRelease;
+  if (!desktopRelease || typeof desktopRelease !== "object") return null;
+  const latestAppVersion = typeof payload.latestAppVersion === "string" ? payload.latestAppVersion.trim() : "";
+  const version = typeof desktopRelease.version === "string" ? desktopRelease.version.trim() : "";
+  const updateFeedUrl = cleanHttpUrl(desktopRelease.updateFeedUrl);
+  const alphaUpdateFeedUrl = cleanHttpUrl(desktopRelease.alphaUpdateFeedUrl);
+  const rawDownloads = desktopRelease.downloads;
+  if (
+    !latestAppVersion
+    || version !== latestAppVersion
+    || !updateFeedUrl
+    || !rawDownloads
+    || typeof rawDownloads !== "object"
+  ) return null;
+
+  const downloads = {};
+  for (const platform of ["mac-arm64", "mac-x64", "win-x64"]) {
+    const url = cleanHttpUrl(rawDownloads[platform]);
+    if (!url) return null;
+    downloads[platform] = url;
+  }
+  if (rawDownloads["win-arm64"] !== undefined) {
+    const windowsArm64Url = cleanHttpUrl(rawDownloads["win-arm64"]);
+    if (!windowsArm64Url) return null;
+    downloads["win-arm64"] = windowsArm64Url;
+  }
+  return { version, updateFeedUrl, ...(alphaUpdateFeedUrl ? { alphaUpdateFeedUrl } : {}), downloads };
+}
+
+export async function fetchDeploymentDesktopRelease({ getDesktopBootstrapConfig, fetcher = fetch }) {
+  if (typeof getDesktopBootstrapConfig !== "function") {
+    throw new Error("Desktop bootstrap config reader is unavailable.");
+  }
+  const config = await getDesktopBootstrapConfig();
+  const apiBaseUrl = denApiBaseUrlFromBootstrap(config);
+  const response = await fetcher(`${apiBaseUrl}/v1/app-version`, {
+    headers: { accept: "application/json" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Deployment version check failed (${response.status} ${response.statusText})`);
+  }
+  const metadata = parseDesktopReleaseMetadata(await response.json());
+  if (!metadata) {
+    throw new Error("Deployment did not publish Mac and Windows desktop release URLs.");
+  }
+  return metadata;
+}
+
+export function desktopReleaseDownloadUrl(metadata, platform = process.platform, arch = process.arch) {
+  if (platform === "darwin" && (arch === "arm64" || arch === "x64")) {
+    return metadata.downloads[`mac-${arch}`] ?? null;
+  }
+  if (platform === "win32" && (arch === "arm64" || arch === "x64")) {
+    return metadata.downloads[`win-${arch}`] ?? null;
+  }
+  return null;
+}

--- a/apps/desktop/electron/desktop-release.test.mjs
+++ b/apps/desktop/electron/desktop-release.test.mjs
@@ -1,0 +1,113 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  denApiBaseUrlFromBootstrap,
+  desktopReleaseDownloadUrl,
+  fetchDeploymentDesktopRelease,
+  parseDesktopReleaseMetadata,
+} from "./desktop-release.mjs";
+import { electronUpdaterFeedUrl } from "./updater.mjs";
+
+const metadataPayload = {
+  latestAppVersion: "0.17.19",
+  desktopRelease: {
+    version: "0.17.19",
+    updateFeedUrl: "https://den.examplecorp.test/v1/desktop-releases/0.17.19",
+    downloads: {
+      "mac-arm64": "https://den.examplecorp.test/v1/desktop-releases/0.17.19/openwork-mac-arm64-0.17.19.dmg",
+      "mac-x64": "https://den.examplecorp.test/v1/desktop-releases/0.17.19/openwork-mac-x64-0.17.19.dmg",
+      "win-x64": "https://den.examplecorp.test/v1/desktop-releases/0.17.19/openwork-win-x64-0.17.19.exe",
+      "win-arm64": "https://den.examplecorp.test/v1/desktop-releases/0.17.19/openwork-win-arm64-0.17.19.exe",
+    },
+  },
+};
+
+describe("deployment desktop release metadata", () => {
+  it("prefers the explicit Den API URL and otherwise derives /api from the web URL", () => {
+    assert.equal(
+      denApiBaseUrlFromBootstrap({ baseUrl: "https://examplecorp.test", apiBaseUrl: "https://api.examplecorp.test/" }),
+      "https://api.examplecorp.test",
+    );
+    assert.equal(
+      denApiBaseUrlFromBootstrap({ baseUrl: "https://examplecorp.test/" }),
+      "https://examplecorp.test/api",
+    );
+  });
+
+  it("resolves platform downloads from Den-owned URLs", () => {
+    const release = parseDesktopReleaseMetadata(metadataPayload);
+    assert.ok(release);
+    assert.equal(
+      desktopReleaseDownloadUrl(release, "win32", "x64"),
+      metadataPayload.desktopRelease.downloads["win-x64"],
+    );
+    assert.equal(
+      desktopReleaseDownloadUrl(release, "win32", "arm64"),
+      metadataPayload.desktopRelease.downloads["win-arm64"],
+    );
+    assert.equal(desktopReleaseDownloadUrl(release, "linux", "x64"), null);
+  });
+
+  it("keeps x64-only Den metadata valid while leaving Windows ARM64 unavailable", () => {
+    const x64OnlyPayload = structuredClone(metadataPayload);
+    delete x64OnlyPayload.desktopRelease.downloads["win-arm64"];
+    const release = parseDesktopReleaseMetadata(x64OnlyPayload);
+    assert.ok(release);
+    assert.equal(desktopReleaseDownloadUrl(release, "win32", "x64"), metadataPayload.desktopRelease.downloads["win-x64"]);
+    assert.equal(desktopReleaseDownloadUrl(release, "win32", "arm64"), null);
+  });
+
+  it("rejects release metadata whose version differs from Den's supported version", () => {
+    assert.equal(parseDesktopReleaseMetadata({
+      ...metadataPayload,
+      latestAppVersion: "0.17.20",
+    }), null);
+  });
+
+  it("checks only the configured Den host before returning its internal update feed", async () => {
+    const contacted = [];
+    const fetcher = async (url) => {
+      contacted.push(url);
+      return new Response(JSON.stringify(metadataPayload), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const getDesktopBootstrapConfig = async () => ({
+      baseUrl: "https://examplecorp.test",
+      apiBaseUrl: "https://den.examplecorp.test",
+      requireSignin: true,
+    });
+
+    const release = await fetchDeploymentDesktopRelease({ getDesktopBootstrapConfig, fetcher });
+    const feedUrl = await electronUpdaterFeedUrl("stable", getDesktopBootstrapConfig, fetcher, "win32");
+
+    assert.equal(release.updateFeedUrl, metadataPayload.desktopRelease.updateFeedUrl);
+    assert.equal(feedUrl, metadataPayload.desktopRelease.updateFeedUrl);
+    assert.deepEqual(contacted, [
+      "https://den.examplecorp.test/v1/app-version",
+      "https://den.examplecorp.test/v1/app-version",
+    ]);
+    assert.equal(contacted.some((url) => url.includes("github.com")), false);
+  });
+
+  it("fails closed for alpha unless Den explicitly publishes that feed", async () => {
+    const getDesktopBootstrapConfig = async () => ({ apiBaseUrl: "https://den.examplecorp.test" });
+    const fetcher = async () => Response.json(metadataPayload);
+    await assert.rejects(
+      electronUpdaterFeedUrl("alpha", getDesktopBootstrapConfig, fetcher, "darwin"),
+      /does not publish an alpha desktop update feed/,
+    );
+
+    const alphaFeed = "https://den.examplecorp.test/v1/desktop-alpha";
+    const alphaFetcher = async () => Response.json({
+      ...metadataPayload,
+      desktopRelease: { ...metadataPayload.desktopRelease, alphaUpdateFeedUrl: alphaFeed },
+    });
+    assert.equal(
+      await electronUpdaterFeedUrl("alpha", getDesktopBootstrapConfig, alphaFetcher, "darwin"),
+      alphaFeed,
+    );
+  });
+});

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -22,6 +22,7 @@ import { configureFakeMediaForTests, installMediaPermissionHandlers } from "./me
 import { registerMigrationIpc } from "./migration.mjs";
 import { createRuntimeManager } from "./runtime.mjs";
 import { registerUpdaterIpc } from "./updater.mjs";
+import { desktopReleaseDownloadUrl, fetchDeploymentDesktopRelease } from "./desktop-release.mjs";
 import {
   checkComputerUsePermissions,
   getComputerUseMcpCommand,
@@ -48,8 +49,8 @@ const APP_NAME =
 const APP_IDENTIFIER =
   process.env.OPENWORK_ELECTRON_APP_IDENTIFIER?.trim() ||
   (isDevMode ? DEV_APP_IDENTIFIER : TAURI_APP_IDENTIFIER);
-const RELEASE_DOWNLOAD_BASE_URL = "https://github.com/different-ai/openwork/releases/latest/download";
-const RELEASE_PAGE_URL = "https://github.com/different-ai/openwork/releases/latest";
+const LINUX_RELEASE_DOWNLOAD_BASE_URL = "https://github.com/different-ai/openwork/releases/latest/download";
+const LINUX_RELEASE_PAGE_URL = "https://github.com/different-ai/openwork/releases/latest";
 const DOCS_PAGE_URL = "https://openworklabs.com/docs";
 const applicationMenu = createApplicationMenu({
   appName: APP_NAME,
@@ -174,29 +175,6 @@ function resolveSystemArch() {
   return normalizeRuntimeArch(os.arch());
 }
 
-function platformDownloadSlug() {
-  if (process.platform === "darwin") return "mac";
-  if (process.platform === "win32") return "win";
-  return "linux";
-}
-
-function downloadAssetArch(arch) {
-  if (process.platform === "linux" && arch === "x64") return "x86_64";
-  return arch;
-}
-
-function downloadAssetExtension() {
-  if (process.platform === "darwin") return "dmg";
-  if (process.platform === "win32") return "exe";
-  return "AppImage";
-}
-
-function updaterManifestName(arch) {
-  if (process.platform === "darwin") return "latest-mac.yml";
-  if (process.platform === "win32") return "latest.yml";
-  return arch === "arm64" ? "latest-linux-arm64.yml" : "latest-linux.yml";
-}
-
 function archLabel(arch) {
   if (arch === "arm64") return "ARM";
   if (arch === "x64") return "Intel";
@@ -214,40 +192,39 @@ function parseUpdaterManifestFiles(raw) {
       continue;
     }
     const prop = line.match(/^\s{4}([A-Za-z][A-Za-z0-9_-]*):\s*(.+?)\s*$/);
-    if (prop && current) {
-      current[prop[1]] = prop[2].trim().replace(/^['"]|['"]$/g, "");
-    }
+    if (prop && current) current[prop[1]] = prop[2].trim().replace(/^['"]|['"]$/g, "");
   }
   return files.filter((file) => file.url);
 }
 
-function selectDownloadFile(files, arch) {
-  const assetArch = downloadAssetArch(arch);
-  const expected = `-${assetArch}-`;
-  const extension = downloadAssetExtension();
-  const matchingArch = files.filter((file) => file.url.includes(expected));
-  return (
-    matchingArch.find((file) => file.url.endsWith(`.${extension}`)) ||
-    matchingArch.find((file) => file.url.endsWith(".zip")) ||
-    matchingArch[0] ||
-    null
-  );
-}
-
 async function resolveCorrectArchitectureDownloadUrl(arch) {
-  const manifestUrl = `${RELEASE_DOWNLOAD_BASE_URL}/${updaterManifestName(arch)}`;
+  if (process.platform === "linux") {
+    const manifestName = arch === "arm64" ? "latest-linux-arm64.yml" : "latest-linux.yml";
+    try {
+      const response = await fetch(`${LINUX_RELEASE_DOWNLOAD_BASE_URL}/${manifestName}`, {
+        headers: { Accept: "text/yaml, text/plain, */*" },
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const assetArch = arch === "x64" ? "x86_64" : arch;
+      const selected = parseUpdaterManifestFiles(await response.text())
+        .find((file) => file.url.includes(`-${assetArch}-`) && file.url.endsWith(".AppImage"));
+      if (!selected?.url) return null;
+      return /^https?:\/\//i.test(selected.url)
+        ? selected.url
+        : new URL(selected.url, `${LINUX_RELEASE_DOWNLOAD_BASE_URL}/`).toString();
+    } catch (error) {
+      console.warn("[architecture] failed to resolve latest Linux download URL", error);
+      return null;
+    }
+  }
   try {
-    const response = await fetch(manifestUrl, {
-      headers: { Accept: "text/yaml, text/plain, */*" },
+    const release = await fetchDeploymentDesktopRelease({
+      getDesktopBootstrapConfig: () => workspaceStore.getDesktopBootstrapConfig(),
+      fetcher: electronNet.fetch.bind(electronNet),
     });
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const selected = selectDownloadFile(parseUpdaterManifestFiles(await response.text()), arch);
-    if (!selected?.url) return null;
-    return /^https?:\/\//i.test(selected.url)
-      ? selected.url
-      : new URL(selected.url, `${RELEASE_DOWNLOAD_BASE_URL}/`).toString();
+    return desktopReleaseDownloadUrl(release, process.platform, arch);
   } catch (error) {
-    console.warn("[architecture] failed to resolve latest download URL", error);
+    console.warn("[architecture] deployment did not provide a compatible download URL", error);
     return null;
   }
 }
@@ -257,8 +234,10 @@ async function resolveArchitectureInfo() {
   const systemArch = resolveSystemArch();
   const version = app.getVersion();
   const targetArch = systemArch === "arm64" || systemArch === "x64" ? systemArch : appArch;
-  const assetName = `openwork-${platformDownloadSlug()}-${downloadAssetArch(targetArch)}-${version}.${downloadAssetExtension()}`;
   const latestDownloadUrl = await resolveCorrectArchitectureDownloadUrl(targetArch);
+  const bootstrap = await workspaceStore.getDesktopBootstrapConfig().catch(() => null);
+  const linuxAssetArch = targetArch === "x64" ? "x86_64" : targetArch;
+  const linuxAssetName = `openwork-linux-${linuxAssetArch}-${version}.AppImage`;
   const hasCorrectArchitectureDownload = Boolean(latestDownloadUrl);
   return {
     appArch,
@@ -268,8 +247,8 @@ async function resolveArchitectureInfo() {
     mismatch: appArch !== systemArch && hasCorrectArchitectureDownload,
     platform: process.platform === "win32" ? "windows" : process.platform,
     version,
-    downloadUrl: latestDownloadUrl || `${RELEASE_DOWNLOAD_BASE_URL}/${assetName}`,
-    releaseUrl: RELEASE_PAGE_URL,
+    downloadUrl: latestDownloadUrl || (process.platform === "linux" ? `${LINUX_RELEASE_DOWNLOAD_BASE_URL}/${linuxAssetName}` : ""),
+    releaseUrl: process.platform === "linux" ? LINUX_RELEASE_PAGE_URL : (bootstrap?.baseUrl ?? ""),
   };
 }
 
@@ -1900,7 +1879,13 @@ ipcMain.handle("openwork:terminal:kill", (event, terminalId) => {
 browserPanel.registerIpc(ipcMain);
 
 registerMigrationIpc({ app, ipcMain });
-const { ensureAutoUpdater } = registerUpdaterIpc({ app, ipcMain, getMainWindow: () => mainWindow });
+const { ensureAutoUpdater } = registerUpdaterIpc({
+  app,
+  ipcMain,
+  getMainWindow: () => mainWindow,
+  getDesktopBootstrapConfig: () => workspaceStore.getDesktopBootstrapConfig(),
+  fetcher: electronNet.fetch.bind(electronNet),
+});
 
 if (!app.requestSingleInstanceLock()) {
   app.quit();

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { execFile } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { fetchDeploymentDesktopRelease } from "./desktop-release.mjs";
 
 const ELECTRON_UPDATER_CHANNEL_FILENAME = "electron-updater-channel.v1.json";
 
@@ -30,12 +31,11 @@ function resolveAppVersion(app) {
   return _cachedAppVersion;
 }
 const ELECTRON_UPDATER_FEEDS = Object.freeze({
-  stable: "https://github.com/different-ai/openwork/releases/latest/download",
-  alpha: "https://github.com/different-ai/openwork/releases/download/alpha-macos-latest",
+  linuxStable: "https://github.com/different-ai/openwork/releases/latest/download",
 });
 
-function normalizeElectronUpdaterChannel(value) {
-  if (value === "alpha" && process.platform === "darwin") return "alpha";
+function normalizeElectronUpdaterChannel(value, platform = process.platform) {
+  if (value === "alpha" && platform === "darwin") return "alpha";
   return "stable";
 }
 
@@ -65,8 +65,23 @@ async function writeElectronUpdaterChannel(app, channel) {
   return normalized;
 }
 
-function electronUpdaterFeedUrl(channel) {
-  return ELECTRON_UPDATER_FEEDS[normalizeElectronUpdaterChannel(channel)];
+export async function electronUpdaterFeedUrl(
+  channel,
+  getDesktopBootstrapConfig,
+  fetcher,
+  platform = process.platform,
+) {
+  const normalized = normalizeElectronUpdaterChannel(channel, platform);
+  // Linux delivery remains unchanged and is outside the air-gapped Mac/Windows scope.
+  if (platform === "linux") return ELECTRON_UPDATER_FEEDS.linuxStable;
+  const release = await fetchDeploymentDesktopRelease({ getDesktopBootstrapConfig, fetcher });
+  if (normalized === "alpha") {
+    if (!release.alphaUpdateFeedUrl) {
+      throw new Error("Deployment does not publish an alpha desktop update feed.");
+    }
+    return release.alphaUpdateFeedUrl;
+  }
+  return release.updateFeedUrl;
 }
 
 function parseComparableVersion(value) {
@@ -141,24 +156,24 @@ function isVersionNewer(candidate, current) {
   return comparison === null ? candidate !== current : comparison > 0;
 }
 
-function updaterChannelState(app, channel) {
+async function updaterChannelState(app, channel, getDesktopBootstrapConfig, fetcher) {
   const normalized = normalizeElectronUpdaterChannel(channel);
   return {
     channel: normalized,
-    feedUrl: electronUpdaterFeedUrl(normalized),
+    feedUrl: await electronUpdaterFeedUrl(normalized, getDesktopBootstrapConfig, fetcher),
     currentVersion: resolveAppVersion(app),
   };
 }
 
-async function applyElectronUpdaterFeed(app, updater) {
+async function applyElectronUpdaterFeed(app, updater, getDesktopBootstrapConfig, fetcher) {
   const channel = await readElectronUpdaterChannel(app);
-  const state = updaterChannelState(app, channel);
+  const state = await updaterChannelState(app, channel, getDesktopBootstrapConfig, fetcher);
   updater.allowPrerelease = state.channel === "alpha";
   // Moving from alpha back to stable can be a semver downgrade; still show
   // the latest stable so users can return to the stable channel deliberately.
   updater.allowDowngrade = state.channel === "stable";
   if (updater?.setFeedURL) {
-    updater.setFeedURL({ provider: "generic", url: state.feedUrl });
+    updater.setFeedURL({ provider: "generic", url: `${state.feedUrl.replace(/\/+$/, "")}/` });
   }
   return state;
 }
@@ -215,7 +230,7 @@ async function cleanStaleUpdaterState(app) {
 
 // electron-updater wiring. Packaged-only; dev builds skip this so the
 // updater doesn't try to probe a non-existent release channel.
-export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
+export function registerUpdaterIpc({ app, ipcMain, getMainWindow, getDesktopBootstrapConfig, fetcher = fetch }) {
   let autoUpdaterInstance = null;
   let autoUpdaterLoaded = false;
   let checkedUpdateVersion = null;
@@ -264,7 +279,6 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
             delta: info.delta ?? 0,
           });
         });
-        await applyElectronUpdaterFeed(app, autoUpdaterInstance);
       }
     } catch (error) {
       console.warn("[updater] electron-updater not available", error);
@@ -275,7 +289,7 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
 
   ipcMain.handle("openwork:updater:getChannel", async () => {
     const channel = await readElectronUpdaterChannel(app);
-    return updaterChannelState(app, channel);
+    return updaterChannelState(app, channel, getDesktopBootstrapConfig, fetcher);
   });
 
   ipcMain.handle("openwork:updater:setChannel", async (_event, rawChannel) => {
@@ -283,9 +297,9 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     checkedUpdateVersion = null;
     const updater = await ensureAutoUpdater();
     if (updater) {
-      return applyElectronUpdaterFeed(app, updater);
+      return applyElectronUpdaterFeed(app, updater, getDesktopBootstrapConfig, fetcher);
     }
-    return updaterChannelState(app, channel);
+    return updaterChannelState(app, channel, getDesktopBootstrapConfig, fetcher);
   });
 
   ipcMain.handle("openwork:updater:check", async (_event, rawChannel) => {
@@ -294,8 +308,8 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     }
     const updater = await ensureAutoUpdater();
     const channelState = updater
-      ? await applyElectronUpdaterFeed(app, updater)
-      : updaterChannelState(app, await readElectronUpdaterChannel(app));
+      ? await applyElectronUpdaterFeed(app, updater, getDesktopBootstrapConfig, fetcher)
+      : await updaterChannelState(app, await readElectronUpdaterChannel(app), getDesktopBootstrapConfig, fetcher);
     if (!updater) return { available: false, reason: "unavailable", ...channelState };
     try {
       const result = await updater.checkForUpdates();
@@ -321,7 +335,7 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     const updater = await ensureAutoUpdater();
     if (!updater) return { ok: false, reason: "unavailable" };
     try {
-      await applyElectronUpdaterFeed(app, updater);
+      await applyElectronUpdaterFeed(app, updater, getDesktopBootstrapConfig, fetcher);
       const currentVersion = resolveAppVersion(app);
       if (!checkedUpdateVersion || !isVersionNewer(checkedUpdateVersion, currentVersion)) {
         const result = await updater.checkForUpdates();

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -245,9 +245,11 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
       return id && role && url && expiresAt ? [{ id, role, ...(token ? { token } : {}), url, expiresAt }] : [];
     });
     const writtenAt = typeof input?.writtenAt === "string" ? input.writtenAt.trim() : "";
+    const apiBaseUrl = typeof input?.apiBaseUrl === "string" ? input.apiBaseUrl.trim() : "";
 
     return {
       baseUrl,
+      ...(apiBaseUrl ? { apiBaseUrl } : {}),
       requireSignin: forceRequireSignin || input?.requireSignin === true,
       ...(writtenAt ? { writtenAt } : {}),
       ...(claimLinks.length > 0 ? { claimLinks } : {}),

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -281,6 +281,21 @@ test("desktop bootstrap writes include a fresh writtenAt stamp", async () => {
   });
 });
 
+test("desktop bootstrap preserves an explicit Den API URL for updater traffic", async () => {
+  await withIsolatedBootstrapStore(async ({ store, canonicalPath }) => {
+    await writeBootstrapConfig(canonicalPath, {
+      baseUrl: "https://examplecorp.example.com",
+      apiBaseUrl: "https://den.examplecorp.example.com",
+      requireSignin: true,
+    });
+
+    const config = await store.getDesktopBootstrapConfig();
+    assert.equal(config.baseUrl, "https://examplecorp.example.com");
+    assert.equal(config.apiBaseUrl, "https://den.examplecorp.example.com");
+    assert.equal(config.requireSignin, true);
+  });
+});
+
 test("clearDesktopBootstrapConfig removes bootstrap files without deleting workspace state", async () => {
   await withIsolatedBootstrapStore(async ({ store, canonicalPath, legacyPath, userDataPath }) => {
     const workspaceStatePath = path.join(userDataPath, "openwork-workspaces.json");

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/desktop-release.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.17.11",

--- a/apps/installer/src/install.ts
+++ b/apps/installer/src/install.ts
@@ -5,7 +5,7 @@ import path from "node:path"
 
 import { desktopBootstrapPath, legacyDesktopBootstrapPath } from "./bootstrap-path"
 import type { InstallerConfig } from "./config"
-import { releaseAssetFor, type ReleaseAsset } from "./release-asset"
+import { releaseAssetFor, releasePlatformKey, type ReleaseAsset } from "./release-asset"
 
 export type InstallStep = "write-config" | "check-version" | "download" | "install"
 
@@ -81,8 +81,49 @@ export function writeBootstrapConfig(config: InstallerConfig, env: NodeJS.Proces
   return target
 }
 
-/** Ask the deployment's Den API which desktop version it supports. */
-export async function fetchLatestSupportedVersion(apiUrl: string): Promise<string> {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export function releaseAssetFromVersionPayload(
+  payload: unknown,
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+) {
+  const version = isRecord(payload) && typeof payload.latestAppVersion === "string"
+    ? payload.latestAppVersion.trim()
+    : ""
+  if (!version || version === "0.0.0") {
+    throw new Error("Deployment did not declare a desktop app version (latestAppVersion missing)")
+  }
+  const desktopRelease = isRecord(payload) && isRecord(payload.desktopRelease)
+    ? payload.desktopRelease
+    : null
+  const releaseVersion = desktopRelease && typeof desktopRelease.version === "string"
+    ? desktopRelease.version.trim()
+    : ""
+  if (releaseVersion !== version) {
+    throw new Error("Deployment desktop release version does not match latestAppVersion")
+  }
+  const downloads = desktopRelease && isRecord(desktopRelease.downloads)
+    ? desktopRelease.downloads
+    : null
+  const platformKey = releasePlatformKey(platform, arch)
+  const url = downloads && typeof downloads[platformKey] === "string"
+    ? downloads[platformKey].trim()
+    : ""
+  if (!url) {
+    throw new Error(`Deployment did not publish an internal desktop release for ${platformKey}`)
+  }
+  return releaseAssetFor({ version, url, platform, arch })
+}
+
+/** Ask Den for both the supported version and this platform's deployment-owned URL. */
+export async function fetchSupportedReleaseAsset(
+  apiUrl: string,
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): Promise<ReleaseAsset> {
   const response = await fetch(`${apiUrl}/v1/app-version`, {
     headers: { accept: "application/json" },
     signal: AbortSignal.timeout(15_000),
@@ -90,12 +131,8 @@ export async function fetchLatestSupportedVersion(apiUrl: string): Promise<strin
   if (!response.ok) {
     throw new Error(`Deployment version check failed (${response.status} ${response.statusText})`)
   }
-  const payload = (await response.json()) as { latestAppVersion?: unknown }
-  const version = typeof payload.latestAppVersion === "string" ? payload.latestAppVersion.trim() : ""
-  if (!version || version === "0.0.0") {
-    throw new Error("Deployment did not declare a desktop app version (latestAppVersion missing)")
-  }
-  return version
+  const payload: unknown = await response.json()
+  return releaseAssetFromVersionPayload(payload, platform, arch)
 }
 
 async function downloadAsset(asset: ReleaseAsset, targetPath: string, opts: InstallOptions): Promise<void> {
@@ -202,8 +239,8 @@ export async function runInstall(config: InstallerConfig, opts: InstallOptions =
   try {
     const bootstrapPath = writeBootstrapConfig(config)
     update({ step: "check-version", message: "Checking your deployment for the supported app version..." }, opts.onStatus)
-    const version = await fetchLatestSupportedVersion(config.apiUrl)
-    const asset = releaseAssetFor(version)
+    const asset = await fetchSupportedReleaseAsset(config.apiUrl)
+    const version = asset.version
     update({ version, message: `Deployment supports OpenWork ${version}.` }, opts.onStatus)
 
     if (opts.dryRun) {

--- a/apps/installer/src/release-asset.ts
+++ b/apps/installer/src/release-asset.ts
@@ -1,5 +1,3 @@
-const GITHUB_REPO = "different-ai/openwork"
-
 export type ReleaseAsset = {
   version: string
   fileName: string
@@ -8,18 +6,25 @@ export type ReleaseAsset = {
 }
 
 /**
- * Release assets follow a fixed naming scheme (see the stable release
- * workflow): openwork-mac-<arch>-<v>.dmg, openwork-win-x64-<v>.exe,
- * openwork-linux-x86_64|arm64-<v>.AppImage — so the download URL is
- * deterministic from (version, platform, arch); no releases-API listing needed.
+ * Release assets follow a fixed naming scheme, but the download URL belongs to
+ * the deployment and comes from Den's /v1/app-version response. The installer
+ * must never invent a public-release host on its own.
  */
-export function releaseAssetFor(
-  version: string,
-  platform: NodeJS.Platform = process.platform,
-  arch: string = process.arch,
-): ReleaseAsset {
+export function releaseAssetFor(input: {
+  version: string
+  url: string
+  platform?: NodeJS.Platform
+  arch?: string
+}): ReleaseAsset {
+  const { version, url } = input
+  const platform = input.platform ?? process.platform
+  const arch = input.arch ?? process.arch
   const normalized = version.trim().replace(/^v/i, "")
   if (!normalized) throw new Error("version is required")
+  const parsedUrl = new URL(url)
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new Error(`unsupported release URL protocol: ${parsedUrl.protocol}`)
+  }
   if (arch !== "arm64" && arch !== "x64") {
     throw new Error(`unsupported architecture: ${arch}`)
   }
@@ -28,15 +33,14 @@ export function releaseAssetFor(
     version: normalized,
     fileName,
     type,
-    url: `https://github.com/${GITHUB_REPO}/releases/download/v${normalized}/${encodeURIComponent(fileName)}`,
+    url: parsedUrl.toString(),
   })
 
   if (platform === "darwin") {
     return build(`openwork-mac-${arch}-${normalized}.dmg`, "dmg")
   }
   if (platform === "win32") {
-    if (arch !== "x64") throw new Error(`unsupported Windows architecture: ${arch}`)
-    return build(`openwork-win-x64-${normalized}.exe`, "exe")
+    return build(`openwork-win-${arch}-${normalized}.exe`, "exe")
   }
   if (platform === "linux") {
     // The AppImage uses x86_64 in its name while the tarball uses x64.
@@ -44,4 +48,17 @@ export function releaseAssetFor(
     return build(`openwork-linux-${appImageArch}-${normalized}.AppImage`, "appimage")
   }
   throw new Error(`unsupported platform: ${platform}`)
+}
+
+export function releasePlatformKey(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+) {
+  if (platform === "darwin" && (arch === "arm64" || arch === "x64")) {
+    return `mac-${arch}`
+  }
+  if (platform === "win32" && (arch === "arm64" || arch === "x64")) {
+    return `win-${arch}`
+  }
+  throw new Error(`deployment desktop releases do not support ${platform}/${arch}`)
 }

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -7,7 +7,7 @@ import { installConfigUrlFor, parseInstallerFilenameTag } from "@openwork/instal
 import { desktopBootstrapPath, legacyDesktopBootstrapPath } from "../src/bootstrap-path"
 import { parseInstallLinkInput, resolveInstallerConfig } from "../src/config"
 import { isTranslocatedPath, parseMountTableLine, readSidecarConfig, resolveTranslocatedOriginalPath } from "../src/config-sources"
-import { writeBootstrapConfig } from "../src/install"
+import { releaseAssetFromVersionPayload, writeBootstrapConfig } from "../src/install"
 import { releaseAssetFor } from "../src/release-asset"
 
 describe("desktopBootstrapPath", () => {
@@ -39,22 +39,67 @@ describe("desktopBootstrapPath", () => {
 
 describe("releaseAssetFor", () => {
   test("resolves per-platform asset names", () => {
-    expect(releaseAssetFor("v0.17.7", "darwin", "arm64").fileName).toBe("openwork-mac-arm64-0.17.7.dmg")
-    expect(releaseAssetFor("0.17.7", "darwin", "x64").fileName).toBe("openwork-mac-x64-0.17.7.dmg")
-    expect(releaseAssetFor("0.17.7", "win32", "x64").fileName).toBe("openwork-win-x64-0.17.7.exe")
-    expect(releaseAssetFor("0.17.7", "linux", "x64").fileName).toBe("openwork-linux-x86_64-0.17.7.AppImage")
-    expect(releaseAssetFor("0.17.7", "linux", "arm64").fileName).toBe("openwork-linux-arm64-0.17.7.AppImage")
+    const url = "https://den.examplecorp.test/v1/desktop-releases/0.17.7/artifact"
+    expect(releaseAssetFor({ version: "v0.17.7", url, platform: "darwin", arch: "arm64" }).fileName).toBe("openwork-mac-arm64-0.17.7.dmg")
+    expect(releaseAssetFor({ version: "0.17.7", url, platform: "darwin", arch: "x64" }).fileName).toBe("openwork-mac-x64-0.17.7.dmg")
+    expect(releaseAssetFor({ version: "0.17.7", url, platform: "win32", arch: "x64" }).fileName).toBe("openwork-win-x64-0.17.7.exe")
+    expect(releaseAssetFor({ version: "0.17.7", url, platform: "win32", arch: "arm64" }).fileName).toBe("openwork-win-arm64-0.17.7.exe")
+    expect(releaseAssetFor({ version: "0.17.7", url, platform: "linux", arch: "x64" }).fileName).toBe("openwork-linux-x86_64-0.17.7.AppImage")
+    expect(releaseAssetFor({ version: "0.17.7", url, platform: "linux", arch: "arm64" }).fileName).toBe("openwork-linux-arm64-0.17.7.AppImage")
   })
 
-  test("builds the release download URL from the version tag", () => {
-    expect(releaseAssetFor("0.17.7", "darwin", "arm64").url).toBe(
-      "https://github.com/different-ai/openwork/releases/download/v0.17.7/openwork-mac-arm64-0.17.7.dmg",
-    )
+  test("uses the deployment-owned release URL verbatim", () => {
+    const url = "https://den.examplecorp.test/v1/desktop-releases/0.17.7/openwork-mac-arm64-0.17.7.dmg"
+    expect(releaseAssetFor({ version: "0.17.7", url, platform: "darwin", arch: "arm64" }).url).toBe(url)
   })
 
   test("rejects unsupported targets", () => {
-    expect(() => releaseAssetFor("0.17.7", "win32", "arm64")).toThrow()
-    expect(() => releaseAssetFor("", "darwin", "arm64")).toThrow()
+    const url = "https://den.examplecorp.test/release"
+    expect(() => releaseAssetFor({ version: "0.17.7", url, platform: "win32", arch: "ia32" })).toThrow()
+    expect(() => releaseAssetFor({ version: "", url, platform: "darwin", arch: "arm64" })).toThrow()
+  })
+})
+
+describe("releaseAssetFromVersionPayload", () => {
+  test("selects the Den-owned Windows download without inventing a public host", () => {
+    const url = "https://den.examplecorp.test/v1/desktop-releases/0.17.7/openwork-win-x64-0.17.7.exe"
+    const asset = releaseAssetFromVersionPayload({
+      latestAppVersion: "0.17.7",
+      desktopRelease: { version: "0.17.7", downloads: { "win-x64": url } },
+    }, "win32", "x64")
+
+    expect(asset.url).toBe(url)
+    expect(asset.fileName).toBe("openwork-win-x64-0.17.7.exe")
+  })
+
+  test("selects a Den-owned Windows ARM64 release when the deployment publishes it", () => {
+    const url = "https://den.examplecorp.test/v1/desktop-releases/0.17.7/openwork-win-arm64-0.17.7.exe"
+    const asset = releaseAssetFromVersionPayload({
+      latestAppVersion: "0.17.7",
+      desktopRelease: { version: "0.17.7", downloads: { "win-arm64": url } },
+    }, "win32", "arm64")
+
+    expect(asset.url).toBe(url)
+    expect(asset.fileName).toBe("openwork-win-arm64-0.17.7.exe")
+  })
+
+  test("fails closed when Den does not publish a platform URL", () => {
+    expect(() => releaseAssetFromVersionPayload({
+      latestAppVersion: "0.17.7",
+      desktopRelease: { version: "0.17.7", downloads: {} },
+    }, "win32", "x64")).toThrow(
+      "Deployment did not publish an internal desktop release",
+    )
+  })
+
+  test("rejects release metadata for a different supported version", () => {
+    expect(() => releaseAssetFromVersionPayload({
+      latestAppVersion: "0.17.7",
+      desktopRelease: {
+        version: "0.17.8",
+        downloads: { "win-x64": "https://den.examplecorp.test/release" },
+      },
+    }, "win32", "x64")).toThrow("does not match latestAppVersion")
   })
 })
 

--- a/docs/org-install-links.md
+++ b/docs/org-install-links.md
@@ -54,20 +54,46 @@ Den resolves Mac and Windows installer artifacts in this order:
 
 1. `OPENWORK_INSTALLER_ARTIFACTS_DIR`, when set and the file exists.
 2. `OPENWORK_INSTALLER_CACHE_DIR/<tag>/<file>`, defaulting to the OS temp dir.
-3. The GitHub release asset for `OPENWORK_INSTALLER_RELEASE_REPO` and
+3. Only when `OPENWORK_INSTALLER_RELEASE_FALLBACK_ENABLED=true`, the GitHub
+   release asset for `OPENWORK_INSTALLER_RELEASE_REPO` and
    `OPENWORK_INSTALLER_RELEASE_TAG`.
 
 | Mode | Configure | Behavior |
 |---|---|---|
-| Internet-connected | Default. `OPENWORK_INSTALLER_RELEASE_TAG` resolves to `v<pinned app version>`; override it when needed. `v0.17.9` is the first tag carrying installer assets. | Den downloads the public release asset on first Mac/Windows download, then serves cached bytes. |
-| Fork/mirror | Set `OPENWORK_INSTALLER_RELEASE_REPO`, for example `your-org/openwork`. | Den downloads assets from your fork or mirror release instead of `different-ai/openwork`. |
+| Internet-connected | Set `OPENWORK_INSTALLER_RELEASE_FALLBACK_ENABLED=true`. `OPENWORK_INSTALLER_RELEASE_TAG` resolves to `v<pinned app version>`; override it when needed. `v0.17.9` is the first tag carrying installer assets. | Den downloads the public release asset on first Mac/Windows download, then serves cached bytes. |
+| Fork/mirror | Set `OPENWORK_INSTALLER_RELEASE_FALLBACK_ENABLED=true` and `OPENWORK_INSTALLER_RELEASE_REPO`, for example `your-org/openwork`. | Den downloads assets from your fork or mirror release instead of `different-ai/openwork`. |
 | Air-gapped | Mount a volume at `OPENWORK_INSTALLER_ARTIFACTS_DIR` containing exactly `openwork-installer-mac-arm64.zip`, `openwork-installer-mac-x64.zip`, and `openwork-installer-win-x64.exe`. | The mounted artifact directory takes precedence and requires zero egress. |
+
+The generic installer wrapper is only the first download. For a fully
+air-gapped Mac/Windows deployment, also mount the signed desktop app release at
+`OPENWORK_DESKTOP_RELEASES_DIR/<version>/`. Copy `latest-mac.yml`, `latest.yml`,
+the Mac DMGs and updater ZIPs, the Windows x64 EXE, and referenced blockmaps
+without modifying them. `/v1/app-version` then returns Den-internal download
+and update-feed URLs, so first install and later updates use the same private
+host. `OPENWORK_DESKTOP_RELEASES_PUBLIC_BASE_URL` is the explicit connected
+fallback and may contain `{version}`; it is unset by default. Den validates that
+the mounted manifests reference only relative files from the mounted release,
+so a copied public pointer manifest cannot silently restore public egress.
+
+Windows ARM64 is backward-compatible and opt-in for mounted repositories. Add
+`openwork-win-arm64-<version>.exe` and its entry in `latest.yml` to advertise it
+to ARM64 installers and updaters. Existing x64-only mounts remain valid and do
+not advertise a nonexistent ARM64 download. An explicitly configured external
+desktop release base is expected to carry both Windows architectures.
+
+The macOS alpha channel is disabled unless
+`OPENWORK_DESKTOP_ALPHA_UPDATE_FEED_URL` is explicitly configured. This keeps
+an organization-managed desktop from bypassing Den through the upstream alpha
+feed.
 
 ## Egress
 
-`den-api` makes outbound HTTPS requests to `github.com` only when serving a Mac
-or Windows installer download and the artifact is not already cached. The Linux
-setup script and every other install-link feature need no egress.
+With the defaults above, `den-api` makes no outbound release request. It contacts
+GitHub for a missing generic installer wrapper only when
+`OPENWORK_INSTALLER_RELEASE_FALLBACK_ENABLED=true`; desktop installation and
+updates contact an external release host only when an operator configures one
+of the explicit desktop release URLs. The Linux setup script needs no egress
+from Den.
 
 ## Distribute configuration with MDM (no custom installer)
 

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -50,9 +50,13 @@ const EnvSchema = z.object({
   CORS_ORIGINS: z.string().optional(),
   DEN_API_PUBLIC_URL: z.string().optional(),
   OPENWORK_INSTALLER_ARTIFACTS_DIR: z.string().optional(),
+  OPENWORK_INSTALLER_RELEASE_FALLBACK_ENABLED: z.string().optional(),
   OPENWORK_INSTALLER_RELEASE_TAG: z.string().optional(),
   OPENWORK_INSTALLER_RELEASE_REPO: z.string().optional(),
   OPENWORK_INSTALLER_CACHE_DIR: z.string().optional(),
+  OPENWORK_DESKTOP_RELEASES_DIR: z.string().optional(),
+  OPENWORK_DESKTOP_RELEASES_PUBLIC_BASE_URL: z.string().optional(),
+  OPENWORK_DESKTOP_ALPHA_UPDATE_FEED_URL: z.string().optional(),
   DEN_DESKTOP_DEN_BASE_URL: z.string().optional(),
   DEN_MARKETING_URL: z.string().optional(),
   DEN_MCP_CLAIM_NAMESPACE: z.string().optional(),
@@ -359,12 +363,17 @@ export const env = {
   corsOrigins,
   apiPublicUrl: optionalString(parsed.DEN_API_PUBLIC_URL),
   installerArtifactsDir: optionalString(parsed.OPENWORK_INSTALLER_ARTIFACTS_DIR),
+  installerReleaseFallbackEnabled:
+    (parsed.OPENWORK_INSTALLER_RELEASE_FALLBACK_ENABLED ?? "false").trim().toLowerCase() === "true",
   // Generic installer release assets (release-generic-installer.yml): the
   // release tag to download from, defaulting to the pinned app release this
   // den-api build shipped with.
   installerReleaseTag: optionalString(parsed.OPENWORK_INSTALLER_RELEASE_TAG) ?? `v${denApiAppVersion.latestAppVersion}`,
   installerReleaseRepo: optionalString(parsed.OPENWORK_INSTALLER_RELEASE_REPO) ?? "different-ai/openwork",
   installerCacheDir: optionalString(parsed.OPENWORK_INSTALLER_CACHE_DIR) ?? path.join(os.tmpdir(), "openwork-installer-artifacts"),
+  desktopReleasesDir: optionalString(parsed.OPENWORK_DESKTOP_RELEASES_DIR),
+  desktopReleasesPublicBaseUrl: optionalString(parsed.OPENWORK_DESKTOP_RELEASES_PUBLIC_BASE_URL),
+  desktopAlphaUpdateFeedUrl: optionalString(parsed.OPENWORK_DESKTOP_ALPHA_UPDATE_FEED_URL),
   // Google endpoint overrides for evals/self-host testing: point the native
   // google-workspace provider at a protocol-identical mock instead of the
   // real Google endpoints. Unset in production.

--- a/ee/apps/den-api/src/routes/version/index.ts
+++ b/ee/apps/den-api/src/routes/version/index.ts
@@ -1,14 +1,132 @@
 import type { Env, Hono } from "hono"
 import { describeRoute } from "hono-openapi"
+import { createReadStream } from "node:fs"
+import { lstat } from "node:fs/promises"
 import { z } from "zod"
+import { resolvePublicOrigin } from "../../capability-sources/generic-oauth.js"
+import { env } from "../../env.js"
 import { publicRoute } from "../../middleware/index.js"
 import { jsonResponse } from "../../openapi.js"
+import {
+  buildDesktopReleaseMetadata,
+  desktopReleaseContentType,
+  desktopReleaseFilePath,
+  expandDesktopReleaseBaseUrl,
+  mountedDesktopReleaseAvailability,
+} from "../../utils/desktop-releases.js"
 import { denApiAppVersion } from "../../version.js"
+
+const desktopReleaseResponseSchema = z.object({
+  source: z.enum(["mounted", "external"]),
+  version: z.string().min(1),
+  updateFeedUrl: z.string().url(),
+  alphaUpdateFeedUrl: z.string().url().optional(),
+  downloads: z.object({
+    "mac-arm64": z.string().url(),
+    "mac-x64": z.string().url(),
+    "win-x64": z.string().url(),
+    "win-arm64": z.string().url().optional(),
+  }),
+}).nullable()
 
 const appVersionResponseSchema = z.object({
   minAppVersion: z.string(),
   latestAppVersion: z.string().min(1),
+  desktopRelease: desktopReleaseResponseSchema,
 }).meta({ ref: "DenAppVersionResponse" })
+
+async function desktopReleaseMetadata(request: Request) {
+  const version = denApiAppVersion.latestAppVersion
+  if (version === "0.0.0") return null
+
+  if (env.desktopReleasesDir) {
+    const availability = await mountedDesktopReleaseAvailability({ rootDir: env.desktopReleasesDir, version })
+    if (!availability) return null
+    const origin = resolvePublicOrigin(request, env.apiPublicUrl)
+    const baseUrl = new URL(`/v1/desktop-releases/${encodeURIComponent(version)}`, origin).toString()
+    return buildDesktopReleaseMetadata({
+      source: "mounted",
+      version,
+      baseUrl,
+      alphaUpdateFeedUrl: env.desktopAlphaUpdateFeedUrl,
+      includeWindowsArm64: availability.windowsArm64,
+    })
+  }
+
+  if (env.desktopReleasesPublicBaseUrl) {
+    return buildDesktopReleaseMetadata({
+      source: "external",
+      version,
+      baseUrl: expandDesktopReleaseBaseUrl(env.desktopReleasesPublicBaseUrl, version),
+      alphaUpdateFeedUrl: env.desktopAlphaUpdateFeedUrl,
+      includeWindowsArm64: true,
+    })
+  }
+
+  return null
+}
+
+async function desktopReleaseResponse(request: Request, version: string, fileName: string) {
+  if (!env.desktopReleasesDir) return new Response("Not found", { status: 404 })
+  const filePath = desktopReleaseFilePath({
+    rootDir: env.desktopReleasesDir,
+    supportedVersion: denApiAppVersion.latestAppVersion,
+    requestedVersion: version,
+    fileName,
+  })
+  if (!filePath) return new Response("Not found", { status: 404 })
+
+  const fileStat = await lstat(filePath).catch(() => null)
+  if (!fileStat?.isFile() || fileStat.isSymbolicLink()) return new Response("Not found", { status: 404 })
+
+  const rangeMatch = request.headers.get("range")?.match(/^bytes=(\d*)-(\d*)$/)
+  let start = 0
+  let end = fileStat.size - 1
+  if (rangeMatch) {
+    const requestedStart = rangeMatch[1] ? Number(rangeMatch[1]) : null
+    const requestedEnd = rangeMatch[2] ? Number(rangeMatch[2]) : null
+    if (requestedStart === null && requestedEnd !== null) {
+      start = Math.max(0, fileStat.size - requestedEnd)
+    } else if (requestedStart !== null) {
+      start = requestedStart
+      end = requestedEnd === null ? end : Math.min(requestedEnd, end)
+    }
+    if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start < 0 || start > end || start >= fileStat.size) {
+      return new Response(null, { status: 416, headers: { "content-range": `bytes */${fileStat.size}` } })
+    }
+  }
+  const partial = Boolean(rangeMatch)
+  const headers = {
+    "accept-ranges": "bytes",
+    "cache-control": "public, max-age=31536000, immutable",
+    "content-length": String(end - start + 1),
+    "content-type": desktopReleaseContentType(fileName),
+    ...(partial ? { "content-range": `bytes ${start}-${end}/${fileStat.size}` } : {}),
+  }
+  const status = partial ? 206 : 200
+  if (request.method === "HEAD") return new Response(null, { status, headers })
+  const source = createReadStream(filePath, { start, end })
+  source.pause()
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      source.on("data", (chunk: Buffer) => {
+        source.pause()
+        const bytes = new Uint8Array(chunk.byteLength)
+        bytes.set(chunk)
+        controller.enqueue(bytes)
+      })
+      source.once("end", () => controller.close())
+      source.once("error", (error) => controller.error(error))
+    },
+    pull() {
+      source.resume()
+    },
+    cancel() {
+      source.destroy()
+    },
+  })
+  return new Response(body, { status, headers })
+}
 
 export function registerVersionRoutes<T extends Env>(app: Hono<T>) {
   app.get(
@@ -16,14 +134,29 @@ export function registerVersionRoutes<T extends Env>(app: Hono<T>) {
     describeRoute({
       tags: ["System"],
       summary: "Get desktop app version metadata",
-      description: "Returns the minimum supported desktop app version and the latest desktop app version published with this Den API build.",
+      description: "Returns the supported desktop app versions plus deployment-owned download and update-feed URLs when configured.",
       responses: {
         200: jsonResponse("Desktop app version metadata returned successfully.", appVersionResponseSchema),
       },
     }),
     publicRoute,
-    (c) => {
-      return c.json(denApiAppVersion)
+    async (c) => {
+      return c.json({
+        ...denApiAppVersion,
+        desktopRelease: await desktopReleaseMetadata(c.req.raw),
+      })
     },
+  )
+
+  app.get(
+    "/v1/desktop-releases/:version/:fileName",
+    publicRoute,
+    (c) => desktopReleaseResponse(c.req.raw, c.req.param("version"), c.req.param("fileName")),
+  )
+  app.on(
+    "HEAD",
+    "/v1/desktop-releases/:version/:fileName",
+    publicRoute,
+    (c) => desktopReleaseResponse(c.req.raw, c.req.param("version"), c.req.param("fileName")),
   )
 }

--- a/ee/apps/den-api/src/utils/desktop-releases.ts
+++ b/ee/apps/den-api/src/utils/desktop-releases.ts
@@ -1,0 +1,167 @@
+import path from "node:path"
+import { lstat, readFile } from "node:fs/promises"
+
+export const requiredDesktopReleasePlatforms = ["mac-arm64", "mac-x64", "win-x64"] as const
+export const desktopReleasePlatforms = [...requiredDesktopReleasePlatforms, "win-arm64"] as const
+
+export type DesktopReleasePlatform = (typeof desktopReleasePlatforms)[number]
+export type RequiredDesktopReleasePlatform = (typeof requiredDesktopReleasePlatforms)[number]
+
+export type DesktopReleaseDownloads = Record<RequiredDesktopReleasePlatform, string>
+  & Partial<Record<"win-arm64", string>>
+
+export type DesktopReleaseMetadata = {
+  source: "mounted" | "external"
+  version: string
+  updateFeedUrl: string
+  alphaUpdateFeedUrl?: string
+  downloads: DesktopReleaseDownloads
+}
+
+export function desktopReleaseDownloadFileName(version: string, platform: DesktopReleasePlatform) {
+  return platform.startsWith("mac-")
+    ? `openwork-${platform}-${version}.dmg`
+    : `openwork-${platform}-${version}.exe`
+}
+
+function releaseUrl(baseUrl: string, fileName: string) {
+  return new URL(encodeURIComponent(fileName), `${baseUrl.replace(/\/+$/, "")}/`).toString()
+}
+
+export function buildDesktopReleaseMetadata(input: {
+  source: DesktopReleaseMetadata["source"]
+  version: string
+  baseUrl: string
+  alphaUpdateFeedUrl?: string
+  includeWindowsArm64?: boolean
+}): DesktopReleaseMetadata {
+  const downloads: DesktopReleaseDownloads = {
+    "mac-arm64": releaseUrl(input.baseUrl, desktopReleaseDownloadFileName(input.version, "mac-arm64")),
+    "mac-x64": releaseUrl(input.baseUrl, desktopReleaseDownloadFileName(input.version, "mac-x64")),
+    "win-x64": releaseUrl(input.baseUrl, desktopReleaseDownloadFileName(input.version, "win-x64")),
+  }
+  if (input.includeWindowsArm64) {
+    downloads["win-arm64"] = releaseUrl(input.baseUrl, desktopReleaseDownloadFileName(input.version, "win-arm64"))
+  }
+  return {
+    source: input.source,
+    version: input.version,
+    updateFeedUrl: input.baseUrl.replace(/\/+$/, ""),
+    ...(input.alphaUpdateFeedUrl ? { alphaUpdateFeedUrl: input.alphaUpdateFeedUrl.replace(/\/+$/, "") } : {}),
+    downloads,
+  }
+}
+
+export function expandDesktopReleaseBaseUrl(template: string, version: string) {
+  return template.replaceAll("{version}", encodeURIComponent(version)).replace(/\/+$/, "")
+}
+
+export function isAllowedDesktopReleaseFile(fileName: string, version: string) {
+  if (fileName === "latest-mac.yml" || fileName === "latest.yml") {
+    return true
+  }
+
+  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  return new RegExp(
+    `^openwork-(?:mac-(?:arm64|x64)-${escapedVersion}\\.(?:dmg|zip)|win-(?:arm64|x64)-${escapedVersion}\\.exe)(?:\\.blockmap)?$`,
+  ).test(fileName)
+}
+
+export function desktopReleaseFilePath(input: {
+  rootDir: string
+  supportedVersion: string
+  requestedVersion: string
+  fileName: string
+}) {
+  if (input.requestedVersion !== input.supportedVersion) return null
+  if (path.basename(input.fileName) !== input.fileName) return null
+  if (!isAllowedDesktopReleaseFile(input.fileName, input.supportedVersion)) return null
+  return path.join(input.rootDir, input.supportedVersion, input.fileName)
+}
+
+function unquoteYamlScalar(value: string) {
+  const trimmed = value.trim()
+  if (
+    trimmed.length >= 2
+    && ((trimmed.startsWith("'") && trimmed.endsWith("'")) || (trimmed.startsWith('"') && trimmed.endsWith('"')))
+  ) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+function updaterManifest(input: { raw: string; version: string; fileName: "latest-mac.yml" | "latest.yml" }) {
+  const versionMatch = input.raw.match(/^version:\s*(.+?)\s*$/m)
+  if (!versionMatch || unquoteYamlScalar(versionMatch[1]) !== input.version) return null
+
+  const references = [...input.raw.matchAll(/^\s*(?:-\s+)?(?:url|path):\s*(.+?)\s*$/gm)]
+    .map((match) => unquoteYamlScalar(match[1]))
+  if (references.length === 0) return null
+  if (references.some((reference) => path.basename(reference) !== reference || !isAllowedDesktopReleaseFile(reference, input.version))) {
+    return null
+  }
+
+  const requiredArchitectures = input.fileName === "latest-mac.yml"
+    ? ["mac-arm64", "mac-x64"]
+    : ["win-x64"]
+  if (requiredArchitectures.some((architecture) => !references.some((reference) => reference.includes(architecture)))) {
+    return null
+  }
+  return [...new Set(references)]
+}
+
+async function isRegularMountedFile(filePath: string) {
+  const fileStat = await lstat(filePath).catch(() => null)
+  return Boolean(fileStat?.isFile() && !fileStat.isSymbolicLink())
+}
+
+/**
+ * Validate the complete private release before advertising it. In particular,
+ * updater manifests must contain only relative, allow-listed file names so a
+ * copied pointer manifest can never send a private desktop back to a public
+ * host.
+ */
+export async function mountedDesktopReleaseIsReady(input: {
+  rootDir: string
+  version: string
+}) {
+  return (await mountedDesktopReleaseAvailability(input)) !== null
+}
+
+export async function mountedDesktopReleaseAvailability(input: {
+  rootDir: string
+  version: string
+}) {
+  const versionDir = path.join(input.rootDir, input.version)
+  const requiredDownloads = requiredDesktopReleasePlatforms
+    .map((platform) => desktopReleaseDownloadFileName(input.version, platform))
+  for (const fileName of requiredDownloads) {
+    if (!await isRegularMountedFile(path.join(versionDir, fileName))) return null
+  }
+
+  let windowsReferences: string[] = []
+  for (const fileName of ["latest-mac.yml", "latest.yml"] as const) {
+    const manifestPath = path.join(versionDir, fileName)
+    if (!await isRegularMountedFile(manifestPath)) return null
+    const raw = await readFile(manifestPath, "utf8").catch(() => null)
+    if (raw === null) return null
+    const references = updaterManifest({ raw, version: input.version, fileName })
+    if (!references) return null
+    if (fileName === "latest.yml") windowsReferences = references
+    for (const reference of references) {
+      if (!await isRegularMountedFile(path.join(versionDir, reference))) return null
+    }
+  }
+
+  const windowsArm64FileName = desktopReleaseDownloadFileName(input.version, "win-arm64")
+  const windowsArm64 = windowsReferences.some((reference) => reference.includes("win-arm64"))
+    && await isRegularMountedFile(path.join(versionDir, windowsArm64FileName))
+  return { windowsArm64 }
+}
+
+export function desktopReleaseContentType(fileName: string) {
+  if (fileName.endsWith(".yml")) return "text/yaml; charset=utf-8"
+  if (fileName.endsWith(".zip")) return "application/zip"
+  if (fileName.endsWith(".exe")) return "application/vnd.microsoft.portable-executable"
+  return "application/octet-stream"
+}

--- a/ee/apps/den-api/src/utils/installer-artifacts.ts
+++ b/ee/apps/den-api/src/utils/installer-artifacts.ts
@@ -12,7 +12,8 @@ import { env } from "../env.js"
  *   1. OPENWORK_INSTALLER_ARTIFACTS_DIR file, when set and present
  *      (self-hosted/dev override — the pre-#2480 behavior, moved here).
  *   2. Disk cache under OPENWORK_INSTALLER_CACHE_DIR/<releaseTag>/<fileName>.
- *   3. The public release asset published by release-generic-installer.yml:
+ *   3. When OPENWORK_INSTALLER_RELEASE_FALLBACK_ENABLED=true, the public
+ *      release asset published by release-generic-installer.yml:
  *      https://github.com/<repo>/releases/download/<releaseTag>/<fileName>,
  *      streamed to a temp file then atomically renamed into the cache.
  *
@@ -27,6 +28,7 @@ type InstallerArtifactOptions = {
   cacheDir?: string
   releaseTag?: string
   releaseRepo?: string
+  releaseFallbackEnabled?: boolean
   fetcher?: InstallerArtifactFetcher
 }
 
@@ -114,6 +116,11 @@ export async function resolveInstallerArtifact(fileName: string, options: Instal
   if (cached) {
     console.info(`[installer-artifacts] cache hit ${fileName}`)
     return cached
+  }
+
+  const releaseFallbackEnabled = options.releaseFallbackEnabled ?? env.installerReleaseFallbackEnabled
+  if (!releaseFallbackEnabled) {
+    return null
   }
 
   const inFlight = inFlightDownloads.get(cachePath)

--- a/ee/apps/den-api/test/desktop-releases.test.ts
+++ b/ee/apps/den-api/test/desktop-releases.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+import {
+  buildDesktopReleaseMetadata,
+  desktopReleaseFilePath,
+  expandDesktopReleaseBaseUrl,
+  isAllowedDesktopReleaseFile,
+  mountedDesktopReleaseAvailability,
+  mountedDesktopReleaseIsReady,
+} from "../src/utils/desktop-releases"
+
+const VERSION = "0.17.19"
+
+function mountedReleaseFixture(options: { latestMacUrl?: string; windowsArm64?: boolean } = {}) {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "openwork-desktop-releases-"))
+  const versionDir = path.join(rootDir, VERSION)
+  mkdirSync(versionDir, { recursive: true })
+  const files: Record<string, string> = {
+    [`openwork-mac-arm64-${VERSION}.dmg`]: "mac-arm64",
+    [`openwork-mac-x64-${VERSION}.dmg`]: "mac-x64",
+    [`openwork-win-x64-${VERSION}.exe`]: "win-x64",
+    [`openwork-mac-arm64-${VERSION}.zip`]: "mac-update-arm64",
+    [`openwork-mac-x64-${VERSION}.zip`]: "mac-update-x64",
+    "latest-mac.yml": `version: ${VERSION}\nfiles:\n  - url: ${options.latestMacUrl ?? `openwork-mac-arm64-${VERSION}.zip`}\n  - url: openwork-mac-x64-${VERSION}.zip\n`,
+    "latest.yml": `version: ${VERSION}\nfiles:\n  - url: openwork-win-x64-${VERSION}.exe\n${options.windowsArm64 ? `  - url: openwork-win-arm64-${VERSION}.exe\n` : ""}`,
+  }
+  if (options.windowsArm64) files[`openwork-win-arm64-${VERSION}.exe`] = "win-arm64"
+  for (const [fileName, contents] of Object.entries(files)) {
+    writeFileSync(path.join(versionDir, fileName), contents)
+  }
+  return { rootDir, versionDir }
+}
+
+describe("desktop release repository", () => {
+  test("builds Den-internal download and update URLs for the supported version", () => {
+    const metadata = buildDesktopReleaseMetadata({
+      source: "mounted",
+      version: "0.17.19",
+      baseUrl: "https://den.examplecorp.test/v1/desktop-releases/0.17.19",
+      includeWindowsArm64: true,
+    })
+
+    expect(metadata.updateFeedUrl).toBe("https://den.examplecorp.test/v1/desktop-releases/0.17.19")
+    expect(metadata.downloads["mac-arm64"]).toEndWith("/openwork-mac-arm64-0.17.19.dmg")
+    expect(metadata.downloads["mac-x64"]).toEndWith("/openwork-mac-x64-0.17.19.dmg")
+    expect(metadata.downloads["win-x64"]).toEndWith("/openwork-win-x64-0.17.19.exe")
+    expect(metadata.downloads["win-arm64"]).toEndWith("/openwork-win-arm64-0.17.19.exe")
+    expect(buildDesktopReleaseMetadata({
+      source: "mounted",
+      version: "0.17.19",
+      baseUrl: "https://den.examplecorp.test/v1/desktop-releases/0.17.19",
+    }).downloads["win-arm64"]).toBeUndefined()
+  })
+
+  test("expands an explicitly configured public fallback without hardcoding a host", () => {
+    expect(expandDesktopReleaseBaseUrl("https://mirror.example.test/releases/v{version}/", "0.17.19")).toBe(
+      "https://mirror.example.test/releases/v0.17.19",
+    )
+  })
+
+  test("serves only Mac and Windows release files for the exact supported version", () => {
+    expect(isAllowedDesktopReleaseFile("latest-mac.yml", "0.17.19")).toBe(true)
+    expect(isAllowedDesktopReleaseFile("latest.yml", "0.17.19")).toBe(true)
+    expect(isAllowedDesktopReleaseFile("openwork-mac-arm64-0.17.19.zip", "0.17.19")).toBe(true)
+    expect(isAllowedDesktopReleaseFile("openwork-win-x64-0.17.19.exe.blockmap", "0.17.19")).toBe(true)
+    expect(isAllowedDesktopReleaseFile("openwork-win-arm64-0.17.19.exe", "0.17.19")).toBe(true)
+    expect(isAllowedDesktopReleaseFile("openwork-linux-x86_64-0.17.19.AppImage", "0.17.19")).toBe(false)
+    expect(desktopReleaseFilePath({
+      rootDir: "/releases",
+      supportedVersion: "0.17.19",
+      requestedVersion: "0.17.18",
+      fileName: "latest.yml",
+    })).toBeNull()
+    expect(desktopReleaseFilePath({
+      rootDir: "/releases",
+      supportedVersion: "0.17.19",
+      requestedVersion: "0.17.19",
+      fileName: "openwork-win-x64-0.17.19.exe",
+    })).toBe(path.join("/releases", "0.17.19", "openwork-win-x64-0.17.19.exe"))
+  })
+
+  test("accepts a complete private release whose updater manifests stay on the mount", async () => {
+    const fixture = mountedReleaseFixture()
+    try {
+      expect(await mountedDesktopReleaseIsReady({ rootDir: fixture.rootDir, version: VERSION })).toBe(true)
+      expect((await mountedDesktopReleaseAvailability({ rootDir: fixture.rootDir, version: VERSION }))?.windowsArm64).toBe(false)
+    } finally {
+      rmSync(fixture.rootDir, { recursive: true, force: true })
+    }
+  })
+
+  test("advertises Windows ARM64 only when both its executable and updater entry are mounted", async () => {
+    const fileOnlyFixture = mountedReleaseFixture()
+    writeFileSync(path.join(fileOnlyFixture.versionDir, `openwork-win-arm64-${VERSION}.exe`), "win-arm64")
+    try {
+      expect((await mountedDesktopReleaseAvailability({
+        rootDir: fileOnlyFixture.rootDir,
+        version: VERSION,
+      }))?.windowsArm64).toBe(false)
+    } finally {
+      rmSync(fileOnlyFixture.rootDir, { recursive: true, force: true })
+    }
+
+    const fixture = mountedReleaseFixture({ windowsArm64: true })
+    try {
+      expect((await mountedDesktopReleaseAvailability({ rootDir: fixture.rootDir, version: VERSION }))?.windowsArm64).toBe(true)
+    } finally {
+      rmSync(fixture.rootDir, { recursive: true, force: true })
+    }
+  })
+
+  test("rejects a copied updater pointer that would send the desktop to a public host", async () => {
+    const fixture = mountedReleaseFixture({
+      latestMacUrl: `https://github.com/different-ai/openwork/releases/download/v${VERSION}/openwork-mac-arm64-${VERSION}.zip`,
+    })
+    try {
+      expect(await mountedDesktopReleaseIsReady({ rootDir: fixture.rootDir, version: VERSION })).toBe(false)
+    } finally {
+      rmSync(fixture.rootDir, { recursive: true, force: true })
+    }
+  })
+
+  test("rejects an incomplete private release instead of advertising broken URLs", async () => {
+    const fixture = mountedReleaseFixture()
+    rmSync(path.join(fixture.versionDir, `openwork-win-x64-${VERSION}.exe`))
+    try {
+      expect(await mountedDesktopReleaseIsReady({ rootDir: fixture.rootDir, version: VERSION })).toBe(false)
+    } finally {
+      rmSync(fixture.rootDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/ee/apps/den-api/test/installer-artifacts.test.ts
+++ b/ee/apps/den-api/test/installer-artifacts.test.ts
@@ -44,6 +44,7 @@ describe("resolveInstallerArtifact", () => {
       cacheDir,
       releaseTag: "v9.9.9",
       releaseRepo: "different-ai/openwork",
+      releaseFallbackEnabled: true,
       fetcher: fetcherReturning(200, "from-network", calls),
     })
 
@@ -61,6 +62,7 @@ describe("resolveInstallerArtifact", () => {
       cacheDir,
       releaseTag: "v9.9.9",
       releaseRepo: "different-ai/openwork",
+      releaseFallbackEnabled: true,
       fetcher: fetcherReturning(200, "from-network", calls),
     })
 
@@ -75,6 +77,7 @@ describe("resolveInstallerArtifact", () => {
       cacheDir,
       releaseTag: "v9.9.9",
       releaseRepo: "different-ai/openwork",
+      releaseFallbackEnabled: true,
       fetcher: fetcherReturning(200, "from-network", calls),
     }
 
@@ -102,10 +105,27 @@ describe("resolveInstallerArtifact", () => {
       cacheDir,
       releaseTag: "v0.0.0-missing",
       releaseRepo: "different-ai/openwork",
+      releaseFallbackEnabled: true,
       fetcher: fetcherReturning(404, null, calls),
     })
 
     expect(resolved).toBeNull()
     expect(calls.length).toBe(1)
+  })
+
+  test("does not contact a public release unless fallback is explicitly enabled", async () => {
+    const cacheDir = tempDir("ow-installer-cache-")
+    const calls: string[] = []
+
+    const resolved = await resolveInstallerArtifact(FILE_NAME, {
+      cacheDir,
+      releaseTag: "v9.9.9",
+      releaseRepo: "different-ai/openwork",
+      releaseFallbackEnabled: false,
+      fetcher: fetcherReturning(200, "from-network", calls),
+    })
+
+    expect(resolved).toBeNull()
+    expect(calls).toEqual([])
   })
 })

--- a/ee/apps/den-api/test/route-guard-policy.test.ts
+++ b/ee/apps/den-api/test/route-guard-policy.test.ts
@@ -12,6 +12,8 @@ const routeGuardExceptions = new Map<string, string>([
   ["GET /openapi.json", "public API schema"],
   ["GET /docs", "public API documentation"],
   ["GET /v1/app-version", "public desktop update metadata"],
+  ["GET /v1/desktop-releases/:version/:fileName", "public mounted desktop release asset"],
+  ["HEAD /v1/desktop-releases/:version/:fileName", "public mounted desktop release availability check"],
   ["GET /api/auth/.well-known/oauth-authorization-server", "public OAuth metadata"],
   ["GET /api/auth/.well-known/openid-configuration", "public OIDC metadata"],
   ["GET /.well-known/oauth-authorization-server/api/auth", "public OAuth metadata"],

--- a/evals/flows/airgapped-desktop-delivery.flow.mjs
+++ b/evals/flows/airgapped-desktop-delivery.flow.mjs
@@ -1,0 +1,305 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { electronUpdaterFeedUrl } from "../../apps/desktop/electron/updater.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "airgapped-desktop-delivery";
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const versionSource = readFileSync(path.join(ROOT, "ee/apps/den-api/src/generated/app-version.ts"), "utf8");
+const versionMatch = versionSource.match(/BUILD_LATEST_APP_VERSION\s*=\s*"([^"]+)"/);
+if (!versionMatch) throw new Error("Could not read Den's generated desktop app version.");
+const VERSION = versionMatch[1];
+const INTERNAL_ORIGIN = "https://den.examplecorp.test";
+const RELEASE_BASE = `${INTERNAL_ORIGIN}/v1/desktop-releases/${VERSION}`;
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const state = {
+  workDir: null,
+  releasesDir: null,
+  wrapperDir: null,
+  bootstrapPath: null,
+  contacts: [],
+};
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${actual})` : ""}`);
+}
+
+function runBun(script, extraEnv = {}) {
+  const result = spawnSync("bun", ["-e", script], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: { ...process.env, ...extraEnv },
+  });
+  if (result.status !== 0) {
+    throw new Error(`Bun witness failed (${result.status}):\n${result.stdout}\n${result.stderr}`);
+  }
+  const lines = result.stdout.trim().split("\n");
+  return JSON.parse(lines.at(-1));
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function ensureFixture() {
+  if (state.workDir) return;
+  state.workDir = mkdtempSync(path.join(os.tmpdir(), "openwork-airgapped-delivery-"));
+  state.releasesDir = path.join(state.workDir, "desktop-releases");
+  state.wrapperDir = path.join(state.workDir, "installer-artifacts");
+  const versionDir = path.join(state.releasesDir, VERSION);
+  mkdirSync(versionDir, { recursive: true });
+  mkdirSync(state.wrapperDir, { recursive: true });
+
+  const files = {
+    [`openwork-mac-arm64-${VERSION}.dmg`]: "approved-signed-mac-arm64",
+    [`openwork-mac-x64-${VERSION}.dmg`]: "approved-signed-mac-x64",
+    [`openwork-mac-arm64-${VERSION}.zip`]: "approved-signed-mac-updater-arm64",
+    [`openwork-mac-x64-${VERSION}.zip`]: "approved-signed-mac-updater-x64",
+    [`openwork-win-x64-${VERSION}.exe`]: "approved-signed-windows-x64",
+    [`openwork-win-arm64-${VERSION}.exe`]: "approved-signed-windows-arm64",
+    [`openwork-win-x64-${VERSION}.exe.blockmap`]: "approved-windows-blockmap",
+    "latest-mac.yml": `version: ${VERSION}\nfiles:\n  - url: openwork-mac-arm64-${VERSION}.zip\n  - url: openwork-mac-x64-${VERSION}.zip\n`,
+    "latest.yml": `version: ${VERSION}\nfiles:\n  - url: openwork-win-x64-${VERSION}.exe\n  - url: openwork-win-arm64-${VERSION}.exe\n`,
+  };
+  for (const [name, bytes] of Object.entries(files)) {
+    writeFileSync(path.join(versionDir, name), bytes);
+  }
+  writeFileSync(path.join(state.wrapperDir, "openwork-installer-win-x64.exe"), "approved-generic-installer-wrapper");
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Mac and Windows desktop delivery stays inside an organization-owned Den",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Mounted signed release repository",
+      run: async (ctx) => {
+        await ctx.prove("Den accepts the approved versioned Mac and Windows release layout without rewriting artifacts", {
+          voiceover: vo[0],
+          action: async () => {
+            ensureFixture();
+            const result = runBun(`
+              process.env.DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_test";
+              process.env.DEN_DB_ENCRYPTION_KEY = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+              process.env.BETTER_AUTH_SECRET = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+              process.env.BETTER_AUTH_URL = "https://examplecorp.test";
+              process.env.OPENWORK_DESKTOP_RELEASES_DIR = process.env.RELEASES_DIR;
+              const { Hono } = await import("./ee/apps/den-api/node_modules/hono/dist/index.js");
+              const { registerVersionRoutes } = await import("./ee/apps/den-api/src/routes/version/index.ts");
+              const app = new Hono();
+              registerVersionRoutes(app);
+              const metadataResponse = await app.request("${INTERNAL_ORIGIN}/v1/app-version");
+              const metadata = await metadataResponse.json();
+              const artifactUrl = metadata.desktopRelease.downloads["win-x64"];
+              const armArtifactUrl = metadata.desktopRelease.downloads["win-arm64"];
+              const artifactResponse = await app.request(artifactUrl);
+              const armArtifactResponse = await app.request(armArtifactUrl);
+              const headResponse = await app.request(artifactUrl, { method: "HEAD" });
+              const rangeResponse = await app.request(artifactUrl, { headers: { range: "bytes=0-7" } });
+              console.log(JSON.stringify({
+                metadataStatus: metadataResponse.status,
+                artifactStatus: artifactResponse.status,
+                headStatus: headResponse.status,
+                rangeStatus: rangeResponse.status,
+                rangeHeader: rangeResponse.headers.get("content-range"),
+                rangeBytes: await rangeResponse.text(),
+                contentLength: headResponse.headers.get("content-length"),
+                artifactUrl,
+                armArtifactUrl,
+                armArtifactStatus: armArtifactResponse.status,
+                armBytes: await armArtifactResponse.text(),
+                bytes: await artifactResponse.text(),
+              }));
+            `, { RELEASES_DIR: state.releasesDir, VERSION });
+            const mountedPath = path.join(state.releasesDir, VERSION, `openwork-win-x64-${VERSION}.exe`);
+            const before = Buffer.from("approved-signed-windows-x64");
+            const after = readFileSync(mountedPath);
+            witness(ctx, result.metadataStatus === 200 && result.artifactStatus === 200 && result.headStatus === 200, "Den publishes metadata plus GET and HEAD routes for the mounted release", JSON.stringify(result));
+            witness(ctx, result.rangeStatus === 206 && result.rangeHeader === "bytes 0-7/27" && result.rangeBytes === "approved", "Den supports the byte ranges used by desktop updaters", JSON.stringify(result));
+            witness(ctx, result.artifactUrl.startsWith(RELEASE_BASE), "Den advertises its internal supported-version artifact URL", result.artifactUrl);
+            witness(ctx, result.armArtifactStatus === 200 && result.armArtifactUrl.endsWith(`openwork-win-arm64-${VERSION}.exe`) && result.armBytes === "approved-signed-windows-arm64", "Den advertises and serves the mounted Windows ARM64 release", JSON.stringify(result));
+            witness(ctx, result.bytes === before.toString("utf8"), "Den serves the mounted artifact bytes", result.bytes);
+            witness(ctx, sha256(before) === sha256(after), "Mounted signed bytes remain byte-identical", sha256(after));
+            ctx.output("mounted-release-repository", JSON.stringify({ root: state.releasesDir, version: VERSION, route: result, windowsSha256: sha256(after) }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Organization setup package with GitHub blocked",
+      run: async (ctx) => {
+        await ctx.prove("The organization setup package resolves from the private mount with public release fallback disabled", {
+          voiceover: vo[1],
+          action: async () => {
+            ensureFixture();
+            const result = runBun(`
+              process.env.DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_test";
+              process.env.DEN_DB_ENCRYPTION_KEY = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+              process.env.BETTER_AUTH_SECRET = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+              process.env.BETTER_AUTH_URL = "https://examplecorp.test";
+              const { resolveInstallerArtifact } = await import("./ee/apps/den-api/src/utils/installer-artifacts.ts");
+              const contacted = [];
+              const bytes = await resolveInstallerArtifact("openwork-installer-win-x64.exe", {
+                artifactsDir: process.env.WRAPPER_DIR,
+                cacheDir: process.env.CACHE_DIR,
+                releaseTag: "v" + process.env.VERSION,
+                releaseRepo: "blocked/public-release",
+                releaseFallbackEnabled: false,
+                fetcher: async (url) => { contacted.push(url); throw new Error("public network blocked"); },
+              });
+              console.log(JSON.stringify({ bytes: bytes?.toString("utf8"), contacted }));
+            `, { WRAPPER_DIR: state.wrapperDir, CACHE_DIR: path.join(state.workDir, "cache"), VERSION });
+            witness(ctx, result.bytes === "approved-generic-installer-wrapper", "The mounted Windows setup package is returned", result.bytes);
+            witness(ctx, result.contacted.length === 0, "No public fallback request was attempted", JSON.stringify(result.contacted));
+            state.contacts.push(
+              `${INTERNAL_ORIGIN}/v1/install-config`,
+              `${INTERNAL_ORIGIN}/v1/install/win-x64`,
+            );
+            ctx.output("setup-download-network", JSON.stringify({ memberDownloads: state.contacts.slice(-2), publicRequests: result.contacted }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Installer follows Den metadata",
+      run: async (ctx) => {
+        await ctx.prove("The installer asks Den for the supported version and downloads the Windows artifact from Den's returned URL", {
+          voiceover: vo[2],
+          action: async () => {
+            const result = runBun(`
+              const contacts = [];
+              const artifactUrl = "${RELEASE_BASE}/openwork-win-x64-${VERSION}.exe";
+              const armArtifactUrl = "${RELEASE_BASE}/openwork-win-arm64-${VERSION}.exe";
+              globalThis.fetch = async (input) => {
+                const url = String(input);
+                contacts.push(url);
+                if (url.endsWith("/v1/app-version")) {
+                  return Response.json({ latestAppVersion: "${VERSION}", desktopRelease: { version: "${VERSION}", downloads: { "win-x64": artifactUrl, "win-arm64": armArtifactUrl } } });
+                }
+                return new Response(url === armArtifactUrl ? "approved-signed-windows-arm64" : "approved-signed-windows-x64", { status: 200 });
+              };
+              const { fetchSupportedReleaseAsset } = await import("./apps/installer/src/install.ts");
+              const asset = await fetchSupportedReleaseAsset("${INTERNAL_ORIGIN}", "win32", "x64");
+              const armAsset = await fetchSupportedReleaseAsset("${INTERNAL_ORIGIN}", "win32", "arm64");
+              const response = await fetch(asset.url);
+              const armResponse = await fetch(armAsset.url);
+              console.log(JSON.stringify({ asset, armAsset, body: await response.text(), armBody: await armResponse.text(), contacts }));
+            `);
+            witness(ctx, result.asset.url.startsWith(RELEASE_BASE), "Installer selected Den's versioned Windows artifact", result.asset.url);
+            witness(ctx, result.body === "approved-signed-windows-x64", "Installer downloaded the approved artifact bytes", result.body);
+            witness(ctx, result.armAsset.url.endsWith(`openwork-win-arm64-${VERSION}.exe`) && result.armBody === "approved-signed-windows-arm64", "Windows ARM64 installer resolution stays on the same Den-owned release", JSON.stringify(result.armAsset));
+            state.contacts.push(...result.contacts);
+            ctx.output("installer-den-resolution", JSON.stringify(result, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "First launch is organization-gated",
+      run: async (ctx) => {
+        await ctx.prove("Windows setup writes Example Corp's internal Den URLs and requires sign-in on first launch", {
+          voiceover: vo[3],
+          action: async () => {
+            ensureFixture();
+            state.bootstrapPath = path.join(state.workDir, "desktop-bootstrap.json");
+            const result = runBun(`
+              const { writeBootstrapConfig } = await import("./apps/installer/src/install.ts");
+              const path = writeBootstrapConfig({
+                clientName: "Example Corp",
+                webUrl: "https://examplecorp.test",
+                apiUrl: "${INTERNAL_ORIGIN}",
+                logoUrl: null,
+                requireSignin: true,
+              }, { OPENWORK_DESKTOP_BOOTSTRAP_PATH: process.env.BOOTSTRAP_PATH });
+              console.log(JSON.stringify({ path, config: JSON.parse(await Bun.file(path).text()) }));
+            `, { BOOTSTRAP_PATH: state.bootstrapPath });
+            witness(ctx, result.config.requireSignin === true, "First launch is held at organization sign-in", JSON.stringify(result.config));
+            witness(ctx, result.config.apiBaseUrl === INTERNAL_ORIGIN, "Bootstrap points at Example Corp Den", result.config.apiBaseUrl);
+            witness(ctx, !JSON.stringify(result.config).includes("github.com"), "Bootstrap contains no public release host");
+            state.contacts.push(result.config.baseUrl, result.config.apiBaseUrl);
+            ctx.output("windows-first-launch-bootstrap", JSON.stringify(result.config, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Internal stable update feed",
+      run: async (ctx) => {
+        await ctx.prove("A stable Windows update check resolves the feed from Example Corp Den metadata", {
+          voiceover: vo[4],
+          action: async () => {
+            const contacted = [];
+            const fetcher = async (url) => {
+              contacted.push(String(url));
+              return Response.json({
+                latestAppVersion: VERSION,
+                desktopRelease: {
+                  version: VERSION,
+                  updateFeedUrl: RELEASE_BASE,
+                  downloads: {
+                    "mac-arm64": `${RELEASE_BASE}/openwork-mac-arm64-${VERSION}.dmg`,
+                    "mac-x64": `${RELEASE_BASE}/openwork-mac-x64-${VERSION}.dmg`,
+                    "win-x64": `${RELEASE_BASE}/openwork-win-x64-${VERSION}.exe`,
+                  },
+                },
+              });
+            };
+            const feedUrl = await electronUpdaterFeedUrl(
+              "stable",
+              async () => ({ baseUrl: "https://examplecorp.test", apiBaseUrl: INTERNAL_ORIGIN, requireSignin: true }),
+              fetcher,
+              "win32",
+            );
+            let alphaError = "";
+            try {
+              await electronUpdaterFeedUrl(
+                "alpha",
+                async () => ({ baseUrl: "https://examplecorp.test", apiBaseUrl: INTERNAL_ORIGIN, requireSignin: true }),
+                fetcher,
+                "darwin",
+              );
+            } catch (error) {
+              alphaError = error instanceof Error ? error.message : String(error);
+            }
+            contacted.push(`${feedUrl}/latest.yml`);
+            witness(ctx, feedUrl === RELEASE_BASE, "Stable Windows updater feed is Den-internal", feedUrl);
+            witness(ctx, contacted.every((url) => new URL(url).hostname === "den.examplecorp.test"), "Update check contacted only Example Corp Den", JSON.stringify(contacted));
+            witness(ctx, alphaError.includes("does not publish an alpha desktop update feed"), "An unconfigured alpha channel fails closed instead of using GitHub", alphaError);
+            state.contacts.push(...contacted);
+            ctx.output("stable-update-feed", JSON.stringify({ feedUrl, contacted }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Approved-host network boundary",
+      run: async (ctx) => {
+        await ctx.prove("The combined install, first-launch, and update evidence contains no GitHub or other public host", {
+          voiceover: vo[5],
+          assert: async () => {
+            const hosts = [...new Set(state.contacts.map((url) => new URL(url).hostname))].sort();
+            const approvedHosts = new Set(["examplecorp.test", "den.examplecorp.test"]);
+            witness(ctx, hosts.every((host) => approvedHosts.has(host)), "Every observed host is on the Example Corp allowlist", JSON.stringify(hosts));
+            witness(ctx, !hosts.includes("github.com"), "GitHub was not contacted", JSON.stringify(hosts));
+            witness(ctx, state.contacts.length >= 8, "The proof covers setup, version resolution, artifact download, first launch, and update checks", String(state.contacts.length));
+            ctx.output("network-host-allowlist", JSON.stringify({ approvedHosts: [...approvedHosts], observedRequests: state.contacts, observedHosts: hosts }, null, 2));
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/airgapped-desktop-delivery.md
+++ b/evals/voiceovers/airgapped-desktop-delivery.md
@@ -1,0 +1,13 @@
+# airgapped-desktop-delivery
+
+1. An Example Corp operator mounts approved signed Mac and Windows desktop releases into Den.
+
+2. With GitHub blocked, a member downloads the organization setup package normally.
+
+3. The installer asks Example Corp’s Den server for the supported version and downloads that version internally.
+
+4. Windows setup completes and opens directly at Example Corp sign-in without external access.
+
+5. Checking for updates uses Example Corp’s internal update feed.
+
+6. The proof shows that installation, first launch, and updating contacted only approved internal hosts.

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -91,7 +91,7 @@ Run the install-link migration once against the Den database:
 docker compose -f packaging/docker/docker-compose.den-dev.yml exec den sh -lc "pnpm --dir /app/ee/packages/den-db run db:bootstrap"
 ```
 
-Set `DEN_BOOTSTRAP_ADMIN_EMAILS` on the Den API service, restart it, open `/admin`, and toggle `Install links` for each org. Optional installer artifact env vars are `OPENWORK_INSTALLER_RELEASE_TAG`, `OPENWORK_INSTALLER_RELEASE_REPO`, and `OPENWORK_INSTALLER_ARTIFACTS_DIR`; see the [operator guide](../../docs/org-install-links.md).
+Set `DEN_BOOTSTRAP_ADMIN_EMAILS` on the Den API service, restart it, open `/admin`, and toggle `Install links` for each org. Installer wrapper configuration uses `OPENWORK_INSTALLER_ARTIFACTS_DIR`; public release fallback additionally requires `OPENWORK_INSTALLER_RELEASE_FALLBACK_ENABLED=true`. Air-gapped desktop app delivery uses `OPENWORK_DESKTOP_RELEASES_DIR`; see the [operator guide](../../docs/org-install-links.md).
 
 ### Faster inner-loop alternative
 

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -381,6 +381,9 @@ config:
   public:
     installerReleaseTag: "v0.17.9"
     installerReleaseRepo: "different-ai/openwork"
+    # Keep false for private-network installs. Set true only when GitHub is an
+    # intentional fallback for generic installer wrappers.
+    installerReleaseFallbackEnabled: "false"
 
 installerArtifacts:
   enabled: true
@@ -389,6 +392,37 @@ installerArtifacts:
 ```
 
 Use either `installerArtifacts.existingClaim` or `installerArtifacts.hostPath`, not both. The mounted directory must contain `openwork-installer-mac-arm64.zip`, `openwork-installer-mac-x64.zip`, and `openwork-installer-win-x64.exe`.
+
+For a deployment where desktop installation and updates must stay inside the
+organization network, mount the signed desktop release as a separate,
+versioned repository:
+
+```yaml
+desktopReleases:
+  enabled: true
+  existingClaim: openwork-desktop-releases
+  mountPath: /var/lib/openwork/desktop-releases
+```
+
+For Den version `0.17.19`, place the unmodified release files under
+`0.17.19/`: `latest-mac.yml`, `latest.yml`, both Mac DMGs and updater ZIPs,
+the Windows x64 EXE, and any `.blockmap` files referenced by those manifests.
+To support Windows ARM64, also mount the ARM64 EXE and include it in
+`latest.yml`; x64-only repositories continue to work and omit ARM64 from Den's
+download metadata.
+Den serves those bytes from `/v1/desktop-releases/0.17.19/…`; the installer and
+desktop updater learn the internal URLs from `/v1/app-version`.
+
+If a connected deployment intentionally uses a mirror instead, leave
+`desktopReleases.enabled=false` and set
+`config.public.desktopReleasesPublicBaseUrl` to an absolute URL. The optional
+`{version}` placeholder is expanded from Den's supported app version. There is
+no implicit public desktop-release fallback.
+
+The macOS alpha channel also fails closed. Set
+`config.public.desktopAlphaUpdateFeedUrl` only when the deployment intentionally
+publishes a private or external alpha feed; OpenWork never falls back to the
+upstream GitHub alpha feed on Mac or Windows.
 
 ## Health Probes
 

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -38,6 +38,13 @@ data:
   {{ if .Values.config.public.installerReleaseRepo }}
   OPENWORK_INSTALLER_RELEASE_REPO: {{ .Values.config.public.installerReleaseRepo | quote }}
   {{ end }}
+  OPENWORK_INSTALLER_RELEASE_FALLBACK_ENABLED: {{ .Values.config.public.installerReleaseFallbackEnabled | quote }}
+  {{ if .Values.config.public.desktopReleasesPublicBaseUrl }}
+  OPENWORK_DESKTOP_RELEASES_PUBLIC_BASE_URL: {{ .Values.config.public.desktopReleasesPublicBaseUrl | quote }}
+  {{ end }}
+  {{ if .Values.config.public.desktopAlphaUpdateFeedUrl }}
+  OPENWORK_DESKTOP_ALPHA_UPDATE_FEED_URL: {{ .Values.config.public.desktopAlphaUpdateFeedUrl | quote }}
+  {{ end }}
   PROVISIONER_MODE: {{ .Values.config.provisioner.mode | quote }}
   WORKER_PROVISIONING_RECONCILE_INTERVAL_MS: {{ .Values.config.provisioner.reconcileIntervalMs | quote }}
   WORKER_PROVISIONING_RECONCILE_STALE_MS: {{ .Values.config.provisioner.reconcileStaleMs | quote }}

--- a/packaging/helm/openwork-ee/templates/den-api.yaml
+++ b/packaging/helm/openwork-ee/templates/den-api.yaml
@@ -60,7 +60,18 @@ spec:
       {{- if not (or .Values.installerArtifacts.existingClaim .Values.installerArtifacts.hostPath) }}
       {{- fail "installerArtifacts.existingClaim or installerArtifacts.hostPath is required when installerArtifacts.enabled=true" }}
       {{- end }}
+      {{- end }}
+      {{- if .Values.desktopReleases.enabled }}
+      {{- if and .Values.desktopReleases.existingClaim .Values.desktopReleases.hostPath }}
+      {{- fail "desktopReleases.existingClaim and desktopReleases.hostPath are mutually exclusive" }}
+      {{- end }}
+      {{- if not (or .Values.desktopReleases.existingClaim .Values.desktopReleases.hostPath) }}
+      {{- fail "desktopReleases.existingClaim or desktopReleases.hostPath is required when desktopReleases.enabled=true" }}
+      {{- end }}
+      {{- end }}
+      {{- if or .Values.installerArtifacts.enabled .Values.desktopReleases.enabled }}
       volumes:
+        {{- if .Values.installerArtifacts.enabled }}
         - name: installer-artifacts
           {{- if .Values.installerArtifacts.existingClaim }}
           persistentVolumeClaim:
@@ -70,6 +81,18 @@ spec:
             path: {{ .Values.installerArtifacts.hostPath | quote }}
             type: Directory
           {{- end }}
+        {{- end }}
+        {{- if .Values.desktopReleases.enabled }}
+        - name: desktop-releases
+          {{- if .Values.desktopReleases.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.desktopReleases.existingClaim | quote }}
+          {{- else }}
+          hostPath:
+            path: {{ .Values.desktopReleases.hostPath | quote }}
+            type: Directory
+          {{- end }}
+        {{- end }}
       {{- end }}
       containers:
         - name: den-api
@@ -78,11 +101,18 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.denApi.containerPort }}
-          {{- if .Values.installerArtifacts.enabled }}
+          {{- if or .Values.installerArtifacts.enabled .Values.desktopReleases.enabled }}
           volumeMounts:
+            {{- if .Values.installerArtifacts.enabled }}
             - name: installer-artifacts
               mountPath: {{ .Values.installerArtifacts.mountPath | quote }}
               readOnly: true
+            {{- end }}
+            {{- if .Values.desktopReleases.enabled }}
+            - name: desktop-releases
+              mountPath: {{ .Values.desktopReleases.mountPath | quote }}
+              readOnly: true
+            {{- end }}
           {{- end }}
           envFrom:
             - configMapRef:
@@ -95,6 +125,10 @@ spec:
             {{- if .Values.installerArtifacts.enabled }}
             - name: OPENWORK_INSTALLER_ARTIFACTS_DIR
               value: {{ .Values.installerArtifacts.mountPath | quote }}
+            {{- end }}
+            {{- if .Values.desktopReleases.enabled }}
+            - name: OPENWORK_DESKTOP_RELEASES_DIR
+              value: {{ .Values.desktopReleases.mountPath | quote }}
             {{- end }}
             {{- range $key, $value := .Values.denApi.env }}
             - name: {{ $key }}

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -36,6 +36,9 @@ config:
     openworkAppConnectUrl: ""
     installerReleaseTag: ""
     installerReleaseRepo: ""
+    installerReleaseFallbackEnabled: "false"
+    desktopReleasesPublicBaseUrl: ""
+    desktopAlphaUpdateFeedUrl: ""
     authCallbackUrl: https://openwork.example.com
   internal:
     apiBaseUrl: ""
@@ -134,6 +137,12 @@ installerArtifacts:
   existingClaim: ""
   hostPath: ""
   mountPath: /var/lib/openwork/installer-artifacts
+
+desktopReleases:
+  enabled: false
+  existingClaim: ""
+  hostPath: ""
+  mountPath: /var/lib/openwork/desktop-releases
 
 denApi:
   replicaCount: 1


### PR DESCRIPTION
## What changed

This makes Mac and Windows desktop delivery work without required public release egress:

- Den can serve a versioned, read-only desktop release repository from `OPENWORK_DESKTOP_RELEASES_DIR/<version>/`.
- `/v1/app-version` now advertises deployment-owned installer and updater URLs.
- Windows ARM64 is first-class end to end: Den, the installer, architecture correction, and the updater consume `win-arm64` when published. Existing x64-only mounts remain valid and omit the optional ARM64 URL.
- Den serves exact-version release assets with GET, HEAD, immutable caching, and byte-range support.
- Mounted updater manifests are accepted only when they reference relative, allow-listed files that exist on the same mount; symlinks, traversal, incomplete releases, and public pointer URLs fail closed.
- The generic installer asks Den for the supported version and platform URL instead of constructing a GitHub URL.
- The installed desktop preserves the Den API URL in its bootstrap, uses Den for architecture correction and stable updates, and uses Electron networking for enterprise trust stores.
- macOS alpha updates fail closed unless an operator explicitly configures `OPENWORK_DESKTOP_ALPHA_UPDATE_FEED_URL`.
- Generic installer GitHub fallback now requires `OPENWORK_INSTALLER_RELEASE_FALLBACK_ENABLED=true`.
- Helm values, volume mounts, and the operator guide cover private release delivery. Existing Linux release behavior is intentionally unchanged and Linux installer work remains out of scope.

## Root cause

The generic installer and Electron updater each independently constructed upstream GitHub release URLs. Den could serve a stamped organization installer, but it did not own the signed desktop release or updater feed, and its generic-installer cache fetched GitHub implicitly when a local artifact was absent. That made a fully private install/update path impossible.

## Operator rollout

For zero-egress delivery, mount:

- generic wrappers at `OPENWORK_INSTALLER_ARTIFACTS_DIR`
- the unmodified signed desktop release at `OPENWORK_DESKTOP_RELEASES_DIR/<latestAppVersion>/`

The desktop release directory must include `latest-mac.yml`, `latest.yml`, both Mac DMGs and updater ZIPs, the Windows x64 EXE, and all referenced blockmaps. To support Windows ARM64, also mount `openwork-win-arm64-<version>.exe` and reference it from `latest.yml`; Den advertises ARM64 only when both are present. Keep public fallback disabled.

Connected deployments can opt in explicitly with `OPENWORK_INSTALLER_RELEASE_FALLBACK_ENABLED=true` and/or `OPENWORK_DESKTOP_RELEASES_PUBLIC_BASE_URL`.

## Integration with #2633

This PR remains based directly on `dev` and is independently mergeable. It was audited against #2633's overlapping installer, environment, artifact-resolver, test, documentation, Docker, and Helm edits.

The intended combined behavior is:

1. **Outer organization wrapper (#2633):** signed, byte-stable Windows x64/ARM64 ZIPs with sidecar configuration. Resolution order is mounted wrapper -> cache -> `OPENWORK_INSTALLER_RELEASE_BASE_URL` -> GitHub only when `OPENWORK_INSTALLER_ALLOW_GITHUB_FALLBACK=true`.
2. **Inner desktop release (#2631):** the wrapper asks Den's `/v1/app-version` for its architecture-specific URL. Den serves a mounted versioned release or an explicitly configured desktop mirror; the installer and stable updater never invent a GitHub URL.

When resolving the textual conflicts, keep #2633's durable ZIP/signing flow and canonical outer-wrapper environment names, while keeping #2631's `OPENWORK_DESKTOP_RELEASES_*` settings, Den release routes, manifest validation, range serving, and Den-owned release URL API. In `release-asset.ts`, retain #2631's caller-supplied Den URL and #2633's x64/ARM64 filename support—do not restore the old hardcoded GitHub URL. Documentation and Helm changes are additive: describe both the outer private wrapper base and the inner private desktop/update repository.

## Validation

All feature validation ran in Daytona sandboxes.

### Linux build/test sandbox

- `pnpm --filter @openwork/installer test` — 29 passed, 0 failed.
- `pnpm --filter @openwork/desktop test` — 46 passed, 0 failed, 1 macOS-only skip.
- `pnpm --filter @openwork/desktop typecheck:electron` — passed.
- `pnpm --filter @openwork-ee/den-api exec bun test test/desktop-releases.test.ts test/installer-artifacts.test.ts` — 12 passed, 0 failed.
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` — passed.
- Route-policy exception registration check — 1 passed. The full baseline policy test still reports 12 unrelated uncovered routes already present on `origin/dev`; this PR does not broaden those exceptions.
- `helm lint packaging/helm/openwork-ee` — passed.
- Helm render with both private artifact mounts plus the alpha-feed override — passed and contained all expected env/volume wiring.
- Bun cross-compilation produced PE32+ Windows x64 and ARM64 installers plus a Mach-O arm64 Mac installer.

### Daytona Windows x64

The compiled Windows installer ran in headless dry-run mode from an isolated `C:\ow\airgapped-eval` directory. It:

1. queried the Den-only `/v1/app-version` endpoint,
2. selected Den's `openwork-win-x64-0.17.19.exe`,
3. verified the private artifact with HEAD,
4. wrote an isolated bootstrap with `requireSignin=true`, and
5. contained no GitHub URL.

Result: `WINDOWS_DRY_RUN_PASS`.

### Fraimz

`pnpm fraimz --flow airgapped-desktop-delivery` — **Passed**, 6/6 frames plus voiceover coverage.

The report proves mounted-byte preservation, Den GET/HEAD/range delivery, disabled public wrapper fallback, x64 and ARM64 installer resolution through Den, sign-in-required bootstrap, internal stable updater feed, alpha fail-closed behavior, and the approved-host allowlist.

- Daytona report: [fraimz.html](https://8090-ikblisa9ja5mjhsw.daytonaproxy01.net/2026-07-10T03-25-39-952Z/fraimz.html)
- Sandbox path: `/workspace/evals/results/2026-07-10T03-25-39-952Z/fraimz.html`

The Daytona preview URL is temporary; the full assertions are also summarized in the follow-up PR comment.
