### PR TITLE
Fix MCP OAuth authorization redirects

### DIFF
--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -19,6 +19,7 @@ import { getSingletonSsoStatus } from "../../orgs.js"
 import { samlResponsePolicyMiddleware } from "../../sso-saml-response-middleware.js"
 import { revokeBearerSession, type AuthContextVariables } from "../../session.js"
 import { registerDesktopAuthRoutes } from "./desktop-handoff.js"
+import { normalizeOAuthAuthorizeRedirect } from "./oauth-redirect.js"
 import { registerScimAuthRoutes } from "./scim.js"
 
 function rewriteAuthRequest(request: Request, path: string) {
@@ -278,7 +279,10 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
   app.get("/.well-known/openid-configuration", publicRoute, (c) => oauthProviderOpenIdConfigMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/openid-configuration")))
   app.post("/register", publicRoute, async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
   app.post("/api/auth/oauth2/register", publicRoute, async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
-  app.get("/api/auth/oauth2/authorize", tokenRoute, (c) => auth.handler(c.req.raw))
+  app.get("/api/auth/oauth2/authorize", tokenRoute, async (c) => {
+    const response = await auth.handler(c.req.raw)
+    return normalizeOAuthAuthorizeRedirect(response)
+  })
 
   app.on(
     ["GET", "POST", "PUT", "PATCH", "DELETE"],

--- a/ee/apps/den-api/src/routes/auth/oauth-redirect.ts
+++ b/ee/apps/den-api/src/routes/auth/oauth-redirect.ts
@@ -1,0 +1,43 @@
+function readRedirectUrl(payload: unknown) {
+  if (typeof payload !== "object" || payload === null || !("redirect" in payload) || !("url" in payload)) {
+    return null
+  }
+  return payload.redirect === true && typeof payload.url === "string" ? payload.url : null
+}
+
+function buildRedirectHeaders(response: Response, url: string) {
+  const headers = new Headers(response.headers)
+  headers.delete("content-length")
+  headers.delete("content-type")
+  headers.set("location", url)
+  return headers
+}
+
+/**
+ * Better Auth returns JSON redirect envelopes for fetch-style requests. An
+ * OAuth authorization endpoint must navigate the user agent, so normalize
+ * that envelope to the same 302 response produced for browser-style requests.
+ */
+export async function normalizeOAuthAuthorizeRedirect(response: Response) {
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? ""
+  if (!contentType.includes("application/json")) {
+    return response
+  }
+
+  let payload: unknown
+  try {
+    payload = await response.clone().json()
+  } catch {
+    return response
+  }
+
+  const url = readRedirectUrl(payload)
+  if (!url) {
+    return response
+  }
+
+  return new Response(null, {
+    status: 302,
+    headers: buildRedirectHeaders(response, url),
+  })
+}

--- a/ee/apps/den-api/test/auth-oauth-redirect.test.ts
+++ b/ee/apps/den-api/test/auth-oauth-redirect.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeOAuthAuthorizeRedirect } from "../src/routes/auth/oauth-redirect.js"
+
+describe("OAuth authorization redirects", () => {
+  test("turns Better Auth's JSON redirect envelope into an HTTP redirect", async () => {
+    const headers = new Headers({
+      "content-type": "application/json",
+      "x-auth-result": "kept",
+    })
+    headers.append("set-cookie", "session=abc; Path=/; HttpOnly")
+    headers.append("set-cookie", "state=xyz; Path=/; HttpOnly")
+    const response = new Response(JSON.stringify({
+      redirect: true,
+      url: "https://app.example.com/mcp/select-organization?state=test",
+    }), { headers })
+
+    const normalized = await normalizeOAuthAuthorizeRedirect(response)
+
+    expect(normalized.status).toBe(302)
+    expect(normalized.headers.get("location")).toBe("https://app.example.com/mcp/select-organization?state=test")
+    expect(normalized.headers.get("x-auth-result")).toBe("kept")
+    expect(normalized.headers.getSetCookie()).toEqual([
+      "session=abc; Path=/; HttpOnly",
+      "state=xyz; Path=/; HttpOnly",
+    ])
+    expect(normalized.headers.get("content-type")).toBeNull()
+    expect(await normalized.text()).toBe("")
+  })
+
+  test("leaves ordinary JSON responses unchanged", async () => {
+    const response = Response.json({ ok: true })
+
+    expect(await normalizeOAuthAuthorizeRedirect(response)).toBe(response)
+    expect(await response.json()).toEqual({ ok: true })
+  })
+})


### PR DESCRIPTION
## What changed

- Normalize Better Auth's fetch-style `{ redirect: true, url }` response from the OAuth authorization endpoint into an HTTP 302 response.
- Preserve response headers and authentication cookies while replacing the JSON body with a `Location` header.
- Leave ordinary JSON responses and the consent endpoint contract unchanged.

## Why

After #2641 made the app-host OAuth issuer canonical, Codex correctly opened `app.openworklabs.com/api/auth/oauth2/authorize`. Better Auth treats JSON-accepting or fetch-style requests as API calls and returned the next URL in a JSON envelope, which Codex displayed instead of navigating to organization selection.

The authorization endpoint is a browser navigation surface, so it now produces the same HTTP redirect for both request styles.

## Validation

- `pnpm exec bun test test/auth-oauth-redirect.test.ts test/mcp-resource-url.test.ts test/mcp-auth.test.ts test/admin-mcp-routes.test.ts` — 18 passed, 0 failed
- `pnpm --filter @openwork-ee/den-api build` — passed
- `pnpm exec tsc -p tsconfig.json --noEmit` from `ee/apps/den-api` — passed

Fraimz remains skipped at the reporter's request; this is a server response normalization fix with focused automated coverage.
