### PR TITLE
test(den): reproduce corporate CA OAuth failures

### DIFF
--- a/ee/apps/den-api/scripts/repro-corporate-ca.ts
+++ b/ee/apps/den-api/scripts/repro-corporate-ca.ts
@@ -1,0 +1,105 @@
+import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
+
+process.env.OPENWORK_DEV_MODE = "1"
+process.env.DEN_ALLOW_PRIVATE_MCP_URLS = "1"
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_den"
+process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "daytona-den-db-encryption-key-please-change-1234567890"
+process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "daytona-den-auth-secret-please-change-1234567890"
+process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8788"
+process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8788"
+
+const connectionUrl = process.env.DEN_TLS_REPRO_URL?.trim()
+const expected = process.env.DEN_TLS_REPRO_EXPECT?.trim()
+
+if (!connectionUrl) throw new Error("DEN_TLS_REPRO_URL is required.")
+if (expected !== "trusted" && expected !== "untrusted") {
+  throw new Error('DEN_TLS_REPRO_EXPECT must be "trusted" or "untrusted".')
+}
+
+const [appModule, dbModule, schema, drizzle, session, connections] = await Promise.all([
+  import("../src/app.js"),
+  import("../src/db.js"),
+  import("@openwork-ee/den-db/schema"),
+  import("@openwork-ee/den-db/drizzle"),
+  import("../src/session.js"),
+  import("../src/capability-sources/external-mcp-connections.js"),
+])
+
+const app = appModule.default
+const db = dbModule.db
+const userId = createDenTypeId("user")
+const organizationId = createDenTypeId("organization")
+const memberId = createDenTypeId("member")
+let connectionId: DenTypeId<"externalMcpConnection"> | undefined
+
+try {
+  await db.insert(schema.AuthUserTable).values({
+    id: userId,
+    name: "Corporate CA Repro User",
+    email: `corporate-ca-repro+${userId}@test.local`,
+  })
+  await db.insert(schema.OrganizationTable).values({
+    id: organizationId,
+    name: "Corporate CA Repro Org",
+    slug: `corporate-ca-repro-${organizationId}`,
+  })
+  await db.insert(schema.MemberTable).values({
+    id: memberId,
+    organizationId,
+    userId,
+    role: "admin",
+  })
+
+  const connection = await connections.createExternalMcpConnection({
+    organizationId,
+    name: "Corporate TLS OAuth MCP",
+    url: `${connectionUrl.replace(/\/+$/, "")}/mcp`,
+    authType: "oauth",
+    credentialMode: "shared",
+    createdByOrgMembershipId: memberId,
+    access: { orgWide: true, memberIds: [], teamIds: [] },
+  })
+  connectionId = connection.id
+
+  const response = await app.fetch(new Request(`http://den-api.local/v1/mcp-connections/${connection.id}/connect/start`, {
+    headers: {
+      "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId, organizationId }),
+    },
+  }))
+  const body = await response.json() as Record<string, unknown>
+  const result = { expected, status: response.status, body }
+
+  if (expected === "untrusted") {
+    if (response.status !== 502 || body.error !== "oauth_handshake_failed") {
+      throw new Error(`Expected an untrusted-CA 502, received ${JSON.stringify(result)}`)
+    }
+    if (!String(body.message ?? "").toLowerCase().includes("fetch failed")) {
+      throw new Error(`Expected the real Den failure to contain fetch failed, received ${JSON.stringify(result)}`)
+    }
+  } else {
+    if (response.status !== 200 || body.status !== "needs_auth") {
+      throw new Error(`Expected trusted CA discovery to return needs_auth, received ${JSON.stringify(result)}`)
+    }
+    const authorizeUrl = String(body.authorizeUrl ?? "")
+    if (!authorizeUrl.startsWith(`${connectionUrl.replace(/\/+$/, "")}/authorize?`)) {
+      throw new Error(`Expected an authorize URL from the TLS fixture, received ${JSON.stringify(result)}`)
+    }
+  }
+
+  console.log(JSON.stringify(result, null, 2))
+} finally {
+  await db.delete(schema.ConnectedAccountTable).where(drizzle.eq(schema.ConnectedAccountTable.organizationId, organizationId))
+  await db.delete(schema.OrgOAuthClientTable).where(drizzle.eq(schema.OrgOAuthClientTable.organizationId, organizationId))
+  await db.delete(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.eq(schema.ExternalMcpConnectionAccessGrantTable.organizationId, organizationId))
+  if (connectionId) {
+    await db.delete(schema.ExternalMcpConnectionTable).where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connectionId))
+  }
+  await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.organizationId, organizationId))
+  await db.delete(schema.OrganizationRoleTable).where(drizzle.eq(schema.OrganizationRoleTable.organizationId, organizationId))
+  await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+  await db.delete(schema.AuthUserTable).where(drizzle.eq(schema.AuthUserTable.id, userId))
+}
+
+// The shared Den DB client intentionally keeps its pool alive in the server.
+// This one-shot repro has finished all cleanup, so terminate the helper process.
+process.exit(0)

