### PR TITLE
Fix MCP OAuth issuer discovery

### DIFF
--- a/ee/apps/den-api/src/mcp/index.ts
+++ b/ee/apps/den-api/src/mcp/index.ts
@@ -2,10 +2,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StreamableHTTPTransport } from "@hono/mcp"
 import type { Hono } from "hono"
 import { z } from "zod"
+import { env } from "../env.js"
 import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { getMcpResourceUrl, verifyMcpRequest } from "./auth.js"
 import { buildMcpCatalog, getToolDescription, loadOpenApiDocument, type McpToolOperation } from "./catalog.js"
 import { invokeMcpOperation } from "./invoke.js"
+import { getDenAuthIssuer } from "./jwt-policy.js"
 import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities } from "./search.js"
 
 const CATALOG_CACHE_TTL_MS = 5 * 60 * 1000
@@ -34,7 +36,10 @@ export function protectedResourceMetadata(request: Request) {
   const resource = getMcpResourceUrl(request)
   return {
     resource,
-    authorization_servers: [resource.replace(/\/mcp$/, "/api/auth")],
+    // OAuth issuers are invariant; the resource may live on a separate API or
+    // reverse-proxy origin, but Better Auth completes the callback with this
+    // configured issuer.
+    authorization_servers: [getDenAuthIssuer(env.betterAuthUrl)],
     // The MCP SDK uses protected-resource scopes for both dynamic client
     // registration and the authorization request. Advertising offline access
     // lets it explicitly request a rotating refresh grant (and prompt for

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -16,7 +16,6 @@ import { normalizeMcpOAuthClientScope } from "../../mcp/scopes.js"
 import { publicRoute, tokenRoute } from "../../middleware/index.js"
 import { emptyResponse, jsonResponse } from "../../openapi.js"
 import { getSingletonSsoStatus } from "../../orgs.js"
-import { publicRequestUrl } from "../../request-url.js"
 import { samlResponsePolicyMiddleware } from "../../sso-saml-response-middleware.js"
 import { revokeBearerSession, type AuthContextVariables } from "../../session.js"
 import { registerDesktopAuthRoutes } from "./desktop-handoff.js"
@@ -214,28 +213,6 @@ async function handleMcpClientRegistrationRequest(request: Request, path: string
   return rewritten instanceof Response ? rewritten : auth.handler(rewritten)
 }
 
-async function rewriteMetadataOrigin(response: Response, origin: string) {
-  const metadata = await response.json() as Record<string, unknown>
-  const headers = new Headers(response.headers)
-  headers.delete("content-length")
-  headers.set("content-type", "application/json")
-
-  for (const [key, value] of Object.entries(metadata)) {
-    if (typeof value === "string") {
-      metadata[key] = value.replace(env.betterAuthUrl, origin)
-    }
-  }
-
-  return new Response(JSON.stringify(metadata), {
-    status: response.status,
-    headers,
-  })
-}
-
-function requestOrigin(request: Request) {
-  return publicRequestUrl(request).origin
-}
-
 const authLoginLockedSchema = z.object({
   error: z.literal("login_locked"),
   message: z.string(),
@@ -290,12 +267,15 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
   registerScimAuthRoutes(app)
   app.use("/api/auth/sso/saml2/callback/*", samlResponsePolicyMiddleware)
   app.use("/api/auth/sso/saml2/sp/acs/*", samlResponsePolicyMiddleware)
-  app.get("/api/auth/.well-known/oauth-authorization-server", publicRoute, async (c) => rewriteMetadataOrigin(await oauthProviderAuthServerMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
-  app.get("/api/auth/.well-known/openid-configuration", publicRoute, async (c) => rewriteMetadataOrigin(await oauthProviderOpenIdConfigMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
-  app.get("/.well-known/oauth-authorization-server/api/auth", publicRoute, async (c) => rewriteMetadataOrigin(await oauthProviderAuthServerMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
-  app.get("/.well-known/openid-configuration/api/auth", publicRoute, async (c) => rewriteMetadataOrigin(await oauthProviderOpenIdConfigMetadata(auth)(c.req.raw), requestOrigin(c.req.raw)))
-  app.get("/.well-known/oauth-authorization-server", publicRoute, async (c) => rewriteMetadataOrigin(await oauthProviderAuthServerMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/oauth-authorization-server")), requestOrigin(c.req.raw)))
-  app.get("/.well-known/openid-configuration", publicRoute, async (c) => rewriteMetadataOrigin(await oauthProviderOpenIdConfigMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/openid-configuration")), requestOrigin(c.req.raw)))
+  // Better Auth uses this configured base URL for the callback `iss` value.
+  // Keep discovery on that same canonical issuer even when these routes are
+  // reached through a separate API or reverse-proxy origin.
+  app.get("/api/auth/.well-known/oauth-authorization-server", publicRoute, (c) => oauthProviderAuthServerMetadata(auth)(c.req.raw))
+  app.get("/api/auth/.well-known/openid-configuration", publicRoute, (c) => oauthProviderOpenIdConfigMetadata(auth)(c.req.raw))
+  app.get("/.well-known/oauth-authorization-server/api/auth", publicRoute, (c) => oauthProviderAuthServerMetadata(auth)(c.req.raw))
+  app.get("/.well-known/openid-configuration/api/auth", publicRoute, (c) => oauthProviderOpenIdConfigMetadata(auth)(c.req.raw))
+  app.get("/.well-known/oauth-authorization-server", publicRoute, (c) => oauthProviderAuthServerMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/oauth-authorization-server")))
+  app.get("/.well-known/openid-configuration", publicRoute, (c) => oauthProviderOpenIdConfigMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/openid-configuration")))
   app.post("/register", publicRoute, async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
   app.post("/api/auth/oauth2/register", publicRoute, async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
   app.get("/api/auth/oauth2/authorize", tokenRoute, (c) => auth.handler(c.req.raw))

--- a/ee/apps/den-api/test/mcp-auth.test.ts
+++ b/ee/apps/den-api/test/mcp-auth.test.ts
@@ -29,6 +29,7 @@ beforeAll(async () => {
 
 test("MCP resource metadata requests an offline refresh grant", () => {
   expect(mcpRoutes.protectedResourceMetadata(new Request("http://127.0.0.1:8790/mcp"))).toMatchObject({
+    authorization_servers: [getDenAuthIssuer("http://127.0.0.1:8790")],
     scopes_supported: ["mcp:read", "mcp:write", "offline_access"],
   })
 })

--- a/ee/apps/den-api/test/mcp-resource-url.test.ts
+++ b/ee/apps/den-api/test/mcp-resource-url.test.ts
@@ -75,6 +75,12 @@ if (authMetadataUrl) {
   if (metadata.issuer !== expectedAuthIssuer) {
     throw new Error(\`Expected auth issuer \${expectedAuthIssuer}, got \${metadata.issuer}\`)
   }
+  for (const key of ["authorization_endpoint", "token_endpoint", "registration_endpoint"]) {
+    const endpoint = metadata[key]
+    if (typeof endpoint !== "string" || !endpoint.startsWith(\`\${expectedAuthIssuer}/\`)) {
+      throw new Error(\`Expected \${key} to use canonical auth issuer \${expectedAuthIssuer}, got \${endpoint}\`)
+    }
+  }
 }
 
 console.log("ok")
@@ -131,7 +137,7 @@ describe("getMcpResourceUrl", () => {
       expectedResource: "https://api.example.com/mcp",
       metadataUrl: "https://api.example.com/mcp/agent",
       expectedMetadataResource: "https://api.example.com/mcp",
-      expectedAuthorizationServer: "https://api.example.com/api/auth",
+      expectedAuthorizationServer: "https://app.example.com/api/auth",
     })
   })
 
@@ -143,7 +149,7 @@ describe("getMcpResourceUrl", () => {
       expectedResource: "https://openwork.example/api/den/mcp",
       metadataUrl: "https://openwork.example/api/den/mcp/agent",
       expectedMetadataResource: "https://openwork.example/api/den/mcp",
-      expectedAuthorizationServer: "https://openwork.example/api/den/api/auth",
+      expectedAuthorizationServer: "https://app.example.com/api/auth",
     })
   })
 
@@ -156,9 +162,9 @@ describe("getMcpResourceUrl", () => {
       expectedResource: "https://api.example.com/mcp",
       metadataUrl: "http://api.example.com/mcp/agent",
       expectedMetadataResource: "https://api.example.com/mcp",
-      expectedAuthorizationServer: "https://api.example.com/api/auth",
+      expectedAuthorizationServer: "https://app.example.com/api/auth",
       authMetadataUrl: "http://api.example.com/api/auth/.well-known/oauth-authorization-server",
-      expectedAuthIssuer: "https://api.example.com/api/auth",
+      expectedAuthIssuer: "https://app.example.com/api/auth",
     })
   })
 
@@ -179,7 +185,7 @@ describe("getMcpResourceUrl", () => {
       expectedResource: "https://api.openworklabs.com/mcp",
       metadataUrl: "https://api.openworklabs.com/mcp/agent",
       expectedMetadataResource: "https://api.openworklabs.com/mcp",
-      expectedAuthorizationServer: "https://api.openworklabs.com/api/auth",
+      expectedAuthorizationServer: "https://app.openworklabs.com/api/auth",
     })
   })
 
@@ -207,7 +213,7 @@ describe("getMcpResourceUrl", () => {
       expectedResource: "https://app.example.com/api/den/mcp",
       metadataUrl: "https://app.example.com/api/den/mcp",
       expectedMetadataResource: "https://app.example.com/api/den/mcp",
-      expectedAuthorizationServer: "https://app.example.com/api/den/api/auth",
+      expectedAuthorizationServer: "https://app.example.com/api/auth",
     })
   })
 })


### PR DESCRIPTION
## What changed

- Advertise the configured Better Auth issuer from MCP protected-resource metadata, independently of the MCP resource origin.
- Stop rewriting OAuth and OIDC discovery documents to the incoming API/proxy origin.
- Cover direct API, path-prefixed proxy, TLS-terminating proxy, offline access, and admin MCP discovery behavior.

## Why

Codex completed the browser authorization flow but discarded the credentials afterward. OpenWork advertised `https://api.openworklabs.com/api/auth` as the issuer while Better Auth returned `https://app.openworklabs.com/api/auth` in the callback `iss` parameter. OAuth clients correctly reject that mismatch.

This keeps the MCP resource on the API host while making the authorization server invariant and consistent with token verification and the callback.

## Validation

- `pnpm exec bun test test/mcp-resource-url.test.ts test/mcp-auth.test.ts test/admin-mcp-routes.test.ts` — 16 passed, 0 failed
- `pnpm --filter @openwork-ee/den-api build` — passed
- `pnpm exec tsc -p tsconfig.json --noEmit` from `ee/apps/den-api` — passed

Fraimz was skipped at the request of the reporter; this is a server metadata fix with focused automated coverage.
