### PR TITLE
Fix organization icons in the Windows taskbar

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -385,11 +385,10 @@ export async function applyBrandAppName(appName: string | null): Promise<string>
   return result.appName;
 }
 
-export async function applyBrandIcon(url: string | null): Promise<boolean> {
+export async function applyBrandIcon(url: string | null): Promise<BrandIconApplyResult> {
   const apply = typeof window !== "undefined" ? window.__OPENWORK_ELECTRON__?.brandIcon?.apply : undefined;
-  if (!apply) return false;
-  const result = await apply(url);
-  return result.ok;
+  if (!apply) return { ok: false, reason: "bridge-unavailable" };
+  return apply(url);
 }
 
 export async function getBrandIconState(): Promise<BrandIconState | null> {

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -177,7 +177,13 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     if (brandIconAction) {
       void applyBrandIcon(
         typeof brandIconAction.nextValue === "string" ? brandIconAction.nextValue : null,
-      ).catch(() => null);
+      ).then((result) => {
+        if (!result.ok) {
+          console.warn(`[brand-icon] Desktop icon was not applied: ${result.reason ?? "unknown failure"}`);
+        }
+      }).catch((error: unknown) => {
+        console.warn("[brand-icon] Desktop icon apply request failed", error);
+      });
     }
 
     const brandAppNameAction = actions.find((action) => action.item === "brandAppName");

--- a/apps/desktop/electron/brand-icon-windows.mjs
+++ b/apps/desktop/electron/brand-icon-windows.mjs
@@ -1,0 +1,134 @@
+import { createHash } from "node:crypto";
+
+const WINDOWS_ICON_SIZES = [16, 24, 32, 48, 64, 128, 256];
+const WINDOWS_APP_USER_MODEL_ID_MAX_LENGTH = 128;
+
+function assertPng(buffer, size) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 24 || buffer.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {
+    throw new Error(`Windows brand icon ${size}x${size} did not encode as PNG.`);
+  }
+}
+
+export function encodeWindowsIcon(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error("Windows brand icon needs at least one image.");
+  }
+
+  const headerSize = 6;
+  const entrySize = 16;
+  const directory = Buffer.alloc(headerSize + entrySize * entries.length);
+  directory.writeUInt16LE(0, 0);
+  directory.writeUInt16LE(1, 2);
+  directory.writeUInt16LE(entries.length, 4);
+
+  let imageOffset = directory.length;
+  for (const [index, entry] of entries.entries()) {
+    const size = Number(entry?.size);
+    const png = entry?.png;
+    if (!Number.isInteger(size) || size < 1 || size > 256) {
+      throw new Error(`Invalid Windows brand icon size: ${entry?.size}`);
+    }
+    assertPng(png, size);
+
+    const offset = headerSize + index * entrySize;
+    directory.writeUInt8(size === 256 ? 0 : size, offset);
+    directory.writeUInt8(size === 256 ? 0 : size, offset + 1);
+    directory.writeUInt8(0, offset + 2);
+    directory.writeUInt8(0, offset + 3);
+    directory.writeUInt16LE(1, offset + 4);
+    directory.writeUInt16LE(32, offset + 6);
+    directory.writeUInt32LE(png.length, offset + 8);
+    directory.writeUInt32LE(imageOffset, offset + 12);
+    imageOffset += png.length;
+  }
+
+  return Buffer.concat([directory, ...entries.map((entry) => entry.png)]);
+}
+
+export function windowsIconFromNativeImage(image) {
+  return encodeWindowsIcon(WINDOWS_ICON_SIZES.map((size) => ({
+    size,
+    png: image.resize({ width: size, height: size, quality: "best" }).toPNG(),
+  })));
+}
+
+export function windowsBrandAppUserModelId(baseAppId, sourceUrl) {
+  const base = String(baseAppId ?? "").trim();
+  if (!base) throw new Error("Windows brand icon requires an App User Model ID.");
+  const source = String(sourceUrl ?? "").trim();
+  if (!source) return base;
+
+  // A window-level AppUserModelID overrides the process/installed-shortcut
+  // identity. Without a distinct ID, Windows keeps rendering the executable's
+  // stock icon for the taskbar group even after WM_SETICON updates the title
+  // bar and Alt-Tab image.
+  const suffix = `.brand.${createHash("sha256").update(source).digest("hex").slice(0, 16)}`;
+  return `${base.slice(0, WINDOWS_APP_USER_MODEL_ID_MAX_LENGTH - suffix.length)}${suffix}`;
+}
+
+export function windowsBrandShortcutFileName(appName) {
+  const safeName = String(appName ?? "OpenWork")
+    .replace(/[<>:"/\\|?*]/g, "-")
+    .trim() || "OpenWork";
+  return `${safeName} Organization.lnk`;
+}
+
+export function windowsBrandShortcutDetails({ target, appId, appIconPath, appName }) {
+  return {
+    target,
+    cwd: target.replace(/[\\/][^\\/]+$/, ""),
+    description: `${appName} organization desktop`,
+    icon: appIconPath,
+    iconIndex: 0,
+    appUserModelId: appId,
+  };
+}
+
+export function writeWindowsBrandShortcut(shellApi, shortcutPath, details, shortcutExists) {
+  return shellApi.writeShortcutLink(shortcutPath, shortcutExists ? "replace" : "create", details);
+}
+
+const WINDOWS_TASKBAR_REFRESH_DELAY_MS = 250;
+
+function waitForWindowsTaskbarRefresh() {
+  return new Promise((resolve) => setTimeout(resolve, WINDOWS_TASKBAR_REFRESH_DELAY_MS));
+}
+
+export async function applyWindowsTaskbarIcon(window, {
+  image,
+  appId,
+  appIconPath,
+  relaunchCommand,
+  relaunchDisplayName,
+}, waitForRefresh = waitForWindowsTaskbarRefresh) {
+  const refreshVisibleButton = window.isVisible() && typeof window.setSkipTaskbar === "function";
+
+  // Explorer coalesces a synchronous true -> false toggle and retains its
+  // cached EXE icon. Remove the live button first, then give Explorer a turn
+  // on each side of staging the new window identity.
+  if (refreshVisibleButton) window.setSkipTaskbar(true);
+
+  try {
+    if (refreshVisibleButton) await waitForRefresh();
+    // Chromium's SetAppDetailsForWindow writes AppUserModel.ID before the
+    // relaunch properties. Windows treats the ID write as the taskbar refresh
+    // event, so a single call refreshes too early and can keep the EXE icon.
+    // Stage every relaunch property first, then make the desired ID the final
+    // write after RelaunchIconResource is already present.
+    window.setAppDetails({
+      appIconPath,
+      appIconIndex: 0,
+      relaunchCommand,
+      relaunchDisplayName,
+    });
+    window.setAppDetails({ appId });
+    window.setIcon(image);
+
+    if (refreshVisibleButton) await waitForRefresh();
+  } finally {
+    // Never strand the app outside the taskbar if native staging fails.
+    if (refreshVisibleButton) window.setSkipTaskbar(false);
+  }
+}
+
+export { WINDOWS_APP_USER_MODEL_ID_MAX_LENGTH, WINDOWS_ICON_SIZES };

--- a/apps/desktop/electron/brand-icon-windows.test.mjs
+++ b/apps/desktop/electron/brand-icon-windows.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyWindowsTaskbarIcon,
+  encodeWindowsIcon,
+  WINDOWS_APP_USER_MODEL_ID_MAX_LENGTH,
+  WINDOWS_ICON_SIZES,
+  windowsBrandAppUserModelId,
+  windowsBrandShortcutDetails,
+  windowsBrandShortcutFileName,
+  writeWindowsBrandShortcut,
+  windowsIconFromNativeImage,
+} from "./brand-icon-windows.mjs";
+
+const PNG_SIGNATURE = Buffer.from("89504e470d0a1a0a", "hex");
+
+function fakePng(size) {
+  const png = Buffer.alloc(24);
+  PNG_SIGNATURE.copy(png);
+  png.writeUInt32BE(size, 16);
+  png.writeUInt32BE(size, 20);
+  return png;
+}
+
+test("encodes PNG entries into a Windows ICO directory", () => {
+  const entries = [16, 256].map((size) => ({ size, png: fakePng(size) }));
+  const icon = encodeWindowsIcon(entries);
+
+  assert.equal(icon.readUInt16LE(0), 0);
+  assert.equal(icon.readUInt16LE(2), 1);
+  assert.equal(icon.readUInt16LE(4), 2);
+  assert.equal(icon.readUInt8(6), 16);
+  assert.equal(icon.readUInt8(7), 16);
+  assert.equal(icon.readUInt8(22), 0);
+  assert.equal(icon.readUInt8(23), 0);
+  assert.equal(icon.readUInt16LE(10), 1);
+  assert.equal(icon.readUInt16LE(12), 32);
+  assert.equal(icon.readUInt32LE(18), 38);
+  assert.deepEqual(icon.subarray(38, 46), PNG_SIGNATURE);
+});
+
+test("renders the standard Windows icon sizes from a native image", () => {
+  const rendered = [];
+  const image = {
+    resize(options) {
+      rendered.push(options);
+      return { toPNG: () => fakePng(options.width) };
+    },
+  };
+
+  const icon = windowsIconFromNativeImage(image);
+
+  assert.deepEqual(rendered.map((entry) => entry.width), WINDOWS_ICON_SIZES);
+  assert.ok(rendered.every((entry) => entry.width === entry.height && entry.quality === "best"));
+  assert.equal(icon.readUInt16LE(4), WINDOWS_ICON_SIZES.length);
+});
+
+test("rejects malformed icon entries", () => {
+  assert.throws(() => encodeWindowsIcon([]), /at least one image/);
+  assert.throws(() => encodeWindowsIcon([{ size: 32, png: Buffer.from("not png") }]), /did not encode as PNG/);
+  assert.throws(() => encodeWindowsIcon([{ size: 512, png: fakePng(512) }]), /Invalid Windows brand icon size/);
+});
+
+test("updates both the live window icon and Windows taskbar identity", async () => {
+  const calls = [];
+  const window = {
+    isVisible() {
+      return true;
+    },
+    setIcon(image) {
+      calls.push(["setIcon", image]);
+    },
+    setAppDetails(details) {
+      calls.push(["setAppDetails", details]);
+    },
+    setSkipTaskbar(value) {
+      calls.push(["setSkipTaskbar", value]);
+    },
+  };
+  const image = { id: "company-icon" };
+
+  await applyWindowsTaskbarIcon(window, {
+    image,
+    appId: "com.differentai.openwork",
+    appIconPath: "C:\\Users\\Admin\\brand-icon.ico",
+    relaunchCommand: "C:\\Program Files\\OpenWork\\OpenWork.exe",
+    relaunchDisplayName: "OpenWork",
+  }, async () => calls.push(["waitForRefresh"]));
+
+  assert.deepEqual(calls, [
+    ["setSkipTaskbar", true],
+    ["waitForRefresh"],
+    ["setAppDetails", {
+      appIconPath: "C:\\Users\\Admin\\brand-icon.ico",
+      appIconIndex: 0,
+      relaunchCommand: "C:\\Program Files\\OpenWork\\OpenWork.exe",
+      relaunchDisplayName: "OpenWork",
+    }],
+    ["setAppDetails", { appId: "com.differentai.openwork" }],
+    ["setIcon", image],
+    ["waitForRefresh"],
+    ["setSkipTaskbar", false],
+  ]);
+});
+
+test("uses a stable per-brand AppUserModelID to avoid the installed shortcut icon", () => {
+  const base = "com.differentai.openwork";
+  const first = windowsBrandAppUserModelId(base, "https://den.internal/assets/acme.png");
+  const repeated = windowsBrandAppUserModelId(base, "https://den.internal/assets/acme.png");
+  const second = windowsBrandAppUserModelId(base, "https://den.internal/assets/other.png");
+
+  assert.match(first, /^com\.differentai\.openwork\.brand\.[a-f0-9]{16}$/);
+  assert.equal(first, repeated);
+  assert.notEqual(first, second);
+  assert.equal(windowsBrandAppUserModelId(base, null), base);
+  assert.ok(windowsBrandAppUserModelId("a".repeat(200), "https://den.internal/icon.png").length <= WINDOWS_APP_USER_MODEL_ID_MAX_LENGTH);
+});
+
+test("does not refresh the taskbar button before the boot window is shown", async () => {
+  const calls = [];
+  await applyWindowsTaskbarIcon({
+    isVisible: () => false,
+    setAppDetails: () => calls.push("details"),
+    setIcon: () => calls.push("icon"),
+    setSkipTaskbar: () => calls.push("skip"),
+  }, {
+    image: { id: "company-icon" },
+    appId: "com.differentai.openwork.brand.1234",
+    appIconPath: "C:\\brand.ico",
+    relaunchCommand: "C:\\OpenWork.exe",
+    relaunchDisplayName: "OpenWork",
+  }, async () => calls.push("wait"));
+
+  assert.deepEqual(calls, ["details", "details", "icon"]);
+});
+
+test("restores a visible taskbar button when refresh staging fails", async () => {
+  const calls = [];
+  await assert.rejects(() => applyWindowsTaskbarIcon({
+    isVisible: () => true,
+    setAppDetails: () => calls.push("details"),
+    setIcon: () => calls.push("icon"),
+    setSkipTaskbar: (value) => calls.push(["skip", value]),
+  }, {
+    image: { id: "company-icon" },
+    appId: "com.differentai.openwork.brand.1234",
+    appIconPath: "C:\\brand.ico",
+    relaunchCommand: "C:\\OpenWork.exe",
+    relaunchDisplayName: "OpenWork",
+  }, async () => {
+    calls.push("wait");
+    throw new Error("refresh failed");
+  }), /refresh failed/);
+
+  assert.deepEqual(calls, [["skip", true], "wait", ["skip", false]]);
+});
+
+test("builds a per-user Start Menu shortcut with the branded Windows identity", () => {
+  assert.equal(windowsBrandShortcutFileName('Agent: Blue/West'), "Agent- Blue-West Organization.lnk");
+  assert.deepEqual(windowsBrandShortcutDetails({
+    target: "C:\\Program Files\\OpenWork\\OpenWork.exe",
+    appId: "com.differentai.openwork.brand.1234",
+    appIconPath: "C:\\Users\\Admin\\brand-icon.ico",
+    appName: "OpenWork",
+  }), {
+    target: "C:\\Program Files\\OpenWork\\OpenWork.exe",
+    cwd: "C:\\Program Files\\OpenWork",
+    description: "OpenWork organization desktop",
+    icon: "C:\\Users\\Admin\\brand-icon.ico",
+    iconIndex: 0,
+    appUserModelId: "com.differentai.openwork.brand.1234",
+  });
+});
+
+test("creates a first-time branded shortcut and replaces it on repeat applies", () => {
+  const calls = [];
+  const details = { appUserModelId: "com.differentai.openwork.brand.1234" };
+  const shellApi = {
+    writeShortcutLink: (...args) => {
+      calls.push(args);
+      return true;
+    },
+  };
+  const shortcutPath = "C:\\Users\\Admin\\OpenWork Organization.lnk";
+
+  const created = writeWindowsBrandShortcut(shellApi, shortcutPath, details, false);
+  const replaced = writeWindowsBrandShortcut(shellApi, shortcutPath, details, true);
+
+  assert.equal(created, true);
+  assert.equal(replaced, true);
+  assert.deepEqual(calls, [
+    [shortcutPath, "create", details],
+    [shortcutPath, "replace", details],
+  ]);
+});

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -33,6 +33,14 @@ import { createApplicationMenu } from "./app-menu.mjs";
 import { createBrowserPanel } from "./browser-panel.mjs";
 import { createWorkspaceStore } from "./workspace-store.mjs";
 import { openExternalUrl } from "./open-external.mjs";
+import {
+  applyWindowsTaskbarIcon,
+  windowsBrandAppUserModelId,
+  windowsBrandShortcutDetails,
+  windowsBrandShortcutFileName,
+  writeWindowsBrandShortcut,
+  windowsIconFromNativeImage,
+} from "./brand-icon-windows.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -282,6 +290,7 @@ const BRAND_ICON_FETCH_TIMEOUT_MS = 10_000;
 // that expect a browser request behave the same at save time and apply time.
 const BRAND_ICON_FETCH_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
 let brandIconApplySequence = 0;
+let brandIconRuntimeState = { applied: false, sourceUrl: null, reason: null };
 
 function brandIconCachePath() {
   return path.join(app.getPath("userData"), "brand-icon.png");
@@ -289,6 +298,46 @@ function brandIconCachePath() {
 
 function brandIconSidecarPath() {
   return path.join(app.getPath("userData"), "brand-icon.json");
+}
+
+function brandIconWindowsPath() {
+  return path.join(app.getPath("userData"), "brand-icon.ico");
+}
+
+function defaultAppWindowsIconPath() {
+  return path.join(app.getPath("userData"), "openwork-stock.ico");
+}
+
+function windowsBrandShortcutPath() {
+  return path.join(
+    app.getPath("appData"),
+    "Microsoft",
+    "Windows",
+    "Start Menu",
+    "Programs",
+    windowsBrandShortcutFileName(APP_NAME),
+  );
+}
+
+async function registerWindowsBrandShortcut(appId, appIconPath) {
+  if (process.platform !== "win32") return null;
+  const shortcutPath = windowsBrandShortcutPath();
+  await mkdir(path.dirname(shortcutPath), { recursive: true });
+  // Create is required for a first-time link; refreshes and relaunches replace
+  // the same per-user link so its icon and AppUserModelID stay current.
+  const written = writeWindowsBrandShortcut(shell, shortcutPath, windowsBrandShortcutDetails({
+    target: process.execPath,
+    appId,
+    appIconPath,
+    appName: APP_NAME,
+  }), existsSync(shortcutPath));
+  if (!written) throw new Error(`Windows rejected the organization shortcut: ${shortcutPath}`);
+  return shortcutPath;
+}
+
+async function removeWindowsBrandShortcut() {
+  if (process.platform !== "win32") return;
+  await rm(windowsBrandShortcutPath(), { force: true });
 }
 
 function resolveBrandIconImage() {
@@ -302,23 +351,94 @@ function resolveBrandIconImage() {
   }
 }
 
-function applyAppIconImage(image) {
-  if (!image || image.isEmpty()) return;
+function brandIconFailure(reason, error) {
+  const detail = error instanceof Error ? error.message : String(error ?? "");
+  console.warn(`[brand-icon] ${reason}${detail ? `: ${detail}` : ""}`);
+  return { ok: false, reason };
+}
+
+function recordBrandIconResult(result, sourceUrl) {
+  if (result.ok) {
+    brandIconRuntimeState = {
+      applied: typeof sourceUrl === "string",
+      sourceUrl: typeof sourceUrl === "string" ? sourceUrl : null,
+      reason: null,
+    };
+  } else {
+    brandIconRuntimeState = { ...brandIconRuntimeState, reason: result.reason ?? "apply-failed" };
+  }
+  return result;
+}
+
+async function applyAppIconImage(image, { taskbarIconPath = null, taskbarAppId = APP_IDENTIFIER } = {}) {
+  if (!image || image.isEmpty()) return brandIconFailure("invalid-image");
   try {
     if (process.platform === "darwin") {
-      if (app.dock) app.dock.setIcon(image);
-      return;
+      if (!app.dock) return brandIconFailure("dock-unavailable");
+      app.dock.setIcon(image);
+      return { ok: true };
     }
-    mainWindow?.setIcon(image);
-  } catch {
-    // Icon application failures should never take down the app.
+
+    if (!mainWindow) return brandIconFailure("window-unavailable");
+    if (process.platform === "win32") {
+      if (!taskbarIconPath || !existsSync(taskbarIconPath)) {
+        return brandIconFailure("taskbar-icon-missing");
+      }
+      await applyWindowsTaskbarIcon(mainWindow, {
+        image,
+        appId: taskbarAppId,
+        appIconPath: taskbarIconPath,
+        relaunchCommand: process.execPath,
+        relaunchDisplayName: APP_NAME,
+      });
+    } else {
+      mainWindow.setIcon(image);
+    }
+    return { ok: true };
+  } catch (error) {
+    return brandIconFailure("os-apply-failed", error);
   }
 }
 
-function applyDefaultAppIconImage() {
-  if (APP_ICON_IMAGE && !APP_ICON_IMAGE.isEmpty()) {
-    applyAppIconImage(APP_ICON_IMAGE);
+async function applyDefaultAppIconImage(expectedSequence = null) {
+  let image = APP_ICON_IMAGE;
+  let taskbarIconPath = null;
+  if (process.platform === "win32") {
+    try {
+      await removeWindowsBrandShortcut();
+      app.setAppUserModelId(APP_IDENTIFIER);
+    } catch (error) {
+      return brandIconFailure("shortcut-remove-failed", error);
+    }
+    if (image && !image.isEmpty()) {
+      try {
+        taskbarIconPath = defaultAppWindowsIconPath();
+        await writeWindowsIconFile(image, taskbarIconPath);
+      } catch (error) {
+        return brandIconFailure("stock-icon-unavailable", error);
+      }
+    } else {
+      try {
+        const executableIcon = await app.getFileIcon(process.execPath, { size: "large" });
+        if (executableIcon && !executableIcon.isEmpty()) image = executableIcon;
+        taskbarIconPath = process.execPath;
+      } catch (error) {
+        return brandIconFailure("stock-icon-unavailable", error);
+      }
+    }
   }
+  if (!image || image.isEmpty()) {
+    // Preserve the pre-existing no-op fallback on platforms whose packaged
+    // application icon is managed entirely by the bundle.
+    return process.platform === "win32" ? brandIconFailure("stock-icon-unavailable") : { ok: true };
+  }
+  if (expectedSequence !== null && expectedSequence !== brandIconApplySequence) {
+    return { ok: false, reason: "stale" };
+  }
+  return applyAppIconImage(image, {
+    taskbarIconPath,
+    taskbarAppId: APP_IDENTIFIER,
+  });
 }
 
 async function readBrandIconSidecar() {
@@ -334,6 +454,7 @@ async function clearBrandIconCache() {
   await Promise.all([
     rm(brandIconCachePath(), { force: true }),
     rm(brandIconSidecarPath(), { force: true }),
+    rm(brandIconWindowsPath(), { force: true }),
   ]);
 }
 
@@ -353,8 +474,10 @@ async function fetchBrandIconBuffer(sourceUrl) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), BRAND_ICON_FETCH_TIMEOUT_MS);
   try {
-    const response = await fetch(sourceUrl, {
+    const response = await electronNet.fetch(sourceUrl, {
       signal: controller.signal,
+      credentials: "omit",
+      cache: "no-store",
       headers: {
         "user-agent": BRAND_ICON_FETCH_USER_AGENT,
         accept: "image/*,*/*",
@@ -391,59 +514,115 @@ function brandIconImageRejectionReason(image) {
 async function writeBrandIconCache(image, sourceUrl) {
   const cachePath = brandIconCachePath();
   const sidecarPath = brandIconSidecarPath();
+  const windowsPath = brandIconWindowsPath();
   const suffix = `${process.pid}-${Date.now()}`;
   const cacheTempPath = `${cachePath}.${suffix}.tmp`;
   const sidecarTempPath = `${sidecarPath}.${suffix}.tmp`;
+  const windowsTempPath = `${windowsPath}.${suffix}.tmp`;
+  const windowsIcon = process.platform === "win32" ? windowsIconFromNativeImage(image) : null;
   try {
     await mkdir(path.dirname(cachePath), { recursive: true });
     await writeFile(cacheTempPath, image.toPNG());
+    if (windowsIcon) await writeFile(windowsTempPath, windowsIcon);
     await writeFile(sidecarTempPath, JSON.stringify({
       sourceUrl,
       appliedAt: new Date().toISOString(),
       appVersion: app.getVersion(),
     }, null, 2), "utf8");
     await rename(cacheTempPath, cachePath);
+    if (windowsIcon) await rename(windowsTempPath, windowsPath);
     await rename(sidecarTempPath, sidecarPath);
   } catch (error) {
     await Promise.all([
       rm(cacheTempPath, { force: true }),
       rm(sidecarTempPath, { force: true }),
+      rm(windowsTempPath, { force: true }),
     ]).catch(() => undefined);
     throw error;
   }
 }
 
+async function writeWindowsIconFile(image, destination) {
+  const tempPath = `${destination}.${process.pid}-${Date.now()}.tmp`;
+  try {
+    await mkdir(path.dirname(destination), { recursive: true });
+    await writeFile(tempPath, windowsIconFromNativeImage(image));
+    await rename(tempPath, destination);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function ensureWindowsBrandIcon(image) {
+  if (process.platform !== "win32") return null;
+  const windowsPath = brandIconWindowsPath();
+  if (!existsSync(windowsPath)) await writeWindowsIconFile(image, windowsPath);
+  return windowsPath;
+}
+
+async function applyCachedBrandIcon(image, sourceUrl, expectedSequence = null) {
+  let taskbarIconPath = null;
+  let taskbarAppId = APP_IDENTIFIER;
+  try {
+    taskbarIconPath = await ensureWindowsBrandIcon(image);
+    if (process.platform === "win32") {
+      taskbarAppId = windowsBrandAppUserModelId(APP_IDENTIFIER, sourceUrl);
+      await registerWindowsBrandShortcut(taskbarAppId, taskbarIconPath);
+      app.setAppUserModelId(taskbarAppId);
+    }
+  } catch (error) {
+    if (expectedSequence !== null && expectedSequence !== brandIconApplySequence) {
+      return { ok: false, reason: "stale" };
+    }
+    return recordBrandIconResult(brandIconFailure("write-failed", error), sourceUrl);
+  }
+  if (expectedSequence !== null && expectedSequence !== brandIconApplySequence) {
+    return { ok: false, reason: "stale" };
+  }
+  return recordBrandIconResult(await applyAppIconImage(image, {
+    taskbarIconPath,
+    taskbarAppId,
+  }), sourceUrl);
+}
+
 async function applyBrandIconUrl(value) {
   const sequence = ++brandIconApplySequence;
   if (value === null) {
-    await clearBrandIconCache().catch(() => undefined);
-    applyDefaultAppIconImage();
-    return { ok: true };
+    const result = await applyDefaultAppIconImage(sequence);
+    if (result.reason === "stale") return result;
+    const applied = recordBrandIconResult(result, null);
+    if (!applied.ok) return applied;
+    try {
+      await clearBrandIconCache();
+      return applied;
+    } catch (error) {
+      return recordBrandIconResult(brandIconFailure("clear-failed", error), null);
+    }
   }
 
   const sourceUrl = normalizeBrandIconSourceUrl(value);
-  if (!sourceUrl) return { ok: false, reason: "invalid-url" };
+  if (!sourceUrl) return recordBrandIconResult(brandIconFailure("invalid-url"), null);
 
   const sidecar = await readBrandIconSidecar();
   const cachedImage = resolveBrandIconImage();
   if (sidecar?.sourceUrl === sourceUrl && cachedImage) {
-    applyAppIconImage(cachedImage);
-    return { ok: true };
+    return applyCachedBrandIcon(cachedImage, sourceUrl, sequence);
   }
 
   const fetched = await fetchBrandIconBuffer(sourceUrl);
-  if (!fetched.ok) return { ok: false, reason: fetched.reason };
   if (sequence !== brandIconApplySequence) return { ok: false, reason: "stale" };
+  if (!fetched.ok) return recordBrandIconResult(brandIconFailure(fetched.reason), sourceUrl);
 
   const image = nativeImage.createFromBuffer(fetched.buffer);
   const rejectionReason = brandIconImageRejectionReason(image);
-  if (rejectionReason) return { ok: false, reason: rejectionReason };
-  if (sequence !== brandIconApplySequence) return { ok: false, reason: "stale" };
+  if (rejectionReason) return recordBrandIconResult(brandIconFailure(rejectionReason), sourceUrl);
 
   try {
     await writeBrandIconCache(image, sourceUrl);
-  } catch {
-    return { ok: false, reason: "write-failed" };
+  } catch (error) {
+    if (sequence !== brandIconApplySequence) return { ok: false, reason: "stale" };
+    return recordBrandIconResult(brandIconFailure("write-failed", error), sourceUrl);
   }
   if (sequence !== brandIconApplySequence) {
     const latestSidecar = await readBrandIconSidecar();
@@ -452,16 +631,11 @@ async function applyBrandIconUrl(value) {
     }
     return { ok: false, reason: "stale" };
   }
-  applyAppIconImage(image);
-  return { ok: true };
+  return applyCachedBrandIcon(image, sourceUrl, sequence);
 }
 
 async function getBrandIconState() {
-  const sidecar = await readBrandIconSidecar();
-  return {
-    applied: Boolean(resolveBrandIconImage()),
-    sourceUrl: typeof sidecar?.sourceUrl === "string" ? sidecar.sourceUrl : null,
-  };
+  return { ...brandIconRuntimeState };
 }
 
 const INITIAL_APP_ICON_IMAGE = resolveBrandIconImage() ?? APP_ICON_IMAGE;
@@ -1727,7 +1901,20 @@ async function createMainWindow() {
     });
   }
 
-  const windowIconImage = resolveBrandIconImage() ?? APP_ICON_IMAGE;
+  const bootSidecar = await readBrandIconSidecar();
+  const bootSourceUrl = typeof bootSidecar?.sourceUrl === "string" ? bootSidecar.sourceUrl : null;
+  const cachedBrandImage = bootSourceUrl ? resolveBrandIconImage() : null;
+  const windowIconImage = cachedBrandImage ?? APP_ICON_IMAGE;
+  if (process.platform === "win32" && cachedBrandImage && bootSourceUrl) {
+    try {
+      const taskbarIconPath = await ensureWindowsBrandIcon(cachedBrandImage);
+      const taskbarAppId = windowsBrandAppUserModelId(APP_IDENTIFIER, bootSourceUrl);
+      await registerWindowsBrandShortcut(taskbarAppId, taskbarIconPath);
+      app.setAppUserModelId(taskbarAppId);
+    } catch (error) {
+      console.warn("[brand-icon] failed to register cached Windows shortcut before window creation", error);
+    }
+  }
   if (process.platform === "darwin" && windowIconImage && !windowIconImage.isEmpty() && app.dock) {
     app.dock.setIcon(windowIconImage);
   }
@@ -1737,6 +1924,7 @@ async function createMainWindow() {
     height: 820,
     title: currentDisplayAppName,
     show: false,
+    ...(process.platform === "win32" ? { skipTaskbar: true } : {}),
     ...windowAppearanceOptions,
     ...(windowIconImage && !windowIconImage.isEmpty() ? { icon: windowIconImage } : {}),
     webPreferences: {
@@ -1752,6 +1940,9 @@ async function createMainWindow() {
       plugins: true,
     },
   });
+  if (cachedBrandImage && bootSourceUrl) {
+    await applyCachedBrandIcon(cachedBrandImage, bootSourceUrl);
+  }
   applicationMenu.applyVisibility(mainWindow);
 
   mainWindow.on("page-title-updated", (event) => {
@@ -1762,6 +1953,7 @@ async function createMainWindow() {
 
   mainWindow.once("ready-to-show", () => {
     mainWindow?.setTitle(currentDisplayAppName);
+    if (process.platform === "win32") mainWindow?.setSkipTaskbar(false);
     mainWindow?.show();
     flushPendingDeepLinks();
   });

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/brand-icon-windows.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.17.11",

--- a/evals/flows/desktop-brand-icon.flow.mjs
+++ b/evals/flows/desktop-brand-icon.flow.mjs
@@ -163,6 +163,12 @@ async function navigateAdminOrgSettings(ctx) {
   // keeps the failed access-check state. A full document load with the fresh
   // cookie recovers it.
   await panelEval(ctx, `location.replace(${JSON.stringify(orgSettingsUrl(ctx))})`).catch(() => undefined);
+  // Daytona's proxy can serve a fully cached Next dev document/chunk set that
+  // never hydrates (the visible page stays on "Checking workspace access"
+  // even though every resource returned 200). Bypass the browser cache for
+  // this proof navigation so the panel executes the current client bundle.
+  await sleep(500);
+  await withPanelClient(ctx, (client) => client.send("Page.reload", { ignoreCache: true })).catch(() => undefined);
   // Cold next-dev compiles and the workspace-access check can exceed 30s on a
   // freshly (re)started stack; retry the reload once midway.
   try {
@@ -170,6 +176,8 @@ async function navigateAdminOrgSettings(ctx) {
   } catch {
     ctx.log("Org settings not ready after 45s; hard-reloading once (cold dev-server compile).");
     await panelEval(ctx, `location.replace(${JSON.stringify(orgSettingsUrl(ctx))})`).catch(() => undefined);
+    await sleep(500);
+    await withPanelClient(ctx, (client) => client.send("Page.reload", { ignoreCache: true })).catch(() => undefined);
     await waitForPanel(ctx, settingsReady, { timeoutMs: 60_000, label: "Brand Appearance card with Icon URL (retry)" });
   }
   await panelEval(ctx, `(() => {

--- a/evals/flows/windows-brand-icon-real-taskbar.flow.mjs
+++ b/evals/flows/windows-brand-icon-real-taskbar.flow.mjs
@@ -1,0 +1,352 @@
+import { readFile } from "node:fs/promises";
+
+import {
+  ORG_SETTINGS_PATH,
+  adminEnsureFreshAuth,
+  assertSignedIntoDen,
+  clickSaveSettings,
+  denFetch,
+  ensureRendererMounted,
+  ensureWorkspaceReady,
+  memberRefresh,
+  navigateAdminOrgSettings,
+  openAdminPanel,
+  panelEval,
+  setIconUrlInPanel,
+  sleep,
+  waitForBrandIconState,
+  waitForDesktopConfig,
+  waitUntil,
+} from "./desktop-brand-icon.flow.mjs";
+import {
+  daytonaComputerUsePress,
+  daytonaComputerUseStart,
+  daytonaComputerUseType,
+  daytonaComputerUseWindows,
+} from "../runner/daytona-computer-use.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/windows-brand-icon-real-taskbar.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("windows-brand-icon-real-taskbar");
+
+function sandboxId(ctx) {
+  return (ctx.env.OPENWORK_EVAL_DAYTONA_SANDBOX_ID || ctx.env.OPENWORK_EVAL_DAYTONA_SANDBOX).trim();
+}
+
+function testIconUrl(ctx) {
+  return ctx.env.OPENWORK_EVAL_BRAND_ICON_URL.trim();
+}
+
+async function getBrandIconState(ctx) {
+  return ctx.eval("window.__OPENWORK_ELECTRON__?.brandIcon?.getState?.()", { awaitPromise: true });
+}
+
+async function closeAdminPanel(ctx) {
+  await ctx.eval(`(async () => {
+    await window.__OPENWORK_ELECTRON__?.browser?.closeAllTabs?.();
+    await window.__OPENWORK_ELECTRON__?.browser?.hide?.();
+    return true;
+  })()`, { awaitPromise: true });
+  await ensureWorkspaceReady(ctx);
+  await ctx.waitForText("Search sessions", { timeoutMs: 30_000 });
+}
+
+async function windowsExec(ctx, label, command) {
+  const encoded = Buffer.from(command, "utf16le").toString("base64");
+  const toolboxBase = (ctx.env.DAYTONA_TOOLBOX_URL || "https://proxy.app.daytona.io/toolbox").replace(/\/$/, "");
+  const response = await fetch(`${toolboxBase}/${encodeURIComponent(sandboxId(ctx))}/process/execute`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${ctx.env.DAYTONA_API_KEY}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      command: `powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encoded}`,
+      timeout: 60,
+    }),
+    signal: AbortSignal.timeout(70_000),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || payload.exitCode !== 0) {
+    throw new Error(`Daytona Windows ${label} failed (${response.status}/${payload.exitCode ?? "unknown"}): ${payload.result ?? ""}`.trim());
+  }
+  const stdout = typeof payload.result === "string" ? payload.result : "";
+  ctx.log(`Daytona Windows ${label}: ${stdout.trim().slice(0, 500)}`);
+  return { stdout };
+}
+
+async function assertWindowsBrandShortcut(ctx, expected) {
+  const result = await windowsExec(ctx, "check organization shortcut", `
+$path = 'C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\OpenWork Organization.lnk'
+if (Test-Path -LiteralPath $path) { Write-Output 'present' } else { Write-Output 'absent' }
+`);
+  const actual = result.stdout.match(/(?:^|\r?\n)(present|absent)(?:\r?\n|$)/)?.[1] ?? result.stdout.trim();
+  ctx.assert(actual === expected, `Expected branded Start Menu shortcut to be ${expected}, got ${actual}`);
+  ctx.recordEvidence({
+    type: "assertion",
+    status: "passed",
+    assertion: expected === "present"
+      ? "The per-user branded Start Menu shortcut exists"
+      : "The per-user branded Start Menu shortcut was removed",
+    actual,
+  });
+}
+
+async function installAltTabHarness(ctx) {
+  const source = await readFile(new URL("../support/windows-hold-alt-tab.ps1", import.meta.url), "utf8");
+  const payload = Buffer.from(source, "utf8").toString("base64");
+  await windowsExec(ctx, "install Alt-Tab harness", `
+$directory = 'C:\\ow'
+New-Item -ItemType Directory -Path $directory -Force | Out-Null
+[IO.File]::WriteAllBytes('C:\\ow\\windows-hold-alt-tab.ps1', [Convert]::FromBase64String('${payload}'))
+Write-Output 'C:\\ow\\windows-hold-alt-tab.ps1'
+`);
+}
+
+async function showAltTabSwitcher(ctx) {
+  const sandbox = sandboxId(ctx);
+  // The key endpoint works across both the current Computer Use plugin and
+  // older Windows snapshots whose hotkey parser does not normalize win/cmd.
+  await daytonaComputerUsePress(sandbox, "r", ["cmd"]);
+  await sleep(300);
+  await daytonaComputerUseType(
+    sandbox,
+    "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\\ow\\windows-hold-alt-tab.ps1",
+  );
+  await daytonaComputerUsePress(sandbox, "enter");
+  await sleep(1_200);
+}
+
+async function assertOpenWorkWindow(ctx) {
+  const result = await daytonaComputerUseWindows(sandboxId(ctx));
+  const windows = Array.isArray(result?.windows) ? result.windows : [];
+  const openwork = windows.find((entry) => /openwork/i.test(entry?.title ?? ""));
+  ctx.assert(Boolean(openwork), `Daytona Computer Use did not find an OpenWork window: ${JSON.stringify(windows)}`);
+  ctx.recordEvidence({
+    type: "assertion",
+    status: "passed",
+    assertion: "Daytona Computer Use sees the real OpenWork window in the interactive Windows session",
+    actual: openwork?.title,
+  });
+}
+
+async function assertWindowsRuntime(ctx) {
+  const info = await ctx.eval("window.__OPENWORK_ELECTRON__?.system?.getArchitectureInfo?.()", { awaitPromise: true });
+  ctx.assert(info?.platform === "windows", `Expected a Windows Electron build, got ${JSON.stringify(info)}`);
+  ctx.recordEvidence({
+    type: "assertion",
+    status: "passed",
+    assertion: "Electron reports the real Windows runtime",
+    actual: JSON.stringify({ platform: info.platform, appArch: info.appArch, version: info.version }),
+  });
+}
+
+function computerUseScreenshot(name, options = {}) {
+  return {
+    name,
+    sandboxCapture: "computer-use",
+    ...options,
+  };
+}
+
+export default {
+  id: "windows-brand-icon-real-taskbar",
+  title: "Organization icon updates the real Windows taskbar live, at boot, and on clear",
+  kind: "user-facing",
+  spec: "evals/voiceovers/windows-brand-icon-real-taskbar.md",
+  preserveTheme: true,
+  requiredEnv: [
+    "DAYTONA_API_KEY",
+    "OPENWORK_EVAL_BRAND_ICON_URL",
+    "OPENWORK_EVAL_DAYTONA_SANDBOX",
+    "OPENWORK_EVAL_DEN_API_URL",
+    "OPENWORK_EVAL_DEN_TOKEN",
+    "OPENWORK_EVAL_DEN_WEB_URL",
+  ],
+  steps: [
+    {
+      name: "setup",
+      run: async (ctx) => {
+        await daytonaComputerUseStart(sandboxId(ctx));
+        await ensureRendererMounted(ctx);
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 30_000,
+          label: "window.__openworkControl",
+        });
+        await assertWindowsRuntime(ctx);
+        await assertSignedIntoDen(ctx);
+        await waitUntil(ctx, "desktop Den auth provider signed in", async () => {
+          const status = await ctx.control("auth.status", {}).catch(() => null);
+          return status?.status !== "checking" && status?.user ? status : null;
+        }, { timeoutMs: 30_000 });
+        await ensureWorkspaceReady(ctx);
+        await denFetch(ctx, "/v1/org", {
+          method: "PATCH",
+          body: JSON.stringify({ brandIconUrl: null }),
+        });
+        await memberRefresh(ctx);
+        await waitForDesktopConfig(ctx, "server brandIconUrl reset", (config) => !config.brandIconUrl);
+        await waitForBrandIconState(ctx, "stock icon active during setup", (state) =>
+          state?.applied === false && state?.reason === null,
+        30_000, { refresh: true });
+        await installAltTabHarness(ctx);
+        await closeAdminPanel(ctx);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The stock OpenWork icon is visible in the real Windows taskbar", {
+          voiceover: vo[0],
+          action: async () => {
+            await assertOpenWorkWindow(ctx);
+          },
+          assert: async () => {
+            const state = await getBrandIconState(ctx);
+            ctx.assert(state?.applied === false && state?.reason === null, `Expected stock icon state, got ${JSON.stringify(state)}`);
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Native icon state is stock with no apply failure", actual: JSON.stringify(state) });
+          },
+          screenshot: computerUseScreenshot("stock-icon-real-taskbar", { requireText: ["Search sessions"] }),
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The organization owner saves a Den-served square icon", {
+          voiceover: vo[1],
+          action: async () => {
+            await openAdminPanel(ctx);
+            await adminEnsureFreshAuth(ctx);
+            await navigateAdminOrgSettings(ctx);
+            await setIconUrlInPanel(ctx, testIconUrl(ctx));
+            await sleep(300);
+            await clickSaveSettings(ctx);
+          },
+          assert: async () => {
+            const config = await waitForDesktopConfig(ctx, "server brandIconUrl to match the Den-served icon", (body) =>
+              body.brandIconUrl === testIconUrl(ctx),
+            );
+            ctx.assert(config.brandIconUrl === testIconUrl(ctx), `Expected brandIconUrl=${testIconUrl(ctx)}, got ${config.brandIconUrl}`);
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Den API returns the saved on-prem icon URL", actual: config.brandIconUrl });
+            const iconFieldVisible = await panelEval(ctx, `(() => {
+              const input = [...document.querySelectorAll('input')].find((entry) => entry.value === ${JSON.stringify(testIconUrl(ctx))});
+              input?.scrollIntoView({ block: 'center' });
+              return Boolean(input);
+            })()`);
+            ctx.assert(iconFieldVisible, "The saved icon field was not available for visible Windows proof.");
+            await sleep(300);
+          },
+          screenshot: computerUseScreenshot("owner-saves-company-icon", {
+            textTargetUrlIncludes: ORG_SETTINGS_PATH,
+            requireText: ["Brand Appearance", "Icon URL"],
+          }),
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("The live Windows taskbar and Alt-Tab identity use the organization icon", {
+          voiceover: vo[2],
+          action: async () => {
+            await memberRefresh(ctx);
+            await waitForBrandIconState(ctx, "Windows taskbar icon applied", (state) =>
+              state?.applied === true && state?.sourceUrl === testIconUrl(ctx) && state?.reason === null,
+            30_000, { refresh: true });
+            await closeAdminPanel(ctx);
+            await showAltTabSwitcher(ctx);
+          },
+          assert: async () => {
+            const state = await getBrandIconState(ctx);
+            ctx.assert(
+              state?.applied === true && state?.sourceUrl === testIconUrl(ctx) && state?.reason === null,
+              `Expected successful Windows icon state, got ${JSON.stringify(state)}`,
+            );
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Windows setIcon and setAppDetails both completed for the Den-served icon", actual: JSON.stringify(state) });
+            await assertWindowsBrandShortcut(ctx, "present");
+            await assertOpenWorkWindow(ctx);
+          },
+          screenshot: computerUseScreenshot("company-icon-taskbar-and-alt-tab", { requireText: ["Search sessions"] }),
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        let bootState = null;
+        await ctx.prove("Relaunch applies the cached organization icon before the first visible window", {
+          voiceover: vo[3],
+          action: async () => {
+            // Wait for the Alt-Tab harness to release Alt before relaunching.
+            await sleep(8_000);
+            const hasEvalRelaunch = await ctx.eval(
+              "window.__openworkControl.listActions().some((action) => action.id === 'eval.app.relaunch' && !action.disabled)",
+            );
+            try {
+              if (hasEvalRelaunch) {
+                await ctx.control("eval.app.relaunch", {});
+              } else {
+                // Release packages intentionally omit the dev-only control
+                // action. Exercise the production relaunch bridge instead.
+                await ctx.eval("window.__OPENWORK_ELECTRON__.shell.relaunch()", { awaitPromise: true });
+              }
+            } catch (error) {
+              ctx.log(`Relaunch ended during the expected process shutdown: ${error instanceof Error ? error.message : String(error)}`);
+            }
+            // Do not reconnect to the outgoing process while it is shutting down.
+            await sleep(1_000);
+            await ctx.reconnect({ timeoutMs: 120_000 });
+            await ensureRendererMounted(ctx);
+            bootState = await waitForBrandIconState(ctx, "cached Windows taskbar icon after relaunch", (state) =>
+              state?.applied === true && state?.sourceUrl === testIconUrl(ctx) && state?.reason === null,
+            30_000);
+            await ctx.waitForText("Search sessions", { timeoutMs: 30_000 });
+            await sleep(3_000);
+          },
+          assert: async () => {
+            ctx.assert(bootState?.applied === true && bootState?.reason === null, `Expected cached icon at boot, got ${JSON.stringify(bootState)}`);
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "The first relaunched BrowserWindow applied the cached Windows taskbar identity", actual: JSON.stringify(bootState) });
+            await assertOpenWorkWindow(ctx);
+          },
+          screenshot: computerUseScreenshot("company-icon-first-window-after-relaunch", { requireText: ["Search sessions"] }),
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("Clearing organization branding restores the stock Windows icon", {
+          voiceover: vo[4],
+          action: async () => {
+            await openAdminPanel(ctx);
+            await adminEnsureFreshAuth(ctx);
+            await navigateAdminOrgSettings(ctx);
+            await setIconUrlInPanel(ctx, "");
+            await sleep(300);
+            await clickSaveSettings(ctx);
+            await waitForDesktopConfig(ctx, "server brandIconUrl cleared", (body) => !body.brandIconUrl);
+            await memberRefresh(ctx);
+            await waitForBrandIconState(ctx, "stock Windows taskbar icon restored", (state) =>
+              state?.applied === false && state?.sourceUrl === null && state?.reason === null,
+            30_000, { refresh: true });
+            await closeAdminPanel(ctx);
+            await sleep(2_000);
+          },
+          assert: async () => {
+            const state = await getBrandIconState(ctx);
+            ctx.assert(
+              state?.applied === false && state?.sourceUrl === null && state?.reason === null,
+              `Expected restored stock icon, got ${JSON.stringify(state)}`,
+            );
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Windows taskbar identity returned to the executable's stock icon", actual: JSON.stringify(state) });
+            await assertWindowsBrandShortcut(ctx, "absent");
+            await assertOpenWorkWindow(ctx);
+          },
+          screenshot: computerUseScreenshot("stock-icon-restored", { requireText: ["Search sessions"] }),
+        });
+      },
+    },
+  ],
+};

--- a/evals/runner/context.mjs
+++ b/evals/runner/context.mjs
@@ -4,6 +4,7 @@ import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { captureScreenshot, connect, debuggerUrlFor, evaluate, listTargets, pickAppTarget } from "./cdp.mjs";
+import { captureDaytonaComputerUseScreenshot } from "./daytona-computer-use.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -463,17 +464,31 @@ export class EvalContext {
     return Buffer.from(base64Png, "base64");
   }
 
+  async _captureComputerUseScreenshot(sandbox) {
+    const buffer = await captureDaytonaComputerUseScreenshot(sandbox);
+    if (buffer.length === 0) {
+      throw new EvalError("Daytona Computer Use screenshot capture returned no data.");
+    }
+    return buffer;
+  }
+
   async screenshot(name, options = {}) {
     this.screenshotIndex += 1;
     const fileName = `${this.flowId}-${String(this.screenshotIndex).padStart(2, "0")}-${slug(name)}.png`;
-    const sandbox = options.sandboxCapture ? this.env.OPENWORK_EVAL_DAYTONA_SANDBOX?.trim() : null;
+    const sandbox = options.sandboxCapture === "computer-use"
+      ? (this.env.OPENWORK_EVAL_DAYTONA_SANDBOX_ID || this.env.OPENWORK_EVAL_DAYTONA_SANDBOX)?.trim()
+      : options.sandboxCapture
+        ? this.env.OPENWORK_EVAL_DAYTONA_SANDBOX?.trim()
+        : null;
     const targetSelector = !sandbox && (options.targetId || options.targetUrlIncludes);
     const textTargetSelector = options.textTargetId || options.textTargetUrlIncludes;
     let screenshotClient = this.client;
     let closeClients = [];
     let preCapturedBuffer = null;
     if (sandbox) {
-      preCapturedBuffer = await this._captureSandboxScreenshot(sandbox);
+      preCapturedBuffer = options.sandboxCapture === "computer-use"
+        ? await this._captureComputerUseScreenshot(sandbox)
+        : await this._captureSandboxScreenshot(sandbox);
     } else if (targetSelector) {
       // Some CDP page targets (e.g. an embedded browser-panel WebContentsView
       // rather than a top-level BrowserWindow page) do not reliably answer

--- a/evals/runner/daytona-computer-use.mjs
+++ b/evals/runner/daytona-computer-use.mjs
@@ -1,0 +1,63 @@
+function computerUseUrl(id, path) {
+  const base = (process.env.DAYTONA_TOOLBOX_URL || "https://proxy.app.daytona.io/toolbox").replace(/\/$/, "");
+  return `${base}/${encodeURIComponent(id)}${path}`;
+}
+
+async function computerUseRequest(id, path, { method = "GET", body } = {}) {
+  const apiKey = process.env.DAYTONA_API_KEY?.trim();
+  if (!apiKey) throw new Error("Daytona Computer Use requires DAYTONA_API_KEY.");
+  const response = await fetch(computerUseUrl(id, path), {
+    method,
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      accept: "application/json",
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Daytona Computer Use ${method} ${path} failed (${response.status}): ${text.slice(0, 500)}`);
+  }
+  return text ? JSON.parse(text) : {};
+}
+
+export async function captureDaytonaComputerUseScreenshot(id) {
+  const result = await computerUseRequest(id, "/computeruse/screenshot");
+  const encoded = result?.screenshot?.replace(/^data:image\/png;base64,/, "");
+  if (!encoded) throw new Error("Daytona Computer Use returned an empty screenshot.");
+  return Buffer.from(encoded, "base64");
+}
+
+export async function daytonaComputerUseHotkey(id, keys) {
+  await computerUseRequest(id, "/computeruse/keyboard/hotkey", {
+    method: "POST",
+    body: { keys },
+  });
+}
+
+export async function daytonaComputerUsePress(id, key, modifiers = []) {
+  await computerUseRequest(id, "/computeruse/keyboard/key", {
+    method: "POST",
+    body: { key, modifiers },
+  });
+}
+
+export async function daytonaComputerUseStart(id) {
+  return computerUseRequest(id, "/computeruse/start", {
+    method: "POST",
+    body: {},
+  });
+}
+
+export async function daytonaComputerUseType(id, value) {
+  await computerUseRequest(id, "/computeruse/keyboard/type", {
+    method: "POST",
+    body: { text: value, delay: 1 },
+  });
+}
+
+export function daytonaComputerUseWindows(id) {
+  return computerUseRequest(id, "/computeruse/display/windows");
+}

--- a/evals/support/windows-hold-alt-tab.ps1
+++ b/evals/support/windows-hold-alt-tab.ps1
@@ -1,0 +1,25 @@
+$ErrorActionPreference = "Stop"
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class OpenWorkKeyboard {
+    [DllImport("user32.dll")]
+    public static extern void keybd_event(byte virtualKey, byte scanCode, uint flags, UIntPtr extraInfo);
+}
+"@
+
+$keyUp = 0x0002
+$alt = 0x12
+$tab = 0x09
+
+try {
+    [OpenWorkKeyboard]::keybd_event($alt, 0, 0, [UIntPtr]::Zero)
+    [OpenWorkKeyboard]::keybd_event($tab, 0, 0, [UIntPtr]::Zero)
+    [OpenWorkKeyboard]::keybd_event($tab, 0, $keyUp, [UIntPtr]::Zero)
+    Start-Sleep -Seconds 8
+}
+finally {
+    [OpenWorkKeyboard]::keybd_event($alt, 0, $keyUp, [UIntPtr]::Zero)
+}

--- a/evals/voiceovers/windows-brand-icon-real-taskbar.md
+++ b/evals/voiceovers/windows-brand-icon-real-taskbar.md
@@ -1,0 +1,13 @@
+# windows-brand-icon-real-taskbar — Organization branding reaches the real Windows taskbar
+
+This Windows-specific proof complements the cross-platform desktop branding flow. It verifies the running app's native taskbar identity without changing the installer, executable, shortcuts, or product name. The test icon is served by the same private, on-prem Daytona Den environment, so the proof does not depend on a public logo CDN.
+
+1. A Windows teammate launches OpenWork and the stock icon is visible in the real taskbar.
+
+2. The organization owner saves a square company icon in Brand Appearance.
+
+3. Without restarting, the visible Windows taskbar and Alt-Tab icon change to the company icon.
+
+4. After closing and relaunching OpenWork, the branded icon appears from the first visible window.
+
+5. Clearing the organization icon restores the stock OpenWork icon.

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -96,7 +96,7 @@ export type WorkspaceExportSummary = {
 };
 
 export type BrandIconApplyResult = { ok: boolean; reason?: string };
-export type BrandIconState = { applied: boolean; sourceUrl: string | null };
+export type BrandIconState = { applied: boolean; sourceUrl: string | null; reason: string | null };
 export type EvalRelaunchResult = { ok: true };
 
 export type OpencodeCommandDraft = {


### PR DESCRIPTION
## What changed

- Apply an organization-managed icon to the Windows title bar, Alt-Tab switcher, and live taskbar button.
- Generate and cache a multi-resolution `.ico` alongside the validated PNG.
- Give each branded icon a stable AppUserModelID and register a matching per-user `OpenWork Organization` Start Menu shortcut, replacing it on refresh/relaunch and removing it when branding is cleared.
- Stage the cached identity while the boot window is still excluded from the taskbar, then add the correctly branded button before the first visible window.
- Refresh an already-visible taskbar button asynchronously so Explorer cannot coalesce the remove/re-add and retain its cached executable icon.
- Fetch the on-prem icon through Electron networking so the desktop follows operating-system proxy and certificate trust.
- Return truthful apply failures instead of reporting success when Windows does not accept the icon.

## Why

`BrowserWindow.setIcon` updated the title bar and Alt-Tab image, but Explorer continued rendering the executable's stock taskbar icon. The running window now has a deterministic branded identity and relaunch resource. For live changes, OpenWork removes the taskbar button, stages the new identity, waits for Explorer to observe it, and then re-adds the button.

## Validation

- `pnpm --filter @openwork/desktop test` — 48 passed, 0 failed, 1 expected platform skip.
- `pnpm --filter @openwork/desktop typecheck:electron` — passed.
- `pnpm --filter @openwork/app typecheck` — passed.
- [Build Electron Desktop](https://github.com/different-ai/openwork/actions/runs/29069101549) — passed on Windows x64, Windows ARM64, macOS, Linux, and the macOS notarization smoke job.
- Daytona Windows Fraimz `2026-07-10T04-43-42-983Z` — passed all five real-OS frames: stock icon, owner save, live taskbar + Alt-Tab update, branded relaunch, and stock restoration. The proof also asserts shortcut creation/removal. [PR proof comment](https://github.com/different-ai/openwork/pull/2636#issuecomment-4932075057).

## On-prem behavior

The icon remains an organization-controlled Den URL. It is fetched at runtime through the desktop's OS-trust-aware network stack and cached locally for offline/relaunch behavior; there is no public GitHub or hosted-service dependency in the apply path.

Windows registers one per-user `OpenWork Organization` Start Menu link while organization branding is active so Explorer can resolve the branded AppUserModelID. It requires no administrator access, does not change the installed executable, and is removed when the owner clears the organization icon.