--- a/evals/den-corporate-ca-tls.md
+++ b/evals/den-corporate-ca-tls.md
@@ -1,0 +1,28 @@
+# Den corporate CA TLS
+
+An OpenWork maintainer needs to distinguish a generic external-MCP `fetch failed`
+from a corporate certificate that the Den Node process does not trust.
+
+The integration proof generates an ephemeral corporate root and a localhost
+server certificate, then runs the repository's complete OAuth MCP fixture over
+HTTPS. The same Den `connect/start` route is evaluated in two fresh Node
+processes:
+
+1. Without the root, Node reports a certificate-chain error and Den returns the
+   user-visible `502 oauth_handshake_failed` response containing `fetch failed`.
+2. With the root supplied through `NODE_EXTRA_CA_CERTS` at process startup, Den
+   completes protected-resource discovery and dynamic client registration, then
+   returns `200 needs_auth` with the fixture's authorization URL.
+
+The test must not use `NODE_TLS_REJECT_UNAUTHORIZED=0`. All generated keys and
+certificates live in a temporary directory and are removed when the run ends.
+
+Run this after the Daytona server helper has started MySQL and pushed the Den
+schema:
+
+```bash
+pnpm evals --flow den-corporate-ca-tls
+```
+
+Expected outcome: the internal fraimz report contains the certificate error,
+the untrusted `502`, the trusted `200 needs_auth`, and the final PASS marker.

