### PR TITLE
fix(app): sync cloud MCP for signed-in users

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -170,7 +170,7 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     oauth: true,
     kind: "mcp",
     iconSrc: "/openwork-mark.svg",
-    // Auto-managed by the signed-in cloud reconciler (syncCloudControlMcp):
+    // Auto-managed by the signed-in cloud reconciler:
     // configured + enabled while signed in to OpenWork Cloud. Hidden from the
     // default catalog; "Show hidden" reveals it.
     defaultHidden: true,

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
@@ -4,7 +4,7 @@ import { CLOUD_MCP_SYNC_MARKER_STORAGE_KEY } from "../../../app/lib/den";
  * Durable record of the user's intent for the auto-configured OpenWork
  * Cloud Control MCP ("openwork-cloud").
  *
- * A background reconciler (`syncCloudControlMcp`) keeps that entry
+ * A background reconciler (`syncCloudControlMcpInBackground`) keeps that entry
  * configured with a fresh first-party token while the user is signed in to
  * OpenWork Cloud. Its writes hardcode `enabled: true` and recreate removed
  * entries, so without a durable record of "the user turned this off" the
@@ -69,7 +69,7 @@ export function writeCloudMcpUserState(state: CloudMcpUserState) {
     getStorage()?.setItem(CLOUD_MCP_USER_STATE_KEY, state);
   } catch {
     // Storage unavailable — the reconciler may resurrect the entry; the
-    // enabled-flag guard in syncCloudControlMcp still applies.
+    // enabled-flag guard in syncCloudControlMcpInBackground still applies.
   }
 }
 

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -10,9 +10,7 @@ import {
 } from "../../../app/constants";
 import { extensionResource } from "../../../app/extensions";
 import {
-  isLegacyWebAppMcpUrl,
   mintCloudControlMcpToken,
-  readDenSettings,
   resolveCloudMcpResourceUrl,
 } from "../../../app/lib/den";
 import { createClient, unwrap } from "../../../app/lib/opencode";
@@ -42,24 +40,11 @@ import type { OpenworkServerStore } from "./openwork-server-store";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
 import {
   CLOUD_MCP_SERVER_NAME,
-  clearCloudMcpUnhealthyRemintAttempt,
   clearCloudMcpUserState,
-  isCloudMcpSyncMarkerFresh,
-  readCloudMcpSyncMarker,
-  readCloudMcpUnhealthyRemintAttempt,
-  readCloudMcpUserState,
-  writeCloudMcpSyncMarker,
-  writeCloudMcpUnhealthyRemintAttempt,
   writeCloudMcpUserState,
 } from "./cloud-mcp-user-state";
 
 type SetStateAction<T> = T | ((current: T) => T);