--- a/evals/flows/den-corporate-ca-tls.flow.mjs
+++ b/evals/flows/den-corporate-ca-tls.flow.mjs
@@ -1,0 +1,54 @@
+/**
+ * App-less integration proof for a corporate CA on an outbound Den OAuth MCP.
+ * Intended to run in the Daytona server sandbox after its MySQL schema is up.
+ */
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "den-corporate-ca-tls";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function witness(ctx, condition, assertion, actual) {
+  if (!condition) {
+    ctx.recordEvidence({ type: "assertion", status: "failed", assertion, actual });
+    ctx.assert(false, assertion + (actual ? ` (actual: ${actual})` : ""));
+  }
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion, actual });
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Den trusts an explicitly mounted corporate CA for OAuth MCP discovery",
+  kind: "internal",
+  spec: "evals/den-corporate-ca-tls.md",
+  requiresApp: false,
+  steps: [
+    {
+      name: "The same Den OAuth route fails before CA injection and succeeds after it",
+      run: async (ctx) => {
+        await ctx.prove("NODE_EXTRA_CA_CERTS changes the real Den OAuth result from 502 fetch failed to needs_auth", {
+          voiceover: vo[0],
+          assert: async () => {
+            const result = spawnSync("bash", [join(ROOT, "scripts", "support", "repro-den-corporate-ca.sh")], {
+              cwd: ROOT,
+              encoding: "utf8",
+              env: process.env,
+              maxBuffer: 4 * 1024 * 1024,
+              timeout: 180_000,
+            });
+            const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+            ctx.output("corporate-ca-reproduction", output);
+            witness(ctx, result.status === 0, "The corporate CA integration repro exits successfully", `status=${result.status}\n${output.slice(-2000)}`);
+            witness(ctx, output.includes("UNABLE_TO_VERIFY_LEAF_SIGNATURE") || output.includes("SELF_SIGNED_CERT_IN_CHAIN") || output.includes("UNABLE_TO_GET_ISSUER_CERT"), "The control request records a certificate-chain rejection");
+            witness(ctx, output.includes('"expected": "untrusted"') && output.includes('"status": 502'), "The real Den route returns 502 without the corporate CA");
+            witness(ctx, output.includes('"expected": "trusted"') && output.includes('"status": 200') && output.includes('"status": "needs_auth"'), "The same Den route reaches OAuth discovery with the corporate CA");
+            witness(ctx, output.includes("PASS: the same Den OAuth route fails without the corporate CA and reaches needs_auth"), "The harness reports its final before/after invariant");
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/den-corporate-ca-tls.md
+++ b/evals/voiceovers/den-corporate-ca-tls.md
@@ -1,0 +1,5 @@
+# den-corporate-ca-tls — Den outbound OAuth uses an explicitly mounted corporate CA
+
+Cast is an OpenWork maintainer reproducing a customer's OAuth MCP failure inside the Daytona Den server environment.
+
+1. The proof sends the same connection through the real Den route twice: first Node rejects the private certificate and Den returns the observed fetch failure; then a fresh process starts with the corporate root and reaches the OAuth authorization handoff without weakening TLS verification.

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -1,14 +1,22 @@
 #!/usr/bin/env node
 import http from "node:http";
+import https from "node:https";
 import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
 
 const host = process.env.HOST || "127.0.0.1";
 const port = Number(process.env.PORT || 3978);
-const issuer = process.env.ISSUER || `http://${host}:${port}`;
+const tlsCertFile = process.env.TLS_CERT_FILE?.trim();
+const tlsKeyFile = process.env.TLS_KEY_FILE?.trim();
+const issuer = process.env.ISSUER || `${tlsCertFile ? "https" : "http"}://${host}:${port}`;
 const autoApprove = process.env.AUTO_APPROVE !== "0";
 const disableDcr = process.env.DISABLE_DCR === "1";
 const mockClientId = process.env.MOCK_CLIENT_ID || "mock-preregistered-client";
 const mockClientSecret = process.env.MOCK_CLIENT_SECRET || "mock-preregistered-secret";
+
+if (Boolean(tlsCertFile) !== Boolean(tlsKeyFile)) {
+  throw new Error("TLS_CERT_FILE and TLS_KEY_FILE must be set together.");
+}
 
 const clients = new Map();
 const codes = new Map();
@@ -329,7 +337,7 @@ async function handleMcp(req, res) {
   json(res, 200, Array.isArray(body) ? responses : responses[0]);
 }
 
-const server = http.createServer(async (req, res) => {
+const requestListener = async (req, res) => {
   try {
     const url = new URL(req.url || "/", issuer);
     record(req, url);
@@ -418,10 +426,18 @@ const server = http.createServer(async (req, res) => {
   } catch (error) {
     json(res, 500, { error: error instanceof Error ? error.message : String(error) });
   }
-});
+};
+
+const server = tlsCertFile && tlsKeyFile
+  ? https.createServer({
+      cert: readFileSync(tlsCertFile),
+      key: readFileSync(tlsKeyFile),
+    }, requestListener)
+  : http.createServer(requestListener);
 
 server.listen(port, host, () => {
   console.log(`[mock-oauth-mcp] listening on ${issuer}`);
+  console.log(`[mock-oauth-mcp] transport: ${tlsCertFile ? "HTTPS" : "HTTP"}`);
   console.log(`[mock-oauth-mcp] MCP URL: ${issuer}/mcp`);
   console.log(`[mock-oauth-mcp] set AUTO_APPROVE=0 to require an approval click`);
 });

--- a/scripts/support/repro-den-corporate-ca.sh
+++ b/scripts/support/repro-den-corporate-ca.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openwork-den-corporate-ca.XXXXXX")"
+PORT="${DEN_TLS_REPRO_PORT:-3979}"
+ISSUER="https://localhost:${PORT}"
+MOCK_PID=""
+
+cleanup() {
+  if [ -n "$MOCK_PID" ]; then
+    kill "$MOCK_PID" >/dev/null 2>&1 || true
+    wait "$MOCK_PID" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+for command in openssl curl node pnpm; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $command" >&2
+    exit 1
+  fi
+done
+
+cat > "$TMP_DIR/server.ext" <<'EOF'
+basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -subj "/CN=OpenWork Corporate TLS Repro Root" \
+  -keyout "$TMP_DIR/root.key" -out "$TMP_DIR/root.pem" >/dev/null 2>&1
+openssl req -newkey rsa:2048 -nodes \
+  -subj "/CN=localhost" \
+  -keyout "$TMP_DIR/server.key" -out "$TMP_DIR/server.csr" >/dev/null 2>&1
+openssl x509 -req -days 1 -sha256 \
+  -in "$TMP_DIR/server.csr" \
+  -CA "$TMP_DIR/root.pem" -CAkey "$TMP_DIR/root.key" -CAcreateserial \
+  -extfile "$TMP_DIR/server.ext" \
+  -out "$TMP_DIR/server.pem" >/dev/null 2>&1
+
+(
+  cd "$ROOT_DIR"
+  HOST=127.0.0.1 \
+  PORT="$PORT" \
+  ISSUER="$ISSUER" \
+  TLS_CERT_FILE="$TMP_DIR/server.pem" \
+  TLS_KEY_FILE="$TMP_DIR/server.key" \
+  node scripts/mock-oauth-mcp-server.mjs > "$TMP_DIR/mock.log" 2>&1
+) &
+MOCK_PID=$!
+
+for _ in $(seq 1 50); do
+  if curl --silent --show-error --fail --cacert "$TMP_DIR/root.pem" "$ISSUER/health" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$MOCK_PID" >/dev/null 2>&1; then
+    echo "ERROR: TLS OAuth fixture exited early" >&2
+    cat "$TMP_DIR/mock.log" >&2
+    exit 1
+  fi
+  sleep 0.2
+done
+curl --silent --show-error --fail --cacert "$TMP_DIR/root.pem" "$ISSUER/health" >/dev/null
+
+echo "==> Control: the certificate is rejected without the corporate root"
+set +e
+UNTRUSTED_PROBE="$(env -u NODE_EXTRA_CA_CERTS node -e '
+fetch(process.argv[1]).then(() => process.exit(0)).catch((error) => {
+  console.error(JSON.stringify({ message: error.message, cause: error.cause?.code ?? error.cause?.message ?? null }));
+  process.exit(23);
+});
+' "$ISSUER/health" 2>&1)"
+UNTRUSTED_PROBE_STATUS=$?
+set -e
+if [ "$UNTRUSTED_PROBE_STATUS" -ne 23 ] || ! grep -Eq 'UNABLE_TO_VERIFY_LEAF_SIGNATURE|SELF_SIGNED_CERT_IN_CHAIN|UNABLE_TO_GET_ISSUER_CERT' <<<"$UNTRUSTED_PROBE"; then
+  echo "ERROR: expected Node to reject the corporate certificate" >&2
+  echo "$UNTRUSTED_PROBE" >&2
+  exit 1
+fi
+echo "$UNTRUSTED_PROBE"
+
+echo "==> Den route without the corporate root: expect 502 fetch failed"
+(
+  cd "$ROOT_DIR"
+  env -u NODE_EXTRA_CA_CERTS \
+    DEN_TLS_REPRO_URL="$ISSUER" \
+    DEN_TLS_REPRO_EXPECT=untrusted \
+    pnpm --filter @openwork-ee/den-api exec tsx scripts/repro-corporate-ca.ts
+)
+
+echo "==> Den route with NODE_EXTRA_CA_CERTS: expect OAuth discovery"
+(
+  cd "$ROOT_DIR"
+  NODE_EXTRA_CA_CERTS="$TMP_DIR/root.pem" \
+    DEN_TLS_REPRO_URL="$ISSUER" \
+    DEN_TLS_REPRO_EXPECT=trusted \
+    pnpm --filter @openwork-ee/den-api exec tsx scripts/repro-corporate-ca.ts
+)
+
+echo "==> PASS: the same Den OAuth route fails without the corporate CA and reaches needs_auth when the CA is mounted at process startup"

--- a/scripts/support/repro-den-corporate-ca.sh
+++ b/scripts/support/repro-den-corporate-ca.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openwork-den-corporate-ca.XXXXXX")"
-PORT="${DEN_TLS_REPRO_PORT:-3979}"
+PORT="${DEN_TLS_REPRO_PORT:-$((39000 + RANDOM % 2000))}"
 ISSUER="https://localhost:${PORT}"
 MOCK_PID=""
 
@@ -56,15 +56,12 @@ openssl x509 -req -days 1 -sha256 \
   -extfile "$TMP_DIR/server.ext" \
   -out "$TMP_DIR/server.pem" >/dev/null 2>&1
 
-(
-  cd "$ROOT_DIR"
-  HOST=127.0.0.1 \
+HOST=127.0.0.1 \
   PORT="$PORT" \
   ISSUER="$ISSUER" \
   TLS_CERT_FILE="$TMP_DIR/server.pem" \
   TLS_KEY_FILE="$TMP_DIR/server.key" \
-  node scripts/mock-oauth-mcp-server.mjs > "$TMP_DIR/mock.log" 2>&1
-) &
+  node "$ROOT_DIR/scripts/mock-oauth-mcp-server.mjs" > "$TMP_DIR/mock.log" 2>&1 &
 MOCK_PID=$!
 
 for _ in $(seq 1 50); do

--- a/scripts/support/repro-den-corporate-ca.sh
+++ b/scripts/support/repro-den-corporate-ca.sh
@@ -23,6 +23,20 @@ for command in openssl curl node pnpm; do
   fi
 done
 
+# A fresh Daytona server snapshot installs workspace dependencies and starts
+# Den from source, but may not have built every linked package that a second
+# one-shot Den process imports. Build only the missing artifacts so the repro
+# behaves the same on a clean sandbox and an already-built checkout.
+if [ ! -f "$ROOT_DIR/packages/email/dist/index.js" ]; then
+  (cd "$ROOT_DIR" && pnpm --filter @openwork/email build)
+fi
+if [ ! -f "$ROOT_DIR/packages/install-config/dist/index.js" ]; then
+  (cd "$ROOT_DIR" && pnpm --filter @openwork/install-config build)
+fi
+if [ ! -f "$ROOT_DIR/ee/packages/den-db/dist/index.js" ]; then
+  (cd "$ROOT_DIR" && pnpm --filter @openwork-ee/den-db build)
+fi
+
 cat > "$TMP_DIR/server.ext" <<'EOF'
 basicConstraints=critical,CA:FALSE
 keyUsage=critical,digitalSignature,keyEncipherment


### PR DESCRIPTION
## Summary

- add optional HTTPS support to the existing full OAuth MCP fixture
- add an exact-route Den harness that runs once without a private root and once with `NODE_EXTRA_CA_CERTS`
- add an app-less eval and runbook for reproducing corporate CA failures in Daytona
- generate ephemeral certificates and clean up all keys, DB rows, and fixture processes

## What this proves

The same `GET /v1/mcp-connections/:id/connect/start` path returns `502 oauth_handshake_failed` with `fetch failed` when Node does not trust the fixture certificate. A fresh Node process with the generated root in `NODE_EXTRA_CA_CERTS` completes protected-resource discovery and dynamic client registration, returning `200 needs_auth` and the authorization URL. No TLS verification bypass is used.

## Evals

- `pnpm --filter @openwork-ee/den-api build`
- `pnpm evals --flow den-corporate-ca-tls` locally: passed
- Daytona server sandbox `ow-den-corporate-ca`, commit `edf9653b3`: passed in 7.363s
  - certificate-chain rejection captured
  - untrusted Den request returned 502
  - trusted Den request returned 200 needs_auth
  - voice-over coverage passed

Daytona report: `evals/results/2026-07-10T05-50-10-439Z/report.md` inside the sandbox.