-
-// Re-mint when less than a day of token validity remains. Must be well
-// below the minted token TTL (7 days, DEN_FIRST_PARTY_MCP_TOKEN_TTL_MS in
-// den-api): when the two were equal, the marker was stale the instant it
-// was written and every sync tick re-wrote the MCP config.
-const CLOUD_MCP_REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
 
 export type ConnectionsStoreSnapshot = {
   mcpServers: McpServerEntry[];
@@ -377,8 +362,8 @@ export function createConnectionsStore(options: {
    * engine only refreshes tokens reactively (once per transport), so an
    * expired access token strands the entry until the user clicks Sign in.
    * `mcp.connect` retries the stored refresh-token grant on a fresh
-   * transport — silently, never opening a browser or modal. Mirrors
-   * syncCloudControlMcp, but for user-added connectors.
+   * transport — silently, never opening a browser or modal. Mirrors the
+   * app-wide Cloud MCP reconciler's quiet behavior for user-added connectors.
    */
   async function healUnhealthyMcpEntries(servers: McpServerEntry[], statuses: McpStatusMap) {
     if (disposed || snapshot.mcpAuthModalOpen || snapshot.mcpConnectingName) return;
@@ -853,122 +838,6 @@ export function createConnectionsStore(options: {
     }
   }
 
-  // Guards the unhealthy-status self-heal in syncCloudControlMcp with a
-  // persisted marker that survives settings-route store remounts: each
-  // re-mint writes a new token to config, which marks an engine reload as
-  // required. Until that reload happens the status stays needs_auth, so
-  // retrying on every sync tick produced an endless "MCP 'openwork-cloud'
-  // was updated. Reload to connect." nag. One attempt per unhealthy episode;
-  // reset when the entry reports connected again.
-  let cloudMcpUnhealthyRemintAttempted = false;
-
-  /**
-   * Background reconciliation for the Den cloud MCP: when the desktop is
-   * signed in to OpenWork Cloud with an active org, keep the
-   * `openwork-cloud` MCP entry configured with a fresh first-party token.
-   * Quiet by design — a failed mint never opens the OAuth modal.
-   *
-   * `force` bypasses the freshness marker: used by the user-facing Refresh
-   * button so "make my cloud connection current NOW" is one click (re-mint
-   * token + rewrite config + reconnect) instead of sign-out/sign-in or
-   * waiting for the marker to expire.
-   */
-  async function syncCloudControlMcp(options?: { force?: boolean }): Promise<"synced" | "unchanged" | "skipped"> {
-    const settings = readDenSettings();
-    const orgId = settings.activeOrgId?.trim() ?? "";
-    if (!orgId || !settings.authToken?.trim()) return "skipped";
-    const workspaceId = await resolveOpenworkWorkspaceId();
-    if (!workspaceId) return "skipped";
-    const serverBaseUrl = getOpenworkSnapshot().openworkServerClient?.baseUrl.trim() ?? "";
-    if (!serverBaseUrl) return "skipped";
-
-    const entry = MCP_QUICK_CONNECT.find((candidate) => candidate.serverName === CLOUD_MCP_SERVER_NAME);
-    if (!entry) return "skipped";
-    const slug = entry.id ?? getMcpServerName(entry);
-
-    // Respect explicit user intent: a Cloud Control MCP the user disabled
-    // or removed must stay that way. Without this guard the reconciler
-    // rewrote the entry with `enabled: true` on every tick, making it
-    // impossible to turn off. Any explicit reconnect clears the record.
-    if (readCloudMcpUserState() !== null) return "skipped";
-    const configuredEntry = snapshot.mcpServers.find((server) => server.name === slug);
-    if (configuredEntry?.config.enabled === false) return "skipped";
-    if (options?.force) {
-      cloudMcpUnhealthyRemintAttempted = false;
-      clearCloudMcpUnhealthyRemintAttempt();
-    }
-
-    const marker = readCloudMcpSyncMarker({
-      denBaseUrl: settings.baseUrl,
-      serverBaseUrl,
-      orgId,
-      workspaceId,
-    });
-    const markerFresh =
-      marker !== null &&
-      marker.orgId === orgId &&
-      marker.workspaceId === workspaceId &&
-      isCloudMcpSyncMarkerFresh({
-        expiresAt: marker.expiresAt,
-        now: Date.now(),
-        refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
-      });
-
-    // A revoked/expired token surfaces as needs_auth or failed from opencode;
-    // while signed in, that means re-mint instead of standing pat — but only
-    // once per unhealthy episode (see cloudMcpUnhealthyRemintAttempted).
-    const entryStatus = snapshot.mcpStatuses[slug]?.status;
-    if (entryStatus === "connected") {
-      cloudMcpUnhealthyRemintAttempted = false;
-      clearCloudMcpUnhealthyRemintAttempt();
-    }
-    const entryUnhealthy = entryStatus === "needs_auth" || entryStatus === "failed";
-    const attempted = cloudMcpUnhealthyRemintAttempted || readCloudMcpUnhealthyRemintAttempt()?.orgId === orgId;
-    const shouldRemintForHealth = entryUnhealthy && !attempted;
-
-    // Builds before #2116's follow-up wrote the MCP URL against the bare
-    // web-app origin (https://app.openworklabs.com/mcp), which 404s.
-    // Reconfigure those entries even when the marker is still fresh.
-    const hasLegacyUrl =
-      configuredEntry?.config.type === "remote" && isLegacyWebAppMcpUrl(configuredEntry.config.url);
-
-    // The marker is the source of truth for "configured recently". Do NOT
-    // gate this on snapshot.mcpServers: the store is recreated on every
-    // settings mount with an empty (or refresh-errored) server list, and
-    // treating that as "not configured" re-minted a token and rewrote config
-    // on every visit — endless "Reload to connect" toasts. If a user
-    // manually removed the entry, we respect that until the marker expires
-    // instead of silently re-adding it.
-    if (!options?.force && markerFresh && !shouldRemintForHealth && !hasLegacyUrl) {
-      return "unchanged";
-    }
-    if (shouldRemintForHealth) {
-      cloudMcpUnhealthyRemintAttempted = true;
-      writeCloudMcpUnhealthyRemintAttempt({ orgId });
-    }
-
-    // Validate the session up front so a failed mint never reaches
-    // connectMcp's signed-out fallback (which opens the OAuth modal).
-    const minted = await mintCloudControlMcpToken().catch(() => null);
-    if (!minted) return "skipped";
-
-    // Trust connectMcp's own result. Judging success via snapshot.mcpServers
-    // broke whenever the post-connect refresh errored: the marker was never
-    // written, so every subsequent tick re-minted and re-wrote config.
-    const connected = await connectMcp(entry);
-    if (!connected) {
-      return "skipped";
-    }
-    writeCloudMcpSyncMarker({
-      denBaseUrl: settings.baseUrl,
-      serverBaseUrl,
-      orgId,
-      workspaceId,
-      expiresAt: minted.expiresAt,
-    });
-    return "synced";
-  }
-
   function authorizeMcp(entry: McpServerEntry) {
     if (entry.config.type !== "remote" || entry.config.oauth === false) {
       setStateField("mcpStatus", t("mcp.login_unavailable"));
@@ -1268,7 +1137,6 @@ export function createConnectionsStore(options: {
     readMcpConfigFile,
     refreshMcpServers,
     connectMcp,
-    syncCloudControlMcp,
     authorizeMcp,
     logoutMcpAuth,
     removeMcp,

--- a/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
+++ b/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import { getMcpServerName, MCP_QUICK_CONNECT } from "../../../app/constants";
 import {
+  isLegacyWebAppMcpUrl,
   mintCloudControlMcpToken,
   readDenSettings,
   resolveCloudMcpResourceUrl,
@@ -26,19 +27,32 @@ export const CLOUD_MCP_REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
 type CloudMcpMaintenanceClient = Pick<OpenworkServerClient, "baseUrl" | "listMcp" | "addMcp">;
 
 const maintenanceInFlight = new Set<string>();
+const cloudMcpSyncInFlight = new Map<string, Promise<void>>();
 
 export function getSessionMcpMaintenanceTargetKey(input: {
   client: Pick<OpenworkServerClient, "baseUrl" | "token">;
-  cloudSignedIn: boolean;
   workspaceId: string;
   directory: string;
 }): string {
   return JSON.stringify([
     input.client.baseUrl.trim().replace(/\/+$/, ""),
     input.client.token?.trim() ?? "",
-    input.cloudSignedIn ? "signed-in" : "local-only",
     input.workspaceId.trim(),
     input.directory.trim(),
+  ]);
+}
+
+export function getCloudControlMcpSyncTargetKey(input: {
+  denBaseUrl: string;
+  serverBaseUrl: string;
+  orgId: string;
+  workspaceId: string;
+}): string {
+  return JSON.stringify([
+    input.denBaseUrl.trim().replace(/\/+$/, ""),
+    input.serverBaseUrl.trim().replace(/\/+$/, ""),
+    input.orgId.trim(),
+    input.workspaceId.trim(),
   ]);
 }
 
@@ -68,56 +82,90 @@ export async function syncCloudControlMcpInBackground(input: {
   const settings = input.settings ?? readDenSettings();
   const orgId = settings.activeOrgId?.trim() ?? "";
   if (!workspaceId || !orgId || !settings.authToken?.trim()) return "skipped";
-  if (readCloudMcpUserState() !== null) return "skipped";
-
-  const cloudEntry = MCP_QUICK_CONNECT.find((entry) => entry.serverName === CLOUD_MCP_SERVER_NAME);
-  if (!cloudEntry) return "skipped";
-  const slug = cloudEntry.id ?? getMcpServerName(cloudEntry);
-  const listed = await input.client.listMcp(workspaceId);
-  const configured = listed.items.find((entry) => entry.name === slug);
-  if (configured?.config.enabled === false) return "skipped";
-
-  const marker = readCloudMcpSyncMarker({
+  const targetKey = getCloudControlMcpSyncTargetKey({
     denBaseUrl: settings.baseUrl,
     serverBaseUrl: input.client.baseUrl,
     orgId,
     workspaceId,
   });
-  const markerFresh =
-    marker !== null &&
-    marker.orgId === orgId &&
-    marker.workspaceId === workspaceId &&
-    isCloudMcpSyncMarkerFresh({
-      expiresAt: marker.expiresAt,
-      now: input.now ?? Date.now(),
-      refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+  while (cloudMcpSyncInFlight.has(targetKey)) {
+    const current = cloudMcpSyncInFlight.get(targetKey);
+    if (!current) break;
+    if (!input.force) return "skipped";
+    await current;
+  }
+
+  let resolveInFlight = () => {};
+  const currentInFlight = new Promise<void>((resolve) => {
+    resolveInFlight = resolve;
+  });
+  cloudMcpSyncInFlight.set(targetKey, currentInFlight);
+  try {
+    if (readCloudMcpUserState() !== null) return "skipped";
+
+    const cloudEntry = MCP_QUICK_CONNECT.find((entry) => entry.serverName === CLOUD_MCP_SERVER_NAME);
+    if (!cloudEntry) return "skipped";
+    const slug = cloudEntry.id ?? getMcpServerName(cloudEntry);
+    const listed = await input.client.listMcp(workspaceId);
+    const configured = listed.items.find((entry) => entry.name === slug);
+    if (configured?.config.enabled === false) return "skipped";
+    const configuredUrl = configured?.config.type === "remote" && typeof configured.config.url === "string"
+      ? configured.config.url
+      : null;
+    const hasLegacyUrl = isLegacyWebAppMcpUrl(configuredUrl);
+
+    const marker = readCloudMcpSyncMarker({
+      denBaseUrl: settings.baseUrl,
+      serverBaseUrl: input.client.baseUrl,
+      orgId,
+      workspaceId,
     });
-  if (!input.force && configured && markerFresh) return "unchanged";
+    const markerFresh =
+      marker !== null &&
+      marker.orgId === orgId &&
+      marker.workspaceId === workspaceId &&
+      isCloudMcpSyncMarkerFresh({
+        expiresAt: marker.expiresAt,
+        now: input.now ?? Date.now(),
+        refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+      });
+    if (!input.force && configured && markerFresh && !hasLegacyUrl) return "unchanged";
 
-  const minted = await (input.mintToken ?? mintCloudControlMcpToken)();
-  if (!minted) return "skipped";
-  const healedResource = resolveCloudMcpResourceUrl(minted.resource);
-  const url = healedResource ? `${healedResource}/agent` : cloudEntry.url;
-  if (!url) return "skipped";
+    let minted: DenMcpToken | null = null;
+    try {
+      minted = await (input.mintToken ?? mintCloudControlMcpToken)();
+    } catch {
+      return "skipped";
+    }
+    if (!minted) return "skipped";
+    const healedResource = resolveCloudMcpResourceUrl(minted.resource);
+    const url = healedResource ? `${healedResource}/agent` : cloudEntry.url;
+    if (!url) return "skipped";
 
-  await input.client.addMcp(workspaceId, {
-    name: slug,
-    config: {
-      type: "remote",
-      enabled: true,
-      url,
-      headers: { Authorization: `Bearer ${minted.token}` },
-      oauth: false,
-    },
-  });
-  writeCloudMcpSyncMarker({
-    denBaseUrl: settings.baseUrl,
-    serverBaseUrl: input.client.baseUrl,
-    orgId,
-    workspaceId,
-    expiresAt: minted.expiresAt,
-  });
-  return "synced";
+    await input.client.addMcp(workspaceId, {
+      name: slug,
+      config: {
+        type: "remote",
+        enabled: true,
+        url,
+        headers: { Authorization: `Bearer ${minted.token}` },
+        oauth: false,
+      },
+    });
+    writeCloudMcpSyncMarker({
+      denBaseUrl: settings.baseUrl,
+      serverBaseUrl: input.client.baseUrl,
+      orgId,
+      workspaceId,
+      expiresAt: minted.expiresAt,
+    });
+    return "synced";
+  } finally {
+    if (cloudMcpSyncInFlight.get(targetKey) === currentInFlight) {
+      cloudMcpSyncInFlight.delete(targetKey);
+    }
+    resolveInFlight();
+  }
 }
 
 export async function healWorkspaceMcpInBackground(input: {
@@ -147,7 +195,6 @@ export async function healWorkspaceMcpInBackground(input: {
 }
 
 export function useSessionMcpMaintenance(input: {
-  cloudSignedIn: boolean;
   client: OpenworkServerClient | null;
   workspaceId: string | null;
   opencodeClient: Client | null;
@@ -161,7 +208,6 @@ export function useSessionMcpMaintenance(input: {
     if (!client || !opencodeClient || !workspaceId || !directory) return;
     const targetKey = getSessionMcpMaintenanceTargetKey({
       client,
-      cloudSignedIn: input.cloudSignedIn,
       workspaceId,
       directory,
     });
@@ -172,18 +218,12 @@ export function useSessionMcpMaintenance(input: {
       await runSessionMcpMaintenanceTask({
         targetKey,
         task: async () => {
-        if (input.cloudSignedIn) {
-          await syncCloudControlMcpInBackground({
+          await healWorkspaceMcpInBackground({
             client,
             workspaceId,
-          }).catch(() => "skipped");
-        }
-        await healWorkspaceMcpInBackground({
-          client,
-          workspaceId,
-          opencodeClient,
-          directory,
-        }).catch(() => false);
+            opencodeClient,
+            directory,
+          }).catch(() => false);
         },
       });
     };
@@ -202,5 +242,5 @@ export function useSessionMcpMaintenance(input: {
       window.removeEventListener("focus", handleFocus);
       window.clearInterval(interval);
     };
-  }, [input.client, input.cloudSignedIn, input.directory, input.opencodeClient, input.workspaceId]);
+  }, [input.client, input.directory, input.opencodeClient, input.workspaceId]);
 }

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -27,6 +27,7 @@ import { LoadingOverlay } from "./loading-overlay";
 import { DevProfiler, DevProfilerOverlay } from "./dev-profiler";
 import { ReactRenderWatchdogOverlay } from "./react-render-watchdog-overlay";
 import { AppMenuProvider } from "./app-menu";
+import { CloudMcpAutoSync } from "./cloud-mcp-auto-sync";
 import {
   OpenworkControlProvider,
   OpenworkRouteControlActions,
@@ -317,6 +318,7 @@ export function AppRoot() {
           <OpenworkRouteControlActions />
           <DenAuthControlActions />
           <BrandThemeControlActions />
+          <CloudMcpAutoSync />
           <DenSigninGate>
             <Routes>
               <Route

--- a/apps/app/src/react-app/shell/cloud-mcp-auto-sync.tsx
+++ b/apps/app/src/react-app/shell/cloud-mcp-auto-sync.tsx
@@ -1,0 +1,221 @@
+/** @jsxImportSource react */
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+
+import { CLOUD_SYNC_INTERVAL_MS } from "@/app/cloud/sync/constants";
+import { readDenSettings } from "@/app/lib/den";
+import {
+  resolveWorkspaceListSelectedId,
+  workspaceBootstrap,
+  type WorkspaceList,
+} from "@/app/lib/desktop";
+import {
+  createOpenworkServerClient,
+  type OpenworkWorkspaceInfo,
+} from "@/app/lib/openwork-server";
+import {
+  resolveWorkspaceEndpoint,
+  type LocalServerHandle,
+  type ResolvedWorkspaceEndpoint,
+} from "@/app/lib/workspace-endpoint";
+import { isDesktopRuntime } from "@/app/utils";
+import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
+import { syncCloudControlMcpInBackground } from "@/react-app/domains/connections/use-session-mcp-maintenance";
+import { denSessionUpdatedEvent, denSettingsChangedEvent } from "@/app/lib/den-session-events";
+import { resolveOpenworkConnection } from "./openwork-connection";
+import {
+  mapDesktopWorkspace,
+  mergeRouteWorkspaces,
+  orderRouteWorkspaces,
+  type RouteWorkspace,
+} from "./route-workspaces";
+import { readActiveWorkspaceId, readWorkspaceOrderIds } from "./session-memory";
+
+export type CloudMcpAutoSyncTargetInput = {
+  workspaces: RouteWorkspace[];
+  routeWorkspaceId?: string | null;
+  persistedActiveWorkspaceId?: string | null;
+  desktopSelectedWorkspaceId?: string | null;
+  serverActiveWorkspaceId?: string | null;
+  localServer: LocalServerHandle;
+};
+
+export function readCloudMcpRouteWorkspaceId(pathname: string): string {
+  const match = /^\/workspace\/([^/?#]+)/.exec(pathname);
+  const raw = match?.[1]?.trim() ?? "";
+  if (!raw) return "";
+  try {
+    return decodeURIComponent(raw).trim();
+  } catch {
+    return raw;
+  }
+}
+
+export function selectCloudMcpWorkspaceId(input: Omit<CloudMcpAutoSyncTargetInput, "localServer">): string {
+  const knownIds = new Set(input.workspaces.map((workspace) => workspace.id));
+  const candidates = [
+    input.routeWorkspaceId,
+    input.persistedActiveWorkspaceId,
+    input.desktopSelectedWorkspaceId,
+    input.serverActiveWorkspaceId,
+  ];
+  for (const candidate of candidates) {
+    const id = candidate?.trim() ?? "";
+    if (id && knownIds.has(id)) return id;
+  }
+  return input.workspaces[0]?.id ?? "";
+}
+
+export function resolveCloudMcpAutoSyncTarget(
+  input: CloudMcpAutoSyncTargetInput,
+): ResolvedWorkspaceEndpoint | null {
+  const workspaceId = selectCloudMcpWorkspaceId(input);
+  const workspace = input.workspaces.find((item) => item.id === workspaceId) ?? null;
+  return resolveWorkspaceEndpoint(workspace, input.localServer);
+}
+
+async function readDesktopWorkspaces(): Promise<{
+  desktopList: WorkspaceList | null;
+  desktopWorkspaces: RouteWorkspace[];
+}> {
+  if (!isDesktopRuntime()) {
+    return { desktopList: null, desktopWorkspaces: [] };
+  }
+  try {
+    const desktopList = await workspaceBootstrap();
+    return {
+      desktopList,
+      desktopWorkspaces: (desktopList.workspaces ?? []).map(mapDesktopWorkspace),
+    };
+  } catch {
+    return { desktopList: null, desktopWorkspaces: [] };
+  }
+}
+
+async function resolveCloudMcpAutoSyncTargetForRoute(
+  routeWorkspaceId: string,
+): Promise<ResolvedWorkspaceEndpoint | null> {
+  const { desktopList, desktopWorkspaces } = await readDesktopWorkspaces();
+  const connection = await resolveOpenworkConnection();
+  let serverWorkspaces: OpenworkWorkspaceInfo[] = [];
+  let serverActiveWorkspaceId: string | null = null;
+
+  if (connection.normalizedBaseUrl && connection.resolvedToken) {
+    try {
+      const client = createOpenworkServerClient({
+        baseUrl: connection.normalizedBaseUrl,
+        token: connection.resolvedToken,
+        hostToken: connection.resolvedHostToken || undefined,
+      });
+      const list = await client.listWorkspaces();
+      serverWorkspaces = list.items;
+      serverActiveWorkspaceId = list.activeId?.trim() || null;
+    } catch {
+      serverWorkspaces = [];
+      serverActiveWorkspaceId = null;
+    }
+  }
+
+  const workspaces = orderRouteWorkspaces(
+    mergeRouteWorkspaces(serverWorkspaces, desktopWorkspaces),
+    readWorkspaceOrderIds(),
+  );
+
+  return resolveCloudMcpAutoSyncTarget({
+    workspaces,
+    routeWorkspaceId,
+    persistedActiveWorkspaceId: readActiveWorkspaceId(),
+    desktopSelectedWorkspaceId: resolveWorkspaceListSelectedId(desktopList),
+    serverActiveWorkspaceId,
+    localServer: {
+      baseUrl: connection.normalizedBaseUrl,
+      token: connection.resolvedToken,
+    },
+  });
+}
+
+export function CloudMcpAutoSync() {
+  const denAuth = useDenAuth();
+  const location = useLocation();
+  const routeWorkspaceIdRef = useRef(readCloudMcpRouteWorkspaceId(location.pathname));
+  const observedPathnameRef = useRef(location.pathname);
+  const inFlightRef = useRef(false);
+  const rerunAfterFlightRef = useRef(false);
+  const runRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    if (!denAuth.isSignedIn || typeof window === "undefined") {
+      runRef.current = null;
+      return;
+    }
+
+    let cancelled = false;
+    const tick = async () => {
+      if (cancelled) return;
+      if (inFlightRef.current) {
+        rerunAfterFlightRef.current = true;
+        return;
+      }
+
+      const settings = readDenSettings();
+      if (!settings.authToken?.trim() || !settings.activeOrgId?.trim()) return;
+
+      inFlightRef.current = true;
+      try {
+        const target = await resolveCloudMcpAutoSyncTargetForRoute(routeWorkspaceIdRef.current);
+        if (target) {
+          await syncCloudControlMcpInBackground({
+            client: target.client,
+            workspaceId: target.workspaceId,
+            settings,
+          });
+        }
+      } catch {
+        // Quiet by design: network, org, worker, and mint failures retry later.
+      } finally {
+        inFlightRef.current = false;
+        const shouldRerun = rerunAfterFlightRef.current;
+        rerunAfterFlightRef.current = false;
+        if (shouldRerun && !cancelled) {
+          void tick();
+        } else if (shouldRerun) {
+          runRef.current?.();
+        }
+      }
+    };
+
+    runRef.current = () => void tick();
+    void tick();
+
+    const run = () => void tick();
+    const runWhenVisible = () => {
+      if (typeof document === "undefined" || document.visibilityState === "visible") void tick();
+    };
+    window.addEventListener(denSettingsChangedEvent, run);
+    window.addEventListener(denSessionUpdatedEvent, run);
+    window.addEventListener("openwork-server-settings-changed", run);
+    window.addEventListener("online", run);
+    window.addEventListener("focus", runWhenVisible);
+    const interval = window.setInterval(run, CLOUD_SYNC_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      runRef.current = null;
+      window.removeEventListener(denSettingsChangedEvent, run);
+      window.removeEventListener(denSessionUpdatedEvent, run);
+      window.removeEventListener("openwork-server-settings-changed", run);
+      window.removeEventListener("online", run);
+      window.removeEventListener("focus", runWhenVisible);
+      window.clearInterval(interval);
+    };
+  }, [denAuth.isSignedIn]);
+
+  useEffect(() => {
+    const changed = observedPathnameRef.current !== location.pathname;
+    observedPathnameRef.current = location.pathname;
+    routeWorkspaceIdRef.current = readCloudMcpRouteWorkspaceId(location.pathname);
+    if (changed) runRef.current?.();
+  }, [location.pathname]);
+
+  return null;
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -391,7 +391,6 @@ export function SessionRoute() {
     onHostInfo: setOpenworkServerHostInfoState,
   });
   useSessionMcpMaintenance({
-    cloudSignedIn: denAuth.isSignedIn,
     client: selectedWorkspaceEndpoint?.client ?? null,
     workspaceId: selectedWorkspaceEndpoint?.workspaceId ?? null,
     opencodeClient,

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -51,6 +51,7 @@ import {
   workspaceLabel,
 } from "@/react-app/shell/route-workspaces";
 import { createConnectionsStore, useConnectionsStoreSnapshot } from "@/react-app/domains/connections/store";
+import { syncCloudControlMcpInBackground } from "@/react-app/domains/connections/use-session-mcp-maintenance";
 import { useOrgMcpConnections } from "@/react-app/domains/connections/use-org-mcp-connections";
 import { createOpenworkServerStore, useOpenworkServerStoreSnapshot } from "@/react-app/domains/connections/openwork-server-store";
 import { createProviderAuthStore, useProviderAuthStoreSnapshot } from "@/react-app/domains/connections/provider-auth/store";
@@ -1483,10 +1484,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   // the settings route owns the provider-auth store.
   useCloudProviderAutoSync(providerAuthStore.runCloudProviderSync);
 
-  // Keep the Den cloud MCP configured with a fresh first-party token while
-  // signed in: connects on sign-in, re-mints on org switch and before expiry.
-  useCloudProviderAutoSync(() => connectionsStore.syncCloudControlMcp());
-
   useEffect(() => {
     if (route.tab !== "cloud-providers") return;
     void providerAuthStore.runCloudProviderSync("settings_cloud_opened");
@@ -2072,7 +2069,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               // Force-sync the cloud MCP first (re-mint token + rewrite
               // config, bypassing the freshness marker) so Refresh really
               // means "make everything current now", then refresh the rest.
-              void connectionsStore.syncCloudControlMcp({ force: true }).then(() => {
+              const cloudMcpRefresh = selectedWorkspaceEndpoint
+                ? syncCloudControlMcpInBackground({
+                    client: selectedWorkspaceEndpoint.client,
+                    workspaceId: selectedWorkspaceEndpoint.workspaceId,
+                    force: true,
+                  }).catch(() => "skipped")
+                : Promise.resolve("skipped");
+              void cloudMcpRefresh.then(() => {
                 void connectionsStore.refreshMcpServers();
               });
               void extensionsStore.refreshPlugins();

--- a/apps/app/tests/cloud-mcp-auto-sync.test.ts
+++ b/apps/app/tests/cloud-mcp-auto-sync.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  readCloudMcpRouteWorkspaceId,
+  resolveCloudMcpAutoSyncTarget,
+  selectCloudMcpWorkspaceId,
+} from "../src/react-app/shell/cloud-mcp-auto-sync";
+import type { RouteWorkspace } from "../src/react-app/shell/route-workspaces";
+
+function workspace(input: {
+  id: string;
+  workspaceType?: "local" | "remote";
+  baseUrl?: string;
+  openworkToken?: string;
+  openworkWorkspaceId?: string;
+}): RouteWorkspace {
+  const workspaceType = input.workspaceType ?? "local";
+  return {
+    id: input.id,
+    name: input.id,
+    path: `/tmp/${input.id}`,
+    preset: "starter",
+    workspaceType,
+    remoteType: workspaceType === "remote" ? "openwork" : null,
+    baseUrl: input.baseUrl ?? null,
+    openworkToken: input.openworkToken ?? null,
+    openworkWorkspaceId: input.openworkWorkspaceId ?? null,
+    displayNameResolved: input.id,
+  };
+}
+
+describe("cloud MCP auto sync target selection", () => {
+  test("reads workspace ids from workspace routes", () => {
+    expect(readCloudMcpRouteWorkspaceId("/workspace/rem_worker/session/abc")).toBe("rem_worker");
+    expect(readCloudMcpRouteWorkspaceId("/workspace/local%201/settings/extensions")).toBe("local 1");
+    expect(readCloudMcpRouteWorkspaceId("/session")).toBe("");
+  });
+
+  test("route-selected remote workspace takes precedence and uses remote routing", () => {
+    const local = workspace({ id: "local_a" });
+    const remote = workspace({
+      id: "rem_cloud",
+      workspaceType: "remote",
+      baseUrl: "https://remote-worker.openwork.test",
+      openworkToken: "remote-token",
+      openworkWorkspaceId: "worker_workspace",
+    });
+
+    const target = resolveCloudMcpAutoSyncTarget({
+      workspaces: [local, remote],
+      routeWorkspaceId: "rem_cloud",
+      persistedActiveWorkspaceId: "local_a",
+      desktopSelectedWorkspaceId: "local_a",
+      serverActiveWorkspaceId: "local_a",
+      localServer: { baseUrl: "https://local.openwork.test", token: "local-token" },
+    });
+
+    expect(target?.isRemote).toBe(true);
+    expect(target?.baseUrl).toBe("https://remote-worker.openwork.test");
+    expect(target?.token).toBe("remote-token");
+    expect(target?.workspaceId).toBe("worker_workspace");
+  });
+
+  test("falls back through persisted, desktop, server active, then first workspace", () => {
+    const first = workspace({ id: "first" });
+    const persisted = workspace({ id: "persisted" });
+    const desktop = workspace({ id: "desktop" });
+    const server = workspace({ id: "server" });
+    const workspaces = [first, persisted, desktop, server];
+
+    expect(selectCloudMcpWorkspaceId({
+      workspaces,
+      routeWorkspaceId: "missing",
+      persistedActiveWorkspaceId: "persisted",
+      desktopSelectedWorkspaceId: "desktop",
+      serverActiveWorkspaceId: "server",
+    })).toBe("persisted");
+    expect(selectCloudMcpWorkspaceId({
+      workspaces,
+      routeWorkspaceId: "missing",
+      persistedActiveWorkspaceId: "missing",
+      desktopSelectedWorkspaceId: "desktop",
+      serverActiveWorkspaceId: "server",
+    })).toBe("desktop");
+    expect(selectCloudMcpWorkspaceId({
+      workspaces,
+      routeWorkspaceId: "missing",
+      persistedActiveWorkspaceId: "missing",
+      desktopSelectedWorkspaceId: "missing",
+      serverActiveWorkspaceId: "server",
+    })).toBe("server");
+    expect(selectCloudMcpWorkspaceId({
+      workspaces,
+      routeWorkspaceId: "missing",
+      persistedActiveWorkspaceId: "missing",
+      desktopSelectedWorkspaceId: "missing",
+      serverActiveWorkspaceId: "missing",
+    })).toBe("first");
+
+    const target = resolveCloudMcpAutoSyncTarget({
+      workspaces,
+      persistedActiveWorkspaceId: "persisted",
+      localServer: { baseUrl: "https://local.openwork.test", token: "local-token" },
+    });
+    expect(target?.isRemote).toBe(false);
+    expect(target?.baseUrl).toBe("https://local.openwork.test");
+    expect(target?.workspaceId).toBe("persisted");
+  });
+});

--- a/apps/app/tests/session-mcp-maintenance.test.ts
+++ b/apps/app/tests/session-mcp-maintenance.test.ts
@@ -229,9 +229,302 @@ describe("session MCP maintenance", () => {
       },
       workspaceId: WORKSPACE_ID,
       settings: SETTINGS,
+      force: true,
       mintToken: async () => MINTED,
     })).resolves.toBe("skipped");
     expect(listed).toBe(false);
+  });
+
+  test("explicit disabled intent skips before list, mint, or write", async () => {
+    writeCloudMcpUserState("disabled");
+    let listCount = 0;
+    let mintCount = 0;
+    let writeCount = 0;
+
+    await expect(syncCloudControlMcpInBackground({
+      client: {
+        baseUrl: "https://worker.openwork.test",
+        listMcp: async () => {
+          listCount += 1;
+          return { items: [] };
+        },
+        addMcp: async () => {
+          writeCount += 1;
+          return { items: [] };
+        },
+      },
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      force: true,
+      mintToken: async () => {
+        mintCount += 1;
+        return MINTED;
+      },
+    })).resolves.toBe("skipped");
+
+    expect(listCount).toBe(0);
+    expect(mintCount).toBe(0);
+    expect(writeCount).toBe(0);
+  });
+
+  test("configured enabled:false skips mint and write even when forced", async () => {
+    let mintCount = 0;
+    let writeCount = 0;
+
+    await expect(syncCloudControlMcpInBackground({
+      client: {
+        baseUrl: "https://worker.openwork.test",
+        listMcp: async () => ({
+          items: [{
+            name: "openwork-cloud",
+            config: { type: "remote", enabled: false, url: "https://api.openwork.test/mcp/agent" },
+          }],
+        }),
+        addMcp: async () => {
+          writeCount += 1;
+          return { items: [] };
+        },
+      },
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      force: true,
+      mintToken: async () => {
+        mintCount += 1;
+        return MINTED;
+      },
+    })).resolves.toBe("skipped");
+
+    expect(mintCount).toBe(0);
+    expect(writeCount).toBe(0);
+  });
+
+  test("force bypasses a fresh marker and rewrites the Cloud MCP", async () => {
+    let mintCount = 0;
+    let writeCount = 0;
+    const client = {
+      baseUrl: "https://worker.openwork.test",
+      listMcp: async () => ({
+        items: [{
+          name: "openwork-cloud",
+          config: { type: "remote", enabled: true, url: "https://api.openwork.test/mcp/agent" },
+        }],
+      }),
+      addMcp: async () => {
+        writeCount += 1;
+        return { items: [] };
+      },
+    };
+    const mintToken = async () => {
+      mintCount += 1;
+      return MINTED;
+    };
+
+    await expect(syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      now: NOW,
+      mintToken,
+    })).resolves.toBe("synced");
+    mintCount = 0;
+    writeCount = 0;
+
+    await expect(syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      now: NOW + 1_000,
+      force: true,
+      mintToken,
+    })).resolves.toBe("synced");
+
+    expect(mintCount).toBe(1);
+    expect(writeCount).toBe(1);
+  });
+
+  test("legacy bare web-app MCP URL bypasses a fresh marker and rewrites healed URL", async () => {
+    const healedMinted: DenMcpToken = {
+      ...MINTED,
+      token: "healed-token",
+      resource: "https://app.openworklabs.com/mcp",
+    };
+    const writes: Array<{ config: Record<string, unknown> }> = [];
+    let mintCount = 0;
+    let listLegacyUrl = false;
+    const client = {
+      baseUrl: "https://worker.openwork.test",
+      listMcp: async () => ({
+        items: listLegacyUrl
+          ? [{
+              name: "openwork-cloud",
+              config: {
+                type: "remote",
+                enabled: true,
+                url: "https://app.openworklabs.com/mcp",
+              },
+            }]
+          : [],
+      }),
+      addMcp: async (_workspaceId: string, payload: { config: Record<string, unknown> }) => {
+        writes.push({ config: payload.config });
+        return { items: [] };
+      },
+    };
+    const mintToken = async () => {
+      mintCount += 1;
+      return healedMinted;
+    };
+
+    await expect(syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      now: NOW,
+      mintToken,
+    })).resolves.toBe("synced");
+    mintCount = 0;
+    writes.length = 0;
+    listLegacyUrl = true;
+
+    await expect(syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      now: NOW + 1_000,
+      mintToken,
+    })).resolves.toBe("synced");
+
+    expect(mintCount).toBe(1);
+    expect(writes).toEqual([{
+      config: {
+        type: "remote",
+        enabled: true,
+        url: "https://app.openworklabs.com/api/den/mcp/agent",
+        headers: { Authorization: "Bearer healed-token" },
+        oauth: false,
+      },
+    }]);
+  });
+
+  test("null or failed mint skips without writing", async () => {
+    let writeCount = 0;
+    const client = {
+      baseUrl: "https://worker.openwork.test",
+      listMcp: async () => ({ items: [] }),
+      addMcp: async () => {
+        writeCount += 1;
+        return { items: [] };
+      },
+    };
+
+    await expect(syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      mintToken: async () => null,
+    })).resolves.toBe("skipped");
+    await expect(syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      mintToken: async () => {
+        throw new Error("mint failed");
+      },
+    })).resolves.toBe("skipped");
+
+    expect(writeCount).toBe(0);
+  });
+
+  test("deduplicates overlapping Cloud MCP reconciliation for the same target", async () => {
+    let mintCount = 0;
+    let writeCount = 0;
+    let releaseMint: (value: DenMcpToken | null) => void = () => {};
+    const mintBlocked = new Promise<DenMcpToken | null>((resolve) => {
+      releaseMint = resolve;
+    });
+    const client = {
+      baseUrl: "https://worker.openwork.test",
+      listMcp: async () => ({ items: [] }),
+      addMcp: async () => {
+        writeCount += 1;
+        return { items: [] };
+      },
+    };
+
+    const first = syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      mintToken: async () => {
+        mintCount += 1;
+        return mintBlocked;
+      },
+    });
+    const second = syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      mintToken: async () => {
+        mintCount += 1;
+        return MINTED;
+      },
+    });
+
+    await expect(second).resolves.toBe("skipped");
+    releaseMint(MINTED);
+    await expect(first).resolves.toBe("synced");
+    expect(mintCount).toBe(1);
+    expect(writeCount).toBe(1);
+  });
+
+  test("forced overlapping Cloud MCP reconciliation waits and rewrites after the current sync", async () => {
+    const writes: string[] = [];
+    let mintCount = 0;
+    let releaseMint: (value: DenMcpToken | null) => void = () => {};
+    const mintBlocked = new Promise<DenMcpToken | null>((resolve) => {
+      releaseMint = resolve;
+    });
+    const client = {
+      baseUrl: "https://worker.openwork.test",
+      listMcp: async () => ({ items: [] }),
+      addMcp: async (_workspaceId: string, payload: { config: Record<string, unknown> }) => {
+        const headers = payload.config.headers;
+        const authorization = headers &&
+          typeof headers === "object" &&
+          "Authorization" in headers &&
+          typeof headers.Authorization === "string"
+          ? headers.Authorization
+          : "";
+        writes.push(authorization);
+        return { items: [] };
+      },
+    };
+
+    const first = syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      mintToken: async () => {
+        mintCount += 1;
+        return mintBlocked;
+      },
+    });
+    const forced = syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      force: true,
+      mintToken: async () => {
+        mintCount += 1;
+        return { ...MINTED, token: "forced-token" };
+      },
+    });
+
+    releaseMint({ ...MINTED, token: "normal-token" });
+    await expect(first).resolves.toBe("synced");
+    await expect(forced).resolves.toBe("synced");
+    expect(mintCount).toBe(2);
+    expect(writes).toEqual(["Bearer normal-token", "Bearer forced-token"]);
   });
 
   test("deduplicates the same target without blocking another workspace", async () => {
@@ -239,19 +532,16 @@ describe("session MCP maintenance", () => {
     const recreatedClient = { baseUrl: "https://worker.openwork.test/", token: "worker-token" };
     const targetA = getSessionMcpMaintenanceTargetKey({
       client: firstClient,
-      cloudSignedIn: true,
       workspaceId: "workspace_a",
       directory: "/workspace/a",
     });
     const recreatedTargetA = getSessionMcpMaintenanceTargetKey({
       client: recreatedClient,
-      cloudSignedIn: true,
       workspaceId: "workspace_a",
       directory: "/workspace/a",
     });
     const targetB = getSessionMcpMaintenanceTargetKey({
       client: recreatedClient,
-      cloudSignedIn: true,
       workspaceId: "workspace_b",
       directory: "/workspace/b",
     });

--- a/evals/flows/cloud-mcp-signed-in-auto-enable.flow.mjs
+++ b/evals/flows/cloud-mcp-signed-in-auto-enable.flow.mjs
@@ -1,0 +1,704 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/cloud-mcp-signed-in-auto-enable.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("cloud-mcp-signed-in-auto-enable");
+
+const CLOUD_TITLE = "OpenWork Cloud Control";
+const CLOUD_SERVER_NAME = "openwork-cloud";
+const USER_STATE_KEY = "openwork.den.mcp.cloudControlUserState";
+const SYNC_MARKER_KEY = "openwork.den.mcp.sync";
+const HIDDEN_KEY = "openwork.extension.hidden.openwork-cloud";
+const RUN_TAG = Date.now();
+const WORKSPACE_PATH = `/tmp/openwork-cloud-mcp-signed-in-auto-enable-${RUN_TAG}`;
+const CONFIGURED_STATUSES = ["Ready", "Paused", "Needs sign-in", "Offline", "Issue", "Checking"];
+
+const state = {
+  workspaceId: "",
+};
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function denApiUrl(ctx) {
+  return ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+}
+
+function bearerToken(ctx) {
+  return ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim();
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function denFetch(ctx, path, options = {}) {
+  const response = await fetch(`${denApiUrl(ctx)}${path}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = null;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body, text };
+}
+
+async function waitForRenderer(ctx, label = "desktop renderer") {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 120_000, label: `${label}: control API` });
+  await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", { timeoutMs: 45_000, label: `${label}: desktop bridge` });
+}
+
+async function closeStaleChrome(ctx) {
+  await ctx.eval(`(() => {
+    window.dispatchEvent(new CustomEvent('openwork-close-right-pane'));
+    for (const dialog of document.querySelectorAll('[role="dialog"]')) {
+      const close = [...dialog.querySelectorAll('button')].find((button) => {
+        const label = button.getAttribute('aria-label') ?? button.textContent ?? '';
+        return /close|cancel/i.test(label);
+      });
+      close?.click();
+    }
+    return true;
+  })()`);
+}
+
+async function setBootstrapAndSignIn(ctx) {
+  await waitForRenderer(ctx, "initial app");
+  const apiBase = denApiUrl(ctx);
+  const bootstrap = { baseUrl: apiBase, apiBaseUrl: apiBase, requireSignin: false, handoff: null };
+  const written = await ctx.eval(`(async () => {
+    const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!bridge) return false;
+    await bridge('setDesktopBootstrapConfig', ${JSON.stringify(bootstrap)});
+    localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(apiBase)});
+    localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(apiBase)});
+    localStorage.removeItem('openwork.den.authToken');
+    localStorage.removeItem('openwork.den.activeOrgId');
+    localStorage.removeItem('openwork.den.activeOrgSlug');
+    localStorage.removeItem(${JSON.stringify(USER_STATE_KEY)});
+    localStorage.removeItem(${JSON.stringify(SYNC_MARKER_KEY)});
+    localStorage.removeItem(${JSON.stringify(HIDDEN_KEY)});
+    return true;
+  })()`, { awaitPromise: true });
+  ctx.assert(written === true, "Failed to write desktop Den bootstrap config.");
+  await ctx.eval("location.reload()");
+  await waitForRenderer(ctx, "app after Den bootstrap reload");
+
+  const handoff = await denFetch(ctx, "/v1/auth/desktop-handoff", {
+    method: "POST",
+    headers: { authorization: `Bearer ${bearerToken(ctx)}` },
+    body: JSON.stringify({ desktopScheme: "openwork" }),
+  });
+  ctx.assert(handoff.response.ok, `Desktop handoff failed: ${handoff.response.status} ${handoff.text.slice(0, 200)}`);
+  ctx.assert(typeof handoff.body?.grant === "string" && handoff.body.grant.length > 0, "Handoff response did not include a grant.");
+  await ctx.control("auth.exchange-grant", { grant: handoff.body.grant, baseUrl: apiBase });
+  await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", { timeoutMs: 45_000, label: "persisted Den auth token" });
+  await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", { timeoutMs: 60_000, label: "active Den organization" });
+}
+
+async function completeOnboardingWithoutSettings(ctx) {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const view = await ctx.eval(`(() => ({
+      hash: location.hash,
+      text: document.body.innerText,
+      hasFolderInput: Boolean(document.querySelector('input[placeholder="/workspace/my-project"]')),
+      hasServerAuth: Boolean(localStorage.getItem('openwork.server.port') && localStorage.getItem('openwork.server.token')),
+      hasCreateAction: Boolean(window.__openworkControl?.listActions?.().find((action) => action.id === 'workspace.create' && !action.disabled)),
+    }))()`);
+    if (view.hasServerAuth && (view.hash.includes("/workspace/") || view.hasCreateAction || !view.text.includes("Choose your organization"))) return;
+    if (view.hasFolderInput) {
+      await ctx.fill('input[placeholder="/workspace/my-project"]', WORKSPACE_PATH);
+      await ctx.clickText("Use this folder", { timeoutMs: 20_000 });
+      await sleep(500);
+      continue;
+    }
+    const clicked = await ctx.eval(`(() => {
+      const labels = ['Continue with organization', 'Continue to workspace', 'Continue without OpenWork Models', 'Continue'];
+      const button = [...document.querySelectorAll('button')].find((candidate) => labels.includes((candidate.textContent ?? '').trim()) && !candidate.disabled);
+      button?.click();
+      return Boolean(button);
+    })()`);
+    if (!clicked && !view.hash.includes("/session")) await ctx.navigateHash("/session").catch(() => undefined);
+    await sleep(750);
+  }
+  ctx.assert(false, "Onboarding did not reach a session/workspace state with local OpenWork server auth.");
+}
+
+async function persistDesktopSelectedWorkspace(ctx, workspaceId) {
+  const selection = await ctx.eval(`(async () => {
+    const invokeDesktop = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!invokeDesktop) return { ok: false, reason: 'missing desktop bridge' };
+    const expected = ${JSON.stringify(workspaceId)};
+    const summarize = (list) => {
+      const selectedId = String(list?.selectedId ?? '').trim();
+      const activeId = String(list?.activeId ?? '').trim();
+      const watchedId = String(list?.watchedId ?? '').trim();
+      return {
+        selectedId,
+        activeId,
+        watchedId,
+        resolvedId: selectedId || activeId,
+        hasWorkspace: (list?.workspaces ?? []).some((workspace) => workspace?.id === expected),
+      };
+    };
+    const afterSet = summarize(await invokeDesktop('workspaceSetSelected', expected));
+    const afterBootstrap = summarize(await invokeDesktop('workspaceBootstrap'));
+    return {
+      ok: afterSet.resolvedId === expected && afterBootstrap.resolvedId === expected,
+      afterSet,
+      afterBootstrap,
+    };
+  })()`, { awaitPromise: true });
+  ctx.assert(selection?.ok, `Desktop workspace selection did not persist for ${workspaceId}: ${JSON.stringify(selection)}`);
+  return selection;
+}
+
+async function assertDesktopSelectedWorkspace(ctx, label) {
+  ctx.assert(Boolean(state.workspaceId), "No eval workspace id recorded.");
+  const selection = await ctx.eval(`(async () => {
+    const invokeDesktop = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!invokeDesktop) return { ok: false, reason: 'missing desktop bridge' };
+    const expected = ${JSON.stringify(state.workspaceId)};
+    const list = await invokeDesktop('workspaceBootstrap');
+    const selectedId = String(list?.selectedId ?? '').trim();
+    const activeId = String(list?.activeId ?? '').trim();
+    const watchedId = String(list?.watchedId ?? '').trim();
+    const resolvedId = selectedId || activeId;
+    return {
+      ok: resolvedId === expected,
+      selectedId,
+      activeId,
+      watchedId,
+      resolvedId,
+      hasWorkspace: (list?.workspaces ?? []).some((workspace) => workspace?.id === expected),
+    };
+  })()`, { awaitPromise: true });
+  ctx.assert(selection?.ok, `${label}: expected desktop-selected workspace ${state.workspaceId}, got ${JSON.stringify(selection)}`);
+  return selection;
+}
+
+async function waitForLocalOpenworkServer(ctx, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await ctx.eval(`(async () => {
+      const port = localStorage.getItem('openwork.server.port');
+      const token = localStorage.getItem('openwork.server.token');
+      const hostToken = localStorage.getItem('openwork.server.hostToken');
+      if (!port || !token) return { ok: false, reason: 'missing server auth', port, hasToken: Boolean(token) };
+      const headers = { authorization: 'Bearer ' + token };
+      if (hostToken) headers['x-openwork-host-token'] = hostToken;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 3_000);
+      try {
+        const response = await fetch('http://127.0.0.1:' + port + '/health', {
+          headers,
+          cache: 'no-store',
+          signal: controller.signal,
+        });
+        const text = await response.text().catch(() => '');
+        return { ok: response.ok, status: response.status, port, hasToken: true, text: text.slice(0, 200) };
+      } catch (error) {
+        return { ok: false, port, hasToken: true, error: error instanceof Error ? error.message : String(error) };
+      } finally {
+        clearTimeout(timeout);
+      }
+    })()`, { awaitPromise: true }).catch((error) => ({ ok: false, error: errorMessage(error) }));
+    if (last?.ok) return last;
+    await sleep(750);
+  }
+  ctx.assert(false, `Local OpenWork server did not become healthy before workspace creation. Last witness: ${JSON.stringify(last)}`);
+  return last;
+}
+
+async function createOrActivateLocalEvalWorkspace(ctx, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await ctx.eval(`(async () => {
+      const port = localStorage.getItem('openwork.server.port');
+      const token = localStorage.getItem('openwork.server.token');
+      const hostToken = localStorage.getItem('openwork.server.hostToken');
+      if (!port || !token) return { ok: false, transient: true, reason: 'missing server auth', port, hasToken: Boolean(token) };
+      const base = 'http://127.0.0.1:' + port;
+      const headers = { 'content-type': 'application/json', authorization: 'Bearer ' + token };
+      if (hostToken) headers['x-openwork-host-token'] = hostToken;
+      let response = null;
+      let text = '';
+      try {
+        response = await fetch(base + '/workspaces/local', {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ folderPath: ${JSON.stringify(WORKSPACE_PATH)}, name: 'cloud-mcp-signed-in-auto-enable', preset: 'starter' }),
+        });
+        text = await response.text();
+      } catch (error) {
+        return { ok: false, transient: true, stage: 'create', port, error: error instanceof Error ? error.message : String(error) };
+      }
+      let payload = null;
+      try { payload = JSON.parse(text); } catch {}
+      if (!response.ok) return { ok: false, transient: response.status >= 500, stage: 'create', status: response.status, text };
+      const workspaces = payload?.workspaces ?? payload?.items ?? [];
+      const workspaceId = payload?.activeId ?? payload?.workspace?.id ?? workspaces.find((workspace) => workspace.path === ${JSON.stringify(WORKSPACE_PATH)})?.id;
+      if (!workspaceId) return { ok: false, transient: false, stage: 'create', status: response.status, text: 'workspace id missing', payload };
+      let activated = null;
+      let activatedText = '';
+      try {
+        activated = await fetch(base + '/workspaces/' + encodeURIComponent(workspaceId) + '/activate?persist=true', { method: 'POST', headers });
+        activatedText = await activated.text();
+      } catch (error) {
+        return { ok: false, transient: true, stage: 'activate', workspaceId, port, error: error instanceof Error ? error.message : String(error) };
+      }
+      if (!activated.ok) return { ok: false, transient: activated.status >= 500, stage: 'activate', workspaceId, status: activated.status, text: activatedText };
+      localStorage.setItem('openwork.react.activeWorkspace', workspaceId);
+      return { ok: true, workspaceId };
+    })()`, { awaitPromise: true }).catch((error) => ({ ok: false, transient: true, error: errorMessage(error) }));
+    if (last?.ok && last.workspaceId) return last;
+    if (last && last.transient === false) {
+      ctx.assert(false, `Failed to create/select local eval workspace: ${JSON.stringify(last)}`);
+    }
+    await sleep(750);
+  }
+  ctx.assert(false, `Timed out creating/selecting local eval workspace. Last witness: ${JSON.stringify(last)}`);
+  return last;
+}
+
+async function ensureLocalEvalWorkspace(ctx) {
+  await ctx.navigateHash("/session");
+  await completeOnboardingWithoutSettings(ctx);
+  await waitForLocalOpenworkServer(ctx);
+  const created = await createOrActivateLocalEvalWorkspace(ctx);
+  ctx.assert(created?.ok && created.workspaceId, `Failed to create/select local eval workspace: ${JSON.stringify(created)}`);
+  state.workspaceId = created.workspaceId;
+  await persistDesktopSelectedWorkspace(ctx, state.workspaceId);
+  await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+  await ctx.waitFor("location.hash.includes('/workspace/') && location.hash.includes('/session')", { timeoutMs: 45_000, label: "eval workspace session route" });
+  await ctx.clickText("Continue without OpenWork Models", { timeoutMs: 5_000 }).catch(() => undefined);
+  await ctx.waitForText("Search sessions", { timeoutMs: 45_000 });
+}
+
+function rawCloudMcpExpr(workspaceId, apiBase) {
+  return `(async () => {
+    const port = localStorage.getItem('openwork.server.port');
+    const token = localStorage.getItem('openwork.server.token');
+    const hostToken = localStorage.getItem('openwork.server.hostToken');
+    const activeOrgId = (localStorage.getItem('openwork.den.activeOrgId') ?? '').trim();
+    const denToken = (localStorage.getItem('openwork.den.authToken') ?? '').trim();
+    const base = port ? 'http://127.0.0.1:' + port : '';
+    const headers = token ? { authorization: 'Bearer ' + token } : {};
+    if (hostToken) headers['x-openwork-host-token'] = hostToken;
+    let payload = null;
+    let status = 0;
+    let text = '';
+    if (base && token) {
+      const response = await fetch(base + '/workspace/' + encodeURIComponent(${JSON.stringify(workspaceId)}) + '/mcp', { headers });
+      status = response.status;
+      text = await response.text();
+      try { payload = JSON.parse(text); } catch {}
+    }
+    const items = payload?.items ?? [];
+    const entry = items.find((item) => item.name === ${JSON.stringify(CLOUD_SERVER_NAME)}) ?? null;
+    const markerRaw = localStorage.getItem(${JSON.stringify(SYNC_MARKER_KEY)});
+    let marker = null;
+    try {
+      const parsed = JSON.parse(markerRaw ?? 'null');
+      const candidates = Array.isArray(parsed) ? parsed : Array.isArray(parsed?.markers) ? parsed.markers : parsed ? [parsed] : [];
+      marker = candidates.find((candidate) => {
+        if (!candidate || candidate.orgId !== activeOrgId || candidate.workspaceId !== ${JSON.stringify(workspaceId)}) return false;
+        let markerPort = '';
+        try { markerPort = new URL(candidate.serverBaseUrl).port; } catch {}
+        let markerDenBaseUrl = String(candidate.denBaseUrl ?? '');
+        while (markerDenBaseUrl.endsWith('/')) markerDenBaseUrl = markerDenBaseUrl.slice(0, -1);
+        return markerPort === String(port ?? '') && markerDenBaseUrl === ${JSON.stringify(apiBase)};
+      }) ?? null;
+    } catch {}
+    const config = entry?.config ?? null;
+    const authHeader = config?.headers?.Authorization ?? config?.headers?.authorization ?? '';
+    const url = typeof config?.url === 'string' ? config.url : '';
+    const enabled = config ? config.enabled !== false : null;
+    const markerFresh = marker ? Date.parse(marker.expiresAt) > Date.now() : false;
+    return {
+      ok: Boolean(status >= 200 && status < 300),
+      status,
+      text,
+      workspaceId: ${JSON.stringify(workspaceId)},
+      signedIn: Boolean(denToken && activeOrgId),
+      activeOrgId,
+      entry,
+      entryNames: items.map((item) => item.name),
+      engineSync: payload?.engineSync ?? null,
+      marker,
+      markerFresh,
+      userIntent: localStorage.getItem(${JSON.stringify(USER_STATE_KEY)}),
+      entryReady: Boolean(config && enabled === true && url.endsWith('/mcp/agent') && authHeader.startsWith('Bearer ') && config.oauth === false),
+      entryPaused: Boolean(config && enabled === false),
+    };
+  })()`;
+}
+
+async function readRawCloudMcp(ctx) {
+  ctx.assert(Boolean(state.workspaceId), "No eval workspace id recorded.");
+  return ctx.eval(rawCloudMcpExpr(state.workspaceId, denApiUrl(ctx)), { awaitPromise: true });
+}
+
+async function waitForRawCloudMcp(ctx, label, predicate, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await readRawCloudMcp(ctx).catch((error) => ({ error: errorMessage(error) }));
+    if (predicate(last)) return last;
+    await sleep(750);
+  }
+  ctx.assert(false, `${label} did not become true. Last raw witness: ${JSON.stringify(last)}`);
+  return last;
+}
+
+async function removeCloudMcpRuntimeEntry(ctx) {
+  const cleanup = await ctx.eval(`(async () => {
+    localStorage.setItem(${JSON.stringify(USER_STATE_KEY)}, 'removed');
+    localStorage.removeItem(${JSON.stringify(SYNC_MARKER_KEY)});
+    localStorage.removeItem(${JSON.stringify(HIDDEN_KEY)});
+    const port = localStorage.getItem('openwork.server.port');
+    const token = localStorage.getItem('openwork.server.token');
+    const hostToken = localStorage.getItem('openwork.server.hostToken');
+    if (!port || !token) return { ok: false, reason: 'missing server auth' };
+    const headers = { authorization: 'Bearer ' + token };
+    if (hostToken) headers['x-openwork-host-token'] = hostToken;
+    const response = await fetch('http://127.0.0.1:' + port + '/workspace/' + encodeURIComponent(${JSON.stringify(state.workspaceId)}) + '/mcp/' + encodeURIComponent(${JSON.stringify(CLOUD_SERVER_NAME)}), {
+      method: 'DELETE',
+      headers,
+    });
+    return { ok: response.ok, status: response.status, text: await response.text().catch(() => '') };
+  })()`, { awaitPromise: true });
+  ctx.assert(cleanup?.ok, `Cloud MCP cleanup failed: ${JSON.stringify(cleanup)}`);
+  await waitForRawCloudMcp(ctx, "openwork-cloud removed while intent blocks resurrection", (raw) => raw?.ok && !raw.entry, 15_000);
+  await ctx.eval(`(() => {
+    localStorage.removeItem(${JSON.stringify(USER_STATE_KEY)});
+    localStorage.removeItem(${JSON.stringify(SYNC_MARKER_KEY)});
+    localStorage.removeItem(${JSON.stringify(HIDDEN_KEY)});
+    return true;
+  })()`);
+}
+
+async function establishCleanBaseline(ctx) {
+  await closeStaleChrome(ctx);
+  await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+  await ctx.waitFor("location.hash.includes('/session') && !location.hash.includes('/settings')", { timeoutMs: 30_000, label: "session route before final cleanup" });
+  await ctx.waitForText("Search sessions", { timeoutMs: 45_000 });
+  // Keep the final cleanup last: after the intent + marker are cleared, the
+  // next reconciliation should be the frame-1 app-load startup hook.
+  await removeCloudMcpRuntimeEntry(ctx);
+}
+
+async function reloadAppAndWait(ctx, label = "app reload") {
+  await assertDesktopSelectedWorkspace(ctx, `desktop selection before ${label}`);
+  await ctx.eval("location.reload()").catch((error) => {
+    ctx.log(`location.reload control call ended during reload: ${errorMessage(error)}`);
+  });
+  await waitForRenderer(ctx, `app after ${label}`);
+  await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim() && (localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", {
+    timeoutMs: 60_000,
+    label: `signed-in Den session after ${label}`,
+  });
+  await assertDesktopSelectedWorkspace(ctx, `desktop selection after ${label}`);
+  await ctx.waitFor(`(() => {
+    const hash = location.hash;
+    return hash.includes(${JSON.stringify(`/workspace/${state.workspaceId}/session`)}) && !hash.includes('/settings');
+  })()`, { timeoutMs: 45_000, label: `pinned workspace route after ${label}` });
+  await ctx.waitForText("Search sessions", { timeoutMs: 45_000 });
+}
+
+const hydratedExtensionsViewReadyExpr = () => `(() => {
+  const visible = (element) => Boolean(element && (element.offsetWidth || element.offsetHeight || element.getClientRects().length > 0));
+  const buttons = [...document.querySelectorAll('button')];
+  const showHidden = buttons.some((button) => visible(button) && !button.disabled && (button.textContent ?? '').trim().startsWith('Show hidden'));
+  const publicEntry = buttons.some((button) => {
+    const text = button.textContent ?? '';
+    return visible(button) && !button.disabled && (text.includes('Notion') || text.includes('Linear'));
+  });
+  return showHidden && publicEntry;
+})()`;
+
+const extensionsSectionAnimationsSettledExpr = () => `(() => {
+  const visible = (element) => Boolean(element && (element.offsetWidth || element.offsetHeight || element.getClientRects().length > 0));
+  const headings = [...document.querySelectorAll('h1,h2,h3,h4,h5,h6,[role="heading"]')];
+  const heading = headings.find((candidate) => visible(candidate) && (candidate.textContent ?? '').trim() === 'Extensions');
+  if (!heading) return false;
+  const section = heading.closest('section') ?? [...document.querySelectorAll('section')].find((candidate) => {
+    const text = candidate.textContent ?? '';
+    return visible(candidate) && text.includes('Add Custom App') && text.includes('Show hidden');
+  });
+  if (!section) return false;
+  return !section.getAnimations({ subtree: true }).some((animation) => animation.playState === 'running');
+})()`;
+
+async function openExtensionsView(ctx) {
+  await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+  await ctx.waitFor(`(() => {
+    const hash = location.hash;
+    return hash.includes(${JSON.stringify(`/workspace/${state.workspaceId}/session`)}) && !hash.includes('/settings');
+  })()`, { timeoutMs: 30_000, label: "session route before Settings Extensions view" });
+  await ctx.waitFor("Boolean(document.querySelector('button[aria-label=\"Settings\"]'))", { timeoutMs: 30_000, label: "Settings button" });
+  const clickedSettings = await ctx.eval(`(() => {
+    const button = document.querySelector('button[aria-label="Settings"]');
+    if (!button || button.disabled) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(clickedSettings, "Could not click the user-facing Settings button.");
+  await ctx.waitFor(`location.hash.includes(${JSON.stringify(`/workspace/${state.workspaceId}/settings`)})`, { timeoutMs: 30_000, label: "workspace Settings route" });
+  await ctx.waitForText("Settings", { timeoutMs: 30_000 });
+  await ctx.waitFor(`(() => {
+    const sidebars = [...document.querySelectorAll('[data-slot="sidebar"], [data-sidebar="sidebar"]')];
+    const buttons = sidebars.flatMap((sidebar) => [...sidebar.querySelectorAll('button[data-sidebar="menu-button"], button[data-slot="sidebar-menu-button"], button')]);
+    return buttons.some((candidate) => (candidate.textContent ?? '').trim() === 'Extensions' && !candidate.disabled);
+  })()`, { timeoutMs: 30_000, label: "Settings sidebar Extensions button" });
+  const clickedExtensions = await ctx.eval(`(() => {
+    const sidebars = [...document.querySelectorAll('[data-slot="sidebar"], [data-sidebar="sidebar"]')];
+    const buttons = sidebars.flatMap((sidebar) => [...sidebar.querySelectorAll('button[data-sidebar="menu-button"], button[data-slot="sidebar-menu-button"], button')]);
+    const button = buttons.find((candidate) => (candidate.textContent ?? '').trim() === 'Extensions' && !candidate.disabled);
+    if (!button) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(clickedExtensions, "Could not click the Settings sidebar Extensions button.");
+  await ctx.waitFor(`location.hash.includes(${JSON.stringify(`/workspace/${state.workspaceId}/settings/extensions`)})`, { timeoutMs: 30_000, label: "workspace Settings Extensions route" });
+  await ctx.waitForText("Add Custom App", { timeoutMs: 45_000 });
+  await ctx.waitFor("document.body.innerText.includes('Show hidden')", { timeoutMs: 30_000, label: "Show hidden control in Extensions view" });
+  await ctx.waitFor(hydratedExtensionsViewReadyExpr(), { timeoutMs: 45_000, label: "hydrated Extensions view controls and public cards" });
+  await ctx.waitFor(extensionsSectionAnimationsSettledExpr(), { timeoutMs: 15_000, label: "Extensions section animations settled" });
+}
+
+async function revealHidden(ctx) {
+  const showing = await ctx.eval("document.body.innerText.includes('Showing hidden')");
+  if (!showing) await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+  await ctx.waitFor("document.body.innerText.includes('Showing hidden')", { timeoutMs: 15_000, label: "hidden extensions revealed" });
+}
+
+async function visiblePublicDirectoryEntry(ctx) {
+  await ctx.waitFor("document.body.innerText.includes('Notion') || document.body.innerText.includes('Linear')", {
+    timeoutMs: 45_000,
+    label: "public MCP directory entry",
+  });
+  return await ctx.eval("document.body.innerText.includes('Notion') ? 'Notion' : 'Linear'");
+}
+
+const cloudRowExpr = (statuses) => `(() => {
+  const statuses = ${JSON.stringify(statuses)};
+  const buttons = [...document.querySelectorAll('button')];
+  return buttons.some((button) => {
+    const text = button.textContent ?? '';
+    return text.includes(${JSON.stringify(CLOUD_TITLE)}) && statuses.some((status) => text.includes(status));
+  });
+})()`;
+
+const scrollCloudRowExpr = (statuses = CONFIGURED_STATUSES) => `(() => {
+  const statuses = ${JSON.stringify(statuses)};
+  const buttons = [...document.querySelectorAll('button')];
+  const row = buttons.find((button) => {
+    const text = button.textContent ?? '';
+    return text.includes(${JSON.stringify(CLOUD_TITLE)}) && statuses.some((status) => text.includes(status));
+  });
+  row?.scrollIntoView({ block: 'center' });
+  return Boolean(row);
+})()`;
+
+const expandAndClickDetailExpr = (statuses, label) => `(() => {
+  const detail = [...document.querySelectorAll('button')].find((button) => (button.textContent ?? '').trim() === ${JSON.stringify(label)} && !button.disabled);
+  if (detail) {
+    detail.scrollIntoView({ block: 'center' });
+    detail.click();
+    return true;
+  }
+  const statuses = ${JSON.stringify(statuses)};
+  const row = [...document.querySelectorAll('button')].find((button) => {
+    const text = button.textContent ?? '';
+    return text.includes(${JSON.stringify(CLOUD_TITLE)}) && statuses.some((status) => text.includes(status));
+  });
+  if (row) {
+    row.scrollIntoView({ block: 'center' });
+    row.click();
+  }
+  return false;
+})()`;
+
+function assertGeneratedExpressionParses(expression) {
+  new Function(`return ${expression};`);
+}
+
+export function validateCloudMcpGeneratedExpressionsForTest() {
+  assertGeneratedExpressionParses(rawCloudMcpExpr("workspace_eval_validation", "https://app.openwork.test/api/den"));
+  assertGeneratedExpressionParses(cloudRowExpr(["Ready"]));
+  assertGeneratedExpressionParses(scrollCloudRowExpr(["Ready"]));
+  assertGeneratedExpressionParses(expandAndClickDetailExpr(["Ready"], "Disable"));
+  assertGeneratedExpressionParses(hydratedExtensionsViewReadyExpr());
+  assertGeneratedExpressionParses(extensionsSectionAnimationsSettledExpr());
+  return true;
+}
+
+async function waitForCloudRow(ctx, statuses, label, timeoutMs = 60_000) {
+  await ctx.waitFor(cloudRowExpr(statuses), { timeoutMs, label });
+  await ctx.eval(scrollCloudRowExpr(statuses));
+}
+
+async function waitForSignedInReadyCloudMcp(ctx) {
+  return waitForRawCloudMcp(ctx, "signed-in enabled openwork-cloud MCP", (raw) =>
+    raw?.signedIn === true &&
+    raw?.entryReady === true &&
+    raw?.engineSync?.status === "ok" &&
+    raw?.markerFresh === true,
+  90_000);
+}
+
+export default {
+  id: "cloud-mcp-signed-in-auto-enable",
+  title: "Signed-in users get OpenWork Cloud Control automatically without cluttering Extensions",
+  kind: "user-facing",
+  spec: "evals/voiceovers/cloud-mcp-signed-in-auto-enable.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  steps: [
+    {
+      name: "Setup: signed-in clean desktop baseline outside Settings",
+      run: async (ctx) => {
+        ctx.assert(vo.length === 4, `Expected 4 approved voiceover paragraphs, got ${vo.length}.`);
+        await setBootstrapAndSignIn(ctx);
+        await ensureLocalEvalWorkspace(ctx);
+        await establishCleanBaseline(ctx);
+      },
+    },
+    {
+      name: "Frame 1 — signed-in launch auto-configures Cloud MCP without Settings",
+      run: async (ctx) => {
+        let preLoadWitness = null;
+        let rawWitness = null;
+        await ctx.prove("A signed-in app load configures OpenWork Cloud Control in the background without opening Settings", {
+          voiceover: vo[0],
+          action: async () => {
+            preLoadWitness = await readRawCloudMcp(ctx);
+            ctx.assert(preLoadWitness?.ok && !preLoadWitness.entry && preLoadWitness.userIntent === null && preLoadWitness.marker === null, `Expected clean pre-load baseline, got ${JSON.stringify(preLoadWitness)}`);
+            await reloadAppAndWait(ctx, "startup reload");
+          },
+          assert: async () => {
+            ctx.assert(preLoadWitness?.ok && !preLoadWitness.entry, `Cloud MCP was not removed immediately before app load: ${JSON.stringify(preLoadWitness)}`);
+            const auth = await ctx.control("auth.status");
+            ctx.assert(auth?.status === "signed_in", `Expected signed_in auth status, got ${JSON.stringify(auth)}.`);
+            rawWitness = await waitForSignedInReadyCloudMcp(ctx);
+            ctx.assert(!String(await ctx.eval("location.hash")).includes("/settings"), "Frame 1 must remain off Settings.");
+            ctx.assert(rawWitness.entry.config.oauth === false, "Cloud MCP must be header-authenticated with oauth:false.");
+            ctx.assert(rawWitness.entry.config.headers.Authorization.startsWith("Bearer "), "Cloud MCP Authorization header must be bearer.");
+          },
+          screenshot: {
+            name: "cloud-mcp-session-auto-enabled",
+            claim: "The user is on the session surface after app load while the server already has an enabled, header-authenticated OpenWork Cloud Control MCP.",
+            requireText: ["Search sessions"],
+            rejectText: ["Something went wrong", "Choose your organization"],
+            hashIncludes: "/session",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2 — Extensions view stays uncluttered by default",
+      run: async (ctx) => {
+        await ctx.prove("The normal Extensions settings view hides OpenWork Cloud Control even though the backend is configured", {
+          voiceover: vo[1],
+          action: async () => {
+            await openExtensionsView(ctx);
+          },
+          assert: async () => {
+            const publicEntry = await visiblePublicDirectoryEntry(ctx);
+            ctx.assert(publicEntry === "Notion" || publicEntry === "Linear", `Expected Notion or Linear, got ${publicEntry}.`);
+            await ctx.expectText("Show hidden", { timeoutMs: 30_000 });
+            await ctx.expectNoText(CLOUD_TITLE);
+            const rawWitness = await readRawCloudMcp(ctx);
+            ctx.assert(rawWitness.entryReady === true, `Backend Cloud MCP should still be enabled: ${JSON.stringify(rawWitness)}`);
+          },
+          screenshot: {
+            name: "cloud-mcp-hidden-default",
+            claim: "The Extensions settings view shows public MCP directory entries and the Show hidden control, but not OpenWork Cloud Control.",
+            requireText: ["Show hidden", "Add Custom App"],
+            rejectText: [CLOUD_TITLE, "Something went wrong"],
+            hashIncludes: "/settings/extensions",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — Show hidden reveals configured and ready Cloud Control",
+      run: async (ctx) => {
+        await ctx.prove("Show hidden in the Extensions settings view reveals OpenWork Cloud Control as a configured Ready connection", {
+          voiceover: vo[2],
+          action: async () => {
+            await revealHidden(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("Showing hidden", { timeoutMs: 15_000 });
+            await ctx.expectText(CLOUD_TITLE, { timeoutMs: 30_000 });
+            await waitForCloudRow(ctx, ["Ready"], "configured OpenWork Cloud Control row is Ready", 90_000);
+            const rawWitness = await readRawCloudMcp(ctx);
+            ctx.assert(rawWitness.entryReady === true, `Backend Cloud MCP should be enabled/header-auth/oauth:false: ${JSON.stringify(rawWitness)}`);
+          },
+          screenshot: {
+            name: "cloud-mcp-revealed-ready",
+            claim: "After Show hidden in the Extensions settings view, OpenWork Cloud Control is visible as a configured Ready app.",
+            requireText: [CLOUD_TITLE, "Ready", "Showing hidden"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4 — Pause survives reload and startup reconciliation",
+      run: async (ctx) => {
+        await ctx.prove("Pausing OpenWork Cloud Control persists across app reload and the startup reconciler does not re-enable it", {
+          voiceover: vo[3],
+          action: async () => {
+            await waitForCloudRow(ctx, ["Ready"], "ready Cloud Control row before disabling", 60_000);
+            await ctx.waitFor(expandAndClickDetailExpr(["Ready"], "Disable"), {
+              timeoutMs: 30_000,
+              label: "expand OpenWork Cloud Control and click Disable",
+            });
+            await waitForCloudRow(ctx, ["Paused"], "OpenWork Cloud Control shows Paused before reload", 45_000);
+            await ctx.waitFor(`localStorage.getItem(${JSON.stringify(USER_STATE_KEY)}) === 'disabled'`, {
+              timeoutMs: 20_000,
+              label: "disabled Cloud MCP intent persisted",
+            });
+            await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+            await ctx.waitFor("location.hash.includes('/session') && !location.hash.includes('/settings')", { timeoutMs: 30_000, label: "session route before pause reload" });
+            await reloadAppAndWait(ctx, "return reload");
+            await openExtensionsView(ctx);
+            await revealHidden(ctx);
+          },
+          assert: async () => {
+            await waitForRawCloudMcp(ctx, "paused Cloud MCP remains disabled after startup", (raw) =>
+              raw?.entryPaused === true && raw?.userIntent === "disabled" && raw?.signedIn === true,
+            20_000);
+            await waitForCloudRow(ctx, ["Paused"], "OpenWork Cloud Control row stays Paused after reload", 45_000);
+            await ctx.waitFor("!(document.body.innerText ?? '').includes('new notifications')", {
+              timeoutMs: 15_000,
+              label: "notification toast gone before paused screenshot",
+            });
+            const rawWitness = await readRawCloudMcp(ctx);
+            ctx.assert(rawWitness.entry?.config?.enabled === false, `Backend entry was resurrected: ${JSON.stringify(rawWitness)}`);
+            ctx.assert(rawWitness.userIntent === "disabled", `Disabled intent was lost: ${JSON.stringify(rawWitness)}`);
+          },
+          screenshot: {
+            name: "cloud-mcp-paused-after-reload",
+            claim: "OpenWork Cloud Control remains Paused in the Extensions settings view after reloading the app and revealing hidden extensions again.",
+            requireText: [CLOUD_TITLE, "Paused", "Showing hidden"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/extensions",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/cloud-mcp-signed-in-auto-enable.md
+++ b/evals/voiceovers/cloud-mcp-signed-in-auto-enable.md
@@ -1,0 +1,9 @@
+# cloud-mcp-signed-in-auto-enable — Signed-in users get Cloud MCP automatically without UI clutter
+
+1. I open OpenWork while signed in to OpenWork Cloud. I can begin working without visiting Settings or manually connecting anything.
+
+2. The Extensions view stays uncluttered because the built-in OpenWork Cloud connection is hidden by default.
+
+3. When I turn on Show hidden, OpenWork Cloud Control appears already configured for my organization and ready to use.
+
+4. I can still pause the connection if I don’t want to use it, and it remains paused when I leave and return.


### PR DESCRIPTION
## Summary
- reconcile OpenWork Cloud Control once at app scope for signed-in users, including workspace and organization changes
- preserve explicit disable/remove intent, legacy URL healing, quiet failures, and forced Refresh semantics
- keep Cloud Control hidden by default and prove the Show hidden / pause experience end to end

## Tests
- `bun test tests/session-mcp-maintenance.test.ts tests/cloud-mcp-auto-sync.test.ts tests/cloud-mcp-user-state.test.ts tests/builtin-mcp-visibility.test.ts tests/extension-items.test.ts tests/den-mcp-url.test.ts` (42 passed)
- `pnpm --filter @openwork/app typecheck` (passed)
- `OPENWORK_EVAL_DEN_PORT=8890 DEN_DEMO_OWNER_EMAIL=alex-cloud-mcp-auto-20260709@acme.test pnpm fraimz --flow cloud-mcp-signed-in-auto-enable --stack den` (passed: 4 frames + voice-over coverage)

## Proof
- `evals/results/2026-07-10T03-43-15-795Z/fraimz.html`
- The fraimz proof will be posted as a PR comment.